### PR TITLE
fix: graceful fallback when topic generation returns non-structured output

### DIFF
--- a/src/mindroom/topic_generator.py
+++ b/src/mindroom/topic_generator.py
@@ -101,7 +101,9 @@ Generate the topic:"""
         logger.exception(f"Error generating topic for room {room_key}")
         return None
     content = response.content
-    assert isinstance(content, RoomTopic)  # Type narrowing for mypy
+    if not isinstance(content, RoomTopic):
+        logger.warning(f"Topic generation returned unexpected type: {type(content)}")
+        return str(content) if content else None
     return content.topic
 
 


### PR DESCRIPTION
## Summary
- Replace `assert isinstance(content, RoomTopic)` with a warning log and string fallback when LiteLLM proxy doesn't pass through `response_model` correctly, preventing startup crashes.

## Test plan
- [ ] Verify topic generation still works normally with structured output
- [ ] Verify graceful fallback when raw text is returned instead of RoomTopic