### PR TITLE
Enforce strict boundaries between agent and team execution

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -924,6 +924,17 @@ async def _run_cached_agent_attempt(
     )
 
 
+def _assert_agent_target(agent_name: str, config: Config) -> None:
+    """Reject configured team names in the agent-only AI helper path."""
+    if agent_name in config.teams:
+        msg = (
+            f"'{agent_name}' is a configured team, not an agent. "
+            "Use the explicit team execution helpers or the OpenAI-compatible model "
+            f"'team/{agent_name}' instead."
+        )
+        raise ValueError(msg)
+
+
 @timed("system_prompt_assembly")
 async def _prepare_agent_and_prompt(
     agent_name: str,
@@ -952,6 +963,7 @@ async def _prepare_agent_and_prompt(
         (empty when using the fallback path).
 
     """
+    _assert_agent_target(agent_name, config)
     storage_path = runtime_paths.storage_root
     enhanced_prompt = await build_memory_enhanced_prompt(
         prompt,
@@ -1113,6 +1125,10 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
     agent: Agent | None = None
     scope_context: ScopeSessionContext | None = None
     try:
+        try:
+            _assert_agent_target(agent_name, config)
+        except ValueError as e:
+            return get_user_friendly_error_message(e, agent_name)
         with open_resolved_scope_session_context(
             agent_name=agent_name,
             scope=HistoryScope(kind="agent", scope_id=agent_name),
@@ -1433,6 +1449,11 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
     scope_context: ScopeSessionContext | None = None
 
     try:
+        try:
+            _assert_agent_target(agent_name, config)
+        except ValueError as e:
+            yield get_user_friendly_error_message(e, agent_name)
+            return
         with open_resolved_scope_session_context(
             agent_name=agent_name,
             scope=HistoryScope(kind="agent", scope_id=agent_name),

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -26,17 +26,12 @@ from fastapi import APIRouter, Header, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-from mindroom.agents import create_agent
 from mindroom.ai import AIStreamChunk, ai_response, stream_agent_response
 from mindroom.api import config_lifecycle
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths, runtime_env_flag
-from mindroom.execution_preparation import (
-    build_prompt_with_thread_history,
-    prepare_bound_team_execution_context,
-)
+from mindroom.execution_preparation import build_prompt_with_thread_history
 from mindroom.history.runtime import (
     ScopeSessionContext,
-    apply_replay_plan,
     close_team_runtime_sqlite_dbs,
     open_bound_scope_session_context,
 )
@@ -45,8 +40,15 @@ from mindroom.knowledge.utils import get_agent_knowledge
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.routing import suggest_agent
-from mindroom.team_runtime_resolution import materialize_exact_requested_team_members
-from mindroom.teams import TeamMode, TeamOutcome, _create_team_instance, format_team_response, resolve_configured_team
+from mindroom.teams import (
+    TeamMode,
+    TeamOutcome,
+    build_materialized_team_instance,
+    format_team_response,
+    materialize_exact_team_members,
+    prepare_materialized_team_execution,
+    resolve_configured_team,
+)
 from mindroom.tool_system.events import format_tool_completed_event, format_tool_started_event
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
@@ -1124,26 +1126,13 @@ def _build_team(
     requested_members = [config_ids[member_name] for member_name in team_config.agents]
     model_name = team_config.model or "default"
 
-    def _build_member(member_name: str) -> Agent:
-        return create_agent(
-            member_name,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-            knowledge=get_agent_knowledge(
-                member_name,
-                config,
-                runtime_paths,
-                on_missing_bases=_log_missing_knowledge_bases(member_name),
-            ),
-            session_id=session_id,
-            include_interactive_questions=False,
-        )
-
-    team_members = materialize_exact_requested_team_members(
+    team_members = materialize_exact_team_members(
         team_config.agents,
-        materializable_agent_names=None,
-        build_member=_build_member,
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=execution_identity,
+        session_id=session_id,
+        reason_prefix=f"Team '{team_name}'",
     )
 
     final_resolution = resolve_configured_team(
@@ -1157,16 +1146,15 @@ def _build_team(
     if final_resolution.outcome is not TeamOutcome.TEAM:
         raise ValueError(final_resolution.reason or f"Team '{team_name}' cannot be materialized")
 
-    team = _create_team_instance(
+    team = build_materialized_team_instance(
+        requested_agent_names=team_members.requested_agent_names,
         agents=team_members.agents,
         mode=mode,
         config=config,
         runtime_paths=runtime_paths,
-        team_display_name=f"Team-{team_name}",
-        fallback_team_id=team_name,
         model_name=model_name,
         configured_team_name=team_name,
-        history_storage=scope_context.storage if scope_context is not None else None,
+        scope_context=scope_context,
     )
     return team_members.agents, team, mode
 
@@ -1190,23 +1178,25 @@ async def _prepare_openai_team_prompt(
 ) -> str:
     """Prepare the final prompt for one OpenAI-compatible team run."""
     fallback_prompt = build_prompt_with_thread_history(prompt, thread_history)
-    runtime_model = config.resolve_runtime_model(entity_name=team_name)
-    prepared_execution = await prepare_bound_team_execution_context(
+    prepared_execution = await prepare_materialized_team_execution(
         scope_context=scope_context,
         agents=agents,
         team=team,
-        prompt=prompt,
+        message=prompt,
         fallback_prompt=fallback_prompt,
         thread_history=thread_history,
-        runtime_paths=runtime_paths,
         config=config,
-        team_name=team_name,
-        active_model_name=runtime_model.model_name,
-        active_context_window=runtime_model.context_window,
+        runtime_paths=runtime_paths,
+        active_model_name=config.resolve_runtime_model(entity_name=team_name).model_name,
+        reply_to_event_id=None,
+        active_event_ids=frozenset(),
+        response_sender_id=None,
+        compaction_outcomes_collector=None,
+        configured_team_name=team_name,
+        matrix_run_metadata=None,
+        system_enrichment_items=(),
     )
-    if prepared_execution.replay_plan is not None:
-        apply_replay_plan(target=team, replay_plan=prepared_execution.replay_plan)
-    return prepared_execution.final_prompt
+    return prepared_execution.prepared_prompt
 
 
 async def _non_stream_team_completion(

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -106,7 +106,6 @@ class TeamMode(str, Enum):
 class _PreparedMaterializedTeamExecution:
     """Shared prepared team execution state used by stream and non-stream paths."""
 
-    team: Team
     prepared_prompt: str
     run_metadata: dict[str, Any] | None
     unseen_event_ids: list[str]
@@ -998,48 +997,62 @@ def _raise_team_run_cancelled(reason: str | None) -> NoReturn:
     raise asyncio.CancelledError(reason or "Run cancelled")
 
 
-def _build_agent_from_orchestrator(
-    agent_name: str,
-    orchestrator: MultiAgentOrchestrator,
-    execution_identity: ToolExecutionIdentity | None,
+def materialize_exact_team_members(
+    requested_agent_names: list[str],
     *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None,
     session_id: str | None = None,
+    materializable_agent_names: set[str] | None = None,
     request_knowledge_managers: Mapping[str, KnowledgeManager] | None = None,
-) -> Agent:
-    """Create one exact team member from orchestrator-backed runtime state."""
-    assert orchestrator.config is not None
+    shared_manager_lookup: Callable[[str], KnowledgeManager | None] | None = None,
+    reason_prefix: str = "Team request",
+) -> ResolvedExactTeamMembers:
+    """Materialize the exact team-member set without silent fallback."""
+    if not requested_agent_names:
+        raise ValueError(_NO_AGENTS_RESPONSE)
 
-    def _shared_manager(base_id: str) -> KnowledgeManager | None:
-        return orchestrator.knowledge_managers.get(base_id)
+    def _build_member(agent_name: str) -> Agent:
+        def _on_missing_agent_bases(missing_base_ids: list[str]) -> None:
+            logger.warning(
+                "Knowledge bases not available for team agent",
+                agent_name=agent_name,
+                knowledge_bases=missing_base_ids,
+            )
 
-    def _on_missing_agent_bases(missing_base_ids: list[str]) -> None:
-        logger.warning(
-            "Knowledge bases not available for team agent",
-            agent_name=agent_name,
-            knowledge_bases=missing_base_ids,
+        knowledge = get_agent_knowledge(
+            agent_name,
+            config,
+            runtime_paths,
+            request_knowledge_managers=request_knowledge_managers,
+            shared_manager_lookup=shared_manager_lookup,
+            on_missing_bases=_on_missing_agent_bases,
+        )
+        return create_agent(
+            agent_name,
+            config,
+            runtime_paths,
+            execution_identity=execution_identity,
+            session_id=session_id
+            if session_id is not None
+            else execution_identity.session_id
+            if execution_identity
+            else None,
+            knowledge=knowledge,
+            include_interactive_questions=False,
         )
 
-    knowledge = get_agent_knowledge(
-        agent_name,
-        orchestrator.config,
-        orchestrator.runtime_paths,
-        request_knowledge_managers=request_knowledge_managers,
-        shared_manager_lookup=_shared_manager,
-        on_missing_bases=_on_missing_agent_bases,
+    team_members = materialize_exact_requested_team_members(
+        requested_agent_names,
+        materializable_agent_names=materializable_agent_names,
+        build_member=_build_member,
     )
-    return create_agent(
-        agent_name,
-        orchestrator.config,
-        orchestrator.runtime_paths,
-        execution_identity=execution_identity,
-        session_id=session_id
-        if session_id is not None
-        else execution_identity.session_id
-        if execution_identity
-        else None,
-        knowledge=knowledge,
-        include_interactive_questions=False,
-    )
+    if team_members.failed_agent_names:
+        raise ValueError(
+            _not_materializable_team_agents_message(team_members.failed_agent_names, prefix=reason_prefix),
+        )
+    return team_members
 
 
 def _requested_team_agent_names(agent_names: list[str]) -> list[str]:
@@ -1058,24 +1071,22 @@ def _materialize_team_members(
 ) -> ResolvedExactTeamMembers:
     """Materialize the exact requested team-member set without silent fallback."""
     requested_agent_names = _requested_team_agent_names(agent_names)
-    if not requested_agent_names:
-        raise ValueError(_NO_AGENTS_RESPONSE)
-    team_members = materialize_exact_requested_team_members(
+    assert orchestrator.config is not None
+
+    def _shared_manager(base_id: str) -> KnowledgeManager | None:
+        return orchestrator.knowledge_managers.get(base_id)
+
+    return materialize_exact_team_members(
         requested_agent_names,
+        config=orchestrator.config,
+        runtime_paths=orchestrator.runtime_paths,
+        execution_identity=execution_identity,
+        session_id=session_id,
         materializable_agent_names=resolve_live_shared_agent_names(orchestrator),
-        build_member=lambda name: _build_agent_from_orchestrator(
-            name,
-            orchestrator,
-            execution_identity,
-            session_id=session_id,
-            request_knowledge_managers=request_knowledge_managers,
-        ),
+        request_knowledge_managers=request_knowledge_managers,
+        shared_manager_lookup=_shared_manager,
+        reason_prefix=reason_prefix,
     )
-    if team_members.failed_agent_names:
-        raise ValueError(
-            _not_materializable_team_agents_message(team_members.failed_agent_names, prefix=reason_prefix),
-        )
-    return team_members
 
 
 async def _ensure_request_team_knowledge_managers(
@@ -1213,15 +1224,48 @@ def select_model_for_team(
     return model_name
 
 
-async def _prepare_materialized_team_execution(
+def build_materialized_team_instance(
+    *,
+    requested_agent_names: list[str],
+    agents: list[Agent],
+    mode: TeamMode,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    scope_context: ScopeSessionContext | None,
+    model_name: str | None,
+    configured_team_name: str | None,
+) -> Team:
+    """Build one agno.Team instance for already-materialized members."""
+    resolved_team_runtime_model = config.resolve_runtime_model(
+        entity_name=configured_team_name,
+        active_model_name=model_name,
+    )
+    resolved_team_model_name = resolved_team_runtime_model.model_name
+    team_label = f"Team-{'-'.join(requested_agent_names)}"
+    return _create_team_instance(
+        agents=agents,
+        mode=mode,
+        config=config,
+        runtime_paths=runtime_paths,
+        team_display_name=team_label,
+        fallback_team_id=team_label,
+        model_name=resolved_team_model_name,
+        configured_team_name=configured_team_name,
+        history_storage=scope_context.storage if scope_context is not None else None,
+    )
+
+
+async def prepare_materialized_team_execution(
     *,
     scope_context: ScopeSessionContext | None,
-    team_members: ResolvedExactTeamMembers,
-    mode: TeamMode,
+    agents: list[Agent],
+    team: Team,
     message: str,
-    orchestrator: MultiAgentOrchestrator,
+    fallback_prompt: str,
     thread_history: Sequence[ResolvedVisibleMessage] | None,
-    model_name: str | None,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    active_model_name: str | None,
     reply_to_event_id: str | None,
     active_event_ids: Collection[str],
     response_sender_id: str | None,
@@ -1231,51 +1275,26 @@ async def _prepare_materialized_team_execution(
     system_enrichment_items: Sequence[EnrichmentItem] = (),
 ) -> _PreparedMaterializedTeamExecution:
     """Prepare one materialized team for execution."""
-    assert orchestrator.config is not None
-
-    fallback_prompt = build_prompt_with_thread_history(
-        message,
-        thread_history,
-        header="Thread Context:",
-        prompt_intro="User: ",
-        max_messages=30,
-        max_message_length=_MAX_CONTEXT_MESSAGE_LENGTH,
-        missing_sender_label="Unknown",
-    )
-    resolved_team_runtime_model = orchestrator.config.resolve_runtime_model(
-        entity_name=configured_team_name,
-        active_model_name=model_name,
-    )
-    resolved_team_model_name = resolved_team_runtime_model.model_name
-    team_label = f"Team-{'-'.join(team_members.requested_agent_names)}"
-    team = _create_team_instance(
-        agents=team_members.agents,
-        mode=mode,
-        config=orchestrator.config,
-        runtime_paths=orchestrator.runtime_paths,
-        team_display_name=team_label,
-        fallback_team_id=team_label,
-        model_name=resolved_team_model_name,
-        configured_team_name=configured_team_name,
-        history_storage=scope_context.storage if scope_context is not None else None,
-    )
     if system_enrichment_items:
         rendered_system_context = render_system_enrichment_block(system_enrichment_items)
         team.additional_context = rendered_system_context
-        for agent in team_members.agents:
+        for agent in agents:
             agent.additional_context = rendered_system_context
     prepared_execution = await prepare_bound_team_execution_context(
         scope_context=scope_context,
-        agents=team_members.agents,
+        agents=agents,
         team=team,
         prompt=message,
         fallback_prompt=fallback_prompt,
         thread_history=thread_history,
-        runtime_paths=orchestrator.runtime_paths,
-        config=orchestrator.config,
+        runtime_paths=runtime_paths,
+        config=config,
         team_name=configured_team_name,
-        active_model_name=resolved_team_runtime_model.model_name,
-        active_context_window=resolved_team_runtime_model.context_window,
+        active_model_name=active_model_name,
+        active_context_window=config.resolve_runtime_model(
+            entity_name=configured_team_name,
+            active_model_name=active_model_name,
+        ).context_window,
         reply_to_event_id=reply_to_event_id,
         active_event_ids=active_event_ids,
         response_sender_id=response_sender_id,
@@ -1289,7 +1308,6 @@ async def _prepare_materialized_team_execution(
         extra_metadata=matrix_run_metadata,
     )
     return _PreparedMaterializedTeamExecution(
-        team=team,
         prepared_prompt=prepared_execution.final_prompt,
         run_metadata=run_metadata,
         unseen_event_ids=prepared_execution.unseen_event_ids,
@@ -1361,14 +1379,35 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                 scope_context=scope_context,
                 entity_name=configured_team_name or team_name,
             )
-            prepared_execution = await _prepare_materialized_team_execution(
-                scope_context=scope_context,
-                team_members=team_members,
+            fallback_prompt = build_prompt_with_thread_history(
+                message,
+                thread_history,
+                header="Thread Context:",
+                prompt_intro="User: ",
+                max_messages=30,
+                max_message_length=_MAX_CONTEXT_MESSAGE_LENGTH,
+                missing_sender_label="Unknown",
+            )
+            team = build_materialized_team_instance(
+                requested_agent_names=team_members.requested_agent_names,
+                agents=agents,
                 mode=mode,
-                message=message,
-                orchestrator=orchestrator,
-                thread_history=thread_history,
+                config=orchestrator.config,
+                runtime_paths=orchestrator.runtime_paths,
+                scope_context=scope_context,
                 model_name=model_name,
+                configured_team_name=configured_team_name,
+            )
+            prepared_execution = await prepare_materialized_team_execution(
+                scope_context=scope_context,
+                agents=agents,
+                team=team,
+                message=message,
+                fallback_prompt=fallback_prompt,
+                thread_history=thread_history,
+                config=orchestrator.config,
+                runtime_paths=orchestrator.runtime_paths,
+                active_model_name=model_name,
                 reply_to_event_id=reply_to_event_id,
                 active_event_ids=active_event_ids,
                 response_sender_id=response_sender_id,
@@ -1377,7 +1416,6 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                 matrix_run_metadata=matrix_run_metadata,
                 system_enrichment_items=system_enrichment_items,
             )
-            team = prepared_execution.team
             prompt = prepared_execution.prepared_prompt
             run_metadata = prepared_execution.run_metadata
             logger.info(f"Executing team response with {len(agents)} agents in {mode.value} mode")
@@ -1627,14 +1665,35 @@ async def team_response_stream(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 scope_context=scope_context,
                 entity_name=configured_team_name or team_label,
             )
-            prepared_execution = await _prepare_materialized_team_execution(
-                scope_context=scope_context,
-                team_members=team_members,
+            fallback_prompt = build_prompt_with_thread_history(
+                message,
+                thread_history,
+                header="Thread Context:",
+                prompt_intro="User: ",
+                max_messages=30,
+                max_message_length=_MAX_CONTEXT_MESSAGE_LENGTH,
+                missing_sender_label="Unknown",
+            )
+            team = build_materialized_team_instance(
+                requested_agent_names=team_members.requested_agent_names,
+                agents=team_members.agents,
                 mode=mode,
-                message=message,
-                orchestrator=orchestrator,
-                thread_history=thread_history,
+                config=orchestrator.config,
+                runtime_paths=orchestrator.runtime_paths,
+                scope_context=scope_context,
                 model_name=model_name,
+                configured_team_name=configured_team_name,
+            )
+            prepared_execution = await prepare_materialized_team_execution(
+                scope_context=scope_context,
+                agents=team_members.agents,
+                team=team,
+                message=message,
+                fallback_prompt=fallback_prompt,
+                thread_history=thread_history,
+                config=orchestrator.config,
+                runtime_paths=orchestrator.runtime_paths,
+                active_model_name=model_name,
                 reply_to_event_id=reply_to_event_id,
                 active_event_ids=active_event_ids,
                 response_sender_id=response_sender_id,
@@ -1643,7 +1702,6 @@ async def team_response_stream(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 matrix_run_metadata=matrix_run_metadata,
                 system_enrichment_items=system_enrichment_items,
             )
-            team = prepared_execution.team
             prepared_prompt = prepared_execution.prepared_prompt
             unseen_event_ids = prepared_execution.unseen_event_ids
             run_metadata = prepared_execution.run_metadata

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -30,7 +30,7 @@ from mindroom.ai import (
     stream_agent_response,
 )
 from mindroom.bot import AgentBot
-from mindroom.config.agent import AgentConfig
+from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import (
@@ -66,6 +66,21 @@ def _runtime_paths(tmp_path: Path, *, config_path: Path | None = None) -> Runtim
 def _config() -> Config:
     return Config(
         agents={"general": AgentConfig(display_name="General")},
+        models={"default": ModelConfig(provider="openai", id="test-model")},
+    )
+
+
+def _config_with_team() -> Config:
+    return Config(
+        agents={"general": AgentConfig(display_name="General")},
+        teams={
+            "ultimate": TeamConfig(
+                display_name="Ultimate",
+                role="Coordinate the team",
+                agents=["general"],
+                mode="coordinate",
+            ),
+        },
         models={"default": ModelConfig(provider="openai", id="test-model")},
     )
 
@@ -565,6 +580,45 @@ class TestUserIdPassthrough:
 
         assert response == "friendly-error"
         mock_friendly_error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ai_response_rejects_configured_team_targets(self, tmp_path: Path) -> None:
+        """Generic ai helpers should reject configured team names explicitly."""
+        with patch("mindroom.ai.get_user_friendly_error_message", return_value="friendly-error") as mock_friendly_error:
+            response = await ai_response(
+                agent_name="ultimate",
+                prompt="test",
+                session_id="session1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config_with_team(),
+            )
+
+        assert response == "friendly-error"
+        error = mock_friendly_error.call_args.args[0]
+        assert isinstance(error, ValueError)
+        assert "configured team" in str(error)
+        assert "team/ultimate" in str(error)
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_rejects_configured_team_targets(self, tmp_path: Path) -> None:
+        """Streaming agent helpers should reject configured team names explicitly."""
+        with patch("mindroom.ai.get_user_friendly_error_message", return_value="friendly-error") as mock_friendly_error:
+            chunks = [
+                chunk
+                async for chunk in stream_agent_response(
+                    agent_name="ultimate",
+                    prompt="test",
+                    session_id="session1",
+                    runtime_paths=_runtime_paths(tmp_path),
+                    config=_config_with_team(),
+                )
+            ]
+
+        assert chunks == ["friendly-error"]
+        error = mock_friendly_error.call_args.args[0]
+        assert isinstance(error, ValueError)
+        assert "configured team" in str(error)
+        assert "team/ultimate" in str(error)
 
     @pytest.mark.asyncio
     async def test_ai_response_passes_all_files_for_vertex_claude(self, tmp_path: Path) -> None:

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -23,7 +23,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.custom_tools.dynamic_tools import DynamicToolsToolkit
-from mindroom.teams import _build_agent_from_orchestrator
+from mindroom.teams import materialize_exact_team_members
 from mindroom.thread_utils import create_session_id
 from mindroom.tool_system import dynamic_toolkits as dynamic_toolkits_module
 from mindroom.tool_system.dynamic_toolkits import (
@@ -998,11 +998,6 @@ def test_team_builder_passes_team_session_id_to_create_agent(tmp_path: Path) -> 
     """Team member creation should share the team session id across member agents."""
     config = _validated_config(tmp_path, _base_config_data())
     runtime_paths = _runtime_paths(tmp_path)
-    orchestrator = SimpleNamespace(
-        config=config,
-        runtime_paths=runtime_paths,
-        knowledge_managers={},
-    )
     execution_identity = ToolExecutionIdentity(
         channel="matrix",
         agent_name="code",
@@ -1017,11 +1012,12 @@ def test_team_builder_passes_team_session_id_to_create_agent(tmp_path: Path) -> 
         patch("mindroom.teams.get_agent_knowledge", return_value=None),
         patch("mindroom.teams.create_agent", return_value=MagicMock(name="CodeAgent")) as mock_create_agent,
     ):
-        result = _build_agent_from_orchestrator(
-            "code",
-            orchestrator,
+        result = materialize_exact_team_members(
+            ["code"],
+            config=config,
+            runtime_paths=runtime_paths,
             execution_identity=execution_identity,
-        )
+        ).agents[0]
 
     assert result is mock_create_agent.return_value
     assert mock_create_agent.call_args.kwargs["session_id"] == "team-session"
@@ -1051,8 +1047,8 @@ def test_openai_team_builder_passes_session_id_to_member_agents(tmp_path: Path) 
     runtime_paths = _runtime_paths(tmp_path)
 
     with (
-        patch("mindroom.api.openai_compat.create_agent", return_value=MagicMock(name="CodeAgent")) as mock_create,
-        patch("mindroom.api.openai_compat.get_agent_knowledge", return_value=None),
+        patch("mindroom.teams.create_agent", return_value=MagicMock(name="CodeAgent")) as mock_create,
+        patch("mindroom.teams.get_agent_knowledge", return_value=None),
         patch(
             "mindroom.api.openai_compat.resolve_bound_team_scope_context",
             create=True,

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -32,7 +33,6 @@ from mindroom.config.agent import AgentConfig, AgentPrivateConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
-from mindroom.execution_preparation import PreparedExecutionContext
 from mindroom.history.runtime import ScopeSessionContext, open_bound_scope_session_context
 from mindroom.history.types import HistoryScope, ResolvedReplayPlan
 from mindroom.matrix.client import ResolvedVisibleMessage
@@ -67,8 +67,9 @@ def _prepared_team_execution_context(
     final_prompt: str,
     replay_plan: ResolvedReplayPlan | None = None,
     replays_persisted_history: bool = False,
-) -> PreparedExecutionContext:
-    return PreparedExecutionContext(
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        prepared_prompt=final_prompt,
         final_prompt=final_prompt,
         replay_plan=replay_plan,
         unseen_event_ids=[],
@@ -2193,7 +2194,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat.prepare_bound_team_execution_context",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -2215,7 +2216,7 @@ class TestTeamCompletion:
         assert mock_prepare.await_count == 1
         assert mock_prepare.await_args.kwargs["agents"] == mock_agents
         assert mock_prepare.await_args.kwargs["team"] is mock_team
-        assert mock_prepare.await_args.kwargs["prompt"] == "Build a feature"
+        assert mock_prepare.await_args.kwargs["message"] == "Build a feature"
 
     def test_team_streaming(self, team_app_client: TestClient) -> None:
         """Streaming team completion streams TeamContentEvent (leader text) directly."""
@@ -2238,7 +2239,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat.prepare_bound_team_execution_context",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -2300,7 +2301,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat.prepare_bound_team_execution_context",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -2400,7 +2401,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat.prepare_bound_team_execution_context",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -2673,9 +2674,9 @@ class TestTeamCompletion:
         """Configured team failures should surface the user-facing materialization error."""
         with (
             patch("mindroom.teams.get_model_instance", return_value=MagicMock()),
-            patch("mindroom.api.openai_compat.get_agent_knowledge", return_value=None),
+            patch("mindroom.teams.get_agent_knowledge", return_value=None),
             patch(
-                "mindroom.api.openai_compat.create_agent",
+                "mindroom.teams.create_agent",
                 side_effect=[_make_test_agent("GeneralAgent"), RuntimeError("boom")],
             ),
         ):
@@ -2951,7 +2952,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat.prepare_bound_team_execution_context",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -2982,7 +2983,7 @@ class TestTeamCompletion:
             )
 
         assert response.status_code == 200
-        assert mock_prepare.await_args.kwargs["prompt"] == "Follow-up"
+        assert mock_prepare.await_args.kwargs["message"] == "Follow-up"
         assert mock_prepare.await_args.kwargs["team"] is mock_team
         assert "Start" in mock_prepare.await_args.kwargs["fallback_prompt"]
         assert "Ack" in mock_prepare.await_args.kwargs["fallback_prompt"]
@@ -2991,7 +2992,6 @@ class TestTeamCompletion:
         assert "Previous conversation in this thread:" not in prompt
         assert "user: Start" not in prompt
         assert "assistant: Ack" not in prompt
-        assert mock_team.num_history_runs == 1
 
     def test_team_streaming_prefers_persisted_history_over_thread_history(self, team_app_client: TestClient) -> None:
         """Persisted team history should suppress request-history stuffing in the streaming path too."""
@@ -3013,7 +3013,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat.prepare_bound_team_execution_context",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -3035,7 +3035,7 @@ class TestTeamCompletion:
             )
 
         assert response.status_code == 200
-        assert mock_prepare.await_args.kwargs["prompt"] == "Follow-up"
+        assert mock_prepare.await_args.kwargs["message"] == "Follow-up"
         assert mock_prepare.await_args.kwargs["team"] is mock_team
         assert "Start" in mock_prepare.await_args.kwargs["fallback_prompt"]
         assert "Ack" in mock_prepare.await_args.kwargs["fallback_prompt"]
@@ -3061,7 +3061,7 @@ class TestTeamCompletion:
             },
         )
         with (
-            patch("mindroom.api.openai_compat.create_agent") as mock_create,
+            patch("mindroom.teams.create_agent") as mock_create,
             patch("mindroom.teams.get_model_instance"),
             patch("agno.team.Team.__init__", return_value=None) as mock_team_init,
         ):
@@ -3077,7 +3077,7 @@ class TestTeamCompletion:
     def test_coordinate_mode_no_delegate_all(self) -> None:
         """Coordinate mode sets delegate_to_all_members=False on Team."""
         with (
-            patch("mindroom.api.openai_compat.create_agent") as mock_create,
+            patch("mindroom.teams.create_agent") as mock_create,
             patch("mindroom.teams.get_model_instance"),
             patch("agno.team.Team.__init__", return_value=None) as mock_team_init,
         ):
@@ -3124,7 +3124,7 @@ class TestTeamCompletion:
         member.id = "general"
 
         with (
-            patch("mindroom.api.openai_compat.create_agent", return_value=member),
+            patch("mindroom.teams.create_agent", return_value=member),
             patch("mindroom.teams.get_model_instance"),
             patch("agno.team.Team.__init__", return_value=None) as mock_team_init,
         ):
@@ -3168,7 +3168,7 @@ class TestTeamCompletion:
         member.id = "general"
 
         with (
-            patch("mindroom.api.openai_compat.create_agent", return_value=member),
+            patch("mindroom.teams.create_agent", return_value=member),
             patch("mindroom.teams.get_model_instance", return_value="openai:test-model"),
         ):
             from mindroom.api.openai_compat import _build_team  # noqa: PLC0415
@@ -3205,9 +3205,9 @@ class TestTeamCompletion:
         )
         mock_knowledge = MagicMock()
         with (
-            patch("mindroom.api.openai_compat.create_agent") as mock_create,
+            patch("mindroom.teams.create_agent") as mock_create,
             patch("mindroom.teams.get_model_instance"),
-            patch("mindroom.api.openai_compat.get_agent_knowledge", return_value=mock_knowledge),
+            patch("mindroom.teams.get_agent_knowledge", return_value=mock_knowledge),
             patch("agno.team.Team.__init__", return_value=None),
         ):
             mock_create.return_value = MagicMock(name="Research")

--- a/tests/test_system_enrich.py
+++ b/tests/test_system_enrich.py
@@ -47,7 +47,7 @@ from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.response_coordinator import ResponseRequest
 from mindroom.team_runtime_resolution import ResolvedExactTeamMembers
-from mindroom.teams import TeamMode, _prepare_materialized_team_execution
+from mindroom.teams import TeamMode, build_materialized_team_instance, prepare_materialized_team_execution
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
@@ -486,14 +486,26 @@ async def test_prepare_materialized_team_execution_applies_system_enrichment_to_
             new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
         ),
     ):
-        prepared = await _prepare_materialized_team_execution(
-            scope_context=None,
-            team_members=team_members,
+        team = build_materialized_team_instance(
+            requested_agent_names=team_members.requested_agent_names,
+            agents=team_members.agents,
             mode=TeamMode.COORDINATE,
-            message="Coordinate",
-            orchestrator=SimpleNamespace(config=config, runtime_paths=runtime_paths),
-            thread_history=[],
+            config=config,
+            runtime_paths=runtime_paths,
+            scope_context=None,
             model_name=None,
+            configured_team_name=None,
+        )
+        await prepare_materialized_team_execution(
+            scope_context=None,
+            agents=team_members.agents,
+            team=team,
+            message="Coordinate",
+            fallback_prompt="Coordinate",
+            thread_history=[],
+            config=config,
+            runtime_paths=runtime_paths,
+            active_model_name=None,
             reply_to_event_id="$event",
             active_event_ids=frozenset(),
             response_sender_id="@mindroom_code:localhost",
@@ -502,9 +514,9 @@ async def test_prepare_materialized_team_execution_applies_system_enrichment_to_
             system_enrichment_items=system_items,
         )
 
-    assert prepared.team is prepared_team
-    assert prepared.team.additional_context == rendered
-    assert rendered in _team_system_message(prepared.team)
+    assert team is prepared_team
+    assert team.additional_context == rendered
+    assert rendered in _team_system_message(team)
     assert all(agent.additional_context == rendered for agent in member_agents)
     assert all(rendered in _agent_system_message(agent) for agent in member_agents)
 

--- a/tests/test_team_collaboration.py
+++ b/tests/test_team_collaboration.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from mindroom.bot import AgentBot
-from mindroom.config.agent import AgentConfig, AgentPrivateConfig
+from mindroom.config.agent import AgentConfig, AgentPrivateConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.matrix.users import AgentMatrixUser
@@ -656,6 +656,74 @@ class TestRouterTeamFormation:
         assert result.outcome is TeamOutcome.INDIVIDUAL
         assert result.intent is TeamIntent.IMPLICIT_THREAD_TEAM
         assert _agent_names(result.eligible_members, config) == ["calculator"]
+
+    @pytest.mark.asyncio
+    async def test_thread_history_ignores_configured_team_participants(self) -> None:
+        """Implicit thread teams must ignore configured team bots instead of treating them as leaf members."""
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        import nio  # noqa: PLC0415
+
+        from mindroom.teams import decide_team_formation  # noqa: PLC0415
+
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "agent_alpha": AgentConfig(display_name="Agent Alpha", role="Alpha"),
+                    "agent_beta": AgentConfig(display_name="Agent Beta", role="Beta"),
+                    "agent_gamma": AgentConfig(display_name="Agent Gamma", role="Gamma"),
+                },
+                teams={
+                    "meta_team": TeamConfig(
+                        display_name="Meta Team",
+                        role="Combined agent team",
+                        agents=["agent_alpha", "agent_beta", "agent_gamma"],
+                        mode="coordinate",
+                    ),
+                },
+                models={"default": ModelConfig(provider="ollama", id="test-model")},
+            ),
+        )
+
+        room = MagicMock(spec=nio.MatrixRoom)
+        room.room_id = "!thread:localhost"
+        room.users = {
+            config.get_ids(runtime_paths_for(config))["meta_team"].full_id: None,
+            config.get_ids(runtime_paths_for(config))["agent_alpha"].full_id: None,
+            config.get_ids(runtime_paths_for(config))["agent_beta"].full_id: None,
+            config.get_ids(runtime_paths_for(config))["agent_gamma"].full_id: None,
+        }
+
+        result = await decide_team_formation(
+            agent=config.get_ids(runtime_paths_for(config))["agent_gamma"],
+            tagged_agents=[],
+            agents_in_thread=[
+                config.get_ids(runtime_paths_for(config))["meta_team"],
+                config.get_ids(runtime_paths_for(config))["agent_alpha"],
+                config.get_ids(runtime_paths_for(config))["agent_beta"],
+                config.get_ids(runtime_paths_for(config))["agent_gamma"],
+            ],
+            all_mentioned_in_thread=[],
+            runtime_paths=runtime_paths_for(config),
+            message="continue the thread",
+            config=config,
+            room=room,
+            is_thread=True,
+            use_ai_decision=False,
+        )
+
+        assert result.outcome is TeamOutcome.TEAM
+        assert result.intent is TeamIntent.IMPLICIT_THREAD_TEAM
+        assert sorted(_agent_names(result.requested_members, config)) == [
+            "agent_alpha",
+            "agent_beta",
+            "agent_gamma",
+        ]
+        assert sorted(_agent_names(result.eligible_members, config)) == [
+            "agent_alpha",
+            "agent_beta",
+            "agent_gamma",
+        ]
 
     @pytest.mark.asyncio
     async def test_previously_mentioned_off_room_agents_degrade_to_individual(self) -> None:


### PR DESCRIPTION
This PR makes the agent-only AI helpers reject configured team names explicitly and routes team execution through the same exact-team materialization helpers everywhere else.

That keeps the single-agent path from silently accepting team targets, and it removes duplicated team-construction logic between the normal runtime and the OpenAI-compatible API.

Summary:
- reject configured team names in the generic agent-only AI entry points
- centralize exact team member materialization in shared helpers
- make the OpenAI-compatible team path use the same prepared team execution flow as the main runtime
- update tests to cover the stricter boundary and the shared team-building path