### PR TITLE
Fix mindroom-stack smoke test for env-driven ports

### DIFF
--- a/scripts/smoke_mindroom_stack.py
+++ b/scripts/smoke_mindroom_stack.py
@@ -9,6 +9,7 @@ import os
 import sys
 import tempfile
 from pathlib import Path
+from urllib.parse import quote
 
 from scripts.smoke_helpers import (
     error,
@@ -77,7 +78,12 @@ def cleanup(stack_dir: Path, project_name: str, env_file: Path, compose_file: Pa
         capture_output=True,
     )
     env_file.unlink(missing_ok=True)
-    compose_file.unlink(missing_ok=True)
+
+
+def room_alias_url(homeserver_port: int, matrix_server_name: str, room_name: str) -> str:
+    """Return the room-alias directory lookup URL for a managed room."""
+    room_alias = quote(f"#{room_name}:{matrix_server_name}", safe="")
+    return f"http://127.0.0.1:{homeserver_port}/_matrix/client/v3/directory/room/{room_alias}"
 
 
 def main() -> int:
@@ -91,6 +97,7 @@ def main() -> int:
     stack_synapse_port = getenv_int("STACK_SYNAPSE_PORT", 18008)
     stack_mindroom_port = getenv_int("STACK_MINDROOM_PORT", 18765)
     stack_client_port = getenv_int("STACK_CLIENT_PORT", 18080)
+    matrix_server_name = os.getenv("STACK_MATRIX_SERVER_NAME", "matrix.localhost")
 
     validate_port("STACK_SYNAPSE_PORT", stack_synapse_port)
     validate_port("STACK_MINDROOM_PORT", stack_mindroom_port)
@@ -104,30 +111,29 @@ def main() -> int:
     with tempfile.TemporaryDirectory() as tmp_dir_name:
         tmp_dir = Path(tmp_dir_name)
         env_file = tmp_dir / "mindroom-stack-smoke.env"
-        compose_file = tmp_dir / "mindroom-stack-compose.yaml"
+        compose_file = compose_source
 
         env_file.write_text(
             "\n".join(
                 [
                     "POSTGRES_PASSWORD=synapse_password",
-                    "MATRIX_SERVER_NAME=matrix.localhost",
+                    f"MATRIX_SERVER_NAME={matrix_server_name}",
                     "OPENAI_API_KEY=test-openai",
                     "ANTHROPIC_API_KEY=test-anthropic",
                     "GOOGLE_API_KEY=",
                     "OPENROUTER_API_KEY=",
                     "OLLAMA_HOST=http://localhost:11434",
+                    f"HOST_HOMESERVER_PORT={stack_synapse_port}",
+                    f"HOST_DASHBOARD_PORT={stack_mindroom_port}",
+                    f"HOST_CLIENT_PORT={stack_client_port}",
                     f"CLIENT_HOMESERVER_URL=http://localhost:{stack_synapse_port}",
+                    f"CLIENT_MINDROOM_URL=http://localhost:{stack_mindroom_port}",
                     "",
                 ],
             ),
             encoding="utf-8",
         )
 
-        compose_text = compose_source.read_text(encoding="utf-8")
-        compose_text = compose_text.replace('"8008:8008"', f'"127.0.0.1:{stack_synapse_port}:8008"')
-        compose_text = compose_text.replace('"8765:8765"', f'"127.0.0.1:{stack_mindroom_port}:8765"')
-        compose_text = compose_text.replace('"8080:80"', f'"127.0.0.1:{stack_client_port}:80"')
-        compose_file.write_text(compose_text, encoding="utf-8")
         exit_code = 0
 
         try:
@@ -151,9 +157,9 @@ def main() -> int:
             )
 
             wait_for_http_match(
-                f"http://127.0.0.1:{stack_mindroom_port}/api/ready",
-                '"ready"',
-                "MindRoom readiness",
+                f"http://127.0.0.1:{stack_synapse_port}/_matrix/client/versions",
+                '"versions"',
+                "Matrix homeserver",
                 attempts=40,
                 sleep_seconds=3,
             )
@@ -164,14 +170,6 @@ def main() -> int:
                 attempts=40,
                 sleep_seconds=3,
             )
-            wait_for_http_match(
-                f"http://127.0.0.1:{stack_synapse_port}/_matrix/client/versions",
-                '"versions"',
-                "Matrix homeserver",
-                attempts=40,
-                sleep_seconds=3,
-            )
-
             wait_for_http_status(
                 f"http://127.0.0.1:{stack_client_port}/",
                 200,
@@ -186,6 +184,14 @@ def main() -> int:
                 attempts=20,
                 sleep_seconds=3,
             )
+            for room_name in ("lobby", "personal"):
+                wait_for_http_match(
+                    room_alias_url(stack_synapse_port, matrix_server_name, room_name),
+                    '"room_id"',
+                    f"Managed room alias #{room_name}:{matrix_server_name}",
+                    attempts=40,
+                    sleep_seconds=3,
+                )
             log("[smoke] mindroom-stack checks passed")
         except Exception as exc:
             error(str(exc))

--- a/tests/test_smoke_mindroom_stack.py
+++ b/tests/test_smoke_mindroom_stack.py
@@ -1,0 +1,78 @@
+"""Tests for the mindroom-stack compose smoke script."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scripts import smoke_mindroom_stack
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_smoke_mindroom_stack_uses_env_port_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The smoke script should drive current mindroom-stack ports via env vars."""
+    stack_dir = tmp_path / "mindroom-stack"
+    stack_dir.mkdir()
+    compose_file = stack_dir / "compose.yaml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+
+    commands: list[list[str]] = []
+    wait_match_calls: list[tuple[str, str, str]] = []
+    wait_status_calls: list[tuple[str, int, str]] = []
+    captured_env_text: str | None = None
+
+    def fake_run_command(
+        command: list[str],
+        *,
+        check: bool = True,
+        capture_output: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        del check, capture_output
+        nonlocal captured_env_text
+        commands.append(command)
+        env_file = Path(command[command.index("--env-file") + 1])
+        if captured_env_text is None and "up" in command:
+            captured_env_text = env_file.read_text(encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    def fake_wait_for_http_match(url: str, expected: str, label: str, **_: object) -> None:
+        wait_match_calls.append((url, expected, label))
+
+    def fake_wait_for_http_status(url: str, expected_status: int, label: str, **_: object) -> None:
+        wait_status_calls.append((url, expected_status, label))
+
+    monkeypatch.setattr(smoke_mindroom_stack, "run_command", fake_run_command)
+    monkeypatch.setattr(smoke_mindroom_stack, "wait_for_http_match", fake_wait_for_http_match)
+    monkeypatch.setattr(smoke_mindroom_stack, "wait_for_http_status", fake_wait_for_http_status)
+    monkeypatch.setattr(sys, "argv", ["smoke_mindroom_stack.py", str(stack_dir)])
+
+    assert smoke_mindroom_stack.main() == 0
+
+    assert captured_env_text is not None
+    assert "HOST_HOMESERVER_PORT=18008" in captured_env_text
+    assert "HOST_DASHBOARD_PORT=18765" in captured_env_text
+    assert "HOST_CLIENT_PORT=18080" in captured_env_text
+    assert "CLIENT_HOMESERVER_URL=http://localhost:18008" in captured_env_text
+    assert "CLIENT_MINDROOM_URL=http://localhost:18765" in captured_env_text
+
+    up_command = next(command for command in commands if "up" in command)
+    assert up_command[up_command.index("-f") + 1] == str(compose_file)
+
+    wait_match_urls = [url for url, _, _ in wait_match_calls]
+    assert "http://127.0.0.1:18008/_matrix/client/versions" in wait_match_urls
+    assert "http://127.0.0.1:18765/" in wait_match_urls
+    assert "http://127.0.0.1:18080/config.json" in wait_match_urls
+    assert all("/api/ready" not in url for url in wait_match_urls)
+    assert "http://127.0.0.1:18008/_matrix/client/v3/directory/room/%23lobby%3Amatrix.localhost" in wait_match_urls
+    assert "http://127.0.0.1:18008/_matrix/client/v3/directory/room/%23personal%3Amatrix.localhost" in wait_match_urls
+
+    assert wait_status_calls == [
+        ("http://127.0.0.1:18080/", 200, "MindRoom client"),
+    ]


### PR DESCRIPTION
## Summary
- fix the `mindroom-stack` smoke test to use env-driven host port overrides instead of rewriting literal port mappings
- validate current stack readiness through the dashboard, client config, and managed room aliases
- add a regression test covering the current compose contract

## Root cause
The failing smoke job in GitHub Actions run `23024452112`, job `66868804846`, was timing out because `mindroom-stack` now maps ports through env vars like `HOST_HOMESERVER_PORT`, `HOST_CLIENT_PORT`, and `HOST_DASHBOARD_PORT`.
The smoke script still rewrote literal compose port strings, so its replacements no longer applied and it polled ports that the stack was not actually using.

## Verification
- `uv run pytest`
- `pre-commit run --all-files`
- `python -m scripts.smoke_mindroom_stack /tmp/mindroom-stack-main`
