### PR TITLE
Keep sentence transformers out of runtime image

### DIFF
--- a/local/instances/deploy/Dockerfile.mindroom
+++ b/local/instances/deploy/Dockerfile.mindroom
@@ -24,12 +24,14 @@ COPY src /app/src
 COPY skills /app/skills
 COPY frontend /app/frontend
 
-# Install the project itself
+# Install the project itself.
+# Keep the sentence_transformers extra runtime-only so the full image doesn't
+# pull torch and CUDA wheels into the smoke-stack build.
 # Set pretend version for setuptools-scm (no .git in container)
 ARG VERSION=0.0.0
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev --all-extras
+    uv sync --locked --no-dev --all-extras --no-extra sentence_transformers
 
 # Final production stage
 FROM public.ecr.aws/docker/library/python:3.12-slim AS final

--- a/tests/test_tool_dependencies.py
+++ b/tests/test_tool_dependencies.py
@@ -76,6 +76,12 @@ def test_tool_extras_in_sync_with_pyproject() -> None:
         pytest.fail(f"Tool extras out of sync with pyproject.toml:\n{output}")
 
 
+def test_full_runtime_image_keeps_sentence_transformers_runtime_only() -> None:
+    """The full image should not preinstall the runtime-only sentence_transformers extra."""
+    dockerfile = Path("local/instances/deploy/Dockerfile.mindroom").read_text(encoding="utf-8")
+    assert "--all-extras --no-extra sentence_transformers" in dockerfile
+
+
 def test_tools_requiring_config_metadata() -> None:
     """Test that tools marked REQUIRES_CONFIG have config_fields or auth_provider."""
     inconsistent = []


### PR DESCRIPTION
## Summary
- exclude the runtime-only \ extra from the full MindRoom Docker image
- keep the extra available for on-demand install at runtime, which is what the merged feature intended
- add a regression test that guards the Dockerfile install flags

## Why
The Smoke Stacks workflow started failing in the `Build and load images` step after the local sentence-transformers extra was added. The full runtime image uses `uv sync --all-extras`, which pulled in `sentence-transformers`, `torch`, and large CUDA wheels during Docker build. Excluding that runtime-only extra restores the image build while preserving the feature.

## Verification
- `docker build --progress=plain -f local/instances/deploy/Dockerfile.mindroom .`
- `pytest -q tests/test_tool_dependencies.py`
- `pre-commit run --all-files`