### PR TITLE
Fix Anthropic image uploads on Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "croniter>=6",
   "diskcache>=5.6.3",
   "fastapi[standard]>=0.116.1",
+  "filetype>=1.2",
   "google-genai",
   "groq>=0.31",
   "httpx>=0.27",

--- a/tests/test_image_handler.py
+++ b/tests/test_image_handler.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 from agno.media import Image
+from agno.utils.models.claude import _format_image_for_message
 
 from mindroom.matrix import image_handler
 from mindroom.matrix.media import _sniff_image_mime_type, extract_media_caption, resolve_image_mime_type
@@ -284,6 +285,14 @@ class TestDownloadImage:
 
         assert isinstance(result, Image)
         assert result.mime_type is None
+
+    def test_anthropic_image_formatter_handles_raw_png_bytes(self) -> None:
+        """Anthropic image formatting should work for Matrix-downloaded image bytes."""
+        formatted = _format_image_for_message(Image(content=b"\x89PNG\r\n\x1a\npayload"))
+
+        assert formatted is not None
+        assert formatted["type"] == "image"
+        assert formatted["source"]["media_type"] == "image/png"
 
 
 class TestSniffImageMimeType:

--- a/uv.lock
+++ b/uv.lock
@@ -1679,6 +1679,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
 name = "firecrawl-py"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3190,6 +3199,7 @@ dependencies = [
     { name = "croniter" },
     { name = "diskcache" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "filetype" },
     { name = "google-genai" },
     { name = "groq" },
     { name = "httpx" },
@@ -3577,6 +3587,7 @@ requires-dist = [
     { name = "exa-py", marker = "extra == 'exa'" },
     { name = "fal-client", marker = "extra == 'fal'" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.116.1" },
+    { name = "filetype", specifier = ">=1.2.0" },
     { name = "firecrawl-py", marker = "extra == 'firecrawl'", specifier = ">=3" },
     { name = "google-api-python-client", marker = "extra == 'gmail'", specifier = ">=2.178" },
     { name = "google-api-python-client", marker = "extra == 'google-calendar'", specifier = ">=2.178" },


### PR DESCRIPTION
## Summary
- add `filetype` as a runtime dependency because Anthropic image formatting falls back to it on Python 3.13
- update the lockfile
- add a regression test for formatting raw PNG bytes through the Anthropic image path

## Testing
- pytest
- pre-commit run --all-files