### PR TITLE
Enable tool-call events in streaming responses

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -404,7 +404,12 @@ async def stream_agent_response(  # noqa: C901, PLR0912
 
     # Execute the streaming AI call - this can fail for network, rate limits, etc.
     try:
-        stream_generator = agent.arun(full_prompt, session_id=session_id, stream=True)
+        stream_generator = agent.arun(
+            full_prompt,
+            session_id=session_id,
+            stream=True,
+            stream_events=True,
+        )
     except Exception as e:
         logger.exception("Error starting streaming AI response")
         yield get_user_friendly_error_message(e, agent_name)
@@ -428,7 +433,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912
                     full_response += result_msg
                     yield result_msg
             else:
-                logger.warning(f"Unhandled event type: {type(event).__name__} - {event}")
+                logger.debug("Skipping stream event", event_type=type(event).__name__)
     except Exception as e:
         logger.exception("Error during streaming AI response")
         yield get_user_friendly_error_message(e, agent_name)

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -611,7 +611,7 @@ async def team_response_stream_raw(
         logger.debug(f"Team member: {agent.name}")
 
     try:
-        return team.arun(prompt, stream=True)
+        return team.arun(prompt, stream=True, stream_events=True)
     except Exception as e:
         logger.exception(f"Error in team streaming with agents {agent_names}")
         team_name = f"Team ({', '.join(agent_names)})"


### PR DESCRIPTION
## Summary
- enable `stream_events` for agent streaming so tool-call events are emitted
- enable `stream_events` for team streaming
- reduce noisy warning for non-content stream events

## Testing
- pre-commit hooks (ruff, mypy)