### PR TITLE
Fix API-only Git knowledge sync/reindex and GitHub token bootstrap

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -204,6 +204,8 @@ Each knowledge base can optionally sync from Git by setting `knowledge_bases.<ba
 - Local uncommitted changes inside that checkout are discarded on sync.
 - Git polling runs even when `watch: false`; `watch` controls only local filesystem watching.
 - GitHub/GitLab webhooks are not part of this V1; updates are pull-based via polling.
+- In API-only mode (`uv run uvicorn mindroom.api.main:app --host 0.0.0.0 --port 8765`), Git-backed bases are auto-cloned/synced/indexed when managers are first initialized.
+- `POST /api/knowledge/bases/{base_id}/reindex` performs a Git sync first for Git-backed bases, then rebuilds the index.
 
 ### Git Fields
 
@@ -226,6 +228,14 @@ Each knowledge base can optionally sync from Git by setting `knowledge_bases.<ba
 ### Private Repository Authentication
 
 For private HTTPS repositories, set credentials under a service name and reference it via `credentials_service`.
+
+If `GITHUB_TOKEN` is set, MindRoom automatically seeds/updates `github_private` credentials as:
+
+- `username: x-access-token`
+- `token: <GITHUB_TOKEN>`
+- `_source: env`
+
+This env bootstrap never overwrites UI-managed (`_source: ui`) or legacy credentials.
 
 ```bash
 curl -X POST http://localhost:8765/api/credentials/github_private \

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -101,6 +101,8 @@ Git-backed knowledge bases are supported, but Git settings are currently configu
 - The dashboard preserves existing `git` settings when you edit `path`/`watch`.
 - `/api/knowledge/bases/{base_id}/files` reflects the manager's filtered file set (for example `include_patterns`/`exclude_patterns`).
 - Private HTTPS repo auth can be managed in the **Credentials** tab, then referenced by `knowledge_bases.<id>.git.credentials_service`.
+- In API-only mode, Git-backed bases are cloned/synced/indexed automatically on first manager initialization.
+- `POST /api/knowledge/bases/{base_id}/reindex` syncs Git first for Git-backed bases before rebuilding the index.
 
 ### Credentials
 
@@ -112,6 +114,7 @@ Manage service credentials directly from the dashboard:
 - **Test credentials existence** using `/api/credentials/{service}/test`
 - **Delete credential sets** using `/api/credentials/{service}`
 - **Reuse credentials for Git knowledge sync** by setting `knowledge_bases.<id>.git.credentials_service` to the same service name
+- `GITHUB_TOKEN` auto-seeds `github_private` (`username: x-access-token`, `token: <GITHUB_TOKEN>`, `_source: env`) unless the service is UI-managed
 
 ### Voice
 

--- a/docs/openai-api.md
+++ b/docs/openai-api.md
@@ -160,6 +160,7 @@ Parallel Claude sub-sessions are supported by using different `session_label` va
 ### Knowledge bases
 
 Agents with configured `knowledge_bases` in `config.yaml` get RAG support automatically. No additional API configuration needed.
+For Git-backed knowledge bases, API-only deployments auto-clone/sync/index on manager initialization.
 
 ## What's ignored
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -407,6 +407,8 @@ Git-backed knowledge bases are supported, but Git settings are currently configu
 - The dashboard preserves existing `git` settings when you edit `path`/`watch`.
 - `/api/knowledge/bases/{base_id}/files` reflects the manager's filtered file set (for example `include_patterns`/`exclude_patterns`).
 - Private HTTPS repo auth can be managed in the **Credentials** tab, then referenced by `knowledge_bases.<id>.git.credentials_service`.
+- In API-only mode, Git-backed bases are cloned/synced/indexed automatically on first manager initialization.
+- `POST /api/knowledge/bases/{base_id}/reindex` syncs Git first for Git-backed bases before rebuilding the index.
 
 ### Credentials
 
@@ -418,6 +420,7 @@ Manage service credentials directly from the dashboard:
 - **Test credentials existence** using `/api/credentials/{service}/test`
 - **Delete credential sets** using `/api/credentials/{service}`
 - **Reuse credentials for Git knowledge sync** by setting `knowledge_bases.<id>.git.credentials_service` to the same service name
+- `GITHUB_TOKEN` auto-seeds `github_private` (`username: x-access-token`, `token: <GITHUB_TOKEN>`, `_source: env`) unless the service is UI-managed
 
 ### Voice
 
@@ -710,6 +713,8 @@ Each knowledge base can optionally sync from Git by setting `knowledge_bases.<ba
 - Local uncommitted changes inside that checkout are discarded on sync.
 - Git polling runs even when `watch: false`; `watch` controls only local filesystem watching.
 - GitHub/GitLab webhooks are not part of this V1; updates are pull-based via polling.
+- In API-only mode (`uv run uvicorn mindroom.api.main:app --host 0.0.0.0 --port 8765`), Git-backed bases are auto-cloned/synced/indexed when managers are first initialized.
+- `POST /api/knowledge/bases/{base_id}/reindex` performs a Git sync first for Git-backed bases, then rebuilds the index.
 
 ### Git Fields
 
@@ -732,6 +737,14 @@ Each knowledge base can optionally sync from Git by setting `knowledge_bases.<ba
 ### Private Repository Authentication
 
 For private HTTPS repositories, set credentials under a service name and reference it via `credentials_service`.
+
+If `GITHUB_TOKEN` is set, MindRoom automatically seeds/updates `github_private` credentials as:
+
+- `username: x-access-token`
+- `token: <GITHUB_TOKEN>`
+- `_source: env`
+
+This env bootstrap never overwrites UI-managed (`_source: ui`) or legacy credentials.
 
 ```
 curl -X POST http://localhost:8765/api/credentials/github_private \
@@ -2482,7 +2495,7 @@ Parallel Claude sub-sessions are supported by using different `session_label` va
 
 ### Knowledge bases
 
-Agents with configured `knowledge_bases` in `config.yaml` get RAG support automatically. No additional API configuration needed.
+Agents with configured `knowledge_bases` in `config.yaml` get RAG support automatically. No additional API configuration needed. For Git-backed knowledge bases, API-only deployments auto-clone/sync/index on manager initialization.
 
 ## What's ignored
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -200,6 +200,8 @@ Each knowledge base can optionally sync from Git by setting `knowledge_bases.<ba
 - Local uncommitted changes inside that checkout are discarded on sync.
 - Git polling runs even when `watch: false`; `watch` controls only local filesystem watching.
 - GitHub/GitLab webhooks are not part of this V1; updates are pull-based via polling.
+- In API-only mode (`uv run uvicorn mindroom.api.main:app --host 0.0.0.0 --port 8765`), Git-backed bases are auto-cloned/synced/indexed when managers are first initialized.
+- `POST /api/knowledge/bases/{base_id}/reindex` performs a Git sync first for Git-backed bases, then rebuilds the index.
 
 ### Git Fields
 
@@ -222,6 +224,14 @@ Each knowledge base can optionally sync from Git by setting `knowledge_bases.<ba
 ### Private Repository Authentication
 
 For private HTTPS repositories, set credentials under a service name and reference it via `credentials_service`.
+
+If `GITHUB_TOKEN` is set, MindRoom automatically seeds/updates `github_private` credentials as:
+
+- `username: x-access-token`
+- `token: <GITHUB_TOKEN>`
+- `_source: env`
+
+This env bootstrap never overwrites UI-managed (`_source: ui`) or legacy credentials.
 
 ```
 curl -X POST http://localhost:8765/api/credentials/github_private \

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -97,6 +97,8 @@ Git-backed knowledge bases are supported, but Git settings are currently configu
 - The dashboard preserves existing `git` settings when you edit `path`/`watch`.
 - `/api/knowledge/bases/{base_id}/files` reflects the manager's filtered file set (for example `include_patterns`/`exclude_patterns`).
 - Private HTTPS repo auth can be managed in the **Credentials** tab, then referenced by `knowledge_bases.<id>.git.credentials_service`.
+- In API-only mode, Git-backed bases are cloned/synced/indexed automatically on first manager initialization.
+- `POST /api/knowledge/bases/{base_id}/reindex` syncs Git first for Git-backed bases before rebuilding the index.
 
 ### Credentials
 
@@ -108,6 +110,7 @@ Manage service credentials directly from the dashboard:
 - **Test credentials existence** using `/api/credentials/{service}/test`
 - **Delete credential sets** using `/api/credentials/{service}`
 - **Reuse credentials for Git knowledge sync** by setting `knowledge_bases.<id>.git.credentials_service` to the same service name
+- `GITHUB_TOKEN` auto-seeds `github_private` (`username: x-access-token`, `token: <GITHUB_TOKEN>`, `_source: env`) unless the service is UI-managed
 
 ### Voice
 

--- a/skills/mindroom-docs/references/page__openai-api__index.md
+++ b/skills/mindroom-docs/references/page__openai-api__index.md
@@ -149,7 +149,7 @@ Parallel Claude sub-sessions are supported by using different `session_label` va
 
 ### Knowledge bases
 
-Agents with configured `knowledge_bases` in `config.yaml` get RAG support automatically. No additional API configuration needed.
+Agents with configured `knowledge_bases` in `config.yaml` get RAG support automatically. No additional API configuration needed. For Git-backed knowledge bases, API-only deployments auto-clone/sync/index on manager initialization.
 
 ## What's ignored
 

--- a/src/mindroom/api/knowledge.py
+++ b/src/mindroom/api/knowledge.py
@@ -83,7 +83,7 @@ async def _ensure_managers(config: Config) -> dict[str, KnowledgeManager]:
         config,
         STORAGE_PATH_OBJ,
         start_watchers=False,
-        reindex_on_create=False,
+        reindex_on_create=True,
     )
 
 
@@ -284,6 +284,9 @@ async def reindex_knowledge(base_id: str) -> dict[str, Any]:
     manager = await _ensure_manager(config, base_id)
     if manager is None:
         raise HTTPException(status_code=500, detail="Knowledge manager is unavailable")
+
+    if config.knowledge_bases[base_id].git is not None:
+        await manager.sync_git_repository()
 
     indexed_count = await manager.reindex_all()
     return {

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -507,7 +507,7 @@ async def _ensure_knowledge_initialized(config: Config) -> None:
         config=config,
         storage_path=STORAGE_PATH_OBJ,
         start_watchers=False,
-        reindex_on_create=False,
+        reindex_on_create=True,
     )
 
 

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -1885,7 +1885,8 @@ class TestKnowledgeIntegration:
                 },
             )
 
-        mock_init.assert_called_once()
+        mock_init.assert_awaited_once()
+        assert mock_init.await_args.kwargs["reindex_on_create"] is True
 
     def test_knowledge_unavailable_returns_none(self, knowledge_app_client: TestClient) -> None:
         """When knowledge manager is not found, knowledge is None."""


### PR DESCRIPTION
## Summary
- enable full knowledge manager initialization in API-only paths so Git-backed knowledge bases clone/sync/index automatically
- update `/api/knowledge/bases/{base_id}/reindex` to sync Git before reindex for Git-backed bases
- auto-seed `github_private` from `GITHUB_TOKEN` (`username: x-access-token`, `token`, `_source: env`) while preserving existing no-overwrite behavior for UI/legacy credentials
- keep Matrix bot behavior unchanged

## Tests
- `uv run pytest tests/api/test_knowledge_api.py tests/test_credentials_sync.py tests/test_openai_compat.py::TestKnowledgeIntegration::test_knowledge_initialization_called`
- `uv run pytest`

## Notes
- no `CONFIG_PATH`/`STORAGE_PATH` alias behavior was introduced; only `MINDROOM_CONFIG_PATH` and `MINDROOM_STORAGE_PATH` remain
