### PR TITLE
fix: declare core runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
   "agno[anthropic,google,ollama,openai]==2.5.13",
+  "aiohttp>=3.13.3",
+  "aiosqlite>=0.20",
   "anthropic>=0.70",
+  "anyio>=4.10",
   "cerebras-cloud-sdk>=1.46",
   "chromadb>=1.0.15",
   "cron-descriptor>=1.4.5",
@@ -37,6 +40,7 @@ dependencies = [
   "mem0ai>=0.1.115",
   "openai",
   "pydantic>=2",
+  "pydantic-settings>=2.10.1",
   "pygments>=2.20",
   "pyjwt>=2.8",
   "python-dotenv>=1",

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -540,7 +540,7 @@ async def test_reindex_all_uses_bounded_file_concurrency(dummy_manager: Knowledg
         active -= 1
         return True
 
-    dummy_manager._index_file_locked = _fake_index  # type: ignore[method-assign]
+    dummy_manager._index_file_locked = _fake_index
 
     indexed_count = await dummy_manager.reindex_all()
 

--- a/tests/test_tool_dependencies.py
+++ b/tests/test_tool_dependencies.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -35,6 +36,18 @@ from mindroom.tools.openbb import openbb_tools
 
 HOOK_SCRIPT = Path(__file__).parent.parent / ".github" / "scripts" / "check_tool_extras_sync.py"
 TEST_RUNTIME_PATHS = resolve_runtime_paths(config_path=Path("config.yaml"))
+
+
+def _base_dependency_names() -> set[str]:
+    """Return normalized base dependency names declared in pyproject.toml."""
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    dependency_names: set[str] = set()
+    for dependency in pyproject["project"]["dependencies"]:
+        name = dependency.split(";", 1)[0].strip()
+        for separator in ("[", " ", "<", ">", "=", "!", "~"):
+            name = name.split(separator, 1)[0]
+        dependency_names.add(name.lower().replace("_", "-"))
+    return dependency_names
 
 
 def test_all_tools_can_be_imported() -> None:
@@ -102,6 +115,22 @@ def test_tool_extras_in_sync_with_pyproject() -> None:
     if result.returncode != 0:
         output = (result.stdout + result.stderr).strip()
         pytest.fail(f"Tool extras out of sync with pyproject.toml:\n{output}")
+
+
+def test_core_runtime_imports_are_declared_as_base_dependencies() -> None:
+    """Core runtime modules should not rely on transitive dependencies."""
+    base_dependencies = _base_dependency_names()
+    required_runtime_dependencies = {
+        "src/mindroom/constants.py": "pydantic-settings",
+        "src/mindroom/matrix/client.py": "aiohttp",
+        "src/mindroom/matrix/event_cache.py": "aiosqlite",
+        "src/mindroom/mcp/transports.py": "anyio",
+    }
+
+    for module_path, dependency_name in required_runtime_dependencies.items():
+        assert dependency_name in base_dependencies, (
+            f"{module_path} imports {dependency_name!r} directly and it should be declared in project.dependencies"
+        )
 
 
 def test_full_runtime_image_keeps_sentence_transformers_runtime_only() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3193,7 +3193,10 @@ name = "mindroom"
 source = { editable = "." }
 dependencies = [
     { name = "agno", extra = ["anthropic", "google", "ollama", "openai"] },
+    { name = "aiohttp" },
+    { name = "aiosqlite" },
     { name = "anthropic" },
+    { name = "anyio" },
     { name = "cerebras-cloud-sdk" },
     { name = "chromadb" },
     { name = "cron-descriptor" },
@@ -3211,6 +3214,7 @@ dependencies = [
     { name = "mem0ai" },
     { name = "openai" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pygments" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
@@ -3561,7 +3565,10 @@ dev = [
 requires-dist = [
     { name = "agentql", marker = "extra == 'agentql'" },
     { name = "agno", extras = ["anthropic", "google", "ollama", "openai"], specifier = "==2.5.13" },
+    { name = "aiohttp", specifier = ">=3.13.3" },
+    { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "anthropic", specifier = ">=0.70" },
+    { name = "anyio", specifier = ">=4.10.0" },
     { name = "apify-client", marker = "platform_machine != 'aarch64' and extra == 'apify'", specifier = ">=1.12.2" },
     { name = "arxiv", marker = "extra == 'arxiv'" },
     { name = "atlassian-python-api", marker = "extra == 'confluence'" },
@@ -3655,6 +3662,7 @@ requires-dist = [
     { name = "pydantic", marker = "extra == 'config-manager'", specifier = ">=2" },
     { name = "pydantic", marker = "extra == 'jina'", specifier = ">=2" },
     { name = "pydantic", marker = "extra == 'self-config'", specifier = ">=2" },
+    { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pygithub", marker = "extra == 'github'", specifier = ">=2.5" },
     { name = "pygments", specifier = ">=2.20" },
     { name = "pyjwt", specifier = ">=2.8" },


### PR DESCRIPTION
## Summary
- add missing base runtime dependencies used by core MindRoom modules
- add a regression test that asserts these direct runtime imports stay in `project.dependencies`
- remove one stale `type: ignore` in a test so repo-wide `pre-commit --all-files` stays green

## Verification
- `uv run pre-commit run --all-files`
- `uv run pytest`