### PR TITLE
Improve auth error messages with provider and details

### DIFF
--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,14 +1,45 @@
 """Tests for error handling module."""
 
-from mindroom.error_handling import get_user_friendly_error_message
+import httpx
+from anthropic import AuthenticationError as AnthropicAuthError
+from openai import AuthenticationError as OpenAIAuthError
+
+from mindroom.error_handling import _extract_provider_from_error, get_user_friendly_error_message
+
+_MOCK_RESPONSE = httpx.Response(status_code=401, request=httpx.Request("POST", "https://api.example.com"))
 
 
 def test_api_key_error() -> None:
-    """Test API key error message."""
+    """Test API key error message includes the original error."""
     error = Exception("Invalid API key")
     message = get_user_friendly_error_message(error, "assistant")
     assert "[assistant]" in message
     assert "Authentication failed" in message
+    assert "Invalid API key" in message
+
+
+def test_api_key_error_with_provider() -> None:
+    """Test that provider is extracted from exception module."""
+    error = OpenAIAuthError(message="Incorrect API key provided", response=_MOCK_RESPONSE, body=None)
+    message = get_user_friendly_error_message(error, "assistant")
+    assert "(openai)" in message
+    assert "Authentication failed" in message
+
+
+def test_401_error() -> None:
+    """Test that 401 errors are recognized as auth failures."""
+    error = Exception("Error code: 401 - Unauthorized")
+    message = get_user_friendly_error_message(error)
+    assert "Authentication failed" in message
+
+
+def test_generic_api_word_not_false_positive() -> None:
+    """Test that the word 'api' alone does not trigger auth error."""
+    error = Exception("Failed to connect to api endpoint")
+    message = get_user_friendly_error_message(error)
+    # Should NOT be auth error - just contains 'api' but no auth keywords
+    assert "Authentication failed" not in message
+    assert "Error:" in message
 
 
 def test_rate_limit_error() -> None:
@@ -31,3 +62,14 @@ def test_generic_error() -> None:
     error = ValueError("Something went wrong")
     message = get_user_friendly_error_message(error)
     assert "Error: Something went wrong" in message
+
+
+def test_extract_provider_from_error() -> None:
+    """Test provider extraction from exception module."""
+    openai_err = OpenAIAuthError(message="test", response=_MOCK_RESPONSE, body=None)
+    assert _extract_provider_from_error(openai_err) == "openai"
+
+    anthropic_err = AnthropicAuthError(message="test", response=_MOCK_RESPONSE, body=None)
+    assert _extract_provider_from_error(anthropic_err) == "anthropic"
+
+    assert _extract_provider_from_error(Exception("test")) is None


### PR DESCRIPTION
## Summary
- Auth error messages now include the **provider name** (e.g., openai, anthropic) extracted from the exception class, so users know which service failed
- The **original error message** is included instead of a generic "Please check your API key configuration"
- Narrowed keyword matching to avoid false positives (bare "api" or "key" no longer trigger auth errors)

**Before:** `[parenting_companion] ❌ Authentication failed. Please check your API key configuration.`
**After:** `[parenting_companion] ❌ Authentication failed (openai): Error code: 401 - Incorrect API key provided`

## Test plan
- [x] All existing error handling tests pass
- [x] New tests for provider extraction, false positive prevention, and original error inclusion
- [x] Pre-commit hooks pass