### PR TITLE
Support explicit API key env selection across runtimes

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -192,6 +192,7 @@ models:
     id: claude-sonnet-4-6            # Required: Model ID for the provider
     host: null                     # Optional: Host URL (e.g., for Ollama)
     api_key: null                  # Optional: API key (usually from env vars)
+    api_key_env_var: null          # Optional: specific env var to read the API key from at runtime
     extra_kwargs: null             # Optional: Provider-specific parameters
     context_window: null           # Optional: Needed on the active runtime model for replay safety; explicit compaction.model also needs its own window for summary generation
 
@@ -280,11 +281,13 @@ memory:
     config:
       model: text-embedding-3-small  # Default embedding model
       api_key: null                # Optional: From env var
+      api_key_env_var: null        # Optional: explicit env var name for the embedder API key
       host: null                   # Optional: For self-hosted
       dimensions: null             # Optional: Embedding dimension override (e.g., 256)
   llm:                             # Optional: LLM for memory operations
     provider: ollama
-    config: {}
+    config:
+      api_key_env_var: null        # Optional: explicit env var name for the memory LLM API key
   file:                            # File-backed memory settings (when backend: file)
     path: null                     # Optional: fallback root for file memory paths
     max_entrypoint_lines: 200      # Default: 200 (max lines preloaded from MEMORY.md)
@@ -337,8 +340,9 @@ voice:
   stt:
     provider: openai               # Default: openai
     model: whisper-1               # Default: whisper-1
-    api_key: null
-    host: null
+    api_key: null                  # Optional: inline STT API key
+    api_key_env_var: null          # Optional: explicit env var name for the STT API key
+    host: null                     # Optional: custom OpenAI-compatible STT host
   intelligence:
     model: default                 # Model for command recognition
 

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -57,6 +57,8 @@ models:
     provider: openai
     id: gpt-5.4
     api_key_env_var: LITELLM_MASTER_KEY
+    extra_kwargs:
+      base_url: http://localhost:4000/v1
 
   # Google Gemini (both 'google' and 'gemini' work as provider names)
   gemini:
@@ -161,6 +163,8 @@ MindRoom resolves model credentials in this order:
 4. shared provider credentials for the model provider
 
 This is useful when one runtime needs, for example, OpenAI-compatible chat traffic to use a gateway key while other OpenAI-compatible features use the real OpenAI key.
+`api_key_env_var` only selects the secret source.
+If the model should also talk to a non-default OpenAI-compatible endpoint, set `extra_kwargs.base_url` on that model or configure `OPENAI_BASE_URL` for the runtime.
 
 For Ollama, you can also set:
 

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -28,6 +28,7 @@ Each model configuration supports the following fields:
 | `id` | Yes | - | Model ID specific to the provider |
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
+| `api_key_env_var` | No | `null` | Specific environment variable name to read the API key from at runtime |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
 | `context_window` | No | `null` | Context window size in tokens. MindRoom needs it on the active runtime model to enforce replay budgets, and an explicit `compaction.model` also needs its own `context_window` for destructive compaction |
 
@@ -50,6 +51,12 @@ models:
   gpt:
     provider: openai
     id: gpt-5.4
+
+  # Route OpenAI-compatible traffic through a gateway with a non-default env var
+  gpt_via_gateway:
+    provider: openai
+    id: gpt-5.4
+    api_key_env_var: LITELLM_MASTER_KEY
 
   # Google Gemini (both 'google' and 'gemini' work as provider names)
   gemini:
@@ -144,6 +151,16 @@ OPENROUTER_API_KEY=...
 CEREBRAS_API_KEY=...
 DEEPSEEK_API_KEY=...
 ```
+
+If you need one model to use a different secret than the provider default, set `api_key_env_var` on that model.
+MindRoom resolves model credentials in this order:
+
+1. `models.<name>.api_key`
+2. `models.<name>.api_key_env_var`
+3. shared credentials stored for `model:<name>`
+4. shared provider credentials for the model provider
+
+This is useful when one runtime needs, for example, OpenAI-compatible chat traffic to use a gateway key while other OpenAI-compatible features use the real OpenAI key.
 
 For Ollama, you can also set:
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -47,6 +47,7 @@ memory:
     provider: openai
     config:
       model: text-embedding-3-small
+      api_key_env_var: OPENAI_EMBEDDER_KEY  # Optional: dedicated env var for the embedder key
       dimensions: null             # Optional: embedding dimension override (e.g., 256)
 ```
 
@@ -90,6 +91,13 @@ memory:
 ```
 
 Supported LLM providers: `ollama` (default), `openai`, `anthropic`.
+
+When `memory.llm.provider` or `memory.embedder.provider` needs a different key than the provider default, set `api_key_env_var` in that config block.
+MindRoom resolves those API keys in this order:
+
+1. inline `api_key`
+2. explicit `api_key_env_var`
+3. shared provider credentials for that provider
 
 ## Backend: `file`
 

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -90,7 +90,24 @@ voice:
     api_key: your-custom-api-key
 ```
 
-If `api_key` is not set, MindRoom falls back to the `OPENAI_API_KEY` environment variable.
+### Custom API Key Environment Variable
+
+When STT should use a different secret than the rest of your OpenAI-compatible stack, point it at a dedicated env var:
+
+```yaml
+voice:
+  enabled: true
+  stt:
+    provider: openai
+    model: whisper-1
+    api_key_env_var: OPENAI_STT_API_KEY
+```
+
+MindRoom resolves the STT key in this order:
+
+1. `voice.stt.api_key`
+2. `voice.stt.api_key_env_var`
+3. `OPENAI_API_KEY`
 
 ## Command Recognition
 
@@ -202,7 +219,8 @@ Reply-permission checks still use the original human sender, not a later router 
 
 | Variable | Description |
 |----------|-------------|
-| `OPENAI_API_KEY` | For OpenAI Whisper API (used as fallback if no `api_key` configured) |
+| `OPENAI_API_KEY` | Default OpenAI Whisper API key |
+| `OPENAI_STT_API_KEY` | Optional dedicated STT key when referenced via `voice.stt.api_key_env_var` |
 
 ## Text-to-Speech Tools
 

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -50,8 +50,7 @@ from mindroom.constants import (
     RuntimePaths,
     runtime_env_path,
 )
-from mindroom.credentials import get_runtime_shared_credentials_manager
-from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host
+from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host, resolve_configured_api_key
 from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.execution_preparation import (
     build_prompt_with_thread_history,
@@ -710,13 +709,15 @@ def get_model_instance(
     # Get extra kwargs if specified
     extra_kwargs = dict(model_config.extra_kwargs or {})
 
-    # Check for model-specific API key first, then fall back to provider-level
-    creds_manager = get_runtime_shared_credentials_manager(runtime_paths)
-    model_creds = creds_manager.load_credentials(f"model:{model_name}")
-    model_api_key = model_creds.get("api_key") if model_creds else None
-
-    if model_api_key:
-        extra_kwargs["api_key"] = model_api_key
+    resolved_api_key = resolve_configured_api_key(
+        runtime_paths=runtime_paths,
+        provider=provider,
+        configured_api_key=model_config.api_key,
+        api_key_env_var=model_config.api_key_env_var,
+        credentials_service=f"model:{model_name}",
+    )
+    if resolved_api_key:
+        extra_kwargs["api_key"] = resolved_api_key
 
     return _create_model_for_provider(
         provider,

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -403,6 +403,10 @@ class EmbedderConfig(BaseModel):
 
     model: str = Field(default="text-embedding-3-small", description="Model name for embeddings")
     api_key: str | None = Field(default=None, description="API key (usually from environment variable)")
+    api_key_env_var: str | None = Field(
+        default=None,
+        description="Optional environment variable name to read the API key from at runtime",
+    )
     host: str | None = Field(default=None, description="Host URL for self-hosted models (Ollama, llama.cpp, etc.)")
     dimensions: int | None = Field(
         default=None,
@@ -420,6 +424,10 @@ class ModelConfig(BaseModel):
     id: str = Field(description="Model ID specific to the provider")
     host: str | None = Field(default=None, description="Optional host URL (e.g., for Ollama)")
     api_key: str | None = Field(default=None, description="Optional API key (usually from env vars)")
+    api_key_env_var: str | None = Field(
+        default=None,
+        description="Optional environment variable name to read the API key from at runtime",
+    )
     extra_kwargs: dict[str, Any] | None = Field(
         default=None,
         description="Additional provider-specific parameters passed directly to the model",

--- a/src/mindroom/config/voice.py
+++ b/src/mindroom/config/voice.py
@@ -11,6 +11,10 @@ class _VoiceSTTConfig(BaseModel):
     provider: str = Field(default="openai", description="STT provider (openai or compatible)")
     model: str = Field(default="whisper-1", description="STT model name")
     api_key: str | None = Field(default=None, description="API key for STT service")
+    api_key_env_var: str | None = Field(
+        default=None,
+        description="Optional environment variable name to read the STT API key from at runtime",
+    )
     host: str | None = Field(default=None, description="Host URL for self-hosted STT")
 
 

--- a/src/mindroom/credentials_sync.py
+++ b/src/mindroom/credentials_sync.py
@@ -153,6 +153,46 @@ def get_api_key_for_provider(provider: str, runtime_paths: RuntimePaths) -> str 
     return creds_manager.get_api_key(provider)
 
 
+def resolve_configured_api_key(
+    *,
+    runtime_paths: RuntimePaths,
+    provider: str | None = None,
+    configured_api_key: str | None = None,
+    api_key_env_var: str | None = None,
+    default_env_var: str | None = None,
+    credentials_service: str | None = None,
+) -> str | None:
+    """Resolve one API key from config, env, credentials, and provider defaults.
+
+    Precedence is:
+    1. Inline ``configured_api_key``
+    2. Explicit ``api_key_env_var``
+    3. ``default_env_var`` when provided
+    4. ``credentials_service`` in the shared credentials store
+    5. Provider-level shared credentials
+    """
+    if configured_api_key:
+        return configured_api_key
+
+    for env_var in (api_key_env_var, default_env_var):
+        if env_var:
+            env_value = get_secret_from_env(env_var, runtime_paths)
+            if env_value:
+                return env_value
+
+    creds_manager = get_runtime_shared_credentials_manager(runtime_paths)
+    if credentials_service:
+        scoped_creds = creds_manager.load_credentials(credentials_service)
+        scoped_api_key = scoped_creds.get("api_key") if scoped_creds else None
+        if isinstance(scoped_api_key, str) and scoped_api_key:
+            return scoped_api_key
+
+    if provider:
+        return get_api_key_for_provider(provider, runtime_paths=runtime_paths)
+
+    return None
+
+
 def get_ollama_host(runtime_paths: RuntimePaths) -> str | None:
     """Get Ollama host configuration.
 

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -27,7 +27,7 @@ from watchfiles import Change, awatch
 
 from mindroom.constants import RuntimePaths, resolve_config_relative_path
 from mindroom.credentials import get_runtime_shared_credentials_manager
-from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host
+from mindroom.credentials_sync import get_ollama_host, resolve_configured_api_key
 from mindroom.embeddings import (
     MindRoomOpenAIEmbedder,
     create_sentence_transformers_embedder,
@@ -126,7 +126,12 @@ def _create_embedder(config: Config, runtime_paths: RuntimePaths) -> Embedder:
     if provider == "openai":
         return MindRoomOpenAIEmbedder(
             id=embedder_config.model,
-            api_key=get_api_key_for_provider("openai", runtime_paths=runtime_paths),
+            api_key=resolve_configured_api_key(
+                runtime_paths=runtime_paths,
+                provider="openai",
+                configured_api_key=embedder_config.api_key,
+                api_key_env_var=embedder_config.api_key_env_var,
+            ),
             base_url=embedder_config.host,
             dimensions=embedder_config.dimensions,
         )

--- a/src/mindroom/memory/config.py
+++ b/src/mindroom/memory/config.py
@@ -9,6 +9,7 @@ from mem0 import AsyncMemory
 from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths
 from mindroom.credentials import get_runtime_shared_credentials_manager
+from mindroom.credentials_sync import resolve_configured_api_key
 from mindroom.embeddings import effective_mem0_embedder_signature, ensure_sentence_transformers_dependencies
 from mindroom.logging_config import get_logger
 from mindroom.timing import timed
@@ -33,7 +34,7 @@ def _memory_collection_name(config: Config) -> str:
     return f"{_MEMORY_COLLECTION_PREFIX}_{digest}"
 
 
-def _get_memory_config(storage_path: Path, config: Config, runtime_paths: RuntimePaths) -> dict:  # noqa: C901, PLR0912
+def _get_memory_config(storage_path: Path, config: Config, runtime_paths: RuntimePaths) -> dict:  # noqa: C901, PLR0912, PLR0915
     """Get Mem0 configuration with ChromaDB backend.
 
     Args:
@@ -65,7 +66,12 @@ def _get_memory_config(storage_path: Path, config: Config, runtime_paths: Runtim
 
     # Add provider-specific configuration
     if embedder_provider == "openai":
-        api_key = creds_manager.get_api_key("openai")
+        api_key = resolve_configured_api_key(
+            runtime_paths=runtime_paths,
+            provider="openai",
+            configured_api_key=app_config.memory.embedder.config.api_key,
+            api_key_env_var=app_config.memory.embedder.config.api_key_env_var,
+        )
         if api_key:
             embedder_config["config"]["api_key"] = api_key
         # Support custom OpenAI-compatible base URL (e.g., llama.cpp)
@@ -100,15 +106,27 @@ def _get_memory_config(storage_path: Path, config: Config, runtime_paths: Runtim
                     llm_config["config"]["ollama_base_url"] = ollama_creds["host"]
                 else:
                     llm_config["config"]["ollama_base_url"] = value or "http://localhost:11434"
+            elif key == "api_key_env_var":
+                continue
             elif key != "host":  # Skip host for other fields
                 llm_config["config"][key] = value
 
         if app_config.memory.llm.provider == "openai":
-            api_key = creds_manager.get_api_key("openai")
+            api_key = resolve_configured_api_key(
+                runtime_paths=runtime_paths,
+                provider="openai",
+                configured_api_key=app_config.memory.llm.config.get("api_key"),
+                api_key_env_var=app_config.memory.llm.config.get("api_key_env_var"),
+            )
             if api_key:
                 llm_config["config"]["api_key"] = api_key
         elif app_config.memory.llm.provider == "anthropic":
-            api_key = creds_manager.get_api_key("anthropic")
+            api_key = resolve_configured_api_key(
+                runtime_paths=runtime_paths,
+                provider="anthropic",
+                configured_api_key=app_config.memory.llm.config.get("api_key"),
+                api_key_env_var=app_config.memory.llm.config.get("api_key_env_var"),
+            )
             if api_key:
                 llm_config["config"]["api_key"] = api_key
 

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -23,7 +23,7 @@ from mindroom.constants import (
     VOICE_PREFIX,
     VOICE_RAW_AUDIO_FALLBACK_KEY,
 )
-from mindroom.credentials_sync import get_secret_from_env
+from mindroom.credentials_sync import resolve_configured_api_key
 from mindroom.logging_config import get_logger
 from mindroom.matrix.identity import agent_username_localpart
 from mindroom.matrix.media import download_media_bytes, extract_media_caption, media_mime_type
@@ -358,7 +358,12 @@ async def _transcribe_audio(audio_data: bytes, config: Config, runtime_paths: Ru
         stt_host = config.voice.stt.host
         url = f"{stt_host}/v1/audio/transcriptions" if stt_host else "https://api.openai.com/v1/audio/transcriptions"
 
-        api_key = config.voice.stt.api_key or get_secret_from_env("OPENAI_API_KEY", runtime_paths)
+        api_key = resolve_configured_api_key(
+            runtime_paths=runtime_paths,
+            configured_api_key=config.voice.stt.api_key,
+            api_key_env_var=config.voice.stt.api_key_env_var,
+            default_env_var="OPENAI_API_KEY",
+        )
         if not api_key:
             logger.error("No OpenAI-compatible STT API key configured for voice transcription")
             return None

--- a/tests/test_credentials_sync.py
+++ b/tests/test_credentials_sync.py
@@ -12,6 +12,7 @@ from mindroom.credentials_sync import (
     get_api_key_for_provider,
     get_ollama_host,
     get_secret_from_env,
+    resolve_configured_api_key,
     sync_env_to_credentials,
 )
 
@@ -264,6 +265,69 @@ class TestCredentialsSync:
 
         # Test non-existent provider
         assert get_api_key_for_provider("anthropic", runtime_paths=runtime_paths) is None
+
+    def test_resolve_configured_api_key_prefers_inline_value(
+        self,
+        credentials_manager: CredentialsManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Inline config should win over env vars and stored credentials."""
+        credentials_manager.set_api_key("openai", "provider-key")
+        runtime_paths = _runtime_paths(
+            credentials_manager.storage_root,
+            shared_credentials_dir=credentials_manager.base_path,
+        )
+        monkeypatch.setenv("LITELLM_MASTER_KEY", "env-key")
+
+        resolved = resolve_configured_api_key(
+            runtime_paths=runtime_paths,
+            provider="openai",
+            configured_api_key="inline-key",
+            api_key_env_var="LITELLM_MASTER_KEY",
+        )
+
+        assert resolved == "inline-key"
+
+    def test_resolve_configured_api_key_prefers_explicit_env_var_over_provider_credentials(
+        self,
+        credentials_manager: CredentialsManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An explicit env-var selector should beat provider-level shared credentials."""
+        credentials_manager.set_api_key("openai", "provider-key")
+        monkeypatch.setenv("LITELLM_MASTER_KEY", "env-key")
+        runtime_paths = _runtime_paths(
+            credentials_manager.storage_root,
+            shared_credentials_dir=credentials_manager.base_path,
+        )
+
+        resolved = resolve_configured_api_key(
+            runtime_paths=runtime_paths,
+            provider="openai",
+            api_key_env_var="LITELLM_MASTER_KEY",
+        )
+
+        assert resolved == "env-key"
+
+    def test_resolve_configured_api_key_prefers_credentials_service_over_provider_credentials(
+        self,
+        credentials_manager: CredentialsManager,
+    ) -> None:
+        """Model-scoped credentials should beat provider-level shared credentials."""
+        credentials_manager.set_api_key("openai", "provider-key")
+        credentials_manager.save_credentials("model:test_model", {"api_key": "model-key"})
+        runtime_paths = _runtime_paths(
+            credentials_manager.storage_root,
+            shared_credentials_dir=credentials_manager.base_path,
+        )
+
+        resolved = resolve_configured_api_key(
+            runtime_paths=runtime_paths,
+            provider="openai",
+            credentials_service="model:test_model",
+        )
+
+        assert resolved == "model-key"
 
     def test_get_ollama_host(self, credentials_manager: CredentialsManager) -> None:
         """Test getting Ollama host configuration."""

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -217,7 +217,6 @@ def test_different_providers_with_extra_kwargs() -> None:
 def test_model_without_extra_kwargs() -> None:
     """Test that models work fine without extra_kwargs."""
     os.environ["OPENAI_API_KEY"] = "test-key"
-
     config_data = {
         "models": {
             "simple_model": {
@@ -249,6 +248,60 @@ def test_model_without_extra_kwargs() -> None:
     model = get_model_instance(config, runtime_paths, "simple_model")
     assert model.id == "gpt-3.5-turbo"
     assert model.provider == "OpenAI"
+
+
+def test_get_model_instance_uses_explicit_api_key_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Model config can select a non-default env var for its API key."""
+    config_data = {
+        "models": {
+            "test_model": {
+                "provider": "openai",
+                "id": "gpt-5.4",
+                "api_key_env_var": "LITELLM_MASTER_KEY",
+            },
+        },
+        "defaults": {"markdown": True},
+        "router": {"model": "test_model"},
+        "memory": {
+            "embedder": {
+                "provider": "openai",
+                "config": {"model": "text-embedding-3-small"},
+            },
+        },
+        "agents": {},
+    }
+    runtime_root = Path(tempfile.mkdtemp())
+    runtime_paths = resolve_runtime_paths(
+        config_path=runtime_root / "config.yaml",
+        storage_path=runtime_root / "mindroom_data",
+        process_env={"LITELLM_MASTER_KEY": "litellm-key"},
+    )
+    config = Config(**config_data)
+
+    captured: dict[str, object] = {}
+
+    def _fake_create_model_for_provider(
+        provider: str,
+        model_id: str,
+        model_config: ModelConfig,
+        extra_kwargs: dict,
+        runtime_paths_arg: RuntimePaths,
+    ) -> object:
+        captured["provider"] = provider
+        captured["model_id"] = model_id
+        captured["model_config"] = model_config
+        captured["extra_kwargs"] = dict(extra_kwargs)
+        captured["runtime_paths"] = runtime_paths_arg
+        return object()
+
+    monkeypatch.setattr("mindroom.ai._create_model_for_provider", _fake_create_model_for_provider)
+
+    get_model_instance(config, runtime_paths, "test_model")
+
+    assert captured["provider"] == "openai"
+    assert captured["model_id"] == "gpt-5.4"
+    assert captured["runtime_paths"] == runtime_paths
+    assert captured["extra_kwargs"] == {"api_key": "litellm-key"}
 
 
 def test_vertexai_claude_provider() -> None:

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -422,6 +422,32 @@ def test_create_embedder_supports_sentence_transformers(monkeypatch: pytest.Monk
     }
 
 
+def test_create_embedder_uses_explicit_api_key_env_var(tmp_path: Path) -> None:
+    """Knowledge embedder should honor an explicit env-var selector."""
+    config = Config(
+        agents={},
+        models={},
+        memory={
+            "embedder": {
+                "provider": "openai",
+                "config": {
+                    "model": "text-embedding-3-small",
+                    "api_key_env_var": "OPENAI_EMBEDDER_KEY",
+                },
+            },
+        },
+    )
+
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={"OPENAI_EMBEDDER_KEY": "embedder-key"},
+    )
+    embedder = _create_embedder(config, runtime_paths)
+
+    assert getattr(embedder, "api_key", None) == "embedder-key"
+
+
 def test_resolve_file_path_rejects_traversal(dummy_manager: KnowledgeManager) -> None:
     """resolve_file_path should reject escapes outside the knowledge root."""
     with pytest.raises(ValueError, match="outside knowledge folder"):

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -241,6 +241,43 @@ class TestMemoryConfig:
 
         assert result["embedder"]["config"]["api_key"] == "shared-openai-key"
 
+    def test_get_memory_config_uses_embedder_and_llm_api_key_env_vars(self, tmp_path: Path) -> None:
+        """Memory config should honor explicit env-var selectors for embedder and memory LLM."""
+        runtime_paths = resolve_primary_runtime_paths(
+            config_path=tmp_path / "config.yaml",
+            storage_path=tmp_path / "storage",
+            process_env={
+                "OPENAI_EMBEDDER_KEY": "embedder-key",
+                "OPENAI_MEMORY_LLM_KEY": "memory-llm-key",
+            },
+        )
+
+        config = Config(
+            memory={
+                "embedder": {
+                    "provider": "openai",
+                    "config": {
+                        "model": "text-embedding-3-small",
+                        "api_key_env_var": "OPENAI_EMBEDDER_KEY",
+                    },
+                },
+                "llm": {
+                    "provider": "openai",
+                    "config": {
+                        "model": "gpt-5.4-mini",
+                        "api_key_env_var": "OPENAI_MEMORY_LLM_KEY",
+                    },
+                },
+            },
+            router=RouterConfig(model="default"),
+        )
+
+        result = _get_memory_config(tmp_path / "memory", config, runtime_paths)
+
+        assert result["embedder"]["config"]["api_key"] == "embedder-key"
+        assert result["llm"]["config"]["api_key"] == "memory-llm-key"
+        assert "api_key_env_var" not in result["llm"]["config"]
+
     @pytest.mark.parametrize(
         ("model", "effective_dimensions"),
         [

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -15,7 +15,7 @@ from mindroom import voice_handler
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.voice import VoiceConfig, _VoiceLLMConfig, _VoiceSTTConfig
-from mindroom.constants import ATTACHMENT_IDS_KEY
+from mindroom.constants import ATTACHMENT_IDS_KEY, resolve_runtime_paths
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 
@@ -51,6 +51,11 @@ async def _process_transcription(transcription: str, config: Config, **kwargs: o
         runtime_paths_for(config),
         **kwargs,
     )
+
+
+async def _transcribe_audio(audio_data: bytes, config: Config) -> str | None:
+    """Run audio transcription with the explicit runtime bound to the test config."""
+    return await voice_handler._transcribe_audio(audio_data, config, runtime_paths_for(config))
 
 
 async def _prepare_voice_message(
@@ -229,6 +234,48 @@ class TestVoiceHandler:
         assert result.content == b"decrypted_audio_data"
         assert result.mime_type == "audio/mpeg"
         mock_download.assert_awaited_once_with(client, event)
+
+    @pytest.mark.asyncio
+    async def test_transcribe_audio_uses_explicit_api_key_env_var(self) -> None:
+        """Voice STT should honor an explicit env-var selector before OPENAI_API_KEY."""
+        runtime_root = Path(tempfile.mkdtemp())
+        runtime_paths = resolve_runtime_paths(
+            config_path=runtime_root / "config.yaml",
+            storage_path=runtime_root / "mindroom_data",
+            process_env={
+                "OPENAI_STT_API_KEY": "stt-key",
+                "OPENAI_API_KEY": "default-openai-key",
+            },
+        )
+        config = bind_runtime_paths(
+            Config(
+                voice=VoiceConfig(
+                    enabled=True,
+                    stt=_VoiceSTTConfig(
+                        provider="openai",
+                        model="whisper-1",
+                        api_key_env_var="OPENAI_STT_API_KEY",
+                    ),
+                ),
+            ),
+            runtime_paths,
+        )
+
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"text": "hello world"}
+
+        http_client = AsyncMock()
+        http_client.post.return_value = response
+
+        http_client_cm = AsyncMock()
+        http_client_cm.__aenter__.return_value = http_client
+        http_client_cm.__aexit__.return_value = None
+
+        with patch("mindroom.voice_handler.httpx.AsyncClient", return_value=http_client_cm):
+            result = await _transcribe_audio(b"audio-bytes", config)
+
+        assert result == "hello world"
+        assert http_client.post.await_args.kwargs["headers"] == {"Authorization": "Bearer stt-key"}
 
     @pytest.mark.asyncio
     async def test_prepare_voice_message_clears_inflight_task_after_failed_download(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `api_key_env_var` support for models, memory embedders, memory LLM config, and voice STT
- introduce a shared runtime API key resolver with explicit precedence
- document the new configuration pattern and cover it with focused regression tests

## Why
Some deployments need different OpenAI-compatible credentials for different runtime paths. Today that pushes people toward awkward secret rewrites or provider-wide overrides. This change makes the credential choice explicit in config while keeping the default provider credential flow intact.

## Testing
- `uv run --group dev --all-extras --with aiosqlite pytest tests/test_credentials_sync.py tests/test_extra_kwargs.py tests/test_memory_config.py tests/test_knowledge_manager.py tests/test_voice_handler.py`
- `uv run --group dev ruff check src/mindroom/config/models.py src/mindroom/config/voice.py src/mindroom/credentials_sync.py src/mindroom/ai.py src/mindroom/memory/config.py src/mindroom/knowledge/manager.py src/mindroom/voice_handler.py tests/test_credentials_sync.py tests/test_extra_kwargs.py tests/test_memory_config.py tests/test_knowledge_manager.py tests/test_voice_handler.py`