### PR TITLE
Add individual memory get, update, and delete tools

### DIFF
--- a/src/mindroom/custom_tools/memory.py
+++ b/src/mindroom/custom_tools/memory.py
@@ -153,7 +153,7 @@ class MemoryTools(Toolkit):
 
         """
         try:
-            result = await get_agent_memory(memory_id, self._storage_path, self._config)
+            result = await get_agent_memory(memory_id, self._agent_name, self._storage_path, self._config)
             if result is None:
                 return f"No memory found with id={memory_id}"
             return f"[id={result.get('id', memory_id)}] {result.get('memory', '')}"
@@ -175,7 +175,7 @@ class MemoryTools(Toolkit):
 
         """
         try:
-            await update_agent_memory(memory_id, new_content, self._storage_path, self._config)
+            await update_agent_memory(memory_id, new_content, self._agent_name, self._storage_path, self._config)
         except Exception as e:
             logger.exception(
                 "Failed to update memory via tool",
@@ -201,7 +201,7 @@ class MemoryTools(Toolkit):
 
         """
         try:
-            await delete_agent_memory(memory_id, self._storage_path, self._config)
+            await delete_agent_memory(memory_id, self._agent_name, self._storage_path, self._config)
         except Exception as e:
             logger.exception(
                 "Failed to delete memory via tool",

--- a/tests/test_memory_tools.py
+++ b/tests/test_memory_tools.py
@@ -197,7 +197,7 @@ class TestMemoryTools:
         ) as mock_get:
             result = await tools.get_memory("abc-123")
 
-            mock_get.assert_called_once_with("abc-123", tools._storage_path, tools._config)
+            mock_get.assert_called_once_with("abc-123", "test_agent", tools._storage_path, tools._config)
             assert "[id=abc-123]" in result
             assert "User likes Python" in result
 
@@ -235,7 +235,13 @@ class TestMemoryTools:
         ) as mock_update:
             result = await tools.update_memory("abc-123", "Updated content")
 
-            mock_update.assert_called_once_with("abc-123", "Updated content", tools._storage_path, tools._config)
+            mock_update.assert_called_once_with(
+                "abc-123",
+                "Updated content",
+                "test_agent",
+                tools._storage_path,
+                tools._config,
+            )
             assert "Updated memory" in result
             assert "[id=abc-123]" in result
             assert "Updated content" in result
@@ -262,7 +268,7 @@ class TestMemoryTools:
         ) as mock_delete:
             result = await tools.delete_memory("abc-123")
 
-            mock_delete.assert_called_once_with("abc-123", tools._storage_path, tools._config)
+            mock_delete.assert_called_once_with("abc-123", "test_agent", tools._storage_path, tools._config)
             assert "Deleted memory" in result
             assert "[id=abc-123]" in result
 


### PR DESCRIPTION
## Summary
- Adds `get_memory`, `update_memory`, and `delete_memory` agent tools that expose the underlying Mem0 per-memory operations (which were previously not available to agents)
- Updates `search_memories` and `list_memories` output to include memory IDs (`[id=...]`) so agents can reference specific memories for get/update/delete
- Adds backend functions `get_agent_memory`, `update_agent_memory`, `delete_agent_memory` in `memory/functions.py`

## Test plan
- [x] All 18 memory tool tests pass (8 new tests for the 3 new tools)
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)
- [ ] Deploy and verify agents can list memories with IDs, then update/delete individual ones