### PR TITLE
Add code debate prompt for async multi-agent review

### DIFF
--- a/.prompts/code-debate.md
+++ b/.prompts/code-debate.md
@@ -23,6 +23,8 @@ Use a portable checksum. Pick the first available:
 CKSUM() { { md5sum "$1" 2>/dev/null || md5 -q "$1" 2>/dev/null || shasum "$1"; } | awk '{print $1}'; }
 ```
 
+Define this function before running the poll loop.
+
 ## Shell requirement
 
 Run polling commands in `bash`. The timeout example uses Bash's `SECONDS`.
@@ -102,10 +104,14 @@ Each section should end with a signature line: `*— Agent A|Agent B (optional t
 ## Follow-up 1
 <Agent A's follow-up on unresolved points>
 
+*— Agent A, 2025-06-15T14:35:00Z*
+
 ---
 
 ## Response 2
 <Agent B's reply>
+
+*— Agent B, 2025-06-15T14:38:00Z*
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `.prompts/code-debate.md` — a protocol for two coding agents (Claude Code, Gemini CLI, Codex, etc.) to asynchronously debate code changes via a shared `DEBATE.md` file
- Role auto-detection: both agents use the same prompt; opener vs responder is determined by whether `DEBATE.md` exists
- Turn-taking via md5sum polling (5s interval, 10min timeout), with explicit turn order enforcement by checking the last `## ` heading
- Convergence within max 5 rounds, explicit per-point categorization (Agreed / Partially agreed / Disagreed)
- The prompt itself was refined through three rounds of agent-to-agent debate using the protocol

## Test plan
- [x] Two agents debated using the protocol (Claude Code vs Codex)
- [x] Role detection worked correctly via file existence
- [x] Turn order enforcement caught ordering issues in first run, fixed in subsequent iterations
- [x] Convergence reached via `## CONSENSUS` section
- [x] Protocol tested three times with successful convergence each time