### PR TITLE
Remove unsupported OpenClaw compatibility stubs

### DIFF
--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -23,7 +23,7 @@ Works well:
 
 Not included:
 
-- OpenClaw gateway control plane (`gateway` returns `not_configured`)
+- OpenClaw gateway control plane
 - Device nodes and canvas platform tools
 - `tts` and `image` tool aliases (use MindRoom's native TTS/image tools directly)
 - Heartbeat runtime — schedule heartbeats via `cron`/`scheduler` instead
@@ -40,7 +40,6 @@ The `openclaw_compat` tool provides OpenClaw-named aliases so prompts and skills
 | `message`, `sessions_*` | Matrix client calls |
 | `subagents`, `agents_list` | Agent registry lookup |
 | `browser` | `BrowserTools` (Playwright, host target only) |
-| `gateway`, `nodes`, `canvas` | Stubs (`not_configured`) |
 
 ## Drop-in config
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1897,7 +1897,7 @@ Works well:
 
 Not included:
 
-- OpenClaw gateway control plane (`gateway` returns `not_configured`)
+- OpenClaw gateway control plane
 - Device nodes and canvas platform tools
 - `tts` and `image` tool aliases (use MindRoom's native TTS/image tools directly)
 - Heartbeat runtime — schedule heartbeats via `cron`/`scheduler` instead
@@ -1906,15 +1906,14 @@ Not included:
 
 The `openclaw_compat` tool provides OpenClaw-named aliases so prompts and skills written for OpenClaw work without rewriting tool calls:
 
-| OpenClaw tool                | MindRoom backend                              |
-| ---------------------------- | --------------------------------------------- |
-| `exec`, `process`            | `ShellTools`                                  |
-| `web_search`, `web_fetch`    | `DuckDuckGoTools`, `WebsiteTools`             |
-| `cron`                       | `SchedulerTools`                              |
-| `message`, `sessions_*`      | Matrix client calls                           |
-| `subagents`, `agents_list`   | Agent registry lookup                         |
-| `browser`                    | `BrowserTools` (Playwright, host target only) |
-| `gateway`, `nodes`, `canvas` | Stubs (`not_configured`)                      |
+| OpenClaw tool              | MindRoom backend                              |
+| -------------------------- | --------------------------------------------- |
+| `exec`, `process`          | `ShellTools`                                  |
+| `web_search`, `web_fetch`  | `DuckDuckGoTools`, `WebsiteTools`             |
+| `cron`                     | `SchedulerTools`                              |
+| `message`, `sessions_*`    | Matrix client calls                           |
+| `subagents`, `agents_list` | Agent registry lookup                         |
+| `browser`                  | `BrowserTools` (Playwright, host target only) |
 
 ## Drop-in config
 

--- a/skills/mindroom-docs/references/page__openclaw__index.md
+++ b/skills/mindroom-docs/references/page__openclaw__index.md
@@ -19,7 +19,7 @@ Works well:
 
 Not included:
 
-- OpenClaw gateway control plane (`gateway` returns `not_configured`)
+- OpenClaw gateway control plane
 - Device nodes and canvas platform tools
 - `tts` and `image` tool aliases (use MindRoom's native TTS/image tools directly)
 - Heartbeat runtime — schedule heartbeats via `cron`/`scheduler` instead
@@ -28,15 +28,14 @@ Not included:
 
 The `openclaw_compat` tool provides OpenClaw-named aliases so prompts and skills written for OpenClaw work without rewriting tool calls:
 
-| OpenClaw tool                | MindRoom backend                              |
-| ---------------------------- | --------------------------------------------- |
-| `exec`, `process`            | `ShellTools`                                  |
-| `web_search`, `web_fetch`    | `DuckDuckGoTools`, `WebsiteTools`             |
-| `cron`                       | `SchedulerTools`                              |
-| `message`, `sessions_*`      | Matrix client calls                           |
-| `subagents`, `agents_list`   | Agent registry lookup                         |
-| `browser`                    | `BrowserTools` (Playwright, host target only) |
-| `gateway`, `nodes`, `canvas` | Stubs (`not_configured`)                      |
+| OpenClaw tool              | MindRoom backend                              |
+| -------------------------- | --------------------------------------------- |
+| `exec`, `process`          | `ShellTools`                                  |
+| `web_search`, `web_fetch`  | `DuckDuckGoTools`, `WebsiteTools`             |
+| `cron`                     | `SchedulerTools`                              |
+| `message`, `sessions_*`    | Matrix client calls                           |
+| `subagents`, `agents_list` | Agent registry lookup                         |
+| `browser`                  | `BrowserTools` (Playwright, host target only) |
 
 ## Drop-in config
 

--- a/src/mindroom/custom_tools/openclaw_compat.py
+++ b/src/mindroom/custom_tools/openclaw_compat.py
@@ -65,9 +65,6 @@ class OpenClawCompatTools(Toolkit):
                 self.sessions_spawn,
                 self.subagents,
                 self.message,
-                self.gateway,
-                self.nodes,
-                self.canvas,
                 self.cron,
                 self.web_search,
                 self.web_fetch,
@@ -1172,58 +1169,6 @@ class OpenClawCompatTools(Toolkit):
             "error",
             action=action,
             message="Unsupported action. Use send, thread-reply, react, or read.",
-        )
-
-    async def gateway(
-        self,
-        action: str,
-        raw: str | None = None,
-        base_hash: str | None = None,
-        note: str | None = None,
-    ) -> str:
-        """Invoke gateway lifecycle/config operations."""
-        return self._payload(
-            "gateway",
-            "not_configured",
-            action=action,
-            raw=raw,
-            base_hash=base_hash,
-            note=note,
-            message="gateway requires an OpenClaw Gateway endpoint and is not configured in MindRoom.",
-        )
-
-    async def nodes(
-        self,
-        action: str,
-        node: str | None = None,
-    ) -> str:
-        """Invoke node discovery and control operations."""
-        return self._payload(
-            "nodes",
-            "not_configured",
-            action=action,
-            node=node,
-            message="nodes requires an OpenClaw Gateway endpoint and is not configured in MindRoom.",
-        )
-
-    async def canvas(
-        self,
-        action: str,
-        node: str | None = None,
-        target: str | None = None,
-        url: str | None = None,
-        java_script: str | None = None,
-    ) -> str:
-        """Control canvas operations on a node."""
-        return self._payload(
-            "canvas",
-            "not_configured",
-            action=action,
-            node=node,
-            target=target,
-            url=url,
-            java_script=java_script,
-            message="canvas requires an OpenClaw Gateway endpoint and is not configured in MindRoom.",
         )
 
     async def cron(self, request: str) -> str:

--- a/tests/test_openclaw_compat_contract.py
+++ b/tests/test_openclaw_compat_contract.py
@@ -30,9 +30,6 @@ OPENCLAW_COMPAT_CORE_TOOLS = {
     "sessions_spawn",
     "subagents",
     "message",
-    "gateway",
-    "nodes",
-    "canvas",
 }
 
 OPENCLAW_COMPAT_ALIAS_TOOLS = {
@@ -96,22 +93,11 @@ async def test_openclaw_compat_placeholder_responses_are_json() -> None:
         ("subagents", await tool.subagents()),
         ("message", await tool.message(action="send", message="hi")),
     ]
-    not_configured = [
-        ("gateway", await tool.gateway(action="config.get")),
-        ("nodes", await tool.nodes(action="status")),
-        ("canvas", await tool.canvas(action="snapshot")),
-    ]
 
     for expected_tool_name, raw_response in context_required:
         payload = json.loads(raw_response)
         assert payload["tool"] == expected_tool_name
         assert payload["status"] == "error"
-        assert "message" in payload
-
-    for expected_tool_name, raw_response in not_configured:
-        payload = json.loads(raw_response)
-        assert payload["tool"] == expected_tool_name
-        assert payload["status"] == "not_configured"
         assert "message" in payload
 
 


### PR DESCRIPTION
## Summary
- remove the `gateway`, `nodes`, and `canvas` placeholder stubs from `openclaw_compat`
- stop exposing those three methods in the toolkit function list
- update OpenClaw contract tests and docs to match the slimmer surface
- regenerate `skills/mindroom-docs/references/*` (required by pre-commit)

## Why
These stubs were non-functional (`not_configured`) and added maintenance overhead without runtime value.

## Validation
- `pytest tests/test_openclaw_compat_contract.py`
- `pytest` (full suite)
  - result: `1747 passed, 19 skipped, 102 warnings`

## Impact
- net diff for this PR: `-72 LOC` (`19 insertions`, `91 deletions`)
- core stub-first removal (runtime/tests/docs before autogenerated refs): `-70 LOC`
