### PR TITLE
ci(docs): remove path filters from docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,15 +3,7 @@ name: Docs
 on:
   push:
     branches: [main]
-    paths:
-      - "docs/**"
-      - "zensical.toml"
-      - ".github/workflows/docs.yml"
   pull_request:
-    paths:
-      - "docs/**"
-      - "zensical.toml"
-      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Remove path filters from the docs workflow so it triggers on all pushes and PRs. The build is cheap and this ensures docs are always validated.

## Changes

- Remove `paths:` filters from push and pull_request triggers