### PR TITLE
Update debate prompt for simultaneous start with designated Agent B

### DIFF
--- a/.prompts/code-debate.md
+++ b/.prompts/code-debate.md
@@ -1,19 +1,23 @@
 # Code Debate Protocol
 
-A protocol for two coding agents (Claude Code, Gemini CLI, Codex, or any other) to debate code changes through a shared file (`DEBATE.md`). Both agents receive this same prompt. Role is determined automatically by file existence.
+A protocol for two coding agents (Claude Code, Gemini CLI, Codex, or any other) to debate code changes through a shared file (`DEBATE.md`). Both agents receive this same prompt. Role is determined by explicit designation when provided, otherwise by file existence.
 
 ## How to use
 
 Open two terminal tabs with coding agents (same or different). Give both this prompt along with a subject to discuss — e.g., a commit, a diff, a PR, or one agent's review of another agent's work.
 
-The first agent to run will create `DEBATE.md` and become the opener. The second agent will find the file already exists and become the responder.
+You may send this prompt to both agents at the same time. If you designate one agent as **Agent B**, that agent must immediately start polling and wait for `DEBATE.md` to exist, then read it and continue as Agent B.
+
+Without designation, the first agent to run will create `DEBATE.md` and become the opener. The second agent will find the file already exists and become the responder.
 
 ## Role detection
 
-- If `DEBATE.md` does **not** exist → you are **Agent A** (opener). Write the opening position.
-- If `DEBATE.md` **already exists** → you are **Agent B** (responder). Read what's there and respond.
+- If the user explicitly designates you as **Agent B** → you are **Agent B**, even if `DEBATE.md` does not exist yet. Start polling and wait for file creation.
+- Otherwise, use file existence:
+  - If `DEBATE.md` does **not** exist → you are **Agent A** (opener). Write the opening position.
+  - If `DEBATE.md` **already exists** → you are **Agent B** (responder). Read what's there and respond.
 
-Do not ask the user which role to play. Detect it from file existence.
+Do not ask the user which role to play. Respect explicit Agent B designation if provided; otherwise detect from file existence.
 
 ## Non-simulation guardrails (MUST)
 
@@ -95,7 +99,14 @@ Before appending, also verify the last signature line role:
 
 ## Agent B (responder) flow
 
-1. Read `DEBATE.md` (it exists — that's how you know you're the responder).
+1. Ensure `DEBATE.md` exists before reading:
+   - If it exists, read it immediately.
+   - If it does not exist (for example, you were explicitly designated as Agent B), start polling and wait until it exists, then read it.
+   - If timeout is reached before the file exists, stop and report timeout. Do not create `DEBATE.md` as Agent B.
+   Example:
+   ```bash
+   SECONDS=0; while [ ! -f DEBATE.md ]; do sleep 5; if [ "$SECONDS" -ge 600 ]; then echo "TIMEOUT waiting for DEBATE.md"; exit 0; fi; done
+   ```
 2. Analyze the same subject the user specified.
 3. Verify it is your turn (check the last `## ` heading). Example:
    ```bash

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -141,6 +141,7 @@ mindroom run
 - [Authorization](https://docs.mindroom.chat/authorization/index.md) - User and room access control
 - [Architecture](https://docs.mindroom.chat/architecture/index.md) - How it works under the hood
 - [Deployment](https://docs.mindroom.chat/deployment/index.md) - Docker and Kubernetes deployment
+- [Bridges](https://docs.mindroom.chat/deployment/bridges/index.md) - Connect Telegram, Slack, and other platforms to Matrix
 - [Sandbox Proxy](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) - Isolate code-execution tools in a sandbox
 - [Google Services OAuth](https://docs.mindroom.chat/deployment/google-services-oauth/index.md) - Admin OAuth setup for Gmail/Calendar/Drive/Sheets
 - [Google Services OAuth (Individual)](https://docs.mindroom.chat/deployment/google-services-user-oauth/index.md) - Single-user OAuth setup
@@ -501,7 +502,6 @@ The dashboard communicates with the backend API at `/api/`:
 | GET    | `/api/matrix/agents/{id}/rooms` | Get specific agent's rooms       |
 | POST   | `/api/matrix/rooms/leave`       | Leave a single room              |
 | POST   | `/api/matrix/rooms/leave-bulk`  | Leave multiple rooms             |
-| POST   | `/api/test/model`               | Test model connection            |
 
 # Configuration
 
@@ -2759,6 +2759,13 @@ MindRoom can be deployed in various ways depending on your needs.
 | [Kubernetes](https://docs.mindroom.chat/deployment/kubernetes/index.md)            | Multi-tenant SaaS, production                               |
 | Direct                                                                             | Development, simple setups                                  |
 
+## Bridges
+
+Connect external messaging platforms to Matrix:
+
+- [Bridges overview](https://docs.mindroom.chat/deployment/bridges/index.md) - available bridges and how they work
+- [Telegram bridge](https://docs.mindroom.chat/deployment/bridges/telegram/index.md) - bridge Telegram chats via mautrix-telegram
+
 ## Google Services (Gmail/Calendar/Drive/Sheets)
 
 Use these guides if you want users to connect Google accounts in the MindRoom frontend:
@@ -2822,6 +2829,280 @@ Direct and single-container deployments:
 1. **Persistent storage** - Mount `mindroom_data/` to persist agent state (including `sessions/`, `learning/`, and memory data)
 
 See the [Docker guide](https://docs.mindroom.chat/deployment/docker/#environment-variables) for the complete environment variable reference.
+
+# Bridges
+
+MindRoom uses [mautrix](https://docs.mau.fi/bridges/) bridges to connect external messaging platforms to Matrix. Bridges run as appservices alongside Synapse, creating ghost users for external contacts and relaying messages bidirectionally.
+
+## Available Bridges
+
+| Bridge                                                                      | Platform  | Mode                       | Status    |
+| --------------------------------------------------------------------------- | --------- | -------------------------- | --------- |
+| [Telegram](https://docs.mindroom.chat/deployment/bridges/telegram/index.md) | Telegram  | Puppet (login as yourself) | Available |
+| Slack                                                                       | Slack     | -                          | Planned   |
+| Email                                                                       | IMAP/SMTP | -                          | Planned   |
+
+## How Bridges Work
+
+Each bridge registers as a Matrix [Application Service](https://spec.matrix.org/latest/application-service-api/) with Synapse. The bridge:
+
+1. Creates ghost users on Matrix for external contacts
+1. Creates Matrix rooms for external chats
+1. Relays messages between the external platform and Matrix in real time
+
+In **puppet mode**, you log into your real account on the external platform. Your messages appear as coming from you on both sides, not from a bot.
+
+## Adding a New Bridge
+
+1. Create a config directory: `telegram-bridge/`, `slack-bridge/`, etc.
+1. Add the bridge service to `compose.yaml`
+1. Generate a registration file and mount it into Synapse
+1. Add the registration path to `homeserver.yaml` under `app_service_config_files`
+1. Restart Synapse and start the bridge
+
+# Telegram Bridge
+
+Bridge Telegram and Matrix using [mautrix-telegram](https://docs.mau.fi/bridges/python/telegram/) in **puppet mode**. Each user logs in with their own Telegram account, so messages appear as the real user on both sides.
+
+## What Can You Do With This?
+
+The bridge enables two main use cases:
+
+1. **Talk to MindRoom agents from Telegram** -- Link a Telegram group to a Matrix room (like Lobby) so you can chat with AI agents directly from the Telegram app, without opening Element.
+1. **Access Telegram chats from Matrix** -- Your existing Telegram conversations appear as Matrix rooms in Element, so you can use one client for everything.
+
+Most users want use case 1. See [Bridging Matrix Rooms to Telegram](#bridging-matrix-rooms-to-telegram) after setup.
+
+## Architecture
+
+```
+Telegram Cloud <--> mautrix-telegram <--> Synapse <--> Element
+                    (bridge bot)         (homeserver)   (client)
+```
+
+- **mautrix-telegram** runs locally and connects outbound to Telegram's API -- your Matrix server does NOT need to be publicly accessible
+- Each Matrix user can log into their own Telegram account (puppeting)
+- Messages flow bidirectionally in real time
+
+## Prerequisites
+
+### 1. Telegram API Credentials
+
+1. Go to [my.telegram.org](https://my.telegram.org) and log in
+1. Click "API development tools"
+1. Create an app (title: "MindRoom Bridge", short name: "mindroom")
+1. Note the **api_id** (numeric) and **api_hash** (string)
+
+### 2. Telegram Bot
+
+1. Message [@BotFather](https://t.me/BotFather) on Telegram
+1. Send `/newbot`, choose a name and username
+1. Note the **bot token** (format: `123456789:ABCdefGHI...`)
+
+## Setup
+
+### 1. Add credentials to config
+
+Edit `/opt/stacks/mindroom/telegram-bridge/config.yaml` and replace the placeholders in the `telegram:` section:
+
+```
+telegram:
+    api_id: 12345678          # Your numeric api_id
+    api_hash: abcdef123456    # Your api_hash string
+    bot_token: 123456:ABC...  # Your bot token from BotFather
+```
+
+Also update the same values in `/opt/stacks/mindroom/.env`:
+
+```
+TELEGRAM_API_ID=12345678
+TELEGRAM_API_HASH=abcdef123456
+TELEGRAM_BOT_TOKEN=123456:ABC...
+```
+
+### 2. Recreate Synapse and start the bridge
+
+Synapse needs a new volume mount for the bridge registration file, so it must be **recreated** (not just restarted):
+
+```
+# Recreate Synapse to pick up the new volume mount and bridge registration
+cf compose mindroom up -d synapse
+
+# Wait for Synapse to become healthy
+cf compose mindroom ps synapse
+
+# Start the bridge
+cf compose mindroom up -d telegram-bridge
+```
+
+> **Note:** `cf compose mindroom restart synapse` will NOT work here because the `registration.yaml` volume mount is new in `compose.yaml`. A restart reuses the existing container; `up -d` recreates it with the updated mounts.
+
+### 3. Verify
+
+```
+# Check bridge logs
+cf compose mindroom logs telegram-bridge --tail 20
+
+# Look for "Startup actions complete"
+```
+
+## Usage
+
+### Step 1: Log in to Telegram via the bridge
+
+Before you can bridge anything, you must link your Telegram account:
+
+1. Open Element at `element.lab.nijho.lt`
+1. Start a DM with `@telegrambot:matrix.lab.nijho.lt`
+1. Send `login`
+1. Enter your phone number in international format (e.g., `+1234567890`)
+1. Enter the verification code sent to your Telegram app
+1. Your existing Telegram chats will appear as Matrix rooms
+
+### Step 2: Bridge Matrix rooms to Telegram
+
+This is the primary use case -- talking to MindRoom agents from Telegram.
+
+The bridge connects a **Telegram group** to a **Matrix room**. You need a Telegram group on the Telegram side because that's what you'll open in the Telegram app to send and receive messages.
+
+**For each Matrix room you want to access from Telegram** (e.g., Lobby):
+
+1. **Create a Telegram group** in the Telegram app (e.g., name it "MindRoom Lobby")
+1. **Add your bridge bot** (e.g., `@mindroom_lab_bot`) to that Telegram group
+1. **In Element**, go to the Matrix room you want to bridge (e.g., Lobby)
+1. **Invite the bridge bot**: invite `@telegrambot:matrix.lab.nijho.lt` to the room
+1. **Link the rooms**: in the Matrix room, send `!tg bridge` -- the bot will list your Telegram groups and let you pick which one to link
+
+Once linked:
+
+- Messages you send in the **Telegram group** appear in the **Matrix room** -- MindRoom agents will see and respond to them
+- Agent responses in the **Matrix room** appear in the **Telegram group**
+- You can chat with MindRoom agents entirely from the Telegram app
+
+Repeat for any other Matrix rooms you want accessible from Telegram.
+
+> **Why can't I just invite the bot directly?** The bridge bot (`@telegrambot`) is Matrix-side infrastructure -- it manages the bridge but isn't a Telegram chat. To use Telegram as your client, there must be a Telegram group for the Telegram app to display. The bridge connects that group to the Matrix room bidirectionally.
+
+### Accessing Telegram chats from Matrix
+
+After logging in (step 1), your Telegram chats automatically appear as Matrix rooms in Element. This lets you use Element as a unified client for both Matrix and Telegram conversations.
+
+- **Private chats**: Automatically bridged as Matrix DMs
+- **Groups**: Automatically bridged if within `sync_create_limit` (default: 30)
+- **Additional groups**: Use `search <query>` in the bridge bot DM to find and bridge more
+
+### Bot Commands Reference
+
+Send these to `@telegrambot:matrix.lab.nijho.lt` in a DM, or in a bridged room:
+
+| Command          | Description                                                     |
+| ---------------- | --------------------------------------------------------------- |
+| `login`          | Link your Telegram account                                      |
+| `logout`         | Unlink your Telegram account                                    |
+| `ping`           | Check bridge connection status                                  |
+| `search <query>` | Search your Telegram chats                                      |
+| `!tg bridge`     | Link current Matrix room to a Telegram group (send in the room) |
+| `unbridge`       | Unlink current room from Telegram                               |
+| `sync`           | Re-sync Telegram chat list                                      |
+| `help`           | Show all commands                                               |
+
+## Configuration Reference
+
+Key settings in `telegram-bridge/config.yaml`:
+
+| Setting                       | Default              | Description                                 |
+| ----------------------------- | -------------------- | ------------------------------------------- |
+| `bridge.username_template`    | `telegram_{userid}`  | Matrix username pattern for Telegram ghosts |
+| `bridge.displayname_template` | `{displayname} (TG)` | Display name pattern for Telegram users     |
+| `bridge.sync_create_limit`    | `30`                 | Max chats to auto-create on first sync      |
+| `bridge.sync_direct_chats`    | `true`               | Auto-bridge private chats                   |
+| `bridge.encryption.allow`     | `true`               | Allow E2EE in bridged rooms                 |
+| `bridge.permissions`          | See config           | Who can use the bridge and at what level    |
+
+### Permission Levels
+
+Set in `bridge.permissions`:
+
+- `relaybot` - Messages relayed through the bot (not puppeted)
+- `user` - Can use the bridge but not log in
+- `puppeting` - Can log in with their Telegram account
+- `full` - Full access including creating portals
+- `admin` - Bridge administration
+
+Default config gives `full` to all `matrix.lab.nijho.lt` users.
+
+## Troubleshooting
+
+### Bridge won't start
+
+- Check credentials: `api_id` must be numeric, `api_hash` must be a hex string, `bot_token` must be a valid BotFather token
+- Check logs: `cf compose mindroom logs telegram-bridge --tail 50`
+- Verify Synapse is healthy: `cf compose mindroom ps`
+
+### Login fails
+
+- Ensure `api_id` and `api_hash` are from the same Telegram app
+- The bot token must be from a bot you own (not revoked)
+- If you get "FLOOD_WAIT", wait the indicated time before retrying
+
+### Messages not bridging
+
+- Check the bridge is connected: DM the bot and send `ping`
+- Verify Synapse has the registration: check `app_service_config_files` in `homeserver.yaml`
+- Check bridge permissions in `config.yaml` - your user domain must have `full` or `puppeting`
+
+### Double puppeting
+
+To make your messages from Matrix appear as your real Telegram account (not the bridge bot):
+
+1. This is automatic when you log in via `login` - puppet mode is the default
+1. If messages still show as the bot, check `bridge.sync_with_custom_puppets` in config
+
+### Database issues
+
+The bridge uses SQLite at `/mnt/data/mindroom/telegram-bridge/mautrix-telegram.db`. To reset:
+
+```
+cf compose mindroom stop telegram-bridge
+rm /mnt/data/mindroom/telegram-bridge/mautrix-telegram.db
+cf compose mindroom up -d telegram-bridge
+```
+
+Note: This will require re-logging into Telegram.
+
+### Registration out of sync
+
+If Synapse reports appservice errors, regenerate the registration:
+
+```
+cf compose mindroom stop telegram-bridge
+rm /opt/stacks/mindroom/telegram-bridge/registration.yaml
+# Temporarily set valid api_id in config.yaml, then:
+cf compose mindroom run --rm --no-deps --entrypoint \
+  "python -m mautrix_telegram -g -c /data/config.yaml -r /data/registration.yaml" \
+  telegram-bridge
+cf compose mindroom restart synapse
+cf compose mindroom up -d telegram-bridge
+```
+
+## Maintenance
+
+### Updating
+
+```
+cf update mindroom
+# Or just the bridge:
+cf compose mindroom pull telegram-bridge
+cf compose mindroom up -d telegram-bridge
+```
+
+### Backup
+
+Important data locations:
+
+- `/opt/stacks/mindroom/telegram-bridge/config.yaml` - Bridge configuration
+- `/opt/stacks/mindroom/telegram-bridge/registration.yaml` - Appservice registration
+- `/mnt/data/mindroom/telegram-bridge/` - SQLite database with session data
 
 # Google Services OAuth (Admin Setup)
 

--- a/skills/mindroom-docs/references/llms.txt
+++ b/skills/mindroom-docs/references/llms.txt
@@ -25,6 +25,8 @@
 - [Matrix Integration](https://docs.mindroom.chat/architecture/matrix/index.md)
 - [Agent Orchestration](https://docs.mindroom.chat/architecture/orchestration/index.md)
 - [Overview](https://docs.mindroom.chat/deployment/index.md)
+- [Overview](https://docs.mindroom.chat/deployment/bridges/index.md)
+- [Telegram](https://docs.mindroom.chat/deployment/bridges/telegram/index.md)
 - [Google Services OAuth (Admin)](https://docs.mindroom.chat/deployment/google-services-oauth/index.md)
 - [Google Services OAuth (Individual)](https://docs.mindroom.chat/deployment/google-services-user-oauth/index.md)
 - [Docker](https://docs.mindroom.chat/deployment/docker/index.md)

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -197,4 +197,3 @@ The dashboard communicates with the backend API at `/api/`:
 | GET    | `/api/matrix/agents/{id}/rooms` | Get specific agent's rooms       |
 | POST   | `/api/matrix/rooms/leave`       | Leave a single room              |
 | POST   | `/api/matrix/rooms/leave-bulk`  | Leave multiple rooms             |
-| POST   | `/api/test/model`               | Test model connection            |

--- a/skills/mindroom-docs/references/page__deployment__bridges__index.md
+++ b/skills/mindroom-docs/references/page__deployment__bridges__index.md
@@ -1,0 +1,29 @@
+# Bridges
+
+MindRoom uses [mautrix](https://docs.mau.fi/bridges/) bridges to connect external messaging platforms to Matrix. Bridges run as appservices alongside Synapse, creating ghost users for external contacts and relaying messages bidirectionally.
+
+## Available Bridges
+
+| Bridge                                                                      | Platform  | Mode                       | Status    |
+| --------------------------------------------------------------------------- | --------- | -------------------------- | --------- |
+| [Telegram](https://docs.mindroom.chat/deployment/bridges/telegram/index.md) | Telegram  | Puppet (login as yourself) | Available |
+| Slack                                                                       | Slack     | -                          | Planned   |
+| Email                                                                       | IMAP/SMTP | -                          | Planned   |
+
+## How Bridges Work
+
+Each bridge registers as a Matrix [Application Service](https://spec.matrix.org/latest/application-service-api/) with Synapse. The bridge:
+
+1. Creates ghost users on Matrix for external contacts
+1. Creates Matrix rooms for external chats
+1. Relays messages between the external platform and Matrix in real time
+
+In **puppet mode**, you log into your real account on the external platform. Your messages appear as coming from you on both sides, not from a bot.
+
+## Adding a New Bridge
+
+1. Create a config directory: `telegram-bridge/`, `slack-bridge/`, etc.
+1. Add the bridge service to `compose.yaml`
+1. Generate a registration file and mount it into Synapse
+1. Add the registration path to `homeserver.yaml` under `app_service_config_files`
+1. Restart Synapse and start the bridge

--- a/skills/mindroom-docs/references/page__deployment__bridges__telegram__index.md
+++ b/skills/mindroom-docs/references/page__deployment__bridges__telegram__index.md
@@ -1,0 +1,243 @@
+# Telegram Bridge
+
+Bridge Telegram and Matrix using [mautrix-telegram](https://docs.mau.fi/bridges/python/telegram/) in **puppet mode**. Each user logs in with their own Telegram account, so messages appear as the real user on both sides.
+
+## What Can You Do With This?
+
+The bridge enables two main use cases:
+
+1. **Talk to MindRoom agents from Telegram** -- Link a Telegram group to a Matrix room (like Lobby) so you can chat with AI agents directly from the Telegram app, without opening Element.
+1. **Access Telegram chats from Matrix** -- Your existing Telegram conversations appear as Matrix rooms in Element, so you can use one client for everything.
+
+Most users want use case 1. See [Bridging Matrix Rooms to Telegram](#bridging-matrix-rooms-to-telegram) after setup.
+
+## Architecture
+
+```
+Telegram Cloud <--> mautrix-telegram <--> Synapse <--> Element
+                    (bridge bot)         (homeserver)   (client)
+```
+
+- **mautrix-telegram** runs locally and connects outbound to Telegram's API -- your Matrix server does NOT need to be publicly accessible
+- Each Matrix user can log into their own Telegram account (puppeting)
+- Messages flow bidirectionally in real time
+
+## Prerequisites
+
+### 1. Telegram API Credentials
+
+1. Go to [my.telegram.org](https://my.telegram.org) and log in
+1. Click "API development tools"
+1. Create an app (title: "MindRoom Bridge", short name: "mindroom")
+1. Note the **api_id** (numeric) and **api_hash** (string)
+
+### 2. Telegram Bot
+
+1. Message [@BotFather](https://t.me/BotFather) on Telegram
+1. Send `/newbot`, choose a name and username
+1. Note the **bot token** (format: `123456789:ABCdefGHI...`)
+
+## Setup
+
+### 1. Add credentials to config
+
+Edit `/opt/stacks/mindroom/telegram-bridge/config.yaml` and replace the placeholders in the `telegram:` section:
+
+```
+telegram:
+    api_id: 12345678          # Your numeric api_id
+    api_hash: abcdef123456    # Your api_hash string
+    bot_token: 123456:ABC...  # Your bot token from BotFather
+```
+
+Also update the same values in `/opt/stacks/mindroom/.env`:
+
+```
+TELEGRAM_API_ID=12345678
+TELEGRAM_API_HASH=abcdef123456
+TELEGRAM_BOT_TOKEN=123456:ABC...
+```
+
+### 2. Recreate Synapse and start the bridge
+
+Synapse needs a new volume mount for the bridge registration file, so it must be **recreated** (not just restarted):
+
+```
+# Recreate Synapse to pick up the new volume mount and bridge registration
+cf compose mindroom up -d synapse
+
+# Wait for Synapse to become healthy
+cf compose mindroom ps synapse
+
+# Start the bridge
+cf compose mindroom up -d telegram-bridge
+```
+
+> **Note:** `cf compose mindroom restart synapse` will NOT work here because the `registration.yaml` volume mount is new in `compose.yaml`. A restart reuses the existing container; `up -d` recreates it with the updated mounts.
+
+### 3. Verify
+
+```
+# Check bridge logs
+cf compose mindroom logs telegram-bridge --tail 20
+
+# Look for "Startup actions complete"
+```
+
+## Usage
+
+### Step 1: Log in to Telegram via the bridge
+
+Before you can bridge anything, you must link your Telegram account:
+
+1. Open Element at `element.lab.nijho.lt`
+1. Start a DM with `@telegrambot:matrix.lab.nijho.lt`
+1. Send `login`
+1. Enter your phone number in international format (e.g., `+1234567890`)
+1. Enter the verification code sent to your Telegram app
+1. Your existing Telegram chats will appear as Matrix rooms
+
+### Step 2: Bridge Matrix rooms to Telegram
+
+This is the primary use case -- talking to MindRoom agents from Telegram.
+
+The bridge connects a **Telegram group** to a **Matrix room**. You need a Telegram group on the Telegram side because that's what you'll open in the Telegram app to send and receive messages.
+
+**For each Matrix room you want to access from Telegram** (e.g., Lobby):
+
+1. **Create a Telegram group** in the Telegram app (e.g., name it "MindRoom Lobby")
+1. **Add your bridge bot** (e.g., `@mindroom_lab_bot`) to that Telegram group
+1. **In Element**, go to the Matrix room you want to bridge (e.g., Lobby)
+1. **Invite the bridge bot**: invite `@telegrambot:matrix.lab.nijho.lt` to the room
+1. **Link the rooms**: in the Matrix room, send `!tg bridge` -- the bot will list your Telegram groups and let you pick which one to link
+
+Once linked:
+
+- Messages you send in the **Telegram group** appear in the **Matrix room** -- MindRoom agents will see and respond to them
+- Agent responses in the **Matrix room** appear in the **Telegram group**
+- You can chat with MindRoom agents entirely from the Telegram app
+
+Repeat for any other Matrix rooms you want accessible from Telegram.
+
+> **Why can't I just invite the bot directly?** The bridge bot (`@telegrambot`) is Matrix-side infrastructure -- it manages the bridge but isn't a Telegram chat. To use Telegram as your client, there must be a Telegram group for the Telegram app to display. The bridge connects that group to the Matrix room bidirectionally.
+
+### Accessing Telegram chats from Matrix
+
+After logging in (step 1), your Telegram chats automatically appear as Matrix rooms in Element. This lets you use Element as a unified client for both Matrix and Telegram conversations.
+
+- **Private chats**: Automatically bridged as Matrix DMs
+- **Groups**: Automatically bridged if within `sync_create_limit` (default: 30)
+- **Additional groups**: Use `search <query>` in the bridge bot DM to find and bridge more
+
+### Bot Commands Reference
+
+Send these to `@telegrambot:matrix.lab.nijho.lt` in a DM, or in a bridged room:
+
+| Command          | Description                                                     |
+| ---------------- | --------------------------------------------------------------- |
+| `login`          | Link your Telegram account                                      |
+| `logout`         | Unlink your Telegram account                                    |
+| `ping`           | Check bridge connection status                                  |
+| `search <query>` | Search your Telegram chats                                      |
+| `!tg bridge`     | Link current Matrix room to a Telegram group (send in the room) |
+| `unbridge`       | Unlink current room from Telegram                               |
+| `sync`           | Re-sync Telegram chat list                                      |
+| `help`           | Show all commands                                               |
+
+## Configuration Reference
+
+Key settings in `telegram-bridge/config.yaml`:
+
+| Setting                       | Default              | Description                                 |
+| ----------------------------- | -------------------- | ------------------------------------------- |
+| `bridge.username_template`    | `telegram_{userid}`  | Matrix username pattern for Telegram ghosts |
+| `bridge.displayname_template` | `{displayname} (TG)` | Display name pattern for Telegram users     |
+| `bridge.sync_create_limit`    | `30`                 | Max chats to auto-create on first sync      |
+| `bridge.sync_direct_chats`    | `true`               | Auto-bridge private chats                   |
+| `bridge.encryption.allow`     | `true`               | Allow E2EE in bridged rooms                 |
+| `bridge.permissions`          | See config           | Who can use the bridge and at what level    |
+
+### Permission Levels
+
+Set in `bridge.permissions`:
+
+- `relaybot` - Messages relayed through the bot (not puppeted)
+- `user` - Can use the bridge but not log in
+- `puppeting` - Can log in with their Telegram account
+- `full` - Full access including creating portals
+- `admin` - Bridge administration
+
+Default config gives `full` to all `matrix.lab.nijho.lt` users.
+
+## Troubleshooting
+
+### Bridge won't start
+
+- Check credentials: `api_id` must be numeric, `api_hash` must be a hex string, `bot_token` must be a valid BotFather token
+- Check logs: `cf compose mindroom logs telegram-bridge --tail 50`
+- Verify Synapse is healthy: `cf compose mindroom ps`
+
+### Login fails
+
+- Ensure `api_id` and `api_hash` are from the same Telegram app
+- The bot token must be from a bot you own (not revoked)
+- If you get "FLOOD_WAIT", wait the indicated time before retrying
+
+### Messages not bridging
+
+- Check the bridge is connected: DM the bot and send `ping`
+- Verify Synapse has the registration: check `app_service_config_files` in `homeserver.yaml`
+- Check bridge permissions in `config.yaml` - your user domain must have `full` or `puppeting`
+
+### Double puppeting
+
+To make your messages from Matrix appear as your real Telegram account (not the bridge bot):
+
+1. This is automatic when you log in via `login` - puppet mode is the default
+1. If messages still show as the bot, check `bridge.sync_with_custom_puppets` in config
+
+### Database issues
+
+The bridge uses SQLite at `/mnt/data/mindroom/telegram-bridge/mautrix-telegram.db`. To reset:
+
+```
+cf compose mindroom stop telegram-bridge
+rm /mnt/data/mindroom/telegram-bridge/mautrix-telegram.db
+cf compose mindroom up -d telegram-bridge
+```
+
+Note: This will require re-logging into Telegram.
+
+### Registration out of sync
+
+If Synapse reports appservice errors, regenerate the registration:
+
+```
+cf compose mindroom stop telegram-bridge
+rm /opt/stacks/mindroom/telegram-bridge/registration.yaml
+# Temporarily set valid api_id in config.yaml, then:
+cf compose mindroom run --rm --no-deps --entrypoint \
+  "python -m mautrix_telegram -g -c /data/config.yaml -r /data/registration.yaml" \
+  telegram-bridge
+cf compose mindroom restart synapse
+cf compose mindroom up -d telegram-bridge
+```
+
+## Maintenance
+
+### Updating
+
+```
+cf update mindroom
+# Or just the bridge:
+cf compose mindroom pull telegram-bridge
+cf compose mindroom up -d telegram-bridge
+```
+
+### Backup
+
+Important data locations:
+
+- `/opt/stacks/mindroom/telegram-bridge/config.yaml` - Bridge configuration
+- `/opt/stacks/mindroom/telegram-bridge/registration.yaml` - Appservice registration
+- `/mnt/data/mindroom/telegram-bridge/` - SQLite database with session data

--- a/skills/mindroom-docs/references/page__deployment__index.md
+++ b/skills/mindroom-docs/references/page__deployment__index.md
@@ -11,6 +11,13 @@ MindRoom can be deployed in various ways depending on your needs.
 | [Kubernetes](https://docs.mindroom.chat/deployment/kubernetes/index.md)            | Multi-tenant SaaS, production                               |
 | Direct                                                                             | Development, simple setups                                  |
 
+## Bridges
+
+Connect external messaging platforms to Matrix:
+
+- [Bridges overview](https://docs.mindroom.chat/deployment/bridges/index.md) - available bridges and how they work
+- [Telegram bridge](https://docs.mindroom.chat/deployment/bridges/telegram/index.md) - bridge Telegram chats via mautrix-telegram
+
 ## Google Services (Gmail/Calendar/Drive/Sheets)
 
 Use these guides if you want users to connect Google accounts in the MindRoom frontend:

--- a/skills/mindroom-docs/references/page__index.md
+++ b/skills/mindroom-docs/references/page__index.md
@@ -135,6 +135,7 @@ mindroom run
 - [Authorization](https://docs.mindroom.chat/authorization/index.md) - User and room access control
 - [Architecture](https://docs.mindroom.chat/architecture/index.md) - How it works under the hood
 - [Deployment](https://docs.mindroom.chat/deployment/index.md) - Docker and Kubernetes deployment
+- [Bridges](https://docs.mindroom.chat/deployment/bridges/index.md) - Connect Telegram, Slack, and other platforms to Matrix
 - [Sandbox Proxy](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) - Isolate code-execution tools in a sandbox
 - [Google Services OAuth](https://docs.mindroom.chat/deployment/google-services-oauth/index.md) - Admin OAuth setup for Gmail/Calendar/Drive/Sheets
 - [Google Services OAuth (Individual)](https://docs.mindroom.chat/deployment/google-services-user-oauth/index.md) - Single-user OAuth setup

--- a/skills/mindroom-docs/references/reference-index.md
+++ b/skills/mindroom-docs/references/reference-index.md
@@ -32,6 +32,8 @@ Generated from `docs/` via `.github/scripts/generate_skill_references.py`.
 | Matrix Integration | `architecture/matrix.md` | `architecture/matrix/index.md` | `page__architecture__matrix__index.md` |
 | Agent Orchestration | `architecture/orchestration.md` | `architecture/orchestration/index.md` | `page__architecture__orchestration__index.md` |
 | Overview | `deployment/index.md` | `deployment/index.md` | `page__deployment__index.md` |
+| Overview | `deployment/bridges/index.md` | `deployment/bridges/index.md` | `page__deployment__bridges__index.md` |
+| Telegram | `deployment/bridges/telegram.md` | `deployment/bridges/telegram/index.md` | `page__deployment__bridges__telegram__index.md` |
 | Google Services OAuth (Admin) | `deployment/google-services-oauth.md` | `deployment/google-services-oauth/index.md` | `page__deployment__google-services-oauth__index.md` |
 | Google Services OAuth (Individual) | `deployment/google-services-user-oauth.md` | `deployment/google-services-user-oauth/index.md` | `page__deployment__google-services-user-oauth__index.md` |
 | Docker | `deployment/docker.md` | `deployment/docker/index.md` | `page__deployment__docker__index.md` |


### PR DESCRIPTION
## Summary
- allow optional explicit designation of one agent as Agent B while still supporting automatic role detection by `DEBATE.md` existence
- clarify that both agents can receive the debate prompt at the same time
- require designated Agent B to poll for `DEBATE.md` creation, then read and continue
- document timeout behavior for Agent B while waiting for file creation

## Validation
- `pre-commit run --all-files`
- `pytest`

## Notes
- pre-commit regenerated `skills/mindroom-docs/references/*` files and those updates are included in this PR
