### PR TITLE
Invite owners to root Matrix spaces

### DIFF
--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -871,22 +871,22 @@ class MultiAgentOrchestrator:
 
         normalized_room_ids = room_ids if isinstance(room_ids, dict) else {}
         root_space_id = await ensure_root_space(router_bot.client, config, normalized_room_ids)
-        if root_space_id is None or config.mindroom_user is None:
+        if root_space_id is None:
             return
 
-        user_id = config.get_mindroom_user_id()
-        if user_id is None:
+        invite_user_ids = _get_root_space_user_ids_to_invite(config)
+        if not invite_user_ids:
             return
 
         current_members = await get_room_members(router_bot.client, root_space_id)
-        if user_id in current_members:
-            return
-
-        success = await invite_to_room(router_bot.client, root_space_id, user_id)
-        if success:
-            logger.info(f"Invited internal user {user_id} to root space {root_space_id}")
-        else:
-            logger.warning(f"Failed to invite internal user {user_id} to root space {root_space_id}")
+        for user_id in sorted(invite_user_ids):
+            if user_id in current_members:
+                continue
+            success = await invite_to_room(router_bot.client, root_space_id, user_id)
+            if success:
+                logger.info(f"Invited user {user_id} to root space {root_space_id}")
+            else:
+                logger.warning(f"Failed to invite user {user_id} to root space {root_space_id}")
 
     async def _ensure_room_invitations(self) -> None:  # noqa: C901, PLR0912
         """Ensure all agents and the user are invited to their configured rooms.
@@ -994,20 +994,36 @@ def _is_concrete_matrix_user_id(user_id: str) -> bool:
     )
 
 
+def _filter_concrete_matrix_user_ids(user_ids: set[str], *, warning_message: str) -> set[str]:
+    """Return inviteable Matrix user IDs and log skipped wildcard or placeholder entries."""
+    concrete_user_ids = {user_id for user_id in user_ids if _is_concrete_matrix_user_id(user_id)}
+    skipped = sorted(user_ids - concrete_user_ids)
+    if skipped:
+        logger.warning(warning_message, user_ids=skipped)
+    return concrete_user_ids
+
+
 def _get_authorized_user_ids_to_invite(config: Config) -> set[str]:
     """Collect Matrix users from authorization config that can be invited."""
     user_ids = set(config.authorization.global_users)
     for room_users in config.authorization.room_permissions.values():
         user_ids.update(room_users)
+    return _filter_concrete_matrix_user_ids(
+        user_ids,
+        warning_message="Skipping non-concrete authorization user IDs for invites",
+    )
 
-    concrete_user_ids = {user_id for user_id in user_ids if _is_concrete_matrix_user_id(user_id)}
-    skipped = sorted(user_ids - concrete_user_ids)
-    if skipped:
-        logger.warning(
-            "Skipping non-concrete authorization user IDs for invites",
-            user_ids=skipped,
-        )
-    return concrete_user_ids
+
+def _get_root_space_user_ids_to_invite(config: Config) -> set[str]:
+    """Collect Matrix users that should be invited to the private root Space."""
+    user_ids = _filter_concrete_matrix_user_ids(
+        set(config.authorization.global_users),
+        warning_message="Skipping non-concrete global user IDs for root space invites",
+    )
+    internal_user_id = config.get_mindroom_user_id()
+    if internal_user_id is not None:
+        user_ids.add(internal_user_id)
+    return user_ids
 
 
 def _get_changed_agents(config: Config | None, new_config: Config, agent_bots: dict[str, Any]) -> set[str]:

--- a/tests/test_matrix_spaces.py
+++ b/tests/test_matrix_spaces.py
@@ -303,13 +303,17 @@ async def test_ensure_root_space_returns_none_when_child_link_fails() -> None:
 
 
 @pytest.mark.asyncio
-async def test_orchestrator_ensure_root_space_invites_internal_user(tmp_path) -> None:  # noqa: ANN001
-    """The orchestrator should invite the internal user to the root Space when configured."""
+async def test_orchestrator_ensure_root_space_invites_internal_and_authorized_users(tmp_path) -> None:  # noqa: ANN001
+    """The orchestrator should invite both the internal user and authorized users to the root Space."""
     orchestrator = MultiAgentOrchestrator(storage_path=tmp_path)
     orchestrator.config = Config(
         agents={"general": {"display_name": "General", "rooms": ["lobby"]}},
         matrix_space={"enabled": True},
         mindroom_user={"username": "mindroom_user", "display_name": "MindRoomUser"},
+        authorization={
+            "global_users": ["@owner:example.com"],
+            "room_permissions": {"lobby": ["@collaborator:example.com"]},
+        },
     )
     router_bot = MagicMock()
     router_bot.client = AsyncMock()
@@ -327,10 +331,37 @@ async def test_orchestrator_ensure_root_space_invites_internal_user(tmp_path) ->
         orchestrator.config,
         {"lobby": "!lobby:localhost"},
     )
+    # Should have invited both the internal user and the authorized owner
+    invited_user_ids = {c.args[2] for c in mock_invite.await_args_list}
+    assert orchestrator.config.get_mindroom_user_id() in invited_user_ids
+    assert "@owner:example.com" in invited_user_ids
+    assert "@collaborator:example.com" not in invited_user_ids
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_ensure_root_space_invites_authorized_user_without_internal_user(tmp_path) -> None:  # noqa: ANN001
+    """The root Space should still invite the owner when no internal user exists."""
+    orchestrator = MultiAgentOrchestrator(storage_path=tmp_path)
+    orchestrator.config = Config(
+        agents={"general": {"display_name": "General", "rooms": ["lobby"]}},
+        matrix_space={"enabled": True},
+        authorization={"global_users": ["@owner:example.com"]},
+    )
+    router_bot = MagicMock()
+    router_bot.client = AsyncMock()
+    orchestrator.agent_bots[ROUTER_AGENT_NAME] = router_bot
+
+    with (
+        patch("mindroom.orchestrator.ensure_root_space", new=AsyncMock(return_value="!space:localhost")),
+        patch("mindroom.orchestrator.get_room_members", new=AsyncMock(return_value={"@mindroom_router:localhost"})),
+        patch("mindroom.orchestrator.invite_to_room", new=AsyncMock(return_value=True)) as mock_invite,
+    ):
+        await orchestrator._ensure_root_space({"lobby": "!lobby:localhost"})
+
     mock_invite.assert_awaited_once_with(
         router_bot.client,
         "!space:localhost",
-        orchestrator.config.get_mindroom_user_id(),
+        "@owner:example.com",
     )
 
 


### PR DESCRIPTION
## Summary
- invite root Space members from `authorization.global_users` as well as the internal `mindroom_user`
- keep room-specific collaborators out of the root Space so the workspace shell stays scoped to global users
- share the concrete Matrix user-id filtering logic between room invites and root Space invites

## Root cause
The merged root Space code only invited `mindroom_user` after creating or reconciling the Space. On self-hosted installs, the human owner lives in `authorization.global_users`, so the owner never received a Space invite.

## Testing
- pre-commit run --all-files
- pytest -q