### PR TITLE
Fix team context to use resolved message body

### DIFF
--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -400,7 +400,7 @@ def _build_prompt_with_context(
     context_parts = []
     for msg in recent_messages:
         sender = msg.get("sender", "Unknown")
-        body = msg.get("content", {}).get("body", "")
+        body = msg.get("body", "")
         if body and len(body) < _MAX_CONTEXT_MESSAGE_LENGTH:
             context_parts.append(f"{sender}: {body}")
 


### PR DESCRIPTION
## Summary
- read thread message text from top-level `body` in `teams._build_prompt_with_context`
- stop reading `content.body`, which can be truncated for large-message sidecar events
- align team context behavior with `extract_and_resolve_message` output and existing `ai.py` usage

## Validation
- `uv run pytest tests/ -x -q -k "team"` ✅ (`112 passed, 3 skipped, 1851 deselected`)
- `uv run pytest tests/ -x -q` ⚠️ fails at `tests/test_multi_agent_bot.py::TestAgentBot::test_agent_bot_thread_response[True]` with `pytest-timeout` (>60s) in this environment
- `uv run pytest tests/test_multi_agent_bot.py -x -q -k "test_agent_bot_thread_response and True"` ✅ (`1 passed`)
- `uv run pre-commit run --all-files` ✅
