### PR TITLE
Add CalVer auto-release workflow

### DIFF
--- a/.github/workflows/calver-auto-release.yml
+++ b/.github/workflows/calver-auto-release.yml
@@ -1,0 +1,18 @@
+name: Create CalVer Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release
+        uses: basnijholt/calver-auto-release@v1
+        with:
+          # A PAT ensures downstream `on: release` workflows are triggered.
+          github_token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add `.github/workflows/calver-auto-release.yml` to create CalVer releases on pushes to `main`
- use `basnijholt/calver-auto-release@v1`
- prefer `secrets.PAT` with fallback to `secrets.GITHUB_TOKEN` so downstream `on: release` workflows can still trigger

## Validation
- `pytest` (856 passed, 34 skipped)
- `pre-commit run --all-files`
