### PR TITLE
Fix runtime bugs (task retention, config race, failure swallowing)

### DIFF
--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -260,10 +260,9 @@ async def save_config(new_config: Config, _user: Annotated[dict, Depends(verify_
     """Save configuration to file."""
     try:
         config_dict = new_config.model_dump(exclude_none=True)
-        save_config_to_file(config_dict)
-
-        # Update current config
         with config_lock:
+            save_config_to_file(config_dict)
+            # Update current config
             config.update(config_dict)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to save configuration: {e!s}") from e
@@ -291,19 +290,17 @@ async def update_agent(
     _user: Annotated[dict, Depends(verify_user)],
 ) -> dict[str, bool]:
     """Update a specific agent."""
-    with config_lock:
-        if "agents" not in config:
-            config["agents"] = {}
-
-        # Remove ID from agent_data if present
-        agent_data_copy = agent_data.copy()
-        agent_data_copy.pop("id", None)
-
-        config["agents"][agent_id] = agent_data_copy
-
-    # Save to file
     try:
-        save_config_to_file(config)
+        with config_lock:
+            if "agents" not in config:
+                config["agents"] = {}
+
+            # Remove ID from agent_data if present
+            agent_data_copy = agent_data.copy()
+            agent_data_copy.pop("id", None)
+
+            config["agents"][agent_id] = agent_data_copy
+            save_config_to_file(config)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to save agent: {e!s}") from e
     else:
@@ -315,27 +312,25 @@ async def create_agent(agent_data: dict[str, Any], _user: Annotated[dict, Depend
     """Create a new agent."""
     agent_id = agent_data.get("display_name", "new_agent").lower().replace(" ", "_")
 
-    with config_lock:
-        if "agents" not in config:
-            config["agents"] = {}
-
-        # Check if agent already exists
-        if agent_id in config["agents"]:
-            # Generate unique ID
-            counter = 1
-            while f"{agent_id}_{counter}" in config["agents"]:
-                counter += 1
-            agent_id = f"{agent_id}_{counter}"
-
-        # Remove ID from agent_data if present
-        agent_data_copy = agent_data.copy()
-        agent_data_copy.pop("id", None)
-
-        config["agents"][agent_id] = agent_data_copy
-
-    # Save to file
     try:
-        save_config_to_file(config)
+        with config_lock:
+            if "agents" not in config:
+                config["agents"] = {}
+
+            # Check if agent already exists
+            if agent_id in config["agents"]:
+                # Generate unique ID
+                counter = 1
+                while f"{agent_id}_{counter}" in config["agents"]:
+                    counter += 1
+                agent_id = f"{agent_id}_{counter}"
+
+            # Remove ID from agent_data if present
+            agent_data_copy = agent_data.copy()
+            agent_data_copy.pop("id", None)
+
+            config["agents"][agent_id] = agent_data_copy
+            save_config_to_file(config)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to create agent: {e!s}") from e
     else:
@@ -350,14 +345,12 @@ async def delete_agent(agent_id: str, _user: Annotated[dict, Depends(verify_user
             raise HTTPException(status_code=404, detail="Agent not found")
 
         del config["agents"][agent_id]
-
-    # Save to file
-    try:
-        save_config_to_file(config)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to delete agent: {e!s}") from e
-    else:
-        return {"success": True}
+        try:
+            save_config_to_file(config)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to delete agent: {e!s}") from e
+        else:
+            return {"success": True}
 
 
 @app.get("/api/config/teams")
@@ -380,19 +373,17 @@ async def update_team(
     _user: Annotated[dict, Depends(verify_user)],
 ) -> dict[str, bool]:
     """Update a specific team."""
-    with config_lock:
-        if "teams" not in config:
-            config["teams"] = {}
-
-        # Remove ID from team_data if present
-        team_data_copy = team_data.copy()
-        team_data_copy.pop("id", None)
-
-        config["teams"][team_id] = team_data_copy
-
-    # Save to file
     try:
-        save_config_to_file(config)
+        with config_lock:
+            if "teams" not in config:
+                config["teams"] = {}
+
+            # Remove ID from team_data if present
+            team_data_copy = team_data.copy()
+            team_data_copy.pop("id", None)
+
+            config["teams"][team_id] = team_data_copy
+            save_config_to_file(config)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to save team: {e!s}") from e
     else:
@@ -404,27 +395,25 @@ async def create_team(team_data: dict[str, Any], _user: Annotated[dict, Depends(
     """Create a new team."""
     team_id = team_data.get("display_name", "new_team").lower().replace(" ", "_")
 
-    with config_lock:
-        if "teams" not in config:
-            config["teams"] = {}
-
-        # Check if team already exists
-        if team_id in config["teams"]:
-            # Generate unique ID
-            counter = 1
-            while f"{team_id}_{counter}" in config["teams"]:
-                counter += 1
-            team_id = f"{team_id}_{counter}"
-
-        # Remove ID from team_data if present
-        team_data_copy = team_data.copy()
-        team_data_copy.pop("id", None)
-
-        config["teams"][team_id] = team_data_copy
-
-    # Save to file
     try:
-        save_config_to_file(config)
+        with config_lock:
+            if "teams" not in config:
+                config["teams"] = {}
+
+            # Check if team already exists
+            if team_id in config["teams"]:
+                # Generate unique ID
+                counter = 1
+                while f"{team_id}_{counter}" in config["teams"]:
+                    counter += 1
+                team_id = f"{team_id}_{counter}"
+
+            # Remove ID from team_data if present
+            team_data_copy = team_data.copy()
+            team_data_copy.pop("id", None)
+
+            config["teams"][team_id] = team_data_copy
+            save_config_to_file(config)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to create team: {e!s}") from e
     else:
@@ -439,14 +428,12 @@ async def delete_team(team_id: str, _user: Annotated[dict, Depends(verify_user)]
             raise HTTPException(status_code=404, detail="Team not found")
 
         del config["teams"][team_id]
-
-    # Save to file
-    try:
-        save_config_to_file(config)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to delete team: {e!s}") from e
-    else:
-        return {"success": True}
+        try:
+            save_config_to_file(config)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to delete team: {e!s}") from e
+        else:
+            return {"success": True}
 
 
 @app.get("/api/config/models")
@@ -464,15 +451,13 @@ async def update_model(
     _user: Annotated[dict, Depends(verify_user)],
 ) -> dict[str, bool]:
     """Update a model configuration."""
-    with config_lock:
-        if "models" not in config:
-            config["models"] = {}
-
-        config["models"][model_id] = model_data
-
-    # Save to file
     try:
-        save_config_to_file(config)
+        with config_lock:
+            if "models" not in config:
+                config["models"] = {}
+
+            config["models"][model_id] = model_data
+            save_config_to_file(config)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to save model: {e!s}") from e
     else:
@@ -493,12 +478,10 @@ async def update_room_models(
     _user: Annotated[dict, Depends(verify_user)],
 ) -> dict[str, bool]:
     """Update room-specific model overrides."""
-    with config_lock:
-        config["room_models"] = room_models
-
-    # Save to file
     try:
-        save_config_to_file(config)
+        with config_lock:
+            config["room_models"] = room_models
+            save_config_to_file(config)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to save room models: {e!s}") from e
     else:

--- a/src/mindroom/credentials.py
+++ b/src/mindroom/credentials.py
@@ -10,8 +10,10 @@ from pathlib import Path
 from typing import Any
 
 from .constants import CREDENTIALS_DIR
+from .logging_config import get_logger
 
 SERVICE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9:_-]+$")
+logger = get_logger(__name__)
 
 
 def validate_service_name(service: str) -> str:
@@ -75,6 +77,11 @@ class CredentialsManager:
                     data: dict[str, Any] = json.load(f)
                     return data
             except Exception:
+                logger.exception(
+                    "Failed to load credentials",
+                    service=service,
+                    path=str(credentials_path),
+                )
                 return None
         return None
 


### PR DESCRIPTION
## Summary

This PR contains three small, independent runtime bug fixes:

1. **Task retention fix (`src/mindroom/bot.py`)**
- Replace `asyncio.create_task(error_handler())` in `_create_task_wrapper` with `create_background_task(error_handler())`.
- Removes the dropped-task reference risk and eliminates the `RUF006` suppression path.

2. **Config save race fix (`src/mindroom/api/main.py`)**
- Move `save_config_to_file(config)` calls inside `config_lock` for endpoints that mutate then persist config.
- Applied to agents, teams, models, room-models, and config save paths to keep mutation + persistence atomic.

3. **Failure swallowing diagnostics (`src/mindroom/bot.py`, `src/mindroom/credentials.py`)**
- In bot post-response memory handling, keep the guard but log full exception context with `logger.exception(...)`.
- In credential loading, log parse/IO failures with `logger.exception(...)` before returning `None`.

## Testing

- `pytest` (full suite): **1809 passed, 19 skipped**
- `pre-commit run --all-files`: failed in this environment on workspace TypeScript check due missing frontend node modules (`Cannot find module 'react'`, etc.)
