### PR TITLE
Disable Agno telemetry by default

### DIFF
--- a/src/mindroom/__init__.py
+++ b/src/mindroom/__init__.py
@@ -1,8 +1,12 @@
 """MindRoom: A universal interface for AI agents with persistent memory."""
 
+import os
 from importlib.metadata import version
 
 from mindroom.constants import patch_chromadb_for_python314
+
+# MindRoom should never emit Agno network telemetry, even if a user .env enables it.
+os.environ["AGNO_TELEMETRY"] = "false"
 
 patch_chromadb_for_python314()
 

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+import os
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -16,6 +18,7 @@ from agno.run.base import RunStatus
 from agno.session.agent import AgentSession
 from pydantic import ValidationError
 
+import mindroom
 from mindroom.agents import (
     _get_agent_session,
     create_agent,
@@ -39,6 +42,15 @@ from mindroom.response_tracker import ResponseTracker
 # ---------------------------------------------------------------------------
 # Config tests
 # ---------------------------------------------------------------------------
+
+
+def test_mindroom_forces_agno_telemetry_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MindRoom startup hard-disables Agno telemetry regardless of env state."""
+    monkeypatch.setenv("AGNO_TELEMETRY", "true")
+
+    importlib.reload(mindroom)
+
+    assert os.environ["AGNO_TELEMETRY"] == "false"
 
 
 class TestHistoryConfig:


### PR DESCRIPTION
## Summary
- force `AGNO_TELEMETRY=false` during MindRoom startup so Agno run telemetry cannot be enabled by user env or `.env` values
- add a regression test that reloads `mindroom` and verifies telemetry stays disabled

## Testing
- `pytest`
- `pytest -q tests/test_agno_history.py -k telemetry`
- `pre-commit run --all-files`