### PR TITLE
Add Agno run metadata to Matrix message content

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -13,15 +13,24 @@ from agno.models.cerebras import Cerebras
 from agno.models.deepseek import DeepSeek
 from agno.models.google import Gemini
 from agno.models.groq import Groq
+from agno.models.metrics import Metrics
 from agno.models.ollama import Ollama
 from agno.models.openai import OpenAIChat
 from agno.models.openrouter import OpenRouter
-from agno.run.agent import RunContentEvent, RunErrorEvent, RunOutput, ToolCallCompletedEvent, ToolCallStartedEvent
+from agno.run.agent import (
+    ModelRequestCompletedEvent,
+    RunCompletedEvent,
+    RunContentEvent,
+    RunErrorEvent,
+    RunOutput,
+    ToolCallCompletedEvent,
+    ToolCallStartedEvent,
+)
 from agno.run.base import RunStatus
 from agno.utils.message import filter_tool_calls
 
 from .agents import _get_agent_session, create_agent, create_session_storage, get_seen_event_ids
-from .constants import ENABLE_AI_CACHE, PROVIDER_ENV_KEYS
+from .constants import AI_RUN_METADATA_KEY, ENABLE_AI_CACHE, PROVIDER_ENV_KEYS, ROUTER_AGENT_NAME
 from .credentials import get_credentials_manager
 from .credentials_sync import get_api_key_for_provider, get_ollama_host
 from .error_handling import get_user_friendly_error_message
@@ -50,6 +59,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 AIStreamChunk = str | RunContentEvent | ToolCallStartedEvent | ToolCallCompletedEvent
+AI_RUN_METADATA_VERSION = 1
 
 
 def _estimate_message_media_chars(message: object) -> int:
@@ -312,6 +322,115 @@ def _extract_tool_trace(response: RunOutput) -> list[ToolTraceEntry]:
         _, trace_entry = format_tool_combined(tool_name, tool_args, tool.result)
         trace.append(trace_entry)
     return trace
+
+
+def _get_model_config(config: Config, agent_name: str) -> tuple[str | None, ModelConfig | None]:
+    """Return configured model name/config for an agent when available."""
+    if agent_name not in config.agents and agent_name not in config.teams and agent_name != ROUTER_AGENT_NAME:
+        return None, None
+    model_name = config.get_entity_model_name(agent_name)
+    return model_name, config.models.get(model_name)
+
+
+def _serialize_metrics(metrics: Metrics | dict[str, Any] | None) -> dict[str, Any] | None:
+    if metrics is None:
+        return None
+    if isinstance(metrics, Metrics):
+        metrics_dict = metrics.to_dict()
+        return metrics_dict or None
+    if isinstance(metrics, dict):
+        return metrics or None
+    return None
+
+
+def _build_model_request_metrics_fallback(
+    totals: dict[str, int],
+    first_token_latency: float | None,
+) -> dict[str, Any] | None:
+    payload = {key: value for key, value in totals.items() if value > 0}
+    if payload.get("total_tokens") is None:
+        input_tokens = payload.get("input_tokens")
+        output_tokens = payload.get("output_tokens")
+        if isinstance(input_tokens, int) and isinstance(output_tokens, int):
+            payload["total_tokens"] = input_tokens + output_tokens
+    if first_token_latency is not None:
+        payload["time_to_first_token"] = first_token_latency
+    return payload or None
+
+
+def _build_context_payload(
+    *,
+    input_tokens: int | None,
+    model_config: ModelConfig | None,
+) -> dict[str, Any] | None:
+    if input_tokens is None or model_config is None or model_config.context_window is None:
+        return None
+    context_window = model_config.context_window
+    if context_window <= 0:
+        return None
+    return {
+        "input_tokens": input_tokens,
+        "window_tokens": context_window,
+    }
+
+
+def _build_ai_run_metadata_content(  # noqa: C901, PLR0912
+    *,
+    agent_name: str,
+    config: Config,
+    run_id: str | None,
+    session_id: str | None,
+    status: RunStatus | str | None,
+    model: str | None,
+    model_provider: str | None,
+    metrics: Metrics | dict[str, Any] | None = None,
+    metrics_fallback: dict[str, Any] | None = None,
+    tool_count: int | None = None,
+) -> dict[str, Any] | None:
+    model_name, model_config = _get_model_config(config, agent_name)
+    model_id = model or (model_config.id if model_config is not None else None)
+    provider = model_provider or (model_config.provider if model_config is not None else None)
+
+    usage_payload = _serialize_metrics(metrics)
+    if usage_payload is None and metrics_fallback:
+        usage_payload = dict(metrics_fallback)
+
+    input_tokens = usage_payload.get("input_tokens") if usage_payload else None
+    if not isinstance(input_tokens, int):
+        input_tokens = None
+
+    payload: dict[str, Any] = {"version": AI_RUN_METADATA_VERSION}
+    if run_id is not None:
+        payload["run_id"] = run_id
+    if session_id is not None:
+        payload["session_id"] = session_id
+    if status is not None:
+        raw_status = status.value if isinstance(status, RunStatus) else str(status)
+        payload["status"] = raw_status.lower()
+    if model_name is not None or model_id is not None or provider is not None:
+        model_payload: dict[str, Any] = {}
+        if model_name is not None:
+            model_payload["config"] = model_name
+        if model_id is not None:
+            model_payload["id"] = model_id
+        if provider is not None:
+            model_payload["provider"] = provider
+        if model_payload:
+            payload["model"] = model_payload
+    if usage_payload:
+        payload["usage"] = usage_payload
+    context_payload = _build_context_payload(
+        input_tokens=input_tokens,
+        model_config=model_config,
+    )
+    if context_payload:
+        payload["context"] = context_payload
+    if tool_count is not None:
+        payload["tools"] = {"count": tool_count}
+
+    if len(payload) == 1:
+        return None
+    return {AI_RUN_METADATA_KEY: payload}
 
 
 @functools.cache
@@ -643,6 +762,7 @@ async def ai_response(
     reply_to_event_id: str | None = None,
     show_tool_calls: bool = True,
     tool_trace_collector: list[ToolTraceEntry] | None = None,
+    run_metadata_collector: dict[str, Any] | None = None,
 ) -> str:
     """Generates a response using the specified agno Agent with memory integration.
 
@@ -665,6 +785,8 @@ async def ai_response(
         show_tool_calls: Whether to include tool call details inline in the response text.
         tool_trace_collector: Optional list that receives structured tool-trace
             entries from this run.
+        run_metadata_collector: Optional mapping that receives versioned
+            run/model/token metadata for Matrix message content.
 
     Returns:
         Agent response string
@@ -710,6 +832,20 @@ async def ai_response(
 
     if tool_trace_collector is not None:
         tool_trace_collector.extend(_extract_tool_trace(response))
+    if run_metadata_collector is not None:
+        run_metadata = _build_ai_run_metadata_content(
+            agent_name=agent_name,
+            config=config,
+            run_id=response.run_id,
+            session_id=response.session_id or session_id,
+            status=response.status,
+            model=response.model,
+            model_provider=response.model_provider,
+            metrics=response.metrics,
+            tool_count=len(response.tools) if response.tools is not None else 0,
+        )
+        if run_metadata:
+            run_metadata_collector.update(run_metadata)
 
     # Extract response content - this shouldn't fail
     return _extract_response_content(response, show_tool_calls=show_tool_calls)
@@ -729,6 +865,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
     images: Sequence[Image] | None = None,
     reply_to_event_id: str | None = None,
     show_tool_calls: bool = True,
+    run_metadata_collector: dict[str, Any] | None = None,
 ) -> AsyncIterator[AIStreamChunk]:
     """Generate streaming AI response using Agno's streaming API.
 
@@ -752,6 +889,8 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
         reply_to_event_id: Matrix event ID of the triggering message, stored
             in run metadata for unseen message tracking and edit cleanup.
         show_tool_calls: Whether to include tool call details inline in the streamed response.
+        run_metadata_collector: Optional mapping that receives versioned
+            run/model/token metadata for Matrix message content.
 
     Yields:
         Streaming chunks/events as they become available
@@ -790,12 +929,39 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
         if cached_result is not None:
             logger.info("Cache hit", agent=agent_name)
             response_text = cached_result.content or ""
+            if run_metadata_collector is not None:
+                cached_metadata = _build_ai_run_metadata_content(
+                    agent_name=agent_name,
+                    config=config,
+                    run_id=getattr(cached_result, "run_id", None),
+                    session_id=getattr(cached_result, "session_id", None) or session_id,
+                    status="cached",
+                    model=getattr(cached_result, "model", None),
+                    model_provider=getattr(cached_result, "model_provider", None),
+                    metrics=getattr(cached_result, "metrics", None),
+                    tool_count=len(cached_result.tools) if getattr(cached_result, "tools", None) else 0,
+                )
+                if cached_metadata:
+                    run_metadata_collector.update(cached_metadata)
             yield response_text
             return
 
     full_response = ""
     tool_count = 0
+    observed_tool_calls = 0
     pending_tools: list[tuple[str, int]] = []
+    latest_model_id: str | None = None
+    latest_model_provider: str | None = None
+    completed_run_event: RunCompletedEvent | None = None
+    request_metric_totals: dict[str, int] = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "reasoning_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+    first_token_latency: float | None = None
 
     # Execute the streaming AI call - this can fail for network, rate limits, etc.
     try:
@@ -821,6 +987,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                 full_response += chunk_text
                 yield event
             elif isinstance(event, ToolCallStartedEvent):
+                observed_tool_calls += 1
                 if show_tool_calls:
                     tool_count += 1
                     tool_msg, trace_entry = format_tool_started_event(event.tool, tool_index=tool_count)
@@ -858,6 +1025,27 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                             tool_index=tool_index,
                         )
                 yield event
+            elif isinstance(event, ModelRequestCompletedEvent):
+                if event.model:
+                    latest_model_id = event.model
+                if event.model_provider:
+                    latest_model_provider = event.model_provider
+                if isinstance(event.input_tokens, int):
+                    request_metric_totals["input_tokens"] += event.input_tokens
+                if isinstance(event.output_tokens, int):
+                    request_metric_totals["output_tokens"] += event.output_tokens
+                if isinstance(event.total_tokens, int):
+                    request_metric_totals["total_tokens"] += event.total_tokens
+                if isinstance(event.reasoning_tokens, int):
+                    request_metric_totals["reasoning_tokens"] += event.reasoning_tokens
+                if isinstance(event.cache_read_tokens, int):
+                    request_metric_totals["cache_read_tokens"] += event.cache_read_tokens
+                if isinstance(event.cache_write_tokens, int):
+                    request_metric_totals["cache_write_tokens"] += event.cache_write_tokens
+                if first_token_latency is None and isinstance(event.time_to_first_token, (int, float)):
+                    first_token_latency = float(event.time_to_first_token)
+            elif isinstance(event, RunCompletedEvent):
+                completed_run_event = event
             elif isinstance(event, RunErrorEvent):
                 error_text = event.content or "Unknown agent error"
                 logger.error("Agent run error during streaming", agent=agent_name, error=error_text)
@@ -869,6 +1057,31 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
         logger.exception("Error during streaming AI response")
         yield get_user_friendly_error_message(e, agent_name)
         return
+
+    if run_metadata_collector is not None:
+        fallback_metrics = _build_model_request_metrics_fallback(request_metric_totals, first_token_latency)
+        run_metadata = _build_ai_run_metadata_content(
+            agent_name=agent_name,
+            config=config,
+            run_id=completed_run_event.run_id if completed_run_event is not None else None,
+            session_id=(
+                completed_run_event.session_id
+                if completed_run_event is not None and completed_run_event.session_id is not None
+                else session_id
+            ),
+            status=RunStatus.completed,
+            model=latest_model_id,
+            model_provider=latest_model_provider,
+            metrics=completed_run_event.metrics if completed_run_event is not None else None,
+            metrics_fallback=fallback_metrics,
+            tool_count=(
+                len(completed_run_event.tools)
+                if completed_run_event is not None and completed_run_event.tools is not None
+                else observed_tool_calls
+            ),
+        )
+        if run_metadata:
+            run_metadata_collector.update(run_metadata)
 
     if cache is not None and full_response:
         cached_response = RunOutput(content=full_response)

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -111,6 +111,7 @@ def env_flag(name: str, *, default: bool = False) -> bool:
 # Other constants
 VOICE_PREFIX = "🎤 "
 ORIGINAL_SENDER_KEY = "com.mindroom.original_sender"
+AI_RUN_METADATA_KEY = "io.mindroom.ai_run"
 ENABLE_AI_CACHE = env_flag("MINDROOM_ENABLE_AI_CACHE", default=True)
 
 # Matrix

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -13,6 +13,7 @@ from typing import Any
 import nio
 from nio import crypto
 
+from mindroom.constants import AI_RUN_METADATA_KEY
 from mindroom.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -20,7 +21,7 @@ logger = get_logger(__name__)
 # Conservative limits accounting for Matrix overhead
 NORMAL_MESSAGE_LIMIT = 55000  # ~55KB for regular messages
 EDIT_MESSAGE_LIMIT = 27000  # ~27KB for edits (they roughly double in size)
-PASSTHROUGH_CONTENT_KEYS = ("m.mentions", "com.mindroom.skip_mentions")
+PASSTHROUGH_CONTENT_KEYS = ("m.mentions", "com.mindroom.skip_mentions", AI_RUN_METADATA_KEY)
 
 
 def _calculate_event_size(content: dict[str, Any]) -> int:
@@ -86,7 +87,7 @@ def _create_preview(text: str, max_bytes: int) -> str:
     return _prefix_by_bytes(text, target_bytes) + _CONTINUATION_INDICATOR
 
 
-async def _upload_text_as_mxc(
+async def _upload_text_as_mxc(  # noqa: C901
     client: nio.AsyncClient,
     text: str,
     room_id: str | None = None,

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -113,6 +113,7 @@ def format_message_with_mentions(
     reply_to_event_id: str | None = None,
     latest_thread_event_id: str | None = None,
     tool_trace: list["ToolTraceEntry"] | None = None,
+    extra_content: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Parse text for mentions and create properly formatted Matrix message.
 
@@ -126,6 +127,7 @@ def format_message_with_mentions(
         reply_to_event_id: Optional event ID to reply to (for genuine replies)
         latest_thread_event_id: Optional latest event ID in thread (for fallback compatibility)
         tool_trace: Optional structured tool trace metadata
+        extra_content: Optional custom metadata fields merged into content
 
     Returns:
         Properly formatted content dict for room_send
@@ -136,7 +138,12 @@ def format_message_with_mentions(
     # Convert markdown (with links) to HTML
     # The markdown converter will properly handle the [@DisplayName](url) format
     formatted_html = markdown_to_html(markdown_text)
-    extra_content = build_tool_trace_content(tool_trace)
+    tool_trace_content = build_tool_trace_content(tool_trace)
+    merged_extra_content: dict[str, Any] = {}
+    if tool_trace_content:
+        merged_extra_content.update(tool_trace_content)
+    if extra_content:
+        merged_extra_content.update(extra_content)
 
     return build_message_content(
         body=plain_text,
@@ -145,5 +152,5 @@ def format_message_with_mentions(
         thread_event_id=thread_event_id,
         reply_to_event_id=reply_to_event_id,
         latest_thread_event_id=latest_thread_event_id,
-        extra_content=extra_content,
+        extra_content=merged_extra_content or None,
     )

--- a/tests/test_ai_error_message_display.py
+++ b/tests/test_ai_error_message_display.py
@@ -41,6 +41,7 @@ class TestAIErrorDisplay:
             text: str,
             thread_id: str | None,  # noqa: ARG001
             tool_trace: object | None = None,  # noqa: ARG001
+            extra_content: object | None = None,  # noqa: ARG001
         ) -> None:
             edited_messages.append((event_id, text))
 
@@ -95,6 +96,7 @@ class TestAIErrorDisplay:
             event_id: str,
             text: str,
             thread_id: str | None,  # noqa: ARG001
+            extra_content: object | None = None,  # noqa: ARG001
         ) -> None:
             edited_messages.append((event_id, text))
 
@@ -150,6 +152,7 @@ class TestAIErrorDisplay:
             event_id: str,
             text: str,
             thread_id: str | None,  # noqa: ARG001
+            extra_content: object | None = None,  # noqa: ARG001
         ) -> None:
             edited_messages.append((event_id, text))
 
@@ -202,6 +205,7 @@ class TestAIErrorDisplay:
             text: str,
             thread_id: str | None,  # noqa: ARG001
             tool_trace: object | None = None,  # noqa: ARG001
+            extra_content: object | None = None,  # noqa: ARG001
         ) -> None:
             edited_messages.append(text)
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -6,10 +6,13 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from agno.models.metrics import Metrics
+from agno.run.agent import ModelRequestCompletedEvent, RunCompletedEvent, RunContentEvent
+from agno.run.base import RunStatus
 
 from mindroom.ai import ai_response, stream_agent_response
 from mindroom.bot import AgentBot
-from mindroom.config import Config
+from mindroom.config import AgentConfig, Config, ModelConfig
 from mindroom.openclaw_context import OpenClawToolContext, get_openclaw_tool_context
 
 if TYPE_CHECKING:
@@ -308,3 +311,175 @@ class TestUserIdPassthrough:
         assert response == "Done."
         assert "<tool>" not in response
         assert len(tool_trace) == 1
+
+    @pytest.mark.asyncio
+    async def test_ai_response_collects_run_metadata(self, tmp_path: Path) -> None:
+        """Non-streaming path should expose model/token/context metadata."""
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "OpenAIChat"
+        mock_agent.model.id = "test-model"
+        mock_agent.name = "GeneralAgent"
+        mock_agent.add_history_to_context = False
+
+        mock_run_output = MagicMock()
+        mock_run_output.content = "Response"
+        mock_run_output.tools = []
+        mock_run_output.run_id = "run-1"
+        mock_run_output.session_id = "session1"
+        mock_run_output.status = RunStatus.completed
+        mock_run_output.model = "test-model"
+        mock_run_output.model_provider = "openai"
+        mock_run_output.metrics = Metrics(
+            input_tokens=800,
+            output_tokens=120,
+            total_tokens=920,
+            time_to_first_token=0.42,
+            duration=1.75,
+        )
+        mock_agent.arun = AsyncMock(return_value=mock_run_output)
+
+        config = Config(
+            agents={"general": AgentConfig(display_name="General")},
+            models={"default": ModelConfig(provider="openai", id="test-model", context_window=2000)},
+        )
+
+        with (
+            patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
+            patch("mindroom.ai.get_cache", return_value=None),
+        ):
+            mock_prepare.return_value = (mock_agent, "test prompt", [])
+            run_metadata: dict[str, object] = {}
+            await ai_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                storage_path=tmp_path,
+                config=config,
+                run_metadata_collector=run_metadata,
+            )
+
+        payload = run_metadata["io.mindroom.ai_run"]
+        assert payload["version"] == 1
+        assert payload["run_id"] == "run-1"
+        assert payload["status"] == "completed"
+        assert payload["usage"]["input_tokens"] == 800
+        assert payload["context"]["input_tokens"] == 800
+        assert payload["context"]["window_tokens"] == 2000
+        assert "utilization_pct" not in payload["context"]
+        assert payload["tools"]["count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_collects_run_metadata(self, tmp_path: Path) -> None:
+        """Streaming path should expose run metadata from completion events."""
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "OpenAIChat"
+        mock_agent.model.id = "test-model"
+        mock_agent.name = "GeneralAgent"
+        mock_agent.add_history_to_context = False
+
+        async def fake_arun_stream(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+            yield RunContentEvent(content="hello")
+            yield ModelRequestCompletedEvent(
+                model="test-model",
+                model_provider="openai",
+                input_tokens=500,
+                output_tokens=60,
+                total_tokens=560,
+                time_to_first_token=0.33,
+            )
+            yield RunCompletedEvent(
+                run_id="run-2",
+                session_id="session1",
+                metrics=Metrics(
+                    input_tokens=500,
+                    output_tokens=60,
+                    total_tokens=560,
+                    duration=2.4,
+                ),
+            )
+
+        mock_agent.arun = MagicMock(return_value=fake_arun_stream())
+
+        config = Config(
+            agents={"general": AgentConfig(display_name="General")},
+            models={"default": ModelConfig(provider="openai", id="test-model", context_window=1000)},
+        )
+
+        with (
+            patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
+            patch("mindroom.ai.get_cache", return_value=None),
+        ):
+            mock_prepare.return_value = (mock_agent, "test prompt", [])
+            run_metadata: dict[str, object] = {}
+            async for _chunk in stream_agent_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                storage_path=tmp_path,
+                config=config,
+                run_metadata_collector=run_metadata,
+            ):
+                pass
+
+        payload = run_metadata["io.mindroom.ai_run"]
+        assert payload["version"] == 1
+        assert payload["run_id"] == "run-2"
+        assert payload["usage"]["total_tokens"] == 560
+        assert payload["context"]["input_tokens"] == 500
+        assert payload["context"]["window_tokens"] == 1000
+        assert "utilization_pct" not in payload["context"]
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_uses_request_metrics_fallback(self, tmp_path: Path) -> None:
+        """Streaming metadata should fall back to model request metrics when needed."""
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "OpenAIChat"
+        mock_agent.model.id = "test-model"
+        mock_agent.name = "GeneralAgent"
+        mock_agent.add_history_to_context = False
+
+        async def fake_arun_stream(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+            yield RunContentEvent(content="ok")
+            yield ModelRequestCompletedEvent(
+                model="test-model",
+                model_provider="openai",
+                input_tokens=12,
+                output_tokens=3,
+                time_to_first_token=0.12,
+            )
+
+        mock_agent.arun = MagicMock(return_value=fake_arun_stream())
+
+        config = Config(
+            agents={"general": AgentConfig(display_name="General")},
+            models={"default": ModelConfig(provider="openai", id="test-model", context_window=100)},
+        )
+
+        with (
+            patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
+            patch("mindroom.ai.get_cache", return_value=None),
+        ):
+            mock_prepare.return_value = (mock_agent, "test prompt", [])
+            run_metadata: dict[str, object] = {}
+            async for _chunk in stream_agent_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                storage_path=tmp_path,
+                config=config,
+                run_metadata_collector=run_metadata,
+            ):
+                pass
+
+        payload = run_metadata["io.mindroom.ai_run"]
+        assert payload["status"] == "completed"
+        assert payload["usage"]["input_tokens"] == 12
+        assert payload["usage"]["output_tokens"] == 3
+        assert payload["usage"]["total_tokens"] == 15
+        assert payload["usage"]["time_to_first_token"] == 0.12
+        assert payload["context"]["input_tokens"] == 12
+        assert payload["context"]["window_tokens"] == 100
+        assert "utilization_pct" not in payload["context"]

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -158,6 +158,7 @@ async def test_bot_regenerates_response_on_edit(tmp_path: Path) -> None:
             "The answer is 6",
             None,  # thread_id
             tool_trace=[],
+            extra_content=None,
         )
 
         # Verify that the response tracker still maps to the same response

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -131,6 +131,23 @@ class TestMentionParsing:
         assert content[TOOL_TRACE_KEY]["version"] == 2
         assert content[TOOL_TRACE_KEY]["events"][0]["tool_name"] == "save_file"
 
+    def test_format_message_with_mentions_merges_extra_content(self) -> None:
+        """Custom metadata should be merged with structured tool trace content."""
+        config = Config.from_yaml()
+        trace = [ToolTraceEntry(type="tool_call_started", tool_name="save_file")]
+
+        content = format_message_with_mentions(
+            config,
+            "Done.",
+            sender_domain="matrix.org",
+            tool_trace=trace,
+            extra_content={"io.mindroom.ai_run": {"version": 1, "usage": {"total_tokens": 42}}},
+        )
+
+        assert TOOL_TRACE_KEY in content
+        assert content["io.mindroom.ai_run"]["version"] == 1
+        assert content["io.mindroom.ai_run"]["usage"]["total_tokens"] == 42
+
     def test_no_mentions_in_text(self) -> None:
         """Test text with no mentions."""
         config = Config.from_yaml()

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -649,6 +649,7 @@ class TestAgentBot:
                 images=None,
                 reply_to_event_id="event123",
                 show_tool_calls=True,
+                run_metadata_collector=ANY,
             )
             mock_ai_response.assert_not_called()
             # With streaming and stop button: initial message + reaction + edits
@@ -669,6 +670,7 @@ class TestAgentBot:
                 reply_to_event_id="event123",
                 show_tool_calls=True,
                 tool_trace_collector=ANY,
+                run_metadata_collector=ANY,
             )
             mock_stream_agent_response.assert_not_called()
             # With stop button support: initial + reaction + final

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -138,6 +138,7 @@ async def test_agent_processes_direct_mention(
                     images=None,
                     reply_to_event_id="$test_event:localhost",
                     show_tool_calls=True,
+                    run_metadata_collector=ANY,
                 )
 
                 # Verify message was sent (thinking + streaming updates)
@@ -426,6 +427,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
                 reply_to_event_id=f"$test_event2:{domain}",
                 show_tool_calls=True,
                 tool_trace_collector=ANY,
+                run_metadata_collector=ANY,
             )
 
             # Verify thread response format (team response with mocking issue)


### PR DESCRIPTION
## Summary
- add Agno run metadata extraction in AI response paths and carry it through streaming/non-streaming response flows
- include model/provider configuration metadata and raw context-usage numbers in Matrix message content
- preserve metadata when large-message fallback uploads text/json sidecars and when mentions/extra content are merged
- add coverage for metadata propagation, context usage fields, and large-message + streaming integration behavior

## Testing
- pytest
