### PR TITLE
docs: finish hosted uvx env-path consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,7 +340,7 @@ cd ~/mindroom-local
 uvx mindroom config init --profile public
 ```
 
-2) Add at least one model provider key in `.env` (for example `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`)
+2) Add at least one model provider key in `~/.mindroom/.env` (for example `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`)
 
 3) Generate a pair code in `https://chat.mindroom.chat` (`Settings -> Local MindRoom`) and pair locally
 ```bash
@@ -352,7 +352,7 @@ uvx mindroom connect --pair-code ABCD-EFGH
 uvx mindroom run
 ```
 
-`mindroom connect` writes `MINDROOM_LOCAL_CLIENT_ID` and `MINDROOM_LOCAL_CLIENT_SECRET` to `.env` (unless `--no-persist-env` is used) and auto-replaces owner placeholder tokens in `config.yaml` when `owner_user_id` is returned.
+`mindroom connect` writes `MINDROOM_LOCAL_CLIENT_ID` and `MINDROOM_LOCAL_CLIENT_SECRET` to `~/.mindroom/.env` by default (unless `--no-persist-env` is used) and auto-replaces owner placeholder tokens in `config.yaml` when `owner_user_id` is returned.
 
 ### SaaS Platform Commands
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Use this path if you want to run only the backend locally while using hosted cha
 mkdir -p ~/mindroom-local
 cd ~/mindroom-local
 
-# Create starter config + .env tuned for hosted matrix
+# Create starter config + .env in ~/.mindroom tuned for hosted matrix
 uvx mindroom config init --profile public
 
 # Add at least one model API key

--- a/docs/deployment/hosted-matrix.md
+++ b/docs/deployment/hosted-matrix.md
@@ -60,7 +60,7 @@ Pair code behavior:
 - Valid for 600 seconds (10 minutes).
 - Only used to bootstrap local pairing.
 
-After successful pairing, local provisioning credentials are written to `.env` unless you use `--no-persist-env`.
+After successful pairing, local provisioning credentials are written to `~/.mindroom/.env` by default unless you use `--no-persist-env`.
 
 ## 4. Start MindRoom
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -37,8 +37,9 @@ Use these guides if you want users to connect Google accounts in the MindRoom fr
 ```bash
 mkdir -p ~/mindroom-local
 cd ~/mindroom-local
+# Creates ~/.mindroom/config.yaml and ~/.mindroom/.env by default
 uvx mindroom config init --profile public
-$EDITOR .env
+$EDITOR ~/.mindroom/.env
 uvx mindroom connect --pair-code ABCD-EFGH
 uvx mindroom run
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,13 +23,13 @@ uvx mindroom config init --profile public
 
 This creates:
 
-- `config.yaml`
-- `.env` prefilled with `MATRIX_HOMESERVER=https://mindroom.chat`
+- `~/.mindroom/config.yaml`
+- `~/.mindroom/.env` prefilled with `MATRIX_HOMESERVER=https://mindroom.chat`
 
 ### 2. Add model API key(s)
 
 ```bash
-$EDITOR .env
+$EDITOR ~/.mindroom/.env
 ```
 
 Set at least one key:
@@ -52,7 +52,7 @@ uvx mindroom connect --pair-code ABCD-EFGH
 Notes:
 
 - Pair code is short-lived (10 minutes).
-- `mindroom connect` writes local provisioning values (including `MINDROOM_NAMESPACE`) into `.env`.
+- `mindroom connect` writes local provisioning values (including `MINDROOM_NAMESPACE`) into `~/.mindroom/.env` by default.
 
 ### 4. Run MindRoom
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -193,13 +193,13 @@ uvx mindroom config init --profile public
 
 This creates:
 
-- `config.yaml`
-- `.env` prefilled with `MATRIX_HOMESERVER=https://mindroom.chat`
+- `~/.mindroom/config.yaml`
+- `~/.mindroom/.env` prefilled with `MATRIX_HOMESERVER=https://mindroom.chat`
 
 ### 2. Add model API key(s)
 
 ```
-$EDITOR .env
+$EDITOR ~/.mindroom/.env
 ```
 
 Set at least one key:
@@ -222,7 +222,7 @@ uvx mindroom connect --pair-code ABCD-EFGH
 Notes:
 
 - Pair code is short-lived (10 minutes).
-- `mindroom connect` writes local provisioning values (including `MINDROOM_NAMESPACE`) into `.env`.
+- `mindroom connect` writes local provisioning values (including `MINDROOM_NAMESPACE`) into `~/.mindroom/.env` by default.
 
 ### 4. Run MindRoom
 
@@ -3995,8 +3995,9 @@ Use these guides if you want users to connect Google accounts in the MindRoom fr
 ```
 mkdir -p ~/mindroom-local
 cd ~/mindroom-local
+# Creates ~/.mindroom/config.yaml and ~/.mindroom/.env by default
 uvx mindroom config init --profile public
-$EDITOR .env
+$EDITOR ~/.mindroom/.env
 uvx mindroom connect --pair-code ABCD-EFGH
 uvx mindroom run
 ```
@@ -4127,7 +4128,7 @@ Pair code behavior:
 - Valid for 600 seconds (10 minutes).
 - Only used to bootstrap local pairing.
 
-After successful pairing, local provisioning credentials are written to `.env` unless you use `--no-persist-env`.
+After successful pairing, local provisioning credentials are written to `~/.mindroom/.env` by default unless you use `--no-persist-env`.
 
 ## 4. Start MindRoom
 

--- a/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
+++ b/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
@@ -56,7 +56,7 @@ Pair code behavior:
 - Valid for 600 seconds (10 minutes).
 - Only used to bootstrap local pairing.
 
-After successful pairing, local provisioning credentials are written to `.env` unless you use `--no-persist-env`.
+After successful pairing, local provisioning credentials are written to `~/.mindroom/.env` by default unless you use `--no-persist-env`.
 
 ## 4. Start MindRoom
 

--- a/skills/mindroom-docs/references/page__deployment__index.md
+++ b/skills/mindroom-docs/references/page__deployment__index.md
@@ -33,8 +33,9 @@ Use these guides if you want users to connect Google accounts in the MindRoom fr
 ```
 mkdir -p ~/mindroom-local
 cd ~/mindroom-local
+# Creates ~/.mindroom/config.yaml and ~/.mindroom/.env by default
 uvx mindroom config init --profile public
-$EDITOR .env
+$EDITOR ~/.mindroom/.env
 uvx mindroom connect --pair-code ABCD-EFGH
 uvx mindroom run
 ```

--- a/skills/mindroom-docs/references/page__getting-started__index.md
+++ b/skills/mindroom-docs/references/page__getting-started__index.md
@@ -18,13 +18,13 @@ uvx mindroom config init --profile public
 
 This creates:
 
-- `config.yaml`
-- `.env` prefilled with `MATRIX_HOMESERVER=https://mindroom.chat`
+- `~/.mindroom/config.yaml`
+- `~/.mindroom/.env` prefilled with `MATRIX_HOMESERVER=https://mindroom.chat`
 
 ### 2. Add model API key(s)
 
 ```
-$EDITOR .env
+$EDITOR ~/.mindroom/.env
 ```
 
 Set at least one key:
@@ -47,7 +47,7 @@ uvx mindroom connect --pair-code ABCD-EFGH
 Notes:
 
 - Pair code is short-lived (10 minutes).
-- `mindroom connect` writes local provisioning values (including `MINDROOM_NAMESPACE`) into `.env`.
+- `mindroom connect` writes local provisioning values (including `MINDROOM_NAMESPACE`) into `~/.mindroom/.env` by default.
 
 ### 4. Run MindRoom
 


### PR DESCRIPTION
## Summary
This is a follow-up docs-only patch after #297 to finish remaining hosted uvx onboarding path inconsistencies.

### Fixes
- Update hosted quickstart docs to use ~/.mindroom/.env instead of relative .env where applicable.
- Clarify that `uvx mindroom config init --profile public` creates files under ~/.mindroom by default.
- Clarify that `mindroom connect` persists credentials to ~/.mindroom/.env by default.
- Regenerate skills/mindroom-docs/references files to match updated docs.

### Files
- docs/getting-started.md
- docs/deployment/index.md
- docs/deployment/hosted-matrix.md
- README.md
- CLAUDE.md
- skills/mindroom-docs/references/llms-full.txt
- skills/mindroom-docs/references/page__getting-started__index.md
- skills/mindroom-docs/references/page__deployment__index.md
- skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md

## Validation
- pytest passed: 1971 passed, 19 skipped.
- pre-commit run --all-files was run and fails on unrelated pre-existing issues outside this docs diff:
  - src/mindroom/media_fallback.py (TC001)
  - ty diagnostics in src/mindroom/cli/config.py and src/mindroom/constants.py
