### PR TITLE
docs: second review pass with subtle fixes and code improvements

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -48,5 +48,5 @@ MindRoom's architecture consists of several key components working together.
 2. **Router decides** which agent should handle it (if no explicit mention)
 3. **Agent processes** the message using the Agno runtime
 4. **Tools execute** as needed (file operations, API calls, etc.)
-5. **Memory updates** with relevant information
-6. **Response sent** back to Matrix room
+5. **Response sent** back to Matrix room
+6. **Memory updates** asynchronously in background

--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -43,7 +43,7 @@ from mindroom.matrix.client import create_matrix_client, login
 client = create_matrix_client(
     homeserver="https://matrix.example.com",
     user_id="@mindroom_agent:example.com",
-    store_path="/path/to/encryption/keys"  # Optional, auto-generated if omitted
+    store_path="/path/to/encryption/keys"  # Optional, defaults to mindroom_data/encryption_keys/<user_id>
 )
 
 # Login with password
@@ -59,9 +59,10 @@ async with matrix_client(homeserver, user_id, access_token) as client:
 
 ### Environment Variables
 
-- `MATRIX_HOMESERVER` - Matrix homeserver URL
+- `MATRIX_HOMESERVER` - Matrix homeserver URL (default: `http://localhost:8008`)
 - `MATRIX_SERVER_NAME` - Federation server name (if different from homeserver hostname)
-- `MATRIX_SSL_VERIFY` - Set to `"false"` to disable SSL verification (dev only)
+- `MATRIX_SSL_VERIFY` - Set to `"false"` to disable SSL verification (default: `"true"`, dev only)
+- `MINDROOM_ENABLE_STREAMING` - Set to `"false"` to disable message streaming/editing (default: `"true"`)
 
 ## Agent Users
 
@@ -275,7 +276,7 @@ async with typing_indicator(client, room_id):
 # Typing indicator automatically stopped
 ```
 
-The typing indicator is automatically refreshed at half the timeout interval (or every 15 seconds) to remain visible during long operations.
+The typing indicator is automatically refreshed at the smaller of half the timeout interval or 15 seconds to remain visible during long operations.
 
 ## Mentions
 

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -23,8 +23,8 @@ main() entry
 ┌──────────────────┐
 │  Initialize()    │
 │ ─────────────────│
-│ 1. Create user   │
-│    account       │
+│ 1. Create "user" │
+│    Matrix account│
 │ 2. Parse config  │
 │    (Pydantic)    │
 │ 3. Load plugins  │
@@ -56,24 +56,25 @@ main() entry
 
 ### Boot Sequence Details
 
-1. **User Account Creation**: A "user" account is created first via `_ensure_user_account()`
-2. **Entity Order**: Router starts first, then agents, then teams
-3. **Room Setup** (`_setup_rooms_and_memberships`):
+1. **User Account Creation**: A shared "user" Matrix account is created first via `_ensure_user_account()` - this is a human user account, separate from agent accounts
+2. **Entity Order**: Router is created first, then agents, then teams (order defined in `all_entities` list)
+3. **Agent Account Setup**: Each bot calls `ensure_user_account()` during `start()` to create its own Matrix account
+4. **Room Setup** (`_setup_rooms_and_memberships`):
    - Ensure all configured rooms exist (router creates them)
    - Invite agents and users to rooms
    - Have bots join their configured rooms
-4. **Sync Loops**: Each bot runs `_sync_forever_with_restart()` with automatic retry on failure
+5. **Sync Loops**: Each bot runs `_sync_forever_with_restart()` with automatic retry on failure
 
 ## Hot Reload
 
 Config changes are detected via polling (not Watchdog):
 
 1. `watch_file()` polls `config.yaml` every second by checking `st_mtime`
-2. On change, `_handle_config_change()` triggers `orchestrator.update_config()`
+2. On change, `_watch_config_task()` calls `orchestrator.update_config()`
 3. Diff computed via `_identify_entities_to_restart()`:
    - Compare agent configs using `model_dump(exclude_none=True)`
    - Check for new/removed entities
-   - Check if router needs restart (room changes)
+   - Check if router needs restart (configured room set changed)
 4. Affected entities are stopped, recreated, and restarted
 5. Removed entities run `cleanup()` (leave rooms, stop bot)
 6. New/restarted bots go through room setup
@@ -90,16 +91,22 @@ Messages are processed via Matrix event callbacks. The actual flow:
    - Callbacks are wrapped in `_create_task_wrapper()` to run as background tasks
    - This ensures the sync loop is never blocked by event processing
 
-2. **Message Processing** (simplified):
-   - Check if message mentions this agent
-   - Check thread context and history
-   - Determine if agent should respond
+2. **Message Processing** (in `_on_message`):
+   - Skip own messages (except voice transcriptions from router)
+   - Check sender authorization
+   - Handle message edits separately
+   - Check if already responded (`ResponseTracker`)
+   - Router handles commands exclusively
+   - Extract message context (mentions, thread history)
+   - Skip messages from other agents (unless mentioned)
+   - Check for team formation or individual response
    - Generate response (streaming or batch)
-   - Store conversation memory
+   - Store conversation memory as background task
 
 3. **Routing** (when no agent mentioned):
    - Router uses `suggest_agent_for_message()` to pick the best agent
    - Considers room configuration and message content
+   - Only routes when multiple agents are available in the room
 
 ## Concurrency
 
@@ -108,18 +115,20 @@ MindRoom handles multiple conversations concurrently:
 - Each bot runs its own sync loop via `_sync_forever_with_restart()`
 - Sync loop failures trigger automatic restart with exponential backoff (5s, 10s, ... up to 60s)
 - Event callbacks run as background tasks (never block the sync loop)
-- `ResponseTracker` prevents duplicate replies per thread
+- `ResponseTracker` prevents duplicate replies to the same message
 - `StopManager` handles cancellation of in-progress responses
 
 ### Sync Loop Recovery
 
 ```python
 # Simplified from _sync_forever_with_restart()
+retry_count = 0
 while bot.running:
     try:
         await bot.sync_forever()
     except Exception:
-        wait_time = min(60, 5 * retry_count)
+        retry_count += 1
+        wait_time = min(60, 5 * retry_count)  # 5s, 10s, 15s, ... up to 60s
         await asyncio.sleep(wait_time)
 ```
 
@@ -129,5 +138,6 @@ On shutdown (`orchestrator.stop()`):
 
 1. Cancel all sync tasks
 2. Signal all bots to stop (`bot.running = False`)
-3. Wait for background tasks to complete (5s timeout)
-4. Close Matrix clients
+3. Call `bot.stop()` for each bot, which:
+   - Waits for background tasks to complete (5s timeout)
+   - Closes the Matrix client

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -111,7 +111,8 @@ Examples:
       ▼
 ┌─────────────┐     ┌─────────────┐
 │ Is MindRoom │────▶│ Authorized  │────▶ Process
-│ agent/team  │ Yes └─────────────┘
+│ agent/team/ │ Yes └─────────────┘
+│ router      │
 └─────┬───────┘
       │ No
       ▼
@@ -121,31 +122,36 @@ Examples:
 └─────┬───────┘
       │ No
       ▼
+┌───────────────────┐
+│ Room in           │
+│ room_permissions? │
+└─────────┬─────────┘
+          │
+     ┌────┴────┐
+    Yes       No
+     │         │
+     ▼         ▼
 ┌─────────────┐     ┌─────────────┐
-│ Check Room  │────▶│ Authorized  │────▶ Process
-│ Permissions │ Yes └─────────────┘
-└─────┬───────┘
-      │ No
-      ▼
-┌─────────────┐     ┌─────────────┐
-│ Check       │────▶│ Authorized  │────▶ Process
-│ Default     │ Yes └─────────────┘
-└─────┬───────┘
-      │ No
-      ▼
-┌─────────────┐
-│ Ignore      │
-│ Message     │
-└─────────────┘
+│ User in     │     │ default_    │
+│ room list?  │     │ room_access │
+└─────┬───────┘     └─────┬───────┘
+   ┌──┴──┐             ┌──┴──┐
+  Yes   No           true  false
+   │     │             │     │
+   ▼     ▼             ▼     ▼
+ ┌───────────┐     ┌───────────┐
+ │ Authorize │     │  Ignore   │
+ │ (Process) │     │  Message  │
+ └───────────┘     └───────────┘
 ```
 
 The authorization checks are performed in order:
 
-1. **Internal system user** - The `@mindroom_user` account is always authorized
-2. **MindRoom agents/teams** - Configured agents and teams are authorized to communicate
+1. **Internal system user** - The `@mindroom_user` account on the current domain is always authorized (note: `@mindroom_user` from a different domain is NOT automatically authorized)
+2. **MindRoom agents/teams/router** - Configured agents, teams, and the router are authorized to communicate
 3. **Global users** - Users in `global_users` have access to all rooms
-4. **Room permissions** - Users listed for a specific room ID
-5. **Default access** - Falls back to `default_room_access` setting
+4. **Room permissions** - Users listed for a specific room ID (if a room is in `room_permissions` but the user is not listed, access is denied - it does not fall through to default access)
+5. **Default access** - For rooms not in `room_permissions` at all, falls back to `default_room_access` setting
 
 ## SaaS Platform Authorization
 

--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -21,9 +21,9 @@ agents:
 
 ```yaml
 agents:
-  code:
+  developer:
     # Display name shown in Matrix
-    display_name: CodeAgent
+    display_name: Developer
 
     # Role description - guides the agent's behavior
     role: Generate code, manage files, execute shell commands
@@ -79,7 +79,7 @@ agents:
 
 ## Rich Prompt Agents
 
-Some agent names have built-in rich prompts that provide detailed behavior:
+Some agent names (the YAML key, not `display_name`) have built-in rich prompts that provide detailed behavior:
 
 - `code` - Code generation, file management, shell commands
 - `research` - Web research and information gathering
@@ -91,7 +91,7 @@ Some agent names have built-in rich prompts that provide detailed behavior:
 - `news` - News aggregation
 - `data_analyst` - Data analysis
 
-When using these names, the built-in prompt is used instead of the `role` field, though `instructions` are still applied.
+When using these names, the built-in prompt is used instead of the `role` field. Note that custom `instructions` from YAML are NOT applied to rich prompt agents - the built-in prompt is used as-is.
 
 ## Defaults
 
@@ -105,7 +105,7 @@ defaults:
   show_stop_button: false
 ```
 
-These defaults apply to all agents unless overridden in the agent's configuration.
+The `num_history_runs`, `markdown`, and `add_history_to_messages` defaults apply to all agents unless overridden in the agent's configuration. The `show_stop_button` setting is global-only and cannot be overridden per-agent.
 
 ## Tools
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -17,7 +17,7 @@ mindroom run --config /path/to/config.yaml
 ## Basic Structure
 
 ```yaml
-# Agent definitions (required)
+# Agent definitions (at least one recommended)
 agents:
   assistant:
     display_name: Assistant        # Required: Human-readable name
@@ -31,10 +31,10 @@ agents:
     markdown: true                 # Optional: Override default markdown
     add_history_to_messages: true  # Optional: Include history in context
 
-# Model configurations (required for non-default models)
+# Model configurations (at least a "default" model is recommended)
 models:
   sonnet:
-    provider: anthropic            # Required: openai, anthropic, ollama, google, groq, cerebras
+    provider: anthropic            # Required: openai, anthropic, ollama, google/gemini, groq, cerebras, openrouter, deepseek
     id: claude-sonnet-4-latest     # Required: Model ID for the provider
     host: null                     # Optional: Host URL (e.g., for Ollama)
     api_key: null                  # Optional: API key (usually from env vars)
@@ -47,7 +47,7 @@ teams:
     role: Collaborative research   # Required: Description of team purpose
     agents: [researcher, writer]   # Required: List of agent names
     mode: collaborate              # Optional: "coordinate" or "collaborate" (default: coordinate)
-    model: sonnet                  # Optional: Model for team coordination
+    model: sonnet                  # Optional: Model for team coordination (default: "default")
     rooms: []                      # Optional: Rooms to auto-join
 
 # Router configuration (optional)
@@ -117,7 +117,7 @@ The memory system stores agent memories using embeddings. Configuration is optio
 ```yaml
 memory:
   embedder:
-    provider: openai               # Provider: openai, huggingface, etc.
+    provider: openai               # Provider: openai, ollama, huggingface, etc.
     config:
       model: text-embedding-3-small  # Embedding model
       api_key: null                # From OPENAI_API_KEY env var
@@ -184,9 +184,10 @@ When `default_room_access` is `false`, only users in `global_users` or the speci
 
 ### Optional Sections
 
-All top-level sections except `agents` are optional:
+All top-level sections are technically optional (with sensible defaults), but you need at least one agent for MindRoom to function:
 
-- `models` - Only needed if agents reference non-default models
+- `agents` - Defaults to empty; at least one agent is needed for a functional setup
+- `models` - A model named "default" is needed unless all agents/teams specify explicit models
 - `teams` - Only needed for multi-agent collaboration
 - `router` - Only needed to customize routing behavior
 - `defaults` - All fields have sensible defaults

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -15,6 +15,7 @@ Models define the AI providers and model IDs used by agents.
 - `groq` - Groq-hosted models (fast inference)
 - `openrouter` - OpenRouter-hosted models (access to many providers)
 - `cerebras` - Cerebras-hosted models
+- `deepseek` - DeepSeek models
 
 ## Model Config Fields
 
@@ -72,6 +73,11 @@ models:
     provider: cerebras
     id: llama3.1-8b
 
+  # DeepSeek
+  deepseek:
+    provider: deepseek
+    id: deepseek-chat
+
   # Custom OpenAI-compatible endpoint (e.g., vLLM, llama.cpp server)
   custom:
     provider: openai
@@ -91,6 +97,7 @@ GOOGLE_API_KEY=...
 GROQ_API_KEY=...
 OPENROUTER_API_KEY=...
 CEREBRAS_API_KEY=...
+DEEPSEEK_API_KEY=...
 ```
 
 For Ollama, you can also set:

--- a/docs/configuration/teams.md
+++ b/docs/configuration/teams.md
@@ -99,7 +99,20 @@ teams:
 
 ## Dynamic Team Formation
 
-When multiple agents are mentioned in a message (e.g., `@code @research analyze this`), MindRoom can automatically form an ad-hoc team. The collaboration mode is selected by AI based on the task:
+When multiple agents are mentioned in a message (e.g., `@code @research analyze this`), MindRoom automatically forms an ad-hoc team. Dynamic teams form in these scenarios:
+
+1. **Multiple agents explicitly tagged** - e.g., `@code @research analyze this`
+2. **Thread with previously mentioned agents** - Follow-up messages in a thread where multiple agents were mentioned earlier
+3. **Thread with multiple agent participants** - Continuing a conversation where multiple agents have responded
+4. **DM room with multiple agents** - Messages in a DM room containing multiple agents (main timeline only)
+
+### Mode Selection
+
+For dynamic teams, the collaboration mode is selected by AI based on the task:
 
 - Tasks with different subtasks for each agent use **coordinate** mode
 - Tasks asking for opinions or brainstorming use **collaborate** mode
+
+When AI mode selection is unavailable, MindRoom falls back to:
+- **coordinate** for explicitly tagged agents (they likely have different roles)
+- **collaborate** for agents from thread history (likely discussing same topic)

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -59,7 +59,7 @@ Create and configure AI agents with a visual editor:
   - **Configured tools** - Tools with credentials already set up
   - **Default tools** - Tools that work without configuration
 - **Instructions** - Custom behavior instructions (add/remove entries)
-- **Rooms** - Select which rooms the agent joins
+- **Agent rooms** - Select rooms where this agent can operate
 - **History runs** - Number of previous conversation turns as context
 
 ### Teams
@@ -73,7 +73,7 @@ Configure multi-agent collaboration:
   - **Collaborate** - Agents work simultaneously in parallel
 - **Team model** - Optional model override for all agents in the team
 - **Team members** - Select agents to include
-- **Team rooms** - Where the team responds
+- **Team rooms** - Select rooms where this team can operate
 
 ### Rooms
 
@@ -81,12 +81,12 @@ Manage Matrix room configuration:
 
 - **Display name** - Human-readable name for the room
 - **Description** - Describe the room's purpose
-- **Room model** - Optional model override for agents in this room
+- **Room model** - Optional model override for agents and teams in this room
 - **Agents in room** - Which agents are members (their room list updates automatically)
 
 ### External Rooms
 
-View and manage rooms that agents have joined but aren't in the configuration:
+View and manage rooms that agents have joined but are not in the configuration:
 
 - **Summary** - Shows total external rooms across all agents
 - **Per-agent view** - See which external rooms each agent has joined
@@ -131,10 +131,10 @@ Supported providers:
 Configure the embedder for agent memory storage and retrieval:
 
 - **Embedder provider** - Choose where embeddings are computed:
-  - Ollama (local)
-  - OpenAI (cloud)
-  - HuggingFace (cloud)
-  - Sentence Transformers (local)
+  - Ollama (Local)
+  - OpenAI
+  - HuggingFace
+  - Sentence Transformers
 - **Embedding model** - Select the specific model for the provider
 - **Host URL** - Configure Ollama server location (for Ollama provider)
 
@@ -144,9 +144,9 @@ Configure voice message handling:
 
 - **Enable/disable** - Toggle voice message support
 - **Speech-to-Text (STT)**:
-  - Provider: OpenAI Whisper (cloud) or self-hosted (OpenAI-compatible)
+  - Provider: OpenAI Whisper (Cloud) or Self-hosted (OpenAI-compatible)
   - Model: Whisper model name
-  - API key (optional for OpenAI, uses environment variable if not set)
+  - API key (optional for OpenAI, uses OPENAI_API_KEY environment variable if not set)
   - Host URL (for self-hosted providers)
 - **Command Intelligence** (advanced settings):
   - AI model for processing transcriptions
@@ -166,7 +166,7 @@ Manage tool integrations:
   - Research
   - Smart Home
   - Information
-- **Filter by status** - All, Available, Unconfigured, Configured, Coming Soon
+- **Filter by status** - Show All, Available, Unconfigured, Configured, Coming Soon
 - **Configure** - Set up API keys and options via dialogs
 - **OAuth flows** - Connect Google, Spotify, Home Assistant, etc.
 - **Edit/disconnect** - Manage connected integrations
@@ -178,8 +178,8 @@ Manage tool integrations:
 Changes in the dashboard are immediately reflected in `config.yaml`. The sync status indicator shows:
 
 - **Synced** - All changes saved
-- **Syncing** - Save in progress
-- **Error** - Sync failed
+- **Syncing...** - Save in progress
+- **Sync Error** - Sync failed
 - **Disconnected** - Lost connection to backend
 
 ### Dark/Light Theme
@@ -230,12 +230,15 @@ The dashboard communicates with the MindRoom backend API at `/api/`. Key endpoin
 - `POST /api/credentials/:service` - Set credentials
 - `POST /api/credentials/:service/api-key` - Set API key
 - `GET /api/credentials/:service/api-key` - Get masked API key
+- `POST /api/credentials/:service/test` - Test credentials validity
 - `DELETE /api/credentials/:service` - Delete credentials
 
 ### Tools & Matrix
 
 - `GET /api/tools` - List available tools with status
 - `GET /api/rooms` - List configured rooms
-- `GET /api/matrix/agents/rooms` - Get agent room memberships
+- `GET /api/matrix/agents/rooms` - Get all agents' room memberships
+- `GET /api/matrix/agents/:id/rooms` - Get specific agent's room memberships
+- `POST /api/matrix/rooms/leave` - Leave a single room
 - `POST /api/matrix/rooms/leave-bulk` - Leave multiple rooms
 - `POST /api/test/model` - Test model connection

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -31,11 +31,11 @@ MindRoom consists of two containers: backend (bot + API) and frontend (dashboard
 ```bash
 docker run -d \
   --name mindroom-backend \
-  -v ./config.yaml:/app/config.yaml \
-  -v ./mindroom_data:/app/mindroom_data \
-  -v ./.env:/app/.env \
   -p 8765:8765 \
-  ghcr.io/mindroom-ai/mindroom-backend:latest
+  -v ./config.yaml:/app/config.yaml:ro \
+  -v ./mindroom_data:/app/mindroom_data \
+  --env-file .env \
+  ghcr.io/basnijholt/mindroom-backend:latest
 ```
 
 See the [Docker deployment guide](docker.md) for full setup including the frontend.
@@ -84,11 +84,13 @@ MindRoom stores data in the following structure:
 
 ```
 mindroom_data/
-├── sessions/         # Agent conversation history (SQLite)
-├── memory/           # Vector store for memories (ChromaDB)
-├── tracking/         # Response tracking to avoid duplicates
-├── credentials/      # Synced credentials from .env
-└── encryption_keys/  # Matrix E2EE keys (if enabled)
+├── sessions/          # Agent conversation history (SQLite)
+├── memory/            # Vector store for memories (ChromaDB)
+├── tracking/          # Response tracking to avoid duplicates
+├── credentials/       # Synced credentials from .env
+├── logs/              # Application logs
+├── matrix_state.yaml  # Matrix connection state
+└── encryption_keys/   # Matrix E2EE keys (if enabled)
 ```
 
 Ensure this directory is persisted across restarts. The `STORAGE_PATH` environment variable controls the location (defaults to `mindroom_data`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,6 +32,7 @@ This guide will help you set up MindRoom and create your first AI agent.
     git clone https://github.com/mindroom-ai/mindroom
     cd mindroom
     uv sync
+    source .venv/bin/activate
     ```
 
 ## Configuration
@@ -68,6 +69,12 @@ Create a `.env` file with your credentials:
 # Matrix homeserver (must allow open registration for agent accounts)
 MATRIX_HOMESERVER=https://matrix.example.com
 
+# Optional: For self-signed certificates (development)
+# MATRIX_SSL_VERIFY=false
+
+# Optional: For federation setups where server_name differs from homeserver hostname
+# MATRIX_SERVER_NAME=example.com
+
 # AI provider API keys
 ANTHROPIC_API_KEY=your_anthropic_key
 # OPENAI_API_KEY=your_openai_key
@@ -77,7 +84,8 @@ ANTHROPIC_API_KEY=your_anthropic_key
 !!! note "Matrix Registration"
     MindRoom automatically creates Matrix user accounts for each agent.
     Your Matrix homeserver must allow open registration, or you need to
-    configure it to allow registration from localhost.
+    configure it to allow registration from localhost. If registration
+    fails, check your homeserver's registration settings.
 
 ### 3. Run MindRoom
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -58,7 +58,7 @@ memory:
     provider: openai  # or "ollama"
     config:
       model: text-embedding-3-small
-      host: null  # Optional: custom base URL for OpenAI-compatible servers
+      host: null  # Optional: host URL for self-hosted models
 
   # LLM for memory extraction (optional)
   llm:
@@ -66,7 +66,6 @@ memory:
     config:
       model: gpt-4o-mini
       temperature: 0.1
-      top_p: 1
 ```
 
 ### Configuration Options
@@ -75,9 +74,11 @@ memory:
 |-------|-------------|
 | `embedder.provider` | Embedding provider: `openai`, `ollama` |
 | `embedder.config.model` | Model name for embeddings |
-| `embedder.config.host` | Custom base URL for OpenAI-compatible servers |
+| `embedder.config.host` | Host URL for self-hosted models (Ollama, OpenAI-compatible servers, etc.) |
 | `llm.provider` | LLM provider for memory extraction: `openai`, `ollama`, `anthropic` |
-| `llm.config` | Provider-specific LLM configuration |
+| `llm.config.model` | Model name for the LLM |
+| `llm.config.temperature` | Temperature for LLM responses (e.g., `0.1`) |
+| `llm.config.ollama_base_url` | Host URL for Ollama LLM (when using `ollama` provider) |
 
 ### Example with Ollama
 
@@ -109,17 +110,17 @@ memory:
 ```
 User Message
     ↓
-┌─────────────────────────────────────┐
-│ Search agent memories (limit: 3)    │
-│ Search team memories (if in team)   │
-│ Search room memories (limit: 3)     │
-└─────────────────────────────────────┘
+┌──────────────────────────────────────────┐
+│ Search agent memories (default limit: 3) │
+│ + team memories (if agent is in a team)  │
+│ Search room memories (default limit: 3)  │
+└──────────────────────────────────────────┘
     ↓
-Enhanced prompt with memory context
+Enhanced prompt: [room context] + [agent context] + [original message]
     ↓
 Agent response
     ↓
-Store conversation in memory
+Store conversation in memory (agent/team + room scopes)
 ```
 
 ## Storage Location
@@ -133,10 +134,10 @@ Memories are stored in ChromaDB under `<storage_path>/chroma/`:
 
 For explicit memory control, agents can use the `mem0` tool which provides functions to:
 
-- Add memories manually
-- Search memories with custom queries
-- Get all memories
-- Delete memories
+- `add_memory`: Add memories manually
+- `search_memory`: Search memories with custom queries
+- `get_all_memories`: Retrieve all stored memories
+- `delete_all_memories`: Delete all memories for the agent
 
 Add the tool to an agent:
 
@@ -150,4 +151,4 @@ With this tool enabled, agents can respond to natural language requests like:
 
 - "Remember that I prefer TypeScript over JavaScript"
 - "What do you know about this project?"
-- "Forget the database credentials I mentioned earlier"
+- "Clear all my memories and start fresh"

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -33,7 +33,7 @@ my-plugin/
 | --- | --- | --- |
 | `name` | string | Plugin identifier (required) |
 | `tools_module` | string | Path to the tools module (optional) |
-| `skills` | list | Relative directories containing skills (optional) |
+| `skills` | list of strings | Relative directories containing skills (optional) |
 
 Unknown fields are ignored.
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -54,7 +54,9 @@ The system can convert event-based requests into smart polling schedules:
 !list_schedules
 ```
 
-Shows all pending scheduled tasks in the current thread.
+Shows all pending scheduled tasks. When used in a thread, shows tasks for that thread. When used in the main room, shows all tasks in the room.
+
+Alternative syntax: `!listschedules`, `!list-schedules`, `!list_schedule`
 
 ### Cancel a Schedule
 
@@ -63,7 +65,9 @@ Shows all pending scheduled tasks in the current thread.
 !cancel_schedule all
 ```
 
-Cancel a specific scheduled task by its ID, or use `all` to cancel all scheduled tasks in the room.
+Cancel a specific scheduled task by its ID, or use `all` to cancel all scheduled tasks in the room (no confirmation required).
+
+Alternative syntax: `!cancelschedule`, `!cancel-schedule`
 
 Use `!list_schedules` to see task IDs.
 
@@ -86,7 +90,7 @@ MindRoom uses AI to parse your natural language request into a structured schedu
 
 ### Agent Mentions
 
-Include `@agent_name` in your schedule to have specific agents respond. The scheduler validates that mentioned agents are available in the thread before creating the task.
+Include `@agent_name` in your schedule to have specific agents respond. The scheduler validates that mentioned agents are available in the room before creating the task.
 
 ## Cron Reference
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -19,7 +19,7 @@ my-skill/
     └── examples.md
 ```
 
-Agents can access these via `get_skill_script()` and `get_skill_reference()`.
+Agents access skills via `get_skill_instructions()`, scripts via `get_skill_script()`, and references via `get_skill_reference()`.
 
 ## SKILL.md format (OpenClaw compatible)
 
@@ -55,9 +55,9 @@ Notes:
 | `metadata` | mapping or JSON5 string | OpenClaw metadata and custom fields |
 | `user-invocable` | bool | Allow `!skill` (default: true) |
 | `disable-model-invocation` | bool | Prevent model invocation (default: false) |
-| `command-dispatch` | string | Set to `tool` to run a tool directly |
-| `command-tool` | string | Function to call: `fn`, `toolkit.fn`, or `toolkit` (if single function) |
-| `command-arg-mode` | string | Only `raw` is supported |
+| `command-dispatch` | `"tool"` | Set to `tool` to run a tool directly |
+| `command-tool` | string | Function to call: `function_name`, `toolkit.function_name`, or `toolkit` (if the toolkit exposes exactly one function) |
+| `command-arg-mode` | `"raw"` | Argument passing mode; only `raw` is currently supported |
 
 ## Eligibility gating (OpenClaw metadata)
 
@@ -76,11 +76,11 @@ Skills without `metadata.openclaw` are always eligible.
 
 MindRoom loads skills from these locations, in this order:
 
-1. Bundled skills: `skills/` in the repo
-2. Plugin-provided skill directories
+1. Bundled skills: `skills/` at the repository root (if present)
+2. Plugin-provided skill directories (see [Plugins](plugins.md))
 3. User skills: `~/.mindroom/skills/`
 
-If multiple skills share the same name, the last one wins. This means user skills override plugin skills, and plugin skills override bundled skills.
+If multiple skills share the same name, the last one wins (user > plugin > bundled).
 
 ## Configuring skills
 
@@ -101,7 +101,7 @@ If `skills` is empty or unset, the agent gets no skills.
 
 ## Using skills at runtime
 
-Agents see available skills in the system prompt and can load details using Agno tools:
+Agents see available skills in the system prompt and can load details using these tools:
 
 - `get_skill_instructions(skill_name)`
 - `get_skill_reference(skill_name, reference_path)`
@@ -139,7 +139,7 @@ Rules:
 
 ## Hot reloading
 
-MindRoom watches skill directories for changes. When a `SKILL.md` file is modified, the skill cache is automatically cleared so agents pick up the new instructions.
+MindRoom polls skill directories every second. When a `SKILL.md` file is added, removed, or modified, the skill cache is automatically cleared so agents pick up the new instructions on their next request.
 
 ## Best practices
 

--- a/docs/tools/builtin.md
+++ b/docs/tools/builtin.md
@@ -57,16 +57,16 @@ MindRoom includes 85+ built-in tool integrations organized by category.
 
 | Tool | Description | Config Required |
 |------|-------------|-----------------|
-| `openai` | OpenAI API access | `api_key` |
-| `gemini` | Google Gemini | `api_key` |
-| `groq` | Groq inference | `api_key` |
-| `replicate` | Run ML models | `api_token` |
-| `fal` | Fal.ai models | `api_key` |
+| `openai` | Transcription, image generation, and speech synthesis | `api_key` |
+| `gemini` | Google AI for image and video generation | `api_key` |
+| `groq` | Audio transcription, translation, and text-to-speech | `api_key` |
+| `replicate` | Generate images and videos using AI models | `api_key` |
+| `fal` | AI media generation (images and videos) | `api_key` |
 | `dalle` | DALL-E image generation | `api_key` |
-| `cartesia` | Voice synthesis | `api_key` |
-| `eleven_labs` | Text-to-speech | `api_key` |
-| `lumalabs` | Luma video generation | `api_key` |
-| `modelslabs` | Custom models | `api_key` |
+| `cartesia` | Text-to-speech and voice localization | `api_key` |
+| `eleven_labs` | Text-to-speech and sound effects | `api_key` |
+| `lumalabs` | 3D content creation and video generation | `api_key` |
+| `modelslabs` | Generate videos, audio, and GIFs from text | `api_key` |
 
 ## Knowledge & Research
 
@@ -75,8 +75,8 @@ MindRoom includes 85+ built-in tool integrations organized by category.
 | `arxiv` | Academic papers search | - |
 | `wikipedia` | Wikipedia lookups | - |
 | `pubmed` | Medical literature | - |
-| `hackernews` | Hacker News | - |
-| `youtube` | YouTube transcripts | - |
+| `hackernews` | Get top stories and user details from Hacker News | - |
+| `youtube` | Extract video data, captions, and timestamps | - |
 | `reddit` | Reddit browsing and interaction | `client_id`, `client_secret` |
 
 ## Communication
@@ -103,8 +103,8 @@ MindRoom includes 85+ built-in tool integrations organized by category.
 | `linear` | Issue tracking and project management | `api_key` |
 | `confluence` | Atlassian wiki pages | `url`, `username`, `password` or `api_key` |
 | `trello` | Trello boards | `api_key`, `token` |
-| `todoist` | Todoist tasks | `api_key` |
-| `zendesk` | Zendesk support | `subdomain`, `email`, `api_token` |
+| `todoist` | Todoist task management | `api_token` |
+| `zendesk` | Search help center articles | `username`, `password`, `company_name` |
 
 ## Calendar & Scheduling
 
@@ -135,7 +135,7 @@ MindRoom includes 85+ built-in tool integrations organized by category.
 |------|-------------|-----------------|
 | `aws_lambda` | AWS Lambda functions | AWS credentials |
 | `aws_ses` | AWS email service | AWS credentials |
-| `airflow` | Apache Airflow | `base_url`, `username`, `password` |
+| `airflow` | Apache Airflow DAG file management | - |
 | `e2b` | Code execution sandbox | `api_key` |
 | `daytona` | Development environments | `api_key` |
 | `composio` | API composition | `api_key` |

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,7 +4,7 @@ icon: lucide/wrench
 
 # Tools
 
-MindRoom includes 80+ tool integrations that agents can use to interact with external services.
+MindRoom includes 85+ tool integrations that agents can use to interact with external services.
 
 ## Enabling Tools
 
@@ -20,45 +20,70 @@ agents:
       - file
       - shell
       - github
-      - web_search
+      - duckduckgo
 ```
 
 ## Tool Categories
 
-### File & System
+Tools are organized by category:
 
-- `file` - Read, write, and manage files
-- `shell` - Execute shell commands
-- `docker` - Manage Docker containers
+- **Development** - File operations, shell, Docker, GitHub, Jira, code execution
+- **Research** - Web search (DuckDuckGo, Tavily, Exa), academic papers (arXiv, PubMed), web scraping
+- **Communication** - Slack, Discord, Telegram, Twilio, WhatsApp, Webex
+- **Email** - Gmail, AWS SES, Resend, generic SMTP
+- **Productivity** - Google Calendar, Todoist, SQL, Pandas, CSV, DuckDB
+- **Social** - Reddit, X/Twitter, Zoom
+- **Entertainment** - YouTube
+- **Smart Home** - Home Assistant
+- **Integrations** - Composio
 
-### AI & Search
+## Quick Examples
 
-- `web_search` - Search the web
-- `tavily` - AI-powered web search
-- `exa` - Neural search engine
-- `arxiv` - Search academic papers
+### Research Agent
 
-### Communication
+```yaml
+agents:
+  researcher:
+    display_name: Researcher
+    role: Find and summarize information from the web and academic sources
+    model: sonnet
+    tools:
+      - duckduckgo
+      - arxiv
+      - wikipedia
+      - pubmed
+```
 
-- `slack` - Send messages to Slack
-- `gmail` - Send and read emails
-- `telegram` - Telegram bot integration
-- `twilio` - SMS and voice calls
+### DevOps Agent
 
-### Development
+```yaml
+agents:
+  devops:
+    display_name: DevOps
+    role: Manage infrastructure, containers, and deployments
+    model: sonnet
+    tools:
+      - shell
+      - docker
+      - github
+      - aws_lambda
+```
 
-- `github` - Manage GitHub repos, issues, PRs
-- `jira` - Issue tracking
-- `confluence` - Wiki documentation
+### Communication Agent
 
-### Productivity
-
-- `google_calendar` - Calendar management
-- `google_sheets` - Spreadsheet access
-- `todoist` - Task management
-- `trello` - Board management
+```yaml
+agents:
+  notifier:
+    display_name: Notifier
+    role: Send notifications and messages across platforms
+    model: sonnet
+    tools:
+      - slack
+      - telegram
+      - gmail
+```
 
 See the full list in:
 
-- [Built-in Tools](builtin.md) - All available tool integrations
+- [Built-in Tools](builtin.md) - Complete list of 85+ available tools with configuration details
 - [MCP Tools](mcp.md) - Model Context Protocol tools (planned)

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -145,10 +145,10 @@ The router agent handles all voice message processing to avoid duplicate transcr
 
 MindRoom also supports text-to-speech (TTS) through agent tools. These are separate from voice message transcription and allow agents to generate audio responses:
 
-- **OpenAI** - TTS via `openai` tool
-- **ElevenLabs** - High-quality AI voices via `eleven_labs` tool
-- **Cartesia** - Voice AI with localization via `cartesia` tool
-- **Groq** - Fast TTS via `groq` tool
+- **OpenAI** - Speech synthesis via `openai` tool
+- **ElevenLabs** - High-quality AI voices and sound effects via `eleven_labs` tool
+- **Cartesia** - Voice AI with optional voice localization via `cartesia` tool
+- **Groq** - Fast speech generation via `groq` tool
 
 See the [Tools documentation](/tools) for configuration details.
 

--- a/src/mindroom/commands.py
+++ b/src/mindroom/commands.py
@@ -274,9 +274,11 @@ Notes:
     if topic == "list_schedules":
         return """**List Schedules Command**
 
-Usage: `!list_schedules` or `!listschedules`
+Usage: `!list_schedules`
 
-Shows all pending scheduled tasks in this thread."""
+Alternative syntax: `!listschedules`, `!list-schedules`, `!list_schedule`
+
+Shows pending scheduled tasks. When used in a thread, shows tasks for that thread. When used in the main room, shows all tasks in the room."""
 
     if topic in {"cancel", "cancel_schedule"}:
         return """**Cancel Schedule Command**
@@ -284,9 +286,11 @@ Shows all pending scheduled tasks in this thread."""
 Usage: `!cancel_schedule <id>` - Cancel a scheduled task
        `!cancel_schedule all` - Cancel ALL scheduled tasks in this room
 
+Alternative syntax: `!cancelschedule`, `!cancel-schedule`
+
 Examples:
 - `!cancel_schedule abc123` - Cancel the task with ID abc123
-- `!cancel_schedule all` - Cancel all scheduled tasks (requires confirmation)
+- `!cancel_schedule all` - Cancel all scheduled tasks
 
 Use `!list_schedules` to see task IDs."""
 


### PR DESCRIPTION
## Summary

- Second thorough review of all 24 documentation pages
- Found and fixed subtle issues the first pass missed
- Also fixed 2 source code bugs discovered during review
- Net change: +453/-210 lines across 24 files

## Documentation Fixes

### Configuration
- **agents.md**: Rich prompt agents ignore custom `instructions` - clarified this behavior
- **index.md**: Clarified that `agents` section is optional but recommended
- **models.md**: Added `deepseek` provider documentation
- **router.md**: Added command handling, config confirmations, single-agent optimization
- **teams.md**: Added 4 scenarios that trigger dynamic team formation

### Architecture  
- **index.md**: Fixed data flow order (response sent before memory updates)
- **matrix.md**: Added environment variable defaults, clarified typing indicator refresh
- **orchestration.md**: Expanded message handling flow, fixed sync loop recovery code

### Features
- **authorization.md**: Clarified room permissions vs default access logic, added router to auth flow
- **memory.md**: Fixed context enhancement order, clarified mem0 tool function names
- **scheduling.md**: Fixed list/cancel command behavior, added syntax variations
- **skills.md**: Clarified polling-based hot reload (not Watchdog), fixed skill locations
- **voice.md**: Fixed TTS tool descriptions

### Tools
- **index.md**: Reorganized categories to match `ToolCategory` enum
- **builtin.md**: Fixed 14 tool descriptions and config requirements
- **mcp.md**: Fixed plugin workaround (must return class, not instance)

### Deployment
- **docker.md**: Fixed frontend port (8080 not 3003), registry path (basnijholt)
- **kubernetes.md**: Added provisioner API documentation, fixed values.yaml examples
- **index.md**: Fixed registry path, added missing directories

### Other
- **dashboard.md**: Fixed sync status text, field labels, added missing API endpoints
- **getting-started.md**: Added venv activation step, optional Matrix env vars
- **plugins.md**: Fixed `skills` field type in manifest table

## Code Fixes

### `src/mindroom/ai.py`
- Implemented `groq` and `deepseek` providers (were mapped in env vars but missing from provider handler)

### `src/mindroom/commands.py`
- Fixed `!list_schedules` help text (thread vs room behavior)
- Fixed `!cancel_schedule` help text (removed incorrect "requires confirmation")
- Added alternative syntax variations to help text

## Test plan

- [x] All 794 tests pass
- [x] Pre-commit hooks pass
- [ ] Verify docs render correctly in MkDocs