### PR TITLE
Fix new agents being started twice during config hot-reload

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -2433,7 +2433,7 @@ class MultiAgentOrchestrator:
         # Also check for new entities that didn't exist before
         all_new_entities = set(new_config.agents.keys()) | set(new_config.teams.keys()) | {ROUTER_AGENT_NAME}
         existing_entities = set(self.agent_bots.keys())
-        new_entities = all_new_entities - existing_entities
+        new_entities = all_new_entities - existing_entities - entities_to_restart
 
         # Always update the orchestrator's config first
         self.config = new_config


### PR DESCRIPTION
## Summary

- Fixes a bug where newly created agents (e.g. via the config_manager tool) would reply twice to every message
- Root cause: `update_config()` processed new agents in **both** `entities_to_restart` and `new_entities`, creating two bot instances with two sync loops for the same agent
- Fix: exclude `entities_to_restart` from `new_entities` (one-line change in `bot.py:2436`)

## Details

When a new agent is added to `config.yaml`:

1. `_get_changed_agents()` sees `old=None, new=exists` → marks it as "changed" → added to `entities_to_restart`
2. The agent is also not in `existing_entities` → added to `new_entities`
3. `update_config()` iterates both sets separately, creating **two** bot instances
4. The first bot's sync task reference is overwritten by the second, leaving it as an orphaned asyncio task that keeps processing messages

Result: two independent sync loops for the same agent, both responding to messages → duplicate replies.

## Test plan

- [x] Added regression test `test_new_agent_not_started_twice` that verifies `create_bot_for_entity` is called exactly once for a newly added agent
- [x] Confirmed the test **fails** without the fix (bot created 2 times) and **passes** with it
- [x] All existing config reload / sync task tests continue to pass