### PR TITLE
fix: keep dedicated worker requests on the pinned worker root

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -418,6 +418,14 @@ def _worker_initialization_failure_response(
     return SandboxRunnerExecuteResponse(ok=False, error=str(exc))
 
 
+def _normalize_request_worker_key(request: SandboxRunnerExecuteRequest) -> SandboxRunnerExecuteRequest:
+    """Fill in the pinned worker key for dedicated worker pods when omitted."""
+    dedicated_worker_key = _runner_dedicated_worker_key()
+    if dedicated_worker_key is not None and request.worker_key is None:
+        request.worker_key = dedicated_worker_key
+    return request
+
+
 async def _execute_request_inprocess(request: SandboxRunnerExecuteRequest) -> SandboxRunnerExecuteResponse:
     runtime_overrides: dict[str, object] | None = None
     if request.worker_key is not None:
@@ -572,6 +580,7 @@ def _run_subprocess_worker() -> int:
             file=sys.stderr,
         )
         return 1
+    request = _normalize_request_worker_key(request)
 
     # Redirect stdout/stderr during tool execution so tool output doesn't
     # interfere with the protocol marker we write to stderr afterwards.
@@ -631,6 +640,7 @@ async def execute_tool_call(
     request: SandboxRunnerExecuteRequest,
 ) -> SandboxRunnerExecuteResponse:
     """Execute a tool function locally and return the serialized result."""
+    request = _normalize_request_worker_key(request)
     credential_overrides: dict[str, object] = {}
     if request.lease_id is not None:
         credential_overrides = _consume_credential_lease(

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -572,6 +572,62 @@ def test_dedicated_worker_mode_uses_mounted_root(
     assert worker_file.read_text(encoding="utf-8") == "hello from dedicated worker"
 
 
+def test_dedicated_worker_mode_defaults_missing_worker_key_to_pinned_worker(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dedicated worker mode should infer the pinned worker key when callers omit it."""
+    _set_sandbox_token(monkeypatch)
+    worker_root = tmp_path / "dedicated-worker"
+    monkeypatch.setenv("MINDROOM_SANDBOX_DEDICATED_WORKER_KEY", "worker-a")
+    monkeypatch.setenv("MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT", str(worker_root))
+
+    def fake_create(_self: object, venv_dir: Path) -> None:
+        (venv_dir / "bin").mkdir(parents=True, exist_ok=True)
+        (venv_dir / "bin" / "python").write_text("", encoding="utf-8")
+
+    def fake_run(
+        cmd: list[str],
+        **run_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        request_payload = json.loads(str(run_kwargs["input"]))
+        assert request_payload["worker_key"] == "worker-a"
+
+        note_path = worker_root / "workspace" / request_payload["args"][1]
+        note_path.parent.mkdir(parents=True, exist_ok=True)
+        note_path.write_text(request_payload["args"][0], encoding="utf-8")
+
+        response = sandbox_runner_module.SandboxRunnerExecuteResponse(ok=True, result="saved")
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout="",
+            stderr=sandbox_runner_module._RESPONSE_MARKER + response.model_dump_json(),
+        )
+
+    with (
+        patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=fake_create),
+        patch("mindroom.api.sandbox_runner.subprocess.run", new=fake_run),
+    ):
+        save_response = runner_client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "file",
+                "function_name": "save_file",
+                "args": ["hello from inferred worker", "note.txt"],
+                "kwargs": {},
+            },
+        )
+
+    assert save_response.status_code == 200
+    assert save_response.json()["ok"] is True
+
+    worker_file = worker_root / "workspace" / "note.txt"
+    assert worker_file.read_text(encoding="utf-8") == "hello from inferred worker"
+
+
 def test_dedicated_worker_mode_rejects_mismatched_worker_key(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- default missing `worker_key` values to the dedicated worker's pinned key
- normalize the request before both direct runner execution and subprocess worker execution
- add a regression test covering dedicated worker requests that omit `worker_key`

## Testing
- `uv run pytest -q tests/api/test_sandbox_runner_api.py -k 'dedicated_worker_mode_uses_mounted_root or dedicated_worker_mode_defaults_missing_worker_key_to_pinned_worker or dedicated_worker_mode_rejects_mismatched_worker_key'`\n- `uv run pytest -q tests/test_sandbox_proxy.py -k 'worker'`