### PR TITLE
Store thread summaries as plain text with a shared 300-character limit

### DIFF
--- a/src/mindroom/custom_tools/subagents.py
+++ b/src/mindroom/custom_tools/subagents.py
@@ -14,7 +14,12 @@ from mindroom.constants import ORIGINAL_SENDER_KEY
 from mindroom.matrix.client import get_latest_thread_event_id_if_needed, send_message
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.message_target import MessageTarget
-from mindroom.thread_summary import send_thread_summary_event, update_last_summary_count
+from mindroom.thread_summary import (
+    THREAD_SUMMARY_MAX_LENGTH,
+    normalize_thread_summary_text,
+    send_thread_summary_event,
+    update_last_summary_count,
+)
 from mindroom.thread_tags import ThreadTagsError, normalize_tag_name, set_thread_tag
 from mindroom.thread_utils import create_session_id
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
@@ -24,7 +29,7 @@ if TYPE_CHECKING:
 
 
 _REGISTRY_LOCK = Lock()
-_MAX_SPAWN_SUMMARY_LENGTH = 500
+_MAX_SPAWN_SUMMARY_LENGTH = THREAD_SUMMARY_MAX_LENGTH
 
 
 def _now_iso() -> str:
@@ -64,9 +69,9 @@ def _normalize_spawn_summary(summary: object) -> str:
         msg = "summary must be a non-empty string."
         raise ValueError(msg)
 
-    normalized_summary = " ".join(summary.split())
+    normalized_summary = normalize_thread_summary_text(summary)
     if len(normalized_summary) > _MAX_SPAWN_SUMMARY_LENGTH:
-        msg = f"summary must be {_MAX_SPAWN_SUMMARY_LENGTH} characters or fewer after whitespace normalization."
+        msg = f"summary must be {_MAX_SPAWN_SUMMARY_LENGTH} characters or fewer after normalization."
         raise ValueError(msg)
     return normalized_summary
 

--- a/src/mindroom/custom_tools/thread_summary.py
+++ b/src/mindroom/custom_tools/thread_summary.py
@@ -8,7 +8,9 @@ from agno.tools import Toolkit
 
 from mindroom.custom_tools.attachment_helpers import resolve_context_thread_id, room_access_allowed
 from mindroom.thread_summary import (
+    THREAD_SUMMARY_MAX_LENGTH,
     _count_non_summary_messages,
+    normalize_thread_summary_text,
     send_thread_summary_event,
     thread_summary_lock,
     update_last_summary_count,
@@ -16,7 +18,7 @@ from mindroom.thread_summary import (
 from mindroom.thread_tags import normalize_thread_root_event_id
 from mindroom.tool_system.runtime_context import get_tool_runtime_context
 
-_MAX_THREAD_SUMMARY_LENGTH = 500
+_MAX_THREAD_SUMMARY_LENGTH = THREAD_SUMMARY_MAX_LENGTH
 
 
 class ThreadSummaryTools(Toolkit):
@@ -42,13 +44,16 @@ class ThreadSummaryTools(Toolkit):
             message="Thread summary tool context is unavailable in this runtime path.",
         )
 
-    async def set_thread_summary(  # noqa: C901, PLR0911, PLR0912
+    async def set_thread_summary(  # noqa: C901, PLR0911, PLR0912, PLR0915
         self,
         summary: str,
         thread_id: str | None = None,
         room_id: str | None = None,
     ) -> str:
-        """Write a manual summary notice into the current or specified Matrix thread."""
+        """Write a plain-text summary notice into the current or specified Matrix thread.
+
+        Summary must be plain text (no markdown), maximum 300 characters.
+        """
         context = get_tool_runtime_context()
         if context is None:
             return self._context_error()
@@ -83,7 +88,14 @@ class ThreadSummaryTools(Toolkit):
                 room_id=resolved_room_id,
                 message="summary must be a non-empty string.",
             )
-        normalized_summary = " ".join(summary.split())
+        normalized_summary = normalize_thread_summary_text(summary)
+        if not normalized_summary:
+            return self._payload(
+                "error",
+                action="set",
+                room_id=resolved_room_id,
+                message="summary must be a non-empty string.",
+            )
         if len(normalized_summary) > _MAX_THREAD_SUMMARY_LENGTH:
             return self._payload(
                 "error",

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import re
 from collections import defaultdict
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -24,6 +25,16 @@ if TYPE_CHECKING:
     from mindroom.matrix.conversation_access import ConversationReadAccess
 
 logger = get_logger(__name__)
+THREAD_SUMMARY_MAX_LENGTH = 300
+_MARKDOWN_LINK_RE = re.compile(r"!\[([^\]]*)\]\([^)]+\)|\[([^\]]+)\]\([^)]+\)")
+_MARKDOWN_CODE_BLOCK_RE = re.compile(r"```(?:[^\n`]*)\n?(.*?)```", re.DOTALL)
+_MARKDOWN_DOUBLE_EMPHASIS_RE = re.compile(r"(\*\*|__)(.*?)\1", re.DOTALL)
+_MARKDOWN_SINGLE_ASTERISK_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", re.DOTALL)
+_MARKDOWN_STRIKETHROUGH_RE = re.compile(r"~~(.*?)~~", re.DOTALL)
+_MARKDOWN_INLINE_CODE_RE = re.compile(r"`([^`]*)`")
+_MARKDOWN_HEADING_RE = re.compile(r"(?m)^\s{0,3}#{1,6}\s+")
+_MARKDOWN_BLOCKQUOTE_RE = re.compile(r"(?m)^\s{0,3}>\s?")
+_MARKDOWN_LIST_ITEM_RE = re.compile(r"(?m)^\s*(?:[-+*]|\d+\.)\s+")
 
 # In-memory tracking of last summarized message count per thread.
 # Key: "{room_id}:{thread_id}", value: message count at last summary.
@@ -34,7 +45,28 @@ _thread_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 class _ThreadSummary(BaseModel):
     """Structured thread summary response."""
 
-    summary: str = Field(description="One-line summary of the thread conversation")
+    summary: str = Field(
+        max_length=THREAD_SUMMARY_MAX_LENGTH,
+        description="One-line summary of the thread conversation",
+    )
+
+
+def normalize_thread_summary_text(raw_text: str) -> str:
+    """Strip common markdown formatting and collapse the result to one plain-text line."""
+    normalized = raw_text.strip()
+    if not normalized:
+        return ""
+
+    normalized = _MARKDOWN_CODE_BLOCK_RE.sub(r"\1", normalized)
+    normalized = _MARKDOWN_LINK_RE.sub(lambda match: match.group(1) or match.group(2) or "", normalized)
+    normalized = _MARKDOWN_HEADING_RE.sub("", normalized)
+    normalized = _MARKDOWN_BLOCKQUOTE_RE.sub("", normalized)
+    normalized = _MARKDOWN_LIST_ITEM_RE.sub("", normalized)
+    normalized = _MARKDOWN_DOUBLE_EMPHASIS_RE.sub(r"\2", normalized)
+    normalized = _MARKDOWN_SINGLE_ASTERISK_RE.sub(r"\1", normalized)
+    normalized = _MARKDOWN_STRIKETHROUGH_RE.sub(r"\1", normalized)
+    normalized = _MARKDOWN_INLINE_CODE_RE.sub(r"\1", normalized)
+    return " ".join(normalized.split())
 
 
 def thread_summary_cache_key(room_id: str, thread_id: str) -> str:
@@ -125,6 +157,72 @@ async def _recover_last_summary_count(
     return best_count
 
 
+_SUMMARY_INSTRUCTIONS = [
+    "You are a thread summary writer. Produce a single concise summary line for a chat thread conversation.",
+    "",
+    "RULES:",
+    "- One line only, under 120 characters",
+    "- Start with 1-2 emojis that meaningfully represent the topic — the emoji should "
+    "help a reader scanning a list of threads instantly understand what the thread is about",
+    "- Capture the main topic AND the current status or outcome",
+    "- Plain text only — no markdown formatting (no bold, headers, bullets, links)",
+    "- If the conversation references a ticket, issue number, or any identifier "
+    "(e.g. PROJ-123, #42, BUG-7), include it near the start after the emoji",
+    "- Be consistent: similar threads should produce similar-style summaries",
+    "- No quotes, no prefixes like 'Summary:', no trailing punctuation",
+    "- Write a NOVEL summary in your own words. Do NOT copy, quote, or truncate any "
+    "message from the thread. Synthesize the key topic and outcome.",
+    "",
+    "GOOD EXAMPLES:",
+    "- \U0001f41b PROJ-42: fix login crash on expired tokens — merged",
+    "- \u2705 Database migration to v3 completed successfully",
+    "- \U0001f4ac Discussing vacation schedule for July",
+    "- \U0001f527 Nginx config updated for new subdomain",
+    "- \U0001f6a8 Production outage — root cause identified, fix deployed",
+    "- \U0001f4e6 #127: add CSV export to reports — in progress",
+    "- \U0001f3a8 Redesigning sidebar navigation — wireframes shared",
+    "- \U0001f4b0 Q2 budget review — approved with minor adjustments",
+    "",
+    "BAD EXAMPLES (do NOT produce these):",
+    "- 'Thread about fixing a bug' (too vague, no emoji, quoted)",
+    "- 'Summary: The team discussed the login issue' (has prefix, no emoji, no outcome)",
+    "- '\U0001f4ac Discussion' (way too vague, no topic)",
+    "- '\U0001f41b\U0001f527\u2705\U0001f680\U0001f525 Fixed the thing' (too many emojis, vague)",
+    "- 'The conversation was about updating the configuration files for nginx' (too long, no emoji, no outcome)",
+    "- 'I wanted to discuss the implementation plan for the new auth system' "
+    "(verbatim copy of a message — summarize the topic, don't quote it)",
+]
+
+_MAX_MESSAGES_BEFORE_TRUNCATION = 50
+_TRUNCATION_SAMPLE_SIZE = 3
+
+
+def _build_conversation_text(thread_history: Sequence[ResolvedVisibleMessage]) -> str:
+    """Build conversation text from thread history.
+
+    Prior thread summary notices (``io.mindroom.thread_summary``) are excluded
+    so they don't pollute the conversation.
+
+    For threads exceeding ``_MAX_MESSAGES_BEFORE_TRUNCATION`` messages, samples
+    the first and last few messages with an omission note in between.
+    """
+    lines: list[str] = []
+    for msg in thread_history:
+        if _is_thread_summary_message(msg):
+            continue
+        sender = msg.sender or "unknown"
+        body = msg.body or ""
+        if body:
+            lines.append(f"{sender}: {body}")
+
+    if len(lines) > _MAX_MESSAGES_BEFORE_TRUNCATION:
+        n = _TRUNCATION_SAMPLE_SIZE
+        omitted = len(lines) - 2 * n
+        lines = [*lines[:n], f"[... {omitted} messages omitted ...]", *lines[-n:]]
+
+    return "\n".join(lines)
+
+
 async def _generate_summary(
     thread_history: Sequence[ResolvedVisibleMessage],
     config: Config,
@@ -133,56 +231,17 @@ async def _generate_summary(
     """Generate a one-line summary of a thread conversation via LLM."""
     model_name = config.defaults.thread_summary_model or "default"
     model = get_model_instance(config, runtime_paths, model_name)
+
+    conversation = _build_conversation_text(thread_history)
+    session_hash = hashlib.sha256(conversation.encode()).hexdigest()[:8]
+
+    prompt = f"<thread_messages>\n{conversation}\n</thread_messages>\n\nSummarize the above thread."
     agent = Agent(
         name="ThreadSummarizer",
-        role="Generate one-line thread summaries",
+        instructions=list(_SUMMARY_INSTRUCTIONS),
         model=model,
         output_schema=_ThreadSummary,
     )
-
-    lines = []
-    for msg in thread_history:
-        sender = msg.sender or "unknown"
-        body = msg.body or ""
-        if body:
-            lines.append(f"{sender}: {body}")
-    conversation = "\n".join(lines)
-
-    prompt = (
-        "You are a thread summary writer. Your job is to produce a single concise summary "
-        "line for a chat thread conversation.\n"
-        "\n"
-        "RULES:\n"
-        "- One line only, under 120 characters\n"
-        "- Start with 1-2 emojis that meaningfully represent the topic — the emoji should "
-        "help a reader scanning a list of threads instantly understand what the thread is about\n"
-        "- Capture the main topic AND the current status or outcome\n"
-        "- If the conversation references a ticket, issue number, or any identifier "
-        "(e.g. PROJ-123, #42, BUG-7), include it near the start after the emoji\n"
-        "- Be consistent: similar threads should produce similar-style summaries\n"
-        "- No quotes, no prefixes like 'Summary:', no trailing punctuation\n"
-        "\n"
-        "GOOD EXAMPLES:\n"
-        "- \U0001f41b PROJ-42: fix login crash on expired tokens — merged\n"
-        "- \u2705 Database migration to v3 completed successfully\n"
-        "- \U0001f4ac Discussing vacation schedule for July\n"
-        "- \U0001f527 Nginx config updated for new subdomain\n"
-        "- \U0001f6a8 Production outage — root cause identified, fix deployed\n"
-        "- \U0001f4e6 #127: add CSV export to reports — in progress\n"
-        "- \U0001f3a8 Redesigning sidebar navigation — wireframes shared\n"
-        "- \U0001f4b0 Q2 budget review — approved with minor adjustments\n"
-        "\n"
-        "BAD EXAMPLES (do NOT produce these):\n"
-        "- 'Thread about fixing a bug' (too vague, no emoji, quoted)\n"
-        "- 'Summary: The team discussed the login issue' (has prefix, no emoji, no outcome)\n"
-        "- '\U0001f4ac Discussion' (way too vague, no topic)\n"
-        "- '\U0001f41b\U0001f527\u2705\U0001f680\U0001f525 Fixed the thing' (too many emojis, vague)\n"
-        "- 'The conversation was about updating the configuration files for nginx' (too long, no emoji, no outcome)\n"
-        "\n"
-        "Now summarize this thread:\n\n"
-        f"{conversation}"
-    )
-    session_hash = hashlib.sha256(conversation.encode()).hexdigest()[:8]
     response = await cached_agent_run(
         agent=agent,
         full_prompt=prompt,
@@ -203,9 +262,24 @@ async def send_thread_summary_event(
     model_name: str,
 ) -> str | None:
     """Send a thread summary as a standard Matrix notice event."""
+    normalized_summary = normalize_thread_summary_text(summary)
+    if not normalized_summary:
+        logger.warning(
+            "Refusing to send empty normalized thread summary",
+            room_id=room_id,
+            thread_id=thread_id,
+            message_count=message_count,
+        )
+        return None
+
+    truncated_summary = (
+        normalized_summary[: THREAD_SUMMARY_MAX_LENGTH - 3] + "..."
+        if len(normalized_summary) > THREAD_SUMMARY_MAX_LENGTH
+        else normalized_summary
+    )
     content: dict[str, Any] = {
         "msgtype": "m.notice",
-        "body": summary,
+        "body": truncated_summary,
         "m.relates_to": {
             "rel_type": "m.thread",
             "event_id": thread_id,
@@ -214,7 +288,7 @@ async def send_thread_summary_event(
         },
         "io.mindroom.thread_summary": {
             "version": 1,
-            "summary": summary,
+            "summary": truncated_summary,
             "message_count": message_count,
             "generated_at": datetime.now(UTC).isoformat(),
             "model": model_name,
@@ -289,8 +363,18 @@ async def maybe_generate_thread_summary(
             update_last_summary_count(room_id, thread_id, message_count)
             return
 
+        normalized_summary = normalize_thread_summary_text(summary)
+        if not normalized_summary:
+            logger.warning(
+                "Thread summary generation returned no plain-text content",
+                room_id=room_id,
+                thread_id=thread_id,
+            )
+            update_last_summary_count(room_id, thread_id, message_count)
+            return
+
         model_name = config.defaults.thread_summary_model or "default"
         # Record count before sending — the LLM cost is already incurred, so don't
         # retry on Matrix send failure (avoids cost amplification loop).
         update_last_summary_count(room_id, thread_id, message_count)
-        await send_thread_summary_event(client, room_id, thread_id, summary, message_count, model_name)
+        await send_thread_summary_event(client, room_id, thread_id, normalized_summary, message_count, model_name)

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -8,12 +8,14 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
+import nio
 import pytest
 
 import mindroom.tools  # noqa: F401
 from mindroom.constants import ORIGINAL_SENDER_KEY, resolve_runtime_paths
 from mindroom.custom_tools import subagents as subagents_module
 from mindroom.custom_tools.subagents import SubAgentsTools
+from mindroom.thread_summary import THREAD_SUMMARY_MAX_LENGTH
 from mindroom.thread_utils import create_session_id
 from mindroom.tool_system.metadata import TOOL_METADATA, get_tool_by_name
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
@@ -432,17 +434,63 @@ async def test_sessions_spawn_rejects_blank_summary(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_sessions_spawn_rejects_overlong_summary(tmp_path: Path) -> None:
-    """sessions_spawn should reject summaries longer than the normalized 500-char limit."""
+    """sessions_spawn should reject summaries longer than the shared thread-summary limit."""
     ctx = _make_context(tmp_path)
 
     with tool_runtime_context(ctx):
         payload = json.loads(
-            await SubAgentsTools().sessions_spawn(task="do thing", summary="x" * 501, tag=TEST_TAG),
+            await SubAgentsTools().sessions_spawn(
+                task="do thing",
+                summary="x" * (THREAD_SUMMARY_MAX_LENGTH + 1),
+                tag=TEST_TAG,
+            ),
         )
 
     assert payload["status"] == "error"
     assert payload["tool"] == "sessions_spawn"
-    assert "500 characters or fewer" in payload["message"]
+    assert f"{THREAD_SUMMARY_MAX_LENGTH} characters or fewer" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_sessions_spawn_strips_markdown_from_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """sessions_spawn should normalize markdown before writing the summary event."""
+    send_mock = AsyncMock(return_value="$event")
+    tag_mock = AsyncMock(return_value=SimpleNamespace())
+    update_mock = MagicMock()
+    monkeypatch.setattr(subagents_module, "_send_matrix_text", send_mock)
+    monkeypatch.setattr(subagents_module, "set_thread_tag", tag_mock)
+    monkeypatch.setattr(subagents_module, "update_last_summary_count", update_mock)
+    ctx = _make_context(tmp_path)
+    ctx.client.room_send = AsyncMock(
+        return_value=nio.RoomSendResponse(event_id="$summary:localhost", room_id=ctx.room_id),
+    )
+
+    with tool_runtime_context(ctx):
+        payload = json.loads(
+            await SubAgentsTools().sessions_spawn(
+                task="do thing",
+                summary="# **Fix** [ISSUE-116](http://example.com)\n> `deploy` ~~done~~",
+                tag=TEST_TAG,
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    assert payload["summary"] == "Fix ISSUE-116 deploy done"
+    ctx.client.room_send.assert_awaited_once()
+    content = ctx.client.room_send.call_args.kwargs["content"]
+    assert content["body"] == "Fix ISSUE-116 deploy done"
+    assert content["io.mindroom.thread_summary"]["summary"] == "Fix ISSUE-116 deploy done"
+    tag_mock.assert_awaited_once_with(
+        ctx.client,
+        ctx.room_id,
+        "$event",
+        TEST_TAG,
+        set_by=ctx.requester_id,
+    )
+    update_mock.assert_called_once_with(ctx.room_id, "$event", 1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -8,14 +8,23 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
 import pytest
+from pydantic import ValidationError
 
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.thread_summary import (
+    _MAX_MESSAGES_BEFORE_TRUNCATION,
+    _TRUNCATION_SAMPLE_SIZE,
+    THREAD_SUMMARY_MAX_LENGTH,
+    _build_conversation_text,
+    _generate_summary,
+    _is_thread_summary_message,
     _last_summary_counts,
     _next_threshold,
     _recover_last_summary_count,
     _thread_locks,
+    _ThreadSummary,
     maybe_generate_thread_summary,
+    normalize_thread_summary_text,
     send_thread_summary_event,
     thread_summary_cache_key,
     update_last_summary_count,
@@ -65,6 +74,22 @@ def _make_summary_notice_message(
         },
         thread_id=thread_id,
     )
+
+
+# -- model validation --
+
+
+def test_thread_summary_model_rejects_overlong_summary() -> None:
+    """Structured summary responses should reject content beyond the hard length limit."""
+    with pytest.raises(ValidationError):
+        _ThreadSummary(summary="x" * (THREAD_SUMMARY_MAX_LENGTH + 1))
+
+
+def test_normalize_thread_summary_text_strips_common_markdown_syntax() -> None:
+    """Thread summary normalization should remove markdown syntax while preserving readable text."""
+    raw_summary = "# **Fix** [ISSUE-116](http://example.com)\n> `deploy` ~~done~~"
+
+    assert normalize_thread_summary_text(raw_summary) == "Fix ISSUE-116 deploy done"
 
 
 # -- threshold arithmetic --
@@ -498,6 +523,42 @@ class TestMaybeGenerateThreadSummary:
             "!room:x",
             "$thread1",
             "Users discussed testing strategies",
+            5,
+            "default",
+        )
+        assert _last_summary_counts[thread_summary_cache_key("!room:x", "$thread1")] == 5
+
+    async def test_auto_generated_summary_strips_markdown_before_send(self) -> None:
+        """Auto summaries should be converted to plain text before the Matrix event is sent."""
+        client = AsyncMock(spec=nio.AsyncClient)
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+
+        with (
+            patch(
+                "mindroom.thread_summary._load_thread_history",
+                return_value=_make_thread_history(5),
+            ),
+            patch(
+                "mindroom.thread_summary._generate_summary",
+                return_value="# **Fix** [ISSUE-116](http://example.com)",
+            ),
+            patch(
+                "mindroom.thread_summary.send_thread_summary_event",
+                new=AsyncMock(return_value="$summary1"),
+            ) as mock_send,
+            patch(
+                "mindroom.thread_summary._recover_last_summary_count",
+                return_value=0,
+            ),
+        ):
+            await self._maybe_generate(client, config, rp)
+
+        mock_send.assert_awaited_once_with(
+            client,
+            "!room:x",
+            "$thread1",
+            "Fix ISSUE-116",
             5,
             "default",
         )
@@ -950,6 +1011,28 @@ class TestSendSummaryEvent:
         assert meta["model"] == "haiku"
         assert "generated_at" in meta
 
+    async def test_event_content_truncates_overlong_summary(self) -> None:
+        """Overlong summaries should be truncated before sending to Matrix."""
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.room_send = AsyncMock(return_value=nio.RoomSendResponse(event_id="$s1", room_id="!r:x"))
+        summary = "x" * (THREAD_SUMMARY_MAX_LENGTH + 1)
+
+        result = await send_thread_summary_event(
+            client,
+            room_id="!room:x",
+            thread_id="$root1",
+            summary=summary,
+            message_count=15,
+            model_name="haiku",
+        )
+
+        assert result == "$s1"
+        content = client.room_send.call_args.kwargs["content"]
+        truncated_summary = ("x" * (THREAD_SUMMARY_MAX_LENGTH - 3)) + "..."
+        assert content["body"] == truncated_summary
+        assert len(content["body"]) == THREAD_SUMMARY_MAX_LENGTH
+        assert content["io.mindroom.thread_summary"]["summary"] == truncated_summary
+
     async def test_send_failure_returns_none(self) -> None:
         """Return None when room_send fails."""
         client = AsyncMock(spec=nio.AsyncClient)
@@ -965,3 +1048,120 @@ class TestSendSummaryEvent:
         )
 
         assert result is None
+
+
+class TestBuildConversationText:
+    """Tests for conversation text building and truncation."""
+
+    def test_short_thread_not_truncated(self) -> None:
+        """Threads below the truncation threshold are passed through intact."""
+        history = _make_thread_history(5)
+        text = _build_conversation_text(history)
+        assert "omitted" not in text
+        assert text.count("\n") == 4  # 5 messages, 4 newlines
+
+    def test_long_thread_truncated(self) -> None:
+        """Threads above the truncation threshold are sampled with an omission note."""
+        count = _MAX_MESSAGES_BEFORE_TRUNCATION + 10
+        history = _make_thread_history(count)
+        text = _build_conversation_text(history)
+        assert "omitted" in text
+        omitted = count - 2 * _TRUNCATION_SAMPLE_SIZE
+        assert f"{omitted} messages omitted" in text
+
+    def test_exactly_at_threshold_not_truncated(self) -> None:
+        """Exactly at the threshold boundary, no truncation occurs."""
+        history = _make_thread_history(_MAX_MESSAGES_BEFORE_TRUNCATION)
+        text = _build_conversation_text(history)
+        assert "omitted" not in text
+
+
+@pytest.mark.asyncio
+class TestGenerateSummary:
+    """Tests for basic summary generation flow."""
+
+    async def test_prompt_instructions_and_delimiters(self) -> None:
+        """The summarizer should keep the anti-echo instructions and wrap thread text explicitly."""
+        history = _make_thread_history(3)
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+        mock_model = object()
+        mock_response = MagicMock()
+        mock_response.content = _ThreadSummary(summary="🧵 ISSUE-133 prompt preserved")
+
+        with (
+            patch("mindroom.thread_summary.get_model_instance", return_value=mock_model),
+            patch("mindroom.thread_summary.Agent") as mock_agent_cls,
+            patch("mindroom.thread_summary.cached_agent_run", new=AsyncMock(return_value=mock_response)) as mock_run,
+        ):
+            result = await _generate_summary(history, config, rp)
+
+        assert result == "🧵 ISSUE-133 prompt preserved"
+        instructions = "\n".join(mock_agent_cls.call_args.kwargs["instructions"])
+        assert "NOVEL summary" in instructions
+        assert "Do NOT copy" in instructions
+
+        conversation = _build_conversation_text(history)
+        prompt = mock_run.await_args.kwargs["full_prompt"]
+        assert prompt == f"<thread_messages>\n{conversation}\n</thread_messages>\n\nSummarize the above thread."
+
+    async def test_summary_returned(self) -> None:
+        """A valid summary is returned directly."""
+        history = _make_thread_history(5)
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+        mock_response = MagicMock()
+        mock_response.content = _ThreadSummary(summary="\U0001f527 Auth deployment discussed and approved")
+
+        with (
+            patch("mindroom.thread_summary.get_model_instance"),
+            patch("mindroom.thread_summary.Agent"),
+            patch("mindroom.thread_summary.cached_agent_run", return_value=mock_response),
+        ):
+            result = await _generate_summary(history, config, rp)
+
+        assert result == "\U0001f527 Auth deployment discussed and approved"
+
+    async def test_none_content_returns_none(self) -> None:
+        """When the agent returns None content, _generate_summary returns None."""
+        history = _make_thread_history(5)
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+        mock_response = MagicMock()
+        mock_response.content = None
+
+        with (
+            patch("mindroom.thread_summary.get_model_instance"),
+            patch("mindroom.thread_summary.Agent"),
+            patch("mindroom.thread_summary.cached_agent_run", return_value=mock_response),
+        ):
+            result = await _generate_summary(history, config, rp)
+
+        assert result is None
+
+
+# -- prior summary notice filtering --
+
+
+class TestSummaryNoticeFiltering:
+    """Prior io.mindroom.thread_summary events must be excluded from summaries."""
+
+    def test_build_conversation_excludes_summary_notices(self) -> None:
+        """Summary notices should not appear in conversation text."""
+        history = [
+            *_make_thread_history(3),
+            _make_summary_notice_message("$thread1", message_count=3, event_id="$summary1"),
+        ]
+        text = _build_conversation_text(history)
+
+        assert "Existing thread summary" not in text
+
+    def test_summary_notice_detected(self) -> None:
+        """_is_thread_summary_message correctly identifies summary notices."""
+        notice = _make_summary_notice_message("$thread1", message_count=5)
+        assert _is_thread_summary_message(notice)
+
+    def test_regular_message_not_detected_as_summary(self) -> None:
+        """Regular messages are not flagged as summary notices."""
+        regular = _make_thread_history(1)[0]
+        assert not _is_thread_summary_message(regular)

--- a/tests/test_thread_summary_tool.py
+++ b/tests/test_thread_summary_tool.py
@@ -16,6 +16,7 @@ from mindroom.config.main import Config
 from mindroom.custom_tools.thread_summary import ThreadSummaryTools
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.thread_summary import (
+    THREAD_SUMMARY_MAX_LENGTH,
     _last_summary_counts,
     _thread_locks,
     thread_summary_cache_key,
@@ -164,6 +165,38 @@ async def test_set_thread_summary_defaults_to_context_room_and_thread() -> None:
         "manual",
     )
     assert _last_summary_counts[thread_summary_cache_key(context.room_id, "$ctx-thread:localhost")] == 3
+
+
+@pytest.mark.asyncio
+async def test_set_thread_summary_strips_markdown_before_send() -> None:
+    """Manual summaries should remove markdown syntax before they are written."""
+    tool = ThreadSummaryTools()
+    context = _make_context(thread_id="$ctx-thread:localhost")
+    context.conversation_access.get_thread_history.return_value = _thread_history(3)
+
+    with (
+        patch(
+            "mindroom.custom_tools.thread_summary.normalize_thread_root_event_id",
+            new=AsyncMock(return_value="$ctx-thread:localhost"),
+        ),
+        patch(
+            "mindroom.custom_tools.thread_summary.send_thread_summary_event",
+            new=AsyncMock(return_value="$summary-event:localhost"),
+        ) as mock_send,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await tool.set_thread_summary("# **Fix** [ISSUE-116](http://example.com)"))
+
+    assert payload["status"] == "ok"
+    assert payload["summary"] == "Fix ISSUE-116"
+    mock_send.assert_awaited_once_with(
+        context.client,
+        context.room_id,
+        "$ctx-thread:localhost",
+        "Fix ISSUE-116",
+        3,
+        "manual",
+    )
 
 
 @pytest.mark.asyncio
@@ -322,11 +355,14 @@ async def test_set_thread_summary_rejects_overlong_summary() -> None:
     context = _make_context()
 
     with tool_runtime_context(context):
-        payload = json.loads(await tool.set_thread_summary("x" * 501))
+        payload = json.loads(await tool.set_thread_summary("x" * (THREAD_SUMMARY_MAX_LENGTH + 1)))
 
     assert payload["status"] == "error"
     assert payload["room_id"] == context.room_id
-    assert payload["message"] == "summary must be 500 characters or fewer after whitespace normalization."
+    assert (
+        payload["message"]
+        == f"summary must be {THREAD_SUMMARY_MAX_LENGTH} characters or fewer after whitespace normalization."
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR makes every thread-summary path use the same normalization and validation rules.

Generated summaries are prompted to stay plain text, manual `set_thread_summary` inputs are normalized the same way, and spawned-session summaries now share the same 300-character cap.
That keeps room-state summaries consistent and avoids one path accepting content that another path would reject.

Summary:
- add a shared thread-summary max-length constant and plain-text normalization helper
- apply the same plain-text normalization and 300-character limit to generated, manual, and subagent summary flows
- keep event emission on the same limit with a final truncation safety net
- add regression coverage across thread-summary, tool, and subagent paths

Test Plan:
- Not rerun during PR refresh; branch was rebuilt from the existing commit and already includes targeted tests in `tests/test_thread_summary.py`, `tests/test_thread_summary_tool.py`, and `tests/test_subagents.py`.
