### PR TITLE
Keep streaming runtime context alive for the full async stream lifetime

### DIFF
--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -54,6 +54,7 @@ from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
     WorkerScope,
     build_tool_execution_identity,
+    stream_with_tool_execution_identity,
     tool_execution_identity,
 )
 
@@ -1046,29 +1047,36 @@ async def _stream_completion(
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> StreamingResponse | JSONResponse:
     """Handle streaming chat completion via SSE."""
-    with tool_execution_identity(execution_identity):
-        stream = stream_agent_response(
-            agent_name=agent_name,
-            prompt=prompt,
-            session_id=session_id,
-            runtime_paths=runtime_paths,
-            config=config,
-            thread_history=thread_history,
-            room_id=None,
-            knowledge=knowledge,
-            user_id=user,
-            include_interactive_questions=False,
-            active_event_ids=set(),
-            execution_identity=execution_identity,
-        )
+    stream = cast(
+        "AsyncGenerator[AIStreamChunk, None]",
+        stream_with_tool_execution_identity(
+            execution_identity,
+            stream_factory=lambda: stream_agent_response(
+                agent_name=agent_name,
+                prompt=prompt,
+                session_id=session_id,
+                runtime_paths=runtime_paths,
+                config=config,
+                thread_history=thread_history,
+                room_id=None,
+                knowledge=knowledge,
+                user_id=user,
+                include_interactive_questions=False,
+                active_event_ids=set(),
+                execution_identity=execution_identity,
+            ),
+        ),
+    )
 
-        # Peek at first event to detect errors before committing to SSE
-        first_event = await anext(aiter(stream), None)
+    # Peek at first event to detect errors before committing to SSE
+    first_event = await anext(aiter(stream), None)
     if first_event is None:
+        await stream.aclose()
         return _error_response(500, "Agent returned empty response", error_type="server_error")
 
     if isinstance(first_event, str) and _is_error_response(first_event):
         logger.warning("Stream returned error", model=agent_name, session_id=session_id, error=first_event)
+        await stream.aclose()
         return _error_response(500, "Agent execution failed", error_type="server_error")
 
     completion_id = f"chatcmpl-{uuid4().hex[:12]}"
@@ -1076,7 +1084,7 @@ async def _stream_completion(
 
     async def event_generator() -> AsyncIterator[str]:
         tool_state = _ToolStreamState()
-        with tool_execution_identity(execution_identity):
+        try:
             # 1. Initial role announcement
             yield f"data: {_chunk_json(completion_id, created, agent_name, delta={'role': 'assistant'})}\n\n"
 
@@ -1099,6 +1107,8 @@ async def _stream_completion(
 
             # 5. Stream terminator
             yield "data: [DONE]\n\n"
+        finally:
+            await stream.aclose()
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 
@@ -1367,16 +1377,23 @@ async def _stream_team_completion(  # noqa: C901
             await _cleanup()
             return _error_response(500, "Team execution failed", error_type="server_error")
         try:
-            with tool_execution_identity(execution_identity):
-                raw_stream = team.arun(
-                    team_prompt,
-                    stream=True,
-                    stream_events=True,
-                    session_id=session_id,
-                    user_id=user,
-                )
-                stream = cast("AsyncGenerator[RunOutputEvent | TeamRunOutputEvent, None]", raw_stream)
-                first_event = await anext(stream, None)
+            stream = cast(
+                "AsyncGenerator[RunOutputEvent | TeamRunOutputEvent, None]",
+                stream_with_tool_execution_identity(
+                    execution_identity,
+                    stream_factory=lambda: cast(
+                        "AsyncGenerator[RunOutputEvent | TeamRunOutputEvent, None]",
+                        team.arun(
+                            team_prompt,
+                            stream=True,
+                            stream_events=True,
+                            session_id=session_id,
+                            user_id=user,
+                        ),
+                    ),
+                ),
+            )
+            first_event = await anext(stream, None)
         except Exception:
             logger.exception("Team execution failed", team=team_name)
             await _cleanup()
@@ -1403,7 +1420,6 @@ async def _stream_team_completion(  # noqa: C901
                     created=created,
                     model_id=model_id,
                     team_name=team_name,
-                    execution_identity=execution_identity,
                 ):
                     yield chunk
             finally:
@@ -1479,7 +1495,6 @@ async def _team_stream_event_generator(
     created: int,
     model_id: str,
     team_name: str,
-    execution_identity: ToolExecutionIdentity | None,
 ) -> AsyncIterator[str]:
     """Yield SSE chunks for team streaming responses.
 
@@ -1496,42 +1511,41 @@ async def _team_stream_event_generator(
     def _chunk(content: str) -> str:
         return f"data: {_chunk_json(completion_id, created, model_id, delta={'content': content})}\n\n"
 
-    with tool_execution_identity(execution_identity):
-        # 1. Role announcement
-        yield f"data: {_chunk_json(completion_id, created, model_id, delta={'role': 'assistant'})}\n\n"
+    # 1. Role announcement
+    yield f"data: {_chunk_json(completion_id, created, model_id, delta={'role': 'assistant'})}\n\n"
 
-        # 2. First event (guaranteed non-error by preflight)
-        text = _classify_team_event(first_event, tool_state)
-        if text:
-            yield _chunk(text)
+    # 2. First event (guaranteed non-error by preflight)
+    text = _classify_team_event(first_event, tool_state)
+    if text:
+        yield _chunk(text)
 
-        # 3. Remaining events
-        try:
-            async for event in stream:
-                if _extract_team_stream_error(event) is not None:
-                    logger.warning("Team stream emitted error event", team=team_name)
-                    pending = _finalize_pending_tools(tool_state)
-                    if pending:
-                        yield _chunk(pending)
-                    yield _chunk("Team execution failed.")
-                    break
+    # 3. Remaining events
+    try:
+        async for event in stream:
+            if _extract_team_stream_error(event) is not None:
+                logger.warning("Team stream emitted error event", team=team_name)
+                pending = _finalize_pending_tools(tool_state)
+                if pending:
+                    yield _chunk(pending)
+                yield _chunk("Team execution failed.")
+                break
 
-                text = _classify_team_event(event, tool_state)
-                if text:
-                    yield _chunk(text)
-        except Exception:
-            logger.exception("Team stream failed during iteration", team=team_name)
-            pending = _finalize_pending_tools(tool_state)
-            if pending:
-                yield _chunk(pending)
-            yield _chunk("Team execution failed.")
-
-        # 4. Finalize any tool calls that started but never completed
+            text = _classify_team_event(event, tool_state)
+            if text:
+                yield _chunk(text)
+    except Exception:
+        logger.exception("Team stream failed during iteration", team=team_name)
         pending = _finalize_pending_tools(tool_state)
         if pending:
             yield _chunk(pending)
+        yield _chunk("Team execution failed.")
 
-        # 5. Finish
-        logger.info("Team completion sent", team=team_name, stream=True)
-        yield f"data: {_chunk_json(completion_id, created, model_id, delta={}, finish_reason='stop')}\n\n"
-        yield "data: [DONE]\n\n"
+    # 4. Finalize any tool calls that started but never completed
+    pending = _finalize_pending_tools(tool_state)
+    if pending:
+        yield _chunk(pending)
+
+    # 5. Finish
+    logger.info("Team completion sent", team=team_name, stream=True)
+    yield f"data: {_chunk_json(completion_id, created, model_id, delta={}, finish_reason='stop')}\n\n"
+    yield "data: [DONE]\n\n"

--- a/src/mindroom/matrix/event_cache.py
+++ b/src/mindroom/matrix/event_cache.py
@@ -342,11 +342,7 @@ def normalize_event_source_for_cache(
     origin_server_ts: int | None = None,
 ) -> dict[str, Any]:
     """Normalize one raw Matrix event payload for persistent cache storage."""
-    source = {
-        key: value
-        for key, value in event_source.items()
-        if key not in _RUNTIME_ONLY_EVENT_SOURCE_KEYS
-    }
+    source = {key: value for key, value in event_source.items() if key not in _RUNTIME_ONLY_EVENT_SOURCE_KEYS}
     if "event_id" not in source and isinstance(event_id, str):
         source["event_id"] = event_id
     if "sender" not in source and isinstance(sender, str):

--- a/src/mindroom/response_coordinator.py
+++ b/src/mindroom/response_coordinator.py
@@ -53,7 +53,10 @@ from mindroom.streaming import (
 from mindroom.teams import TeamMode, select_model_for_team, team_response, team_response_stream
 from mindroom.timing import DispatchPipelineTiming, timed
 from mindroom.timing import timing_scope as timing_scope_context
-from mindroom.tool_system.worker_routing import tool_execution_identity
+from mindroom.tool_system.worker_routing import (
+    run_with_tool_execution_identity,
+    stream_with_tool_execution_identity,
+)
 
 from .delivery_gateway import (
     DeliveryGateway,
@@ -393,11 +396,13 @@ class ResponseCoordinator:
         operation: Callable[[], Awaitable[_ToolContextResult]],
     ) -> _ToolContextResult:
         """Execute one operation inside the response-owned execution and tool context."""
-        with tool_execution_identity(execution_identity):
-            return await self.deps.tool_runtime.run_in_context(
-                tool_context=tool_context,
+        return await self.deps.tool_runtime.run_in_context(
+            tool_context=tool_context,
+            operation=lambda: run_with_tool_execution_identity(
+                execution_identity,
                 operation=operation,
-            )
+            ),
+        )
 
     def _stream_in_tool_context(
         self,
@@ -407,16 +412,13 @@ class ResponseCoordinator:
         stream_factory: Callable[[], AsyncIterator[_ToolStreamChunk]],
     ) -> AsyncIterator[_ToolStreamChunk]:
         """Wrap one stream inside the response-owned execution and tool context."""
-
-        async def wrapped_stream() -> AsyncIterator[_ToolStreamChunk]:
-            with tool_execution_identity(execution_identity):
-                async for chunk in self.deps.tool_runtime.stream_in_context(
-                    tool_context=tool_context,
-                    stream_factory=stream_factory,
-                ):
-                    yield chunk
-
-        return wrapped_stream()
+        return self.deps.tool_runtime.stream_in_context(
+            tool_context=tool_context,
+            stream_factory=lambda: stream_with_tool_execution_identity(
+                execution_identity,
+                stream_factory=stream_factory,
+            ),
+        )
 
     def _resolve_request_target(self, request: ResponseRequest) -> MessageTarget:
         """Resolve the canonical response target for one request."""

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 from uuid import uuid4
 
 from mindroom.hooks import (
@@ -41,6 +42,21 @@ if TYPE_CHECKING:
 
 _ToolContextReturn = TypeVar("_ToolContextReturn")
 _StreamChunk = TypeVar("_StreamChunk")
+
+
+@runtime_checkable
+class _AsyncClosableIterator(Protocol):
+    """Minimal async-iterator surface that can be closed explicitly."""
+
+    async def aclose(self) -> None:
+        """Close the async iterator and release any underlying resources."""
+
+
+@contextmanager
+def _tool_runtime_context_scope(tool_context: ToolRuntimeContext | None) -> Iterator[None]:
+    """Bind tool runtime state only for the duration of one concrete operation."""
+    with tool_runtime_context(tool_context):
+        yield
 
 
 @dataclass(frozen=True)
@@ -163,7 +179,7 @@ class ToolRuntimeSupport:
         operation: Callable[[], Awaitable[_ToolContextReturn]],
     ) -> _ToolContextReturn:
         """Execute one async operation inside the ambient tool runtime context."""
-        with tool_runtime_context(tool_context):
+        with _tool_runtime_context_scope(tool_context):
             return await operation()
 
     def stream_in_context(
@@ -172,12 +188,24 @@ class ToolRuntimeSupport:
         tool_context: ToolRuntimeContext | None,
         stream_factory: Callable[[], AsyncIterator[_StreamChunk]],
     ) -> AsyncIterator[_StreamChunk]:
-        """Wrap one async iterator so it runs inside the ambient tool runtime context."""
+        """Wrap one async iterator without spanning tool-runtime tokens across yields."""
 
         async def wrapped_stream() -> AsyncIterator[_StreamChunk]:
-            with tool_runtime_context(tool_context):
-                async for chunk in stream_factory():
+            stream: AsyncIterator[_StreamChunk] | None = None
+            try:
+                with _tool_runtime_context_scope(tool_context):
+                    stream = stream_factory()
+                while True:
+                    try:
+                        with _tool_runtime_context_scope(tool_context):
+                            chunk = await anext(stream)
+                    except StopAsyncIteration:
+                        return
                     yield chunk
+            finally:
+                if isinstance(stream, (AsyncGenerator, _AsyncClosableIterator)):
+                    with _tool_runtime_context_scope(tool_context):
+                        await stream.aclose()
 
         return wrapped_stream()
 

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import hashlib
 import re
+from collections.abc import AsyncGenerator as AsyncGeneratorABC
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal, Protocol, cast, runtime_checkable
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Iterator
+    from collections.abc import AsyncIterator, Awaitable, Callable, Collection, Iterator
 
     from mindroom.constants import RuntimePaths
 
@@ -32,6 +33,14 @@ SHARED_ONLY_INTEGRATION_NAMES = frozenset(
         "google_sheets",
     },
 )
+
+
+@runtime_checkable
+class _AsyncClosableIterator(Protocol):
+    """Minimal async-iterator surface that can be closed explicitly."""
+
+    async def aclose(self) -> None:
+        """Close the async iterator and release any underlying resources."""
 
 
 @dataclass(frozen=True)
@@ -104,6 +113,43 @@ def tool_execution_identity(identity: ToolExecutionIdentity | None) -> Iterator[
         yield
     finally:
         _TOOL_EXECUTION_IDENTITY.reset(token)
+
+
+async def run_with_tool_execution_identity[ReturnT](
+    identity: ToolExecutionIdentity | None,
+    *,
+    operation: Callable[[], Awaitable[ReturnT]],
+) -> ReturnT:
+    """Execute one async operation inside one execution-identity boundary."""
+    with tool_execution_identity(identity):
+        return await operation()
+
+
+def stream_with_tool_execution_identity[ChunkT](
+    identity: ToolExecutionIdentity | None,
+    *,
+    stream_factory: Callable[[], AsyncIterator[ChunkT]],
+) -> AsyncIterator[ChunkT]:
+    """Wrap one async iterator without spanning execution-identity tokens across yields."""
+
+    async def wrapped_stream() -> AsyncIterator[ChunkT]:
+        stream: AsyncIterator[ChunkT] | None = None
+        try:
+            with tool_execution_identity(identity):
+                stream = stream_factory()
+            while True:
+                try:
+                    with tool_execution_identity(identity):
+                        chunk = await anext(stream)
+                except StopAsyncIteration:
+                    return
+                yield chunk
+        finally:
+            if isinstance(stream, (AsyncGeneratorABC, _AsyncClosableIterator)):
+                with tool_execution_identity(identity):
+                    await stream.aclose()
+
+    return wrapped_stream()
 
 
 def _normalize_worker_key_part(value: str) -> str:

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextvars import Context
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -48,7 +49,13 @@ from mindroom.media_inputs import MediaInputs
 from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsSupport
 from mindroom.response_coordinator import ResponseCoordinator, ResponseCoordinatorDeps, ResponseRequest
-from mindroom.tool_system.runtime_context import ToolRuntimeSupport, get_tool_runtime_context
+from mindroom.tool_system.runtime_context import ToolRuntimeSupport, get_tool_runtime_context, tool_runtime_context
+from mindroom.tool_system.worker_routing import (
+    build_tool_execution_identity,
+    get_tool_execution_identity,
+    stream_with_tool_execution_identity,
+    tool_execution_identity,
+)
 from tests.conftest import bind_runtime_paths, resolve_response_thread_root_for_test
 
 if TYPE_CHECKING:
@@ -312,6 +319,138 @@ class TestUserIdPassthrough:
             mock_stream.assert_called_once()
             assert mock_stream.call_args.kwargs["user_id"] == "@bob:localhost"
             assert callable(mock_stream.call_args.kwargs["run_id_callback"])
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_context_cleanup_survives_cross_task_close(self, tmp_path: Path) -> None:
+        """Wrapped response streams should clean up across task-context boundaries."""
+        runtime_paths = _runtime_paths(tmp_path)
+        config = bind_runtime_paths(_config(), runtime_paths)
+        bot = MagicMock(spec=AgentBot)
+        bot.logger = MagicMock()
+        bot.stop_manager = MagicMock()
+        bot.stop_manager.remove_stop_button = AsyncMock()
+        bot.client = AsyncMock()
+        bot.agent_name = "general"
+        bot.storage_path = tmp_path
+        bot.config = config
+        bot.runtime_paths = runtime_paths
+
+        coordinator = _build_response_coordinator(
+            bot,
+            config=config,
+            runtime_paths=runtime_paths,
+            storage_path=tmp_path,
+            requester_id="@alice:localhost",
+        )
+        target = MessageTarget.resolve("!test:localhost", None, "$user_msg", room_mode=True)
+        tool_context = coordinator.deps.tool_runtime.build_context(
+            target,
+            user_id="@alice:localhost",
+            session_id="session-1",
+        )
+        assert tool_context is not None
+        execution_identity = coordinator.deps.tool_runtime.build_execution_identity(
+            target=target,
+            user_id="@alice:localhost",
+            session_id="session-1",
+        )
+        observed_final_contexts: list[tuple[object | None, object | None]] = []
+
+        async def source() -> AsyncIterator[str]:
+            try:
+                assert get_tool_runtime_context() is tool_context
+                assert get_tool_execution_identity() == execution_identity
+                yield "chunk"
+                await asyncio.Future()
+            finally:
+                observed_final_contexts.append(
+                    (get_tool_runtime_context(), get_tool_execution_identity()),
+                )
+
+        stream = coordinator._stream_in_tool_context(
+            execution_identity=execution_identity,
+            tool_context=tool_context,
+            stream_factory=source,
+        )
+
+        first_chunk = await asyncio.create_task(anext(stream), context=Context())
+        assert first_chunk == "chunk"
+        await asyncio.create_task(stream.aclose(), context=Context())
+        assert observed_final_contexts == [(tool_context, execution_identity)]
+
+    @pytest.mark.asyncio
+    async def test_execution_identity_stream_factory_masks_outer_context(self, tmp_path: Path) -> None:
+        """Factory setup should not inherit an outer execution identity when None is explicit."""
+        runtime_paths = _runtime_paths(tmp_path)
+        outer_identity = build_tool_execution_identity(
+            channel="matrix",
+            agent_name="outer",
+            runtime_paths=runtime_paths,
+            requester_id="@outer:localhost",
+            room_id="!test:localhost",
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id="outer-session",
+        )
+        observed_identity: list[object | None] = []
+
+        def factory() -> AsyncIterator[str]:
+            observed_identity.append(get_tool_execution_identity())
+            msg = "factory boom"
+            raise RuntimeError(msg)
+
+        with tool_execution_identity(outer_identity):
+            stream = stream_with_tool_execution_identity(None, stream_factory=factory)
+            with pytest.raises(RuntimeError, match="factory boom"):
+                await anext(stream)
+
+        assert observed_identity == [None]
+
+    @pytest.mark.asyncio
+    async def test_tool_runtime_stream_factory_masks_outer_context(self, tmp_path: Path) -> None:
+        """Factory setup should not inherit an outer tool runtime context when None is explicit."""
+        runtime_paths = _runtime_paths(tmp_path)
+        config = bind_runtime_paths(_config(), runtime_paths)
+        bot = MagicMock(spec=AgentBot)
+        bot.logger = MagicMock()
+        bot.stop_manager = MagicMock()
+        bot.stop_manager.remove_stop_button = AsyncMock()
+        bot.client = AsyncMock()
+        bot.agent_name = "general"
+        bot.storage_path = tmp_path
+        bot.config = config
+        bot.runtime_paths = runtime_paths
+
+        coordinator = _build_response_coordinator(
+            bot,
+            config=config,
+            runtime_paths=runtime_paths,
+            storage_path=tmp_path,
+            requester_id="@alice:localhost",
+        )
+        target = MessageTarget.resolve("!test:localhost", None, "$user_msg", room_mode=True)
+        outer_context = coordinator.deps.tool_runtime.build_context(
+            target,
+            user_id="@outer:localhost",
+            session_id="outer-session",
+        )
+        assert outer_context is not None
+        observed_context: list[object | None] = []
+
+        def factory() -> AsyncIterator[str]:
+            observed_context.append(get_tool_runtime_context())
+            msg = "factory boom"
+            raise RuntimeError(msg)
+
+        with tool_runtime_context(outer_context):
+            stream = coordinator.deps.tool_runtime.stream_in_context(
+                tool_context=None,
+                stream_factory=factory,
+            )
+            with pytest.raises(RuntimeError, match="factory boom"):
+                await anext(stream)
+
+        assert observed_context == [None]
 
     @pytest.mark.asyncio
     async def test_ai_response_passes_user_id_to_agent_arun(self, tmp_path: Path) -> None:

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from contextlib import contextmanager
+from contextvars import Context
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -16,7 +18,7 @@ import pytest
 from agno.agent import Agent as AgnoAgent
 from agno.team import Team as AgnoTeam
 from fastapi import Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.testclient import TestClient
 
 from mindroom import constants
@@ -1271,6 +1273,51 @@ class TestStreamingCompletion:
         assert len(observed_session_ids) == 2
         assert all(session_id is not None for session_id in observed_session_ids)
 
+    @pytest.mark.asyncio
+    async def test_streaming_close_from_other_task_keeps_execution_identity(self, test_config: Config) -> None:
+        """Closing the SSE body from another task should still clean up inside the execution identity."""
+        from agno.run.agent import RunContentEvent  # noqa: PLC0415
+
+        runtime_paths = _runtime_paths()
+        execution_identity = build_tool_execution_identity(
+            channel="openai_compat",
+            agent_name="general",
+            session_id="session-123",
+            runtime_paths=runtime_paths,
+            requester_id=None,
+            room_id=None,
+            thread_id=None,
+            resolved_thread_id=None,
+        )
+        observed_final_identities: list[ToolExecutionIdentity | None] = []
+
+        async def mock_stream(**_kw: object) -> AsyncIterator[RunContentEvent]:
+            try:
+                assert get_tool_execution_identity() == execution_identity
+                yield RunContentEvent(content="Hello")
+                await asyncio.Future()
+            finally:
+                observed_final_identities.append(get_tool_execution_identity())
+
+        with patch("mindroom.api.openai_compat.stream_agent_response", side_effect=mock_stream):
+            response = await openai_compat._stream_completion(
+                "general",
+                "Hello",
+                "session-123",
+                test_config,
+                runtime_paths,
+                None,
+                None,
+                None,
+                execution_identity=execution_identity,
+            )
+
+        assert isinstance(response, StreamingResponse)
+        body_iterator = response.body_iterator
+        await asyncio.create_task(anext(body_iterator), context=Context())
+        await asyncio.create_task(body_iterator.aclose(), context=Context())
+        assert observed_final_identities == [execution_identity]
+
     def test_streaming_cached_response(self, app_client: TestClient) -> None:
         """Cached full response (string) is streamed correctly."""
 
@@ -2455,6 +2502,65 @@ class TestTeamCompletion:
         assert response.status_code == 200
         assert len(observed_session_ids) == 2
         assert all(session_id is not None for session_id in observed_session_ids)
+
+    @pytest.mark.asyncio
+    async def test_team_streaming_close_from_other_task_keeps_execution_identity(
+        self,
+        team_config: Config,
+    ) -> None:
+        """Closing the team SSE body from another task should still clean up inside the execution identity."""
+        from agno.run.team import RunContentEvent as TeamContentEvent  # noqa: PLC0415
+
+        from mindroom.teams import TeamMode  # noqa: PLC0415
+
+        runtime_paths = _runtime_paths()
+        execution_identity = build_tool_execution_identity(
+            channel="openai_compat",
+            agent_name="team/super_team",
+            session_id="session-123",
+            runtime_paths=runtime_paths,
+            requester_id=None,
+            room_id=None,
+            thread_id=None,
+            resolved_thread_id=None,
+        )
+        mock_team = _make_test_team()
+        observed_final_identities: list[ToolExecutionIdentity | None] = []
+
+        async def mock_stream_events(*_a: object, **_kw: object) -> AsyncIterator[object]:
+            try:
+                assert get_tool_execution_identity() == execution_identity
+                yield TeamContentEvent(content="Hello")
+                await asyncio.Future()
+            finally:
+                observed_final_identities.append(get_tool_execution_identity())
+
+        mock_team.arun = mock_stream_events
+
+        with (
+            patch(
+                "mindroom.api.openai_compat._build_team",
+                return_value=([_make_test_agent("GeneralAgent")], mock_team, TeamMode.COORDINATE),
+            ),
+            patch("mindroom.api.openai_compat._prepare_openai_team_prompt", new=AsyncMock(return_value="Build it")),
+        ):
+            response = await openai_compat._stream_team_completion(
+                "super_team",
+                "team/super_team",
+                "Build it",
+                "session-123",
+                team_config,
+                runtime_paths,
+                None,
+                None,
+                execution_identity=execution_identity,
+            )
+
+        assert isinstance(response, StreamingResponse)
+        body_iterator = response.body_iterator
+        await asyncio.create_task(anext(body_iterator), context=Context())
+        await asyncio.create_task(body_iterator.aclose(), context=Context())
+        assert observed_final_identities == [execution_identity]
 
     def test_team_streaming_builds_team_inside_execution_identity(self, team_app_client: TestClient) -> None:
         """Streamed team requests must establish execution identity before member agents are built."""


### PR DESCRIPTION
This PR fixes runtime-context scoping for streaming responses.

The old behavior only wrapped the stream factory call, which meant the tool execution context could fall out of scope while the async stream was still being consumed. This change keeps the context alive for the full stream lifetime and closes streams explicitly on early exit paths.

Summary:
- keep tool execution identity bound across the full async lifetime of agent and team SSE streams
- explicitly close streams when preflight exits early
- align OpenAI-compatible streaming and team streaming with the real stream lifetime
- add coverage for the corrected streaming context boundaries