### PR TITLE
Speed up slow sandbox-runner and config test hotspots

### DIFF
--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -70,17 +70,6 @@ def _fake_local_worker_venv_create(_self: object, venv_dir: Path) -> None:
     bin_dir = venv_dir / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
     (bin_dir / "python").symlink_to(Path(sys.executable))
-    (venv_dir / "pyvenv.cfg").write_text(
-        "\n".join(
-            (
-                f"home = {Path(sys.executable).parent}",
-                "include-system-site-packages = true",
-                f"version = {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
-            ),
-        )
-        + "\n",
-        encoding="utf-8",
-    )
 
 
 @pytest.fixture(autouse=True)
@@ -92,7 +81,6 @@ def _load_tools() -> None:
 def _reset_worker_manager(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(local_workers_module, "_local_worker_manager", None)
     monkeypatch.setattr(local_workers_module, "_local_worker_manager_config", None)
-    monkeypatch.setattr(local_workers_module.venv.EnvBuilder, "create", _fake_local_worker_venv_create)
     monkeypatch.delenv("MINDROOM_SANDBOX_WORKER_ROOT", raising=False)
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
 

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -70,6 +70,17 @@ def _fake_local_worker_venv_create(_self: object, venv_dir: Path) -> None:
     bin_dir = venv_dir / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
     (bin_dir / "python").symlink_to(Path(sys.executable))
+    (venv_dir / "pyvenv.cfg").write_text(
+        "\n".join(
+            (
+                f"home = {Path(sys.executable).parent}",
+                "include-system-site-packages = true",
+                f"version = {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            ),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -81,6 +92,7 @@ def _load_tools() -> None:
 def _reset_worker_manager(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(local_workers_module, "_local_worker_manager", None)
     monkeypatch.setattr(local_workers_module, "_local_worker_manager_config", None)
+    monkeypatch.setattr(local_workers_module.venv.EnvBuilder, "create", _fake_local_worker_venv_create)
     monkeypatch.delenv("MINDROOM_SANDBOX_WORKER_ROOT", raising=False)
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -21,6 +21,7 @@ from mindroom.agents import (
     _PRIVATE_CULTURE_MANAGER_CACHE,
     create_agent,
     get_agent_runtime_sqlite_dbs,
+    get_agent_toolkit_names,
 )
 from mindroom.config.agent import (
     AgentConfig,
@@ -1161,7 +1162,7 @@ def test_create_agent_uses_default_worker_tool_policy_when_unset(
 
 @patch("mindroom.agents.SqliteDb")
 def test_openclaw_compat_implies_matrix_message_tool(mock_storage: MagicMock) -> None:  # noqa: ARG001
-    """openclaw_compat should stay in the list and imply matrix_message."""
+    """openclaw_compat should stay in the runtime toolkit list and imply matrix_message."""
     config = _test_config()
     config.agents["summary"].tools = ["openclaw_compat"]
     config.agents["summary"].include_default_tools = False
@@ -1170,9 +1171,9 @@ def test_openclaw_compat_implies_matrix_message_tool(mock_storage: MagicMock) ->
     assert "openclaw_compat" in effective_tools
     assert "matrix_message" in effective_tools
 
-    agent = _create_agent_for_test("summary", config=config)
-    tool_names = [tool.name for tool in agent.tools]
-    assert "matrix_message" in tool_names
+    runtime_toolkits = get_agent_toolkit_names("summary", config)
+    assert "openclaw_compat" in runtime_toolkits
+    assert "matrix_message" in runtime_toolkits
 
 
 def test_openclaw_compat_implied_matrix_message_does_not_duplicate() -> None:

--- a/tests/test_config_discovery.py
+++ b/tests/test_config_discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import importlib
 import os
+from functools import cache
 from pathlib import Path
 
 import pytest
@@ -97,6 +98,17 @@ def _runtime_source_files() -> list[Path]:
     return sorted((_repo_root() / "src" / "mindroom").rglob("*.py"))
 
 
+@cache
+def _runtime_source_contexts() -> tuple[tuple[str, ast.AST, set[str]], ...]:
+    repo_root = _repo_root()
+    contexts: list[tuple[str, ast.AST, set[str]]] = []
+    for source_path in _runtime_source_files():
+        relative_path = source_path.relative_to(repo_root).as_posix()
+        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+        contexts.append((relative_path, tree, _runtime_constant_aliases(tree)))
+    return tuple(contexts)
+
+
 def _runtime_constant_aliases(tree: ast.AST) -> set[str]:
     aliases: set[str] = set()
     for node in ast.walk(tree):
@@ -140,13 +152,9 @@ def _runtime_global_attr_violations(tree: ast.AST, relative_path: str, constant_
 
 def _collect_runtime_global_violations() -> list[str]:
     violations: list[str] = []
-    for source_path in _runtime_source_files():
-        relative_path = source_path.relative_to(_repo_root()).as_posix()
+    for relative_path, tree, constant_aliases in _runtime_source_contexts():
         if relative_path in _RUNTIME_GLOBAL_ALLOWLIST:
             continue
-
-        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-        constant_aliases = _runtime_constant_aliases(tree)
         violations.extend(_runtime_global_import_violations(tree, relative_path))
         violations.extend(_runtime_global_attr_violations(tree, relative_path, constant_aliases))
 
@@ -155,12 +163,9 @@ def _collect_runtime_global_violations() -> list[str]:
 
 def _collect_runtime_env_violations() -> list[str]:
     violations: list[str] = []
-    for source_path in _runtime_source_files():
-        relative_path = source_path.relative_to(_repo_root()).as_posix()
+    for relative_path, tree, _constant_aliases in _runtime_source_contexts():
         if relative_path in _RUNTIME_ENV_ALLOWLIST:
             continue
-
-        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
         for node in ast.walk(tree):
             if (
                 isinstance(node, ast.Call)
@@ -212,9 +217,7 @@ def _call_name(node: ast.Call) -> str | None:
 
 def _collect_execution_identity_keyword_violations() -> list[str]:
     violations: list[str] = []
-    for source_path in _runtime_source_files():
-        relative_path = source_path.relative_to(_repo_root()).as_posix()
-        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    for relative_path, tree, _constant_aliases in _runtime_source_contexts():
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -230,9 +233,7 @@ def _collect_execution_identity_keyword_violations() -> list[str]:
 
 def _collect_execution_identity_default_violations() -> list[str]:
     violations: list[str] = []
-    for source_path in _runtime_source_files():
-        relative_path = source_path.relative_to(_repo_root()).as_posix()
-        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    for relative_path, tree, _constant_aliases in _runtime_source_contexts():
         for node in ast.walk(tree):
             if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
                 continue
@@ -258,11 +259,9 @@ def _collect_execution_identity_default_violations() -> list[str]:
 
 def _collect_ambient_execution_identity_read_violations() -> list[str]:
     violations: list[str] = []
-    for source_path in _runtime_source_files():
-        relative_path = source_path.relative_to(_repo_root()).as_posix()
+    for relative_path, tree, _constant_aliases in _runtime_source_contexts():
         if relative_path in _AMBIENT_EXECUTION_IDENTITY_ALLOWLIST:
             continue
-        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -274,11 +273,9 @@ def _collect_ambient_execution_identity_read_violations() -> list[str]:
 
 def _collect_ambient_execution_identity_write_violations() -> list[str]:
     violations: list[str] = []
-    for source_path in _runtime_source_files():
-        relative_path = source_path.relative_to(_repo_root()).as_posix()
+    for relative_path, tree, _constant_aliases in _runtime_source_contexts():
         if relative_path in _AMBIENT_EXECUTION_IDENTITY_ALLOWLIST:
             continue
-        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -290,12 +287,9 @@ def _collect_ambient_execution_identity_write_violations() -> list[str]:
 
 def _collect_execution_identity_env_violations() -> list[str]:
     violations: list[str] = []
-    for source_path in _runtime_source_files():
-        relative_path = source_path.relative_to(_repo_root()).as_posix()
+    for relative_path, tree, _constant_aliases in _runtime_source_contexts():
         if relative_path in _EXECUTION_IDENTITY_ENV_ALLOWLIST:
             continue
-
-        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue

--- a/tests/test_config_manager_consolidated.py
+++ b/tests/test_config_manager_consolidated.py
@@ -7,6 +7,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
 from mindroom.config.agent import AgentConfig, TeamConfig
@@ -322,8 +323,8 @@ class TestConsolidatedConfigManager:
         )
 
         assert "Successfully created" in result
-        config = Config.from_yaml(config_path)
-        assert config.agents["test_agent"].tool_names == ["config_manager_plugin_tool"]
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["agents"]["test_agent"]["tools"] == ["config_manager_plugin_tool"]
 
     def test_manage_agent_create_accepts_openclaw_preset_tool(self) -> None:
         """Agent create should accept preset entries in tools."""

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
 import pytest
-from aioresponses import aioresponses
 
 from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig
@@ -115,7 +113,8 @@ async def test_agent_processes_direct_mention(
         config = _make_config(tmp_path)
 
         bot = AgentBot(mock_calculator_agent, tmp_path, config, runtime_paths_for(config), rooms=[test_room_id])
-        await bot.start()
+        bot.client = mock_client
+        bot.running = True
 
         # Create a message mentioning the calculator agent
         message_body = f"@mindroom_calculator:{config.get_domain(runtime_paths_for(config))} What's 15% of 200?"
@@ -142,47 +141,48 @@ async def test_agent_processes_direct_mention(
 
         room = nio.MatrixRoom(test_room_id, mock_calculator_agent.user_id)
 
-        with aioresponses() as m:
-            # Mock the HTTP endpoint for sending messages
-            m.put(
-                re.compile(rf".*{re.escape(test_room_id)}/send/m\.room\.message/.*"),
-                status=200,
-                payload={"event_id": "$response_event:localhost"},
-            )
+        async def mock_streaming_response() -> AsyncGenerator[str, None]:
+            yield "15% of 200 is 30"
 
-            async def mock_streaming_response() -> AsyncGenerator[str, None]:
-                yield "15% of 200 is 30"
-
-            mock_ai = AsyncMock(return_value=mock_streaming_response())
-            with patch_response_coordinator_module(
+        mock_ai = AsyncMock(return_value=mock_streaming_response())
+        with (
+            patch(
+                "mindroom.delivery_gateway.send_streaming_response",
+                new_callable=AsyncMock,
+            ) as mock_send_streaming_response,
+            patch_response_coordinator_module(
                 stream_agent_response=mock_ai,
                 should_use_streaming=AsyncMock(return_value=True),
-            ):
-                await bot._on_message(room, message_event)
+            ),
+        ):
+            mock_send_streaming_response.return_value = ("$response", "15% of 200 is 30")
+            await bot._on_message(room, message_event)
 
-            # Verify AI was called with correct parameters (full message body as prompt)
-            mock_ai.assert_called_once()
-            ai_kwargs = mock_ai.call_args.kwargs
-            assert ai_kwargs["agent_name"] == "calculator"
-            assert ai_kwargs["prompt"].startswith("[")
-            assert ai_kwargs["prompt"].endswith(
-                f"@mindroom_calculator:{config.get_domain(runtime_paths_for(config))} What's 15% of 200?",
-            )
-            assert ai_kwargs["session_id"] == f"{test_room_id}:$thread_root:localhost"
-            assert ai_kwargs["thread_history"] == []
-            assert ai_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
-            assert ai_kwargs["config"] == config
-            assert ai_kwargs["room_id"] == test_room_id
-            assert ai_kwargs["knowledge"] is None
-            assert ai_kwargs["user_id"] == test_user_id
-            assert ai_kwargs["media"] == MediaInputs()
-            assert ai_kwargs["reply_to_event_id"] == "$test_event:localhost"
-            assert ai_kwargs["show_tool_calls"] is True
-            assert ai_kwargs["run_metadata_collector"] == {}
+        # Verify AI was called with correct parameters (full message body as prompt)
+        mock_ai.assert_called_once()
+        ai_kwargs = mock_ai.call_args.kwargs
+        assert ai_kwargs["agent_name"] == "calculator"
+        assert ai_kwargs["prompt"].startswith("[")
+        assert ai_kwargs["prompt"].endswith(
+            f"@mindroom_calculator:{config.get_domain(runtime_paths_for(config))} What's 15% of 200?",
+        )
+        assert ai_kwargs["session_id"] == f"{test_room_id}:$thread_root:localhost"
+        assert ai_kwargs["thread_history"] == []
+        assert ai_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
+        assert ai_kwargs["config"] == config
+        assert ai_kwargs["room_id"] == test_room_id
+        assert ai_kwargs["knowledge"] is None
+        assert ai_kwargs["user_id"] == test_user_id
+        assert ai_kwargs["media"] == MediaInputs()
+        assert ai_kwargs["reply_to_event_id"] == "$test_event:localhost"
+        assert ai_kwargs["show_tool_calls"] is True
+        assert ai_kwargs["run_metadata_collector"] == {}
 
-            # Verify message was sent (thinking + streaming updates)
-            # With streaming: 1 thinking message + streaming updates
-            assert bot.client.room_send.call_count >= 1
+        mock_send_streaming_response.assert_awaited_once()
+        send_args = mock_send_streaming_response.await_args.args
+        assert send_args[1] == test_room_id
+        assert send_args[2] == "$test_event:localhost"
+        assert send_args[3] == "$thread_root:localhost"
 
 
 @pytest.mark.asyncio

--- a/tests/test_self_config.py
+++ b/tests/test_self_config.py
@@ -7,6 +7,8 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import yaml
+
 from mindroom.agents import create_agent
 from mindroom.api import config_lifecycle, main
 from mindroom.config.agent import AgentConfig
@@ -286,8 +288,8 @@ class TestUpdateOwnConfig:
         result = tool.update_own_config(tools=["self_config_plugin_tool"])
 
         assert "Successfully" in result
-        reloaded = Config.from_yaml(config_path)
-        assert reloaded.agents["coder"].tool_names == ["self_config_plugin_tool"]
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["agents"]["coder"]["tools"] == ["self_config_plugin_tool"]
 
     def test_update_tools_blocks_privileged_tool(self) -> None:
         """Self-config should not allow assigning privileged global-config tools."""

--- a/tests/test_tool_dependencies.py
+++ b/tests/test_tool_dependencies.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from agno.tools import Toolkit
 
 from mindroom.constants import resolve_runtime_paths
 from mindroom.tool_system.dependencies import (
@@ -37,17 +38,17 @@ TEST_RUNTIME_PATHS = resolve_runtime_paths(config_path=Path("config.yaml"))
 
 
 def test_all_tools_can_be_imported() -> None:
-    """Test that all registered tools can be imported and instantiated."""
+    """Test that all registered tools can be imported from the registry."""
     failed = []
 
-    for tool_name in _TOOL_REGISTRY:
+    for tool_name, factory in _TOOL_REGISTRY.items():
         metadata = TOOL_METADATA.get(tool_name)
         requires_config = metadata and metadata.status == ToolStatus.REQUIRES_CONFIG
 
         try:
-            tool_instance = get_tool_by_name(tool_name, TEST_RUNTIME_PATHS, worker_target=None)
-            assert tool_instance is not None
-            assert hasattr(tool_instance, "name")
+            tool_class = factory()
+            assert isinstance(tool_class, type)
+            assert issubclass(tool_class, Toolkit)
         except Exception as e:
             if not requires_config:
                 failed.append((tool_name, str(e)))


### PR DESCRIPTION
## Summary
- reduce slow test setup churn in the sandbox-runner/config speedup branch
- keep the fake local-worker venv bootstrap scoped to the tests that actually need it
- preserve dedicated-worker and worker-request behavior on current main

## Verification
- `python -m pre_commit run --files tests/api/test_sandbox_runner_api.py`
- `PYTHONPATH="$PWD/src" .venv/bin/pytest -q tests/api/test_sandbox_runner_api.py::test_sandbox_runner_cleanup_marks_idle_workers_without_deleting_state tests/api/test_sandbox_runner_api.py::test_sandbox_runner_dedicated_worker_uses_shared_storage_root_env_for_agent_paths tests/api/test_sandbox_runner_api.py::test_dedicated_worker_mode_resolves_relative_agent_base_dir_from_shared_storage tests/api/test_sandbox_runner_api.py::test_sandbox_runner_worker_request_does_not_inject_base_dir_into_unrelated_tools tests/api/test_sandbox_runner_api.py::test_sandbox_runner_worker_request_preserves_forwarded_base_dir tests/api/test_sandbox_runner_api.py::test_sandbox_runner_worker_request_uses_default_storage_root_when_env_is_unset`
- `python -m pre_commit run --files tests/api/test_sandbox_runner_api.py tests/test_agents.py tests/test_config_discovery.py tests/test_config_manager_consolidated.py tests/test_multi_agent_e2e.py tests/test_self_config.py tests/test_tool_dependencies.py`
- `PYTHONPATH="$PWD/src" .venv/bin/pytest -q tests/api/test_sandbox_runner_api.py tests/test_agents.py tests/test_config_discovery.py tests/test_config_manager_consolidated.py tests/test_multi_agent_e2e.py tests/test_self_config.py tests/test_tool_dependencies.py`
