### PR TITLE
Recommend full-stack Docker Compose onboarding

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -10,11 +10,23 @@ MindRoom can be deployed in various ways depending on your needs.
 
 | Method | Best For |
 |--------|----------|
-| [Docker](docker.md) | Single-instance deployments, development |
+| Full Stack (Docker Compose) | All-in-one: backend + frontend + Matrix (Synapse) + Element |
+| [Docker (single container)](docker.md) | Backend-only or when you already have Matrix |
 | [Kubernetes](kubernetes.md) | Multi-tenant SaaS, production |
 | Direct | Development, simple setups |
 
 ## Quick Start
+
+### Full Stack (recommended)
+
+```bash
+git clone https://github.com/mindroom-ai/mindroom-stack
+cd mindroom-stack
+cp .env.example .env
+$EDITOR .env  # add at least one AI provider key
+
+docker compose up -d
+```
 
 ### Direct (Development)
 
@@ -24,7 +36,7 @@ mindroom run --storage-path ./mindroom_data
 
 The config file path is set via `MINDROOM_CONFIG_PATH` (defaults to `./config.yaml`).
 
-### Docker
+### Docker (single container)
 
 ```bash
 docker run -d \
@@ -44,7 +56,15 @@ See the [Kubernetes deployment guide](kubernetes.md) for Helm chart configuratio
 
 ## Required Configuration
 
-All deployments need:
+Full stack:
+
+```bash
+# .env in the full stack repo
+ANTHROPIC_API_KEY=sk-ant-...
+# Add other providers as needed
+```
+
+Direct and single-container deployments:
 
 1. **Matrix homeserver** - Set `MATRIX_HOMESERVER` (must allow open registration for agent accounts)
 2. **AI provider keys** - At least one of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,13 +6,48 @@ icon: lucide/rocket
 
 This guide will help you set up MindRoom and create your first AI agent.
 
-## Prerequisites
+## Recommended: Full Stack Docker Compose (backend + frontend + Matrix + Element)
+
+MindRoom depends on a Matrix homeserver plus supporting services. The easiest onboarding is the full stack Docker Compose repo, which brings everything up together.
+
+**Prereqs:** Docker + Docker Compose.
+
+### 1. Clone the full stack repo
+
+```bash
+git clone https://github.com/mindroom-ai/mindroom-stack
+cd mindroom-stack
+```
+
+### 2. Add your API keys
+
+```bash
+cp .env.example .env
+$EDITOR .env  # add at least one AI provider key
+```
+
+### 3. Start everything
+
+```bash
+docker compose up -d
+```
+
+Open:
+- MindRoom UI: http://localhost:3003
+- Element: http://localhost:8080
+- Matrix homeserver: http://matrix.localhost:8008
+
+## Manual Install (advanced)
+
+Use this if you already have a Matrix homeserver and want to run MindRoom directly.
+
+### Prerequisites
 
 - Python 3.12 or higher
 - A Matrix homeserver (or use a public one like matrix.org)
 - API keys for your preferred AI provider (Anthropic, OpenAI, etc.)
 
-## Installation
+### Installation
 
 === "uv (recommended)"
 
@@ -35,9 +70,9 @@ This guide will help you set up MindRoom and create your first AI agent.
     source .venv/bin/activate
     ```
 
-## Configuration
+### Configuration
 
-### 1. Create your config file
+#### 1. Create your config file
 
 Create a `config.yaml` in your working directory:
 
@@ -61,7 +96,7 @@ defaults:
 timezone: America/Los_Angeles
 ```
 
-### 2. Set up environment variables
+#### 2. Set up environment variables
 
 Create a `.env` file with your credentials:
 
@@ -84,7 +119,7 @@ ANTHROPIC_API_KEY=your_anthropic_key
 > [!NOTE]
 > MindRoom automatically creates Matrix user accounts for each agent. Your Matrix homeserver must allow open registration, or you need to configure it to allow registration from localhost. If registration fails, check your homeserver's registration settings.
 
-### 3. Run MindRoom
+#### 3. Run MindRoom
 
 ```bash
 mindroom run

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,17 +24,37 @@ MindRoom is an AI agent orchestration system with Matrix integration. It provide
 
 ## Quick Start
 
-### Installation
+### Recommended: Full Stack Docker Compose (backend + frontend + Matrix + Element)
+
+**Prereqs:** Docker + Docker Compose.
 
 ```bash
-# Using uv (recommended)
+git clone https://github.com/mindroom-ai/mindroom-stack
+cd mindroom-stack
+cp .env.example .env
+$EDITOR .env  # add at least one AI provider key
+
+docker compose up -d
+```
+
+Open:
+- MindRoom UI: http://localhost:3003
+- Element: http://localhost:8080
+- Matrix homeserver: http://matrix.localhost:8008
+
+### Manual Install (advanced)
+
+Use this if you already have a Matrix homeserver and want to run MindRoom directly.
+
+```bash
+# Using uv
 uv tool install mindroom
 
-# Using pip
+# Or using pip
 pip install mindroom
 ```
 
-### Basic Usage
+### Basic Usage (manual)
 
 1. Create a `config.yaml`:
 


### PR DESCRIPTION
## Summary
- recommend the full-stack Docker Compose repo as the default onboarding path
- update Getting Started and Deployment pages to reflect the full stack flow
- keep manual install and single-container Docker as advanced options

## Testing
- pytest
- pre-commit run --all-files