### PR TITLE
Fix onboarding: quote Matrix user IDs in YAML and correct .env path

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ cd ~/mindroom-local
 uvx mindroom config init --profile public
 
 # Add at least one model API key
-$EDITOR .env
+$EDITOR ~/.mindroom/.env
 
 # Generate pair code in https://chat.mindroom.chat:
 # Settings -> Local MindRoom -> Generate Pair Code

--- a/docs/deployment/hosted-matrix.md
+++ b/docs/deployment/hosted-matrix.md
@@ -33,11 +33,11 @@ cd ~/mindroom-local
 uvx mindroom config init --profile public
 ```
 
-This creates `config.yaml` and `.env` with hosted defaults.
+This creates `~/.mindroom/config.yaml` and `~/.mindroom/.env` with hosted defaults.
 
 ## 2. Add AI Provider Key
 
-Edit `.env` and set at least one provider key:
+Edit `~/.mindroom/.env` and set at least one provider key:
 
 ```bash
 OPENAI_API_KEY=...

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -4100,11 +4100,11 @@ cd ~/mindroom-local
 uvx mindroom config init --profile public
 ```
 
-This creates `config.yaml` and `.env` with hosted defaults.
+This creates `~/.mindroom/config.yaml` and `~/.mindroom/.env` with hosted defaults.
 
 ## 2. Add AI Provider Key
 
-Edit `.env` and set at least one provider key:
+Edit `~/.mindroom/.env` and set at least one provider key:
 
 ```
 OPENAI_API_KEY=...

--- a/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
+++ b/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
@@ -29,11 +29,11 @@ cd ~/mindroom-local
 uvx mindroom config init --profile public
 ```
 
-This creates `config.yaml` and `.env` with hosted defaults.
+This creates `~/.mindroom/config.yaml` and `~/.mindroom/.env` with hosted defaults.
 
 ## 2. Add AI Provider Key
 
-Edit `.env` and set at least one provider key:
+Edit `~/.mindroom/.env` and set at least one provider key:
 
 ```
 OPENAI_API_KEY=...

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -176,7 +176,7 @@ def config_init(
     console.print(f"[green]Config created:[/green] {target}")
     console.print("\nNext steps:")
     if env_created:
-        console.print(f"  [cyan]Edit {env_path.name}[/cyan]            Set your API keys and Matrix homeserver")
+        console.print(f"  [cyan]Edit {env_path}[/cyan]  Set your API keys and Matrix homeserver")
     console.print("  [cyan]mindroom config edit[/cyan]      Customize your config")
     console.print("  [cyan]mindroom config validate[/cyan]  Verify it's valid")
     console.print("  [cyan]mindroom run[/cyan]              Start the system")

--- a/src/mindroom/cli/connect.py
+++ b/src/mindroom/cli/connect.py
@@ -131,9 +131,12 @@ def replace_owner_placeholders_in_config(*, config_path: Path, owner_user_id: st
         return False
 
     content = config_path.read_text(encoding="utf-8")
-    replaced = content.replace(OWNER_MATRIX_USER_ID_PLACEHOLDER, owner_user_id).replace(
+    # Quote the Matrix user ID so the leading '@' doesn't break YAML parsing
+    # (@ starts a YAML tag/anchor when unquoted).
+    quoted = f'"{owner_user_id}"'
+    replaced = content.replace(OWNER_MATRIX_USER_ID_PLACEHOLDER, quoted).replace(
         _LEGACY_OWNER_PLACEHOLDER,
-        owner_user_id,
+        quoted,
     )
     if replaced == content:
         return False

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 import pytest
+import yaml
 
 import mindroom.cli.connect as cli_connect
 from mindroom.constants import OWNER_MATRIX_USER_ID_PLACEHOLDER
@@ -68,7 +69,7 @@ def test_persist_local_provisioning_env_writes_credentials_only(tmp_path: Path) 
 
 
 def test_replace_owner_placeholders_in_config_accepts_server_port(tmp_path: Path) -> None:
-    """Placeholder replacement should work for valid MXIDs with server ports."""
+    """Placeholder replacement should quote MXIDs so '@' doesn't break YAML."""
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
         "authorization:\n"
@@ -88,7 +89,13 @@ def test_replace_owner_placeholders_in_config_accepts_server_port(tmp_path: Path
     updated = config_path.read_text()
     assert OWNER_MATRIX_USER_ID_PLACEHOLDER not in updated
     assert "__PLACEHOLDER__" not in updated
-    assert "@alice:mindroom.chat:8448" in updated
+    # Value must be YAML-quoted so the leading '@' doesn't break parsing
+    assert '"@alice:mindroom.chat:8448"' in updated
+
+    # Verify the result is valid YAML
+    parsed = yaml.safe_load(updated)
+    assert parsed["authorization"]["global_users"] == ["@alice:mindroom.chat:8448"]
+    assert parsed["authorization"]["agent_reply_permissions"]["*"] == ["@alice:mindroom.chat:8448"]
 
 
 def test_complete_local_pairing_rejects_non_json_response() -> None:


### PR DESCRIPTION
## Summary

Fixes three issues reported by Joe during a fresh install walkthrough:

- **YAML parse error on `mindroom run`**: `mindroom connect --pair-code` replaces the owner placeholder with bare `@user:mindroom.chat`, but `@` starts a YAML tag/anchor when unquoted. Now the replacement is wrapped in double quotes (`"@user:mindroom.chat"`).
- **Wrong `.env` path in docs**: README and hosted-matrix guide said `$EDITOR .env`, but `config init --profile public` creates files in `~/.mindroom/`. Updated to `$EDITOR ~/.mindroom/.env`.
- **CLI "next steps" showed filename only**: `config init` printed `Edit .env` instead of the full path like `Edit ~/.mindroom/.env`.

## Test plan

- [x] `test_replace_owner_placeholders_in_config_accepts_server_port` updated to verify YAML quoting and round-trip via `yaml.safe_load()`
- [x] All `test_cli_connect.py` tests pass
- [ ] Manual: run `uvx mindroom config init --profile public` then `uvx mindroom connect --pair-code XXXX-XXXX` and verify `config.yaml` has quoted user IDs that parse cleanly