### PR TITLE
Improve agent config docs with detailed parameter descriptions

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -75,21 +75,23 @@ agents:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `display_name` | string | *required* | Human-readable name shown in Matrix |
-| `role` | string | `""` | Description of the agent's purpose and behavior |
-| `model` | string | `"default"` | Model name (must be defined in `models` section) |
-| `tools` | list | `[]` | Tool names the agent can use |
-| `skills` | list | `[]` | Skill names the agent can use |
-| `instructions` | list | `[]` | Additional behavioral instructions |
-| `rooms` | list | `[]` | Room names/aliases to auto-join |
-| `num_history_runs` | int | from defaults | Previous conversation runs to include for context |
-| `markdown` | bool | from defaults | Format responses as markdown |
-| `add_history_to_messages` | bool | from defaults | Include conversation history in context |
-| `learning` | bool | from defaults | Enable Agno Learning for this agent |
-| `learning_mode` | string | from defaults | Learning mode: `always` or `agentic` |
-| `knowledge_base` | string or null | `null` | Knowledge base ID from top-level `knowledge_bases` |
+| `display_name` | string | *required* | Human-readable name shown in Matrix as the bot's display name |
+| `role` | string | `""` | System prompt describing the agent's purpose — guides its behavior and expertise |
+| `model` | string | `"default"` | Model name (must match a key in the `models` section) |
+| `tools` | list | `[]` | Tool names the agent can use (see [Tools](../tools/index.md) for available options) |
+| `skills` | list | `[]` | Skill names the agent can use (see [Skills](../skills.md)) |
+| `instructions` | list | `[]` | Extra lines appended to the system prompt after the role |
+| `rooms` | list | `[]` | Room aliases to auto-join; rooms are created if they don't exist |
+| `num_history_runs` | int | `5` | How many previous conversation turns are loaded into context when the agent responds. Higher values give more context but use more tokens |
+| `markdown` | bool | `true` | When enabled, the agent is instructed to format responses as Markdown |
+| `add_history_to_messages` | bool | `true` | Whether previous turns are injected into the message list sent to the model. When `false`, only the current message is sent (useful for stateless tasks) |
+| `learning` | bool | `true` | Enable [Agno Learning](https://docs.agno.com/agents/learning) — the agent builds a persistent profile of user preferences and adapts over time |
+| `learning_mode` | string | `"always"` | `always`: agent automatically learns from every interaction. `agentic`: agent decides when to learn via a tool call |
+| `knowledge_base` | string or null | `null` | Knowledge base ID from top-level `knowledge_bases` — gives the agent RAG access to the indexed documents |
 
 If `knowledge_base` is set, it must match a key under `knowledge_bases` in `config.yaml`.
+
+All per-agent settings above that show a default value inherit from the `defaults` section. Per-agent values override them.
 
 Learning data is persisted to `STORAGE_PATH/learning/<agent>.db` (default: `mindroom_data/learning/<agent>.db`), so it survives container restarts when `mindroom_data` is mounted.
 
@@ -103,14 +105,14 @@ When using these names, the built-in prompt replaces the `role` field and any cu
 
 ## Defaults
 
+The `defaults` section sets fallback values for all agents. Any agent that omits a setting inherits the value from here.
+
 ```yaml
 defaults:
-  num_history_runs: 5
-  markdown: true
-  add_history_to_messages: true
-  learning: true
-  learning_mode: always
-  show_stop_button: false  # global-only, cannot be overridden per-agent
+  num_history_runs: 5        # Conversation turns loaded into context
+  markdown: true             # Format responses as Markdown
+  add_history_to_messages: true  # Inject previous turns into model messages
+  learning: true             # Enable Agno Learning
+  learning_mode: always      # "always" or "agentic"
+  show_stop_button: false    # Show a stop button while agent is responding (global-only, cannot be overridden per-agent)
 ```
-
-When an agent omits `learning` or `learning_mode`, MindRoom inherits those values from `defaults`.


### PR DESCRIPTION
## Summary
- Expand terse table descriptions in `docs/configuration/agents.md` into clear explanations of what each setting actually does
- Add links to related docs (Tools, Skills) from the table
- Show concrete default values instead of "from defaults"
- Explain `num_history_runs` (token trade-off), `add_history_to_messages` (stateless use case), `learning_mode` (always vs agentic), `show_stop_button` (global-only)
- Add inline comments to the defaults YAML block

## Test plan
- [ ] Verify docs site renders the table correctly
- [ ] Confirm links to tools/skills pages work