### PR TITLE
fix: wait for orchestrator to start before skills watcher loop

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -2797,6 +2797,9 @@ async def _watch_config_task(config_path: Path, orchestrator: MultiAgentOrchestr
 
 async def _watch_skills_task(orchestrator: MultiAgentOrchestrator) -> None:
     """Watch skill roots for changes and clear cached skills."""
+    # Wait for orchestrator to start before watching
+    while not orchestrator.running:
+        await asyncio.sleep(0.1)
     last_snapshot = get_skill_snapshot()
     while orchestrator.running:
         await asyncio.sleep(1.0)


### PR DESCRIPTION
## Summary
The skills watcher task was checking `while orchestrator.running:` immediately at startup, but `running` is only set to True after initialization completes. This caused the watcher to exit immediately, triggering `asyncio.wait(..., FIRST_COMPLETED)` to return and shut down the entire bot.

## Root cause
```python
async def _watch_skills_task(orchestrator):
    last_snapshot = get_skill_snapshot()
    while orchestrator.running:  # False at startup!
        ...
```

The loop exits immediately because `orchestrator.running` is `False` until `start()` completes initialization.

## Fix
Add a wait loop before the main loop:
```python
while not orchestrator.running:
    await asyncio.sleep(0.1)
```

## Test plan
- [ ] Run `mindroom run` - bot should start and stay running
- [ ] CI tests pass