### PR TITLE
Include MXC URL in download failure logs

### DIFF
--- a/src/mindroom/matrix/message_content.py
+++ b/src/mindroom/matrix/message_content.py
@@ -208,7 +208,7 @@ async def _download_mxc_text(  # noqa: PLR0911, PLR0912, C901
         response = await client.download(server_name, media_id)
 
         if not isinstance(response, nio.DownloadResponse):
-            logger.error(f"Failed to download MXC content: {response}")
+            logger.error(f"Failed to download MXC content: {response}", mxc_url=mxc_url)
             return None
 
         # Handle encryption if needed


### PR DESCRIPTION
## Summary
- Include `mxc_url` in `_download_mxc_text` when download returns a non-`DownloadResponse`.
- This adds the failing MXC URL to error logs for malformed URL debugging.

## Verification
- `uv run pytest tests/ -x -q -k "mxc or large_message or message_content"`
  - Result: `47 passed, 1919 deselected`
- `uv run pre-commit run --all-files`
  - Result: all hooks passed except `typescript-check` in this environment due to missing `tsc` binary.
