### PR TITLE
fix(teams): build preconfigured team members as agent Matrix IDs

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -549,8 +549,10 @@ def create_bot_for_entity(
     if entity_name in config.teams:
         team_config = config.teams[entity_name]
         rooms = resolve_room_aliases(team_config.rooms)
-        # Convert agent names to MatrixID objects
-        team_matrix_ids = [MatrixID.from_username(agent_name, config.domain) for agent_name in team_config.agents]
+        # Convert team member agent names into canonical agent Matrix IDs.
+        # Team streaming resolves config agents from these IDs, so they must keep
+        # the `mindroom_` prefix used by MatrixID.from_agent().
+        team_matrix_ids = [MatrixID.from_agent(agent_name, config.domain) for agent_name in team_config.agents]
         return TeamBot(
             agent_user=agent_user,
             storage_path=storage_path,

--- a/tests/test_router_rooms.py
+++ b/tests/test_router_rooms.py
@@ -11,6 +11,7 @@ import pytest
 from mindroom.bot import MultiAgentOrchestrator, create_bot_for_entity
 from mindroom.config import AgentConfig, Config, TeamConfig
 from mindroom.constants import ROUTER_AGENT_NAME
+from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
 
 from .conftest import TEST_PASSWORD
@@ -99,6 +100,10 @@ def test_team_bot_uses_defaults_streaming_setting(
 
     assert team_bot is not None
     assert team_bot.enable_streaming is False
+    assert team_bot.team_agents == [
+        MatrixID.from_agent("agent1", config_with_rooms.domain),
+        MatrixID.from_agent("agent2", config_with_rooms.domain),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fix team bot construction to use `MatrixID.from_agent(...)` for configured team members
- this preserves the `mindroom_` prefix expected by team streaming agent resolution
- add a regression assertion in `tests/test_router_rooms.py`

## Root Cause
Preconfigured teams were creating member IDs with `MatrixID.from_username(agent_name, domain)`.
For agent names like `agent1`, this produced IDs without the `mindroom_` prefix, so `mid.agent_name(config)` returned `None` and team streaming hit an assertion when resolving members.

## Validation
- `uv run pytest tests/test_router_rooms.py -q`
