### PR TITLE
Document Kubernetes worker backend

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -149,7 +149,7 @@ MindRoom stores data in the `mindroom_data` directory:
 
 When configured, `shell`, `file`, and `python` tool calls can be proxied to a separate **sandbox-runner** sidecar container. The sidecar runs the same image but without access to secrets, credentials, or the primary data volume. This provides real process-level isolation for code-execution tools. Without proxy configuration, all tools execute locally in the MindRoom process.
 
-See [Sandbox Proxy Isolation](sandbox-proxy.md) for full documentation including Docker Compose examples, Kubernetes sidecar setup, host-machine-with-container mode, credential leases, and environment variable reference.
+See [Sandbox Proxy Isolation](sandbox-proxy.md) for full documentation including Docker Compose examples, Kubernetes shared-sidecar and dedicated-worker modes, host-machine-with-container mode, credential leases, and environment variable reference.
 
 > [!TIP]
 > For production, use a reverse proxy (Traefik, Nginx) in front of the MindRoom container when you want TLS, host routing, or additional auth layers. See `local/instances/deploy/docker-compose.yml` for an example with Traefik labels.

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -51,6 +51,76 @@ helm upgrade --install instance-1 ./cluster/k8s/instance \
   --set supabaseServiceKey="your-service-key"
 ```
 
+## Worker Backends
+
+The instance chart supports two worker backend modes for worker-routed tools such as `shell`, `file`, and `python`.
+
+| Helm value | Behavior | Best for |
+|------------|----------|----------|
+| `workerBackend: static_runner` | Runs one shared sandbox-runner sidecar inside the main MindRoom pod | Simpler deployments and the current shared-worker model |
+| `workerBackend: kubernetes` | Creates dedicated worker Deployments and Services on demand from the primary runtime | Stronger isolation and persistent worker state per worker key |
+
+### Shared Sidecar Mode
+
+`workerBackend: static_runner` is the default.
+The primary runtime talks to a shared sidecar over `localhost`.
+This keeps the deployment simple, but all worker-routed tool calls share the same runner process.
+
+### Dedicated Worker Mode
+
+`workerBackend: kubernetes` enables the built-in Kubernetes worker backend.
+The primary runtime creates worker Deployments and Services on demand and routes tool calls to the resolved worker handle.
+Each worker pod runs the sandbox-runner app and mounts worker-owned state from the shared PVC under a worker-specific subpath.
+Idle cleanup scales worker Deployments to zero while preserving that state.
+
+Typical Helm values look like:
+
+```yaml
+workerBackend: kubernetes
+workerCleanupIntervalSeconds: 30
+storageAccessMode: ReadWriteMany
+controlPlaneNodeName: ""
+kubernetesWorkerImage: ""
+kubernetesWorkerImagePullPolicy: ""
+kubernetesWorkerServiceAccountName: ""
+kubernetesWorkerNamePrefix: "mindroom-worker"
+kubernetesWorkerStorageSubpathPrefix: "workers"
+kubernetesWorkerPort: 8766
+kubernetesWorkerReadyTimeoutSeconds: 60
+kubernetesWorkerIdleTimeoutSeconds: 1800
+sandbox_proxy_token: "replace-me"
+```
+
+Important behavior and constraints:
+
+- `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
+- `workerCleanupIntervalSeconds` controls how often the primary runtime runs idle-worker cleanup.
+- `kubernetesWorkerIdleTimeoutSeconds` controls when a worker is considered idle and eligible to scale down.
+- `kubernetesWorkerReadyTimeoutSeconds` controls how long the primary runtime waits for a worker Deployment to become ready.
+- `kubernetesWorkerPort` is the internal Service and container port used by dedicated workers.
+- The worker state lives on the shared instance PVC under `kubernetesWorkerStorageSubpathPrefix/<worker-dir>/`.
+
+### Storage Requirements
+
+Dedicated workers need access to the same PVC as the primary runtime.
+For multi-node operation, set `storageAccessMode: ReadWriteMany`.
+If your storage class only supports `ReadWriteOnce`, set `controlPlaneNodeName` so the control plane and dedicated workers stay on the same node.
+The chart enforces this constraint during template rendering.
+
+### RBAC And Network Policy
+
+When `workerBackend: kubernetes` is enabled, the chart creates:
+
+- A worker-manager ServiceAccount for the primary runtime.
+- A Role and RoleBinding that allow managing worker Deployments and Services in the instance namespace.
+- NetworkPolicy rules that allow the primary runtime to reach the internal worker port and allow worker traffic within the instance namespace.
+
+### Operations
+
+The authenticated dashboard API exposes `/api/workers` to list active or idle workers and `/api/workers/cleanup` to trigger cleanup manually.
+Dedicated workers are internal-only cluster Services and are authenticated with the shared `sandbox_proxy_token`.
+See [Sandbox Proxy Isolation](sandbox-proxy.md) for the execution model, credential leases, and non-Kubernetes deployment modes.
+
 ## Secrets Management
 
 API keys are mounted as files at `/etc/secrets/` (not environment variables). MindRoom reads paths from `*_API_KEY_FILE` environment variables:

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -4,32 +4,42 @@ icon: lucide/shield
 
 # Sandbox Proxy Isolation
 
-When agents have code-execution tools (`shell`, `file`, `python`), they can read and modify anything on the filesystem — config files, credentials, application code. The **sandbox proxy** isolates these tools by forwarding their calls to a separate process (the **sandbox runner**) that has no access to secrets or sensitive data.
+When agents have code-execution tools (`shell`, `file`, `python`), they can read and modify anything on the filesystem, including config files, credentials, and application code.
+The **sandbox proxy** isolates these tools by forwarding their calls to a separate worker runtime that has no direct access to the primary process secrets.
 
 ## How it works
 
 ```
 ┌──────────────────────────┐         HTTP          ┌──────────────────────────┐
-│ Primary MindRoom runtime │  ── tool call ──▶     │ Sandbox runner           │
-│ has secrets              │  ◀── result ───       │ no secrets               │
-│ has credentials          │                       │ no credentials           │
-│ has persistent data      │                       │ writable scratch only    │
+│ Primary MindRoom runtime │  ── tool call ──▶     │ Worker runtime           │
+│ has secrets              │  ◀── result ───       │ no primary secrets       │
+│ has credentials          │                       │ leased credentials only  │
+│ has orchestration state  │                       │ worker-owned state       │
 └──────────────────────────┘                       └──────────────────────────┘
 ```
 
-1. Agent invokes `shell.run_shell_command(...)` (or file/python tool)
-2. Primary MindRoom runtime detects the tool is in the proxy list
-3. Call is forwarded over HTTP to the sandbox runner
-4. Runner executes the tool locally and returns the result
-5. All other tools (API tools, search, etc.) execute in the primary MindRoom runtime as usual
+1. Agent invokes `shell.run_shell_command(...)` or another worker-routed tool.
+2. The primary MindRoom runtime resolves the target worker from the configured backend plus worker scope.
+3. The call is forwarded over HTTP to the target worker runtime.
+4. The worker executes the tool locally against its own state and returns the result.
+5. All other tools such as API tools or Matrix-bound tools execute in the primary MindRoom runtime as usual.
 
-The runner authenticates requests with a shared token (`MINDROOM_SANDBOX_PROXY_TOKEN`). For tools that need credentials (e.g., a shell tool that calls an authenticated API), the primary MindRoom runtime can create a short-lived **credential lease** that the runner consumes once — credentials never persist in the runner's memory.
+The worker runtime authenticates requests with a shared token (`MINDROOM_SANDBOX_PROXY_TOKEN`).
+For tools that need credentials, such as a shell tool that calls an authenticated API, the primary MindRoom runtime can create a short-lived **credential lease** that the worker consumes once.
+Credentials never become part of the normal tool arguments or the model prompt.
+
+MindRoom currently ships two worker backend shapes:
+
+- `static_runner`: one shared sandbox-runner process, usually a sidecar container or a local HTTP service.
+- `kubernetes`: dedicated worker pods created on demand from the primary runtime, with one logical worker per worker key.
 
 ## Deployment modes
 
-### Docker Compose (sidecar container)
+### Docker Compose (`static_runner`)
 
-Add a `sandbox-runner` service alongside MindRoom. Both use the same image; the runner just has a different entrypoint and no access to `.env` or the data volume.
+Add a `sandbox-runner` service alongside MindRoom.
+Both use the same image.
+The runner just has a different entrypoint and no access to `.env` or the primary data volume.
 
 ```yaml
 services:
@@ -40,6 +50,7 @@ services:
       - ./config.yaml:/app/config.yaml:ro
       - ./mindroom_data:/app/mindroom_data
     environment:
+      - MINDROOM_WORKER_BACKEND=static_runner
       - MINDROOM_SANDBOX_PROXY_URL=http://sandbox-runner:8766
       - MINDROOM_SANDBOX_PROXY_TOKEN=${MINDROOM_SANDBOX_PROXY_TOKEN}
       - MINDROOM_SANDBOX_EXECUTION_MODE=selective
@@ -74,12 +85,46 @@ Key differences from the primary MindRoom runtime:
 - **Scratch workspace** — a dedicated volume for file operations
 - **`MINDROOM_STORAGE_PATH`** — pointed at a writable location inside the workspace so the tool registry can initialize without access to the primary data volume
 
-### Kubernetes (pod sidecar)
+### Kubernetes shared sidecar (`workerBackend: static_runner`)
 
-In Kubernetes the runner runs as a second container in the same pod, sharing `localhost` networking. See `cluster/k8s/instance/templates/deployment-mindroom.yaml` for the full manifest. The runner gets:
-- An `emptyDir` volume for scratch workspace
-- Read-only access to config (for plugin tool registration)
-- No access to the secrets volume
+In Kubernetes the shared runner can still run as a second container in the same pod, sharing `localhost` networking.
+This is the `workerBackend: static_runner` Helm mode.
+See `cluster/k8s/instance/templates/deployment-mindroom.yaml` for the full manifest.
+The sidecar gets:
+
+- An `emptyDir` volume for scratch workspace.
+- Read-only access to config for plugin tool registration.
+- No access to the primary secrets volume.
+
+### Kubernetes dedicated workers (`workerBackend: kubernetes`)
+
+In dedicated-worker mode the primary MindRoom runtime creates worker Deployments and Services on demand.
+Each worker pod runs the sandbox-runner app and is addressed through an internal cluster Service.
+The worker state is mounted from the shared instance PVC under a worker-specific subpath, so files, virtualenvs, caches, sessions, and other worker-owned state survive pod recreation.
+Idle cleanup scales worker Deployments to zero while keeping the PVC-backed state intact.
+
+Use the instance Helm chart with values like:
+
+```yaml
+workerBackend: kubernetes
+workerCleanupIntervalSeconds: 30
+storageAccessMode: ReadWriteMany
+kubernetesWorkerPort: 8766
+kubernetesWorkerReadyTimeoutSeconds: 60
+kubernetesWorkerIdleTimeoutSeconds: 1800
+sandbox_proxy_token: "replace-me"
+```
+
+Important notes for this mode:
+
+- `storageAccessMode` should be `ReadWriteMany` for multi-node shared storage.
+- If you must keep `ReadWriteOnce`, set `controlPlaneNodeName` so the control plane and dedicated workers stay on the same node.
+- `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
+- The chart creates the worker-manager ServiceAccount, Role, RoleBinding, and worker-specific NetworkPolicy rules automatically when this backend is enabled.
+- The primary runtime does not need `MINDROOM_SANDBOX_PROXY_URL` in this mode because worker endpoints come from the Kubernetes worker handles.
+- The authenticated `/api/workers` and `/api/workers/cleanup` endpoints on the primary runtime expose backend-neutral worker lifecycle information.
+
+For the full Helm-side deployment guidance, see [Kubernetes Deployment](kubernetes.md).
 
 ### Host machine + Docker sandbox container
 
@@ -90,6 +135,7 @@ Run MindRoom directly on the host while isolating code-execution tools in a Dock
 docker run -d \
   --name mindroom-sandbox-runner \
   -p 8766:8766 \
+  -e MINDROOM_WORKER_BACKEND=static_runner \
   -e MINDROOM_SANDBOX_RUNNER_MODE=true \
   -e MINDROOM_SANDBOX_PROXY_TOKEN=your-secret-token \
   -e MINDROOM_STORAGE_PATH=/app/workspace/.mindroom \
@@ -97,6 +143,7 @@ docker run -d \
   /app/run-sandbox-runner.sh
 
 # 2. Start MindRoom on the host with proxy config
+export MINDROOM_WORKER_BACKEND=static_runner
 export MINDROOM_SANDBOX_PROXY_URL=http://localhost:8766
 export MINDROOM_SANDBOX_PROXY_TOKEN=your-secret-token
 export MINDROOM_SANDBOX_EXECUTION_MODE=selective
@@ -107,6 +154,7 @@ mindroom run
 Or add the proxy variables to your `.env` file:
 
 ```bash
+MINDROOM_WORKER_BACKEND=static_runner
 MINDROOM_SANDBOX_PROXY_URL=http://localhost:8766
 MINDROOM_SANDBOX_PROXY_TOKEN=your-secret-token
 MINDROOM_SANDBOX_EXECUTION_MODE=selective
@@ -136,13 +184,18 @@ This gives you the convenience of running MindRoom natively while keeping code-e
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `MINDROOM_SANDBOX_PROXY_URL` | URL of the sandbox runner | _(none — proxy disabled)_ |
-| `MINDROOM_SANDBOX_PROXY_TOKEN` | Shared auth token | _(required when proxy URL is set)_ |
+| `MINDROOM_WORKER_BACKEND` | Worker backend name: `static_runner` or `kubernetes` | `static_runner` |
+| `MINDROOM_SANDBOX_PROXY_URL` | URL of the shared sandbox runner when using `static_runner` | _(none — proxy disabled for `static_runner`)_ |
+| `MINDROOM_SANDBOX_PROXY_TOKEN` | Shared auth token used by the worker runtime | _(required for worker-routed execution)_ |
 | `MINDROOM_SANDBOX_EXECUTION_MODE` | `selective`, `all`, `off` | _(unset — uses proxy tools list)_ |
 | `MINDROOM_SANDBOX_PROXY_TOOLS` | Comma-separated tool names to proxy | `*` (all, unless mode is `selective`) |
 | `MINDROOM_SANDBOX_PROXY_TIMEOUT_SECONDS` | HTTP timeout for proxy calls | `120` |
 | `MINDROOM_SANDBOX_CREDENTIAL_LEASE_TTL_SECONDS` | Credential lease lifetime | `60` |
 | `MINDROOM_SANDBOX_CREDENTIAL_POLICY_JSON` | JSON mapping tool selectors to credential services | `{}` |
+
+When `MINDROOM_WORKER_BACKEND=kubernetes`, the primary runtime resolves worker endpoints through the Kubernetes backend and does not use `MINDROOM_SANDBOX_PROXY_URL`.
+The Helm chart sets the Kubernetes backend environment variables automatically.
+If you deploy that mode without Helm, see [Kubernetes Deployment](kubernetes.md) and `src/mindroom/workers/backends/kubernetes_config.py` for the required environment surface.
 
 ### Sandbox runner
 
@@ -178,12 +231,13 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 
 ## Security considerations
 
-- The sandbox runner **never has** API keys, Matrix credentials, or access to `mindroom_data/`
-- The shared token authenticates all proxy traffic — use a strong random value
-- Credential leases are single-use by default and expire after 60 seconds
-- The runner's `securityContext` drops all capabilities and disables privilege escalation
-- In Kubernetes, the runner uses `emptyDir` for scratch space — no persistent state
-- The primary MindRoom runtime **does not** mount the sandbox runner router — the `/api/sandbox-runner/` endpoints exist only in the runner process
+- The worker runtime never gets the primary runtime API key files, Matrix client state, or orchestrator authority.
+- The shared token authenticates all proxy traffic, so use a strong random value.
+- Credential leases are single-use by default and expire after 60 seconds.
+- The worker container `securityContext` drops all capabilities and disables privilege escalation.
+- With `workerBackend: static_runner`, the Kubernetes sidecar uses `emptyDir` scratch space and has no persistent state of its own.
+- With `workerBackend: kubernetes`, dedicated worker pods mount a worker-specific PVC subpath and keep worker-owned state across pod recreation.
+- The primary MindRoom runtime does not mount the sandbox-runner router, so `/api/sandbox-runner/` exists only in runner or dedicated worker processes.
 
 ## Per-agent configuration
 
@@ -215,7 +269,9 @@ The `worker_tools` field has three states:
 | `[]` (empty list) | Explicitly disable sandbox proxying for this agent |
 | `["shell", "file"]` | Proxy exactly these tools for this agent |
 
-Agent-level `worker_tools` overrides `defaults.worker_tools`. A sandbox proxy URL (`MINDROOM_SANDBOX_PROXY_URL`) must still be configured for any proxying to take effect.
+Agent-level `worker_tools` overrides `defaults.worker_tools`.
+With `MINDROOM_WORKER_BACKEND=static_runner`, a sandbox proxy URL (`MINDROOM_SANDBOX_PROXY_URL`) must still be configured for proxying to take effect.
+With `MINDROOM_WORKER_BACKEND=kubernetes`, worker endpoints are resolved dynamically and `MINDROOM_SANDBOX_PROXY_URL` is not used.
 
 ## Worker Scope
 
@@ -259,6 +315,8 @@ If `worker_scope` is unset, proxied tools still use the sandbox runner, but the 
 The dashboard credential UI only supports unscoped agents and agents with `worker_scope=shared`.
 Agents using `user`, `user_agent`, or `room_thread` must treat credentials as runtime-owned worker state.
 
-## Without sandbox proxy
+## Without configured worker routing
 
-When no `MINDROOM_SANDBOX_PROXY_URL` is set, all tools execute directly in the primary MindRoom runtime process. This is fine for development but not recommended for production deployments where agents run untrusted code.
+With `MINDROOM_WORKER_BACKEND=static_runner` and no `MINDROOM_SANDBOX_PROXY_URL`, tool calls execute directly in the primary MindRoom runtime process.
+This is fine for development but not recommended for production deployments where agents run untrusted code.
+With `MINDROOM_WORKER_BACKEND=kubernetes`, worker-routed tool calls fail closed when the backend is misconfigured instead of silently running locally.

--- a/docs/dev/persistent-worker-runtime-plan.md
+++ b/docs/dev/persistent-worker-runtime-plan.md
@@ -2,7 +2,11 @@
 
 Last updated: 2026-03-11
 Owner: MindRoom backend
-Status: Phase 2 complete and smoke-validated in GKE on the current shared sandbox-runner provider, and Phase 3 is now the backend/provider abstraction phase
+Status: Phases 1-3 are complete in code.
+Phase 4 is in progress.
+The backend-neutral worker contract, lifecycle handling, and default routing policy are implemented.
+The built-in Kubernetes provider is also implemented and deployment-wired.
+What remains is production hardening, richer metrics, operator documentation, dedicated-worker production validation, and deferred product-boundary decisions around `/v1` identity and credential defaults.
 
 ## Objective
 
@@ -22,17 +26,26 @@ Doing the work in this order prevents expensive lifecycle and deployment work fr
 ## Current Status
 
 Phase 1 is implemented and already useful for proving persistent tool execution.
-The current prototype provides generic worker routing for tool calls rather than a `shell`-only special case.
-The current prototype validates persistence with `shell`, `file`, and `python`.
-Phase 2 has been smoke-validated in GKE on the current shared provider shape of one shared MindRoom pod, one shared sandbox-runner sidecar, and one shared PVC.
+The implementation provides generic worker routing for tool calls rather than a `shell`-only special case.
+The implementation validates persistence with `shell`, `file`, and `python`.
+Phase 2 has been smoke-validated in GKE on the shared provider shape of one shared MindRoom pod, one shared sandbox-runner sidecar, and one shared PVC.
 That smoke validation confirmed same-worker-key persistence across turns, isolation across different worker keys, persistent Python environments, and survival of worker-owned state across pod replacement.
-That smoke validation did not validate dynamic per-user Kubernetes workers.
-The current prototype carries execution identity from Matrix and from the currently permitted `/v1` surface into worker-routing decisions.
-The current prototype persists worker workspace, cache, and Python packages inside worker-owned state.
-The current prototype aligns file-backed memory reads and writes with worker-owned state for worker-scoped agents.
+The implementation carries execution identity from Matrix and from the currently permitted `/v1` surface into worker-routing decisions.
+The implementation persists worker workspace, cache, and Python packages inside worker-owned state.
+The implementation aligns file-backed memory reads and writes with worker-owned state for worker-scoped agents.
 For file-backed agents that set `memory_file_path`, local workspace-aware tools now derive their base directory from that same path.
 Worker-routed scoped tools still execute against the resolved worker workspace, so the agent-level workspace hint does not bypass worker-owned state.
 Sessions, learning, and most credentials are now worker-scope-aware.
+Phase 3 is implemented in code.
+The worker backend contract, worker manager facade, worker handle model, and handle-based routed execution are the active runtime architecture.
+The primary runtime now ships built-in `static_runner` and `kubernetes` backends behind the same contract.
+The primary runtime exposes backend-neutral worker observability and cleanup endpoints through `/api/workers`.
+The primary runtime also runs optional background idle cleanup using the configured backend.
+The built-in default worker-routing policy now comes from per-tool metadata plus agent/default `worker_tools` overrides rather than only from environment-driven sandbox selection.
+Phase 4 has started.
+The built-in Kubernetes backend now provisions dedicated worker Deployments and Services, mounts durable worker state from the shared PVC by worker subpath, waits for readiness, records failure metadata, and evicts idle workers by scaling them to zero while keeping state.
+The current codebase and test suite therefore already include a production-provider implementation, even though some rollout and operator work remains.
+This document does not claim a recent dedicated-worker GKE smoke or soak validation for the Kubernetes backend.
 Google Services, Spotify, Home Assistant, and the Google-backed `gmail`, `google_calendar`, and `google_sheets` tools remain shared-only.
 Those integrations are supported only for agents without worker routing or with `worker_scope=shared`.
 Dashboard credential management is intentionally limited to unscoped agents and agents with `worker_scope=shared`.
@@ -130,7 +143,10 @@ That means the dashboard must not read or write credentials for `user`, `user_ag
 
 Tool execution policy should become an explicit concept rather than a side effect of the old sandbox settings.
 The minimum policy categories are local execution in the primary runtime and worker-routed execution in a scoped worker.
-The source of truth is `worker_tools` and `worker_scope`.
+The source of truth is the combination of tool metadata, `worker_tools`, and `worker_scope`.
+
+The current policy model already supports the first item below.
+The remaining items are still design goals rather than fully explicit first-class config.
 
 The final policy model should support these per-tool decisions.
 
@@ -215,7 +231,7 @@ For worker-routed execution, runtime worker workspace resolution remains authori
 ## Memory Design
 
 If worker-routed tools can edit memory, memory reads during prompt assembly must resolve against the same worker-owned storage.
-The current prototype already does this for file-backed memory.
+The current implementation already does this for file-backed memory.
 The full design should keep file-backed memory as the only worker-editable memory backend until another backend has a deliberate synchronization model.
 
 The final memory rules are:
@@ -248,7 +264,7 @@ The target credentials model is:
 
 - Credentials are stored under a scope-aware namespace rather than only `service_name`.
 - The common credential scopes are `shared`, `user`, and `worker`.
-- The current leading option is to default worker-routed tools to `user` when a requester identity exists, but the exact per-tool defaults are still a Phase 3 policy decision.
+- The current leading option is to default worker-routed tools to `user` when a requester identity exists, but the exact per-tool defaults are still an open policy decision.
 - Shared credentials require explicit opt-in.
 - Credential leases are created on the target worker and are short-lived and single-use by default.
 - Leased credentials never become part of the model prompt or normal tool arguments.
@@ -280,11 +296,11 @@ The current product rule is:
 ## Provider Model
 
 MindRoom core owns worker scope semantics, execution identity resolution, worker key resolution, tool routing policy, and worker-owned state semantics.
-MindRoom core must not own Kubernetes object names, namespaces, storage classes, pod names, or other provider-specific control-plane concepts.
-MindRoom core should ship the interface and the built-in local/shared-runner provider implementations needed for development and the current deployment shape.
-The local development model and the current shared sandbox-runner deployment are providers behind the same worker backend contract.
-Kubernetes is a future provider rather than a core MindRoom runtime concept.
-A Kubernetes-backed provider or controller may live outside MindRoom core and consume the same worker contract without changing core routing logic.
+MindRoom core must not leak provider-specific lifecycle details into the generic routing layer.
+MindRoom core now ships the interface and the built-in `static_runner` and `kubernetes` backends needed for current development and hosted deployment shapes.
+The local development model, the shared sandbox-runner deployment, and the dedicated Kubernetes-worker deployment are providers behind the same worker backend contract.
+The current codebase therefore treats Kubernetes as a built-in provider, not only a future idea.
+A future external provider or controller can still consume the same contract without changing core routing logic.
 
 ## Local Provider
 
@@ -294,10 +310,11 @@ The local provider should support introspection of active workers and cleanup of
 
 ## Kubernetes Provider
 
-The Kubernetes provider belongs to Phase 4 and should be implemented against the worker backend contract introduced in Phase 3.
-The long-term Kubernetes model is a provider or controller that can realize worker handles from worker keys using cluster-native primitives without changing MindRoom core routing semantics.
-A Kubernetes-backed implementation does not need to live inside MindRoom core as long as it satisfies the same contract.
-Each Kubernetes worker still needs durable worker-owned storage and an authenticated internal endpoint.
+The Kubernetes provider is implemented against the worker backend contract introduced in Phase 3.
+The current implementation creates dedicated worker Deployments and Services, mounts durable worker-owned storage from the shared PVC via worker-specific subpaths, propagates the shared sandbox token, and waits for readiness before returning a worker handle.
+Idle cleanup currently scales workers to zero while preserving state and deletes the per-worker Service.
+The long-term architecture may still move this behavior behind an external controller, but that is no longer a prerequisite for shipping the current provider model.
+Each Kubernetes worker still needs durable worker-owned storage and an authenticated internal endpoint, and the current implementation satisfies that contract.
 
 ## Provider Interface Contract
 
@@ -350,7 +367,9 @@ The initialization rules are:
 
 ## Observability
 
-The full system should expose enough telemetry to answer whether worker routing is correct and whether isolation boundaries are holding.
+The system already exposes backend-neutral worker listing and idle cleanup through the primary runtime and local worker listing and cleanup through the sandbox-runner runtime.
+Worker handles already carry startup counts, failure counts, failure reasons, timestamps, and provider debug metadata.
+What is still missing is richer aggregate telemetry that can be scraped or graphed over time.
 
 At minimum we need:
 
@@ -361,6 +380,33 @@ At minimum we need:
 - Credential lease creation and expiration counts.
 - Storage path resolution traces for debugging.
 - Health and failure reason visibility for worker startup errors.
+
+## What Is Left Now
+
+The remaining work is no longer core routing architecture.
+It is productionization, deferred policy decisions, and operator experience.
+
+1. Trusted `/v1` identity for isolating worker scopes.
+   Current `/v1` requests still build execution identity with `requester_id=None`, and the API intentionally only supports unscoped agents and `worker_scope=shared`.
+   Remaining work is to decide the authenticated principal source for `/v1`, decide whether `room_thread` should key from conversation or session identity, and then safely enable additional scopes.
+
+2. Finalize explicit credential policy defaults.
+   Credentials are already scope-aware and leased to workers, but the long-term default policy by tool class is still not fully codified as a first-class model.
+   The main remaining decision is when worker-routed tools should default to `user`, `shared`, or another explicit credential scope.
+
+3. Add aggregate metrics and dashboards.
+   We still need counters and histograms for worker creation and reuse, startup latency, idle eviction counts, execute requests by tool and scope, and credential lease issuance and expiry.
+   The current `/api/workers` surfaces are useful for debugging but are not sufficient for fleet-level observability.
+
+4. Do dedicated-worker production validation beyond unit and integration coverage.
+   The Kubernetes backend is implemented and tested, but this document should still treat dedicated-worker GKE smoke and soak validation as remaining rollout work unless and until it is recorded explicitly.
+   The most valuable checks are end-to-end persistence across worker recreation, failure injection, restart handling, and concurrency or capacity behavior under real cluster conditions.
+
+5. Finish operator-facing documentation.
+   We still need final docs for retention and cleanup behavior per provider, storage layout and PVC expectations, deployment mode selection, and incident handling for stuck or unhealthy workers.
+
+6. Decide optional product affordances.
+   Open decisions remain around user-facing worker reset commands, long-term retention controls, and whether any of that should surface in the dashboard or chat UX.
 
 ## Operational Policies
 
@@ -436,49 +482,54 @@ Phase 2 delivered:
 
 ### Phase 3: Backend Contract, Policy, And Observability
 
-Phase 3 should introduce the backend/provider abstraction that makes future providers possible without rewriting core routing code.
-Phase 3 is the abstraction and policy phase.
+Phase 3 is complete.
+Phase 3 was the abstraction and policy phase.
 
-Phase 3 work items are:
+Phase 3 delivered:
 
 - Introduce a first-class backend-neutral worker manager and worker backend contract.
 - Refactor routed tool execution to resolve a worker handle through that contract.
 - Treat the current shared sandbox-runner deployment as the first concrete provider so Phase 2 behavior remains unchanged.
 - Implement idle cleanup and state retention rules.
 - Tighten `/v1` scope eligibility based on trusted requester identity.
-- Add observability surfaces for active workers and worker failures.
-- Finalize defaults for which tools are local versus worker-routed.
+- Add backend-neutral observability surfaces for active workers and worker failures.
+- Add per-tool default execution targets so built-in routing defaults are explicit.
 
 ### Phase 4: Production Provider Implementations
 
-Phase 4 should move the design from backend-neutral correctness to production providers.
-Phase 4 is the provider-implementation phase.
+Phase 4 is in progress.
+Phase 4 is the provider-implementation and productionization phase.
 
-Phase 4 work items are:
+Phase 4 already delivered:
 
 - Implement a Kubernetes-backed worker provider.
 - Attach durable storage to provider-managed workers.
 - Add provider health checks and readiness handling.
-- Add metrics and debugging endpoints for provider operations.
+
+Phase 4 remaining work is:
+
+- Add aggregate metrics and dashboards for provider operations.
+- Record dedicated-worker production validation, especially on GKE.
 - Document retention, cleanup, and storage strategy per provider.
 - Document incident handling for stuck or unhealthy workers.
 
 ## Recommended Immediate Next Step
 
-The next step is to complete Phase 3 around the new backend contract.
-The first concrete targets are explicit worker lifecycle through the backend interface, backend-neutral observability, conservative `/v1` trust enforcement, and final local-versus-worker tool policy defaults.
+The next step is to finish the remaining productionization work rather than redesign the routing model again.
+The highest-value targets are richer metrics, dedicated-worker GKE smoke and soak validation, provider and incident documentation, and the deferred `/v1` identity plus credential-policy decisions.
 
 ## File Map For Remaining Work
 
 - `src/mindroom/tool_system/worker_routing.py` is the source of truth for execution identity, scope semantics, worker keys, and scoped path helpers.
+- `src/mindroom/tool_system/metadata.py` is the source of truth for per-tool default execution targets and for the built-in default worker-routing policy.
 - `src/mindroom/agents.py` now resolves session and learning storage through worker-aware paths and remains the place to keep agent construction aligned with scoped state.
 - `src/mindroom/credentials.py` is now scope-aware and remains the place where runtime credential ownership rules should continue to consolidate.
 - `src/mindroom/api/openai_compat.py` keeps enforcing conservative `/v1` scope eligibility and trusted requester identity rules.
 - `src/mindroom/api/sandbox_runner.py` should remain an execution runtime component over the worker backend contract rather than a lifecycle owner.
 - `src/mindroom/tool_system/sandbox_proxy.py` should resolve worker handles through the worker manager and stay free of provider-specific assumptions.
-- `src/mindroom/workers/` should remain the home of the backend-neutral worker contract plus the built-in local/shared-runner providers that ship with core.
-- External providers or controllers, including a future Kubernetes-backed implementation, should consume the same contract without forcing Kubernetes concepts into core routing code.
-- `cluster/k8s/instance/templates/deployment-mindroom.yaml` remains only the current shared-runner deployment model rather than the final provider architecture.
+- `src/mindroom/workers/` is now the home of the backend-neutral worker contract plus the built-in `static_runner` and `kubernetes` backends that ship with core.
+- `src/mindroom/api/workers.py` and the background cleanup loop in `src/mindroom/api/main.py` are the current backend-neutral observability and lifecycle surfaces.
+- `cluster/k8s/instance/templates/deployment-mindroom.yaml` and related worker templates now encode both the shared-runner and dedicated Kubernetes-worker deployment shapes.
 
 ## Open Decisions
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -4960,38 +4960,43 @@ MindRoom stores data in the `mindroom_data` directory:
 
 When configured, `shell`, `file`, and `python` tool calls can be proxied to a separate **sandbox-runner** sidecar container. The sidecar runs the same image but without access to secrets, credentials, or the primary data volume. This provides real process-level isolation for code-execution tools. Without proxy configuration, all tools execute locally in the MindRoom process.
 
-See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for full documentation including Docker Compose examples, Kubernetes sidecar setup, host-machine-with-container mode, credential leases, and environment variable reference.
+See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for full documentation including Docker Compose examples, Kubernetes shared-sidecar and dedicated-worker modes, host-machine-with-container mode, credential leases, and environment variable reference.
 
 > [!TIP] For production, use a reverse proxy (Traefik, Nginx) in front of the MindRoom container when you want TLS, host routing, or additional auth layers. See `local/instances/deploy/docker-compose.yml` for an example with Traefik labels.
 
 # Sandbox Proxy Isolation
 
-When agents have code-execution tools (`shell`, `file`, `python`), they can read and modify anything on the filesystem — config files, credentials, application code. The **sandbox proxy** isolates these tools by forwarding their calls to a separate process (the **sandbox runner**) that has no access to secrets or sensitive data.
+When agents have code-execution tools (`shell`, `file`, `python`), they can read and modify anything on the filesystem, including config files, credentials, and application code. The **sandbox proxy** isolates these tools by forwarding their calls to a separate worker runtime that has no direct access to the primary process secrets.
 
 ## How it works
 
 ```
 ┌──────────────────────────┐         HTTP          ┌──────────────────────────┐
-│ Primary MindRoom runtime │  ── tool call ──▶     │ Sandbox runner           │
-│ has secrets              │  ◀── result ───       │ no secrets               │
-│ has credentials          │                       │ no credentials           │
-│ has persistent data      │                       │ writable scratch only    │
+│ Primary MindRoom runtime │  ── tool call ──▶     │ Worker runtime           │
+│ has secrets              │  ◀── result ───       │ no primary secrets       │
+│ has credentials          │                       │ leased credentials only  │
+│ has orchestration state  │                       │ worker-owned state       │
 └──────────────────────────┘                       └──────────────────────────┘
 ```
 
-1. Agent invokes `shell.run_shell_command(...)` (or file/python tool)
-1. Primary MindRoom runtime detects the tool is in the proxy list
-1. Call is forwarded over HTTP to the sandbox runner
-1. Runner executes the tool locally and returns the result
-1. All other tools (API tools, search, etc.) execute in the primary MindRoom runtime as usual
+1. Agent invokes `shell.run_shell_command(...)` or another worker-routed tool.
+1. The primary MindRoom runtime resolves the target worker from the configured backend plus worker scope.
+1. The call is forwarded over HTTP to the target worker runtime.
+1. The worker executes the tool locally against its own state and returns the result.
+1. All other tools such as API tools or Matrix-bound tools execute in the primary MindRoom runtime as usual.
 
-The runner authenticates requests with a shared token (`MINDROOM_SANDBOX_PROXY_TOKEN`). For tools that need credentials (e.g., a shell tool that calls an authenticated API), the primary MindRoom runtime can create a short-lived **credential lease** that the runner consumes once — credentials never persist in the runner's memory.
+The worker runtime authenticates requests with a shared token (`MINDROOM_SANDBOX_PROXY_TOKEN`). For tools that need credentials, such as a shell tool that calls an authenticated API, the primary MindRoom runtime can create a short-lived **credential lease** that the worker consumes once. Credentials never become part of the normal tool arguments or the model prompt.
+
+MindRoom currently ships two worker backend shapes:
+
+- `static_runner`: one shared sandbox-runner process, usually a sidecar container or a local HTTP service.
+- `kubernetes`: dedicated worker pods created on demand from the primary runtime, with one logical worker per worker key.
 
 ## Deployment modes
 
-### Docker Compose (sidecar container)
+### Docker Compose (`static_runner`)
 
-Add a `sandbox-runner` service alongside MindRoom. Both use the same image; the runner just has a different entrypoint and no access to `.env` or the data volume.
+Add a `sandbox-runner` service alongside MindRoom. Both use the same image. The runner just has a different entrypoint and no access to `.env` or the primary data volume.
 
 ```
 services:
@@ -5002,6 +5007,7 @@ services:
       - ./config.yaml:/app/config.yaml:ro
       - ./mindroom_data:/app/mindroom_data
     environment:
+      - MINDROOM_WORKER_BACKEND=static_runner
       - MINDROOM_SANDBOX_PROXY_URL=http://sandbox-runner:8766
       - MINDROOM_SANDBOX_PROXY_TOKEN=${MINDROOM_SANDBOX_PROXY_TOKEN}
       - MINDROOM_SANDBOX_EXECUTION_MODE=selective
@@ -5032,13 +5038,40 @@ Key differences from the primary MindRoom runtime:
 - **Scratch workspace** — a dedicated volume for file operations
 - **`MINDROOM_STORAGE_PATH`** — pointed at a writable location inside the workspace so the tool registry can initialize without access to the primary data volume
 
-### Kubernetes (pod sidecar)
+### Kubernetes shared sidecar (`workerBackend: static_runner`)
 
-In Kubernetes the runner runs as a second container in the same pod, sharing `localhost` networking. See `cluster/k8s/instance/templates/deployment-mindroom.yaml` for the full manifest. The runner gets:
+In Kubernetes the shared runner can still run as a second container in the same pod, sharing `localhost` networking. This is the `workerBackend: static_runner` Helm mode. See `cluster/k8s/instance/templates/deployment-mindroom.yaml` for the full manifest. The sidecar gets:
 
-- An `emptyDir` volume for scratch workspace
-- Read-only access to config (for plugin tool registration)
-- No access to the secrets volume
+- An `emptyDir` volume for scratch workspace.
+- Read-only access to config for plugin tool registration.
+- No access to the primary secrets volume.
+
+### Kubernetes dedicated workers (`workerBackend: kubernetes`)
+
+In dedicated-worker mode the primary MindRoom runtime creates worker Deployments and Services on demand. Each worker pod runs the sandbox-runner app and is addressed through an internal cluster Service. The worker state is mounted from the shared instance PVC under a worker-specific subpath, so files, virtualenvs, caches, sessions, and other worker-owned state survive pod recreation. Idle cleanup scales worker Deployments to zero while keeping the PVC-backed state intact.
+
+Use the instance Helm chart with values like:
+
+```
+workerBackend: kubernetes
+workerCleanupIntervalSeconds: 30
+storageAccessMode: ReadWriteMany
+kubernetesWorkerPort: 8766
+kubernetesWorkerReadyTimeoutSeconds: 60
+kubernetesWorkerIdleTimeoutSeconds: 1800
+sandbox_proxy_token: "replace-me"
+```
+
+Important notes for this mode:
+
+- `storageAccessMode` should be `ReadWriteMany` for multi-node shared storage.
+- If you must keep `ReadWriteOnce`, set `controlPlaneNodeName` so the control plane and dedicated workers stay on the same node.
+- `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
+- The chart creates the worker-manager ServiceAccount, Role, RoleBinding, and worker-specific NetworkPolicy rules automatically when this backend is enabled.
+- The primary runtime does not need `MINDROOM_SANDBOX_PROXY_URL` in this mode because worker endpoints come from the Kubernetes worker handles.
+- The authenticated `/api/workers` and `/api/workers/cleanup` endpoints on the primary runtime expose backend-neutral worker lifecycle information.
+
+For the full Helm-side deployment guidance, see [Kubernetes Deployment](https://docs.mindroom.chat/deployment/kubernetes/index.md).
 
 ### Host machine + Docker sandbox container
 
@@ -5049,6 +5082,7 @@ Run MindRoom directly on the host while isolating code-execution tools in a Dock
 docker run -d \
   --name mindroom-sandbox-runner \
   -p 8766:8766 \
+  -e MINDROOM_WORKER_BACKEND=static_runner \
   -e MINDROOM_SANDBOX_RUNNER_MODE=true \
   -e MINDROOM_SANDBOX_PROXY_TOKEN=your-secret-token \
   -e MINDROOM_STORAGE_PATH=/app/workspace/.mindroom \
@@ -5056,6 +5090,7 @@ docker run -d \
   /app/run-sandbox-runner.sh
 
 # 2. Start MindRoom on the host with proxy config
+export MINDROOM_WORKER_BACKEND=static_runner
 export MINDROOM_SANDBOX_PROXY_URL=http://localhost:8766
 export MINDROOM_SANDBOX_PROXY_TOKEN=your-secret-token
 export MINDROOM_SANDBOX_EXECUTION_MODE=selective
@@ -5066,6 +5101,7 @@ mindroom run
 Or add the proxy variables to your `.env` file:
 
 ```
+MINDROOM_WORKER_BACKEND=static_runner
 MINDROOM_SANDBOX_PROXY_URL=http://localhost:8766
 MINDROOM_SANDBOX_PROXY_TOKEN=your-secret-token
 MINDROOM_SANDBOX_EXECUTION_MODE=selective
@@ -5080,15 +5116,18 @@ This gives you the convenience of running MindRoom natively while keeping code-e
 
 ### Primary MindRoom runtime (proxy client)
 
-| Variable                                        | Description                                        | Default                               |
-| ----------------------------------------------- | -------------------------------------------------- | ------------------------------------- |
-| `MINDROOM_SANDBOX_PROXY_URL`                    | URL of the sandbox runner                          | *(none — proxy disabled)*             |
-| `MINDROOM_SANDBOX_PROXY_TOKEN`                  | Shared auth token                                  | *(required when proxy URL is set)*    |
-| `MINDROOM_SANDBOX_EXECUTION_MODE`               | `selective`, `all`, `off`                          | *(unset — uses proxy tools list)*     |
-| `MINDROOM_SANDBOX_PROXY_TOOLS`                  | Comma-separated tool names to proxy                | `*` (all, unless mode is `selective`) |
-| `MINDROOM_SANDBOX_PROXY_TIMEOUT_SECONDS`        | HTTP timeout for proxy calls                       | `120`                                 |
-| `MINDROOM_SANDBOX_CREDENTIAL_LEASE_TTL_SECONDS` | Credential lease lifetime                          | `60`                                  |
-| `MINDROOM_SANDBOX_CREDENTIAL_POLICY_JSON`       | JSON mapping tool selectors to credential services | `{}`                                  |
+| Variable                                        | Description                                                 | Default                                       |
+| ----------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------- |
+| `MINDROOM_WORKER_BACKEND`                       | Worker backend name: `static_runner` or `kubernetes`        | `static_runner`                               |
+| `MINDROOM_SANDBOX_PROXY_URL`                    | URL of the shared sandbox runner when using `static_runner` | *(none — proxy disabled for `static_runner`)* |
+| `MINDROOM_SANDBOX_PROXY_TOKEN`                  | Shared auth token used by the worker runtime                | *(required for worker-routed execution)*      |
+| `MINDROOM_SANDBOX_EXECUTION_MODE`               | `selective`, `all`, `off`                                   | *(unset — uses proxy tools list)*             |
+| `MINDROOM_SANDBOX_PROXY_TOOLS`                  | Comma-separated tool names to proxy                         | `*` (all, unless mode is `selective`)         |
+| `MINDROOM_SANDBOX_PROXY_TIMEOUT_SECONDS`        | HTTP timeout for proxy calls                                | `120`                                         |
+| `MINDROOM_SANDBOX_CREDENTIAL_LEASE_TTL_SECONDS` | Credential lease lifetime                                   | `60`                                          |
+| `MINDROOM_SANDBOX_CREDENTIAL_POLICY_JSON`       | JSON mapping tool selectors to credential services          | `{}`                                          |
+
+When `MINDROOM_WORKER_BACKEND=kubernetes`, the primary runtime resolves worker endpoints through the Kubernetes backend and does not use `MINDROOM_SANDBOX_PROXY_URL`. The Helm chart sets the Kubernetes backend environment variables automatically. If you deploy that mode without Helm, see [Kubernetes Deployment](https://docs.mindroom.chat/deployment/kubernetes/index.md) and `src/mindroom/workers/backends/kubernetes_config.py` for the required environment surface.
 
 ### Sandbox runner
 
@@ -5124,12 +5163,13 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 
 ## Security considerations
 
-- The sandbox runner **never has** API keys, Matrix credentials, or access to `mindroom_data/`
-- The shared token authenticates all proxy traffic — use a strong random value
-- Credential leases are single-use by default and expire after 60 seconds
-- The runner's `securityContext` drops all capabilities and disables privilege escalation
-- In Kubernetes, the runner uses `emptyDir` for scratch space — no persistent state
-- The primary MindRoom runtime **does not** mount the sandbox runner router — the `/api/sandbox-runner/` endpoints exist only in the runner process
+- The worker runtime never gets the primary runtime API key files, Matrix client state, or orchestrator authority.
+- The shared token authenticates all proxy traffic, so use a strong random value.
+- Credential leases are single-use by default and expire after 60 seconds.
+- The worker container `securityContext` drops all capabilities and disables privilege escalation.
+- With `workerBackend: static_runner`, the Kubernetes sidecar uses `emptyDir` scratch space and has no persistent state of its own.
+- With `workerBackend: kubernetes`, dedicated worker pods mount a worker-specific PVC subpath and keep worker-owned state across pod recreation.
+- The primary MindRoom runtime does not mount the sandbox-runner router, so `/api/sandbox-runner/` exists only in runner or dedicated worker processes.
 
 ## Per-agent configuration
 
@@ -5161,7 +5201,7 @@ The `worker_tools` field has three states:
 | `[]` (empty list)   | Explicitly disable sandbox proxying for this agent                                                                                                        |
 | `["shell", "file"]` | Proxy exactly these tools for this agent                                                                                                                  |
 
-Agent-level `worker_tools` overrides `defaults.worker_tools`. A sandbox proxy URL (`MINDROOM_SANDBOX_PROXY_URL`) must still be configured for any proxying to take effect.
+Agent-level `worker_tools` overrides `defaults.worker_tools`. With `MINDROOM_WORKER_BACKEND=static_runner`, a sandbox proxy URL (`MINDROOM_SANDBOX_PROXY_URL`) must still be configured for proxying to take effect. With `MINDROOM_WORKER_BACKEND=kubernetes`, worker endpoints are resolved dynamically and `MINDROOM_SANDBOX_PROXY_URL` is not used.
 
 ## Worker Scope
 
@@ -5199,9 +5239,9 @@ The supported values are:
 
 If `worker_scope` is unset, proxied tools still use the sandbox runner, but the request stays unscoped and no worker-specific storage root is selected. `worker_scope` also affects dashboard credential support and OpenAI-compatible agent eligibility. The dashboard credential UI only supports unscoped agents and agents with `worker_scope=shared`. Agents using `user`, `user_agent`, or `room_thread` must treat credentials as runtime-owned worker state.
 
-## Without sandbox proxy
+## Without configured worker routing
 
-When no `MINDROOM_SANDBOX_PROXY_URL` is set, all tools execute directly in the primary MindRoom runtime process. This is fine for development but not recommended for production deployments where agents run untrusted code.
+With `MINDROOM_WORKER_BACKEND=static_runner` and no `MINDROOM_SANDBOX_PROXY_URL`, tool calls execute directly in the primary MindRoom runtime process. This is fine for development but not recommended for production deployments where agents run untrusted code. With `MINDROOM_WORKER_BACKEND=kubernetes`, worker-routed tool calls fail closed when the backend is misconfigured instead of silently running locally.
 
 # Kubernetes Deployment
 
@@ -5251,6 +5291,66 @@ helm upgrade --install instance-1 ./cluster/k8s/instance \
   --set supabaseAnonKey="your-anon-key" \
   --set supabaseServiceKey="your-service-key"
 ```
+
+## Worker Backends
+
+The instance chart supports two worker backend modes for worker-routed tools such as `shell`, `file`, and `python`.
+
+| Helm value                     | Behavior                                                                             | Best for                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| `workerBackend: static_runner` | Runs one shared sandbox-runner sidecar inside the main MindRoom pod                  | Simpler deployments and the current shared-worker model       |
+| `workerBackend: kubernetes`    | Creates dedicated worker Deployments and Services on demand from the primary runtime | Stronger isolation and persistent worker state per worker key |
+
+### Shared Sidecar Mode
+
+`workerBackend: static_runner` is the default. The primary runtime talks to a shared sidecar over `localhost`. This keeps the deployment simple, but all worker-routed tool calls share the same runner process.
+
+### Dedicated Worker Mode
+
+`workerBackend: kubernetes` enables the built-in Kubernetes worker backend. The primary runtime creates worker Deployments and Services on demand and routes tool calls to the resolved worker handle. Each worker pod runs the sandbox-runner app and mounts worker-owned state from the shared PVC under a worker-specific subpath. Idle cleanup scales worker Deployments to zero while preserving that state.
+
+Typical Helm values look like:
+
+```
+workerBackend: kubernetes
+workerCleanupIntervalSeconds: 30
+storageAccessMode: ReadWriteMany
+controlPlaneNodeName: ""
+kubernetesWorkerImage: ""
+kubernetesWorkerImagePullPolicy: ""
+kubernetesWorkerServiceAccountName: ""
+kubernetesWorkerNamePrefix: "mindroom-worker"
+kubernetesWorkerStorageSubpathPrefix: "workers"
+kubernetesWorkerPort: 8766
+kubernetesWorkerReadyTimeoutSeconds: 60
+kubernetesWorkerIdleTimeoutSeconds: 1800
+sandbox_proxy_token: "replace-me"
+```
+
+Important behavior and constraints:
+
+- `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
+- `workerCleanupIntervalSeconds` controls how often the primary runtime runs idle-worker cleanup.
+- `kubernetesWorkerIdleTimeoutSeconds` controls when a worker is considered idle and eligible to scale down.
+- `kubernetesWorkerReadyTimeoutSeconds` controls how long the primary runtime waits for a worker Deployment to become ready.
+- `kubernetesWorkerPort` is the internal Service and container port used by dedicated workers.
+- The worker state lives on the shared instance PVC under `kubernetesWorkerStorageSubpathPrefix/<worker-dir>/`.
+
+### Storage Requirements
+
+Dedicated workers need access to the same PVC as the primary runtime. For multi-node operation, set `storageAccessMode: ReadWriteMany`. If your storage class only supports `ReadWriteOnce`, set `controlPlaneNodeName` so the control plane and dedicated workers stay on the same node. The chart enforces this constraint during template rendering.
+
+### RBAC And Network Policy
+
+When `workerBackend: kubernetes` is enabled, the chart creates:
+
+- A worker-manager ServiceAccount for the primary runtime.
+- A Role and RoleBinding that allow managing worker Deployments and Services in the instance namespace.
+- NetworkPolicy rules that allow the primary runtime to reach the internal worker port and allow worker traffic within the instance namespace.
+
+### Operations
+
+The authenticated dashboard API exposes `/api/workers` to list active or idle workers and `/api/workers/cleanup` to trigger cleanup manually. Dedicated workers are internal-only cluster Services and are authenticated with the shared `sandbox_proxy_token`. See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for the execution model, credential leases, and non-Kubernetes deployment modes.
 
 ## Secrets Management
 

--- a/skills/mindroom-docs/references/page__deployment__docker__index.md
+++ b/skills/mindroom-docs/references/page__deployment__docker__index.md
@@ -143,6 +143,6 @@ MindRoom stores data in the `mindroom_data` directory:
 
 When configured, `shell`, `file`, and `python` tool calls can be proxied to a separate **sandbox-runner** sidecar container. The sidecar runs the same image but without access to secrets, credentials, or the primary data volume. This provides real process-level isolation for code-execution tools. Without proxy configuration, all tools execute locally in the MindRoom process.
 
-See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for full documentation including Docker Compose examples, Kubernetes sidecar setup, host-machine-with-container mode, credential leases, and environment variable reference.
+See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for full documentation including Docker Compose examples, Kubernetes shared-sidecar and dedicated-worker modes, host-machine-with-container mode, credential leases, and environment variable reference.
 
 > [!TIP] For production, use a reverse proxy (Traefik, Nginx) in front of the MindRoom container when you want TLS, host routing, or additional auth layers. See `local/instances/deploy/docker-compose.yml` for an example with Traefik labels.

--- a/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
+++ b/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
@@ -47,6 +47,66 @@ helm upgrade --install instance-1 ./cluster/k8s/instance \
   --set supabaseServiceKey="your-service-key"
 ```
 
+## Worker Backends
+
+The instance chart supports two worker backend modes for worker-routed tools such as `shell`, `file`, and `python`.
+
+| Helm value                     | Behavior                                                                             | Best for                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| `workerBackend: static_runner` | Runs one shared sandbox-runner sidecar inside the main MindRoom pod                  | Simpler deployments and the current shared-worker model       |
+| `workerBackend: kubernetes`    | Creates dedicated worker Deployments and Services on demand from the primary runtime | Stronger isolation and persistent worker state per worker key |
+
+### Shared Sidecar Mode
+
+`workerBackend: static_runner` is the default. The primary runtime talks to a shared sidecar over `localhost`. This keeps the deployment simple, but all worker-routed tool calls share the same runner process.
+
+### Dedicated Worker Mode
+
+`workerBackend: kubernetes` enables the built-in Kubernetes worker backend. The primary runtime creates worker Deployments and Services on demand and routes tool calls to the resolved worker handle. Each worker pod runs the sandbox-runner app and mounts worker-owned state from the shared PVC under a worker-specific subpath. Idle cleanup scales worker Deployments to zero while preserving that state.
+
+Typical Helm values look like:
+
+```
+workerBackend: kubernetes
+workerCleanupIntervalSeconds: 30
+storageAccessMode: ReadWriteMany
+controlPlaneNodeName: ""
+kubernetesWorkerImage: ""
+kubernetesWorkerImagePullPolicy: ""
+kubernetesWorkerServiceAccountName: ""
+kubernetesWorkerNamePrefix: "mindroom-worker"
+kubernetesWorkerStorageSubpathPrefix: "workers"
+kubernetesWorkerPort: 8766
+kubernetesWorkerReadyTimeoutSeconds: 60
+kubernetesWorkerIdleTimeoutSeconds: 1800
+sandbox_proxy_token: "replace-me"
+```
+
+Important behavior and constraints:
+
+- `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
+- `workerCleanupIntervalSeconds` controls how often the primary runtime runs idle-worker cleanup.
+- `kubernetesWorkerIdleTimeoutSeconds` controls when a worker is considered idle and eligible to scale down.
+- `kubernetesWorkerReadyTimeoutSeconds` controls how long the primary runtime waits for a worker Deployment to become ready.
+- `kubernetesWorkerPort` is the internal Service and container port used by dedicated workers.
+- The worker state lives on the shared instance PVC under `kubernetesWorkerStorageSubpathPrefix/<worker-dir>/`.
+
+### Storage Requirements
+
+Dedicated workers need access to the same PVC as the primary runtime. For multi-node operation, set `storageAccessMode: ReadWriteMany`. If your storage class only supports `ReadWriteOnce`, set `controlPlaneNodeName` so the control plane and dedicated workers stay on the same node. The chart enforces this constraint during template rendering.
+
+### RBAC And Network Policy
+
+When `workerBackend: kubernetes` is enabled, the chart creates:
+
+- A worker-manager ServiceAccount for the primary runtime.
+- A Role and RoleBinding that allow managing worker Deployments and Services in the instance namespace.
+- NetworkPolicy rules that allow the primary runtime to reach the internal worker port and allow worker traffic within the instance namespace.
+
+### Operations
+
+The authenticated dashboard API exposes `/api/workers` to list active or idle workers and `/api/workers/cleanup` to trigger cleanup manually. Dedicated workers are internal-only cluster Services and are authenticated with the shared `sandbox_proxy_token`. See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for the execution model, credential leases, and non-Kubernetes deployment modes.
+
 ## Secrets Management
 
 API keys are mounted as files at `/etc/secrets/` (not environment variables). MindRoom reads paths from `*_API_KEY_FILE` environment variables:

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -1,31 +1,36 @@
 # Sandbox Proxy Isolation
 
-When agents have code-execution tools (`shell`, `file`, `python`), they can read and modify anything on the filesystem — config files, credentials, application code. The **sandbox proxy** isolates these tools by forwarding their calls to a separate process (the **sandbox runner**) that has no access to secrets or sensitive data.
+When agents have code-execution tools (`shell`, `file`, `python`), they can read and modify anything on the filesystem, including config files, credentials, and application code. The **sandbox proxy** isolates these tools by forwarding their calls to a separate worker runtime that has no direct access to the primary process secrets.
 
 ## How it works
 
 ```
 ┌──────────────────────────┐         HTTP          ┌──────────────────────────┐
-│ Primary MindRoom runtime │  ── tool call ──▶     │ Sandbox runner           │
-│ has secrets              │  ◀── result ───       │ no secrets               │
-│ has credentials          │                       │ no credentials           │
-│ has persistent data      │                       │ writable scratch only    │
+│ Primary MindRoom runtime │  ── tool call ──▶     │ Worker runtime           │
+│ has secrets              │  ◀── result ───       │ no primary secrets       │
+│ has credentials          │                       │ leased credentials only  │
+│ has orchestration state  │                       │ worker-owned state       │
 └──────────────────────────┘                       └──────────────────────────┘
 ```
 
-1. Agent invokes `shell.run_shell_command(...)` (or file/python tool)
-1. Primary MindRoom runtime detects the tool is in the proxy list
-1. Call is forwarded over HTTP to the sandbox runner
-1. Runner executes the tool locally and returns the result
-1. All other tools (API tools, search, etc.) execute in the primary MindRoom runtime as usual
+1. Agent invokes `shell.run_shell_command(...)` or another worker-routed tool.
+1. The primary MindRoom runtime resolves the target worker from the configured backend plus worker scope.
+1. The call is forwarded over HTTP to the target worker runtime.
+1. The worker executes the tool locally against its own state and returns the result.
+1. All other tools such as API tools or Matrix-bound tools execute in the primary MindRoom runtime as usual.
 
-The runner authenticates requests with a shared token (`MINDROOM_SANDBOX_PROXY_TOKEN`). For tools that need credentials (e.g., a shell tool that calls an authenticated API), the primary MindRoom runtime can create a short-lived **credential lease** that the runner consumes once — credentials never persist in the runner's memory.
+The worker runtime authenticates requests with a shared token (`MINDROOM_SANDBOX_PROXY_TOKEN`). For tools that need credentials, such as a shell tool that calls an authenticated API, the primary MindRoom runtime can create a short-lived **credential lease** that the worker consumes once. Credentials never become part of the normal tool arguments or the model prompt.
+
+MindRoom currently ships two worker backend shapes:
+
+- `static_runner`: one shared sandbox-runner process, usually a sidecar container or a local HTTP service.
+- `kubernetes`: dedicated worker pods created on demand from the primary runtime, with one logical worker per worker key.
 
 ## Deployment modes
 
-### Docker Compose (sidecar container)
+### Docker Compose (`static_runner`)
 
-Add a `sandbox-runner` service alongside MindRoom. Both use the same image; the runner just has a different entrypoint and no access to `.env` or the data volume.
+Add a `sandbox-runner` service alongside MindRoom. Both use the same image. The runner just has a different entrypoint and no access to `.env` or the primary data volume.
 
 ```
 services:
@@ -36,6 +41,7 @@ services:
       - ./config.yaml:/app/config.yaml:ro
       - ./mindroom_data:/app/mindroom_data
     environment:
+      - MINDROOM_WORKER_BACKEND=static_runner
       - MINDROOM_SANDBOX_PROXY_URL=http://sandbox-runner:8766
       - MINDROOM_SANDBOX_PROXY_TOKEN=${MINDROOM_SANDBOX_PROXY_TOKEN}
       - MINDROOM_SANDBOX_EXECUTION_MODE=selective
@@ -66,13 +72,40 @@ Key differences from the primary MindRoom runtime:
 - **Scratch workspace** — a dedicated volume for file operations
 - **`MINDROOM_STORAGE_PATH`** — pointed at a writable location inside the workspace so the tool registry can initialize without access to the primary data volume
 
-### Kubernetes (pod sidecar)
+### Kubernetes shared sidecar (`workerBackend: static_runner`)
 
-In Kubernetes the runner runs as a second container in the same pod, sharing `localhost` networking. See `cluster/k8s/instance/templates/deployment-mindroom.yaml` for the full manifest. The runner gets:
+In Kubernetes the shared runner can still run as a second container in the same pod, sharing `localhost` networking. This is the `workerBackend: static_runner` Helm mode. See `cluster/k8s/instance/templates/deployment-mindroom.yaml` for the full manifest. The sidecar gets:
 
-- An `emptyDir` volume for scratch workspace
-- Read-only access to config (for plugin tool registration)
-- No access to the secrets volume
+- An `emptyDir` volume for scratch workspace.
+- Read-only access to config for plugin tool registration.
+- No access to the primary secrets volume.
+
+### Kubernetes dedicated workers (`workerBackend: kubernetes`)
+
+In dedicated-worker mode the primary MindRoom runtime creates worker Deployments and Services on demand. Each worker pod runs the sandbox-runner app and is addressed through an internal cluster Service. The worker state is mounted from the shared instance PVC under a worker-specific subpath, so files, virtualenvs, caches, sessions, and other worker-owned state survive pod recreation. Idle cleanup scales worker Deployments to zero while keeping the PVC-backed state intact.
+
+Use the instance Helm chart with values like:
+
+```
+workerBackend: kubernetes
+workerCleanupIntervalSeconds: 30
+storageAccessMode: ReadWriteMany
+kubernetesWorkerPort: 8766
+kubernetesWorkerReadyTimeoutSeconds: 60
+kubernetesWorkerIdleTimeoutSeconds: 1800
+sandbox_proxy_token: "replace-me"
+```
+
+Important notes for this mode:
+
+- `storageAccessMode` should be `ReadWriteMany` for multi-node shared storage.
+- If you must keep `ReadWriteOnce`, set `controlPlaneNodeName` so the control plane and dedicated workers stay on the same node.
+- `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
+- The chart creates the worker-manager ServiceAccount, Role, RoleBinding, and worker-specific NetworkPolicy rules automatically when this backend is enabled.
+- The primary runtime does not need `MINDROOM_SANDBOX_PROXY_URL` in this mode because worker endpoints come from the Kubernetes worker handles.
+- The authenticated `/api/workers` and `/api/workers/cleanup` endpoints on the primary runtime expose backend-neutral worker lifecycle information.
+
+For the full Helm-side deployment guidance, see [Kubernetes Deployment](https://docs.mindroom.chat/deployment/kubernetes/index.md).
 
 ### Host machine + Docker sandbox container
 
@@ -83,6 +116,7 @@ Run MindRoom directly on the host while isolating code-execution tools in a Dock
 docker run -d \
   --name mindroom-sandbox-runner \
   -p 8766:8766 \
+  -e MINDROOM_WORKER_BACKEND=static_runner \
   -e MINDROOM_SANDBOX_RUNNER_MODE=true \
   -e MINDROOM_SANDBOX_PROXY_TOKEN=your-secret-token \
   -e MINDROOM_STORAGE_PATH=/app/workspace/.mindroom \
@@ -90,6 +124,7 @@ docker run -d \
   /app/run-sandbox-runner.sh
 
 # 2. Start MindRoom on the host with proxy config
+export MINDROOM_WORKER_BACKEND=static_runner
 export MINDROOM_SANDBOX_PROXY_URL=http://localhost:8766
 export MINDROOM_SANDBOX_PROXY_TOKEN=your-secret-token
 export MINDROOM_SANDBOX_EXECUTION_MODE=selective
@@ -100,6 +135,7 @@ mindroom run
 Or add the proxy variables to your `.env` file:
 
 ```
+MINDROOM_WORKER_BACKEND=static_runner
 MINDROOM_SANDBOX_PROXY_URL=http://localhost:8766
 MINDROOM_SANDBOX_PROXY_TOKEN=your-secret-token
 MINDROOM_SANDBOX_EXECUTION_MODE=selective
@@ -114,15 +150,18 @@ This gives you the convenience of running MindRoom natively while keeping code-e
 
 ### Primary MindRoom runtime (proxy client)
 
-| Variable                                        | Description                                        | Default                               |
-| ----------------------------------------------- | -------------------------------------------------- | ------------------------------------- |
-| `MINDROOM_SANDBOX_PROXY_URL`                    | URL of the sandbox runner                          | *(none — proxy disabled)*             |
-| `MINDROOM_SANDBOX_PROXY_TOKEN`                  | Shared auth token                                  | *(required when proxy URL is set)*    |
-| `MINDROOM_SANDBOX_EXECUTION_MODE`               | `selective`, `all`, `off`                          | *(unset — uses proxy tools list)*     |
-| `MINDROOM_SANDBOX_PROXY_TOOLS`                  | Comma-separated tool names to proxy                | `*` (all, unless mode is `selective`) |
-| `MINDROOM_SANDBOX_PROXY_TIMEOUT_SECONDS`        | HTTP timeout for proxy calls                       | `120`                                 |
-| `MINDROOM_SANDBOX_CREDENTIAL_LEASE_TTL_SECONDS` | Credential lease lifetime                          | `60`                                  |
-| `MINDROOM_SANDBOX_CREDENTIAL_POLICY_JSON`       | JSON mapping tool selectors to credential services | `{}`                                  |
+| Variable                                        | Description                                                 | Default                                       |
+| ----------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------- |
+| `MINDROOM_WORKER_BACKEND`                       | Worker backend name: `static_runner` or `kubernetes`        | `static_runner`                               |
+| `MINDROOM_SANDBOX_PROXY_URL`                    | URL of the shared sandbox runner when using `static_runner` | *(none — proxy disabled for `static_runner`)* |
+| `MINDROOM_SANDBOX_PROXY_TOKEN`                  | Shared auth token used by the worker runtime                | *(required for worker-routed execution)*      |
+| `MINDROOM_SANDBOX_EXECUTION_MODE`               | `selective`, `all`, `off`                                   | *(unset — uses proxy tools list)*             |
+| `MINDROOM_SANDBOX_PROXY_TOOLS`                  | Comma-separated tool names to proxy                         | `*` (all, unless mode is `selective`)         |
+| `MINDROOM_SANDBOX_PROXY_TIMEOUT_SECONDS`        | HTTP timeout for proxy calls                                | `120`                                         |
+| `MINDROOM_SANDBOX_CREDENTIAL_LEASE_TTL_SECONDS` | Credential lease lifetime                                   | `60`                                          |
+| `MINDROOM_SANDBOX_CREDENTIAL_POLICY_JSON`       | JSON mapping tool selectors to credential services          | `{}`                                          |
+
+When `MINDROOM_WORKER_BACKEND=kubernetes`, the primary runtime resolves worker endpoints through the Kubernetes backend and does not use `MINDROOM_SANDBOX_PROXY_URL`. The Helm chart sets the Kubernetes backend environment variables automatically. If you deploy that mode without Helm, see [Kubernetes Deployment](https://docs.mindroom.chat/deployment/kubernetes/index.md) and `src/mindroom/workers/backends/kubernetes_config.py` for the required environment surface.
 
 ### Sandbox runner
 
@@ -158,12 +197,13 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 
 ## Security considerations
 
-- The sandbox runner **never has** API keys, Matrix credentials, or access to `mindroom_data/`
-- The shared token authenticates all proxy traffic — use a strong random value
-- Credential leases are single-use by default and expire after 60 seconds
-- The runner's `securityContext` drops all capabilities and disables privilege escalation
-- In Kubernetes, the runner uses `emptyDir` for scratch space — no persistent state
-- The primary MindRoom runtime **does not** mount the sandbox runner router — the `/api/sandbox-runner/` endpoints exist only in the runner process
+- The worker runtime never gets the primary runtime API key files, Matrix client state, or orchestrator authority.
+- The shared token authenticates all proxy traffic, so use a strong random value.
+- Credential leases are single-use by default and expire after 60 seconds.
+- The worker container `securityContext` drops all capabilities and disables privilege escalation.
+- With `workerBackend: static_runner`, the Kubernetes sidecar uses `emptyDir` scratch space and has no persistent state of its own.
+- With `workerBackend: kubernetes`, dedicated worker pods mount a worker-specific PVC subpath and keep worker-owned state across pod recreation.
+- The primary MindRoom runtime does not mount the sandbox-runner router, so `/api/sandbox-runner/` exists only in runner or dedicated worker processes.
 
 ## Per-agent configuration
 
@@ -195,7 +235,7 @@ The `worker_tools` field has three states:
 | `[]` (empty list)   | Explicitly disable sandbox proxying for this agent                                                                                                        |
 | `["shell", "file"]` | Proxy exactly these tools for this agent                                                                                                                  |
 
-Agent-level `worker_tools` overrides `defaults.worker_tools`. A sandbox proxy URL (`MINDROOM_SANDBOX_PROXY_URL`) must still be configured for any proxying to take effect.
+Agent-level `worker_tools` overrides `defaults.worker_tools`. With `MINDROOM_WORKER_BACKEND=static_runner`, a sandbox proxy URL (`MINDROOM_SANDBOX_PROXY_URL`) must still be configured for proxying to take effect. With `MINDROOM_WORKER_BACKEND=kubernetes`, worker endpoints are resolved dynamically and `MINDROOM_SANDBOX_PROXY_URL` is not used.
 
 ## Worker Scope
 
@@ -233,6 +273,6 @@ The supported values are:
 
 If `worker_scope` is unset, proxied tools still use the sandbox runner, but the request stays unscoped and no worker-specific storage root is selected. `worker_scope` also affects dashboard credential support and OpenAI-compatible agent eligibility. The dashboard credential UI only supports unscoped agents and agents with `worker_scope=shared`. Agents using `user`, `user_agent`, or `room_thread` must treat credentials as runtime-owned worker state.
 
-## Without sandbox proxy
+## Without configured worker routing
 
-When no `MINDROOM_SANDBOX_PROXY_URL` is set, all tools execute directly in the primary MindRoom runtime process. This is fine for development but not recommended for production deployments where agents run untrusted code.
+With `MINDROOM_WORKER_BACKEND=static_runner` and no `MINDROOM_SANDBOX_PROXY_URL`, tool calls execute directly in the primary MindRoom runtime process. This is fine for development but not recommended for production deployments where agents run untrusted code. With `MINDROOM_WORKER_BACKEND=kubernetes`, worker-routed tool calls fail closed when the backend is misconfigured instead of silently running locally.


### PR DESCRIPTION
## Summary
- add first-class deployment docs for the built-in Kubernetes worker backend
- update sandbox proxy docs to cover `static_runner` versus `kubernetes` execution modes
- refresh the persistent worker runtime plan to match the current implementation state
- regenerate the derived mindroom-docs reference pages

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `pytest -q tests/test_kubernetes_worker_backend.py tests/test_sandbox_proxy.py tests/api/test_sandbox_runner_api.py tests/test_openai_compat.py tests/api/test_api.py`