### PR TITLE
Clarify dispatch pipeline timing summaries

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import os
-import time
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
@@ -1305,10 +1303,10 @@ async def _process_stream_events(  # noqa: C901, PLR0912
     media_inputs: MediaInputs,
     retried_without_inline_media: bool,
     timing_scope: str,
-    request_started_at: float,
     pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> AsyncGenerator[AIStreamChunk, None]:
     """Consume one streaming attempt, yielding chunks and mutating *state*."""
+    del timing_scope
     try:
         async for event in stream_generator:
             if isinstance(event, RunContentEvent) and event.content:
@@ -1316,16 +1314,6 @@ async def _process_stream_events(  # noqa: C901, PLR0912
                     state.first_token_logged = True
                     if pipeline_timing is not None:
                         pipeline_timing.mark("model_first_token")
-                    if os.environ.get("MINDROOM_TIMING") == "1":
-                        elapsed_seconds = time.monotonic() - request_started_at
-                        logger.info(
-                            "timing_model_request_to_first_token",
-                            timing_scope=timing_scope,
-                            timing_step="model_request_to_first_token",
-                            elapsed_s=round(elapsed_seconds, 3),
-                            retried_without_inline_media=retried_without_inline_media,
-                            agent=agent_name,
-                        )
                 chunk_text = str(event.content)
                 state.full_response += chunk_text
                 yield event
@@ -1535,7 +1523,6 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     state = _StreamingAttemptState()
 
                     try:
-                        request_started_at = time.monotonic()
                         if pipeline_timing is not None:
                             pipeline_timing.mark("model_request_sent", overwrite=True)
                         _note_attempt_run_id(run_id_callback, attempt_run_id)
@@ -1560,7 +1547,6 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                             media_inputs=attempt_media_inputs,
                             retried_without_inline_media=retried_without_inline_media,
                             timing_scope=timing_scope,
-                            request_started_at=request_started_at,
                             pipeline_timing=pipeline_timing,
                         ):
                             yield stream_chunk

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -219,7 +219,6 @@ __all__ = ["AgentBot", "MultiKnowledgeVectorDb"]
 # Constants
 _SYNC_TIMEOUT_MS = 30000
 _STOPPING_RESPONSE_TEXT = "⏹️ Stopping generation..."
-_RECEIVED_MONOTONIC_KEY = "com.mindroom.received_monotonic"
 
 
 def _thread_summary_message_count_hint(
@@ -1565,8 +1564,6 @@ class AgentBot:
         }:
             return
 
-        if isinstance(event.source, dict):
-            event.source[_RECEIVED_MONOTONIC_KEY] = time.monotonic()
         prechecked_event = self._precheck_dispatch_event(room, event, is_edit=event_info.is_edit)
         if prechecked_event is None:
             return
@@ -2558,7 +2555,6 @@ class AgentBot:
         correlation_id: str | None = None,
         target: MessageTarget | None = None,
         matrix_run_metadata: dict[str, Any] | None = None,
-        received_monotonic: float | None = None,
         on_lifecycle_lock_acquired: Callable[[], None] | None = None,
     ) -> str | None:
         """Generate and send/edit a response using AI.
@@ -2586,7 +2582,6 @@ class AgentBot:
             target: Optional canonical response target used for lifecycle locking and delivery.
             matrix_run_metadata: Optional Matrix-specific run metadata persisted with the run
                 for unseen-message tracking, coalesced edit regeneration, and cleanup.
-            received_monotonic: Optional receive timestamp used for queued-message signaling.
             on_lifecycle_lock_acquired: Optional callback that runs after the response
                 lifecycle lock is acquired and before response generation starts.
 
@@ -2613,7 +2608,6 @@ class AgentBot:
                 matrix_run_metadata=matrix_run_metadata,
                 system_enrichment_items=system_enrichment_items,
                 strip_transient_enrichment_after_run=strip_transient_enrichment_after_run,
-                received_monotonic=received_monotonic,
                 on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
             ),
         )
@@ -3087,11 +3081,9 @@ class TeamBot(AgentBot):
         correlation_id: str | None = None,
         target: MessageTarget | None = None,
         matrix_run_metadata: dict[str, Any] | None = None,
-        received_monotonic: float | None = None,
         on_lifecycle_lock_acquired: Callable[[], None] | None = None,
     ) -> str | None:
         """Generate a team response instead of individual agent response."""
-        del received_monotonic
         if not prompt.strip():
             return None
 

--- a/src/mindroom/dispatch_planner.py
+++ b/src/mindroom/dispatch_planner.py
@@ -219,16 +219,6 @@ class DispatchHookService:
         return await emit_collect(self.hook_context.registry, EVENT_SYSTEM_ENRICH, context)
 
 
-def _received_monotonic_from_source(source: dict[str, Any] | None) -> float | None:
-    """Return the inbound receipt timestamp persisted on one event source."""
-    if not isinstance(source, dict):
-        return None
-    raw_received_monotonic = source.get("com.mindroom.received_monotonic")
-    if isinstance(raw_received_monotonic, float | int):
-        return float(raw_received_monotonic)
-    return None
-
-
 @dataclass(frozen=True)
 class ResponseAction:
     """Result of the shared team-formation and should-respond decision."""
@@ -1016,6 +1006,7 @@ class DispatchPlanner:
                 handled_turn.with_response_event_id(response_event_id),
             )
             if dispatch_timing is not None and response_event_id is not None:
+                dispatch_timing.mark_first_visible_reply("final")
                 dispatch_timing.mark("response_complete")
                 dispatch_timing.emit_summary(self.deps.logger, outcome="reject")
             return
@@ -1073,6 +1064,7 @@ class DispatchPlanner:
                     handled_turn.with_response_event_id(response_event_id),
                 )
                 if dispatch_timing is not None:
+                    dispatch_timing.mark_first_visible_reply("final")
                     dispatch_timing.mark("response_complete")
                     dispatch_timing.emit_summary(self.deps.logger, outcome="dispatch_failure")
             return
@@ -1086,7 +1078,6 @@ class DispatchPlanner:
         )
 
         self.deps.logger.info(processing_log, event_id=event.event_id)
-        received_monotonic = _received_monotonic_from_source(event.source)
         try:
             if action.kind == "team":
                 assert action.form_team is not None
@@ -1108,7 +1099,6 @@ class DispatchPlanner:
                         matrix_run_metadata=matrix_run_metadata,
                         system_enrichment_items=prepared_payload.system_enrichment_items,
                         strip_transient_enrichment_after_run=prepared_payload.strip_transient_enrichment_after_run,
-                        received_monotonic=received_monotonic,
                         pipeline_timing=dispatch_timing,
                     ),
                     team_agents=action.form_team.eligible_members,
@@ -1132,7 +1122,6 @@ class DispatchPlanner:
                         matrix_run_metadata=matrix_run_metadata,
                         system_enrichment_items=prepared_payload.system_enrichment_items,
                         strip_transient_enrichment_after_run=prepared_payload.strip_transient_enrichment_after_run,
-                        received_monotonic=received_monotonic,
                         pipeline_timing=dispatch_timing,
                     ),
                 )

--- a/src/mindroom/response_coordinator.py
+++ b/src/mindroom/response_coordinator.py
@@ -3,16 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import os
-import time
 from dataclasses import dataclass, field, replace
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 from agno.db.base import SessionType
-from agno.run.agent import RunContentEvent
 
 from mindroom import interactive
 from mindroom.agents import show_tool_calls_for_agent
@@ -52,7 +49,6 @@ from mindroom.streaming import (
 )
 from mindroom.teams import TeamMode, select_model_for_team, team_response, team_response_stream
 from mindroom.timing import DispatchPipelineTiming, timed
-from mindroom.timing import timing_scope as timing_scope_context
 from mindroom.tool_system.worker_routing import (
     run_with_tool_execution_identity,
     stream_with_tool_execution_identity,
@@ -290,7 +286,6 @@ class ResponseRequest:
     matrix_run_metadata: Mapping[str, Any] | None = None
     system_enrichment_items: tuple[EnrichmentItem, ...] = ()
     strip_transient_enrichment_after_run: bool = False
-    received_monotonic: float | None = None
     on_lifecycle_lock_acquired: Callable[[], None] | None = None
     pipeline_timing: DispatchPipelineTiming | None = None
 
@@ -952,6 +947,7 @@ class ResponseCoordinator:
                     ),
                 )
                 if request.pipeline_timing is not None:
+                    request.pipeline_timing.mark_first_visible_reply("final")
                     request.pipeline_timing.mark("response_complete")
             else:
                 try:
@@ -1031,6 +1027,7 @@ class ResponseCoordinator:
                     ),
                 )
                 if request.pipeline_timing is not None:
+                    request.pipeline_timing.mark_first_visible_reply("final")
                     request.pipeline_timing.mark("response_complete")
 
         thinking_msg = None
@@ -1115,6 +1112,7 @@ class ResponseCoordinator:
                 )
                 if initial_message_id is not None and pipeline_timing is not None:
                     pipeline_timing.mark("placeholder_sent")
+                    pipeline_timing.mark_first_visible_reply("placeholder")
 
             message_id = existing_event_id or initial_message_id
             task: asyncio.Task[None] = asyncio.create_task(response_function(message_id))
@@ -1179,36 +1177,6 @@ class ResponseCoordinator:
             return message_id
         finally:
             self.in_flight_response_count -= 1
-
-    async def _stream_response_with_first_token_log(
-        self,
-        response_stream: object,
-        *,
-        room_id: str,
-        received_monotonic: float | None = None,
-    ) -> AsyncIterator[object]:
-        """Proxy one streaming response and log time-to-first visible token."""
-        first_visible_token_logged = False
-        async for chunk in cast("AsyncIterator[object]", response_stream):
-            if (
-                received_monotonic is not None
-                and os.environ.get("MINDROOM_TIMING") == "1"
-                and not first_visible_token_logged
-                and isinstance(chunk, RunContentEvent)
-                and chunk.content
-            ):
-                first_visible_token_logged = True
-                elapsed_seconds = time.monotonic() - received_monotonic
-                scope = timing_scope_context.get()
-                prefix = f"[{scope}] " if scope else ""
-                self.deps.logger.info(
-                    f"TIMING {prefix}message_receipt_to_first_stream_token: {elapsed_seconds:.3f}s",
-                    timing_scope=scope,
-                    timing_step="message_receipt_to_first_stream_token",
-                    elapsed_s=round(elapsed_seconds, 3),
-                    room_id=room_id,
-                )
-            yield chunk
 
     async def _prepare_response_runtime_common(
         self,
@@ -1374,7 +1342,6 @@ class ResponseCoordinator:
         tool_trace: list[Any],
         run_metadata_content: dict[str, Any],
         compaction_outcomes: list[CompactionOutcome],
-        received_monotonic: float | None = None,
         pipeline_timing: DispatchPipelineTiming | None = None,
     ) -> tuple[str | None, str]:
         """Run one streaming AI request and send the streamed Matrix response."""
@@ -1417,11 +1384,6 @@ class ResponseCoordinator:
                 tool_context=runtime.tool_context,
                 stream_factory=lambda: response_stream,
             )
-            timed_response_stream = self._stream_response_with_first_token_log(
-                wrapped_response_stream,
-                room_id=request.room_id,
-                received_monotonic=received_monotonic,
-            )
             response_extra_content = _merge_response_extra_content(
                 run_metadata_content,
                 request.attachment_ids,
@@ -1431,7 +1393,7 @@ class ResponseCoordinator:
                     room_id=request.room_id,
                     reply_to_event_id=request.reply_to_event_id,
                     response_thread_id=runtime.response_thread_id,
-                    response_stream=timed_response_stream,
+                    response_stream=wrapped_response_stream,
                     existing_event_id=request.existing_event_id,
                     adopt_existing_placeholder=request.existing_event_id is not None
                     and request.existing_event_is_placeholder,
@@ -1534,6 +1496,7 @@ class ResponseCoordinator:
             ),
         )
         if request.pipeline_timing is not None:
+            request.pipeline_timing.mark_first_visible_reply("final")
             request.pipeline_timing.mark("response_complete")
         if compaction_outcomes_collector is not None:
             compaction_outcomes_collector.extend(compaction_outcomes)
@@ -1545,7 +1508,6 @@ class ResponseCoordinator:
         *,
         run_id: str | None = None,
         response_kind: str = "ai",
-        received_monotonic: float | None = None,
         compaction_outcomes_collector: list[CompactionOutcome] | None = None,
     ) -> DeliveryResult:
         """Process a message and send a streamed response."""
@@ -1571,7 +1533,6 @@ class ResponseCoordinator:
                 tool_trace=tool_trace,
                 run_metadata_content=run_metadata_content,
                 compaction_outcomes=compaction_outcomes,
-                received_monotonic=received_monotonic,
                 pipeline_timing=request.pipeline_timing,
             )
         except StreamingDeliveryError as error:
@@ -1622,6 +1583,7 @@ class ResponseCoordinator:
             if compaction_outcomes_collector is not None:
                 compaction_outcomes_collector.extend(compaction_outcomes)
             if request.pipeline_timing is not None:
+                request.pipeline_timing.mark_first_visible_reply("final")
                 request.pipeline_timing.mark("response_complete")
             return DeliveryResult(
                 event_id=event_id,
@@ -1651,6 +1613,7 @@ class ResponseCoordinator:
             ),
         )
         if request.pipeline_timing is not None:
+            request.pipeline_timing.mark_first_visible_reply("final")
             request.pipeline_timing.mark("response_complete")
 
         if compaction_outcomes_collector is not None:
@@ -2012,7 +1975,6 @@ class ResponseCoordinator:
                 delivery_result = await self.process_and_respond_streaming(
                     delivery_request,
                     run_id=response_run_id,
-                    received_monotonic=request.received_monotonic,
                     compaction_outcomes_collector=compaction_outcomes,
                 )
             else:

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -396,7 +396,7 @@ class StreamingResponse:
                     if response_event_id:
                         self.event_id = response_event_id
                         if self.pipeline_timing is not None and self.accumulated_text.strip():
-                            self.pipeline_timing.mark("first_visible_stream_update")
+                            self.pipeline_timing.mark_first_visible_reply("stream_update")
                         logger.debug("Initial streaming message sent", event_id=self.event_id)
                         return True
                     logger.error("Failed to send initial streaming message", attempt=attempt)
@@ -405,7 +405,7 @@ class StreamingResponse:
                     response_event_id = await edit_message(client, self.room_id, self.event_id, content, display_text)
                     if response_event_id:
                         if self.pipeline_timing is not None and self.accumulated_text.strip():
-                            self.pipeline_timing.mark("first_visible_stream_update")
+                            self.pipeline_timing.mark_first_visible_reply("stream_update")
                         return True
                     logger.error("Failed to edit streaming message", attempt=attempt)
             except Exception:

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -34,6 +34,34 @@ def _is_enabled() -> bool:
 
 type TimingMetadataValue = str | int | float | bool
 
+PRIMARY_SEGMENTS: tuple[tuple[str, str, str], ...] = (
+    ("seg_ingress_ms", "message_received", "gate_enter"),
+    ("seg_coalescing_ms", "gate_enter", "gate_exit"),
+    ("seg_dispatch_ms", "gate_exit", "response_payload_ready"),
+    ("seg_response_queue_ms", "response_payload_ready", "lock_acquired"),
+    ("seg_thread_refresh_ms", "lock_acquired", "thread_refresh_ready"),
+    ("seg_first_visible_reply_ms", "thread_refresh_ready", "first_visible_reply"),
+    ("seg_after_first_visible_ms", "first_visible_reply", "response_complete"),
+)
+
+PRIMARY_TOTALS: tuple[tuple[str, str, str], ...] = (
+    ("time_to_first_visible_reply_ms", "message_received", "first_visible_reply"),
+    ("total_pipeline_ms", "message_received", "response_complete"),
+)
+
+DIAGNOSTIC_SPANS: tuple[tuple[str, str, str], ...] = (
+    ("diag_dispatch_prepare_ms", "dispatch_prepare_start", "dispatch_prepare_ready"),
+    ("diag_dispatch_plan_ms", "dispatch_plan_start", "dispatch_plan_ready"),
+    ("diag_response_payload_setup_ms", "response_payload_start", "response_payload_ready"),
+    ("diag_lock_wait_ms", "lock_wait_start", "lock_acquired"),
+    ("diag_runtime_prepare_ms", "response_runtime_start", "response_runtime_ready"),
+    ("diag_llm_prepare_ms", "ai_prepare_start", "history_ready"),
+    ("diag_history_ready_to_model_request_ms", "history_ready", "model_request_sent"),
+    ("diag_provider_ttft_ms", "model_request_sent", "model_first_token"),
+    ("diag_first_visible_to_stream_complete_ms", "first_visible_reply", "streaming_complete"),
+    ("diag_model_request_to_completion_ms", "model_request_sent", "response_complete"),
+)
+
 
 @dataclass(slots=True)
 class DispatchPipelineTiming:
@@ -56,6 +84,13 @@ class DispatchPipelineTiming:
             if value is not None:
                 self.metadata[key] = value
 
+    def mark_first_visible_reply(self, kind: str) -> None:
+        """Record the first user-visible response milestone once."""
+        if "first_visible_reply" in self.marks:
+            return
+        self.marks["first_visible_reply"] = time.perf_counter()
+        self.metadata["first_visible_kind"] = kind
+
     def elapsed_ms(self, start_label: str, end_label: str) -> float | None:
         """Return elapsed time between two recorded phase boundaries."""
         start = self.marks.get(start_label)
@@ -75,34 +110,8 @@ class DispatchPipelineTiming:
             "outcome": outcome,
             **self.metadata,
         }
-        duration_pairs = {
-            "arrival_to_gate_entry_ms": ("message_received", "gate_enter"),
-            "coalescing_gate_ms": ("gate_enter", "gate_exit"),
-            "gate_exit_to_dispatch_start_ms": ("gate_exit", "dispatch_start"),
-            "prepare_dispatch_ms": ("dispatch_prepare_start", "dispatch_prepare_ready"),
-            "plan_dispatch_ms": ("dispatch_plan_start", "dispatch_plan_ready"),
-            "response_payload_setup_ms": ("response_payload_start", "response_payload_ready"),
-            "lock_wait_ms": ("lock_wait_start", "lock_acquired"),
-            "post_lock_thread_refresh_ms": ("lock_acquired", "thread_refresh_ready"),
-            "lock_acquired_to_placeholder_ms": ("lock_acquired", "placeholder_sent"),
-            "placeholder_to_runtime_start_ms": ("placeholder_sent", "response_runtime_start"),
-            "runtime_prepare_ms": ("response_runtime_start", "response_runtime_ready"),
-            "system_prompt_history_ms": ("ai_prepare_start", "history_ready"),
-            "history_ready_to_model_request_ms": ("history_ready", "model_request_sent"),
-            "model_request_to_first_token_ms": ("model_request_sent", "model_first_token"),
-            "model_first_token_to_first_visible_stream_update_ms": (
-                "model_first_token",
-                "first_visible_stream_update",
-            ),
-            "first_visible_stream_update_to_stream_complete_ms": (
-                "first_visible_stream_update",
-                "streaming_complete",
-            ),
-            "placeholder_visible_ms": ("placeholder_sent", "response_complete"),
-            "total_pipeline_ms": ("message_received", "response_complete"),
-            "model_request_to_completion_ms": ("model_request_sent", "response_complete"),
-        }
-        for key, (start_label, end_label) in duration_pairs.items():
+        duration_pairs = (*PRIMARY_SEGMENTS, *PRIMARY_TOTALS, *DIAGNOSTIC_SPANS)
+        for key, start_label, end_label in duration_pairs:
             elapsed = self.elapsed_ms(start_label, end_label)
             if elapsed is not None:
                 summary[key] = elapsed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,7 +407,6 @@ def install_generate_response_mock(bot: object, generate_response: AsyncMock) ->
             correlation_id=request.correlation_id,
             target=request.target,
             matrix_run_metadata=request.matrix_run_metadata,
-            received_monotonic=request.received_monotonic,
         )
 
     bot._response_coordinator.generate_response = AsyncMock(side_effect=_generate)

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -204,7 +204,6 @@ def _response_request(
     target: MessageTarget | None = None,
     matrix_run_metadata: dict[str, Any] | None = None,
     system_enrichment_items: tuple[EnrichmentItem, ...] = (),
-    received_monotonic: float | None = None,
 ) -> ResponseRequest:
     """Build one response request for direct bot seam tests."""
     return ResponseRequest(
@@ -224,7 +223,6 @@ def _response_request(
         target=target,
         matrix_run_metadata=matrix_run_metadata,
         system_enrichment_items=system_enrichment_items,
-        received_monotonic=received_monotonic,
     )
 
 

--- a/tests/test_stop_emoji_reuse.py
+++ b/tests/test_stop_emoji_reuse.py
@@ -455,10 +455,7 @@ async def test_stop_manager_cleanup_uses_captured_run_id_after_task_finishes() -
 
     async def short_lived_response() -> None:
         started.set()
-        try:
-            await asyncio.sleep(999)
-        except asyncio.CancelledError:
-            raise
+        await asyncio.sleep(999)
 
     task = asyncio.create_task(short_lived_response())
     await started.wait()

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 import pytest
 
 import mindroom.timing as timing_module
-from mindroom.timing import timed, timing_scope
+from mindroom.timing import DispatchPipelineTiming, timed, timing_scope
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -224,3 +224,79 @@ def test_timed_logs_omit_scope_when_unset(monkeypatch: pytest.MonkeyPatch) -> No
     run()
 
     _assert_timing_logged(logger, "plain_label")
+
+
+def test_dispatch_pipeline_summary_emits_additive_segments_and_diagnostics() -> None:
+    """Pipeline summary should separate additive segments from drill-down diagnostics."""
+    logger = Mock()
+    timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room")
+    timing.metadata["first_visible_kind"] = "stream_update"
+    timing.marks.update(
+        {
+            "message_received": 0.0,
+            "gate_enter": 1.0,
+            "gate_exit": 3.0,
+            "dispatch_prepare_start": 4.0,
+            "dispatch_prepare_ready": 6.0,
+            "dispatch_plan_start": 6.5,
+            "dispatch_plan_ready": 7.5,
+            "response_payload_start": 8.0,
+            "response_payload_ready": 9.0,
+            "lock_wait_start": 10.0,
+            "lock_acquired": 12.0,
+            "thread_refresh_ready": 13.0,
+            "response_runtime_start": 14.0,
+            "response_runtime_ready": 15.0,
+            "ai_prepare_start": 15.5,
+            "history_ready": 17.0,
+            "model_request_sent": 18.0,
+            "model_first_token": 19.5,
+            "first_visible_reply": 20.0,
+            "streaming_complete": 24.0,
+            "response_complete": 25.0,
+        },
+    )
+
+    timing.emit_summary(logger, outcome="edited")
+
+    logger.info.assert_called_once()
+    assert logger.info.call_args.args == ("Dispatch pipeline timing",)
+    summary = logger.info.call_args.kwargs
+    assert summary["first_visible_kind"] == "stream_update"
+    assert summary["seg_ingress_ms"] == 1000.0
+    assert summary["seg_coalescing_ms"] == 2000.0
+    assert summary["seg_dispatch_ms"] == 6000.0
+    assert summary["seg_response_queue_ms"] == 3000.0
+    assert summary["seg_thread_refresh_ms"] == 1000.0
+    assert summary["seg_first_visible_reply_ms"] == 7000.0
+    assert summary["seg_after_first_visible_ms"] == 5000.0
+    assert summary["time_to_first_visible_reply_ms"] == 20000.0
+    assert summary["total_pipeline_ms"] == 25000.0
+    assert summary["diag_dispatch_prepare_ms"] == 2000.0
+    assert summary["diag_dispatch_plan_ms"] == 1000.0
+    assert summary["diag_response_payload_setup_ms"] == 1000.0
+    assert summary["diag_lock_wait_ms"] == 2000.0
+    assert summary["diag_runtime_prepare_ms"] == 1000.0
+    assert summary["diag_llm_prepare_ms"] == 1500.0
+    assert summary["diag_history_ready_to_model_request_ms"] == 1000.0
+    assert summary["diag_provider_ttft_ms"] == 1500.0
+    assert summary["diag_first_visible_to_stream_complete_ms"] == 4000.0
+    assert summary["diag_model_request_to_completion_ms"] == 7000.0
+    assert "model_first_token_to_first_visible_stream_update_ms" not in summary
+    assert "placeholder_visible_ms" not in summary
+    assert "model_request_to_completion_ms" not in summary
+
+
+def test_dispatch_pipeline_first_visible_reply_is_first_write_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first visible reply mark should preserve the earliest visible milestone."""
+    perf_counter = Mock(side_effect=[1.5, 9.0])
+    monkeypatch.setattr(timing_module.time, "perf_counter", perf_counter)
+    timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room")
+
+    timing.mark_first_visible_reply("placeholder")
+    timing.mark_first_visible_reply("final")
+
+    assert timing.marks["first_visible_reply"] == 1.5
+    assert timing.metadata["first_visible_kind"] == "placeholder"


### PR DESCRIPTION
## Summary
- simplify dispatch pipeline timing summaries so each segment is easier to interpret
- remove duplicate or low-value timing fields from the runtime summary payload
- tighten the timing tests around additive segment accounting and first-write tracking

## Why
The current timing summary is useful as temporary instrumentation, but it is harder to read than it needs to be.
This change trims the summary down to the parts that actually help explain where time went in a dispatch.

## What changed
- collapses redundant timing fields in the pipeline summary output
- keeps first-visible-reply tracking explicit instead of mixing it into less clear summary data
- updates timing coverage so the summary shape stays stable

## Verification
- `python -m pre_commit run --files src/mindroom/ai.py src/mindroom/bot.py src/mindroom/dispatch_planner.py src/mindroom/response_coordinator.py src/mindroom/streaming.py src/mindroom/timing.py tests/conftest.py tests/test_multi_agent_bot.py tests/test_timing.py`
- `PYTHONPATH="$PWD/src" /home/basnijholt/Work/dev/mindroom/.venv/bin/pytest -q tests/test_timing.py tests/test_multi_agent_bot.py -k 'timing or pipeline'`
  - `13 passed`
