### PR TITLE
Stop injecting session summaries into cached prompt assembly

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -1233,7 +1233,6 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         update_cultural_knowledge=update_cultural_knowledge,
         enable_agentic_culture=enable_agentic_culture,
         compress_tool_results=compress_tool_results,
-        add_session_summary_to_context=True,
         max_tool_calls_from_history=max_tool_calls_from_history,
     )
     if include_all_history:

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -910,14 +910,13 @@ def estimate_prompt_visible_history_tokens(
     scope: HistoryScope,
     history_settings: ResolvedHistorySettings,
 ) -> int:
-    """Estimate the persisted summary plus raw history Agno would replay for one run."""
-    summary_tokens = estimate_session_summary_tokens(session.summary.summary if session.summary is not None else None)
+    """Estimate the raw persisted history Agno would replay for one run."""
     history_messages = _history_messages_for_session(
         session=session,
         scope=scope,
         history_settings=history_settings,
     )
-    return summary_tokens + estimate_history_messages_tokens(history_messages)
+    return estimate_history_messages_tokens(history_messages)
 
 
 def estimate_history_messages_tokens(messages: list[Message]) -> int:
@@ -1026,20 +1025,6 @@ def _history_skip_roles(history_settings: ResolvedHistorySettings) -> list[str] 
     if history_settings.system_message_role in _STANDARD_HISTORY_ROLES:
         return None
     return [history_settings.system_message_role]
-
-
-def estimate_session_summary_tokens(summary_text: str | None) -> int:
-    """Estimate replay-visible tokens for one stored Agno session summary."""
-    if summary_text is None or summary_text.strip() == "":
-        return 0
-    wrapper = (
-        "Here is a brief summary of your previous interactions:\n\n"
-        "<summary_of_previous_interactions>\n"
-        f"{summary_text.strip()}\n"
-        "</summary_of_previous_interactions>\n\n"
-        "You should ALWAYS prefer information from this conversation over the past summary.\n\n"
-    )
-    return estimate_text_tokens(wrapper)
 
 
 def completed_top_level_runs(session: AgentSession | TeamSession) -> list[RunOutput | TeamRunOutput]:

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -24,7 +24,6 @@ from mindroom.history.compaction import (
     completed_top_level_runs,
     estimate_agent_static_tokens,
     estimate_prompt_visible_history_tokens,
-    estimate_session_summary_tokens,
     estimate_team_static_tokens,
     runs_for_scope,
 )
@@ -1023,29 +1022,16 @@ def plan_replay_that_fits(
             mode="limited",
             estimated_tokens=fitting_tokens,
             add_history_to_context=True,
-            add_session_summary_to_context=True,
             num_history_runs=num_history_runs,
             num_history_messages=num_history_messages,
             history_limit_mode=limit_mode,
             history_limit=fitting_limit,
         )
 
-    summary_tokens = estimate_session_summary_tokens(
-        session.summary.summary if session.summary is not None else None,
-    )
-    if 0 < summary_tokens <= available_history_budget:
-        return ResolvedReplayPlan(
-            mode="summary_only",
-            estimated_tokens=summary_tokens,
-            add_history_to_context=False,
-            add_session_summary_to_context=True,
-        )
-
     return ResolvedReplayPlan(
         mode="disabled",
         estimated_tokens=0,
         add_history_to_context=False,
-        add_session_summary_to_context=False,
     )
 
 
@@ -1056,7 +1042,6 @@ def apply_replay_plan(
 ) -> None:
     """Apply one resolved persisted-replay plan to a live Agent or Team."""
     target.add_history_to_context = replay_plan.add_history_to_context
-    target.add_session_summary_to_context = replay_plan.add_session_summary_to_context
     target.num_history_runs = replay_plan.num_history_runs
     target.num_history_messages = replay_plan.num_history_messages
 
@@ -1138,7 +1123,6 @@ def _log_replay_plan(
     logger.warning(
         "Replay planner disabled raw persisted replay for this run",
         scope=scope.key,
-        keep_summary_only=replay_plan.mode == "summary_only",
         estimated_tokens=current_history_tokens,
         fitted_tokens=replay_plan.estimated_tokens,
         available_history_budget=available_history_budget,
@@ -1158,7 +1142,6 @@ def _configured_replay_plan(
         mode="configured",
         estimated_tokens=estimated_tokens,
         add_history_to_context=True,
-        add_session_summary_to_context=True,
         num_history_runs=num_history_runs,
         num_history_messages=num_history_messages,
     )
@@ -1195,11 +1178,6 @@ def _has_effective_persisted_replay(
     scope: HistoryScope,
     replay_plan: ResolvedReplayPlan,
 ) -> bool:
-    summary = session.summary.summary if session.summary is not None else None
-    has_replayed_summary = (
-        replay_plan.add_session_summary_to_context and isinstance(summary, str) and bool(summary.strip())
-    )
-    has_replayed_runs = replay_plan.add_history_to_context and bool(
+    return replay_plan.add_history_to_context and bool(
         runs_for_scope(completed_top_level_runs(session), scope),
     )
-    return has_replayed_summary or has_replayed_runs

--- a/src/mindroom/history/types.py
+++ b/src/mindroom/history/types.py
@@ -9,7 +9,7 @@ _ScopeKind = Literal["agent", "team"]
 _HistoryMode = Literal["all", "runs", "messages"]
 _CompactionMode = Literal["auto", "manual"]
 _CompactionAvailabilityReason = Literal["no_context_window", "non_positive_summary_input_budget"]
-_ReplayPlanMode = Literal["configured", "limited", "summary_only", "disabled"]
+_ReplayPlanMode = Literal["configured", "limited", "disabled"]
 
 
 @dataclass(frozen=True)
@@ -79,7 +79,6 @@ class ResolvedReplayPlan:
     mode: _ReplayPlanMode
     estimated_tokens: int
     add_history_to_context: bool
-    add_session_summary_to_context: bool
     num_history_runs: int | None = None
     num_history_messages: int | None = None
     history_limit_mode: Literal["runs", "messages"] | None = None

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1162,7 +1162,6 @@ def _create_team_instance(
         # Team-owned replay should come from the shared TeamSession, not from
         # each member independently replaying their own session state.
         agent.add_history_to_context = False
-        agent.add_session_summary_to_context = False
 
     team = Team(
         members=agents,  # type: ignore[arg-type]
@@ -1172,7 +1171,6 @@ def _create_team_instance(
         db=history_storage,
         delegate_to_all_members=mode == TeamMode.COLLABORATE,
         add_history_to_context=True,
-        add_session_summary_to_context=True,
         num_history_runs=history_settings.policy.limit if history_settings.policy.mode == "runs" else None,
         num_history_messages=history_settings.policy.limit if history_settings.policy.mode == "messages" else None,
         max_tool_calls_from_history=history_settings.max_tool_calls_from_history,

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -41,7 +41,6 @@ from mindroom.history.compaction import (
     estimate_agent_static_tokens,
     estimate_history_messages_tokens,
     estimate_prompt_visible_history_tokens,
-    estimate_session_summary_tokens,
     estimate_static_tokens,
     estimate_tool_definition_tokens,
 )
@@ -303,7 +302,6 @@ def _agent(
         model=model or FakeModel(id="fake-model", provider="fake"),
         db=db,
         add_history_to_context=True,
-        add_session_summary_to_context=True,
         num_history_runs=num_history_runs,
         num_history_messages=num_history_messages,
         store_history_messages=False,
@@ -468,7 +466,6 @@ def test_create_agent_enables_agno_native_history_replay(tmp_path: Path) -> None
         )
 
     assert agent.add_history_to_context is True
-    assert agent.add_session_summary_to_context is True
     assert agent.num_history_runs == 2
     assert agent.num_history_messages is None
     assert agent.store_history_messages is False
@@ -600,7 +597,7 @@ async def test_prepare_history_for_run_forced_compaction_rewrites_session(tmp_pa
     assert state.force_compact_before_next_run is False
     assert state.last_compacted_at is not None
 
-    assert prepared.replays_persisted_history is True
+    assert prepared.replays_persisted_history is False
     assert len(prepared.compaction_outcomes) == 1
     assert prepared.compaction_outcomes[0].summary == "merged summary"
 
@@ -983,7 +980,6 @@ async def test_prepare_history_for_run_uses_context_window_guard_without_authore
     assert prepared.replay_plan is not None
     assert prepared.replay_plan.mode == "limited"
     assert prepared.replay_plan.add_history_to_context is True
-    assert prepared.replay_plan.add_session_summary_to_context is True
     assert prepared.replay_plan.num_history_runs == 2
     assert prepared.replay_plan.num_history_messages is None
 
@@ -1040,7 +1036,6 @@ async def test_prepare_history_for_run_context_window_guard_preserves_custom_sys
     assert prepared.replay_plan is not None
     assert prepared.replay_plan.mode == "limited"
     assert prepared.replay_plan.add_history_to_context is True
-    assert prepared.replay_plan.add_session_summary_to_context is True
     assert prepared.replay_plan.num_history_runs == 1
     assert prepared.replay_plan.num_history_messages is None
 
@@ -1192,7 +1187,6 @@ async def test_prepare_history_for_run_authored_compaction_still_plans_safe_repl
     assert prepared.replay_plan is not None
     assert prepared.replay_plan.mode == "limited"
     assert prepared.replay_plan.add_history_to_context is True
-    assert prepared.replay_plan.add_session_summary_to_context is True
     assert prepared.replay_plan.num_history_runs == 1
     assert prepared.replay_plan.num_history_messages is None
 
@@ -1652,11 +1646,8 @@ def test_create_team_instance_enables_native_team_history_and_disables_members(t
         )
 
     assert alpha.add_history_to_context is False
-    assert alpha.add_session_summary_to_context is False
     assert zeta.add_history_to_context is False
-    assert zeta.add_session_summary_to_context is False
     assert team.add_history_to_context is True
-    assert team.add_session_summary_to_context is True
     assert team.num_history_messages == 2
     assert team.store_history_messages is False
 
@@ -2665,7 +2656,6 @@ async def test_prepare_history_for_run_without_budget_returns_configured_replay_
             ),
         ),
         add_history_to_context=True,
-        add_session_summary_to_context=True,
         num_history_runs=2,
         num_history_messages=None,
     )
@@ -2721,7 +2711,9 @@ async def test_prepare_history_for_run_tracks_disabled_replay_separately_from_se
 
 
 @pytest.mark.asyncio
-async def test_prepare_history_for_run_forced_compaction_can_fall_back_to_summary_only(tmp_path: Path) -> None:
+async def test_prepare_history_for_run_forced_compaction_leaves_no_effective_replay_when_no_runs_fit(
+    tmp_path: Path,
+) -> None:
     config, runtime_paths = _make_config(
         tmp_path,
         compaction=CompactionOverrideConfig(enabled=True),
@@ -2789,20 +2781,16 @@ async def test_prepare_history_for_run_forced_compaction_can_fall_back_to_summar
     assert prepared.compaction_outcomes[0].runs_after == 0
     assert prepared.compaction_outcomes[0].summary == "merged summary"
     assert prepared.replay_plan is not None
-    assert prepared.replay_plan.mode == "disabled"
-    assert prepared.replay_plan.add_history_to_context is False
-    assert prepared.replay_plan.add_session_summary_to_context is False
+    assert prepared.replay_plan.mode == "configured"
+    assert prepared.replay_plan.estimated_tokens == 0
+    assert prepared.replays_persisted_history is False
 
 
-def test_plan_replay_that_fits_disables_summary_only_when_wrapped_summary_exceeds_budget() -> None:
-    summary_text = "s" * 360
-    available_history_budget = estimate_text_tokens(summary_text)
-    assert estimate_session_summary_tokens(summary_text) > available_history_budget
-
+def test_plan_replay_that_fits_disables_replay_when_no_history_fits_budget() -> None:
+    available_history_budget = estimate_text_tokens("budget")
     agent = _agent()
     session = _session(
         "session-1",
-        summary=SessionSummary(summary=summary_text, updated_at=datetime.now(UTC)),
         runs=[
             _completed_run(
                 "run-1",
@@ -2827,7 +2815,6 @@ def test_plan_replay_that_fits_disables_summary_only_when_wrapped_summary_exceed
 
     assert replay_plan.mode == "disabled"
     assert agent.add_history_to_context is False
-    assert agent.add_session_summary_to_context is False
     assert agent.num_history_runs is None
     assert agent.num_history_messages is None
 
@@ -2991,7 +2978,7 @@ async def test_prepare_history_for_run_compaction_preserves_seen_event_ids(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_native_agno_replays_summary_and_recent_raw_history_without_persisting_replay(
+async def test_native_agno_replays_recent_raw_history_without_persisting_replay(
     tmp_path: Path,
 ) -> None:
     config, runtime_paths = _make_config(tmp_path)
@@ -3016,13 +3003,13 @@ async def test_native_agno_replays_summary_and_recent_raw_history_without_persis
     response = await agent.arun("Current prompt", session_id="session-1")
 
     assert response.content == "ok"
-    assert model.seen_messages[0].role == "system"
-    assert "stored summary" in str(model.seen_messages[0].content)
-    assert [message.content for message in model.seen_messages[1:3]] == [
+    assert [message.role for message in model.seen_messages[:2]] == ["user", "assistant"]
+    assert "stored summary" not in str(model.seen_messages)
+    assert [message.content for message in model.seen_messages[:2]] == [
         "run-2 question",
         "run-2 answer",
     ]
-    assert [message.from_history for message in model.seen_messages[1:3]] == [True, True]
+    assert [message.from_history for message in model.seen_messages[:2]] == [True, True]
     assert model.seen_messages[-1].role == "user"
     assert model.seen_messages[-1].content == "Current prompt"
 
@@ -3031,7 +3018,6 @@ async def test_native_agno_replays_summary_and_recent_raw_history_without_persis
     latest_run = persisted.runs[-1]
     assert isinstance(latest_run, RunOutput)
     assert [message.content for message in latest_run.messages or []] == [
-        model.seen_messages[0].content,
         "Current prompt",
         "ok",
     ]
@@ -3091,9 +3077,9 @@ async def test_prepare_agent_and_prompt_uses_native_history_with_unseen_thread_c
     response = await agent.arun(full_prompt, session_id="session-1")
 
     assert response.content == "ok"
-    assert recording_model.seen_messages[0].role == "system"
-    assert "stored summary" in str(recording_model.seen_messages[0].content)
-    assert [message.content for message in recording_model.seen_messages[1:3]] == [
+    assert [message.role for message in recording_model.seen_messages[:2]] == ["user", "assistant"]
+    assert "stored summary" not in str(recording_model.seen_messages)
+    assert [message.content for message in recording_model.seen_messages[:2]] == [
         "run-2 question",
         "run-2 answer",
     ]

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -2905,7 +2905,6 @@ class TestTeamCompletion:
         mock_team = _make_test_team()
         mock_team.arun = AsyncMock(return_value=TeamRunOutput(content="ok"))
         mock_team.add_history_to_context = True
-        mock_team.add_session_summary_to_context = True
         mock_team.num_history_runs = 3
         mock_team.num_history_messages = None
         mock_agents = [_make_test_agent("GeneralAgent"), _make_test_agent("CodeAgent")]
@@ -2962,7 +2961,6 @@ class TestTeamCompletion:
                     mode="limited",
                     estimated_tokens=100,
                     add_history_to_context=True,
-                    add_session_summary_to_context=True,
                     num_history_runs=1,
                     num_history_messages=None,
                     history_limit_mode="runs",


### PR DESCRIPTION
This PR removes the extra session-summary injection step from history and prompt assembly paths.

That summary text was mutating prompt inputs in ways that broke prompt caching while duplicating context that is already available through the normal history flow.

Summary:
- remove `add_session_summary_to_context` from the agent and team prompt paths
- simplify the supporting history types and compaction/runtime helpers
- update history and OpenAI-compatible tests to match the stable cached-prompt behavior