### PR TITLE
Handle non-text thread roots when building thread snapshots

### DIFF
--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -29,6 +29,7 @@ from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_content import (
     extract_and_resolve_message,
     extract_edit_body,
+    resolve_event_source_content,
     visible_body_from_event_source,
 )
 from mindroom.matrix.room_cache import cached_room
@@ -1136,7 +1137,26 @@ def _history_message_sort_key(message: ResolvedVisibleMessage) -> tuple[int, str
     return (message.timestamp, message.event_id)
 
 
-def _snapshot_message_dict(event: nio.RoomMessageText | nio.RoomMessageNotice) -> ResolvedVisibleMessage:
+def _is_room_message_event(event: nio.Event) -> bool:
+    """Return whether one nio event is a readable Matrix room message."""
+    event_source = event.source if isinstance(event.source, dict) else {}
+    return event_source.get("type") == "m.room.message"
+
+
+def _room_message_fallback_body(event: nio.Event) -> str:
+    """Return one best-effort fallback body for a room message event."""
+    if isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES):
+        return event.body
+    event_source = event.source if isinstance(event.source, dict) else {}
+    content = event_source.get("content")
+    if isinstance(content, dict):
+        body = content.get("body")
+        if isinstance(body, str):
+            return body
+    return ""
+
+
+def _snapshot_message_dict(event: nio.Event) -> ResolvedVisibleMessage:
     """Build one lightweight visible message without hydrating sidecars."""
     event_source = event.source if isinstance(event.source, dict) else {}
     content = event_source.get("content", {})
@@ -1144,8 +1164,8 @@ def _snapshot_message_dict(event: nio.RoomMessageText | nio.RoomMessageNotice) -
     event_info = EventInfo.from_event(event_source)
     message = ResolvedVisibleMessage.synthetic(
         sender=event.sender,
-        body=visible_body_from_event_source(event_source, event.body),
-        timestamp=event.server_timestamp,
+        body=visible_body_from_event_source(event_source, _room_message_fallback_body(event)),
+        timestamp=event.server_timestamp if isinstance(event.server_timestamp, int) else 0,
         event_id=event.event_id,
         content=normalized_content,
         thread_id=event_info.thread_id,
@@ -1171,11 +1191,11 @@ async def _fetch_thread_context_via_relations(
         raise _ThreadHistoryFastPathUnavailableError(msg)
 
     root_event = root_response.event
-    if not isinstance(root_event, (nio.RoomMessageText, nio.RoomMessageNotice)):
+    if not _is_room_message_event(root_event):
         msg = f"thread root {thread_id} is not a readable room message"
         raise _ThreadHistoryFastPathUnavailableError(msg)
 
-    thread_events: list[nio.RoomMessageText | nio.RoomMessageNotice] = []
+    thread_events: list[nio.Event] = []
     try:
         async for event in client.room_get_event_relations(
             room_id,
@@ -1183,7 +1203,7 @@ async def _fetch_thread_context_via_relations(
             rel_type=RelationshipType.thread,
             event_type="m.room.message",
         ):
-            if not isinstance(event, (nio.RoomMessageText, nio.RoomMessageNotice)):
+            if not _is_room_message_event(event):
                 continue
             event_info = EventInfo.from_event(event.source)
             if event_info.is_edit:
@@ -1601,23 +1621,50 @@ async def _collect_thread_relation_events(
     return thread_events, latest_edits_by_original_event_id
 
 
+async def _resolve_thread_history_message(
+    event: nio.Event,
+    client: nio.AsyncClient,
+) -> ResolvedVisibleMessage:
+    """Resolve one room-message event into the normalized thread-history shape."""
+    if isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES):
+        message_data = await extract_and_resolve_message(event, client)
+        return ResolvedVisibleMessage.from_message_data(
+            message_data,
+            thread_id=EventInfo.from_event(event.source).thread_id,
+            latest_event_id=event.event_id,
+        )
+
+    resolved_event_source = await resolve_event_source_content(
+        event.source if isinstance(event.source, dict) else {},
+        client,
+    )
+    content = resolved_event_source.get("content", {})
+    normalized_content = content if isinstance(content, dict) else {}
+    event_info = EventInfo.from_event(resolved_event_source)
+    message = ResolvedVisibleMessage.synthetic(
+        sender=event.sender,
+        body=visible_body_from_event_source(resolved_event_source, _room_message_fallback_body(event)),
+        timestamp=event.server_timestamp if isinstance(event.server_timestamp, int) else 0,
+        event_id=event.event_id,
+        content=normalized_content,
+        thread_id=event_info.thread_id,
+    )
+    message.refresh_stream_status()
+    return message
+
+
 async def _record_relations_history_messages(
     client: nio.AsyncClient,
     *,
-    root_message_event: nio.RoomMessageText | nio.RoomMessageNotice | None,
-    thread_events: list[nio.RoomMessageText | nio.RoomMessageNotice],
+    root_message_event: nio.Event | None,
+    thread_events: list[nio.Event],
 ) -> dict[str, ResolvedVisibleMessage]:
     """Resolve the root and direct thread children into canonical visible messages."""
     messages_by_event_id: dict[str, ResolvedVisibleMessage] = {}
     for event in [root_message_event, *thread_events]:
         if event is None:
             continue
-        message_data = await extract_and_resolve_message(event, client)
-        messages_by_event_id[event.event_id] = ResolvedVisibleMessage.from_message_data(
-            message_data,
-            thread_id=EventInfo.from_event(event.source).thread_id,
-            latest_event_id=event.event_id,
-        )
+        messages_by_event_id[event.event_id] = await _resolve_thread_history_message(event, client)
     return messages_by_event_id
 
 
@@ -1651,7 +1698,7 @@ def _record_latest_thread_edit(
 
 
 async def _record_thread_message(
-    event: nio.RoomMessageText | nio.RoomMessageNotice,
+    event: nio.Event,
     *,
     event_info: EventInfo,
     client: nio.AsyncClient,
@@ -1667,21 +1714,11 @@ async def _record_thread_message(
     is_thread_message = event_info.is_thread and event_info.thread_id == thread_id
 
     if is_root_message and not root_message_found:
-        message_data = await extract_and_resolve_message(event, client)
-        messages_by_event_id[event.event_id] = ResolvedVisibleMessage.from_message_data(
-            message_data,
-            thread_id=event_info.thread_id,
-            latest_event_id=event.event_id,
-        )
+        messages_by_event_id[event.event_id] = await _resolve_thread_history_message(event, client)
         return True
 
     if is_thread_message:
-        message_data = await extract_and_resolve_message(event, client)
-        messages_by_event_id[event.event_id] = ResolvedVisibleMessage.from_message_data(
-            message_data,
-            thread_id=event_info.thread_id,
-            latest_event_id=event.event_id,
-        )
+        messages_by_event_id[event.event_id] = await _resolve_thread_history_message(event, client)
 
     return root_message_found
 
@@ -1825,9 +1862,7 @@ async def _fetch_thread_history_via_relations_with_events(
         raise _ThreadHistoryFastPathUnavailableError(msg)
 
     root_message = root_response.event
-    root_message_event = (
-        root_message if isinstance(root_message, (nio.RoomMessageText, nio.RoomMessageNotice)) else None
-    )
+    root_message_event = root_message if _is_room_message_event(root_message) else None
     messages_by_event_id = await _record_relations_history_messages(
         client,
         root_message_event=root_message_event,
@@ -1835,7 +1870,7 @@ async def _fetch_thread_history_via_relations_with_events(
     )
 
     for event in [root_message_event, *thread_events]:
-        if event is None:
+        if event is None or not isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES):
             continue
         replacement = await _fetch_latest_message_replacement(client, room_id, event)
         if replacement is not None:
@@ -1898,15 +1933,17 @@ async def _fetch_thread_history_via_room_messages_with_events(
             break
 
         for event in response.chunk:
-            if not isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES):
+            if not isinstance(event, nio.Event) or not _is_room_message_event(event):
                 continue
 
             event_info = EventInfo.from_event(event.source)
-            if _record_latest_thread_edit(
+            if isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES) and _record_latest_thread_edit(
                 event,
                 event_info=event_info,
                 latest_edits_by_original_event_id=latest_edits_by_original_event_id,
             ):
+                continue
+            if event_info.is_edit:
                 continue
 
             if event.event_id == thread_id or (event_info.is_thread and event_info.thread_id == thread_id):

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -79,6 +79,29 @@ class TestThreadHistory:
         return event
 
     @staticmethod
+    def _make_audio_event(
+        *,
+        event_id: str,
+        sender: str,
+        body: str,
+        server_timestamp: int,
+        source_content: dict,
+    ) -> MagicMock:
+        event = MagicMock(spec=nio.RoomMessageAudio)
+        event.event_id = event_id
+        event.sender = sender
+        event.body = body
+        event.server_timestamp = server_timestamp
+        normalized_content = dict(source_content)
+        normalized_content.setdefault("msgtype", "m.audio")
+        normalized_content.setdefault("body", body)
+        event.source = {
+            "type": "m.room.message",
+            "content": normalized_content,
+        }
+        return event
+
+    @staticmethod
     def _make_room_get_event_response(event: nio.Event) -> MagicMock:
         response = MagicMock(spec=nio.RoomGetEventResponse)
         response.event = event
@@ -493,6 +516,42 @@ class TestThreadHistory:
         assert isinstance(snapshot, ThreadHistoryResult)
         assert snapshot.is_full_history is False
         assert [message.event_id for message in snapshot] == ["$thread_root", "$reply_a", "$reply_b"]
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_snapshot_relations_fast_path_accepts_audio_root(self) -> None:
+        """Snapshot fast path should keep non-text room-message roots without room-scan fallback."""
+        root_event = self._make_audio_event(
+            event_id="$thread_root",
+            sender="@user:localhost",
+            body="voice-note.ogg",
+            server_timestamp=1000,
+            source_content={"url": "mxc://localhost/voice-note"},
+        )
+        reply_event = self._make_text_event(
+            event_id="$reply",
+            sender="@agent:localhost",
+            body="transcribed reply",
+            server_timestamp=2000,
+            source_content={
+                "body": "transcribed reply",
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+        )
+        client = self._make_relations_client(
+            root_event=root_event,
+            relations={
+                self._relation_key("$thread_root", RelationshipType.thread): [reply_event],
+            },
+        )
+
+        snapshot = await fetch_thread_snapshot(client, "!room:localhost", "$thread_root")
+
+        assert isinstance(snapshot, ThreadHistoryResult)
+        assert snapshot.is_full_history is False
+        assert [message.event_id for message in snapshot] == ["$thread_root", "$reply"]
+        assert snapshot[0].body == "voice-note.ogg"
+        assert snapshot[0].to_dict()["msgtype"] == "m.audio"
+        client.room_messages.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_latest_thread_event_id_uses_relations_fast_path(self) -> None:
@@ -1528,6 +1587,44 @@ class TestThreadHistory:
 
         assert client.room_messages.call_count == 1
         assert [msg.event_id for msg in history] == ["$thread_root", "$agent_msg"]
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_history_stops_when_non_text_root_is_found(self) -> None:
+        """Stop pagination once a non-text thread root has been seen."""
+        client = AsyncMock()
+
+        root_event = self._make_audio_event(
+            event_id="$thread_root",
+            sender="@user:localhost",
+            body="voice-note.ogg",
+            server_timestamp=1000,
+            source_content={"url": "mxc://localhost/voice-note"},
+        )
+        thread_message = self._make_text_event(
+            event_id="$agent_msg",
+            sender="@agent:localhost",
+            body="reply",
+            server_timestamp=2000,
+            source_content={
+                "body": "reply",
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": "$thread_root",
+                },
+            },
+        )
+
+        first_page = MagicMock(spec=nio.RoomMessagesResponse)
+        first_page.chunk = [thread_message, root_event]
+        first_page.end = "older_page"
+
+        client.room_messages.return_value = first_page
+
+        history = await fetch_thread_history(client, "!room:localhost", "$thread_root")
+
+        assert client.room_messages.call_count == 1
+        assert [msg.event_id for msg in history] == ["$thread_root", "$agent_msg"]
+        assert history[0].to_dict()["msgtype"] == "m.audio"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR makes thread snapshot and history resolution tolerate readable room-message roots that are not narrow text/notice event classes.

That prevents snapshot-building from failing just because the thread root is a different room-message shape, while still resolving the visible body and normalized content through the same thread-history pipeline.

Summary:
- treat any readable `m.room.message` event as a valid thread root for snapshot/history resolution
- resolve non-text room-message roots into the normal `ResolvedVisibleMessage` shape
- keep edit handling and relation/history traversal aligned with the broader room-message check
- add thread-history coverage for non-text thread roots