### PR TITLE
Make pr-review prompt zero-tolerance

### DIFF
--- a/.prompts/pr-review.md
+++ b/.prompts/pr-review.md
@@ -1,4 +1,12 @@
-Review the pull request for:
+Review the pull request with a **zero-tolerance standard**. Every issue you find is a blocker — there is no such thing as a "minor issue" or "non-blocking suggestion". Either the PR is flawless and ready to merge, or it has problems that MUST be fixed before merging. Do not approve a PR with caveats like "ready to merge but consider..." or "minor nit:". If you would mention it, it must be fixed.
+
+**Your verdict must be one of**:
+- ✅ **APPROVE** — The code is near-perfect. No issues found. Merge immediately.
+- ❌ **CHANGES REQUIRED** — Issues found. List every one. All must be fixed before re-review.
+
+Never approve with suggestions. Never say "looks good overall but...". If there's a "but", it's CHANGES REQUIRED.
+
+## Review checklist
 
 - **Code cleanliness**: Is the implementation clean and well-structured?
 - **DRY principle**: Does it avoid duplication?
@@ -14,5 +22,7 @@ Review the pull request for:
 - **Tests**: Are there tests, and do they cover the changes adequately? Are they testing something meaningful or are they just trivial? Run `just test-backend` to verify.
 - **Live tests**: If feasible, test the changes with a local Matrix stack (`just local-matrix-up`) and the Matty CLI to verify agent behavior end-to-end.
 - **Rules**: Does the code follow the project's coding standards and guidelines as laid out in @CLAUDE.md?
+
+## How to review
 
 Look at `git diff origin/main..HEAD` for the changes made in this pull request.


### PR DESCRIPTION
## Summary
- Enforce a binary APPROVE / CHANGES REQUIRED verdict in the pr-review prompt — no "minor nits" or "non-blocking suggestions"
- Every issue found is a blocker; if it's worth mentioning, it must be fixed before merge

## Motivation
Reviews were approving PRs with caveats like "ready to merge but consider..." which required follow-up work. Given the pace of development, PRs should be near-perfect on the first pass.