### PR TITLE
fix: install git in backend container image

### DIFF
--- a/local/instances/deploy/Dockerfile.backend
+++ b/local/instances/deploy/Dockerfile.backend
@@ -37,8 +37,10 @@ ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 
 WORKDIR /app
 
-# Install runtime dependencies (curl for health checks)
-RUN apt-get update && apt-get install -y curl \
+# Install runtime dependencies:
+# - curl for health checks
+# - git for remote knowledge base cloning/sync
+RUN apt-get update && apt-get install -y curl git \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy the app with venv from builder


### PR DESCRIPTION
## Summary
- install git in the runtime stage of local/instances/deploy/Dockerfile.backend
- keep existing curl health-check dependency and apt cleanup
- enables git-based knowledge sources (e.g. pipefunc) to clone/sync inside backend containers

## Validation
- uv run pytest -> 1086 passed, 20 skipped
- built image with updated Dockerfile and verified runtime binary: git --version