### PR TITLE
Improve module privacy checker false-positive filtering

### DIFF
--- a/src/mindroom/api/google_integration.py
+++ b/src/mindroom/api/google_integration.py
@@ -130,14 +130,14 @@ def _get_google_credentials() -> Credentials | None:
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(google_request_cls())
             # Save refreshed credentials
-            save_credentials(creds)
+            _save_credentials(creds)
     except Exception:
         return None
     else:
         return creds if creds and creds.valid else None
 
 
-def save_credentials(creds: Credentials) -> None:
+def _save_credentials(creds: Credentials) -> None:
     """Save credentials using the unified credentials manager."""
     # Full token with all scopes
     token_data = {
@@ -300,7 +300,7 @@ async def callback(request: Request) -> RedirectResponse:
         flow.fetch_token(code=code)
 
         # Save credentials
-        save_credentials(flow.credentials)
+        _save_credentials(flow.credentials)
 
         # Redirect back to widget with success message
         # Extract the domain from the redirect URI for the final redirect

--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -103,7 +103,7 @@ def load_rooms() -> dict[str, MatrixRoom]:
     return state.rooms
 
 
-def get_room_aliases() -> dict[str, str]:
+def _get_room_aliases() -> dict[str, str]:
     """Get mapping of room aliases to room IDs."""
     state = MatrixState.load()
     return state.get_room_aliases()
@@ -116,7 +116,7 @@ def _get_room_id(room_key: str) -> str | None:
     return room.room_id if room else None
 
 
-def add_room(room_key: str, room_id: str, alias: str, name: str) -> None:
+def _add_room(room_key: str, room_id: str, alias: str, name: str) -> None:
     """Add a new room to the state."""
     state = MatrixState.load()
     state.add_room(room_key, room_id, alias, name)
@@ -143,7 +143,7 @@ def resolve_room_aliases(room_list: list[str]) -> list[str]:
         List of room IDs (aliases resolved to IDs, IDs passed through)
 
     """
-    room_aliases = get_room_aliases()
+    room_aliases = _get_room_aliases()
     return [room_aliases.get(room, room) for room in room_list]
 
 
@@ -157,7 +157,7 @@ def get_room_alias_from_id(room_id: str) -> str | None:
         Room alias if found, None otherwise
 
     """
-    room_aliases = get_room_aliases()
+    room_aliases = _get_room_aliases()
     for alias, rid in room_aliases.items():
         if rid == room_id:
             return alias
@@ -201,7 +201,7 @@ async def _ensure_room_exists(  # noqa: C901, PLR0912
         if room_key not in existing_rooms or existing_rooms[room_key].room_id != room_id:
             if room_name is None:
                 room_name = _room_key_to_name(room_key)
-            add_room(room_key, room_id, full_alias, room_name)
+            _add_room(room_key, room_id, full_alias, room_name)
             logger.info(f"Updated state with existing room {room_key} (ID: {room_id})")
 
         # Try to join the room
@@ -261,7 +261,7 @@ async def _ensure_room_exists(  # noqa: C901, PLR0912
 
     if created_room_id:
         # Save room info
-        add_room(room_key, created_room_id, full_alias, room_name)
+        _add_room(room_key, created_room_id, full_alias, room_name)
         logger.info(f"Created room {room_key} with ID {created_room_id}")
 
         if config.matrix_room_access.is_multi_user_mode():

--- a/tests/test_check_module_privacy.py
+++ b/tests/test_check_module_privacy.py
@@ -1,0 +1,203 @@
+"""Tests for ``scripts.check_module_privacy``."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.check_module_privacy import find_private_candidates
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _symbols(project_root: Path) -> set[tuple[str, str]]:
+    return {(symbol.module, symbol.name) for symbol in find_private_candidates(project_root)}
+
+
+def test_fastapi_route_functions_and_models_are_skipped(tmp_path: Path) -> None:
+    """FastAPI route handlers and request/response models should not be flagged."""
+    _write(
+        tmp_path / "src" / "pkg" / "api.py",
+        """
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+class RequestModel(BaseModel):
+    value: int
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+def local_helper() -> int:
+    return 1
+""".strip()
+        + "\n",
+    )
+
+    symbols = _symbols(tmp_path)
+    assert ("pkg.api", "health") not in symbols
+    assert ("pkg.api", "RequestModel") not in symbols
+    assert ("pkg.api", "router") not in symbols
+    assert ("pkg.api", "local_helper") in symbols
+
+
+def test_fastapi_related_type_aliases_and_derived_models_are_skipped(tmp_path: Path) -> None:
+    """Names only referenced from route signatures/decorators should be skipped."""
+    _write(
+        tmp_path / "src" / "pkg" / "api.py",
+        """
+from fastapi import APIRouter, Query
+from pydantic import BaseModel
+from typing import Annotated
+
+router = APIRouter()
+
+class BasePayload(BaseModel):
+    name: str
+
+class ExtendedPayload(BasePayload):
+    age: int
+
+RoomFilter = Annotated[str | None, Query(default=None)]
+
+@router.get("/items", response_model=ExtendedPayload)
+async def list_items(room_id: RoomFilter = None) -> ExtendedPayload:
+    return ExtendedPayload(name="a", age=1)
+""".strip()
+        + "\n",
+    )
+
+    symbols = _symbols(tmp_path)
+    assert ("pkg.api", "ExtendedPayload") not in symbols
+    assert ("pkg.api", "RoomFilter") not in symbols
+    assert ("pkg.api", "list_items") not in symbols
+
+
+def test_typer_callbacks_are_skipped(tmp_path: Path) -> None:
+    """Typer command callbacks should not be flagged."""
+    _write(
+        tmp_path / "src" / "pkg" / "cli.py",
+        """
+import typer
+
+app = typer.Typer()
+
+@app.command()
+def run() -> None:
+    pass
+
+def local_helper() -> int:
+    return 1
+""".strip()
+        + "\n",
+    )
+
+    symbols = _symbols(tmp_path)
+    assert ("pkg.cli", "app") not in symbols
+    assert ("pkg.cli", "run") not in symbols
+    assert ("pkg.cli", "local_helper") in symbols
+
+
+def test_logger_variable_is_ignored(tmp_path: Path) -> None:
+    """Module-level logger should be ignored by privacy checks."""
+    _write(
+        tmp_path / "src" / "pkg" / "mod.py",
+        """
+from logging import getLogger
+
+logger = getLogger(__name__)
+
+def local_helper() -> int:
+    logger.info("x")
+    return 1
+""".strip()
+        + "\n",
+    )
+
+    symbols = _symbols(tmp_path)
+    assert ("pkg.mod", "logger") not in symbols
+    assert ("pkg.mod", "local_helper") in symbols
+
+
+def test_pyproject_console_entrypoint_is_skipped(tmp_path: Path) -> None:
+    """Console-script entrypoints in pyproject.toml should not be flagged."""
+    _write(
+        tmp_path / "src" / "pkg" / "cli.py",
+        """
+def main() -> int:
+    return 0
+""".strip()
+        + "\n",
+    )
+    _write(
+        tmp_path / "pyproject.toml",
+        """
+[project]
+name = "example"
+version = "0.1.0"
+scripts.example = "pkg.cli:main"
+""".strip()
+        + "\n",
+    )
+
+    symbols = _symbols(tmp_path)
+    assert ("pkg.cli", "main") not in symbols
+
+
+def test_fastapi_include_router_dependency_symbols_are_skipped(tmp_path: Path) -> None:
+    """FastAPI dependency callbacks used via include_router should not be flagged."""
+    _write(
+        tmp_path / "src" / "pkg" / "api.py",
+        """
+from fastapi import APIRouter, Depends, FastAPI
+
+app = FastAPI()
+router = APIRouter()
+
+async def verify_user() -> dict[str, str]:
+    return {"id": "1"}
+
+app.include_router(router, dependencies=[Depends(verify_user)])
+
+def local_helper() -> int:
+    return 1
+""".strip()
+        + "\n",
+    )
+
+    symbols = _symbols(tmp_path)
+    assert ("pkg.api", "verify_user") not in symbols
+    assert ("pkg.api", "local_helper") in symbols
+
+
+def test_shell_uvicorn_entrypoint_is_skipped(tmp_path: Path) -> None:
+    """Uvicorn entrypoints in shell scripts should not be flagged."""
+    _write(
+        tmp_path / "src" / "pkg" / "server.py",
+        """
+def build_app() -> object:
+    return object()
+
+asgi = build_app()
+""".strip()
+        + "\n",
+    )
+    _write(
+        tmp_path / "run-server.sh",
+        """
+#!/usr/bin/env bash
+exec uvicorn pkg.server:asgi --host 0.0.0.0 --port 8000
+""".strip()
+        + "\n",
+    )
+
+    symbols = _symbols(tmp_path)
+    assert ("pkg.server", "asgi") not in symbols

--- a/tests/test_matrix_room_access.py
+++ b/tests/test_matrix_room_access.py
@@ -150,7 +150,7 @@ async def test_existing_room_reconciliation_respects_flag(
     )
 
     monkeypatch.setattr(matrix_rooms, "load_rooms", dict)
-    monkeypatch.setattr(matrix_rooms, "add_room", MagicMock())
+    monkeypatch.setattr(matrix_rooms, "_add_room", MagicMock())
     monkeypatch.setattr(matrix_rooms, "join_room", AsyncMock(return_value=True))
     monkeypatch.setattr(matrix_rooms, "ensure_room_has_topic", AsyncMock())
     configure_access = AsyncMock(return_value=True)
@@ -185,7 +185,7 @@ async def test_new_room_creation_applies_access_policy_in_multi_user_mode(monkey
     monkeypatch.setattr(matrix_rooms, "load_rooms", dict)
     monkeypatch.setattr(matrix_rooms, "generate_room_topic_ai", AsyncMock(return_value="topic"))
     monkeypatch.setattr(matrix_rooms, "create_room", AsyncMock(return_value="!lobby:example.com"))
-    monkeypatch.setattr(matrix_rooms, "add_room", MagicMock())
+    monkeypatch.setattr(matrix_rooms, "_add_room", MagicMock())
     configure_access = AsyncMock(return_value=True)
     monkeypatch.setattr(matrix_rooms, "_configure_managed_room_access", configure_access)
 
@@ -309,7 +309,7 @@ async def test_existing_room_reconciliation_skipped_when_not_joined(monkeypatch:
     )
 
     monkeypatch.setattr(matrix_rooms, "load_rooms", dict)
-    monkeypatch.setattr(matrix_rooms, "add_room", MagicMock())
+    monkeypatch.setattr(matrix_rooms, "_add_room", MagicMock())
     monkeypatch.setattr(matrix_rooms, "join_room", AsyncMock(return_value=False))
     configure_access = AsyncMock(return_value=True)
     monkeypatch.setattr(matrix_rooms, "_configure_managed_room_access", configure_access)


### PR DESCRIPTION
## Summary
- extend `scripts/check_module_privacy.py` to ignore framework-driven public symbols (FastAPI routes, Typer callbacks, framework constructors/registration)
- ignore external entrypoint symbols from `pyproject.toml` scripts and shell `uvicorn module:symbol` launches
- keep module-level `logger` public by explicitly allowlisting it, and add targeted regression tests
- keep true privacy fixes in `matrix/rooms.py` (`_get_room_aliases`, `_add_room`) and update related tests
- fix Google integration to call `CredentialsManager.save_credentials(...)` via the public API

## Validation
- `uv run python scripts/check_module_privacy.py .`
- `uv run pytest`
- `uv run pre-commit run --all-files`
