### PR TITLE
Supervise auxiliary runtime tasks

### DIFF
--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import time
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -50,6 +51,8 @@ _MATRIX_HOMESERVER_REQUEST_TIMEOUT_SECONDS = 5.0
 _MATRIX_HOMESERVER_RETRY_INTERVAL_SECONDS = 2.0
 _STARTUP_RETRY_INITIAL_DELAY_SECONDS = 2.0
 _STARTUP_RETRY_MAX_DELAY_SECONDS = 60.0
+_AUXILIARY_TASK_RESTART_INITIAL_DELAY_SECONDS = 1.0
+_AUXILIARY_TASK_RESTART_MAX_DELAY_SECONDS = 30.0
 _PERMANENT_STARTUP_ERROR_MARKERS = (
     "M_FORBIDDEN",
     "M_USER_DEACTIVATED",
@@ -1082,7 +1085,7 @@ async def _sync_forever_with_restart(bot: AgentBot | TeamBot, max_retries: int =
             await asyncio.sleep(wait_time)
 
 
-async def _handle_config_change(orchestrator: MultiAgentOrchestrator, stop_watching: asyncio.Event) -> None:
+async def _handle_config_change(orchestrator: MultiAgentOrchestrator) -> None:
     """Handle configuration file changes."""
     logger.info("Configuration file changed, checking for updates...")
     if orchestrator.running:
@@ -1091,18 +1094,17 @@ async def _handle_config_change(orchestrator: MultiAgentOrchestrator, stop_watch
             logger.info("Configuration update applied to affected agents")
         else:
             logger.info("No agent changes detected in configuration update")
-    if not orchestrator.running:
-        stop_watching.set()
+        return
+    logger.info("Ignoring config change while startup is still in progress")
 
 
 async def _watch_config_task(config_path: Path, orchestrator: MultiAgentOrchestrator) -> None:
     """Watch config file for changes."""
-    stop_watching = asyncio.Event()
 
     async def on_config_change() -> None:
-        await _handle_config_change(orchestrator, stop_watching)
+        await _handle_config_change(orchestrator)
 
-    await watch_file(config_path, on_config_change, stop_watching)
+    await watch_file(config_path, on_config_change)
 
 
 async def _watch_skills_task(orchestrator: MultiAgentOrchestrator) -> None:
@@ -1127,6 +1129,55 @@ async def _run_api_server(host: str, port: int, log_level: str) -> None:
     config = uvicorn.Config(api_app, host=host, port=port, log_level=log_level.lower())
     server = uvicorn.Server(config)
     await server.serve()
+
+
+async def _run_auxiliary_task_forever(
+    task_name: str,
+    operation: Callable[[], Awaitable[None]],
+    *,
+    initial_delay_seconds: float = _AUXILIARY_TASK_RESTART_INITIAL_DELAY_SECONDS,
+    max_delay_seconds: float = _AUXILIARY_TASK_RESTART_MAX_DELAY_SECONDS,
+) -> None:
+    """Restart a non-critical background task whenever it exits or crashes."""
+    restart_count = 0
+    while True:
+        started_at = time.monotonic()
+        try:
+            await operation()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            if time.monotonic() - started_at >= max_delay_seconds:
+                restart_count = 0
+            restart_count += 1
+            retry_in_seconds = _retry_delay_seconds(
+                restart_count,
+                initial_delay_seconds=initial_delay_seconds,
+                max_delay_seconds=max_delay_seconds,
+            )
+            logger.exception(
+                "Auxiliary task crashed; restarting",
+                task_name=task_name,
+                restart_count=restart_count,
+                retry_in_seconds=retry_in_seconds,
+            )
+            await asyncio.sleep(retry_in_seconds)
+        else:
+            if time.monotonic() - started_at >= max_delay_seconds:
+                restart_count = 0
+            restart_count += 1
+            retry_in_seconds = _retry_delay_seconds(
+                restart_count,
+                initial_delay_seconds=initial_delay_seconds,
+                max_delay_seconds=max_delay_seconds,
+            )
+            logger.warning(
+                "Auxiliary task exited unexpectedly; restarting",
+                task_name=task_name,
+                restart_count=restart_count,
+                retry_in_seconds=retry_in_seconds,
+            )
+            await asyncio.sleep(retry_in_seconds)
 
 
 async def main(
@@ -1167,51 +1218,55 @@ async def main(
     logger.info("Starting orchestrator...")
     orchestrator = MultiAgentOrchestrator(storage_path=storage_path)
     set_runtime_starting()
+    auxiliary_tasks: list[asyncio.Task] = []
 
     try:
-        # Create task to run the orchestrator
-        orchestrator_task = asyncio.create_task(orchestrator.start())
-
-        # Create task to watch config file for changes
-        watcher_task = asyncio.create_task(_watch_config_task(config_path, orchestrator))
-
-        # Create task to watch skills for changes
-        skills_watcher_task = asyncio.create_task(_watch_skills_task(orchestrator))
-
-        tasks = {orchestrator_task, watcher_task, skills_watcher_task}
+        # Keep auxiliary tasks alive independently of the main runtime task.
+        auxiliary_tasks.append(
+            asyncio.create_task(
+                _run_auxiliary_task_forever(
+                    "config watcher",
+                    lambda: _watch_config_task(config_path, orchestrator),
+                ),
+                name="config_watcher_supervisor",
+            ),
+        )
+        auxiliary_tasks.append(
+            asyncio.create_task(
+                _run_auxiliary_task_forever(
+                    "skills watcher",
+                    lambda: _watch_skills_task(orchestrator),
+                ),
+                name="skills_watcher_supervisor",
+            ),
+        )
 
         # Optionally start the bundled dashboard/API server
         if api:
             logger.info("Starting bundled dashboard/API server on %s:%d", api_host, api_port)
-            api_task = asyncio.create_task(_run_api_server(api_host, api_port, log_level))
-            tasks.add(api_task)
+            auxiliary_tasks.append(
+                asyncio.create_task(
+                    _run_auxiliary_task_forever(
+                        "bundled API server",
+                        lambda: _run_api_server(api_host, api_port, log_level),
+                    ),
+                    name="api_server_supervisor",
+                ),
+            )
 
-        # Wait for any task to complete (or fail)
-        done, pending = await asyncio.wait(
-            tasks,
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-
-        # Check if any completed task had an exception
-        for task in done:
-            try:
-                task.result()
-            except asyncio.CancelledError:
-                logger.info("Task was cancelled")
-            except Exception:
-                logger.exception("Task failed with exception")
-
-        # Cancel any pending tasks
-        for task in pending:
-            task.cancel()
-            with suppress(asyncio.CancelledError):
-                await task
+        await orchestrator.start()
 
     except KeyboardInterrupt:
         logger.info("Multi-agent bot system stopped by user")
     except Exception:
         logger.exception("Error in orchestrator")
+        raise
     finally:
+        for task in auxiliary_tasks:
+            task.cancel()
+        for task in auxiliary_tasks:
+            with suppress(asyncio.CancelledError):
+                await task
         # Final cleanup
         await orchestrator.stop()
         reset_runtime_state()

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -34,6 +34,7 @@ from mindroom.media_inputs import MediaInputs
 from mindroom.orchestrator import (
     MultiAgentOrchestrator,
     _matrix_homeserver_startup_timeout_seconds_from_env,
+    _run_auxiliary_task_forever,
     _run_with_retry,
     _wait_for_matrix_homeserver,
 )
@@ -3265,6 +3266,78 @@ class TestMultiAgentOrchestrator:
 
         assert "general" in orchestrator.agent_bots
         mock_schedule_retry.assert_awaited_once_with("general")
+
+    @pytest.mark.asyncio
+    async def test_run_auxiliary_task_forever_restarts_after_failure(self) -> None:
+        """Auxiliary supervisors should restart tasks that crash."""
+        started = asyncio.Event()
+        calls = 0
+
+        async def _operation() -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                msg = "boom"
+                raise RuntimeError(msg)
+            started.set()
+            await asyncio.Future()
+
+        task = asyncio.create_task(
+            _run_auxiliary_task_forever(
+                "test task",
+                _operation,
+                initial_delay_seconds=0,
+                max_delay_seconds=0,
+            ),
+        )
+
+        await asyncio.wait_for(started.wait(), timeout=1)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert calls == 2
+
+    @pytest.mark.asyncio
+    async def test_run_auxiliary_task_forever_resets_backoff_after_healthy_run(self) -> None:
+        """Long healthy runs should reset crash-loop backoff for auxiliary tasks."""
+        retry_attempts: list[int] = []
+        calls = 0
+        third_start = asyncio.Event()
+
+        async def _operation() -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                await asyncio.sleep(0.02)
+            if calls == 3:
+                third_start.set()
+                await asyncio.Future()
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        with (
+            patch(
+                "mindroom.orchestrator._retry_delay_seconds",
+                side_effect=lambda attempt, **_: retry_attempts.append(attempt) or 0,
+            ),
+        ):
+            task = asyncio.create_task(
+                _run_auxiliary_task_forever(
+                    "test task",
+                    _operation,
+                    initial_delay_seconds=1,
+                    max_delay_seconds=0.01,
+                ),
+            )
+            await asyncio.wait_for(third_start.wait(), timeout=1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert calls == 3
+        assert retry_attempts == [1, 1]
 
     @pytest.mark.asyncio
     async def test_run_with_retry_can_skip_runtime_state_updates(self) -> None:


### PR DESCRIPTION
## Summary
- supervise the config watcher, skills watcher, and bundled API server independently of the main runtime task
- keep auxiliary tasks restarting with bounded backoff instead of tearing down the whole process on a single exit
- add focused regression coverage for auxiliary task restart behavior

## Verification
- uv run pytest tests/test_multi_agent_bot.py -k 'run_auxiliary_task_forever or run_with_retry_can_skip_runtime_state_updates or schedule_knowledge_refresh_retries_until_success or update_config_keeps_failed_new_bot or orchestrator_start_schedules_retry_for_failed_agents'
- pre-commit run --all-files

Stacked on #330.