### PR TITLE
Document room-specific thread mode configuration

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -154,6 +154,24 @@ The dashboard Agents tab exposes this as the **Memory Backend** selector for eac
 
 Learning data is persisted to `mindroom_data/learning/<agent>.db`, so it survives container restarts when the storage directory is mounted.
 
+## Thread Mode Resolution
+
+Thread mode is resolved per message using the current room ID.
+For an agent, MindRoom checks `room_thread_modes` in this order.
+First, it checks an exact room ID key.
+Second, it checks the managed room key/alias associated with that room ID.
+Third, it resolves each configured `room_thread_modes` key to a room ID and matches that against the current room.
+If none match, it falls back to `thread_mode`.
+
+For a team, MindRoom resolves mode per member agent for that room.
+If all member agents resolve to the same mode, the team uses that mode.
+If member modes differ, the team defaults to `thread`.
+
+For the router, MindRoom resolves mode using agents relevant to the active room.
+This includes agents directly configured for the room and agents included via `teams.<name>.rooms`.
+If all relevant agents resolve to the same mode, the router uses that mode.
+If modes are mixed, the router defaults to `thread`.
+
 ## File-Based Context Loading
 
 You can inject file content directly into an agent's role context without using a knowledge base.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -259,7 +259,7 @@ timezone: America/Los_Angeles      # Default: UTC
 - A model named `default` is required unless agents, teams, and the router all specify explicit non-`default` models
 - Agents can set `knowledge_bases`, but each entry must exist in the top-level `knowledge_bases` section
 - `agents.<name>.context_files` inject file-based context at agent creation/reload (see [Agents](agents.md))
-- `agents.<name>.room_thread_modes` overrides `thread_mode` for specific rooms (see [Agents](agents.md))
+- `agents.<name>.room_thread_modes` overrides `thread_mode` for specific rooms, and resolution is room-aware for agents, teams, and router decisions (see [Agents](agents.md))
 - `memory.backend` sets the global memory default, `agents.<name>.memory_backend` overrides it per agent, and `agents.<name>.memory_file_path` sets a custom file-memory scope for that agent
 - `defaults.max_preload_chars` caps preloaded file context (`context_files`)
 - When `authorization.default_room_access` is `false`, only users in `global_users` or room-specific `room_permissions` can interact with agents

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -877,7 +877,7 @@ timezone: America/Los_Angeles      # Default: UTC
 - A model named `default` is required unless agents, teams, and the router all specify explicit non-`default` models
 - Agents can set `knowledge_bases`, but each entry must exist in the top-level `knowledge_bases` section
 - `agents.<name>.context_files` inject file-based context at agent creation/reload (see [Agents](https://docs.mindroom.chat/configuration/agents/index.md))
-- `agents.<name>.room_thread_modes` overrides `thread_mode` for specific rooms (see [Agents](https://docs.mindroom.chat/configuration/agents/index.md))
+- `agents.<name>.room_thread_modes` overrides `thread_mode` for specific rooms, and resolution is room-aware for agents, teams, and router decisions (see [Agents](https://docs.mindroom.chat/configuration/agents/index.md))
 - `memory.backend` sets the global memory default, `agents.<name>.memory_backend` overrides it per agent, and `agents.<name>.memory_file_path` sets a custom file-memory scope for that agent
 - `defaults.max_preload_chars` caps preloaded file context (`context_files`)
 - When `authorization.default_room_access` is `false`, only users in `global_users` or room-specific `room_permissions` can interact with agents
@@ -1034,6 +1034,14 @@ Each entry in `knowledge_bases` must match a key under `knowledge_bases` in `con
 Per-agent fields with a `null` default inherit from the `defaults` section at runtime. Per-agent values override them. `memory.backend` is the global memory default, and `agents.<name>.memory_backend` overrides it per agent. `show_stop_button` and `enable_streaming` are global-only settings in `defaults` and cannot be overridden per-agent. The dashboard Agents tab exposes this as the **Memory Backend** selector for each agent.
 
 Learning data is persisted to `mindroom_data/learning/<agent>.db`, so it survives container restarts when the storage directory is mounted.
+
+## Thread Mode Resolution
+
+Thread mode is resolved per message using the current room ID. For an agent, MindRoom checks `room_thread_modes` in this order. First, it checks an exact room ID key. Second, it checks the managed room key/alias associated with that room ID. Third, it resolves each configured `room_thread_modes` key to a room ID and matches that against the current room. If none match, it falls back to `thread_mode`.
+
+For a team, MindRoom resolves mode per member agent for that room. If all member agents resolve to the same mode, the team uses that mode. If member modes differ, the team defaults to `thread`.
+
+For the router, MindRoom resolves mode using agents relevant to the active room. This includes agents directly configured for the room and agents included via `teams.<name>.rooms`. If all relevant agents resolve to the same mode, the router uses that mode. If modes are mixed, the router defaults to `thread`.
 
 ## File-Based Context Loading
 

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -145,6 +145,14 @@ Per-agent fields with a `null` default inherit from the `defaults` section at ru
 
 Learning data is persisted to `mindroom_data/learning/<agent>.db`, so it survives container restarts when the storage directory is mounted.
 
+## Thread Mode Resolution
+
+Thread mode is resolved per message using the current room ID. For an agent, MindRoom checks `room_thread_modes` in this order. First, it checks an exact room ID key. Second, it checks the managed room key/alias associated with that room ID. Third, it resolves each configured `room_thread_modes` key to a room ID and matches that against the current room. If none match, it falls back to `thread_mode`.
+
+For a team, MindRoom resolves mode per member agent for that room. If all member agents resolve to the same mode, the team uses that mode. If member modes differ, the team defaults to `thread`.
+
+For the router, MindRoom resolves mode using agents relevant to the active room. This includes agents directly configured for the room and agents included via `teams.<name>.rooms`. If all relevant agents resolve to the same mode, the router uses that mode. If modes are mixed, the router defaults to `thread`.
+
 ## File-Based Context Loading
 
 You can inject file content directly into an agent's role context without using a knowledge base.

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -255,7 +255,7 @@ timezone: America/Los_Angeles      # Default: UTC
 - A model named `default` is required unless agents, teams, and the router all specify explicit non-`default` models
 - Agents can set `knowledge_bases`, but each entry must exist in the top-level `knowledge_bases` section
 - `agents.<name>.context_files` inject file-based context at agent creation/reload (see [Agents](https://docs.mindroom.chat/configuration/agents/index.md))
-- `agents.<name>.room_thread_modes` overrides `thread_mode` for specific rooms (see [Agents](https://docs.mindroom.chat/configuration/agents/index.md))
+- `agents.<name>.room_thread_modes` overrides `thread_mode` for specific rooms, and resolution is room-aware for agents, teams, and router decisions (see [Agents](https://docs.mindroom.chat/configuration/agents/index.md))
 - `memory.backend` sets the global memory default, `agents.<name>.memory_backend` overrides it per agent, and `agents.<name>.memory_file_path` sets a custom file-memory scope for that agent
 - `defaults.max_preload_chars` caps preloaded file context (`context_files`)
 - When `authorization.default_room_access` is `false`, only users in `global_users` or room-specific `room_permissions` can interact with agents

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -43,7 +43,14 @@ def _resolve_agent_thread_mode(
     agent_config: AgentConfig,
     room_id: str | None,
 ) -> Literal["thread", "room"]:
-    """Get effective thread mode for one agent in an optional room context."""
+    """Resolve one agent's effective thread mode for an optional room context.
+
+    Resolution order is:
+    1. Explicit room ID key match in ``room_thread_modes``.
+    2. Reverse alias lookup from room ID to managed room key.
+    3. Any ``room_thread_modes`` key that resolves to the active room ID.
+    4. Fallback to ``thread_mode``.
+    """
     default_mode = agent_config.thread_mode
     if room_id is None or not agent_config.room_thread_modes:
         return default_mode
@@ -55,6 +62,7 @@ def _resolve_agent_thread_mode(
     if direct_mode is not None:
         return direct_mode
 
+    # Keep this import local to avoid config<->matrix import cycles during module initialization.
     from mindroom.matrix.rooms import get_room_alias_from_id, resolve_room_aliases  # noqa: PLC0415
 
     room_alias = get_room_alias_from_id(room_id)
@@ -75,10 +83,18 @@ def _router_agents_for_room(
     teams: dict[str, TeamConfig],
     room_id: str | None,
 ) -> set[str]:
-    """Get agent names relevant for router mode resolution in a room context."""
+    """Return agents relevant for router mode resolution in one room context.
+
+    Includes:
+    - Agents directly configured for the room.
+    - Agents brought into the room via ``teams.<name>.rooms`` mappings.
+
+    Falls back to all agents when no room-specific subset is found.
+    """
     if room_id is None:
         return set(agents)
 
+    # Keep this import local to avoid config<->matrix import cycles during module initialization.
     from mindroom.matrix.rooms import resolve_room_aliases  # noqa: PLC0415
 
     router_agents: set[str] = set()


### PR DESCRIPTION
## Summary
- add a dedicated **Thread Mode Resolution** section in agent configuration docs
- clarify how to set `thread_mode` defaults and `room_thread_modes` overrides
- document agent/team/router resolution behavior in room context
- add inline code comments in config thread-mode helpers explaining why matrix-room imports are local (cycle avoidance)
- regenerate `skills/mindroom-docs/references/*` via pre-commit hook

## Validation
- `pre-commit run --all-files`
- `just test-backend`
