### PR TITLE
feat: support custom base URL for OpenAI embedder

### DIFF
--- a/src/mindroom/config.py
+++ b/src/mindroom/config.py
@@ -46,7 +46,7 @@ class EmbedderConfig(BaseModel):
 
     model: str = Field(default="text-embedding-3-small", description="Model name for embeddings")
     api_key: str | None = Field(default=None, description="API key (usually from environment variable)")
-    host: str | None = Field(default=None, description="Host URL for self-hosted models like Ollama")
+    host: str | None = Field(default=None, description="Host URL for self-hosted models (Ollama, llama.cpp, etc.)")
 
 
 class MemoryEmbedderConfig(BaseModel):

--- a/src/mindroom/memory/config.py
+++ b/src/mindroom/memory/config.py
@@ -45,6 +45,9 @@ def get_memory_config(storage_path: Path, config: Config) -> dict:  # noqa: C901
         api_key = creds_manager.get_api_key("openai")
         if api_key:
             os.environ["OPENAI_API_KEY"] = api_key
+        # Support custom OpenAI-compatible base URL (e.g., llama.cpp)
+        if app_config.memory.embedder.config.host:
+            embedder_config["config"]["openai_base_url"] = app_config.memory.embedder.config.host
     elif app_config.memory.embedder.provider == "ollama":
         # Check CredentialsManager for Ollama host
         ollama_creds = creds_manager.load_credentials("ollama")


### PR DESCRIPTION
## Summary
- Allow using OpenAI-compatible APIs (e.g., llama.cpp) for memory embeddings
- Pass the `host` config option as `openai_base_url` when using the `openai` embedder provider

## Example config
```yaml
memory:
  embedder:
    provider: openai
    config:
      host: http://192.168.1.5:9292/v1
      model: embeddinggemma:300m
```

## Test plan
- [ ] Test with llama.cpp OpenAI-compatible endpoint
- [ ] Verify embeddings work with custom base URL