### PR TITLE
docs: add MindRoom ecosystem forks section to CLAUDE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,17 @@ MindRoom - AI agents that live in Matrix and work everywhere via bridges. The pr
 | `cluster/` | Terraform + Helm for hosted deployments |
 | `local/` | Docker Compose helpers for local dev stacks |
 
+### Ecosystem Repositories
+
+MindRoom also maintains related repositories under `github.com/mindroom-ai`:
+- `mindroom-element` - our Element fork for MindRoom message UX: collapsible tool-trace rendering, `!` command autocomplete synced from backend commands, long-text sidecar hydration, AI run metadata tooltip, and MindRoom branding/thread-first defaults. See `README.md` and `FORK_CHANGES.md` in that repo.
+- `synapse` - our Synapse fork for MindRoom streaming workloads: optional compact-edit collapsing for superseded `m.replace` events across `/sync`, Sliding Sync, pagination, and context responses, plus `/versions` advertisement via `org.mindroom.compact_edits` and fork-owned Docker/CI flows. See `README.md` and `FORK_CHANGES.md`.
+- `mindroom-librechat` - our LibreChat fork that parses MindRoom inline `<tool>` / `<tool-group>` tags into native `ToolCall` cards so tool execution stays server-side; also includes fork Docker CI and MindRoom-specific UX additions. See `README.md` and `.mindroom/` docs (`fork-context.md`, `tool-tag-rendering.md`).
+- `mindroom-cinny` - our Cinny fork optimized for MindRoom agent workflows with MindRoom branding/default homeserver config, subpath deployment support (runtime/build base path for `/mindroom`), and thread/auth/sidebar UX refinements. See `README.md` and `FORK_CHANGES.md`.
+- `mindroom-stack` - a full Docker Compose reference stack that boots MindRoom backend/frontend, Synapse + Postgres + Redis, and Element together, including first-login and model/API-key setup guidance.
+
+In this dev environment, many of these repositories are cloned in the parent directory (`../`) and can be inspected directly.
+
 ### Configuration Model
 
 The authoritative config is `config.yaml`, loaded via Pydantic models in `src/mindroom/config.py`:


### PR DESCRIPTION
## Summary
- add an Ecosystem Repositories section in CLAUDE.md
- document what each MindRoom fork is responsible for (Element, Synapse, LibreChat, Cinny)
- note that mindroom-stack is the full Docker Compose reference stack
- mention sibling clones in ../ can be inspected during local development

## Testing
- docs-only change
