### PR TITLE
chore: follow-up review fixes for tool expansion and typing

### DIFF
--- a/cluster/k8s/instance/default-config.yaml
+++ b/cluster/k8s/instance/default-config.yaml
@@ -272,7 +272,6 @@ agents:
     - duckduckgo
     - website
     - openclaw_compat
-    - attachments
     - python
     - calculator
   research:

--- a/config.yaml
+++ b/config.yaml
@@ -292,7 +292,6 @@ agents:
     - duckduckgo
     - website
     - openclaw_compat
-    - attachments
     - python
     - calculator
   research:

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -48,7 +48,7 @@ from mindroom.tool_system.events import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Sequence
+    from collections.abc import AsyncGenerator, AsyncIterator, Sequence
     from pathlib import Path
 
     from agno.agent import Agent
@@ -1077,7 +1077,7 @@ async def _process_stream_events(  # noqa: C901
     agent_name: str,
     media_inputs: MediaInputs,
     retried_without_inline_media: bool,
-) -> AsyncIterator[AIStreamChunk]:
+) -> AsyncGenerator[AIStreamChunk, None]:
     """Consume one streaming attempt, yielding chunks and mutating *state*."""
     try:
         async for event in stream_generator:

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections import deque
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Literal
@@ -350,9 +351,9 @@ class Config(BaseModel):
         """Expand tool presets and implied tools, deduping while preserving order."""
         expanded: list[str] = []
         seen: set[str] = set()
-        queue = list(tool_names)
+        queue = deque(tool_names)
         while queue:
-            tool_name = queue.pop(0)
+            tool_name = queue.popleft()
             if tool_name in seen:
                 continue
             seen.add(tool_name)

--- a/src/mindroom/tools/__init__.py
+++ b/src/mindroom/tools/__init__.py
@@ -249,7 +249,7 @@ __all__ = [
     helper_text="Implies: shell, coding, duckduckgo, website, browser, scheduler, subagents, matrix_message, attachments.",
 )
 def _openclaw_compat_tools() -> type[Toolkit]:
-    """Return an empty toolkit — the real tools are loaded via IMPLIED_TOOLS."""
+    """Return an empty toolkit — the real tools are loaded via tool preset expansion."""
     from agno.tools import Toolkit
 
     return Toolkit


### PR DESCRIPTION
## Summary
- switch `Config.expand_tool_names` queue handling from `list.pop(0)` to `deque.popleft()`
- remove redundant explicit `attachments` entries where `openclaw_compat` already implies them
- reword `_openclaw_compat_tools` docstring to avoid leaking internal symbol names
- tighten `_process_stream_events` return type to `AsyncGenerator[AIStreamChunk, None]`

## Validation
- `pytest`
- `pre-commit run --all-files`
