### PR TITLE
fix: use API_ENDPOINTS in GoogleIntegration instead of hardcoded URLs

### DIFF
--- a/frontend/src/components/GoogleIntegration/GoogleIntegration.tsx
+++ b/frontend/src/components/GoogleIntegration/GoogleIntegration.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/use-toast';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { API_BASE } from '@/lib/api';
+import { API_ENDPOINTS } from '@/lib/api';
 
 interface GoogleStatus {
   connected: boolean;
@@ -63,7 +63,7 @@ export function GoogleIntegration({ onSuccess }: GoogleIntegrationProps = {}) {
 
   const checkGoogleStatus = async () => {
     try {
-      const response = await fetch(`${API_BASE}/api/google/status`);
+      const response = await fetch(API_ENDPOINTS.google.status);
       const data = await response.json();
       setStatus({
         connected: data.connected,
@@ -82,7 +82,7 @@ export function GoogleIntegration({ onSuccess }: GoogleIntegrationProps = {}) {
   const connectGoogle = async () => {
     setLoading(true);
     try {
-      const response = await fetch(`${API_BASE}/api/google/connect`, {
+      const response = await fetch(API_ENDPOINTS.google.connect, {
         method: 'POST',
       });
 
@@ -146,7 +146,7 @@ export function GoogleIntegration({ onSuccess }: GoogleIntegrationProps = {}) {
   const disconnectGoogle = async () => {
     setLoading(true);
     try {
-      const response = await fetch(`${API_BASE}/api/google/disconnect`, {
+      const response = await fetch(API_ENDPOINTS.google.disconnect, {
         method: 'POST',
       });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -58,6 +58,13 @@ export const API_ENDPOINTS = {
       `${API_BASE_URL}/api/credentials/${encodeURIComponent(service)}/test`,
   },
 
+  // Google integration
+  google: {
+    status: `${API_BASE_URL}/api/google/status`,
+    connect: `${API_BASE_URL}/api/google/connect`,
+    disconnect: `${API_BASE_URL}/api/google/disconnect`,
+  },
+
   // Other endpoints
   tools: `${API_BASE_URL}/api/tools`,
   rooms: `${API_BASE_URL}/api/rooms`,


### PR DESCRIPTION
## Summary
- Add `google.{status, connect, disconnect}` entries to the centralized `API_ENDPOINTS` map in `frontend/src/lib/api.ts`
- Update `GoogleIntegration.tsx` to import `API_ENDPOINTS` instead of `API_BASE` and use the new entries

This aligns the component with the pattern used by other components (Knowledge, Credentials, UnconfiguredRooms), keeping all endpoint URLs defined in one place.

Closes #133

## Test plan
- [x] TypeScript type-check passes
- [x] All pre-commit hooks pass (prettier, eslint, tsc)
- [ ] Verify Google connect/disconnect/status flows work in the UI