### PR TITLE
Fix mobile scroll and empty state on Knowledge page

### DIFF
--- a/frontend/src/components/Knowledge/Knowledge.tsx
+++ b/frontend/src/components/Knowledge/Knowledge.tsx
@@ -604,13 +604,13 @@ export function Knowledge() {
               </CardContent>
             </Card>
           </>
-        ) : (
+        ) : baseNames.length === 0 ? (
           <Card>
             <CardContent className="py-4 text-sm text-muted-foreground">
               No knowledge bases configured yet. Add one above to start uploading files.
             </CardContent>
           </Card>
-        )}
+        ) : null}
 
         {isDirty && (
           <Card className="border-amber-500/30">


### PR DESCRIPTION
## Summary
- enable vertical scrolling in the Knowledge tab on mobile by switching Knowledge wrappers from hidden overflow to vertical auto scrolling
- keep horizontal page overflow hidden while preserving scrollability of the tab content
- when no knowledge base is configured/selected, hide the upload + files table section and show a clear empty-state prompt instead of an empty files table

## Testing
- bun run type-check
- pytest -q
- pre-commit run --all-files