### PR TITLE
chore: stricter ty config with error-on-warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,19 +233,24 @@ python-version = "3.12"
 include = [ "src", "tests" ]
 
 [tool.ty.rules]
-deprecated = "ignore"
+deprecated = "ignore" # FastAPI on_event deprecation; refactor to lifespan separately
 
-# Tests: suppress rules that fire on mock patterns (method-assign, attr-defined, etc.)
+[tool.ty.terminal]
+error-on-warning = true
+
 [[tool.ty.overrides]]
-include = [ "tests/**" ]
+include = [ "tests/" ]
+
 [tool.ty.overrides.rules]
-invalid-argument-type = "ignore"
-unresolved-attribute = "ignore"
-unsupported-operator = "ignore"
-invalid-assignment = "ignore"
-not-subscriptable = "ignore"
+# Mock patterns cause many false positives in tests (e.g., mock.call_args
+# returns _Call | None, attribute access on MagicMock, passing mocks as
+# typed arguments).
 call-non-callable = "ignore"
-too-many-positional-arguments = "ignore"
+invalid-argument-type = "ignore"
+invalid-assignment = "ignore"
 no-matching-overload = "ignore"
 not-iterable = "ignore"
-unused-type-ignore-comment = "ignore"
+not-subscriptable = "ignore"
+too-many-positional-arguments = "ignore"
+unresolved-attribute = "ignore"
+unsupported-operator = "ignore"

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -46,7 +46,7 @@ def mock_agent_bot() -> AgentBot:
         bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
     bot.client = AsyncMock()
     bot.logger = MagicMock()
-    bot._send_response = AsyncMock()  # type: ignore[method-assign]
+    bot._send_response = AsyncMock()
     return bot
 
 
@@ -94,8 +94,8 @@ class TestBotScheduleCommands:
             )
 
             # Verify response was sent
-            mock_agent_bot._send_response.assert_called_once()  # type: ignore[attr-defined]
-            call_args = mock_agent_bot._send_response.call_args  # type: ignore[attr-defined]
+            mock_agent_bot._send_response.assert_called_once()
+            call_args = mock_agent_bot._send_response.call_args
             assert "✅ Scheduled: 5 minutes from now" in call_args[0][2]
 
     @pytest.mark.asyncio
@@ -150,7 +150,7 @@ class TestBotScheduleCommands:
                 config=mock_agent_bot.config,
             )
 
-            mock_agent_bot._send_response.assert_called_once()  # type: ignore[attr-defined]
+            mock_agent_bot._send_response.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_handle_cancel_schedule_command(self, mock_agent_bot: AgentBot) -> None:
@@ -200,8 +200,8 @@ class TestBotScheduleCommands:
 
             mock_cancel_all.assert_called_once_with(client=mock_agent_bot.client, room_id="!test:server")
 
-        mock_agent_bot._send_response.assert_called_once()  # type: ignore[attr-defined]
-        call_args = mock_agent_bot._send_response.call_args  # type: ignore[attr-defined]
+        mock_agent_bot._send_response.assert_called_once()
+        call_args = mock_agent_bot._send_response.call_args
         assert "✅ Cancelled 3 scheduled task(s)" in call_args[0][2]
 
     @pytest.mark.asyncio
@@ -240,8 +240,8 @@ class TestBotScheduleCommands:
                 thread_id="$thread123",
             )
 
-        mock_agent_bot._send_response.assert_called_once()  # type: ignore[attr-defined]
-        call_args = mock_agent_bot._send_response.call_args  # type: ignore[attr-defined]
+        mock_agent_bot._send_response.assert_called_once()
+        call_args = mock_agent_bot._send_response.call_args
         assert "✅ Updated task `task123`." in call_args[0][2]
 
     @pytest.mark.asyncio
@@ -265,8 +265,8 @@ class TestBotScheduleCommands:
             await mock_agent_bot._handle_command(room, event, command)
 
         # Should successfully schedule the task (auto-creates thread)
-        mock_agent_bot._send_response.assert_called_once()  # type: ignore[attr-defined]
-        call_args = mock_agent_bot._send_response.call_args  # type: ignore[attr-defined]
+        mock_agent_bot._send_response.assert_called_once()
+        call_args = mock_agent_bot._send_response.call_args
         assert "✅" in call_args[0][2] or "Task ID" in call_args[0][2]
         # The thread_id should be None (will be handled by _send_response)
         # and the event should be passed for thread creation
@@ -386,8 +386,8 @@ class TestCommandHandling:
             bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._generate_response = AsyncMock()  # type: ignore[method-assign]
-        bot._extract_message_context = AsyncMock()  # type: ignore[method-assign]
+        bot._generate_response = AsyncMock()
+        bot._extract_message_context = AsyncMock()
 
         # Create a room and event
         room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
@@ -425,7 +425,7 @@ class TestCommandHandling:
             bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
             bot.client = AsyncMock()
             bot.logger = MagicMock()
-            bot._handle_command = AsyncMock()  # type: ignore[method-assign]
+            bot._handle_command = AsyncMock()
 
             # Create a room and event with thread info
             room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
@@ -471,7 +471,7 @@ class TestCommandHandling:
             bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._generate_response = AsyncMock()  # type: ignore[method-assign]
+        bot._generate_response = AsyncMock()
         bot.response_tracker = MagicMock()
         bot.response_tracker.has_responded.return_value = False
 
@@ -483,7 +483,7 @@ class TestCommandHandling:
         mock_context.thread_history = []
         # mentioned_agents should be a list of MatrixID objects
         mock_context.mentioned_agents = [config.ids["calculator"]] if "calculator" in config.ids else []
-        bot._extract_message_context = AsyncMock(return_value=mock_context)  # type: ignore[method-assign]
+        bot._extract_message_context = AsyncMock(return_value=mock_context)
 
         # Mock should_agent_respond to return True
         with patch("mindroom.bot.should_agent_respond", return_value=True):
@@ -522,7 +522,7 @@ class TestCommandHandling:
             bot.client = AsyncMock()
             bot.client.user_id = "@mindroom_general:localhost"  # Set the bot's user ID
             bot.logger = MagicMock()
-            bot._generate_response = AsyncMock()  # type: ignore[method-assign]
+            bot._generate_response = AsyncMock()
             bot.response_tracker = MagicMock()
             bot.response_tracker.has_responded.return_value = False
 
@@ -533,7 +533,7 @@ class TestCommandHandling:
             mock_context.thread_id = "$thread123"
             mock_context.thread_history = []
             mock_context.mentioned_agents = []
-            bot._extract_message_context = AsyncMock(return_value=mock_context)  # type: ignore[method-assign]
+            bot._extract_message_context = AsyncMock(return_value=mock_context)
 
             # Create a room and event with error message from router agent
             room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
@@ -639,7 +639,7 @@ class TestCommandHandling:
             bot.client = AsyncMock()
             bot.client.user_id = "@mindroom_finance:localhost"
             bot.logger = MagicMock()
-            bot._generate_response = AsyncMock()  # type: ignore[method-assign]
+            bot._generate_response = AsyncMock()
             bot.response_tracker = MagicMock()
             bot.response_tracker.has_responded.return_value = False
 
@@ -650,7 +650,7 @@ class TestCommandHandling:
             mock_context.is_thread = True
             mock_context.thread_id = "$thread123"
             mock_context.thread_history = []
-            bot._extract_message_context = AsyncMock(return_value=mock_context)  # type: ignore[method-assign]
+            bot._extract_message_context = AsyncMock(return_value=mock_context)
 
             # Create router's error message event
             room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
@@ -700,8 +700,8 @@ class TestCommandHandling:
         bot.client = AsyncMock()
         bot.client.user_id = "@mindroom_news:localhost"
         bot.logger = MagicMock()
-        bot._generate_response = AsyncMock()  # type: ignore[method-assign]
-        bot._send_response = AsyncMock()  # type: ignore[method-assign]
+        bot._generate_response = AsyncMock()
+        bot._send_response = AsyncMock()
         bot.response_tracker = MagicMock()
         bot.response_tracker.has_responded.return_value = False
         bot.orchestrator = MagicMock()
@@ -741,7 +741,7 @@ class TestCommandHandling:
         mock_context.thread_id = "$thread123"
         mock_context.thread_history = thread_history  # History before router error
         mock_context.mentioned_agents = []  # Router doesn't mention anyone
-        bot._extract_message_context = AsyncMock(return_value=mock_context)  # type: ignore[method-assign]
+        bot._extract_message_context = AsyncMock(return_value=mock_context)
 
         # Create room and event for router error
         room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
@@ -799,7 +799,7 @@ class TestCommandHandling:
         bot.client = AsyncMock()
         bot.client.user_id = "@mindroom_finance:localhost"
         bot.logger = MagicMock()
-        bot._generate_response = AsyncMock()  # type: ignore[method-assign]
+        bot._generate_response = AsyncMock()
         bot.response_tracker = MagicMock()
         bot.response_tracker.has_responded.return_value = False
 
@@ -853,7 +853,7 @@ class TestCommandHandling:
             },
         ]
         mock_context.mentioned_agents = []
-        bot._extract_message_context = AsyncMock(return_value=mock_context)  # type: ignore[method-assign]
+        bot._extract_message_context = AsyncMock(return_value=mock_context)
 
         # Create room and event for router error
         room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
@@ -905,7 +905,7 @@ class TestCommandHandling:
         bot.client = AsyncMock()
         bot.client.user_id = "@mindroom_general:localhost"
         bot.logger = MagicMock()
-        bot._generate_response = AsyncMock()  # type: ignore[method-assign]
+        bot._generate_response = AsyncMock()
         bot.response_tracker = MagicMock()
         bot.response_tracker.has_responded.return_value = False
 
@@ -916,7 +916,7 @@ class TestCommandHandling:
         mock_context.is_thread = True
         mock_context.thread_id = "$thread123"
         mock_context.thread_history = []
-        bot._extract_message_context = AsyncMock(return_value=mock_context)  # type: ignore[method-assign]
+        bot._extract_message_context = AsyncMock(return_value=mock_context)
 
         # Create a room and event with message from router agent without mentions
         room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
@@ -975,7 +975,7 @@ class TestRouterSkipsSingleAgent:
             bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._handle_ai_routing = AsyncMock()  # type: ignore[method-assign]
+        bot._handle_ai_routing = AsyncMock()
         bot.response_tracker = MagicMock()
         bot.response_tracker.has_responded.return_value = False
 
@@ -986,7 +986,7 @@ class TestRouterSkipsSingleAgent:
         mock_context.is_thread = False
         mock_context.thread_id = None
         mock_context.thread_history = []
-        bot._extract_message_context = AsyncMock(return_value=mock_context)  # type: ignore[method-assign]
+        bot._extract_message_context = AsyncMock(return_value=mock_context)
 
         # Create room with only general agent (router is also there but excluded from available agents)
         room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
@@ -1054,7 +1054,7 @@ class TestRouterSkipsSingleAgent:
             bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._handle_ai_routing = AsyncMock()  # type: ignore[method-assign]
+        bot._handle_ai_routing = AsyncMock()
         bot.response_tracker = MagicMock()
         bot.response_tracker.has_responded.return_value = False
 
@@ -1065,7 +1065,7 @@ class TestRouterSkipsSingleAgent:
         mock_context.is_thread = False
         mock_context.thread_id = None
         mock_context.thread_history = []
-        bot._extract_message_context = AsyncMock(return_value=mock_context)  # type: ignore[method-assign]
+        bot._extract_message_context = AsyncMock(return_value=mock_context)
 
         # Create room with multiple agents
         room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
@@ -1130,8 +1130,8 @@ class TestRouterSkipsSingleAgent:
             bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._handle_command = AsyncMock()  # type: ignore[method-assign]
-        bot._send_response = AsyncMock()  # type: ignore[method-assign]
+        bot._handle_command = AsyncMock()
+        bot._send_response = AsyncMock()
 
         # Room with router + one agent + a human
         room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
@@ -1190,8 +1190,8 @@ class TestRouterSkipsSingleAgent:
             bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._handle_command = AsyncMock()  # type: ignore[method-assign]
-        bot._send_response = AsyncMock()  # type: ignore[method-assign]
+        bot._handle_command = AsyncMock()
+        bot._send_response = AsyncMock()
 
         # Room with router + one agent + a human
         room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
@@ -1250,7 +1250,7 @@ class TestRouterSkipsSingleAgent:
             bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._handle_ai_routing = AsyncMock()  # type: ignore[method-assign]
+        bot._handle_ai_routing = AsyncMock()
         bot.response_tracker = MagicMock()
         bot.response_tracker.has_responded.return_value = False
 
@@ -1279,7 +1279,7 @@ class TestRouterSkipsSingleAgent:
         mock_context.is_thread = False
         mock_context.thread_id = None
         mock_context.thread_history = []
-        bot._extract_message_context = AsyncMock(return_value=mock_context)  # type: ignore[method-assign]
+        bot._extract_message_context = AsyncMock(return_value=mock_context)
 
         with (
             patch("mindroom.bot.interactive.handle_text_response"),
@@ -1326,7 +1326,7 @@ class TestRouterSkipsSingleAgent:
             bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._handle_command = AsyncMock()  # type: ignore[method-assign]
+        bot._handle_command = AsyncMock()
 
         # Room with router + two agents + a human
         room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")

--- a/tests/test_claude_agent_tool.py
+++ b/tests/test_claude_agent_tool.py
@@ -291,8 +291,8 @@ def fake_anthropic_gateway() -> Iterator[dict[str, Any]]:
             self.end_headers()
             self.wfile.write(encoded)
 
-        def log_message(self, format_str: str, *args: object) -> None:
-            _ = (format_str, args)
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            _ = (format, args)
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
     thread = Thread(target=server.serve_forever, daemon=True)

--- a/tests/test_config_manager_consolidated.py
+++ b/tests/test_config_manager_consolidated.py
@@ -326,7 +326,7 @@ class TestConsolidatedConfigManager:
         """Test manage_agent with invalid operation."""
         cm = ConfigManagerTools()
         result = cm.manage_agent(
-            operation="invalid",  # type: ignore[arg-type]
+            operation="invalid",
             agent_name="test",
         )
         assert "Error: Unknown operation" in result

--- a/tests/test_credentials_api.py
+++ b/tests/test_credentials_api.py
@@ -37,7 +37,7 @@ def test_client(mock_credentials_manager: CredentialsManager) -> Generator[TestC
         mock_get.return_value = mock_credentials_manager
         client = TestClient(app)
         # Store the mock for use in tests
-        client.mock_manager = mock_credentials_manager  # type: ignore[attr-defined]
+        client.mock_manager = mock_credentials_manager
         yield client
 
 

--- a/tests/test_dynamic_config_update.py
+++ b/tests/test_dynamic_config_update.py
@@ -19,7 +19,7 @@ class TestDynamicConfigUpdate:
         """Test that when config is updated, all existing bots get the new config."""
         # Create initial config with just one agent
         initial_config = Config(
-            agents={  # type: ignore[arg-type]
+            agents={
                 "general": {
                     "display_name": "GeneralAgent",
                     "role": "General assistant",
@@ -27,7 +27,7 @@ class TestDynamicConfigUpdate:
                     "rooms": ["lobby"],
                 },
             },
-            models={"default": {"provider": "test", "id": "test-model"}},  # type: ignore[arg-type]
+            models={"default": {"provider": "test", "id": "test-model"}},
         )
 
         # Create orchestrator and set initial config
@@ -42,7 +42,7 @@ class TestDynamicConfigUpdate:
 
         # Create updated config with a new agent
         updated_config = Config(
-            agents={  # type: ignore[arg-type]
+            agents={
                 "general": {
                     "display_name": "GeneralAgent",
                     "role": "General assistant",
@@ -56,7 +56,7 @@ class TestDynamicConfigUpdate:
                     "rooms": ["lobby"],
                 },
             },
-            models={"default": {"provider": "test", "id": "test-model"}},  # type: ignore[arg-type]
+            models={"default": {"provider": "test", "id": "test-model"}},
         )
 
         # Mock the from_yaml method to return our updated config
@@ -95,7 +95,7 @@ class TestDynamicConfigUpdate:
         """Test that scheduling commands work correctly with dynamically added agents."""
         # Update config to add callagent
         updated_config = Config(
-            agents={  # type: ignore[arg-type]
+            agents={
                 "email_assistant": {
                     "display_name": "EmailAssistant",
                     "role": "Email assistant",
@@ -109,7 +109,7 @@ class TestDynamicConfigUpdate:
                     "rooms": ["lobby"],
                 },
             },
-            models={"default": {"provider": "test", "id": "test-model"}},  # type: ignore[arg-type]
+            models={"default": {"provider": "test", "id": "test-model"}},
         )
 
         # Test that parse_workflow_schedule correctly recognizes the new agent

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -233,8 +233,8 @@ async def test_sync_git_repository_updates_index_for_changed_and_deleted_files(
         "_sync_git_repository_once",
         lambda _git_config: ({"docs/new.md", "docs/updated.md"}, {"docs/deleted.md"}, True),
     )
-    manager.index_file = AsyncMock(return_value=True)  # type: ignore[method-assign]
-    manager.remove_file = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    manager.index_file = AsyncMock(return_value=True)
+    manager.remove_file = AsyncMock(return_value=True)
 
     result = await manager.sync_git_repository()
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 class MockConfig:
     """Mock configuration for testing."""
 
-    agents: dict[str, Any] = None  # type: ignore[assignment]
+    agents: dict[str, Any] = None
 
     def __post_init__(self) -> None:
         """Initialize agents dictionary if not provided."""
@@ -960,7 +960,7 @@ class TestMultiAgentOrchestrator:
                 # Create a mock that tracks the call
                 mock_start = AsyncMock()
                 # Replace start with our mock
-                bot.start = mock_start  # type: ignore[method-assign]
+                bot.start = mock_start
                 start_mocks.append(mock_start)
                 bot.running = False
 
@@ -1003,7 +1003,7 @@ class TestMultiAgentOrchestrator:
             for bot in orchestrator.agent_bots.values():
                 bot.client = AsyncMock()
                 bot.running = True
-                bot.ensure_user_account = AsyncMock()  # type: ignore[method-assign]
+                bot.ensure_user_account = AsyncMock()
 
             await orchestrator.stop()
 

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -139,7 +139,7 @@ async def test_agent_processes_direct_mention(
 
                 # Verify message was sent (thinking + streaming updates)
                 # With streaming: 1 thinking message + streaming updates
-                assert bot.client.room_send.call_count >= 1  # type: ignore[union-attr]
+                assert bot.client.room_send.call_count >= 1
 
 
 @pytest.mark.asyncio
@@ -184,7 +184,7 @@ async def test_agent_ignores_other_agents(
 
             # Should not process the message
             mock_ai.assert_not_called()
-            bot.client.room_send.assert_not_called()  # type: ignore[union-attr]
+            bot.client.room_send.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -294,10 +294,10 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             # Should process the message as only agent in thread
             mock_ai.assert_called_once()
             # With stop button: The test is mocking room_send incorrectly so only 2 succeed
-            assert bot.client.room_send.call_count == 2  # type: ignore[union-attr]
+            assert bot.client.room_send.call_count == 2
 
         # Test 2: Thread with multiple agents - should form team and respond
-        bot.client.room_send.reset_mock()  # type: ignore[union-attr]
+        bot.client.room_send.reset_mock()
         mock_team_arun.reset_mock()
 
         # Create a new message event with a different ID for Test 2
@@ -351,10 +351,10 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             # Should form team and send team response when multiple agents in thread
             mock_ai.assert_not_called()
             mock_team_arun.assert_called_once()
-            assert bot.client.room_send.call_count == 2  # type: ignore[union-attr]  # Team response (thinking + final)
+            assert bot.client.room_send.call_count == 2  # Team response (thinking + final)
 
         # Reset mocks for Test 3
-        bot.client.room_send.reset_mock()  # type: ignore[union-attr]
+        bot.client.room_send.reset_mock()
         mock_team_arun.reset_mock()
 
         # Test 3: Thread with multiple agents WITH mention - should respond
@@ -422,8 +422,8 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             )
 
             # Verify thread response format (team response with mocking issue)
-            assert bot.client.room_send.call_count == 2  # type: ignore[union-attr]
-            sent_content = bot.client.room_send.call_args[1]["content"]  # type: ignore[union-attr]
+            assert bot.client.room_send.call_count == 2
+            sent_content = bot.client.room_send.call_args[1]["content"]
             assert sent_content["m.relates_to"]["rel_type"] == "m.thread"
             assert sent_content["m.relates_to"]["event_id"] == thread_root_id
 
@@ -521,4 +521,4 @@ async def test_agent_handles_room_invite(mock_calculator_agent: AgentMatrixUser,
         await bot._on_invite(mock_room, mock_event)
 
         # Verify new room was joined (not the initial room)
-        bot.client.join.assert_called_with(invite_room)  # type: ignore[union-attr]
+        bot.client.join.assert_called_with(invite_room)

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -948,7 +948,7 @@ class TestSessionIdDerivation:
         original_derive = _derive_session_id
 
         def capture_session_id(*args: object, **kwargs: object) -> str:
-            sid = original_derive(*args, **kwargs)  # type: ignore[arg-type]
+            sid = original_derive(*args, **kwargs)
             session_ids.append(sid)
             return sid
 
@@ -1073,7 +1073,7 @@ class TestContentExtraction:
         content: list[dict] = [
             {"type": "text"},  # missing "text" key
             {"type": "text", "text": "Valid"},
-            "not a dict",  # type: ignore[list-item]
+            "not a dict",
         ]
         assert _extract_content_text(content) == "Valid"
 

--- a/tests/test_response_tracking_regression.py
+++ b/tests/test_response_tracking_regression.py
@@ -168,7 +168,7 @@ class TestResponseTrackingRegression:
         mock_room.users = {mock_router_agent.user_id: MagicMock()}
 
         # Mock the necessary methods for _on_message flow
-        bot._extract_message_context = AsyncMock()  # type: ignore[method-assign]
+        bot._extract_message_context = AsyncMock()
         mock_context = MagicMock()
         mock_context.am_i_mentioned = False
         mock_context.is_thread = False
@@ -179,7 +179,7 @@ class TestResponseTrackingRegression:
 
         # Mock the _send_response to track the call
         original_send_response = bot._send_response
-        bot._send_response = AsyncMock(side_effect=original_send_response)  # type: ignore[method-assign]
+        bot._send_response = AsyncMock(side_effect=original_send_response)
 
         # Mock constants to make router handle commands
         with patch("mindroom.constants.ROUTER_AGENT_NAME", "router"):

--- a/tests/test_routing_integration.py
+++ b/tests/test_routing_integration.py
@@ -125,12 +125,12 @@ class TestRoutingIntegration:
         await news_bot._on_message(mock_room, user_message)
 
         # Only research bot should respond (streaming makes 2 calls)
-        assert research_bot.client.room_send.call_count >= 1  # type: ignore[union-attr]  # At least initial message
-        assert news_bot.client.room_send.call_count == 0  # type: ignore[union-attr]
+        assert research_bot.client.room_send.call_count >= 1  # At least initial message
+        assert news_bot.client.room_send.call_count == 0
 
         # Router should NOT have been called at all
         assert mock_suggest_agent.call_count == 0
 
         # Verify the response was sent
-        last_call = research_bot.client.room_send.call_args_list[-1]  # type: ignore[union-attr]
+        last_call = research_bot.client.room_send.call_args_list[-1]
         assert "body" in last_call[1]["content"]

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -102,8 +102,8 @@ class TestRoutingRegression:
         mock_send_response = MagicMock()
         mock_send_response.__class__ = nio.RoomSendResponse
         mock_send_response.event_id = "$response_123"
-        research_bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
-        news_bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
+        research_bot.client.room_send.return_value = mock_send_response
+        news_bot.client.room_send.return_value = mock_send_response
 
         # Create room with both agents
         mock_room = MagicMock()
@@ -127,12 +127,12 @@ class TestRoutingRegression:
 
         # Process with research bot - SHOULD respond
         await research_bot._on_message(mock_room, message_event)
-        assert research_bot.client.room_send.call_count == 3  # type: ignore[union-attr]  # thinking + 🛑 + final
+        assert research_bot.client.room_send.call_count == 3  # thinking + 🛑 + final
         assert mock_ai_response.call_count == 1
 
         # Process with news bot - should NOT respond and NOT use router
         await news_bot._on_message(mock_room, message_event)
-        assert news_bot.client.room_send.call_count == 0  # type: ignore[union-attr]
+        assert news_bot.client.room_send.call_count == 0
         # Router should NOT have been called
         assert mock_suggest_agent.call_count == 0
 
@@ -193,9 +193,9 @@ class TestRoutingRegression:
         mock_send_response = MagicMock()
         mock_send_response.__class__ = nio.RoomSendResponse
         mock_send_response.event_id = "$response_123"
-        router_bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
-        research_bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
-        news_bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
+        router_bot.client.room_send.return_value = mock_send_response
+        research_bot.client.room_send.return_value = mock_send_response
+        news_bot.client.room_send.return_value = mock_send_response
 
         # Create room with all agents
         mock_room = MagicMock()
@@ -223,13 +223,13 @@ class TestRoutingRegression:
         # Router SHOULD have been called
         mock_suggest_agent.assert_called_once()
         # Router bot should send the routing message
-        assert router_bot.client.room_send.call_count == 1  # type: ignore[union-attr]  # Router doesn't use stop button
+        assert router_bot.client.room_send.call_count == 1  # Router doesn't use stop button
 
         # Process with other bots - they should not do anything
         await research_bot._on_message(mock_room, message_event)
         await news_bot._on_message(mock_room, message_event)
-        assert research_bot.client.room_send.call_count == 0  # type: ignore[union-attr]
-        assert news_bot.client.room_send.call_count == 0  # type: ignore[union-attr]
+        assert research_bot.client.room_send.call_count == 0
+        assert news_bot.client.room_send.call_count == 0
 
     @pytest.mark.asyncio
     @patch("mindroom.teams.Team.arun")
@@ -297,8 +297,8 @@ class TestRoutingRegression:
         mock_send_response = MagicMock()
         mock_send_response.__class__ = nio.RoomSendResponse
         mock_send_response.event_id = "$response_123"
-        research_bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
-        news_bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
+        research_bot.client.room_send.return_value = mock_send_response
+        news_bot.client.room_send.return_value = mock_send_response
 
         # Create room
         mock_room = MagicMock()
@@ -323,8 +323,8 @@ class TestRoutingRegression:
         # With simplified team behavior: multiple mentions should form a team
         # The alphabetically first agent (news) handles team formation
         # The other agent (research) does not respond individually
-        assert research_bot.client.room_send.call_count == 0  # type: ignore[union-attr]  # No individual response
-        assert news_bot.client.room_send.call_count == 2  # type: ignore[union-attr]  # Team response (thinking + final)
+        assert research_bot.client.room_send.call_count == 0  # No individual response
+        assert news_bot.client.room_send.call_count == 2  # Team response (thinking + final)
         assert mock_team_arun.call_count == 1  # Team formed once
 
     @pytest.mark.asyncio
@@ -369,8 +369,8 @@ class TestRoutingRegression:
         mock_send_response = MagicMock()
         mock_send_response.__class__ = nio.RoomSendResponse
         mock_send_response.event_id = "$router_msg"
-        router_bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
-        research_bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
+        router_bot.client.room_send.return_value = mock_send_response
+        research_bot.client.room_send.return_value = mock_send_response
 
         # Create room
         mock_room = MagicMock()
@@ -393,5 +393,5 @@ class TestRoutingRegression:
         await research_bot._on_message(mock_room, router_message)
 
         # Research bot SHOULD respond
-        assert research_bot.client.room_send.call_count == 3  # type: ignore[union-attr]  # thinking + 🛑 + final
+        assert research_bot.client.room_send.call_count == 3  # thinking + 🛑 + final
         assert mock_ai_response.call_count == 1

--- a/tests/test_scheduled_task_restoration.py
+++ b/tests/test_scheduled_task_restoration.py
@@ -21,7 +21,7 @@ class TestScheduledTaskRestoration:
         """Test that only the router agent restores scheduled tasks."""
         # Create a mock config with multiple agents
         config = Config(
-            agents={  # type: ignore[arg-type]
+            agents={
                 "general": {
                     "display_name": "GeneralAgent",
                     "role": "General assistant",
@@ -35,7 +35,7 @@ class TestScheduledTaskRestoration:
                     "rooms": ["lobby"],
                 },
             },
-            models={"default": {"provider": "test", "id": "test-model"}},  # type: ignore[arg-type]
+            models={"default": {"provider": "test", "id": "test-model"}},
         )
 
         # Test with RouterAgent
@@ -69,7 +69,7 @@ class TestScheduledTaskRestoration:
     async def test_non_router_agents_dont_restore_tasks(self) -> None:
         """Test that non-router agents don't restore scheduled tasks."""
         config = Config(
-            agents={  # type: ignore[arg-type]
+            agents={
                 "general": {
                     "display_name": "GeneralAgent",
                     "role": "General assistant",
@@ -77,7 +77,7 @@ class TestScheduledTaskRestoration:
                     "rooms": ["lobby"],
                 },
             },
-            models={"default": {"provider": "test", "id": "test-model"}},  # type: ignore[arg-type]
+            models={"default": {"provider": "test", "id": "test-model"}},
         )
 
         # Test with regular agent (not router)
@@ -111,7 +111,7 @@ class TestScheduledTaskRestoration:
     async def test_multiple_agents_only_router_restores(self) -> None:
         """Test that when multiple agents join a room, only router restores tasks."""
         config = Config(
-            agents={  # type: ignore[arg-type]
+            agents={
                 "general": {
                     "display_name": "GeneralAgent",
                     "role": "General assistant",
@@ -125,7 +125,7 @@ class TestScheduledTaskRestoration:
                     "rooms": ["lobby"],
                 },
             },
-            models={"default": {"provider": "test", "id": "test-model"}},  # type: ignore[arg-type]
+            models={"default": {"provider": "test", "id": "test-model"}},
         )
 
         agents_to_test = [

--- a/tests/test_streaming_e2e.py
+++ b/tests/test_streaming_e2e.py
@@ -72,11 +72,11 @@ async def test_streaming_edits_e2e(  # noqa: C901, PLR0915
         # Set a proper user_id based on agent_name if we have agent_name
         if hasattr(bot_self, "agent_name"):
             if bot_self.agent_name == "helper":
-                bot_self.agent_user.user_id = "@mindroom_helper:localhost"  # type: ignore[attr-defined]
+                bot_self.agent_user.user_id = "@mindroom_helper:localhost"
             elif bot_self.agent_name == "calculator":
-                bot_self.agent_user.user_id = "@mindroom_calculator:localhost"  # type: ignore[attr-defined]
+                bot_self.agent_user.user_id = "@mindroom_calculator:localhost"
             elif bot_self.agent_name == "router":
-                bot_self.agent_user.user_id = "@mindroom_router:localhost"  # type: ignore[attr-defined]
+                bot_self.agent_user.user_id = "@mindroom_router:localhost"
         elif hasattr(bot_self, "agent_user") and hasattr(bot_self.agent_user, "agent_name"):
             # Alternative: get agent_name from agent_user
             agent_user = bot_self.agent_user
@@ -185,14 +185,14 @@ async def test_streaming_edits_e2e(  # noqa: C901, PLR0915
             ) -> object:
                 # Update the agent_user with proper user_id
                 if entity_name == "helper":
-                    agent_user.user_id = "@mindroom_helper:localhost"  # type: ignore[attr-defined]
+                    agent_user.user_id = "@mindroom_helper:localhost"
                 elif entity_name == "calculator":
-                    agent_user.user_id = "@mindroom_calculator:localhost"  # type: ignore[attr-defined]
+                    agent_user.user_id = "@mindroom_calculator:localhost"
                 elif entity_name == "router":
-                    agent_user.user_id = "@mindroom_router:localhost"  # type: ignore[attr-defined]
+                    agent_user.user_id = "@mindroom_router:localhost"
 
                 # Create the actual bot with config
-                return AgentBot(agent_user, Path(str(storage_path)), config, rooms=[test_room_id])  # type: ignore[arg-type]
+                return AgentBot(agent_user, Path(str(storage_path)), config, rooms=[test_room_id])
 
             mock_create_bot.side_effect = create_bot_side_effect
             await orchestrator.initialize()

--- a/tests/test_streaming_edits.py
+++ b/tests/test_streaming_edits.py
@@ -83,7 +83,7 @@ class TestStreamingEdits:
         # Mock successful room_send response
         mock_send_response = MagicMock()
         mock_send_response.__class__ = nio.RoomSendResponse
-        bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
+        bot.client.room_send.return_value = mock_send_response
 
         # Mock AI response
         mock_ai_response.return_value = "I can help with that!"
@@ -106,11 +106,11 @@ class TestStreamingEdits:
 
         # Process initial message - bot should respond
         await bot._on_message(mock_room, initial_event)
-        assert bot.client.room_send.call_count == 2  # type: ignore[union-attr]  # thinking + final
+        assert bot.client.room_send.call_count == 2  # thinking + final
         assert mock_ai_response.call_count == 1
 
         # Reset mocks
-        bot.client.room_send.reset_mock()  # type: ignore[union-attr]
+        bot.client.room_send.reset_mock()
         mock_ai_response.reset_mock()
 
         # Edit event 1 - simulating streaming update
@@ -136,7 +136,7 @@ class TestStreamingEdits:
         # Process edit - bot SHOULD regenerate its response
         await bot._on_message(mock_room, edit_event1)
         # Bot should regenerate: 1 call for thinking message (non-streaming, editing existing)
-        assert bot.client.room_send.call_count == 1  # type: ignore[union-attr]  # thinking message only
+        assert bot.client.room_send.call_count == 1  # thinking message only
         assert mock_ai_response.call_count == 1  # AI should be called again for regeneration
 
         # Edit event 2 - another streaming update
@@ -160,12 +160,12 @@ class TestStreamingEdits:
         }
 
         # Reset mocks again
-        bot.client.room_send.reset_mock()  # type: ignore[union-attr]
+        bot.client.room_send.reset_mock()
         mock_ai_response.reset_mock()
 
         # Process second edit - bot should regenerate again
         await bot._on_message(mock_room, edit_event2)
-        assert bot.client.room_send.call_count == 1  # type: ignore[union-attr]  # thinking message only
+        assert bot.client.room_send.call_count == 1  # thinking message only
         assert mock_ai_response.call_count == 1  # AI should be called again
 
     @pytest.mark.asyncio
@@ -183,7 +183,7 @@ class TestStreamingEdits:
         # Mock successful room_send response
         mock_send_response = MagicMock()
         mock_send_response.__class__ = nio.RoomSendResponse
-        bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
+        bot.client.room_send.return_value = mock_send_response
 
         # Mock AI response
         mock_ai_response.return_value = "Here's the answer!"
@@ -209,7 +209,7 @@ class TestStreamingEdits:
 
         # Process new message - bot SHOULD respond
         await bot._on_message(mock_room, new_event)
-        assert bot.client.room_send.call_count == 2  # type: ignore[union-attr]  # thinking + final
+        assert bot.client.room_send.call_count == 2  # thinking + final
         assert mock_ai_response.call_count == 1
 
     @pytest.mark.asyncio
@@ -227,7 +227,7 @@ class TestStreamingEdits:
         # Mock successful room_send response
         mock_send_response = MagicMock()
         mock_send_response.__class__ = nio.RoomSendResponse
-        bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
+        bot.client.room_send.return_value = mock_send_response
 
         # Mock AI response
         mock_ai_response.return_value = "I can help with that!"
@@ -249,7 +249,7 @@ class TestStreamingEdits:
 
         # Process initial message - calculator should NOT respond (not mentioned)
         await bot._on_message(mock_room, initial_event)
-        assert bot.client.room_send.call_count == 0  # type: ignore[union-attr]
+        assert bot.client.room_send.call_count == 0
         assert mock_ai_response.call_count == 0
 
         # Edit from agent that NOW mentions calculator (with in-progress marker)
@@ -277,7 +277,7 @@ class TestStreamingEdits:
             # Make extract_agent_name return 'helper' for the sender
             mock_extract.return_value = "helper"
             await bot._on_message(mock_room, edit_event)
-        assert bot.client.room_send.call_count == 0  # type: ignore[union-attr]
+        assert bot.client.room_send.call_count == 0
         assert mock_ai_response.call_count == 0
 
     @pytest.mark.asyncio
@@ -299,7 +299,7 @@ class TestStreamingEdits:
         # Mock successful room_send response
         mock_send_response = MagicMock()
         mock_send_response.__class__ = nio.RoomSendResponse
-        bot.client.room_send.return_value = mock_send_response  # type: ignore[union-attr]
+        bot.client.room_send.return_value = mock_send_response
 
         # Mock AI response
         mock_ai_response.return_value = "I can help with that!"
@@ -321,7 +321,7 @@ class TestStreamingEdits:
 
         # Process initial message - calculator should NOT respond (not mentioned)
         await bot._on_message(mock_room, initial_event)
-        assert bot.client.room_send.call_count == 0  # type: ignore[union-attr]
+        assert bot.client.room_send.call_count == 0
         assert mock_ai_response.call_count == 0
 
         # Edit from user that NOW mentions calculator
@@ -346,5 +346,5 @@ class TestStreamingEdits:
 
         # Process edit - calculator should NOT respond (bot ignores all edits)
         await bot._on_message(mock_room, edit_event)
-        assert bot.client.room_send.call_count == 0  # type: ignore[union-attr]
+        assert bot.client.room_send.call_count == 0
         assert mock_ai_response.call_count == 0

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -219,7 +219,7 @@ async def test_new_agent_not_started_twice() -> None:
         orchestrator = MultiAgentOrchestrator(storage_path=MagicMock())
 
         old_config = Config(
-            agents={  # type: ignore[arg-type]
+            agents={
                 "general": {
                     "display_name": "GeneralAgent",
                     "role": "General assistant",
@@ -227,7 +227,7 @@ async def test_new_agent_not_started_twice() -> None:
                     "rooms": ["lobby"],
                 },
             },
-            models={"default": {"provider": "test", "id": "test-model"}},  # type: ignore[arg-type]
+            models={"default": {"provider": "test", "id": "test-model"}},
         )
         orchestrator.config = old_config
 
@@ -241,7 +241,7 @@ async def test_new_agent_not_started_twice() -> None:
 
         # --- new config adds "coach" ---
         new_config = Config(
-            agents={  # type: ignore[arg-type]
+            agents={
                 "general": {
                     "display_name": "GeneralAgent",
                     "role": "General assistant",
@@ -255,7 +255,7 @@ async def test_new_agent_not_started_twice() -> None:
                     "rooms": ["lobby", "personal"],
                 },
             },
-            models={"default": {"provider": "test", "id": "test-model"}},  # type: ignore[arg-type]
+            models={"default": {"provider": "test", "id": "test-model"}},
         )
         mock_from_yaml.return_value = new_config
 

--- a/tests/test_team_scheduler_context.py
+++ b/tests/test_team_scheduler_context.py
@@ -47,8 +47,8 @@ def _make_bot(tmp_path: Path) -> AgentBot:
     bot.client.user_id = agent_user.user_id
     bot.client.rooms = {"!team:localhost": MagicMock(room_id="!team:localhost")}
     bot.orchestrator = MagicMock(config=config)
-    bot._send_response = AsyncMock(return_value="$team_response")  # type: ignore[method-assign]
-    bot._handle_interactive_question = AsyncMock()  # type: ignore[method-assign]
+    bot._send_response = AsyncMock(return_value="$team_response")
+    bot._handle_interactive_question = AsyncMock()
     return bot
 
 
@@ -69,7 +69,7 @@ async def test_team_non_streaming_has_scheduler_context(tmp_path: Path) -> None:
         assert get_scheduling_tool_context() is not None
         return "team non-streaming response"
 
-    bot._run_cancellable_response = AsyncMock(side_effect=fake_run_cancellable_response)  # type: ignore[method-assign]
+    bot._run_cancellable_response = AsyncMock(side_effect=fake_run_cancellable_response)
 
     with (
         patch("mindroom.bot.should_use_streaming", new=AsyncMock(return_value=False)),
@@ -110,7 +110,7 @@ async def test_team_streaming_has_scheduler_context(tmp_path: Path) -> None:
         assert get_scheduling_tool_context() is not None
         yield "stream chunk"
 
-    bot._run_cancellable_response = AsyncMock(side_effect=fake_run_cancellable_response)  # type: ignore[method-assign]
+    bot._run_cancellable_response = AsyncMock(side_effect=fake_run_cancellable_response)
 
     with (
         patch("mindroom.bot.should_use_streaming", new=AsyncMock(return_value=True)),

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -90,7 +90,7 @@ class TestThreadingBehavior:
     @pytest.mark.asyncio
     async def test_agent_creates_thread_when_mentioned_in_main_room(self, bot: AgentBot) -> None:
         """Test that agents create threads when mentioned in main room messages."""
-        room = nio.MatrixRoom(room_id="!test:localhost", own_user_id=bot.client.user_id)  # type: ignore[union-attr]
+        room = nio.MatrixRoom(room_id="!test:localhost", own_user_id=bot.client.user_id)
         room.name = "Test Room"
 
         # Create a main room message that mentions the agent
@@ -110,12 +110,12 @@ class TestThreadingBehavior:
         )
 
         # The bot should send a response
-        bot.client.room_send = AsyncMock(  # type: ignore[union-attr]
+        bot.client.room_send = AsyncMock(
             return_value=nio.RoomSendResponse.from_dict({"event_id": "$response:localhost"}, room_id="!test:localhost"),
         )
 
         # Mock thread history fetch (returns empty for new thread)
-        bot.client.room_messages = AsyncMock(  # type: ignore[union-attr]
+        bot.client.room_messages = AsyncMock(
             return_value=nio.RoomMessagesResponse.from_dict(
                 {"chunk": [], "start": "s1", "end": "e1"},
                 room_id="!test:localhost",
@@ -123,7 +123,7 @@ class TestThreadingBehavior:
         )
 
         # Initialize the bot (to set up components it needs)
-        bot.response_tracker.has_responded.return_value = False  # type: ignore[attr-defined]
+        bot.response_tracker.has_responded.return_value = False
 
         # Mock interactive.handle_text_response to return None (not an interactive response)
         # Mock _generate_response to capture the call and send a test response
@@ -141,10 +141,10 @@ class TestThreadingBehavior:
             await bot._send_response(room.room_id, event.event_id, "I can help you with that!", None)
 
         # Verify the bot sent a response
-        bot.client.room_send.assert_called_once()  # type: ignore[union-attr]
+        bot.client.room_send.assert_called_once()
 
         # Check the content of the response
-        call_args = bot.client.room_send.call_args  # type: ignore[union-attr]
+        call_args = bot.client.room_send.call_args
         content = call_args.kwargs["content"]
 
         # The response should create a thread from the original message
@@ -156,7 +156,7 @@ class TestThreadingBehavior:
     @pytest.mark.asyncio
     async def test_agent_responds_in_existing_thread(self, bot: AgentBot) -> None:
         """Test that agents respond correctly in existing threads."""
-        room = nio.MatrixRoom(room_id="!test:localhost", own_user_id=bot.client.user_id)  # type: ignore[union-attr]
+        room = nio.MatrixRoom(room_id="!test:localhost", own_user_id=bot.client.user_id)
         room.name = "Test Room"
 
         # Create a message in a thread
@@ -177,12 +177,12 @@ class TestThreadingBehavior:
         )
 
         # Mock the bot's response
-        bot.client.room_send = AsyncMock(  # type: ignore[union-attr]
+        bot.client.room_send = AsyncMock(
             return_value=nio.RoomSendResponse.from_dict({"event_id": "$response:localhost"}, room_id="!test:localhost"),
         )
 
         # Mock thread history
-        bot.client.room_messages = AsyncMock(  # type: ignore[union-attr]
+        bot.client.room_messages = AsyncMock(
             return_value=nio.RoomMessagesResponse.from_dict(
                 {"chunk": [], "start": "s1", "end": "e1"},
                 room_id="!test:localhost",
@@ -190,7 +190,7 @@ class TestThreadingBehavior:
         )
 
         # Initialize response tracking
-        bot.response_tracker.has_responded.return_value = False  # type: ignore[attr-defined]
+        bot.response_tracker.has_responded.return_value = False
 
         # Mock interactive.handle_text_response and make AI fast
         with (
@@ -202,10 +202,10 @@ class TestThreadingBehavior:
             await bot._on_message(room, event)
 
         # Verify the bot sent messages (thinking + final)
-        assert bot.client.room_send.call_count == 2  # type: ignore[union-attr]
+        assert bot.client.room_send.call_count == 2
 
         # Check the initial message (first call)
-        first_call = bot.client.room_send.call_args_list[0]  # type: ignore[union-attr]
+        first_call = bot.client.room_send.call_args_list[0]
         initial_content = first_call.kwargs["content"]
         assert "m.relates_to" in initial_content
         assert initial_content["m.relates_to"]["rel_type"] == "m.thread"
@@ -419,7 +419,7 @@ class TestThreadingBehavior:
     @pytest.mark.asyncio
     async def test_message_with_multiple_relations_handled_correctly(self, bot: AgentBot) -> None:
         """Test that messages with complex relations are handled properly."""
-        room = nio.MatrixRoom(room_id="!test:localhost", own_user_id=bot.client.user_id)  # type: ignore[union-attr]
+        room = nio.MatrixRoom(room_id="!test:localhost", own_user_id=bot.client.user_id)
         room.name = "Test Room"
 
         # Create a message that's both in a thread AND a reply (complex relations)
@@ -444,12 +444,12 @@ class TestThreadingBehavior:
         )
 
         # Mock the bot's response
-        bot.client.room_send = AsyncMock(  # type: ignore[union-attr]
+        bot.client.room_send = AsyncMock(
             return_value=nio.RoomSendResponse.from_dict({"event_id": "$response:localhost"}, room_id="!test:localhost"),
         )
 
         # Mock thread history
-        bot.client.room_messages = AsyncMock(  # type: ignore[union-attr]
+        bot.client.room_messages = AsyncMock(
             return_value=nio.RoomMessagesResponse.from_dict(
                 {"chunk": [], "start": "s1", "end": "e1"},
                 room_id="!test:localhost",
@@ -457,7 +457,7 @@ class TestThreadingBehavior:
         )
 
         # Initialize response tracking
-        bot.response_tracker.has_responded.return_value = False  # type: ignore[attr-defined]
+        bot.response_tracker.has_responded.return_value = False
 
         # Mock interactive.handle_text_response and generate_response
         with (
@@ -479,10 +479,10 @@ class TestThreadingBehavior:
             )
 
         # Verify the bot sent a response
-        bot.client.room_send.assert_called_once()  # type: ignore[union-attr]
+        bot.client.room_send.assert_called_once()
 
         # Check the content
-        call_args = bot.client.room_send.call_args  # type: ignore[union-attr]
+        call_args = bot.client.room_send.call_args
         content = call_args.kwargs["content"]
 
         # The response should maintain the thread context

--- a/tests/test_tool_config_sync.py
+++ b/tests/test_tool_config_sync.py
@@ -36,7 +36,7 @@ def verify_tool_configfields(tool_name: str, tool_class: type) -> None:  # noqa:
 
     """
     # Get the actual parameters from agno
-    sig = inspect.signature(tool_class.__init__)  # type: ignore[misc]
+    sig = inspect.signature(tool_class.__init__)
     agno_params = {}
 
     for name, param in sig.parameters.items():

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -31,7 +31,7 @@ def mock_router_bot() -> AgentBot:
         bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
     bot.client = AsyncMock()
     bot.logger = MagicMock()
-    bot._send_response = AsyncMock()  # type: ignore[method-assign]
+    bot._send_response = AsyncMock()
     bot.response_tracker = MagicMock()
     bot.response_tracker.has_responded.return_value = False
     return bot
@@ -55,8 +55,8 @@ async def test_voice_message_in_main_room_creates_thread(mock_router_bot: AgentB
         await bot._on_voice_message(room, voice_event)
 
         # Verify _send_response was called with correct threading
-        bot._send_response.assert_called_once()  # type: ignore[attr-defined]
-        call_kwargs = bot._send_response.call_args[1]  # type: ignore[attr-defined]
+        bot._send_response.assert_called_once()
+        call_kwargs = bot._send_response.call_args[1]
 
         # Should reply to voice message
         assert call_kwargs["reply_to_event_id"] == "$voice123"
@@ -91,8 +91,8 @@ async def test_voice_message_in_thread_continues_thread(mock_router_bot: AgentBo
         await bot._on_voice_message(room, voice_event)
 
         # Verify _send_response was called with correct threading
-        bot._send_response.assert_called_once()  # type: ignore[attr-defined]
-        call_kwargs = bot._send_response.call_args[1]  # type: ignore[attr-defined]
+        bot._send_response.assert_called_once()
+        call_kwargs = bot._send_response.call_args[1]
 
         # Should reply to voice message
         assert call_kwargs["reply_to_event_id"] == "$voice456"

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -99,7 +99,7 @@ class TestVoiceHandler:
                 return True
             if obj is response and cls is nio.DownloadError:
                 return False  # Not an error
-            return isinstance.__wrapped__(obj, cls)  # type: ignore[attr-defined]
+            return isinstance.__wrapped__(obj, cls)
 
         with patch("mindroom.voice_handler.isinstance", side_effect=mock_isinstance_check):
             result = await voice_handler._download_audio(client, event)

--- a/tests/test_voice_thread_agent_response.py
+++ b/tests/test_voice_thread_agent_response.py
@@ -32,7 +32,7 @@ def mock_home_bot() -> AgentBot:
         bot = AgentBot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
     bot.client = AsyncMock()
     bot.logger = MagicMock()
-    bot._generate_response = AsyncMock()  # type: ignore[method-assign]
+    bot._generate_response = AsyncMock()
     bot.response_tracker = MagicMock()
     bot.response_tracker.has_responded.return_value = False
     return bot


### PR DESCRIPTION
## Summary
- Enable `error-on-warning = true` so new ty warnings are immediately caught as errors
- Remove `unused-type-ignore-comment` from test overrides (no longer needed since stale comments are cleaned up)
- Remove 142 stale `# type: ignore[...]` comments across 20 test files, replaced by centralized test overrides
- Sort and document the 9 override rules for clarity
- Fix `log_message` parameter name override in `test_claude_agent_tool.py`

## Test plan
- [x] `ty check src/ tests/` passes with zero diagnostics
- [x] `pre-commit run ty --all-files` passes
- [x] `pytest` — 1115 passed, 21 skipped