### PR TITLE
fix: pass user_id to agent.arun() to enable Agno learning

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1428,6 +1428,7 @@ class AgentBot:
         thread_id: str | None,
         thread_history: list[dict],
         existing_event_id: str | None = None,
+        user_id: str | None = None,
     ) -> str | None:
         """Process a message and send a response (non-streaming)."""
         if not prompt.strip():
@@ -1448,6 +1449,7 @@ class AgentBot:
                     thread_history=thread_history,
                     room_id=room_id,
                     knowledge=knowledge,
+                    user_id=user_id,
                 )
         except asyncio.CancelledError:
             # Handle cancellation - send a message showing it was stopped
@@ -1610,6 +1612,7 @@ class AgentBot:
         thread_id: str | None,
         thread_history: list[dict],
         existing_event_id: str | None = None,
+        user_id: str | None = None,
     ) -> str | None:
         """Process a message and send a response (streaming)."""
         assert self.client is not None
@@ -1631,6 +1634,7 @@ class AgentBot:
                     thread_history=thread_history,
                     room_id=room_id,
                     knowledge=knowledge,
+                    user_id=user_id,
                 )
 
                 event_id, accumulated = await send_streaming_response(
@@ -1716,6 +1720,7 @@ class AgentBot:
                     thread_id,
                     thread_history,
                     message_id,  # Edit the thinking message or existing
+                    user_id=user_id,
                 )
             else:
                 await self._process_and_respond(
@@ -1725,6 +1730,7 @@ class AgentBot:
                     thread_id,
                     thread_history,
                     message_id,  # Edit the thinking message or existing
+                    user_id=user_id,
                 )
 
         # Use unified handler for cancellation support

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -1,0 +1,195 @@
+"""Test that user_id is passed through to agent.arun() for Agno learning."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mindroom.bot import AgentBot
+from mindroom.config import Config
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+class TestUserIdPassthrough:
+    """Test that user_id reaches agent.arun() in both streaming and non-streaming paths."""
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_passes_user_id(self, tmp_path: Path) -> None:
+        """Test that _process_and_respond passes user_id through to ai_response."""
+        bot = MagicMock(spec=AgentBot)
+        bot.logger = MagicMock()
+        bot.stop_manager = MagicMock()
+        bot.stop_manager.remove_stop_button = AsyncMock()
+        bot.client = AsyncMock()
+        bot.agent_name = "general"
+        bot.storage_path = tmp_path
+        bot.config = Config.from_yaml()
+        bot._knowledge_for_agent = MagicMock(return_value=None)
+        bot._send_response = AsyncMock(return_value="$response_id")
+
+        process_method = AgentBot._process_and_respond
+
+        with patch("mindroom.bot.ai_response") as mock_ai:
+            mock_ai.return_value = "Hello!"
+
+            await process_method(
+                bot,
+                room_id="!test:localhost",
+                prompt="Hello",
+                reply_to_event_id="$user_msg",
+                thread_id=None,
+                thread_history=[],
+                user_id="@alice:localhost",
+            )
+
+            mock_ai.assert_called_once()
+            assert mock_ai.call_args.kwargs["user_id"] == "@alice:localhost"
+
+    @pytest.mark.asyncio
+    async def test_streaming_passes_user_id(self, tmp_path: Path) -> None:
+        """Test that _process_and_respond_streaming passes user_id through to stream_agent_response."""
+        bot = MagicMock(spec=AgentBot)
+        bot.logger = MagicMock()
+        bot.stop_manager = MagicMock()
+        bot.stop_manager.remove_stop_button = AsyncMock()
+        bot.client = AsyncMock()
+        bot.agent_name = "general"
+        bot.matrix_id = MagicMock()
+        bot.matrix_id.domain = "localhost"
+        bot.config = Config.from_yaml()
+        bot.storage_path = tmp_path
+        bot._knowledge_for_agent = MagicMock(return_value=None)
+        bot._handle_interactive_question = AsyncMock()
+
+        streaming_method = AgentBot._process_and_respond_streaming
+
+        with patch("mindroom.bot.stream_agent_response") as mock_stream:
+
+            async def fake_stream() -> AsyncIterator[str]:
+                yield "Hello!"
+
+            mock_stream.return_value = fake_stream()
+
+            with patch("mindroom.bot.send_streaming_response") as mock_send_streaming:
+                mock_send_streaming.return_value = ("$msg_id", "Hello!")
+
+                await streaming_method(
+                    bot,
+                    room_id="!test:localhost",
+                    prompt="Hello",
+                    reply_to_event_id="$user_msg",
+                    thread_id=None,
+                    thread_history=[],
+                    user_id="@bob:localhost",
+                )
+
+                mock_stream.assert_called_once()
+                assert mock_stream.call_args.kwargs["user_id"] == "@bob:localhost"
+
+    @pytest.mark.asyncio
+    async def test_ai_response_passes_user_id_to_agent_arun(self, tmp_path: Path) -> None:
+        """Test that ai_response passes user_id all the way to agent.arun()."""
+        from mindroom.ai import ai_response
+
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "OpenAIChat"
+        mock_agent.model.id = "test-model"
+        mock_agent.name = "GeneralAgent"
+        mock_run_output = MagicMock()
+        mock_run_output.content = "Response"
+        mock_run_output.tools = None
+        mock_agent.arun = AsyncMock(return_value=mock_run_output)
+
+        with (
+            patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
+            patch("mindroom.ai.get_cache", return_value=None),
+        ):
+            mock_prepare.return_value = (mock_agent, "test prompt")
+
+            await ai_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                storage_path=tmp_path,
+                config=Config.from_yaml(),
+                user_id="@user:localhost",
+            )
+
+            mock_agent.arun.assert_called_once()
+            assert mock_agent.arun.call_args.kwargs["user_id"] == "@user:localhost"
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_passes_user_id_to_agent_arun(self, tmp_path: Path) -> None:
+        """Test that stream_agent_response passes user_id all the way to agent.arun()."""
+        from mindroom.ai import stream_agent_response
+
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "OpenAIChat"
+        mock_agent.model.id = "test-model"
+        mock_agent.name = "GeneralAgent"
+
+        async def fake_arun_stream(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
+            yield "chunk"
+
+        mock_agent.arun = MagicMock(return_value=fake_arun_stream())
+
+        with (
+            patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
+            patch("mindroom.ai.get_cache", return_value=None),
+        ):
+            mock_prepare.return_value = (mock_agent, "test prompt")
+
+            # Consume the async generator to trigger the agent.arun call
+            chunks = []
+            async for chunk in stream_agent_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                storage_path=tmp_path,
+                config=Config.from_yaml(),
+                user_id="@user:localhost",
+            ):
+                chunks.append(chunk)
+
+            mock_agent.arun.assert_called_once()
+            assert mock_agent.arun.call_args.kwargs["user_id"] == "@user:localhost"
+
+    @pytest.mark.asyncio
+    async def test_user_id_none_when_not_provided(self, tmp_path: Path) -> None:
+        """Test that user_id defaults to None when not provided (backward compatibility)."""
+        from mindroom.ai import ai_response
+
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "OpenAIChat"
+        mock_agent.model.id = "test-model"
+        mock_agent.name = "GeneralAgent"
+        mock_run_output = MagicMock()
+        mock_run_output.content = "Response"
+        mock_run_output.tools = None
+        mock_agent.arun = AsyncMock(return_value=mock_run_output)
+
+        with (
+            patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
+            patch("mindroom.ai.get_cache", return_value=None),
+        ):
+            mock_prepare.return_value = (mock_agent, "test prompt")
+
+            # Call without user_id
+            await ai_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                storage_path=tmp_path,
+                config=Config.from_yaml(),
+            )
+
+            mock_agent.arun.assert_called_once()
+            assert mock_agent.arun.call_args.kwargs["user_id"] is None

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -333,6 +333,7 @@ class TestAgentBot:
                 thread_history=[],
                 room_id="!test:localhost",
                 knowledge=None,
+                user_id="@user:localhost",
             )
             mock_ai_response.assert_not_called()
             # With streaming and stop button: initial message + reaction + edits
@@ -348,6 +349,7 @@ class TestAgentBot:
                 thread_history=[],
                 room_id="!test:localhost",
                 knowledge=None,
+                user_id="@user:localhost",
             )
             mock_stream_agent_response.assert_not_called()
             # With stop button support: initial + reaction + final

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -134,6 +134,7 @@ async def test_agent_processes_direct_mention(
                     config=config,
                     room_id=test_room_id,
                     knowledge=None,
+                    user_id=f"@alice:{config.domain}",
                 )
 
                 # Verify message was sent (thinking + streaming updates)
@@ -417,6 +418,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
                 config=config,
                 room_id=test_room_id,
                 knowledge=None,
+                user_id=test_user_id,
             )
 
             # Verify thread response format (team response with mocking issue)


### PR DESCRIPTION
## Summary

- Agno's `LearningMachine` stores (`UserProfileStore`, `UserMemoryStore`) silently skip extraction when `user_id` is `None`
- The `user_id` (Matrix sender) was available in `bot.py` but was never threaded through to the `agent.arun()` calls in `ai.py`
- This meant learning was configured, initialized, and "completed" on every conversation — but never actually wrote any data

The fix threads `user_id` through the full call chain:
```
bot._on_message (has event.sender)
  → _generate_response (had user_id but didn't pass it down)
    → _process_and_respond / _process_and_respond_streaming
      → ai_response / stream_agent_response
        → agent.arun(user_id=...)
```

## Test plan

- [x] 5 new regression tests in `test_ai_user_id.py` verifying `user_id` reaches `agent.arun()` in both streaming and non-streaming paths
- [x] Updated 4 existing tests that assert exact kwargs to include the new `user_id` parameter
- [x] Full test suite passes (899 passed)