### PR TITLE
Add MindRoom logo avatar for root Matrix spaces

### DIFF
--- a/avatars/spaces/root_space.png
+++ b/avatars/spaces/root_space.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d492ede8282c611bf277b4b85e766c031787b6b00160a726bedac9aba93fde21
+size 106832

--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -37,6 +37,47 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 _ROOT_SPACE_TOPIC = "Your MindRoom AI workspace"
+_ROOT_SPACE_AVATAR_KEY = "root_space"
+_AVATARS_DIR = Path(__file__).resolve().parents[3] / "avatars"
+
+
+def _managed_avatar_path(category: str, avatar_name: str) -> Path:
+    """Return the bundled avatar path for a managed room-like entity."""
+    return _AVATARS_DIR / category / f"{avatar_name}.png"
+
+
+async def _set_room_avatar_if_available(
+    client: nio.AsyncClient,
+    room_id: str,
+    *,
+    avatar_category: str,
+    avatar_name: str,
+    context: str,
+) -> None:
+    """Set a room avatar when a bundled asset exists.
+
+    Avatar reconciliation is cosmetic, so failures are logged but do not abort
+    room or Space creation.
+    """
+    avatar_path = _managed_avatar_path(avatar_category, avatar_name)
+    if not avatar_path.exists():
+        return
+
+    if await check_and_set_avatar(client, avatar_path, room_id=room_id):
+        logger.info(
+            "Set avatar for managed Matrix room",
+            room_id=room_id,
+            avatar_path=str(avatar_path),
+            context=context,
+        )
+        return
+
+    logger.warning(
+        "Failed to set avatar for managed Matrix room",
+        room_id=room_id,
+        avatar_path=str(avatar_path),
+        context=context,
+    )
 
 
 async def _configure_managed_room_access(
@@ -303,14 +344,13 @@ async def _ensure_room_exists(  # noqa: C901, PLR0912
                 directory_visibility="private",
             )
 
-        # Set room avatar if available (for newly created rooms)
-        # Note: Avatars can also be updated later using scripts/generate_avatars.py
-        avatar_path = Path(__file__).parent.parent.parent.parent / "avatars" / "rooms" / f"{room_key}.png"
-        if avatar_path.exists():
-            if await check_and_set_avatar(client, avatar_path, room_id=created_room_id):
-                logger.info(f"Set avatar for newly created room {room_key}")
-            else:
-                logger.warning(f"Failed to set avatar for room {room_key}")
+        await _set_room_avatar_if_available(
+            client,
+            created_room_id,
+            avatar_category="rooms",
+            avatar_name=room_key,
+            context=f"managed_room:{room_key}",
+        )
 
         return created_room_id
     logger.error(f"Failed to create room {room_key}")
@@ -440,6 +480,14 @@ async def ensure_root_space(
                 room_id=room_id,
             )
             return None
+
+    await _set_room_avatar_if_available(
+        client,
+        root_space_id,
+        avatar_category="spaces",
+        avatar_name=_ROOT_SPACE_AVATAR_KEY,
+        context="root_space",
+    )
 
     return root_space_id
 

--- a/tests/test_matrix_spaces.py
+++ b/tests/test_matrix_spaces.py
@@ -162,6 +162,7 @@ async def test_ensure_root_space_creates_space_links_rooms_and_persists_state() 
         patch("mindroom.matrix.rooms.create_space", new=AsyncMock(return_value="!space:localhost")) as mock_create,
         patch("mindroom.matrix.rooms.ensure_room_name", new=AsyncMock(return_value=True)) as mock_name,
         patch("mindroom.matrix.rooms.add_room_to_space", new=AsyncMock(return_value=True)) as mock_add,
+        patch("mindroom.matrix.rooms._set_room_avatar_if_available", new=AsyncMock()) as mock_avatar,
     ):
         space_id = await matrix_rooms.ensure_root_space(
             client,
@@ -178,6 +179,13 @@ async def test_ensure_root_space_creates_space_links_rooms_and_persists_state() 
         call(client, "!space:localhost", "!lobby:localhost", "localhost"),
         call(client, "!space:localhost", "!dev:localhost", "localhost"),
     ]
+    mock_avatar.assert_awaited_once_with(
+        client,
+        "!space:localhost",
+        avatar_category="spaces",
+        avatar_name="root_space",
+        context="root_space",
+    )
 
 
 @pytest.mark.asyncio
@@ -205,6 +213,7 @@ async def test_ensure_root_space_resolves_existing_alias_without_recreating() ->
         patch("mindroom.matrix.rooms.create_space", new=AsyncMock()) as mock_create,
         patch("mindroom.matrix.rooms.ensure_room_name", new=AsyncMock(return_value=True)) as mock_name,
         patch("mindroom.matrix.rooms.add_room_to_space", new=AsyncMock(return_value=True)) as mock_add,
+        patch("mindroom.matrix.rooms._set_room_avatar_if_available", new=AsyncMock()) as mock_avatar,
     ):
         space_id = await matrix_rooms.ensure_root_space(client, config, {"lobby": "!lobby:localhost"})
 
@@ -215,6 +224,13 @@ async def test_ensure_root_space_resolves_existing_alias_without_recreating() ->
     mock_create.assert_not_awaited()
     mock_name.assert_awaited_once_with(client, "!space:localhost", "Workspace")
     mock_add.assert_awaited_once_with(client, "!space:localhost", "!lobby:localhost", "localhost")
+    mock_avatar.assert_awaited_once_with(
+        client,
+        "!space:localhost",
+        avatar_category="spaces",
+        avatar_name="root_space",
+        context="root_space",
+    )
 
 
 @pytest.mark.asyncio
@@ -242,6 +258,7 @@ async def test_ensure_root_space_skips_existing_alias_when_router_cannot_join() 
         patch("mindroom.matrix.rooms.create_space", new=AsyncMock()) as mock_create,
         patch("mindroom.matrix.rooms.ensure_room_name", new=AsyncMock(return_value=True)) as mock_name,
         patch("mindroom.matrix.rooms.add_room_to_space", new=AsyncMock(return_value=True)) as mock_add,
+        patch("mindroom.matrix.rooms._set_room_avatar_if_available", new=AsyncMock()) as mock_avatar,
     ):
         space_id = await matrix_rooms.ensure_root_space(client, config, {"lobby": "!lobby:localhost"})
 
@@ -252,6 +269,7 @@ async def test_ensure_root_space_skips_existing_alias_when_router_cannot_join() 
     mock_create.assert_not_awaited()
     mock_name.assert_not_awaited()
     mock_add.assert_not_awaited()
+    mock_avatar.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -271,11 +289,13 @@ async def test_ensure_root_space_returns_none_when_name_write_fails() -> None:
         patch("mindroom.matrix.rooms.get_joined_rooms", new=AsyncMock(return_value=["!space:localhost"])),
         patch("mindroom.matrix.rooms.ensure_room_name", new=AsyncMock(return_value=False)),
         patch("mindroom.matrix.rooms.add_room_to_space", new=AsyncMock(return_value=True)) as mock_add,
+        patch("mindroom.matrix.rooms._set_room_avatar_if_available", new=AsyncMock()) as mock_avatar,
     ):
         space_id = await matrix_rooms.ensure_root_space(client, config, {"lobby": "!lobby:localhost"})
 
     assert space_id is None
     mock_add.assert_not_awaited()
+    mock_avatar.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -295,11 +315,13 @@ async def test_ensure_root_space_returns_none_when_child_link_fails() -> None:
         patch("mindroom.matrix.rooms.get_joined_rooms", new=AsyncMock(return_value=["!space:localhost"])),
         patch("mindroom.matrix.rooms.ensure_room_name", new=AsyncMock(return_value=True)),
         patch("mindroom.matrix.rooms.add_room_to_space", new=AsyncMock(return_value=False)) as mock_add,
+        patch("mindroom.matrix.rooms._set_room_avatar_if_available", new=AsyncMock()) as mock_avatar,
     ):
         space_id = await matrix_rooms.ensure_root_space(client, config, {"lobby": "!lobby:localhost"})
 
     assert space_id is None
     mock_add.assert_awaited_once_with(client, "!space:localhost", "!lobby:localhost", "localhost")
+    mock_avatar.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- set the root Matrix Space avatar from a bundled MindRoom logo asset after successful reconciliation
- reuse the same non-blocking room avatar helper for managed rooms and the root Space
- cover successful and failure reconciliation paths in the Space tests

## Testing
- pre-commit run --all-files
- pytest -q tests/test_matrix_spaces.py tests/test_matrix_room_access.py
- pytest -q