### PR TITLE
fix: dynamic version + skills watcher startup race

### DIFF
--- a/src/mindroom/__init__.py
+++ b/src/mindroom/__init__.py
@@ -1,3 +1,5 @@
 """MindRoom: A universal interface for AI agents with persistent memory."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version
+
+__version__ = version("mindroom")


### PR DESCRIPTION
## Summary
- Replace hardcoded `__version__ = "0.1.0"` with dynamic version from `importlib.metadata`
- Fix skills watcher exiting immediately before orchestrator starts (causing bot to shut down on startup)

## Root cause
The skills watcher task checked `while orchestrator.running:` immediately, but `running` is only set to True after initialization completes. This caused the watcher to exit immediately, which triggered `asyncio.wait(..., FIRST_COMPLETED)` to return and clean up all tasks.

## Test plan
- [ ] Run `mindroom version` after install - should show correct version from package metadata
- [ ] Run `mindroom run` - bot should start and stay running
- [ ] CI tests pass