### PR TITLE
Fix renamed MindRoom Dockerfile references

### DIFF
--- a/cluster/k8s/kind/build_load_images.sh
+++ b/cluster/k8s/kind/build_load_images.sh
@@ -44,11 +44,11 @@ if [ "${BUILD_MINDROOM_IMAGES}" = "1" ]; then
   echo "[images] Building MindRoom images locally..."
   docker build \
     -t "${MINDROOM_IMAGE}" \
-    -f local/instances/deploy/Dockerfile.backend .
+    -f local/instances/deploy/Dockerfile.mindroom .
 
   docker build \
     -t "${MINDROOM_MINIMAL_IMAGE}" \
-    -f local/instances/deploy/Dockerfile.backend-minimal .
+    -f local/instances/deploy/Dockerfile.mindroom-minimal .
 else
   echo "[images] Pulling published MindRoom images..."
   docker pull "${MINDROOM_IMAGE}"

--- a/justfile
+++ b/justfile
@@ -217,7 +217,7 @@ check-module-privacy:
 # Docker builds (local)
 # Build the core MindRoom runtime image (bot + dashboard + APIs)
 docker-build-mindroom:
-    docker build -t mindroom:dev -f local/instances/deploy/Dockerfile.backend .
+    docker build -t mindroom:dev -f local/instances/deploy/Dockerfile.mindroom .
 
 # Build SaaS platform frontend (Next.js standalone)
 docker-build-saas-frontend:

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -5346,7 +5346,7 @@ Start MindRoom with your configuration.
 │                                          (state, sessions, tracking)                   │
 │                                          [default: mindroom_data]                      │
 │ --api               --no-api             Start the bundled dashboard/API server        │
-│                                          bot                                           │
+│                                          alongside the bot                             │
 │                                          [default: api]                                │
 │ --api-port                      INTEGER  Port for the bundled dashboard/API server     │
 │                                          [default: 8765]                               │

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -75,7 +75,7 @@ Start MindRoom with your configuration.
 │                                          (state, sessions, tracking)                   │
 │                                          [default: mindroom_data]                      │
 │ --api               --no-api             Start the bundled dashboard/API server        │
-│                                          bot                                           │
+│                                          alongside the bot                             │
 │                                          [default: api]                                │
 │ --api-port                      INTEGER  Port for the bundled dashboard/API server     │
 │                                          [default: 8765]                               │


### PR DESCRIPTION
## Summary
- fix stale references to the renamed MindRoom runtime Dockerfiles
- update the local `just` target and kind image builder to use `Dockerfile.mindroom`
- include regenerated `mindroom-docs` skill references from pre-commit

## Testing
- docker build -t mindroom:dev -f local/instances/deploy/Dockerfile.mindroom .
- docker build -t mindroom-minimal:dev -f local/instances/deploy/Dockerfile.mindroom-minimal .
- pre-commit run --all-files
- uv run pytest