### PR TITLE
Fix model config inline editor losing focus after one character

### DIFF
--- a/frontend/src/components/ModelConfig/ModelConfig.test.tsx
+++ b/frontend/src/components/ModelConfig/ModelConfig.test.tsx
@@ -208,6 +208,25 @@ describe('ModelConfig', () => {
     });
   });
 
+  it('keeps focus in model id input while typing', () => {
+    render(<ModelConfig />);
+
+    fireEvent.click(screen.getByText('anthropic'));
+
+    const row = screen.getByDisplayValue('anthropic').closest('tr');
+    if (!row) throw new Error('row not found');
+
+    const modelIdInput = within(row).getByDisplayValue('claude-3-5-haiku-latest');
+    modelIdInput.focus();
+    expect(modelIdInput).toHaveFocus();
+
+    fireEvent.change(modelIdInput, { target: { value: 'claude-3-5-haiku-latesta' } });
+
+    const updatedInput = within(row).getByDisplayValue('claude-3-5-haiku-latesta');
+    expect(updatedInput).toBe(modelIdInput);
+    expect(updatedInput).toHaveFocus();
+  });
+
   it('shows OpenAI endpoint details and allows editing base URL', async () => {
     render(<ModelConfig />);
 

--- a/frontend/src/components/ModelConfig/ModelConfig.tsx
+++ b/frontend/src/components/ModelConfig/ModelConfig.tsx
@@ -1,5 +1,6 @@
 import {
   type Dispatch,
+  type ReactNode,
   type SetStateAction,
   useCallback,
   useEffect,
@@ -10,7 +11,6 @@ import {
   type Column,
   type ColumnDef,
   type SortingState,
-  flexRender,
   getCoreRowModel,
   getSortedRowModel,
   useReactTable,
@@ -277,6 +277,16 @@ function SortableHeader({
       <ArrowUpDown className="ml-1.5 h-3.5 w-3.5 opacity-60" />
     </Button>
   );
+}
+
+function renderTableValue<TContext>(
+  renderer: ((context: TContext) => ReactNode) | ReactNode,
+  context: TContext
+): ReactNode {
+  if (typeof renderer === 'function') {
+    return renderer(context);
+  }
+  return renderer;
 }
 
 export function ModelConfig() {
@@ -1176,7 +1186,7 @@ export function ModelConfig() {
                       >
                         {header.isPlaceholder
                           ? null
-                          : flexRender(header.column.columnDef.header, header.getContext())}
+                          : renderTableValue(header.column.columnDef.header, header.getContext())}
                       </th>
                     ))}
                   </tr>
@@ -1314,7 +1324,7 @@ export function ModelConfig() {
                               cell.column.id === 'actions' ? 'text-right' : ''
                             )}
                           >
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                            {renderTableValue(cell.column.columnDef.cell, cell.getContext())}
                           </td>
                         ))}
                       </tr>


### PR DESCRIPTION
## Summary
- fix inline model row editing so text inputs no longer lose focus after one keystroke
- replace `flexRender` usage in `ModelConfig` table cells/headers with a stable direct renderer helper to avoid input remounts during controlled updates
- add regression test that verifies model-id input keeps focus and node identity while typing

## Testing
- `cd frontend && bun run test --run src/components/ModelConfig`
- `cd frontend && bun run type-check`
- `pytest` *(existing unrelated failure: `tests/test_response_tracker.py::TestResponseTracker::test_concurrent_access`)*
