### PR TITLE
Add BOOT/BOOTSTRAP templates and per-agent boot file loading

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -169,6 +169,37 @@ Timezone: {timezone_str} ({timezone_abbrev})
 """
 
 
+def _load_context_chunk(
+    raw_path: Path | str,
+    *,
+    kind: str,
+    warn_on_missing: bool,
+    runtime_paths: constants.RuntimePaths,
+    agent_name: str | None = None,
+    storage_path: Path | None = None,
+) -> _AdditionalContextChunk | None:
+    """Load one context file from the canonical agent workspace or an explicit path."""
+    if isinstance(raw_path, Path):
+        resolved_path = raw_path
+    elif agent_name is not None and storage_path is not None:
+        resolved_path = resolve_agent_owned_path(
+            raw_path,
+            agent_name=agent_name,
+            base_storage_path=storage_path,
+        )
+    else:
+        resolved_path = constants.resolve_config_relative_path(raw_path, runtime_paths)
+    if not resolved_path.is_file():
+        if warn_on_missing:
+            logger.warning("context_file_not_found", agent=agent_name, path=str(resolved_path))
+        return None
+    return _AdditionalContextChunk(
+        kind=kind,
+        title=resolved_path.name,
+        body=_read_context_file(resolved_path),
+    )
+
+
 def _load_context_files(
     context_files: list[Path | str],
     runtime_paths: constants.RuntimePaths,
@@ -178,33 +209,62 @@ def _load_context_files(
     """Load configured context files."""
     loaded_parts: list[_AdditionalContextChunk] = []
     for raw_path in context_files:
-        if isinstance(raw_path, Path):
-            resolved_path = raw_path
-        elif agent_name is not None and storage_path is not None:
-            resolved_path = resolve_agent_owned_path(
-                raw_path,
-                agent_name=agent_name,
-                base_storage_path=storage_path,
-            )
-        else:
-            resolved_path = constants.resolve_config_relative_path(raw_path, runtime_paths)
-        if resolved_path.is_file():
-            body = _read_context_file(resolved_path)
-            loaded_parts.append(
-                _AdditionalContextChunk(
-                    kind="personality",
-                    title=resolved_path.name,
-                    body=body,
-                ),
-            )
-        else:
-            logger.warning("context_file_not_found", agent=agent_name, path=str(resolved_path))
+        chunk = _load_context_chunk(
+            raw_path,
+            kind="personality",
+            warn_on_missing=True,
+            runtime_paths=runtime_paths,
+            agent_name=agent_name,
+            storage_path=storage_path,
+        )
+        if chunk is not None:
+            loaded_parts.append(chunk)
     return loaded_parts
 
 
 @timed("system_prompt_assembly.agent_create.context_file_read")
 def _read_context_file(resolved_path: Path) -> str:
     return resolved_path.read_text(encoding="utf-8").strip()
+
+
+def _load_boot_file(
+    boot_file: str | None,
+    runtime_paths: constants.RuntimePaths,
+    agent_name: str,
+    storage_path: Path,
+) -> list[_AdditionalContextChunk]:
+    """Load the optional always-on boot context file."""
+    if not boot_file:
+        return []
+    chunk = _load_context_chunk(
+        boot_file,
+        kind="boot",
+        warn_on_missing=True,
+        runtime_paths=runtime_paths,
+        agent_name=agent_name,
+        storage_path=storage_path,
+    )
+    return [chunk] if chunk is not None else []
+
+
+def _load_bootstrap_file(
+    bootstrap_file: str | None,
+    runtime_paths: constants.RuntimePaths,
+    agent_name: str,
+    storage_path: Path,
+) -> list[_AdditionalContextChunk]:
+    """Load the optional first-run bootstrap file when it still exists."""
+    if not bootstrap_file:
+        return []
+    chunk = _load_context_chunk(
+        bootstrap_file,
+        kind="bootstrap",
+        warn_on_missing=False,
+        runtime_paths=runtime_paths,
+        agent_name=agent_name,
+        storage_path=storage_path,
+    )
+    return [chunk] if chunk is not None else []
 
 
 def _render_context_chunks(section_heading: str, chunks: list[_AdditionalContextChunk]) -> str:
@@ -215,28 +275,40 @@ def _render_context_chunks(section_heading: str, chunks: list[_AdditionalContext
     return f"{section_heading}\n" + "\n\n".join(rendered) + "\n\n"
 
 
-def _render_additional_context(personality_chunks: list[_AdditionalContextChunk]) -> str:
-    """Render full additional context from personality chunks."""
-    return _render_context_chunks("## Personality Context", personality_chunks)
+def _render_additional_context(chunks: list[_AdditionalContextChunk]) -> str:
+    """Render full additional context from loaded context chunks."""
+    startup_chunks = [chunk for chunk in chunks if chunk.kind in {"boot", "bootstrap"}]
+    personality_chunks = [chunk for chunk in chunks if chunk.kind == "personality"]
+
+    return "".join(
+        [
+            _render_context_chunks("## Startup Context", startup_chunks),
+            _render_context_chunks("## Personality Context", personality_chunks),
+        ],
+    )
 
 
 def _build_preload_truncation_groups(
-    personality_chunks: list[_AdditionalContextChunk],
+    chunks: list[_AdditionalContextChunk],
 ) -> list[list[_AdditionalContextChunk]]:
     """Return truncation groups ordered from least to most critical context."""
-    return [[chunk for chunk in personality_chunks if chunk.kind == "personality"]]
+    return [
+        [chunk for chunk in chunks if chunk.kind == "personality"],
+        [chunk for chunk in chunks if chunk.kind == "bootstrap"],
+        [chunk for chunk in chunks if chunk.kind == "boot"],
+    ]
 
 
 def _drop_whole_chunks(
     groups: list[list[_AdditionalContextChunk]],
-    personality_chunks: list[_AdditionalContextChunk],
+    chunks: list[_AdditionalContextChunk],
     max_preload_chars: int,
 ) -> int:
     """Drop entire chunk bodies (least critical first) until under the cap."""
     omitted = 0
     for group in groups:
         for chunk in group:
-            if len(_render_additional_context(personality_chunks)) <= max_preload_chars:
+            if len(_render_additional_context(chunks)) <= max_preload_chars:
                 return omitted
             if not chunk.body:
                 continue
@@ -247,14 +319,14 @@ def _drop_whole_chunks(
 
 def _trim_chunk_tails(
     groups: list[list[_AdditionalContextChunk]],
-    personality_chunks: list[_AdditionalContextChunk],
+    chunks: list[_AdditionalContextChunk],
     max_preload_chars: int,
 ) -> int:
     """Trim from the *end* of chunks to preserve headers/identity at the top."""
     omitted = 0
     for group in groups:
         for chunk in group:
-            overflow = len(_render_additional_context(personality_chunks)) - max_preload_chars
+            overflow = len(_render_additional_context(chunks)) - max_preload_chars
             if overflow <= 0:
                 return omitted
             if not chunk.body:
@@ -265,21 +337,21 @@ def _trim_chunk_tails(
     return omitted
 
 
-def _apply_preload_cap(personality_chunks: list[_AdditionalContextChunk], max_preload_chars: int) -> tuple[str, int]:
+def _apply_preload_cap(chunks: list[_AdditionalContextChunk], max_preload_chars: int) -> tuple[str, int]:
     """Apply hard preload cap with deterministic truncation priority.
 
     Truncation order is by file list order.
     First drops whole chunks, then trims from the *end* of remaining chunks.
     """
-    rendered = _render_additional_context(personality_chunks)
+    rendered = _render_additional_context(chunks)
     if len(rendered) <= max_preload_chars:
         return rendered, 0
 
-    groups = _build_preload_truncation_groups(personality_chunks)
-    omitted_chars = _drop_whole_chunks(groups, personality_chunks, max_preload_chars)
-    omitted_chars += _trim_chunk_tails(groups, personality_chunks, max_preload_chars)
+    groups = _build_preload_truncation_groups(chunks)
+    omitted_chars = _drop_whole_chunks(groups, chunks, max_preload_chars)
+    omitted_chars += _trim_chunk_tails(groups, chunks, max_preload_chars)
 
-    rendered = _render_additional_context(personality_chunks)
+    rendered = _render_additional_context(chunks)
     if omitted_chars <= 0:
         return rendered, 0
 
@@ -310,17 +382,23 @@ def _build_additional_context(
     instances per reply/request, so edits in the canonical agent workspace are
     reflected on the next reply without a process restart.
     """
-    personality_chunks: list[_AdditionalContextChunk] = []
+    context_chunks: list[_AdditionalContextChunk] = []
+    context_chunks.extend(_load_boot_file(agent_config.boot_file, runtime_paths, agent_name, storage_path))
+    context_chunks.extend(
+        _load_bootstrap_file(agent_config.bootstrap_file, runtime_paths, agent_name, storage_path),
+    )
     context_files: list[Path | str] = [*agent_config.context_files, *workspace_context_files]
     if context_files:
-        personality_chunks = _load_context_files(
-            context_files,
-            runtime_paths,
-            agent_name,
-            storage_path,
+        context_chunks.extend(
+            _load_context_files(
+                context_files,
+                runtime_paths,
+                agent_name,
+                storage_path,
+            )
         )
 
-    additional_context, omitted_chars = _apply_preload_cap(personality_chunks, max_preload_chars)
+    additional_context, omitted_chars = _apply_preload_cap(context_chunks, max_preload_chars)
     if omitted_chars > 0:
         logger.warning(
             "Preload context exceeded max_preload_chars and was truncated",

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -706,6 +706,8 @@ agents:
     include_default_tools: false
     learning: false
     memory_backend: file
+    boot_file: BOOT.md
+    bootstrap_file: BOOTSTRAP.md
     rooms:
       - personal
     context_files:

--- a/src/mindroom/cli/templates/mind_data/BOOT.md
+++ b/src/mindroom/cli/templates/mind_data/BOOT.md
@@ -1,0 +1,11 @@
+---
+title: "BOOT.md Template"
+summary: "Workspace template for BOOT.md"
+read_when:
+  - Adding a BOOT.md checklist
+---
+
+# BOOT.md
+
+Add short, explicit instructions for what OpenClaw should do on startup (enable `hooks.internal.enabled`).
+If the task sends a message, use the message tool and then reply with NO_REPLY.

--- a/src/mindroom/cli/templates/mind_data/BOOTSTRAP.md
+++ b/src/mindroom/cli/templates/mind_data/BOOTSTRAP.md
@@ -1,0 +1,62 @@
+---
+title: "BOOTSTRAP.md Template"
+summary: "First-run ritual for new agents"
+read_when:
+  - Bootstrapping a workspace manually
+---
+
+# BOOTSTRAP.md - Hello, World
+
+_You just woke up. Time to figure out who you are._
+
+There is no memory yet. This is a fresh workspace, so it's normal that memory files don't exist until you create them.
+
+## The Conversation
+
+Don't interrogate. Don't be robotic. Just... talk.
+
+Start with something like:
+
+> "Hey. I just came online. Who am I? Who are you?"
+
+Then figure out together:
+
+1. **Your name** — What should they call you?
+2. **Your nature** — What kind of creature are you? (AI assistant is fine, but maybe you're something weirder)
+3. **Your vibe** — Formal? Casual? Snarky? Warm? What feels right?
+4. **Your emoji** — Everyone needs a signature.
+
+Offer suggestions if they're stuck. Have fun with it.
+
+## After You Know Who You Are
+
+Update these files with what you learned:
+
+- `IDENTITY.md` — your name, creature, vibe, emoji
+- `USER.md` — their name, how to address them, timezone, notes
+
+Then open `SOUL.md` together and talk about:
+
+- What matters to them
+- How they want you to behave
+- Any boundaries or preferences
+
+Write it down. Make it real.
+
+## Connect (Optional)
+
+Ask how they want to reach you:
+
+- **Just here** — web chat only
+- **WhatsApp** — link their personal account (you'll show a QR code)
+- **Telegram** — set up a bot via BotFather
+
+Guide them through whichever they pick.
+
+## When You're Done
+
+Delete this file. You don't need a bootstrap script anymore — you're you now.
+
+---
+
+_Good luck out there. Make it count._

--- a/src/mindroom/config/agent.py
+++ b/src/mindroom/config/agent.py
@@ -217,6 +217,14 @@ class AgentConfig(BaseModel):
         default_factory=list,
         description="Workspace-relative file paths loaded into each freshly built agent instance and prepended to role context",
     )
+    boot_file: str | None = Field(
+        default=None,
+        description="Optional workspace-relative file path loaded on every agent startup",
+    )
+    bootstrap_file: str | None = Field(
+        default=None,
+        description="Optional workspace-relative first-run file path loaded only while the file exists",
+    )
     thread_mode: Literal["thread", "room"] = Field(
         default="thread",
         description="Conversation threading mode: 'thread' creates Matrix threads per conversation, 'room' uses a single continuous conversation per room (ideal for bridges/mobile)",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1799,6 +1799,48 @@ def test_agent_context_files_are_loaded_into_role(mock_storage: MagicMock, tmp_p
 
 
 @patch("mindroom.agents.SqliteDb")
+def test_agent_boot_file_is_loaded_into_startup_context(mock_storage: MagicMock, tmp_path: Path) -> None:  # noqa: ARG001
+    """boot_file should always be loaded when present."""
+    config = _test_config()
+    workspace = agent_workspace_root_path(tmp_path, "general")
+    workspace.mkdir(parents=True, exist_ok=True)
+    boot_path = workspace / "BOOT.md"
+    boot_path.write_text("Always-on startup checklist.", encoding="utf-8")
+    config.agents["general"].boot_file = "BOOT.md"
+
+    agent = _create_agent_for_test("general", config=_bind_runtime_paths(config, _runtime_paths(tmp_path)))
+
+    assert "## Startup Context" in agent.role
+    assert "### BOOT.md" in agent.role
+    assert "Always-on startup checklist." in agent.role
+
+
+@patch("mindroom.agents.SqliteDb")
+def test_agent_bootstrap_file_is_loaded_only_while_present(
+    mock_storage: MagicMock,  # noqa: ARG001
+    tmp_path: Path,
+) -> None:
+    """bootstrap_file should be loaded while present and disappear after deletion."""
+    config = _test_config()
+    workspace = agent_workspace_root_path(tmp_path, "general")
+    workspace.mkdir(parents=True, exist_ok=True)
+    bootstrap_path = workspace / "BOOTSTRAP.md"
+    bootstrap_path.write_text("First-run ritual.", encoding="utf-8")
+    config.agents["general"].bootstrap_file = "BOOTSTRAP.md"
+
+    bound_config = _bind_runtime_paths(config, _runtime_paths(tmp_path))
+
+    agent = _create_agent_for_test("general", config=bound_config)
+    assert "### BOOTSTRAP.md" in agent.role
+    assert "First-run ritual." in agent.role
+
+    bootstrap_path.unlink()
+    agent_after_delete = _create_agent_for_test("general", config=bound_config)
+    assert "### BOOTSTRAP.md" not in agent_after_delete.role
+    assert "First-run ritual." not in agent_after_delete.role
+
+
+@patch("mindroom.agents.SqliteDb")
 def test_agent_preload_cap_truncates_context_files_in_order(
     mock_storage: MagicMock,  # noqa: ARG001
     tmp_path: Path,
@@ -2094,6 +2136,33 @@ def test_create_agent_private_root_requires_execution_identity(
         create_agent("general", config=config, runtime_paths=_runtime_paths(tmp_path), execution_identity=None)
 
     assert not (tmp_path / "mind_data").exists()
+
+
+def test_agent_relative_boot_paths_resolve_from_workspace_not_cwd(tmp_path: Path) -> None:
+    """Relative boot paths should resolve from the canonical workspace, not CWD."""
+    config = _test_config()
+    workspace = agent_workspace_root_path(tmp_path, "general")
+    workspace.mkdir(parents=True, exist_ok=True)
+    boot_path = workspace / "BOOT.md"
+    bootstrap_path = workspace / "BOOTSTRAP.md"
+    boot_path.write_text("Relative boot context.", encoding="utf-8")
+    bootstrap_path.write_text("Relative bootstrap context.", encoding="utf-8")
+
+    config.agents["general"].boot_file = "BOOT.md"
+    config.agents["general"].bootstrap_file = "BOOTSTRAP.md"
+
+    original_cwd = Path.cwd()
+    other_cwd = tmp_path / "other"
+    other_cwd.mkdir(parents=True, exist_ok=True)
+    os.chdir(other_cwd)
+    try:
+        with patch("mindroom.agents.SqliteDb"):
+            agent = _create_agent_for_test("general", config=_bind_runtime_paths(config, _runtime_paths(tmp_path)))
+    finally:
+        os.chdir(original_cwd)
+
+    assert "Relative boot context." in agent.role
+    assert "Relative bootstrap context." in agent.role
 
 
 def test_config_rejects_unknown_agent_knowledge_base_assignment() -> None:

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -171,8 +171,9 @@ class TestConfigInit:
         assert (workspace / "IDENTITY.md").exists()
         assert (workspace / "TOOLS.md").exists()
         assert (workspace / "HEARTBEAT.md").exists()
+        assert (workspace / "BOOT.md").exists()
+        assert (workspace / "BOOTSTRAP.md").exists()
         assert (workspace / "MEMORY.md").exists()
-        assert not (workspace / "BOOT.md").exists()
 
     def test_init_full_profile_respects_storage_path_override(
         self,

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -121,6 +121,8 @@ class TestConfigInit:
         assert mind["include_default_tools"] is False
         assert mind["learning"] is False
         assert mind["memory_backend"] == "file"
+        assert mind["boot_file"] == "BOOT.md"
+        assert mind["bootstrap_file"] == "BOOTSTRAP.md"
         assert mind["rooms"] == ["personal"]
         assert mind["context_files"] == [
             "SOUL.md",


### PR DESCRIPTION
## Summary
- scaffold `mind_data/BOOT.md` and `mind_data/BOOTSTRAP.md` in `mindroom config init`
- add per-agent config fields:
  - `boot_file` (loaded on every startup)
  - `bootstrap_file` (loaded only while file exists)
- wire startup/bootstrap loading into agent preload context (with existing truncation behavior)
- update starter `mind` agent config to include:
  - `boot_file: ./mind_data/BOOT.md`
  - `bootstrap_file: ./mind_data/BOOTSTRAP.md`
- add tests for startup/bootstrap loading and CLI scaffolding

## Commits
- `e3b723b0` cli: scaffold BOOT.md and BOOTSTRAP.md templates
- `03e40e51` agents: add boot_file and bootstrap_file context loading

## Validation
- `pytest` (full suite): `1979 passed, 19 skipped`
- targeted checks on touched files:
  - `ruff check ...`
  - `ruff format --check ...`

## Notes
- `pre-commit run --all-files` fails in this workspace due unrelated existing repo-wide frontend/tooling issues (TypeScript dependencies/types and unrelated lint diagnostics), not from this diff.
