### PR TITLE
Fix backend /app permissions for uv cache initialization

### DIFF
--- a/local/instances/deploy/Dockerfile.backend
+++ b/local/instances/deploy/Dockerfile.backend
@@ -57,11 +57,11 @@ COPY --chown=1000:1000 scripts /app/scripts/
 COPY --chown=1000:1000 tools /app/tools/
 COPY --chown=1000:1000 avatars /app/avatars/
 
-# Make startup scripts executable
-RUN chmod +x /app/run-sandbox-runner.sh
-
-# Create necessary directories
-RUN mkdir -p /app/logs /app/mindroom_data
+# Make startup scripts executable and ensure runtime/cache directories
+# are writable by the non-root runtime user.
+RUN chmod +x /app/run-sandbox-runner.sh \
+    && mkdir -p /app/logs /app/mindroom_data /app/.cache/uv \
+    && chown 1000:1000 /app /app/logs /app/mindroom_data /app/.cache /app/.cache/uv
 
 # Set environment variable to indicate Docker mode
 ENV DOCKER_CONTAINER=1


### PR DESCRIPTION
## Summary
- fix backend image permissions so runtime user (UID/GID 1000) can write under /app
- pre-create /app/.cache/uv and set ownership for /app, /app/logs, /app/mindroom_data
- keep non-root runtime behavior unchanged

## Root cause
WORKDIR /app creates /app as root-owned. After switching to COPY --chown, copied contents were owned correctly but /app itself could remain root-owned, so uv failed creating .cache/uv when HOME=/app.

## Validation
- docker build -f local/instances/deploy/Dockerfile.backend -t mindroom-backend-test .
- verified runtime write access as uid/gid 1000:1000 by creating /app/.cache/uv/probe
- pytest: 1251 passed, 19 skipped
- pre-commit run --files local/instances/deploy/Dockerfile.backend passed
