### PR TITLE
Add git-backed knowledge sync for knowledge bases (polling + force reset)

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -90,6 +90,14 @@ knowledge_bases:
   docs:
     path: ./knowledge_docs/default # Folder containing documents for this base
     watch: true                    # Reindex automatically when files change
+    git:                           # Optional: Sync this folder from a Git repository
+      repo_url: https://github.com/pipefunc/pipefunc
+      branch: main
+      poll_interval_seconds: 300
+      skip_hidden: true
+      include_patterns: ["docs/**"]  # Optional: root-anchored glob filters
+      exclude_patterns: []
+      credentials_service: github_private # Optional: service in CredentialsManager
 
 # Voice message handling (optional)
 voice:
@@ -118,6 +126,62 @@ plugins: []
 
 # Timezone for scheduled tasks (optional)
 timezone: America/Los_Angeles      # Default: UTC
+```
+
+## Git-backed Knowledge Bases
+
+Each knowledge base can optionally sync from Git by setting `knowledge_bases.<base_id>.git`.
+
+- One knowledge base maps to one local folder and optional one Git repo.
+- You can configure multiple knowledge bases, each with its own `git` settings.
+- Sync behavior is: `git fetch` then `git reset --hard origin/<branch>`.
+- Local uncommitted changes inside that checkout are discarded on sync.
+- Git polling runs even when `watch: false`; `watch` controls only local filesystem watching.
+- GitHub/GitLab webhooks are not part of this V1; updates are pull-based via polling.
+
+### Git Fields
+
+- `repo_url` (required): repository URL to clone/fetch.
+- `branch` (default `main`): branch to track.
+- `poll_interval_seconds` (default `300`, minimum `5`): polling interval.
+- `credentials_service` (optional): service name in CredentialsManager for private HTTPS repos.
+- `skip_hidden` (default `true`): skip files/folders with any path segment starting with `.`.
+- `include_patterns` (optional): root-anchored glob patterns to include (for example `docs/**` or `content/post/*/index.md`).
+- `exclude_patterns` (optional): root-anchored glob patterns excluded after include filtering.
+
+### Pattern Semantics
+
+- Patterns are matched from the repository root.
+- `*` matches one path segment, `**` matches zero or more segments.
+- If `include_patterns` is empty, all non-hidden files are eligible.
+- If `include_patterns` is set, a file must match at least one include pattern.
+- `exclude_patterns` are applied last and remove matching files.
+
+### Private Repository Authentication
+
+For private HTTPS repositories, set credentials under a service name and reference it via `credentials_service`.
+
+```bash
+curl -X POST http://localhost:8765/api/credentials/github_private \
+  -H "Content-Type: application/json" \
+  -d '{"credentials":{"username":"x-access-token","token":"ghp_your_token_here"}}'
+```
+
+You can also set credentials from the Dashboard Integrations/API-Keys area. The service name must match `credentials_service`.
+
+### Example: Clone Pipefunc, Index Only `docs/`
+
+```yaml
+knowledge_bases:
+  pipefunc_docs:
+    path: ./knowledge_docs/pipefunc
+    watch: false
+    git:
+      repo_url: https://github.com/pipefunc/pipefunc
+      branch: main
+      poll_interval_seconds: 300
+      include_patterns:
+        - "docs/**"
 ```
 
 ## Sections

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -97,6 +97,11 @@ Manage file-backed RAG knowledge bases:
 - **Track index status** (`file_count` and `indexed_count`)
 - **Assign agents** to a specific knowledge base from the Agents tab
 
+Git-backed knowledge bases are supported, but Git settings are currently configured in `config.yaml` (`knowledge_bases.<id>.git`), not via dedicated dashboard controls yet.
+
+- The dashboard preserves existing `git` settings when you edit `path`/`watch`.
+- `/api/knowledge/bases/{base_id}/files` reflects the manager's filtered file set (for example `include_patterns`/`exclude_patterns`).
+
 ### Voice
 
 Configure voice message handling:

--- a/frontend/src/store/configStore.test.ts
+++ b/frontend/src/store/configStore.test.ts
@@ -553,6 +553,46 @@ describe('configStore', () => {
   });
 
   describe('knowledge bases', () => {
+    it('should preserve git settings when updating base path or watch', () => {
+      useConfigStore.setState({
+        config: {
+          memory: { embedder: { provider: 'openai', config: { model: 'test' } } },
+          knowledge_bases: {
+            docs: {
+              path: './docs',
+              watch: true,
+              git: {
+                repo_url: 'https://github.com/pipefunc/pipefunc',
+                branch: 'main',
+                include_patterns: ['docs/**'],
+              },
+            },
+          },
+          models: {},
+          agents: {},
+          defaults: {
+            markdown: true,
+          },
+          router: { model: 'default' },
+        } as Config,
+      });
+
+      const { updateKnowledgeBase } = useConfigStore.getState();
+      updateKnowledgeBase('docs', { path: './docs-sync', watch: false });
+
+      const state = useConfigStore.getState();
+      expect(state.config?.knowledge_bases?.docs).toEqual({
+        path: './docs-sync',
+        watch: false,
+        git: {
+          repo_url: 'https://github.com/pipefunc/pipefunc',
+          branch: 'main',
+          include_patterns: ['docs/**'],
+        },
+      });
+      expect(state.isDirty).toBe(true);
+    });
+
     it('should remove deleted knowledge base from all agent assignments', () => {
       useConfigStore.setState({
         config: {

--- a/frontend/src/store/configStore.ts
+++ b/frontend/src/store/configStore.ts
@@ -477,12 +477,14 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
   updateKnowledgeBase: (baseName, baseConfig) => {
     set(state => {
       if (!state.config) return state;
+      const existingBaseConfig = state.config.knowledge_bases?.[baseName] || {};
       return {
         config: {
           ...state.config,
           knowledge_bases: {
             ...(state.config.knowledge_bases || {}),
             [baseName]: {
+              ...existingBaseConfig,
               ...baseConfig,
             },
           },

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -19,9 +19,20 @@ export interface MemoryConfig {
   };
 }
 
+export interface KnowledgeGitConfig {
+  repo_url: string;
+  branch?: string;
+  poll_interval_seconds?: number;
+  credentials_service?: string;
+  skip_hidden?: boolean;
+  include_patterns?: string[];
+  exclude_patterns?: string[];
+}
+
 export interface KnowledgeBaseConfig {
   path: string;
   watch: boolean;
+  git?: KnowledgeGitConfig;
 }
 
 export type LearningMode = 'always' | 'agentic';

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -393,6 +393,11 @@ Manage file-backed RAG knowledge bases:
 - **Track index status** (`file_count` and `indexed_count`)
 - **Assign agents** to a specific knowledge base from the Agents tab
 
+Git-backed knowledge bases are supported, but Git settings are currently configured in `config.yaml` (`knowledge_bases.<id>.git`), not via dedicated dashboard controls yet.
+
+- The dashboard preserves existing `git` settings when you edit `path`/`watch`.
+- `/api/knowledge/bases/{base_id}/files` reflects the manager's filtered file set (for example `include_patterns`/`exclude_patterns`).
+
 ### Voice
 
 Configure voice message handling:
@@ -571,6 +576,14 @@ knowledge_bases:
   docs:
     path: ./knowledge_docs/default # Folder containing documents for this base
     watch: true                    # Reindex automatically when files change
+    git:                           # Optional: Sync this folder from a Git repository
+      repo_url: https://github.com/pipefunc/pipefunc
+      branch: main
+      poll_interval_seconds: 300
+      skip_hidden: true
+      include_patterns: ["docs/**"]  # Optional: root-anchored glob filters
+      exclude_patterns: []
+      credentials_service: github_private # Optional: service in CredentialsManager
 
 # Voice message handling (optional)
 voice:
@@ -599,6 +612,62 @@ plugins: []
 
 # Timezone for scheduled tasks (optional)
 timezone: America/Los_Angeles      # Default: UTC
+```
+
+## Git-backed Knowledge Bases
+
+Each knowledge base can optionally sync from Git by setting `knowledge_bases.<base_id>.git`.
+
+- One knowledge base maps to one local folder and optional one Git repo.
+- You can configure multiple knowledge bases, each with its own `git` settings.
+- Sync behavior is: `git fetch` then `git reset --hard origin/<branch>`.
+- Local uncommitted changes inside that checkout are discarded on sync.
+- Git polling runs even when `watch: false`; `watch` controls only local filesystem watching.
+- GitHub/GitLab webhooks are not part of this V1; updates are pull-based via polling.
+
+### Git Fields
+
+- `repo_url` (required): repository URL to clone/fetch.
+- `branch` (default `main`): branch to track.
+- `poll_interval_seconds` (default `300`, minimum `5`): polling interval.
+- `credentials_service` (optional): service name in CredentialsManager for private HTTPS repos.
+- `skip_hidden` (default `true`): skip files/folders with any path segment starting with `.`.
+- `include_patterns` (optional): root-anchored glob patterns to include (for example `docs/**` or `content/post/*/index.md`).
+- `exclude_patterns` (optional): root-anchored glob patterns excluded after include filtering.
+
+### Pattern Semantics
+
+- Patterns are matched from the repository root.
+- `*` matches one path segment, `**` matches zero or more segments.
+- If `include_patterns` is empty, all non-hidden files are eligible.
+- If `include_patterns` is set, a file must match at least one include pattern.
+- `exclude_patterns` are applied last and remove matching files.
+
+### Private Repository Authentication
+
+For private HTTPS repositories, set credentials under a service name and reference it via `credentials_service`.
+
+```
+curl -X POST http://localhost:8765/api/credentials/github_private \
+  -H "Content-Type: application/json" \
+  -d '{"credentials":{"username":"x-access-token","token":"ghp_your_token_here"}}'
+```
+
+You can also set credentials from the Dashboard Integrations/API-Keys area. The service name must match `credentials_service`.
+
+### Example: Clone Pipefunc, Index Only `docs/`
+
+```
+knowledge_bases:
+  pipefunc_docs:
+    path: ./knowledge_docs/pipefunc
+    watch: false
+    git:
+      repo_url: https://github.com/pipefunc/pipefunc
+      branch: main
+      poll_interval_seconds: 300
+      include_patterns:
+        - "docs/**"
 ```
 
 ## Sections

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -86,6 +86,14 @@ knowledge_bases:
   docs:
     path: ./knowledge_docs/default # Folder containing documents for this base
     watch: true                    # Reindex automatically when files change
+    git:                           # Optional: Sync this folder from a Git repository
+      repo_url: https://github.com/pipefunc/pipefunc
+      branch: main
+      poll_interval_seconds: 300
+      skip_hidden: true
+      include_patterns: ["docs/**"]  # Optional: root-anchored glob filters
+      exclude_patterns: []
+      credentials_service: github_private # Optional: service in CredentialsManager
 
 # Voice message handling (optional)
 voice:
@@ -114,6 +122,62 @@ plugins: []
 
 # Timezone for scheduled tasks (optional)
 timezone: America/Los_Angeles      # Default: UTC
+```
+
+## Git-backed Knowledge Bases
+
+Each knowledge base can optionally sync from Git by setting `knowledge_bases.<base_id>.git`.
+
+- One knowledge base maps to one local folder and optional one Git repo.
+- You can configure multiple knowledge bases, each with its own `git` settings.
+- Sync behavior is: `git fetch` then `git reset --hard origin/<branch>`.
+- Local uncommitted changes inside that checkout are discarded on sync.
+- Git polling runs even when `watch: false`; `watch` controls only local filesystem watching.
+- GitHub/GitLab webhooks are not part of this V1; updates are pull-based via polling.
+
+### Git Fields
+
+- `repo_url` (required): repository URL to clone/fetch.
+- `branch` (default `main`): branch to track.
+- `poll_interval_seconds` (default `300`, minimum `5`): polling interval.
+- `credentials_service` (optional): service name in CredentialsManager for private HTTPS repos.
+- `skip_hidden` (default `true`): skip files/folders with any path segment starting with `.`.
+- `include_patterns` (optional): root-anchored glob patterns to include (for example `docs/**` or `content/post/*/index.md`).
+- `exclude_patterns` (optional): root-anchored glob patterns excluded after include filtering.
+
+### Pattern Semantics
+
+- Patterns are matched from the repository root.
+- `*` matches one path segment, `**` matches zero or more segments.
+- If `include_patterns` is empty, all non-hidden files are eligible.
+- If `include_patterns` is set, a file must match at least one include pattern.
+- `exclude_patterns` are applied last and remove matching files.
+
+### Private Repository Authentication
+
+For private HTTPS repositories, set credentials under a service name and reference it via `credentials_service`.
+
+```
+curl -X POST http://localhost:8765/api/credentials/github_private \
+  -H "Content-Type: application/json" \
+  -d '{"credentials":{"username":"x-access-token","token":"ghp_your_token_here"}}'
+```
+
+You can also set credentials from the Dashboard Integrations/API-Keys area. The service name must match `credentials_service`.
+
+### Example: Clone Pipefunc, Index Only `docs/`
+
+```
+knowledge_bases:
+  pipefunc_docs:
+    path: ./knowledge_docs/pipefunc
+    watch: false
+    git:
+      repo_url: https://github.com/pipefunc/pipefunc
+      branch: main
+      poll_interval_seconds: 300
+      include_patterns:
+        - "docs/**"
 ```
 
 ## Sections

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -93,6 +93,11 @@ Manage file-backed RAG knowledge bases:
 - **Track index status** (`file_count` and `indexed_count`)
 - **Assign agents** to a specific knowledge base from the Agents tab
 
+Git-backed knowledge bases are supported, but Git settings are currently configured in `config.yaml` (`knowledge_bases.<id>.git`), not via dedicated dashboard controls yet.
+
+- The dashboard preserves existing `git` settings when you edit `path`/`watch`.
+- `/api/knowledge/bases/{base_id}/files` reflects the manager's filtered file set (for example `include_patterns`/`exclude_patterns`).
+
 ### Voice
 
 Configure voice message handling:

--- a/src/mindroom/config.py
+++ b/src/mindroom/config.py
@@ -126,6 +126,14 @@ class KnowledgeGitConfig(BaseModel):
         default=True,
         description="Skip hidden files/folders (paths with components starting with '.') during indexing",
     )
+    include_patterns: list[str] = Field(
+        default_factory=list,
+        description="Optional root-anchored glob patterns to include (e.g. 'content/post/*/index.md')",
+    )
+    exclude_patterns: list[str] = Field(
+        default_factory=list,
+        description="Optional root-anchored glob patterns to exclude after include filtering",
+    )
 
 
 class KnowledgeBaseConfig(BaseModel):


### PR DESCRIPTION
## Summary
- add optional `knowledge_bases.<id>.git` config (`repo_url`, `branch`, `poll_interval_seconds`, `credentials_service`, `skip_hidden`)
- add Git sync lifecycle to `KnowledgeManager` so git-backed folders are cloned/fetched and indexed automatically
- switch sync mode to force-align local checkout to remote (`git reset --hard origin/<branch>`) so dirty local state does not block updates
- keep indexing incremental by removing deleted files and upserting changed files
- skip hidden dot-prefixed files/directories for git-backed bases when `skip_hidden: true`
- add unit tests for git sync changed/deleted handling, hidden-path skipping, and watcher startup behavior

## Testing
- `pre-commit run --all-files` ✅
- `ruff check src/mindroom/knowledge.py` ✅
- `pytest -q tests/test_knowledge_manager.py` ✅
- `pytest` ⚠️ one unrelated flaky failure (`tests/test_response_tracker.py::TestResponseTracker::test_concurrent_access`), isolated rerun passed:
  - `pytest -q tests/test_response_tracker.py::TestResponseTracker::test_concurrent_access` ✅
