### PR TITLE
Fix empty Knowledge Files table on mobile

### DIFF
--- a/frontend/src/components/Knowledge/Knowledge.tsx
+++ b/frontend/src/components/Knowledge/Knowledge.tsx
@@ -680,12 +680,12 @@ export function Knowledge() {
               </CardContent>
             </Card>
 
-            <Card className="flex-1 min-h-0">
+            <Card>
               <CardHeader className="pb-3">
                 <CardTitle className="text-base">Knowledge Files</CardTitle>
               </CardHeader>
-              <CardContent className="h-[calc(100%-4.5rem)] min-h-0">
-                <div className="h-full overflow-auto rounded-md border">
+              <CardContent>
+                <div className="max-h-[55vh] overflow-auto rounded-md border">
                   <table className="w-full min-w-[760px] text-sm">
                     <thead>
                       {table.getHeaderGroups().map(headerGroup => (


### PR DESCRIPTION
## Summary
- fix a layout issue in the Knowledge page where the file table container could collapse on mobile/small viewports
- replace percentage/calc-based height in the Knowledge Files card with a stable viewport-based max height
- keep the table scrollable and visible when data is present

## Root Cause
The table wrapper depended on parent height math (`h-[calc(100%-4.5rem)]` + `h-full`), which can resolve to an effectively collapsed area in constrained mobile layouts.

## Validation
- `pre-commit run --files frontend/src/components/Knowledge/Knowledge.tsx`
- Verified on live stack that API returns files and table now renders after reload
