### PR TITLE
Add missing config fields to reference config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -353,7 +353,12 @@ authorization:
   global_users:
   - '@test:m-test-4.mindroom.chat'
   room_permissions: {}
+bot_accounts: []
+mindroom_user:
+  display_name: MindRoomUser
+  username: mindroom_user
 defaults:
+  enable_streaming: true
   learning: true
   learning_mode: always
   markdown: true


### PR DESCRIPTION
## Summary
- Add `bot_accounts: []` — list of non-MindRoom bot Matrix IDs that should be treated like agents for response logic
- Add `mindroom_user` section — internal MindRoom user account settings (display_name, username)
- Add `enable_streaming: true` under `defaults` — streaming responses via progressive message edits

These fields exist in the Pydantic model (`src/mindroom/config.py`) but were missing from the reference `config.yaml`.

## Test plan
- [ ] Verify `config.yaml` parses correctly: `uv run python -c "from mindroom.config import load_config; load_config('config.yaml')"`
- [ ] Confirm field defaults match `Config` model in `src/mindroom/config.py`