### PR TITLE
Classify restart cancellations from the cancel message instead of shared bot state

### DIFF
--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -40,6 +40,12 @@ STARTUP_RETRY_MAX_DELAY_SECONDS = 60.0
 _CANCELLING_LOGGED_TASKS: set[asyncio.Task[Any]] = set()
 _MATRIX_SYNC_WATCHDOG_POLL_INTERVAL_SECONDS = 5.0
 _MATRIX_SYNC_STARTUP_TIMEOUT_ENV = "MINDROOM_MATRIX_SYNC_STARTUP_TIMEOUT_SECONDS"
+SYNC_RESTART_CANCEL_MSG = "sync_restart"
+
+
+def is_sync_restart_cancel(exc: asyncio.CancelledError) -> bool:
+    """Return whether one cancellation was caused by a sync restart."""
+    return len(exc.args) > 0 and exc.args[0] == SYNC_RESTART_CANCEL_MSG
 
 
 def matrix_sync_startup_timeout_seconds(runtime_paths: RuntimePaths) -> float:
@@ -90,11 +96,15 @@ async def cancel_task(
     task: asyncio.Task | None,
     *,
     suppress_exceptions: tuple[type[BaseException], ...] = (asyncio.CancelledError,),
+    cancel_msg: str | None = None,
 ) -> None:
     """Cancel a detached task and wait for it to finish."""
     if task is None:
         return
-    task.cancel()
+    if cancel_msg is None:
+        task.cancel()
+    else:
+        task.cancel(msg=cancel_msg)
     with suppress(*suppress_exceptions):
         await task
 
@@ -160,7 +170,7 @@ class _SyncIteration:
                     last_sync_time=bot.last_sync_time.isoformat() if bot.last_sync_time is not None else None,
                 )
 
-            sync_task.cancel()
+            sync_task.cancel(msg=SYNC_RESTART_CANCEL_MSG)
             with suppress(asyncio.CancelledError):
                 await sync_task
             msg = f"Matrix sync loop stalled for {bot.agent_name}"
@@ -210,7 +220,10 @@ class _SyncIteration:
             if task is None:
                 continue
             setattr(self, attr, None)
-            task.cancel()
+            if attr == "sync_task":
+                task.cancel(msg=SYNC_RESTART_CANCEL_MSG)
+            else:
+                task.cancel()
             try:
                 await task
             except (asyncio.CancelledError, MatrixSyncStalledError):
@@ -376,10 +389,15 @@ def create_temp_user(entity_name: str, config: Config) -> AgentMatrixUser:
     )
 
 
-async def cancel_sync_task(entity_name: str, sync_tasks: dict[str, asyncio.Task]) -> None:
+async def cancel_sync_task(
+    entity_name: str,
+    sync_tasks: dict[str, asyncio.Task],
+    *,
+    cancel_msg: str | None = None,
+) -> None:
     """Cancel and remove a sync task for an entity."""
     task = sync_tasks.pop(entity_name, None)
-    await cancel_task(task)
+    await cancel_task(task, cancel_msg=cancel_msg)
 
 
 async def stop_entities(
@@ -396,7 +414,7 @@ async def stop_entities(
 
     # Cancel sync tasks next so restarted entities do not accumulate duplicate loops.
     for entity_name in entities_to_restart:
-        await cancel_sync_task(entity_name, sync_tasks)
+        await cancel_sync_task(entity_name, sync_tasks, cancel_msg=SYNC_RESTART_CANCEL_MSG)
 
     stop_tasks = [
         agent_bots[entity_name].stop(reason="restart")

--- a/src/mindroom/response_coordinator.py
+++ b/src/mindroom/response_coordinator.py
@@ -22,6 +22,8 @@ from mindroom.constants import (
     ATTACHMENT_IDS_KEY,
     ORIGINAL_SENDER_KEY,
     ROUTER_AGENT_NAME,
+    STREAM_STATUS_CANCELLED,
+    STREAM_STATUS_ERROR,
     STREAM_STATUS_KEY,
     STREAM_STATUS_PENDING,
 )
@@ -35,6 +37,7 @@ from mindroom.matrix.typing import typing_indicator
 from mindroom.memory import store_conversation_memory
 from mindroom.memory._prompting import strip_user_turn_time_prefix
 from mindroom.memory.auto_flush import mark_auto_flush_dirty_session, reprioritize_auto_flush_sessions
+from mindroom.orchestration.runtime import is_sync_restart_cancel
 from mindroom.post_response_effects import (
     PostResponseEffectsSupport,
     ResponseOutcome,
@@ -45,6 +48,7 @@ from mindroom.streaming import (
     ReplacementStreamingResponse,
     StreamingDeliveryError,
     StreamingResponse,
+    build_restart_interrupted_body,
 )
 from mindroom.teams import TeamMode, select_model_for_team, team_response, team_response_stream
 from mindroom.timing import timed
@@ -347,6 +351,12 @@ class ResponseCoordinator:
             msg = "Matrix client is not ready for response coordination"
             raise RuntimeError(msg)
         return client
+
+    def _cancelled_response_update(self, *, restart: bool) -> tuple[str, dict[str, str]]:
+        """Return the visible note and terminal status for one cancelled response."""
+        if restart:
+            return build_restart_interrupted_body(""), {STREAM_STATUS_KEY: STREAM_STATUS_ERROR}
+        return _CANCELLED_RESPONSE_TEXT, {STREAM_STATUS_KEY: STREAM_STATUS_CANCELLED}
 
     @property
     def in_flight_response_count(self) -> int:
@@ -936,19 +946,28 @@ class ResponseCoordinator:
                             tool_context=tool_context,
                             operation=build_response_text,
                         )
-                except asyncio.CancelledError:
-                    self.deps.logger.warning(
-                        "Team non-streaming response cancelled — traceback for diagnosis",
-                        message_id=message_id,
-                        exc_info=True,
-                    )
+                except asyncio.CancelledError as exc:
+                    restart = is_sync_restart_cancel(exc)
+                    if restart:
+                        self.deps.logger.info(
+                            "Team non-streaming response interrupted by sync restart",
+                            message_id=message_id,
+                        )
+                    else:
+                        self.deps.logger.warning(
+                            "Team non-streaming response cancelled — traceback for diagnosis",
+                            message_id=message_id,
+                            exc_info=True,
+                        )
                     if message_id:
+                        cancelled_text, extra_content = self._cancelled_response_update(restart=restart)
                         await self.deps.delivery_gateway.edit_text(
                             EditTextRequest(
                                 room_id=request.room_id,
                                 event_id=message_id,
-                                new_text=_CANCELLED_RESPONSE_TEXT,
+                                new_text=cancelled_text,
                                 thread_id=delivery_target.resolved_thread_id,
+                                extra_content=extra_content,
                             ),
                         )
                     raise
@@ -1073,12 +1092,18 @@ class ResponseCoordinator:
 
             try:
                 await task
-            except asyncio.CancelledError:
-                self.deps.logger.warning(
-                    "Response cancelled — traceback for diagnosis",
-                    message_id=message_to_track or tracked_message_id,
-                    exc_info=True,
-                )
+            except asyncio.CancelledError as exc:
+                if is_sync_restart_cancel(exc):
+                    self.deps.logger.info(
+                        "Response interrupted by sync restart",
+                        message_id=message_to_track or tracked_message_id,
+                    )
+                else:
+                    self.deps.logger.warning(
+                        "Response cancelled — traceback for diagnosis",
+                        message_id=message_to_track or tracked_message_id,
+                        exc_info=True,
+                    )
             except Exception as error:
                 self.deps.logger.exception("Error during response generation", error=str(error))
                 raise
@@ -1382,19 +1407,28 @@ class ResponseCoordinator:
                 run_metadata_content=run_metadata_content,
                 compaction_outcomes=compaction_outcomes,
             )
-        except asyncio.CancelledError:
-            self.deps.logger.warning(
-                "Non-streaming response cancelled — traceback for diagnosis",
-                message_id=request.existing_event_id,
-                exc_info=True,
-            )
+        except asyncio.CancelledError as exc:
+            restart = is_sync_restart_cancel(exc)
+            if restart:
+                self.deps.logger.info(
+                    "Non-streaming response interrupted by sync restart",
+                    message_id=request.existing_event_id,
+                )
+            else:
+                self.deps.logger.warning(
+                    "Non-streaming response cancelled — traceback for diagnosis",
+                    message_id=request.existing_event_id,
+                    exc_info=True,
+                )
             if request.existing_event_id:
+                cancelled_text, extra_content = self._cancelled_response_update(restart=restart)
                 await self.deps.delivery_gateway.edit_text(
                     EditTextRequest(
                         room_id=request.room_id,
                         event_id=request.existing_event_id,
-                        new_text=_CANCELLED_RESPONSE_TEXT,
+                        new_text=cancelled_text,
                         thread_id=runtime.response_thread_id,
+                        extra_content=extra_content,
                     ),
                 )
             raise
@@ -1429,7 +1463,7 @@ class ResponseCoordinator:
             compaction_outcomes_collector.extend(compaction_outcomes)
         return delivery
 
-    async def process_and_respond_streaming(  # noqa: C901
+    async def process_and_respond_streaming(  # noqa: C901, PLR0912
         self,
         request: ResponseRequest,
         *,
@@ -1472,12 +1506,18 @@ class ResponseCoordinator:
                 response_text=error.accumulated_text,
                 delivery_kind=delivery_kind,
             )
-        except asyncio.CancelledError:
-            self.deps.logger.warning(
-                "Bot streaming response cancelled — traceback for diagnosis",
-                message_id=request.existing_event_id,
-                exc_info=True,
-            )
+        except asyncio.CancelledError as exc:
+            if is_sync_restart_cancel(exc):
+                self.deps.logger.info(
+                    "Bot streaming response interrupted by sync restart",
+                    message_id=request.existing_event_id,
+                )
+            else:
+                self.deps.logger.warning(
+                    "Bot streaming response cancelled — traceback for diagnosis",
+                    message_id=request.existing_event_id,
+                    exc_info=True,
+                )
             raise
         except Exception as error:
             self.deps.logger.exception("Error in streaming response", error=str(error))

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -22,6 +22,7 @@ from mindroom.logging_config import get_logger
 from mindroom.matrix.client import edit_message, send_message
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.message_target import MessageTarget
+from mindroom.orchestration.runtime import is_sync_restart_cancel
 from mindroom.tool_system.events import (
     StructuredStreamChunk,
     ToolTraceEntry,
@@ -274,6 +275,7 @@ class StreamingResponse:
         client: nio.AsyncClient,
         *,
         cancelled: bool = False,
+        restart_interrupted: bool = False,
         error: Exception | None = None,
     ) -> None:
         """Send final message update."""
@@ -281,6 +283,8 @@ class StreamingResponse:
             stripped_text = self.accumulated_text.rstrip()
             error_note = _format_stream_error_note(error)
             self.accumulated_text = f"{stripped_text}\n\n{error_note}" if stripped_text else error_note
+        elif restart_interrupted:
+            self.accumulated_text = build_restart_interrupted_body(self.accumulated_text)
         elif cancelled:
             stripped_text = self.accumulated_text.rstrip()
             self.accumulated_text = (
@@ -293,7 +297,7 @@ class StreamingResponse:
             self.event_id is not None and self.placeholder_progress_sent and not self.accumulated_text.strip()
         )
         final_stream_status = STREAM_STATUS_COMPLETED
-        if error is not None:
+        if error is not None or restart_interrupted:
             final_stream_status = STREAM_STATUS_ERROR
         elif cancelled:
             final_stream_status = STREAM_STATUS_CANCELLED
@@ -580,13 +584,17 @@ async def send_streaming_response(
 
     try:
         await _consume_streaming_chunks(client, response_stream, streaming)
-    except asyncio.CancelledError:
-        logger.warning(
-            "Streaming response cancelled — traceback for diagnosis",
-            message_id=streaming.event_id,
-            exc_info=True,
-        )
-        await streaming.finalize(client, cancelled=True)
+    except asyncio.CancelledError as exc:
+        if is_sync_restart_cancel(exc):
+            logger.info("Streaming response interrupted by sync restart", message_id=streaming.event_id)
+            await streaming.finalize(client, restart_interrupted=True)
+        else:
+            logger.warning(
+                "Streaming response cancelled — traceback for diagnosis",
+                message_id=streaming.event_id,
+                exc_info=True,
+            )
+            await streaming.finalize(client, cancelled=True)
         raise
     except Exception as e:
         logger.exception("Streaming response failed", error=str(e))

--- a/tests/test_ai_error_message_display.py
+++ b/tests/test_ai_error_message_display.py
@@ -15,10 +15,13 @@ from agno.db.base import SessionType
 from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
+from mindroom.constants import STREAM_STATUS_ERROR, STREAM_STATUS_KEY
 from mindroom.hooks import HookRegistry
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
+from mindroom.orchestration.runtime import SYNC_RESTART_CANCEL_MSG
 from mindroom.response_coordinator import ResponseRequest
+from mindroom.streaming import build_restart_interrupted_body
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
@@ -305,6 +308,47 @@ class TestAIErrorDisplay:
                     assert "unavailable" in displayed_msg
                 elif "Invalid model" in error_msg:
                     assert "Invalid model" in displayed_msg
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_sync_restart_edits_thinking_message_with_restart_status(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Sync restarts should not render as user-initiated cancellation."""
+        bot = _mock_bot(tmp_path)
+
+        edited_messages: list[tuple[str, dict[str, object], str]] = []
+
+        async def mock_gateway_edit_message(
+            client: object,  # noqa: ARG001
+            room_id: str,  # noqa: ARG001
+            event_id: str,
+            content: dict[str, object],
+            text: str,
+        ) -> str:
+            edited_messages.append((event_id, content, text))
+            return "$edit"
+
+        process_method = AgentBot._process_and_respond
+
+        with (
+            patch("mindroom.response_coordinator.ai_response") as mock_ai,
+            patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(side_effect=mock_gateway_edit_message)),
+        ):
+            _build_response_coordinator(bot)
+            mock_ai.side_effect = asyncio.CancelledError(SYNC_RESTART_CANCEL_MSG)
+
+            with pytest.raises(asyncio.CancelledError):
+                await process_method(
+                    bot,
+                    _response_request(existing_event_id="$thinking_msg"),
+                )
+
+        assert len(edited_messages) == 1
+        event_id, content, text = edited_messages[0]
+        assert event_id == "$thinking_msg"
+        assert text == build_restart_interrupted_body("")
+        assert content[STREAM_STATUS_KEY] == STREAM_STATUS_ERROR
 
     @pytest.mark.asyncio
     async def test_knowledge_init_failure_falls_back_to_response_without_knowledge(self, tmp_path: Path) -> None:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -17,11 +17,12 @@ from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig, StreamingConfig
-from mindroom.constants import STREAM_STATUS_COMPLETED, STREAM_STATUS_KEY, STREAM_STATUS_STREAMING
+from mindroom.constants import STREAM_STATUS_COMPLETED, STREAM_STATUS_ERROR, STREAM_STATUS_KEY, STREAM_STATUS_STREAMING
 from mindroom.hooks import MessageEnvelope
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
+from mindroom.orchestration.runtime import SYNC_RESTART_CANCEL_MSG
 from mindroom.response_coordinator import ResponseRequest
 from mindroom.streaming import (
     CANCELLED_RESPONSE_NOTE,
@@ -29,6 +30,7 @@ from mindroom.streaming import (
     ReplacementStreamingResponse,
     StreamingDeliveryError,
     StreamingResponse,
+    build_restart_interrupted_body,
     clean_partial_reply_text,
     is_interrupted_partial_reply,
     send_streaming_response,
@@ -1002,6 +1004,48 @@ class TestStreamingBehavior:
         assert len(edited_texts) == 2
         assert IN_PROGRESS_MARKER not in edited_texts[0]
         assert edited_texts[-1] == f"Partial answer\n\n{CANCELLED_RESPONSE_NOTE}"
+
+    @pytest.mark.asyncio
+    async def test_sync_restart_stream_preserves_partial_text_with_restart_suffix(self) -> None:
+        """Sync-restart cancellation should keep streamed text and append the restart marker."""
+        mock_client = _make_matrix_client_mock()
+        edited_messages: list[tuple[dict[str, object], str]] = []
+
+        async def record_edit(
+            _client: object,
+            _room_id: str,
+            _event_id: str,
+            new_content: dict[str, object],
+            new_text: str,
+        ) -> str:
+            edited_messages.append((new_content, new_text))
+            return "$edit"
+
+        async def cancelling_stream() -> AsyncIterator[str]:
+            yield "Partial answer"
+            raise asyncio.CancelledError(SYNC_RESTART_CANCEL_MSG)
+
+        with (
+            patch("mindroom.streaming.edit_message", new=AsyncMock(side_effect=record_edit)),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await send_streaming_response(
+                client=mock_client,
+                room_id="!test:localhost",
+                reply_to_event_id="$original_123",
+                thread_id=None,
+                sender_domain="localhost",
+                config=self.config,
+                runtime_paths=runtime_paths_for(self.config),
+                response_stream=cancelling_stream(),
+                existing_event_id="$thinking_123",
+                room_mode=True,
+            )
+
+        assert len(edited_messages) == 2
+        final_content, final_text = edited_messages[-1]
+        assert final_text == build_restart_interrupted_body("Partial answer")
+        assert final_content[STREAM_STATUS_KEY] == STREAM_STATUS_ERROR
 
     @pytest.mark.asyncio
     async def test_stream_error_preserves_partial_text_and_appends_error_hint(self) -> None:

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -14,8 +14,10 @@ from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths
 from mindroom.orchestration import runtime as runtime_helpers
 from mindroom.orchestration.runtime import (
+    SYNC_RESTART_CANCEL_MSG,
     _SyncIteration,
     cancel_sync_task,
+    is_sync_restart_cancel,
     matrix_sync_startup_timeout_seconds,
     stop_entities,
     sync_forever_with_restart,
@@ -48,6 +50,7 @@ class _FakeBot:
         self._sync_shutting_down = False
         self.sync_calls = 0
         self.first_call_cancelled = False
+        self.first_call_cancel_args: tuple[object, ...] = ()
         self.prepare_for_sync_shutdown_calls = 0
         self.runtime_paths = _fake_runtime_paths(**env_overrides)
 
@@ -66,9 +69,10 @@ class _FakeBot:
         self.sync_calls += 1
         try:
             await asyncio.Event().wait()
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as exc:
             if self.sync_calls == 1:
                 self.first_call_cancelled = True
+                self.first_call_cancel_args = exc.args
             raise
 
     async def prepare_for_sync_shutdown(self) -> None:
@@ -141,8 +145,16 @@ async def test_sync_forever_with_restart_restarts_stalled_sync(monkeypatch: pyte
     await sync_forever_with_restart(bot, max_retries=2)
 
     assert bot.first_call_cancelled is True
+    assert bot.first_call_cancel_args == (SYNC_RESTART_CANCEL_MSG,)
     assert bot.sync_calls == 1  # sync_forever called once, then sync_then_stop stopped
     assert bot.prepare_for_sync_shutdown_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_is_sync_restart_cancel_checks_cancel_message() -> None:
+    """The restart helper should only match the dedicated cancel message."""
+    assert is_sync_restart_cancel(asyncio.CancelledError(SYNC_RESTART_CANCEL_MSG)) is True
+    assert is_sync_restart_cancel(asyncio.CancelledError()) is False
 
 
 @pytest.mark.asyncio
@@ -432,6 +444,7 @@ async def test_stop_entities_cancels_sync_tasks() -> None:
 async def test_stop_entities_prepares_bots_before_cancelling_sync_tasks() -> None:
     """Restart teardown should cancel deferred work before the sync loop stops."""
     call_order: list[tuple[str, str]] = []
+    cancel_messages: list[tuple[str, str | None]] = []
 
     mock_bot1 = AsyncMock()
     mock_bot1.prepare_for_sync_shutdown = AsyncMock(
@@ -454,8 +467,14 @@ async def test_stop_entities_prepares_bots_before_cancelling_sync_tasks() -> Non
         "agent2": asyncio.create_task(asyncio.sleep(60)),
     }
 
-    async def fake_cancel_sync_task(entity_name: str, _sync_tasks: dict[str, asyncio.Task]) -> None:
+    async def fake_cancel_sync_task(
+        entity_name: str,
+        _sync_tasks: dict[str, asyncio.Task],
+        *,
+        cancel_msg: str | None = None,
+    ) -> None:
         call_order.append(("cancel", entity_name))
+        cancel_messages.append((entity_name, cancel_msg))
         task = _sync_tasks.pop(entity_name)
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)
@@ -469,6 +488,10 @@ async def test_stop_entities_prepares_bots_before_cancelling_sync_tasks() -> Non
     assert prepare_indexes
     assert cancel_indexes
     assert max(prepare_indexes) < min(cancel_indexes)
+    assert sorted(cancel_messages) == [
+        ("agent1", SYNC_RESTART_CANCEL_MSG),
+        ("agent2", SYNC_RESTART_CANCEL_MSG),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_team_scheduler_context.py
+++ b/tests/test_team_scheduler_context.py
@@ -13,12 +13,15 @@ from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
+from mindroom.constants import STREAM_STATUS_CANCELLED, STREAM_STATUS_ERROR, STREAM_STATUS_KEY
 from mindroom.hooks import MessageEnvelope
 from mindroom.inbound_turn_normalizer import DispatchPayload
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
+from mindroom.orchestration.runtime import SYNC_RESTART_CANCEL_MSG
 from mindroom.response_coordinator import ResponseCoordinator
+from mindroom.streaming import build_restart_interrupted_body
 from mindroom.tool_system.runtime_context import get_tool_runtime_context
 from tests.conftest import (
     TEST_ACCESS_TOKEN,
@@ -209,7 +212,70 @@ async def test_team_non_streaming_cancellation_edits_placeholder(tmp_path: Path)
         "**[Response cancelled by user]**",
         "$thread_root",
         tool_trace=None,
-        extra_content=None,
+        extra_content={STREAM_STATUS_KEY: STREAM_STATUS_CANCELLED},
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_non_streaming_sync_restart_edits_placeholder_with_restart_note(tmp_path: Path) -> None:
+    """Sync restarts should mark team placeholders as interrupted, not user-cancelled."""
+    bot = _make_bot(tmp_path)
+    team_agents = [
+        MatrixID.from_agent(
+            "general",
+            bot.config.get_domain(runtime_paths_for(bot.config)),
+            runtime_paths_for(bot.config),
+        ),
+        MatrixID.from_agent(
+            "research",
+            bot.config.get_domain(runtime_paths_for(bot.config)),
+            runtime_paths_for(bot.config),
+        ),
+    ]
+
+    async def fake_run_cancellable_response(**kwargs: object) -> None:
+        response_function = kwargs["response_function"]
+        with suppress(asyncio.CancelledError):
+            await response_function("$thinking")
+
+    async def fake_team_response(*_args: object, **_kwargs: object) -> str:
+        raise asyncio.CancelledError(SYNC_RESTART_CANCEL_MSG)
+
+    bot._edit_message = AsyncMock()
+    install_edit_message_mock(bot, bot._edit_message)
+
+    with (
+        patch.object(
+            ResponseCoordinator,
+            "run_cancellable_response",
+            new=AsyncMock(side_effect=fake_run_cancellable_response),
+        ),
+        patch("mindroom.response_coordinator.typing_indicator", new=_noop_typing_indicator),
+        patch_response_coordinator_module(
+            should_use_streaming=AsyncMock(return_value=False),
+            team_response=fake_team_response,
+        ),
+    ):
+        await bot._generate_team_response_helper(
+            room_id="!team:localhost",
+            reply_to_event_id="$user_event",
+            thread_id="$thread_root",
+            payload=DispatchPayload(prompt="Please coordinate and schedule a reminder"),
+            team_agents=team_agents,
+            team_mode="coordinate",
+            thread_history=[],
+            requester_user_id="@user:localhost",
+            response_envelope=_response_envelope(),
+            correlation_id="corr-team-restart",
+        )
+
+    bot._edit_message.assert_awaited_once_with(
+        "!team:localhost",
+        "$thinking",
+        build_restart_interrupted_body(""),
+        "$thread_root",
+        tool_trace=None,
+        extra_content={STREAM_STATUS_KEY: STREAM_STATUS_ERROR},
     )
 
 


### PR DESCRIPTION
This PR replaces the bot-global sync-restart flag with cancellation-message classification.

The restart reason now stays attached to the `CancelledError` itself instead of being stored in shared per-bot state, which avoids restart-state races and misclassification when multiple async paths are cancelling or streaming at the same time.

Summary:
- remove the shared sync-restart flag
- classify restart cancellations from the cancel message itself
- thread the clearer cancellation reason through response coordination, streaming, and runtime shutdown paths
- add regression coverage for restart-related cancellation handling