### PR TITLE
Coordinate shared event-cache writes and reuse background sync state

### DIFF
--- a/src/mindroom/background_tasks.py
+++ b/src/mindroom/background_tasks.py
@@ -11,15 +11,19 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
 logger = get_logger(__name__)
+_MAX_BACKGROUND_TASK_CANCEL_ROUNDS = 3
 
-# Global set to track background tasks and prevent them from being garbage collected
+# Global registries keep strong references to background tasks and optional owners.
 _background_tasks: set[asyncio.Task[Any]] = set()
+_background_task_owners: dict[asyncio.Task[Any], object] = {}
 
 
 def create_background_task(
     coro: Coroutine[Any, Any, Any],
     name: str | None = None,
     error_handler: Callable[[Exception], None] | None = None,
+    *,
+    owner: object | None = None,
 ) -> asyncio.Task[Any]:
     """Create a background task that won't block the main execution.
 
@@ -27,6 +31,7 @@ def create_background_task(
         coro: The coroutine to run in the background
         name: Optional name for the task (for logging)
         error_handler: Optional error handler function
+        owner: Optional logical owner used for scoped shutdown waits
 
     Returns:
         The created task
@@ -38,10 +43,13 @@ def create_background_task(
 
     # Add to global set to prevent garbage collection
     _background_tasks.add(task)
+    if owner is not None:
+        _background_task_owners[task] = owner
 
     # Add completion callback to remove from set and handle errors
     def _task_done_callback(task: asyncio.Task[Any]) -> None:
         _background_tasks.discard(task)
+        _background_task_owners.pop(task, None)
         try:
             # This will raise if the task had an exception
             task.result()
@@ -61,25 +69,68 @@ def create_background_task(
     return task
 
 
-async def wait_for_background_tasks(timeout: float | None = None) -> None:  # noqa: ASYNC109
+def _tasks_for_owner(owner: object | None) -> tuple[asyncio.Task[Any], ...]:
+    if owner is None:
+        return tuple(_background_tasks)
+    return tuple(task for task in _background_tasks if _background_task_owners.get(task) is owner)
+
+
+async def _cancel_and_drain_background_tasks(
+    tasks: tuple[asyncio.Task[Any], ...],
+    *,
+    owner: object | None,
+) -> None:
+    pending_tasks = tasks
+    for _ in range(_MAX_BACKGROUND_TASK_CANCEL_ROUNDS):
+        if not pending_tasks:
+            return
+        for task in pending_tasks:
+            task.cancel()
+        await asyncio.gather(*pending_tasks, return_exceptions=True)
+        pending_tasks = _tasks_for_owner(owner)
+    if pending_tasks:
+        logger.warning(
+            "Background tasks still running after bounded cancellation drain",
+            task_count=len(pending_tasks),
+            cancel_rounds=_MAX_BACKGROUND_TASK_CANCEL_ROUNDS,
+        )
+
+
+async def wait_for_background_tasks(
+    timeout: float | None = None,  # noqa: ASYNC109
+    *,
+    owner: object | None = None,
+) -> None:
     """Wait for all background tasks to complete.
 
     Args:
         timeout: Optional timeout in seconds
+        owner: Optional logical owner to scope the wait to one bot
 
     """
-    if not _background_tasks:
-        return
+    deadline: float | None = None
+    if timeout is not None:
+        deadline = asyncio.get_running_loop().time() + timeout
 
-    try:
-        await asyncio.wait_for(asyncio.gather(*_background_tasks, return_exceptions=True), timeout=timeout)
-    except TimeoutError:
-        logger.warning("background_tasks_wait_timeout", timeout_seconds=timeout)
-        # Cancel remaining tasks
-        for task in _background_tasks:
-            task.cancel()
-        # Wait for cancellation to complete
-        await asyncio.gather(*_background_tasks, return_exceptions=True)
+    while True:
+        tasks = _tasks_for_owner(owner)
+        if not tasks:
+            return
+
+        remaining: float | None = None
+        if deadline is not None:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                logger.warning("background_tasks_wait_timeout", timeout_seconds=timeout)
+                await _cancel_and_drain_background_tasks(tasks, owner=owner)
+                return
+
+        done, pending = await asyncio.wait(tasks, timeout=remaining)
+        await asyncio.gather(*done, return_exceptions=True)
+        if pending:
+            logger.warning("background_tasks_wait_timeout", timeout_seconds=timeout)
+            await _cancel_and_drain_background_tasks(tuple(pending), owner=owner)
+            return
 
 
 def _get_background_task_count() -> int:

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -169,13 +169,17 @@ from .matrix.client import (
     get_joined_rooms,
     join_room,
 )
-from .matrix.event_cache import ConversationEventCache, EventCache
 from .media_inputs import MediaInputs
 from .response_coordinator import (
     ResponseCoordinator,
     ResponseCoordinatorDeps,
     ResponseRequest,
     prepare_memory_and_model_context,
+)
+from .runtime_support import (
+    StandaloneRuntimeSupport,
+    close_standalone_runtime_support,
+    create_standalone_runtime_support,
 )
 from .scheduling import (
     cancel_all_running_scheduled_tasks,
@@ -197,6 +201,8 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.history.types import HistoryScope
     from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.event_cache import ConversationEventCache
+    from mindroom.matrix.event_cache_write_coordinator import EventCacheWriteCoordinator
     from mindroom.orchestrator import MultiAgentOrchestrator
     from mindroom.tool_system.events import ToolTraceEntry
 
@@ -227,6 +233,8 @@ def _thread_summary_message_count_hint(
 
 def _create_task_wrapper(
     callback: Callable[..., Awaitable[None]],
+    *,
+    owner: object | None = None,
 ) -> Callable[..., Awaitable[None]]:
     """Create a wrapper that runs the callback as a background task.
 
@@ -248,7 +256,7 @@ def _create_task_wrapper(
                 logger.exception("Error in event callback")
 
         # Keep a strong reference via background task registry.
-        create_background_task(error_handler())
+        create_background_task(error_handler(), owner=owner)
 
     return wrapper
 
@@ -392,6 +400,7 @@ class AgentBot:
     _hook_context_support: HookContextSupport
     _knowledge_access_support: KnowledgeAccessSupport
     _deferred_overdue_task_drain_task: asyncio.Task[None] | None
+    _standalone_runtime_support: StandaloneRuntimeSupport | None
 
     def __init__(
         self,
@@ -420,7 +429,10 @@ class AgentBot:
             config=config,
             enable_streaming=enable_streaming,
             orchestrator=None,
+            event_cache=None,
+            event_cache_write_coordinator=None,
         )
+        self._standalone_runtime_support = None
         self._deferred_overdue_task_drain_task = None
         self._init_runtime_components()
 
@@ -451,7 +463,10 @@ class AgentBot:
             logger=self.logger,
             runtime_paths=self.runtime_paths,
         )
-        self._conversation_access = MatrixConversationAccess(logger=self.logger)
+        self._conversation_access = MatrixConversationAccess(
+            logger=self.logger,
+            runtime=self._runtime_view,
+        )
         self._conversation_state_writer = ConversationStateWriter(
             ConversationStateWriterDeps(
                 runtime=self._runtime_view,
@@ -558,7 +573,6 @@ class AgentBot:
     def client(self, value: nio.AsyncClient | None) -> None:
         """Update the current Matrix client."""
         self._runtime_view.client = value
-        self._conversation_access.client = value
 
     @property
     def config(self) -> Config:
@@ -593,12 +607,22 @@ class AgentBot:
     @property
     def event_cache(self) -> ConversationEventCache | None:
         """Return the advisory event cache."""
-        return self._conversation_access.event_cache
+        return self._runtime_view.event_cache
 
     @event_cache.setter
     def event_cache(self, value: ConversationEventCache | None) -> None:
         """Update the advisory event cache."""
-        self._conversation_access.event_cache = value
+        self._runtime_view.event_cache = value
+
+    @property
+    def event_cache_write_coordinator(self) -> EventCacheWriteCoordinator | None:
+        """Return the advisory event-cache write coordinator."""
+        return self._runtime_view.event_cache_write_coordinator
+
+    @event_cache_write_coordinator.setter
+    def event_cache_write_coordinator(self, value: EventCacheWriteCoordinator | None) -> None:
+        """Update the advisory event-cache write coordinator."""
+        self._runtime_view.event_cache_write_coordinator = value
 
     @property
     def hook_registry(self) -> HookRegistry:
@@ -1117,7 +1141,7 @@ class AgentBot:
             return
 
         if isinstance(_response, nio.SyncResponse):
-            await self._conversation_access.cache_sync_timeline(_response)
+            self._conversation_access.cache_sync_timeline(_response)
 
         self._first_sync_done = True
 
@@ -1142,42 +1166,69 @@ class AgentBot:
         await self.join_configured_rooms()
         await self.leave_unconfigured_rooms()
 
-    async def _initialize_event_cache(self) -> None:
-        """Initialize the persistent Matrix event cache when enabled."""
-        assert self.client is not None
-        if not self.config.cache.enabled:
+    async def _initialize_runtime_support_services(self) -> None:
+        """Initialize standalone runtime support services with an all-or-nothing injection contract."""
+        if self._standalone_runtime_support is not None:
             return
-
-        event_cache = EventCache(self.config.cache.resolve_db_path(self.runtime_paths))
-        try:
-            await event_cache.initialize()
-        except Exception as exc:
-            self.logger.warning("Failed to initialize event cache", error=str(exc))
+        injected_service_count = self._runtime_support_injection_count()
+        if injected_service_count == 2:
             return
+        if injected_service_count != 0:
+            msg = self._partial_runtime_support_injection_error()
+            raise RuntimeError(msg)
 
-        self.event_cache = event_cache
+        support = await create_standalone_runtime_support(
+            config=self.config,
+            runtime_paths=self.runtime_paths,
+            logger=self.logger,
+            background_task_owner=self._runtime_view,
+        )
+        self._standalone_runtime_support = support
+        self.event_cache = support.event_cache
+        self.event_cache_write_coordinator = support.event_cache_write_coordinator
 
-    async def _close_event_cache(self) -> None:
-        """Close the persistent Matrix event cache when present."""
-        event_cache = self.event_cache
+    async def _close_runtime_support_services(self) -> None:
+        """Clear runtime support bindings and close standalone-owned services when present."""
+        support = self._standalone_runtime_support
+        self._standalone_runtime_support = None
         self.event_cache = None
-        if event_cache is None:
+        self.event_cache_write_coordinator = None
+        if support is None:
             return
+        await close_standalone_runtime_support(support, logger=self.logger)
 
-        try:
-            await event_cache.close()
-        except Exception as exc:
-            self.logger.warning("Failed to close event cache", error=str(exc))
+    def _runtime_support_injection_count(self) -> int:
+        """Return how many runtime support services are currently injected."""
+        return sum(
+            service is not None
+            for service in (
+                self.event_cache,
+                self.event_cache_write_coordinator,
+            )
+        )
+
+    @staticmethod
+    def _partial_runtime_support_injection_error() -> str:
+        """Return the shared error text for invalid mixed runtime support injection."""
+        return "Runtime support services must be injected all together or not at all; partial injection is unsupported"
+
+    def _validate_runtime_support_injection_contract_for_startup(self) -> None:
+        """Reject mixed runtime support injection before startup side effects begin."""
+        injected_service_count = self._runtime_support_injection_count()
+        if injected_service_count in {0, 2}:
+            return
+        raise PermanentMatrixStartupError(self._partial_runtime_support_injection_error())
 
     async def start(self) -> None:
         """Start the agent bot with user account setup (but don't join rooms yet)."""
+        self._validate_runtime_support_injection_contract_for_startup()
         await self.ensure_user_account()
         self.client = await login_agent_user(
             constants.runtime_matrix_homeserver(runtime_paths=self.runtime_paths),
             self.agent_user,
             runtime_paths=self.runtime_paths,
         )
-        await self._initialize_event_cache()
+        await self._initialize_runtime_support_services()
         await self._set_avatar_if_available()
         await self._set_presence_with_model_info()
         interactive.init_persistence(self.runtime_paths.storage_root)
@@ -1186,20 +1237,50 @@ class AgentBot:
 
         # Register event callbacks - wrap them to run as background tasks
         # This ensures the sync loop is never blocked, allowing stop reactions to work
-        client.add_event_callback(_create_task_wrapper(self._on_invite), nio.InviteEvent)  # ty: ignore[invalid-argument-type]  # InviteEvent doesn't inherit Event
-        client.add_event_callback(_create_task_wrapper(self._on_message), nio.RoomMessageText)
-        client.add_event_callback(_create_task_wrapper(self._on_redaction), nio.RedactionEvent)
-        client.add_event_callback(_create_task_wrapper(self._on_reaction), nio.ReactionEvent)
+        client.add_event_callback(
+            _create_task_wrapper(self._on_invite, owner=self._runtime_view),
+            nio.InviteEvent,  # ty: ignore[invalid-argument-type]  # InviteEvent doesn't inherit Event
+        )
+        client.add_event_callback(_create_task_wrapper(self._on_message, owner=self._runtime_view), nio.RoomMessageText)
+        client.add_event_callback(
+            _create_task_wrapper(self._on_redaction, owner=self._runtime_view),
+            nio.RedactionEvent,
+        )
+        client.add_event_callback(_create_task_wrapper(self._on_reaction, owner=self._runtime_view), nio.ReactionEvent)
 
         # Register media callbacks on all agents (each agent handles its own routing)
-        client.add_event_callback(_create_task_wrapper(self._on_media_message), nio.RoomMessageImage)
-        client.add_event_callback(_create_task_wrapper(self._on_media_message), nio.RoomEncryptedImage)
-        client.add_event_callback(_create_task_wrapper(self._on_media_message), nio.RoomMessageFile)
-        client.add_event_callback(_create_task_wrapper(self._on_media_message), nio.RoomEncryptedFile)
-        client.add_event_callback(_create_task_wrapper(self._on_media_message), nio.RoomMessageVideo)
-        client.add_event_callback(_create_task_wrapper(self._on_media_message), nio.RoomEncryptedVideo)
-        client.add_event_callback(_create_task_wrapper(self._on_media_message), nio.RoomMessageAudio)
-        client.add_event_callback(_create_task_wrapper(self._on_media_message), nio.RoomEncryptedAudio)
+        client.add_event_callback(
+            _create_task_wrapper(self._on_media_message, owner=self._runtime_view),
+            nio.RoomMessageImage,
+        )
+        client.add_event_callback(
+            _create_task_wrapper(self._on_media_message, owner=self._runtime_view),
+            nio.RoomEncryptedImage,
+        )
+        client.add_event_callback(
+            _create_task_wrapper(self._on_media_message, owner=self._runtime_view),
+            nio.RoomMessageFile,
+        )
+        client.add_event_callback(
+            _create_task_wrapper(self._on_media_message, owner=self._runtime_view),
+            nio.RoomEncryptedFile,
+        )
+        client.add_event_callback(
+            _create_task_wrapper(self._on_media_message, owner=self._runtime_view),
+            nio.RoomMessageVideo,
+        )
+        client.add_event_callback(
+            _create_task_wrapper(self._on_media_message, owner=self._runtime_view),
+            nio.RoomEncryptedVideo,
+        )
+        client.add_event_callback(
+            _create_task_wrapper(self._on_media_message, owner=self._runtime_view),
+            nio.RoomMessageAudio,
+        )
+        client.add_event_callback(
+            _create_task_wrapper(self._on_media_message, owner=self._runtime_view),
+            nio.RoomEncryptedAudio,
+        )
         client.add_response_callback(self._on_sync_response, nio.SyncResponse)  # ty: ignore[invalid-argument-type]  # matrix-nio callback types are too strict here
         client.add_response_callback(self._on_sync_error, nio.SyncError)  # ty: ignore[invalid-argument-type]
 
@@ -1275,7 +1356,7 @@ class AgentBot:
 
         # Wait for any pending background tasks (like memory saves) to complete
         try:
-            await wait_for_background_tasks(timeout=5.0)  # 5 second timeout
+            await wait_for_background_tasks(timeout=5.0, owner=self._runtime_view)  # 5 second timeout
             self.logger.info("Background tasks completed")
         except Exception as e:
             self.logger.warning("background_tasks_incomplete", error=str(e))
@@ -1290,7 +1371,7 @@ class AgentBot:
 
         if self.client is not None:
             self.logger.warning("Client is not None in stop()")
-            await self._close_event_cache()
+            await self._close_runtime_support_services()
             await self.client.close()
         self.logger.info("Stopped agent bot")
 
@@ -2880,6 +2961,7 @@ class TeamBot(AgentBot):
                     execution_identity=execution_identity,
                 ),
                 name=f"memory_save_team_{session_id}",
+                owner=self._runtime_view,
             )
 
         media_inputs = media or MediaInputs()

--- a/src/mindroom/bot_runtime_view.py
+++ b/src/mindroom/bot_runtime_view.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
     import nio
 
     from mindroom.config.main import Config
+    from mindroom.matrix.event_cache import ConversationEventCache
+    from mindroom.matrix.event_cache_write_coordinator import EventCacheWriteCoordinator
     from mindroom.orchestrator import MultiAgentOrchestrator
 
 
@@ -27,6 +29,12 @@ class BotRuntimeView(Protocol):
     @property
     def orchestrator(self) -> MultiAgentOrchestrator | None: ...  # noqa: D102
 
+    @property
+    def event_cache(self) -> ConversationEventCache | None: ...  # noqa: D102
+
+    @property
+    def event_cache_write_coordinator(self) -> EventCacheWriteCoordinator | None: ...  # noqa: D102
+
 
 @dataclass
 class BotRuntimeState:
@@ -36,3 +44,5 @@ class BotRuntimeState:
     config: Config
     enable_streaming: bool
     orchestrator: MultiAgentOrchestrator | None
+    event_cache: ConversationEventCache | None
+    event_cache_write_coordinator: EventCacheWriteCoordinator | None

--- a/src/mindroom/config/matrix.py
+++ b/src/mindroom/config/matrix.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from mindroom.constants import resolve_config_relative_path
 from mindroom.matrix.identity import managed_room_key_from_alias_localpart, room_alias_localpart
@@ -181,21 +181,21 @@ class MatrixRoomAccessConfig(BaseModel):
 
 
 class CacheConfig(BaseModel):
-    """Persistent Matrix event cache configuration."""
+    """Startup configuration for the always-on Matrix event cache."""
 
-    enabled: bool = Field(
-        default=True,
-        description="Whether to persist thread history in SQLite for incremental reuse",
-    )
+    model_config = ConfigDict(extra="forbid")
+
     db_path: str | None = Field(
         default=None,
         description=(
-            "SQLite database path for the Matrix event cache. Defaults to <storage>/event_cache.db when omitted."
+            "SQLite database path for the always-on Matrix event cache. "
+            "Defaults to <storage>/event_cache.db when omitted. "
+            "Changing this path requires a restart because hot reload intentionally keeps the active cache file."
         ),
     )
 
     def resolve_db_path(self, runtime_paths: RuntimePaths) -> Path:
-        """Resolve the configured database path for the active runtime."""
+        """Resolve the configured database path for the active runtime startup."""
         if self.db_path is None:
             return runtime_paths.storage_root / "event_cache.db"
         return resolve_config_relative_path(self.db_path, runtime_paths)

--- a/src/mindroom/config_template.yaml
+++ b/src/mindroom/config_template.yaml
@@ -51,9 +51,10 @@ matrix_space:
   enabled: true
   name: MindRoom
 
-# Persistent Matrix thread history cache (enabled by default)
+# Persistent Matrix thread history cache.
+# This cache is always enabled.
+# `db_path` is read at startup and changing it requires a restart.
 cache:
-  enabled: true
   db_path: mindroom_data/event_cache.db
 
 # Optional debug logging for pre-provider LLM request assembly data.

--- a/src/mindroom/matrix/conversation_access.py
+++ b/src/mindroom/matrix/conversation_access.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import typing
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import nio
 from nio.responses import RoomGetEventError
@@ -16,10 +17,12 @@ from mindroom.matrix.room_cache import cached_room_get_event
 from mindroom.matrix.thread_history_result import ThreadHistoryResult, thread_history_result
 
 if TYPE_CHECKING:
+    import asyncio
     from collections.abc import AsyncIterator, Sequence
 
     import structlog
 
+    from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.matrix.event_info import EventInfo
 
 
@@ -92,8 +95,7 @@ class MatrixConversationAccess(ConversationReadAccess):
     """Own Matrix conversation reads and advisory cache writes for one bot."""
 
     logger: structlog.stdlib.BoundLogger
-    client: nio.AsyncClient | None = None
-    event_cache: ConversationEventCache | None = None
+    runtime: BotRuntimeView
     _turn_event_cache: ContextVar[dict[tuple[str, str], EventLookupResult] | None] = field(
         default_factory=lambda: ContextVar("mindroom_turn_event_lookup_cache", default=None),
     )
@@ -105,11 +107,24 @@ class MatrixConversationAccess(ConversationReadAccess):
     )
 
     def _require_client(self) -> nio.AsyncClient:
-        client = self.client
+        client = self.runtime.client
         if client is None:
             msg = "Matrix client is not ready for conversation access"
             raise RuntimeError(msg)
         return client
+
+    def _queue_room_cache_update(
+        self,
+        room_id: str,
+        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        *,
+        name: str,
+    ) -> asyncio.Task[object]:
+        coordinator = self.runtime.event_cache_write_coordinator
+        if coordinator is None:
+            msg = "Event cache write coordinator is not configured"
+            raise RuntimeError(msg)
+        return coordinator.queue_room_update(room_id, update_coro_factory, name=name)
 
     @asynccontextmanager
     async def turn_scope(self) -> AsyncIterator[None]:
@@ -138,7 +153,7 @@ class MatrixConversationAccess(ConversationReadAccess):
 
         response = await cached_room_get_event(
             self._require_client(),
-            self.event_cache,
+            self.runtime.event_cache,
             room_id,
             event_id,
         )
@@ -182,7 +197,7 @@ class MatrixConversationAccess(ConversationReadAccess):
                     self._require_client(),
                     room_id,
                     thread_id,
-                    event_cache=self.event_cache,
+                    event_cache=self.runtime.event_cache,
                 ),
             )
             if history_cache is not None:
@@ -196,7 +211,7 @@ class MatrixConversationAccess(ConversationReadAccess):
                 self._require_client(),
                 room_id,
                 thread_id,
-                event_cache=self.event_cache,
+                event_cache=self.runtime.event_cache,
             ),
         )
         if snapshot_cache is not None:
@@ -230,7 +245,7 @@ class MatrixConversationAccess(ConversationReadAccess):
         event_info: EventInfo,
     ) -> None:
         """Append one live thread event into the advisory cache when the thread is known."""
-        event_cache = self.event_cache
+        event_cache = self.runtime.event_cache
         if event_cache is None:
             return
 
@@ -266,7 +281,11 @@ class MatrixConversationAccess(ConversationReadAccess):
         )
 
         try:
-            await event_cache.append_event(room_id, thread_id, event_source)
+            await self._queue_room_cache_update(
+                room_id,
+                lambda: event_cache.append_event(room_id, thread_id, event_source),
+                name="matrix_cache_append_live_event",
+            )
         except Exception as exc:
             self.logger.warning(
                 "Failed to append live thread event to cache",
@@ -278,7 +297,7 @@ class MatrixConversationAccess(ConversationReadAccess):
 
     async def apply_redaction(self, room_id: str, event: nio.RedactionEvent) -> None:
         """Apply one redaction to the advisory cache when the affected thread is known."""
-        event_cache = self.event_cache
+        event_cache = self.runtime.event_cache
         if event_cache is None:
             return
 
@@ -304,11 +323,15 @@ class MatrixConversationAccess(ConversationReadAccess):
             else None,
         )
         try:
-            await event_cache.redact_event(
+            await self._queue_room_cache_update(
                 room_id,
-                event.redacts,
-                thread_id=thread_id,
-                redaction_event=redaction_source,
+                lambda: event_cache.redact_event(
+                    room_id,
+                    event.redacts,
+                    thread_id=thread_id,
+                    redaction_event=redaction_source,
+                ),
+                name="matrix_cache_apply_redaction",
             )
         except Exception as exc:
             self.logger.warning(
@@ -319,9 +342,31 @@ class MatrixConversationAccess(ConversationReadAccess):
                 error=str(exc),
             )
 
-    async def cache_sync_timeline(self, response: nio.SyncResponse) -> None:
-        """Persist sync timeline events so later reads can reuse the advisory cache."""
-        event_cache = self.event_cache
+    async def _persist_room_sync_timeline_updates(
+        self,
+        event_cache: ConversationEventCache,
+        room_id: str,
+        cached_events: list[tuple[str, str, dict[str, object]]],
+        redacted_event_ids: list[str],
+    ) -> None:
+        """Persist one room's prepared sync timeline updates."""
+        try:
+            if cached_events:
+                await event_cache.store_events_batch(cached_events)
+            for redacted_event_id in redacted_event_ids:
+                await event_cache.redact_event(room_id, redacted_event_id)
+        except Exception as exc:
+            self.logger.warning(
+                "Failed to cache sync timeline events",
+                room_id=room_id,
+                error=str(exc),
+                events=len(cached_events),
+                redactions=len(redacted_event_ids),
+            )
+
+    def cache_sync_timeline(self, response: nio.SyncResponse) -> None:
+        """Schedule sync timeline persistence so sync callbacks do not wait on SQLite."""
+        event_cache = self.runtime.event_cache
         if event_cache is None:
             return
 
@@ -329,15 +374,24 @@ class MatrixConversationAccess(ConversationReadAccess):
         if not filtered_cached_events and not redacted_events:
             return
 
-        try:
-            if filtered_cached_events:
-                await event_cache.store_events_batch(filtered_cached_events)
-            for room_id, redacted_event_id in redacted_events:
-                await event_cache.redact_event(room_id, redacted_event_id)
-        except Exception as exc:
-            self.logger.warning(
-                "Failed to cache sync timeline events",
-                error=str(exc),
-                events=len(filtered_cached_events),
-                redactions=len(redacted_events),
+        updates_by_room: dict[str, tuple[list[tuple[str, str, dict[str, object]]], list[str]]] = {}
+        for event_id, room_id, event_source in filtered_cached_events:
+            room_events, _room_redactions = updates_by_room.setdefault(room_id, ([], []))
+            room_events.append((event_id, room_id, event_source))
+        for room_id, redacted_event_id in redacted_events:
+            _room_events, room_redactions = updates_by_room.setdefault(room_id, ([], []))
+            room_redactions.append(redacted_event_id)
+
+        for room_id, (room_events, room_redactions) in updates_by_room.items():
+            self._queue_room_cache_update(
+                room_id,
+                lambda room_events=room_events,
+                room_id=room_id,
+                room_redactions=room_redactions: self._persist_room_sync_timeline_updates(
+                    event_cache,
+                    room_id,
+                    room_events,
+                    room_redactions,
+                ),
+                name="matrix_cache_sync_timeline",
             )

--- a/src/mindroom/matrix/event_cache_write_coordinator.py
+++ b/src/mindroom/matrix/event_cache_write_coordinator.py
@@ -1,0 +1,100 @@
+"""Shared runtime coordinator for advisory Matrix event-cache writes."""
+
+from __future__ import annotations
+
+import asyncio
+import typing
+import weakref
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from mindroom.background_tasks import create_background_task, wait_for_background_tasks
+
+if TYPE_CHECKING:
+    import structlog
+
+
+@dataclass
+class EventCacheWriteCoordinator:
+    """Serialize same-room advisory cache writes across the whole runtime."""
+
+    logger: structlog.stdlib.BoundLogger
+    background_task_owner: object = field(default_factory=object)
+    _room_update_tasks: dict[str, asyncio.Task[Any]] = field(default_factory=dict, init=False)
+    _room_update_predecessors: weakref.WeakKeyDictionary[
+        asyncio.Task[Any],
+        asyncio.Task[Any] | None,
+    ] = field(default_factory=weakref.WeakKeyDictionary, init=False)
+
+    def _pending_predecessor(self, task: asyncio.Task[Any]) -> asyncio.Task[Any] | None:
+        predecessor = self._room_update_predecessors.get(task)
+        while predecessor is not None and predecessor.done():
+            if not predecessor.cancelled():
+                return None
+            predecessor = self._room_update_predecessors.get(predecessor)
+        return predecessor
+
+    async def _await_predecessor(
+        self,
+        room_id: str,
+        operation: str,
+        previous_task: asyncio.Task[Any] | None,
+    ) -> None:
+        predecessor = previous_task
+        while predecessor is not None:
+            try:
+                await predecessor
+            except asyncio.CancelledError:
+                current_task = asyncio.current_task()
+                if current_task is not None and current_task.cancelling():
+                    raise
+                predecessor = self._pending_predecessor(predecessor)
+            except Exception as exc:
+                self.logger.debug(
+                    "Previous room cache update failed before follow-up update",
+                    room_id=room_id,
+                    operation=operation,
+                    error=str(exc),
+                )
+                return
+            else:
+                return
+
+    def _clear_room_tail(self, room_id: str, done_task: asyncio.Task[object]) -> None:
+        if self._room_update_tasks.get(room_id) is not done_task:
+            return
+        predecessor = self._pending_predecessor(done_task)
+        if done_task.cancelled() and predecessor is not None:
+            self._room_update_tasks[room_id] = predecessor
+            return
+        self._room_update_tasks.pop(room_id, None)
+
+    def queue_room_update(
+        self,
+        room_id: str,
+        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        *,
+        name: str,
+    ) -> asyncio.Task[object]:
+        """Schedule one room-scoped cache update behind any active predecessor."""
+        previous_task = self._room_update_tasks.get(room_id)
+
+        async def run_after_previous() -> object:
+            await self._await_predecessor(room_id, name, previous_task)
+            return await update_coro_factory()
+
+        task = create_background_task(
+            run_after_previous(),
+            name=name,
+            owner=self.background_task_owner,
+        )
+        self._room_update_predecessors[task] = previous_task
+        self._room_update_tasks[room_id] = task
+        task.add_done_callback(lambda done_task: self._clear_room_tail(room_id, done_task))
+        return task
+
+    async def close(self) -> None:
+        """Drain any queued cache writes for this coordinator."""
+        await wait_for_background_tasks(timeout=5.0, owner=self.background_task_owner)
+        self._room_update_tasks.clear()
+        self._room_update_predecessors.clear()

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -35,6 +35,8 @@ from mindroom.matrix.client import (
     get_room_members,
     invite_to_room,
 )
+from mindroom.matrix.event_cache import EventCache
+from mindroom.matrix.event_cache_write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.health import reset_matrix_sync_health
 from mindroom.matrix.identity import MatrixID, extract_server_name_from_homeserver
 from mindroom.matrix.rooms import (
@@ -211,6 +213,9 @@ class MultiAgentOrchestrator:
     _config_reload_requested_at: float | None = field(default=None, init=False)
     _mcp_manager: MCPServerManager | None = field(default=None, init=False)
     _mcp_catalog_change_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+    _event_cache: EventCache | None = field(default=None, init=False)
+    _event_cache_write_coordinator: EventCacheWriteCoordinator | None = field(default=None, init=False)
+    _event_cache_write_task_owner: object = field(default_factory=object, init=False)
     hook_registry: HookRegistry = field(default_factory=HookRegistry.empty, init=False)
 
     def __post_init__(self) -> None:
@@ -252,6 +257,95 @@ class MultiAgentOrchestrator:
         )
         self._memory_auto_flush_worker = worker
         self._memory_auto_flush_task = asyncio.create_task(worker.run(), name="memory_auto_flush_worker")
+
+    def _bind_runtime_support_services(self, bot: AgentBot | TeamBot) -> None:
+        """Bind the current runtime support services to one managed bot."""
+        bot.event_cache = self._event_cache
+        bot.event_cache_write_coordinator = self._event_cache_write_coordinator
+
+    def _rebind_runtime_support_services(self) -> None:
+        """Rebind the current runtime support services to every managed bot."""
+        for bot in self.agent_bots.values():
+            self._bind_runtime_support_services(bot)
+
+    async def _sync_event_cache_service(self, config: Config) -> None:
+        """Ensure the runtime has one shared event-cache service.
+
+        The cache is intentionally always attempted, but it remains advisory.
+        Startup should therefore degrade to no cache service if SQLite init fails.
+        Hot reload may rebind bots to the existing shared service, but it must not
+        swap the live SQLite file underneath running bots.
+        Future changes to ``cache.db_path`` should therefore apply on restart, not
+        by mutating the active service during ``update_config()``.
+        """
+        desired_db_path = config.cache.resolve_db_path(self.runtime_paths)
+        cache = self._event_cache
+        coordinator = self._event_cache_write_coordinator
+        if cache is None:
+            if coordinator is not None:
+                await self._close_event_cache_write_coordinator()
+            cache = EventCache(desired_db_path)
+            try:
+                await cache.initialize()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to initialize event cache",
+                    db_path=str(desired_db_path),
+                    error=str(exc),
+                )
+                try:
+                    await cache.close()
+                except Exception as close_exc:
+                    logger.warning(
+                        "Failed to close partially initialized event cache",
+                        db_path=str(desired_db_path),
+                        error=str(close_exc),
+                    )
+                self._event_cache = None
+                self._event_cache_write_coordinator = None
+                self._rebind_runtime_support_services()
+                return
+
+            coordinator = EventCacheWriteCoordinator(
+                logger=logger,
+                background_task_owner=self._event_cache_write_task_owner,
+            )
+            self._event_cache = cache
+            self._event_cache_write_coordinator = coordinator
+            self._rebind_runtime_support_services()
+            return
+
+        if cache.db_path != desired_db_path:
+            logger.info(
+                "Event cache db_path change will apply after restart",
+                active_db_path=str(cache.db_path),
+                configured_db_path=str(desired_db_path),
+            )
+
+        if cache is not None:
+            if coordinator is None:
+                coordinator = EventCacheWriteCoordinator(
+                    logger=logger,
+                    background_task_owner=self._event_cache_write_task_owner,
+                )
+                self._event_cache_write_coordinator = coordinator
+            self._rebind_runtime_support_services()
+
+    async def _close_event_cache_write_coordinator(self) -> None:
+        """Drain the shared event-cache write coordinator."""
+        coordinator = self._event_cache_write_coordinator
+        self._event_cache_write_coordinator = None
+        if coordinator is None:
+            return
+        await coordinator.close()
+
+    async def _close_event_cache(self) -> None:
+        """Close the shared event cache."""
+        cache = self._event_cache
+        self._event_cache = None
+        if cache is None:
+            return
+        await cache.close()
 
     async def _ensure_user_account(self, config: Config) -> None:
         """Ensure a user account exists, creating one if necessary.
@@ -602,6 +696,7 @@ class MultiAgentOrchestrator:
     ) -> None:
         """Refresh runtime support services that depend on the active config."""
         ensure_default_agent_workspaces(config, self.storage_path)
+        await self._sync_event_cache_service(config)
         await self._refresh_knowledge_for_runtime(config, start_watcher=start_watcher)
         await self._sync_memory_auto_flush_worker()
 
@@ -667,6 +762,7 @@ class MultiAgentOrchestrator:
         )
         bot.orchestrator = self
         bot.hook_registry = self.hook_registry
+        self._bind_runtime_support_services(bot)
         self.agent_bots[entity_name] = bot
         return bot
 
@@ -750,6 +846,7 @@ class MultiAgentOrchestrator:
         self.config = config
         self._activate_hook_registry(hook_registry)
         await self._sync_mcp_manager(config)
+        await self._sync_event_cache_service(config)
         for entity_name in self._configured_entity_names(config):
             self._create_managed_bot(entity_name, config)
 
@@ -1132,6 +1229,7 @@ class MultiAgentOrchestrator:
         self.config = new_config
         self._activate_hook_registry(new_hook_registry)
         changed_runtime_mcp_servers = await self._sync_mcp_manager(new_config)
+        await self._sync_event_cache_service(new_config)
         logger.info(
             "updating_config_authorization",
             authorized_user_ids=new_config.authorization.global_users,
@@ -1450,6 +1548,8 @@ class MultiAgentOrchestrator:
 
         stop_tasks = [bot.stop(reason="shutdown") for bot in self.agent_bots.values()]
         await asyncio.gather(*stop_tasks)
+        await self._close_event_cache_write_coordinator()
+        await self._close_event_cache()
         logger.info("All agent bots stopped")
 
 

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -180,6 +180,7 @@ class PostResponseEffectsSupport:
                 summary_coro=summary_coro,
             ),
             name=f"thread_summary_{room_id}_{thread_id}",
+            owner=self.runtime,
         )
 
     def build_deps(

--- a/src/mindroom/response_coordinator.py
+++ b/src/mindroom/response_coordinator.py
@@ -1783,6 +1783,7 @@ class ResponseCoordinator:
                             execution_identity=execution_identity,
                         ),
                         name=f"memory_save_{agent_name}_{session_id}",
+                        owner=self.deps.runtime,
                     )
             except Exception:  # pragma: no cover
                 self.deps.logger.debug("Skipping memory storage due to configuration error")
@@ -1924,6 +1925,7 @@ class ResponseCoordinator:
                         execution_identity=execution_identity,
                     ),
                     name=f"memory_save_{self.deps.agent_name}_{session_id}",
+                    owner=self.deps.runtime,
                 )
 
         strip_transient_enrichment, persist_response_event_id = self._build_session_storage_effects(

--- a/src/mindroom/runtime_support.py
+++ b/src/mindroom/runtime_support.py
@@ -1,0 +1,114 @@
+"""Standalone runtime support service lifecycle helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from mindroom.matrix.event_cache import EventCache
+from mindroom.matrix.event_cache_write_coordinator import EventCacheWriteCoordinator
+
+if TYPE_CHECKING:
+    import structlog
+
+    from mindroom.config.main import Config
+    from mindroom.constants import RuntimePaths
+
+
+@dataclass(slots=True)
+class StandaloneRuntimeSupport:
+    """Concrete standalone-owned runtime support services for one bot."""
+
+    event_cache: EventCache | None
+    event_cache_write_coordinator: EventCacheWriteCoordinator | None
+
+
+async def create_standalone_runtime_support(
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    logger: structlog.stdlib.BoundLogger,
+    background_task_owner: object,
+) -> StandaloneRuntimeSupport:
+    """Create the standalone runtime support services for one direct bot runtime.
+
+    The event cache is advisory, so SQLite init failures degrade to no cache support.
+    The cache and its write coordinator are therefore injected together or not at all.
+    """
+    event_cache = await _initialize_standalone_event_cache(
+        config=config,
+        runtime_paths=runtime_paths,
+        logger=logger,
+    )
+    if event_cache is None:
+        return StandaloneRuntimeSupport(
+            event_cache=None,
+            event_cache_write_coordinator=None,
+        )
+
+    event_cache_write_coordinator = EventCacheWriteCoordinator(
+        logger=logger,
+        background_task_owner=background_task_owner,
+    )
+    return StandaloneRuntimeSupport(
+        event_cache=event_cache,
+        event_cache_write_coordinator=event_cache_write_coordinator,
+    )
+
+
+async def close_standalone_runtime_support(
+    support: StandaloneRuntimeSupport,
+    *,
+    logger: structlog.stdlib.BoundLogger,
+) -> None:
+    """Close one standalone-owned runtime support bundle in dependency order."""
+    await _close_standalone_event_cache_write_coordinator(
+        support.event_cache_write_coordinator,
+        logger=logger,
+    )
+    await _close_standalone_event_cache(support.event_cache, logger=logger)
+
+
+async def _initialize_standalone_event_cache(
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    logger: structlog.stdlib.BoundLogger,
+) -> EventCache | None:
+    event_cache = EventCache(config.cache.resolve_db_path(runtime_paths))
+    try:
+        await event_cache.initialize()
+    except Exception as exc:
+        logger.warning("Failed to initialize event cache", error=str(exc))
+        try:
+            await event_cache.close()
+        except Exception as close_exc:
+            logger.warning("Failed to close partially initialized event cache", error=str(close_exc))
+        return None
+    return event_cache
+
+
+async def _close_standalone_event_cache_write_coordinator(
+    event_cache_write_coordinator: EventCacheWriteCoordinator | None,
+    *,
+    logger: structlog.stdlib.BoundLogger,
+) -> None:
+    if event_cache_write_coordinator is None:
+        return
+    try:
+        await event_cache_write_coordinator.close()
+    except Exception as exc:
+        logger.warning("Failed to close event cache write coordinator", error=str(exc))
+
+
+async def _close_standalone_event_cache(
+    event_cache: EventCache | None,
+    *,
+    logger: structlog.stdlib.BoundLogger,
+) -> None:
+    if event_cache is None:
+        return
+    try:
+        await event_cache.close()
+    except Exception as exc:
+        logger.warning("Failed to close event cache", error=str(exc))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,10 +300,6 @@ def sync_bot_runtime_state(bot: object) -> None:
     runtime.config = bot.config
     runtime.enable_streaming = bot.enable_streaming
     runtime.orchestrator = bot.orchestrator
-    conversation_access = getattr(bot, "_conversation_access", None)
-    if conversation_access is not None:
-        conversation_access.client = bot.client
-        conversation_access.event_cache = getattr(bot, "event_cache", None)
 
 
 def replace_dispatch_planner_deps(bot: object, **changes: object) -> DispatchPlanner:

--- a/tests/test_dynamic_config_update.py
+++ b/tests/test_dynamic_config_update.py
@@ -29,6 +29,8 @@ def _mock_agent_bot(config: Config, *, enable_streaming: bool = True) -> MagicMo
         config=config,
         enable_streaming=enable_streaming,
         orchestrator=None,
+        event_cache=None,
+        event_cache_write_coordinator=None,
     )
     return bot
 

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -854,6 +854,7 @@ async def test_team_bot_regenerates_edits_against_team_history_storage(tmp_path:
         *,
         name: str,
         error_handler: object | None = None,  # noqa: ARG001
+        owner: object | None = None,  # noqa: ARG001
     ) -> asyncio.Task[None]:
         task = asyncio.create_task(coro, name=name)
         scheduled_tasks.append(task)

--- a/tests/test_interactive_thread_fix.py
+++ b/tests/test_interactive_thread_fix.py
@@ -42,6 +42,7 @@ async def test_interactive_question_preserves_thread_root_in_streaming(tmp_path:
         *,
         name: str,
         error_handler: object | None = None,  # noqa: ARG001
+        owner: object | None = None,  # noqa: ARG001
     ) -> asyncio.Task[None]:
         task = asyncio.create_task(coro, name=name)
         scheduled_tasks.append(task)
@@ -141,6 +142,7 @@ async def test_interactive_question_preserves_thread_root_in_non_streaming(tmp_p
         *,
         name: str,
         error_handler: object | None = None,  # noqa: ARG001
+        owner: object | None = None,  # noqa: ARG001
     ) -> asyncio.Task[None]:
         task = asyncio.create_task(coro, name=name)
         scheduled_tasks.append(task)

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -234,6 +234,17 @@ def _runtime_bound_config(config: Config, runtime_root: Path) -> Config:
     )
 
 
+def _mock_managed_bot(config: Config) -> MagicMock:
+    """Return a lightweight managed-bot double for orchestrator reload tests."""
+    bot = MagicMock()
+    bot.config = config
+    bot.enable_streaming = config.defaults.enable_streaming
+    bot.event_cache = None
+    bot.event_cache_write_coordinator = None
+    bot._set_presence_with_model_info = AsyncMock()
+    return bot
+
+
 def _mock_shared_knowledge_manager(
     *,
     base_id: str,
@@ -2847,6 +2858,7 @@ class TestAgentBot:
             *,
             name: str,
             error_handler: object | None = None,  # noqa: ARG001
+            owner: object | None = None,  # noqa: ARG001
         ) -> asyncio.Task[None]:
             task: asyncio.Task[None] = asyncio.create_task(coro, name=name)
             scheduled_tasks.append(task)
@@ -2950,6 +2962,7 @@ class TestAgentBot:
             *,
             name: str,
             error_handler: object | None = None,  # noqa: ARG001
+            owner: object | None = None,  # noqa: ARG001
         ) -> asyncio.Task[None]:
             task: asyncio.Task[None] = asyncio.create_task(coro, name=name)
             scheduled_tasks.append(task)
@@ -3066,6 +3079,7 @@ class TestAgentBot:
             *,
             name: str,
             error_handler: object | None = None,  # noqa: ARG001
+            owner: object | None = None,  # noqa: ARG001
         ) -> asyncio.Task[None]:
             task: asyncio.Task[None] = asyncio.create_task(coro, name=name)
             scheduled_tasks.append(task)
@@ -3236,6 +3250,7 @@ class TestAgentBot:
             *,
             name: str,
             error_handler: object | None = None,  # noqa: ARG001
+            owner: object | None = None,  # noqa: ARG001
         ) -> asyncio.Task[None]:
             task: asyncio.Task[None] = asyncio.create_task(coro, name=name)
             scheduled_tasks.append(task)
@@ -3329,6 +3344,7 @@ class TestAgentBot:
             *,
             name: str,
             error_handler: object | None = None,  # noqa: ARG001
+            owner: object | None = None,  # noqa: ARG001
         ) -> asyncio.Task[None]:
             task: asyncio.Task[None] = asyncio.create_task(coro, name=name)
             scheduled_tasks.append(task)
@@ -3463,6 +3479,7 @@ class TestAgentBot:
             *,
             name: str,
             error_handler: object | None = None,  # noqa: ARG001
+            owner: object | None = None,  # noqa: ARG001
         ) -> asyncio.Task[None]:
             task: asyncio.Task[None] = asyncio.create_task(coro, name=name)
             scheduled_tasks.append(task)
@@ -3552,6 +3569,7 @@ class TestAgentBot:
             *,
             name: str,
             error_handler: object | None = None,  # noqa: ARG001
+            owner: object | None = None,  # noqa: ARG001
         ) -> asyncio.Task[None]:
             task: asyncio.Task[None] = asyncio.create_task(coro, name=name)
             scheduled_tasks.append(task)
@@ -7935,6 +7953,40 @@ class TestMultiAgentOrchestrator:
         assert mock_load_config.call_args.args[0].config_path == config_path.resolve()
 
     @pytest.mark.asyncio
+    async def test_initialize_degrades_when_shared_event_cache_init_fails(self, tmp_path: Path) -> None:
+        """Initialize should keep running when the advisory shared event cache fails to open."""
+        orchestrator = MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": {
+                        "display_name": "GeneralAgent",
+                        "role": "General assistant",
+                        "model": "default",
+                        "rooms": ["lobby"],
+                    },
+                },
+                models={"default": {"provider": "test", "id": "test-model"}},
+            ),
+            tmp_path,
+        )
+
+        with (
+            patch("mindroom.orchestrator.load_config", return_value=config),
+            patch("mindroom.orchestrator.load_plugins", return_value=[]),
+            patch.object(orchestrator, "_prepare_user_account", new=AsyncMock()),
+            patch.object(orchestrator, "_sync_mcp_manager", new=AsyncMock(return_value=set())),
+            patch("mindroom.orchestrator.EventCache.initialize", new=AsyncMock(side_effect=RuntimeError("boom"))),
+            patch.object(MultiAgentOrchestrator, "_create_managed_bot") as mock_create_managed_bot,
+        ):
+            await orchestrator.initialize()
+
+        assert orchestrator.config is config
+        assert orchestrator._event_cache is None
+        assert orchestrator._event_cache_write_coordinator is None
+        assert mock_create_managed_bot.call_count == 2
+
+    @pytest.mark.asyncio
     async def test_initialize_does_not_activate_hook_runtime_before_user_account_succeeds(
         self,
         tmp_path: Path,
@@ -8536,6 +8588,7 @@ class TestMultiAgentOrchestrator:
         config.mindroom_user = None
         config.matrix_room_access = MagicMock()
         config.authorization = MagicMock()
+        config.cache = MagicMock()
         config.defaults.enable_streaming = True
 
         orchestrator.config = config
@@ -8553,6 +8606,7 @@ class TestMultiAgentOrchestrator:
                 "mindroom.orchestration.config_updates._identify_entities_to_restart",
                 return_value=set(),
             ),
+            patch.object(orchestrator, "_sync_event_cache_service", new=AsyncMock()),
             patch.object(orchestrator, "_schedule_knowledge_refresh", new=AsyncMock()) as mock_schedule_knowledge,
             patch.object(orchestrator, "_configure_knowledge", new=AsyncMock()) as mock_configure_knowledge,
             patch.object(orchestrator, "_sync_memory_auto_flush_worker", new=AsyncMock()),
@@ -8569,8 +8623,10 @@ class TestMultiAgentOrchestrator:
         config_path = tmp_path / "custom-config.yaml"
         current_config = MagicMock()
         current_config.authorization.global_users = []
+        current_config.cache = MagicMock()
         new_config = MagicMock()
         new_config.authorization.global_users = []
+        new_config.cache = MagicMock()
         new_config.defaults.enable_streaming = True
 
         orchestrator = MultiAgentOrchestrator(
@@ -8595,6 +8651,7 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.load_config", return_value=new_config) as mock_load_config,
             patch("mindroom.orchestrator.load_plugins"),
             patch("mindroom.orchestrator.build_config_update_plan", return_value=plan),
+            patch.object(orchestrator, "_sync_event_cache_service", new=AsyncMock()),
             patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
         ):
             updated = await orchestrator.update_config()
@@ -8610,8 +8667,10 @@ class TestMultiAgentOrchestrator:
 
         current_config = MagicMock()
         current_config.authorization.global_users = []
+        current_config.cache = MagicMock()
         new_config = MagicMock()
         new_config.authorization.global_users = []
+        new_config.cache = MagicMock()
         old_hook_registry = HookRegistry.empty()
         new_hook_registry = HookRegistry.empty()
 
@@ -8647,6 +8706,131 @@ class TestMultiAgentOrchestrator:
         assert orchestrator.hook_registry is old_hook_registry
         mock_reset_hook_execution_state.assert_not_called()
         mock_set_scheduling_hook_registry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_config_initializes_shared_event_cache_for_unchanged_bots(self, tmp_path: Path) -> None:
+        """Cache service should initialize and bind when a test runtime skipped startup wiring."""
+        orchestrator = MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+
+        old_config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": {
+                        "display_name": "GeneralAgent",
+                        "role": "General assistant",
+                        "model": "default",
+                        "rooms": ["lobby"],
+                    },
+                },
+                models={"default": {"provider": "test", "id": "test-model"}},
+            ),
+            tmp_path,
+        )
+        new_config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": {
+                        "display_name": "GeneralAgent",
+                        "role": "General assistant",
+                        "model": "default",
+                        "rooms": ["lobby"],
+                    },
+                },
+                models={"default": {"provider": "test", "id": "test-model"}},
+            ),
+            tmp_path,
+        )
+
+        orchestrator.config = old_config
+        orchestrator.running = True
+        router_bot = _mock_managed_bot(old_config)
+        general_bot = _mock_managed_bot(old_config)
+        orchestrator.agent_bots = {"router": router_bot, "general": general_bot}
+
+        with (
+            patch("mindroom.orchestrator.load_config", return_value=new_config),
+            patch("mindroom.orchestrator.load_plugins", return_value=[]),
+            patch.object(orchestrator, "_sync_mcp_manager", new=AsyncMock(return_value=set())),
+            patch.object(orchestrator, "_schedule_knowledge_refresh", new=AsyncMock()),
+            patch.object(orchestrator, "_sync_memory_auto_flush_worker", new=AsyncMock()),
+        ):
+            try:
+                updated = await orchestrator.update_config()
+                assert updated is False
+                assert orchestrator._event_cache is not None
+                assert router_bot.event_cache is orchestrator._event_cache
+                assert general_bot.event_cache is orchestrator._event_cache
+                assert router_bot.event_cache_write_coordinator is orchestrator._event_cache_write_coordinator
+                assert general_bot.event_cache_write_coordinator is orchestrator._event_cache_write_coordinator
+            finally:
+                await orchestrator._close_event_cache_write_coordinator()
+                await orchestrator._close_event_cache()
+
+    @pytest.mark.asyncio
+    async def test_update_config_keeps_shared_event_cache_when_db_path_changes(self, tmp_path: Path) -> None:
+        """Hot reload should keep the active cache service and defer db_path changes to restart."""
+        orchestrator = MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+
+        old_config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": {
+                        "display_name": "GeneralAgent",
+                        "role": "General assistant",
+                        "model": "default",
+                        "rooms": ["lobby"],
+                    },
+                },
+                models={"default": {"provider": "test", "id": "test-model"}},
+                cache={"db_path": "event-cache-old.db"},
+            ),
+            tmp_path,
+        )
+        new_config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": {
+                        "display_name": "GeneralAgent",
+                        "role": "General assistant",
+                        "model": "default",
+                        "rooms": ["lobby"],
+                    },
+                },
+                models={"default": {"provider": "test", "id": "test-model"}},
+                cache={"db_path": "event-cache-new.db"},
+            ),
+            tmp_path,
+        )
+
+        orchestrator.config = old_config
+        orchestrator.running = True
+        router_bot = _mock_managed_bot(old_config)
+        general_bot = _mock_managed_bot(old_config)
+        orchestrator.agent_bots = {"router": router_bot, "general": general_bot}
+        await orchestrator._sync_event_cache_service(old_config)
+        old_cache = orchestrator._event_cache
+        assert old_cache is not None
+
+        with (
+            patch("mindroom.orchestrator.load_config", return_value=new_config),
+            patch("mindroom.orchestrator.load_plugins", return_value=[]),
+            patch.object(orchestrator, "_sync_mcp_manager", new=AsyncMock(return_value=set())),
+            patch.object(orchestrator, "_schedule_knowledge_refresh", new=AsyncMock()),
+            patch.object(orchestrator, "_sync_memory_auto_flush_worker", new=AsyncMock()),
+        ):
+            try:
+                updated = await orchestrator.update_config()
+                assert updated is False
+                assert orchestrator._event_cache is old_cache
+                assert old_cache.db_path == old_config.cache.resolve_db_path(orchestrator.runtime_paths)
+                assert router_bot.event_cache is old_cache
+                assert general_bot.event_cache is old_cache
+                assert orchestrator._event_cache_write_coordinator is not None
+                assert router_bot.event_cache_write_coordinator is orchestrator._event_cache_write_coordinator
+                assert general_bot.event_cache_write_coordinator is orchestrator._event_cache_write_coordinator
+            finally:
+                await orchestrator._close_event_cache_write_coordinator()
+                await orchestrator._close_event_cache()
 
     @pytest.mark.asyncio
     async def test_update_config_keeps_failed_new_bot_and_schedules_retry(self, tmp_path: Path) -> None:

--- a/tests/test_preformed_team_routing.py
+++ b/tests/test_preformed_team_routing.py
@@ -248,6 +248,7 @@ async def test_preformed_team_bot_schedules_memory_save_for_all_file_members(
         coro: object,
         name: str | None = None,
         error_handler: object | None = None,  # noqa: ARG001
+        owner: object | None = None,  # noqa: ARG001
     ) -> asyncio.Task[Any]:
         assert asyncio.iscoroutine(coro)
         task = asyncio.create_task(coro, name=name)

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -523,6 +523,8 @@ async def test_orchestrator_tracks_sync_tasks(tmp_path: Path) -> None:
         config.teams = {}
         config.mcp_servers = {}
         config.plugins = []
+        config.cache = MagicMock()
+        config.cache.resolve_db_path.return_value = tmp_path / "event_cache.db"
         config.mindroom_user = None
         config.get_all_configured_rooms.return_value = []
         mock_load_config.return_value = config
@@ -569,6 +571,8 @@ async def test_orchestrator_update_config_cancels_old_tasks(tmp_path: Path) -> N
         old_config.agents = {"agent1": MagicMock()}
         old_config.teams = {}
         old_config.mcp_servers = {}
+        old_config.cache = MagicMock()
+        old_config.cache.resolve_db_path.return_value = tmp_path / "event_cache-old.db"
         old_config.authorization = MagicMock()
         old_config.authorization.global_users = []
         orchestrator.config = old_config
@@ -586,6 +590,8 @@ async def test_orchestrator_update_config_cancels_old_tasks(tmp_path: Path) -> N
         new_config.agents = {"agent1": MagicMock()}
         new_config.teams = {}
         new_config.mcp_servers = {}
+        new_config.cache = MagicMock()
+        new_config.cache.resolve_db_path.return_value = tmp_path / "event_cache-new.db"
         new_config.authorization = MagicMock()
         new_config.authorization.global_users = []  # Add this for the logging
         mock_load_config.return_value = new_config

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -20,6 +20,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
 from mindroom.conversation_resolver import MessageContext
+from mindroom.matrix.event_cache_write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.thread_history_result import ThreadHistoryResult
 from mindroom.matrix.users import AgentMatrixUser
@@ -1133,6 +1134,10 @@ class TestExtractedModuleLoggerRebinding:
         event_cache = AsyncMock()
         event_cache.append_event.side_effect = RuntimeError("cache write failed")
         bot.event_cache = event_cache
+        bot.event_cache_write_coordinator = EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=bot._runtime_view,
+        )
 
         event = nio.RoomMessageText.from_dict(
             {
@@ -1226,7 +1231,7 @@ class TestExtractedModuleLoggerRebinding:
             "mindroom.matrix.conversation_access.fetch_thread_history",
             new=AsyncMock(return_value=[]),
         ) as fetch_thread_history_mock:
-            bot._conversation_access.client = client
+            bot.client = client
             await bot._conversation_access.get_thread_history(
                 "!room:localhost",
                 "$threadroot",
@@ -1271,7 +1276,7 @@ class TestExtractedModuleLoggerRebinding:
                 new=AsyncMock(),
             ) as fetch_thread_history_mock,
         ):
-            bot._conversation_access.client = MagicMock()
+            bot.client = MagicMock()
             async with bot._conversation_access.turn_scope():
                 snapshot_history = await bot._conversation_access.get_thread_snapshot(
                     "!room:localhost",
@@ -1320,7 +1325,7 @@ class TestExtractedModuleLoggerRebinding:
                 new=AsyncMock(return_value=hydrated_history),
             ) as fetch_thread_history_mock,
         ):
-            bot._conversation_access.client = MagicMock()
+            bot.client = MagicMock()
             async with bot._conversation_access.turn_scope():
                 snapshot_history = await bot._conversation_access.get_thread_snapshot(
                     "!room:localhost",

--- a/tests/test_thread_tags.py
+++ b/tests/test_thread_tags.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, call
 
@@ -29,7 +30,12 @@ if TYPE_CHECKING:
 
 def _conversation_access(client: AsyncMock) -> MatrixConversationAccess:
     """Build one explicit conversation-access seam for thread-tag tests."""
-    return MatrixConversationAccess(logger=MagicMock(), client=client)
+    runtime = SimpleNamespace(
+        client=client,
+        event_cache=None,
+        event_cache_write_coordinator=None,
+    )
+    return MatrixConversationAccess(logger=MagicMock(), runtime=runtime)
 
 
 def _message_event_response(

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -8,6 +8,7 @@ This test verifies that:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -16,12 +17,16 @@ import nio
 import pytest
 import pytest_asyncio
 
+from mindroom.background_tasks import create_background_task, wait_for_background_tasks
 from mindroom.bot import AgentBot
+from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
-from mindroom.matrix.client import ResolvedVisibleMessage, ThreadHistoryResult
+from mindroom.matrix.client import PermanentMatrixStartupError, ResolvedVisibleMessage, ThreadHistoryResult
+from mindroom.matrix.conversation_access import MatrixConversationAccess
 from mindroom.matrix.event_cache import EventCache
+from mindroom.matrix.event_cache_write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.message_content import _clear_mxc_cache
 from mindroom.matrix.reply_chain import ReplyChainCaches, _merge_thread_and_chain_history
@@ -58,6 +63,33 @@ def _message(*, event_id: str, body: str, sender: str = "@user:localhost") -> Re
 def _state_writer(bot: AgentBot) -> object:
     """Return the writer instance actually captured by the resolver."""
     return unwrap_extracted_collaborator(bot._conversation_state_writer)
+
+
+def _conversation_runtime(
+    *,
+    client: nio.AsyncClient | None = None,
+    event_cache: EventCache | None = None,
+    coordinator: EventCacheWriteCoordinator | None = None,
+) -> BotRuntimeState:
+    """Build one minimal live runtime state for conversation-access tests."""
+    return BotRuntimeState(
+        client=client,
+        config=MagicMock(spec=Config),
+        enable_streaming=True,
+        orchestrator=None,
+        event_cache=event_cache,
+        event_cache_write_coordinator=coordinator,
+    )
+
+
+def _install_runtime_write_coordinator(bot: AgentBot) -> EventCacheWriteCoordinator:
+    """Attach one explicit runtime write coordinator to a bot test double."""
+    coordinator = EventCacheWriteCoordinator(
+        logger=MagicMock(),
+        background_task_owner=bot._runtime_view,
+    )
+    bot.event_cache_write_coordinator = coordinator
+    return coordinator
 
 
 class TestThreadingBehavior:
@@ -128,7 +160,7 @@ class TestThreadingBehavior:
 
     @pytest.mark.asyncio
     async def test_start_and_stop_manage_persistent_event_cache(self, bot: AgentBot) -> None:
-        """Startup should wire the persistent cache into the explicit access layer."""
+        """Startup should wire standalone runtime support services onto the live runtime."""
         start_client = AsyncMock(spec=nio.AsyncClient)
         start_client.rooms = {}
         start_client.user_id = "@mindroom_general:localhost"
@@ -148,19 +180,112 @@ class TestThreadingBehavior:
         ):
             await bot.start()
             assert bot.event_cache is not None
-            assert bot._conversation_access.client is start_client
-            assert bot._conversation_access.event_cache is bot.event_cache
+            assert bot.client is start_client
+            assert bot.event_cache_write_coordinator is not None
 
             await bot.stop(reason="test")
 
         assert bot.event_cache is None
-        assert bot._conversation_access.event_cache is None
+        assert bot.event_cache_write_coordinator is None
         start_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_injected_shared_event_cache_stays_open_for_other_bots(self, bot: AgentBot, tmp_path: Path) -> None:
+        """A non-owned injected cache should stay open until its explicit owner closes it."""
+        other_user = AgentMatrixUser(
+            user_id="@mindroom_router:localhost",
+            password=TEST_PASSWORD,
+            display_name="RouterAgent",
+            agent_name="router",
+        )
+        other_bot = AgentBot(
+            agent_user=other_user,
+            storage_path=tmp_path,
+            rooms=["!test:localhost"],
+            enable_streaming=False,
+            config=bot.config,
+            runtime_paths=bot.runtime_paths,
+        )
+
+        shared_cache = EventCache(bot.config.cache.resolve_db_path(bot.runtime_paths))
+        await shared_cache.initialize()
+        bot.event_cache = shared_cache
+        other_bot.event_cache = shared_cache
+
+        try:
+            await shared_cache.store_event(
+                "$shared-event",
+                "!test:localhost",
+                {
+                    "event_id": "$shared-event",
+                    "sender": "@user:localhost",
+                    "origin_server_ts": 1234567890,
+                    "type": "m.room.message",
+                    "content": {"body": "shared cache", "msgtype": "m.text"},
+                },
+            )
+            await bot._close_runtime_support_services()
+            assert bot.event_cache is None
+            assert other_bot.event_cache is shared_cache
+
+            cached_event = await other_bot.event_cache.get_event("!test:localhost", "$shared-event")
+        finally:
+            await other_bot._close_runtime_support_services()
+            await shared_cache.close()
+
+        assert cached_event is not None
+        assert cached_event["event_id"] == "$shared-event"
+
+    @pytest.mark.asyncio
+    async def test_partial_runtime_support_injection_fails_fast(self, bot: AgentBot) -> None:
+        """Standalone runtime ownership requires all support services to be injected together."""
+        bot.event_cache = MagicMock(spec=EventCache)
+
+        with pytest.raises(
+            RuntimeError,
+            match="Runtime support services must be injected all together or not at all",
+        ):
+            await bot._initialize_runtime_support_services()
+
+    @pytest.mark.asyncio
+    async def test_try_start_partial_runtime_support_injection_fails_before_login(self, bot: AgentBot) -> None:
+        """Mixed runtime support injection should stop startup before any login side effects."""
+        bot.client = None
+        bot.event_cache = MagicMock(spec=EventCache)
+
+        with (
+            patch.object(bot, "ensure_user_account", AsyncMock()) as ensure_user_account,
+            patch("mindroom.bot.login_agent_user", AsyncMock()) as login_agent_user,
+            pytest.raises(
+                PermanentMatrixStartupError,
+                match="Runtime support services must be injected all together or not at all",
+            ),
+        ):
+            await bot.try_start()
+
+        ensure_user_account.assert_not_awaited()
+        login_agent_user.assert_not_awaited()
+        assert bot.client is None
+
+    @pytest.mark.asyncio
+    async def test_standalone_runtime_support_survives_event_cache_init_failure(self, bot: AgentBot) -> None:
+        """Standalone startup should degrade cleanly to no runtime support when SQLite cache init fails."""
+        with patch("mindroom.runtime_support.EventCache.initialize", AsyncMock(side_effect=RuntimeError("boom"))):
+            await bot._initialize_runtime_support_services()
+            await bot._initialize_runtime_support_services()
+
+        assert bot.event_cache is None
+        assert bot.event_cache_write_coordinator is None
+
+        await bot._close_runtime_support_services()
+
+        assert bot.event_cache is None
+        assert bot.event_cache_write_coordinator is None
 
     @pytest.mark.asyncio
     async def test_sync_response_caches_timeline_events_for_point_lookups(self, bot: AgentBot) -> None:
         """Sync-response handling should persist timeline events into SQLite-backed lookups."""
-        await bot._initialize_event_cache()
+        await bot._initialize_runtime_support_services()
         assert bot.event_cache is not None
 
         try:
@@ -187,18 +312,200 @@ class TestThreadingBehavior:
             bot._first_sync_done = True
 
             await bot._on_sync_response(sync_response)
+            await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
             cached_event = await bot.event_cache.get_event("!test:localhost", "$thread_msg:localhost")
         finally:
-            await bot._close_event_cache()
+            await bot._close_runtime_support_services()
 
         assert cached_event is not None
         assert cached_event["event_id"] == "$thread_msg:localhost"
         assert cached_event["content"]["body"] == "Thread reply"
 
     @pytest.mark.asyncio
+    async def test_cache_sync_timeline_schedules_background_write(self, bot: AgentBot) -> None:
+        """Sync timeline caching should return before a slow cache write finishes."""
+        store_started = asyncio.Event()
+        allow_store_finish = asyncio.Event()
+
+        async def slow_store_events_batch(_events: object) -> None:
+            store_started.set()
+            await allow_store_finish.wait()
+
+        event_cache = MagicMock(spec=EventCache)
+        event_cache.store_events_batch = AsyncMock(side_effect=slow_store_events_batch)
+        event_cache.redact_event = AsyncMock()
+        bot.event_cache = event_cache
+        _install_runtime_write_coordinator(bot)
+
+        message_event = nio.RoomMessageText.from_dict(
+            {
+                "content": {
+                    "body": "Thread reply",
+                    "msgtype": "m.text",
+                    "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root:localhost"},
+                },
+                "event_id": "$thread_msg:localhost",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "room_id": "!test:localhost",
+                "type": "m.room.message",
+            },
+        )
+        sync_response = MagicMock()
+        sync_response.__class__ = nio.SyncResponse
+        sync_response.rooms = MagicMock()
+        sync_response.rooms.join = {
+            "!test:localhost": MagicMock(timeline=MagicMock(events=[message_event])),
+        }
+
+        bot._conversation_access.cache_sync_timeline(sync_response)
+        await asyncio.wait_for(store_started.wait(), timeout=1.0)
+
+        allow_store_finish.set()
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+        event_cache.store_events_batch.assert_awaited_once()
+        event_cache.redact_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cache_sync_timeline_serializes_same_room_updates_in_order(self, bot: AgentBot) -> None:
+        """Later sync updates for one room should wait for earlier queued cache writes."""
+        store_started = asyncio.Event()
+        allow_store_finish = asyncio.Event()
+        call_order: list[str] = []
+
+        async def slow_store_events_batch(_events: object) -> None:
+            call_order.append("store-start")
+            store_started.set()
+            await allow_store_finish.wait()
+            call_order.append("store-finish")
+
+        async def record_redaction(*_args: object, **_kwargs: object) -> bool:
+            call_order.append("redact")
+            return True
+
+        event_cache = MagicMock(spec=EventCache)
+        event_cache.store_events_batch = AsyncMock(side_effect=slow_store_events_batch)
+        event_cache.redact_event = AsyncMock(side_effect=record_redaction)
+        bot.event_cache = event_cache
+        _install_runtime_write_coordinator(bot)
+
+        message_event = nio.RoomMessageText.from_dict(
+            {
+                "content": {
+                    "body": "Thread reply",
+                    "msgtype": "m.text",
+                    "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root:localhost"},
+                },
+                "event_id": "$thread_msg:localhost",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "room_id": "!test:localhost",
+                "type": "m.room.message",
+            },
+        )
+        redaction_event = MagicMock(spec=nio.RedactionEvent)
+        redaction_event.event_id = "$redaction:localhost"
+        redaction_event.redacts = "$thread_msg:localhost"
+        redaction_event.sender = "@user:localhost"
+        redaction_event.server_timestamp = 1234567891
+        redaction_event.source = {
+            "content": {},
+            "event_id": "$redaction:localhost",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1234567891,
+            "redacts": "$thread_msg:localhost",
+            "room_id": "!test:localhost",
+            "type": "m.room.redaction",
+        }
+
+        first_sync_response = MagicMock()
+        first_sync_response.__class__ = nio.SyncResponse
+        first_sync_response.rooms = MagicMock()
+        first_sync_response.rooms.join = {
+            "!test:localhost": MagicMock(timeline=MagicMock(events=[message_event])),
+        }
+
+        second_sync_response = MagicMock()
+        second_sync_response.__class__ = nio.SyncResponse
+        second_sync_response.rooms = MagicMock()
+        second_sync_response.rooms.join = {
+            "!test:localhost": MagicMock(timeline=MagicMock(events=[redaction_event])),
+        }
+
+        bot._conversation_access.cache_sync_timeline(first_sync_response)
+        await asyncio.wait_for(store_started.wait(), timeout=1.0)
+
+        bot._conversation_access.cache_sync_timeline(second_sync_response)
+        await asyncio.sleep(0)
+        event_cache.redact_event.assert_not_awaited()
+
+        allow_store_finish.set()
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+        assert call_order == ["store-start", "store-finish", "redact"]
+
+    @pytest.mark.asyncio
+    async def test_cache_sync_timeline_keeps_room_updates_isolated(self, bot: AgentBot) -> None:
+        """One room's queued cache write should not block another room's write."""
+        room_a_started = asyncio.Event()
+        release_room_a = asyncio.Event()
+        room_b_finished = asyncio.Event()
+
+        async def store_events_batch(events: list[tuple[str, str, dict[str, object]]]) -> None:
+            room_id = events[0][1]
+            if room_id == "!room-a:localhost":
+                room_a_started.set()
+                await release_room_a.wait()
+                return
+            if room_id == "!room-b:localhost":
+                room_b_finished.set()
+                return
+            msg = f"Unexpected room_id {room_id}"
+            raise AssertionError(msg)
+
+        def sync_response_for(room_id: str, event_id: str) -> nio.SyncResponse:
+            message_event = nio.RoomMessageText.from_dict(
+                {
+                    "content": {
+                        "body": f"Thread reply for {room_id}",
+                        "msgtype": "m.text",
+                        "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root:localhost"},
+                    },
+                    "event_id": event_id,
+                    "sender": "@user:localhost",
+                    "origin_server_ts": 1234567890,
+                    "room_id": room_id,
+                    "type": "m.room.message",
+                },
+            )
+            sync_response = MagicMock()
+            sync_response.__class__ = nio.SyncResponse
+            sync_response.rooms = MagicMock()
+            sync_response.rooms.join = {room_id: MagicMock(timeline=MagicMock(events=[message_event]))}
+            return sync_response
+
+        event_cache = MagicMock(spec=EventCache)
+        event_cache.store_events_batch = AsyncMock(side_effect=store_events_batch)
+        event_cache.redact_event = AsyncMock()
+        bot.event_cache = event_cache
+        _install_runtime_write_coordinator(bot)
+
+        bot._conversation_access.cache_sync_timeline(sync_response_for("!room-a:localhost", "$room_a_msg:localhost"))
+        await asyncio.wait_for(room_a_started.wait(), timeout=1.0)
+
+        bot._conversation_access.cache_sync_timeline(sync_response_for("!room-b:localhost", "$room_b_msg:localhost"))
+        await asyncio.wait_for(room_b_finished.wait(), timeout=1.0)
+
+        release_room_a.set()
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+        assert event_cache.store_events_batch.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_live_redaction_callback_removes_persisted_lookup_event(self, bot: AgentBot) -> None:
         """Live redaction callbacks should remove point-lookup cache entries."""
-        await bot._initialize_event_cache()
+        await bot._initialize_runtime_support_services()
         assert bot.event_cache is not None
 
         try:
@@ -236,14 +543,14 @@ class TestThreadingBehavior:
             await bot._on_redaction(room, redaction_event)
             cached_event = await bot.event_cache.get_event("!test:localhost", "$thread_msg:localhost")
         finally:
-            await bot._close_event_cache()
+            await bot._close_runtime_support_services()
 
         assert cached_event is None
 
     @pytest.mark.asyncio
     async def test_sync_timeline_redaction_does_not_resurrect_point_lookup_cache(self, bot: AgentBot) -> None:
         """A sync batch that contains both a message and its redaction must leave no cached lookup entry."""
-        await bot._initialize_event_cache()
+        await bot._initialize_runtime_support_services()
         assert bot.event_cache is not None
 
         try:
@@ -282,12 +589,106 @@ class TestThreadingBehavior:
                 "!test:localhost": MagicMock(timeline=MagicMock(events=[message_event, redaction_event])),
             }
 
-            await bot._conversation_access.cache_sync_timeline(sync_response)
+            bot._conversation_access.cache_sync_timeline(sync_response)
+            await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
             cached_event = await bot.event_cache.get_event("!test:localhost", "$thread_msg:localhost")
         finally:
-            await bot._close_event_cache()
+            await bot._close_runtime_support_services()
 
         assert cached_event is None
+
+    @pytest.mark.asyncio
+    async def test_wait_for_background_tasks_owner_scope_isolated(self, bot: AgentBot) -> None:
+        """Scoped waits should not block on background tasks owned by another bot."""
+        other_owner = object()
+        other_task_started = asyncio.Event()
+        release_other_task = asyncio.Event()
+
+        async def other_owner_task() -> None:
+            other_task_started.set()
+            await release_other_task.wait()
+
+        other_task = create_background_task(
+            other_owner_task(),
+            name="other_owner_task",
+            owner=other_owner,
+        )
+
+        await asyncio.wait_for(other_task_started.wait(), timeout=1.0)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+        assert not other_task.done()
+
+        release_other_task.set()
+        await wait_for_background_tasks(timeout=1.0, owner=other_owner)
+        assert other_task.done()
+
+    @pytest.mark.asyncio
+    async def test_wait_for_background_tasks_drains_child_tasks_created_during_wait(self) -> None:
+        """Owner-scoped draining should keep waiting for child tasks spawned by awaited tasks."""
+        owner = object()
+        parent_started = asyncio.Event()
+        release_parent = asyncio.Event()
+        child_started = asyncio.Event()
+        release_child = asyncio.Event()
+        child_finished = asyncio.Event()
+
+        async def child_task() -> None:
+            child_started.set()
+            await release_child.wait()
+            child_finished.set()
+
+        async def parent_task() -> None:
+            parent_started.set()
+            await release_parent.wait()
+            create_background_task(child_task(), name="child_task", owner=owner)
+
+        parent = create_background_task(parent_task(), name="parent_task", owner=owner)
+        await asyncio.wait_for(parent_started.wait(), timeout=1.0)
+
+        drain_task = asyncio.create_task(wait_for_background_tasks(timeout=1.0, owner=owner))
+        await asyncio.sleep(0)
+
+        release_parent.set()
+        await asyncio.wait_for(child_started.wait(), timeout=1.0)
+        assert drain_task.done() is False
+
+        release_child.set()
+        await drain_task
+
+        assert parent.done()
+        assert child_finished.is_set()
+
+    @pytest.mark.asyncio
+    async def test_wait_for_background_tasks_timeout_stops_after_bounded_cancel_rounds(self) -> None:
+        """Timed-out draining should return even if cancelled tasks keep spawning replacements."""
+        owner = object()
+        respawned_count = 0
+        respawned_replacement = asyncio.Event()
+        allow_respawn = True
+
+        async def respawning_task() -> None:
+            nonlocal respawned_count
+            try:
+                await asyncio.Future()
+            finally:
+                if allow_respawn:
+                    respawned_count += 1
+                    respawned_replacement.set()
+                    create_background_task(
+                        respawning_task(),
+                        name=f"respawning_task_{respawned_count}",
+                        owner=owner,
+                    )
+
+        create_background_task(respawning_task(), name="respawning_task_root", owner=owner)
+
+        try:
+            await asyncio.wait_for(wait_for_background_tasks(timeout=0.01, owner=owner), timeout=0.5)
+            await asyncio.wait_for(respawned_replacement.wait(), timeout=0.5)
+            assert respawned_count >= 1
+        finally:
+            allow_respawn = False
+            await wait_for_background_tasks(timeout=0.05, owner=owner)
 
     @pytest.mark.asyncio
     async def test_live_edit_cache_lookup_failure_does_not_raise(self, bot: AgentBot) -> None:
@@ -329,6 +730,7 @@ class TestThreadingBehavior:
         event_cache.get_thread_id_for_event = AsyncMock(side_effect=RuntimeError("database is locked"))
         event_cache.redact_event = AsyncMock(return_value=False)
         bot.event_cache = event_cache
+        _install_runtime_write_coordinator(bot)
 
         redaction_event = MagicMock(spec=nio.RedactionEvent)
         redaction_event.event_id = "$redaction:localhost"
@@ -352,9 +754,199 @@ class TestThreadingBehavior:
         assert event_cache.redact_event.await_args.kwargs["thread_id"] is None
 
     @pytest.mark.asyncio
+    async def test_live_event_cache_update_recovers_after_same_room_failure(self) -> None:
+        """A failed same-room cache update should not block the next queued write."""
+        first_update_started = asyncio.Event()
+        allow_first_failure = asyncio.Event()
+        second_update_finished = asyncio.Event()
+        owner = object()
+        coordinator = EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=owner,
+        )
+        access = MatrixConversationAccess(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(coordinator=coordinator),
+        )
+
+        async def failing_update() -> None:
+            first_update_started.set()
+            await allow_first_failure.wait()
+            msg = "update failed"
+            raise RuntimeError(msg)
+
+        async def second_update() -> None:
+            second_update_finished.set()
+
+        access._queue_room_cache_update(
+            "!test:localhost",
+            lambda: failing_update(),
+            name="matrix_cache_first_update",
+        )
+        await asyncio.wait_for(first_update_started.wait(), timeout=1.0)
+
+        access._queue_room_cache_update(
+            "!test:localhost",
+            lambda: second_update(),
+            name="matrix_cache_second_update",
+        )
+        await asyncio.sleep(0)
+        assert second_update_finished.is_set() is False
+
+        allow_first_failure.set()
+        await wait_for_background_tasks(timeout=1.0, owner=owner)
+
+        assert second_update_finished.is_set()
+
+    @pytest.mark.asyncio
+    async def test_shared_event_cache_write_coordinator_serializes_same_room_updates_across_accesses(self) -> None:
+        """Same-room cache writes should serialize even when different bots enqueue them."""
+        first_update_started = asyncio.Event()
+        release_first_update = asyncio.Event()
+        second_update_started = asyncio.Event()
+        owner = object()
+        coordinator = EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=owner,
+        )
+        first_access = MatrixConversationAccess(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(coordinator=coordinator),
+        )
+        second_access = MatrixConversationAccess(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(coordinator=coordinator),
+        )
+
+        async def first_update() -> None:
+            first_update_started.set()
+            await release_first_update.wait()
+
+        async def second_update() -> None:
+            second_update_started.set()
+
+        first_access._queue_room_cache_update(
+            "!test:localhost",
+            lambda: first_update(),
+            name="matrix_cache_first_update",
+        )
+        await asyncio.wait_for(first_update_started.wait(), timeout=1.0)
+
+        second_access._queue_room_cache_update(
+            "!test:localhost",
+            lambda: second_update(),
+            name="matrix_cache_second_update",
+        )
+        await asyncio.sleep(0)
+        assert second_update_started.is_set() is False
+
+        release_first_update.set()
+        await wait_for_background_tasks(timeout=1.0, owner=owner)
+
+        assert second_update_started.is_set()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_room_cache_update_does_not_start_queued_coro(self) -> None:
+        """Cancelling a queued room update before it runs should not invoke its coroutine factory."""
+        blocker_started = asyncio.Event()
+        release_blocker = asyncio.Event()
+        queued_update_started = asyncio.Event()
+        owner = object()
+        coordinator = EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=owner,
+        )
+        access = MatrixConversationAccess(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(coordinator=coordinator),
+        )
+
+        async def blocking_update() -> None:
+            blocker_started.set()
+            await release_blocker.wait()
+
+        async def queued_update() -> None:
+            queued_update_started.set()
+
+        access._queue_room_cache_update(
+            "!test:localhost",
+            lambda: blocking_update(),
+            name="matrix_cache_blocking_update",
+        )
+        await asyncio.wait_for(blocker_started.wait(), timeout=1.0)
+
+        queued_task = access._queue_room_cache_update(
+            "!test:localhost",
+            lambda: queued_update(),
+            name="matrix_cache_queued_update",
+        )
+        queued_task.cancel()
+        await asyncio.gather(queued_task, return_exceptions=True)
+
+        release_blocker.set()
+        await wait_for_background_tasks(timeout=1.0, owner=owner)
+
+        assert queued_update_started.is_set() is False
+
+    @pytest.mark.asyncio
+    async def test_cancelled_room_cache_update_keeps_follow_up_update_behind_running_predecessor(self) -> None:
+        """Cancelling a queued room update must not break the same-room serialization chain."""
+        first_update_started = asyncio.Event()
+        release_first_update = asyncio.Event()
+        third_update_started = asyncio.Event()
+        owner = object()
+        coordinator = EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=owner,
+        )
+        access = MatrixConversationAccess(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(coordinator=coordinator),
+        )
+
+        async def first_update() -> None:
+            first_update_started.set()
+            await release_first_update.wait()
+
+        async def cancelled_update() -> None:
+            msg = "Cancelled room cache update should not start"
+            raise AssertionError(msg)
+
+        async def third_update() -> None:
+            third_update_started.set()
+
+        access._queue_room_cache_update(
+            "!test:localhost",
+            lambda: first_update(),
+            name="matrix_cache_first_update",
+        )
+        await asyncio.wait_for(first_update_started.wait(), timeout=1.0)
+
+        cancelled_task = access._queue_room_cache_update(
+            "!test:localhost",
+            lambda: cancelled_update(),
+            name="matrix_cache_cancelled_update",
+        )
+        cancelled_task.cancel()
+        await asyncio.gather(cancelled_task, return_exceptions=True)
+
+        access._queue_room_cache_update(
+            "!test:localhost",
+            lambda: third_update(),
+            name="matrix_cache_third_update",
+        )
+        await asyncio.sleep(0)
+        assert third_update_started.is_set() is False
+
+        release_first_update.set()
+        await wait_for_background_tasks(timeout=1.0, owner=owner)
+
+        assert third_update_started.is_set()
+
+    @pytest.mark.asyncio
     async def test_reply_chain_event_cache_write_through_supports_later_sqlite_lookup(self, bot: AgentBot) -> None:
         """Reply-chain resolution should populate the event cache and later reuse it without network I/O."""
-        await bot._initialize_event_cache()
+        await bot._initialize_runtime_support_services()
         assert bot.event_cache is not None
 
         room = MagicMock(spec=nio.MatrixRoom)
@@ -407,6 +999,7 @@ class TestThreadingBehavior:
         try:
             with patch.object(bot._conversation_access, "get_thread_history", AsyncMock()) as mock_fetch:
                 first_context = await bot._conversation_resolver.extract_message_context(room, event)
+            await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
             assert first_context.is_thread is True
             assert first_context.thread_id == "$msg1:localhost"
@@ -433,7 +1026,7 @@ class TestThreadingBehavior:
             mock_fetch_again.assert_not_called()
             bot.client.room_get_event.assert_not_awaited()
         finally:
-            await bot._close_event_cache()
+            await bot._close_runtime_support_services()
 
     @pytest.mark.asyncio
     async def test_agent_creates_thread_when_mentioned_in_main_room(self, bot: AgentBot) -> None:


### PR DESCRIPTION
## Summary
- add a shared room-scoped event-cache write coordinator so advisory cache writes do not race each other across the runtime
- keep standalone runtime support ownership for the cache and coordinator lifecycle, including graceful degradation when cache init fails
- reuse background sync caches and cover the new coordination path with regression tests

## Verification
- `PYTHONPATH="$PWD/src" .venv/bin/pytest -q`
- `python -m pre_commit run --all-files`