### PR TITLE
Fix stale Thinking placeholder on streaming errors

### DIFF
--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -37,8 +37,19 @@ logger = get_logger(__name__)
 IN_PROGRESS_MARKER = " ⋯"
 _PROGRESS_PLACEHOLDER = "Thinking..."
 _CANCELLED_RESPONSE_NOTE = "**[Response cancelled by user]**"
+_STREAM_ERROR_RESPONSE_NOTE = "**[Response interrupted by an error"
 _StreamInputChunk = str | StructuredStreamChunk | RunContentEvent | ToolCallStartedEvent | ToolCallCompletedEvent
 _IN_PROGRESS_MESSAGE_PATTERN = re.compile(rf"{re.escape(IN_PROGRESS_MARKER)}\.*$")
+
+
+def _format_stream_error_note(error: Exception) -> str:
+    """Return a concise user-facing note for stream-time exceptions."""
+    normalized_error = " ".join(str(error).split())
+    if not normalized_error:
+        return f"{_STREAM_ERROR_RESPONSE_NOTE}. Please retry.]**"
+    if len(normalized_error) > 220:
+        normalized_error = f"{normalized_error[:219]}…"
+    return f"{_STREAM_ERROR_RESPONSE_NOTE}: {normalized_error}]**"
 
 
 def is_in_progress_message(text: object) -> bool:
@@ -179,9 +190,19 @@ class StreamingResponse:
         self._update(new_chunk)
         await self._throttled_send(client)
 
-    async def finalize(self, client: nio.AsyncClient, *, cancelled: bool = False) -> None:
+    async def finalize(
+        self,
+        client: nio.AsyncClient,
+        *,
+        cancelled: bool = False,
+        error: Exception | None = None,
+    ) -> None:
         """Send final message update."""
-        if cancelled:
+        if error is not None:
+            stripped_text = self.accumulated_text.rstrip()
+            error_note = _format_stream_error_note(error)
+            self.accumulated_text = f"{stripped_text}\n\n{error_note}" if stripped_text else error_note
+        elif cancelled:
             stripped_text = self.accumulated_text.rstrip()
             self.accumulated_text = (
                 f"{stripped_text}\n\n{_CANCELLED_RESPONSE_NOTE}" if stripped_text else _CANCELLED_RESPONSE_NOTE
@@ -425,7 +446,11 @@ async def send_streaming_response(
     except asyncio.CancelledError:
         await streaming.finalize(client, cancelled=True)
         raise
-
-    await streaming.finalize(client)
+    except Exception as e:
+        logger.exception("Streaming response failed", error=str(e))
+        await streaming.finalize(client, error=e)
+        raise
+    else:
+        await streaming.finalize(client)
 
     return streaming.event_id, streaming.accumulated_text

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -751,3 +751,91 @@ class TestStreamingBehavior:
         assert len(edited_texts) == 2
         assert IN_PROGRESS_MARKER in edited_texts[0]
         assert edited_texts[-1] == f"Partial answer\n\n{_CANCELLED_RESPONSE_NOTE}"
+
+    @pytest.mark.asyncio
+    async def test_stream_error_preserves_partial_text_and_appends_error_hint(self) -> None:
+        """Stream failures should remove pending state and append an error hint."""
+        mock_client = AsyncMock()
+        edited_texts: list[str] = []
+
+        async def record_edit(
+            _client: object,
+            _room_id: str,
+            _event_id: str,
+            _new_content: dict[str, object],
+            new_text: str,
+        ) -> str:
+            edited_texts.append(new_text)
+            return "$edit"
+
+        async def failing_stream() -> AsyncIterator[str]:
+            yield "Partial answer"
+            msg = "model backend disconnected"
+            raise RuntimeError(msg)
+
+        with (
+            patch("mindroom.streaming.edit_message", new=AsyncMock(side_effect=record_edit)),
+            pytest.raises(RuntimeError, match="model backend disconnected"),
+        ):
+            await send_streaming_response(
+                client=mock_client,
+                room_id="!test:localhost",
+                reply_to_event_id="$original_123",
+                thread_id=None,
+                sender_domain="localhost",
+                config=self.config,
+                response_stream=failing_stream(),
+                existing_event_id="$thinking_123",
+                room_mode=True,
+            )
+
+        assert len(edited_texts) == 2
+        assert IN_PROGRESS_MARKER in edited_texts[0]
+        final_text = edited_texts[-1]
+        assert final_text.startswith("Partial answer\n\n**[Response interrupted by an error:")
+        assert "model backend disconnected" in final_text
+        assert IN_PROGRESS_MARKER not in final_text
+
+    @pytest.mark.asyncio
+    async def test_stream_error_replaces_placeholder_when_no_text_arrives(self) -> None:
+        """Stream failures before first chunk should replace a thinking placeholder with an error hint."""
+        mock_client = AsyncMock()
+        edited_texts: list[str] = []
+
+        async def record_edit(
+            _client: object,
+            _room_id: str,
+            _event_id: str,
+            _new_content: dict[str, object],
+            new_text: str,
+        ) -> str:
+            edited_texts.append(new_text)
+            return "$edit"
+
+        async def failing_stream() -> AsyncIterator[str]:
+            if False:
+                yield ""
+            msg = "provider stream failed"
+            raise RuntimeError(msg)
+
+        with (
+            patch("mindroom.streaming.edit_message", new=AsyncMock(side_effect=record_edit)),
+            pytest.raises(RuntimeError, match="provider stream failed"),
+        ):
+            await send_streaming_response(
+                client=mock_client,
+                room_id="!test:localhost",
+                reply_to_event_id="$original_123",
+                thread_id=None,
+                sender_domain="localhost",
+                config=self.config,
+                response_stream=failing_stream(),
+                existing_event_id="$thinking_123",
+                room_mode=True,
+            )
+
+        assert len(edited_texts) == 1
+        final_text = edited_texts[0]
+        assert final_text.startswith("**[Response interrupted by an error:")
+        assert "provider stream failed" in final_text
+        assert IN_PROGRESS_MARKER not in final_text


### PR DESCRIPTION
## Summary
- finalize streaming messages with an explicit error hint when a non-cancellation exception occurs mid-stream
- preserve any partial streamed text and append the error hint instead of leaving the in-progress marker hanging
- keep cancellation behavior unchanged and add regression tests for both partial-output and placeholder-only failures

## Testing
- pytest -q tests/test_streaming_behavior.py -k "stream_error or cancelled_stream"
- pre-commit run --files src/mindroom/streaming.py tests/test_streaming_behavior.py
- pytest