### PR TITLE
fix: harden dedicated worker pod startup

### DIFF
--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -47,6 +47,7 @@ _TOKEN_ENV_NAME = "MINDROOM_SANDBOX_PROXY_TOKEN"  # noqa: S105
 _RUNNER_PORT_ENV_NAME = "MINDROOM_SANDBOX_RUNNER_PORT"
 _DEDICATED_WORKER_KEY_ENV = "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY"
 _DEDICATED_WORKER_ROOT_ENV = "MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT"
+_DEFAULT_CONTAINER_PATH = "/app/.venv/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 
 class _ApiStatusError(Exception):
@@ -455,6 +456,11 @@ class KubernetesResourceManager:
                         "periodSeconds": 5,
                         "failureThreshold": 6,
                     },
+                    "startupProbe": {
+                        "httpGet": {"path": "/healthz", "port": "api"},
+                        "periodSeconds": 5,
+                        "failureThreshold": 60,
+                    },
                     "livenessProbe": {
                         "httpGet": {"path": "/healthz", "port": "api"},
                         "periodSeconds": 10,
@@ -491,11 +497,14 @@ class KubernetesResourceManager:
         }
 
     def _worker_env(self, worker_key: str) -> list[dict[str, object]]:
+        venv_path = f"{self.config.storage_mount_path}/venv"
         env: list[dict[str, object]] = [
             {"name": "MINDROOM_SANDBOX_RUNNER_MODE", "value": "true"},
             {"name": "MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE", "value": "subprocess"},
             {"name": _RUNNER_PORT_ENV_NAME, "value": str(self.config.worker_port)},
             {"name": "MINDROOM_STORAGE_PATH", "value": self.config.storage_mount_path},
+            {"name": "VIRTUAL_ENV", "value": venv_path},
+            {"name": "PATH", "value": f"{venv_path}/bin:{_DEFAULT_CONTAINER_PATH}"},
             {
                 "name": SHARED_CREDENTIALS_PATH_ENV,
                 "value": f"{self.config.storage_mount_path}/.shared_credentials",

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -214,10 +214,14 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:
     assert "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY" in env_names
     assert "MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT" in env_names
     assert "MINDROOM_STORAGE_PATH" in env_names
+    assert "VIRTUAL_ENV" in env_names
+    assert "PATH" in env_names
     assert "MINDROOM_SHARED_CREDENTIALS_PATH" in env_names
     assert "MINDROOM_SANDBOX_PROXY_TOKEN" in env_names
     assert env_values["MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE"] == "subprocess"
     assert env_values["MINDROOM_SANDBOX_RUNNER_PORT"] == "8766"
+    assert env_values["VIRTUAL_ENV"] == "/app/worker/venv"
+    assert env_values["PATH"].startswith("/app/worker/venv/bin:")
     assert env_values["MINDROOM_SHARED_CREDENTIALS_PATH"] == "/app/worker/.shared_credentials"
     assert container["volumeMounts"][0]["subPath"] == f"workers/{worker_dir_name('worker-a')}"
     assert (
@@ -259,6 +263,11 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:
     }
     assert container["resources"]["requests"] == {"memory": "256Mi", "cpu": "100m"}
     assert container["resources"]["limits"] == {"memory": "1Gi", "cpu": "500m"}
+    assert container["startupProbe"] == {
+        "httpGet": {"path": "/healthz", "port": "api"},
+        "periodSeconds": 5,
+        "failureThreshold": 60,
+    }
 
 
 def test_kubernetes_backend_requires_configured_owner_deployment_to_exist() -> None:


### PR DESCRIPTION
## Summary
- add a startup probe to dedicated worker pods so slow startup does not trip readiness and liveness prematurely
- expose the worker venv through PATH and VIRTUAL_ENV in dedicated worker pods
- add backend tests for the generated pod manifest

## Testing
- uv run pytest -q tests/test_kubernetes_worker_backend.py
