### PR TITLE
Canonicalize cached event lookups after edits

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -169,7 +169,7 @@ from .matrix.client import (
     get_joined_rooms,
     join_room,
 )
-from .matrix.event_cache import EventCache
+from .matrix.event_cache import ConversationEventCache, EventCache
 from .media_inputs import MediaInputs
 from .response_coordinator import (
     ResponseCoordinator,
@@ -591,12 +591,12 @@ class AgentBot:
         self._runtime_view.orchestrator = value
 
     @property
-    def event_cache(self) -> EventCache | None:
+    def event_cache(self) -> ConversationEventCache | None:
         """Return the advisory event cache."""
         return self._conversation_access.event_cache
 
     @event_cache.setter
-    def event_cache(self, value: EventCache | None) -> None:
+    def event_cache(self, value: ConversationEventCache | None) -> None:
         """Update the advisory event cache."""
         self._conversation_access.event_cache = value
 

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -21,7 +21,7 @@ from mindroom.config.main import Config
 from mindroom.config.matrix import RoomDirectoryVisibility, RoomJoinRule
 from mindroom.constants import STREAM_STATUS_KEY, RuntimePaths, encryption_keys_dir, runtime_matrix_ssl_verify
 from mindroom.logging_config import get_logger
-from mindroom.matrix.event_cache import EventCache, normalize_event_source_for_cache
+from mindroom.matrix.event_cache import ConversationEventCache, normalize_event_source_for_cache
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.large_messages import prepare_large_message
 from mindroom.matrix.mentions import format_message_with_mentions
@@ -1295,7 +1295,7 @@ async def _load_cached_thread_history(
     *,
     room_id: str,
     thread_id: str,
-    event_cache: EventCache,
+    event_cache: ConversationEventCache,
     hydrate_sidecars: bool = True,
     refresh_cache: bool = True,
 ) -> list[ResolvedVisibleMessage] | None:
@@ -1353,7 +1353,7 @@ async def _load_cached_thread_result(
     *,
     room_id: str,
     thread_id: str,
-    event_cache: EventCache,
+    event_cache: ConversationEventCache,
     hydrate_sidecars: bool,
     refresh_cache: bool,
 ) -> ThreadHistoryResult | None:
@@ -1379,7 +1379,7 @@ async def _refresh_cached_thread_event_sources(
     room_id: str,
     thread_id: str,
     cached_event_ids: Collection[str],
-    event_cache: EventCache,
+    event_cache: ConversationEventCache,
     cached_event_sources: Sequence[dict[str, Any]],
 ) -> Sequence[dict[str, Any]]:
     """Apply incremental refreshes to one cached thread payload when possible."""
@@ -1422,7 +1422,7 @@ async def _resolve_cached_thread_history(
     *,
     room_id: str,
     thread_id: str,
-    event_cache: EventCache,
+    event_cache: ConversationEventCache,
     cached_event_sources: Sequence[dict[str, Any]],
     hydrate_sidecars: bool = True,
 ) -> list[ResolvedVisibleMessage] | None:
@@ -1446,7 +1446,7 @@ async def _resolve_cached_thread_history(
 
 
 async def _invalidate_thread_cache_entry(
-    event_cache: EventCache,
+    event_cache: ConversationEventCache,
     *,
     room_id: str,
     thread_id: str,
@@ -1528,7 +1528,7 @@ async def _fetch_thread_event_sources_via_relations(
 
 
 async def _store_thread_history_cache(
-    event_cache: EventCache,
+    event_cache: ConversationEventCache,
     *,
     room_id: str,
     thread_id: str,
@@ -1830,7 +1830,7 @@ async def fetch_thread_history(
     client: nio.AsyncClient,
     room_id: str,
     thread_id: str,
-    event_cache: EventCache | None = None,
+    event_cache: ConversationEventCache | None = None,
 ) -> list[ResolvedVisibleMessage]:
     """Fetch all messages in a thread."""
     if event_cache is None:
@@ -2082,7 +2082,7 @@ async def fetch_thread_snapshot(
     client: nio.AsyncClient,
     room_id: str,
     thread_id: str,
-    event_cache: EventCache | None = None,
+    event_cache: ConversationEventCache | None = None,
 ) -> ThreadHistoryResult:
     """Fetch lightweight thread context for dispatch decisions."""
     if event_cache is not None:

--- a/src/mindroom/matrix/conversation_access.py
+++ b/src/mindroom/matrix/conversation_access.py
@@ -11,7 +11,7 @@ import nio
 from nio.responses import RoomGetEventError
 
 from mindroom.matrix.client import ResolvedVisibleMessage, fetch_thread_history, fetch_thread_snapshot
-from mindroom.matrix.event_cache import EventCache, normalize_event_source_for_cache
+from mindroom.matrix.event_cache import ConversationEventCache, normalize_event_source_for_cache
 from mindroom.matrix.room_cache import cached_room_get_event
 from mindroom.matrix.thread_history_result import ThreadHistoryResult, thread_history_result
 
@@ -93,7 +93,7 @@ class MatrixConversationAccess(ConversationReadAccess):
 
     logger: structlog.stdlib.BoundLogger
     client: nio.AsyncClient | None = None
-    event_cache: EventCache | None = None
+    event_cache: ConversationEventCache | None = None
     _turn_event_cache: ContextVar[dict[tuple[str, str], EventLookupResult] | None] = field(
         default_factory=lambda: ContextVar("mindroom_turn_event_lookup_cache", default=None),
     )

--- a/src/mindroom/matrix/event_cache.py
+++ b/src/mindroom/matrix/event_cache.py
@@ -1,33 +1,179 @@
-"""SQLite cache for Matrix thread events and individual event lookups."""
+"""Cache boundary and SQLite-backed implementation for Matrix event lookups."""
 
 from __future__ import annotations
 
 import asyncio
 import json
 import time
-from typing import TYPE_CHECKING, Any
+from collections import OrderedDict
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
 
 import aiosqlite
 
+from mindroom.logging_config import get_logger
+from mindroom.matrix.event_info import EventInfo
+
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import AsyncIterator, Mapping
     from pathlib import Path
 
 
 _RUNTIME_ONLY_EVENT_SOURCE_KEYS = frozenset({"com.mindroom.dispatch_pipeline_timing"})
+_LOCK_WAIT_LOG_THRESHOLD_SECONDS = 0.1
+_MAX_CACHED_ROOM_LOCKS = 256
+_EVENT_CACHE_SCHEMA_VERSION = 1
+logger = get_logger(__name__)
+
+
+@dataclass
+class _RoomLockEntry:
+    """Track one room lock plus queued users that still rely on it."""
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    active_users: int = 0
+
+
+class ConversationEventCache(Protocol):
+    """Storage-agnostic cache API for Matrix event and thread lookups."""
+
+    async def initialize(self) -> None:
+        """Initialize any backing storage."""
+
+    async def close(self) -> None:
+        """Close any backing storage."""
+
+    async def get_thread_events(self, room_id: str, thread_id: str) -> list[dict[str, Any]] | None:
+        """Return cached events for one thread sorted by timestamp."""
+
+    async def get_latest_ts(self, room_id: str, thread_id: str) -> int | None:
+        """Return the latest cached timestamp for one thread."""
+
+    async def get_event(self, room_id: str, event_id: str) -> dict[str, Any] | None:
+        """Return one cached event payload by event ID."""
+
+    async def get_latest_edit(self, room_id: str, original_event_id: str) -> dict[str, Any] | None:
+        """Return the latest cached edit event for one original event."""
+
+    async def store_event(self, event_id: str, room_id: str, event_data: dict[str, Any]) -> None:
+        """Insert or replace one individually cached Matrix event."""
+
+    async def store_events_batch(self, events: list[tuple[str, str, dict[str, Any]]]) -> None:
+        """Insert or replace a batch of individually cached Matrix events."""
+
+    async def store_events(self, room_id: str, thread_id: str, events: list[dict[str, Any]]) -> None:
+        """Insert or replace one batch of thread events."""
+
+    async def invalidate_thread(self, room_id: str, thread_id: str) -> None:
+        """Delete cached events for one thread."""
+
+    async def get_latest_timestamp(self, room_id: str, thread_id: str) -> int | None:
+        """Compatibility wrapper for older cache call sites."""
+
+    async def store_thread_events(self, room_id: str, thread_id: str, events: list[dict[str, Any]]) -> None:
+        """Compatibility wrapper for older cache call sites."""
+
+    async def append_event(self, room_id: str, thread_id: str, event: dict[str, Any]) -> bool:
+        """Append one event when the thread already has cached data."""
+
+    async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
+        """Return the cached thread ID for one event."""
+
+    async def redact_event(
+        self,
+        room_id: str,
+        event_id: str,
+        *,
+        thread_id: str | None = None,
+        redaction_event: dict[str, Any] | None = None,
+    ) -> bool:
+        """Delete one cached event after a redaction."""
 
 
 class EventCache:
-    """Persist raw Matrix events for thread-history and reply-chain reconstruction."""
+    """SQLite-backed ConversationEventCache implementation."""
 
     def __init__(self, db_path: Path) -> None:
         self._db_path = db_path
         self._db: aiosqlite.Connection | None = None
-        self._lock = asyncio.Lock()
+        # One shared SQLite connection must serialize lifecycle changes with all
+        # in-flight DB operations so shutdown cannot close it mid-query.
+        self._db_lock = asyncio.Lock()
+        # These locks preserve logical room ordering for the advisory cache and
+        # keep contention visible in logs even though DB operations are gated by
+        # the shared connection lock above.
+        self._room_locks: OrderedDict[str, _RoomLockEntry] = OrderedDict()
+
+    @property
+    def db_path(self) -> Path:
+        """Return the SQLite database path for this cache instance."""
+        return self._db_path
+
+    def _prune_room_locks(self) -> None:
+        while len(self._room_locks) > _MAX_CACHED_ROOM_LOCKS:
+            evicted_room_id: str | None = None
+            for cached_room_id, cached_entry in self._room_locks.items():
+                if cached_entry.active_users > 0:
+                    continue
+                evicted_room_id = cached_room_id
+                break
+            if evicted_room_id is None:
+                return
+            self._room_locks.pop(evicted_room_id, None)
+
+    def _room_lock_entry(self, room_id: str, *, active_user_increment: int = 0) -> _RoomLockEntry:
+        entry = self._room_locks.get(room_id)
+        if entry is None:
+            entry = _RoomLockEntry(active_users=active_user_increment)
+        else:
+            entry.active_users += active_user_increment
+        self._room_locks[room_id] = entry
+        self._room_locks.move_to_end(room_id)
+        self._prune_room_locks()
+        return entry
+
+    def _room_lock(self, room_id: str) -> asyncio.Lock:
+        return self._room_lock_entry(room_id).lock
+
+    @asynccontextmanager
+    async def _acquire_room_lock(self, room_id: str, *, operation: str) -> AsyncIterator[None]:
+        entry = self._room_lock_entry(room_id, active_user_increment=1)
+        wait_started = time.perf_counter()
+        acquired = False
+        try:
+            await entry.lock.acquire()
+            acquired = True
+            wait_time = time.perf_counter() - wait_started
+            if wait_time > _LOCK_WAIT_LOG_THRESHOLD_SECONDS:
+                logger.debug(
+                    "Waited for EventCache room lock",
+                    room_id=room_id,
+                    operation=operation,
+                    wait_time_ms=round(wait_time * 1000, 2),
+                )
+            yield
+        finally:
+            if acquired:
+                entry.lock.release()
+            entry.active_users -= 1
+            if entry.active_users == 0:
+                self._prune_room_locks()
+
+    @asynccontextmanager
+    async def _acquire_db_operation(
+        self,
+        room_id: str,
+        *,
+        operation: str,
+    ) -> AsyncIterator[aiosqlite.Connection]:
+        """Serialize one DB operation with lifecycle changes and room ordering."""
+        async with self._db_lock, self._acquire_room_lock(room_id, operation=operation):
+            yield self._require_db()
 
     async def initialize(self) -> None:
         """Open the SQLite database and create the cache schema."""
-        async with self._lock:
+        async with self._db_lock:
             if self._db is not None:
                 return
 
@@ -63,20 +209,40 @@ class EventCache:
                 )
                 """,
             )
+            await self._db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS event_edits (
+                    edit_event_id TEXT PRIMARY KEY,
+                    room_id TEXT NOT NULL,
+                    original_event_id TEXT NOT NULL,
+                    origin_server_ts INTEGER NOT NULL
+                )
+                """,
+            )
+            await self._db.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_event_edits_room_original_ts
+                ON event_edits(room_id, original_event_id, origin_server_ts DESC, edit_event_id DESC)
+                """,
+            )
+            schema_version = await self._schema_version()
+            if schema_version < _EVENT_CACHE_SCHEMA_VERSION:
+                await self._backfill_event_edits()
+                await self._db.execute(f"PRAGMA user_version = {_EVENT_CACHE_SCHEMA_VERSION}")
             await self._db.commit()
 
     async def close(self) -> None:
         """Close the SQLite connection when the cache is no longer needed."""
-        async with self._lock:
+        async with self._db_lock:
             if self._db is None:
                 return
             await self._db.close()
             self._db = None
+            self._room_locks.clear()
 
     async def get_thread_events(self, room_id: str, thread_id: str) -> list[dict[str, Any]] | None:
         """Return cached events for one thread sorted by timestamp."""
-        async with self._lock:
-            db = self._require_db()
+        async with self._acquire_db_operation(room_id, operation="get_thread_events") as db:
             cursor = await db.execute(
                 """
                 SELECT event_json
@@ -94,8 +260,7 @@ class EventCache:
 
     async def get_latest_ts(self, room_id: str, thread_id: str) -> int | None:
         """Return the latest cached server timestamp for one thread."""
-        async with self._lock:
-            db = self._require_db()
+        async with self._acquire_db_operation(room_id, operation="get_latest_ts") as db:
             cursor = await db.execute(
                 """
                 SELECT MAX(origin_server_ts)
@@ -108,10 +273,9 @@ class EventCache:
             await cursor.close()
             return None if row is None or row[0] is None else int(row[0])
 
-    async def get_event(self, event_id: str) -> dict[str, Any] | None:
+    async def get_event(self, room_id: str, event_id: str) -> dict[str, Any] | None:
         """Return one cached event payload by event ID."""
-        async with self._lock:
-            db = self._require_db()
+        async with self._acquire_db_operation(room_id, operation="get_event") as db:
             cursor = await db.execute(
                 """
                 SELECT event_json
@@ -119,6 +283,24 @@ class EventCache:
                 WHERE event_id = ?
                 """,
                 (event_id,),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
+            return None if row is None else json.loads(row[0])
+
+    async def get_latest_edit(self, room_id: str, original_event_id: str) -> dict[str, Any] | None:
+        """Return the latest cached edit event for one original event."""
+        async with self._acquire_db_operation(room_id, operation="get_latest_edit") as db:
+            cursor = await db.execute(
+                """
+                SELECT events.event_json
+                FROM event_edits
+                JOIN events ON events.event_id = event_edits.edit_event_id
+                WHERE event_edits.room_id = ? AND event_edits.original_event_id = ?
+                ORDER BY event_edits.origin_server_ts DESC, event_edits.edit_event_id DESC
+                LIMIT 1
+                """,
+                (room_id, original_event_id),
             )
             row = await cursor.fetchone()
             await cursor.close()
@@ -134,27 +316,45 @@ class EventCache:
             return
 
         cached_at = time.time()
-        async with self._lock:
-            db = self._require_db()
-            await db.executemany(
-                """
-                INSERT OR REPLACE INTO events(event_id, room_id, event_json, cached_at)
-                VALUES (?, ?, ?, ?)
-                """,
-                [
-                    (
-                        event_id,
-                        room_id,
-                        json.dumps(
-                            normalize_event_source_for_cache(event_data, event_id=event_id),
-                            separators=(",", ":"),
-                        ),
-                        cached_at,
+        events_by_room: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+        for event_id, room_id, event_data in events:
+            normalized_event = normalize_event_source_for_cache(event_data, event_id=event_id)
+            events_by_room.setdefault(room_id, []).append((event_id, normalized_event))
+
+        for room_id, room_events in events_by_room.items():
+            async with self._acquire_db_operation(room_id, operation="store_events_batch") as db:
+                await db.executemany(
+                    """
+                    INSERT OR REPLACE INTO events(event_id, room_id, event_json, cached_at)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    [
+                        (
+                            event_id,
+                            room_id,
+                            json.dumps(
+                                normalize_event_source_for_cache(event_data, event_id=event_id),
+                                separators=(",", ":"),
+                            ),
+                            cached_at,
+                        )
+                        for event_id, event_data in room_events
+                    ],
+                )
+                edit_rows = [
+                    row
+                    for row in (_edit_cache_row(room_id, event_data) for _event_id, event_data in room_events)
+                    if row is not None
+                ]
+                if edit_rows:
+                    await db.executemany(
+                        """
+                        INSERT OR REPLACE INTO event_edits(edit_event_id, room_id, original_event_id, origin_server_ts)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        edit_rows,
                     )
-                    for event_id, room_id, event_data in events
-                ],
-            )
-            await db.commit()
+                await db.commit()
 
     async def store_events(self, room_id: str, thread_id: str, events: list[dict[str, Any]]) -> None:
         """Insert or replace one batch of thread events."""
@@ -163,8 +363,7 @@ class EventCache:
 
         cached_at = time.time()
         normalized_events = [normalize_event_source_for_cache(event) for event in events]
-        async with self._lock:
-            db = self._require_db()
+        async with self._acquire_db_operation(room_id, operation="store_events") as db:
             serialized_events = [
                 (
                     _event_id(event),
@@ -204,12 +403,22 @@ class EventCache:
                     for event_id, _origin_server_ts, event_json in serialized_events
                 ],
             )
+            edit_rows = [
+                row for row in (_edit_cache_row(room_id, event) for event in normalized_events) if row is not None
+            ]
+            if edit_rows:
+                await db.executemany(
+                    """
+                    INSERT OR REPLACE INTO event_edits(edit_event_id, room_id, original_event_id, origin_server_ts)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    edit_rows,
+                )
             await db.commit()
 
     async def invalidate_thread(self, room_id: str, thread_id: str) -> None:
         """Delete cached events for one thread."""
-        async with self._lock:
-            db = self._require_db()
+        async with self._acquire_db_operation(room_id, operation="invalidate_thread") as db:
             cursor = await db.execute(
                 """
                 SELECT event_id
@@ -235,6 +444,13 @@ class EventCache:
                     """,
                     [(event_id,) for event_id in event_ids],
                 )
+                await db.executemany(
+                    """
+                    DELETE FROM event_edits
+                    WHERE room_id = ? AND edit_event_id = ?
+                    """,
+                    [(room_id, event_id) for event_id in event_ids],
+                )
             await db.commit()
 
     async def get_latest_timestamp(self, room_id: str, thread_id: str) -> int | None:
@@ -247,15 +463,64 @@ class EventCache:
 
     async def append_event(self, room_id: str, thread_id: str, event: dict[str, Any]) -> bool:
         """Append one event when the thread already has cached data."""
-        if await self.get_latest_ts(room_id, thread_id) is None:
-            return False
-        await self.store_events(room_id, thread_id, [event])
-        return True
+        normalized_event = normalize_event_source_for_cache(event)
+        async with self._acquire_db_operation(room_id, operation="append_event") as db:
+            cursor = await db.execute(
+                """
+                SELECT 1
+                FROM thread_events
+                WHERE room_id = ? AND thread_id = ?
+                LIMIT 1
+                """,
+                (room_id, thread_id),
+            )
+            row = await cursor.fetchone()
+            await cursor.close()
+            if row is None:
+                return False
+
+            event_id = _event_id(normalized_event)
+            event_json = json.dumps(normalized_event, separators=(",", ":"))
+            await db.execute(
+                """
+                INSERT OR REPLACE INTO thread_events(room_id, thread_id, event_id, origin_server_ts, event_json)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    room_id,
+                    thread_id,
+                    event_id,
+                    _event_timestamp(normalized_event),
+                    event_json,
+                ),
+            )
+            await db.execute(
+                """
+                INSERT OR REPLACE INTO events(event_id, room_id, event_json, cached_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    event_id,
+                    room_id,
+                    event_json,
+                    time.time(),
+                ),
+            )
+            edit_row = _edit_cache_row(room_id, normalized_event)
+            if edit_row is not None:
+                await db.execute(
+                    """
+                    INSERT OR REPLACE INTO event_edits(edit_event_id, room_id, original_event_id, origin_server_ts)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    edit_row,
+                )
+            await db.commit()
+            return True
 
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
         """Return the cached thread ID for one event."""
-        async with self._lock:
-            db = self._require_db()
+        async with self._acquire_db_operation(room_id, operation="get_thread_id_for_event") as db:
             cursor = await db.execute(
                 """
                 SELECT thread_id
@@ -277,45 +542,62 @@ class EventCache:
         redaction_event: dict[str, Any] | None = None,
     ) -> bool:
         """Delete one cached event after a redaction."""
-        del redaction_event
+        del redaction_event, thread_id
 
-        async with self._lock:
-            db = self._require_db()
-            if thread_id is None:
-                cursor = await db.execute(
-                    """
-                    DELETE FROM thread_events
-                    WHERE room_id = ? AND event_id = ?
-                    """,
-                    (room_id, event_id),
-                )
-            else:
-                cursor = await db.execute(
-                    """
-                    DELETE FROM thread_events
-                    WHERE room_id = ? AND thread_id = ? AND event_id = ?
-                    """,
-                    (room_id, thread_id, event_id),
-                )
-            deleted_thread_rows = 0 if cursor.rowcount is None else int(cursor.rowcount)
-            await cursor.close()
-            cursor = await db.execute(
-                """
-                DELETE FROM events
-                WHERE event_id = ?
-                """,
-                (event_id,),
+        async with self._acquire_db_operation(room_id, operation="redact_event") as db:
+            dependent_edit_ids = await _dependent_edit_event_ids(db, room_id, original_event_id=event_id)
+            removed_event_ids = list(dict.fromkeys([event_id, *dependent_edit_ids]))
+            deleted_thread_rows = await _delete_room_thread_events(db, room_id, event_ids=removed_event_ids)
+            deleted_event_rows = await _delete_cached_events(db, event_ids=removed_event_ids)
+            deleted_edit_rows = await _delete_event_edit_rows(
+                db,
+                room_id,
+                event_ids=removed_event_ids,
+                original_event_id=event_id,
             )
-            deleted_event_rows = 0 if cursor.rowcount is None else int(cursor.rowcount)
-            await cursor.close()
             await db.commit()
-        return deleted_thread_rows > 0 or deleted_event_rows > 0
+        return deleted_thread_rows > 0 or deleted_event_rows > 0 or deleted_edit_rows > 0
 
     def _require_db(self) -> aiosqlite.Connection:
         if self._db is None:
             msg = "EventCache has not been initialized"
             raise RuntimeError(msg)
         return self._db
+
+    async def _schema_version(self) -> int:
+        """Return the current SQLite schema version for this cache."""
+        db = self._require_db()
+        cursor = await db.execute("PRAGMA user_version")
+        row = await cursor.fetchone()
+        await cursor.close()
+        return 0 if row is None else int(row[0])
+
+    async def _backfill_event_edits(self) -> None:
+        """Populate the derived edit index from existing cached event payloads."""
+        db = self._require_db()
+        cursor = await db.execute(
+            """
+            SELECT room_id, event_json
+            FROM events
+            """,
+        )
+        rows = await cursor.fetchall()
+        await cursor.close()
+        edit_rows = [
+            row
+            for room_id, event_json in rows
+            for row in [_edit_cache_row(str(room_id), json.loads(str(event_json)))]
+            if row is not None
+        ]
+        if not edit_rows:
+            return
+        await db.executemany(
+            """
+            INSERT OR REPLACE INTO event_edits(edit_event_id, room_id, original_event_id, origin_server_ts)
+            VALUES (?, ?, ?, ?)
+            """,
+            edit_rows,
+        )
 
 
 def _event_id(event: dict[str, Any]) -> str:
@@ -332,6 +614,106 @@ def _event_timestamp(event: dict[str, Any]) -> int:
         return timestamp
     msg = f"Cached Matrix event {_event_id(event)} is missing origin_server_ts"
     raise ValueError(msg)
+
+
+def _edit_cache_row(room_id: str, event: dict[str, Any]) -> tuple[str, str, str, int] | None:
+    """Return one edit-index row for a cached event when it is an edit."""
+    if event.get("type") != "m.room.message":
+        return None
+
+    event_info = EventInfo.from_event(event)
+    if not event_info.is_edit or not isinstance(event_info.original_event_id, str):
+        return None
+
+    return (_event_id(event), room_id, event_info.original_event_id, _event_timestamp(event))
+
+
+async def _dependent_edit_event_ids(
+    db: aiosqlite.Connection,
+    room_id: str,
+    *,
+    original_event_id: str,
+) -> list[str]:
+    """Return cached edit event IDs that target one original event."""
+    cursor = await db.execute(
+        """
+        SELECT edit_event_id
+        FROM event_edits
+        WHERE room_id = ? AND original_event_id = ?
+        """,
+        (room_id, original_event_id),
+    )
+    rows = await cursor.fetchall()
+    await cursor.close()
+    return [str(row[0]) for row in rows]
+
+
+async def _delete_room_thread_events(
+    db: aiosqlite.Connection,
+    room_id: str,
+    *,
+    event_ids: list[str],
+) -> int:
+    """Delete cached thread rows for the provided event IDs within one room."""
+    if not event_ids:
+        return 0
+    cursor = await db.executemany(
+        """
+        DELETE FROM thread_events
+        WHERE room_id = ? AND event_id = ?
+        """,
+        [(room_id, event_id) for event_id in event_ids],
+    )
+    return 0 if cursor.rowcount is None else int(cursor.rowcount)
+
+
+async def _delete_cached_events(
+    db: aiosqlite.Connection,
+    *,
+    event_ids: list[str],
+) -> int:
+    """Delete point-lookup cache rows for the provided event IDs."""
+    if not event_ids:
+        return 0
+    cursor = await db.executemany(
+        """
+        DELETE FROM events
+        WHERE event_id = ?
+        """,
+        [(event_id,) for event_id in event_ids],
+    )
+    return 0 if cursor.rowcount is None else int(cursor.rowcount)
+
+
+async def _delete_event_edit_rows(
+    db: aiosqlite.Connection,
+    room_id: str,
+    *,
+    event_ids: list[str],
+    original_event_id: str,
+) -> int:
+    """Delete derived edit-index rows affected by one event redaction."""
+    deleted_rows = 0
+    for event_id in event_ids:
+        cursor = await db.execute(
+            """
+            DELETE FROM event_edits
+            WHERE room_id = ? AND edit_event_id = ?
+            """,
+            (room_id, event_id),
+        )
+        deleted_rows += 0 if cursor.rowcount is None else int(cursor.rowcount)
+        await cursor.close()
+    cursor = await db.execute(
+        """
+        DELETE FROM event_edits
+        WHERE room_id = ? AND original_event_id = ?
+        """,
+        (room_id, original_event_id),
+    )
+    deleted_rows += 0 if cursor.rowcount is None else int(cursor.rowcount)
+    await cursor.close()
+    return deleted_rows
 
 
 def normalize_event_source_for_cache(

--- a/src/mindroom/matrix/room_cache.py
+++ b/src/mindroom/matrix/room_cache.py
@@ -2,18 +2,80 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import nio
 
 from mindroom.logging_config import get_logger
-from mindroom.matrix.event_cache import EventCache, normalize_event_source_for_cache
+from mindroom.matrix.event_cache import ConversationEventCache, normalize_event_source_for_cache
+from mindroom.matrix.event_info import EventInfo
+from mindroom.matrix.message_content import extract_edit_body
 
 if TYPE_CHECKING:
     from nio.responses import RoomGetEventError
 
 
 logger = get_logger(__name__)
+
+
+async def _apply_cached_latest_edit(
+    event_source: dict[str, Any],
+    *,
+    room_id: str,
+    client: nio.AsyncClient,
+    event_cache: ConversationEventCache | None,
+) -> dict[str, Any]:
+    """Project one cached original event into its latest visible edited state."""
+    if event_cache is None or event_source.get("type") != "m.room.message":
+        return event_source
+
+    event_info = EventInfo.from_event(event_source)
+    event_id = event_source.get("event_id")
+    if event_info.is_edit or not isinstance(event_id, str) or not event_id:
+        return event_source
+
+    latest_edit_source = await event_cache.get_latest_edit(room_id, event_id)
+    if latest_edit_source is None:
+        return event_source
+
+    edited_body, edited_content = await extract_edit_body(latest_edit_source, client)
+    if edited_body is None or edited_content is None:
+        return event_source
+
+    original_content = event_source.get("content", {})
+    merged_content = (
+        {key: value for key, value in original_content.items() if isinstance(key, str)}
+        if isinstance(original_content, dict)
+        else {}
+    )
+    merged_content.update(edited_content)
+    merged_content.setdefault("body", edited_body)
+
+    updated_event_source = {key: value for key, value in event_source.items() if isinstance(key, str)}
+    updated_event_source["content"] = merged_content
+
+    latest_edit_timestamp = latest_edit_source.get("origin_server_ts")
+    if isinstance(latest_edit_timestamp, int) and not isinstance(latest_edit_timestamp, bool):
+        updated_event_source["origin_server_ts"] = latest_edit_timestamp
+    return updated_event_source
+
+
+async def _cached_room_get_event_response(
+    client: nio.AsyncClient,
+    event_cache: ConversationEventCache | None,
+    *,
+    room_id: str,
+    event_source: dict[str, Any],
+) -> nio.RoomGetEventResponse | None:
+    """Reconstruct one cached room-get-event response, applying visible edits when present."""
+    visible_event_source = await _apply_cached_latest_edit(
+        event_source,
+        room_id=room_id,
+        client=client,
+        event_cache=event_cache,
+    )
+    cached_response = nio.RoomGetEventResponse.from_dict(visible_event_source)
+    return cached_response if isinstance(cached_response, nio.RoomGetEventResponse) else None
 
 
 def cached_rooms(client: nio.AsyncClient) -> dict[str, nio.MatrixRoom]:
@@ -34,7 +96,7 @@ def cached_room(client: nio.AsyncClient, room_id: str) -> nio.MatrixRoom | None:
 
 async def cached_room_get_event(
     client: nio.AsyncClient,
-    event_cache: EventCache | None,
+    event_cache: ConversationEventCache | None,
     room_id: str,
     event_id: str,
 ) -> nio.RoomGetEventResponse | RoomGetEventError:
@@ -42,7 +104,7 @@ async def cached_room_get_event(
     normalized_event_id = event_id.strip()
     if event_cache is not None and normalized_event_id:
         try:
-            cached_event = await event_cache.get_event(normalized_event_id)
+            cached_event = await event_cache.get_event(room_id, normalized_event_id)
         except Exception as exc:
             logger.warning(
                 "Failed to read cached Matrix event",
@@ -52,8 +114,13 @@ async def cached_room_get_event(
             )
         else:
             if cached_event is not None:
-                cached_response = nio.RoomGetEventResponse.from_dict(cached_event)
-                if isinstance(cached_response, nio.RoomGetEventResponse):
+                cached_response = await _cached_room_get_event_response(
+                    client,
+                    event_cache,
+                    room_id=room_id,
+                    event_source=cached_event,
+                )
+                if cached_response is not None:
                     return cached_response
                 logger.warning(
                     "Cached Matrix event could not be reconstructed",
@@ -88,4 +155,19 @@ async def cached_room_get_event(
                 event_id=normalized_event_id,
                 error=str(exc),
             )
+        reconstructed_response = await _cached_room_get_event_response(
+            client,
+            event_cache,
+            room_id=room_id,
+            event_source=normalize_event_source_for_cache(
+                event_source,
+                event_id=event.event_id if isinstance(event.event_id, str) else normalized_event_id,
+                sender=event.sender if isinstance(event.sender, str) else None,
+                origin_server_ts=server_timestamp
+                if isinstance(server_timestamp, int) and not isinstance(server_timestamp, bool)
+                else None,
+            ),
+        )
+        if reconstructed_response is not None:
+            return reconstructed_response
     return response

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+import sqlite3
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
@@ -9,8 +12,10 @@ import nio
 import pytest
 from nio.api import RelationshipType
 
+from mindroom.matrix import event_cache as event_cache_module
 from mindroom.matrix.client import fetch_thread_history
 from mindroom.matrix.event_cache import EventCache
+from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.room_cache import cached_room_get_event
 from mindroom.timing import DispatchPipelineTiming
 
@@ -171,8 +176,8 @@ async def test_individual_event_cache_store_and_retrieve(tmp_path: Path) -> None
             ],
         )
 
-        cached_event = await cache.get_event("$reply")
-        missing_event = await cache.get_event("$missing")
+        cached_event = await cache.get_event("!room:localhost", "$reply")
+        missing_event = await cache.get_event("!room:localhost", "$missing")
     finally:
         await cache.close()
 
@@ -180,6 +185,188 @@ async def test_individual_event_cache_store_and_retrieve(tmp_path: Path) -> None
     assert cached_event["event_id"] == "$reply"
     assert cached_event["content"]["body"] == "Reply in thread"
     assert missing_event is None
+
+
+def test_event_cache_room_lock_cache_evicts_idle_rooms(tmp_path: Path) -> None:
+    """Idle per-room locks should be evicted instead of growing without bound."""
+    cache = EventCache(tmp_path / "event_cache.db")
+
+    for index in range(event_cache_module._MAX_CACHED_ROOM_LOCKS + 8):
+        cache._room_lock(f"!room-{index}:localhost")
+
+    assert len(cache._room_locks) == event_cache_module._MAX_CACHED_ROOM_LOCKS
+    assert "!room-0:localhost" not in cache._room_locks
+
+
+@pytest.mark.asyncio
+async def test_event_cache_room_lock_cache_keeps_contended_room_waiters(tmp_path: Path) -> None:
+    """Queued waiters must keep a room lock alive across pruning churn."""
+    cache = EventCache(tmp_path / "event_cache.db")
+    room_id = "!busy:localhost"
+    holder_entered = asyncio.Event()
+    release_holder = asyncio.Event()
+    pruned_after_release = asyncio.Event()
+    allow_waiter_exit = asyncio.Event()
+    waiter_acquired = asyncio.Event()
+    post_release_snapshot: dict[str, object] = {}
+
+    async def first_holder() -> None:
+        async with cache._acquire_room_lock(room_id, operation="first_holder"):
+            holder_entered.set()
+            await release_holder.wait()
+        for index in range(event_cache_module._MAX_CACHED_ROOM_LOCKS + 8):
+            cache._room_lock(f"!churn-{index}:localhost")
+        entry = cache._room_locks.get(room_id)
+        post_release_snapshot["room_present"] = entry is not None
+        post_release_snapshot["active_users"] = entry.active_users if entry is not None else None
+        post_release_snapshot["lock_locked"] = entry.lock.locked() if entry is not None else None
+        pruned_after_release.set()
+
+    async def queued_waiter() -> None:
+        async with cache._acquire_room_lock(room_id, operation="queued_waiter"):
+            waiter_acquired.set()
+            await allow_waiter_exit.wait()
+
+    async def wait_for_waiter_registration() -> None:
+        loop = asyncio.get_running_loop()
+        waiter_registered = loop.create_future()
+
+        def check_waiter_registration() -> None:
+            if cache._room_locks[room_id].active_users >= 2:
+                waiter_registered.set_result(None)
+                return
+            loop.call_soon(check_waiter_registration)
+
+        loop.call_soon(check_waiter_registration)
+        await asyncio.wait_for(waiter_registered, timeout=1.0)
+
+    holder_task = asyncio.create_task(first_holder())
+    waiter_task = asyncio.create_task(queued_waiter())
+
+    await asyncio.wait_for(holder_entered.wait(), timeout=1.0)
+    await wait_for_waiter_registration()
+
+    busy_lock = cache._room_lock(room_id)
+    release_holder.set()
+    await asyncio.wait_for(pruned_after_release.wait(), timeout=1.0)
+
+    assert post_release_snapshot == {
+        "room_present": True,
+        "active_users": 1,
+        "lock_locked": False,
+    }
+    assert cache._room_lock(room_id) is busy_lock
+
+    await asyncio.wait_for(waiter_acquired.wait(), timeout=1.0)
+    allow_waiter_exit.set()
+    await asyncio.gather(holder_task, waiter_task)
+
+
+@pytest.mark.asyncio
+async def test_event_cache_room_lock_cache_keeps_new_active_room_at_capacity(tmp_path: Path) -> None:
+    """A newly acquired room lock must survive pruning when the cache is already full of active rooms."""
+    cache = EventCache(tmp_path / "event_cache.db")
+    release_active_rooms = asyncio.Event()
+    active_rooms_registered = asyncio.Event()
+    release_new_room_holder = asyncio.Event()
+    new_room_holder_entered = asyncio.Event()
+    new_room_waiter_acquired = asyncio.Event()
+    active_room_count = 0
+    new_room_id = "!new-room:localhost"
+
+    async def hold_active_room(room_id: str) -> None:
+        nonlocal active_room_count
+        async with cache._acquire_room_lock(room_id, operation="hold_active_room"):
+            active_room_count += 1
+            if active_room_count == event_cache_module._MAX_CACHED_ROOM_LOCKS:
+                active_rooms_registered.set()
+            await release_active_rooms.wait()
+
+    async def hold_new_room() -> None:
+        async with cache._acquire_room_lock(new_room_id, operation="hold_new_room"):
+            new_room_holder_entered.set()
+            await release_new_room_holder.wait()
+
+    async def wait_for_new_room() -> None:
+        async with cache._acquire_room_lock(new_room_id, operation="wait_for_new_room"):
+            new_room_waiter_acquired.set()
+
+    active_room_tasks = [
+        asyncio.create_task(hold_active_room(f"!active-room-{index}:localhost"))
+        for index in range(event_cache_module._MAX_CACHED_ROOM_LOCKS)
+    ]
+    new_room_holder_task: asyncio.Task[None] | None = None
+    new_room_waiter_task: asyncio.Task[None] | None = None
+    try:
+        await asyncio.wait_for(active_rooms_registered.wait(), timeout=1.0)
+
+        new_room_holder_task = asyncio.create_task(hold_new_room())
+        await asyncio.wait_for(new_room_holder_entered.wait(), timeout=1.0)
+
+        new_room_waiter_task = asyncio.create_task(wait_for_new_room())
+        await asyncio.sleep(0)
+
+        assert new_room_waiter_acquired.is_set() is False
+
+        release_new_room_holder.set()
+        await asyncio.wait_for(new_room_waiter_acquired.wait(), timeout=1.0)
+    finally:
+        release_new_room_holder.set()
+        release_active_rooms.set()
+        await asyncio.gather(
+            *active_room_tasks,
+            *(task for task in (new_room_holder_task, new_room_waiter_task) if task is not None),
+            return_exceptions=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_event_cache_close_waits_for_in_flight_operation(tmp_path: Path) -> None:
+    """Closing the cache should wait for active DB work instead of closing mid-query."""
+    cache = EventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+    await cache.store_event(
+        "$reply",
+        "!room:localhost",
+        {
+            "event_id": "$reply",
+            "sender": "@agent:localhost",
+            "origin_server_ts": 2000,
+            "type": "m.room.message",
+            "content": {"body": "Cached reply", "msgtype": "m.text"},
+        },
+    )
+    assert cache._db is not None
+
+    operation_started = asyncio.Event()
+    allow_operation_finish = asyncio.Event()
+    original_execute = cache._db.execute
+
+    async def blocking_execute(*args: object, **kwargs: object) -> object:
+        operation_started.set()
+        await allow_operation_finish.wait()
+        return await original_execute(*args, **kwargs)
+
+    cache._db.execute = blocking_execute
+
+    try:
+        get_task = asyncio.create_task(cache.get_event("!room:localhost", "$reply"))
+        await asyncio.wait_for(operation_started.wait(), timeout=1.0)
+
+        close_task = asyncio.create_task(cache.close())
+        await asyncio.sleep(0)
+        assert close_task.done() is False
+
+        allow_operation_finish.set()
+        cached_event = await get_task
+        await close_task
+    finally:
+        if cache._db is not None:
+            await cache.close()
+
+    assert cached_event is not None
+    assert cached_event["event_id"] == "$reply"
+    assert cache._db is None
 
 
 @pytest.mark.asyncio
@@ -203,7 +390,7 @@ async def test_individual_event_cache_strips_runtime_timing_marker(tmp_path: Pat
 
     try:
         await cache.store_events_batch([("$reply", "!room:localhost", event_source)])
-        cached_event = await cache.get_event("$reply")
+        cached_event = await cache.get_event("!room:localhost", "$reply")
     finally:
         await cache.close()
 
@@ -242,7 +429,7 @@ async def test_thread_cache_store_populates_individual_event_lookup(tmp_path: Pa
             "$thread_root",
             [_cache_source(root_event), _cache_source(reply_event)],
         )
-        cached_event = await cache.get_event("$reply")
+        cached_event = await cache.get_event("!room:localhost", "$reply")
     finally:
         await cache.close()
 
@@ -275,7 +462,7 @@ async def test_thread_event_cache_strips_runtime_timing_marker(tmp_path: Path) -
 
     try:
         await cache.store_events("!room:localhost", "$thread_root", [event_source])
-        cached_event = await cache.get_event("$reply")
+        cached_event = await cache.get_event("!room:localhost", "$reply")
         cached_thread_events = await cache.get_thread_events("!room:localhost", "$thread_root")
     finally:
         await cache.close()
@@ -315,6 +502,154 @@ async def test_cached_room_get_event_cache_hit_avoids_network_call(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_cached_room_get_event_cache_hit_returns_latest_visible_edit(tmp_path: Path) -> None:
+    """Point-event cache hits should surface the latest edited content for originals."""
+    cache = EventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+
+    original_event = _make_text_event(
+        event_id="$reply",
+        sender="@agent:localhost",
+        body="Original reply",
+        server_timestamp=2000,
+        source_content={
+            "body": "Original reply",
+            "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+        },
+    )
+    edit_event = _make_text_event(
+        event_id="$reply_edit",
+        sender="@agent:localhost",
+        body="* Final reply",
+        server_timestamp=3000,
+        source_content={
+            "body": "* Final reply",
+            "m.new_content": {"body": "Final reply", "msgtype": "m.text"},
+            "m.relates_to": {"rel_type": "m.replace", "event_id": "$reply"},
+        },
+    )
+    client = MagicMock()
+    client.room_get_event = AsyncMock()
+
+    try:
+        await cache.store_events_batch(
+            [
+                ("$reply", "!room:localhost", _cache_source(original_event)),
+                ("$reply_edit", "!room:localhost", _cache_source(edit_event)),
+            ],
+        )
+        response = await cached_room_get_event(client, cache, "!room:localhost", "$reply")
+    finally:
+        await cache.close()
+
+    assert isinstance(response, nio.RoomGetEventResponse)
+    assert response.event.event_id == "$reply"
+    assert response.event.body == "Final reply"
+    assert response.event.server_timestamp == 3000
+    assert EventInfo.from_event(response.event.source).thread_id == "$thread_root"
+    client.room_get_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cached_room_get_event_network_fetch_merges_cached_latest_edit(tmp_path: Path) -> None:
+    """Network fetches should still project originals through cached latest edits."""
+    cache = EventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+
+    original_event = _make_text_event(
+        event_id="$reply",
+        sender="@agent:localhost",
+        body="Original reply",
+        server_timestamp=2000,
+        source_content={"body": "Original reply"},
+    )
+    edit_event = _make_text_event(
+        event_id="$reply_edit",
+        sender="@agent:localhost",
+        body="* Final reply",
+        server_timestamp=3000,
+        source_content={
+            "body": "* Final reply",
+            "m.new_content": {"body": "Final reply", "msgtype": "m.text"},
+            "m.relates_to": {"rel_type": "m.replace", "event_id": "$reply"},
+        },
+    )
+    client = MagicMock()
+    client.room_get_event = AsyncMock(return_value=_make_room_get_event_response(original_event))
+
+    try:
+        await cache.store_event("$reply_edit", "!room:localhost", _cache_source(edit_event))
+        response = await cached_room_get_event(client, cache, "!room:localhost", "$reply")
+    finally:
+        await cache.close()
+
+    assert isinstance(response, nio.RoomGetEventResponse)
+    assert response.event.event_id == "$reply"
+    assert response.event.body == "Final reply"
+    client.room_get_event.assert_awaited_once_with("!room:localhost", "$reply")
+
+
+@pytest.mark.asyncio
+async def test_redacting_latest_edit_falls_back_to_previous_cached_edit(tmp_path: Path) -> None:
+    """Removing the newest edit should expose the previous cached visible state."""
+    cache = EventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+
+    original_event = _make_text_event(
+        event_id="$reply",
+        sender="@agent:localhost",
+        body="Original reply",
+        server_timestamp=1000,
+        source_content={"body": "Original reply"},
+    )
+    older_edit = _make_text_event(
+        event_id="$reply_edit_1",
+        sender="@agent:localhost",
+        body="* Intermediate reply",
+        server_timestamp=2000,
+        source_content={
+            "body": "* Intermediate reply",
+            "m.new_content": {"body": "Intermediate reply", "msgtype": "m.text"},
+            "m.relates_to": {"rel_type": "m.replace", "event_id": "$reply"},
+        },
+    )
+    newer_edit = _make_text_event(
+        event_id="$reply_edit_2",
+        sender="@agent:localhost",
+        body="* Final reply",
+        server_timestamp=3000,
+        source_content={
+            "body": "* Final reply",
+            "m.new_content": {"body": "Final reply", "msgtype": "m.text"},
+            "m.relates_to": {"rel_type": "m.replace", "event_id": "$reply"},
+        },
+    )
+    client = MagicMock()
+    client.room_get_event = AsyncMock()
+
+    try:
+        await cache.store_events_batch(
+            [
+                ("$reply", "!room:localhost", _cache_source(original_event)),
+                ("$reply_edit_1", "!room:localhost", _cache_source(older_edit)),
+                ("$reply_edit_2", "!room:localhost", _cache_source(newer_edit)),
+            ],
+        )
+        latest_response = await cached_room_get_event(client, cache, "!room:localhost", "$reply")
+        redacted = await cache.redact_event("!room:localhost", "$reply_edit_2")
+        fallback_response = await cached_room_get_event(client, cache, "!room:localhost", "$reply")
+    finally:
+        await cache.close()
+
+    assert redacted is True
+    assert isinstance(latest_response, nio.RoomGetEventResponse)
+    assert latest_response.event.body == "Final reply"
+    assert isinstance(fallback_response, nio.RoomGetEventResponse)
+    assert fallback_response.event.body == "Intermediate reply"
+    client.room_get_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_redaction_removes_individual_event_cache_entry(tmp_path: Path) -> None:
     """Redactions should also remove individually cached events."""
     cache = EventCache(tmp_path / "event_cache.db")
@@ -343,14 +678,208 @@ async def test_redaction_removes_individual_event_cache_entry(tmp_path: Path) ->
             "$thread_root",
             [_cache_source(root_event), _cache_source(reply_event)],
         )
-        assert await cache.get_event("$reply") is not None
+        assert await cache.get_event("!room:localhost", "$reply") is not None
         redacted = await cache.redact_event("!room:localhost", "$reply", thread_id="$thread_root")
-        cached_event = await cache.get_event("$reply")
+        cached_event = await cache.get_event("!room:localhost", "$reply")
     finally:
         await cache.close()
 
     assert redacted is True
     assert cached_event is None
+
+
+@pytest.mark.asyncio
+async def test_redacting_original_removes_dependent_cached_edits_from_thread_history(tmp_path: Path) -> None:
+    """Redacting an original must also remove cached edits that would resurrect it."""
+    cache = EventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+
+    root_event = _make_text_event(
+        event_id="$thread_root",
+        sender="@user:localhost",
+        body="Root message",
+        server_timestamp=1000,
+        source_content={"body": "Root message"},
+    )
+    original_event = _make_text_event(
+        event_id="$reply",
+        sender="@agent:localhost",
+        body="Original reply",
+        server_timestamp=2000,
+        source_content={
+            "body": "Original reply",
+            "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+        },
+    )
+    edit_event = _make_text_event(
+        event_id="$reply_edit",
+        sender="@agent:localhost",
+        body="* Final reply",
+        server_timestamp=3000,
+        source_content={
+            "body": "* Final reply",
+            "m.new_content": {
+                "body": "Final reply",
+                "msgtype": "m.text",
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+            "m.relates_to": {"rel_type": "m.replace", "event_id": "$reply"},
+        },
+    )
+    client = MagicMock()
+    client.room_get_event = AsyncMock()
+    client.room_messages = AsyncMock(return_value=nio.RoomMessagesResponse([], None, None, None))
+    client.room_get_event_relations = MagicMock()
+
+    try:
+        await cache.store_events(
+            "!room:localhost",
+            "$thread_root",
+            [_cache_source(root_event), _cache_source(original_event), _cache_source(edit_event)],
+        )
+        history_before = await fetch_thread_history(client, "!room:localhost", "$thread_root", event_cache=cache)
+
+        redacted = await cache.redact_event("!room:localhost", "$reply", thread_id="$thread_root")
+        latest_edit = await cache.get_latest_edit("!room:localhost", "$reply")
+        cached_edit = await cache.get_event("!room:localhost", "$reply_edit")
+        history_after = await fetch_thread_history(client, "!room:localhost", "$thread_root", event_cache=cache)
+    finally:
+        await cache.close()
+
+    assert redacted is True
+    assert [(message.event_id, message.body) for message in history_before] == [
+        ("$thread_root", "Root message"),
+        ("$reply", "Final reply"),
+    ]
+    assert latest_edit is None
+    assert cached_edit is None
+    assert [(message.event_id, message.body) for message in history_after] == [
+        ("$thread_root", "Root message"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_invalidate_thread_preserves_separately_cached_latest_edit(tmp_path: Path) -> None:
+    """Thread invalidation should not sever edit projection for separately cached edits."""
+    cache = EventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+
+    root_event = _make_text_event(
+        event_id="$thread_root",
+        sender="@user:localhost",
+        body="Root message",
+        server_timestamp=1000,
+        source_content={"body": "Root message"},
+    )
+    original_event = _make_text_event(
+        event_id="$reply",
+        sender="@agent:localhost",
+        body="Original reply",
+        server_timestamp=2000,
+        source_content={
+            "body": "Original reply",
+            "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+        },
+    )
+    edit_event = _make_text_event(
+        event_id="$reply_edit",
+        sender="@agent:localhost",
+        body="* Final reply",
+        server_timestamp=3000,
+        source_content={
+            "body": "* Final reply",
+            "m.new_content": {"body": "Final reply", "msgtype": "m.text"},
+            "m.relates_to": {"rel_type": "m.replace", "event_id": "$reply"},
+        },
+    )
+    client = MagicMock()
+    client.room_get_event = AsyncMock(return_value=_make_room_get_event_response(original_event))
+
+    try:
+        await cache.store_events(
+            "!room:localhost",
+            "$thread_root",
+            [_cache_source(root_event), _cache_source(original_event)],
+        )
+        await cache.store_event("$reply_edit", "!room:localhost", _cache_source(edit_event))
+        await cache.invalidate_thread("!room:localhost", "$thread_root")
+
+        latest_edit = await cache.get_latest_edit("!room:localhost", "$reply")
+        response = await cached_room_get_event(client, cache, "!room:localhost", "$reply")
+    finally:
+        await cache.close()
+
+    assert latest_edit is not None
+    assert latest_edit["event_id"] == "$reply_edit"
+    assert isinstance(response, nio.RoomGetEventResponse)
+    assert response.event.body == "Final reply"
+    client.room_get_event.assert_awaited_once_with("!room:localhost", "$reply")
+
+
+@pytest.mark.asyncio
+async def test_initialize_backfills_event_edit_index_from_old_schema(tmp_path: Path) -> None:
+    """Initialization should rebuild the edit index for pre-event_edits cache databases."""
+    db_path = tmp_path / "event_cache.db"
+    original_event = _cache_source(
+        _make_text_event(
+            event_id="$reply",
+            sender="@agent:localhost",
+            body="Original reply",
+            server_timestamp=2000,
+            source_content={"body": "Original reply"},
+        ),
+    )
+    edit_event = _cache_source(
+        _make_text_event(
+            event_id="$reply_edit",
+            sender="@agent:localhost",
+            body="* Final reply",
+            server_timestamp=3000,
+            source_content={
+                "body": "* Final reply",
+                "m.new_content": {"body": "Final reply", "msgtype": "m.text"},
+                "m.relates_to": {"rel_type": "m.replace", "event_id": "$reply"},
+            },
+        ),
+    )
+
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            """
+            CREATE TABLE events (
+                event_id TEXT PRIMARY KEY,
+                room_id TEXT NOT NULL,
+                event_json TEXT NOT NULL,
+                cached_at REAL NOT NULL
+            )
+            """,
+        )
+        db.executemany(
+            """
+            INSERT INTO events(event_id, room_id, event_json, cached_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            [
+                ("$reply", "!room:localhost", json.dumps(original_event, separators=(",", ":")), 1.0),
+                ("$reply_edit", "!room:localhost", json.dumps(edit_event, separators=(",", ":")), 1.0),
+            ],
+        )
+        db.commit()
+
+    cache = EventCache(db_path)
+    await cache.initialize()
+    try:
+        latest_edit = await cache.get_latest_edit("!room:localhost", "$reply")
+    finally:
+        await cache.close()
+
+    with sqlite3.connect(db_path) as db:
+        schema_version = db.execute("PRAGMA user_version").fetchone()[0]
+
+    assert latest_edit is not None
+    assert latest_edit["event_id"] == "$reply_edit"
+    assert latest_edit["content"]["m.new_content"]["body"] == "Final reply"
+    assert schema_version == 1
 
 
 @pytest.mark.asyncio
@@ -439,6 +968,14 @@ async def test_fetch_thread_history_cache_miss_does_full_fetch(tmp_path: Path) -
     assert [event["event_id"] for event in cached_events] == ["$thread_root", "$reply"]
     client.room_get_event.assert_awaited_once_with("!room:localhost", "$thread_root")
     client.room_messages.assert_not_awaited()
+
+
+def test_event_cache_uses_distinct_locks_per_room(tmp_path: Path) -> None:
+    """Event cache should keep independent locks per room."""
+    cache = EventCache(tmp_path / "event_cache.db")
+
+    assert cache._room_lock("!room:localhost") is cache._room_lock("!room:localhost")
+    assert cache._room_lock("!room:localhost") is not cache._room_lock("!other:localhost")
 
 
 @pytest.mark.asyncio

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -187,7 +187,7 @@ class TestThreadingBehavior:
             bot._first_sync_done = True
 
             await bot._on_sync_response(sync_response)
-            cached_event = await bot.event_cache.get_event("$thread_msg:localhost")
+            cached_event = await bot.event_cache.get_event("!test:localhost", "$thread_msg:localhost")
         finally:
             await bot._close_event_cache()
 
@@ -234,7 +234,7 @@ class TestThreadingBehavior:
             }
 
             await bot._on_redaction(room, redaction_event)
-            cached_event = await bot.event_cache.get_event("$thread_msg:localhost")
+            cached_event = await bot.event_cache.get_event("!test:localhost", "$thread_msg:localhost")
         finally:
             await bot._close_event_cache()
 
@@ -283,7 +283,7 @@ class TestThreadingBehavior:
             }
 
             await bot._conversation_access.cache_sync_timeline(sync_response)
-            cached_event = await bot.event_cache.get_event("$thread_msg:localhost")
+            cached_event = await bot.event_cache.get_event("!test:localhost", "$thread_msg:localhost")
         finally:
             await bot._close_event_cache()
 
@@ -414,8 +414,8 @@ class TestThreadingBehavior:
                 "$msg1:localhost",
                 "$msg2:localhost",
             ]
-            assert await bot.event_cache.get_event("$msg2:localhost") is not None
-            assert await bot.event_cache.get_event("$msg1:localhost") is not None
+            assert await bot.event_cache.get_event("!test:localhost", "$msg2:localhost") is not None
+            assert await bot.event_cache.get_event("!test:localhost", "$msg1:localhost") is not None
             mock_fetch.assert_not_called()
 
             bot._conversation_resolver.reply_chain = ReplyChainCaches()


### PR DESCRIPTION
## Summary
Makes event-cache lookups stable across edit-derived event identities so cached Matrix events are still found after canonicalization and reply-chain rewrites. Includes focused cache regression coverage.

## Verification
- Cherry-picks cleanly onto current 	t
- Full test suite passed on the extracted branch: 4136 passed, 24 skipped
