### PR TITLE
test(teams): use MatrixID.from_agent for TeamBot member fixtures

### DIFF
--- a/tests/test_preformed_team_routing.py
+++ b/tests/test_preformed_team_routing.py
@@ -111,8 +111,8 @@ async def test_preformed_team_bot_responds_when_mentioned(config_with_team: Conf
     )
     # Convert agent names to MatrixID objects
     team_matrix_ids = [
-        MatrixID.from_username("a1", config_with_team.domain),
-        MatrixID.from_username("a2", config_with_team.domain),
+        MatrixID.from_agent("a1", config_with_team.domain),
+        MatrixID.from_agent("a2", config_with_team.domain),
     ]
     bot = TeamBot(
         agent_user=team_user,
@@ -164,8 +164,8 @@ async def test_preformed_team_reply_chain_uses_existing_thread_root(config_with_
         password="p",  # noqa: S106
     )
     team_matrix_ids = [
-        MatrixID.from_username("a1", config_with_team.domain),
-        MatrixID.from_username("a2", config_with_team.domain),
+        MatrixID.from_agent("a1", config_with_team.domain),
+        MatrixID.from_agent("a2", config_with_team.domain),
     ]
     bot = TeamBot(
         agent_user=team_user,
@@ -242,8 +242,8 @@ async def test_team_does_not_respond_to_different_domain_mention(config_with_tea
     )
     # Convert agent names to MatrixID objects
     team_matrix_ids = [
-        MatrixID.from_username("a1", config_with_team.domain),
-        MatrixID.from_username("a2", config_with_team.domain),
+        MatrixID.from_agent("a1", config_with_team.domain),
+        MatrixID.from_agent("a2", config_with_team.domain),
     ]
     bot = TeamBot(
         agent_user=team_user,

--- a/tests/test_team_invitations.py
+++ b/tests/test_team_invitations.py
@@ -59,7 +59,7 @@ class TestTeamRoomMembership:
         # Create the team bot with configured rooms
         config = Config(router=RouterConfig(model="default"))
         # Convert agent names to MatrixID objects
-        team_matrix_ids = [MatrixID.from_username("agent1", config.domain)]
+        team_matrix_ids = [MatrixID.from_agent("agent1", config.domain)]
         bot = TeamBot(
             agent_user=team_user,
             storage_path=tmp_path,
@@ -111,7 +111,7 @@ class TestTeamRoomMembership:
         # Create the team bot with no configured rooms
         config = Config(router=RouterConfig(model="default"))
         # Convert agent names to MatrixID objects
-        team_matrix_ids = [MatrixID.from_username("agent1", config.domain)]
+        team_matrix_ids = [MatrixID.from_agent("agent1", config.domain)]
         bot = TeamBot(
             agent_user=team_user,
             storage_path=tmp_path,


### PR DESCRIPTION
## Summary
- update TeamBot test fixtures to build team member IDs with `MatrixID.from_agent(...)`
- remove stale `MatrixID.from_username(...)` fixture usage that no longer matches runtime ID shape
- keep tests aligned with the production fix merged in #232

## Testing
- `uv run pytest tests/test_preformed_team_routing.py tests/test_team_invitations.py tests/test_router_rooms.py -q`
- result: `9 passed, 2 skipped, 3 warnings`