### PR TITLE
Enable stop button by default

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -240,7 +240,7 @@ defaults:
   learning: true                        # Enable Agno Learning
   learning_mode: always                 # "always" or "agentic"
   max_preload_chars: 50000              # Hard cap for preloaded context from context_files
-  show_stop_button: false               # Show a stop button while agent is responding (global-only, cannot be overridden per-agent)
+  show_stop_button: true                # Show a stop button while agent is responding (global-only, cannot be overridden per-agent)
   num_history_runs: null                # Number of prior runs to include (null = all)
   num_history_messages: null            # Max messages from history (null = use num_history_runs)
   enable_streaming: true                # Stream agent responses via progressive message edits

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -146,7 +146,7 @@ defaults:
   learning: true                   # Default: true
   learning_mode: always            # Default: always (or agentic)
   max_preload_chars: 50000         # Hard cap for preloaded context from context_files
-  show_stop_button: false          # Default: false (global only, cannot be overridden per-agent)
+  show_stop_button: true           # Default: true (global only, cannot be overridden per-agent)
   num_history_runs: null           # Number of prior runs to include (null = all)
   num_history_messages: null       # Max messages from history (null = use num_history_runs)
   compress_tool_results: true      # Compress tool results in history to save context

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -761,7 +761,7 @@ defaults:
   learning: true                   # Default: true
   learning_mode: always            # Default: always (or agentic)
   max_preload_chars: 50000         # Hard cap for preloaded context from context_files
-  show_stop_button: false          # Default: false (global only, cannot be overridden per-agent)
+  show_stop_button: true           # Default: true (global only, cannot be overridden per-agent)
   num_history_runs: null           # Number of prior runs to include (null = all)
   num_history_messages: null       # Max messages from history (null = use num_history_runs)
   compress_tool_results: true      # Compress tool results in history to save context
@@ -1108,7 +1108,7 @@ defaults:
   learning: true                        # Enable Agno Learning
   learning_mode: always                 # "always" or "agentic"
   max_preload_chars: 50000              # Hard cap for preloaded context from context_files
-  show_stop_button: false               # Show a stop button while agent is responding (global-only, cannot be overridden per-agent)
+  show_stop_button: true                # Show a stop button while agent is responding (global-only, cannot be overridden per-agent)
   num_history_runs: null                # Number of prior runs to include (null = all)
   num_history_messages: null            # Max messages from history (null = use num_history_runs)
   enable_streaming: true                # Stream agent responses via progressive message edits

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -221,7 +221,7 @@ defaults:
   learning: true                        # Enable Agno Learning
   learning_mode: always                 # "always" or "agentic"
   max_preload_chars: 50000              # Hard cap for preloaded context from context_files
-  show_stop_button: false               # Show a stop button while agent is responding (global-only, cannot be overridden per-agent)
+  show_stop_button: true                # Show a stop button while agent is responding (global-only, cannot be overridden per-agent)
   num_history_runs: null                # Number of prior runs to include (null = all)
   num_history_messages: null            # Max messages from history (null = use num_history_runs)
   enable_streaming: true                # Stream agent responses via progressive message edits

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -142,7 +142,7 @@ defaults:
   learning: true                   # Default: true
   learning_mode: always            # Default: always (or agentic)
   max_preload_chars: 50000         # Hard cap for preloaded context from context_files
-  show_stop_button: false          # Default: false (global only, cannot be overridden per-agent)
+  show_stop_button: true           # Default: true (global only, cannot be overridden per-agent)
   num_history_runs: null           # Number of prior runs to include (null = all)
   num_history_messages: null       # Max messages from history (null = use num_history_runs)
   compress_tool_results: true      # Compress tool results in history to save context

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -22,7 +22,7 @@ class DefaultsConfig(BaseModel):
         default=True,
         description="Enable streaming responses via progressive message edits",
     )
-    show_stop_button: bool = Field(default=False, description="Whether to automatically show stop button on messages")
+    show_stop_button: bool = Field(default=True, description="Whether to automatically show stop button on messages")
     learning: bool = Field(default=True, description="Default Agno Learning setting")
     learning_mode: AgentLearningMode = Field(default="always", description="Default Agno Learning mode")
     num_history_runs: int | None = Field(

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -362,7 +362,7 @@ def test_save_config(test_client: TestClient, temp_config_file: Path) -> None:
         "tools": ["scheduler"],
         "markdown": True,
         "enable_streaming": True,
-        "show_stop_button": False,
+        "show_stop_button": True,
         "learning": True,
         "learning_mode": "always",
         "compress_tool_results": True,

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -50,6 +50,11 @@ class TestHistoryConfig:
         assert defaults.num_history_runs is None
         assert defaults.num_history_messages is None
 
+    def test_show_stop_button_default_true(self) -> None:
+        """DefaultsConfig.show_stop_button defaults to True."""
+        defaults = DefaultsConfig()
+        assert defaults.show_stop_button is True
+
     def test_agent_config_history_defaults_none(self) -> None:
         """AgentConfig history fields default to None (inherit from defaults)."""
         agent = AgentConfig(display_name="Test")


### PR DESCRIPTION
## Summary
- make `defaults.show_stop_button` default to `true`
- update config serialization and tests to match the new default
- refresh configuration docs and generated `mindroom-docs` skill references

## Testing
- `pytest tests/test_cli_config.py tests/test_agno_history.py tests/api/test_api.py -q`
- `pytest`
- `pre-commit run --all-files`