### PR TITLE
Extract non-runtime helpers from constants

### DIFF
--- a/src/mindroom/__init__.py
+++ b/src/mindroom/__init__.py
@@ -3,7 +3,7 @@
 import os
 from importlib.metadata import version
 
-from mindroom.constants import patch_chromadb_for_python314
+from mindroom.chromadb_compat import patch_chromadb_for_python314
 
 # MindRoom should never emit Agno network telemetry, even if a user .env enables it.
 os.environ["AGNO_TELEMETRY"] = "false"

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -36,6 +36,7 @@ from mindroom.api.workers import router as workers_router
 from mindroom.config.main import Config
 from mindroom.config.main import load_config as load_runtime_config_model
 from mindroom.credentials_sync import sync_env_to_credentials
+from mindroom.file_ops import safe_replace
 from mindroom.file_watcher import watch_file
 from mindroom.frontend_assets import ensure_frontend_dist_dir
 from mindroom.logging_config import get_logger
@@ -349,7 +350,7 @@ def _save_config_to_file(
             sort_keys=True,
             allow_unicode=True,
         )
-    constants.safe_replace(tmp_path, config_path)
+    safe_replace(tmp_path, config_path)
 
 
 def _validated_config_payload(

--- a/src/mindroom/api/skills.py
+++ b/src/mindroom/api/skills.py
@@ -9,7 +9,7 @@ import yaml
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from mindroom.constants import safe_replace
+from mindroom.file_ops import safe_replace
 from mindroom.tool_system.skills import (
     get_user_skills_dir,
     list_skill_listings,

--- a/src/mindroom/chromadb_compat.py
+++ b/src/mindroom/chromadb_compat.py
@@ -1,0 +1,61 @@
+"""Compatibility shims for chromadb."""
+
+from __future__ import annotations
+
+import sys
+from typing import cast
+
+_CHROMADB_PY314_PATCHED = False
+
+
+def patch_chromadb_for_python314() -> None:
+    """Patch pydantic internals so chromadb works on Python 3.14+.
+
+    chromadb currently relies on pydantic v1 `BaseSettings` behavior and defines
+    untyped fields in its settings model. This runtime shim can be removed once
+    chromadb ships an upstream fix.
+    """
+    global _CHROMADB_PY314_PATCHED
+    if _CHROMADB_PY314_PATCHED or sys.version_info < (3, 14):
+        return
+
+    import pydantic  # noqa: PLC0415
+    from pydantic._internal import _model_construction  # noqa: PLC0415
+    from pydantic_settings import BaseSettings  # noqa: PLC0415
+
+    # pydantic-settings v2 defaults to extra="forbid", but pydantic v1's
+    # BaseSettings silently ignored env vars / .env keys that didn't match
+    # any field. chromadb relies on that tolerance, so we must restore it.
+    class _PermissiveBaseSettings(BaseSettings):
+        model_config = BaseSettings.model_config.copy()
+        model_config["extra"] = "ignore"
+
+    pydantic.BaseSettings = _PermissiveBaseSettings
+
+    original_inspect_namespace = _model_construction.inspect_namespace
+
+    def _patched_inspect_namespace(*args: object, **kwargs: object) -> object:
+        try:
+            return original_inspect_namespace(*args, **kwargs)
+        except pydantic.errors.PydanticUserError as exc:
+            if "non-annotated attribute" not in str(exc):
+                raise
+
+            namespace = args[0] if args else kwargs.get("namespace")
+            raw_annotations = args[1] if len(args) > 1 else kwargs.get("raw_annotations")
+            if not isinstance(namespace, dict) or not isinstance(raw_annotations, dict):
+                raise
+            namespace_dict = cast("dict[str, object]", namespace)
+            raw_annotations_dict = cast("dict[str, object]", raw_annotations)
+
+            for field in (
+                "chroma_coordinator_host",
+                "chroma_logservice_host",
+                "chroma_logservice_port",
+            ):
+                if field in namespace_dict and field not in raw_annotations_dict:
+                    raw_annotations_dict[field] = type(namespace_dict[field])
+            return original_inspect_namespace(*args, **kwargs)
+
+    _model_construction.inspect_namespace = _patched_inspect_namespace
+    _CHROMADB_PY314_PATCHED = True

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -22,15 +22,14 @@ from rich.syntax import Syntax
 from mindroom.config.main import Config, load_config
 from mindroom.constants import (
     OWNER_MATRIX_USER_ID_PLACEHOLDER,
-    VERTEXAI_CLAUDE_ENV_KEYS,
     RuntimePaths,
     config_search_locations,
-    env_key_for_provider,
     exported_process_env,
     resolve_primary_runtime_paths,
     resolve_runtime_paths,
 )
 from mindroom.credentials_sync import get_secret_from_env
+from mindroom.provider_env import VERTEXAI_CLAUDE_ENV_KEYS, env_key_for_provider
 from mindroom.tool_system.worker_routing import agent_workspace_root_path
 
 if TYPE_CHECKING:

--- a/src/mindroom/cli/doctor.py
+++ b/src/mindroom/cli/doctor.py
@@ -18,12 +18,9 @@ from google.auth.exceptions import DefaultCredentialsError, RefreshError
 from pydantic import ValidationError
 
 from mindroom import constants
-from mindroom.constants import (
-    RuntimePaths,
-    env_key_for_provider,
-)
 from mindroom.embeddings import create_sentence_transformers_embedder
 from mindroom.matrix.health import matrix_versions_url, response_has_matrix_versions
+from mindroom.provider_env import env_key_for_provider
 
 from .config import _activate_cli_runtime, _load_config_quiet, console
 
@@ -32,6 +29,7 @@ if TYPE_CHECKING:
 
     from mindroom.config.main import Config
     from mindroom.config.models import ModelConfig
+    from mindroom.constants import RuntimePaths
 
 
 def doctor() -> None:

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -22,8 +22,8 @@ from mindroom.constants import (
     RuntimePaths,
     resolve_runtime_paths,
     runtime_matrix_homeserver,
-    safe_replace,
 )
+from mindroom.file_ops import safe_replace
 from mindroom.logging_config import get_logger
 from mindroom.matrix.identity import (
     agent_username_localpart,

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -1,14 +1,13 @@
 """Shared constants for the mindroom package.
 
 This module contains constants that are used across multiple modules
-to avoid circular imports. It does not import anything from the internal
-codebase.
+to avoid circular imports.
+It keeps the runtime path and env source-of-truth together.
 """
 
 import os
 import re
 import shutil
-import sys
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -16,6 +15,8 @@ from types import MappingProxyType
 from typing import cast
 
 from dotenv import dotenv_values
+
+from mindroom.provider_env import PROVIDER_ENV_KEYS, VERTEXAI_CLAUDE_ENV_KEYS
 
 # Agent names
 ROUTER_AGENT_NAME = "router"
@@ -576,100 +577,6 @@ AI_RUN_METADATA_KEY = "io.mindroom.ai_run"
 # automatically replace this token with the owner Matrix user ID returned
 # by the provisioning service.
 OWNER_MATRIX_USER_ID_PLACEHOLDER = "__MINDROOM_OWNER_USER_ID_FROM_PAIRING__"
-
-
-# Canonical mapping from provider name to the environment variable it requires.
-# Other modules derive their own views from this single source of truth.
-PROVIDER_ENV_KEYS: dict[str, str] = {
-    "anthropic": "ANTHROPIC_API_KEY",
-    "openai": "OPENAI_API_KEY",
-    "google": "GOOGLE_API_KEY",
-    "openrouter": "OPENROUTER_API_KEY",
-    "deepseek": "DEEPSEEK_API_KEY",
-    "cerebras": "CEREBRAS_API_KEY",
-    "groq": "GROQ_API_KEY",
-    "ollama": "OLLAMA_HOST",
-}
-VERTEXAI_CLAUDE_ENV_KEYS: tuple[str, str] = ("ANTHROPIC_VERTEX_PROJECT_ID", "CLOUD_ML_REGION")
-
-_CHROMADB_PY314_PATCHED = False
-
-
-def env_key_for_provider(provider: str) -> str | None:
-    """Get the environment variable name for a provider's API key.
-
-    Handles the gemini→google alias so callers don't need to.
-    """
-    if provider == "gemini":
-        return PROVIDER_ENV_KEYS.get("google")
-    return PROVIDER_ENV_KEYS.get(provider)
-
-
-def patch_chromadb_for_python314() -> None:
-    """Patch pydantic internals so chromadb works on Python 3.14+.
-
-    chromadb currently relies on pydantic v1 `BaseSettings` behavior and defines
-    untyped fields in its settings model. This runtime shim can be removed once
-    chromadb ships an upstream fix.
-    """
-    global _CHROMADB_PY314_PATCHED
-    if _CHROMADB_PY314_PATCHED or sys.version_info < (3, 14):
-        return
-
-    import pydantic  # noqa: PLC0415
-    from pydantic._internal import _model_construction  # noqa: PLC0415
-    from pydantic_settings import BaseSettings  # noqa: PLC0415
-
-    # pydantic-settings v2 defaults to extra="forbid", but pydantic v1's
-    # BaseSettings silently ignored env vars / .env keys that didn't match
-    # any field.  chromadb relies on that tolerance, so we must restore it.
-    class _PermissiveBaseSettings(BaseSettings):
-        model_config = BaseSettings.model_config.copy()
-        model_config["extra"] = "ignore"
-
-    pydantic.BaseSettings = _PermissiveBaseSettings
-
-    original_inspect_namespace = _model_construction.inspect_namespace
-
-    def _patched_inspect_namespace(*args: object, **kwargs: object) -> object:
-        try:
-            return original_inspect_namespace(*args, **kwargs)
-        except pydantic.errors.PydanticUserError as exc:
-            if "non-annotated attribute" not in str(exc):
-                raise
-
-            namespace = args[0] if args else kwargs.get("namespace")
-            raw_annotations = args[1] if len(args) > 1 else kwargs.get("raw_annotations")
-            if not isinstance(namespace, dict) or not isinstance(raw_annotations, dict):
-                raise
-            namespace_dict = cast("dict[str, object]", namespace)
-            raw_annotations_dict = cast("dict[str, object]", raw_annotations)
-
-            for field in (
-                "chroma_coordinator_host",
-                "chroma_logservice_host",
-                "chroma_logservice_port",
-            ):
-                if field in namespace_dict and field not in raw_annotations_dict:
-                    raw_annotations_dict[field] = type(namespace_dict[field])
-            return original_inspect_namespace(*args, **kwargs)
-
-    _model_construction.inspect_namespace = _patched_inspect_namespace
-    _CHROMADB_PY314_PATCHED = True
-
-
-def safe_replace(tmp_path: Path, target_path: Path) -> None:
-    """Replace *target_path* with *tmp_path*, with a fallback for bind mounts.
-
-    ``Path.replace`` performs an atomic rename which fails on some filesystems
-    (e.g. Docker bind mounts) with ``OSError: [Errno 16] Device or resource
-    busy``.  When that happens we fall back to a non-atomic copy.
-    """
-    try:
-        tmp_path.replace(target_path)
-    except OSError:
-        shutil.copy2(tmp_path, target_path)
-        tmp_path.unlink(missing_ok=True)
 
 
 def ensure_writable_config_path(

--- a/src/mindroom/credentials_sync.py
+++ b/src/mindroom/credentials_sync.py
@@ -11,9 +11,10 @@ private Git knowledge sync.
 It is not a generic bridge for tool-specific env var configuration.
 """
 
-from mindroom.constants import PROVIDER_ENV_KEYS, RuntimePaths, runtime_env_path
+from mindroom.constants import RuntimePaths, runtime_env_path
 from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.logging_config import get_logger
+from mindroom.provider_env import PROVIDER_ENV_KEYS
 
 logger = get_logger(__name__)
 

--- a/src/mindroom/file_ops.py
+++ b/src/mindroom/file_ops.py
@@ -1,0 +1,18 @@
+"""Focused filesystem helpers."""
+
+import shutil
+from pathlib import Path
+
+
+def safe_replace(tmp_path: Path, target_path: Path) -> None:
+    """Replace *target_path* with *tmp_path*, with a fallback for bind mounts.
+
+    ``Path.replace`` performs an atomic rename which fails on some filesystems
+    (e.g. Docker bind mounts) with ``OSError: [Errno 16] Device or resource
+    busy``. When that happens we fall back to a non-atomic copy.
+    """
+    try:
+        tmp_path.replace(target_path)
+    except OSError:
+        shutil.copy2(tmp_path, target_path)
+        tmp_path.unlink(missing_ok=True)

--- a/src/mindroom/provider_env.py
+++ b/src/mindroom/provider_env.py
@@ -1,0 +1,20 @@
+"""Provider credential env-key mappings."""
+
+PROVIDER_ENV_KEYS: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "cerebras": "CEREBRAS_API_KEY",
+    "groq": "GROQ_API_KEY",
+    "ollama": "OLLAMA_HOST",
+}
+VERTEXAI_CLAUDE_ENV_KEYS: tuple[str, str] = ("ANTHROPIC_VERTEX_PROJECT_ID", "CLOUD_ML_REGION")
+
+
+def env_key_for_provider(provider: str) -> str | None:
+    """Get the environment variable name for a provider's API key."""
+    if provider == "gemini":
+        return PROVIDER_ENV_KEYS.get("google")
+    return PROVIDER_ENV_KEYS.get(provider)


### PR DESCRIPTION
## Summary
- keep the runtime path and env authority in `constants.py`
- extract provider env-key lookup into `src/mindroom/provider_env.py`
- extract the Chroma Python 3.14 compatibility shim into `src/mindroom/chromadb_compat.py`
- extract `safe_replace` into `src/mindroom/file_ops.py` and update direct imports

## Testing
- `uv run pytest tests/test_config_discovery.py tests/test_config_reload.py tests/test_cli_config.py tests/test_openai_compat.py tests/api/test_api.py -q`
- `uv run pre-commit run --all-files`