### PR TITLE
Capture full LLM request payloads in debug logs

### DIFF
--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -1,15 +1,17 @@
-"""Lightweight opt-in LLM request logging."""
+"""Opt-in LLM request logging."""
 
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
-from dataclasses import fields, is_dataclass
+from dataclasses import asdict, fields, is_dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 from agno.models.message import Message
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Sequence
@@ -37,6 +39,22 @@ _SKIP_MODEL_PARAM_NAMES = {
     "default_headers",
     "default_query",
 }
+_NON_API_MESSAGE_FIELDS = {
+    "id",
+    "reasoning_content",
+    "tool_name",
+    "tool_args",
+    "tool_call_error",
+    "stop_after_tool_call",
+    "add_to_agent_memory",
+    "from_history",
+    "metrics",
+    "references",
+    "created_at",
+    "temporary",
+}
+type JSONScalar = str | int | float | bool | None
+type JSONValue = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
 
 
 def _daily_log_path(log_dir: str | None, default_log_dir: Path, now: datetime) -> Path:
@@ -47,14 +65,14 @@ def _daily_log_path(log_dir: str | None, default_log_dir: Path, now: datetime) -
 def _system_prompt(messages: Sequence[Message], model: Model) -> str:
     for message in messages:
         if message.role == "system":
-            return message.get_content_string()[:500]
-    return (model.system_prompt or "")[:500]
+            return message.get_content_string()
+    return model.system_prompt or ""
 
 
-def _model_params(model: Model) -> dict[str, Any]:
+def _model_params(model: Model) -> dict[str, JSONValue]:
     if not is_dataclass(model):
         return {}
-    payload: dict[str, Any] = {}
+    payload: dict[str, JSONValue] = {}
     for field in fields(model):
         if field.name in _SKIP_MODEL_PARAM_NAMES:
             continue
@@ -69,11 +87,46 @@ def _model_params(model: Model) -> dict[str, Any]:
     return payload
 
 
-def _write_jsonl_line(path: Path, payload: dict[str, Any]) -> None:
+def _write_jsonl_line(path: Path, payload: dict[str, JSONValue]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(payload))
         handle.write("\n")
+
+
+def _json_safe(value: object) -> JSONValue:
+    normalized: object = value
+    if isinstance(normalized, BaseModel):
+        normalized = normalized.model_dump(mode="python", exclude_none=True)
+    elif not isinstance(normalized, type) and is_dataclass(normalized):
+        normalized = asdict(normalized)
+
+    if isinstance(normalized, dict):
+        return {str(key): _json_safe(item) for key, item in normalized.items()}
+    if isinstance(normalized, (list, tuple, set)):
+        return [_json_safe(item) for item in normalized]
+    if isinstance(normalized, bytes):
+        return {
+            "__type__": "bytes",
+            "base64": base64.b64encode(normalized).decode("ascii"),
+        }
+    if isinstance(normalized, Path):
+        return str(normalized)
+    if isinstance(normalized, str | int | float | bool) or normalized is None:
+        return normalized
+    return repr(normalized)
+
+
+def _request_message_payloads(messages: Sequence[Message]) -> list[dict[str, JSONValue]]:
+    payloads: list[dict[str, JSONValue]] = []
+    for message in messages:
+        payload = message.model_dump(
+            mode="python",
+            exclude_none=True,
+            exclude=_NON_API_MESSAGE_FIELDS,
+        )
+        payloads.append(cast("dict[str, JSONValue]", _json_safe(payload)))
+    return payloads
 
 
 def _request_messages(value: object) -> list[Message] | None:
@@ -82,9 +135,9 @@ def _request_messages(value: object) -> list[Message] | None:
     return None
 
 
-def _request_tools(value: object) -> list[dict[str, Any]] | None:
+def _request_tools(value: object) -> list[dict[str, JSONValue]] | None:
     if isinstance(value, list) and all(isinstance(tool, dict) for tool in value):
-        return cast("list[dict[str, Any]]", value)
+        return cast("list[dict[str, JSONValue]]", value)
     return None
 
 
@@ -93,11 +146,11 @@ async def write_llm_request_log(
     model: Model,
     agent_name: str,
     messages: Sequence[Message],
-    tools: list[dict[str, Any]] | None,
+    tools: list[dict[str, JSONValue]] | None,
     log_dir: str | None,
     default_log_dir: Path,
 ) -> None:
-    """Persist one request-summary record for an LLM invocation."""
+    """Persist one request record for an LLM invocation."""
     now = datetime.now().astimezone()
     await asyncio.to_thread(
         _write_jsonl_line,
@@ -107,7 +160,9 @@ async def write_llm_request_log(
             "agent_name": agent_name,
             "model_id": model.id,
             "system_prompt": _system_prompt(messages, model),
+            "messages": _request_message_payloads(messages),
             "message_count": len(messages),
+            "tools": _json_safe(tools),
             "tool_count": len(tools or []),
             "model_params": _model_params(model),
         },

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -48,9 +48,7 @@ _NON_API_MESSAGE_FIELDS = {
     "stop_after_tool_call",
     "add_to_agent_memory",
     "from_history",
-    "metrics",
     "references",
-    "created_at",
     "temporary",
 }
 type JSONScalar = str | int | float | bool | None

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from agno.models.message import Message
+from agno.models.message import Message, MessageMetrics
 
 from mindroom.config.main import Config
 from mindroom.config.models import DebugConfig
@@ -65,8 +65,13 @@ async def test_llm_request_logging_writes_jsonl(tmp_path: Path) -> None:
         default_log_dir=tmp_path / "unused",
     )
     messages = [
-        Message(role="system", content="s" * 600),
-        Message(role="user", content="hello"),
+        Message(role="system", content="s" * 600, created_at=111),
+        Message(
+            role="user",
+            content="hello",
+            created_at=222,
+            metrics=MessageMetrics(input_tokens=2, total_tokens=2, duration=1.5),
+        ),
     ]
     assistant_message = Message(role="assistant")
 
@@ -83,19 +88,23 @@ async def test_llm_request_logging_writes_jsonl(tmp_path: Path) -> None:
     assert entries[0]["agent_name"] == "assistant"
     assert entries[0]["model_id"] == "test-model"
     assert entries[0]["system_prompt"] == "s" * 600
-    assert entries[0]["messages"] == [
-        {"role": "system", "content": "s" * 600},
-        {"role": "user", "content": "hello"},
-    ]
+    assert entries[0]["messages"][0]["role"] == "system"
+    assert entries[0]["messages"][0]["content"] == "s" * 600
+    assert entries[0]["messages"][0]["created_at"] == 111
+    assert entries[0]["messages"][1]["role"] == "user"
+    assert entries[0]["messages"][1]["content"] == "hello"
+    assert entries[0]["messages"][1]["created_at"] == 222
+    assert entries[0]["messages"][1]["metrics"]["input_tokens"] == 2
+    assert entries[0]["messages"][1]["metrics"]["total_tokens"] == 2
+    assert entries[0]["messages"][1]["metrics"]["duration"] == 1.5
     assert entries[0]["message_count"] == 2
     assert entries[0]["tools"] == [{"name": "search"}]
     assert entries[0]["tool_count"] == 1
     assert entries[0]["model_params"] == {"temperature": 0.7}
     assert "timestamp" in entries[0]
-    assert entries[1]["messages"] == [
-        {"role": "system", "content": "s" * 600},
-        {"role": "user", "content": "hello"},
-    ]
+    assert entries[1]["messages"][0]["created_at"] == 111
+    assert entries[1]["messages"][1]["created_at"] == 222
+    assert entries[1]["messages"][1]["metrics"]["input_tokens"] == 2
     assert entries[1]["tools"] == []
     assert entries[1]["tool_count"] == 0
 

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -1,4 +1,4 @@
-"""Tests for lean LLM request logging."""
+"""Tests for full LLM request logging."""
 
 from __future__ import annotations
 
@@ -56,7 +56,7 @@ def test_debug_config_parses() -> None:
 
 @pytest.mark.asyncio
 async def test_llm_request_logging_writes_jsonl(tmp_path: Path) -> None:
-    """Enabled request logging should emit one JSONL entry per invoke path."""
+    """Enabled request logging should emit one full JSONL entry per invoke path."""
     model = _FakeModel()
     install_llm_request_logging(
         model,
@@ -82,11 +82,21 @@ async def test_llm_request_logging_writes_jsonl(tmp_path: Path) -> None:
     assert len(entries) == 2
     assert entries[0]["agent_name"] == "assistant"
     assert entries[0]["model_id"] == "test-model"
-    assert entries[0]["system_prompt"] == "s" * 500
+    assert entries[0]["system_prompt"] == "s" * 600
+    assert entries[0]["messages"] == [
+        {"role": "system", "content": "s" * 600},
+        {"role": "user", "content": "hello"},
+    ]
     assert entries[0]["message_count"] == 2
+    assert entries[0]["tools"] == [{"name": "search"}]
     assert entries[0]["tool_count"] == 1
     assert entries[0]["model_params"] == {"temperature": 0.7}
     assert "timestamp" in entries[0]
+    assert entries[1]["messages"] == [
+        {"role": "system", "content": "s" * 600},
+        {"role": "user", "content": "hello"},
+    ]
+    assert entries[1]["tools"] == []
     assert entries[1]["tool_count"] == 0
 
 


### PR DESCRIPTION
## Summary
- preserve the full assembled LLM request payload in debug logging instead of truncating it
- keep the logging output structured so large payloads stay inspectable during debugging
- extend the request-logging tests to cover the full-payload behavior

## Verification
- `python -m pre_commit run --files src/mindroom/llm_request_logging.py tests/test_llm_request_logging.py`
- `PYTHONPATH="$PWD/src" .venv/bin/pytest -q tests/test_llm_request_logging.py`