### PR TITLE
Fix login failure for existing users in register_user

### DIFF
--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -163,7 +163,7 @@ async def register_user(
     server_name = extract_server_name_from_homeserver(homeserver)
     user_id = MatrixID.from_username(username, server_name).full_id
 
-    async with matrix_client(homeserver) as client:
+    async with matrix_client(homeserver, user_id=user_id) as client:
         # Try to register the user
         response = await client.register(
             username=username,


### PR DESCRIPTION
## Summary
- `register_user` creates a `matrix_client(homeserver)` without a `user_id`, so when it falls back to `client.login(password)` for already-existing users, nio sends an empty user field in the login request
- Synapse rejects this with `User identifier is missing 'user' key`, causing the backend to crash-loop on startup
- Fix: pass the already-computed `user_id` to `matrix_client()` so nio includes it in the login request

Regression from #142 (`a0d339df`) which added the login-to-sync-display-name path for existing users.

## Test plan
- [x] All 34 matrix-related tests pass (`test_matrix_agent_manager.py`, `test_dynamic_config_update.py`, `test_cli.py`)
- [ ] Deploy updated image and verify backend starts without login errors