### PR TITLE
Add thread IDs to structured log lines

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from uuid import uuid4
 
 import nio
+from structlog.contextvars import bind_contextvars, bound_contextvars
 from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wait_exponential
 
 from mindroom.bot_runtime_view import BotRuntimeState
@@ -881,37 +882,12 @@ class AgentBot:
         room_id: str,
         event: nio.ReactionEvent,
         correlation_id: str,
+        thread_id: str | None,
     ) -> None:
         """Emit reaction:received after built-in handlers decline the reaction."""
         assert self.client is not None
         if not self.hook_registry.has_hooks(EVENT_REACTION_RECEIVED):
             return
-
-        normalized_target_event_id = event.reacts_to.strip()
-        thread_id: str | None = None
-        if normalized_target_event_id:
-            response = await self._conversation_access.get_event(room_id, normalized_target_event_id)
-            if isinstance(response, nio.RoomGetEventResponse):
-                target_info = EventInfo.from_event(response.event.source)
-                if target_info.thread_id:
-                    thread_id = target_info.thread_id
-                elif target_info.thread_id_from_edit:
-                    thread_id = target_info.thread_id_from_edit
-                elif not target_info.has_relations:
-                    thread_history = await self._conversation_resolver.fetch_thread_history(
-                        self.client,
-                        room_id,
-                        normalized_target_event_id,
-                    )
-                    if len(thread_history) > 1:
-                        thread_id = normalized_target_event_id
-            else:
-                self.logger.debug(
-                    "Failed to fetch reaction target event for hook context",
-                    room_id=room_id,
-                    target_event_id=normalized_target_event_id,
-                    error=str(response),
-                )
 
         context = ReactionReceivedContext(
             **self._hook_context_support.base_kwargs(EVENT_REACTION_RECEIVED, correlation_id),
@@ -923,6 +899,53 @@ class AgentBot:
             thread_id=thread_id,
         )
         await emit(self.hook_registry, EVENT_REACTION_RECEIVED, context)
+
+    async def _resolve_reaction_target_thread_id(
+        self,
+        *,
+        room_id: str,
+        target_event_id: str,
+    ) -> str | None:
+        """Resolve the canonical thread scope for one reaction target event."""
+        assert self.client is not None
+        normalized_target_event_id = target_event_id.strip()
+        if not normalized_target_event_id:
+            return None
+        resolved_thread_id: str | None = None
+        try:
+            response = await self._conversation_access.get_event(room_id, normalized_target_event_id)
+        except Exception as exc:
+            self.logger.debug(
+                "Failed to fetch reaction target event for hook context",
+                room_id=room_id,
+                target_event_id=normalized_target_event_id,
+                error=str(exc),
+            )
+            return None
+
+        if isinstance(response, nio.RoomGetEventResponse):
+            target_info = EventInfo.from_event(response.event.source)
+            if target_info.thread_id:
+                resolved_thread_id = target_info.thread_id
+            elif target_info.thread_id_from_edit:
+                resolved_thread_id = target_info.thread_id_from_edit
+            elif not target_info.has_relations:
+                thread_history = await self._conversation_resolver.fetch_thread_history(
+                    self.client,
+                    room_id,
+                    normalized_target_event_id,
+                )
+                if len(thread_history) > 1:
+                    resolved_thread_id = normalized_target_event_id
+            return resolved_thread_id
+
+        self.logger.debug(
+            "Failed to fetch reaction target event for hook context",
+            room_id=room_id,
+            target_event_id=normalized_target_event_id,
+            error=str(response),
+        )
+        return None
 
     async def _emit_agent_lifecycle_event(
         self,
@@ -1516,37 +1539,44 @@ class AgentBot:
             sender=event.sender,
             source=event.source,
         )
-        if self._is_trusted_internal_relay_event(event):
-            if dispatch_timing is not None:
-                dispatch_timing.note(coalescing_bypassed=True, coalescing_bypass_reason="trusted_internal_relay")
-                dispatch_timing.mark("gate_exit")
-            trusted_relay_event = cast("_TextDispatchEvent", event)
-            await self._dispatch_text_message(
-                room,
-                trusted_relay_event,
-                effective_requester_user_id,
-            )
-            return
-        await self._coalescing_gate.enqueue(
-            coalescing_key or await self._coalescing_key_for_event(room, event, effective_requester_user_id),
-            PendingEvent(
-                event=event,
-                room=room,
-                source_kind=source_kind,
-            ),
+        effective_coalescing_key = coalescing_key or await self._coalescing_key_for_event(
+            room,
+            event,
+            effective_requester_user_id,
         )
+        with bound_contextvars(room_id=room.room_id, thread_id=effective_coalescing_key[1]):
+            if self._is_trusted_internal_relay_event(event):
+                if dispatch_timing is not None:
+                    dispatch_timing.note(coalescing_bypassed=True, coalescing_bypass_reason="trusted_internal_relay")
+                    dispatch_timing.mark("gate_exit")
+                trusted_relay_event = cast("_TextDispatchEvent", event)
+                await self._dispatch_text_message(
+                    room,
+                    trusted_relay_event,
+                    effective_requester_user_id,
+                )
+                return
+            await self._coalescing_gate.enqueue(
+                effective_coalescing_key,
+                PendingEvent(
+                    event=event,
+                    room=room,
+                    source_kind=source_kind,
+                ),
+            )
 
     async def _dispatch_coalesced_batch(self, batch: CoalescedBatch) -> None:
         """Dispatch one flushed batch through the normal text pipeline."""
         dispatch_event = build_batch_dispatch_event(batch)
         dispatch_timing = get_dispatch_pipeline_timing(dispatch_event.source)
-        if dispatch_timing is not None:
-            dispatch_timing.mark("gate_exit")
         batch_coalescing_key = await self._coalescing_key_for_event(
             batch.room,
             batch.primary_event,
             batch.requester_user_id,
         )
+        bind_contextvars(room_id=batch.room.room_id, thread_id=batch_coalescing_key[1])
+        if dispatch_timing is not None:
+            dispatch_timing.mark("gate_exit")
         # The first room message opens the gate with thread_id=None, but dispatch
         # resolves that turn into a new thread rooted at the source event ID.
         canonical_key = (
@@ -1560,6 +1590,7 @@ class AgentBot:
             batch.requester_user_id,
         )
         self._coalescing_gate.retarget(batch_coalescing_key, canonical_key)
+        bind_contextvars(thread_id=canonical_key[1])
         async with self._conversation_resolver.turn_thread_cache_scope():
             await self._dispatch_text_message(
                 batch.room,
@@ -1578,14 +1609,16 @@ class AgentBot:
 
     async def _handle_message_inner(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
         """Handle one text message inside the per-turn thread-history cache scope."""
-        self.logger.info("Received message", event_id=event.event_id, room_id=room.room_id, sender=event.sender)
+event_info = EventInfo.from_event(event.source)
+        thread_id = event_info.thread_id or event_info.thread_id_from_edit
+        bind_contextvars(room_id=room.room_id, thread_id=thread_id)
+        self.logger.info("Received message", event_id=event.event_id, room_id=room.room_id, sender=event.sender, thread_id=thread_id)
         assert self.client is not None
         dispatch_timing = create_dispatch_pipeline_timing(
             event_id=event.event_id,
             room_id=room.room_id,
         )
         attach_dispatch_pipeline_timing(event.source, dispatch_timing)
-        event_info = EventInfo.from_event(event.source)
         await self._conversation_access.append_live_event(room.room_id, event, event_info=event_info)
         if not isinstance(event.body, str):
             return
@@ -1627,6 +1660,7 @@ class AgentBot:
         if should_handle_interactive_text_response(envelope):
             await interactive.handle_text_response(self.client, room, prepared_event, self.agent_name)
         coalescing_thread_id = await self._conversation_resolver.coalescing_thread_id(room, prepared_event)
+        bind_contextvars(thread_id=coalescing_thread_id)
         target = self._conversation_resolver.build_message_target(
             room_id=room.room_id,
             thread_id=coalescing_thread_id,
@@ -1721,6 +1755,7 @@ class AgentBot:
             if dispatch is None:
                 return
 
+            bind_contextvars(room_id=room.room_id, thread_id=dispatch.target.resolved_thread_id)
             # Commands always dispatch and bypass thread-history suppression.
             command = command_parser.parse(event.body) if not media_events else None
             if command:
@@ -1907,6 +1942,11 @@ class AgentBot:
             self.logger.debug("Ignoring reaction due to reply permissions", sender=event.sender)
             return
 
+        reaction_thread_id = await self._resolve_reaction_target_thread_id(
+            room_id=room.room_id,
+            target_event_id=event.reacts_to,
+        )
+        bind_contextvars(room_id=room.room_id, thread_id=reaction_thread_id)
         if event.key == "🛑":
             sender_agent_name = extract_agent_name(event.sender, self.config, self.runtime_paths)
             if not sender_agent_name and await self.stop_manager.handle_stop_reaction(event.reacts_to):
@@ -1939,6 +1979,7 @@ class AgentBot:
             room_id=room.room_id,
             event=event,
             correlation_id=event.event_id,
+            thread_id=reaction_thread_id,
         )
 
     async def _handle_interactive_reaction_result(
@@ -2080,6 +2121,7 @@ class AgentBot:
         event: _MediaDispatchEvent,
     ) -> None:
         """Handle one media event inside the per-turn thread-history cache scope."""
+        bind_contextvars(room_id=room.room_id, thread_id=None)
         assert self.client is not None
 
         prechecked_event = self._precheck_dispatch_event(room, event)
@@ -2592,6 +2634,7 @@ class AgentBot:
             event,
             conversation_target=turn_record.conversation_target if turn_record is not None else None,
         )
+        bind_contextvars(room_id=room.room_id, thread_id=context.thread_id)
         persisted_turn_metadata = self._load_persisted_turn_metadata(
             room=room,
             thread_id=context.thread_id,
@@ -2756,7 +2799,6 @@ class AgentBot:
                     self._mark_source_events_responded(regeneration_handled_turn)
                 return
 
-        # Generate new response
         regenerated_event_id = await self._generate_response(
             room_id=room.room_id,
             prompt=regeneration_prompt,
@@ -2780,7 +2822,6 @@ class AgentBot:
             ),
         )
 
-        # Update the handled-turn ledger linkage for the edited source turn.
         if regenerated_event_id is not None:
             self._mark_source_events_responded(
                 regeneration_handled_turn.with_response_event_id(regenerated_event_id),

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1609,10 +1609,16 @@ class AgentBot:
 
     async def _handle_message_inner(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
         """Handle one text message inside the per-turn thread-history cache scope."""
-event_info = EventInfo.from_event(event.source)
+        event_info = EventInfo.from_event(event.source)
         thread_id = event_info.thread_id or event_info.thread_id_from_edit
         bind_contextvars(room_id=room.room_id, thread_id=thread_id)
-        self.logger.info("Received message", event_id=event.event_id, room_id=room.room_id, sender=event.sender, thread_id=thread_id)
+        self.logger.info(
+            "Received message",
+            event_id=event.event_id,
+            room_id=room.room_id,
+            sender=event.sender,
+            thread_id=thread_id,
+        )
         assert self.client is not None
         dispatch_timing = create_dispatch_pipeline_timing(
             event_id=event.event_id,

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -366,15 +366,29 @@ class DeliveryGateway:
 
         event_id = await send_message(client, request.room_id, content)
         if event_id:
-            self.deps.logger.info("Sent response", event_id=event_id, room_id=request.room_id)
+            self.deps.logger.info(
+                "Sent response",
+                event_id=event_id,
+                room_id=request.room_id,
+                thread_id=effective_thread_id,
+            )
             return event_id
-        self.deps.logger.error("Failed to send response to room", room_id=request.room_id)
+        self.deps.logger.error(
+            "Failed to send response to room",
+            room_id=request.room_id,
+            thread_id=effective_thread_id,
+        )
         return None
 
     async def edit_text(self, request: EditTextRequest) -> bool:
         """Edit one existing response message."""
         client = self._client()
         config = self.deps.runtime.config
+        effective_thread_id = self.deps.resolver.build_message_target(
+            room_id=request.room_id,
+            thread_id=request.thread_id,
+            reply_to_event_id=None,
+        ).resolved_thread_id
         if (
             config.get_entity_thread_mode(
                 self.deps.agent_name,
@@ -412,9 +426,14 @@ class DeliveryGateway:
             request.new_text,
         )
         if isinstance(response, nio.RoomSendResponse):
-            self.deps.logger.info("Edited message", event_id=request.event_id)
+            self.deps.logger.info("Edited message", event_id=request.event_id, thread_id=effective_thread_id)
             return True
-        self.deps.logger.error("Failed to edit message", event_id=request.event_id, error=str(response))
+        self.deps.logger.error(
+            "Failed to edit message",
+            event_id=request.event_id,
+            thread_id=effective_thread_id,
+            error=str(response),
+        )
         return False
 
     async def redact_suppressed_response_event(
@@ -457,6 +476,7 @@ class DeliveryGateway:
             response_kind=response_kind,
             source_event_id=response_envelope.source_event_id,
             correlation_id=correlation_id,
+            thread_id=response_envelope.target.resolved_thread_id,
         )
         return await self.redact_suppressed_response_event(
             room_id=room_id,
@@ -483,6 +503,7 @@ class DeliveryGateway:
 
     async def deliver_final(self, request: FinalDeliveryRequest) -> DeliveryResult:
         """Apply before/after hooks around one final send or edit."""
+        resolved_target = request.target or request.response_envelope.target
         draft = (
             await self.deps.response_hooks.apply_before_response(
                 correlation_id=request.correlation_id,
@@ -515,6 +536,7 @@ class DeliveryGateway:
                 response_kind=request.response_kind,
                 source_event_id=request.response_envelope.source_event_id,
                 correlation_id=request.correlation_id,
+                thread_id=resolved_target.resolved_thread_id,
             )
             if request.existing_event_id is not None and request.existing_event_is_placeholder:
                 return await self.redact_suppressed_response_event(
@@ -532,7 +554,6 @@ class DeliveryGateway:
 
         interactive_response = interactive.parse_and_format_interactive(draft.response_text, extract_mapping=True)
         display_text = interactive_response.formatted_text
-        resolved_target = request.target or request.response_envelope.target
         if request.existing_event_id:
             edited = await self.edit_text(
                 EditTextRequest(
@@ -606,10 +627,15 @@ class DeliveryGateway:
                 "Sent compaction notice",
                 event_id=event_id,
                 room_id=request.room_id,
+                thread_id=effective_thread_id,
                 summary_model=request.outcome.summary_model,
             )
             return event_id
-        self.deps.logger.error("Failed to send compaction notice", room_id=request.room_id)
+        self.deps.logger.error(
+            "Failed to send compaction notice",
+            room_id=request.room_id,
+            thread_id=effective_thread_id,
+        )
         return None
 
     async def deliver_stream(
@@ -673,6 +699,7 @@ class DeliveryGateway:
                 "Streaming response was already delivered before a suppressing hook ran",
                 source_event_id=request.response_envelope.source_event_id,
                 correlation_id=request.correlation_id,
+                thread_id=request.target.resolved_thread_id,
             )
             return DeliveryResult(
                 event_id=request.streamed_event_id,

--- a/src/mindroom/dispatch_planner.py
+++ b/src/mindroom/dispatch_planner.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 import nio
+from structlog.contextvars import bound_contextvars
 
 from mindroom.attachments import merge_attachment_ids, parse_attachment_ids_from_event_source
 from mindroom.authorization import (
@@ -472,41 +473,42 @@ class DispatchPlanner:
             reply_to_event_id=event.event_id,
             event_source=event.source,
         )
-        correlation_id = event.event_id
-        envelope = self.deps.resolver.build_message_envelope(
-            room_id=room.room_id,
-            event=event,
-            requester_user_id=requester_user_id,
-            context=context,
-            target=target,
-        )
-        ingress_policy = hook_ingress_policy(envelope)
-        suppressed = await self.deps.hook_service.emit_message_received_hooks(
-            envelope=envelope,
-            correlation_id=correlation_id,
-            policy=ingress_policy,
-        )
-        if suppressed:
-            self._mark_source_events_responded(handled_turn)
-            return None
-
-        sender_agent_name = extract_agent_name(requester_user_id, self.deps.runtime.config, self.deps.runtime_paths)
-        if sender_agent_name and not context.am_i_mentioned and not ingress_policy.bypass_unmentioned_agent_gate:
-            self.deps.logger.debug(
-                "ignore_unmentioned_agent_event",
-                agent=sender_agent_name,
-                event_label=event_label,
-                user_id=requester_user_id,
+        with bound_contextvars(room_id=room.room_id, thread_id=target.resolved_thread_id):
+            correlation_id = event.event_id
+            envelope = self.deps.resolver.build_message_envelope(
+                room_id=room.room_id,
+                event=event,
+                requester_user_id=requester_user_id,
+                context=context,
+                target=target,
             )
-            return None
+            ingress_policy = hook_ingress_policy(envelope)
+            suppressed = await self.deps.hook_service.emit_message_received_hooks(
+                envelope=envelope,
+                correlation_id=correlation_id,
+                policy=ingress_policy,
+            )
+            if suppressed:
+                self._mark_source_events_responded(handled_turn)
+                return None
 
-        return PreparedDispatch(
-            requester_user_id=requester_user_id,
-            context=context,
-            target=target,
-            correlation_id=correlation_id,
-            envelope=envelope,
-        )
+            sender_agent_name = extract_agent_name(requester_user_id, self.deps.runtime.config, self.deps.runtime_paths)
+            if sender_agent_name and not context.am_i_mentioned and not ingress_policy.bypass_unmentioned_agent_gate:
+                self.deps.logger.debug(
+                    "ignore_unmentioned_agent_event",
+                    agent=sender_agent_name,
+                    event_label=event_label,
+                    user_id=requester_user_id,
+                )
+                return None
+
+            return PreparedDispatch(
+                requester_user_id=requester_user_id,
+                context=context,
+                target=target,
+                correlation_id=correlation_id,
+                envelope=envelope,
+            )
 
     async def resolve_text_dispatch_event(self, event: TextDispatchEvent) -> PreparedTextEvent:
         """Return one canonical text event for hooks, routing, and command handling."""

--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -178,14 +178,14 @@ def _store_active_question_locked(event_id: str, question: _InteractiveQuestion)
     _deleted_question_ids.discard(event_id)
 
 
-def _remove_active_question_locked(event_id: str) -> bool:
+def _remove_active_question_locked(event_id: str) -> _InteractiveQuestion | None:
     """Remove a tracked question and record the deletion for persistence."""
-    if event_id not in _active_questions:
-        return False
-    del _active_questions[event_id]
+    question = _active_questions.pop(event_id, None)
+    if question is None:
+        return None
     _dirty_question_ids.discard(event_id)
     _deleted_question_ids.add(event_id)
-    return True
+    return question
 
 
 def _apply_local_changes_locked(
@@ -435,12 +435,14 @@ async def handle_reaction(
         logger.info(
             "Received answer via reaction",
             user=event.sender,
+            room_id=question.room_id,
             reaction=reaction_key,
+            thread_id=question.thread_id,
             value=selected_value,
         )
 
         # The emoji reaction itself is the user's response, so just consume the question.
-        if _remove_active_question_locked(event.reacts_to):
+        if _remove_active_question_locked(event.reacts_to) is not None:
             _save_active_questions_locked()
 
         return (selected_value, question.thread_id)
@@ -510,10 +512,12 @@ def _handle_text_response_locked(
         logger.info(
             "Received answer via text",
             user=sender,
+            room_id=question.room_id,
             text=message_text,
+            thread_id=question.thread_id,
             value=selected_value,
         )
-        if _remove_active_question_locked(question_event_id):
+        if _remove_active_question_locked(question_event_id) is not None:
             _save_active_questions_locked()
         return (selected_value, question.thread_id)
     return None
@@ -626,16 +630,28 @@ def register_interactive_question(
             ),
         )
         _save_active_questions_locked()
-    logger.info("Registered interactive question", event_id=event_id, options=len(option_map))
+    logger.info(
+        "Registered interactive question",
+        event_id=event_id,
+        room_id=room_id,
+        thread_id=thread_id,
+        options=len(option_map),
+    )
 
 
 def clear_interactive_question(event_id: str) -> None:
     """Remove one tracked interactive question when its message is edited away."""
     with _thread_lock:
-        if not _remove_active_question_locked(event_id):
+        question = _remove_active_question_locked(event_id)
+        if question is None:
             return
         _save_active_questions_locked()
-    logger.info("Cleared interactive question", event_id=event_id)
+    logger.info(
+        "Cleared interactive question",
+        event_id=event_id,
+        room_id=question.room_id,
+        thread_id=question.thread_id,
+    )
 
 
 async def add_reaction_buttons(
@@ -667,7 +683,13 @@ async def add_reaction_buttons(
             },
         )
         if not isinstance(reaction_response, nio.RoomSendResponse):
-            logger.warning("Failed to add reaction", emoji=emoji_char, error=str(reaction_response))
+            logger.warning(
+                "Failed to add reaction",
+                emoji=emoji_char,
+                error=str(reaction_response),
+                room_id=room_id,
+                thread_id=None,
+            )
 
 
 def _cleanup() -> None:

--- a/src/mindroom/logging_config.py
+++ b/src/mindroom/logging_config.py
@@ -6,11 +6,13 @@ import logging
 import logging.config
 import os
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import structlog
 
 if TYPE_CHECKING:
+    from structlog.typing import Processor
+
     from mindroom.constants import RuntimePaths
 
 __all__ = ["get_logger", "setup_logging"]
@@ -39,6 +41,16 @@ class _NioValidationFilter(logging.Filter):
         return True
 
 
+def _add_default_thread_id(
+    _logger: logging.Logger,
+    _method_name: str,
+    event_dict: dict[str, object],
+) -> dict[str, object]:
+    """Ensure every structured log payload carries a thread_id key."""
+    event_dict.setdefault("thread_id", None)
+    return event_dict
+
+
 def setup_logging(
     *,
     level: str = "INFO",
@@ -61,7 +73,7 @@ def setup_logging(
 
     # Shared processors that don't affect output format
     timestamper = structlog.processors.TimeStamper(fmt="iso")
-    pre_chain = [
+    pre_chain: list[Processor] = [
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
         timestamper,
@@ -155,9 +167,11 @@ def setup_logging(
     )
 
     # Configure structlog to use stdlib logging
-    structlog.configure(
-        processors=[
+    processors = cast(
+        "list[Processor]",
+        [
             structlog.contextvars.merge_contextvars,
+            _add_default_thread_id,
             structlog.stdlib.filter_by_level,
             structlog.stdlib.add_logger_name,
             structlog.stdlib.add_log_level,
@@ -167,6 +181,9 @@ def setup_logging(
             structlog.processors.UnicodeDecoder(),
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         ],
+    )
+    structlog.configure(
+        processors=processors,
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,

--- a/src/mindroom/response_coordinator.py
+++ b/src/mindroom/response_coordinator.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 from agno.db.base import SessionType
+from structlog.contextvars import bound_contextvars
 
 from mindroom import interactive
 from mindroom.agents import show_tool_calls_for_agent
@@ -493,11 +494,15 @@ class ResponseCoordinator:
             if request.pipeline_timing is not None:
                 request.pipeline_timing.mark("lock_acquired")
             try:
-                if queued_human_message:
-                    queued_signal.consume_waiting_human_message()
-                    queued_human_message = False
-                with queued_message_signal_context(queued_signal):
-                    return await locked_operation(resolved_target)
+                with bound_contextvars(
+                    room_id=resolved_target.room_id,
+                    thread_id=resolved_target.resolved_thread_id,
+                ):
+                    if queued_human_message:
+                        queued_signal.consume_waiting_human_message()
+                        queued_human_message = False
+                    with queued_message_signal_context(queued_signal):
+                        return await locked_operation(resolved_target)
             finally:
                 if lock_acquired:
                     lifecycle_lock.release()
@@ -1127,6 +1132,7 @@ class ResponseCoordinator:
                 task,
                 None,
                 run_id=run_id,
+                thread_id=resolved_target.resolved_thread_id,
             )
 
             if message_to_track:
@@ -1641,17 +1647,18 @@ class ResponseCoordinator:
         )
         lifecycle_lock = self._response_lifecycle_lock(target)
         async with lifecycle_lock:
-            return await self.send_skill_command_response_locked(
-                room_id=room_id,
-                reply_to_event_id=reply_to_event_id,
-                thread_id=thread_id,
-                thread_history=thread_history,
-                prompt=prompt,
-                agent_name=agent_name,
-                user_id=user_id,
-                reply_to_event=reply_to_event,
-                source_envelope=source_envelope,
-            )
+            with bound_contextvars(room_id=target.room_id, thread_id=target.resolved_thread_id):
+                return await self.send_skill_command_response_locked(
+                    room_id=room_id,
+                    reply_to_event_id=reply_to_event_id,
+                    thread_id=thread_id,
+                    thread_history=thread_history,
+                    prompt=prompt,
+                    agent_name=agent_name,
+                    user_id=user_id,
+                    reply_to_event=reply_to_event,
+                    source_envelope=source_envelope,
+                )
 
     async def send_skill_command_response_locked(
         self,

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -18,6 +18,7 @@ from agno.agent import Agent
 from cron_descriptor import get_description
 from croniter import croniter
 from pydantic import BaseModel, Field
+from structlog.contextvars import bind_contextvars
 
 from mindroom.ai import get_model_instance
 from mindroom.authorization import get_available_agents_for_sender
@@ -744,6 +745,7 @@ async def _execute_scheduled_workflow(
         runtime_paths=runtime_paths,
     )
 
+    bind_contextvars(room_id=workflow.room_id, thread_id=target.resolved_thread_id)
     try:
         message_text = workflow.message
         if _ACTIVE_HOOK_REGISTRY.has_hooks(EVENT_SCHEDULE_FIRED):
@@ -793,14 +795,22 @@ async def _execute_scheduled_workflow(
             event_id=event_id,
         )
     except Exception as e:
-        logger.exception("Failed to execute scheduled workflow")
+        logger.exception(
+            "Failed to execute scheduled workflow",
+            room_id=workflow.room_id,
+            thread_id=target.resolved_thread_id,
+        )
         if workflow.room_id:
             error_message = f"❌ Scheduled task failed: {workflow.description}\nError: {e!s}"
             error_content = await _build_scheduled_failure_content(client, workflow, target, error_message)
             try:
                 await send_message(client, workflow.room_id, error_content)
             except Exception:
-                logger.exception("Failed to send scheduled workflow failure message")
+                logger.exception(
+                    "Failed to send scheduled workflow failure message",
+                    room_id=workflow.room_id,
+                    thread_id=target.resolved_thread_id,
+                )
         return False
     else:
         return True

--- a/src/mindroom/stop.py
+++ b/src/mindroom/stop.py
@@ -27,6 +27,7 @@ class _TrackedMessage:
     message_id: str
     room_id: str
     task: asyncio.Task[None]
+    thread_id: str | None = None
     reaction_event_id: str | None = None
     run_id: str | None = None
     cancel_requested: bool = False
@@ -51,12 +52,14 @@ class StopManager:
         task: asyncio.Task[None],
         reaction_event_id: str | None = None,
         run_id: str | None = None,
+        thread_id: str | None = None,
     ) -> None:
         """Track a message generation."""
         self.tracked_messages[message_id] = _TrackedMessage(
             message_id=message_id,
             room_id=room_id,
             task=task,
+            thread_id=thread_id,
             reaction_event_id=reaction_event_id,
             run_id=run_id,
         )
@@ -64,6 +67,7 @@ class StopManager:
             "Tracking message generation",
             message_id=message_id,
             room_id=room_id,
+            thread_id=thread_id,
             reaction_event_id=reaction_event_id,
             run_id=run_id,
             total_tracked=len(self.tracked_messages),
@@ -83,6 +87,7 @@ class StopManager:
         logger.info(
             "Updated tracked run id",
             message_id=message_id,
+            thread_id=tracked.thread_id,
             previous_run_id=previous_run_id,
             run_id=run_id,
             cancel_requested=tracked.cancel_requested,
@@ -92,6 +97,7 @@ class StopManager:
             logger.info(
                 "Stop already requested; scheduling best-effort cleanup for updated run id",
                 message_id=message_id,
+                thread_id=tracked.thread_id,
                 run_id=run_id,
             )
             self._schedule_graceful_run_cancel(message_id, run_id)
@@ -115,6 +121,8 @@ class StopManager:
 
     async def _probe_graceful_cancel(self, message_id: str, run_id: str, deadline: float) -> str:
         """Request Agno run cancellation for one known run during the post-cancel probe window."""
+        tracked = self.tracked_messages.get(message_id)
+        thread_id = tracked.thread_id if tracked is not None else None
         loop = asyncio.get_running_loop()
         probe_deadline = min(deadline, loop.time() + _GRACEFUL_CANCEL_PROBE_SECONDS)
         while loop.time() < probe_deadline:
@@ -126,6 +134,7 @@ class StopManager:
                     logger.info(
                         "Requested Agno run cancellation after hard task cancel",
                         message_id=message_id,
+                        thread_id=thread_id,
                         run_id=run_id,
                     )
                     return "requested"
@@ -133,6 +142,7 @@ class StopManager:
                 logger.warning(
                     "Agno run cancellation request timed out after hard task cancel",
                     message_id=message_id,
+                    thread_id=thread_id,
                     run_id=run_id,
                 )
                 return "manager_failed"
@@ -140,6 +150,7 @@ class StopManager:
                 logger.warning(
                     "Agno run cancellation request failed after hard task cancel",
                     message_id=message_id,
+                    thread_id=thread_id,
                     run_id=run_id,
                     error=str(exc),
                 )
@@ -151,6 +162,8 @@ class StopManager:
 
     async def _graceful_run_cancel_cleanup(self, message_id: str, run_id: str) -> None:
         """Best-effort Agno run cleanup after the response task was already hard-cancelled."""
+        tracked = self.tracked_messages.get(message_id)
+        thread_id = tracked.thread_id if tracked is not None else None
         try:
             loop = asyncio.get_running_loop()
             deadline = loop.time() + self.graceful_cancel_fallback_seconds
@@ -160,6 +173,7 @@ class StopManager:
                 logger.warning(
                     "Agno cancellation manager unavailable after hard task cancel",
                     message_id=message_id,
+                    thread_id=thread_id,
                     run_id=run_id,
                 )
                 return
@@ -168,6 +182,7 @@ class StopManager:
                 logger.warning(
                     "Agno run never became cancellable after hard task cancel",
                     message_id=message_id,
+                    thread_id=thread_id,
                     run_id=run_id,
                     cancel_requested=True,
                 )
@@ -177,6 +192,7 @@ class StopManager:
                 logger.warning(
                     "Unexpected graceful cancellation outcome after hard task cancel",
                     message_id=message_id,
+                    thread_id=thread_id,
                     run_id=run_id,
                     outcome=outcome,
                 )
@@ -185,12 +201,14 @@ class StopManager:
             logger.info(
                 "Finished graceful Agno cancellation cleanup after hard task cancel",
                 message_id=message_id,
+                thread_id=thread_id,
                 run_id=run_id,
             )
         except asyncio.CancelledError:
             logger.warning(
                 "Graceful cancellation probe was cancelled after hard task cancel",
                 message_id=message_id,
+                thread_id=thread_id,
                 run_id=run_id,
             )
             raise
@@ -221,7 +239,7 @@ class StopManager:
             if remove_button and message_id in self.tracked_messages:
                 tracked = self.tracked_messages[message_id]
                 if tracked.reaction_event_id:
-                    logger.info("Removing stop button in cleanup", message_id=message_id)
+                    logger.info("Removing stop button in cleanup", message_id=message_id, thread_id=tracked.thread_id)
                     try:
                         await client.room_redact(
                             room_id=tracked.room_id,
@@ -230,17 +248,30 @@ class StopManager:
                         )
                         tracked.reaction_event_id = None
                     except Exception as e:
-                        logger.warning("stop_button_cleanup_failed", message_id=message_id, error=str(e))
+                        logger.warning(
+                            "stop_button_cleanup_failed",
+                            message_id=message_id,
+                            thread_id=tracked.thread_id,
+                            error=str(e),
+                        )
 
             await asyncio.sleep(delay)
             if message_id in self.tracked_messages:
-                logger.info("Clearing tracked message after delay", message_id=message_id, delay=delay)
+                tracked = self.tracked_messages[message_id]
+                logger.info(
+                    "Clearing tracked message after delay",
+                    message_id=message_id,
+                    thread_id=tracked.thread_id,
+                    delay=delay,
+                )
                 del self.tracked_messages[message_id]
 
         if message_id in self.tracked_messages:
+            tracked = self.tracked_messages[message_id]
             logger.info(
                 "Scheduling message cleanup",
                 message_id=message_id,
+                thread_id=tracked.thread_id,
                 delay=delay,
                 remove_button=remove_button,
             )
@@ -253,23 +284,29 @@ class StopManager:
 
         Returns True if hard cancellation was initiated or is already in progress, False otherwise.
         """
+        tracked = self.tracked_messages.get(message_id)
         logger.info(
             "Handling stop reaction",
             message_id=message_id,
+            thread_id=tracked.thread_id if tracked is not None else None,
             tracked_messages=list(self.tracked_messages.keys()),
         )
 
-        if message_id in self.tracked_messages:
-            tracked = self.tracked_messages[message_id]
+        if tracked is not None:
             if tracked.task and not tracked.task.done():
                 if tracked.cancel_requested:
-                    logger.info("Cancellation already requested for message", message_id=message_id)
+                    logger.info(
+                        "Cancellation already requested for message",
+                        message_id=message_id,
+                        thread_id=tracked.thread_id,
+                    )
                     return True
 
                 tracked.cancel_requested = True
                 logger.info(
                     "Hard cancelling tracked response task",
                     message_id=message_id,
+                    thread_id=tracked.thread_id,
                     run_id=tracked.run_id,
                 )
                 tracked.task.cancel()
@@ -277,6 +314,7 @@ class StopManager:
                     logger.info(
                         "Scheduling best-effort Agno run cleanup after hard task cancel",
                         message_id=message_id,
+                        thread_id=tracked.thread_id,
                         run_id=tracked.run_id,
                     )
                     self._schedule_graceful_run_cancel(message_id, tracked.run_id)
@@ -286,11 +324,12 @@ class StopManager:
             logger.info(
                 "Task already completed or missing",
                 message_id=message_id,
+                thread_id=tracked.thread_id,
                 task_exists=tracked.task is not None,
                 task_done=tracked.task.done() if tracked.task else None,
             )
         else:
-            logger.warning("Stop reaction for untracked message", message_id=message_id)
+            logger.warning("Stop reaction for untracked message", message_id=message_id, thread_id=None)
         return False
 
     async def add_stop_button(self, client: AsyncClient, room_id: str, message_id: str) -> str | None:
@@ -300,7 +339,9 @@ class StopManager:
             The event ID of the reaction if successful, None otherwise.
 
         """
-        logger.info("Adding stop button", room_id=room_id, message_id=message_id)
+        tracked = self.tracked_messages.get(message_id)
+        thread_id = tracked.thread_id if tracked is not None else None
+        logger.info("Adding stop button", room_id=room_id, message_id=message_id, thread_id=thread_id)
         try:
             response = await client.room_send(
                 room_id=room_id,
@@ -315,14 +356,23 @@ class StopManager:
             )
             if isinstance(response, nio.RoomSendResponse):
                 event_id = str(response.event_id)
-                logger.info("Stop button added successfully", reaction_event_id=event_id, message_id=message_id)
+                logger.info(
+                    "Stop button added successfully",
+                    reaction_event_id=event_id,
+                    message_id=message_id,
+                    thread_id=thread_id,
+                )
                 # Update the tracked message with the reaction event ID
                 if message_id in self.tracked_messages:
                     self.tracked_messages[message_id].reaction_event_id = event_id
                 return event_id
-            logger.warning("Failed to add stop button - no event_id in response", response=response)
+            logger.warning(
+                "Failed to add stop button - no event_id in response",
+                response=response,
+                thread_id=thread_id,
+            )
         except Exception as e:
-            logger.exception("Exception adding stop button", error=str(e))
+            logger.exception("Exception adding stop button", error=str(e), thread_id=thread_id)
         return None
 
     async def remove_stop_button(self, client: AsyncClient, message_id: str | None = None) -> None:
@@ -339,6 +389,7 @@ class StopManager:
                 logger.info(
                     "Removing stop button immediately (user clicked)",
                     message_id=message_id,
+                    thread_id=tracked.thread_id,
                     reaction_event_id=tracked.reaction_event_id,
                 )
                 try:
@@ -348,14 +399,15 @@ class StopManager:
                         reason="User clicked stop",
                     )
                     tracked.reaction_event_id = None
-                    logger.info("Stop button removed successfully")
+                    logger.info("Stop button removed successfully", thread_id=tracked.thread_id)
                 except Exception as e:
-                    logger.exception("Failed to remove stop button", error=str(e))
+                    logger.exception("Failed to remove stop button", error=str(e), thread_id=tracked.thread_id)
             else:
                 logger.debug(
                     "Stop button already removed or missing",
                     message_id=message_id,
+                    thread_id=tracked.thread_id,
                     has_reaction_id=tracked.reaction_event_id is not None,
                 )
         else:
-            logger.debug("Message not tracked, cannot remove stop button", message_id=message_id)
+            logger.debug("Message not tracked, cannot remove stop button", message_id=message_id, thread_id=None)

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -573,6 +573,13 @@ class TestCommandHandling:
 
             # Verify the command was handled
             bot._handle_command.assert_called_once()
+            bot.logger.info.assert_any_call(
+                "Received message",
+                event_id="$event123",
+                room_id="!test:server",
+                sender="@user:server",
+                thread_id="$thread123",
+            )
 
     @pytest.mark.asyncio
     async def test_router_command_blocked_by_reply_permissions(self) -> None:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -8,6 +8,7 @@ import sys
 from typing import TYPE_CHECKING, NoReturn
 
 import pytest
+import structlog
 
 from mindroom.constants import RuntimePaths
 from mindroom.logging_config import get_logger, setup_logging
@@ -59,6 +60,51 @@ def test_setup_logging_json_mode_emits_expected_fields(
     assert payload["logger"] == "tests.logging"
     assert payload["room_id"] == "!room:example.org"
     assert "timestamp" in payload
+
+
+def test_setup_logging_json_mode_defaults_thread_id_to_null_for_room_level_logs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Room-level logs should still emit a null thread_id field."""
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    structlog.contextvars.clear_contextvars()
+    setup_logging(level="INFO", runtime_paths=_runtime_paths(tmp_path))
+    capsys.readouterr()
+
+    with structlog.contextvars.bound_contextvars(room_id="!room:example.org"):
+        get_logger("tests.logging").info("room_level_event")
+
+    payload = _last_stderr_payload(capsys)
+
+    assert payload["event"] == "room_level_event"
+    assert payload["room_id"] == "!room:example.org"
+    assert payload["thread_id"] is None
+
+
+def test_setup_logging_json_mode_includes_thread_id_for_threaded_logs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Thread-scoped logs should include the bound thread id."""
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    structlog.contextvars.clear_contextvars()
+    setup_logging(level="INFO", runtime_paths=_runtime_paths(tmp_path))
+    capsys.readouterr()
+
+    with structlog.contextvars.bound_contextvars(
+        room_id="!room:example.org",
+        thread_id="$thread:example.org",
+    ):
+        get_logger("tests.logging").info("threaded_event")
+
+    payload = _last_stderr_payload(capsys)
+
+    assert payload["event"] == "threaded_event"
+    assert payload["room_id"] == "!room:example.org"
+    assert payload["thread_id"] == "$thread:example.org"
 
 
 def test_setup_logging_json_mode_includes_logger_for_foreign_logger(


### PR DESCRIPTION
## Summary
- bind `thread_id` into the structured logging context across message, reaction, scheduling, delivery, and dispatch paths
- include `thread_id: null` explicitly for room-level logs so log consumers always get a stable field
- restack the message-entry logging hunk so the extracted patch is valid on current `main`

## Verification
- `python -m pre_commit run --files src/mindroom/bot.py src/mindroom/delivery_gateway.py src/mindroom/dispatch_planner.py src/mindroom/interactive.py src/mindroom/logging_config.py src/mindroom/response_coordinator.py src/mindroom/scheduling.py tests/test_logging_config.py tests/test_bot_scheduling.py`
- `PYTHONPATH="$PWD/src" .venv/bin/pytest -q tests/test_logging_config.py tests/test_bot_scheduling.py -k "thread_id or logging"`