### PR TITLE
Fix instance startup probe for smoke deploys

### DIFF
--- a/cluster/k8s/instance/templates/deployment-mindroom.yaml
+++ b/cluster/k8s/instance/templates/deployment-mindroom.yaml
@@ -98,10 +98,10 @@ spec:
           limits:
             memory: "2Gi"
             cpu: "1000m"
-        # First boot registers Matrix users, creates rooms, and initializes knowledge.
+        # Startup only needs the API process to bind the socket; readiness waits for full bootstrap.
         startupProbe:
           httpGet:
-            path: /api/ready
+            path: /api/health
             port: api
           periodSeconds: 2
           failureThreshold: 90


### PR DESCRIPTION
## Summary
- switch the instance `startupProbe` to `/api/health` so startup only depends on the API server binding
- keep `readinessProbe` on `/api/ready` so rollout availability still waits for full MindRoom bootstrap
- fix the `Smoke Stacks` rollout timeout seen on `main` when startup was gated on readiness

## Testing
- `bash cluster/k8s/kind/up.sh`
- `bash cluster/k8s/kind/build_load_images.sh`
- `bash cluster/k8s/kind/install_platform.sh`
- `bash cluster/k8s/kind/smoke_instance.sh`
- `just test-backend`
- `pre-commit run --all-files`