### PR TITLE
docs: add blank lines before list items

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -48,6 +48,7 @@ authorization:
 ```
 
 Use this for:
+
 - Administrators
 - Developers
 - Trusted team members
@@ -89,6 +90,7 @@ User IDs follow the Matrix format:
 ```
 
 Examples:
+
 - `@alice:matrix.org`
 - `@bob:example.com`
 - `@admin:company.internal`

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -93,6 +93,7 @@ Configure AI model providers:
 - **Test connection** - Verify model accessibility
 
 Supported providers:
+
 - Anthropic (Claude)
 - OpenAI (GPT)
 - Google (Gemini)

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -76,6 +76,7 @@ helm install instance-1 mindroom/mindroom-instance \
 ```
 
 Each instance gets:
+
 - Separate deployment
 - Isolated storage
 - Independent configuration

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -48,6 +48,7 @@ plugins:
 ```
 
 Paths may be:
+
 - Absolute paths
 - Paths relative to `config.yaml`
 - Python package specs (see below)
@@ -65,6 +66,7 @@ plugins:
 ```
 
 Rules:
+
 - A bare package name is allowed if it contains no slashes.
 - `python:`, `pkg:`, and `module:` are explicit prefixes.
 - `:sub/path` points to a subdirectory inside the package.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -27,6 +27,7 @@ command-arg-mode: raw
 ```
 
 Notes:
+
 - `metadata` can be a JSON5 string (shown above) or a YAML mapping.
 - `user-invocable`, `disable-model-invocation`, and `command-*` also accept snake_case names.
 
@@ -100,6 +101,7 @@ Users can run a skill by name:
 ```
 
 Rules:
+
 - The skill must be in the agent allowlist and `user-invocable` must be `true`.
 - If `command-dispatch: tool` is set, MindRoom runs the tool directly.
 - If `disable-model-invocation: true` and no tool dispatch is configured, the command fails.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -26,28 +26,33 @@ agents:
 ## Tool Categories
 
 ### File & System
+
 - `file` - Read, write, and manage files
 - `shell` - Execute shell commands
 - `docker` - Manage Docker containers
 
 ### AI & Search
+
 - `web_search` - Search the web
 - `tavily` - AI-powered web search
 - `exa` - Neural search engine
 - `arxiv` - Search academic papers
 
 ### Communication
+
 - `slack` - Send messages to Slack
 - `gmail` - Send and read emails
 - `telegram` - Telegram bot integration
 - `twilio` - SMS and voice calls
 
 ### Development
+
 - `github` - Manage GitHub repos, issues, PRs
 - `jira` - Issue tracking
 - `confluence` - Wiki documentation
 
 ### Productivity
+
 - `google_calendar` - Calendar management
 - `google_sheets` - Spreadsheet access
 - `todoist` - Task management


### PR DESCRIPTION
## Summary

- Fix markdown rendering issues by adding blank lines before list items
- Ensures proper spacing after colons and headers that precede lists
- Fixes 6 documentation files in the main docs

## Files changed

- `docs/authorization.md` - "Use this for:" and "Examples:" sections
- `docs/dashboard.md` - "Supported providers:" section
- `docs/deployment/kubernetes.md` - "Each instance gets:" section
- `docs/plugins.md` - "Paths may be:" and "Rules:" sections
- `docs/skills.md` - "Notes:" and "Rules:" sections
- `docs/tools/index.md` - Category headers (File & System, AI & Search, etc.)

## Test plan

- [x] Verified no remaining issues with regex search
- [ ] Visual inspection of rendered markdown