### PR TITLE
Add end-to-end timing instrumentation for the dispatch pipeline

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -74,7 +74,7 @@ from mindroom.logging_config import get_logger
 from mindroom.media_fallback import append_inline_media_fallback_prompt, should_retry_without_inline_media
 from mindroom.media_inputs import MediaInputs
 from mindroom.memory import build_memory_enhanced_prompt
-from mindroom.timing import timed
+from mindroom.timing import DispatchPipelineTiming, timed
 from mindroom.tool_system.events import (
     complete_pending_tool_block,
     extract_tool_completed_info,
@@ -1071,6 +1071,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
     delegation_depth: int = 0,
     matrix_run_metadata: dict[str, Any] | None = None,
     system_enrichment_items: Sequence[EnrichmentItem] = (),
+    pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> str:
     """Generates a response using the specified agno Agent with memory integration.
 
@@ -1109,6 +1110,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
         matrix_run_metadata: Optional Matrix-specific run metadata persisted with the run
             for unseen-message tracking, coalesced edit regeneration, and cleanup.
         system_enrichment_items: Optional system-prompt enrichment items for this run.
+        pipeline_timing: Optional dispatch timing collector updated with AI-stage milestones.
 
     Returns:
         Agent response string
@@ -1143,6 +1145,8 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 entity_name=agent_name,
             )
             try:
+                if pipeline_timing is not None:
+                    pipeline_timing.mark("ai_prepare_start")
                 agent, full_prompt, unseen_event_ids, _prepared_history = await _prepare_agent_and_prompt(
                     agent_name,
                     prompt,
@@ -1162,6 +1166,8 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                     system_enrichment_items=system_enrichment_items,
                     timing_scope=timing_scope,
                 )
+                if pipeline_timing is not None:
+                    pipeline_timing.mark("history_ready")
             except Exception as e:
                 logger.exception("Error preparing agent", agent=agent_name)
                 return get_user_friendly_error_message(e, agent_name)
@@ -1183,6 +1189,8 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                 for retried_without_inline_media in (False, True):
                     response = None
                     try:
+                        if pipeline_timing is not None:
+                            pipeline_timing.mark("model_request_sent", overwrite=True)
                         response = await _run_cached_agent_attempt(
                             agent,
                             attempt_prompt,
@@ -1289,6 +1297,7 @@ async def _process_stream_events(  # noqa: C901, PLR0912
     retried_without_inline_media: bool,
     timing_scope: str,
     request_started_at: float,
+    pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> AsyncGenerator[AIStreamChunk, None]:
     """Consume one streaming attempt, yielding chunks and mutating *state*."""
     try:
@@ -1296,6 +1305,8 @@ async def _process_stream_events(  # noqa: C901, PLR0912
             if isinstance(event, RunContentEvent) and event.content:
                 if not state.first_token_logged:
                     state.first_token_logged = True
+                    if pipeline_timing is not None:
+                        pipeline_timing.mark("model_first_token")
                     if os.environ.get("MINDROOM_TIMING") == "1":
                         elapsed_seconds = time.monotonic() - request_started_at
                         prefix = f"[{timing_scope}] " if timing_scope else ""
@@ -1396,6 +1407,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
     delegation_depth: int = 0,
     matrix_run_metadata: dict[str, Any] | None = None,
     system_enrichment_items: Sequence[EnrichmentItem] = (),
+    pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> AsyncIterator[AIStreamChunk]:
     """Generate streaming AI response using Agno's streaming API.
 
@@ -1432,6 +1444,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
         matrix_run_metadata: Optional Matrix-specific run metadata persisted with the run
             for unseen-message tracking, coalesced edit regeneration, and cleanup.
         system_enrichment_items: Optional system-prompt enrichment items for this run.
+        pipeline_timing: Optional dispatch timing collector updated with AI-stage milestones.
 
     Yields:
         Streaming chunks/events as they become available
@@ -1468,6 +1481,8 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                 entity_name=agent_name,
             )
             try:
+                if pipeline_timing is not None:
+                    pipeline_timing.mark("ai_prepare_start")
                 agent, full_prompt, unseen_event_ids, _prepared_history = await _prepare_agent_and_prompt(
                     agent_name,
                     prompt,
@@ -1487,6 +1502,8 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     system_enrichment_items=system_enrichment_items,
                     timing_scope=timing_scope,
                 )
+                if pipeline_timing is not None:
+                    pipeline_timing.mark("history_ready")
             except Exception as e:
                 logger.exception("Error preparing agent for streaming", agent=agent_name)
                 yield get_user_friendly_error_message(e, agent_name)
@@ -1511,6 +1528,8 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
 
                     try:
                         request_started_at = time.monotonic()
+                        if pipeline_timing is not None:
+                            pipeline_timing.mark("model_request_sent", overwrite=True)
                         _note_attempt_run_id(run_id_callback, attempt_run_id)
                         stream_generator = agent.arun(
                             attempt_prompt,
@@ -1551,6 +1570,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         retried_without_inline_media=retried_without_inline_media,
                         timing_scope=timing_scope,
                         request_started_at=request_started_at,
+                        pipeline_timing=pipeline_timing,
                     ):
                         yield stream_chunk
 

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -69,6 +69,11 @@ from mindroom.teams import TeamMode, TeamOutcome, TeamResolution, resolve_config
 from mindroom.thread_utils import (
     should_agent_respond,
 )
+from mindroom.timing import (
+    attach_dispatch_pipeline_timing,
+    create_dispatch_pipeline_timing,
+    get_dispatch_pipeline_timing,
+)
 from mindroom.timing import timing_scope as timing_scope_context
 from mindroom.tool_system.runtime_context import ToolRuntimeSupport
 from mindroom.tool_system.worker_routing import (
@@ -1584,11 +1589,17 @@ class AgentBot:
         requester_user_id: str | None = None,
     ) -> None:
         """Route one inbound event through the live coalescing gate."""
+        dispatch_timing = get_dispatch_pipeline_timing(event.source)
+        if dispatch_timing is not None:
+            dispatch_timing.mark("gate_enter")
         effective_requester_user_id = requester_user_id or self._requester_user_id(
             sender=event.sender,
             source=event.source,
         )
         if self._is_trusted_internal_relay_event(event):
+            if dispatch_timing is not None:
+                dispatch_timing.note(coalescing_bypassed=True, coalescing_bypass_reason="trusted_internal_relay")
+                dispatch_timing.mark("gate_exit")
             trusted_relay_event = cast("_TextDispatchEvent", event)
             await self._dispatch_text_message(
                 room,
@@ -1609,6 +1620,9 @@ class AgentBot:
     async def _dispatch_coalesced_batch(self, batch: CoalescedBatch) -> None:
         """Dispatch one flushed batch through the normal text pipeline."""
         dispatch_event = build_batch_dispatch_event(batch)
+        dispatch_timing = get_dispatch_pipeline_timing(dispatch_event.source)
+        if dispatch_timing is not None:
+            dispatch_timing.mark("gate_exit")
         batch_coalescing_key = await self._coalescing_key_for_event(
             batch.room,
             batch.primary_event,
@@ -1647,6 +1661,11 @@ class AgentBot:
         """Handle one text message inside the per-turn thread-history cache scope."""
         self.logger.info("Received message", event_id=event.event_id, room_id=room.room_id, sender=event.sender)
         assert self.client is not None
+        dispatch_timing = create_dispatch_pipeline_timing(
+            event_id=event.event_id,
+            room_id=room.room_id,
+        )
+        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
         event_info = EventInfo.from_event(event.source)
         await self._cache_thread_event(room.room_id, event, event_info=event_info)
         if not isinstance(event.body, str):
@@ -1677,6 +1696,7 @@ class AgentBot:
         prepared_event = await self._inbound_turn_normalizer.resolve_text_event(
             TextNormalizationRequest(event=prechecked_event.event),
         )
+        attach_dispatch_pipeline_timing(prepared_event.source, dispatch_timing)
         envelope = await self._conversation_resolver.build_dispatch_envelope(
             room=room,
             event=prepared_event,
@@ -1690,6 +1710,13 @@ class AgentBot:
         if should_handle_interactive_text_response(envelope):
             await interactive.handle_text_response(self.client, room, prepared_event, self.agent_name)
         if self._should_bypass_coalescing_for_active_thread_follow_up(envelope):
+            if dispatch_timing is not None:
+                dispatch_timing.mark("gate_enter")
+                dispatch_timing.note(
+                    coalescing_bypassed=True,
+                    coalescing_bypass_reason="active_thread_follow_up",
+                )
+                dispatch_timing.mark("gate_exit")
             await self._dispatch_text_message(
                 room,
                 prepared_event,
@@ -1736,11 +1763,17 @@ class AgentBot:
         event = await self._inbound_turn_normalizer.resolve_text_event(
             TextNormalizationRequest(event=raw_event),
         )
+        dispatch_timing = get_dispatch_pipeline_timing(raw_event.source)
+        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
         timing_scope_token = timing_scope_context.set(event.event_id[:20] if event.event_id else "unknown")
         try:
+            if dispatch_timing is not None:
+                dispatch_timing.mark("dispatch_start")
             dispatch_started_at = time.monotonic()
             handled_turn = handled_turn or HandledTurnState.from_source_event_id(event.event_id)
 
+            if dispatch_timing is not None:
+                dispatch_timing.mark("dispatch_prepare_start")
             dispatch = await self._dispatch_planner.prepare_dispatch(
                 room,
                 event,
@@ -1748,6 +1781,8 @@ class AgentBot:
                 event_label="message",
                 handled_turn=handled_turn,
             )
+            if dispatch_timing is not None:
+                dispatch_timing.mark("dispatch_prepare_ready")
             if dispatch is None:
                 return
 
@@ -1795,6 +1830,8 @@ class AgentBot:
             router_extra_content = dict(message_extra_content)
             if media_events and ORIGINAL_SENDER_KEY not in router_extra_content:
                 router_extra_content[ORIGINAL_SENDER_KEY] = requester_user_id
+            if dispatch_timing is not None:
+                dispatch_timing.mark("dispatch_plan_start")
             plan = await self._dispatch_planner.plan_dispatch(
                 room,
                 event,
@@ -1806,6 +1843,8 @@ class AgentBot:
                 if media_events and len(handled_turn.source_event_ids) == 1
                 else router_event,
             )
+            if dispatch_timing is not None:
+                dispatch_timing.mark("dispatch_plan_ready")
             if plan.kind == "ignore":
                 if plan.handled_turn_outcome is not None:
                     self._mark_source_events_responded(plan.handled_turn_outcome)

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from mindroom.hooks import MessageEnvelope
     from mindroom.message_target import MessageTarget
     from mindroom.streaming import _StreamInputChunk
+    from mindroom.timing import DispatchPipelineTiming
     from mindroom.tool_system.events import ToolTraceEntry
 
 
@@ -201,6 +202,7 @@ class StreamingDeliveryRequest:
     extra_content: dict[str, Any] | None = None
     tool_trace_collector: list[ToolTraceEntry] | None = None
     streaming_cls: type[StreamingResponse] = StreamingResponse
+    pipeline_timing: DispatchPipelineTiming | None = None
 
 
 @dataclass(frozen=True)
@@ -546,6 +548,7 @@ class DeliveryGateway:
             room_mode=request.room_mode,
             extra_content=request.extra_content,
             tool_trace_collector=request.tool_trace_collector,
+            pipeline_timing=request.pipeline_timing,
         )
 
     async def finalize_streamed_response(

--- a/src/mindroom/dispatch_planner.py
+++ b/src/mindroom/dispatch_planner.py
@@ -83,7 +83,7 @@ from mindroom.thread_utils import (
     has_multiple_non_agent_users_in_thread,
     should_agent_respond,
 )
-from mindroom.timing import timed
+from mindroom.timing import get_dispatch_pipeline_timing, timed
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -977,7 +977,7 @@ class DispatchPlanner:
         configured_team_action = self.configured_team_response_action()
         return configured_team_action or action
 
-    async def execute_response_action(  # noqa: C901
+    async def execute_response_action(  # noqa: C901, PLR0912, PLR0915
         self,
         room: nio.MatrixRoom,
         event: DispatchEvent,
@@ -992,6 +992,9 @@ class DispatchPlanner:
     ) -> None:
         """Execute the final response path for a prepared dispatch action."""
         action = self._effective_response_action(action)
+        dispatch_timing = get_dispatch_pipeline_timing(event.source)
+        if dispatch_timing is not None:
+            dispatch_timing.note(response_action_kind=action.kind)
 
         if action.kind == "reject":
             assert action.rejection_message is not None
@@ -1006,6 +1009,9 @@ class DispatchPlanner:
             self._mark_source_events_responded(
                 handled_turn.with_response_event_id(response_event_id),
             )
+            if dispatch_timing is not None and response_event_id is not None:
+                dispatch_timing.mark("response_complete")
+                dispatch_timing.emit_summary(self.deps.logger, outcome="reject")
             return
 
         if not dispatch.context.am_i_mentioned:
@@ -1021,6 +1027,8 @@ class DispatchPlanner:
             )
 
         try:
+            if dispatch_timing is not None:
+                dispatch_timing.mark("response_payload_start")
             if dispatch.context.requires_full_thread_history:
                 await self.deps.resolver.hydrate_dispatch_context(room, event, dispatch.context)
             context_ready_monotonic = time.monotonic()
@@ -1045,6 +1053,8 @@ class DispatchPlanner:
                     system_enrichment_items=tuple(system_enrichment_items),
                 )
             payload_ready_monotonic = time.monotonic()
+            if dispatch_timing is not None:
+                dispatch_timing.mark("response_payload_ready")
         except Exception as error:
             response_event_id = await self.finalize_dispatch_failure(
                 room_id=room.room_id,
@@ -1056,6 +1066,9 @@ class DispatchPlanner:
                 self._mark_source_events_responded(
                     handled_turn.with_response_event_id(response_event_id),
                 )
+                if dispatch_timing is not None:
+                    dispatch_timing.mark("response_complete")
+                    dispatch_timing.emit_summary(self.deps.logger, outcome="dispatch_failure")
             return
 
         self.log_dispatch_latency(
@@ -1090,6 +1103,7 @@ class DispatchPlanner:
                         system_enrichment_items=prepared_payload.system_enrichment_items,
                         strip_transient_enrichment_after_run=prepared_payload.strip_transient_enrichment_after_run,
                         received_monotonic=received_monotonic,
+                        pipeline_timing=dispatch_timing,
                     ),
                     team_agents=action.form_team.eligible_members,
                     team_mode=action.form_team.mode.value,
@@ -1113,6 +1127,7 @@ class DispatchPlanner:
                         system_enrichment_items=prepared_payload.system_enrichment_items,
                         strip_transient_enrichment_after_run=prepared_payload.strip_transient_enrichment_after_run,
                         received_monotonic=received_monotonic,
+                        pipeline_timing=dispatch_timing,
                     ),
                 )
         except SuppressedPlaceholderCleanupError:

--- a/src/mindroom/matrix/event_cache.py
+++ b/src/mindroom/matrix/event_cache.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+_RUNTIME_ONLY_EVENT_SOURCE_KEYS = frozenset({"com.mindroom.dispatch_pipeline_timing"})
+
+
 class EventCache:
     """Persist raw Matrix events for thread-history and reply-chain reconstruction."""
 
@@ -159,6 +162,7 @@ class EventCache:
             return
 
         cached_at = time.time()
+        normalized_events = [normalize_event_source_for_cache(event) for event in events]
         async with self._lock:
             db = self._require_db()
             serialized_events = [
@@ -167,7 +171,7 @@ class EventCache:
                     _event_timestamp(event),
                     json.dumps(event, separators=(",", ":")),
                 )
-                for event in events
+                for event in normalized_events
             ]
             await db.executemany(
                 """
@@ -338,7 +342,11 @@ def normalize_event_source_for_cache(
     origin_server_ts: int | None = None,
 ) -> dict[str, Any]:
     """Normalize one raw Matrix event payload for persistent cache storage."""
-    source = dict(event_source)
+    source = {
+        key: value
+        for key, value in event_source.items()
+        if key not in _RUNTIME_ONLY_EVENT_SOURCE_KEYS
+    }
     if "event_id" not in source and isinstance(event_id, str):
         source["event_id"] = event_id
     if "sender" not in source and isinstance(sender, str):

--- a/src/mindroom/response_coordinator.py
+++ b/src/mindroom/response_coordinator.py
@@ -47,7 +47,7 @@ from mindroom.streaming import (
     StreamingResponse,
 )
 from mindroom.teams import TeamMode, select_model_for_team, team_response, team_response_stream
-from mindroom.timing import timed
+from mindroom.timing import DispatchPipelineTiming, timed
 from mindroom.timing import timing_scope as timing_scope_context
 from mindroom.tool_system.worker_routing import tool_execution_identity
 
@@ -285,6 +285,7 @@ class ResponseRequest:
     strip_transient_enrichment_after_run: bool = False
     received_monotonic: float | None = None
     on_lifecycle_lock_acquired: Callable[[], None] | None = None
+    pipeline_timing: DispatchPipelineTiming | None = None
 
 
 @dataclass(frozen=True)
@@ -478,8 +479,12 @@ class ResponseCoordinator:
             queued_signal.add_waiting_human_message()
         lock_acquired = False
         try:
+            if request.pipeline_timing is not None:
+                request.pipeline_timing.mark("lock_wait_start")
             await lifecycle_lock.acquire()
             lock_acquired = True
+            if request.pipeline_timing is not None:
+                request.pipeline_timing.mark("lock_acquired")
             try:
                 if queued_human_message:
                     queued_signal.consume_waiting_human_message()
@@ -587,6 +592,32 @@ class ResponseCoordinator:
         )
         return replace(request, thread_history=refreshed_history)
 
+    def _note_pipeline_metadata(
+        self,
+        request: ResponseRequest,
+        *,
+        response_kind: str,
+        used_streaming: bool,
+    ) -> None:
+        """Attach shared response metadata to one timing tracker."""
+        if request.pipeline_timing is None:
+            return
+        request.pipeline_timing.note(
+            response_kind=response_kind,
+            used_streaming=used_streaming,
+        )
+
+    def _emit_pipeline_timing_summary(
+        self,
+        request: ResponseRequest,
+        *,
+        outcome: str,
+    ) -> None:
+        """Emit one structured end-to-end timing summary when available."""
+        if request.pipeline_timing is None:
+            return
+        request.pipeline_timing.emit_summary(self.deps.logger, outcome=outcome)
+
     def _response_envelope_for_request(
         self,
         request: ResponseRequest,
@@ -673,6 +704,8 @@ class ResponseCoordinator:
         if request.on_lifecycle_lock_acquired is not None:
             request.on_lifecycle_lock_acquired()
         request = await self._refresh_thread_history_after_lock(request)
+        if request.pipeline_timing is not None:
+            request.pipeline_timing.mark("thread_refresh_ready")
         team_request = replace(team_request, request=request)
         requester_user_id = request.user_id or ""
         prepared_prompt = _prefix_user_turn_time(
@@ -704,6 +737,7 @@ class ResponseCoordinator:
             requester_user_id=requester_user_id,
             enable_streaming=self.deps.runtime.enable_streaming,
         )
+        self._note_pipeline_metadata(request, response_kind="team", used_streaming=use_streaming)
         show_tool_calls = self._show_tool_calls()
         mode = TeamMode.COORDINATE if team_request.team_mode == "coordinate" else TeamMode.COLLABORATE
         agent_names = [
@@ -808,7 +842,7 @@ class ResponseCoordinator:
                 ),
             )
 
-        async def generate_team_response(message_id: str | None) -> None:
+        async def generate_team_response(message_id: str | None) -> None:  # noqa: C901
             nonlocal delivery_result
             delivery_request = self._request_for_delivery(delivery_request_base, message_id=message_id)
             delivery_target = delivery_request.target
@@ -871,8 +905,11 @@ class ResponseCoordinator:
                             header=None,
                             show_tool_calls=show_tool_calls,
                             streaming_cls=ReplacementStreamingResponse,
+                            pipeline_timing=request.pipeline_timing,
                         ),
                     )
+                if request.pipeline_timing is not None:
+                    request.pipeline_timing.mark("streaming_complete")
                 if event_id is None:
                     delivery_result = DeliveryResult(
                         event_id=None,
@@ -901,6 +938,8 @@ class ResponseCoordinator:
                         ),
                     ),
                 )
+                if request.pipeline_timing is not None:
+                    request.pipeline_timing.mark("response_complete")
             else:
                 try:
                     async with typing_indicator(self._client(), request.room_id):
@@ -969,6 +1008,8 @@ class ResponseCoordinator:
                         extra_content=None,
                     ),
                 )
+                if request.pipeline_timing is not None:
+                    request.pipeline_timing.mark("response_complete")
 
         thinking_msg = None
         if not request.existing_event_id:
@@ -984,6 +1025,7 @@ class ResponseCoordinator:
             existing_event_id=request.existing_event_id,
             user_id=requester_user_id,
             run_id=response_run_id,
+            pipeline_timing=request.pipeline_timing,
         )
         if resolved_event_id is None:
             resolved_event_id = self.resolve_response_event_id(
@@ -993,6 +1035,12 @@ class ResponseCoordinator:
                 existing_event_is_placeholder=request.existing_event_is_placeholder,
             )
         await finalize_post_response_effects(tracked_event_id)
+        outcome = "no_visible_response"
+        if delivery_result is not None and delivery_result.suppressed:
+            outcome = "suppressed"
+        elif delivery_result is not None and delivery_result.delivery_kind is not None:
+            outcome = delivery_result.delivery_kind
+        self._emit_pipeline_timing_summary(request, outcome=outcome)
         return resolved_event_id
 
     async def run_cancellable_response(
@@ -1007,6 +1055,7 @@ class ResponseCoordinator:
         user_id: str | None = None,
         run_id: str | None = None,
         target: MessageTarget | None = None,
+        pipeline_timing: DispatchPipelineTiming | None = None,
     ) -> str | None:
         """Run one response generation function with cancellation support."""
         resolved_target = target or self.deps.resolver.build_message_target(
@@ -1035,6 +1084,8 @@ class ResponseCoordinator:
                         extra_content={STREAM_STATUS_KEY: STREAM_STATUS_PENDING},
                     ),
                 )
+                if initial_message_id is not None and pipeline_timing is not None:
+                    pipeline_timing.mark("placeholder_sent")
 
             message_id = existing_event_id or initial_message_id
             task: asyncio.Task[None] = asyncio.create_task(response_function(message_id))
@@ -1232,6 +1283,7 @@ class ResponseCoordinator:
         tool_trace: list[Any],
         run_metadata_content: dict[str, Any],
         compaction_outcomes: list[CompactionOutcome],
+        pipeline_timing: DispatchPipelineTiming | None = None,
     ) -> str:
         """Run one non-streaming AI request."""
 
@@ -1266,6 +1318,7 @@ class ResponseCoordinator:
                 compaction_outcomes_collector=compaction_outcomes,
                 matrix_run_metadata=matrix_run_metadata,
                 system_enrichment_items=request.system_enrichment_items,
+                pipeline_timing=pipeline_timing,
             )
 
         async with typing_indicator(self._client(), request.room_id):
@@ -1287,6 +1340,7 @@ class ResponseCoordinator:
         run_metadata_content: dict[str, Any],
         compaction_outcomes: list[CompactionOutcome],
         received_monotonic: float | None = None,
+        pipeline_timing: DispatchPipelineTiming | None = None,
     ) -> tuple[str | None, str]:
         """Run one streaming AI request and send the streamed Matrix response."""
 
@@ -1319,6 +1373,7 @@ class ResponseCoordinator:
             compaction_outcomes_collector=compaction_outcomes,
             matrix_run_metadata=matrix_run_metadata,
             system_enrichment_items=request.system_enrichment_items,
+            pipeline_timing=pipeline_timing,
         )
 
         async with typing_indicator(self._client(), request.room_id):
@@ -1336,7 +1391,7 @@ class ResponseCoordinator:
                 run_metadata_content,
                 request.attachment_ids,
             )
-            return await self.deps.delivery_gateway.deliver_stream(
+            event_id, accumulated = await self.deps.delivery_gateway.deliver_stream(
                 StreamingDeliveryRequest(
                     room_id=request.room_id,
                     reply_to_event_id=request.reply_to_event_id,
@@ -1351,8 +1406,12 @@ class ResponseCoordinator:
                     extra_content=response_extra_content,
                     tool_trace_collector=tool_trace,
                     streaming_cls=StreamingResponse,
+                    pipeline_timing=request.pipeline_timing,
                 ),
             )
+            if request.pipeline_timing is not None:
+                request.pipeline_timing.mark("streaming_complete")
+            return event_id, accumulated
 
     async def process_and_respond(
         self,
@@ -1366,7 +1425,11 @@ class ResponseCoordinator:
         if not request.prompt.strip():
             return DeliveryResult(event_id=request.existing_event_id, response_text="", delivery_kind=None)
 
+        if request.pipeline_timing is not None:
+            request.pipeline_timing.mark("response_runtime_start")
         runtime = await self.prepare_non_streaming_runtime(request)
+        if request.pipeline_timing is not None:
+            request.pipeline_timing.mark("response_runtime_ready")
         tool_trace: list[Any] = []
         compaction_outcomes: list[CompactionOutcome] = []
         run_metadata_content: dict[str, Any] = {}
@@ -1381,6 +1444,7 @@ class ResponseCoordinator:
                 tool_trace=tool_trace,
                 run_metadata_content=run_metadata_content,
                 compaction_outcomes=compaction_outcomes,
+                pipeline_timing=request.pipeline_timing,
             )
         except asyncio.CancelledError:
             self.deps.logger.warning(
@@ -1425,6 +1489,8 @@ class ResponseCoordinator:
                 extra_content=response_extra_content or None,
             ),
         )
+        if request.pipeline_timing is not None:
+            request.pipeline_timing.mark("response_complete")
         if compaction_outcomes_collector is not None:
             compaction_outcomes_collector.extend(compaction_outcomes)
         return delivery
@@ -1442,7 +1508,11 @@ class ResponseCoordinator:
         if not request.prompt.strip():
             return DeliveryResult(event_id=request.existing_event_id, response_text="", delivery_kind=None)
 
+        if request.pipeline_timing is not None:
+            request.pipeline_timing.mark("response_runtime_start")
         runtime = await self.prepare_streaming_runtime(request)
+        if request.pipeline_timing is not None:
+            request.pipeline_timing.mark("response_runtime_ready")
         compaction_outcomes: list[CompactionOutcome] = []
         run_metadata_content: dict[str, Any] = {}
         active_event_ids = self._active_response_event_ids(request.room_id)
@@ -1458,6 +1528,7 @@ class ResponseCoordinator:
                 run_metadata_content=run_metadata_content,
                 compaction_outcomes=compaction_outcomes,
                 received_monotonic=received_monotonic,
+                pipeline_timing=request.pipeline_timing,
             )
         except StreamingDeliveryError as error:
             self.deps.logger.exception("Error in streaming response", error=str(error.error))
@@ -1500,6 +1571,8 @@ class ResponseCoordinator:
             )
             if compaction_outcomes_collector is not None:
                 compaction_outcomes_collector.extend(compaction_outcomes)
+            if request.pipeline_timing is not None:
+                request.pipeline_timing.mark("response_complete")
             return DeliveryResult(
                 event_id=event_id,
                 response_text=interactive_response.formatted_text,
@@ -1527,6 +1600,8 @@ class ResponseCoordinator:
                 ),
             ),
         )
+        if request.pipeline_timing is not None:
+            request.pipeline_timing.mark("response_complete")
 
         if compaction_outcomes_collector is not None:
             compaction_outcomes_collector.extend(compaction_outcomes)
@@ -1754,7 +1829,7 @@ class ResponseCoordinator:
             ),
         )
 
-    async def generate_response_locked(
+    async def generate_response_locked(  # noqa: C901
         self,
         request: ResponseRequest,
         *,
@@ -1766,6 +1841,8 @@ class ResponseCoordinator:
         if request.on_lifecycle_lock_acquired is not None:
             request.on_lifecycle_lock_acquired()
         request = await self._refresh_thread_history_after_lock(request)
+        if request.pipeline_timing is not None:
+            request.pipeline_timing.mark("thread_refresh_ready")
         memory_prompt, memory_thread_history, model_prompt_text, model_thread_history = (
             prepare_memory_and_model_context(
                 request.prompt,
@@ -1805,6 +1882,7 @@ class ResponseCoordinator:
             requester_user_id=request.user_id,
             enable_streaming=self.deps.runtime.enable_streaming,
         )
+        self._note_pipeline_metadata(request, response_kind="agent", used_streaming=use_streaming)
         delivery_result: DeliveryResult | None = None
         compaction_outcomes: list[CompactionOutcome] = []
         response_run_id = str(uuid4())
@@ -1908,6 +1986,7 @@ class ResponseCoordinator:
             existing_event_id=request.existing_event_id,
             user_id=request.user_id,
             run_id=response_run_id,
+            pipeline_timing=request.pipeline_timing,
         )
         if resolved_event_id is None:
             resolved_event_id = self.resolve_response_event_id(
@@ -1921,4 +2000,10 @@ class ResponseCoordinator:
             tracked_event_id=tracked_event_id,
             swallow_late_cancellation=True,
         )
+        outcome = "no_visible_response"
+        if delivery_result is not None and delivery_result.suppressed:
+            outcome = "suppressed"
+        elif delivery_result is not None and delivery_result.delivery_kind is not None:
+            outcome = delivery_result.delivery_kind
+        self._emit_pipeline_timing_summary(request, outcome=outcome)
         return resolved_event_id

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
+    from mindroom.timing import DispatchPipelineTiming
 
 from mindroom.matrix.client import get_latest_thread_event_id_if_needed
 
@@ -185,6 +186,7 @@ class StreamingResponse:
     stream_started_at: float | None = None
     chars_since_last_update: int = 0
     placeholder_progress_sent: bool = False
+    pipeline_timing: DispatchPipelineTiming | None = None
 
     def __post_init__(self) -> None:
         """Normalize transitional target fields onto one canonical target."""
@@ -389,6 +391,8 @@ class StreamingResponse:
                     response_event_id = await send_message(client, self.room_id, content)
                     if response_event_id:
                         self.event_id = response_event_id
+                        if self.pipeline_timing is not None and self.accumulated_text.strip():
+                            self.pipeline_timing.mark("first_visible_stream_update")
                         logger.debug("Initial streaming message sent", event_id=self.event_id)
                         return True
                     logger.error("Failed to send initial streaming message", attempt=attempt)
@@ -396,6 +400,8 @@ class StreamingResponse:
                     logger.debug("Editing streaming message", event_id=self.event_id, attempt=attempt)
                     response_event_id = await edit_message(client, self.room_id, self.event_id, content, display_text)
                     if response_event_id:
+                        if self.pipeline_timing is not None and self.accumulated_text.strip():
+                            self.pipeline_timing.mark("first_visible_stream_update")
                         return True
                     logger.error("Failed to edit streaming message", attempt=attempt)
             except Exception:
@@ -529,6 +535,7 @@ async def send_streaming_response(
     show_tool_calls: bool = True,
     extra_content: dict[str, Any] | None = None,
     tool_trace_collector: list[ToolTraceEntry] | None = None,
+    pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> tuple[str | None, str]:
     """Stream chunks to a Matrix room, returning (event_id, accumulated_text)."""
     resolved_target = target or MessageTarget.resolve(
@@ -565,6 +572,7 @@ async def send_streaming_response(
         update_interval=sc.update_interval,
         min_update_interval=sc.min_update_interval,
         interval_ramp_seconds=sc.interval_ramp_seconds,
+        pipeline_timing=pipeline_timing,
     )
 
     # Ensure the first chunk triggers an initial send immediately

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -9,10 +9,13 @@ import logging
 import os
 import time
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, ParamSpec, TypeVar, cast
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
+
+    from structlog.stdlib import BoundLogger
 
 logger = logging.getLogger(__name__)
 
@@ -21,10 +24,120 @@ R = TypeVar("R")
 
 # When set, log lines include the scope for grouping related timers.
 timing_scope: ContextVar[str | None] = ContextVar("timing_scope", default=None)
+_DISPATCH_PIPELINE_TIMING_KEY = "com.mindroom.dispatch_pipeline_timing"
 
 
 def _is_enabled() -> bool:
     return os.environ.get("MINDROOM_TIMING", "") == "1"
+
+
+type TimingMetadataValue = str | int | float | bool
+
+
+@dataclass(slots=True)
+class DispatchPipelineTiming:
+    """Collect phase timestamps for one dispatch turn and emit a summary."""
+
+    source_event_id: str
+    room_id: str
+    marks: dict[str, float] = field(default_factory=dict)
+    metadata: dict[str, TimingMetadataValue] = field(default_factory=dict)
+    summary_emitted: bool = False
+
+    def mark(self, label: str, *, overwrite: bool = False) -> None:
+        """Record one high-level phase boundary."""
+        if overwrite or label not in self.marks:
+            self.marks[label] = time.perf_counter()
+
+    def note(self, **metadata: TimingMetadataValue) -> None:
+        """Attach diagnostic metadata for the eventual summary log."""
+        for key, value in metadata.items():
+            if value is not None:
+                self.metadata[key] = value
+
+    def elapsed_ms(self, start_label: str, end_label: str) -> float | None:
+        """Return elapsed time between two recorded phase boundaries."""
+        start = self.marks.get(start_label)
+        end = self.marks.get(end_label)
+        if start is None or end is None:
+            return None
+        return round((end - start) * 1000, 1)
+
+    def emit_summary(self, logger: BoundLogger, *, outcome: str) -> None:
+        """Log one structured end-to-end timing summary."""
+        if self.summary_emitted:
+            return
+        self.summary_emitted = True
+        summary: dict[str, Any] = {
+            "source_event_id": self.source_event_id,
+            "room_id": self.room_id,
+            "outcome": outcome,
+            **self.metadata,
+        }
+        duration_pairs = {
+            "arrival_to_gate_entry_ms": ("message_received", "gate_enter"),
+            "coalescing_gate_ms": ("gate_enter", "gate_exit"),
+            "gate_exit_to_dispatch_start_ms": ("gate_exit", "dispatch_start"),
+            "prepare_dispatch_ms": ("dispatch_prepare_start", "dispatch_prepare_ready"),
+            "plan_dispatch_ms": ("dispatch_plan_start", "dispatch_plan_ready"),
+            "response_payload_setup_ms": ("response_payload_start", "response_payload_ready"),
+            "lock_wait_ms": ("lock_wait_start", "lock_acquired"),
+            "post_lock_thread_refresh_ms": ("lock_acquired", "thread_refresh_ready"),
+            "lock_acquired_to_placeholder_ms": ("lock_acquired", "placeholder_sent"),
+            "placeholder_to_runtime_start_ms": ("placeholder_sent", "response_runtime_start"),
+            "runtime_prepare_ms": ("response_runtime_start", "response_runtime_ready"),
+            "system_prompt_history_ms": ("ai_prepare_start", "history_ready"),
+            "history_ready_to_model_request_ms": ("history_ready", "model_request_sent"),
+            "model_request_to_first_token_ms": ("model_request_sent", "model_first_token"),
+            "model_first_token_to_first_visible_stream_update_ms": (
+                "model_first_token",
+                "first_visible_stream_update",
+            ),
+            "first_visible_stream_update_to_stream_complete_ms": (
+                "first_visible_stream_update",
+                "streaming_complete",
+            ),
+            "placeholder_visible_ms": ("placeholder_sent", "response_complete"),
+            "total_pipeline_ms": ("message_received", "response_complete"),
+            "model_request_to_completion_ms": ("model_request_sent", "response_complete"),
+        }
+        for key, (start_label, end_label) in duration_pairs.items():
+            elapsed = self.elapsed_ms(start_label, end_label)
+            if elapsed is not None:
+                summary[key] = elapsed
+        logger.info("Dispatch pipeline timing", **summary)
+
+
+def create_dispatch_pipeline_timing(*, event_id: str, room_id: str) -> DispatchPipelineTiming | None:
+    """Return a new tracker when timing instrumentation is enabled."""
+    if not _is_enabled():
+        return None
+    timing = DispatchPipelineTiming(source_event_id=event_id, room_id=room_id)
+    timing.mark("message_received")
+    return timing
+
+
+def attach_dispatch_pipeline_timing(
+    source: object,
+    timing: DispatchPipelineTiming | None,
+) -> DispatchPipelineTiming | None:
+    """Persist one tracker on an in-memory Matrix event source dict."""
+    if timing is None or not isinstance(source, dict):
+        return timing
+    source_dict = cast("dict[str, object]", source)
+    source_dict[_DISPATCH_PIPELINE_TIMING_KEY] = timing
+    return timing
+
+
+def get_dispatch_pipeline_timing(source: object) -> DispatchPipelineTiming | None:
+    """Return the tracker stored on one in-memory Matrix event source dict."""
+    if not isinstance(source, dict):
+        return None
+    source_dict = cast("dict[str, object]", source)
+    raw_timing = source_dict.get(_DISPATCH_PIPELINE_TIMING_KEY)
+    if isinstance(raw_timing, DispatchPipelineTiming):
+        return raw_timing
+    return None
 
 
 def timed(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:  # noqa: C901

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -12,6 +12,7 @@ from nio.api import RelationshipType
 from mindroom.matrix.client import fetch_thread_history
 from mindroom.matrix.event_cache import EventCache
 from mindroom.matrix.room_cache import cached_room_get_event
+from mindroom.timing import DispatchPipelineTiming
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -182,6 +183,36 @@ async def test_individual_event_cache_store_and_retrieve(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
+async def test_individual_event_cache_strips_runtime_timing_marker(tmp_path: Path) -> None:
+    """Batch event caching should drop in-memory timing objects before serialization."""
+    cache = EventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+
+    reply_event = _make_text_event(
+        event_id="$reply",
+        sender="@agent:localhost",
+        body="Cached reply",
+        server_timestamp=2000,
+        source_content={"body": "Cached reply"},
+    )
+    event_source = _cache_source(reply_event)
+    event_source["com.mindroom.dispatch_pipeline_timing"] = DispatchPipelineTiming(
+        source_event_id="$reply",
+        room_id="!room:localhost",
+    )
+
+    try:
+        await cache.store_events_batch([("$reply", "!room:localhost", event_source)])
+        cached_event = await cache.get_event("$reply")
+    finally:
+        await cache.close()
+
+    assert cached_event is not None
+    assert cached_event["event_id"] == "$reply"
+    assert "com.mindroom.dispatch_pipeline_timing" not in cached_event
+
+
+@pytest.mark.asyncio
 async def test_thread_cache_store_populates_individual_event_lookup(tmp_path: Path) -> None:
     """Thread cache writes should also populate the individual event table."""
     cache = EventCache(tmp_path / "event_cache.db")
@@ -218,6 +249,41 @@ async def test_thread_cache_store_populates_individual_event_lookup(tmp_path: Pa
     assert cached_event is not None
     assert cached_event["event_id"] == "$reply"
     assert cached_event["content"]["body"] == "Cached reply"
+
+
+@pytest.mark.asyncio
+async def test_thread_event_cache_strips_runtime_timing_marker(tmp_path: Path) -> None:
+    """Thread cache writes should strip runtime-only timing markers before JSON storage."""
+    cache = EventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+
+    reply_event = _make_text_event(
+        event_id="$reply",
+        sender="@agent:localhost",
+        body="Reply in thread",
+        server_timestamp=2000,
+        source_content={
+            "body": "Reply in thread",
+            "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+        },
+    )
+    event_source = _cache_source(reply_event)
+    event_source["com.mindroom.dispatch_pipeline_timing"] = DispatchPipelineTiming(
+        source_event_id="$reply",
+        room_id="!room:localhost",
+    )
+
+    try:
+        await cache.store_events("!room:localhost", "$thread_root", [event_source])
+        cached_event = await cache.get_event("$reply")
+        cached_thread_events = await cache.get_thread_events("!room:localhost", "$thread_root")
+    finally:
+        await cache.close()
+
+    assert cached_event is not None
+    assert "com.mindroom.dispatch_pipeline_timing" not in cached_event
+    assert cached_thread_events is not None
+    assert "com.mindroom.dispatch_pipeline_timing" not in cached_thread_events[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR adds end-to-end timing instrumentation around the dispatch pipeline so we can measure where response time is being spent across planning, AI execution, delivery, and streaming.

It also strips the runtime-only timing marker before event-cache serialization so the instrumentation does not leak into cached Matrix event payloads.

Summary:
- add dispatch-pipeline timing markers across the main runtime path
- thread timing metadata through the planner, coordinator, delivery, streaming, and AI helpers
- drop the runtime-only timing marker before event-cache JSON serialization
- add event-cache coverage for the stripped runtime marker