### PR TITLE
Rename DEFAULT_AGENTS_CONFIG to CONFIG_PATH

### DIFF
--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -27,7 +27,7 @@ from mindroom.api.schedules import router as schedules_router
 from mindroom.api.skills import router as skills_router
 from mindroom.api.tools import router as tools_router
 from mindroom.config import Config
-from mindroom.constants import DEFAULT_AGENTS_CONFIG, DEFAULT_CONFIG_TEMPLATE, safe_replace
+from mindroom.constants import CONFIG_PATH, CONFIG_TEMPLATE_PATH, safe_replace
 from mindroom.credentials_sync import sync_env_to_credentials
 from mindroom.tool_dependencies import auto_install_enabled, auto_install_tool_extra
 
@@ -82,10 +82,6 @@ app.add_middleware(
     allow_headers=["*"],
     expose_headers=["*"],
 )
-
-# Resolve configurable config paths
-CONFIG_PATH = DEFAULT_AGENTS_CONFIG
-CONFIG_TEMPLATE_PATH = DEFAULT_CONFIG_TEMPLATE
 
 
 def load_runtime_config() -> tuple[Config, Path]:

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -35,7 +35,7 @@ from mindroom.ai import (
     stream_agent_response,
 )
 from mindroom.config import Config
-from mindroom.constants import DEFAULT_AGENTS_CONFIG, ROUTER_AGENT_NAME, STORAGE_PATH_OBJ
+from mindroom.constants import CONFIG_PATH, ROUTER_AGENT_NAME, STORAGE_PATH_OBJ
 from mindroom.knowledge import get_knowledge_manager, initialize_knowledge_managers
 from mindroom.knowledge_utils import resolve_agent_knowledge
 from mindroom.logging_config import get_logger
@@ -76,7 +76,7 @@ def _load_config() -> tuple[Config, Path]:
     Loads directly from Config.from_yaml rather than sharing with main.py's
     loader to avoid circular imports (main.py imports this router).
     """
-    return Config.from_yaml(DEFAULT_AGENTS_CONFIG), DEFAULT_AGENTS_CONFIG
+    return Config.from_yaml(CONFIG_PATH), CONFIG_PATH
 
 
 # ---------------------------------------------------------------------------

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -27,7 +27,7 @@ from .commands import (
 )
 from .config import Config
 from .config_commands import handle_config_command
-from .constants import DEFAULT_AGENTS_CONFIG, ENABLE_STREAMING, MATRIX_HOMESERVER, ROUTER_AGENT_NAME, VOICE_PREFIX
+from .constants import CONFIG_PATH, ENABLE_STREAMING, MATRIX_HOMESERVER, ROUTER_AGENT_NAME, VOICE_PREFIX
 from .credentials_sync import sync_env_to_credentials
 from .file_watcher import watch_file
 from .knowledge import initialize_knowledge_managers, shutdown_knowledge_managers
@@ -3009,7 +3009,7 @@ async def main(
     storage_path.mkdir(parents=True, exist_ok=True)
 
     # Get config file path
-    config_path = Path(DEFAULT_AGENTS_CONFIG)
+    config_path = Path(CONFIG_PATH)
 
     # Create and start orchestrator
     logger.info("Starting orchestrator...")

--- a/src/mindroom/cli.py
+++ b/src/mindroom/cli.py
@@ -26,7 +26,7 @@ from mindroom.cli_config import (
     console,
 )
 from mindroom.constants import (
-    DEFAULT_AGENTS_CONFIG,
+    CONFIG_PATH,
     MATRIX_HOMESERVER,
     MATRIX_SSL_VERIFY,
     STORAGE_PATH,
@@ -110,7 +110,7 @@ async def _run(
 ) -> None:
     """Run the multi-agent system with friendly error handling."""
     # Check config exists before starting
-    config_path = Path(DEFAULT_AGENTS_CONFIG)
+    config_path = Path(CONFIG_PATH)
     if not config_path.exists():
         _print_missing_config_error()
         raise typer.Exit(1)
@@ -169,7 +169,7 @@ def doctor() -> None:
     failed = 0
     warnings = 0
 
-    config_path = Path(DEFAULT_AGENTS_CONFIG)
+    config_path = Path(CONFIG_PATH)
 
     # 1. Config file exists
     p, f, w = _check_config_exists(config_path)

--- a/src/mindroom/cli_config.py
+++ b/src/mindroom/cli_config.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from rich.syntax import Syntax
 
 from mindroom.config import Config
-from mindroom.constants import DEFAULT_AGENTS_CONFIG, config_search_locations, env_key_for_provider
+from mindroom.constants import CONFIG_PATH, config_search_locations, env_key_for_provider
 
 console = Console()
 
@@ -40,7 +40,7 @@ def _resolve_config_path(path: Path | None) -> Path:
     """Resolve the config file path from explicit argument or default."""
     if path is not None:
         return path.expanduser().resolve()
-    return Path(DEFAULT_AGENTS_CONFIG).resolve()
+    return Path(CONFIG_PATH).resolve()
 
 
 def _get_editor() -> str:

--- a/src/mindroom/config.py
+++ b/src/mindroom/config.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from .constants import DEFAULT_AGENTS_CONFIG, MATRIX_HOMESERVER, ROUTER_AGENT_NAME, safe_replace
+from .constants import CONFIG_PATH, MATRIX_HOMESERVER, ROUTER_AGENT_NAME, safe_replace
 from .logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -365,7 +365,7 @@ class Config(BaseModel):
     @classmethod
     def from_yaml(cls, config_path: Path | None = None) -> Config:
         """Create a Config instance from YAML data."""
-        path = config_path or DEFAULT_AGENTS_CONFIG
+        path = config_path or CONFIG_PATH
 
         if not path.exists():
             msg = f"Agent configuration file not found: {path}"
@@ -499,10 +499,10 @@ class Config(BaseModel):
         """Save the config to a YAML file, excluding None values.
 
         Args:
-            config_path: Path to save the config to. If None, uses DEFAULT_AGENTS_CONFIG.
+            config_path: Path to save the config to. If None, uses CONFIG_PATH.
 
         """
-        path = config_path or DEFAULT_AGENTS_CONFIG
+        path = config_path or CONFIG_PATH
         config_dict = self.model_dump(exclude_none=True)
         path_obj = Path(path)
         path_obj.parent.mkdir(parents=True, exist_ok=True)

--- a/src/mindroom/config_commands.py
+++ b/src/mindroom/config_commands.py
@@ -10,7 +10,7 @@ import yaml
 from pydantic import ValidationError
 
 from .config import Config
-from .constants import DEFAULT_AGENTS_CONFIG
+from .constants import CONFIG_PATH
 from .logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -165,7 +165,7 @@ async def handle_config_command(args_text: str, config_path: Path | None = None)
 
     """
     operation, args = parse_config_args(args_text)
-    path = config_path or DEFAULT_AGENTS_CONFIG
+    path = config_path or CONFIG_PATH
 
     # Load current config
     config = Config.from_yaml(path)
@@ -292,7 +292,7 @@ async def apply_config_change(
         Success or error message
 
     """
-    path = config_file_path or DEFAULT_AGENTS_CONFIG
+    path = config_file_path or CONFIG_PATH
 
     try:
         # Load the current configuration

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -59,23 +59,23 @@ def find_config() -> Path:
     return _CONFIG_SEARCH_PATHS[0]  # default to ./config.yaml for creation
 
 
-DEFAULT_AGENTS_CONFIG = find_config()
+CONFIG_PATH = find_config()
 
 # Also load .env from the config directory so that API keys placed next to the
 # config file (e.g. ~/.mindroom/.env) are picked up even when CWD is elsewhere.
 # override=False (the default) means real env vars and CWD .env take precedence.
-_config_dotenv = DEFAULT_AGENTS_CONFIG.parent / ".env"
+_config_dotenv = CONFIG_PATH.parent / ".env"
 if _config_dotenv.is_file():
     load_dotenv(_config_dotenv)
 
 # Optional template path used to seed the writable config file if it does not
-# exist yet. Defaults to the same location as DEFAULT_AGENTS_CONFIG so the
+# exist yet. Defaults to the same location as CONFIG_PATH so the
 # behaviour is unchanged when no overrides are provided.
 _CONFIG_TEMPLATE_ENV = os.getenv("MINDROOM_CONFIG_TEMPLATE")
-DEFAULT_CONFIG_TEMPLATE = Path(_CONFIG_TEMPLATE_ENV).expanduser() if _CONFIG_TEMPLATE_ENV else DEFAULT_AGENTS_CONFIG
+CONFIG_TEMPLATE_PATH = Path(_CONFIG_TEMPLATE_ENV).expanduser() if _CONFIG_TEMPLATE_ENV else CONFIG_PATH
 
 _STORAGE_PATH_ENV = os.getenv("MINDROOM_STORAGE_PATH")
-STORAGE_PATH = _STORAGE_PATH_ENV or str(DEFAULT_AGENTS_CONFIG.parent / "mindroom_data")
+STORAGE_PATH = _STORAGE_PATH_ENV or str(CONFIG_PATH.parent / "mindroom_data")
 STORAGE_PATH_OBJ = Path(STORAGE_PATH)
 
 # Specific files and directories

--- a/src/mindroom/custom_tools/config_manager.py
+++ b/src/mindroom/custom_tools/config_manager.py
@@ -12,7 +12,7 @@ from agno.tools import Toolkit
 
 from mindroom.commands import get_command_help
 from mindroom.config import AgentConfig, AgentLearningMode, Config, TeamConfig
-from mindroom.constants import DEFAULT_AGENTS_CONFIG
+from mindroom.constants import CONFIG_PATH
 from mindroom.logging_config import get_logger
 from mindroom.tools_metadata import TOOL_METADATA, ToolCategory, ToolStatus
 
@@ -47,7 +47,7 @@ class ConfigManagerTools(Toolkit):
             config_path: Optional path to configuration file
 
         """
-        self.config_path = config_path or DEFAULT_AGENTS_CONFIG
+        self.config_path = config_path or CONFIG_PATH
         self._mindroom_docs: str | None = None
         self._help_text: str | None = None
 

--- a/src/mindroom/plugins.py
+++ b/src/mindroom/plugins.py
@@ -10,7 +10,7 @@ from importlib import util
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .constants import DEFAULT_AGENTS_CONFIG
+from .constants import CONFIG_PATH
 from .logging_config import get_logger
 from .skills import set_plugin_skill_roots
 
@@ -83,7 +83,7 @@ def _resolve_plugin_root(plugin_path: str, config_path: Path | None) -> Path:
     if path.is_absolute():
         return path
 
-    base = (config_path or DEFAULT_AGENTS_CONFIG).expanduser().resolve()
+    base = (config_path or CONFIG_PATH).expanduser().resolve()
     relative = (base.parent / path).resolve()
     if relative.exists():
         return relative

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -181,7 +181,7 @@ class TestRunErrorHandling:
 
     def test_run_missing_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Run shows friendly error when config is missing."""
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", tmp_path / "no_such_config.yaml")
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", tmp_path / "no_such_config.yaml")
         result = runner.invoke(app, ["run"])
         assert result.exit_code == 1
         assert "No config.yaml found" in result.output
@@ -191,7 +191,7 @@ class TestRunErrorHandling:
         """Run shows friendly error when config is invalid."""
         bad_cfg = tmp_path / "config.yaml"
         bad_cfg.write_text("agents: not_a_dict\n")
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", bad_cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", bad_cfg)
         result = runner.invoke(app, ["run"])
         assert result.exit_code == 1
         assert "Invalid configuration" in result.output
@@ -244,7 +244,7 @@ class TestRunApiFlags:
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n",
         )
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", cfg)
         mock_main = AsyncMock()
         with patch("mindroom.bot.main", mock_main):
             result = runner.invoke(app, ["run"])
@@ -263,7 +263,7 @@ class TestRunApiFlags:
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n",
         )
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", cfg)
         mock_main = AsyncMock()
         with patch("mindroom.bot.main", mock_main):
             result = runner.invoke(app, ["run", "--no-api"])
@@ -278,7 +278,7 @@ class TestRunApiFlags:
             "agents:\n  a:\n    display_name: A\n    model: default\n"
             "router:\n  model: default\n",
         )
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", cfg)
         mock_main = AsyncMock()
         with patch("mindroom.bot.main", mock_main):
             result = runner.invoke(app, ["run", "--api-port", "9000", "--api-host", "127.0.0.1"])
@@ -324,7 +324,7 @@ class TestDoctor:
         cfg = tmp_path / "config.yaml"
         cfg.write_text(_VALID_CONFIG)
         storage = tmp_path / "storage"
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", cfg)
         monkeypatch.setattr("mindroom.cli.STORAGE_PATH", str(storage))
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         _patch_homeserver_ok(monkeypatch)
@@ -341,7 +341,7 @@ class TestDoctor:
 
     def test_missing_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Doctor reports failure when config file is missing."""
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", tmp_path / "missing.yaml")
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", tmp_path / "missing.yaml")
         monkeypatch.setattr("mindroom.cli.STORAGE_PATH", str(tmp_path / "storage"))
         _patch_homeserver_ok(monkeypatch)
 
@@ -354,7 +354,7 @@ class TestDoctor:
         cfg = tmp_path / "config.yaml"
         cfg.write_text("agents: not_a_dict\n")
         storage = tmp_path / "storage"
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", cfg)
         monkeypatch.setattr("mindroom.cli.STORAGE_PATH", str(storage))
         _patch_homeserver_ok(monkeypatch)
 
@@ -367,7 +367,7 @@ class TestDoctor:
         cfg = tmp_path / "config.yaml"
         cfg.write_text(_VALID_CONFIG)
         storage = tmp_path / "storage"
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", cfg)
         monkeypatch.setattr("mindroom.cli.STORAGE_PATH", str(storage))
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         _patch_homeserver_ok(monkeypatch)
@@ -382,7 +382,7 @@ class TestDoctor:
         cfg = tmp_path / "config.yaml"
         cfg.write_text(_VALID_CONFIG)
         storage = tmp_path / "storage"
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", cfg)
         monkeypatch.setattr("mindroom.cli.STORAGE_PATH", str(storage))
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         _patch_homeserver_fail(monkeypatch)
@@ -395,7 +395,7 @@ class TestDoctor:
         """Doctor reports failure when storage directory is not writable."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(_VALID_CONFIG)
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", cfg)
         monkeypatch.setattr("mindroom.cli.STORAGE_PATH", "/proc/fake_mindroom_storage")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         _patch_homeserver_ok(monkeypatch)
@@ -406,7 +406,7 @@ class TestDoctor:
 
     def test_skips_config_checks_when_missing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Doctor skips config-validation and provider checks when config is missing."""
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", tmp_path / "missing.yaml")
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", tmp_path / "missing.yaml")
         monkeypatch.setattr("mindroom.cli.STORAGE_PATH", str(tmp_path / "storage"))
         _patch_homeserver_ok(monkeypatch)
 
@@ -420,7 +420,7 @@ class TestDoctor:
         cfg = tmp_path / "config.yaml"
         cfg.write_text(_VALID_CONFIG)
         storage = tmp_path / "storage"
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", cfg)
         monkeypatch.setattr("mindroom.cli.STORAGE_PATH", str(storage))
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-invalid")
         monkeypatch.setattr("mindroom.cli.MATRIX_HOMESERVER", "http://localhost:8008")
@@ -448,7 +448,7 @@ class TestDoctor:
             "router:\n  model: default\n",
         )
         storage = tmp_path / "storage"
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", cfg)
         monkeypatch.setattr("mindroom.cli.STORAGE_PATH", str(storage))
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
@@ -473,7 +473,7 @@ class TestDoctor:
             "router:\n  model: default\n",
         )
         storage = tmp_path / "storage"
-        monkeypatch.setattr("mindroom.cli.DEFAULT_AGENTS_CONFIG", cfg)
+        monkeypatch.setattr("mindroom.cli.CONFIG_PATH", cfg)
         monkeypatch.setattr("mindroom.cli.STORAGE_PATH", str(storage))
         monkeypatch.setenv("OPENAI_API_KEY", "sk-local")
         monkeypatch.setattr("mindroom.cli.MATRIX_HOMESERVER", "http://localhost:8008")


### PR DESCRIPTION
## Summary

- Rename `DEFAULT_AGENTS_CONFIG` → `CONFIG_PATH` (it's the resolved config path, not a default)
- Rename `DEFAULT_CONFIG_TEMPLATE` → `CONFIG_TEMPLATE_PATH` for consistency
- Remove self-assignment no-ops in `api/main.py` that resulted from the rename

Pure rename, no behavior change. All 1194 tests pass.