### PR TITLE
Add live-test skill for local end-to-end verification

### DIFF
--- a/.claude/skills/live-test/SKILL.md
+++ b/.claude/skills/live-test/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: live-test
+description: Run live end-to-end checks for this repository. Use when booting the local MindRoom stack or SaaS sandbox, starting an isolated local Matrix/backend instance, creating disposable Matrix accounts, sending or reading messages with Matty, hitting live API endpoints, taking frontend screenshots, or verifying behavior through the real UI instead of tests alone. Also use when a live-test workflow struggled and the skill itself should be improved.
+---
+
+# Live Test
+
+Run the real product and collect runtime evidence.
+
+## Workflow
+
+1. Choose the surface you need to test.
+- For the core MindRoom runtime, local Matrix, Matty, and bundled dashboard, read [references/core-mindroom.md](references/core-mindroom.md).
+- For the core frontend screenshot flow, frontend-only dev server, SaaS sandbox, and platform frontend screenshots, read [references/frontend-and-platform.md](references/frontend-and-platform.md).
+
+2. Prefer isolated local runs when the worktree or machine is already busy.
+- Existing local instances often collide on ports, Matrix usernames, room aliases, and dashboard API ports.
+- If you see conflicts, create a temporary config, set a unique `MINDROOM_NAMESPACE`, use a unique `mindroom_user.username`, isolate `MINDROOM_STORAGE_PATH`, and choose a non-default `--api-port`.
+- If the isolated run writes a temporary `.env`, inspect it before hitting authenticated `/api/*` routes because it may contain the instance-specific `MINDROOM_API_KEY`.
+
+3. Verify behavior, not just startup.
+- For chat flows, send a real message and inspect the actual reply thread.
+- For backend changes, hit the live endpoint on the same instance you started.
+- For frontend changes, capture screenshots and inspect the generated PNGs.
+
+4. Preserve evidence.
+- Record the exact command, port, room name, room ID, thread ID, and returned payload or screenshot path.
+- Prefer Matty `--format json` when you need stable confirmation.
+- If room aliases or thread listings are flaky, fall back to the concrete room ID from backend logs and direct `matty thread` reads.
+
+5. Improve this skill when it struggles.
+- If a live run exposes missing instructions, stale ports, missing workarounds, or a better repo-specific path, update this skill or its references in the same task when reasonable.
+- Keep `SKILL.md` concise and move detailed command sequences into the reference files.

--- a/.claude/skills/live-test/agents/openai.yaml
+++ b/.claude/skills/live-test/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Live Test"
+  short_description: "Run local Matrix, UI, and smoke checks"
+  default_prompt: "Use $live-test to boot the local stack, exercise MindRoom live, and verify the UI with Matty and screenshots."

--- a/.claude/skills/live-test/references/core-mindroom.md
+++ b/.claude/skills/live-test/references/core-mindroom.md
@@ -1,0 +1,234 @@
+# Core MindRoom Live Run
+
+Use this reference for the local Matrix stack, the Python backend, Matty smoke tests, disposable Matrix users, and live API checks.
+
+## Preflight
+
+Run from the repo root.
+
+```bash
+uv sync --all-extras
+just local-matrix-up
+curl -s http://localhost:8008/_matrix/client/versions | head -c 200
+curl -s http://localhost:9292/v1/models | head -c 200
+```
+
+If you switched homeservers or see `M_FORBIDDEN`, clear local Matrix state before restarting MindRoom.
+
+```bash
+rm -f mindroom_data/matrix_state.yaml
+```
+
+## Fast Path: Use Existing Repo Config
+
+Use this when the checked-in `config.yaml` already points at a working local or hosted model provider and there are no port or Matrix ID conflicts.
+
+```bash
+MATRIX_HOMESERVER=http://localhost:8008 \
+MATRIX_SSL_VERIFY=false \
+OPENAI_BASE_URL=http://localhost:9292/v1 \
+OPENAI_API_KEY=sk-test \
+UV_PYTHON=3.13 \
+uv run mindroom run
+```
+
+Then wait for health and rooms.
+
+```bash
+curl -s http://localhost:8765/api/health
+MATRIX_HOMESERVER=http://localhost:8008 MATRIX_SSL_VERIFY=false \
+uv run --python 3.13 matty rooms
+```
+
+## Isolated Path: Temporary Config
+
+Use this when the machine already has local MindRoom instances, existing Matrix users, occupied dashboard ports, or stale config.
+
+```bash
+tmp="$(mktemp -d /tmp/mindroom-live-test.XXXXXX)"
+uv run mindroom config init --minimal --provider openai --force --path "$tmp/config.yaml"
+```
+
+Patch the generated config so it can run locally without private credentials and without restrictive room auth.
+
+Minimum changes:
+
+```yaml
+models:
+  default:
+    provider: openai
+    id: gpt-oss-low:20b
+    extra_kwargs:
+      base_url: http://localhost:9292/v1
+
+agents:
+  assistant:
+    learning: false
+
+memory:
+  backend: file
+
+mindroom_user:
+  username: mindroom_user_<unique_suffix>
+
+matrix_room_access:
+  mode: multi_user
+  multi_user_join_rule: public
+
+authorization:
+  default_room_access: true
+  global_users: []
+  agent_reply_permissions: {}
+```
+
+Then export an isolated runtime.
+
+```bash
+export MINDROOM_CONFIG_PATH="$tmp/config.yaml"
+export MINDROOM_STORAGE_PATH="$tmp/mindroom_data"
+export MINDROOM_NAMESPACE="live$(date +%H%M%S)"
+export MATRIX_HOMESERVER=http://localhost:8008
+export MATRIX_SSL_VERIFY=false
+export OPENAI_API_KEY=sk-test
+export UV_PYTHON=3.13
+```
+
+In practice, it is often cleaner to write a temporary `"$tmp/.env"` and `source` it so the live run and later `curl` commands use the same values.
+
+Example:
+
+```bash
+cat > "$tmp/.env" <<EOF
+MATRIX_HOMESERVER=http://localhost:8008
+MATRIX_SSL_VERIFY=false
+MINDROOM_STORAGE_PATH=$tmp/mindroom_data
+MINDROOM_API_KEY=live-test-$(date +%H%M%S)
+OPENAI_API_KEY=sk-test
+OPENAI_BASE_URL=http://localhost:9292/v1
+EOF
+
+set -a
+source "$tmp/.env"
+set +a
+```
+
+If `"$tmp/.env"` exists, inspect it for `MINDROOM_API_KEY`.
+Use that key for `/api/*` requests so you are talking to the same isolated instance you started.
+
+Start the isolated backend on a non-default API port.
+
+```bash
+uv run mindroom run --storage-path "$MINDROOM_STORAGE_PATH" --api-port 9876 --log-level INFO
+```
+
+Health check:
+
+```bash
+curl -s http://localhost:9876/api/health
+```
+
+## Create a Disposable Matrix Account
+
+When open registration is enabled on local Synapse, create a throwaway user directly through the Matrix client API.
+
+```bash
+username="smoketest$(date +%H%M%S)"
+password="smoketestpass"
+curl -sS -X POST 'http://localhost:8008/_matrix/client/v3/register' \
+  -H 'Content-Type: application/json' \
+  -d "{\"auth\":{\"type\":\"m.login.dummy\"},\"username\":\"$username\",\"password\":\"$password\"}"
+```
+
+The response includes `user_id` and `access_token`.
+
+## Join a Public Room
+
+If the agent room is public, join it with the Matrix API before using Matty.
+Prefer the concrete room ID from backend logs because aliases are not always predictable in isolated runs.
+
+Join by room ID:
+
+```bash
+room_id='!example:localhost'
+encoded_room_id="$(python -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$room_id")"
+curl -sS -X POST "http://localhost:8008/_matrix/client/v3/join/$encoded_room_id" \
+  -H "Authorization: Bearer $access_token"
+```
+
+Join by alias only when you know the exact alias:
+
+```bash
+room_alias='#lobby_<namespace>:localhost'
+encoded_alias="$(python -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$room_alias")"
+curl -sS -X POST "http://localhost:8008/_matrix/client/v3/join/$encoded_alias" \
+  -H "Authorization: Bearer $access_token"
+```
+
+Use the actual alias created by the active config.
+
+## Read and Send Messages with Matty
+
+Matty accepts per-command credentials with `-u` and `-p`.
+
+List rooms:
+
+```bash
+MATRIX_HOMESERVER=http://localhost:8008 MATRIX_SSL_VERIFY=false \
+uv run --python 3.13 matty rooms -u "$username" -p "$password" --format json
+```
+
+Inspect room membership:
+
+```bash
+MATRIX_HOMESERVER=http://localhost:8008 MATRIX_SSL_VERIFY=false \
+uv run --python 3.13 matty users "Lobby" -u "$username" -p "$password" --format json
+```
+
+Send a smoke message:
+
+```bash
+MATRIX_HOMESERVER=http://localhost:8008 MATRIX_SSL_VERIFY=false \
+uv run --python 3.13 matty send "Lobby" \
+  "Hello @mindroom_assistant:localhost please reply with pong." \
+  -u "$username" -p "$password"
+```
+
+Read recent room messages:
+
+```bash
+MATRIX_HOMESERVER=http://localhost:8008 MATRIX_SSL_VERIFY=false \
+uv run --python 3.13 matty messages "Lobby" -u "$username" -p "$password" --format json
+```
+
+List threads:
+
+```bash
+MATRIX_HOMESERVER=http://localhost:8008 MATRIX_SSL_VERIFY=false \
+uv run --python 3.13 matty threads "Lobby" -u "$username" -p "$password" --format json
+```
+
+Read one thread:
+
+```bash
+MATRIX_HOMESERVER=http://localhost:8008 MATRIX_SSL_VERIFY=false \
+uv run --python 3.13 matty thread "Lobby" t1 -u "$username" -p "$password" --format json
+```
+
+Agents usually reply in threads and may stream by editing the same event.
+If you see partial output, wait and read the thread again.
+If `matty threads` looks empty or flaky, use `matty messages --format json` to discover the thread handle and then read it directly with `matty thread`.
+
+## Live API Checks
+
+When a change affects the bundled API, hit the live endpoint on the instance you started instead of testing a different local server by accident.
+
+With dashboard auth enabled:
+
+```bash
+curl -sS -X POST 'http://localhost:9876/api/config/agent-policies' \
+  -H "Authorization: Bearer $MINDROOM_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"defaults":{},"agents":{"helper":{"delegate_to":[]},"leader":{"delegate_to":["mind"]},"mind":{"private":{"per":"user"}}}}'
+```
+
+Always confirm the port belongs to the same MindRoom instance you launched.

--- a/.claude/skills/live-test/references/frontend-and-platform.md
+++ b/.claude/skills/live-test/references/frontend-and-platform.md
@@ -1,0 +1,126 @@
+# Frontend And Platform Live Workflows
+
+Use this reference for the bundled dashboard, the frontend-only dev server, screenshot capture, and the SaaS platform sandbox.
+
+## Core Dashboard: Bundled With The Backend
+
+The default backend serves the dashboard on `http://localhost:8765`.
+
+Use this when you want the real app with the real backend instead of a frontend-only dev server.
+
+Quick checks:
+
+```bash
+curl -s http://localhost:8765/api/health
+curl -I http://localhost:8765
+```
+
+## Core Frontend: Dev Server Mode
+
+Use this when iterating on the React app itself.
+
+```bash
+./run-frontend.sh
+```
+
+That starts Vite on port `3003`.
+
+Equivalent manual path:
+
+```bash
+cd frontend
+bun install
+bun run dev -- --host 0.0.0.0 --port 3003
+```
+
+## Core Frontend Screenshots
+
+Preferred wrapper:
+
+```bash
+python frontend/take_screenshot.py
+python frontend/take_screenshot.py 3003
+python frontend/take_screenshot.py http://localhost:3003
+```
+
+Direct Puppeteer path:
+
+```bash
+cd frontend
+DEMO_URL="http://localhost:8765" bun run screenshot
+DEMO_URL="http://localhost:3003" bun run screenshot
+```
+
+Outputs land in `frontend/screenshots/`.
+The script captures the full page, an agent-selected view, and the Models tab.
+
+If the session supports local image viewing, open the generated PNGs directly after capture instead of describing them blindly.
+
+## Interact With The Frontend
+
+Prefer the real UI over assumptions.
+
+- Use the bundled dashboard at `http://localhost:8765` for backend-connected checks.
+- Use `http://localhost:3003` for React-only UI iteration.
+- Use screenshot capture for deterministic visual evidence.
+- If browser automation is available in the session, drive the live URL directly.
+- If browser automation is not available, combine screenshots with `curl` and backend API checks.
+
+## SaaS Platform Sandbox
+
+Start the full local Compose sandbox:
+
+```bash
+just local-platform-compose-up
+```
+
+Stop it:
+
+```bash
+just local-platform-compose-down
+```
+
+Tail logs:
+
+```bash
+just local-platform-compose-logs
+```
+
+For service-by-service development instead of Compose:
+
+```bash
+cd saas-platform/platform-backend
+uv run uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```
+
+```bash
+cd saas-platform/platform-frontend
+bun install
+bun run dev
+```
+
+The platform frontend dev server runs on `http://localhost:3000` with `NEXT_PUBLIC_DEV_AUTH=true`.
+
+## Platform Frontend Screenshots
+
+Use the built-in screenshot script.
+It will start the dev server automatically if needed and save PNGs under `saas-platform/platform-frontend/screenshots/`.
+
+```bash
+cd saas-platform/platform-frontend
+bun run screenshot
+```
+
+Set `PORT` if the frontend is running somewhere else.
+
+```bash
+cd saas-platform/platform-frontend
+PORT=3001 bun run screenshot
+```
+
+The current script captures:
+
+- Landing page desktop
+- Landing page mobile
+- Login page
+- Signup page


### PR DESCRIPTION
## Summary
- add a `live-test` skill for real MindRoom runtime, Matrix, Matty, API, and UI verification
- include a core MindRoom reference with isolated local-run, disposable-user, room-join, Matty, and live API workflows
- include a frontend/platform reference for screenshots and SaaS sandbox checks

## Testing
- `uv run pre-commit run --files .claude/skills/live-test/SKILL.md .claude/skills/live-test/agents/openai.yaml .claude/skills/live-test/references/core-mindroom.md .claude/skills/live-test/references/frontend-and-platform.md`