### PR TITLE
fix: replace deprecated FastAPI on_event with lifespan context manager

### DIFF
--- a/saas-platform/platform-backend/src/main.py
+++ b/saas-platform/platform-backend/src/main.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import logging
 import socket
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -44,8 +46,48 @@ if TYPE_CHECKING:
 
     from starlette.responses import Response as StarletteResponse
 
+
+def _run_cleanup_job() -> None:
+    """Execute periodic cleanup tasks with logging."""
+    try:
+        result = run_all_cleanup_tasks()
+        logger = logging.getLogger("mindroom.cleanup")
+        logger.info("Cleanup job completed", extra={"result": result})
+    except Exception:  # noqa: BLE001
+        logging.getLogger("mindroom.cleanup").exception("Scheduled cleanup job failed")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Manage application startup and shutdown."""
+    # Start cleanup scheduler if enabled
+    if ENABLE_CLEANUP_SCHEDULER:
+        scheduler = AsyncIOScheduler(timezone="UTC")
+        scheduler.add_job(
+            _run_cleanup_job,
+            trigger="cron",
+            hour=3,
+            minute=0,
+            id="daily_cleanup",
+            replace_existing=True,
+            misfire_grace_time=3600,
+        )
+        scheduler.start()
+        app.state.cleanup_scheduler = scheduler
+        logging.getLogger("mindroom.cleanup").info("Cleanup scheduler started (daily at 03:00 UTC)")
+
+    yield
+
+    # Shut down cleanup scheduler
+    scheduler_ref: AsyncIOScheduler | None = getattr(app.state, "cleanup_scheduler", None)
+    if scheduler_ref:
+        scheduler_ref.shutdown(wait=False)
+        logging.getLogger("mindroom.cleanup").info("Cleanup scheduler stopped")
+        app.state.cleanup_scheduler = None
+
+
 # FastAPI app
-app = FastAPI(title="MindRoom Backend")
+app = FastAPI(title="MindRoom Backend", lifespan=lifespan)
 
 instrument_app(app)
 
@@ -182,50 +224,6 @@ app.include_router(gdpr.router)
 
 # Keep a reference list of primary endpoints for tooling/tests that grep this file
 EXPOSED_ENDPOINTS = ["/my/subscription", "/my/usage", "/my/account/admin-status", "/admin/stats"]
-
-
-def _run_cleanup_job() -> None:
-    """Execute periodic cleanup tasks with logging."""
-
-    try:
-        result = run_all_cleanup_tasks()
-        logger = logging.getLogger("mindroom.cleanup")
-        logger.info("Cleanup job completed", extra={"result": result})
-    except Exception:  # noqa: BLE001
-        logging.getLogger("mindroom.cleanup").exception("Scheduled cleanup job failed")
-
-
-@app.on_event("startup")
-async def start_cleanup_scheduler() -> None:
-    """Start APScheduler for periodic cleanup when enabled."""
-
-    if not ENABLE_CLEANUP_SCHEDULER:
-        return
-
-    scheduler = AsyncIOScheduler(timezone="UTC")
-    scheduler.add_job(
-        _run_cleanup_job,
-        trigger="cron",
-        hour=3,
-        minute=0,
-        id="daily_cleanup",
-        replace_existing=True,
-        misfire_grace_time=3600,
-    )
-    scheduler.start()
-    app.state.cleanup_scheduler = scheduler
-    logging.getLogger("mindroom.cleanup").info("Cleanup scheduler started (daily at 03:00 UTC)")
-
-
-@app.on_event("shutdown")
-async def stop_cleanup_scheduler() -> None:
-    """Shut down the APScheduler instance on application exit."""
-
-    scheduler: AsyncIOScheduler | None = getattr(app.state, "cleanup_scheduler", None)
-    if scheduler:
-        scheduler.shutdown(wait=False)
-        logging.getLogger("mindroom.cleanup").info("Cleanup scheduler stopped")
-        app.state.cleanup_scheduler = None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace deprecated `@app.on_event("startup")` / `@app.on_event("shutdown")` with the modern `lifespan` async context manager pattern in both FastAPI apps
- `src/mindroom/api/main.py`: credential sync (startup) and file watcher cleanup (shutdown) now live in a single `lifespan` function
- `saas-platform/platform-backend/src/main.py`: APScheduler startup/shutdown now lives in a single `lifespan` function

## Test plan
- [x] All 115 core API tests pass (`test_credentials_api.py`, `test_openai_compat.py`)
- [x] All 285 SaaS backend tests pass
- [x] Pre-commit hooks pass (ruff, ty, formatting)