### PR TITLE
fix(openai-compat): disable interactive question prompts

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -109,13 +109,14 @@ def create_learning_storage(agent_name: str, storage_path: Path) -> SqliteDb:
     return SqliteDb(session_table=f"{agent_name}_learning_sessions", db_file=str(learning_dir / f"{agent_name}.db"))
 
 
-def create_agent(
+def create_agent(  # noqa: C901, PLR0912
     agent_name: str,
     config: Config,
     *,
     storage_path: Path | None = None,
     knowledge: KnowledgeProtocol | None = None,
     include_default_tools: bool = True,
+    include_interactive_questions: bool = True,
 ) -> Agent:
     """Create an agent instance from configuration.
 
@@ -128,6 +129,9 @@ def create_agent(
         include_default_tools: Whether to include DEFAULT_AGENT_TOOL_NAMES
             (e.g. "scheduler"). Set to False when creating agents outside
             of Matrix context where those tools are unavailable.
+        include_interactive_questions: Whether to include the interactive
+            question authoring prompt. Set to False for channels that do not
+            support Matrix reaction-based question flows.
 
     Returns:
         Configured Agent instance
@@ -223,7 +227,8 @@ def create_agent(
     if skills and skills.get_skill_names():
         instructions.append(agent_prompts.SKILLS_TOOL_USAGE_PROMPT)
 
-    instructions.append(agent_prompts.INTERACTIVE_QUESTION_PROMPT)
+    if include_interactive_questions:
+        instructions.append(agent_prompts.INTERACTIVE_QUESTION_PROMPT)
 
     knowledge_enabled = bool(agent_config.knowledge_bases) and knowledge is not None
 

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -264,6 +264,7 @@ async def _prepare_agent_and_prompt(
     thread_history: list[dict[str, Any]] | None = None,
     knowledge: Knowledge | None = None,
     include_default_tools: bool = True,
+    include_interactive_questions: bool = True,
 ) -> tuple[Agent, str]:
     """Prepare agent and full prompt for AI processing.
 
@@ -280,6 +281,7 @@ async def _prepare_agent_and_prompt(
         storage_path=storage_path,
         knowledge=knowledge,
         include_default_tools=include_default_tools,
+        include_interactive_questions=include_interactive_questions,
     )
     return agent, full_prompt
 
@@ -295,6 +297,7 @@ async def ai_response(
     knowledge: Knowledge | None = None,
     user_id: str | None = None,
     include_default_tools: bool = True,
+    include_interactive_questions: bool = True,
 ) -> str:
     """Generates a response using the specified agno Agent with memory integration.
 
@@ -310,6 +313,9 @@ async def ai_response(
         user_id: Matrix user ID of the sender, used by Agno's LearningMachine
         include_default_tools: Whether to include default tools (e.g. scheduler).
             Set to False when calling outside of Matrix context.
+        include_interactive_questions: Whether to include the interactive
+            question authoring prompt. Set to False for channels that do not
+            support Matrix reaction-based question flows.
 
     Returns:
         Agent response string
@@ -328,6 +334,7 @@ async def ai_response(
             thread_history,
             knowledge,
             include_default_tools=include_default_tools,
+            include_interactive_questions=include_interactive_questions,
         )
     except Exception as e:
         logger.exception("Error preparing agent", agent=agent_name)
@@ -355,6 +362,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
     knowledge: Knowledge | None = None,
     user_id: str | None = None,
     include_default_tools: bool = True,
+    include_interactive_questions: bool = True,
 ) -> AsyncIterator[AIStreamChunk]:
     """Generate streaming AI response using Agno's streaming API.
 
@@ -373,6 +381,9 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
         user_id: Matrix user ID of the sender, used by Agno's LearningMachine
         include_default_tools: Whether to include default tools (e.g. scheduler).
             Set to False when calling outside of Matrix context.
+        include_interactive_questions: Whether to include the interactive
+            question authoring prompt. Set to False for channels that do not
+            support Matrix reaction-based question flows.
 
     Yields:
         Streaming chunks/events as they become available
@@ -391,6 +402,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
             thread_history,
             knowledge,
             include_default_tools=include_default_tools,
+            include_interactive_questions=include_interactive_questions,
         )
     except Exception as e:
         logger.exception("Error preparing agent for streaming", agent=agent_name)

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -685,6 +685,7 @@ async def _non_stream_completion(
         knowledge=knowledge,
         user_id=user,
         include_default_tools=False,
+        include_interactive_questions=False,
     )
 
     # Detect error responses from ai_response()
@@ -831,6 +832,7 @@ async def _stream_completion(
         knowledge=knowledge,
         user_id=user,
         include_default_tools=False,
+        include_interactive_questions=False,
     )
 
     # Peek at first event to detect errors before committing to SSE
@@ -903,6 +905,7 @@ def _build_team(team_name: str, config: Config) -> tuple[list[Agent], Team | Non
                     storage_path=STORAGE_PATH_OBJ,
                     knowledge=_resolve_knowledge(member_name, config),
                     include_default_tools=False,
+                    include_interactive_questions=False,
                 ),
             )
         except Exception:


### PR DESCRIPTION
## Summary
- add `include_interactive_questions` flag to agent creation (default enabled)
- disable interactive-question prompt injection for OpenAI-compatible non-streaming, streaming, and team member creation
- add tests asserting OpenAI-compat passes `include_interactive_questions=False`

## Validation
- `pytest -q tests/test_openai_compat.py`
- `pytest -q tests/test_ai_user_id.py tests/test_agents.py`
- `pytest -q`
- `pre-commit run --all-files`
