### PR TITLE
Fix frontend API auth by defaulting to proxied /api routes

### DIFF
--- a/frontend/src/components/Credentials/Credentials.test.tsx
+++ b/frontend/src/components/Credentials/Credentials.test.tsx
@@ -156,7 +156,7 @@ describe('Credentials', () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:8765/api/credentials/github_private',
+        '/api/credentials/github_private',
         expect.objectContaining({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -252,7 +252,7 @@ describe('Credentials', () => {
     await waitFor(() => {
       expect(window.confirm).toHaveBeenCalledWith("Delete credentials for 'github_private'?");
       expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:8765/api/credentials/github_private',
+        '/api/credentials/github_private',
         expect.objectContaining({
           method: 'DELETE',
         })
@@ -302,7 +302,7 @@ describe('Credentials', () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:8765/api/credentials/github_private/test',
+        '/api/credentials/github_private/test',
         expect.objectContaining({
           method: 'POST',
         })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,11 +1,9 @@
 // API configuration
-// If VITE_API_URL is explicitly set to empty string, use relative URLs (for Docker/production)
-// Otherwise use the provided URL or fallback to localhost
+// Default to relative URLs so requests use the current origin (/api/* via proxy/reverse-proxy).
+// Set VITE_API_URL to override (for explicit cross-origin backend setups).
 const viteApiUrl = (import.meta as any).env?.VITE_API_URL;
 export const API_BASE_URL =
-  viteApiUrl === ''
-    ? '' // Use relative URLs when empty (Docker/production mode)
-    : viteApiUrl ?? `http://localhost:${(import.meta as any).env?.VITE_BACKEND_PORT || '8765'}`;
+  typeof viteApiUrl === 'string' && viteApiUrl.length > 0 ? viteApiUrl : '';
 
 // Export as API_BASE for compatibility
 export const API_BASE = API_BASE_URL;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,7 +11,9 @@ const isDocker = process.env.DOCKER_CONTAINER === '1';
 // The empty prefix '' makes loadEnv read ALL vars, not just VITE_-prefixed ones.
 // This key is used server-side by the dev proxy and never reaches the browser.
 const rootEnv = loadEnv('development', path.resolve(__dirname, '..'), '');
-const apiKey = process.env.MINDROOM_API_KEY || rootEnv.MINDROOM_API_KEY;
+const userEnvDir = process.env.HOME ? path.join(process.env.HOME, '.mindroom') : '';
+const userEnv = userEnvDir ? loadEnv('development', userEnvDir, '') : {};
+const apiKey = process.env.MINDROOM_API_KEY || rootEnv.MINDROOM_API_KEY || userEnv.MINDROOM_API_KEY;
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Default frontend API requests to relative paths instead of `http://localhost:8765`
- Ensure Vite dev proxy can read `MINDROOM_API_KEY` from `~/.mindroom/.env` as well as repo env
- Update credentials component tests to assert relative `/api` requests

## Why
When `MINDROOM_API_KEY` is enabled, some frontend requests bypassed the Vite proxy and hit backend directly without auth headers, causing `401 Unauthorized` on endpoints like `/api/tools`, `/api/skills`, and `/api/matrix/agents/rooms`.

## Validation
- `pre-commit run --files frontend/src/lib/api.ts frontend/vite.config.ts frontend/src/components/Credentials/Credentials.test.tsx`
- `bun run test:unit -- src/components/Credentials/Credentials.test.tsx`
- `bun run type-check`
- `bun run build`
- `MINDROOM_API_KEY='' uv run pytest tests/api/test_api.py::test_load_config -q`

## Notes
- Left unrelated local changes untouched (`.envrc`, `.env.backup`).
