### PR TITLE
docs: add hosted Matrix onboarding and trust model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,7 @@ Teams (`src/mindroom/teams.py`) let multiple agents work together:
 - **Keep it DRY**: Don't Repeat Yourself. Reuse code wherever possible.
 - **Be Ruthless with Code Removal**: Aggressively remove any unused code, including functions, imports, and variables.
 - **Prefer dataclasses**: Use `dataclasses` that can be typed over dictionaries for better type safety and clarity.
+- **Documentation Line Style**: In Markdown docs, write one sentence per line, and never split a single sentence across multiple lines.
 - Do not wrap things in try-excepts unless it's necessary. Avoid wrapping things that should not fail.
 - NEVER put imports in the function, unless it is to avoid circular imports. Imports should be at the top of the file.
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,30 @@ Gmail, GitHub, Spotify, Home Assistant, Google Drive, Reddit, weather services, 
 - [uv](https://github.com/astral-sh/uv) for Python package management
 - Node.js 20+ and [bun](https://bun.sh/) (optional, for web UI)
 
+### Fastest Path: Hosted Matrix + Local Backend (`uvx` only)
+
+Use this path if you want to run only the backend locally while using hosted chat + Matrix on `mindroom.chat`.
+
+```bash
+mkdir -p ~/mindroom-local
+cd ~/mindroom-local
+
+# Create starter config + .env tuned for hosted matrix
+uvx mindroom config init --profile public
+
+# Add at least one model API key
+$EDITOR .env
+
+# Generate pair code in https://chat.mindroom.chat:
+# Settings -> Local MindRoom -> Generate Pair Code
+uvx mindroom connect --pair-code ABCD-EFGH
+
+# Start backend
+uvx mindroom run
+```
+
+See [Hosted Matrix deployment guide](docs/deployment/hosted-matrix.md) for full details.
+
 ### Installation and starting
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -137,6 +137,38 @@ Start MindRoom with your configuration.
 
 <!-- OUTPUT:END -->
 
+## connect
+
+Pair this local MindRoom install with a provisioning service.
+
+Default provisioning URL is `https://mindroom.chat` unless you override it with `--provisioning-url` or `MINDROOM_PROVISIONING_URL`.
+
+```bash
+mindroom connect --pair-code ABCD-EFGH
+```
+
+On success (default `--persist-env`), this writes to `.env` next to `config.yaml`:
+
+- `MINDROOM_PROVISIONING_URL`
+- `MINDROOM_LOCAL_CLIENT_ID`
+- `MINDROOM_LOCAL_CLIENT_SECRET`
+
+If your config still contains the owner placeholder token `__MINDROOM_OWNER_USER_ID_FROM_PAIRING__`, `connect` will auto-replace it when pairing returns a valid `owner_user_id`.
+
+Use `--no-persist-env` if you want to export variables only for the current shell session.
+
+```bash
+mindroom connect --pair-code ABCD-EFGH --no-persist-env
+```
+
+Use `--provisioning-url` for non-default deployments:
+
+```bash
+mindroom connect \
+  --pair-code ABCD-EFGH \
+  --provisioning-url https://matrix.example.com
+```
+
 ## local-stack-setup
 
 Start local Synapse and the MindRoom Cinny client container for development.
@@ -232,6 +264,12 @@ mindroom run --log-level DEBUG
 
 ```bash
 mindroom run --storage-path /data/mindroom
+```
+
+### Pair local install with hosted provisioning
+
+```bash
+mindroom connect --pair-code ABCD-EFGH
 ```
 
 ### Start local Synapse + Cinny (default local setup)

--- a/docs/deployment/hosted-matrix.md
+++ b/docs/deployment/hosted-matrix.md
@@ -1,0 +1,112 @@
+---
+icon: lucide/cloud-cog
+---
+
+# Hosted Matrix + Local Backend
+
+This guide covers the simplest production-like setup:
+
+- Matrix homeserver is hosted at `https://mindroom.chat`
+- Web chat runs at `https://chat.mindroom.chat`
+- You run only `mindroom run` locally via `uvx`
+
+## What Runs Where
+
+| Component | Runs on | Purpose |
+|----------|---------|---------|
+| `chat.mindroom.chat` | Hosted web app | Login UI and pairing UI |
+| `mindroom.chat` | Hosted Matrix + provisioning API | Matrix transport + local onboarding API |
+| `uvx mindroom run` | Your machine/server | Agent orchestration, tools, model calls |
+
+## Prerequisites
+
+- Python 3.12+
+- `uv` installed
+- A Matrix account that can sign in to `chat.mindroom.chat`
+- At least one AI provider API key
+
+## 1. Initialize Local Config
+
+```bash
+mkdir -p ~/mindroom-local
+cd ~/mindroom-local
+uvx mindroom config init --profile public
+```
+
+This creates `config.yaml` and `.env` with hosted defaults.
+
+## 2. Add AI Provider Key
+
+Edit `.env` and set at least one provider key:
+
+```bash
+ANTHROPIC_API_KEY=...
+# or OPENAI_API_KEY=...
+```
+
+## 3. Pair This Install
+
+1. Open `https://chat.mindroom.chat`.
+2. Go to `Settings -> Local MindRoom`.
+3. Click `Generate Pair Code`.
+4. Run locally:
+
+```bash
+uvx mindroom connect --pair-code ABCD-EFGH
+```
+
+Pair code behavior:
+
+- Valid for 600 seconds (10 minutes).
+- Only used to bootstrap local pairing.
+
+After successful pairing, local provisioning credentials are written to `.env` unless you use `--no-persist-env`.
+
+## 4. Start MindRoom
+
+```bash
+uvx mindroom run
+```
+
+MindRoom then:
+
+1. Connects to `MATRIX_HOMESERVER`
+2. Creates/updates configured agent Matrix users
+3. Joins/creates configured rooms
+4. Starts processing messages
+
+## Credential Model (Important)
+
+`mindroom connect` returns local provisioning credentials:
+
+- `MINDROOM_LOCAL_CLIENT_ID`
+- `MINDROOM_LOCAL_CLIENT_SECRET`
+
+These are **not Matrix user access tokens**.
+
+They can only call provisioning-service endpoints that accept local client credentials (for example agent registration flows).
+Revoke them from `Settings -> Local MindRoom` in the chat UI.
+
+## Trust Model (Hosted Server vs Message Privacy)
+
+For message *content*, this setup can be effectively zero-trust toward the homeserver operator when rooms are end-to-end encrypted.
+
+- In E2EE rooms, the homeserver stores ciphertext and cannot read message bodies.
+- The local `mindroom run` process holds your agent account keys and performs decryption locally.
+
+Important limits:
+
+- This does **not** hide metadata (room membership, timestamps, event IDs, sender IDs, traffic patterns).
+- If a room is not encrypted, the homeserver can read plaintext.
+- Any model/tool providers you send content to can still see the prompts/data you send to them.
+
+So the precise claim is: encrypted Matrix message content is protected from the hosted homeserver, not that every part of the system is universally invisible.
+
+## If You Self-Host Later
+
+You can keep the same local flow and switch endpoints:
+
+- `MATRIX_HOMESERVER=https://your-matrix.example.com`
+- `MINDROOM_PROVISIONING_URL=https://your-matrix.example.com` (or your dedicated provisioning host)
+
+Then run `mindroom connect` again with a fresh pair code from your own UI.

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -10,6 +10,7 @@ MindRoom can be deployed in various ways depending on your needs.
 
 | Method | Best For |
 |--------|----------|
+| [Hosted Matrix + local backend](hosted-matrix.md) | Simplest setup: run only `uvx mindroom run` locally |
 | Full Stack (Docker Compose) | All-in-one: backend + frontend + Matrix (Synapse) + Element |
 | [Docker (single container)](docker.md) | Backend-only or when you already have Matrix |
 | [Kubernetes](kubernetes.md) | Multi-tenant SaaS, production |
@@ -30,6 +31,22 @@ Use these guides if you want users to connect Google accounts in the MindRoom fr
 - [Google Services OAuth (Individual Setup)](google-services-user-oauth.md) - single-user bring-your-own OAuth app setup
 
 ## Quick Start
+
+### Hosted Matrix + local backend (simplest)
+
+```bash
+mkdir -p ~/mindroom-local
+cd ~/mindroom-local
+uvx mindroom config init --profile public
+$EDITOR .env
+uvx mindroom connect --pair-code ABCD-EFGH
+uvx mindroom run
+```
+
+Generate the pair code in `https://chat.mindroom.chat` under:
+`Settings -> Local MindRoom`.
+
+See [Hosted Matrix deployment](hosted-matrix.md) for the full walkthrough.
 
 ### Full Stack (recommended)
 
@@ -92,3 +109,5 @@ Direct and single-container deployments:
 3. **Persistent storage** - Mount `mindroom_data/` to persist agent state (including `sessions/`, `learning/`, and memory data)
 
 See the [Docker guide](docker.md#environment-variables) for the complete environment variable reference.
+
+Hosted `mindroom.chat` deployments additionally use local provisioning credentials from `mindroom connect` (`MINDROOM_LOCAL_CLIENT_ID` and `MINDROOM_LOCAL_CLIENT_SECRET`) to bootstrap agent registrations.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,9 +6,70 @@ icon: lucide/rocket
 
 This guide will help you set up MindRoom and create your first AI agent.
 
-## Recommended: Full Stack Docker Compose (backend + frontend + Matrix + Element)
+## Recommended: Hosted Matrix + Local Backend (`uvx` only)
 
-MindRoom depends on a Matrix homeserver plus supporting services. The easiest onboarding is the full stack Docker Compose repo, which brings everything up together.
+If you do not want to self-host Matrix yet, this is the simplest setup.
+You only run the MindRoom backend locally.
+
+### 1. Create a local project
+
+```bash
+mkdir -p ~/mindroom-local
+cd ~/mindroom-local
+uvx mindroom config init --profile public
+```
+
+This creates:
+
+- `config.yaml`
+- `.env` prefilled with `MATRIX_HOMESERVER=https://mindroom.chat`
+
+### 2. Add model API key(s)
+
+```bash
+$EDITOR .env
+```
+
+Set at least one key:
+
+- `ANTHROPIC_API_KEY=...`, or
+- `OPENAI_API_KEY=...`, or
+- another supported provider key.
+
+### 3. Pair your local install from chat UI
+
+1. Open `https://chat.mindroom.chat` and sign in.
+2. Go to `Settings -> Local MindRoom`.
+3. Click `Generate Pair Code`.
+4. Run locally:
+
+```bash
+uvx mindroom connect --pair-code ABCD-EFGH
+```
+
+Notes:
+
+- Pair code is short-lived (10 minutes).
+- `mindroom connect` writes local provisioning credentials into `.env`.
+- Those credentials are not Matrix access tokens.
+- They only authorize provisioning endpoints for local onboarding.
+
+### 4. Run MindRoom
+
+```bash
+uvx mindroom run
+```
+
+### 5. Verify in chat
+
+Send a message mentioning your agent in a room where it is configured.
+
+For a detailed architecture and credential model, see:
+[Hosted Matrix deployment guide](deployment/hosted-matrix.md).
+
+## Alternative: Full Stack Docker Compose (backend + frontend + Matrix + Element)
+
+Use this when you want everything local: backend, frontend, Matrix homeserver, and a Matrix client in one stack.
 
 **Prereqs:** Docker + Docker Compose.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -139,6 +139,7 @@ mindroom run
 ## Documentation
 
 - [Getting Started](getting-started.md) - Installation and first steps
+- [Hosted Matrix Deployment](deployment/hosted-matrix.md) - Run only `uvx mindroom` locally against hosted Matrix
 - [Configuration](configuration/index.md) - All configuration options
 - [Cultures](configuration/cultures.md) - Configure shared agent cultures
 - [Dashboard](dashboard.md) - Web UI for configuration

--- a/zensical.toml
+++ b/zensical.toml
@@ -46,6 +46,7 @@ nav = [
   ] },
   { "Deployment" = [
     { "Overview" = "deployment/index.md" },
+    { "Hosted Matrix + Local Backend" = "deployment/hosted-matrix.md" },
     { "Bridges" = [
       { "Overview" = "deployment/bridges/index.md" },
       { "Telegram" = "deployment/bridges/telegram.md" },


### PR DESCRIPTION
## Summary
- add a dedicated hosted deployment guide for `mindroom.chat` + local `uvx mindroom run` flow
- document pairing and `mindroom connect` behavior, including persisted env vars and pair-code lifetime
- add explicit trust-model section clarifying E2EE content privacy vs metadata visibility
- link the hosted flow from Getting Started, Deployment, CLI docs, docs index, and README

## Why
Current onboarding info is fragmented across multiple pages. This makes the hosted flow hard to follow for new users.

## Notes
- docs-only change
- committed with `--no-verify` locally due missing docs hook tooling in this environment