### PR TITLE
Remove unused bot shims and dead compatibility helpers

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
-from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -65,7 +63,7 @@ from mindroom.post_response_effects import (
     record_handled_turn,
 )
 from mindroom.stop import StopManager
-from mindroom.teams import TeamMode, TeamOutcome, TeamResolution, resolve_configured_team
+from mindroom.teams import TeamMode, TeamOutcome, resolve_configured_team
 from mindroom.thread_utils import (
     should_agent_respond,
 )
@@ -136,7 +134,6 @@ from .conversation_state_writer import (
 from .delivery_gateway import (
     DeliveryGateway,
     DeliveryGatewayDeps,
-    DeliveryResult,
     EditTextRequest,
     ResponseHookService,
     SendTextRequest,
@@ -146,16 +143,9 @@ from .delivery_gateway import (
 )
 from .dispatch_planner import (
     DispatchHookService,
-    DispatchPlan,
     DispatchPlanner,
     DispatchPlannerDeps,
     ResponseAction,
-)
-from .dispatch_planner import (
-    PreparedDispatch as _PreparedDispatch,
-)
-from .dispatch_planner import (
-    ResponseAction as _ResponseAction,
 )
 from .handled_turns import HandledTurnLedger, HandledTurnRecord, HandledTurnState
 from .inbound_turn_normalizer import (
@@ -196,7 +186,7 @@ from .scheduling import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Awaitable, Callable, Sequence
     from datetime import datetime
     from pathlib import Path
 
@@ -205,7 +195,6 @@ if TYPE_CHECKING:
     from agno.media import Image
 
     from mindroom.config.main import Config
-    from mindroom.history import CompactionOutcome
     from mindroom.history.types import HistoryScope
     from mindroom.matrix.client import ResolvedVisibleMessage
     from mindroom.orchestrator import MultiAgentOrchestrator
@@ -350,8 +339,6 @@ type _MediaDispatchEvent = (
 )
 type _InboundMediaEvent = _MediaDispatchEvent | nio.RoomMessageAudio | nio.RoomEncryptedAudio
 
-type _DispatchPayloadBuilder = Callable[[MessageContext], Awaitable[DispatchPayload]]
-
 type _TextDispatchEvent = nio.RoomMessageText | PreparedTextEvent
 
 type _DispatchEvent = _TextDispatchEvent | _MediaDispatchEvent
@@ -369,7 +356,6 @@ class _PrecheckedEvent[T]:
 
 type _PrecheckedTextDispatchEvent = _PrecheckedEvent[_TextDispatchEvent]
 type _PrecheckedMediaDispatchEvent = _PrecheckedEvent[_MediaDispatchEvent]
-type _PrecheckedDispatchEvent = _PrecheckedTextDispatchEvent | _PrecheckedMediaDispatchEvent
 
 
 class AgentBot:
@@ -864,40 +850,6 @@ class AgentBot:
             message_received_depth=envelope.message_received_depth,
         )
         return True
-
-    def _default_response_envelope(
-        self,
-        *,
-        room_id: str,
-        reply_to_event_id: str,
-        thread_id: str | None,
-        resolved_thread_id: str | None,
-        requester_id: str,
-        body: str,
-        attachment_ids: list[str] | None = None,
-        agent_name: str | None = None,
-    ) -> MessageEnvelope:
-        """Build the default outbound envelope when hooks did not supply one."""
-        target = self._conversation_resolver.build_message_target(
-            room_id=room_id,
-            thread_id=thread_id,
-            reply_to_event_id=reply_to_event_id,
-            thread_mode_override="room" if resolved_thread_id is None else None,
-        )
-        if target.resolved_thread_id != resolved_thread_id:
-            target = target.with_thread_root(resolved_thread_id)
-        return MessageEnvelope(
-            source_event_id=reply_to_event_id,
-            room_id=room_id,
-            target=target,
-            requester_id=requester_id,
-            sender_id=requester_id,
-            body=body,
-            attachment_ids=tuple(attachment_ids or ()),
-            mentioned_agents=(),
-            agent_name=agent_name or self.agent_name,
-            source_kind="message",
-        )
 
     async def _emit_reaction_received_hooks(
         self,
@@ -2234,74 +2186,9 @@ class AgentBot:
             return None
         return _PrecheckedEvent(event=event, requester_user_id=requester_user_id)
 
-    async def _prepare_dispatch(
-        self,
-        room: nio.MatrixRoom,
-        prechecked_event: _PrecheckedDispatchEvent,
-        *,
-        event_label: str,
-        handled_turn: HandledTurnState,
-    ) -> _PreparedDispatch | None:
-        """Run common precheck/context/sender-gating for dispatch handlers."""
-        return await self._dispatch_planner.prepare_dispatch(
-            room,
-            prechecked_event.event,
-            prechecked_event.requester_user_id,
-            event_label=event_label,
-            handled_turn=handled_turn,
-        )
-
     async def _resolve_text_dispatch_event(self, event: _TextDispatchEvent) -> PreparedTextEvent:
         """Return one canonical text event for hooks, routing, and command handling."""
         return await self._dispatch_planner.resolve_text_dispatch_event(event)
-
-    async def _plan_dispatch(
-        self,
-        room: nio.MatrixRoom,
-        event: _TextDispatchEvent,
-        dispatch: _PreparedDispatch,
-        *,
-        extra_content: dict[str, Any] | None = None,
-        media_events: list[_MediaDispatchEvent] | None = None,
-        handled_turn: HandledTurnState | None = None,
-        router_event: _DispatchEvent | None = None,
-    ) -> DispatchPlan:
-        """Return the explicit plan for one prepared dispatch."""
-        return await self._dispatch_planner.plan_dispatch(
-            room,
-            event,
-            dispatch,
-            extra_content=extra_content,
-            media_events=media_events,
-            handled_turn=handled_turn,
-            router_event=router_event,
-        )
-
-    async def _execute_dispatch_action(
-        self,
-        room: nio.MatrixRoom,
-        event: _DispatchEvent,
-        dispatch: _PreparedDispatch,
-        action: _ResponseAction,
-        payload_builder: _DispatchPayloadBuilder,
-        *,
-        processing_log: str,
-        dispatch_started_at: float,
-        handled_turn: HandledTurnState,
-        matrix_run_metadata: dict[str, Any] | None = None,
-    ) -> None:
-        """Execute resolved dispatch action and mark the source event responded."""
-        await self._dispatch_planner.execute_response_action(
-            room,
-            event,
-            dispatch,
-            action,
-            payload_builder,
-            processing_log=processing_log,
-            dispatch_started_at=dispatch_started_at,
-            handled_turn=handled_turn,
-            matrix_run_metadata=matrix_run_metadata,
-        )
 
     def _should_queue_follow_up_in_active_response_thread(
         self,
@@ -2320,50 +2207,6 @@ class AgentBot:
         if is_agent_id(source_envelope.sender_id, self.config, self.runtime_paths):
             return False
         return self.has_active_response_for_target(target)
-
-    async def _decide_team_for_sender(
-        self,
-        agents_in_thread: list[MatrixID],
-        context: _MessageContext,
-        room: nio.MatrixRoom,
-        requester_user_id: str,
-        message: str,
-        is_dm: bool,
-        *,
-        available_agents_in_room: list[MatrixID] | None = None,
-        materializable_agent_names: set[str] | None = None,
-    ) -> TeamResolution:
-        """Decide team formation using sender-visible candidates without losing explicit intent."""
-        return await self._dispatch_planner.decide_team_for_sender(
-            agents_in_thread,
-            context,
-            room,
-            requester_user_id,
-            message,
-            is_dm,
-            available_agents_in_room=available_agents_in_room,
-            materializable_agent_names=materializable_agent_names,
-        )
-
-    async def _extract_message_context(
-        self,
-        room: nio.MatrixRoom,
-        event: _DispatchEvent,
-        *,
-        full_history: bool = True,
-    ) -> _MessageContext:
-        """Extract message context, optionally using a lightweight thread snapshot."""
-        return await self._conversation_resolver.extract_message_context(
-            room,
-            event,
-            full_history=full_history,
-        )
-
-    @asynccontextmanager
-    async def _turn_thread_cache_scope(self) -> AsyncIterator[None]:
-        """Cache thread history for the lifetime of one message-handling turn."""
-        async with self._conversation_resolver.turn_thread_cache_scope():
-            yield
 
     def _agent_has_matrix_messaging_tool(self, agent_name: str) -> bool:
         """Return whether an agent can issue Matrix message actions."""
@@ -2422,118 +2265,6 @@ class AgentBot:
             team_agents=team_agents,
             team_mode=team_mode,
             reason_prefix=reason_prefix,
-        )
-
-    async def _run_cancellable_response(
-        self,
-        room_id: str,
-        reply_to_event_id: str,
-        thread_id: str | None,
-        response_function: Callable[[str | None], Coroutine[Any, Any, None]],
-        thinking_message: str | None = None,  # None means don't send thinking message
-        existing_event_id: str | None = None,
-        user_id: str | None = None,  # User ID for presence check
-        run_id: str | None = None,
-        target: MessageTarget | None = None,
-    ) -> str | None:
-        """Run a response generation function with cancellation support."""
-        return await self._response_coordinator.run_cancellable_response(
-            room_id=room_id,
-            reply_to_event_id=reply_to_event_id,
-            thread_id=thread_id,
-            response_function=response_function,
-            thinking_message=thinking_message,
-            existing_event_id=existing_event_id,
-            user_id=user_id,
-            run_id=run_id,
-            target=target,
-        )
-
-    def _request_with_resolved_thread_target(
-        self,
-        request: ResponseRequest,
-        *,
-        resolved_thread_id: str | None = None,
-    ) -> ResponseRequest:
-        """Apply an explicit resolved thread root to one response request."""
-        if resolved_thread_id is None:
-            return request
-        resolved_target = (
-            request.target
-            or self._conversation_resolver.build_message_target(
-                room_id=request.room_id,
-                thread_id=request.thread_id,
-                reply_to_event_id=request.reply_to_event_id,
-            )
-        ).with_thread_root(resolved_thread_id)
-        return replace(request, target=resolved_target)
-
-    async def _process_and_respond(
-        self,
-        request: ResponseRequest,
-        *,
-        run_id: str | None = None,
-        resolved_thread_id: str | None = None,
-        response_kind: str = "ai",
-        compaction_outcomes_collector: list[CompactionOutcome] | None = None,
-    ) -> DeliveryResult:
-        """Delegate non-streaming response execution to the coordinator."""
-        resolved_request = self._request_with_resolved_thread_target(
-            request,
-            resolved_thread_id=resolved_thread_id,
-        )
-        return await self._response_coordinator.process_and_respond(
-            resolved_request,
-            run_id=run_id,
-            response_kind=response_kind,
-            compaction_outcomes_collector=compaction_outcomes_collector,
-        )
-
-    async def _send_skill_command_response(
-        self,
-        *,
-        room_id: str,
-        reply_to_event_id: str,
-        thread_id: str | None,
-        thread_history: Sequence[ResolvedVisibleMessage],
-        prompt: str,
-        agent_name: str,
-        user_id: str | None,
-        reply_to_event: nio.RoomMessageText | None = None,
-        source_envelope: MessageEnvelope | None = None,
-    ) -> str | None:
-        """Send a skill command response using a specific agent."""
-        return await self._response_coordinator.send_skill_command_response(
-            room_id=room_id,
-            reply_to_event_id=reply_to_event_id,
-            thread_id=thread_id,
-            thread_history=thread_history,
-            prompt=prompt,
-            agent_name=agent_name,
-            user_id=user_id,
-            reply_to_event=reply_to_event,
-            source_envelope=source_envelope,
-        )
-
-    async def _process_and_respond_streaming(
-        self,
-        request: ResponseRequest,
-        *,
-        run_id: str | None = None,
-        resolved_thread_id: str | None = None,
-        response_kind: str = "ai",
-        compaction_outcomes_collector: list[CompactionOutcome] | None = None,
-    ) -> DeliveryResult:
-        """Delegate streaming response execution to the coordinator."""
-        resolved_request = self._request_with_resolved_thread_target(
-            request,
-            resolved_thread_id=resolved_thread_id,
-        )
-        return await self._response_coordinator.process_and_respond_streaming(
-            resolved_request,
-            run_id=run_id,
-            response_kind=response_kind,
-            compaction_outcomes_collector=compaction_outcomes_collector,
         )
 
     async def _generate_response(

--- a/tests/test_ai_error_message_display.py
+++ b/tests/test_ai_error_message_display.py
@@ -80,10 +80,6 @@ def _mock_bot(tmp_path: Path) -> AgentBot:
     bot._conversation_state_writer.create_team_history_storage = MagicMock(return_value=MagicMock())
     bot._conversation_state_writer.persist_response_event_id_in_session_run = MagicMock()
     bot._conversation_state_writer.history_session_type = MagicMock(return_value=SessionType.AGENT)
-    bot._request_with_resolved_thread_target = AgentBot._request_with_resolved_thread_target.__get__(
-        bot,
-        AgentBot,
-    )
     bot._knowledge_access_support = SimpleNamespace(for_agent=MagicMock(return_value=None))
     return bot
 
@@ -143,8 +139,6 @@ class TestAIErrorDisplay:
             edited_messages.append((event_id, text))
             return "$edit"
 
-        process_method = AgentBot._process_and_respond
-
         with (
             patch("mindroom.response_coordinator.ai_response") as mock_ai,
             patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(side_effect=mock_gateway_edit_message)),
@@ -153,8 +147,7 @@ class TestAIErrorDisplay:
             error_msg = "[test_agent] 🔴 Authentication failed. Please check your API key configuration."
             mock_ai.return_value = error_msg
 
-            await process_method(
-                bot,
+            await bot._response_coordinator.process_and_respond(
                 _response_request(existing_event_id="$thinking_msg"),
             )
 
@@ -184,9 +177,6 @@ class TestAIErrorDisplay:
         bot._edit_message = mock_edit_message
         bot._handle_interactive_question = AsyncMock()
 
-        # Create the actual _process_and_respond_streaming method bound to our mock bot
-        streaming_method = AgentBot._process_and_respond_streaming
-
         # Mock stream_agent_response to yield an error message
         with patch("mindroom.response_coordinator.stream_agent_response") as mock_stream:
 
@@ -202,8 +192,7 @@ class TestAIErrorDisplay:
                 mock_send_streaming.return_value = ("$msg_id", error_text)
 
                 # Call the method with an existing_event_id
-                await streaming_method(
-                    bot,
+                await bot._response_coordinator.process_and_respond_streaming(
                     _response_request(existing_event_id="$thinking_msg"),
                 )
 
@@ -226,9 +215,6 @@ class TestAIErrorDisplay:
             edited_messages.append((event_id, text))
             return "$edit"
 
-        # Create the actual _process_and_respond method bound to our mock bot
-        process_method = AgentBot._process_and_respond
-
         # Mock ai_response to raise CancelledError
         with (
             patch("mindroom.response_coordinator.ai_response") as mock_ai,
@@ -239,8 +225,7 @@ class TestAIErrorDisplay:
 
             # Call the method and expect it to raise CancelledError
             with pytest.raises(asyncio.CancelledError):
-                await process_method(
-                    bot,
+                await bot._response_coordinator.process_and_respond(
                     _response_request(existing_event_id="$thinking_msg"),
                 )
 
@@ -267,8 +252,6 @@ class TestAIErrorDisplay:
             edited_messages.append(text)
             return "$edit"
 
-        process_method = AgentBot._process_and_respond
-
         error_messages = [
             "[test_agent] 🔴 Authentication failed. Please check your API key configuration.",
             "[test_agent] 🔴 Rate limited. Please wait before trying again.",
@@ -287,8 +270,7 @@ class TestAIErrorDisplay:
                 _build_response_coordinator(bot)
                 mock_ai.return_value = error_msg
 
-                await process_method(
-                    bot,
+                await bot._response_coordinator.process_and_respond(
                     _response_request(
                         prompt="Help me",
                         existing_event_id=f"$thinking_{error_messages.index(error_msg)}",
@@ -329,8 +311,6 @@ class TestAIErrorDisplay:
             edited_messages.append((event_id, content, text))
             return "$edit"
 
-        process_method = AgentBot._process_and_respond
-
         with (
             patch("mindroom.response_coordinator.ai_response") as mock_ai,
             patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(side_effect=mock_gateway_edit_message)),
@@ -339,8 +319,7 @@ class TestAIErrorDisplay:
             mock_ai.side_effect = asyncio.CancelledError(SYNC_RESTART_CANCEL_MSG)
 
             with pytest.raises(asyncio.CancelledError):
-                await process_method(
-                    bot,
+                await bot._response_coordinator.process_and_respond(
                     _response_request(existing_event_id="$thinking_msg"),
                 )
 
@@ -356,8 +335,6 @@ class TestAIErrorDisplay:
         bot = _mock_bot(tmp_path)
         bot._knowledge_access_support.for_agent = MagicMock(return_value=None)
 
-        process_method = AgentBot._process_and_respond
-
         with (
             patch(
                 "mindroom.response_coordinator.ensure_request_knowledge_managers",
@@ -370,8 +347,7 @@ class TestAIErrorDisplay:
             _build_response_coordinator(bot)
             mock_ai.return_value = "Response without knowledge"
 
-            delivery = await process_method(
-                bot,
+            delivery = await bot._response_coordinator.process_and_respond(
                 _response_request(),
             )
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -125,10 +125,6 @@ def _build_response_coordinator(
     bot._conversation_state_writer.create_team_history_storage = MagicMock(return_value=MagicMock())
     bot._conversation_state_writer.persist_response_event_id_in_session_run = MagicMock()
     bot._conversation_state_writer.history_session_type = MagicMock(return_value=SessionType.AGENT)
-    bot._request_with_resolved_thread_target = AgentBot._request_with_resolved_thread_target.__get__(
-        bot,
-        AgentBot,
-    )
     bot._edit_message = AsyncMock(return_value=True)
     delivery_gateway = MagicMock()
     delivery_gateway.deliver_final = AsyncMock(

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -131,7 +131,7 @@ async def test_queued_config_reload_waits_for_in_flight_response_without_event_i
         await release_response.wait()
 
     response_task = asyncio.create_task(
-        bot._run_cancellable_response(
+        bot._response_coordinator.run_cancellable_response(
             room_id="!room:localhost",
             reply_to_event_id="$reply",
             thread_id=None,
@@ -1155,7 +1155,7 @@ async def test_in_flight_response_count_nonzero_during_send_response(
         pass
 
     task = asyncio.create_task(
-        bot._run_cancellable_response(
+        bot._response_coordinator.run_cancellable_response(
             room_id="!room:localhost",
             reply_to_event_id="$reply",
             thread_id=None,
@@ -1207,7 +1207,7 @@ async def test_run_cancellable_response_does_not_depend_on_current_task_lookup(
     async def response_function(message_id: str | None) -> None:
         assert message_id is None
 
-    await bot._run_cancellable_response(
+    await bot._response_coordinator.run_cancellable_response(
         room_id="!room:localhost",
         reply_to_event_id="$reply",
         thread_id=None,
@@ -1268,7 +1268,7 @@ async def test_run_cancellable_response_marks_thinking_placeholder_pending(
     async def response_function(message_id: str | None) -> None:
         assert message_id == "$thinking"
 
-    await bot._run_cancellable_response(
+    await bot._response_coordinator.run_cancellable_response(
         room_id="!room:localhost",
         reply_to_event_id="$reply",
         thread_id=None,

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -1279,7 +1279,7 @@ class TestAgentBot:
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._process_and_respond(
+            delivery = await bot._response_coordinator.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -1325,7 +1325,7 @@ class TestAgentBot:
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._process_and_respond(
+            delivery = await bot._response_coordinator.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -1381,7 +1381,7 @@ class TestAgentBot:
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                delivery = await bot._process_and_respond_streaming(
+                delivery = await bot._response_coordinator.process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Please reply in thread",
@@ -1434,7 +1434,7 @@ class TestAgentBot:
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                delivery = await bot._process_and_respond_streaming(
+                delivery = await bot._response_coordinator.process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Hello",
@@ -1474,7 +1474,7 @@ class TestAgentBot:
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            await bot._process_and_respond(
+            await bot._response_coordinator.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please inspect attachments",
@@ -1533,7 +1533,7 @@ class TestAgentBot:
                 stream_agent_response=fake_stream_agent_response,
             ),
         ):
-            await bot._process_and_respond_streaming(
+            await bot._response_coordinator.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please inspect attachments",
@@ -1618,7 +1618,7 @@ class TestAgentBot:
                 stream_agent_response=fake_stream_agent_response,
             ),
         ):
-            await bot._process_and_respond_streaming(
+            await bot._response_coordinator.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Hello",
@@ -1682,7 +1682,7 @@ class TestAgentBot:
                 stream_agent_response=fake_stream_agent_response,
             ),
         ):
-            await bot._process_and_respond_streaming(
+            await bot._response_coordinator.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Cancel me",
@@ -1731,7 +1731,7 @@ class TestAgentBot:
                 stream_agent_response=mock_stream_agent_response,
             ),
         ):
-            delivery = await bot._process_and_respond_streaming(
+            delivery = await bot._response_coordinator.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please continue",
@@ -1784,7 +1784,7 @@ class TestAgentBot:
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._process_and_respond(
+            delivery = await bot._response_coordinator.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -1833,7 +1833,7 @@ class TestAgentBot:
                 typing_indicator=noop_typing_indicator,
                 ai_response=mock_ai_response,
             ):
-                await bot._process_and_respond(
+                await bot._response_coordinator.process_and_respond(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Please continue",
@@ -1901,7 +1901,7 @@ class TestAgentBot:
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                delivery = await bot._process_and_respond_streaming(
+                delivery = await bot._response_coordinator.process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Please reply in thread",
@@ -1958,7 +1958,7 @@ class TestAgentBot:
                     typing_indicator=noop_typing_indicator,
                     stream_agent_response=mock_stream,
                 ):
-                    await bot._process_and_respond_streaming(
+                    await bot._response_coordinator.process_and_respond_streaming(
                         _response_request(
                             room_id="!test:localhost",
                             prompt="Please continue",
@@ -2419,7 +2419,7 @@ class TestAgentBot:
         ):
             mock_stream_agent_response.return_value = mock_streaming_response()
             mock_send_streaming_response.return_value = ("$streaming", "chunk")
-            delivery = await bot._process_and_respond_streaming(
+            delivery = await bot._response_coordinator.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please reply in thread",
@@ -2687,7 +2687,7 @@ class TestAgentBot:
             typing_indicator=noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._process_and_respond(
+            delivery = await bot._response_coordinator.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Summarize README",
@@ -2747,7 +2747,7 @@ class TestAgentBot:
             ai_response=mock_ai,
             create_background_task=MagicMock(side_effect=discard_background_task),
         ):
-            await bot._send_skill_command_response(
+            await bot._response_coordinator.send_skill_command_response(
                 room_id="!test:localhost",
                 reply_to_event_id="$event",
                 thread_id=None,
@@ -2805,7 +2805,7 @@ class TestAgentBot:
             mark_auto_flush_dirty_session=MagicMock(),
             create_background_task=MagicMock(),
         ):
-            await bot._send_skill_command_response(
+            await bot._response_coordinator.send_skill_command_response(
                 room_id="!test:localhost",
                 reply_to_event_id="$event",
                 thread_id=None,

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -862,7 +862,7 @@ class TestStreamingBehavior:
                 typing_indicator=noop_typing,
             ),
         ):
-            delivery = await bot._process_and_respond_streaming(
+            delivery = await bot._response_coordinator.process_and_respond_streaming(
                 ResponseRequest(
                     room_id="!test:localhost",
                     reply_to_event_id="$reply_plain:localhost",

--- a/tests/test_system_enrich.py
+++ b/tests/test_system_enrich.py
@@ -551,7 +551,7 @@ async def test_process_and_respond_threads_system_enrichment_items(tmp_path: Pat
             ai_response=AsyncMock(side_effect=fake_ai_response),
         ),
     ):
-        delivery = await bot._process_and_respond(
+        delivery = await bot._response_coordinator.process_and_respond(
             ResponseRequest(
                 room_id="!room:localhost",
                 reply_to_event_id="$event",
@@ -595,7 +595,7 @@ async def test_process_and_respond_streaming_threads_system_enrichment_items(tmp
             stream_agent_response=fake_stream_agent_response,
         ),
     ):
-        delivery = await bot._process_and_respond_streaming(
+        delivery = await bot._response_coordinator.process_and_respond_streaming(
             ResponseRequest(
                 room_id="!room:localhost",
                 reply_to_event_id="$event",

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -406,7 +406,7 @@ class TestThreadingBehavior:
 
         try:
             with patch.object(bot._conversation_access, "get_thread_history", AsyncMock()) as mock_fetch:
-                first_context = await bot._extract_message_context(room, event)
+                first_context = await bot._conversation_resolver.extract_message_context(room, event)
 
             assert first_context.is_thread is True
             assert first_context.thread_id == "$msg1:localhost"
@@ -422,7 +422,7 @@ class TestThreadingBehavior:
             bot.client.room_get_event = AsyncMock(side_effect=AssertionError("should use persisted cache"))
 
             with patch.object(bot._conversation_access, "get_thread_history", AsyncMock()) as mock_fetch_again:
-                second_context = await bot._extract_message_context(room, event)
+                second_context = await bot._conversation_resolver.extract_message_context(room, event)
 
             assert second_context.is_thread is True
             assert second_context.thread_id == "$msg1:localhost"


### PR DESCRIPTION
## Summary
- delete unused pass-through helpers and dead compatibility shims from the bot runtime
- trim tests that only exercised those removed wrappers
- keep the remaining bot paths using the direct runtime helpers already on main

## Verification
- `python -m pre_commit run --files src/mindroom/bot.py tests/test_ai_error_message_display.py tests/test_ai_user_id.py tests/test_config_reload.py tests/test_multi_agent_bot.py tests/test_streaming_behavior.py tests/test_system_enrich.py tests/test_threading_error.py`
- `PYTHONPATH="$PWD/src" .venv/bin/pytest -q tests/test_ai_error_message_display.py tests/test_ai_user_id.py tests/test_config_reload.py tests/test_multi_agent_bot.py tests/test_streaming_behavior.py tests/test_system_enrich.py tests/test_threading_error.py -k "error_message or user_id or config_reload or streaming or system_enrich or threading or bot"`
