### PR TITLE
Check actual Vertex AI models in doctor

### DIFF
--- a/src/mindroom/cli/doctor.py
+++ b/src/mindroom/cli/doctor.py
@@ -12,7 +12,8 @@ from urllib.parse import urlparse
 import httpx
 import typer
 import yaml
-from anthropic import AnthropicVertex, APIStatusError
+from agno.models.vertexai.claude import Claude as VertexAIClaude
+from anthropic import APIStatusError
 from google.auth.exceptions import DefaultCredentialsError, RefreshError
 from pydantic import ValidationError
 
@@ -21,7 +22,6 @@ from mindroom.constants import (
     MATRIX_HOMESERVER,
     MATRIX_SSL_VERIFY,
     STORAGE_PATH,
-    VERTEXAI_CLAUDE_ENV_KEYS,
     env_key_for_provider,
 )
 
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from mindroom.config.main import Config
+    from mindroom.config.models import ModelConfig
 
 
 def doctor() -> None:
@@ -284,23 +285,33 @@ def _validate_provider_key(
     return _http_check(url, headers)
 
 
-def _validate_vertexai_claude_connection(model: str) -> tuple[bool | None, str]:
-    """Validate Anthropic-on-Vertex access with a tiny count-tokens request."""
-    missing = [env_key for env_key in VERTEXAI_CLAUDE_ENV_KEYS if not os.getenv(env_key)]
+def _validate_vertexai_claude_connection(model_config: ModelConfig) -> tuple[bool | None, str]:
+    """Validate the configured Vertex AI Claude model with the runtime request path."""
+    extra_kwargs = dict(model_config.extra_kwargs or {})
+    project_id = extra_kwargs.get("project_id") or os.getenv("ANTHROPIC_VERTEX_PROJECT_ID")
+    region = extra_kwargs.get("region") or os.getenv("CLOUD_ML_REGION")
+    missing = []
+    if not project_id:
+        missing.append("ANTHROPIC_VERTEX_PROJECT_ID")
+    if not region:
+        missing.append("CLOUD_ML_REGION")
     if missing:
         return None, f"missing {', '.join(missing)}"
 
-    project_id = os.getenv("ANTHROPIC_VERTEX_PROJECT_ID")
-    region = os.getenv("CLOUD_ML_REGION")
-    assert project_id is not None
-    assert region is not None
+    extra_kwargs.setdefault("project_id", project_id)
+    extra_kwargs.setdefault("region", region)
+    extra_kwargs.setdefault("timeout", 10)
 
     try:
-        client = AnthropicVertex(project_id=project_id, region=region, timeout=10, max_retries=0)
-        client.messages.count_tokens(
-            model=model,
-            messages=[{"role": "user", "content": "mindroom doctor vertexai check"}],
-            timeout=10,
+        model = VertexAIClaude(id=model_config.id, **extra_kwargs)
+        request_kwargs = model.get_request_params().copy()
+        request_kwargs["model"] = model_config.id
+        request_kwargs["messages"] = [{"role": "user", "content": "Reply with OK."}]
+        request_kwargs.setdefault("max_tokens", 1)
+        request_kwargs["timeout"] = request_kwargs.get("timeout", 10)
+        client = model.get_client()
+        client.messages.create(
+            **request_kwargs,
         )
     except APIStatusError as exc:
         return False, f"HTTP {exc.status_code}"
@@ -377,15 +388,24 @@ def _check_single_provider(
 ) -> tuple[int, int, int]:
     """Validate a single provider. Returns (passed, failed, warnings)."""
     if provider == "vertexai_claude":
-        model_id = next(model.id for model in config.models.values() if model.provider == provider)
-        valid, detail = _validate_vertexai_claude_connection(model_id)
-        return _print_validation(
-            valid,
-            detail,
-            f"{provider} connection valid for {model_id}",
-            f"{provider} connection failed for {model_id}",
-            f"{provider}: could not validate connection for {model_id}",
-        )
+        passed = 0
+        failed = 0
+        warnings = 0
+        for model_config in config.models.values():
+            if model_config.provider != provider:
+                continue
+            valid, detail = _validate_vertexai_claude_connection(model_config)
+            p, f, w = _print_validation(
+                valid,
+                detail,
+                f"{provider} connection valid for {model_config.id}",
+                f"{provider} connection failed for {model_config.id}",
+                f"{provider}: could not validate connection for {model_config.id}",
+            )
+            passed += p
+            failed += f
+            warnings += w
+        return passed, failed, warnings
 
     if provider == "ollama":
         host = _get_ollama_host(config)

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -581,6 +581,13 @@ _VALID_VERTEXAI_CLAUDE_CONFIG = (
     "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
     "router:\n  model: default\n"
 )
+_VALID_MULTI_VERTEXAI_CLAUDE_CONFIG = (
+    "models:\n"
+    "  default:\n    provider: vertexai_claude\n    id: claude-opus-4-6@default\n"
+    "  fast:\n    provider: vertexai_claude\n    id: claude-sonnet-4@20250514\n"
+    "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
+    "router:\n  model: default\n"
+)
 
 
 def _patch_homeserver_ok(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -784,7 +791,7 @@ class TestDoctor:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Doctor validates Vertex AI Claude with a count-tokens smoke test."""
+        """Doctor validates Vertex AI Claude with a tiny messages smoke test."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text(_VALID_VERTEXAI_CLAUDE_CONFIG)
         storage = tmp_path / "storage"
@@ -798,31 +805,83 @@ class TestDoctor:
         called: dict[str, object] = {}
 
         class _FakeMessages:
-            def count_tokens(self, **kwargs: object) -> SimpleNamespace:
+            def create(self, **kwargs: object) -> SimpleNamespace:
                 called["kwargs"] = kwargs
-                return SimpleNamespace(input_tokens=6)
+                return SimpleNamespace(content=[{"type": "text", "text": "OK"}])
 
-        class _FakeVertexClient:
+        class _FakeVertexModel:
             def __init__(self, **kwargs: object) -> None:
+                called["model_id"] = kwargs["id"]
                 called["client_kwargs"] = kwargs
-                self.messages = _FakeMessages()
+                self.id = str(kwargs["id"])
 
-        monkeypatch.setattr("mindroom.cli.doctor.AnthropicVertex", _FakeVertexClient)
+            def get_request_params(self) -> dict[str, object]:
+                return {"timeout": called["client_kwargs"]["timeout"]}
+
+            def get_client(self) -> SimpleNamespace:
+                return SimpleNamespace(messages=_FakeMessages())
+
+        monkeypatch.setattr("mindroom.cli.doctor.VertexAIClaude", _FakeVertexModel)
 
         result = runner.invoke(app, ["doctor"])
         assert result.exit_code == 0
         assert "vertexai_claude connection valid for claude-opus-4-6@default" in result.output
+        assert called["model_id"] == "claude-opus-4-6@default"
         assert called["client_kwargs"] == {
+            "id": "claude-opus-4-6@default",
             "project_id": "mindroom-test",
             "region": "us-central1",
             "timeout": 10,
-            "max_retries": 0,
         }
         assert called["kwargs"] == {
             "model": "claude-opus-4-6@default",
-            "messages": [{"role": "user", "content": "mindroom doctor vertexai check"}],
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": "Reply with OK."}],
             "timeout": 10,
         }
+
+    def test_vertexai_claude_connection_checks_each_configured_model(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Doctor validates every configured Vertex AI Claude model by its actual ID."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(_VALID_MULTI_VERTEXAI_CLAUDE_CONFIG)
+        storage = tmp_path / "storage"
+        monkeypatch.setattr("mindroom.cli.doctor.CONFIG_PATH", cfg)
+        monkeypatch.setattr("mindroom.cli.doctor.STORAGE_PATH", str(storage))
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "mindroom-test")
+        monkeypatch.setenv("CLOUD_ML_REGION", "us-central1")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        _patch_homeserver_ok(monkeypatch)
+
+        created_models: list[str] = []
+        requested_models: list[str] = []
+
+        class _FakeMessages:
+            def create(self, **kwargs: object) -> SimpleNamespace:
+                requested_models.append(str(kwargs["model"]))
+                return SimpleNamespace(content=[{"type": "text", "text": "OK"}])
+
+        class _FakeVertexModel:
+            def __init__(self, **kwargs: object) -> None:
+                created_models.append(str(kwargs["id"]))
+
+            def get_request_params(self) -> dict[str, object]:
+                return {"timeout": 10}
+
+            def get_client(self) -> SimpleNamespace:
+                return SimpleNamespace(messages=_FakeMessages())
+
+        monkeypatch.setattr("mindroom.cli.doctor.VertexAIClaude", _FakeVertexModel)
+
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "vertexai_claude connection valid for claude-opus-4-6@default" in result.output
+        assert "vertexai_claude connection valid for claude-sonnet-4@20250514" in result.output
+        assert created_models == ["claude-opus-4-6@default", "claude-sonnet-4@20250514"]
+        assert requested_models == ["claude-opus-4-6@default", "claude-sonnet-4@20250514"]
 
     def test_vertexai_claude_missing_env_is_warning(
         self,
@@ -863,15 +922,21 @@ class TestDoctor:
         _patch_homeserver_ok(monkeypatch)
 
         class _MissingCredentialsMessages:
-            def count_tokens(self, **_kwargs: object) -> None:
+            def create(self, **_kwargs: object) -> None:
                 message = "ADC unavailable"
                 raise DefaultCredentialsError(message)
 
-        class _MissingCredentialsClient:
-            def __init__(self, **_kwargs: object) -> None:
-                self.messages = _MissingCredentialsMessages()
+        class _MissingCredentialsModel:
+            def __init__(self, **kwargs: object) -> None:
+                self.id = str(kwargs["id"])
 
-        monkeypatch.setattr("mindroom.cli.doctor.AnthropicVertex", _MissingCredentialsClient)
+            def get_request_params(self) -> dict[str, object]:
+                return {"timeout": 10}
+
+            def get_client(self) -> SimpleNamespace:
+                return SimpleNamespace(messages=_MissingCredentialsMessages())
+
+        monkeypatch.setattr("mindroom.cli.doctor.VertexAIClaude", _MissingCredentialsModel)
 
         result = runner.invoke(app, ["doctor"])
         assert result.exit_code == 0
@@ -895,16 +960,22 @@ class TestDoctor:
         _patch_homeserver_ok(monkeypatch)
 
         class _RejectedMessages:
-            def count_tokens(self, **_kwargs: object) -> None:
+            def create(self, **_kwargs: object) -> None:
                 response = httpx.Response(403, request=httpx.Request("POST", "https://vertex.test"))
                 message = "denied"
                 raise PermissionDeniedError(message, response=response, body={"error": "denied"})
 
-        class _RejectedClient:
-            def __init__(self, **_kwargs: object) -> None:
-                self.messages = _RejectedMessages()
+        class _RejectedModel:
+            def __init__(self, **kwargs: object) -> None:
+                self.id = str(kwargs["id"])
 
-        monkeypatch.setattr("mindroom.cli.doctor.AnthropicVertex", _RejectedClient)
+            def get_request_params(self) -> dict[str, object]:
+                return {"timeout": 10}
+
+            def get_client(self) -> SimpleNamespace:
+                return SimpleNamespace(messages=_RejectedMessages())
+
+        monkeypatch.setattr("mindroom.cli.doctor.VertexAIClaude", _RejectedModel)
 
         result = runner.invoke(app, ["doctor"])
         assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- validate `vertexai_claude` models through the actual runtime request path used for replies
- check each configured `vertexai_claude` model individually instead of only one provider-level smoke test
- use configured model `extra_kwargs` plus Vertex env defaults when building the runtime client

## Validation
- `pytest tests/test_cli_config.py -q`
- `pytest -q`
- `pre-commit run --all-files`
- `MINDROOM_CONFIG_PATH=$HOME/.mindroom/config.yaml uv run mindroom doctor` -> `6 passed, 0 failed, 0 warnings`