### PR TITLE
Switch the runtime to structured logging with an optional JSON renderer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
   "httpx>=0.27",
   "humanize>=4.12.3",
   "json5>=0.13",
-  "loguru>=0.7.3",
   "markdown-it-py>=4",
   "matrix-nio>=0.25",
   "mcp[cli]>=1.12.4",

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -198,7 +198,7 @@ def _load_context_files(
                 ),
             )
         else:
-            logger.warning(f"Context file not found: {resolved_path}")
+            logger.warning("context_file_not_found", agent=agent_name, path=str(resolved_path))
     return loaded_parts
 
 
@@ -462,13 +462,16 @@ def build_agent_toolkit(  # noqa: PLR0911
 
         if not agent_config.delegate_to:
             logger.warning(
-                f"Skipping 'delegate' tool for agent '{agent_name}': delegate_to is empty",
+                "Skipping delegate tool because delegate_to is empty",
+                agent=agent_name,
             )
             return None
         if delegation_depth >= delegate.MAX_DELEGATION_DEPTH:
             logger.warning(
-                f"Skipping explicit 'delegate' tool for agent '{agent_name}': "
-                f"delegation depth {delegation_depth} >= max {delegate.MAX_DELEGATION_DEPTH}",
+                "Skipping delegate tool because delegation depth limit was reached",
+                agent=agent_name,
+                delegation_depth=delegation_depth,
+                max_delegation_depth=delegate.MAX_DELEGATION_DEPTH,
             )
             return None
         return delegate.DelegateTools(
@@ -1112,19 +1115,24 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
 
     # Use rich prompt if available, otherwise use YAML config
     if agent_name in _RICH_PROMPTS:
-        logger.info(f"Using rich prompt for agent: {agent_name}")
+        logger.info("using_rich_prompt", agent=agent_name)
         # Prepend full context to the rich prompt
         role = full_context + _RICH_PROMPTS[agent_name]
         instructions = []  # Instructions are in the rich prompt
     else:
-        logger.info(f"Using YAML config for agent: {agent_name}")
+        logger.info("using_yaml_agent_config", agent=agent_name)
         # For YAML agents, prepend full context to role and keep original instructions
         role = full_context + agent_config.role
         instructions = list(agent_config.instructions)
 
     # Create agent with defaults applied
     model = _load_agent_model_instance(config, runtime_paths, model_name)
-    logger.info(f"Creating agent '{agent_name}' with model: {model.__class__.__name__}(id={model.id})")
+    logger.info(
+        "create_agent",
+        agent=agent_name,
+        model_class=model.__class__.__name__,
+        model_id=model.id,
+    )
 
     skills = _load_agent_skills(agent_name, config, runtime_paths)
     if skills and skills.get_skill_names():

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -644,7 +644,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0912
         # Priority: model config > env/CredentialsManager > default
         # This allows per-model host configuration in config.yaml
         host = model_config.host or get_ollama_host(runtime_paths=runtime_paths) or "http://localhost:11434"
-        logger.debug(f"Using Ollama host: {host}")
+        logger.debug("using_ollama_host", host=host)
         return Ollama(id=model_id, host=host, **extra_kwargs)
 
     # Handle OpenRouter separately due to API key capture timing issue
@@ -1318,9 +1318,8 @@ async def _process_stream_events(  # noqa: C901, PLR0912
                         pipeline_timing.mark("model_first_token")
                     if os.environ.get("MINDROOM_TIMING") == "1":
                         elapsed_seconds = time.monotonic() - request_started_at
-                        prefix = f"[{timing_scope}] " if timing_scope else ""
                         logger.info(
-                            f"TIMING {prefix}model_request_to_first_token: {elapsed_seconds:.3f}s",
+                            "timing_model_request_to_first_token",
                             timing_scope=timing_scope,
                             timing_step="model_request_to_first_token",
                             elapsed_s=round(elapsed_seconds, 3),

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -18,13 +18,13 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Annotated, Any
 
 from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request
-from loguru import logger
 from pydantic import BaseModel, Field, ValidationError
 
 from mindroom import constants
 from mindroom.api import sandbox_exec, sandbox_protocol, sandbox_worker_prep
 from mindroom.config.main import Config, load_config
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager
+from mindroom.logging_config import get_logger
 from mindroom.tool_system import sandbox_proxy
 from mindroom.tool_system.metadata import (
     TOOL_METADATA,
@@ -51,6 +51,8 @@ if TYPE_CHECKING:
 
     from mindroom.constants import RuntimePaths
     from mindroom.workers.models import WorkerHandle
+
+logger = get_logger(__name__)
 
 _SUBPROCESS_WORKER_ARG = "--sandbox-subprocess-worker"
 _STARTUP_RUNTIME_PATHS_ENV = "MINDROOM_RUNTIME_PATHS_JSON"
@@ -460,8 +462,11 @@ async def _execute_request_inprocess(
             else:
                 result = await _maybe_await(entrypoint(*request.args, **request.kwargs))
         except Exception as exc:
-            logger.opt(exception=True).warning(
-                f"Sandbox tool execution failed: {request.tool_name}.{request.function_name}",
+            logger.warning(
+                "sandbox_tool_execution_failed",
+                tool_name=request.tool_name,
+                function_name=request.function_name,
+                exc_info=True,
             )
             return SandboxRunnerExecuteResponse(
                 ok=False,

--- a/src/mindroom/api/sandbox_worker_prep.py
+++ b/src/mindroom/api/sandbox_worker_prep.py
@@ -10,9 +10,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException
-from loguru import logger
 
 from mindroom.api import sandbox_exec
+from mindroom.logging_config import get_logger
 from mindroom.tool_system import sandbox_proxy
 from mindroom.tool_system.worker_routing import (
     resolved_worker_key_scope,
@@ -31,6 +31,8 @@ from mindroom.workers.models import WorkerHandle, WorkerSpec
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
+
+logger = get_logger(__name__)
 
 MAX_LEASE_TTL_SECONDS = 3600
 DEFAULT_LEASE_TTL_SECONDS = 60
@@ -260,7 +262,7 @@ def prepare_worker_request(
     try:
         worker_handle = prepare_worker(worker_key, runtime_paths, runner_token=runner_token)
     except WorkerBackendError as exc:
-        logger.opt(exception=True).warning("Sandbox worker initialization failed", worker_key=worker_key)
+        logger.warning("sandbox_worker_initialization_failed", worker_key=worker_key, exc_info=True)
         raise WorkerRequestPreparationError(str(exc)) from exc
 
     try:

--- a/src/mindroom/background_tasks.py
+++ b/src/mindroom/background_tasks.py
@@ -74,7 +74,7 @@ async def wait_for_background_tasks(timeout: float | None = None) -> None:  # no
     try:
         await asyncio.wait_for(asyncio.gather(*_background_tasks, return_exceptions=True), timeout=timeout)
     except TimeoutError:
-        logger.warning(f"Background tasks did not complete within {timeout} seconds")
+        logger.warning("background_tasks_wait_timeout", timeout_seconds=timeout)
         # Cancel remaining tasks
         for task in _background_tasks:
             task.cancel()

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -171,7 +171,7 @@ from .knowledge.utils import (
     KnowledgeAccessSupport,
     MultiKnowledgeVectorDb,
 )
-from .logging_config import emoji, get_logger
+from .logging_config import get_logger
 from .matrix.avatar import check_and_set_avatar
 from .matrix.client import (
     PermanentMatrixStartupError,
@@ -643,7 +643,7 @@ class AgentBot:
     @cached_property
     def logger(self) -> structlog.stdlib.BoundLogger:
         """Get a logger with agent context bound."""
-        return logger.bind(agent=emoji(self.agent_name))
+        return logger.bind(agent=self.agent_name)
 
     @cached_property
     def matrix_id(self) -> MatrixID:
@@ -1056,11 +1056,15 @@ class AgentBot:
 
         restored_tasks = await restore_scheduled_tasks(self.client, room_id, self.config, self.runtime_paths)
         if restored_tasks > 0:
-            self.logger.info(f"Restored {restored_tasks} scheduled tasks in room {room_id}")
+            self.logger.info("restored_scheduled_tasks", room_id=room_id, restored_task_count=restored_tasks)
 
         restored_configs = await config_confirmation.restore_pending_changes(self.client, room_id)
         if restored_configs > 0:
-            self.logger.info(f"Restored {restored_configs} pending config changes in room {room_id}")
+            self.logger.info(
+                "restored_pending_config_changes",
+                room_id=room_id,
+                restored_config_count=restored_configs,
+            )
 
         await self._send_welcome_message_if_empty(room_id)
 
@@ -1104,7 +1108,7 @@ class AgentBot:
             self.agent_user.display_name,  # Use existing display name if available
             runtime_paths=self.runtime_paths,
         )
-        self.logger.info(f"Ensured Matrix user account: {self.agent_user.user_id}")
+        self.logger.info("ensured_matrix_user_account", user_id=self.agent_user.user_id)
 
     async def _set_avatar_if_available(self) -> None:
         """Set avatar for the agent if an avatar file exists."""
@@ -1118,11 +1122,11 @@ class AgentBot:
             try:
                 success = await check_and_set_avatar(self.client, avatar_path)
                 if success:
-                    self.logger.info(f"Successfully set avatar for {self.agent_name}")
+                    self.logger.info("avatar_set")
                 else:
-                    self.logger.warning(f"Failed to set avatar for {self.agent_name}")
+                    self.logger.warning("avatar_set_failed")
             except Exception as e:
-                self.logger.warning(f"Failed to set avatar: {e}")
+                self.logger.warning("avatar_set_failed", error=str(e))
 
     async def _set_presence_with_model_info(self) -> None:
         """Set presence status with model information."""
@@ -1255,10 +1259,10 @@ class AgentBot:
             try:
                 await cleanup_all_orphaned_bots(client, self.config, self.runtime_paths)
             except Exception as e:
-                self.logger.warning(f"Could not cleanup orphaned bots (non-critical): {e}")
+                self.logger.warning("orphaned_bot_cleanup_failed", error=str(e))
 
         # Note: Room joining is deferred until after invitations are handled
-        self.logger.info(f"Agent setup complete: {self.agent_user.user_id}")
+        self.logger.info("agent_setup_complete", user_id=self.agent_user.user_id)
         await self._emit_agent_lifecycle_event(EVENT_AGENT_STARTED)
 
     async def try_start(self) -> bool:
@@ -1285,9 +1289,9 @@ class AgentBot:
             return True  # noqa: TRY300
         except Exception as exc:
             if isinstance(exc, PermanentMatrixStartupError):
-                logger.error(f"Failed to start agent {self.agent_name}: {exc}")  # noqa: TRY400
+                logger.error("agent_start_failed_permanently", agent=self.agent_name, error=str(exc))  # noqa: TRY400
                 raise
-            logger.exception(f"Failed to start agent {self.agent_name}")
+            logger.exception("agent_start_failed", agent=self.agent_name)
             return False
 
     async def cleanup(self) -> None:
@@ -1323,7 +1327,7 @@ class AgentBot:
             await wait_for_background_tasks(timeout=5.0)  # 5 second timeout
             self.logger.info("Background tasks completed")
         except Exception as e:
-            self.logger.warning(f"Some background tasks did not complete: {e}")
+            self.logger.warning("background_tasks_incomplete", error=str(e))
 
         if self.agent_name == ROUTER_AGENT_NAME:
             cleared_queued_tasks = clear_deferred_overdue_tasks()
@@ -1866,7 +1870,7 @@ class AgentBot:
             self.runtime_paths,
             room_alias=room.canonical_alias,
         ):
-            self.logger.debug(f"Ignoring reaction from unauthorized sender: {event.sender}")
+            self.logger.debug("ignoring_reaction_from_unauthorized_sender", user_id=event.sender)
             return
 
         if not self._dispatch_planner.can_reply_to_sender(event.sender):
@@ -2768,7 +2772,7 @@ class AgentBot:
         # Skip edits from other agents
         sender_agent_name = extract_agent_name(event.sender, self.config, self.runtime_paths)
         if sender_agent_name:
-            self.logger.debug(f"Ignoring edit from other agent: {sender_agent_name}")
+            self.logger.debug("ignoring_edit_from_other_agent", agent=sender_agent_name)
             return
 
         # Known limitations for edit regeneration (ISSUE-110 Phase 5):
@@ -2813,7 +2817,7 @@ class AgentBot:
             else turn_record.response_event_id
         )
         if response_event_id is None:
-            self.logger.debug(f"No previous response found for edited message {original_event_id}")
+            self.logger.debug("missing_previous_response_for_edit", event_id=original_event_id)
             return
         regeneration_target = turn_record.conversation_target or self._conversation_resolver.build_message_target(
             room_id=room.room_id,

--- a/src/mindroom/commands/parsing.py
+++ b/src/mindroom/commands/parsing.py
@@ -203,7 +203,7 @@ class _CommandParser:
             )
 
         # Unknown command - return a special Command indicating it's unknown
-        logger.debug(f"Unknown command: {message}")
+        logger.debug("unknown_command", command=message)
         return Command(
             type=CommandType.UNKNOWN,
             args={"raw_command": message},

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -903,8 +903,8 @@ class Config(BaseModel):
 
         runtime_paths = resolve_runtime_paths(config_path=path)
         config = cls.validate_with_runtime(data, runtime_paths)
-        logger.info(f"Loaded agent configuration from {path}")
-        logger.info(f"Found {len(config.agents)} agent configurations")
+        logger.info("loaded_agent_configuration", path=str(path))
+        logger.info("loaded_agent_configuration_count", agent_count=len(config.agents))
         return config
 
     def get_agent_culture(self, agent_name: str) -> tuple[str, CultureConfig] | None:
@@ -1712,7 +1712,7 @@ class Config(BaseModel):
                 width=120,  # Wider lines to reduce wrapping
             )
         safe_replace(tmp_path, path_obj)
-        logger.info(f"Saved configuration to {config_path}")
+        logger.info("saved_configuration", path=str(config_path))
 
 
 def load_config(
@@ -1734,8 +1734,8 @@ def load_config(
         runtime_paths,
         tolerate_plugin_load_errors=tolerate_plugin_load_errors,
     )
-    logger.info(f"Loaded agent configuration from {path}")
-    logger.info(f"Found {len(config.agents)} agent configurations")
+    logger.info("loaded_agent_configuration", path=str(path))
+    logger.info("loaded_agent_configuration_count", agent_count=len(config.agents))
     return config
 
 

--- a/src/mindroom/credentials_sync.py
+++ b/src/mindroom/credentials_sync.py
@@ -72,6 +72,33 @@ def _sync_github_private_credentials(runtime_paths: RuntimePaths) -> bool:
     return True
 
 
+def _sync_service_credentials(
+    *,
+    service: str,
+    credentials: dict[str, str],
+    runtime_paths: RuntimePaths,
+    env_var: str | None = None,
+) -> bool:
+    """Seed or update one env-backed named service."""
+    creds_manager = get_runtime_shared_credentials_manager(runtime_paths)
+    existing = creds_manager.load_credentials(service)
+    if existing is not None:
+        source = existing.get("_source")
+        if source != "env":
+            logger.debug("credential_env_sync_skipped", service=service, source=source)
+            return False
+
+    creds_manager.save_credentials(service, {**credentials, "_source": "env"})
+    log_context = {"service": service}
+    if env_var is not None:
+        log_context["env_var"] = env_var
+    if existing is None:
+        logger.info("credential_seeded_from_env", **log_context)
+    else:
+        logger.info("credential_updated_from_env", **log_context)
+    return True
+
+
 def sync_env_to_credentials(runtime_paths: RuntimePaths) -> None:
     """Sync supported shared provider/bootstrap env values into CredentialsManager.
 
@@ -84,44 +111,57 @@ def sync_env_to_credentials(runtime_paths: RuntimePaths) -> None:
     This keeps conventional provider/bootstrap `.env` support without treating
     arbitrary tool-specific env vars as a supported tool configuration path.
     """
-    creds_manager = get_runtime_shared_credentials_manager(runtime_paths)
     synced_count = 0
 
     for env_var, service in _ENV_TO_SERVICE_MAP.items():
         env_value = get_secret_from_env(env_var, runtime_paths=runtime_paths)
 
         if not env_value:
-            logger.debug(f"No value found for {env_var} or {env_var}_FILE")
+            logger.debug("credential_env_value_missing", env_var=env_var)
             continue
 
-        logger.debug(f"Found value for {env_var}: length={len(env_value)}")
+        logger.debug("credential_env_value_found", env_var=env_var, value_length=len(env_value))
 
-        # Check existing credentials and their source
-        existing = creds_manager.load_credentials(service)
-        if existing is not None:
-            source = existing.get("_source")
-            if source != "env":
-                # UI-set or legacy (no _source) — don't overwrite
-                logger.debug(f"Credentials for {service} not env-sourced, skipping env sync")
-                continue
+        credentials = {"host": env_value} if service == "ollama" else {"api_key": env_value}
+        if _sync_service_credentials(
+            service=service,
+            credentials=credentials,
+            runtime_paths=runtime_paths,
+            env_var=env_var,
+        ):
+            synced_count += 1
 
-        if service == "ollama":
-            new_creds = {"host": env_value, "_source": "env"}
-        else:
-            new_creds = {"api_key": env_value, "_source": "env"}
+    adc_path = runtime_env_path(runtime_paths, "GOOGLE_APPLICATION_CREDENTIALS")
+    if adc_path is not None:
+        if _sync_service_credentials(
+            service="google_vertex_adc",
+            credentials={"application_credentials_path": str(adc_path)},
+            runtime_paths=runtime_paths,
+            env_var="GOOGLE_APPLICATION_CREDENTIALS",
+        ):
+            synced_count += 1
+    else:
+        logger.debug("No GOOGLE_APPLICATION_CREDENTIALS path found for google_vertex_adc")
 
-        creds_manager.save_credentials(service, new_creds)
-        if existing is None:
-            logger.info(f"Seeded {service} credentials from environment")
-        else:
-            logger.info(f"Updated {service} credentials from environment")
+    client_id = get_secret_from_env("GOOGLE_CLIENT_ID", runtime_paths=runtime_paths)
+    client_secret = get_secret_from_env("GOOGLE_CLIENT_SECRET", runtime_paths=runtime_paths)
+    if (
+        client_id
+        and client_secret
+        and _sync_service_credentials(
+            service="google_oauth_client",
+            credentials={"client_id": client_id, "client_secret": client_secret},
+            runtime_paths=runtime_paths,
+            env_var="GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET",
+        )
+    ):
         synced_count += 1
 
     if _sync_github_private_credentials(runtime_paths=runtime_paths):
         synced_count += 1
 
     if synced_count > 0:
-        logger.info(f"Synced {synced_count} credentials from environment")
+        logger.info("credentials_synced_from_env", synced_count=synced_count)
     else:
         logger.debug("No credentials to sync from environment")
 

--- a/src/mindroom/custom_tools/_google_oauth.py
+++ b/src/mindroom/custom_tools/_google_oauth.py
@@ -15,7 +15,7 @@ from mindroom.tool_system.worker_routing import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from loguru import Logger
+    from structlog.stdlib import BoundLogger
 
     from mindroom.constants import RuntimePaths
     from mindroom.credentials import CredentialsManager
@@ -36,7 +36,7 @@ class ScopedGoogleOAuthMixin:
     _oauth_tool_name: str
     _oauth_log_name: str
     DEFAULT_SCOPES: list[str] | dict[str, str]
-    _oauth_logger: Logger
+    _oauth_logger: BoundLogger
     _runtime_paths: RuntimePaths
     _creds_manager: CredentialsManager
     _worker_target: ResolvedWorkerTarget | None
@@ -49,7 +49,7 @@ class ScopedGoogleOAuthMixin:
         *,
         worker_target: ResolvedWorkerTarget | None,
         provided_creds: Any,  # noqa: ANN401
-        logger: Logger,
+        logger: BoundLogger,
     ) -> Any:  # noqa: ANN401
         """Validate scope and prepare initial Google credentials for the tool."""
         worker_scope = worker_target.worker_scope if worker_target is not None else None
@@ -113,10 +113,10 @@ class ScopedGoogleOAuthMixin:
         try:
             creds = self._build_credentials(token_data)
         except Exception:
-            self._oauth_logger.exception(f"Failed to load {self._oauth_log_name} credentials")
+            self._oauth_logger.exception("google_oauth_credentials_load_failed", tool_name=self._oauth_tool_name)
             return None
 
-        self._oauth_logger.info(f"Loaded {self._oauth_log_name} credentials from MindRoom storage")
+        self._oauth_logger.info("google_oauth_credentials_loaded", tool_name=self._oauth_tool_name)
         return creds
 
     def _should_fallback_to_original_auth(self) -> bool:
@@ -154,9 +154,15 @@ class ScopedGoogleOAuthMixin:
                     token_data["token"] = self.creds.token
                     self._save_token_data(token_data)
 
-                self._oauth_logger.info(f"{self._oauth_log_name} authentication successful")
+                self._oauth_logger.info(
+                    "google_oauth_authentication_succeeded",
+                    tool_name=self._oauth_tool_name,
+                )
             except Exception:
-                self._oauth_logger.exception(f"Failed to authenticate with {self._oauth_log_name}")
+                self._oauth_logger.exception(
+                    "google_oauth_authentication_failed",
+                    tool_name=self._oauth_tool_name,
+                )
                 raise
             return
 

--- a/src/mindroom/custom_tools/config_manager.py
+++ b/src/mindroom/custom_tools/config_manager.py
@@ -176,7 +176,7 @@ class ConfigManagerTools(Toolkit):
                 return self._generate_agent_template(name)
             return f"Error: Unknown info_type '{info_type}'. Valid options: {', '.join([t.value for t in _InfoType])}"
         except Exception as e:
-            logger.exception(f"Failed to get info for type {info_type}")
+            logger.exception("config_info_lookup_failed", info_type=info_type)
             return f"Error getting {info_type}: {e}"
 
     def manage_agent(
@@ -287,7 +287,7 @@ class ConfigManagerTools(Toolkit):
                 with readme_path.open() as f:
                     self._mindroom_docs = f.read()
             except Exception as e:
-                logger.warning(f"Could not load README.md: {e}")
+                logger.warning("mindroom_readme_load_failed", error=str(e))
                 self._mindroom_docs = "README.md not available"
         return self._mindroom_docs
 

--- a/src/mindroom/custom_tools/gmail.py
+++ b/src/mindroom/custom_tools/gmail.py
@@ -9,14 +9,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from agno.tools.gmail import GmailTools as AgnoGmailTools
-from loguru import logger
 
 from mindroom.custom_tools._google_oauth import ScopedGoogleOAuthMixin
+from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.credentials import CredentialsManager
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+
+logger = get_logger(__name__)
 
 
 class GmailTools(ScopedGoogleOAuthMixin, AgnoGmailTools):

--- a/src/mindroom/custom_tools/google_calendar.py
+++ b/src/mindroom/custom_tools/google_calendar.py
@@ -9,14 +9,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from agno.tools.googlecalendar import GoogleCalendarTools as AgnoGoogleCalendarTools
-from loguru import logger
 
 from mindroom.custom_tools._google_oauth import ScopedGoogleOAuthMixin
+from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.credentials import CredentialsManager
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+
+logger = get_logger(__name__)
 
 
 class GoogleCalendarTools(ScopedGoogleOAuthMixin, AgnoGoogleCalendarTools):

--- a/src/mindroom/custom_tools/google_sheets.py
+++ b/src/mindroom/custom_tools/google_sheets.py
@@ -9,14 +9,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from agno.tools.googlesheets import GoogleSheetsTools as AgnoGoogleSheetsTools
-from loguru import logger
 
 from mindroom.custom_tools._google_oauth import ScopedGoogleOAuthMixin
+from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.credentials import CredentialsManager
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+
+logger = get_logger(__name__)
 
 
 class GoogleSheetsTools(ScopedGoogleOAuthMixin, AgnoGoogleSheetsTools):

--- a/src/mindroom/custom_tools/matrix_api.py
+++ b/src/mindroom/custom_tools/matrix_api.py
@@ -10,10 +10,12 @@ from typing import ClassVar
 
 import nio
 from agno.tools import Toolkit
-from loguru import logger
 
 from mindroom.custom_tools.attachment_helpers import room_access_allowed
+from mindroom.logging_config import get_logger
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
+
+logger = get_logger(__name__)
 
 
 class MatrixApiTools(Toolkit):
@@ -289,7 +291,22 @@ class MatrixApiTools(Toolkit):
             audit_payload["response"] = normalized_response
         if status_code is not None:
             audit_payload["status_code"] = status_code
-        logger.warning("matrix_api write audit: {}", json.dumps(audit_payload, sort_keys=True))
+        logger.warning(
+            "matrix_api_write_audit",
+            agent=context.agent_name,
+            user_id=context.requester_id,
+            room_id=room_id,
+            action=action,
+            status=status,
+            event_type=event_type,
+            event_id=target_event_id,
+            state_key=state_key,
+            reason=reason,
+            dangerous=dangerous,
+            **(content_summary or {}),
+            response=normalized_response,
+            status_code=status_code,
+        )
 
     @classmethod
     def _state_write_policy_error(

--- a/src/mindroom/dispatch_planner.py
+++ b/src/mindroom/dispatch_planner.py
@@ -502,7 +502,12 @@ class DispatchPlanner:
 
         sender_agent_name = extract_agent_name(requester_user_id, self.deps.runtime.config, self.deps.runtime_paths)
         if sender_agent_name and not context.am_i_mentioned and not ingress_policy.bypass_unmentioned_agent_gate:
-            self.deps.logger.debug(f"Ignoring {event_label} from other agent (not mentioned)")
+            self.deps.logger.debug(
+                "ignore_unmentioned_agent_event",
+                agent=sender_agent_name,
+                event_label=event_label,
+                user_id=requester_user_id,
+            )
             return None
 
         return PreparedDispatch(

--- a/src/mindroom/error_handling.py
+++ b/src/mindroom/error_handling.py
@@ -41,7 +41,12 @@ def get_user_friendly_error_message(error: Exception, agent_name: str | None = N
     agent_prefix = f"[{agent_name}] " if agent_name else ""
 
     # Log the full error for debugging
-    logger.error(f"Error in {agent_name or 'agent'}: {error!r}")
+    logger.error(
+        "agent_error",
+        agent=agent_name or "agent",
+        error_type=type(error).__name__,
+        error=repr(error),
+    )
 
     # Only distinguish the most important error types
     if any(x in error_str for x in ["401", "auth", "unauthorized", "api key", "api_key", "apikey"]):

--- a/src/mindroom/file_watcher.py
+++ b/src/mindroom/file_watcher.py
@@ -6,12 +6,12 @@ import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import structlog
+from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-logger = structlog.get_logger(__name__)
+logger = get_logger(__name__)
 
 
 async def watch_file(

--- a/src/mindroom/handled_turns.py
+++ b/src/mindroom/handled_turns.py
@@ -266,7 +266,7 @@ class HandledTurnLedger:
                     conversation_target=conversation_target,
                 )
             self._save_responses_locked()
-        logger.debug(f"Recorded handled outcome for {len(normalized_source_event_ids)} source events")
+        logger.debug("handled_turn_recorded", source_event_count=len(normalized_source_event_ids))
 
     def record_visible_echo(self, source_event_id: str, echo_event_id: str) -> None:
         """Track a visible echo without marking the turn terminally handled."""
@@ -290,7 +290,12 @@ class HandledTurnLedger:
                 conversation_target=conversation_target,
             )
             self._save_responses_locked()
-        logger.debug(f"Tracked visible echo for event {source_event_id} on agent {self.agent_name}")
+        logger.debug(
+            "visible_echo_tracked",
+            agent=self.agent_name,
+            event_id=source_event_id,
+            visible_echo_event_id=echo_event_id,
+        )
 
     def has_responded(self, event_id: str) -> bool:
         """Return whether the source event has a terminal recorded outcome."""
@@ -378,7 +383,11 @@ class HandledTurnLedger:
                 max_age_days=max_age_days,
             )
             self._save_responses_locked()
-        logger.info(f"Cleaned up old events for {self.agent_name}, keeping {len(self._responses)} events")
+        logger.info(
+            "handled_turn_cleanup_completed",
+            agent=self.agent_name,
+            kept_event_count=len(self._responses),
+        )
 
     @contextmanager
     def _file_lock(self, *, exclusive: bool) -> typing.Iterator[None]:

--- a/src/mindroom/logging_config.py
+++ b/src/mindroom/logging_config.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import logging.config
+import os
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -13,7 +13,7 @@ import structlog
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
 
-__all__ = ["emoji", "get_logger", "setup_logging"]
+__all__ = ["get_logger", "setup_logging"]
 
 
 class _NioValidationFilter(logging.Filter):
@@ -39,44 +39,6 @@ class _NioValidationFilter(logging.Filter):
         return True
 
 
-def emoji(agent_name: str) -> str:
-    """Get an emoji-prefixed agent name string with consistent emoji based on the name.
-
-    Args:
-        agent_name: The agent name to add emoji to
-
-    Returns:
-        The agent name with a unique emoji prefix
-
-    """
-    # Emojis for different agents
-    emojis = [
-        "🤖",  # robot
-        "🧮",  # abacus
-        "💡",  # light bulb
-        "🔧",  # wrench
-        "📊",  # chart
-        "🎯",  # target
-        "🚀",  # rocket
-        "⚡",  # lightning
-        "🔍",  # magnifying glass
-        "📝",  # memo
-        "🎨",  # artist palette
-        "🧪",  # test tube
-        "🎪",  # circus tent
-        "🌟",  # star
-        "🔮",  # crystal ball
-        "🛠️",  # hammer and wrench
-    ]
-
-    # Use hash to get consistent emoji for each agent
-    hash_value = int(hashlib.sha256(agent_name.encode()).hexdigest(), 16)
-    emoji_index = hash_value % len(emojis)
-    emoji = emojis[emoji_index]
-
-    return f"{emoji} {agent_name}"
-
-
 def setup_logging(
     *,
     level: str = "INFO",
@@ -100,8 +62,31 @@ def setup_logging(
     # Shared processors that don't affect output format
     timestamper = structlog.processors.TimeStamper(fmt="iso")
     pre_chain = [
+        structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
         timestamper,
+    ]
+    log_format = os.getenv("MINDROOM_LOG_FORMAT", "text").strip().lower()
+    renderer_name = "json" if log_format == "json" else "text"
+
+    text_processors = [
+        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+        structlog.dev.ConsoleRenderer(colors=False),
+    ]
+    colored_processors = [
+        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+        structlog.dev.ConsoleRenderer(
+            colors=True,
+            exception_formatter=structlog.dev.RichTracebackFormatter(
+                # The locals can be very large, so we hide them by default
+                show_locals=False,
+            ),
+        ),
+    ]
+    json_processors = [
+        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+        structlog.processors.ExceptionRenderer(),
+        structlog.processors.JSONRenderer(),
     ]
 
     # Configure logging with both console and file handlers
@@ -110,26 +95,19 @@ def setup_logging(
             "version": 1,
             "disable_existing_loggers": False,
             "formatters": {
-                "plain": {
+                "text": {
                     "()": structlog.stdlib.ProcessorFormatter,
-                    "processors": [
-                        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-                        structlog.dev.ConsoleRenderer(colors=False),
-                    ],
+                    "processors": text_processors,
                     "foreign_pre_chain": pre_chain,
                 },
                 "colored": {
                     "()": structlog.stdlib.ProcessorFormatter,
-                    "processors": [
-                        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-                        structlog.dev.ConsoleRenderer(
-                            colors=True,
-                            exception_formatter=structlog.dev.RichTracebackFormatter(
-                                # The locals can be very large, so we hide them by default
-                                show_locals=False,
-                            ),
-                        ),
-                    ],
+                    "processors": colored_processors,
+                    "foreign_pre_chain": pre_chain,
+                },
+                "json": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processors": json_processors,
                     "foreign_pre_chain": pre_chain,
                 },
             },
@@ -143,7 +121,7 @@ def setup_logging(
                     "level": level.upper(),
                     "class": "logging.StreamHandler",
                     "stream": "ext://sys.stderr",
-                    "formatter": "colored",
+                    "formatter": "json" if renderer_name == "json" else "colored",
                     "filters": ["nio_validation"],
                 },
                 "file": {
@@ -152,7 +130,7 @@ def setup_logging(
                     "filename": str(log_file),
                     "mode": "a",
                     "encoding": "utf-8",
-                    "formatter": "plain",
+                    "formatter": "json" if renderer_name == "json" else "text",
                     "filters": ["nio_validation"],
                 },
             },
@@ -197,7 +175,7 @@ def setup_logging(
 
     # Log startup message
     logger = get_logger(__name__)
-    logger.info("Logging initialized", log_file=str(log_file), level=level)
+    logger.info("Logging initialized", log_file=str(log_file), level=level, log_format=renderer_name)
 
 
 def get_logger(name: str = __name__) -> structlog.stdlib.BoundLogger:

--- a/src/mindroom/matrix/avatar.py
+++ b/src/mindroom/matrix/avatar.py
@@ -43,7 +43,7 @@ async def _upload_avatar_file(
 
     """
     if not avatar_path.exists():
-        logger.warning(f"Avatar file not found: {avatar_path}")
+        logger.warning("avatar_file_missing", path=str(avatar_path))
         return None
 
     content_type = _guess_avatar_content_type(avatar_path)
@@ -67,17 +67,17 @@ async def _upload_avatar_file(
     if isinstance(upload_result, tuple):
         upload_response, error = upload_result
         if error:
-            logger.error(f"Upload error: {error}")
+            logger.error("avatar_upload_failed", path=str(avatar_path), error=str(error))
             return None
     else:
         upload_response = upload_result
 
     if not isinstance(upload_response, nio.UploadResponse):
-        logger.error(f"Failed to upload avatar: {upload_response}")
+        logger.error("avatar_upload_failed", path=str(avatar_path), error=str(upload_response))
         return None
 
     if not upload_response.content_uri:
-        logger.error("Upload response missing content_uri")
+        logger.error("avatar_upload_missing_content_uri", path=str(avatar_path))
         return None
 
     return str(upload_response.content_uri)
@@ -104,10 +104,10 @@ async def _set_avatar_from_file(
     response = await client.set_avatar(avatar_url)
 
     if isinstance(response, nio.ProfileSetAvatarResponse):
-        logger.info(f"✅ Successfully set avatar for {client.user_id}")
+        logger.info("user_avatar_set", user_id=client.user_id)
         return True
 
-    logger.error(f"Failed to set avatar for {client.user_id}: {response}")
+    logger.error("user_avatar_set_failed", user_id=client.user_id, error=str(response))
     return False
 
 
@@ -134,7 +134,7 @@ async def check_and_set_avatar(
     # Check user avatar
     response = await client.get_profile(client.user_id)
     if isinstance(response, nio.ProfileGetResponse) and response.avatar_url:
-        logger.debug(f"Avatar already set for {client.user_id}")
+        logger.debug("user_avatar_already_set", user_id=client.user_id)
         return True
     # Set user avatar
     return await _set_avatar_from_file(client, avatar_path)
@@ -168,10 +168,10 @@ async def set_room_avatar_from_file(
     )
 
     if isinstance(response, nio.RoomPutStateResponse):
-        logger.info(f"✅ Successfully set avatar for room {room_id}")
+        logger.info("room_avatar_set", room_id=room_id)
         return True
 
-    logger.error(f"Failed to set avatar for room {room_id}: {response}")
+    logger.error("room_avatar_set_failed", room_id=room_id, error=str(response))
     return False
 
 
@@ -179,6 +179,6 @@ async def room_has_avatar(client: nio.AsyncClient, room_id: str) -> bool:
     """Return whether the Matrix room already has an avatar URL configured."""
     response = await client.room_get_state_event(room_id, "m.room.avatar")
     if isinstance(response, nio.RoomGetStateEventResponse) and response.content and response.content.get("url"):
-        logger.debug(f"Avatar already set for room {room_id}")
+        logger.debug("room_avatar_already_set", room_id=room_id)
         return True
     return False

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -376,7 +376,7 @@ async def login(
 
     response = await client.login(password)
     if isinstance(response, nio.LoginResponse):
-        logger.info(f"Successfully logged in: {user_id}")
+        logger.info("matrix_login_succeeded", user_id=user_id)
         return client
     await client.close()
     msg = f"Failed to login {user_id}: {response}"
@@ -401,9 +401,9 @@ async def invite_to_room(
     """
     response = await client.room_invite(room_id, user_id)
     if isinstance(response, nio.RoomInviteResponse):
-        logger.info(f"Invited {user_id} to room {room_id}")
+        logger.info("matrix_room_invited", room_id=room_id, user_id=user_id)
         return True
-    logger.error(f"Failed to invite {user_id} to room {room_id}: {response}")
+    logger.error("matrix_room_invite_failed", room_id=room_id, user_id=user_id, error=str(response))
     return False
 
 
@@ -450,7 +450,7 @@ async def create_room(
 
     response = await client.room_create(**room_config)
     if isinstance(response, nio.RoomCreateResponse):
-        logger.info(f"Created room: {name} ({response.room_id})")
+        logger.info("matrix_room_created", room_id=str(response.room_id), name=name)
         room_id = str(response.room_id)
 
         # Invite power users to the room
@@ -461,7 +461,7 @@ async def create_room(
                     await invite_to_room(client, room_id, user_id)
 
         return room_id
-    logger.error(f"Failed to create room {name}: {response}")
+    logger.error("matrix_room_creation_failed", name=name, error=str(response))
     return None
 
 
@@ -553,10 +553,10 @@ async def create_space(
 
     response = await client.room_create(**room_config)
     if isinstance(response, nio.RoomCreateResponse):
-        logger.info(f"Created space: {name} ({response.room_id})")
+        logger.info("matrix_space_created", room_id=str(response.room_id), name=name)
         return str(response.room_id)
 
-    logger.error(f"Failed to create space {name}: {response}")
+    logger.error("matrix_space_creation_failed", name=name, error=str(response))
     return None
 
 
@@ -823,10 +823,10 @@ async def _create_dm_room(
 
     response = await client.room_create(**room_config)
     if isinstance(response, nio.RoomCreateResponse):
-        logger.info(f"Created DM room: {response.room_id}")
+        logger.info("matrix_dm_room_created", room_id=str(response.room_id))
         return str(response.room_id)
 
-    logger.error(f"Failed to create DM room: {response}")
+    logger.error("matrix_dm_room_creation_failed", error=str(response))
     return None
 
 
@@ -843,9 +843,9 @@ async def join_room(client: nio.AsyncClient, room_id: str) -> bool:
     """
     response = await client.join(room_id)
     if isinstance(response, nio.JoinResponse):
-        logger.info(f"Joined room: {room_id}")
+        logger.info("matrix_room_joined", room_id=room_id)
         return True
-    logger.warning(f"Could not join room {room_id}: {response}")
+    logger.warning("matrix_room_join_failed", room_id=room_id, error=str(response))
     return False
 
 
@@ -863,7 +863,7 @@ async def get_room_members(client: nio.AsyncClient, room_id: str) -> set[str]:
     response = await client.joined_members(room_id)
     if isinstance(response, nio.JoinedMembersResponse):
         return {member.user_id for member in response.members}
-    logger.warning(f"⚠️ Could not check members for room {room_id}")
+    logger.warning("matrix_room_members_fetch_failed", room_id=room_id)
     return set()
 
 
@@ -880,7 +880,7 @@ async def get_joined_rooms(client: nio.AsyncClient) -> list[str] | None:
     response = await client.joined_rooms()
     if isinstance(response, nio.JoinedRoomsResponse):
         return list(response.rooms)
-    logger.error(f"Failed to get joined rooms: {response}")
+    logger.error("matrix_joined_rooms_fetch_failed", error=str(response))
     return None
 
 
@@ -937,9 +937,9 @@ async def leave_room(client: nio.AsyncClient, room_id: str) -> bool:
     """
     response = await client.room_leave(room_id)
     if isinstance(response, nio.RoomLeaveResponse):
-        logger.info(f"Left room {room_id}")
+        logger.info("matrix_room_left", room_id=room_id)
         return True
-    logger.error(f"Failed to leave room {room_id}: {response}")
+    logger.error("matrix_room_leave_failed", room_id=room_id, error=str(response))
     return False
 
 
@@ -967,9 +967,9 @@ async def send_message(client: nio.AsyncClient, room_id: str, content: dict[str,
         content=content,
     )
     if isinstance(response, nio.RoomSendResponse):
-        logger.debug(f"Sent message to {room_id}: {response.event_id}")
+        logger.debug("matrix_message_sent", room_id=room_id, event_id=str(response.event_id))
         return str(response.event_id)
-    logger.error(f"Failed to send message to {room_id}: {response}")
+    logger.error("matrix_message_send_failed", room_id=room_id, error=str(response))
     return None
 
 

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -204,7 +204,11 @@ async def _upload_text_as_mxc(  # noqa: C901
 
         # Check if upload was successful
         if not isinstance(upload_result, nio.UploadResponse):
-            logger.error(f"Failed to upload text: {upload_result}")
+            logger.error(
+                "large_message_sidecar_upload_failed",
+                room_id=room_id,
+                error=str(upload_result),
+            )
             return None, None
 
         if not upload_result.content_uri:
@@ -279,7 +283,12 @@ async def prepare_large_message(
 
     source_content = content["m.new_content"] if is_edit and "m.new_content" in content else content
     preview_text = source_content["body"]
-    logger.info(f"Message too large ({current_size} bytes), uploading full content JSON to MXC")
+    logger.info(
+        "large_message_sidecar_upload_started",
+        room_id=room_id,
+        original_size_bytes=current_size,
+        is_edit=is_edit,
+    )
 
     mxc_uri, file_info, modified_content = await _build_file_content(
         client,
@@ -318,11 +327,20 @@ async def prepare_large_message(
 
     final_size = _calculate_event_size(modified_content)
     if final_size > 64000:
-        logger.warning(f"Large message still exceeds 64KB after preparation ({final_size} bytes)")
+        logger.warning(
+            "large_message_still_exceeds_limit",
+            room_id=room_id,
+            final_size_bytes=final_size,
+            size_limit_bytes=64000,
+        )
 
     inner: dict[str, Any] = modified_content.get("m.new_content", modified_content)  # type: ignore[assignment]
     logger.info(
-        f"Large message prepared: {current_size} bytes -> {len(inner['body'])} preview + JSON sidecar",
+        "large_message_prepared",
+        room_id=room_id,
+        original_size_bytes=current_size,
+        preview_length=len(inner["body"]),
+        is_edit=is_edit,
     )
 
     return modified_content

--- a/src/mindroom/matrix/message_content.py
+++ b/src/mindroom/matrix/message_content.py
@@ -110,7 +110,7 @@ async def _download_mxc_text(  # noqa: PLR0911, C901
     if mxc_url in _mxc_cache:
         content, timestamp = _mxc_cache[mxc_url]
         if current_time - timestamp < _cache_ttl:
-            logger.debug(f"Cache hit for MXC URL: {mxc_url}")
+            logger.debug("mxc_cache_hit", mxc_url=mxc_url)
             return content
         # Expired, remove from cache
         del _mxc_cache[mxc_url]
@@ -118,19 +118,19 @@ async def _download_mxc_text(  # noqa: PLR0911, C901
     try:
         # Parse MXC URL
         if not mxc_url.startswith("mxc://"):
-            logger.error(f"Invalid MXC URL: {mxc_url}")
+            logger.error("invalid_mxc_url", mxc_url=mxc_url)
             return None
 
         # Validate the MXC URL structure before issuing the download.
         parts = mxc_url[6:].split("/", 1)
         if len(parts) != 2 or not parts[0] or not parts[1]:
-            logger.error(f"Invalid MXC URL format: {mxc_url}")
+            logger.error("invalid_mxc_url_format", mxc_url=mxc_url)
             return None
 
         response = await client.download(mxc=mxc_url)
 
         if not isinstance(response, nio.DownloadResponse):
-            logger.error(f"Failed to download MXC content: {response}", mxc_url=mxc_url)
+            logger.error("mxc_download_failed", mxc_url=mxc_url, error=str(response))
             return None
 
         # Handle encryption if needed
@@ -158,7 +158,7 @@ async def _download_mxc_text(  # noqa: PLR0911, C901
             return None
         # Cache the result
         _mxc_cache[mxc_url] = (decoded_text, time.time())
-        logger.debug(f"Cached MXC content for: {mxc_url}")
+        logger.debug("mxc_content_cached", mxc_url=mxc_url)
 
         # Clean old entries if cache is getting large
         if len(_mxc_cache) > 100:
@@ -274,7 +274,7 @@ def _clean_expired_cache() -> None:
     for key in expired_keys:
         del _mxc_cache[key]
     if expired_keys:
-        logger.debug(f"Cleaned {len(expired_keys)} expired cache entries")
+        logger.debug("mxc_cache_cleaned", expired_entries=len(expired_keys))
 
 
 def _clear_mxc_cache() -> None:

--- a/src/mindroom/matrix/presence.py
+++ b/src/mindroom/matrix/presence.py
@@ -32,9 +32,20 @@ async def set_presence_status(
     response = await client.set_presence(presence, status_msg)
 
     if isinstance(response, nio.PresenceSetResponse):
-        logger.info(f"Set presence status: {status_msg}")
+        logger.info(
+            "presence_status_set",
+            user_id=client.user_id,
+            presence=presence,
+            status=status_msg,
+        )
     else:
-        logger.warning(f"Failed to set presence: {response}")
+        logger.warning(
+            "presence_status_set_failed",
+            user_id=client.user_id,
+            presence=presence,
+            status=status_msg,
+            error=str(response),
+        )
 
 
 def build_agent_status_message(

--- a/src/mindroom/matrix/room_cleanup.py
+++ b/src/mindroom/matrix/room_cleanup.py
@@ -70,18 +70,18 @@ async def _cleanup_orphaned_bots_in_room(
     # and no agents are explicitly configured for it, so every bot looks orphaned.
     state = MatrixState.load(runtime_paths=runtime_paths)
     if state.space_room_id and room_id == state.space_room_id:
-        logger.debug(f"Skipping root space {room_id} cleanup")
+        logger.debug("orphaned_bot_cleanup_skipped_root_space", room_id=room_id)
         return []
 
     # When DM mode is enabled, check if this is actually a DM room
     if await is_dm_room(client, room_id):
-        logger.debug(f"Skipping DM room {room_id} cleanup")
+        logger.debug("orphaned_bot_cleanup_skipped_dm_room", room_id=room_id)
         return []
 
     # Get room members
     member_ids = await get_room_members(client, room_id)
     if not member_ids:
-        logger.warning(f"No members found or failed to get members for room {room_id}")
+        logger.warning("orphaned_bot_cleanup_members_unavailable", room_id=room_id)
         return []
 
     # Get configured bots for this room
@@ -96,18 +96,26 @@ async def _cleanup_orphaned_bots_in_room(
         # Check if this is a mindroom bot and shouldn't be in this room
         if matrix_id.username in known_bot_usernames and matrix_id.username not in configured_bots:
             logger.info(
-                f"Found orphaned bot {matrix_id.username} in room {room_id} "
-                f"(configured bots for this room: {configured_bots})",
+                "orphaned_bot_found",
+                agent=matrix_id.username,
+                room_id=room_id,
+                configured_bots=sorted(configured_bots),
             )
 
             # Kick the bot
             kick_response = await client.room_kick(room_id, user_id, reason="Bot no longer configured for this room")
 
             if isinstance(kick_response, nio.RoomKickResponse):
-                logger.info(f"Kicked {matrix_id.username} from {room_id}")
+                logger.info("orphaned_bot_kicked", agent=matrix_id.username, room_id=room_id, user_id=user_id)
                 kicked_bots.append(matrix_id.username)
             else:
-                logger.error(f"Failed to kick {matrix_id.username} from {room_id}: {kick_response}")
+                logger.error(
+                    "orphaned_bot_kick_failed",
+                    agent=matrix_id.username,
+                    room_id=room_id,
+                    user_id=user_id,
+                    error=str(kick_response),
+                )
 
     return kicked_bots
 
@@ -134,7 +142,7 @@ async def cleanup_all_orphaned_bots(
     if joined_rooms is None:
         return kicked_bots
 
-    logger.info(f"Checking {len(joined_rooms)} rooms for orphaned bots")
+    logger.info("orphaned_bot_cleanup_started", room_count=len(joined_rooms))
 
     for room_id in joined_rooms:
         room_kicked = await _cleanup_orphaned_bots_in_room(client, room_id, config, runtime_paths)
@@ -144,7 +152,11 @@ async def cleanup_all_orphaned_bots(
     # Summary
     total_kicked = sum(len(bots) for bots in kicked_bots.values())
     if total_kicked > 0:
-        logger.info(f"Kicked {total_kicked} orphaned bots from {len(kicked_bots)} rooms")
+        logger.info(
+            "orphaned_bot_cleanup_completed",
+            total_kicked=total_kicked,
+            room_count=len(kicked_bots),
+        )
     else:
         logger.info("No orphaned bots found in any room")
 

--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -275,14 +275,14 @@ async def _ensure_room_exists(  # noqa: C901, PLR0912
     response = await client.room_resolve_alias(full_alias)
     if isinstance(response, nio.RoomResolveAliasResponse):
         room_id = str(response.room_id)
-        logger.debug(f"Room alias {full_alias} exists on server, room ID: {room_id}")
+        logger.debug("managed_room_alias_resolved", room_key=room_key, room_alias=full_alias, room_id=room_id)
 
         # Update our state if needed
         if room_key not in existing_rooms or existing_rooms[room_key].room_id != room_id:
             if room_name is None:
                 room_name = _room_key_to_name(room_key)
             _add_room(room_key, room_id, full_alias, room_name, runtime_paths)
-            logger.info(f"Updated state with existing room {room_key} (ID: {room_id})")
+            logger.info("managed_room_state_updated", room_key=room_key, room_id=room_id, room_alias=full_alias)
 
         # Room existence and room membership are separate concerns. Existing
         # private rooms may be managed outside MindRoom, so don't force a join
@@ -332,7 +332,7 @@ async def _ensure_room_exists(  # noqa: C901, PLR0912
     # Room alias doesn't exist on server, so we can create it
     if room_key in existing_rooms:
         # Remove stale entry from state
-        logger.debug(f"Removing stale room {room_key} from state")
+        logger.debug("managed_room_state_entry_removed", room_key=room_key)
         _remove_room(room_key, runtime_paths=runtime_paths)
 
     # Create the room
@@ -341,7 +341,7 @@ async def _ensure_room_exists(  # noqa: C901, PLR0912
 
     # Generate a contextual topic for the room using AI
     topic = await generate_room_topic_ai(room_key, room_name, config, runtime_paths)
-    logger.info(f"Creating room {room_key} with topic: {topic}")
+    logger.info("managed_room_creation_started", room_key=room_key, topic=topic)
 
     created_room_id = await create_room(
         client=client,
@@ -354,7 +354,7 @@ async def _ensure_room_exists(  # noqa: C901, PLR0912
     if created_room_id:
         # Save room info
         _add_room(room_key, created_room_id, full_alias, room_name, runtime_paths)
-        logger.info(f"Created room {room_key} with ID {created_room_id}")
+        logger.info("managed_room_created", room_key=room_key, room_id=created_room_id, room_alias=full_alias)
 
         if config.matrix_room_access.is_multi_user_mode():
             await _configure_managed_room_access(
@@ -386,7 +386,7 @@ async def _ensure_room_exists(  # noqa: C901, PLR0912
         )
 
         return created_room_id
-    logger.error(f"Failed to create room {room_key}")
+    logger.error("managed_room_creation_failed", room_key=room_key, room_alias=full_alias)
     return None
 
 
@@ -558,18 +558,23 @@ async def ensure_user_in_rooms(
         # Login as the user
         login_response = await user_client.login(password=user_account.password)
         if not isinstance(login_response, nio.LoginResponse):
-            logger.error(f"Failed to login as user {user_id}: {login_response}")
+            logger.error("matrix_user_login_failed", user_id=user_id, error=str(login_response))
             return
 
-        logger.info(f"User {user_id} logged in to join rooms")
+        logger.info("matrix_user_logged_in", user_id=user_id)
 
         for room_key, room_id in room_ids.items():
             # Try to join the room (will work if invited or room is public)
             join_success = await join_room(user_client, room_id)
             if join_success:
-                logger.info(f"User {user_id} joined room {room_key}")
+                logger.info("matrix_user_joined_room", user_id=user_id, room_id=room_id, room_key=room_key)
             else:
-                logger.warning(f"User {user_id} failed to join room {room_key} - may need invitation")
+                logger.warning(
+                    "matrix_user_room_join_failed",
+                    user_id=user_id,
+                    room_id=room_id,
+                    room_key=room_key,
+                )
 
 
 _DM_ROOM_CACHE: dict[tuple[str, str], tuple[float, bool]] = {}
@@ -694,10 +699,10 @@ async def leave_non_dm_rooms(
     """Leave all rooms in *room_ids* that are not DM rooms."""
     for room_id in room_ids:
         if await is_dm_room(client, room_id):
-            logger.debug(f"Preserving DM room {room_id}")
+            logger.debug("dm_room_preserved", room_id=room_id)
             continue
         success = await leave_room(client, room_id)
         if success:
-            logger.info(f"Left room {room_id}")
+            logger.info("room_left", room_id=room_id)
         else:
-            logger.error(f"Failed to leave room {room_id}")
+            logger.error("room_leave_failed", room_id=room_id)

--- a/src/mindroom/matrix/users.py
+++ b/src/mindroom/matrix/users.py
@@ -100,7 +100,7 @@ def _save_agent_credentials(
     agent_key = _account_key_for_agent(agent_name)
     state.add_account(agent_key, username, password)
     state.save(runtime_paths=runtime_paths)
-    logger.info(f"Saved credentials for agent {agent_name}")
+    logger.info("agent_credentials_saved", agent=agent_name)
 
 
 async def _homeserver_requires_registration_token(
@@ -191,9 +191,9 @@ async def _register_user_with_token(
 
     detail, errcode = _registration_http_error_details(response)
     if response.is_success:
-        logger.info(f"✅ Successfully registered user with token: {user_id}")
+        logger.info("matrix_user_registered_with_token", user_id=user_id)
     elif errcode == "M_USER_IN_USE":
-        logger.info(f"User {user_id} already exists")
+        logger.info("matrix_user_already_exists", user_id=user_id)
     else:
         permanent_error = _direct_token_registration_error(username=username, errcode=errcode, detail=detail)
         if permanent_error is not None:
@@ -313,7 +313,11 @@ async def _login_and_sync_display_name(
     if isinstance(login_response, nio.LoginResponse):
         display_response = await client.set_displayname(display_name)
         if isinstance(display_response, nio.ErrorResponse):
-            logger.warning(f"Failed to set display name for existing user: {display_response}")
+            logger.warning(
+                "matrix_user_display_name_sync_failed",
+                user_id=client.user_id,
+                error=str(display_response),
+            )
     return login_response
 
 
@@ -391,18 +395,22 @@ async def _handle_register_response(
 ) -> str:
     """Handle a matrix-nio register response and finalize account setup."""
     if isinstance(response, nio.RegisterResponse):
-        logger.info(f"✅ Successfully registered user: {user_id}")
+        logger.info("matrix_user_registered", user_id=user_id)
         client.user_id = response.user_id
         client.access_token = response.access_token
         client.device_id = response.device_id
 
         display_response = await client.set_displayname(display_name)
         if isinstance(display_response, nio.ErrorResponse):
-            logger.warning(f"Failed to set display name: {display_response}")
+            logger.warning(
+                "matrix_user_display_name_set_failed",
+                user_id=user_id,
+                error=str(display_response),
+            )
 
         return user_id
     if isinstance(response, nio.ErrorResponse) and response.status_code == "M_USER_IN_USE":
-        logger.info(f"User {user_id} already exists")
+        logger.info("matrix_user_already_exists", user_id=user_id)
         return await _login_existing_user_with_client_or_raise_collision(
             client=client,
             user_id=user_id,
@@ -515,7 +523,7 @@ async def _register_user_via_provisioning_if_configured(
         runtime_paths=runtime_paths,
     )
     if provisioning_result.status == "created":
-        logger.info(f"✅ Successfully registered user via provisioning service: {provisioning_result.user_id}")
+        logger.info("matrix_user_registered_via_provisioning", user_id=provisioning_result.user_id)
         return provisioning_result.user_id
 
     login_user_id = user_id
@@ -525,7 +533,7 @@ async def _register_user_via_provisioning_if_configured(
             provisioning_user_id=provisioning_result.user_id,
             expected_user_id=user_id,
         )
-    logger.info(f"User {login_user_id} already exists (provisioning service)")
+    logger.info("matrix_user_already_exists_via_provisioning", user_id=login_user_id)
     return await _login_existing_user_or_raise_collision(
         homeserver=homeserver,
         user_id=login_user_id,
@@ -608,13 +616,13 @@ async def create_agent_user(
     if existing_creds and (preferred_username is None or existing_creds["username"] == preferred_username):
         matrix_username = existing_creds["username"]
         password = existing_creds["password"]
-        logger.info(f"Using existing credentials for agent {agent_name} from matrix_state.yaml")
+        logger.info("agent_credentials_loaded", agent=agent_name)
         registration_needed = False
     else:
         # Generate new credentials
         matrix_username = preferred_username or agent_username_localpart(agent_name, runtime_paths=runtime_paths)
         password = secrets.token_urlsafe(24)
-        logger.info(f"Generated new credentials for agent {agent_name}")
+        logger.info("agent_credentials_generated", agent=agent_name)
         registration_needed = True
 
     # Extract server name from homeserver URL
@@ -654,7 +662,7 @@ async def create_agent_user(
     # Save credentials only after registration/verification succeeds.
     if registration_needed:
         _save_agent_credentials(agent_name, matrix_username, password, runtime_paths)
-        logger.info(f"Saved credentials for agent {agent_name} after successful registration")
+        logger.info("agent_credentials_saved_after_registration", agent=agent_name)
 
     return AgentMatrixUser(
         agent_name=agent_name,
@@ -722,7 +730,7 @@ async def _ensure_all_agent_users(
             runtime_paths=runtime_paths,
         )
         agent_users[ROUTER_AGENT_NAME] = router_user
-        logger.info(f"Ensured Matrix user for built-in router agent: {router_user.user_id}")
+        logger.info("matrix_user_ensured_for_router", agent=ROUTER_AGENT_NAME, user_id=router_user.user_id)
     except Exception:
         logger.exception("Failed to create Matrix user for built-in router agent")
 
@@ -736,7 +744,7 @@ async def _ensure_all_agent_users(
                 runtime_paths=runtime_paths,
             )
             agent_users[agent_name] = agent_user
-            logger.info(f"Ensured Matrix user for agent: {agent_name} -> {agent_user.user_id}")
+            logger.info("matrix_user_ensured_for_agent", agent=agent_name, user_id=agent_user.user_id)
         except Exception:
             # Continue with other agents even if one fails
             logger.exception("Failed to create Matrix user for agent", agent_name=agent_name)
@@ -751,7 +759,7 @@ async def _ensure_all_agent_users(
                 runtime_paths=runtime_paths,
             )
             agent_users[team_name] = team_user
-            logger.info(f"Ensured Matrix user for team: {team_name} -> {team_user.user_id}")
+            logger.info("matrix_user_ensured_for_team", agent=team_name, user_id=team_user.user_id)
         except Exception:
             # Continue with other teams even if one fails
             logger.exception("Failed to create Matrix user for team", team_name=team_name)

--- a/src/mindroom/memory/config.py
+++ b/src/mindroom/memory/config.py
@@ -113,7 +113,9 @@ def _get_memory_config(storage_path: Path, config: Config, runtime_paths: Runtim
                 llm_config["config"]["api_key"] = api_key
 
         logger.info(
-            f"Using {app_config.memory.llm.provider} model '{app_config.memory.llm.config.get('model')}' for memory",
+            "Configured memory LLM",
+            provider=app_config.memory.llm.provider,
+            model=app_config.memory.llm.config.get("model"),
         )
     else:
         # Fallback if no LLM configured
@@ -173,5 +175,5 @@ async def create_memory_instance(
     # Mem0 expects a dict for configuration, not config objects
     memory = await AsyncMemory.from_config(config_dict)
 
-    logger.info(f"Created memory instance with ChromaDB at {config_dict['vector_store']['config']['path']}")
+    logger.info("created_memory_instance", path=config_dict["vector_store"]["config"]["path"])
     return memory

--- a/src/mindroom/orchestration/config_updates.py
+++ b/src/mindroom/orchestration/config_updates.py
@@ -102,13 +102,13 @@ def _get_changed_agents(
         if (agents_differ or culture_differ) and (agent_name in agent_bots or new_agent is not None):
             if old_agent and new_agent:
                 if agents_differ:
-                    logger.debug(f"Agent {agent_name} configuration changed, will restart")
+                    logger.debug("agent_configuration_changed_restart_required", agent=agent_name)
                 else:
-                    logger.debug(f"Agent {agent_name} culture assignment changed, will restart")
+                    logger.debug("agent_culture_changed_restart_required", agent=agent_name)
             elif new_agent:
-                logger.info(f"Agent {agent_name} is new, will start")
+                logger.info("new_agent_will_start", agent=agent_name)
             else:
-                logger.info(f"Agent {agent_name} was removed, will stop")
+                logger.info("removed_agent_will_stop", agent=agent_name)
             changed.add(agent_name)
 
     return changed

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -281,7 +281,7 @@ async def run_with_retry(
             raise
         except Exception as exc:
             if permanent_error_check is not None and permanent_error_check(exc):
-                logger.error("%s failed with a permanent error: %s", step_name, exc)  # noqa: TRY400
+                logger.error("startup_step_failed_permanently", step_name=step_name, error=str(exc))  # noqa: TRY400
                 raise
             attempt += 1
             retry_in_seconds = retry_delay_seconds(
@@ -290,8 +290,8 @@ async def run_with_retry(
                 max_delay_seconds=max_delay_seconds,
             )
             logger.warning(
-                "%s failed; retrying",
-                step_name,
+                "startup_step_retrying",
+                step_name=step_name,
                 attempt=attempt,
                 retry_in_seconds=retry_in_seconds,
                 exc_info=True,
@@ -434,21 +434,21 @@ async def sync_forever_with_restart(bot: AgentBot | TeamBot, max_retries: int = 
     while bot.running and (max_retries < 0 or retry_count < max_retries):
         iteration: _SyncIteration | None = None
         try:
-            logger.info(f"Starting sync loop for {bot.agent_name}")
+            logger.info("starting_sync_loop", agent=bot.agent_name)
             iteration = _SyncIteration.start(bot)
             await iteration.wait()
             # sync_forever returned normally, so the bot was stopped intentionally.
             break
         except asyncio.CancelledError:
             # Task cancellation is part of normal shutdown.
-            logger.info(f"Sync task for {bot.agent_name} was cancelled")
+            logger.info("sync_task_cancelled", agent=bot.agent_name)
             break
         except MatrixSyncStalledError:
             retry_count += 1
-            logger.warning(f"Restarting stalled sync loop for {bot.agent_name} (retry {retry_count})")
+            logger.warning("restarting_stalled_sync_loop", agent=bot.agent_name, retry_count=retry_count)
         except Exception:
             retry_count += 1
-            logger.exception(f"Sync loop failed for {bot.agent_name} (retry {retry_count})")
+            logger.exception("sync_loop_failed", agent=bot.agent_name, retry_count=retry_count)
         finally:
             if iteration is not None:
                 await bot.prepare_for_sync_shutdown()
@@ -462,5 +462,5 @@ async def sync_forever_with_restart(bot: AgentBot | TeamBot, max_retries: int = 
             initial_delay_seconds=5.0,
             max_delay_seconds=60.0,
         )
-        logger.info(f"Restarting sync loop for {bot.agent_name} in {wait_time:.0f} seconds...")
+        logger.info("restarting_sync_loop", agent=bot.agent_name, retry_count=retry_count, wait_seconds=wait_time)
         await asyncio.sleep(wait_time)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -271,7 +271,7 @@ class MultiAgentOrchestrator:
             username=config.mindroom_user.username,
             runtime_paths=self.runtime_paths,
         )
-        logger.info(f"User account ready: {user_account.user_id}")
+        logger.info("user_account_ready", user_id=user_account.user_id)
 
     def _require_config(self) -> Config:
         """Return the active config or fail fast if it has not been loaded."""
@@ -815,9 +815,11 @@ class MultiAgentOrchestrator:
         """Log degraded startup status for failed non-router bots."""
         if failed_agents:
             logger.warning(
-                f"System starting in degraded mode. "
-                f"Failed agents: {', '.join(failed_agents)} "
-                f"({len(self.agent_bots) - len(failed_agents)}/{len(self.agent_bots)} operational)",
+                "System starting in degraded mode",
+                failed_agents=failed_agents,
+                failed_agent_count=len(failed_agents),
+                operational_agent_count=len(self.agent_bots) - len(failed_agents),
+                total_agent_count=len(self.agent_bots),
             )
             return
         logger.info("All agent bots started successfully")
@@ -951,7 +953,7 @@ class MultiAgentOrchestrator:
             bot.enable_streaming = plan.new_config.defaults.enable_streaming
             bot.hook_registry = self.hook_registry
             await bot._set_presence_with_model_info()
-            logger.debug(f"Updated config for {entity_name}")
+            logger.debug("bot_config_updated", agent=entity_name)
 
     @staticmethod
     def _plugin_change_paths(current_config: Config, new_config: Config) -> tuple[str, ...]:
@@ -1130,7 +1132,10 @@ class MultiAgentOrchestrator:
         self.config = new_config
         self._activate_hook_registry(new_hook_registry)
         changed_runtime_mcp_servers = await self._sync_mcp_manager(new_config)
-        logger.info(f"Updating config. New authorization: {new_config.authorization.global_users}")
+        logger.info(
+            "updating_config_authorization",
+            authorized_user_ids=new_config.authorization.global_users,
+        )
         if changed_runtime_mcp_servers:
             plan = replace(
                 plan,
@@ -1177,7 +1182,8 @@ class MultiAgentOrchestrator:
         )
 
         logger.info(
-            f"Configuration update complete: {len(plan.entities_to_restart) + len(plan.new_entities)} bots affected",
+            "configuration_update_complete",
+            affected_bot_count=len(plan.entities_to_restart) + len(plan.new_entities),
         )
         return True
 
@@ -1250,7 +1256,7 @@ class MultiAgentOrchestrator:
 
         config = self._require_config()
         room_ids = await ensure_all_rooms_exist(router_bot.client, config, self.runtime_paths)
-        logger.info(f"Ensured existence of {len(room_ids)} rooms")
+        logger.info("ensured_room_existence", room_count=len(room_ids))
         return room_ids
 
     async def _ensure_root_space(self, room_ids: dict[str, str] | None = None) -> None:
@@ -1284,9 +1290,9 @@ class MultiAgentOrchestrator:
                 continue
             success = await invite_to_room(router_bot.client, root_space_id, user_id)
             if success:
-                logger.info(f"Invited user {user_id} to root space {root_space_id}")
+                logger.info("invited_user_to_root_space", user_id=user_id, room_id=root_space_id)
             else:
-                logger.warning(f"Failed to invite user {user_id} to root space {root_space_id}")
+                logger.warning("invite_user_to_root_space_failed", user_id=user_id, room_id=root_space_id)
 
     async def _invite_user_if_missing(
         self,
@@ -1569,7 +1575,7 @@ async def main(
 
         if api:
             # Optionally run the bundled dashboard/API server alongside the orchestrator.
-            logger.info("Starting bundled dashboard/API server on %s:%d", api_host, api_port)
+            logger.info("starting_bundled_dashboard_api_server", host=api_host, port=api_port)
             auxiliary_specs.append(
                 (
                     "bundled API server",

--- a/src/mindroom/routing.py
+++ b/src/mindroom/routing.py
@@ -83,7 +83,12 @@ Choose the most appropriate agent based on their role, tools, and instructions."
         router_model_name = config.router.model
 
         model = get_model_instance(config, runtime_paths, router_model_name)
-        logger.info(f"Using router model: {router_model_name} -> {model.__class__.__name__}(id={model.id})")
+        logger.info(
+            "using_router_model",
+            model_name=router_model_name,
+            model_class=model.__class__.__name__,
+            model_id=model.id,
+        )
 
         agent = Agent(
             name="Router",

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -885,13 +885,13 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
             await _execute_scheduled_workflow(client, workflow, config, runtime_paths, task_id=task_id)
             if task_id not in running_tasks:
-                logger.info(f"Task {task_id} no longer in running tasks, stopping")
+                logger.info("scheduled_task_missing_from_running_tasks", task_id=task_id)
                 return
     except asyncio.CancelledError:
-        logger.info(f"Cron task {task_id} was cancelled")
+        logger.info("cron_task_cancelled", task_id=task_id)
         raise
     except Exception as e:
-        logger.exception(f"Error in cron task {task_id}")
+        logger.exception("cron_task_failed", task_id=task_id)
         if workflow.room_id:
             error_message = f"❌ Recurring task failed: {workflow.description}\nTask ID: {task_id}\nError: {e!s}"
             error_content = await _build_scheduled_failure_content(
@@ -977,10 +977,10 @@ async def _run_once_task(  # noqa: C901, PLR0912
                 status=final_status,
             )
     except asyncio.CancelledError:
-        logger.info(f"One-time task {task_id} was cancelled")
+        logger.info("one_time_task_cancelled", task_id=task_id)
         raise
     except Exception as e:
-        logger.exception(f"Error in one-time task {task_id}")
+        logger.exception("one_time_task_failed", task_id=task_id)
         if workflow.room_id:
             error_message = f"❌ One-time task failed: {workflow.description}\nTask ID: {task_id}\nError: {e!s}"
             error_content = await _build_scheduled_failure_content(
@@ -1438,9 +1438,9 @@ async def cancel_all_scheduled_tasks(
                         state_key=task_id,
                     )
                     cancelled_count += 1
-                    logger.info(f"Cancelled task {task_id}")
+                    logger.info("scheduled_task_cancelled", task_id=task_id)
                 except Exception:
-                    logger.exception(f"Failed to cancel task {task_id}")
+                    logger.exception("scheduled_task_cancel_failed", task_id=task_id)
                     failed_count += 1
 
     if cancelled_count == 0:
@@ -1488,7 +1488,7 @@ async def restore_scheduled_tasks(  # noqa: C901, PLR0912
             # Validate workflow has required fields
             if workflow.schedule_type == "once":
                 if not workflow.execute_at:
-                    logger.warning(f"Skipping one-time task {task_id} without execution time")
+                    logger.warning("skipping_one_time_task_without_execution_time", task_id=task_id)
                     continue
                 # Handle past one-time tasks: execute if within grace period, fail if too old
                 if workflow.execute_at <= datetime.now(UTC):
@@ -1524,10 +1524,10 @@ async def restore_scheduled_tasks(  # noqa: C901, PLR0912
                     continue
             elif workflow.schedule_type == "cron":
                 if not workflow.cron_schedule:
-                    logger.warning(f"Skipping recurring task {task_id} without cron schedule")
+                    logger.warning("skipping_recurring_task_without_cron_schedule", task_id=task_id)
                     continue
             else:
-                logger.warning(f"Unknown schedule type for task {task_id}: {workflow.schedule_type}")
+                logger.warning("unknown_schedule_type", task_id=task_id, schedule_type=workflow.schedule_type)
                 continue
 
             # Start the appropriate task

--- a/src/mindroom/stop.py
+++ b/src/mindroom/stop.py
@@ -10,12 +10,12 @@ from typing import TYPE_CHECKING
 import nio
 from agno.run.cancel import acancel_run
 
+from mindroom.logging_config import get_logger
+
 if TYPE_CHECKING:
     from nio import AsyncClient
 
-import structlog
-
-logger = structlog.get_logger(__name__)
+logger = get_logger(__name__)
 _GRACEFUL_CANCEL_FALLBACK_SECONDS = 10.0
 _GRACEFUL_CANCEL_PROBE_SECONDS = 0.25
 
@@ -230,7 +230,7 @@ class StopManager:
                         )
                         tracked.reaction_event_id = None
                     except Exception as e:
-                        logger.warning(f"Failed to remove stop button in cleanup: {e}")
+                        logger.warning("stop_button_cleanup_failed", message_id=message_id, error=str(e))
 
             await asyncio.sleep(delay)
             if message_id in self.tracked_messages:

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -514,7 +514,7 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
                 continue
             text_chunk = ""
         else:
-            logger.debug(f"Unhandled streaming event type: {type(chunk).__name__}")
+            logger.debug("unhandled_streaming_event_type", event_type=type(chunk).__name__)
             continue
 
         if text_chunk:

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -491,13 +491,16 @@ Return the mode and a one-sentence reason why."""
         response = await agent.arun(prompt, session_id="team_mode_decision")
         decision = response.content
         if isinstance(decision, _TeamModeDecision):
-            logger.info(f"Team mode: {decision.mode} - {decision.reasoning}")
+            logger.info("team_mode_decided", mode=decision.mode, reasoning=decision.reasoning)
             return TeamMode.COORDINATE if decision.mode == "coordinate" else TeamMode.COLLABORATE
         # Fallback if response is unexpected
-        logger.debug(f"Unexpected response type from AI: {type(decision).__name__}, defaulting to collaborate")
+        logger.debug(
+            "team_mode_decision_unexpected_type",
+            response_type=type(decision).__name__,
+        )
         return TeamMode.COLLABORATE  # noqa: TRY300
     except Exception as e:
-        logger.debug(f"AI team mode decision failed (will use default): {e}")
+        logger.debug("team_mode_decision_failed", error=str(e))
         return TeamMode.COLLABORATE
 
 
@@ -581,7 +584,7 @@ async def decide_team_formation(
         # Use COORDINATE when agents are explicitly tagged (they likely have different roles)
         # Use COLLABORATE when agents are from thread history (likely discussing same topic)
         mode = TeamMode.COORDINATE if len(tagged_agents) > 1 else TeamMode.COLLABORATE
-        logger.info(f"Using hardcoded mode selection: {mode.value}")
+        logger.info("team_mode_selected_hardcoded", mode=mode.value)
 
     return replace(resolution, mode=mode)
 
@@ -644,17 +647,29 @@ def _select_team_request(
     """Return the normalized team request implied by one message context."""
     normalized_tagged_agents = _normalize_team_request_members(tagged_agents, config, runtime_paths)
     if len(normalized_tagged_agents) > 1:
-        logger.info(f"Team formation needed for tagged agents: {normalized_tagged_agents}")
+        logger.info(
+            "team_formation_requested",
+            trigger="tagged_agents",
+            agents=[agent.full_id for agent in normalized_tagged_agents],
+        )
         return _SelectedTeamRequest(TeamIntent.EXPLICIT_MEMBERS, normalized_tagged_agents)
 
     normalized_mentioned_agents = _normalize_team_request_members(all_mentioned_in_thread, config, runtime_paths)
     if not normalized_tagged_agents and len(normalized_mentioned_agents) > 1:
-        logger.info(f"Team formation needed for previously mentioned agents: {normalized_mentioned_agents}")
+        logger.info(
+            "team_formation_requested",
+            trigger="previously_mentioned_agents",
+            agents=[agent.full_id for agent in normalized_mentioned_agents],
+        )
         return _SelectedTeamRequest(TeamIntent.IMPLICIT_THREAD_TEAM, normalized_mentioned_agents)
 
     normalized_thread_agents = _normalize_team_request_members(agents_in_thread, config, runtime_paths)
     if not normalized_tagged_agents and len(normalized_thread_agents) > 1:
-        logger.info(f"Team formation needed for thread agents: {normalized_thread_agents}")
+        logger.info(
+            "team_formation_requested",
+            trigger="thread_agents",
+            agents=[agent.full_id for agent in normalized_thread_agents],
+        )
         return _SelectedTeamRequest(TeamIntent.IMPLICIT_THREAD_TEAM, normalized_thread_agents)
 
     if not (is_dm_room and not is_thread and not normalized_tagged_agents and room and config):
@@ -667,7 +682,11 @@ def _select_team_request(
     if len(normalized_available_agents) <= 1:
         return _SelectedTeamRequest(None, [])
 
-    logger.info(f"Team formation needed for DM room with multiple agents: {normalized_available_agents}")
+    logger.info(
+        "team_formation_requested",
+        trigger="dm_room_multiple_agents",
+        agents=[agent.full_id for agent in normalized_available_agents],
+    )
     return _SelectedTeamRequest(TeamIntent.DM_AUTO_TEAM, normalized_available_agents)
 
 
@@ -1214,11 +1233,11 @@ def select_model_for_team(
     ).model_name
     room_alias = get_room_alias_from_id(room_id, runtime_paths)
     if room_alias and room_alias in config.room_models:
-        logger.info(f"Using room-specific model for {team_name} in {room_alias}: {model_name}")
+        logger.info("using_room_specific_team_model", team_name=team_name, room_alias=room_alias, model_name=model_name)
     elif team_name in config.teams and config.teams[team_name].model:
-        logger.info(f"Using team-specific model for {team_name}: {model_name}")
+        logger.info("using_team_specific_model", team_name=team_name, model_name=model_name)
     else:
-        logger.info(f"Using default model for {team_name}")
+        logger.info("using_default_team_model", team_name=team_name)
     return model_name
 
 
@@ -1416,8 +1435,8 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
             )
             prompt = prepared_execution.prepared_prompt
             run_metadata = prepared_execution.run_metadata
-            logger.info(f"Executing team response with {len(agents)} agents in {mode.value} mode")
-            logger.info(f"TEAM PROMPT: {prompt[:500]}")
+            logger.info("executing_team_response", agent_count=len(agents), mode=mode.value)
+            logger.info("team_prompt_preview", agents=agent_list, prompt_preview=prompt[:500])
 
             async def _run(
                 current_prompt: str,
@@ -1459,7 +1478,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                         attempt_run_id = _next_retry_run_id(run_id)
                         continue
 
-                    logger.exception(f"Error in team response with agents {agent_list}")
+                    logger.exception("team_response_failed", agents=agent_list)
                     return get_user_friendly_error_message(e, team_name)
 
                 if isinstance(response, TeamRunOutput) and response.status == RunStatus.error:
@@ -1506,19 +1525,30 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
 
             if isinstance(response, TeamRunOutput):
                 if response.member_responses:
-                    logger.debug(f"Team had {len(response.member_responses)} member responses")
+                    logger.debug("team_member_response_count", response_count=len(response.member_responses))
 
-                logger.info(f"Team consensus content: {response.content[:200] if response.content else 'None'}")
+                logger.info(
+                    "team_consensus_preview",
+                    content_preview=response.content[:200] if response.content else None,
+                )
 
                 parts = format_team_response(response)
                 team_response_text = "\n\n".join(parts) if parts else "No team response generated."
             else:
-                logger.warning(f"Unexpected response type: {type(response)}", response=response)
+                logger.warning(
+                    "team_response_unexpected_type",
+                    response_type=type(response).__name__,
+                    response=response,
+                )
                 team_response_text = str(response)
 
-            logger.info(f"TEAM RESPONSE ({agent_list}): {team_response_text[:_MAX_LOG_MESSAGE_LENGTH]}")
+            logger.info(
+                "team_response_preview",
+                agents=agent_list,
+                response_preview=team_response_text[:_MAX_LOG_MESSAGE_LENGTH],
+            )
             if len(team_response_text) > _MAX_LOG_MESSAGE_LENGTH:
-                logger.debug(f"TEAM RESPONSE (full): {team_response_text}")
+                logger.debug("team_response_full", agents=agent_list, response=team_response_text)
 
             team_header = _format_team_header(team_members.display_names)
             return team_header + team_response_text
@@ -1559,10 +1589,12 @@ async def _team_response_stream_raw(
 
     media_inputs = media or MediaInputs()
     logger.info(
-        f"Created team with {len(agents)} agents in {(team.delegate_to_all_members and 'collaborate') or 'coordinate'} mode",
+        "team_created",
+        agent_count=len(agents),
+        mode=(team.delegate_to_all_members and "collaborate") or "coordinate",
     )
     for agent in agents:
-        logger.debug(f"Team member: {agent.name}")
+        logger.debug("team_member", agent=agent.name)
 
     def _start_stream(current_prompt: str, current_media_inputs: MediaInputs) -> AsyncIterator[Any]:
         return team.arun(
@@ -1582,7 +1614,7 @@ async def _team_response_stream_raw(
     try:
         return _start_stream(prompt, media_inputs)
     except Exception as e:
-        logger.exception(f"Error in team streaming with agents {team_members.display_names}")
+        logger.exception("team_streaming_failed", agents=team_members.display_names)
         error_text = str(e)
 
         async def _error(content: str = error_text) -> AsyncIterator[TeamRunErrorEvent]:
@@ -1703,7 +1735,7 @@ async def team_response_stream(  # noqa: C901, PLR0911, PLR0912, PLR0915
             prepared_prompt = prepared_execution.prepared_prompt
             unseen_event_ids = prepared_execution.unseen_event_ids
             run_metadata = prepared_execution.run_metadata
-            logger.info(f"Team streaming setup - agents: {agent_names}, display names: {display_names}")
+            logger.info("team_streaming_setup", agents=agent_names, display_names=display_names)
             media_inputs = media or MediaInputs()
             attempt_prompt = prepared_prompt
             attempt_media_inputs = media_inputs
@@ -1963,7 +1995,7 @@ async def team_response_stream(  # noqa: C901, PLR0911, PLR0912, PLR0915
                                 tool=event.tool,
                             )
                         else:
-                            logger.debug(f"Ignoring event type: {type(event).__name__}")
+                            logger.debug("ignoring_team_stream_event_type", event_type=type(event).__name__)
                             continue
 
                         parts: list[str] = []

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -5,19 +5,20 @@ from __future__ import annotations
 import asyncio
 import functools
 import inspect
-import logging
 import os
 import time
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 
+from mindroom.logging_config import get_logger
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
 
     from structlog.stdlib import BoundLogger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -147,7 +148,7 @@ def timed(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:  # noqa: C9
     Log format: TIMING [<scope>] <label>: <elapsed>s  (scope omitted if not set)
     """
 
-    def decorator(fn: Callable[P, R]) -> Callable[P, R]:
+    def decorator(fn: Callable[P, R]) -> Callable[P, R]:  # noqa: C901
         if not _is_enabled():
             return fn
 
@@ -155,8 +156,14 @@ def timed(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:  # noqa: C9
             scope = kwargs.get("timing_scope")
             if not isinstance(scope, str) or not scope:
                 scope = timing_scope.get()
-            prefix = f"[{scope}] " if scope else ""
-            logger.info("TIMING %s%s: %.3fs", prefix, label, time.monotonic() - start)
+            duration_ms = round((time.monotonic() - start) * 1000, 1)
+            event_data: dict[str, object] = {
+                "label": label,
+                "duration_ms": duration_ms,
+            }
+            if scope:
+                event_data["timing_scope"] = scope
+            logger.info("timing_elapsed", **event_data)
 
         if inspect.isasyncgenfunction(fn):
 

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -14,9 +14,8 @@ from importlib import util as importlib_util
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-from loguru import logger
-
 from mindroom.credentials import get_runtime_credentials_manager, load_scoped_credentials
+from mindroom.logging_config import get_logger
 from mindroom.tool_system import plugins as plugin_module
 from mindroom.tool_system.dependencies import auto_install_tool_extra, check_deps_installed
 from mindroom.tool_system.plugins import load_plugins
@@ -36,7 +35,10 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.credentials import CredentialsManager
+
 # Registry mapping tool names to their factory functions
+logger = get_logger(__name__)
+
 _TOOL_REGISTRY: dict[str, Callable[[], type[Toolkit]]] = {}
 _BUILTIN_TOOL_REGISTRY: dict[str, Callable[[], type[Toolkit]]] = {}
 _PLUGIN_TOOL_METADATA_BY_MODULE: dict[str, dict[str, ToolMetadata]] = {}
@@ -622,11 +624,11 @@ def get_tool_by_name(
     if deps and not check_deps_installed(deps):
         if not auto_install_tool_extra(tool_name, runtime_paths):
             missing = ", ".join(deps)
-            logger.warning(f"Missing dependencies for tool '{tool_name}': {missing}")
-            logger.warning(f"Make sure the required dependencies are installed for {tool_name}")
+            logger.warning("tool_dependencies_missing", tool_name=tool_name, missing_dependencies=missing)
+            logger.warning("tool_dependency_install_required", tool_name=tool_name)
             msg = f"Missing dependencies for tool '{tool_name}': {missing}"
             raise ImportError(msg)
-        logger.info(f"Auto-installed optional dependencies for tool '{tool_name}'")
+        logger.info("tool_optional_dependencies_auto_installed", tool_name=tool_name)
         importlib.invalidate_caches()
 
     try:
@@ -634,17 +636,17 @@ def get_tool_by_name(
     except ImportError as first_error:
         # Safety net: deps may not be exhaustively listed in metadata
         if not auto_install_tool_extra(tool_name, runtime_paths):
-            logger.warning(f"Could not import tool '{tool_name}': {first_error}")
-            logger.warning(f"Make sure the required dependencies are installed for {tool_name}")
+            logger.warning("tool_import_failed", tool_name=tool_name, error=str(first_error))
+            logger.warning("tool_dependency_install_required", tool_name=tool_name)
             raise
 
-        logger.info(f"Auto-installing optional dependencies for tool '{tool_name}'")
+        logger.info("auto_installing_tool_optional_dependencies", tool_name=tool_name)
         importlib.invalidate_caches()
 
         try:
             return build()
         except ImportError as second_error:
-            logger.warning(f"Auto-install did not resolve dependencies for '{tool_name}': {second_error}")
+            logger.warning("tool_auto_install_failed", tool_name=tool_name, error=str(second_error))
             raise second_error from first_error
 
 

--- a/src/mindroom/tools/python.py
+++ b/src/mindroom/tools/python.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import subprocess
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
+from mindroom.logging_config import get_logger
 from mindroom.tool_system.dependencies import install_command_for_current_python
 from mindroom.tool_system.metadata import (
     ConfigField,
@@ -16,13 +17,12 @@ from mindroom.tool_system.metadata import (
 )
 
 if TYPE_CHECKING:
+    import logging
     from collections.abc import Callable
 
     from agno.tools.python import PythonTools
 
-
-class _ExceptionLogger(Protocol):
-    def exception(self, message: str) -> None: ...
+logger = get_logger(__name__)
 
 
 def _install_package_with_current_python(package_name: str) -> None:
@@ -35,24 +35,28 @@ def _install_package_with_status(
     *,
     warn: Callable[[], None],
     log_debug: Callable[[str], None],
-    logger: _ExceptionLogger,
+    agno_logger: logging.Logger,
 ) -> str:
     """Install a package and format the tool response."""
     try:
         warn()
-        log_debug(f"Installing package {package_name}")
+        log_debug("Installing package " + package_name)
+        logger.debug("python_package_install_started", package_name=package_name)
         _install_package_with_current_python(package_name)
     except Exception as exc:
-        logger.exception(f"Error installing package {package_name}")
+        error_message = f"Error installing package {package_name}"
+        agno_logger.exception(error_message)
+        logger.exception("python_package_install_failed", package_name=package_name)
         return f"Error installing package {package_name}: {exc}"
     return f"successfully installed package {package_name}"
 
 
 def _python_tools_runtime() -> tuple[Any, Any, Any, Any]:
     """Load Agno's Python tool runtime pieces lazily."""
-    from agno.tools.python import PythonTools, log_debug, logger, warn
+    from agno.tools.python import PythonTools, log_debug, warn
+    from agno.tools.python import logger as agno_logger
 
-    return PythonTools, warn, log_debug, logger
+    return PythonTools, warn, log_debug, agno_logger
 
 
 @register_tool_with_metadata(
@@ -101,17 +105,27 @@ def _python_tools_runtime() -> tuple[Any, Any, Any, Any]:
 )
 def python_tools() -> type[PythonTools]:
     """Return Python tools for code execution and file management."""
-    python_tools_class, warn, log_debug, logger = _python_tools_runtime()
+    python_tools_class, warn, log_debug, agno_logger = _python_tools_runtime()
 
     class MindRoomPythonTools(python_tools_class):
         """MindRoom wrapper around Agno's Python tool implementation."""
 
         def pip_install_package(self, package_name: str) -> str:
             """Install a package into the current interpreter environment."""
-            return _install_package_with_status(package_name, warn=warn, log_debug=log_debug, logger=logger)
+            return _install_package_with_status(
+                package_name,
+                warn=warn,
+                log_debug=log_debug,
+                agno_logger=agno_logger,
+            )
 
         def uv_pip_install_package(self, package_name: str) -> str:
             """Backward-compatible alias for the shared installer path."""
-            return _install_package_with_status(package_name, warn=warn, log_debug=log_debug, logger=logger)
+            return _install_package_with_status(
+                package_name,
+                warn=warn,
+                log_debug=log_debug,
+                agno_logger=agno_logger,
+            )
 
     return MindRoomPythonTools

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import logging
 import os
 import re
 import signal
@@ -17,6 +16,7 @@ from pathlib import Path
 from agno.tools.toolkit import Toolkit
 
 from mindroom.constants import RuntimePaths, shell_execution_runtime_env_values
+from mindroom.logging_config import get_logger
 from mindroom.tool_system.metadata import (
     ConfigField,
     SetupType,
@@ -431,7 +431,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
     return MindRoomShellTools
 
 
-_log = logging.getLogger(__name__)
+_log = get_logger(__name__)
 
 
 async def _read_stream(stream: asyncio.StreamReader | None, buf: deque[str]) -> None:

--- a/src/mindroom/topic_generator.py
+++ b/src/mindroom/topic_generator.py
@@ -102,11 +102,15 @@ Generate the topic:"""
             session_id=session_id,
         )
     except Exception:
-        logger.exception(f"Error generating topic for room {room_key}")
+        logger.exception("room_topic_generation_failed", room_key=room_key, session_id=session_id)
         return None
     content = response.content
     if not isinstance(content, _RoomTopic):
-        logger.warning(f"Topic generation returned unexpected type: {type(content)}")
+        logger.warning(
+            "room_topic_generation_unexpected_type",
+            room_key=room_key,
+            content_type=type(content).__name__,
+        )
         return str(content) if content else None
     return content.topic
 
@@ -135,14 +139,19 @@ async def ensure_room_has_topic(
     """
     response = await client.room_get_state_event(room_id, "m.room.topic")
     if isinstance(response, nio.RoomGetStateEventResponse) and response.content.get("topic"):
-        logger.debug(f"Room {room_key} already has topic: {response.content['topic']}")
+        logger.debug(
+            "room_topic_already_present",
+            room_id=room_id,
+            room_key=room_key,
+            topic=response.content["topic"],
+        )
         return True
 
     # Generate and set topic
-    logger.info(f"Generating AI topic for existing room {room_key}")
+    logger.info("generate_room_topic", room_id=room_id, room_key=room_key, room_name=room_name)
     topic = await generate_room_topic_ai(room_key, room_name, config, runtime_paths)
     if topic is None:
-        logger.warning(f"Failed to generate topic for room {room_key}")
+        logger.warning("generate_room_topic_failed", room_id=room_id, room_key=room_key)
         return False
 
     # Set the topic
@@ -153,8 +162,8 @@ async def ensure_room_has_topic(
     )
 
     if isinstance(response, nio.RoomPutStateResponse):
-        logger.info(f"Set topic for room {room_key}: {topic}")
+        logger.info("room_topic_set", room_id=room_id, room_key=room_key, topic=topic)
         return True
 
-    logger.warning(f"Failed to set topic for room {room_key}: {response}")
+    logger.warning("set_room_topic_failed", room_id=room_id, room_key=room_key, error=response)
     return False

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -300,7 +300,7 @@ async def _handle_voice_message(
             logger.warning("Failed to transcribe audio or empty transcription")
             return None
 
-        logger.info(f"Raw transcription: {transcription}")
+        logger.info("voice_transcription_received", transcription=transcription)
 
         available_agent_names, available_team_names = _get_available_entities_for_sender(
             room,
@@ -318,7 +318,7 @@ async def _handle_voice_message(
             available_team_names=available_team_names,
         )
 
-        logger.info(f"Formatted message: {formatted_message}")
+        logger.info("voice_message_formatted", formatted_message=formatted_message)
 
         if formatted_message:
             # Add a note that this was transcribed from voice
@@ -370,7 +370,11 @@ async def _transcribe_audio(audio_data: bytes, config: Config, runtime_paths: Ru
         async with httpx.AsyncClient(verify=False) as http_client:  # noqa: S501
             response = await http_client.post(url, headers=headers, files=files, data=form_data)
             if response.status_code != 200:
-                logger.error(f"STT API error: {response.status_code} - {response.text}")
+                logger.error(
+                    "stt_api_error",
+                    status_code=response.status_code,
+                    error=response.text,
+                )
                 return None
 
             result = response.json()

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -857,7 +857,7 @@ class TestCommandHandling:
             bot._generate_response.assert_not_called()
             # Check log calls - should be caught by the general agent message check
             debug_calls = [call[0][0] for call in bot.logger.debug.call_args_list]
-            assert "Ignoring message from other agent (not mentioned)" in debug_calls
+            assert "ignore_unmentioned_agent_event" in debug_calls
 
     @pytest.mark.asyncio
     async def test_router_error_without_mentions_ignored_by_other_agents(self) -> None:
@@ -989,7 +989,7 @@ class TestCommandHandling:
 
         # Verify it was caught early by the agent message check
         debug_calls = [call[0][0] for call in bot.logger.debug.call_args_list]
-        assert "Ignoring message from other agent (not mentioned)" in debug_calls
+        assert "ignore_unmentioned_agent_event" in debug_calls
 
     @pytest.mark.asyncio
     async def test_router_error_prevents_team_formation(self) -> None:
@@ -1109,7 +1109,7 @@ class TestCommandHandling:
         # Verify it was logged as being ignored
         debug_calls = [call[0][0] for call in bot.logger.debug.call_args_list]
         # The general "agent without mentions" check catches this first
-        assert "Ignoring message from other agent (not mentioned)" in debug_calls
+        assert "ignore_unmentioned_agent_event" in debug_calls
 
     @pytest.mark.asyncio
     async def test_full_router_error_flow_integration(self) -> None:
@@ -1232,7 +1232,7 @@ class TestCommandHandling:
 
         # Verify it was logged as being ignored
         debug_calls = [call[0][0] for call in bot.logger.debug.call_args_list]
-        assert "Ignoring message from other agent (not mentioned)" in debug_calls
+        assert "ignore_unmentioned_agent_event" in debug_calls
 
     @pytest.mark.asyncio
     async def test_agents_ignore_any_agent_messages_without_mentions(self) -> None:
@@ -1301,7 +1301,7 @@ class TestCommandHandling:
         bot._generate_response.assert_not_called()
         # Check debug calls for the new log message
         debug_calls = [call[0][0] for call in bot.logger.debug.call_args_list]
-        assert "Ignoring message from other agent (not mentioned)" in debug_calls
+        assert "ignore_unmentioned_agent_event" in debug_calls
 
 
 class TestRouterSkipsSingleAgent:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,164 @@
+"""Tests for structured logging configuration."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from typing import TYPE_CHECKING, NoReturn
+
+import pytest
+
+from mindroom.constants import RuntimePaths
+from mindroom.logging_config import get_logger, setup_logging
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _runtime_paths(tmp_path: Path) -> RuntimePaths:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("agents: {}\n", encoding="utf-8")
+    return RuntimePaths(
+        config_path=config_path,
+        config_dir=tmp_path,
+        env_path=tmp_path / ".env",
+        storage_root=tmp_path / "mindroom_data",
+    )
+
+
+def _last_stderr_line(capsys: pytest.CaptureFixture[str]) -> str:
+    return capsys.readouterr().err.strip().splitlines()[-1]
+
+
+def _last_stderr_payload(capsys: pytest.CaptureFixture[str]) -> dict[str, object]:
+    return json.loads(_last_stderr_line(capsys))
+
+
+def _raise_value_error() -> NoReturn:
+    msg = "boom"
+    raise ValueError(msg)
+
+
+def test_setup_logging_json_mode_emits_expected_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON mode should emit the expected structured fields for structlog loggers."""
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=_runtime_paths(tmp_path))
+    capsys.readouterr()
+
+    get_logger("tests.logging").info("test_event", room_id="!room:example.org")
+
+    payload = _last_stderr_payload(capsys)
+
+    assert payload["event"] == "test_event"
+    assert payload["level"] == "info"
+    assert payload["logger"] == "tests.logging"
+    assert payload["room_id"] == "!room:example.org"
+    assert "timestamp" in payload
+
+
+def test_setup_logging_json_mode_includes_logger_for_foreign_logger(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON mode should add the stdlib logger name for foreign log records."""
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=_runtime_paths(tmp_path))
+    capsys.readouterr()
+
+    logging.getLogger("test.foreign").info("foreign message")
+
+    payload = _last_stderr_payload(capsys)
+
+    assert payload["event"] == "foreign message"
+    assert payload["level"] == "info"
+    assert payload["logger"] == "test.foreign"
+    assert "timestamp" in payload
+
+
+def test_setup_logging_text_mode_does_not_emit_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Text mode should keep the default console renderer instead of emitting JSON."""
+    monkeypatch.delenv("MINDROOM_LOG_FORMAT", raising=False)
+    setup_logging(level="INFO", runtime_paths=_runtime_paths(tmp_path))
+    capsys.readouterr()
+
+    get_logger("tests.logging").info("text_mode_event", room_id="!room:example.org")
+
+    line = _last_stderr_line(capsys)
+
+    assert "text_mode_event" in line
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(line)
+
+
+def test_setup_logging_json_mode_renders_exception_field_for_exc_info_true(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON mode should render exc_info=True into an exception field."""
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=_runtime_paths(tmp_path))
+    capsys.readouterr()
+
+    try:
+        _raise_value_error()
+    except ValueError:
+        get_logger("tests.logging").exception("test_exception", agent="alpha")
+
+    payload = _last_stderr_payload(capsys)
+
+    assert payload["event"] == "test_exception"
+    assert payload["agent"] == "alpha"
+    assert isinstance(payload["exception"], str)
+    assert "ValueError: boom" in payload["exception"]
+
+
+def test_setup_logging_json_mode_renders_exception_field_for_exception_instance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON mode should render exception instances passed via exc_info."""
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=_runtime_paths(tmp_path))
+    capsys.readouterr()
+
+    get_logger("tests.logging").error("test_exception_instance", exc_info=ValueError("boom"))
+
+    payload = _last_stderr_payload(capsys)
+
+    assert payload["event"] == "test_exception_instance"
+    assert isinstance(payload["exception"], str)
+    assert "ValueError: boom" in payload["exception"]
+
+
+def test_setup_logging_json_mode_renders_exception_field_for_exc_info_tuple(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON mode should render exc_info tuples into an exception field."""
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=_runtime_paths(tmp_path))
+    capsys.readouterr()
+
+    try:
+        _raise_value_error()
+    except ValueError:
+        get_logger("tests.logging").error("test_exception_tuple", exc_info=sys.exc_info())
+
+    payload = _last_stderr_payload(capsys)
+
+    assert payload["event"] == "test_exception_tuple"
+    assert isinstance(payload["exception"], str)
+    assert "ValueError: boom" in payload["exception"]

--- a/tests/test_matrix_api_tool.py
+++ b/tests/test_matrix_api_tool.py
@@ -1027,13 +1027,13 @@ async def test_matrix_api_audit_logs_real_writes(
 
     assert payload["status"] == "ok"
     mock_warning.assert_called_once()
-    assert mock_warning.call_args.args[0] == "matrix_api write audit: {}"
-    audit_payload = json.loads(mock_warning.call_args.args[1])
+    assert mock_warning.call_args.args[0] == "matrix_api_write_audit"
+    audit_payload = mock_warning.call_args.kwargs
     assert audit_payload["action"] == action
-    assert audit_payload["agent_name"] == ctx.agent_name
-    assert audit_payload["requester_id"] == ctx.requester_id
+    assert audit_payload["agent"] == ctx.agent_name
+    assert audit_payload["user_id"] == ctx.requester_id
     assert audit_payload["room_id"] == ctx.room_id
     assert audit_payload["status"] == "ok"
-    assert set(audit_payload).issuperset({"action", "agent_name", "requester_id", "room_id", "status"})
+    assert set(audit_payload).issuperset({"action", "agent", "user_id", "room_id", "status"})
     assert set(audit_payload).issuperset(expected_summary)
-    assert "dont-log-me" not in mock_warning.call_args.args[1]
+    assert "dont-log-me" not in repr(audit_payload)

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -232,7 +232,7 @@ class TestStreamingBehavior:
             mock_check.return_value = ([MatrixID.parse("@mindroom_calculator:localhost")], True, False)
 
             # Debug: let's see what happens
-            calc_bot.logger.info(f"Processing initial message: '{initial_event.body}'")
+            calc_bot.logger.info("processing_initial_message", body=initial_event.body)
 
             # Add more logging to understand the flow
             with patch("mindroom.bot.extract_agent_name") as mock_extract:

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -3,144 +3,146 @@
 from __future__ import annotations
 
 import asyncio
-import logging
-import re
 from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
 import pytest
 
+import mindroom.timing as timing_module
 from mindroom.timing import timed, timing_scope
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
 
-def _assert_timing_logged(caplog: pytest.LogCaptureFixture, label: str, *, scope: str | None = None) -> None:
-    prefix = f"\\[{scope}\\] " if scope is not None else ""
-    assert re.fullmatch(rf"TIMING {prefix}{label}: \d+\.\d{{3}}s", caplog.messages[-1]) is not None
+def _mock_timing_logger(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    logger = Mock()
+    monkeypatch.setattr(timing_module, "logger", logger)
+    return logger
 
 
-def test_timed_sync_logs_when_enabled(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def _assert_timing_logged(logger: Mock, label: str, *, scope: str | None = None) -> None:
+    logger.info.assert_called_once()
+    assert logger.info.call_args.args == ("timing_elapsed",)
+    assert logger.info.call_args.kwargs["label"] == label
+    assert isinstance(logger.info.call_args.kwargs["duration_ms"], float)
+    assert logger.info.call_args.kwargs["duration_ms"] >= 0
+    if scope is None:
+        assert "timing_scope" not in logger.info.call_args.kwargs
+    else:
+        assert logger.info.call_args.kwargs["timing_scope"] == scope
+
+
+def test_timed_sync_logs_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     """Sync functions should emit a timing log when timing is enabled."""
     monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
 
     @timed("sync_label")
     def add(left: int, right: int) -> int:
         return left + right
 
-    caplog.set_level(logging.INFO, logger="mindroom.timing")
-
     assert add(2, 3) == 5
-    _assert_timing_logged(caplog, "sync_label")
+    _assert_timing_logged(logger, "sync_label")
 
 
 def test_timed_sync_logs_on_exception(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Sync functions should still emit a timing log when they raise."""
     monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
 
     @timed("sync_error_label")
     def fail() -> None:
         msg = "boom"
         raise RuntimeError(msg)
 
-    caplog.set_level(logging.INFO, logger="mindroom.timing")
-
     with pytest.raises(RuntimeError, match="boom"):
         fail()
 
-    _assert_timing_logged(caplog, "sync_error_label")
+    _assert_timing_logged(logger, "sync_error_label")
 
 
 @pytest.mark.asyncio
 async def test_timed_async_logs_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Async functions should emit a timing log when timing is enabled."""
     monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
 
     @timed("async_label")
     async def compute() -> str:
         return "done"
 
-    caplog.set_level(logging.INFO, logger="mindroom.timing")
-
     assert await compute() == "done"
-    _assert_timing_logged(caplog, "async_label")
+    _assert_timing_logged(logger, "async_label")
 
 
 @pytest.mark.asyncio
 async def test_timed_async_logs_on_exception(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Async functions should still emit a timing log when they raise."""
     monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
 
     @timed("async_error_label")
     async def fail() -> None:
         msg = "boom"
         raise RuntimeError(msg)
 
-    caplog.set_level(logging.INFO, logger="mindroom.timing")
-
     with pytest.raises(RuntimeError, match="boom"):
         await fail()
 
-    _assert_timing_logged(caplog, "async_error_label")
+    _assert_timing_logged(logger, "async_error_label")
 
 
 @pytest.mark.asyncio
 async def test_timed_async_generator_logs_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Async generators should emit a timing log after iteration completes."""
     monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
 
     @timed("async_generator_label")
     async def generate() -> AsyncIterator[str]:
         yield "a"
         yield "b"
 
-    caplog.set_level(logging.INFO, logger="mindroom.timing")
-
     assert [item async for item in generate()] == ["a", "b"]
-    _assert_timing_logged(caplog, "async_generator_label")
+    _assert_timing_logged(logger, "async_generator_label")
 
 
 @pytest.mark.asyncio
 async def test_timed_async_generator_logs_on_early_close(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Async generators should emit a timing log when iteration stops early."""
     monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
 
     @timed("async_generator_early_close_label")
     async def generate() -> AsyncIterator[str]:
         yield "a"
         yield "b"
 
-    caplog.set_level(logging.INFO, logger="mindroom.timing")
-
     generator = generate()
     assert await anext(generator) == "a"
     await generator.aclose()
 
-    _assert_timing_logged(caplog, "async_generator_early_close_label")
+    _assert_timing_logged(logger, "async_generator_early_close_label")
 
 
 @pytest.mark.asyncio
 async def test_timed_async_generator_uses_explicit_scope_on_cross_task_close(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Explicit timing_scope kwargs should survive async-generator close in another task."""
     monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
 
     @timed("async_generator_cross_task_close_label")
     async def generate(*, timing_scope: str | None = None) -> AsyncIterator[str]:
@@ -148,22 +150,20 @@ async def test_timed_async_generator_uses_explicit_scope_on_cross_task_close(
         yield "a"
         yield "b"
 
-    caplog.set_level(logging.INFO, logger="mindroom.timing")
-
     generator = generate(timing_scope="scope-123")
     assert await anext(generator) == "a"
     await asyncio.create_task(generator.aclose())
 
-    _assert_timing_logged(caplog, "async_generator_cross_task_close_label", scope="scope-123")
+    _assert_timing_logged(logger, "async_generator_cross_task_close_label", scope="scope-123")
 
 
 @pytest.mark.asyncio
 async def test_timed_async_generator_logs_on_exception(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Async generators should emit a timing log when iteration raises."""
     monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
 
     @timed("async_generator_error_label")
     async def generate() -> AsyncIterator[str]:
@@ -171,15 +171,13 @@ async def test_timed_async_generator_logs_on_exception(
         msg = "boom"
         raise RuntimeError(msg)
 
-    caplog.set_level(logging.INFO, logger="mindroom.timing")
-
     generator = generate()
     assert await anext(generator) == "a"
 
     with pytest.raises(RuntimeError, match="boom"):
         await anext(generator)
 
-    _assert_timing_logged(caplog, "async_generator_error_label")
+    _assert_timing_logged(logger, "async_generator_error_label")
 
 
 def test_timed_returns_original_function_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -196,16 +194,14 @@ def test_timed_returns_original_function_when_disabled(monkeypatch: pytest.Monke
 
 def test_timed_includes_scope_when_set(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The current timing scope should be rendered in the log line."""
     monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
 
     @timed("scoped_label")
     def run() -> None:
         return None
-
-    caplog.set_level(logging.INFO, logger="mindroom.timing")
 
     token = timing_scope.set("scope-123")
     try:
@@ -213,23 +209,18 @@ def test_timed_includes_scope_when_set(
     finally:
         timing_scope.reset(token)
 
-    _assert_timing_logged(caplog, "scoped_label", scope="scope-123")
+    _assert_timing_logged(logger, "scoped_label", scope="scope-123")
 
 
-def test_timed_log_format_omits_scope_when_unset(
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Unscoped timing lines should not render an empty scope prefix."""
+def test_timed_logs_omit_scope_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unscoped timing logs should not include the optional timing_scope field."""
     monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
 
     @timed("plain_label")
     def run() -> None:
         return None
 
-    caplog.set_level(logging.INFO, logger="mindroom.timing")
-
     run()
 
-    assert caplog.messages[-1].startswith("TIMING plain_label: ")
-    assert "[scope" not in caplog.messages[-1]
+    _assert_timing_logged(logger, "plain_label")

--- a/uv.lock
+++ b/uv.lock
@@ -2878,19 +2878,6 @@ wheels = [
 ]
 
 [[package]]
-name = "loguru"
-version = "0.7.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
-]
-
-[[package]]
 name = "lumaai"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3218,7 +3205,6 @@ dependencies = [
     { name = "httpx" },
     { name = "humanize" },
     { name = "json5" },
-    { name = "loguru" },
     { name = "markdown-it-py" },
     { name = "matrix-nio" },
     { name = "mcp", extra = ["cli"] },
@@ -3640,7 +3626,6 @@ requires-dist = [
     { name = "jira", marker = "extra == 'jira'", specifier = ">=3.10.5" },
     { name = "json5", specifier = ">=0.13" },
     { name = "linkup-sdk", marker = "extra == 'linkup'", specifier = ">=0.2.8" },
-    { name = "loguru", specifier = ">=0.7.3" },
     { name = "lumaai", marker = "extra == 'lumalabs'" },
     { name = "lxml-html-clean", marker = "extra == 'newspaper'" },
     { name = "markdown-it-py", specifier = ">=4" },
@@ -7632,15 +7617,6 @@ dependencies = [
     { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/35/25e68fbc99e672127cc6fbb14b8ec1ba3dfef035bf1e4c90f78f24a80b7d/wikipedia-1.4.0.tar.gz", hash = "sha256:db0fad1829fdd441b1852306e9856398204dc0786d2996dd2e0c8bb8e26133b2", size = 27748, upload-time = "2014-11-15T15:59:49.808Z" }
-
-[[package]]
-name = "win32-setctime"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
-]
 
 [[package]]
 name = "wrapt"


### PR DESCRIPTION
## Summary
- switch runtime logging to structured log events instead of ad hoc formatted strings
- add an optional JSON renderer toggle in logging configuration
- keep credential env syncing behavior while moving those paths to structured fields and shared helpers

## Why
The current runtime mixes formatted strings, partial context, and inconsistent event naming across critical paths.
That makes logs harder to search, aggregate, and ship to structured backends.
This change standardizes those call sites so operators can filter by event name and fields instead of parsing prose.

## What changed
- introduces a structured logging migration across agent, bot, Matrix, tool, scheduling, and orchestration paths
- adds explicit logging configuration support for switching between console and JSON rendering
- cleans up high-volume call sites so important fields are logged as structured metadata
- adds regression coverage for logging configuration and timing behavior

## Verification
- `PYTHONPATH="$PWD/src" /home/basnijholt/Work/dev/mindroom/.venv/bin/pytest -q`
  - `4144 passed, 24 skipped`
- `python -m pre_commit run --files $(git show --name-only --format='' HEAD | sed '/^$/d' | tr '\n' ' ')`
  - passed

## Note
- `pre-commit --all-files` is currently blocked on `main` by an unrelated Ruff violation in `tests/test_stop_emoji_reuse.py`, so this PR was verified on its touched files plus the full test suite.
