### PR TITLE
Support configured teams in ai helpers

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -76,6 +76,7 @@ from mindroom.media_inputs import MediaInputs
 from mindroom.memory import build_memory_enhanced_prompt
 from mindroom.timing import timed
 from mindroom.tool_system.events import (
+    StructuredStreamChunk,
     complete_pending_tool_block,
     extract_tool_completed_info,
     format_tool_combined,
@@ -93,6 +94,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.config.models import ModelConfig
     from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.orchestrator import MultiAgentOrchestrator
     from mindroom.tool_system.events import ToolTraceEntry
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
@@ -110,7 +112,7 @@ __all__ = [
     "stream_agent_response",
 ]
 
-AIStreamChunk = str | RunContentEvent | ToolCallStartedEvent | ToolCallCompletedEvent
+AIStreamChunk = str | StructuredStreamChunk | RunContentEvent | ToolCallStartedEvent | ToolCallCompletedEvent
 _AI_RUN_METADATA_VERSION = 1
 _QUEUED_MESSAGE_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
 _QUEUED_MESSAGE_NOTICE_HOOK_ATTR = "_mindroom_queued_message_notice_hook_installed"
@@ -160,6 +162,126 @@ def _has_queued_notice_marker(message: Message) -> bool:
 def _is_queued_notice_message(message: Message) -> bool:
     """Return whether one Agno message is the hidden queued-message notice."""
     return _has_queued_notice_marker(message)
+
+
+def _is_configured_team(config: Config, entity_name: str) -> bool:
+    """Return whether one execution target is a configured team."""
+    return entity_name in config.teams
+
+
+def _build_ephemeral_team_orchestrator(
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> MultiAgentOrchestrator:
+    """Return a minimal orchestrator view for configured-team execution helpers."""
+    from mindroom.orchestrator import MultiAgentOrchestrator  # noqa: PLC0415
+
+    orchestrator = MultiAgentOrchestrator(runtime_paths=runtime_paths)
+    orchestrator.config = config
+    return orchestrator
+
+
+async def _configured_team_response(
+    *,
+    team_name: str,
+    prompt: str,
+    session_id: str,
+    runtime_paths: RuntimePaths,
+    config: Config,
+    thread_history: Sequence[ResolvedVisibleMessage] | None,
+    user_id: str | None,
+    run_id: str | None,
+    run_id_callback: Callable[[str], None] | None,
+    media: MediaInputs | None,
+    reply_to_event_id: str | None,
+    active_event_ids: Collection[str],
+    execution_identity: ToolExecutionIdentity | None,
+    compaction_outcomes_collector: list[CompactionOutcome] | None,
+    matrix_run_metadata: dict[str, Any] | None,
+    system_enrichment_items: Sequence[EnrichmentItem],
+) -> str:
+    """Route one generic AI request through the configured-team execution path."""
+    from mindroom.teams import TeamMode, team_response  # noqa: PLC0415
+
+    team_config = config.teams[team_name]
+    orchestrator = _build_ephemeral_team_orchestrator(
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    return await team_response(
+        agent_names=list(team_config.agents),
+        mode=TeamMode(team_config.mode),
+        message=prompt,
+        orchestrator=orchestrator,
+        execution_identity=execution_identity,
+        thread_history=thread_history,
+        media=media,
+        session_id=session_id,
+        run_id=run_id,
+        run_id_callback=run_id_callback,
+        user_id=user_id,
+        reply_to_event_id=reply_to_event_id,
+        active_event_ids=active_event_ids,
+        compaction_outcomes_collector=compaction_outcomes_collector,
+        configured_team_name=team_name,
+        matrix_run_metadata=matrix_run_metadata,
+        system_enrichment_items=system_enrichment_items,
+    )
+
+
+async def _configured_team_stream(
+    *,
+    team_name: str,
+    prompt: str,
+    session_id: str,
+    runtime_paths: RuntimePaths,
+    config: Config,
+    thread_history: Sequence[ResolvedVisibleMessage] | None,
+    user_id: str | None,
+    run_id: str | None,
+    run_id_callback: Callable[[str], None] | None,
+    media: MediaInputs | None,
+    reply_to_event_id: str | None,
+    active_event_ids: Collection[str],
+    show_tool_calls: bool,
+    execution_identity: ToolExecutionIdentity | None,
+    compaction_outcomes_collector: list[CompactionOutcome] | None,
+    matrix_run_metadata: dict[str, Any] | None,
+    system_enrichment_items: Sequence[EnrichmentItem],
+) -> AsyncIterator[AIStreamChunk]:
+    """Stream one configured team through the generic AI streaming interface."""
+    from mindroom.matrix.identity import MatrixID  # noqa: PLC0415
+    from mindroom.teams import TeamMode, team_response_stream  # noqa: PLC0415
+
+    team_config = config.teams[team_name]
+    orchestrator = _build_ephemeral_team_orchestrator(
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    domain = config.get_domain(runtime_paths)
+    agent_ids = [MatrixID.from_agent(member_name, domain, runtime_paths) for member_name in team_config.agents]
+    async for chunk in team_response_stream(
+        agent_ids=agent_ids,
+        message=prompt,
+        orchestrator=orchestrator,
+        execution_identity=execution_identity,
+        mode=TeamMode(team_config.mode),
+        thread_history=thread_history,
+        media=media,
+        show_tool_calls=show_tool_calls,
+        session_id=session_id,
+        run_id=run_id,
+        run_id_callback=run_id_callback,
+        user_id=user_id,
+        reply_to_event_id=reply_to_event_id,
+        active_event_ids=active_event_ids,
+        compaction_outcomes_collector=compaction_outcomes_collector,
+        configured_team_name=team_name,
+        matrix_run_metadata=matrix_run_metadata,
+        system_enrichment_items=system_enrichment_items,
+    ):
+        yield chunk
 
 
 def _strip_queued_notice_messages(messages: list[Message] | None) -> bool:
@@ -1109,6 +1231,25 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
         session_id=session_id,
         agent_name=agent_name,
     )
+    if _is_configured_team(config, agent_name):
+        return await _configured_team_response(
+            team_name=agent_name,
+            prompt=prompt,
+            session_id=session_id,
+            runtime_paths=runtime_paths,
+            config=config,
+            thread_history=thread_history,
+            user_id=user_id,
+            run_id=run_id,
+            run_id_callback=run_id_callback,
+            media=media,
+            reply_to_event_id=reply_to_event_id,
+            active_event_ids=active_event_ids,
+            execution_identity=execution_identity,
+            compaction_outcomes_collector=compaction_outcomes_collector,
+            matrix_run_metadata=matrix_run_metadata,
+            system_enrichment_items=system_enrichment_items,
+        )
     media_inputs = media or MediaInputs()
     agent: Agent | None = None
     scope_context: ScopeSessionContext | None = None
@@ -1428,6 +1569,28 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
         session_id=session_id,
         agent_name=agent_name,
     )
+    if _is_configured_team(config, agent_name):
+        async for chunk in _configured_team_stream(
+            team_name=agent_name,
+            prompt=prompt,
+            session_id=session_id,
+            runtime_paths=runtime_paths,
+            config=config,
+            thread_history=thread_history,
+            user_id=user_id,
+            run_id=run_id,
+            run_id_callback=run_id_callback,
+            media=media,
+            reply_to_event_id=reply_to_event_id,
+            active_event_ids=active_event_ids,
+            show_tool_calls=show_tool_calls,
+            execution_identity=execution_identity,
+            compaction_outcomes_collector=compaction_outcomes_collector,
+            matrix_run_metadata=matrix_run_metadata,
+            system_enrichment_items=system_enrichment_items,
+        ):
+            yield chunk
+        return
     media_inputs = media or MediaInputs()
     agent: Agent | None = None
     scope_context: ScopeSessionContext | None = None

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -47,7 +47,7 @@ from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.routing import suggest_agent
 from mindroom.team_runtime_resolution import materialize_exact_requested_team_members
 from mindroom.teams import TeamMode, TeamOutcome, _create_team_instance, format_team_response, resolve_configured_team
-from mindroom.tool_system.events import format_tool_completed_event, format_tool_started_event
+from mindroom.tool_system.events import StructuredStreamChunk, format_tool_completed_event, format_tool_started_event
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
     WorkerScope,
@@ -1027,6 +1027,8 @@ def _extract_stream_text(event: AIStreamChunk, tool_state: _ToolStreamState) -> 
     """Extract text content from a stream event."""
     if isinstance(event, RunContentEvent) and event.content:
         return str(event.content)
+    if isinstance(event, StructuredStreamChunk):
+        return event.content
     if isinstance(event, str):
         return event
     return _format_stream_tool_event(event, tool_state)

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -30,7 +30,7 @@ from mindroom.ai import (
     stream_agent_response,
 )
 from mindroom.bot import AgentBot
-from mindroom.config.agent import AgentConfig
+from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import (
@@ -48,6 +48,8 @@ from mindroom.media_inputs import MediaInputs
 from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsSupport
 from mindroom.response_coordinator import ResponseCoordinator, ResponseCoordinatorDeps, ResponseRequest
+from mindroom.teams import TeamMode
+from mindroom.tool_system.events import StructuredStreamChunk
 from mindroom.tool_system.runtime_context import ToolRuntimeSupport, get_tool_runtime_context
 from tests.conftest import bind_runtime_paths, resolve_response_thread_root_for_test
 
@@ -567,6 +569,48 @@ class TestUserIdPassthrough:
         mock_friendly_error.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_ai_response_routes_configured_team_names_to_team_runtime(self, tmp_path: Path) -> None:
+        """Configured teams should use the stable team execution path, not agent-only history resolution."""
+        config = Config(
+            agents={
+                "general": AgentConfig(display_name="General"),
+                "helper": AgentConfig(display_name="Helper"),
+            },
+            models={"default": ModelConfig(provider="openai", id="test-model")},
+            teams={
+                "ultimate": TeamConfig(
+                    display_name="Ultimate",
+                    role="Coordinate a final answer",
+                    agents=["general", "helper"],
+                    mode="coordinate",
+                ),
+            },
+        )
+
+        with (
+            patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
+            patch("mindroom.teams.team_response", new_callable=AsyncMock, return_value="team reply") as mock_team,
+        ):
+            response = await ai_response(
+                agent_name="ultimate",
+                prompt="test",
+                session_id="session1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=config,
+            )
+
+        assert response == "team reply"
+        mock_prepare.assert_not_called()
+        mock_team.assert_awaited_once()
+        kwargs = mock_team.await_args.kwargs
+        assert kwargs["agent_names"] == ["general", "helper"]
+        assert kwargs["mode"] is TeamMode.COORDINATE
+        assert kwargs["message"] == "test"
+        assert kwargs["configured_team_name"] == "ultimate"
+        assert kwargs["orchestrator"].config is config
+        assert kwargs["orchestrator"].runtime_paths == _runtime_paths(tmp_path)
+
+    @pytest.mark.asyncio
     async def test_ai_response_passes_all_files_for_vertex_claude(self, tmp_path: Path) -> None:
         """Vertex Claude path should not silently drop non-PDF file media."""
         mock_agent = MagicMock()
@@ -634,6 +678,61 @@ class TestUserIdPassthrough:
         mock_agent.arun.assert_called_once()
         sent_files = list(mock_agent.arun.call_args.kwargs["files"])
         assert sent_files == [pdf_file, zip_file]
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_routes_configured_team_names_to_team_stream_runtime(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Configured teams should stream through the stable team execution path."""
+        config = Config(
+            agents={
+                "general": AgentConfig(display_name="General"),
+                "helper": AgentConfig(display_name="Helper"),
+            },
+            models={"default": ModelConfig(provider="openai", id="test-model")},
+            teams={
+                "ultimate": TeamConfig(
+                    display_name="Ultimate",
+                    role="Coordinate a final answer",
+                    agents=["general", "helper"],
+                    mode="coordinate",
+                ),
+            },
+        )
+
+        async def fake_team_stream(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+            yield StructuredStreamChunk(content="team chunk")
+            yield "done"
+
+        with (
+            patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
+            patch("mindroom.teams.team_response_stream", side_effect=fake_team_stream) as mock_team_stream,
+        ):
+            chunks = [
+                chunk
+                async for chunk in stream_agent_response(
+                    agent_name="ultimate",
+                    prompt="test",
+                    session_id="session1",
+                    runtime_paths=_runtime_paths(tmp_path),
+                    config=config,
+                )
+            ]
+
+        assert chunks == [StructuredStreamChunk(content="team chunk"), "done"]
+        mock_prepare.assert_not_called()
+        mock_team_stream.assert_called_once()
+        kwargs = mock_team_stream.call_args.kwargs
+        assert kwargs["mode"] is TeamMode.COORDINATE
+        assert kwargs["message"] == "test"
+        assert kwargs["configured_team_name"] == "ultimate"
+        assert [agent_id.agent_name(config, _runtime_paths(tmp_path)) for agent_id in kwargs["agent_ids"]] == [
+            "general",
+            "helper",
+        ]
+        assert kwargs["orchestrator"].config is config
+        assert kwargs["orchestrator"].runtime_paths == _runtime_paths(tmp_path)
 
     @pytest.mark.asyncio
     async def test_ai_response_retries_without_media_on_validation_error(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- route configured team names through the existing team runtime in `ai_response` and `stream_agent_response`
- keep the generic helper behavior aligned with stable team scope/session handling
- add regression coverage for both non-streaming and streaming configured-team calls

## Testing
- uv run --group dev --all-extras --with aiosqlite pytest tests/test_ai_user_id.py -k "configured_team_names_to_team"
- uv run --group dev ruff check src/mindroom/ai.py src/mindroom/api/openai_compat.py tests/test_ai_user_id.py