### PR TITLE
docs: position MCP under plugins and reduce parity with built-ins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -73,6 +73,55 @@ Rules:
 
 MindRoom resolves the package location and looks for `mindroom.plugin.json` in that directory.
 
+## MCP via plugins (advanced)
+
+MindRoom does not yet support direct MCP server configuration in `config.yaml`.
+If you need MCP today, wrap Agno `MCPTools` in a plugin tool factory:
+
+```python
+from agno.tools.mcp import MCPTools
+from mindroom.tools_metadata import (
+    SetupType,
+    ToolCategory,
+    ToolStatus,
+    register_tool_with_metadata,
+)
+
+
+class FilesystemMCPTools(MCPTools):
+    def __init__(self, **kwargs):
+        super().__init__(
+            command="npx -y @modelcontextprotocol/server-filesystem /path/to/dir",
+            **kwargs,
+        )
+
+
+@register_tool_with_metadata(
+    name="mcp_filesystem",
+    display_name="MCP Filesystem",
+    description="Tools from an MCP filesystem server",
+    category=ToolCategory.DEVELOPMENT,
+    status=ToolStatus.AVAILABLE,
+    setup_type=SetupType.NONE,
+)
+def mcp_filesystem_tools():
+    return FilesystemMCPTools
+```
+
+Reference the plugin and tool in `config.yaml`:
+
+```yaml
+plugins:
+  - ./plugins/mcp-filesystem
+
+agents:
+  assistant:
+    tools:
+      - mcp_filesystem
+```
+
+The factory function must return the toolkit class, not an instance. MCP toolkits are async; Agno's async agent runs (`arun`, `aprint_response`) handle MCP connect and disconnect automatically.
+
 ## Tools module example
 
 ```python

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -85,5 +85,5 @@ agents:
 
 See the full list in:
 
-- [Built-in Tools](builtin.md) - Complete list of 85+ available tools with configuration details
-- [MCP Tools](mcp.md) - Model Context Protocol tools via plugin workaround
+- [Built-in Tools](builtin.md) - Complete list of available built-in tools with configuration details
+- [Plugins](../plugins.md) - Extend MindRoom with custom tools and skills (including MCP via plugin workaround)

--- a/docs/tools/mcp.md
+++ b/docs/tools/mcp.md
@@ -2,96 +2,13 @@
 icon: lucide/plug
 ---
 
-# MCP Tools
+# MCP (Planned)
 
-> [!NOTE]
-> MCP (Model Context Protocol) integration is planned for a future release of MindRoom. The functionality described below is not yet implemented.
+> [!WARNING]
+> MindRoom does not currently support direct MCP server configuration in `config.yaml`.
 
-## What is MCP?
+MCP can still be used today through the plugin system by wrapping Agno `MCPTools` in a plugin tool factory.
 
-MCP (Model Context Protocol) is an open protocol that enables AI models to connect to external data sources and tools through a standardized interface. It allows agents to dynamically discover and use tools exposed by MCP servers.
+See [Plugins](../plugins.md#mcp-via-plugins-advanced) for the current workaround and setup instructions.
 
-## Current Status
-
-MindRoom includes the `mcp` library as a dependency, but direct MCP server configuration in agent YAML is not yet supported. The underlying Agno framework provides `MCPTools` and `MultiMCPTools` classes that MindRoom plans to integrate in a future release.
-
-## Planned Features
-
-When implemented, MCP support will allow:
-
-- Connecting to external MCP servers (filesystem, GitHub, databases, etc.)
-- Automatic tool discovery from MCP server capabilities
-- Support for stdio, SSE, and Streamable HTTP transports
-
-## Workaround: Using Agno MCPTools Directly
-
-Until native MindRoom configuration is available, you can use MCP tools through a [custom plugin](../plugins.md). The key is to create a subclass that pre-configures the MCP server parameters, since MindRoom's tool registry expects a class (not an instance).
-
-### Plugin Structure
-
-Create a plugin directory with the following structure:
-
-```
-plugins/
-└── mcp-filesystem/
-    ├── mindroom.plugin.json
-    └── tools.py
-```
-
-**mindroom.plugin.json:**
-
-```json
-{
-  "name": "mcp-filesystem",
-  "tools_module": "tools.py",
-  "skills": []
-}
-```
-
-**tools.py:**
-
-```python
-from agno.tools.mcp import MCPTools
-from mindroom.tools_metadata import register_tool_with_metadata, ToolCategory, ToolStatus, SetupType
-
-
-class FilesystemMCPTools(MCPTools):
-    """Pre-configured MCPTools for filesystem access."""
-
-    def __init__(self, **kwargs):
-        super().__init__(
-            command="npx -y @modelcontextprotocol/server-filesystem /path/to/dir",
-            **kwargs,
-        )
-
-
-@register_tool_with_metadata(
-    name="my_mcp_server",
-    display_name="My MCP Server",
-    description="Tools from my custom MCP server",
-    category=ToolCategory.DEVELOPMENT,
-    status=ToolStatus.AVAILABLE,
-    setup_type=SetupType.NONE,
-)
-def my_mcp_tools():
-    """Return the MCPTools subclass (not an instance)."""
-    return FilesystemMCPTools
-```
-
-### Configuration
-
-Reference the plugin directory in your `config.yaml`:
-
-```yaml
-plugins:
-  - ./plugins/mcp-filesystem
-
-agents:
-  assistant:
-    display_name: Assistant
-    tools:
-      - my_mcp_server
-```
-
-> [!NOTE]
-> MCP tools require async operations. Agno's Agent class automatically handles connecting and disconnecting MCP servers during async runs (`arun`, `aprint_response`). The MCP server process starts when the agent runs and stops when the run completes.
+This page remains as a compatibility pointer and will be expanded when native MCP support is added.

--- a/zensical.toml
+++ b/zensical.toml
@@ -26,7 +26,6 @@ nav = [
   { "Tools" = [
     { "Overview" = "tools/index.md" },
     { "Built-in Tools" = "tools/builtin.md" },
-    { "MCP Tools" = "tools/mcp.md" },
   ] },
   { "Skills" = "skills.md" },
   { "Plugins" = "plugins.md" },


### PR DESCRIPTION
## Summary
- remove `MCP Tools` from the Tools nav section to avoid equal prominence with built-in tools
- update `docs/tools/index.md` to point users to `Plugins` (including MCP workaround) instead of a peer MCP tools page
- add an `MCP via plugins (advanced)` section in `docs/plugins.md` with the practical wrapper pattern
- convert `docs/tools/mcp.md` into a short compatibility pointer page

## Why
MCP is not natively supported in MindRoom yet. The docs should make built-in tools the primary supported path and position MCP as a plugin-based workaround.

## Verification
- `uv run zensical build`
- `uv run pre-commit run --all-files`
- `uv run pytest -q`
