### PR TITLE
fix(docs): Fix 13 documentation issues from comprehensive review

### DIFF
--- a/.prompts/docs-review.md
+++ b/.prompts/docs-review.md
@@ -78,10 +78,17 @@ For examples in any doc:
 - Are names and references realistic and current?
 - Do examples use current syntax (not deprecated options)?
 - Do setup snippets reference real files/flags/commands that exist in this repo/CLI?
+- Do NOT flag AI model names as invalid based on your training cutoff — look them up online first
 
 ### 6. Cross-Reference Consistency
 
 The same info appears in multiple places. Check for conflicts between README.md, `docs/`, and `CLAUDE.md`.
+
+Also verify that script paths and file references in CLAUDE.md and `docs/deployment/` match the actual filesystem layout.
+
+### 6b. Verify Deployment Docs
+
+Check `docs/deployment/` files against actual Dockerfiles, Helm charts, scripts, and environment variable defaults in `src/mindroom/constants.py`.
 
 ### 7. Self-Check This Prompt
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ MindRoom - AI agents that live in Matrix and work everywhere via bridges. The pr
 | `config.py` | Pydantic models for YAML config parsing |
 | `routing.py` | Intelligent agent selection when no agent is mentioned |
 | `teams.py` | Multi-agent collaboration (coordinate vs collaborate modes) |
-| `memory/` | Mem0-inspired dual memory: agent, room, and team-scoped |
+| `memory/` | Mem0 dual memory: agent, room, and team-scoped |
 | `knowledge.py` | Knowledge base / RAG file indexing with watcher |
 | `skills.py` | Skill integration system (OpenClaw-compatible) |
 | `plugins.py` | Plugin loading and tool/skill extension |
@@ -40,6 +40,11 @@ MindRoom - AI agents that live in Matrix and work everywhere via bridges. The pr
 | `ai.py` | AI model instantiation, caching, and response generation |
 | `credentials.py` | Unified credential management (CredentialsManager) |
 | `matrix/` | Matrix protocol integration (client, users, rooms, presence) |
+| `commands.py` | Chat command parsing (`!help`, `!schedule`, `!skill`, etc.) |
+| `voice_handler.py` | Voice message download, transcription, and command recognition |
+| `sandbox_proxy.py` | Container sandbox proxy for isolating shell/python tools |
+| `streaming.py` | Response streaming via progressive message edits |
+| `agent_prompts.py` | Rich built-in prompts for named agents (code, research, etc.) |
 
 **Persistent state** lives under `mindroom_data/` (overridable via `STORAGE_PATH`):
 - `sessions/` – Per-agent SQLite event history for Agno conversations
@@ -119,7 +124,7 @@ timezone: America/Los_Angeles
 
 ### Memory System
 
-Mem0-inspired dual memory (`src/mindroom/memory/functions.py`):
+Mem0 dual memory (`src/mindroom/memory/functions.py`):
 - **Agent memory** (`agent_<name>`) – Personal preferences, coding style, tasks
 - **Team memory** – Shared context for team collaboration
 - **Room memory** (`room_<id>`) – Project-specific knowledge
@@ -150,6 +155,7 @@ Teams (`src/mindroom/teams.py`) let multiple agents work together:
 - **Explore the Codebase**: List existing files and read the `README.md` to understand the project's structure and purpose.
 - **READ THE SOURCE CODE**: This library has a `.venv` folder with all the dependencies installed. So read the source code when in doubt.
 - **Consult Documentation**: Review documentation capabilities! If you're unsure, never guess. Do a search online.
+- **Model Names**: Never assume an AI model name is invalid based on your training cutoff. Always look up current model names online before claiming one doesn't exist.
 
 ### Step 2: Environment & Dependencies
 
@@ -184,7 +190,7 @@ curl -s http://localhost:9292/v1/models | head -c 200
 - Add `extra_kwargs.base_url: http://localhost:9292/v1` for those models
 - For memory, prefer `provider: openai` and an embedding model that exists (e.g., `embeddinggemma:300m`)
 
-5) Run the backend with explicit env overrides (use Python 3.13)
+5) Run the backend with explicit env overrides (use Python 3.13; production Dockerfile uses 3.12)
 ```bash
 MATRIX_HOMESERVER=http://localhost:8008 \
 MATRIX_SSL_VERIFY=false \
@@ -236,7 +242,7 @@ cd cluster/k8s/platform
 helm upgrade --install platform . -f values.yaml --namespace mindroom-staging
 
 # Deploy instance - ALWAYS use the provisioner API:
-./scripts/mindroom-cli.sh provision 1
+./cluster/scripts/mindroom-cli.sh provision 1
 
 # The provisioner handles everything:
 # - Creates database records
@@ -259,9 +265,9 @@ cd saas-platform
 ./deploy.sh platform-backend   # Build, push, and deploy backend
 
 # Use the CLI helper for common operations
-./scripts/mindroom-cli.sh status
-./scripts/mindroom-cli.sh list
-./scripts/mindroom-cli.sh logs 1
+./cluster/scripts/mindroom-cli.sh status
+./cluster/scripts/mindroom-cli.sh list
+./cluster/scripts/mindroom-cli.sh logs 1
 ```
 
 ### Step 3: Development & Git

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Writer: I'll compile everything into an executive summary...
 ### 🧠 Dual Memory System
 - **Agent Memory**: Each agent remembers conversations, preferences, and patterns across all platforms
 - **Room Memory**: Contextual knowledge that stays within specific rooms (work projects, personal notes)
-- Tags for sharing memories across related threads
 
 ### 🤝 Multi-Agent Collaboration
 ```
@@ -132,7 +131,7 @@ Gmail, GitHub, Spotify, Home Assistant, Google Drive, Reddit, weather services, 
 ### 📅 Automation & Scheduling
 - Daily check-ins from your mindfulness agent
 - Scheduled reports and summaries
-- Event-based triggers (coming soon)
+- Event-driven workflows (conditional requests converted to polling schedules)
 - Background tasks with human escalation
 
 ## Who This Is For

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -19,7 +19,7 @@ MINDROOM_CONFIG_PATH=/path/to/config.yaml mindroom run
 You can also validate a specific file directly:
 
 ```bash
-mindroom validate --config /path/to/config.yaml
+mindroom validate --config /path/to/config.yaml  # or: -c
 ```
 
 ## Basic Structure

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -51,14 +51,16 @@ The `host` field is converted internally to `openai_base_url` or `ollama_base_ur
 
 Memories are stored in ChromaDB at `<storage_path>/chroma/` with collection name `mindroom_memories`.
 
-## Mem0 Tool (Optional)
+## Memory Tool (Optional)
 
-For explicit memory control, add the `mem0` tool to an agent:
+For explicit memory control, add the `memory` tool to an agent:
 
 ```yaml
 agents:
   assistant:
-    tools: [mem0]
+    tools: [memory]
 ```
 
 This provides functions: `add_memory`, `search_memory`, `get_all_memories`, `delete_all_memories`.
+
+Note: The `memory` tool is for the built-in agent memory system. The separate `mem0` tool is for Mem0's cloud service.

--- a/docs/tools/builtin.md
+++ b/docs/tools/builtin.md
@@ -124,6 +124,7 @@ MindRoom includes 100+ built-in tool integrations organized by category.
 |------|------|-------------|-----------------|
 | :lucide-calendar: | `google_calendar` | View and schedule meetings | Google OAuth |
 | :lucide-calendar: | `cal_com` | Cal.com scheduling | `api_key` |
+| :lucide-calendar: | `scheduler` | Schedule, edit, list, and cancel tasks and reminders | - |
 
 ## Data & Business
 
@@ -176,6 +177,7 @@ MindRoom includes 100+ built-in tool integrations organized by category.
 
 | Icon | Tool | Description | Config Required |
 |------|------|-------------|-----------------|
+| :lucide-database: | `memory` | Explicitly store and search agent memories on demand | - |
 | :lucide-database: | `mem0` | Persistent memory system | `api_key` (optional for cloud) |
 | :lucide-database: | `zep` | Conversation memory | `api_key` |
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -27,7 +27,7 @@ agents:
 
 Tools are organized by category:
 
-- **Development** - File operations, shell, Docker, GitHub, Jira, Python, Airflow, code execution sandboxes (E2B, Daytona), Claude Agent SDK
+- **Development** - File operations, shell, Docker, GitHub, Jira, Python, Airflow, code execution sandboxes (E2B, Daytona, or MindRoom's built-in [container sandbox proxy](../deployment/sandbox-proxy.md)), Claude Agent SDK
 - **Research** - Web search (DuckDuckGo, Tavily, Exa, SerpAPI), academic papers (arXiv, PubMed), Wikipedia, Hacker News, web scraping (Firecrawl, Crawl4AI, Jina)
 - **Communication** - Slack, Discord, Telegram, Twilio, WhatsApp, Webex
 - **Email** - Gmail, AWS SES, Resend, generic SMTP

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -520,7 +520,7 @@ MINDROOM_CONFIG_PATH=/path/to/config.yaml mindroom run
 You can also validate a specific file directly:
 
 ```
-mindroom validate --config /path/to/config.yaml
+mindroom validate --config /path/to/config.yaml  # or: -c
 ```
 
 ## Basic Structure
@@ -1177,7 +1177,7 @@ agents:
 
 Tools are organized by category:
 
-- **Development** - File operations, shell, Docker, GitHub, Jira, Python, Airflow, code execution sandboxes (E2B, Daytona), Claude Agent SDK
+- **Development** - File operations, shell, Docker, GitHub, Jira, Python, Airflow, code execution sandboxes (E2B, Daytona, or MindRoom's built-in [container sandbox proxy](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md)), Claude Agent SDK
 - **Research** - Web search (DuckDuckGo, Tavily, Exa, SerpAPI), academic papers (arXiv, PubMed), Wikipedia, Hacker News, web scraping (Firecrawl, Crawl4AI, Jina)
 - **Communication** - Slack, Discord, Telegram, Twilio, WhatsApp, Webex
 - **Email** - Gmail, AWS SES, Resend, generic SMTP
@@ -1378,10 +1378,11 @@ MindRoom includes 100+ built-in tool integrations organized by category.
 
 ## Calendar & Scheduling
 
-| Icon              | Tool              | Description                | Config Required |
-| ----------------- | ----------------- | -------------------------- | --------------- |
-| :lucide-calendar: | `google_calendar` | View and schedule meetings | Google OAuth    |
-| :lucide-calendar: | `cal_com`         | Cal.com scheduling         | `api_key`       |
+| Icon              | Tool              | Description                                          | Config Required |
+| ----------------- | ----------------- | ---------------------------------------------------- | --------------- |
+| :lucide-calendar: | `google_calendar` | View and schedule meetings                           | Google OAuth    |
+| :lucide-calendar: | `cal_com`         | Cal.com scheduling                                   | `api_key`       |
+| :lucide-calendar: | `scheduler`       | Schedule, edit, list, and cancel tasks and reminders | -               |
 
 ## Data & Business
 
@@ -1432,10 +1433,11 @@ MindRoom includes 100+ built-in tool integrations organized by category.
 
 ## Memory & Storage
 
-| Icon              | Tool   | Description              | Config Required                |
-| ----------------- | ------ | ------------------------ | ------------------------------ |
-| :lucide-database: | `mem0` | Persistent memory system | `api_key` (optional for cloud) |
-| :lucide-database: | `zep`  | Conversation memory      | `api_key`                      |
+| Icon              | Tool     | Description                                          | Config Required                |
+| ----------------- | -------- | ---------------------------------------------------- | ------------------------------ |
+| :lucide-database: | `memory` | Explicitly store and search agent memories on demand | -                              |
+| :lucide-database: | `mem0`   | Persistent memory system                             | `api_key` (optional for cloud) |
+| :lucide-database: | `zep`    | Conversation memory                                  | `api_key`                      |
 
 ## Custom & Config
 
@@ -1915,17 +1917,19 @@ The `host` field is converted internally to `openai_base_url` or `ollama_base_ur
 
 Memories are stored in ChromaDB at `<storage_path>/chroma/` with collection name `mindroom_memories`.
 
-## Mem0 Tool (Optional)
+## Memory Tool (Optional)
 
-For explicit memory control, add the `mem0` tool to an agent:
+For explicit memory control, add the `memory` tool to an agent:
 
 ```
 agents:
   assistant:
-    tools: [mem0]
+    tools: [memory]
 ```
 
 This provides functions: `add_memory`, `search_memory`, `get_all_memories`, `delete_all_memories`.
+
+Note: The `memory` tool is for the built-in agent memory system. The separate `mem0` tool is for Mem0's cloud service.
 
 # Voice Messages
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -15,7 +15,7 @@ MINDROOM_CONFIG_PATH=/path/to/config.yaml mindroom run
 You can also validate a specific file directly:
 
 ```
-mindroom validate --config /path/to/config.yaml
+mindroom validate --config /path/to/config.yaml  # or: -c
 ```
 
 ## Basic Structure

--- a/skills/mindroom-docs/references/page__memory__index.md
+++ b/skills/mindroom-docs/references/page__memory__index.md
@@ -48,14 +48,16 @@ The `host` field is converted internally to `openai_base_url` or `ollama_base_ur
 
 Memories are stored in ChromaDB at `<storage_path>/chroma/` with collection name `mindroom_memories`.
 
-## Mem0 Tool (Optional)
+## Memory Tool (Optional)
 
-For explicit memory control, add the `mem0` tool to an agent:
+For explicit memory control, add the `memory` tool to an agent:
 
 ```
 agents:
   assistant:
-    tools: [mem0]
+    tools: [memory]
 ```
 
 This provides functions: `add_memory`, `search_memory`, `get_all_memories`, `delete_all_memories`.
+
+Note: The `memory` tool is for the built-in agent memory system. The separate `mem0` tool is for Mem0's cloud service.

--- a/skills/mindroom-docs/references/page__tools__builtin__index.md
+++ b/skills/mindroom-docs/references/page__tools__builtin__index.md
@@ -116,10 +116,11 @@ MindRoom includes 100+ built-in tool integrations organized by category.
 
 ## Calendar & Scheduling
 
-| Icon              | Tool              | Description                | Config Required |
-| ----------------- | ----------------- | -------------------------- | --------------- |
-| :lucide-calendar: | `google_calendar` | View and schedule meetings | Google OAuth    |
-| :lucide-calendar: | `cal_com`         | Cal.com scheduling         | `api_key`       |
+| Icon              | Tool              | Description                                          | Config Required |
+| ----------------- | ----------------- | ---------------------------------------------------- | --------------- |
+| :lucide-calendar: | `google_calendar` | View and schedule meetings                           | Google OAuth    |
+| :lucide-calendar: | `cal_com`         | Cal.com scheduling                                   | `api_key`       |
+| :lucide-calendar: | `scheduler`       | Schedule, edit, list, and cancel tasks and reminders | -               |
 
 ## Data & Business
 
@@ -170,10 +171,11 @@ MindRoom includes 100+ built-in tool integrations organized by category.
 
 ## Memory & Storage
 
-| Icon              | Tool   | Description              | Config Required                |
-| ----------------- | ------ | ------------------------ | ------------------------------ |
-| :lucide-database: | `mem0` | Persistent memory system | `api_key` (optional for cloud) |
-| :lucide-database: | `zep`  | Conversation memory      | `api_key`                      |
+| Icon              | Tool     | Description                                          | Config Required                |
+| ----------------- | -------- | ---------------------------------------------------- | ------------------------------ |
+| :lucide-database: | `memory` | Explicitly store and search agent memories on demand | -                              |
+| :lucide-database: | `mem0`   | Persistent memory system                             | `api_key` (optional for cloud) |
+| :lucide-database: | `zep`    | Conversation memory                                  | `api_key`                      |
 
 ## Custom & Config
 

--- a/skills/mindroom-docs/references/page__tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__index.md
@@ -23,7 +23,7 @@ agents:
 
 Tools are organized by category:
 
-- **Development** - File operations, shell, Docker, GitHub, Jira, Python, Airflow, code execution sandboxes (E2B, Daytona), Claude Agent SDK
+- **Development** - File operations, shell, Docker, GitHub, Jira, Python, Airflow, code execution sandboxes (E2B, Daytona, or MindRoom's built-in [container sandbox proxy](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md)), Claude Agent SDK
 - **Research** - Web search (DuckDuckGo, Tavily, Exa, SerpAPI), academic papers (arXiv, PubMed), Wikipedia, Hacker News, web scraping (Firecrawl, Crawl4AI, Jina)
 - **Communication** - Slack, Discord, Telegram, Twilio, WhatsApp, Webex
 - **Email** - Gmail, AWS SES, Resend, generic SMTP


### PR DESCRIPTION
## Summary

- **Critical**: Fix wrong script path in CLAUDE.md (`./scripts/mindroom-cli.sh` → `./cluster/scripts/mindroom-cli.sh`) — 4 occurrences that would cause "command not found"
- **Missing tools**: Add `scheduler` and `memory` tools to `docs/tools/builtin.md`; fix `mem0` vs `memory` tool name confusion in `docs/memory.md`
- **Missing modules**: Add `commands.py`, `voice_handler.py`, `sandbox_proxy.py`, `streaming.py`, `agent_prompts.py` to CLAUDE.md key modules table
- **Inconsistencies**: Fix README claiming event triggers "coming soon" (implemented), remove non-existent memory "tags" reference, fix "Mem0-inspired" → "Mem0"
- **Minor**: Add CLI `-c` shorthand note, document Python 3.12/3.13 difference, mention container sandbox proxy in tools index
- **Process**: Add model name lookup guidance to CLAUDE.md, improve docs-review prompt with deployment checks

## Test plan

- [ ] Verify `./cluster/scripts/mindroom-cli.sh` exists at the referenced path
- [ ] Verify `scheduler` and `memory` tools are registered in `src/mindroom/tools/__init__.py`
- [ ] Verify docs render correctly with `mkdocs serve`
- [ ] Check no broken links in updated cross-references