### PR TITLE
Learn model-level inline-audio preflight across team and agent runs

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -70,7 +70,13 @@ from mindroom.history.types import HistoryScope
 from mindroom.hooks import EnrichmentItem, render_system_enrichment_block
 from mindroom.llm_request_logging import install_llm_request_logging
 from mindroom.logging_config import get_logger
-from mindroom.media_fallback import append_inline_media_fallback_prompt, should_retry_without_inline_media
+from mindroom.media_fallback import (
+    append_inline_media_fallback_prompt,
+    remember_inline_audio_unsupported,
+    should_mark_inline_audio_unsupported,
+    should_preflight_skip_inline_audio,
+    should_retry_without_inline_media,
+)
 from mindroom.media_inputs import MediaInputs
 from mindroom.memory import build_memory_enhanced_prompt
 from mindroom.timing import DispatchPipelineTiming, timed
@@ -119,6 +125,23 @@ QUEUED_MESSAGE_NOTICE_TEXT = (
     "Avoid further tool calls unless strictly necessary. "
     "The new message will be handled in your next turn."
 )
+
+
+def _resolve_model_capability_identity(
+    config: Config,
+    entity_name: str,
+) -> tuple[str | None, str | None, str | None]:
+    """Resolve model identity used for learned inline-media capability caching."""
+    model_name = config.get_entity_model_name(entity_name)
+    model_config = config.models.get(model_name)
+    if model_config is None:
+        return None, None, None
+    model_base_url = None
+    if model_config.extra_kwargs:
+        base_url = model_config.extra_kwargs.get("base_url")
+        if isinstance(base_url, str):
+            model_base_url = base_url
+    return model_config.provider, model_config.id, model_base_url
 
 
 class _SupportsQueuedMessageState(Protocol):
@@ -809,6 +832,9 @@ def _request_stream_retry(
     error: Exception | str,
     log_message: str,
     agent_name: str,
+    model_provider: str | None,
+    model_id: str | None,
+    model_base_url: str | None,
 ) -> bool:
     """Set retry flag when inline-media fallback should be attempted."""
     if retried_without_inline_media or state.full_response:
@@ -816,6 +842,12 @@ def _request_stream_retry(
         return False
     if not should_retry_without_inline_media(error, media_inputs):
         return False
+    if should_mark_inline_audio_unsupported(error, media_inputs):
+        remember_inline_audio_unsupported(
+            provider=model_provider,
+            model_id=model_id,
+            base_url=model_base_url,
+        )
     state.retry_requested = True
     logger.warning(
         log_message,
@@ -1214,10 +1246,30 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 unseen_event_ids,
                 extra_metadata=matrix_run_metadata,
             )
+            model_provider, model_id, model_base_url = _resolve_model_capability_identity(config, agent_name)
 
             response: RunOutput | None = None
-            attempt_prompt = full_prompt
-            attempt_media_inputs = media_inputs
+            if should_preflight_skip_inline_audio(
+                media_inputs,
+                provider=model_provider,
+                model_id=model_id,
+                base_url=model_base_url,
+            ):
+                logger.info(
+                    "Preflight dropping inline audio from learned capability cache",
+                    agent=agent_name,
+                    model_provider=model_provider,
+                    model_id=model_id,
+                )
+                attempt_prompt = append_inline_media_fallback_prompt(full_prompt)
+                attempt_media_inputs = MediaInputs(
+                    images=media_inputs.images,
+                    files=media_inputs.files,
+                    videos=media_inputs.videos,
+                )
+            else:
+                attempt_prompt = full_prompt
+                attempt_media_inputs = media_inputs
             attempt_run_id = run_id
 
             try:
@@ -1247,6 +1299,12 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                                 agent=agent_name,
                                 error=str(e),
                             )
+                            if should_mark_inline_audio_unsupported(e, attempt_media_inputs):
+                                remember_inline_audio_unsupported(
+                                    provider=model_provider,
+                                    model_id=model_id,
+                                    base_url=model_base_url,
+                                )
                             attempt_prompt = append_inline_media_fallback_prompt(full_prompt)
                             attempt_media_inputs = MediaInputs()
                             attempt_run_id = _next_retry_run_id(run_id)
@@ -1266,6 +1324,12 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                                 agent=agent_name,
                                 error=error_text,
                             )
+                            if should_mark_inline_audio_unsupported(error_text, attempt_media_inputs):
+                                remember_inline_audio_unsupported(
+                                    provider=model_provider,
+                                    model_id=model_id,
+                                    base_url=model_base_url,
+                                )
                             attempt_prompt = append_inline_media_fallback_prompt(full_prompt)
                             attempt_media_inputs = MediaInputs()
                             attempt_run_id = _next_retry_run_id(run_id)
@@ -1330,6 +1394,9 @@ async def _process_stream_events(  # noqa: C901, PLR0912
     agent_name: str,
     media_inputs: MediaInputs,
     retried_without_inline_media: bool,
+    model_provider: str | None,
+    model_id: str | None,
+    model_base_url: str | None,
     timing_scope: str,
     pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> AsyncGenerator[AIStreamChunk, None]:
@@ -1387,6 +1454,9 @@ async def _process_stream_events(  # noqa: C901, PLR0912
                     error=error_text,
                     log_message="Retrying streaming AI response without inline media after run error",
                     agent_name=agent_name,
+                    model_provider=model_provider,
+                    model_id=model_id,
+                    model_base_url=model_base_url,
                 ):
                     return
                 logger.error("Agent run error during streaming", agent=agent_name, error=error_text)
@@ -1402,6 +1472,9 @@ async def _process_stream_events(  # noqa: C901, PLR0912
             error=e,
             log_message="Retrying streaming AI response without inline media after stream exception",
             agent_name=agent_name,
+            model_provider=model_provider,
+            model_id=model_id,
+            model_base_url=model_base_url,
         ):
             return
         logger.exception("Error during streaming AI response")
@@ -1540,9 +1613,32 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                 unseen_event_ids,
                 extra_metadata=matrix_run_metadata,
             )
+            model_provider, model_id, model_base_url = _resolve_model_capability_identity(
+                config,
+                agent_name,
+            )
 
-            attempt_prompt = full_prompt
-            attempt_media_inputs = media_inputs
+            if should_preflight_skip_inline_audio(
+                media_inputs,
+                provider=model_provider,
+                model_id=model_id,
+                base_url=model_base_url,
+            ):
+                logger.info(
+                    "Preflight dropping inline audio from learned capability cache",
+                    agent=agent_name,
+                    model_provider=model_provider,
+                    model_id=model_id,
+                )
+                attempt_prompt = append_inline_media_fallback_prompt(full_prompt)
+                attempt_media_inputs = MediaInputs(
+                    images=media_inputs.images,
+                    files=media_inputs.files,
+                    videos=media_inputs.videos,
+                )
+            else:
+                attempt_prompt = full_prompt
+                attempt_media_inputs = media_inputs
             attempt_run_id = run_id
             state = _StreamingAttemptState()
 
@@ -1574,6 +1670,9 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                             agent_name=agent_name,
                             media_inputs=attempt_media_inputs,
                             retried_without_inline_media=retried_without_inline_media,
+                            model_provider=model_provider,
+                            model_id=model_id,
+                            model_base_url=model_base_url,
                             timing_scope=timing_scope,
                             pipeline_timing=pipeline_timing,
                         ):
@@ -1586,6 +1685,9 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                             error=e,
                             log_message="Retrying streaming AI response without inline media after validation error",
                             agent_name=agent_name,
+                            model_provider=model_provider,
+                            model_id=model_id,
+                            model_base_url=model_base_url,
                         ):
                             attempt_prompt = append_inline_media_fallback_prompt(full_prompt)
                             attempt_media_inputs = MediaInputs()

--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -12,6 +12,8 @@ _INLINE_MEDIA_FALLBACK_MARKER = "[Inline media unavailable for this model]"
 _INLINE_MEDIA_FIELD_PATTERN = re.compile(r"(?:document|image|audio|video)\.source\.base64(?:\.media_type)?")
 _INLINE_MEDIA_MIME_MISMATCH_PATTERN = re.compile(r"image was specified using the .* media type")
 _INLINE_MEDIA_UNSUPPORTED_PATTERN = re.compile(r"(?:audio|image|video|file|document) input is not supported")
+_INLINE_AUDIO_UNSUPPORTED_PATTERN = re.compile(r"audio input is not supported")
+_UNSUPPORTED_INLINE_AUDIO_MODELS: set[tuple[str, str, str]] = set()
 
 
 def _is_media_validation_error_text(error_text: str) -> bool:
@@ -41,3 +43,70 @@ def append_inline_media_fallback_prompt(full_prompt: str) -> str:
         "The model rejected inline attachments for this turn. "
         "Use available attachment IDs and tools to inspect files instead."
     )
+
+
+def _normalize_model_capability_key(
+    *,
+    provider: str | None,
+    model_id: str | None,
+    base_url: str | None,
+) -> tuple[str, str, str] | None:
+    normalized_provider = (provider or "").strip().lower().replace("-", "_")
+    normalized_model_id = (model_id or "").strip().lower()
+    if not normalized_provider or not normalized_model_id:
+        return None
+    normalized_base_url = (base_url or "").strip().lower()
+    return (normalized_provider, normalized_model_id, normalized_base_url)
+
+
+def remember_inline_audio_unsupported(
+    *,
+    provider: str | None,
+    model_id: str | None,
+    base_url: str | None,
+) -> None:
+    """Record that this model/backend rejected inline audio."""
+    key = _normalize_model_capability_key(
+        provider=provider,
+        model_id=model_id,
+        base_url=base_url,
+    )
+    if key is None:
+        return
+    _UNSUPPORTED_INLINE_AUDIO_MODELS.add(key)
+
+
+def should_mark_inline_audio_unsupported(error: Exception | str, media_inputs: MediaInputs) -> bool:
+    """Return whether this failure should teach the cache to preflight-drop audio."""
+    if not media_inputs.audio:
+        return False
+    return bool(_INLINE_AUDIO_UNSUPPORTED_PATTERN.search(str(error).lower()))
+
+
+def should_preflight_skip_inline_audio(
+    media_inputs: MediaInputs,
+    *,
+    provider: str | None,
+    model_id: str | None,
+    base_url: str | None,
+) -> bool:
+    """Return whether inline audio should be dropped before the first model call.
+
+    Uses a small learned cache populated from prior inline-audio rejections.
+    """
+    if not media_inputs.audio:
+        return False
+
+    key = _normalize_model_capability_key(
+        provider=provider,
+        model_id=model_id,
+        base_url=base_url,
+    )
+    if key is None:
+        return False
+    return key in _UNSUPPORTED_INLINE_AUDIO_MODELS
+
+
+def clear_inline_audio_capability_cache() -> None:
+    """Clear learned inline-audio capability cache (mainly for tests)."""
+    _UNSUPPORTED_INLINE_AUDIO_MODELS.clear()

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -54,7 +54,13 @@ from mindroom.hooks import EnrichmentItem, render_system_enrichment_block
 from mindroom.knowledge.utils import ensure_request_knowledge_managers, get_agent_knowledge
 from mindroom.logging_config import get_logger
 from mindroom.matrix.rooms import get_room_alias_from_id
-from mindroom.media_fallback import append_inline_media_fallback_prompt, should_retry_without_inline_media
+from mindroom.media_fallback import (
+    append_inline_media_fallback_prompt,
+    remember_inline_audio_unsupported,
+    should_mark_inline_audio_unsupported,
+    should_preflight_skip_inline_audio,
+    should_retry_without_inline_media,
+)
 from mindroom.media_inputs import MediaInputs
 from mindroom.team_runtime_resolution import (
     ResolvedExactTeamMembers,
@@ -1737,10 +1743,38 @@ async def team_response_stream(  # noqa: C901, PLR0911, PLR0912, PLR0915
             prepared_prompt = prepared_execution.prepared_prompt
             unseen_event_ids = prepared_execution.unseen_event_ids
             run_metadata = prepared_execution.run_metadata
-            logger.info("team_streaming_setup", agents=agent_names, display_names=display_names)
             media_inputs = media or MediaInputs()
-            attempt_prompt = prepared_prompt
-            attempt_media_inputs = media_inputs
+            resolved_model_name = model_name or "default"
+            model_config = orchestrator.config.models.get(resolved_model_name)
+            model_provider = model_config.provider if model_config else None
+            model_id = model_config.id if model_config else None
+            model_base_url = None
+            if model_config and model_config.extra_kwargs:
+                base_url = model_config.extra_kwargs.get("base_url")
+                if isinstance(base_url, str):
+                    model_base_url = base_url
+            logger.info("team_streaming_setup", agents=agent_names, display_names=display_names)
+            if should_preflight_skip_inline_audio(
+                media_inputs,
+                provider=model_provider,
+                model_id=model_id,
+                base_url=model_base_url,
+            ):
+                logger.info(
+                    "Preflight dropping inline audio from learned capability cache",
+                    model=resolved_model_name,
+                    provider=model_provider,
+                    model_id=model_id,
+                )
+                attempt_prompt = append_inline_media_fallback_prompt(prepared_prompt)
+                attempt_media_inputs = MediaInputs(
+                    images=media_inputs.images,
+                    files=media_inputs.files,
+                    videos=media_inputs.videos,
+                )
+            else:
+                attempt_prompt = prepared_prompt
+                attempt_media_inputs = media_inputs
             attempt_run_id = run_id
 
             per_member: dict[str, str] = {}
@@ -1920,6 +1954,12 @@ async def team_response_stream(  # noqa: C901, PLR0911, PLR0912, PLR0915
                                         agents=", ".join(agent_names),
                                         error=error_text,
                                     )
+                                    if should_mark_inline_audio_unsupported(error_text, attempt_media_inputs):
+                                        remember_inline_audio_unsupported(
+                                            provider=model_provider,
+                                            model_id=model_id,
+                                            base_url=model_base_url,
+                                        )
                                     attempt_prompt = append_inline_media_fallback_prompt(prepared_prompt)
                                     attempt_media_inputs = MediaInputs()
                                     attempt_run_id = _next_retry_run_id(run_id)
@@ -1952,6 +1992,12 @@ async def team_response_stream(  # noqa: C901, PLR0911, PLR0912, PLR0915
                                     agents=", ".join(agent_names),
                                     error=error_text,
                                 )
+                                if should_mark_inline_audio_unsupported(error_text, attempt_media_inputs):
+                                    remember_inline_audio_unsupported(
+                                        provider=model_provider,
+                                        model_id=model_id,
+                                        base_url=model_base_url,
+                                    )
                                 attempt_prompt = append_inline_media_fallback_prompt(prepared_prompt)
                                 attempt_media_inputs = MediaInputs()
                                 attempt_run_id = _next_retry_run_id(run_id)

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -66,6 +66,7 @@ from mindroom.hooks.execution import reset_hook_execution_state
 from mindroom.hooks.registry import HookRegistryState
 from mindroom.hooks.types import RESERVED_EVENT_NAMESPACES, default_timeout_ms_for_event, validate_event_name
 from mindroom.matrix.identity import MatrixID
+from mindroom.media_fallback import clear_inline_audio_capability_cache
 from mindroom.media_inputs import MediaInputs
 from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsSupport
@@ -1764,6 +1765,10 @@ async def test_send_skill_command_response_locked_emits_session_started_after_pe
 class TestUserIdPassthrough:
     """Test that user_id reaches agent.arun() in both streaming and non-streaming paths."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_inline_audio_cache(self) -> None:
+        clear_inline_audio_capability_cache()
+
     @pytest.mark.asyncio
     async def test_non_streaming_passes_user_id(self, tmp_path: Path) -> None:
         """Test that _process_and_respond passes user_id through to ai_response."""
@@ -2474,6 +2479,95 @@ class TestUserIdPassthrough:
         assert seen_run_ids[1] is not None
         assert seen_run_ids[1] != "run-123"
         assert callback_run_ids == [run_id for run_id in seen_run_ids if run_id is not None]
+
+    @pytest.mark.asyncio
+    async def test_ai_response_preflights_audio_for_other_agent_sharing_model(self, tmp_path: Path) -> None:
+        """Model-level learned audio capability should apply across agents using the same model."""
+        runtime_paths = _runtime_paths(tmp_path)
+        config = bind_runtime_paths(
+            Config(
+                agents={
+                    "general": AgentConfig(display_name="GeneralAgent"),
+                    "research": AgentConfig(display_name="ResearchAgent"),
+                },
+                models={
+                    "default": ModelConfig(
+                        provider="openai",
+                        id="gpt-4o",
+                        extra_kwargs={"base_url": "https://api.openai.com/v1"},
+                    ),
+                },
+            ),
+            runtime_paths,
+        )
+
+        mock_agent_general = MagicMock()
+        mock_agent_general.model = MagicMock()
+        mock_agent_general.model.__class__.__name__ = "OpenAIChat"
+        mock_agent_general.model.id = "gpt-4o"
+        mock_agent_general.name = "GeneralAgent"
+        mock_agent_general.add_history_to_context = False
+        general_recovered_output = MagicMock()
+        general_recovered_output.content = "Recovered general response"
+        general_recovered_output.status = RunStatus.completed
+        general_recovered_output.tools = None
+        mock_agent_general.arun = AsyncMock(
+            side_effect=[
+                Exception("Error code: 500 - audio input is not supported"),
+                general_recovered_output,
+            ],
+        )
+
+        mock_agent_research = MagicMock()
+        mock_agent_research.model = MagicMock()
+        mock_agent_research.model.__class__.__name__ = "OpenAIChat"
+        mock_agent_research.model.id = "gpt-4o"
+        mock_agent_research.name = "ResearchAgent"
+        mock_agent_research.add_history_to_context = False
+        research_output = MagicMock()
+        research_output.content = "Preflight research response"
+        research_output.status = RunStatus.completed
+        research_output.tools = None
+        mock_agent_research.arun = AsyncMock(return_value=research_output)
+
+        audio_input = MagicMock(name="audio_input")
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.side_effect = [
+                _prepared_prompt_result(mock_agent_general, prompt="general prompt"),
+                _prepared_prompt_result(mock_agent_research, prompt="research prompt"),
+            ]
+            response_general = await ai_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                runtime_paths=runtime_paths,
+                config=config,
+                media=MediaInputs(audio=[audio_input]),
+            )
+            response_research = await ai_response(
+                agent_name="research",
+                prompt="test",
+                session_id="session2",
+                runtime_paths=runtime_paths,
+                config=config,
+                media=MediaInputs(audio=[audio_input]),
+            )
+
+        assert response_general == "Recovered general response"
+        assert response_research == "Preflight research response"
+
+        assert mock_agent_general.arun.await_count == 2
+        general_first_call = mock_agent_general.arun.await_args_list[0]
+        general_retry_call = mock_agent_general.arun.await_args_list[1]
+        assert list(general_first_call.kwargs["audio"]) == [audio_input]
+        assert list(general_retry_call.kwargs["audio"]) == []
+        assert "Inline media unavailable for this model" in general_retry_call.args[0]
+
+        assert mock_agent_research.arun.await_count == 1
+        research_call = mock_agent_research.arun.await_args_list[0]
+        assert list(research_call.kwargs["audio"]) == []
+        assert "Inline media unavailable for this model" in research_call.args[0]
 
     @pytest.mark.asyncio
     async def test_stream_agent_response_retries_without_media_on_validation_error(self, tmp_path: Path) -> None:

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -26,6 +26,7 @@ from mindroom.execution_preparation import PreparedExecutionContext
 from mindroom.history.runtime import open_bound_scope_session_context
 from mindroom.history.storage import read_scope_seen_event_ids, update_scope_seen_event_ids
 from mindroom.matrix.identity import MatrixID
+from mindroom.media_fallback import clear_inline_audio_capability_cache
 from mindroom.media_inputs import MediaInputs
 from mindroom.team_runtime_resolution import (
     ResolvedExactTeamMembers,
@@ -62,13 +63,14 @@ def _make_test_team(
     return AgnoTeam(name=name, id=team_id, model=_TEST_MODEL, members=[], tools=[])
 
 
-def _build_test_config() -> Config:
+def _build_test_config(model_config: ModelConfig | None = None) -> Config:
     runtime_paths = test_runtime_paths(Path(tempfile.mkdtemp()))
     return bind_runtime_paths(
         Config(
             agents={
                 "general": AgentConfig(display_name="GeneralAgent", rooms=["#test:example.org"]),
             },
+            models={"default": model_config} if model_config else {},
         ),
         runtime_paths,
     )
@@ -87,6 +89,11 @@ def _prepared_team_execution_context(
         replays_persisted_history=replays_persisted_history,
         compaction_outcomes=[],
     )
+
+
+@pytest.fixture(autouse=True)
+def _clear_inline_audio_cache() -> None:
+    clear_inline_audio_capability_cache()
 
 
 def test_resolve_live_shared_agent_names_returns_none_when_runtime_availability_is_unknown() -> None:
@@ -1241,8 +1248,14 @@ async def test_team_stream_rejects_request_time_materialization_failure() -> Non
 
 @pytest.mark.asyncio
 async def test_team_stream_retries_without_inline_media_on_setup_error() -> None:
-    """Team streaming should retry when stream setup fails before any output is emitted."""
-    config = _build_test_config()
+    """Unknown capability paths should keep first audio attempt and rely on existing retry behavior."""
+    config = _build_test_config(
+        ModelConfig(
+            provider="openai",
+            id="gpt-4o",
+            extra_kwargs={"base_url": "https://api.openai.com/v1"},
+        ),
+    )
     orchestrator = MagicMock()
     orchestrator.config = config
     orchestrator.runtime_paths = runtime_paths_for(config)
@@ -1285,6 +1298,136 @@ async def test_team_stream_retries_without_inline_media_on_setup_error() -> None
 
     rendered_output = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
     assert "Recovered setup stream" in rendered_output
+
+
+@pytest.mark.asyncio
+async def test_team_stream_does_not_preflight_inline_audio_for_ollama() -> None:
+    """Ollama should keep the first inline-audio attempt and rely on the retry path."""
+    config = _build_test_config(
+        ModelConfig(
+            provider="ollama",
+            id="llama3",
+        ),
+    )
+    orchestrator = MagicMock()
+    orchestrator.config = config
+    orchestrator.runtime_paths = runtime_paths_for(config)
+    orchestrator.knowledge_managers = {}
+    orchestrator.agent_bots = {"general": MagicMock()}
+
+    media_validation_error = "Error code: 500 - audio input is not supported"
+
+    async def successful_stream() -> AsyncIterator[object]:
+        yield TeamRunContentEvent(content="Recovered ollama stream")
+
+    mock_team = _make_test_team()
+    mock_team.arun = MagicMock(side_effect=[Exception(media_validation_error), successful_stream()])
+    audio_input = MagicMock(name="audio_input")
+
+    fake_agent = _make_test_agent("GeneralAgent")
+    with (
+        patch("mindroom.teams.create_agent", return_value=fake_agent),
+        patch("mindroom.teams.get_agent_knowledge", return_value=None),
+        patch("mindroom.teams._create_team_instance", return_value=mock_team),
+    ):
+        chunks = [
+            chunk
+            async for chunk in team_response_stream(
+                agent_ids=[config.get_ids(runtime_paths_for(config))["general"]],
+                mode=TeamMode.COORDINATE,
+                message="Analyze this.",
+                orchestrator=orchestrator,
+                execution_identity=None,
+                media=MediaInputs(audio=[audio_input]),
+            )
+        ]
+
+    assert mock_team.arun.call_count == 2
+    first_call = mock_team.arun.call_args_list[0]
+    second_call = mock_team.arun.call_args_list[1]
+    assert list(first_call.kwargs["audio"]) == [audio_input]
+    assert list(second_call.kwargs["audio"]) == []
+    assert "Inline media unavailable for this model" in second_call.args[0]
+    rendered_output = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
+    assert "Recovered ollama stream" in rendered_output
+
+
+@pytest.mark.asyncio
+async def test_team_stream_preflight_strips_inline_audio_after_learning_unsupported_model() -> None:
+    """A learned inline-audio rejection should preflight-drop audio on the next stream."""
+    config = _build_test_config(
+        ModelConfig(
+            provider="openai",
+            id="gpt-4o",
+            extra_kwargs={"base_url": "https://api.openai.com/v1"},
+        ),
+    )
+    orchestrator = MagicMock()
+    orchestrator.config = config
+    orchestrator.runtime_paths = runtime_paths_for(config)
+    orchestrator.knowledge_managers = {}
+    orchestrator.agent_bots = {"general": MagicMock()}
+
+    media_validation_error = "Error code: 500 - audio input is not supported"
+
+    async def recovered_stream() -> AsyncIterator[object]:
+        yield TeamRunContentEvent(content="Recovered stream")
+
+    async def preflight_stream() -> AsyncIterator[object]:
+        yield TeamRunContentEvent(content="Preflight stream")
+
+    mock_team_first = _make_test_team()
+    mock_team_first.arun = MagicMock(side_effect=[Exception(media_validation_error), recovered_stream()])
+    mock_team_second = _make_test_team()
+    mock_team_second.arun = MagicMock(return_value=preflight_stream())
+    audio_input = MagicMock(name="audio_input")
+
+    fake_agent = _make_test_agent("GeneralAgent")
+    with (
+        patch("mindroom.teams.create_agent", return_value=fake_agent),
+        patch("mindroom.teams.get_agent_knowledge", return_value=None),
+        patch("mindroom.teams._create_team_instance", side_effect=[mock_team_first, mock_team_second]),
+    ):
+        first_chunks = [
+            chunk
+            async for chunk in team_response_stream(
+                agent_ids=[config.get_ids(runtime_paths_for(config))["general"]],
+                mode=TeamMode.COORDINATE,
+                message="Analyze this.",
+                orchestrator=orchestrator,
+                execution_identity=None,
+                media=MediaInputs(audio=[audio_input]),
+            )
+        ]
+        second_chunks = [
+            chunk
+            async for chunk in team_response_stream(
+                agent_ids=[config.get_ids(runtime_paths_for(config))["general"]],
+                mode=TeamMode.COORDINATE,
+                message="Analyze this.",
+                orchestrator=orchestrator,
+                execution_identity=None,
+                media=MediaInputs(audio=[audio_input]),
+            )
+        ]
+
+    assert mock_team_first.arun.call_count == 2
+    first_run_call = mock_team_first.arun.call_args_list[0]
+    first_run_retry = mock_team_first.arun.call_args_list[1]
+    assert list(first_run_call.kwargs["audio"]) == [audio_input]
+    assert list(first_run_retry.kwargs["audio"]) == []
+    assert "Inline media unavailable for this model" in first_run_retry.args[0]
+    first_rendered_output = "".join(
+        chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in first_chunks
+    )
+    assert "Recovered stream" in first_rendered_output
+
+    assert mock_team_second.arun.call_count == 1
+    second_run_call = mock_team_second.arun.call_args_list[0]
+    assert list(second_run_call.kwargs["audio"]) == []
+    assert "Inline media unavailable for this model" in second_run_call.args[0]
+    rendered_output = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in second_chunks)
+    assert "Preflight stream" in rendered_output
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a learned inline-audio capability cache keyed by `(provider, model_id, base_url)`
- apply the learned preflight gate in both team streaming and single-agent runs (non-stream + stream)
- keep existing retry-without-inline-media behavior for unknown model/media paths
- when a run fails with `audio input is not supported` and audio was present, record that model key and preflight-drop inline audio on subsequent runs
- keep preflight scoped to inline audio and preserve image/file/video inputs

## Why
- avoid repeated first-attempt failures for model/backend combinations that have already proven they do not accept inline audio
- share learned capability across agents and teams that use the same model identity

## Tests
- `pre-commit run --all-files`
- `uv run pytest tests/test_team_media_fallback.py`
- `uv run pytest tests/test_ai_user_id.py -k "preflight or retries_without_media_on_validation_error or should_retry_without_inline_media_error_matching or append_inline_media_fallback_prompt_is_idempotent or preflights_audio_for_other_agent_sharing_model"`

## Notes
- `.claude/REPORT.md` was updated locally as requested but is ignored by repo `.gitignore`, so it is not part of this PR.
