### PR TITLE
Remove stale dashboard endpoint doc and dead encrypt helper

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -201,4 +201,3 @@ The dashboard communicates with the backend API at `/api/`:
 | GET | `/api/matrix/agents/{id}/rooms` | Get specific agent's rooms |
 | POST | `/api/matrix/rooms/leave` | Leave a single room |
 | POST | `/api/matrix/rooms/leave-bulk` | Leave multiple rooms |
-| POST | `/api/test/model` | Test model connection |

--- a/frontend/src/services/configService.ts
+++ b/frontend/src/services/configService.ts
@@ -37,23 +37,6 @@ export async function saveConfig(config: Config): Promise<void> {
   }
 }
 
-export async function encryptAPIKey(provider: string, key: string): Promise<string> {
-  const response = await fetch(`${API_BASE}/keys/encrypt`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ provider, key }),
-  });
-
-  if (!response.ok) {
-    throw new Error('Failed to encrypt API key');
-  }
-
-  const result = await response.json();
-  return result.encryptedKey;
-}
-
 export async function getAvailableTools(): Promise<string[]> {
   const response = await fetch(`${API_BASE}/tools`);
 


### PR DESCRIPTION
## Summary
- remove stale `/api/test/model` row from dashboard API docs
- remove dead `encryptAPIKey()` helper in `frontend/src/services/configService.ts`
  - this helper called `/api/keys/encrypt`, which is not a live backend endpoint

## Validation
- pre-commit hooks run on commit (passed)
  - prettier: passed
  - TypeScript type checking: passed
