### PR TITLE
docs: add blank lines before list items

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,7 @@ docker compose up -d
 ```
 
 Open:
+
 - MindRoom UI: http://localhost:3003
 - Element: http://localhost:8080
 - Matrix homeserver: http://matrix.localhost:8008

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ docker compose up -d
 ```
 
 Open:
+
 - MindRoom UI: http://localhost:3003
 - Element: http://localhost:8080
 - Matrix homeserver: http://matrix.localhost:8008


### PR DESCRIPTION
## Summary

- Fixes markdown rendering issue where list items after "Open:" were not properly rendered as a list due to missing blank line separator
- Affected files: `docs/getting-started.md` and `docs/index.md`

## Test plan

- [x] Verify lists render correctly in GitHub markdown preview