### PR TITLE
Patch chromadb runtime for Python 3.14 compatibility

### DIFF
--- a/src/mindroom/__init__.py
+++ b/src/mindroom/__init__.py
@@ -2,4 +2,8 @@
 
 from importlib.metadata import version
 
+from .constants import patch_chromadb_for_python314
+
+patch_chromadb_for_python314()
+
 __version__ = version("mindroom")

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -7,7 +7,9 @@ codebase.
 
 import os
 import shutil
+import sys
 from pathlib import Path
+from typing import cast
 
 from dotenv import load_dotenv
 
@@ -142,6 +144,8 @@ PROVIDER_ENV_KEYS: dict[str, str] = {
     "ollama": "OLLAMA_HOST",
 }
 
+_CHROMADB_PY314_PATCHED = False
+
 
 def env_key_for_provider(provider: str) -> str | None:
     """Get the environment variable name for a provider's API key.
@@ -151,6 +155,52 @@ def env_key_for_provider(provider: str) -> str | None:
     if provider == "gemini":
         return PROVIDER_ENV_KEYS.get("google")
     return PROVIDER_ENV_KEYS.get(provider)
+
+
+def patch_chromadb_for_python314() -> None:
+    """Patch pydantic internals so chromadb works on Python 3.14+.
+
+    chromadb currently relies on pydantic v1 `BaseSettings` behavior and defines
+    untyped fields in its settings model. This runtime shim can be removed once
+    chromadb ships an upstream fix.
+    """
+    global _CHROMADB_PY314_PATCHED
+    if _CHROMADB_PY314_PATCHED or sys.version_info < (3, 14):
+        return
+
+    import pydantic  # noqa: PLC0415
+    from pydantic._internal import _model_construction  # noqa: PLC0415
+    from pydantic_settings import BaseSettings  # noqa: PLC0415
+
+    pydantic.BaseSettings = BaseSettings
+
+    original_inspect_namespace = _model_construction.inspect_namespace
+
+    def _patched_inspect_namespace(*args: object, **kwargs: object) -> object:
+        try:
+            return original_inspect_namespace(*args, **kwargs)
+        except pydantic.errors.PydanticUserError as exc:
+            if "non-annotated attribute" not in str(exc):
+                raise
+
+            namespace = args[0] if args else kwargs.get("namespace")
+            raw_annotations = args[1] if len(args) > 1 else kwargs.get("raw_annotations")
+            if not isinstance(namespace, dict) or not isinstance(raw_annotations, dict):
+                raise
+            namespace_dict = cast("dict[str, object]", namespace)
+            raw_annotations_dict = cast("dict[str, object]", raw_annotations)
+
+            for field in (
+                "chroma_coordinator_host",
+                "chroma_logservice_host",
+                "chroma_logservice_port",
+            ):
+                if field in namespace_dict and field not in raw_annotations_dict:
+                    raw_annotations_dict[field] = type(namespace_dict[field])
+            return original_inspect_namespace(*args, **kwargs)
+
+    _model_construction.inspect_namespace = _patched_inspect_namespace
+    _CHROMADB_PY314_PATCHED = True
 
 
 def safe_replace(tmp_path: Path, target_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a Python 3.14 runtime monkeypatch for chromadb's pydantic v1 assumptions
- run the patch at package import so it applies before chromadb/mem0 imports
- keep the patch idempotent and gated to Python 3.14+

## Context
Upstream should fix this in: https://github.com/chroma-core/chroma/pull/6356
This temporary patch can be removed after a chromadb release includes that change.

## Validation
- uv run pre-commit run --all-files
- uv run pytest