### PR TITLE
feat: respect show_tool_calls in tool trace metadata

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -2211,6 +2211,7 @@ class AgentBot:
         skip_mentions: bool = False,
         tool_trace: list[ToolTraceEntry] | None = None,
         extra_content: dict[str, Any] | None = None,
+        show_tool_calls: bool | None = None,
     ) -> str | None:
         """Send a response message to a room.
 
@@ -2223,6 +2224,7 @@ class AgentBot:
             skip_mentions: If True, add metadata to indicate mentions should not trigger responses
             tool_trace: Optional structured tool trace metadata for message content
             extra_content: Optional content fields merged into the outgoing Matrix event
+            show_tool_calls: Whether tool trace should be displayed by clients (defaults to agent setting)
 
         Returns:
             Event ID if message was sent successfully, None otherwise.
@@ -2230,6 +2232,7 @@ class AgentBot:
         """
         sender_id = self.matrix_id
         sender_domain = sender_id.domain
+        effective_show_tool_calls = show_tool_calls if show_tool_calls is not None else self.show_tool_calls
 
         effective_thread_id = self._resolve_reply_thread_id(
             thread_id,
@@ -2247,6 +2250,7 @@ class AgentBot:
                 reply_to_event_id=None,
                 latest_thread_event_id=None,
                 tool_trace=tool_trace,
+                show_tool_calls=effective_show_tool_calls,
             )
         else:
             # Get the latest message in thread for MSC3440 fallback compatibility
@@ -2265,6 +2269,7 @@ class AgentBot:
                 reply_to_event_id=reply_to_event_id,
                 latest_thread_event_id=latest_thread_event_id,
                 tool_trace=tool_trace,
+                show_tool_calls=effective_show_tool_calls,
             )
 
         # Add metadata to indicate mentions should be ignored for responses
@@ -2288,6 +2293,7 @@ class AgentBot:
         new_text: str,
         thread_id: str | None,
         tool_trace: list[ToolTraceEntry] | None = None,
+        show_tool_calls: bool | None = None,
     ) -> bool:
         """Edit an existing message.
 
@@ -2297,6 +2303,7 @@ class AgentBot:
         """
         sender_id = self.matrix_id
         sender_domain = sender_id.domain
+        effective_show_tool_calls = show_tool_calls if show_tool_calls is not None else self.show_tool_calls
 
         if self.thread_mode == "room":
             # Room mode: no thread metadata on edits
@@ -2305,6 +2312,7 @@ class AgentBot:
                 new_text,
                 sender_domain=sender_domain,
                 tool_trace=tool_trace,
+                show_tool_calls=effective_show_tool_calls,
             )
         else:
             # For edits in threads, we need to get the latest thread event ID for MSC3440 compliance
@@ -2327,6 +2335,7 @@ class AgentBot:
                 thread_event_id=thread_id,
                 latest_thread_event_id=latest_thread_event_id,
                 tool_trace=tool_trace,
+                show_tool_calls=effective_show_tool_calls,
             )
 
         assert self.client is not None

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -113,6 +113,7 @@ def format_message_with_mentions(
     reply_to_event_id: str | None = None,
     latest_thread_event_id: str | None = None,
     tool_trace: list["ToolTraceEntry"] | None = None,
+    show_tool_calls: bool = True,
 ) -> dict[str, Any]:
     """Parse text for mentions and create properly formatted Matrix message.
 
@@ -126,6 +127,7 @@ def format_message_with_mentions(
         reply_to_event_id: Optional event ID to reply to (for genuine replies)
         latest_thread_event_id: Optional latest event ID in thread (for fallback compatibility)
         tool_trace: Optional structured tool trace metadata
+        show_tool_calls: Whether tool trace should be displayed by clients
 
     Returns:
         Properly formatted content dict for room_send
@@ -136,7 +138,7 @@ def format_message_with_mentions(
     # Convert markdown (with links) to HTML
     # The markdown converter will properly handle the [@DisplayName](url) format
     formatted_html = markdown_to_html(markdown_text)
-    extra_content = build_tool_trace_content(tool_trace)
+    extra_content = build_tool_trace_content(tool_trace, show_tool_calls=show_tool_calls)
 
     return build_message_content(
         body=plain_text,

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -209,6 +209,7 @@ class StreamingResponse:
             reply_to_event_id=None if self.room_mode else self.reply_to_event_id,
             latest_thread_event_id=latest_for_message,
             tool_trace=self.tool_trace,
+            show_tool_calls=self.show_tool_calls,
         )
 
         send_succeeded = False

--- a/src/mindroom/tool_events.py
+++ b/src/mindroom/tool_events.py
@@ -221,7 +221,11 @@ def extract_tool_completed_info(tool: ToolExecution | None) -> tuple[str, str | 
     return tool_name, tool.result
 
 
-def build_tool_trace_content(tool_trace: Sequence[ToolTraceEntry] | None) -> dict[str, object] | None:
+def build_tool_trace_content(
+    tool_trace: Sequence[ToolTraceEntry] | None,
+    *,
+    show_tool_calls: bool = True,
+) -> dict[str, object] | None:
     """Build message content payload for tool trace metadata."""
     if not tool_trace:
         return None
@@ -251,6 +255,8 @@ def build_tool_trace_content(tool_trace: Sequence[ToolTraceEntry] | None) -> dic
         "version": TOOL_TRACE_VERSION,
         "events": events,
     }
+    if not show_tool_calls:
+        payload["display"] = False
     if overflow:
         payload["events_truncated"] = overflow
     if has_truncated_content:


### PR DESCRIPTION
When show_tool_calls is false, add 'display: false' to the io.mindroom.tool_trace payload so clients know not to render tool call details inline. The trace data is still sent for debugging/logging purposes.

Passes show_tool_calls through the full chain:
streaming → format_message_with_mentions → build_tool_trace_content