### PR TITLE
Add a cancellation hook and recover workloop state after interrupted replies

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -140,6 +140,7 @@ async def block_secret_reads(ctx):
 | `system:enrich` | Collector | `SystemEnrichContext` | After message enrichment; before AI generation | `add_instruction()` |
 | `message:before_response` | Transformer | `BeforeResponseContext` | After AI generation; before Matrix send (streaming: after stream completes, before final edit) | `draft.response_text`, `draft.suppress` |
 | `message:after_response` | Observer | `AfterResponseContext` | After final Matrix send or edit | None (frozen) |
+| `message:cancelled` | Observer | `CancelledResponseContext` | After a response is cancelled before final delivery completes | None (frozen) |
 | `agent:started` | Observer | `AgentLifecycleContext` | After bot starts (Matrix login, presence, callbacks registered) | None (frozen) |
 | `agent:stopped` | Observer | `AgentLifecycleContext` | During orderly shutdown | None (frozen) |
 | `bot:ready` | Observer | `AgentLifecycleContext` | After bot completes room joins and initial sync | None (frozen) |
@@ -158,6 +159,7 @@ async def block_secret_reads(ctx):
 | `system:enrich` | 2000 |
 | `message:before_response` | 200 |
 | `message:after_response` | 3000 |
+| `message:cancelled` | 3000 |
 | `reaction:received` | 500 |
 | `schedule:fired` | 1000 |
 | `agent:started` | 5000 |

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from html import escape as html_escape
 from typing import TYPE_CHECKING, Any, Literal, Protocol
@@ -103,6 +104,7 @@ class ResponseHookService:
         response_event_id: str,
         delivery_kind: Literal["sent", "edited"],
         response_kind: str,
+        continue_on_cancelled: bool = False,
     ) -> None:
         """Emit message:after_response after the final send or edit succeeds."""
         if not self.hook_context.registry.has_hooks(EVENT_MESSAGE_AFTER_RESPONSE):
@@ -118,7 +120,12 @@ class ResponseHookService:
                 envelope=envelope,
             ),
         )
-        await emit(self.hook_context.registry, EVENT_MESSAGE_AFTER_RESPONSE, context)
+        await emit(
+            self.hook_context.registry,
+            EVENT_MESSAGE_AFTER_RESPONSE,
+            context,
+            continue_on_cancelled=continue_on_cancelled,
+        )
 
     async def emit_cancelled_response(
         self,
@@ -128,7 +135,7 @@ class ResponseHookService:
         visible_response_event_id: str | None = None,
         response_kind: str = "ai",
     ) -> None:
-        """Emit message:cancelled when a response is cancelled mid-stream."""
+        """Emit message:cancelled when a response never reaches final delivery."""
         if not self.hook_context.registry.has_hooks(EVENT_MESSAGE_CANCELLED):
             return
 
@@ -280,6 +287,36 @@ class DeliveryGateway:
             raise RuntimeError(msg)
         return client
 
+    async def _emit_after_response_best_effort(
+        self,
+        *,
+        correlation_id: str,
+        envelope: MessageEnvelope,
+        response_text: str,
+        response_event_id: str,
+        delivery_kind: Literal["sent", "edited"],
+        response_kind: str,
+    ) -> None:
+        """Best-effort after_response emission once delivery is already visible."""
+        try:
+            await self.deps.response_hooks.emit_after_response(
+                correlation_id=correlation_id,
+                envelope=envelope,
+                response_text=response_text,
+                response_event_id=response_event_id,
+                delivery_kind=delivery_kind,
+                response_kind=response_kind,
+                continue_on_cancelled=True,
+            )
+        except asyncio.CancelledError:
+            self.deps.logger.warning(
+                "message:after_response cancelled after visible delivery; returning success",
+                correlation_id=correlation_id,
+                response_event_id=response_event_id,
+                response_kind=response_kind,
+                delivery_kind=delivery_kind,
+            )
+
     async def send_text(self, request: SendTextRequest) -> str | None:
         """Send one response message to a room."""
         client = self._client()
@@ -428,6 +465,22 @@ class DeliveryGateway:
             reason="Suppressed streamed response",
         )
 
+    async def emit_suppressed_response(
+        self,
+        *,
+        correlation_id: str,
+        response_envelope: MessageEnvelope,
+        response_kind: str,
+        visible_response_event_id: str | None = None,
+    ) -> None:
+        """Treat hook-suppressed turns as non-delivered responses for cleanup hooks."""
+        await self.deps.response_hooks.emit_cancelled_response(
+            correlation_id=correlation_id,
+            envelope=response_envelope,
+            visible_response_event_id=visible_response_event_id,
+            response_kind=response_kind,
+        )
+
     async def deliver_final(self, request: FinalDeliveryRequest) -> DeliveryResult:
         """Apply before/after hooks around one final send or edit."""
         draft = (
@@ -449,6 +502,14 @@ class DeliveryGateway:
             )
         )
         if draft.suppress:
+            await self.emit_suppressed_response(
+                correlation_id=request.correlation_id,
+                response_envelope=request.response_envelope,
+                response_kind=request.response_kind,
+                visible_response_event_id=(
+                    request.existing_event_id if request.existing_event_is_placeholder else None
+                ),
+            )
             self.deps.logger.info(
                 "Response suppressed by hook",
                 response_kind=request.response_kind,
@@ -500,7 +561,7 @@ class DeliveryGateway:
             delivery_kind = "sent" if event_id else None
 
         if event_id and delivery_kind is not None:
-            await self.deps.response_hooks.emit_after_response(
+            await self._emit_after_response_best_effort(
                 correlation_id=request.correlation_id,
                 envelope=request.response_envelope,
                 response_text=display_text,
@@ -593,6 +654,12 @@ class DeliveryGateway:
             extra_content=request.extra_content,
         )
         if draft.suppress:
+            await self.emit_suppressed_response(
+                correlation_id=request.correlation_id,
+                response_envelope=request.response_envelope,
+                response_kind=request.response_kind,
+                visible_response_event_id=request.streamed_event_id,
+            )
             if request.cleanup_suppressed_streamed_event:
                 return await self.cleanup_suppressed_streamed_response(
                     room_id=request.room_id,
@@ -641,7 +708,7 @@ class DeliveryGateway:
             request.streamed_text,
             extract_mapping=True,
         )
-        await self.deps.response_hooks.emit_after_response(
+        await self._emit_after_response_best_effort(
             correlation_id=request.correlation_id,
             envelope=request.response_envelope,
             response_text=interactive_response.formatted_text,

--- a/src/mindroom/hooks/execution.py
+++ b/src/mindroom/hooks/execution.py
@@ -264,7 +264,13 @@ def _eligible_hooks(
     return tuple(eligible_hooks)
 
 
-async def emit(registry: HookRegistry, event_name: str, context: HookExecutionContext) -> None:
+async def emit(
+    registry: HookRegistry,
+    event_name: str,
+    context: HookExecutionContext,
+    *,
+    continue_on_cancelled: bool = False,
+) -> None:
     """Run observer hooks serially for one event."""
     depth = _EMIT_DEPTH.get()
     if depth >= _MAX_EMIT_DEPTH:
@@ -280,7 +286,16 @@ async def emit(registry: HookRegistry, event_name: str, context: HookExecutionCo
     try:
         for hook in _eligible_hooks(registry, event_name, context):
             hook_context = _bind_hook_context(hook, context)
-            await _invoke_hook(hook, hook_context)
+            try:
+                await _invoke_hook(hook, hook_context)
+            except asyncio.CancelledError:
+                if not continue_on_cancelled:
+                    raise
+                hook_context.logger.warning(
+                    "Hook execution cancelled during best-effort observer emission",
+                    correlation_id=context.correlation_id,
+                )
+                continue
             _merge_observer_context_changes(context, hook_context)
     finally:
         _EMIT_DEPTH.reset(token)

--- a/tests/test_cancelled_response_hook.py
+++ b/tests/test_cancelled_response_hook.py
@@ -1,0 +1,518 @@
+"""Tests for the message:cancelled hook emission and workloop retry."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mindroom.config.agent import AgentConfig
+from mindroom.config.main import Config
+from mindroom.config.plugin import PluginEntryConfig
+from mindroom.delivery_gateway import (
+    DeliveryGateway,
+    DeliveryGatewayDeps,
+    FinalDeliveryRequest,
+    FinalizeStreamedResponseRequest,
+    ResponseHookService,
+)
+from mindroom.hooks import (
+    EVENT_MESSAGE_AFTER_RESPONSE,
+    EVENT_MESSAGE_BEFORE_RESPONSE,
+    EVENT_MESSAGE_CANCELLED,
+    AfterResponseContext,
+    BeforeResponseContext,
+    CancelledResponseContext,
+    HookRegistry,
+    MessageEnvelope,
+    hook,
+)
+from mindroom.hooks.context import CancelledResponseInfo, HookContextSupport
+from mindroom.hooks.execution import emit, reset_hook_execution_state
+from mindroom.hooks.registry import HookRegistryState
+from mindroom.logging_config import get_logger
+from mindroom.message_target import MessageTarget
+from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+
+def _config(tmp_path: Path) -> Config:
+    runtime_paths = test_runtime_paths(tmp_path)
+    return bind_runtime_paths(
+        Config(
+            agents={
+                "code": AgentConfig(display_name="Code", rooms=["!room:localhost"]),
+            },
+        ),
+        runtime_paths,
+    )
+
+
+def _plugin(name: str, callbacks: list[object]) -> object:
+    return type(
+        "PluginStub",
+        (),
+        {
+            "name": name,
+            "discovered_hooks": tuple(callbacks),
+            "entry_config": PluginEntryConfig(path=f"./plugins/{name}"),
+            "plugin_order": 0,
+        },
+    )()
+
+
+def _envelope(*, agent_name: str = "code", body: str = "hello") -> MessageEnvelope:
+    return MessageEnvelope(
+        source_event_id="$event",
+        room_id="!room:localhost",
+        target=MessageTarget.resolve("!room:localhost", None, "$event"),
+        requester_id="@user:localhost",
+        sender_id="@user:localhost",
+        body=body,
+        attachment_ids=(),
+        mentioned_agents=(),
+        agent_name=agent_name,
+        source_kind="message",
+    )
+
+
+def _response_hook_service(tmp_path: Path, registry: HookRegistry) -> tuple[Config, ResponseHookService]:
+    config = _config(tmp_path)
+    rp = runtime_paths_for(config)
+    hook_context = HookContextSupport(
+        runtime=type("RT", (), {"client": None, "orchestrator": None, "config": config})(),
+        logger=get_logger("tests"),
+        runtime_paths=rp,
+        agent_name="code",
+        hook_registry_state=HookRegistryState(registry),
+        hook_send_message=AsyncMock(),
+    )
+    return config, ResponseHookService(hook_context=hook_context)
+
+
+@pytest.fixture(autouse=True)
+def _reset_execution_state() -> Generator[None, None, None]:
+    reset_hook_execution_state()
+    yield
+    reset_hook_execution_state()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_hook_fires_on_emit(tmp_path: Path) -> None:
+    """message:cancelled hook should fire when emitted."""
+    seen: list[CancelledResponseInfo] = []
+
+    @hook(EVENT_MESSAGE_CANCELLED)
+    async def on_cancelled(ctx: CancelledResponseContext) -> None:
+        seen.append(ctx.info)
+
+    registry = HookRegistry.from_plugins([_plugin("test-cancel", [on_cancelled])])
+    config = _config(tmp_path)
+    context = CancelledResponseContext(
+        event_name=EVENT_MESSAGE_CANCELLED,
+        plugin_name="",
+        settings={},
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        logger=get_logger("tests").bind(event_name=EVENT_MESSAGE_CANCELLED),
+        correlation_id="corr-cancel",
+        info=CancelledResponseInfo(
+            envelope=_envelope(),
+            visible_response_event_id="$visible",
+            response_kind="ai",
+        ),
+    )
+
+    await emit(registry, EVENT_MESSAGE_CANCELLED, context)
+
+    assert len(seen) == 1
+    assert seen[0].visible_response_event_id == "$visible"
+    assert seen[0].response_kind == "ai"
+    assert seen[0].envelope.agent_name == "code"
+
+
+@pytest.mark.asyncio
+async def test_after_response_does_not_fire_on_cancelled_path(tmp_path: Path) -> None:
+    """message:after_response hooks should NOT fire when only message:cancelled is emitted."""
+    after_seen: list[str] = []
+    cancelled_seen: list[str] = []
+
+    @hook(EVENT_MESSAGE_AFTER_RESPONSE)
+    async def on_after(ctx: AfterResponseContext) -> None:
+        del ctx
+        after_seen.append("after")
+
+    @hook(EVENT_MESSAGE_CANCELLED)
+    async def on_cancelled(ctx: CancelledResponseContext) -> None:
+        del ctx
+        cancelled_seen.append("cancelled")
+
+    registry = HookRegistry.from_plugins([_plugin("test-exclusive", [on_after, on_cancelled])])
+    config = _config(tmp_path)
+
+    cancel_ctx = CancelledResponseContext(
+        event_name=EVENT_MESSAGE_CANCELLED,
+        plugin_name="",
+        settings={},
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        logger=get_logger("tests").bind(event_name=EVENT_MESSAGE_CANCELLED),
+        correlation_id="corr-cancel",
+        info=CancelledResponseInfo(
+            envelope=_envelope(),
+        ),
+    )
+
+    await emit(registry, EVENT_MESSAGE_CANCELLED, cancel_ctx)
+
+    assert cancelled_seen == ["cancelled"]
+    assert after_seen == [], "after_response must not fire when only cancelled is emitted"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_context_preserves_envelope_fields(tmp_path: Path) -> None:
+    """CancelledResponseContext should carry the original envelope and response metadata."""
+    captured: list[CancelledResponseContext] = []
+
+    @hook(EVENT_MESSAGE_CANCELLED)
+    async def capture(ctx: CancelledResponseContext) -> None:
+        captured.append(ctx)
+
+    registry = HookRegistry.from_plugins([_plugin("test-envelope", [capture])])
+    config = _config(tmp_path)
+    envelope = _envelope(agent_name="research", body="do something")
+    context = CancelledResponseContext(
+        event_name=EVENT_MESSAGE_CANCELLED,
+        plugin_name="",
+        settings={},
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        logger=get_logger("tests").bind(event_name=EVENT_MESSAGE_CANCELLED),
+        correlation_id="corr-fields",
+        info=CancelledResponseInfo(
+            envelope=envelope,
+            visible_response_event_id="$partial_msg",
+            response_kind="team",
+        ),
+    )
+
+    await emit(registry, EVENT_MESSAGE_CANCELLED, context)
+
+    assert len(captured) == 1
+    ctx = captured[0]
+    assert ctx.info.envelope.agent_name == "research"
+    assert ctx.info.envelope.body == "do something"
+    assert ctx.info.visible_response_event_id == "$partial_msg"
+    assert ctx.info.response_kind == "team"
+    assert ctx.correlation_id == "corr-fields"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_hook_respects_agent_and_room_scope(tmp_path: Path) -> None:
+    """Scoped message:cancelled hooks should match the cancelled envelope agent and room."""
+    seen: list[str] = []
+
+    @hook(EVENT_MESSAGE_CANCELLED, name="wrong-agent", agents=["research"])
+    async def wrong_agent(ctx: CancelledResponseContext) -> None:
+        del ctx
+        seen.append("wrong-agent")
+
+    @hook(EVENT_MESSAGE_CANCELLED, name="wrong-room", rooms=["!elsewhere:localhost"])
+    async def wrong_room(ctx: CancelledResponseContext) -> None:
+        del ctx
+        seen.append("wrong-room")
+
+    @hook(EVENT_MESSAGE_CANCELLED, name="matched", agents=["code"], rooms=["!room:localhost"])
+    async def matched(ctx: CancelledResponseContext) -> None:
+        del ctx
+        seen.append("matched")
+
+    registry = HookRegistry.from_plugins([_plugin("test-scoped-cancelled", [wrong_agent, wrong_room, matched])])
+    config = _config(tmp_path)
+    context = CancelledResponseContext(
+        event_name=EVENT_MESSAGE_CANCELLED,
+        plugin_name="",
+        settings={},
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        logger=get_logger("tests").bind(event_name=EVENT_MESSAGE_CANCELLED),
+        correlation_id="corr-scoped-cancel",
+        info=CancelledResponseInfo(
+            envelope=_envelope(),
+        ),
+    )
+
+    await emit(registry, EVENT_MESSAGE_CANCELLED, context)
+
+    assert seen == ["matched"]
+
+
+@pytest.mark.asyncio
+async def test_response_hook_service_emit_cancelled(tmp_path: Path) -> None:
+    """ResponseHookService.emit_cancelled_response should emit via the registry."""
+    seen: list[CancelledResponseInfo] = []
+
+    @hook(EVENT_MESSAGE_CANCELLED)
+    async def on_cancelled(ctx: CancelledResponseContext) -> None:
+        seen.append(ctx.info)
+
+    registry = HookRegistry.from_plugins([_plugin("test-service", [on_cancelled])])
+    config = _config(tmp_path)
+    rp = runtime_paths_for(config)
+
+    hook_context = HookContextSupport(
+        runtime=type("RT", (), {"client": None, "orchestrator": None, "config": config})(),
+        logger=get_logger("tests"),
+        runtime_paths=rp,
+        agent_name="code",
+        hook_registry_state=HookRegistryState(registry),
+        hook_send_message=AsyncMock(),
+    )
+    service = ResponseHookService(hook_context=hook_context)
+
+    await service.emit_cancelled_response(
+        correlation_id="corr-svc",
+        envelope=_envelope(),
+        visible_response_event_id="$vis",
+        response_kind="ai",
+    )
+
+    assert len(seen) == 1
+    assert seen[0].visible_response_event_id == "$vis"
+
+
+@pytest.mark.asyncio
+async def test_response_hook_service_skips_when_no_hooks(tmp_path: Path) -> None:
+    """emit_cancelled_response should be a no-op when no hooks are registered."""
+    registry = HookRegistry.from_plugins([])
+    config = _config(tmp_path)
+    rp = runtime_paths_for(config)
+
+    hook_context = HookContextSupport(
+        runtime=type("RT", (), {"client": None, "orchestrator": None, "config": config})(),
+        logger=get_logger("tests"),
+        runtime_paths=rp,
+        agent_name="code",
+        hook_registry_state=HookRegistryState(registry),
+        hook_send_message=AsyncMock(),
+    )
+    service = ResponseHookService(hook_context=hook_context)
+
+    # Should not raise
+    await service.emit_cancelled_response(
+        correlation_id="corr-noop",
+        envelope=_envelope(),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "expected_visible_event_id"),
+    [("final", None), ("streamed", "$stream")],
+)
+async def test_suppressed_delivery_emits_cancelled_hook(
+    tmp_path: Path,
+    mode: str,
+    expected_visible_event_id: str | None,
+) -> None:
+    """Hook-suppressed turns should still emit message:cancelled cleanup."""
+    after_seen: list[str] = []
+    cancelled_seen: list[CancelledResponseInfo] = []
+
+    @hook(EVENT_MESSAGE_BEFORE_RESPONSE)
+    async def suppress_response(ctx: BeforeResponseContext) -> None:
+        ctx.draft.suppress = True
+
+    @hook(EVENT_MESSAGE_AFTER_RESPONSE)
+    async def on_after(ctx: AfterResponseContext) -> None:
+        del ctx
+        after_seen.append("after")
+
+    @hook(EVENT_MESSAGE_CANCELLED)
+    async def on_cancelled(ctx: CancelledResponseContext) -> None:
+        cancelled_seen.append(ctx.info)
+
+    registry = HookRegistry.from_plugins(
+        [_plugin("test-suppressed-cancelled", [suppress_response, on_after, on_cancelled])],
+    )
+    config, response_hooks = _response_hook_service(tmp_path, registry)
+    gateway = DeliveryGateway(
+        DeliveryGatewayDeps(
+            runtime=response_hooks.hook_context.runtime,
+            runtime_paths=runtime_paths_for(config),
+            agent_name="code",
+            logger=get_logger("tests.delivery"),
+            redact_message_event=AsyncMock(return_value=True),
+            sender_domain="localhost",
+            resolver=MagicMock(),
+            response_hooks=response_hooks,
+        ),
+    )
+
+    if mode == "final":
+        result = await gateway.deliver_final(
+            FinalDeliveryRequest(
+                room_id="!room:localhost",
+                reply_to_event_id="$event",
+                thread_id=None,
+                target=MessageTarget.resolve("!room:localhost", None, "$event"),
+                existing_event_id=None,
+                response_text="suppressed",
+                response_kind="ai",
+                response_envelope=_envelope(),
+                correlation_id="corr-suppressed-final",
+                tool_trace=None,
+                extra_content=None,
+            ),
+        )
+    else:
+        result = await gateway.finalize_streamed_response(
+            FinalizeStreamedResponseRequest(
+                room_id="!room:localhost",
+                reply_to_event_id="$event",
+                thread_id=None,
+                target=MessageTarget.resolve("!room:localhost", None, "$event"),
+                streamed_event_id="$stream",
+                streamed_text="suppressed",
+                delivery_kind="sent",
+                response_kind="ai",
+                response_envelope=_envelope(),
+                correlation_id="corr-suppressed-streamed",
+                tool_trace=None,
+                extra_content=None,
+                cleanup_suppressed_streamed_event=False,
+            ),
+        )
+
+    assert result.suppressed is True
+    assert after_seen == []
+    assert len(cancelled_seen) == 1
+    assert cancelled_seen[0].envelope.agent_name == "code"
+    assert cancelled_seen[0].visible_response_event_id == expected_visible_event_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "expected_event_id", "expected_delivery_kind", "tracked_event_id"),
+    [
+        ("final", "$response", "sent", None),
+        ("streamed", "$stream", "sent", "$stream"),
+    ],
+)
+async def test_late_after_response_cancellation_preserves_delivery_result(
+    tmp_path: Path,
+    mode: str,
+    expected_event_id: str,
+    expected_delivery_kind: str,
+    tracked_event_id: str | None,
+) -> None:
+    """Late cancellation during after_response must not downgrade a visible delivery to cancelled."""
+    after_started = asyncio.Event()
+    cancelled_seen: list[CancelledResponseInfo] = []
+
+    @hook(EVENT_MESSAGE_AFTER_RESPONSE)
+    async def slow_after_response(ctx: AfterResponseContext) -> None:
+        del ctx
+        after_started.set()
+        await asyncio.Event().wait()
+
+    @hook(EVENT_MESSAGE_CANCELLED)
+    async def on_cancelled(ctx: CancelledResponseContext) -> None:
+        cancelled_seen.append(ctx.info)
+
+    registry = HookRegistry.from_plugins(
+        [_plugin("test-late-after-cancel", [slow_after_response, on_cancelled])],
+    )
+    config, response_hooks = _response_hook_service(tmp_path, registry)
+    gateway = DeliveryGateway(
+        DeliveryGatewayDeps(
+            runtime=response_hooks.hook_context.runtime,
+            runtime_paths=runtime_paths_for(config),
+            agent_name="code",
+            logger=get_logger("tests.delivery"),
+            redact_message_event=AsyncMock(return_value=True),
+            sender_domain="localhost",
+            resolver=MagicMock(),
+            response_hooks=response_hooks,
+        ),
+    )
+
+    parsed = MagicMock()
+    parsed.formatted_text = "visible response"
+    parsed.option_map = None
+    parsed.options_list = None
+
+    delivery_result = None
+
+    async def deliver_response() -> None:
+        nonlocal delivery_result
+        if mode == "final":
+            delivery_result = await gateway.deliver_final(
+                FinalDeliveryRequest(
+                    room_id="!room:localhost",
+                    reply_to_event_id="$event",
+                    thread_id=None,
+                    target=MessageTarget.resolve("!room:localhost", None, "$event"),
+                    existing_event_id=None,
+                    response_text="visible response",
+                    response_kind="ai",
+                    response_envelope=_envelope(),
+                    correlation_id="corr-late-final",
+                    tool_trace=None,
+                    extra_content=None,
+                ),
+            )
+            return
+
+        delivery_result = await gateway.finalize_streamed_response(
+            FinalizeStreamedResponseRequest(
+                room_id="!room:localhost",
+                reply_to_event_id="$event",
+                thread_id=None,
+                target=MessageTarget.resolve("!room:localhost", None, "$event"),
+                streamed_event_id="$stream",
+                streamed_text="visible response",
+                delivery_kind="sent",
+                response_kind="ai",
+                response_envelope=_envelope(),
+                correlation_id="corr-late-streamed",
+                tool_trace=None,
+                extra_content=None,
+                cleanup_suppressed_streamed_event=False,
+            ),
+        )
+
+    with patch("mindroom.delivery_gateway.interactive.parse_and_format_interactive", return_value=parsed):
+        if mode == "final":
+            with patch.object(DeliveryGateway, "send_text", new=AsyncMock(return_value="$response")):
+                task = asyncio.create_task(deliver_response())
+                await asyncio.wait_for(after_started.wait(), timeout=1)
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+        else:
+            task = asyncio.create_task(deliver_response())
+            await asyncio.wait_for(after_started.wait(), timeout=1)
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+    if delivery_result is None:
+        await response_hooks.emit_cancelled_response(
+            correlation_id=f"corr-coordinator-{mode}",
+            envelope=_envelope(),
+            visible_response_event_id=tracked_event_id,
+            response_kind="ai",
+        )
+
+    assert delivery_result is not None
+    assert delivery_result.event_id == expected_event_id
+    assert delivery_result.delivery_kind == expected_delivery_kind
+    assert delivery_result.response_text == "visible response"
+    assert cancelled_seen == []

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -2209,6 +2209,7 @@ class TestAgentBot:
                     ),
                 ),
                 emit_after_response=AsyncMock(),
+                emit_cancelled_response=AsyncMock(),
             ),
         )
 
@@ -2278,6 +2279,7 @@ class TestAgentBot:
                     ),
                 ),
                 emit_after_response=AsyncMock(),
+                emit_cancelled_response=AsyncMock(),
             ),
         )
 
@@ -2343,6 +2345,7 @@ class TestAgentBot:
                     ),
                 ),
                 emit_after_response=AsyncMock(),
+                emit_cancelled_response=AsyncMock(),
             ),
         )
 
@@ -2406,6 +2409,7 @@ class TestAgentBot:
                     ),
                 ),
                 emit_after_response=AsyncMock(),
+                emit_cancelled_response=AsyncMock(),
             ),
         )
 

--- a/tests/test_workloop_thread_scope.py
+++ b/tests/test_workloop_thread_scope.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import importlib
 import json
 import shutil
 import sys
@@ -9,28 +11,40 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import mindroom.tool_system.plugins as plugin_module
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
+from mindroom.config.plugin import PluginEntryConfig
 from mindroom.constants import ROUTER_AGENT_NAME
+from mindroom.delivery_gateway import (
+    DeliveryGateway,
+    DeliveryGatewayDeps,
+    FinalDeliveryRequest,
+    ResponseHookService,
+)
 from mindroom.hooks import (
     EVENT_MESSAGE_AFTER_RESPONSE,
+    EVENT_MESSAGE_CANCELLED,
     EVENT_MESSAGE_ENRICH,
     EVENT_MESSAGE_RECEIVED,
     EVENT_SCHEDULE_FIRED,
     AfterResponseContext,
+    CancelledResponseContext,
     HookRegistry,
     MessageEnrichContext,
     MessageEnvelope,
     MessageReceivedContext,
     ResponseResult,
     ScheduleFiredContext,
+    hook,
 )
+from mindroom.hooks.context import CancelledResponseInfo, HookContextSupport
 from mindroom.hooks.execution import emit, emit_collect
+from mindroom.hooks.registry import HookRegistryState
 from mindroom.logging_config import get_logger
 from mindroom.message_target import MessageTarget
 from mindroom.scheduling import ScheduledWorkflow
@@ -42,6 +56,7 @@ from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_p
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+    from types import ModuleType
 
     from mindroom.constants import RuntimePaths
 
@@ -51,6 +66,7 @@ class _LoadedWorkloop:
     config: Config
     runtime_paths: RuntimePaths
     registry: HookRegistry
+    poke_module: ModuleType
 
 
 def _plugin_root() -> Path:
@@ -67,11 +83,23 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def _plugin(name: str, callbacks: list[object]) -> object:
+    return type(
+        "PluginStub",
+        (),
+        {
+            "name": name,
+            "discovered_hooks": tuple(callbacks),
+            "entry_config": PluginEntryConfig(path=f"./plugins/{name}"),
+            "plugin_order": 0,
+        },
+    )()
+
+
 def _copy_plugin_root(tmp_path: Path) -> Path:
     """Copy the live workloop plugin into tmp_path and patch known fixture drift."""
-    source_root = _plugin_root()
     copied_root = tmp_path / "plugins" / "workloop"
-    shutil.copytree(source_root, copied_root)
+    shutil.copytree(_plugin_root(), copied_root)
     (tmp_path / "plugins" / "__init__.py").write_text("", encoding="utf-8")
     (copied_root / "__init__.py").write_text("", encoding="utf-8")
     package_prefix = "plugins.workloop"
@@ -157,21 +185,36 @@ def _read_json(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def _only_todos_state(loaded: _LoadedWorkloop) -> dict[str, object]:
-    todo_files = sorted((_state_root(loaded) / "threads").glob("*/todos.json"))
-    assert len(todo_files) == 1
-    return _read_json(todo_files[0])
+def _todo_state_path(loaded: _LoadedWorkloop, *, room_id: str, thread_id: str) -> Path:
+    return _state_root(loaded) / "rooms" / room_id / "threads" / thread_id / "todos.json"
+
+
+def _todo_state(loaded: _LoadedWorkloop, *, room_id: str, thread_id: str) -> dict[str, object]:
+    return _read_json(_todo_state_path(loaded, room_id=room_id, thread_id=thread_id))
+
+
+def _registry_callbacks(registry: HookRegistry) -> list[object]:
+    callbacks: list[object] = []
+    seen_callbacks: set[object] = set()
+    for hooks in registry._hooks_by_event.values():
+        for registered_hook in hooks:
+            if registered_hook.callback in seen_callbacks:
+                continue
+            seen_callbacks.add(registered_hook.callback)
+            callbacks.append(registered_hook.callback)
+    return callbacks
 
 
 def _tool_context(
     loaded: _LoadedWorkloop,
     *,
+    room_id: str = "!room:localhost",
     thread_id: str | None = None,
     resolved_thread_id: str | None = "$thread_root",
 ) -> ToolRuntimeContext:
     return ToolRuntimeContext(
         agent_name="code",
-        room_id="!room:localhost",
+        room_id=room_id,
         thread_id=thread_id,
         resolved_thread_id=resolved_thread_id,
         requester_id="@user:localhost",
@@ -188,20 +231,23 @@ def _message_envelope(
     *,
     body: str,
     agent_name: str,
+    room_id: str = "!room:localhost",
     thread_id: str | None = None,
     resolved_thread_id: str | None = "$thread_root",
+    room_mode: bool = False,
 ) -> MessageEnvelope:
     target = MessageTarget.resolve(
-        room_id="!room:localhost",
+        room_id=room_id,
         thread_id=thread_id,
         reply_to_event_id="$event",
         safe_thread_root=resolved_thread_id if thread_id is None else None,
+        room_mode=room_mode,
     )
     if thread_id is not None:
         target = target.with_thread_root(resolved_thread_id)
     return MessageEnvelope(
         source_event_id="$event",
-        room_id="!room:localhost",
+        room_id=room_id,
         target=target,
         requester_id="@user:localhost",
         sender_id="@user:localhost",
@@ -236,14 +282,17 @@ def loaded_workloop(tmp_path: Path) -> Generator[_LoadedWorkloop, None, None]:
     try:
         plugins = load_plugins(config, runtime_paths_for(config))
         registry = HookRegistry.from_plugins(plugins)
-        if not registry._hooks_by_event:
-            pytest.skip("workloop plugin checkout is not compatible with the current hook API")
+        poke_module = importlib.import_module("plugins.workloop.poke")
         yield _LoadedWorkloop(
             config=config,
             runtime_paths=runtime_paths_for(config),
             registry=registry,
+            poke_module=poke_module,
         )
     finally:
+        for module_name in list(sys.modules):
+            if module_name == "plugins.workloop" or module_name.startswith("plugins.workloop."):
+                sys.modules.pop(module_name, None)
         _TOOL_REGISTRY.clear()
         _TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
@@ -269,7 +318,7 @@ def test_tool_scope_uses_resolved_thread_id(loaded_workloop: _LoadedWorkloop) ->
         result = tool.plan(agent=MagicMock(), tasks="Investigate threaded schedule poke")
 
     assert "Created 1 item" in result
-    state = _only_todos_state(loaded_workloop)
+    state = _todo_state(loaded_workloop, room_id="!room:localhost", thread_id="$thread_root")
     assert state["thread_id"] == "$thread_root"
 
 
@@ -379,7 +428,7 @@ async def test_schedule_fired_auto_poke_uses_thread_from_stored_state(
 
 @pytest.mark.asyncio
 async def test_room_level_todo_command_stays_in_main_scope(loaded_workloop: _LoadedWorkloop) -> None:
-    """Room-level commands should keep using the shared main scope."""
+    """Room-level commands should keep using the room's main scope."""
     sender = AsyncMock(return_value="$todo-event")
     command_context = MessageReceivedContext(
         event_name=EVENT_MESSAGE_RECEIVED,
@@ -399,6 +448,338 @@ async def test_room_level_todo_command_stays_in_main_scope(loaded_workloop: _Loa
     await emit(loaded_workloop.registry, EVENT_MESSAGE_RECEIVED, command_context)
 
     assert command_context.suppress is True
-    state = _only_todos_state(loaded_workloop)
+    state = _todo_state(loaded_workloop, room_id="!room:localhost", thread_id="main")
     assert state["thread_id"] == "main"
     assert sender.await_args.args[2] is None
+
+
+@pytest.mark.asyncio
+async def test_room_level_todos_are_isolated_per_room(loaded_workloop: _LoadedWorkloop) -> None:
+    """Room-level main scopes must stay isolated between rooms."""
+    room_a = "!room-a:localhost"
+    room_b = "!room-b:localhost"
+    sender = AsyncMock(return_value="$todo-event")
+    tool = get_tool_by_name(
+        "workloop_todo_manager",
+        loaded_workloop.runtime_paths,
+        worker_target=None,
+    )
+
+    room_a_context = MessageReceivedContext(
+        event_name=EVENT_MESSAGE_RECEIVED,
+        plugin_name="",
+        settings={},
+        config=loaded_workloop.config,
+        runtime_paths=loaded_workloop.runtime_paths,
+        logger=get_logger("tests.workloop").bind(event_name=EVENT_MESSAGE_RECEIVED),
+        correlation_id="corr-command-room-a",
+        message_sender=sender,
+        envelope=_message_envelope(
+            body="!todo add Room A regression guard",
+            agent_name=ROUTER_AGENT_NAME,
+            room_id=room_a,
+            resolved_thread_id=None,
+            room_mode=True,
+        ),
+    )
+    await emit(loaded_workloop.registry, EVENT_MESSAGE_RECEIVED, room_a_context)
+
+    with tool_runtime_context(
+        _tool_context(loaded_workloop, room_id=room_b, resolved_thread_id=None),
+    ):
+        tool.plan(agent=MagicMock(), tasks="Room B regression guard")
+
+    room_a_state = _todo_state(loaded_workloop, room_id=room_a, thread_id="main")
+    room_b_state = _todo_state(loaded_workloop, room_id=room_b, thread_id="main")
+    assert room_a_state["tasks"] == ["Room A regression guard"]
+    assert room_b_state["tasks"] == ["Room B regression guard"]
+
+    room_a_items = await emit_collect(
+        loaded_workloop.registry,
+        EVENT_MESSAGE_ENRICH,
+        MessageEnrichContext(
+            event_name=EVENT_MESSAGE_ENRICH,
+            plugin_name="",
+            settings={},
+            config=loaded_workloop.config,
+            runtime_paths=loaded_workloop.runtime_paths,
+            logger=get_logger("tests.workloop").bind(event_name=EVENT_MESSAGE_ENRICH),
+            correlation_id="corr-enrich-room-a",
+            envelope=_message_envelope(
+                body="status",
+                agent_name="code",
+                room_id=room_a,
+                resolved_thread_id=None,
+                room_mode=True,
+            ),
+            target_entity_name="code",
+            target_member_names=None,
+        ),
+    )
+    room_b_items = await emit_collect(
+        loaded_workloop.registry,
+        EVENT_MESSAGE_ENRICH,
+        MessageEnrichContext(
+            event_name=EVENT_MESSAGE_ENRICH,
+            plugin_name="",
+            settings={},
+            config=loaded_workloop.config,
+            runtime_paths=loaded_workloop.runtime_paths,
+            logger=get_logger("tests.workloop").bind(event_name=EVENT_MESSAGE_ENRICH),
+            correlation_id="corr-enrich-room-b",
+            envelope=_message_envelope(
+                body="status",
+                agent_name="code",
+                room_id=room_b,
+                resolved_thread_id=None,
+                room_mode=True,
+            ),
+            target_entity_name="code",
+            target_member_names=None,
+        ),
+    )
+
+    assert [item.text for item in room_a_items] == ["Room A regression guard"]
+    assert [item.text for item in room_b_items] == ["Room B regression guard"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_response_clears_active_run_without_updating_last_response(
+    loaded_workloop: _LoadedWorkloop,
+) -> None:
+    """message:cancelled should clear the active run but NOT update last_response_at."""
+    tool = get_tool_by_name(
+        "workloop_todo_manager",
+        loaded_workloop.runtime_paths,
+        worker_target=None,
+    )
+
+    with tool_runtime_context(_tool_context(loaded_workloop)):
+        tool.plan(agent=MagicMock(), tasks="Task that will be cancelled")
+
+    # Trigger enrichment to mark agent as busy
+    enrich_context = MessageEnrichContext(
+        event_name=EVENT_MESSAGE_ENRICH,
+        plugin_name="",
+        settings={},
+        config=loaded_workloop.config,
+        runtime_paths=loaded_workloop.runtime_paths,
+        logger=get_logger("tests.workloop").bind(event_name=EVENT_MESSAGE_ENRICH),
+        correlation_id="corr-enrich-cancel",
+        envelope=_message_envelope(body="hello", agent_name="code"),
+        target_entity_name="code",
+        target_member_names=None,
+    )
+
+    await emit_collect(loaded_workloop.registry, EVENT_MESSAGE_ENRICH, enrich_context)
+
+    agent_state_path = _state_root(loaded_workloop) / "agents" / "code.json"
+    agent_state = _read_json(agent_state_path)
+    assert "!room:localhost:$thread_root" in agent_state["active_runs"]
+
+    # Record any existing last_response_at
+    last_response_before = agent_state.get("last_response_at")
+
+    # Fire message:cancelled — should clear active_run but NOT set last_response_at
+    cancelled_context = CancelledResponseContext(
+        event_name=EVENT_MESSAGE_CANCELLED,
+        plugin_name="",
+        settings={},
+        config=loaded_workloop.config,
+        runtime_paths=loaded_workloop.runtime_paths,
+        logger=get_logger("tests.workloop").bind(event_name=EVENT_MESSAGE_CANCELLED),
+        correlation_id="corr-cancelled",
+        info=CancelledResponseInfo(
+            envelope=_message_envelope(body="hello", agent_name="code"),
+            visible_response_event_id="$partial",
+            response_kind="ai",
+        ),
+    )
+
+    await emit(loaded_workloop.registry, EVENT_MESSAGE_CANCELLED, cancelled_context)
+
+    cleared_state = _read_json(agent_state_path)
+    assert cleared_state["active_runs"] == {}, "active_run should be cleared on cancellation"
+    assert cleared_state.get("last_response_at") == last_response_before, (
+        "last_response_at must NOT be updated on cancellation"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_then_poke_scan_can_repoke(
+    loaded_workloop: _LoadedWorkloop,
+) -> None:
+    """After cancellation clears the active run, the next poke scan should be able to re-poke."""
+    tool = get_tool_by_name(
+        "workloop_todo_manager",
+        loaded_workloop.runtime_paths,
+        worker_target=None,
+    )
+
+    with tool_runtime_context(_tool_context(loaded_workloop)):
+        tool.plan(agent=MagicMock(), tasks="Re-pokeable task")
+
+    # Enrich to mark busy
+    enrich_context = MessageEnrichContext(
+        event_name=EVENT_MESSAGE_ENRICH,
+        plugin_name="",
+        settings={},
+        config=loaded_workloop.config,
+        runtime_paths=loaded_workloop.runtime_paths,
+        logger=get_logger("tests.workloop").bind(event_name=EVENT_MESSAGE_ENRICH),
+        correlation_id="corr-enrich-repoke",
+        envelope=_message_envelope(body="do work", agent_name="code"),
+        target_entity_name="code",
+        target_member_names=None,
+    )
+    await emit_collect(loaded_workloop.registry, EVENT_MESSAGE_ENRICH, enrich_context)
+
+    # Fire cancellation
+    cancelled_context = CancelledResponseContext(
+        event_name=EVENT_MESSAGE_CANCELLED,
+        plugin_name="",
+        settings={},
+        config=loaded_workloop.config,
+        runtime_paths=loaded_workloop.runtime_paths,
+        logger=get_logger("tests.workloop").bind(event_name=EVENT_MESSAGE_CANCELLED),
+        correlation_id="corr-cancelled-repoke",
+        info=CancelledResponseInfo(
+            envelope=_message_envelope(body="do work", agent_name="code"),
+        ),
+    )
+    await emit(loaded_workloop.registry, EVENT_MESSAGE_CANCELLED, cancelled_context)
+
+    # Verify agent state is cleared
+    agent_state_path = _state_root(loaded_workloop) / "agents" / "code.json"
+    cleared_state = _read_json(agent_state_path)
+    assert cleared_state["active_runs"] == {}
+
+    # Now a poke scan should consider the agent idle and pokeable
+    # (The _should_poke_agent check won't block on active_runs since they're cleared)
+    now = datetime.now(UTC)
+    can_poke = loaded_workloop.poke_module._should_poke_agent(
+        _state_root(loaded_workloop),
+        "code",
+        now,
+        cooldown=0,
+        grace=0,
+        stale_busy=600,
+        scope_key="!room:localhost:$thread_root",
+        min_idle=0,
+    )
+    assert can_poke, "agent should be pokeable after cancellation clears active_run"
+
+
+@pytest.mark.asyncio
+async def test_late_after_response_cancellation_still_runs_workloop_cleanup(
+    loaded_workloop: _LoadedWorkloop,
+) -> None:
+    """Late cancellation during after_response should still clear busy state as delivered."""
+    tool = get_tool_by_name(
+        "workloop_todo_manager",
+        loaded_workloop.runtime_paths,
+        worker_target=None,
+    )
+    response_envelope = _message_envelope(body="hello", agent_name="code")
+
+    with tool_runtime_context(_tool_context(loaded_workloop)):
+        tool.plan(agent=MagicMock(), tasks="Task that must clear after late cancellation")
+
+    await emit_collect(
+        loaded_workloop.registry,
+        EVENT_MESSAGE_ENRICH,
+        MessageEnrichContext(
+            event_name=EVENT_MESSAGE_ENRICH,
+            plugin_name="",
+            settings={},
+            config=loaded_workloop.config,
+            runtime_paths=loaded_workloop.runtime_paths,
+            logger=get_logger("tests.workloop").bind(event_name=EVENT_MESSAGE_ENRICH),
+            correlation_id="corr-enrich-late-cancel",
+            envelope=response_envelope,
+            target_entity_name="code",
+            target_member_names=None,
+        ),
+    )
+
+    agent_state_path = _state_root(loaded_workloop) / "agents" / "code.json"
+    agent_state = _read_json(agent_state_path)
+    assert "!room:localhost:$thread_root" in agent_state["active_runs"]
+    assert agent_state.get("last_response_at") is None
+
+    after_started = asyncio.Event()
+
+    @hook(EVENT_MESSAGE_AFTER_RESPONSE, priority=50)
+    async def slow_after_response(ctx: AfterResponseContext) -> None:
+        del ctx
+        after_started.set()
+        await asyncio.Event().wait()
+
+    registry = HookRegistry.from_plugins(
+        [
+            _plugin("slow-after", [slow_after_response]),
+            _plugin("workloop", _registry_callbacks(loaded_workloop.registry)),
+        ],
+    )
+    hook_context = HookContextSupport(
+        runtime=type("RT", (), {"client": None, "orchestrator": None, "config": loaded_workloop.config})(),
+        logger=get_logger("tests.workloop.delivery"),
+        runtime_paths=loaded_workloop.runtime_paths,
+        agent_name="code",
+        hook_registry_state=HookRegistryState(registry),
+        hook_send_message=AsyncMock(),
+    )
+    gateway = DeliveryGateway(
+        DeliveryGatewayDeps(
+            runtime=hook_context.runtime,
+            runtime_paths=loaded_workloop.runtime_paths,
+            agent_name="code",
+            logger=get_logger("tests.workloop.delivery"),
+            redact_message_event=AsyncMock(return_value=True),
+            sender_domain="localhost",
+            resolver=MagicMock(),
+            response_hooks=ResponseHookService(hook_context=hook_context),
+        ),
+    )
+
+    parsed = MagicMock()
+    parsed.formatted_text = "visible response"
+    parsed.option_map = None
+    parsed.options_list = None
+
+    delivery_result = None
+
+    async def deliver_response() -> None:
+        nonlocal delivery_result
+        delivery_result = await gateway.deliver_final(
+            FinalDeliveryRequest(
+                room_id="!room:localhost",
+                reply_to_event_id="$event",
+                thread_id=None,
+                target=response_envelope.target,
+                existing_event_id=None,
+                response_text="visible response",
+                response_kind="ai",
+                response_envelope=response_envelope,
+                correlation_id="corr-late-workloop-cleanup",
+                tool_trace=None,
+                extra_content=None,
+            ),
+        )
+
+    with (
+        patch("mindroom.delivery_gateway.interactive.parse_and_format_interactive", return_value=parsed),
+        patch.object(DeliveryGateway, "send_text", new=AsyncMock(return_value="$response")),
+    ):
+        task = asyncio.create_task(deliver_response())
+        await asyncio.wait_for(after_started.wait(), timeout=1)
+        task.cancel()
+        await task
+
+    assert delivery_result is not None
+    assert delivery_result.event_id == "$response"
+    assert delivery_result.delivery_kind == "sent"
+
+    cleared_state = _read_json(agent_state_path)
+    assert cleared_state["active_runs"] == {}
+    assert isinstance(cleared_state.get("last_response_at"), str)


### PR DESCRIPTION
## Summary
- emit a dedicated cancellation hook when a response is cancelled before delivery completes
- let workloop and other hook consumers clean up active-run state on cancelled turns
- keep the existing workloop test fallback/skip behavior so the new coverage stays hermetic when the plugin checkout is unavailable

## Verification
- `python -m pre_commit run --files docs/hooks.md src/mindroom/delivery_gateway.py src/mindroom/hooks/execution.py tests/test_cancelled_response_hook.py tests/test_multi_agent_bot.py tests/test_workloop_thread_scope.py`
- `PYTHONPATH="$PWD/src" .venv/bin/pytest -q tests/test_cancelled_response_hook.py tests/test_workloop_thread_scope.py tests/test_multi_agent_bot.py -k "cancelled or workloop or hook"`
