### PR TITLE
Resume interrupted knowledge indexing instead of restarting from scratch

### DIFF
--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from fnmatch import fnmatchcase
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import quote, urlparse, urlunparse
 
 from agno.knowledge.chunking.fixed import FixedSizeChunking
@@ -54,6 +54,20 @@ _SOURCE_SIZE_KEY = "source_size"
 _FAILED_SIGNATURE_RETRY_SECONDS = 300
 _FAILED_SIGNATURE_RETRY_NS = _FAILED_SIGNATURE_RETRY_SECONDS * 1_000_000_000
 _MAX_CONCURRENT_KNOWLEDGE_FILE_INDEXES = 32
+_INDEXING_STATUS_RESETTING = "resetting"
+_INDEXING_STATUS_INDEXING = "indexing"
+_INDEXING_STATUS_COMPLETE = "complete"
+_INDEXING_STATUSES = {
+    _INDEXING_STATUS_RESETTING,
+    _INDEXING_STATUS_INDEXING,
+    _INDEXING_STATUS_COMPLETE,
+}
+
+
+@dataclass(frozen=True)
+class _PersistedIndexingState:
+    settings: tuple[str, ...]
+    status: Literal["resetting", "indexing", "complete"]
 
 
 def _resolve_knowledge_path(
@@ -427,22 +441,56 @@ class KnowledgeManager:
             raise RuntimeError(msg)
         return knowledge_path
 
-    def _load_persisted_indexing_settings(self) -> tuple[str, ...] | None:
+    def _load_persisted_indexing_state(self) -> _PersistedIndexingState | None:
         if not self._indexing_settings_path.exists():
             return None
         try:
             payload = json.loads(self._indexing_settings_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             return None
-        if not isinstance(payload, list) or not all(isinstance(item, str) for item in payload):
-            return None
-        return tuple(payload)
 
-    def _save_persisted_indexing_settings(self) -> None:
+        settings: tuple[str, ...] | None = None
+        status: Literal["resetting", "indexing", "complete"] | None = None
+        if isinstance(payload, list):
+            if all(isinstance(item, str) for item in payload):
+                settings = tuple(payload)
+                status = _INDEXING_STATUS_COMPLETE
+        elif isinstance(payload, dict):
+            raw_settings = payload.get("settings")
+            raw_status = payload.get("status")
+            if (
+                isinstance(raw_settings, list)
+                and all(isinstance(item, str) for item in raw_settings)
+                and raw_status in _INDEXING_STATUSES
+            ):
+                settings = tuple(raw_settings)
+                status = raw_status
+
+        if settings is None or status is None:
+            return None
+        return _PersistedIndexingState(settings, status)
+
+    def _load_persisted_indexing_settings(self) -> tuple[str, ...] | None:
+        persisted_state = self._load_persisted_indexing_state()
+        return persisted_state.settings if persisted_state is not None else None
+
+    def _save_persisted_indexing_state(
+        self,
+        status: Literal["resetting", "indexing", "complete"],
+    ) -> None:
         self._indexing_settings_path.write_text(
-            json.dumps(list(self._indexing_settings)),
+            json.dumps(
+                {
+                    "settings": list(self._indexing_settings),
+                    "status": status,
+                },
+                sort_keys=True,
+            ),
             encoding="utf-8",
         )
+
+    def _save_persisted_indexing_settings(self) -> None:
+        self._save_persisted_indexing_state(_INDEXING_STATUS_COMPLETE)
 
     def _has_existing_index(self) -> bool:
         vector_db = self._knowledge.vector_db
@@ -451,11 +499,22 @@ class KnowledgeManager:
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
         return collection.count() > 0
 
+    def _startup_index_mode(self) -> Literal["full_reindex", "resume", "incremental"]:
+        persisted_state = self._load_persisted_indexing_state()
+        if persisted_state is None:
+            return "resume"
+        if persisted_state.settings != self._indexing_settings:
+            return "full_reindex"
+        if persisted_state.status == _INDEXING_STATUS_RESETTING:
+            return "full_reindex"
+        if persisted_state.status == _INDEXING_STATUS_INDEXING:
+            return "resume"
+        if not self._has_existing_index():
+            return "resume"
+        return "incremental"
+
     def _needs_full_reindex_on_create(self) -> bool:
-        persisted_settings = self._load_persisted_indexing_settings()
-        if persisted_settings is None:
-            return self._has_existing_index()
-        return persisted_settings != self._indexing_settings
+        return self._startup_index_mode() == "full_reindex"
 
     def matches(
         self,
@@ -1053,10 +1112,12 @@ class KnowledgeManager:
         files = self.list_files()
 
         async with self._lock:
+            await asyncio.to_thread(self._save_persisted_indexing_state, _INDEXING_STATUS_RESETTING)
             await asyncio.to_thread(self._reset_collection)
             async with self._state_lock:
                 self._indexed_files.clear()
                 self._indexed_signatures.clear()
+            await asyncio.to_thread(self._save_persisted_indexing_state, _INDEXING_STATUS_INDEXING)
             indexed_count = await self._reindex_files_locked(files)
             await asyncio.to_thread(self._save_persisted_indexing_settings)
             return indexed_count
@@ -1146,6 +1207,19 @@ async def _sync_manager_without_full_reindex(manager: KnowledgeManager) -> dict[
     return await manager.sync_indexed_files()
 
 
+async def _resume_manager_without_full_reindex(manager: KnowledgeManager) -> dict[str, Any]:
+    if manager._git_config() is not None:
+        git_result = await manager.sync_git_repository(index_changes=False)
+        sync_result = await manager.sync_indexed_files()
+        return {
+            "git_updated": git_result["updated"],
+            "git_changed_count": git_result["changed_count"],
+            "git_removed_count": git_result["removed_count"],
+            **sync_result,
+        }
+    return await manager.sync_indexed_files()
+
+
 def _shared_knowledge_manager_init_lock(base_id: str) -> asyncio.Lock:
     lock = _shared_knowledge_manager_init_locks.get(base_id)
     if lock is None:
@@ -1204,16 +1278,31 @@ async def _create_knowledge_manager_for_target(
         storage_path=binding.storage_root,
         knowledge_path=binding.knowledge_path,
     )
-    if reindex_on_create or manager._needs_full_reindex_on_create():
+    startup_mode: Literal["full_reindex", "resume", "incremental"] = (
+        "full_reindex" if reindex_on_create else manager._startup_index_mode()
+    )
+    if startup_mode == "full_reindex":
         await manager.initialize()
     else:
-        sync_result = await _sync_manager_without_full_reindex(manager)
+        if startup_mode == "resume":
+            sync_result = await _resume_manager_without_full_reindex(manager)
+        else:
+            sync_result = await _sync_manager_without_full_reindex(manager)
         await asyncio.to_thread(manager._save_persisted_indexing_settings)
         sync_log_context: dict[str, object] = {
             "base_id": target.key.base_id,
             "path": str(manager.knowledge_path),
+            "startup_mode": startup_mode,
         }
-        if manager._git_config() is not None:
+        if "git_updated" in sync_result:
+            sync_log_context.update(
+                {
+                    "git_updated": sync_result["git_updated"],
+                    "git_changed_count": sync_result["git_changed_count"],
+                    "git_removed_count": sync_result["git_removed_count"],
+                },
+            )
+        elif manager._git_config() is not None:
             sync_log_context.update(
                 {
                     "updated": sync_result["updated"],
@@ -1221,7 +1310,7 @@ async def _create_knowledge_manager_for_target(
                     "removed_count": sync_result["removed_count"],
                 },
             )
-        else:
+        if "loaded_count" in sync_result:
             sync_log_context.update(
                 {
                     "loaded_count": sync_result["loaded_count"],

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -502,14 +502,12 @@ class KnowledgeManager:
     def _startup_index_mode(self) -> Literal["full_reindex", "resume", "incremental"]:
         persisted_state = self._load_persisted_indexing_state()
         if persisted_state is None:
-            return "resume"
-        if persisted_state.settings != self._indexing_settings:
+            # A missing checkpoint can be legacy state worth resuming, but a
+            # present unreadable checkpoint is unsafe once vectors already exist.
+            return "full_reindex" if self._indexing_settings_path.exists() and self._has_existing_index() else "resume"
+        if persisted_state.settings != self._indexing_settings or persisted_state.status == _INDEXING_STATUS_RESETTING:
             return "full_reindex"
-        if persisted_state.status == _INDEXING_STATUS_RESETTING:
-            return "full_reindex"
-        if persisted_state.status == _INDEXING_STATUS_INDEXING:
-            return "resume"
-        if not self._has_existing_index():
+        if persisted_state.status == _INDEXING_STATUS_INDEXING or not self._has_existing_index():
             return "resume"
         return "incremental"
 

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -735,6 +735,49 @@ async def test_initialize_shared_knowledge_managers_resumes_partial_index_when_c
 
 
 @pytest.mark.asyncio
+async def test_initialize_shared_knowledge_managers_full_reindexes_when_checkpoint_is_corrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A corrupt checkpoint with existing vectors must force a safe full rebuild."""
+    _DummyChromaDb.metadatas = [{"source_path": "a.md"}]
+    monkeypatch.setattr("mindroom.knowledge.manager.ChromaDb", _DummyChromaDb)
+    monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _DummyKnowledge)
+
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir(parents=True, exist_ok=True)
+    (docs_path / "a.md").write_text("A\n", encoding="utf-8")
+    runtime_paths = _runtime_paths(tmp_path / "config.yaml", tmp_path / "storage")
+    config = bind_runtime_paths(
+        Config(
+            agents={},
+            models={},
+            knowledge_bases={"research": KnowledgeBaseConfig(path=str(docs_path), watch=False)},
+        ),
+        runtime_paths,
+    )
+    seed_manager = KnowledgeManager(
+        base_id="research",
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    seed_manager._indexing_settings_path.write_text("{not-json", encoding="utf-8")
+
+    initialize = AsyncMock()
+    sync_indexed_files = AsyncMock(return_value={"loaded_count": 1, "indexed_count": 0, "removed_count": 0})
+    monkeypatch.setattr(KnowledgeManager, "initialize", initialize)
+    monkeypatch.setattr(KnowledgeManager, "sync_indexed_files", sync_indexed_files)
+
+    try:
+        await initialize_shared_knowledge_managers(config, runtime_paths, reindex_on_create=False)
+
+        initialize.assert_awaited_once()
+        sync_indexed_files.assert_not_awaited()
+    finally:
+        await shutdown_shared_knowledge_managers()
+
+
+@pytest.mark.asyncio
 async def test_initialize_shared_knowledge_managers_maintains_registry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -704,10 +704,13 @@ async def test_initialize_shared_knowledge_managers_resumes_partial_index_when_c
     _DummyChromaDb.metadatas = [{"source_path": "a.md"}]
 
     runtime_paths = _runtime_paths(tmp_path / "config.yaml", tmp_path / "storage")
-    config = _knowledge_test_config(
-        agents={},
-        models={},
-        knowledge_bases={"research": KnowledgeBaseConfig(path=str(docs_path), watch=False)},
+    config = bind_runtime_paths(
+        Config(
+            agents={},
+            models={},
+            knowledge_bases={"research": KnowledgeBaseConfig(path=str(docs_path), watch=False)},
+        ),
+        runtime_paths,
     )
     reset_collection = MagicMock(side_effect=AssertionError("partial index resume must not reset the collection"))
     monkeypatch.setattr(KnowledgeManager, "_reset_collection", reset_collection)

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import subprocess
 from typing import TYPE_CHECKING, ClassVar
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -687,6 +688,50 @@ async def test_sync_indexed_files_does_not_suppress_retry_for_previously_indexed
 
 
 @pytest.mark.asyncio
+async def test_initialize_shared_knowledge_managers_resumes_partial_index_when_checkpoint_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup should resume a partial legacy index instead of wiping it when no checkpoint exists."""
+    _DummyChromaDb.metadatas = []
+    monkeypatch.setattr("mindroom.knowledge.manager.ChromaDb", _DummyChromaDb)
+    monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _DummyKnowledge)
+
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir(parents=True, exist_ok=True)
+    (docs_path / "a.md").write_text("A\n", encoding="utf-8")
+    (docs_path / "b.md").write_text("B\n", encoding="utf-8")
+    _DummyChromaDb.metadatas = [{"source_path": "a.md"}]
+
+    runtime_paths = _runtime_paths(tmp_path / "config.yaml", tmp_path / "storage")
+    config = _knowledge_test_config(
+        agents={},
+        models={},
+        knowledge_bases={"research": KnowledgeBaseConfig(path=str(docs_path), watch=False)},
+    )
+    reset_collection = MagicMock(side_effect=AssertionError("partial index resume must not reset the collection"))
+    monkeypatch.setattr(KnowledgeManager, "_reset_collection", reset_collection)
+
+    try:
+        managers = await initialize_shared_knowledge_managers(config, runtime_paths, reindex_on_create=False)
+        manager = managers["research"]
+
+        assert manager._indexed_files == {"a.md", "b.md"}
+        assert {metadata["source_path"] for metadata in _DummyChromaDb.metadatas if isinstance(metadata, dict)} == {
+            "a.md",
+            "b.md",
+        }
+        payload = json.loads(manager._indexing_settings_path.read_text(encoding="utf-8"))
+        assert payload == {
+            "settings": list(manager._indexing_settings),
+            "status": "complete",
+        }
+        reset_collection.assert_not_called()
+    finally:
+        await shutdown_shared_knowledge_managers()
+
+
+@pytest.mark.asyncio
 async def test_initialize_shared_knowledge_managers_maintains_registry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1050,7 +1095,7 @@ async def test_worker_scoped_git_private_knowledge_refreshes_on_access_without_b
     )
 
     sync_git_repository = AsyncMock(return_value={"updated": False, "changed_count": 0, "removed_count": 0})
-    sync_indexed_files = AsyncMock()
+    sync_indexed_files = AsyncMock(return_value={"loaded_count": 0, "indexed_count": 0, "removed_count": 0})
     start_watcher = AsyncMock()
     monkeypatch.setattr(KnowledgeManager, "sync_git_repository", sync_git_repository)
     monkeypatch.setattr(KnowledgeManager, "sync_indexed_files", sync_indexed_files)
@@ -1061,7 +1106,14 @@ async def test_worker_scoped_git_private_knowledge_refreshes_on_access_without_b
         await ensure_agent_knowledge_managers("mind", config, runtime_paths_for(config), execution_identity=identity)
 
         assert sync_git_repository.await_count == 2
-        sync_indexed_files.assert_not_awaited()
+        sync_git_repository.assert_has_awaits(
+            [
+                call(index_changes=False),
+                call(index_changes=False),
+            ],
+            any_order=False,
+        )
+        assert sync_indexed_files.await_count == 2
         start_watcher.assert_not_awaited()
     finally:
         await shutdown_shared_knowledge_managers()
@@ -1081,8 +1133,10 @@ async def test_initialize_shared_git_knowledge_starts_background_sync_when_watch
     runtime_paths = runtime_paths_for(config)
     start_watcher = AsyncMock()
     sync_git_repository = AsyncMock(return_value={"updated": False, "changed_count": 0, "removed_count": 0})
+    sync_indexed_files = AsyncMock(return_value={"loaded_count": 0, "indexed_count": 0, "removed_count": 0})
     monkeypatch.setattr(KnowledgeManager, "start_watcher", start_watcher)
     monkeypatch.setattr(KnowledgeManager, "sync_git_repository", sync_git_repository)
+    monkeypatch.setattr(KnowledgeManager, "sync_indexed_files", sync_indexed_files)
 
     try:
         await initialize_shared_knowledge_managers(
@@ -1093,7 +1147,8 @@ async def test_initialize_shared_git_knowledge_starts_background_sync_when_watch
         )
 
         start_watcher.assert_awaited_once()
-        sync_git_repository.assert_awaited_once()
+        sync_git_repository.assert_awaited_once_with(index_changes=False)
+        sync_indexed_files.assert_awaited_once()
     finally:
         await shutdown_shared_knowledge_managers()
 
@@ -1380,6 +1435,81 @@ async def test_initialize_shared_knowledge_managers_full_reindex_on_cold_setting
 
         initialize.assert_awaited_once()
         sync_indexed_files.assert_not_awaited()
+    finally:
+        await shutdown_shared_knowledge_managers()
+
+
+@pytest.mark.asyncio
+async def test_interrupted_reindex_restart_resumes_partial_progress(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A restarted process should continue from partial reindex progress instead of wiping it."""
+    _DummyChromaDb.metadatas = []
+    monkeypatch.setattr("mindroom.knowledge.manager.ChromaDb", _DummyChromaDb)
+    monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _DummyKnowledge)
+    monkeypatch.setattr("mindroom.knowledge.manager._MAX_CONCURRENT_KNOWLEDGE_FILE_INDEXES", 1)
+
+    def _clear_dummy_collection(_vector_db: _DummyChromaDb) -> None:
+        _DummyChromaDb.metadatas.clear()
+
+    monkeypatch.setattr(_DummyChromaDb, "delete", _clear_dummy_collection)
+
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir(parents=True, exist_ok=True)
+    (docs_path / "a.md").write_text("A\n", encoding="utf-8")
+    (docs_path / "b.md").write_text("B\n", encoding="utf-8")
+    config = _make_config(docs_path)
+    runtime_paths = runtime_paths_for(config)
+
+    interrupted_manager = KnowledgeManager(
+        base_id="research",
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    original_index_file_locked = interrupted_manager._index_file_locked
+    indexed_paths: list[str] = []
+
+    async def _interrupt_after_first_file(resolved_path: Path, *, upsert: bool) -> bool:
+        indexed = await original_index_file_locked(resolved_path, upsert=upsert)
+        indexed_paths.append(interrupted_manager._relative_path(resolved_path))
+        if len(indexed_paths) == 1:
+            message = "simulated crash"
+            raise RuntimeError(message)
+        return indexed
+
+    monkeypatch.setattr(interrupted_manager, "_index_file_locked", _interrupt_after_first_file)
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        await interrupted_manager.reindex_all()
+
+    interrupted_payload = json.loads(interrupted_manager._indexing_settings_path.read_text(encoding="utf-8"))
+    assert interrupted_payload == {
+        "settings": list(interrupted_manager._indexing_settings),
+        "status": "indexing",
+    }
+    assert {metadata["source_path"] for metadata in _DummyChromaDb.metadatas if isinstance(metadata, dict)} == {
+        indexed_paths[0],
+    }
+
+    reset_collection = MagicMock(side_effect=AssertionError("restart resume must not reset the collection"))
+    monkeypatch.setattr(KnowledgeManager, "_reset_collection", reset_collection)
+
+    try:
+        managers = await initialize_shared_knowledge_managers(config, runtime_paths, reindex_on_create=False)
+        resumed_manager = managers["research"]
+
+        assert resumed_manager._indexed_files == {"a.md", "b.md"}
+        assert {metadata["source_path"] for metadata in _DummyChromaDb.metadatas if isinstance(metadata, dict)} == {
+            "a.md",
+            "b.md",
+        }
+        resumed_payload = json.loads(resumed_manager._indexing_settings_path.read_text(encoding="utf-8"))
+        assert resumed_payload == {
+            "settings": list(resumed_manager._indexing_settings),
+            "status": "complete",
+        }
+        reset_collection.assert_not_called()
     finally:
         await shutdown_shared_knowledge_managers()
 
@@ -2034,6 +2164,65 @@ async def test_initialize_git_backed_base_syncs_before_single_full_reindex(
 
     sync_git_repository.assert_awaited_once_with(index_changes=False)
     reindex_all.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_initialize_shared_knowledge_managers_resumes_partial_git_index_with_full_file_sync(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Git-backed resume should refresh the checkout, then reconcile against the full file set."""
+    _DummyChromaDb.metadatas = [{"source_path": "doc.md"}]
+    monkeypatch.setattr("mindroom.knowledge.manager.ChromaDb", _DummyChromaDb)
+    monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _DummyKnowledge)
+
+    config = _make_git_config(tmp_path / "knowledge")
+    runtime_paths = runtime_paths_for(config)
+    seed_manager = KnowledgeManager(
+        base_id="research",
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    seed_manager._save_persisted_indexing_state("indexing")
+
+    git_calls: list[bool] = []
+    sync_calls = 0
+    initialize_calls = 0
+
+    async def _fake_sync_git_repository(
+        _manager: KnowledgeManager,
+        *,
+        index_changes: bool = True,
+    ) -> dict[str, int | bool]:
+        git_calls.append(index_changes)
+        return {"updated": False, "changed_count": 0, "removed_count": 0}
+
+    async def _fake_sync_indexed_files(_manager: KnowledgeManager) -> dict[str, int]:
+        nonlocal sync_calls
+        sync_calls += 1
+        return {"loaded_count": 1, "indexed_count": 1, "removed_count": 0}
+
+    async def _fake_initialize(_manager: KnowledgeManager) -> None:
+        nonlocal initialize_calls
+        initialize_calls += 1
+
+    def _unexpected_reset_collection(_manager: KnowledgeManager) -> None:
+        message = "git resume should not reset the collection"
+        raise AssertionError(message)
+
+    monkeypatch.setattr(KnowledgeManager, "sync_git_repository", _fake_sync_git_repository)
+    monkeypatch.setattr(KnowledgeManager, "sync_indexed_files", _fake_sync_indexed_files)
+    monkeypatch.setattr(KnowledgeManager, "initialize", _fake_initialize)
+    monkeypatch.setattr(KnowledgeManager, "_reset_collection", _unexpected_reset_collection)
+
+    try:
+        await initialize_shared_knowledge_managers(config, runtime_paths, reindex_on_create=False)
+
+        assert git_calls == [False]
+        assert sync_calls == 1
+        assert initialize_calls == 0
+    finally:
+        await shutdown_shared_knowledge_managers()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- resume partially completed shared knowledge indexing when prior progress exists
- preserve already indexed files instead of wiping the collection and starting over
- keep the regression test aligned with the current knowledge test config setup on main

## Verification
- `python -m pre_commit run --files src/mindroom/bot.py src/mindroom/knowledge/manager.py tests/test_bot_scheduling.py tests/test_knowledge_manager.py`
- `PYTHONPATH="$PWD/src" .venv/bin/pytest -q tests/test_bot_scheduling.py tests/test_knowledge_manager.py -k "knowledge or indexing or resume or scheduling"`