### PR TITLE
Fix mindroom-stack smoke test and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ MindRoom also maintains related repositories under `github.com/mindroom-ai`:
 - `synapse` - our Synapse fork for MindRoom streaming workloads: optional compact-edit collapsing for superseded `m.replace` events across `/sync`, Sliding Sync, pagination, and context responses, plus `/versions` advertisement via `org.mindroom.compact_edits` and fork-owned Docker/CI flows. See `README.md` and `FORK_CHANGES.md`.
 - `mindroom-librechat` - our LibreChat fork that parses MindRoom inline `<tool>` / `<tool-group>` tags into native `ToolCall` cards so tool execution stays server-side; also includes fork Docker CI and MindRoom-specific UX additions. See `README.md` and `.mindroom/` docs (`fork-context.md`, `tool-tag-rendering.md`).
 - `mindroom-cinny` - our Cinny fork optimized for MindRoom agent workflows with MindRoom branding/default homeserver config, subpath deployment support (runtime/build base path for `/mindroom`), and thread/auth/sidebar UX refinements. See `README.md` and `FORK_CHANGES.md`.
-- `mindroom-stack` - a full Docker Compose reference stack that boots MindRoom backend/frontend, Synapse + Postgres + Redis, and Element together, including first-login and model/API-key setup guidance.
+- `mindroom-stack` - a full Docker Compose reference stack that boots the published MindRoom backend/frontend, a Tuwunel Matrix homeserver, and the MindRoom client together, including first-login and model/API-key setup guidance.
 
 In this dev environment, many of these repositories are cloned in the parent directory (`../`) and can be inspected directly.
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -11,7 +11,7 @@ MindRoom can be deployed in various ways depending on your needs.
 | Method | Best For |
 |--------|----------|
 | [Hosted Matrix + local MindRoom](hosted-matrix.md) | Simplest setup: run only `uvx mindroom run` locally |
-| Full Stack (Docker Compose) | All-in-one: bundled dashboard + Matrix (Synapse) + MindRoom client |
+| Full Stack (Docker Compose) | All-in-one: bundled dashboard + Matrix (Tuwunel) + MindRoom client |
 | [Docker (single container)](docker.md) | Single MindRoom runtime or when you already have Matrix |
 | [Kubernetes](kubernetes.md) | Multi-tenant SaaS, production |
 | Direct | Development, simple setups |
@@ -51,15 +51,15 @@ See [Hosted Matrix deployment](hosted-matrix.md) for the full walkthrough.
 
 ```bash
 git clone https://github.com/mindroom-ai/mindroom-stack
-git clone https://github.com/mindroom-ai/mindroom-cinny
 cd mindroom-stack
 cp .env.example .env
 $EDITOR .env  # add at least one AI provider key
 
-docker compose up -d --build
+docker compose up -d
 ```
 
 The stack exposes MindRoom at `http://localhost:8765`, the MindRoom client at `http://localhost:8080`, and Matrix at `http://localhost:8008`.
+The stack uses published `mindroom`, `mindroom-cinny`, and `mindroom-tuwunel` images by default.
 If you access it from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
 
 ### Direct (Development)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,13 +69,12 @@ For a detailed architecture and credential model, see:
 
 Use this when you want everything local: the bundled MindRoom dashboard, Matrix homeserver, and a Matrix client in one stack.
 
-**Prereqs:** Docker, Docker Compose, and a sibling `mindroom-cinny` checkout.
+**Prereqs:** Docker + Docker Compose.
 
-### 1. Clone the full stack repos
+### 1. Clone the full stack repo
 
 ```bash
 git clone https://github.com/mindroom-ai/mindroom-stack
-git clone https://github.com/mindroom-ai/mindroom-cinny
 cd mindroom-stack
 ```
 
@@ -89,7 +88,7 @@ $EDITOR .env  # add at least one AI provider key
 ### 3. Start everything
 
 ```bash
-docker compose up -d --build
+docker compose up -d
 ```
 
 Open:
@@ -97,6 +96,8 @@ Open:
 - MindRoom UI: http://localhost:8765
 - MindRoom client: http://localhost:8080
 - Matrix homeserver: http://localhost:8008
+
+The stack uses published `mindroom`, `mindroom-cinny`, and `mindroom-tuwunel` images by default.
 
 If you access the stack from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,16 +27,15 @@ MindRoom is an AI agent orchestration system with Matrix integration. It provide
 
 ### Recommended: Full Stack Docker Compose (bundled dashboard + Matrix + MindRoom client)
 
-**Prereqs:** Docker, Docker Compose, and a sibling `mindroom-cinny` checkout.
+**Prereqs:** Docker + Docker Compose.
 
 ```bash
 git clone https://github.com/mindroom-ai/mindroom-stack
-git clone https://github.com/mindroom-ai/mindroom-cinny
 cd mindroom-stack
 cp .env.example .env
 $EDITOR .env  # add at least one AI provider key
 
-docker compose up -d --build
+docker compose up -d
 ```
 
 Open:
@@ -44,6 +43,8 @@ Open:
 - MindRoom UI: http://localhost:8765
 - MindRoom client: http://localhost:8080
 - Matrix homeserver: http://localhost:8008
+
+The stack uses published `mindroom`, `mindroom-cinny`, and `mindroom-tuwunel` images by default.
 
 If you access the stack from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
 

--- a/scripts/smoke_mindroom_stack.py
+++ b/scripts/smoke_mindroom_stack.py
@@ -90,11 +90,11 @@ def main() -> int:
     project_name = os.getenv("PROJECT_NAME", "mindroom-stack-smoke")
     stack_synapse_port = getenv_int("STACK_SYNAPSE_PORT", 18008)
     stack_mindroom_port = getenv_int("STACK_MINDROOM_PORT", 18765)
-    stack_element_port = getenv_int("STACK_ELEMENT_PORT", 18080)
+    stack_client_port = getenv_int("STACK_CLIENT_PORT", 18080)
 
     validate_port("STACK_SYNAPSE_PORT", stack_synapse_port)
     validate_port("STACK_MINDROOM_PORT", stack_mindroom_port)
-    validate_port("STACK_ELEMENT_PORT", stack_element_port)
+    validate_port("STACK_CLIENT_PORT", stack_client_port)
 
     compose_source = stack_dir / "compose.yaml"
     if not compose_source.is_file():
@@ -126,7 +126,7 @@ def main() -> int:
         compose_text = compose_source.read_text(encoding="utf-8")
         compose_text = compose_text.replace('"8008:8008"', f'"127.0.0.1:{stack_synapse_port}:8008"')
         compose_text = compose_text.replace('"8765:8765"', f'"127.0.0.1:{stack_mindroom_port}:8765"')
-        compose_text = compose_text.replace('"8080:80"', f'"127.0.0.1:{stack_element_port}:80"')
+        compose_text = compose_text.replace('"8080:80"', f'"127.0.0.1:{stack_client_port}:80"')
         compose_file.write_text(compose_text, encoding="utf-8")
         exit_code = 0
 
@@ -146,7 +146,6 @@ def main() -> int:
                     str(compose_file),
                     "up",
                     "-d",
-                    "--build",
                 ],
                 capture_output=True,
             )
@@ -168,22 +167,22 @@ def main() -> int:
             wait_for_http_match(
                 f"http://127.0.0.1:{stack_synapse_port}/_matrix/client/versions",
                 '"versions"',
-                "Synapse",
+                "Matrix homeserver",
                 attempts=40,
                 sleep_seconds=3,
             )
 
             wait_for_http_status(
-                f"http://127.0.0.1:{stack_element_port}/",
+                f"http://127.0.0.1:{stack_client_port}/",
                 200,
-                "Element",
+                "MindRoom client",
                 attempts=20,
                 sleep_seconds=3,
             )
             wait_for_http_match(
-                f"http://127.0.0.1:{stack_element_port}/config.json",
+                f"http://127.0.0.1:{stack_client_port}/config.json",
                 f'"http://localhost:{stack_synapse_port}"',
-                "Element config",
+                "MindRoom client config",
                 attempts=20,
                 sleep_seconds=3,
             )

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -28,16 +28,15 @@ MindRoom is an AI agent orchestration system with Matrix integration. It provide
 
 ### Recommended: Full Stack Docker Compose (bundled dashboard + Matrix + MindRoom client)
 
-**Prereqs:** Docker, Docker Compose, and a sibling `mindroom-cinny` checkout.
+**Prereqs:** Docker + Docker Compose.
 
 ```
 git clone https://github.com/mindroom-ai/mindroom-stack
-git clone https://github.com/mindroom-ai/mindroom-cinny
 cd mindroom-stack
 cp .env.example .env
 $EDITOR .env  # add at least one AI provider key
 
-docker compose up -d --build
+docker compose up -d
 ```
 
 Open:
@@ -45,6 +44,8 @@ Open:
 - MindRoom UI: http://localhost:8765
 - MindRoom client: http://localhost:8080
 - Matrix homeserver: http://localhost:8008
+
+The stack uses published `mindroom`, `mindroom-cinny`, and `mindroom-tuwunel` images by default.
 
 If you access the stack from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
 
@@ -241,13 +242,12 @@ For a detailed architecture and credential model, see: [Hosted Matrix deployment
 
 Use this when you want everything local: the bundled MindRoom dashboard, Matrix homeserver, and a Matrix client in one stack.
 
-**Prereqs:** Docker, Docker Compose, and a sibling `mindroom-cinny` checkout.
+**Prereqs:** Docker + Docker Compose.
 
-### 1. Clone the full stack repos
+### 1. Clone the full stack repo
 
 ```
 git clone https://github.com/mindroom-ai/mindroom-stack
-git clone https://github.com/mindroom-ai/mindroom-cinny
 cd mindroom-stack
 ```
 
@@ -261,7 +261,7 @@ $EDITOR .env  # add at least one AI provider key
 ### 3. Start everything
 
 ```
-docker compose up -d --build
+docker compose up -d
 ```
 
 Open:
@@ -269,6 +269,8 @@ Open:
 - MindRoom UI: http://localhost:8765
 - MindRoom client: http://localhost:8080
 - Matrix homeserver: http://localhost:8008
+
+The stack uses published `mindroom`, `mindroom-cinny`, and `mindroom-tuwunel` images by default.
 
 If you access the stack from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
 
@@ -4050,7 +4052,7 @@ MindRoom can be deployed in various ways depending on your needs.
 | Method                                                                                         | Best For                                                           |
 | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
 | [Hosted Matrix + local MindRoom](https://docs.mindroom.chat/deployment/hosted-matrix/index.md) | Simplest setup: run only `uvx mindroom run` locally                |
-| Full Stack (Docker Compose)                                                                    | All-in-one: bundled dashboard + Matrix (Synapse) + MindRoom client |
+| Full Stack (Docker Compose)                                                                    | All-in-one: bundled dashboard + Matrix (Tuwunel) + MindRoom client |
 | [Docker (single container)](https://docs.mindroom.chat/deployment/docker/index.md)             | Single MindRoom runtime or when you already have Matrix            |
 | [Kubernetes](https://docs.mindroom.chat/deployment/kubernetes/index.md)                        | Multi-tenant SaaS, production                                      |
 | Direct                                                                                         | Development, simple setups                                         |
@@ -4089,15 +4091,14 @@ See [Hosted Matrix deployment](https://docs.mindroom.chat/deployment/hosted-matr
 
 ```
 git clone https://github.com/mindroom-ai/mindroom-stack
-git clone https://github.com/mindroom-ai/mindroom-cinny
 cd mindroom-stack
 cp .env.example .env
 $EDITOR .env  # add at least one AI provider key
 
-docker compose up -d --build
+docker compose up -d
 ```
 
-The stack exposes MindRoom at `http://localhost:8765`, the MindRoom client at `http://localhost:8080`, and Matrix at `http://localhost:8008`. If you access it from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
+The stack exposes MindRoom at `http://localhost:8765`, the MindRoom client at `http://localhost:8080`, and Matrix at `http://localhost:8008`. The stack uses published `mindroom`, `mindroom-cinny`, and `mindroom-tuwunel` images by default. If you access it from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
 
 ### Direct (Development)
 

--- a/skills/mindroom-docs/references/page__deployment__index.md
+++ b/skills/mindroom-docs/references/page__deployment__index.md
@@ -7,7 +7,7 @@ MindRoom can be deployed in various ways depending on your needs.
 | Method                                                                                         | Best For                                                           |
 | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
 | [Hosted Matrix + local MindRoom](https://docs.mindroom.chat/deployment/hosted-matrix/index.md) | Simplest setup: run only `uvx mindroom run` locally                |
-| Full Stack (Docker Compose)                                                                    | All-in-one: bundled dashboard + Matrix (Synapse) + MindRoom client |
+| Full Stack (Docker Compose)                                                                    | All-in-one: bundled dashboard + Matrix (Tuwunel) + MindRoom client |
 | [Docker (single container)](https://docs.mindroom.chat/deployment/docker/index.md)             | Single MindRoom runtime or when you already have Matrix            |
 | [Kubernetes](https://docs.mindroom.chat/deployment/kubernetes/index.md)                        | Multi-tenant SaaS, production                                      |
 | Direct                                                                                         | Development, simple setups                                         |
@@ -46,15 +46,14 @@ See [Hosted Matrix deployment](https://docs.mindroom.chat/deployment/hosted-matr
 
 ```
 git clone https://github.com/mindroom-ai/mindroom-stack
-git clone https://github.com/mindroom-ai/mindroom-cinny
 cd mindroom-stack
 cp .env.example .env
 $EDITOR .env  # add at least one AI provider key
 
-docker compose up -d --build
+docker compose up -d
 ```
 
-The stack exposes MindRoom at `http://localhost:8765`, the MindRoom client at `http://localhost:8080`, and Matrix at `http://localhost:8008`. If you access it from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
+The stack exposes MindRoom at `http://localhost:8765`, the MindRoom client at `http://localhost:8080`, and Matrix at `http://localhost:8008`. The stack uses published `mindroom`, `mindroom-cinny`, and `mindroom-tuwunel` images by default. If you access it from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
 
 ### Direct (Development)
 

--- a/skills/mindroom-docs/references/page__getting-started__index.md
+++ b/skills/mindroom-docs/references/page__getting-started__index.md
@@ -63,13 +63,12 @@ For a detailed architecture and credential model, see: [Hosted Matrix deployment
 
 Use this when you want everything local: the bundled MindRoom dashboard, Matrix homeserver, and a Matrix client in one stack.
 
-**Prereqs:** Docker, Docker Compose, and a sibling `mindroom-cinny` checkout.
+**Prereqs:** Docker + Docker Compose.
 
-### 1. Clone the full stack repos
+### 1. Clone the full stack repo
 
 ```
 git clone https://github.com/mindroom-ai/mindroom-stack
-git clone https://github.com/mindroom-ai/mindroom-cinny
 cd mindroom-stack
 ```
 
@@ -83,7 +82,7 @@ $EDITOR .env  # add at least one AI provider key
 ### 3. Start everything
 
 ```
-docker compose up -d --build
+docker compose up -d
 ```
 
 Open:
@@ -91,6 +90,8 @@ Open:
 - MindRoom UI: http://localhost:8765
 - MindRoom client: http://localhost:8080
 - Matrix homeserver: http://localhost:8008
+
+The stack uses published `mindroom`, `mindroom-cinny`, and `mindroom-tuwunel` images by default.
 
 If you access the stack from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
 

--- a/skills/mindroom-docs/references/page__index.md
+++ b/skills/mindroom-docs/references/page__index.md
@@ -22,16 +22,15 @@ MindRoom is an AI agent orchestration system with Matrix integration. It provide
 
 ### Recommended: Full Stack Docker Compose (bundled dashboard + Matrix + MindRoom client)
 
-**Prereqs:** Docker, Docker Compose, and a sibling `mindroom-cinny` checkout.
+**Prereqs:** Docker + Docker Compose.
 
 ```
 git clone https://github.com/mindroom-ai/mindroom-stack
-git clone https://github.com/mindroom-ai/mindroom-cinny
 cd mindroom-stack
 cp .env.example .env
 $EDITOR .env  # add at least one AI provider key
 
-docker compose up -d --build
+docker compose up -d
 ```
 
 Open:
@@ -39,6 +38,8 @@ Open:
 - MindRoom UI: http://localhost:8765
 - MindRoom client: http://localhost:8080
 - Matrix homeserver: http://localhost:8008
+
+The stack uses published `mindroom`, `mindroom-cinny`, and `mindroom-tuwunel` images by default.
 
 If you access the stack from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
 


### PR DESCRIPTION
## Summary
- update the mindroom-stack smoke script for the current compose shape and client config
- build the stack during the smoke run and verify the generated client config points at the remapped Synapse port
- sync the full-stack docs and generated mindroom-docs references with the current mindroom-stack README

## Testing
- python -m scripts.smoke_mindroom_stack /home/basnijholt/Work/dev/mindroom-stack
- pytest -q
- pre-commit run --all-files