### PR TITLE
Fix team external room sync

### DIFF
--- a/frontend/src/components/UnconfiguredRooms/UnconfiguredRooms.test.tsx
+++ b/frontend/src/components/UnconfiguredRooms/UnconfiguredRooms.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, type Mock } from 'vitest';
+import { UnconfiguredRooms } from './UnconfiguredRooms';
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('UnconfiguredRooms', () => {
+  it('renders teams in the external room list', async () => {
+    (global.fetch as Mock).mockResolvedValueOnce(
+      jsonResponse({
+        agents: [
+          {
+            agent_id: 'test_team',
+            display_name: 'Test Team',
+            configured_rooms: ['team_room'],
+            joined_rooms: ['team_room', '!external_room:localhost'],
+            unconfigured_rooms: ['!external_room:localhost'],
+            unconfigured_room_details: [
+              { room_id: '!external_room:localhost', name: 'Partner Room' },
+            ],
+          },
+        ],
+      })
+    );
+
+    render(<UnconfiguredRooms />);
+
+    expect(await screen.findByText('Test Team')).toBeInTheDocument();
+    expect(screen.getByText('Partner Room')).toBeInTheDocument();
+    expect(
+      screen.getByText('Manage rooms that agents and teams have joined but are not in the configuration')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/1 external room found across 1 entity/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/UnconfiguredRooms/UnconfiguredRooms.tsx
+++ b/frontend/src/components/UnconfiguredRooms/UnconfiguredRooms.tsx
@@ -14,8 +14,8 @@ interface RoomInfo {
   name?: string;
 }
 
-interface AgentRoomsInfo {
-  agent_id: string;
+interface MatrixEntityRoomsInfo {
+  agent_id: string; // Legacy API field; contains either an agent ID or team ID.
   display_name: string;
   configured_rooms: string[];
   joined_rooms: string[];
@@ -29,22 +29,22 @@ interface RoomLeaveRequest {
 }
 
 export function UnconfiguredRooms() {
-  const [agentsRooms, setAgentsRooms] = useState<AgentRoomsInfo[]>([]);
+  const [entitiesRooms, setEntitiesRooms] = useState<MatrixEntityRoomsInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedRooms, setSelectedRooms] = useState<Set<string>>(new Set());
   const [leavingRooms, setLeavingRooms] = useState(false);
 
-  // Load agent rooms data
+  // Load configured Matrix entity rooms data.
   const loadAgentRooms = async () => {
     setLoading(true);
     setError(null);
     try {
       const response = await fetchAPI(API_ENDPOINTS.matrix.agentsRooms);
-      setAgentsRooms(response.agents);
+      setEntitiesRooms(response.agents);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load agent rooms');
-      console.error('Error loading agent rooms:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load external rooms');
+      console.error('Error loading external rooms:', err);
     } finally {
       setLoading(false);
     }
@@ -131,12 +131,15 @@ export function UnconfiguredRooms() {
   };
 
   // Calculate total unconfigured rooms
-  const totalUnconfiguredRooms = agentsRooms.reduce(
-    (sum, agent) => sum + agent.unconfigured_rooms.length,
+  const totalUnconfiguredRooms = entitiesRooms.reduce(
+    (sum, entity) => sum + entity.unconfigured_rooms.length,
     0
   );
+  const entitiesWithExternalRooms = entitiesRooms.filter(
+    entity => entity.unconfigured_rooms.length > 0
+  );
 
-  // Check if all rooms for an agent are selected
+  // Check if all rooms for an entity are selected.
   const areAllSelectedForAgent = (agentId: string, rooms: string[]) => {
     return rooms.every(roomId => selectedRooms.has(`${agentId}:${roomId}`));
   };
@@ -158,7 +161,7 @@ export function UnconfiguredRooms() {
         <div>
           <h2 className="text-2xl font-semibold tracking-tight">External Rooms</h2>
           <p className="text-sm text-muted-foreground mt-1">
-            Manage rooms that agents have joined but are not in the configuration
+            Manage rooms that agents and teams have joined but are not in the configuration
           </p>
         </div>
         <Button variant="outline" size="sm" onClick={loadAgentRooms} disabled={loading}>
@@ -185,8 +188,8 @@ export function UnconfiguredRooms() {
                 <CardDescription>
                   {totalUnconfiguredRooms} external room
                   {totalUnconfiguredRooms !== 1 ? 's' : ''} found across{' '}
-                  {agentsRooms.filter(a => a.unconfigured_rooms.length > 0).length} agent
-                  {agentsRooms.filter(a => a.unconfigured_rooms.length > 0).length !== 1 ? 's' : ''}
+                  {entitiesWithExternalRooms.length} entit
+                  {entitiesWithExternalRooms.length === 1 ? 'y' : 'ies'}
                 </CardDescription>
               </div>
               {selectedRooms.size > 0 && (
@@ -210,121 +213,119 @@ export function UnconfiguredRooms() {
         <Card>
           <CardContent className="pt-6">
             <p className="text-center text-muted-foreground">
-              All agent rooms are properly configured. No action needed.
+              All configured agents and teams are only in configured rooms. No action needed.
             </p>
           </CardContent>
         </Card>
       )}
 
-      {/* Agent Room Lists */}
+      {/* Entity Room Lists */}
       <ScrollArea className="h-[600px] pr-4">
         <div className="space-y-4">
-          {agentsRooms
-            .filter(agent => agent.unconfigured_rooms.length > 0)
-            .map(agent => (
-              <Card key={agent.agent_id}>
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <CardTitle className="text-lg">{agent.display_name}</CardTitle>
-                      <CardDescription>
-                        {agent.unconfigured_rooms.length} external room
-                        {agent.unconfigured_rooms.length !== 1 ? 's' : ''}
-                      </CardDescription>
-                    </div>
-                    <div className="flex gap-2">
-                      {agent.unconfigured_rooms.length > 1 && (
-                        <>
-                          {areAllSelectedForAgent(agent.agent_id, agent.unconfigured_rooms) ? (
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() =>
-                                deselectAllForAgent(agent.agent_id, agent.unconfigured_rooms)
-                              }
-                            >
-                              Deselect All
-                            </Button>
-                          ) : (
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() =>
-                                selectAllForAgent(agent.agent_id, agent.unconfigured_rooms)
-                              }
-                            >
-                              Select All
-                            </Button>
-                          )}
-                        </>
-                      )}
-                    </div>
+          {entitiesWithExternalRooms.map(entity => (
+            <Card key={entity.agent_id}>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <CardTitle className="text-lg">{entity.display_name}</CardTitle>
+                    <CardDescription>
+                      {entity.unconfigured_rooms.length} external room
+                      {entity.unconfigured_rooms.length !== 1 ? 's' : ''}
+                    </CardDescription>
                   </div>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-2">
-                    {agent.unconfigured_rooms.map((roomId, index) => {
-                      const key = `${agent.agent_id}:${roomId}`;
-                      const isSelected = selectedRooms.has(key);
-                      const roomDetails = agent.unconfigured_room_details?.[index];
+                  <div className="flex gap-2">
+                    {entity.unconfigured_rooms.length > 1 && (
+                      <>
+                        {areAllSelectedForAgent(entity.agent_id, entity.unconfigured_rooms) ? (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              deselectAllForAgent(entity.agent_id, entity.unconfigured_rooms)
+                            }
+                          >
+                            Deselect All
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              selectAllForAgent(entity.agent_id, entity.unconfigured_rooms)
+                            }
+                          >
+                            Select All
+                          </Button>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-2">
+                  {entity.unconfigured_rooms.map((roomId, index) => {
+                    const key = `${entity.agent_id}:${roomId}`;
+                    const isSelected = selectedRooms.has(key);
+                    const roomDetails = entity.unconfigured_room_details?.[index];
 
-                      return (
-                        <div
-                          key={roomId}
-                          className={cn(
-                            'flex items-center space-x-3 p-3 rounded-lg border transition-colors cursor-pointer',
-                            isSelected ? 'bg-muted/50 border-primary/20' : 'hover:bg-muted/30'
+                    return (
+                      <div
+                        key={roomId}
+                        className={cn(
+                          'flex items-center space-x-3 p-3 rounded-lg border transition-colors cursor-pointer',
+                          isSelected ? 'bg-muted/50 border-primary/20' : 'hover:bg-muted/30'
+                        )}
+                        onClick={() => toggleRoomSelection(entity.agent_id, roomId)}
+                      >
+                        <Checkbox
+                          checked={isSelected}
+                          onCheckedChange={() => toggleRoomSelection(entity.agent_id, roomId)}
+                          disabled={leavingRooms}
+                          onClick={e => e.stopPropagation()}
+                        />
+                        <div className="flex-1 min-w-0 select-none">
+                          {/* Show room name if available */}
+                          {roomDetails?.name && (
+                            <div className="font-medium text-sm mb-1">{roomDetails.name}</div>
                           )}
-                          onClick={() => toggleRoomSelection(agent.agent_id, roomId)}
-                        >
-                          <Checkbox
-                            checked={isSelected}
-                            onCheckedChange={() => toggleRoomSelection(agent.agent_id, roomId)}
-                            disabled={leavingRooms}
-                            onClick={e => e.stopPropagation()}
-                          />
-                          <div className="flex-1 min-w-0 select-none">
-                            {/* Show room name if available */}
-                            {roomDetails?.name && (
-                              <div className="font-medium text-sm mb-1">{roomDetails.name}</div>
-                            )}
-                            <div className="flex items-center gap-2">
-                              <code className="text-xs font-mono truncate text-muted-foreground">
-                                {roomId}
-                              </code>
-                              {roomId.startsWith('!') && roomId.includes(':') && (
-                                <Badge variant="outline" className="text-xs pointer-events-none">
-                                  {roomId.split(':')[1]}
-                                </Badge>
-                              )}
-                            </div>
-                            {/* Show if it's a DM room */}
-                            {roomId.includes('dm') && (
-                              <p className="text-xs text-muted-foreground mt-1">
-                                Direct Message Room
-                              </p>
+                          <div className="flex items-center gap-2">
+                            <code className="text-xs font-mono truncate text-muted-foreground">
+                              {roomId}
+                            </code>
+                            {roomId.startsWith('!') && roomId.includes(':') && (
+                              <Badge variant="outline" className="text-xs pointer-events-none">
+                                {roomId.split(':')[1]}
+                              </Badge>
                             )}
                           </div>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={e => {
-                              e.stopPropagation();
-                              // Open room in Element/Matrix client
-                              const matrixUrl = `https://matrix.to/#/${roomId}`;
-                              window.open(matrixUrl, '_blank');
-                            }}
-                            title="Open in Matrix client"
-                          >
-                            <ExternalLink className="h-4 w-4" />
-                          </Button>
+                          {/* Show if it's a DM room */}
+                          {roomId.includes('dm') && (
+                            <p className="text-xs text-muted-foreground mt-1">
+                              Direct Message Room
+                            </p>
+                          )}
                         </div>
-                      );
-                    })}
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={e => {
+                            e.stopPropagation();
+                            // Open room in Element/Matrix client
+                            const matrixUrl = `https://matrix.to/#/${roomId}`;
+                            window.open(matrixUrl, '_blank');
+                          }}
+                          title="Open in Matrix client"
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    );
+                  })}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
         </div>
       </ScrollArea>
     </div>

--- a/src/mindroom/api/matrix_operations.py
+++ b/src/mindroom/api/matrix_operations.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from mindroom.constants import MATRIX_HOMESERVER
 from mindroom.logging_config import get_logger
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/api/matrix", tags=["matrix"])
 
 
 class RoomLeaveRequest(BaseModel):
-    """Request to leave a room."""
+    """Request for an agent or team to leave a room."""
 
     agent_id: str
     room_id: str
@@ -32,28 +32,47 @@ class _RoomInfo(BaseModel):
 
 
 class AgentRoomsResponse(BaseModel):
-    """Response containing agent rooms information."""
+    """Response containing Matrix entity room information."""
 
     agent_id: str
     display_name: str
     configured_rooms: list[str]
     joined_rooms: list[str]
     unconfigured_rooms: list[str]
-    unconfigured_room_details: list[_RoomInfo] = []
+    unconfigured_room_details: list[_RoomInfo] = Field(default_factory=list)
 
 
 class AllAgentsRoomsResponse(BaseModel):
-    """Response containing all agents' room information."""
+    """Response containing all configured Matrix entities' room information."""
 
     agents: list[AgentRoomsResponse]
 
 
+def _get_configured_matrix_entities(config_data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return configured agents and teams keyed by their Matrix entity ID."""
+    return {
+        **config_data.get("agents", {}),
+        **config_data.get("teams", {}),
+    }
+
+
+def _get_configured_matrix_entity(
+    config_data: dict[str, Any],
+    entity_id: str,
+) -> dict[str, Any]:
+    """Return one configured Matrix entity or raise a 404."""
+    entities = _get_configured_matrix_entities(config_data)
+    if entity_id not in entities:
+        raise HTTPException(status_code=404, detail=f"Agent or team {entity_id} not found")
+    return entities[entity_id]
+
+
 async def _get_agent_matrix_rooms(agent_id: str, agent_data: dict[str, Any]) -> AgentRoomsResponse:
-    """Get Matrix rooms for a specific agent.
+    """Get Matrix rooms for a specific configured agent or team.
 
     Args:
-        agent_id: The agent identifier
-        agent_data: The agent configuration data
+        agent_id: The agent or team identifier
+        agent_data: The entity configuration data
 
     Returns:
         AgentRoomsResponse with room information
@@ -101,20 +120,18 @@ async def _get_agent_matrix_rooms(agent_id: str, agent_data: dict[str, Any]) -> 
 
 @router.get("/agents/rooms")
 async def get_all_agents_rooms() -> AllAgentsRoomsResponse:
-    """Get room information for all agents.
+    """Get room information for all configured agents and teams.
 
     Returns information about configured rooms, joined rooms,
-    and unconfigured rooms (joined but not in config) for each agent.
+    and unconfigured rooms (joined but not in config) for each Matrix entity.
     """
     from mindroom.api.main import config, config_lock  # noqa: PLC0415
 
-    agents_rooms = []
-
     with config_lock:
-        agents = config.get("agents", {})
+        entities = _get_configured_matrix_entities(config)
 
-    # Gather room information for all agents concurrently
-    tasks = [_get_agent_matrix_rooms(agent_id, agent_data) for agent_id, agent_data in agents.items()]
+    # Gather room information for all configured Matrix entities concurrently.
+    tasks = [_get_agent_matrix_rooms(agent_id, agent_data) for agent_id, agent_data in entities.items()]
     agents_rooms = await asyncio.gather(*tasks)
 
     return AllAgentsRoomsResponse(agents=agents_rooms)
@@ -122,54 +139,46 @@ async def get_all_agents_rooms() -> AllAgentsRoomsResponse:
 
 @router.get("/agents/{agent_id}/rooms")
 async def get_agent_rooms(agent_id: str) -> AgentRoomsResponse:
-    """Get room information for a specific agent.
+    """Get room information for a specific configured agent or team.
 
     Args:
-        agent_id: The agent identifier
+        agent_id: The agent or team identifier
 
     Returns:
-        Room information for the agent
+        Room information for the configured Matrix entity
 
     Raises:
-        HTTPException: If agent not found or error occurs
+        HTTPException: If the entity is not found or an error occurs
 
     """
     from mindroom.api.main import config, config_lock  # noqa: PLC0415
 
     with config_lock:
-        agents = config.get("agents", {})
-        if agent_id not in agents:
-            raise HTTPException(status_code=404, detail=f"Agent {agent_id} not found")
-        agent_data = agents[agent_id]
+        agent_data = _get_configured_matrix_entity(config, agent_id)
 
     return await _get_agent_matrix_rooms(agent_id, agent_data)
 
 
 @router.post("/rooms/leave")
 async def leave_room_endpoint(request: RoomLeaveRequest) -> dict[str, bool]:
-    """Make an agent leave a specific room.
+    """Make an agent or team leave a specific room.
 
     Args:
-        request: Contains agent_id and room_id
+        request: Contains the agent/team ID and room ID
 
     Returns:
         Success status
 
     Raises:
-        HTTPException: If agent not found or leave operation fails
+        HTTPException: If the entity is not found or the leave operation fails
 
     """
     from mindroom.api.main import config, config_lock  # noqa: PLC0415
 
     with config_lock:
-        agents = config.get("agents", {})
-        if request.agent_id not in agents:
-            raise HTTPException(status_code=404, detail=f"Agent {request.agent_id} not found")
+        agent_data = _get_configured_matrix_entity(config, request.agent_id)
 
-    # Get agent configuration
-    agent_data = agents[request.agent_id]
-
-    # Create or get the agent user
+    # Create or get the Matrix user for this configured entity.
     agent_user = await create_agent_user(
         MATRIX_HOMESERVER,
         request.agent_id,

--- a/tests/api/test_matrix_operations.py
+++ b/tests/api/test_matrix_operations.py
@@ -6,6 +6,22 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from mindroom.api import main
+
+
+def _add_test_team_to_runtime_config() -> None:
+    """Add a configured team to the API runtime config for one test."""
+    with main.config_lock:
+        main.config["teams"] = {
+            "test_team": {
+                "display_name": "Test Team",
+                "role": "A test team",
+                "agents": ["test_agent"],
+                "rooms": ["team_room"],
+                "mode": "coordinate",
+            },
+        }
+
 
 @pytest.fixture
 def mock_matrix_client() -> AsyncMock:
@@ -37,13 +53,15 @@ class TestMatrixOperations:
         mock_agent_user: Any,  # noqa: ANN401
         mock_matrix_client: Any,  # noqa: ANN401
     ) -> None:
-        """Test getting room information for all agents."""
+        """Test getting room information for configured agents and teams."""
+        _add_test_team_to_runtime_config()
+
         with (
             patch("mindroom.api.matrix_operations.create_agent_user", return_value=mock_agent_user),
             patch("mindroom.api.matrix_operations.login_agent_user", return_value=mock_matrix_client),
             patch(
                 "mindroom.api.matrix_operations.get_joined_rooms",
-                return_value=["test_room", "!extra_room:localhost", "!dm_room:localhost"],
+                return_value=["test_room", "team_room", "!extra_room:localhost", "!dm_room:localhost"],
             ),
         ):
             response = test_client.get("/api/matrix/agents/rooms")
@@ -51,15 +69,20 @@ class TestMatrixOperations:
             assert response.status_code == 200
             data = response.json()
             assert "agents" in data
-            assert len(data["agents"]) == 1  # One test agent from fixture
+            assert len(data["agents"]) == 2
 
-            agent = data["agents"][0]
-            assert agent["agent_id"] == "test_agent"
-            assert agent["display_name"] == "Test Agent"
-            assert "test_room" in agent["configured_rooms"]
-            assert len(agent["unconfigured_rooms"]) == 2
-            assert "!extra_room:localhost" in agent["unconfigured_rooms"]
-            assert "!dm_room:localhost" in agent["unconfigured_rooms"]
+            entities_by_id = {entity["agent_id"]: entity for entity in data["agents"]}
+
+            assert set(entities_by_id) == {"test_agent", "test_team"}
+            assert entities_by_id["test_agent"]["display_name"] == "Test Agent"
+            assert "test_room" in entities_by_id["test_agent"]["configured_rooms"]
+            assert "!extra_room:localhost" in entities_by_id["test_agent"]["unconfigured_rooms"]
+            assert "!dm_room:localhost" in entities_by_id["test_agent"]["unconfigured_rooms"]
+
+            assert entities_by_id["test_team"]["display_name"] == "Test Team"
+            assert "team_room" in entities_by_id["test_team"]["configured_rooms"]
+            assert "!extra_room:localhost" in entities_by_id["test_team"]["unconfigured_rooms"]
+            assert "!dm_room:localhost" in entities_by_id["test_team"]["unconfigured_rooms"]
 
     @pytest.mark.asyncio
     async def test_get_specific_agent_rooms(
@@ -86,6 +109,33 @@ class TestMatrixOperations:
             assert len(data["configured_rooms"]) == 1
             assert len(data["unconfigured_rooms"]) == 1
             assert "!extra_room:localhost" in data["unconfigured_rooms"]
+
+    @pytest.mark.asyncio
+    async def test_get_specific_team_rooms(
+        self,
+        test_client: TestClient,
+        mock_agent_user: Any,  # noqa: ANN401
+        mock_matrix_client: Any,  # noqa: ANN401
+    ) -> None:
+        """Test getting rooms for a specific configured team."""
+        _add_test_team_to_runtime_config()
+
+        with (
+            patch("mindroom.api.matrix_operations.create_agent_user", return_value=mock_agent_user),
+            patch("mindroom.api.matrix_operations.login_agent_user", return_value=mock_matrix_client),
+            patch(
+                "mindroom.api.matrix_operations.get_joined_rooms",
+                return_value=["team_room", "!external_room:localhost"],
+            ),
+        ):
+            response = test_client.get("/api/matrix/agents/test_team/rooms")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["agent_id"] == "test_team"
+            assert data["display_name"] == "Test Team"
+            assert data["configured_rooms"] == ["team_room"]
+            assert data["unconfigured_rooms"] == ["!external_room:localhost"]
 
     @pytest.mark.asyncio
     async def test_get_agent_rooms_not_found(self, test_client: TestClient) -> None:
@@ -135,6 +185,29 @@ class TestMatrixOperations:
 
             assert response.status_code == 500
             assert "Failed to leave room" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_leave_room_for_team(
+        self,
+        test_client: TestClient,
+        mock_agent_user: Any,  # noqa: ANN401
+        mock_matrix_client: Any,  # noqa: ANN401
+    ) -> None:
+        """Test leaving a room for a configured team."""
+        _add_test_team_to_runtime_config()
+
+        with (
+            patch("mindroom.api.matrix_operations.create_agent_user", return_value=mock_agent_user),
+            patch("mindroom.api.matrix_operations.login_agent_user", return_value=mock_matrix_client),
+            patch("mindroom.api.matrix_operations.leave_room", return_value=True),
+        ):
+            response = test_client.post(
+                "/api/matrix/rooms/leave",
+                json={"agent_id": "test_team", "room_id": "!room_to_leave:localhost"},
+            )
+
+            assert response.status_code == 200
+            assert response.json()["success"] is True
 
     @pytest.mark.asyncio
     async def test_leave_room_agent_not_found(self, test_client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- include configured teams in the Matrix external-room API and leave-room handling
- update the External Rooms frontend copy/rendering so teams show up as first-class entities
- add backend and frontend regression coverage for team external-room visibility

## Testing
- pytest
- pre-commit run --all-files
- bun run test --run src/components/UnconfiguredRooms/UnconfiguredRooms.test.tsx