### PR TITLE
Fix config writes failing on Docker bind mounts

### DIFF
--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -22,7 +22,7 @@ from mindroom.api.matrix_operations import router as matrix_router
 from mindroom.api.skills import router as skills_router
 from mindroom.api.tools import router as tools_router
 from mindroom.config import Config
-from mindroom.constants import DEFAULT_AGENTS_CONFIG, DEFAULT_CONFIG_TEMPLATE
+from mindroom.constants import DEFAULT_AGENTS_CONFIG, DEFAULT_CONFIG_TEMPLATE, safe_replace
 from mindroom.credentials_sync import sync_env_to_credentials
 
 # Load environment variables from .env file
@@ -94,7 +94,7 @@ def save_config_to_file(config: dict[str, Any]) -> None:
             sort_keys=True,
             allow_unicode=True,
         )
-    tmp_path.replace(CONFIG_PATH)
+    safe_replace(tmp_path, CONFIG_PATH)
 
 
 # Global variable to store current config

--- a/src/mindroom/api/skills.py
+++ b/src/mindroom/api/skills.py
@@ -9,6 +9,7 @@ import yaml
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from mindroom.constants import safe_replace
 from mindroom.skills import (
     get_user_skills_dir,
     list_skill_listings,
@@ -98,7 +99,7 @@ async def update_skill(skill_name: str, payload: SkillUpdateRequest) -> dict[str
     tmp_path = listing.path.with_suffix(listing.path.suffix + ".tmp")
     try:
         tmp_path.write_text(payload.content, encoding="utf-8")
-        tmp_path.replace(listing.path)
+        safe_replace(tmp_path, listing.path)
     except OSError as exc:
         raise HTTPException(status_code=500, detail="Failed to update skill") from exc
 

--- a/src/mindroom/config.py
+++ b/src/mindroom/config.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 import yaml
 from pydantic import BaseModel, Field
 
-from .constants import DEFAULT_AGENTS_CONFIG, MATRIX_HOMESERVER, ROUTER_AGENT_NAME
+from .constants import DEFAULT_AGENTS_CONFIG, MATRIX_HOMESERVER, ROUTER_AGENT_NAME, safe_replace
 from .logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -342,5 +342,5 @@ class Config(BaseModel):
                 allow_unicode=True,  # Preserve Unicode characters like ë
                 width=120,  # Wider lines to reduce wrapping
             )
-        tmp_path.replace(path_obj)
+        safe_replace(tmp_path, path_obj)
         logger.info(f"Saved configuration to {path}")

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -6,6 +6,7 @@ codebase.
 """
 
 import os
+import shutil
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -50,3 +51,17 @@ MATRIX_HOMESERVER = os.getenv("MATRIX_HOMESERVER", "http://localhost:8008")
 # (for federation setups where hostname != server_name)
 MATRIX_SERVER_NAME = os.getenv("MATRIX_SERVER_NAME", None)
 MATRIX_SSL_VERIFY = os.getenv("MATRIX_SSL_VERIFY", "true").lower() != "false"
+
+
+def safe_replace(tmp_path: Path, target_path: Path) -> None:
+    """Replace *target_path* with *tmp_path*, with a fallback for bind mounts.
+
+    ``Path.replace`` performs an atomic rename which fails on some filesystems
+    (e.g. Docker bind mounts) with ``OSError: [Errno 16] Device or resource
+    busy``.  When that happens we fall back to a non-atomic copy.
+    """
+    try:
+        tmp_path.replace(target_path)
+    except OSError:
+        shutil.copy2(tmp_path, target_path)
+        tmp_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- `manage_agent` (and other config-writing tools) fail with `[Errno 16] Device or resource busy` when `config.yaml` is a Docker bind mount
- `Path.replace()` does an atomic rename which isn't supported on bind-mounted files
- Added a `safe_replace()` helper in `constants.py` that tries atomic rename first, falls back to `shutil.copy2()` on `OSError`
- Used the helper in all three places that write config/skill files atomically: `config.py`, `api/main.py`, `api/skills.py`

## Context

The agent_builder agent uses `manage_agent(operation=create, ...)` which calls `Config.save_to_yaml()`. This writes to a `.tmp` file then calls `Path.replace()` to atomically swap it in. On Docker bind mounts (e.g. `./config.yaml:/app/config.yaml` in compose), this rename fails with EBUSY because the container runtime holds a reference to the mount target.

The companion PR [mindroom-stack#3](https://github.com/mindroom-ai/mindroom-stack/pull/3) removes the `:ro` flag from the bind mount so the fallback can actually write to the file.

## Test plan

- [x] All 856 tests pass
- [x] Pre-commit (ruff, mypy, formatting) passes
- [ ] Verify `manage_agent` works in Docker Compose deployment