### PR TITLE
Propagate MessageTarget through response delivery paths

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -2438,18 +2438,20 @@ class AgentBot:
         target: MessageTarget | None = None,
     ) -> str | None:
         """Send a response message to a room."""
+        resolved_target = target or self._conversation_resolver.build_message_target(
+            room_id=room_id,
+            thread_id=thread_id,
+            reply_to_event_id=reply_to_event_id,
+            event_source=reply_to_event.source if reply_to_event is not None else None,
+            thread_mode_override=thread_mode_override,
+        )
         return await self._delivery_gateway.send_text(
             SendTextRequest(
-                room_id=room_id,
-                reply_to_event_id=reply_to_event_id,
+                target=resolved_target,
                 response_text=response_text,
-                thread_id=thread_id,
-                reply_to_event=reply_to_event,
                 skip_mentions=skip_mentions,
                 tool_trace=tool_trace,
                 extra_content=extra_content,
-                thread_mode_override=thread_mode_override,
-                target=target,
             ),
         )
 
@@ -2503,10 +2505,13 @@ class AgentBot:
         """
         return await self._delivery_gateway.edit_text(
             EditTextRequest(
-                room_id=room_id,
+                target=self._conversation_resolver.build_message_target(
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    reply_to_event_id=None,
+                ),
                 event_id=event_id,
                 new_text=new_text,
-                thread_id=thread_id,
                 tool_trace=tool_trace,
                 extra_content=extra_content,
             ),

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from html import escape as html_escape
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal
 
 import nio
 
@@ -50,12 +50,6 @@ if TYPE_CHECKING:
     from mindroom.streaming import _StreamInputChunk
     from mindroom.timing import DispatchPipelineTiming
     from mindroom.tool_system.events import ToolTraceEntry
-
-
-class _ReplyEventWithSource(Protocol):
-    """Minimal reply event surface needed for threaded send resolution."""
-
-    source: dict[str, Any]
 
 
 class SuppressedPlaceholderCleanupError(RuntimeError):
@@ -166,26 +160,20 @@ class DeliveryResult:
 class SendTextRequest:
     """Parameters for one visible Matrix send."""
 
-    room_id: str
-    reply_to_event_id: str | None
+    target: MessageTarget
     response_text: str
-    thread_id: str | None
-    reply_to_event: _ReplyEventWithSource | None = None
     skip_mentions: bool = False
     tool_trace: list[ToolTraceEntry] | None = None
     extra_content: dict[str, Any] | None = None
-    thread_mode_override: Literal["thread", "room"] | None = None
-    target: MessageTarget | None = None
 
 
 @dataclass(frozen=True)
 class EditTextRequest:
     """Parameters for one Matrix edit."""
 
-    room_id: str
+    target: MessageTarget
     event_id: str
     new_text: str
-    thread_id: str | None
     tool_trace: list[ToolTraceEntry] | None = None
     extra_content: dict[str, Any] | None = None
 
@@ -194,10 +182,7 @@ class EditTextRequest:
 class FinalDeliveryRequest:
     """Parameters for final hook-wrapped response delivery."""
 
-    room_id: str
-    reply_to_event_id: str
-    thread_id: str | None
-    target: MessageTarget | None
+    target: MessageTarget
     existing_event_id: str | None
     response_text: str
     response_kind: str
@@ -213,10 +198,8 @@ class FinalDeliveryRequest:
 class CompactionNoticeRequest:
     """Parameters for a compaction notice send."""
 
-    room_id: str
-    reply_to_event_id: str
+    target: MessageTarget
     main_response_event_id: str
-    thread_id: str | None
     outcome: CompactionOutcome
 
 
@@ -224,14 +207,10 @@ class CompactionNoticeRequest:
 class StreamingDeliveryRequest:
     """Parameters for streamed Matrix delivery."""
 
-    room_id: str
-    reply_to_event_id: str
-    response_thread_id: str | None
+    target: MessageTarget
     response_stream: AsyncIterator[_StreamInputChunk]
     existing_event_id: str | None = None
     adopt_existing_placeholder: bool = False
-    target: MessageTarget | None = None
-    room_mode: bool = False
     header: str | None = None
     show_tool_calls: bool = False
     extra_content: dict[str, Any] | None = None
@@ -258,9 +237,6 @@ class DeliveryGatewayDeps:
 class FinalizeStreamedResponseRequest:
     """Parameters for finalizing one streamed Matrix response."""
 
-    room_id: str
-    reply_to_event_id: str
-    thread_id: str | None
     target: MessageTarget
     streamed_event_id: str
     streamed_text: str
@@ -321,13 +297,7 @@ class DeliveryGateway:
         """Send one response message to a room."""
         client = self._client()
         config = self.deps.runtime.config
-        resolved_target = request.target or self.deps.resolver.build_message_target(
-            room_id=request.room_id,
-            thread_id=request.thread_id,
-            reply_to_event_id=request.reply_to_event_id,
-            event_source=request.reply_to_event.source if request.reply_to_event else None,
-            thread_mode_override=request.thread_mode_override,
-        )
+        resolved_target = request.target
         effective_thread_id = resolved_target.resolved_thread_id
 
         if effective_thread_id is None:
@@ -345,7 +315,7 @@ class DeliveryGateway:
         else:
             latest_thread_event_id = await get_latest_thread_event_id_if_needed(
                 client,
-                request.room_id,
+                resolved_target.room_id,
                 effective_thread_id,
                 resolved_target.reply_to_event_id,
             )
@@ -364,22 +334,23 @@ class DeliveryGateway:
         if request.skip_mentions:
             content["com.mindroom.skip_mentions"] = True
 
-        event_id = await send_message(client, request.room_id, content)
+        event_id = await send_message(client, resolved_target.room_id, content)
         if event_id:
-            self.deps.logger.info("Sent response", event_id=event_id, room_id=request.room_id)
+            self.deps.logger.info("Sent response", event_id=event_id, **resolved_target.log_context)
             return event_id
-        self.deps.logger.error("Failed to send response to room", room_id=request.room_id)
+        self.deps.logger.error("Failed to send response to room", **resolved_target.log_context)
         return None
 
     async def edit_text(self, request: EditTextRequest) -> bool:
         """Edit one existing response message."""
         client = self._client()
         config = self.deps.runtime.config
+        target = request.target
         if (
             config.get_entity_thread_mode(
                 self.deps.agent_name,
                 self.deps.runtime_paths,
-                room_id=request.room_id,
+                room_id=target.room_id,
             )
             == "room"
         ):
@@ -394,9 +365,9 @@ class DeliveryGateway:
         else:
             content = await build_threaded_edit_content(
                 client,
-                room_id=request.room_id,
+                room_id=target.room_id,
                 new_text=request.new_text,
-                thread_id=request.thread_id,
+                thread_id=target.resolved_thread_id,
                 config=config,
                 runtime_paths=self.deps.runtime_paths,
                 sender_domain=self.deps.sender_domain,
@@ -406,15 +377,20 @@ class DeliveryGateway:
 
         response = await edit_message(
             client,
-            request.room_id,
+            target.room_id,
             request.event_id,
             content,
             request.new_text,
         )
         if isinstance(response, nio.RoomSendResponse):
-            self.deps.logger.info("Edited message", event_id=request.event_id)
+            self.deps.logger.info("Edited message", event_id=request.event_id, **target.log_context)
             return True
-        self.deps.logger.error("Failed to edit message", event_id=request.event_id, error=str(response))
+        self.deps.logger.error(
+            "Failed to edit message",
+            event_id=request.event_id,
+            error=str(response),
+            **target.log_context,
+        )
         return False
 
     async def redact_suppressed_response_event(
@@ -518,7 +494,7 @@ class DeliveryGateway:
             )
             if request.existing_event_id is not None and request.existing_event_is_placeholder:
                 return await self.redact_suppressed_response_event(
-                    room_id=request.room_id,
+                    room_id=request.target.room_id,
                     event_id=request.existing_event_id,
                     response_text=draft.response_text,
                     reason="Suppressed placeholder response",
@@ -532,14 +508,13 @@ class DeliveryGateway:
 
         interactive_response = interactive.parse_and_format_interactive(draft.response_text, extract_mapping=True)
         display_text = interactive_response.formatted_text
-        resolved_target = request.target or request.response_envelope.target
+        resolved_target = request.target
         if request.existing_event_id:
             edited = await self.edit_text(
                 EditTextRequest(
-                    room_id=request.room_id,
+                    target=resolved_target,
                     event_id=request.existing_event_id,
                     new_text=display_text,
-                    thread_id=resolved_target.resolved_thread_id,
                     tool_trace=draft.tool_trace,
                     extra_content=draft.extra_content,
                 ),
@@ -549,13 +524,10 @@ class DeliveryGateway:
         else:
             event_id = await self.send_text(
                 SendTextRequest(
-                    room_id=request.room_id,
-                    reply_to_event_id=request.reply_to_event_id,
+                    target=resolved_target,
                     response_text=display_text,
-                    thread_id=request.thread_id,
                     tool_trace=draft.tool_trace,
                     extra_content=draft.extra_content,
-                    target=resolved_target,
                 ),
             )
             delivery_kind = "sent" if event_id else None
@@ -584,11 +556,8 @@ class DeliveryGateway:
         client = self._client()
         summary_line = request.outcome.format_notice()
         formatted_body = f"<em>{html_escape(summary_line).replace(chr(10), '<br/>')}</em>"
-        effective_thread_id = self.deps.resolver.build_message_target(
-            room_id=request.room_id,
-            thread_id=request.thread_id,
-            reply_to_event_id=request.reply_to_event_id,
-        ).resolved_thread_id
+        target = request.target
+        effective_thread_id = target.resolved_thread_id
         content = build_message_content(
             summary_line,
             formatted_body=formatted_body,
@@ -600,16 +569,16 @@ class DeliveryGateway:
                 "com.mindroom.skip_mentions": True,
             },
         )
-        event_id = await send_message(client, request.room_id, content)
+        event_id = await send_message(client, target.room_id, content)
         if event_id:
             self.deps.logger.info(
                 "Sent compaction notice",
                 event_id=event_id,
-                room_id=request.room_id,
+                **target.log_context,
                 summary_model=request.outcome.summary_model,
             )
             return event_id
-        self.deps.logger.error("Failed to send compaction notice", room_id=request.room_id)
+        self.deps.logger.error("Failed to send compaction notice", **target.log_context)
         return None
 
     async def deliver_stream(
@@ -621,9 +590,9 @@ class DeliveryGateway:
         config = self.deps.runtime.config
         return await send_streaming_response(
             client,
-            request.room_id,
-            request.reply_to_event_id,
-            request.response_thread_id,
+            request.target.room_id,
+            request.target.reply_to_event_id,
+            request.target.resolved_thread_id,
             self.deps.sender_domain,
             config,
             self.deps.runtime_paths,
@@ -634,7 +603,7 @@ class DeliveryGateway:
             existing_event_id=request.existing_event_id,
             adopt_existing_placeholder=request.adopt_existing_placeholder,
             target=request.target,
-            room_mode=request.room_mode,
+            room_mode=request.target.is_room_mode,
             extra_content=request.extra_content,
             tool_trace_collector=request.tool_trace_collector,
             pipeline_timing=request.pipeline_timing,
@@ -662,7 +631,7 @@ class DeliveryGateway:
             )
             if request.cleanup_suppressed_streamed_event:
                 return await self.cleanup_suppressed_streamed_response(
-                    room_id=request.room_id,
+                    room_id=request.target.room_id,
                     event_id=request.streamed_event_id,
                     response_text=request.streamed_text,
                     response_kind=request.response_kind,
@@ -689,9 +658,6 @@ class DeliveryGateway:
         if needs_final_edit:
             return await self.deliver_final(
                 FinalDeliveryRequest(
-                    room_id=request.room_id,
-                    reply_to_event_id=request.reply_to_event_id,
-                    thread_id=request.thread_id,
                     target=request.target,
                     existing_event_id=request.streamed_event_id,
                     response_text=draft.response_text,

--- a/src/mindroom/dispatch_planner.py
+++ b/src/mindroom/dispatch_planner.py
@@ -766,13 +766,16 @@ class DispatchPlanner:
             reply_to_event: nio.RoomMessageText | None = None,
             skip_mentions: bool = False,
         ) -> str | None:
+            target = self.deps.resolver.build_message_target(
+                room_id=room_id,
+                thread_id=thread_id,
+                reply_to_event_id=reply_to_event_id,
+                event_source=reply_to_event.source if reply_to_event is not None else None,
+            )
             return await self.deps.delivery_gateway.send_text(
                 SendTextRequest(
-                    room_id=room_id,
-                    reply_to_event_id=reply_to_event_id,
+                    target=target,
                     response_text=response_text,
-                    thread_id=thread_id,
-                    reply_to_event=reply_to_event,
                     skip_mentions=skip_mentions,
                 ),
             )
@@ -941,11 +944,8 @@ class DispatchPlanner:
 
         event_id = await self.deps.delivery_gateway.send_text(
             SendTextRequest(
-                room_id=room.room_id,
-                reply_to_event_id=event.event_id,
-                response_text=response_text,
-                thread_id=resolved_target.thread_id,
                 target=resolved_target,
+                response_text=response_text,
                 extra_content=routed_extra_content or None,
             ),
         )
@@ -996,10 +996,8 @@ class DispatchPlanner:
             assert action.rejection_message is not None
             response_event_id = await self.deps.delivery_gateway.send_text(
                 SendTextRequest(
-                    room_id=room.room_id,
-                    reply_to_event_id=event.event_id,
+                    target=dispatch.target,
                     response_text=action.rejection_message,
-                    thread_id=dispatch.context.thread_id,
                 ),
             )
             self._mark_source_events_responded(
@@ -1150,10 +1148,12 @@ class DispatchPlanner:
         terminal_extra_content = {STREAM_STATUS_KEY: STREAM_STATUS_COMPLETED}
         return await self.deps.delivery_gateway.send_text(
             SendTextRequest(
-                room_id=room_id,
-                reply_to_event_id=reply_to_event_id,
+                target=self.deps.resolver.build_message_target(
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    reply_to_event_id=reply_to_event_id,
+                ),
                 response_text=error_text,
-                thread_id=thread_id,
                 extra_content=terminal_extra_content,
             ),
         )

--- a/src/mindroom/message_target.py
+++ b/src/mindroom/message_target.py
@@ -27,6 +27,11 @@ class MessageTarget:
         """Return whether the target resolves to room-level delivery."""
         return self.resolved_thread_id is None
 
+    @property
+    def log_context(self) -> dict[str, str | None]:
+        """Return the canonical room/thread log fields for this target."""
+        return {"room_id": self.room_id, "thread_id": self.resolved_thread_id}
+
     @staticmethod
     def _build_session_id(room_id: str, resolved_thread_id: str | None) -> str:
         """Build the canonical persisted session ID for one target."""

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from mindroom import constants, interactive
 from mindroom.background_tasks import create_background_task
 from mindroom.delivery_gateway import CompactionNoticeRequest
+from mindroom.message_target import MessageTarget
 from mindroom.thread_summary import maybe_generate_thread_summary
 from mindroom.timing import timed
 
@@ -25,7 +26,6 @@ if TYPE_CHECKING:
     from mindroom.history.types import CompactionOutcome
     from mindroom.matrix.client import ResolvedVisibleMessage
     from mindroom.matrix.conversation_access import ConversationReadAccess
-    from mindroom.message_target import MessageTarget
     from mindroom.stop import StopManager
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
@@ -150,10 +150,12 @@ class PostResponseEffectsSupport:
                 continue
             await self.delivery_gateway.send_compaction_notice(
                 CompactionNoticeRequest(
-                    room_id=room_id,
-                    reply_to_event_id=reply_to_event_id,
+                    target=MessageTarget.resolve(
+                        room_id=room_id,
+                        thread_id=thread_id,
+                        reply_to_event_id=reply_to_event_id,
+                    ),
                     main_response_event_id=main_response_event_id,
-                    thread_id=thread_id,
                     outcome=outcome,
                 ),
             )

--- a/src/mindroom/response_coordinator.py
+++ b/src/mindroom/response_coordinator.py
@@ -465,7 +465,7 @@ class ResponseCoordinator:
         return {
             event_id
             for event_id, tracked in self.deps.stop_manager.tracked_messages.items()
-            if tracked.room_id == room_id and not tracked.task.done()
+            if tracked.target.room_id == room_id and not tracked.task.done()
         }
 
     async def _run_locked_response_lifecycle(
@@ -731,14 +731,6 @@ class ResponseCoordinator:
             self.deps.runtime.config,
             self.deps.runtime_paths,
         )
-        room_mode = (
-            self.deps.runtime.config.get_entity_thread_mode(
-                self.deps.agent_name,
-                self.deps.runtime_paths,
-                room_id=request.room_id,
-            )
-            == "room"
-        )
         use_streaming = await should_use_streaming(
             self._client(),
             request.room_id,
@@ -901,15 +893,11 @@ class ResponseCoordinator:
 
                     event_id, accumulated = await self.deps.delivery_gateway.deliver_stream(
                         StreamingDeliveryRequest(
-                            room_id=request.room_id,
-                            reply_to_event_id=request.reply_to_event_id,
-                            response_thread_id=delivery_target.resolved_thread_id,
+                            target=delivery_target,
                             response_stream=response_stream,
                             existing_event_id=delivery_request.existing_event_id,
                             adopt_existing_placeholder=delivery_request.existing_event_id is not None
                             and delivery_request.existing_event_is_placeholder,
-                            target=delivery_target,
-                            room_mode=room_mode,
                             header=None,
                             show_tool_calls=show_tool_calls,
                             streaming_cls=ReplacementStreamingResponse,
@@ -929,9 +917,6 @@ class ResponseCoordinator:
                 delivery_kind: Literal["sent", "edited"] = "edited" if message_id else "sent"
                 delivery_result = await self.deps.delivery_gateway.finalize_streamed_response(
                     FinalizeStreamedResponseRequest(
-                        room_id=request.room_id,
-                        reply_to_event_id=request.reply_to_event_id,
-                        thread_id=request.thread_id,
                         target=delivery_target,
                         streamed_event_id=event_id,
                         streamed_text=accumulated,
@@ -1001,10 +986,9 @@ class ResponseCoordinator:
                         cancelled_text, extra_content = self._cancelled_response_update(restart=restart)
                         await self.deps.delivery_gateway.edit_text(
                             EditTextRequest(
-                                room_id=request.room_id,
+                                target=delivery_target,
                                 event_id=message_id,
                                 new_text=cancelled_text,
-                                thread_id=delivery_target.resolved_thread_id,
                                 extra_content=extra_content,
                             ),
                         )
@@ -1012,9 +996,6 @@ class ResponseCoordinator:
 
                 delivery_result = await self.deps.delivery_gateway.deliver_final(
                     FinalDeliveryRequest(
-                        room_id=request.room_id,
-                        reply_to_event_id=request.reply_to_event_id,
-                        thread_id=request.thread_id,
                         target=delivery_target,
                         existing_event_id=message_id,
                         existing_event_is_placeholder=delivery_request.existing_event_is_placeholder,
@@ -1102,11 +1083,8 @@ class ResponseCoordinator:
                 assert not existing_event_id
                 initial_message_id = await self.deps.delivery_gateway.send_text(
                     SendTextRequest(
-                        room_id=room_id,
-                        reply_to_event_id=reply_to_event_id,
-                        response_text=thinking_message,
-                        thread_id=thread_id,
                         target=resolved_target,
+                        response_text=thinking_message,
                         extra_content={STREAM_STATUS_KEY: STREAM_STATUS_PENDING},
                     ),
                 )
@@ -1123,7 +1101,7 @@ class ResponseCoordinator:
 
             self.deps.stop_manager.set_current(
                 tracked_message_id,
-                room_id,
+                resolved_target,
                 task,
                 None,
                 run_id=run_id,
@@ -1147,7 +1125,7 @@ class ResponseCoordinator:
 
                 if show_stop_button:
                     self.deps.logger.info("Adding stop button", message_id=message_to_track)
-                    await self.deps.stop_manager.add_stop_button(self._client(), room_id, message_to_track)
+                    await self.deps.stop_manager.add_stop_button(self._client(), message_to_track)
 
             try:
                 await task
@@ -1390,15 +1368,11 @@ class ResponseCoordinator:
             )
             event_id, accumulated = await self.deps.delivery_gateway.deliver_stream(
                 StreamingDeliveryRequest(
-                    room_id=request.room_id,
-                    reply_to_event_id=request.reply_to_event_id,
-                    response_thread_id=runtime.response_thread_id,
+                    target=runtime.resolved_target,
                     response_stream=wrapped_response_stream,
                     existing_event_id=request.existing_event_id,
                     adopt_existing_placeholder=request.existing_event_id is not None
                     and request.existing_event_is_placeholder,
-                    target=runtime.resolved_target,
-                    room_mode=runtime.room_mode,
                     show_tool_calls=self._show_tool_calls(),
                     extra_content=response_extra_content,
                     tool_trace_collector=tool_trace,
@@ -1460,10 +1434,9 @@ class ResponseCoordinator:
                 cancelled_text, extra_content = self._cancelled_response_update(restart=restart)
                 await self.deps.delivery_gateway.edit_text(
                     EditTextRequest(
-                        room_id=request.room_id,
+                        target=runtime.resolved_target,
                         event_id=request.existing_event_id,
                         new_text=cancelled_text,
-                        thread_id=runtime.response_thread_id,
                         extra_content=extra_content,
                     ),
                 )
@@ -1478,9 +1451,6 @@ class ResponseCoordinator:
         )
         delivery = await self.deps.delivery_gateway.deliver_final(
             FinalDeliveryRequest(
-                room_id=request.room_id,
-                reply_to_event_id=request.reply_to_event_id,
-                thread_id=request.thread_id,
                 target=runtime.resolved_target,
                 existing_event_id=request.existing_event_id,
                 existing_event_is_placeholder=request.existing_event_is_placeholder,
@@ -1595,9 +1565,6 @@ class ResponseCoordinator:
 
         delivery = await self.deps.delivery_gateway.finalize_streamed_response(
             FinalizeStreamedResponseRequest(
-                room_id=request.room_id,
-                reply_to_event_id=request.reply_to_event_id,
-                thread_id=request.thread_id,
                 target=runtime.resolved_target,
                 streamed_event_id=event_id,
                 streamed_text=accumulated,
@@ -1747,12 +1714,8 @@ class ResponseCoordinator:
         response = interactive.parse_and_format_interactive(response_text, extract_mapping=True)
         event_id = await self.deps.delivery_gateway.send_text(
             SendTextRequest(
-                room_id=room_id,
-                reply_to_event_id=reply_to_event_id,
-                response_text=response.formatted_text,
-                thread_id=thread_id,
                 target=resolved_target,
-                reply_to_event=reply_to_event,
+                response_text=response.formatted_text,
                 skip_mentions=True,
                 tool_trace=tool_trace if show_tool_calls else None,
                 extra_content=run_metadata_content or None,

--- a/src/mindroom/stop.py
+++ b/src/mindroom/stop.py
@@ -15,6 +15,8 @@ from mindroom.logging_config import get_logger
 if TYPE_CHECKING:
     from nio import AsyncClient
 
+    from mindroom.message_target import MessageTarget
+
 logger = get_logger(__name__)
 _GRACEFUL_CANCEL_FALLBACK_SECONDS = 10.0
 _GRACEFUL_CANCEL_PROBE_SECONDS = 0.25
@@ -25,7 +27,7 @@ class _TrackedMessage:
     """Track a message with stop button."""
 
     message_id: str
-    room_id: str
+    target: MessageTarget
     task: asyncio.Task[None]
     reaction_event_id: str | None = None
     run_id: str | None = None
@@ -37,17 +39,23 @@ class StopManager:
 
     def __init__(self, graceful_cancel_fallback_seconds: float = _GRACEFUL_CANCEL_FALLBACK_SECONDS) -> None:
         """Initialize the stop manager."""
-        # Track multiple concurrent messages by message_id
         self.tracked_messages: dict[str, _TrackedMessage] = {}
-        # Keep references to cleanup tasks
         self.cleanup_tasks: list[asyncio.Task[None]] = []
         self.graceful_cancel_fallback_seconds = graceful_cancel_fallback_seconds
         logger.info("StopManager initialized")
 
+    @staticmethod
+    def _log_target(target: MessageTarget) -> dict[str, str | None]:
+        """Return standard room/thread fields for tracked-message logs."""
+        return {
+            "room_id": target.room_id,
+            "thread_id": target.resolved_thread_id,
+        }
+
     def set_current(
         self,
         message_id: str,
-        room_id: str,
+        target: MessageTarget,
         task: asyncio.Task[None],
         reaction_event_id: str | None = None,
         run_id: str | None = None,
@@ -55,7 +63,7 @@ class StopManager:
         """Track a message generation."""
         self.tracked_messages[message_id] = _TrackedMessage(
             message_id=message_id,
-            room_id=room_id,
+            target=target,
             task=task,
             reaction_event_id=reaction_event_id,
             run_id=run_id,
@@ -63,10 +71,10 @@ class StopManager:
         logger.info(
             "Tracking message generation",
             message_id=message_id,
-            room_id=room_id,
             reaction_event_id=reaction_event_id,
             run_id=run_id,
             total_tracked=len(self.tracked_messages),
+            **self._log_target(target),
         )
 
     def update_run_id(self, message_id: str | None, run_id: str | None) -> None:
@@ -86,6 +94,7 @@ class StopManager:
             previous_run_id=previous_run_id,
             run_id=run_id,
             cancel_requested=tracked.cancel_requested,
+            **self._log_target(tracked.target),
         )
 
         if tracked.cancel_requested and run_id:
@@ -93,6 +102,7 @@ class StopManager:
                 "Stop already requested; scheduling best-effort cleanup for updated run id",
                 message_id=message_id,
                 run_id=run_id,
+                **self._log_target(tracked.target),
             )
             self._schedule_graceful_run_cancel(message_id, run_id)
 
@@ -115,6 +125,8 @@ class StopManager:
 
     async def _probe_graceful_cancel(self, message_id: str, run_id: str, deadline: float) -> str:
         """Request Agno run cancellation for one known run during the post-cancel probe window."""
+        tracked = self.tracked_messages.get(message_id)
+        target_log = self._log_target(tracked.target) if tracked is not None else {}
         loop = asyncio.get_running_loop()
         probe_deadline = min(deadline, loop.time() + _GRACEFUL_CANCEL_PROBE_SECONDS)
         while loop.time() < probe_deadline:
@@ -127,6 +139,7 @@ class StopManager:
                         "Requested Agno run cancellation after hard task cancel",
                         message_id=message_id,
                         run_id=run_id,
+                        **target_log,
                     )
                     return "requested"
             except TimeoutError:
@@ -134,6 +147,7 @@ class StopManager:
                     "Agno run cancellation request timed out after hard task cancel",
                     message_id=message_id,
                     run_id=run_id,
+                    **target_log,
                 )
                 return "manager_failed"
             except Exception as exc:
@@ -142,6 +156,7 @@ class StopManager:
                     message_id=message_id,
                     run_id=run_id,
                     error=str(exc),
+                    **target_log,
                 )
                 return "manager_failed"
 
@@ -151,6 +166,8 @@ class StopManager:
 
     async def _graceful_run_cancel_cleanup(self, message_id: str, run_id: str) -> None:
         """Best-effort Agno run cleanup after the response task was already hard-cancelled."""
+        tracked = self.tracked_messages.get(message_id)
+        target_log = self._log_target(tracked.target) if tracked is not None else {}
         try:
             loop = asyncio.get_running_loop()
             deadline = loop.time() + self.graceful_cancel_fallback_seconds
@@ -161,6 +178,7 @@ class StopManager:
                     "Agno cancellation manager unavailable after hard task cancel",
                     message_id=message_id,
                     run_id=run_id,
+                    **target_log,
                 )
                 return
 
@@ -170,6 +188,7 @@ class StopManager:
                     message_id=message_id,
                     run_id=run_id,
                     cancel_requested=True,
+                    **target_log,
                 )
                 return
 
@@ -179,6 +198,7 @@ class StopManager:
                     message_id=message_id,
                     run_id=run_id,
                     outcome=outcome,
+                    **target_log,
                 )
                 return
 
@@ -186,12 +206,14 @@ class StopManager:
                 "Finished graceful Agno cancellation cleanup after hard task cancel",
                 message_id=message_id,
                 run_id=run_id,
+                **target_log,
             )
         except asyncio.CancelledError:
             logger.warning(
                 "Graceful cancellation probe was cancelled after hard task cancel",
                 message_id=message_id,
                 run_id=run_id,
+                **target_log,
             )
             raise
 
@@ -206,43 +228,52 @@ class StopManager:
         remove_button: bool = True,
         delay: float = 5.0,
     ) -> None:
-        """Clear tracking for a specific message and optionally remove stop button.
-
-        Args:
-            message_id: The message ID to clear
-            client: Matrix client for removing stop button
-            remove_button: Whether to remove the stop button (default True)
-            delay: Seconds to wait before clearing (default 5.0)
-
-        """
+        """Clear tracking for a specific message and optionally remove stop button."""
 
         async def delayed_clear() -> None:
             """Clear the message and remove stop button after a delay."""
             if remove_button and message_id in self.tracked_messages:
                 tracked = self.tracked_messages[message_id]
                 if tracked.reaction_event_id:
-                    logger.info("Removing stop button in cleanup", message_id=message_id)
+                    logger.info(
+                        "Removing stop button in cleanup",
+                        message_id=message_id,
+                        **self._log_target(tracked.target),
+                    )
                     try:
                         await client.room_redact(
-                            room_id=tracked.room_id,
+                            room_id=tracked.target.room_id,
                             event_id=tracked.reaction_event_id,
                             reason="Response completed",
                         )
                         tracked.reaction_event_id = None
                     except Exception as e:
-                        logger.warning("stop_button_cleanup_failed", message_id=message_id, error=str(e))
+                        logger.warning(
+                            "stop_button_cleanup_failed",
+                            message_id=message_id,
+                            error=str(e),
+                            **self._log_target(tracked.target),
+                        )
 
             await asyncio.sleep(delay)
             if message_id in self.tracked_messages:
-                logger.info("Clearing tracked message after delay", message_id=message_id, delay=delay)
+                tracked = self.tracked_messages[message_id]
+                logger.info(
+                    "Clearing tracked message after delay",
+                    message_id=message_id,
+                    delay=delay,
+                    **self._log_target(tracked.target),
+                )
                 del self.tracked_messages[message_id]
 
         if message_id in self.tracked_messages:
+            tracked = self.tracked_messages[message_id]
             logger.info(
                 "Scheduling message cleanup",
                 message_id=message_id,
                 delay=delay,
                 remove_button=remove_button,
+                **self._log_target(tracked.target),
             )
             self._track_cleanup_task(asyncio.create_task(delayed_clear()))
         else:
@@ -253,17 +284,23 @@ class StopManager:
 
         Returns True if hard cancellation was initiated or is already in progress, False otherwise.
         """
+        tracked = self.tracked_messages.get(message_id)
+        target_log = self._log_target(tracked.target) if tracked is not None else {}
         logger.info(
             "Handling stop reaction",
             message_id=message_id,
             tracked_messages=list(self.tracked_messages.keys()),
+            **target_log,
         )
 
-        if message_id in self.tracked_messages:
-            tracked = self.tracked_messages[message_id]
+        if tracked is not None:
             if tracked.task and not tracked.task.done():
                 if tracked.cancel_requested:
-                    logger.info("Cancellation already requested for message", message_id=message_id)
+                    logger.info(
+                        "Cancellation already requested for message",
+                        message_id=message_id,
+                        **target_log,
+                    )
                     return True
 
                 tracked.cancel_requested = True
@@ -271,6 +308,7 @@ class StopManager:
                     "Hard cancelling tracked response task",
                     message_id=message_id,
                     run_id=tracked.run_id,
+                    **target_log,
                 )
                 tracked.task.cancel()
                 if tracked.run_id:
@@ -278,32 +316,36 @@ class StopManager:
                         "Scheduling best-effort Agno run cleanup after hard task cancel",
                         message_id=message_id,
                         run_id=tracked.run_id,
+                        **target_log,
                     )
                     self._schedule_graceful_run_cancel(message_id, tracked.run_id)
-
-                # Don't clear here - let the finally block handle it
                 return True
             logger.info(
                 "Task already completed or missing",
                 message_id=message_id,
                 task_exists=tracked.task is not None,
                 task_done=tracked.task.done() if tracked.task else None,
+                **target_log,
             )
         else:
             logger.warning("Stop reaction for untracked message", message_id=message_id)
         return False
 
-    async def add_stop_button(self, client: AsyncClient, room_id: str, message_id: str) -> str | None:
-        """Add a stop button reaction to a message.
+    async def add_stop_button(self, client: AsyncClient, message_id: str) -> str | None:
+        """Add a stop button reaction to a tracked message."""
+        tracked = self.tracked_messages.get(message_id)
+        if tracked is None:
+            logger.warning("Cannot add stop button for untracked message", message_id=message_id)
+            return None
 
-        Returns:
-            The event ID of the reaction if successful, None otherwise.
-
-        """
-        logger.info("Adding stop button", room_id=room_id, message_id=message_id)
+        logger.info(
+            "Adding stop button",
+            message_id=message_id,
+            **self._log_target(tracked.target),
+        )
         try:
             response = await client.room_send(
-                room_id=room_id,
+                room_id=tracked.target.room_id,
                 message_type="m.reaction",
                 content={
                     "m.relates_to": {
@@ -315,47 +357,58 @@ class StopManager:
             )
             if isinstance(response, nio.RoomSendResponse):
                 event_id = str(response.event_id)
-                logger.info("Stop button added successfully", reaction_event_id=event_id, message_id=message_id)
-                # Update the tracked message with the reaction event ID
-                if message_id in self.tracked_messages:
-                    self.tracked_messages[message_id].reaction_event_id = event_id
+                logger.info(
+                    "Stop button added successfully",
+                    reaction_event_id=event_id,
+                    message_id=message_id,
+                    **self._log_target(tracked.target),
+                )
+                tracked.reaction_event_id = event_id
                 return event_id
-            logger.warning("Failed to add stop button - no event_id in response", response=response)
+            logger.warning(
+                "Failed to add stop button - no event_id in response",
+                response=response,
+                **self._log_target(tracked.target),
+            )
         except Exception as e:
-            logger.exception("Exception adding stop button", error=str(e))
+            logger.exception(
+                "Exception adding stop button",
+                error=str(e),
+                **self._log_target(tracked.target),
+            )
         return None
 
     async def remove_stop_button(self, client: AsyncClient, message_id: str | None = None) -> None:
-        """Remove the stop button reaction immediately when user clicks it.
-
-        Args:
-            client: The Matrix client
-            message_id: The message ID to remove the button from
-
-        """
+        """Remove the stop button reaction immediately when user clicks it."""
         if message_id and message_id in self.tracked_messages:
             tracked = self.tracked_messages[message_id]
-            if tracked.reaction_event_id and tracked.room_id:
+            if tracked.reaction_event_id:
                 logger.info(
                     "Removing stop button immediately (user clicked)",
                     message_id=message_id,
                     reaction_event_id=tracked.reaction_event_id,
+                    **self._log_target(tracked.target),
                 )
                 try:
                     await client.room_redact(
-                        room_id=tracked.room_id,
+                        room_id=tracked.target.room_id,
                         event_id=tracked.reaction_event_id,
                         reason="User clicked stop",
                     )
                     tracked.reaction_event_id = None
-                    logger.info("Stop button removed successfully")
+                    logger.info("Stop button removed successfully", **self._log_target(tracked.target))
                 except Exception as e:
-                    logger.exception("Failed to remove stop button", error=str(e))
+                    logger.exception(
+                        "Failed to remove stop button",
+                        error=str(e),
+                        **self._log_target(tracked.target),
+                    )
             else:
                 logger.debug(
                     "Stop button already removed or missing",
                     message_id=message_id,
                     has_reaction_id=tracked.reaction_event_id is not None,
+                    **self._log_target(tracked.target),
                 )
         else:
             logger.debug("Message not tracked, cannot remove stop button", message_id=message_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -356,15 +356,15 @@ def install_send_response_mock(bot: object, send_response: AsyncMock) -> None:
 
     async def _send_text(request: SendTextRequest) -> str | None:
         return await send_response(
-            request.room_id,
-            request.reply_to_event_id,
+            request.target.room_id,
+            request.target.reply_to_event_id,
             request.response_text,
-            request.thread_id,
-            reply_to_event=request.reply_to_event,
+            request.target.thread_id,
+            reply_to_event=None,
             skip_mentions=request.skip_mentions,
             tool_trace=request.tool_trace,
             extra_content=request.extra_content,
-            thread_mode_override=request.thread_mode_override,
+            thread_mode_override=None,
             target=request.target,
         )
 
@@ -420,10 +420,10 @@ def install_edit_message_mock(bot: object, edit_message: AsyncMock) -> None:
 
     async def _edit_text(request: EditTextRequest) -> bool:
         return await edit_message(
-            request.room_id,
+            request.target.room_id,
             request.event_id,
             request.new_text,
-            request.thread_id,
+            request.target.thread_id,
             tool_trace=request.tool_trace,
             extra_content=request.extra_content,
         )

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -355,13 +355,11 @@ class TestBotScheduleCommands:
         mock_agent_bot._send_response.assert_called_once()
         call_args = mock_agent_bot._send_response.call_args
         assert "✅" in call_args[0][2] or "Task ID" in call_args[0][2]
-        # The thread_id should be None (will be handled by _send_response)
-        # and the event should be passed for thread creation
-        reply_to_event = call_args[1].get("reply_to_event")
-        assert reply_to_event is not None
-        assert reply_to_event.event_id == event.event_id
-        assert reply_to_event.body == event.body
-        assert reply_to_event.source == event.source
+        target = call_args[1].get("target")
+        assert target is not None
+        assert target.room_id == room.room_id
+        assert target.reply_to_event_id == event.event_id
+        assert target.resolved_thread_id == event.event_id
 
 
 class TestBotTaskRestoration:

--- a/tests/test_cancelled_response_hook.py
+++ b/tests/test_cancelled_response_hook.py
@@ -358,9 +358,6 @@ async def test_suppressed_delivery_emits_cancelled_hook(
     if mode == "final":
         result = await gateway.deliver_final(
             FinalDeliveryRequest(
-                room_id="!room:localhost",
-                reply_to_event_id="$event",
-                thread_id=None,
                 target=MessageTarget.resolve("!room:localhost", None, "$event"),
                 existing_event_id=None,
                 response_text="suppressed",
@@ -374,9 +371,6 @@ async def test_suppressed_delivery_emits_cancelled_hook(
     else:
         result = await gateway.finalize_streamed_response(
             FinalizeStreamedResponseRequest(
-                room_id="!room:localhost",
-                reply_to_event_id="$event",
-                thread_id=None,
                 target=MessageTarget.resolve("!room:localhost", None, "$event"),
                 streamed_event_id="$stream",
                 streamed_text="suppressed",
@@ -455,9 +449,6 @@ async def test_late_after_response_cancellation_preserves_delivery_result(
         if mode == "final":
             delivery_result = await gateway.deliver_final(
                 FinalDeliveryRequest(
-                    room_id="!room:localhost",
-                    reply_to_event_id="$event",
-                    thread_id=None,
                     target=MessageTarget.resolve("!room:localhost", None, "$event"),
                     existing_event_id=None,
                     response_text="visible response",
@@ -472,9 +463,6 @@ async def test_late_after_response_cancellation_preserves_delivery_result(
 
         delivery_result = await gateway.finalize_streamed_response(
             FinalizeStreamedResponseRequest(
-                room_id="!room:localhost",
-                reply_to_event_id="$event",
-                thread_id=None,
                 target=MessageTarget.resolve("!room:localhost", None, "$event"),
                 streamed_event_id="$stream",
                 streamed_text="visible response",

--- a/tests/test_compact_context.py
+++ b/tests/test_compact_context.py
@@ -33,6 +33,7 @@ from mindroom.history.runtime import ScopeSessionContext, open_scope_session_con
 from mindroom.history.storage import read_scope_state, write_scope_state
 from mindroom.history.types import CompactionOutcome, HistoryScope, HistoryScopeState
 from mindroom.matrix.users import AgentMatrixUser
+from mindroom.message_target import MessageTarget
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 from tests.conftest import TEST_PASSWORD, bind_runtime_paths
 
@@ -473,10 +474,8 @@ async def test_send_compaction_notice_omits_zero_breakdown_fields_in_html_body(t
     with patch("mindroom.delivery_gateway.send_message", new=AsyncMock(return_value="$notice")) as mock_send:
         event_id = await bot._delivery_gateway.send_compaction_notice(
             CompactionNoticeRequest(
-                room_id="!room:localhost",
-                reply_to_event_id="$incoming",
+                target=MessageTarget.resolve("!room:localhost", None, "$incoming"),
                 main_response_event_id="$reply",
-                thread_id=None,
                 outcome=outcome,
             ),
         )

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -1834,9 +1834,13 @@ class TestAgentBot:
         done_task = asyncio.create_task(asyncio.sleep(0))
         other_room_task = asyncio.create_task(asyncio.sleep(60))
         await done_task
-        bot.stop_manager.set_current("$active", "!test:localhost", running_task)
-        bot.stop_manager.set_current("$done", "!test:localhost", done_task)
-        bot.stop_manager.set_current("$other-room", "!other:localhost", other_room_task)
+        bot.stop_manager.set_current("$active", MessageTarget.resolve("!test:localhost", None, "$active"), running_task)
+        bot.stop_manager.set_current("$done", MessageTarget.resolve("!test:localhost", None, "$done"), done_task)
+        bot.stop_manager.set_current(
+            "$other-room",
+            MessageTarget.resolve("!other:localhost", None, "$other-room"),
+            other_room_task,
+        )
 
         try:
             mock_ai_response = AsyncMock(return_value="Handled")
@@ -1954,9 +1958,13 @@ class TestAgentBot:
         done_task = asyncio.create_task(asyncio.sleep(0))
         other_room_task = asyncio.create_task(asyncio.sleep(60))
         await done_task
-        bot.stop_manager.set_current("$active", "!test:localhost", running_task)
-        bot.stop_manager.set_current("$done", "!test:localhost", done_task)
-        bot.stop_manager.set_current("$other-room", "!other:localhost", other_room_task)
+        bot.stop_manager.set_current("$active", MessageTarget.resolve("!test:localhost", None, "$active"), running_task)
+        bot.stop_manager.set_current("$done", MessageTarget.resolve("!test:localhost", None, "$done"), done_task)
+        bot.stop_manager.set_current(
+            "$other-room",
+            MessageTarget.resolve("!other:localhost", None, "$other-room"),
+            other_room_task,
+        )
 
         try:
             mock_stream = AsyncMock(return_value=mock_streaming_response())
@@ -2226,9 +2234,6 @@ class TestAgentBot:
 
         delivery = await gateway.deliver_final(
             FinalDeliveryRequest(
-                room_id="!test:localhost",
-                reply_to_event_id="$event123",
-                thread_id="$thread123",
                 target=MessageTarget.resolve("!test:localhost", "$thread123", "$event123"),
                 existing_event_id="$placeholder",
                 existing_event_is_placeholder=True,
@@ -2296,9 +2301,6 @@ class TestAgentBot:
 
         delivery = await gateway.deliver_final(
             FinalDeliveryRequest(
-                room_id="!test:localhost",
-                reply_to_event_id="$event123",
-                thread_id="$thread123",
                 target=MessageTarget.resolve("!test:localhost", "$thread123", "$event123"),
                 existing_event_id="$existing",
                 existing_event_is_placeholder=False,
@@ -2363,9 +2365,6 @@ class TestAgentBot:
         with pytest.raises(SuppressedPlaceholderCleanupError):
             await gateway.deliver_final(
                 FinalDeliveryRequest(
-                    room_id="!test:localhost",
-                    reply_to_event_id="$event123",
-                    thread_id="$thread123",
                     target=MessageTarget.resolve("!test:localhost", "$thread123", "$event123"),
                     existing_event_id="$placeholder",
                     existing_event_is_placeholder=True,
@@ -6991,7 +6990,7 @@ class TestAgentBot:
             tool_trace=None,
             extra_content={STREAM_STATUS_KEY: STREAM_STATUS_COMPLETED},
             thread_mode_override=None,
-            target=None,
+            target=MessageTarget.resolve("!test:localhost", "$thread_root", "$event"),
         )
 
     @pytest.mark.asyncio

--- a/tests/test_skip_mentions.py
+++ b/tests/test_skip_mentions.py
@@ -323,9 +323,6 @@ async def test_delivery_gateway_deliver_final_uses_send_text_for_new_messages(tm
     ):
         result = await gateway.deliver_final(
             FinalDeliveryRequest(
-                room_id="!test:server",
-                reply_to_event_id="$event123",
-                thread_id="$thread",
                 target=_delivery_envelope().target,
                 existing_event_id=None,
                 response_text="raw response",
@@ -366,9 +363,6 @@ async def test_delivery_gateway_deliver_final_uses_edit_text_for_existing_messag
     ):
         result = await gateway.deliver_final(
             FinalDeliveryRequest(
-                room_id="!test:server",
-                reply_to_event_id="$event123",
-                thread_id="$thread",
                 target=_delivery_envelope().target,
                 existing_event_id="$existing",
                 response_text="raw response",

--- a/tests/test_stop_emoji_reuse.py
+++ b/tests/test_stop_emoji_reuse.py
@@ -13,6 +13,7 @@ from mindroom.bot import AgentBot
 from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
 from mindroom.matrix.users import AgentMatrixUser
+from mindroom.message_target import MessageTarget
 from mindroom.stop import StopManager
 from tests.conftest import bind_runtime_paths, orchestrator_runtime_paths, runtime_paths_for
 
@@ -100,7 +101,7 @@ async def test_stop_emoji_only_stops_during_generation(tmp_path: Path) -> None:
         task.done = MagicMock(return_value=False)  # done() is a regular method, not async
         bot.stop_manager.set_current(
             message_id="$message:example.com",
-            room_id="!test:example.com",
+            target=MessageTarget.resolve("!test:example.com", None, "$message:example.com"),
             task=task,
         )
 
@@ -169,7 +170,7 @@ async def test_stop_emoji_hard_cancels_and_schedules_agno_cleanup_when_run_id_pr
     task.done = MagicMock(return_value=False)
     bot.stop_manager.set_current(
         message_id="$message:example.com",
-        room_id="!test:example.com",
+        target=MessageTarget.resolve("!test:example.com", None, "$message:example.com"),
         task=task,
         run_id="run-123",
     )
@@ -209,7 +210,7 @@ async def test_stop_manager_force_cancels_task_when_run_never_becomes_cancellabl
 
     stop_manager.set_current(
         message_id="$message:example.com",
-        room_id="!test:example.com",
+        target=MessageTarget.resolve("!test:example.com", None, "$message:example.com"),
         task=task,
         run_id="run-123",
     )
@@ -244,7 +245,7 @@ async def test_stop_manager_force_cancels_task_when_graceful_cancel_errors() -> 
 
     stop_manager.set_current(
         message_id="$message:example.com",
-        room_id="!test:example.com",
+        target=MessageTarget.resolve("!test:example.com", None, "$message:example.com"),
         task=task,
         run_id="run-123",
     )
@@ -281,7 +282,7 @@ async def test_stop_manager_immediately_cancels_task_even_when_acancel_run_succe
 
     stop_manager.set_current(
         message_id="$message:example.com",
-        room_id="!test:example.com",
+        target=MessageTarget.resolve("!test:example.com", None, "$message:example.com"),
         task=task,
         run_id="run-123",
     )
@@ -329,7 +330,7 @@ async def test_stop_manager_immediately_cancels_task_when_acancel_run_is_slow() 
 
     stop_manager.set_current(
         message_id="$message:example.com",
-        room_id="!test:example.com",
+        target=MessageTarget.resolve("!test:example.com", None, "$message:example.com"),
         task=task,
         run_id="run-123",
     )
@@ -378,7 +379,7 @@ async def test_stop_manager_retries_until_run_becomes_cancellable() -> None:
 
     stop_manager.set_current(
         message_id="$message:example.com",
-        room_id="!test:example.com",
+        target=MessageTarget.resolve("!test:example.com", None, "$message:example.com"),
         task=task,
         run_id="run-123",
     )
@@ -428,7 +429,7 @@ async def test_stop_manager_reprobes_when_retry_updates_run_id() -> None:
 
     stop_manager.set_current(
         message_id="$message:example.com",
-        room_id="!test:example.com",
+        target=MessageTarget.resolve("!test:example.com", None, "$message:example.com"),
         task=task,
         run_id="run-123",
     )
@@ -462,7 +463,7 @@ async def test_stop_manager_cleanup_uses_captured_run_id_after_task_finishes() -
 
     stop_manager.set_current(
         message_id="$message:example.com",
-        room_id="!test:example.com",
+        target=MessageTarget.resolve("!test:example.com", None, "$message:example.com"),
         task=task,
         run_id="run-123",
     )
@@ -544,7 +545,7 @@ async def test_stop_emoji_from_agent_falls_through(tmp_path: Path) -> None:
         task.done = MagicMock(return_value=False)  # done() is a regular method, not async
         bot.stop_manager.set_current(
             message_id="$message:example.com",
-            room_id="!test:example.com",
+            target=MessageTarget.resolve("!test:example.com", None, "$message:example.com"),
             task=task,
         )
 
@@ -604,7 +605,7 @@ async def test_stop_reaction_blocked_by_reply_permissions(tmp_path: Path) -> Non
     task.done = MagicMock(return_value=False)
     bot.stop_manager.set_current(
         message_id="$message:example.com",
-        room_id="!test:example.com",
+        target=MessageTarget.resolve("!test:example.com", None, "$message:example.com"),
         task=task,
     )
 

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -878,9 +878,9 @@ async def test_router_posts_visible_voice_echo_when_enabled(tmp_path) -> None:  
 
     bot._delivery_gateway.send_text.assert_called_once()
     request = bot._delivery_gateway.send_text.call_args.args[0]
-    assert request.reply_to_event_id == "$voice_event"
+    assert request.target.reply_to_event_id == "$voice_event"
     assert request.response_text == f"{VOICE_PREFIX}@home turn on the lights"
-    assert request.thread_id == "$voice_event"
+    assert request.target.thread_id == "$voice_event"
     assert request.skip_mentions is True
 
 
@@ -956,11 +956,11 @@ async def test_router_visible_voice_echo_keeps_multi_agent_handoff(tmp_path) -> 
     assert bot._delivery_gateway.send_text.await_count == 2
     echo_request = bot._delivery_gateway.send_text.call_args_list[0].args[0]
     handoff_request = bot._delivery_gateway.send_text.call_args_list[1].args[0]
-    assert echo_request.reply_to_event_id == "$voice_event"
+    assert echo_request.target.reply_to_event_id == "$voice_event"
     assert echo_request.response_text == f"{VOICE_PREFIX}summarize this audio"
     assert echo_request.skip_mentions is True
     assert echo_request.extra_content is None
-    assert handoff_request.reply_to_event_id == "$voice_event"
+    assert handoff_request.target.reply_to_event_id == "$voice_event"
     assert handoff_request.response_text == "@home could you help with this?"
     assert handoff_request.extra_content == {
         ORIGINAL_SENDER_KEY: "@alice:example.com",
@@ -1111,7 +1111,7 @@ async def test_router_routes_transcribed_audio_when_multiple_agents_are_present(
 
     bot._delivery_gateway.send_text.assert_called_once()
     request = bot._delivery_gateway.send_text.call_args.args[0]
-    assert request.reply_to_event_id == "$voice_event"
+    assert request.target.reply_to_event_id == "$voice_event"
     assert request.response_text == "@home could you help with this?"
     assert request.extra_content == {
         ORIGINAL_SENDER_KEY: "@alice:example.com",

--- a/tests/test_workloop_thread_scope.py
+++ b/tests/test_workloop_thread_scope.py
@@ -753,9 +753,6 @@ async def test_late_after_response_cancellation_still_runs_workloop_cleanup(
         nonlocal delivery_result
         delivery_result = await gateway.deliver_final(
             FinalDeliveryRequest(
-                room_id="!room:localhost",
-                reply_to_event_id="$event",
-                thread_id=None,
                 target=response_envelope.target,
                 existing_event_id=None,
                 response_text="visible response",


### PR DESCRIPTION
## Summary
- push `MessageTarget` through delivery, stop, and response-coordinator paths instead of re-passing raw `room_id`/`thread_id` tuples
- simplify thread-aware logging and delivery behavior by deriving context from the resolved target in one place
- update test helpers and regressions to assert the target-native request shape

## Test Plan
- `uv run pre-commit run --files src/mindroom/bot.py src/mindroom/delivery_gateway.py src/mindroom/dispatch_planner.py src/mindroom/message_target.py src/mindroom/post_response_effects.py src/mindroom/response_coordinator.py src/mindroom/stop.py tests/conftest.py tests/test_cancelled_response_hook.py tests/test_compact_context.py tests/test_multi_agent_bot.py tests/test_skip_mentions.py tests/test_stop_emoji_reuse.py tests/test_workloop_thread_scope.py`
- `uv run pytest tests/test_stop_emoji_reuse.py tests/test_skip_mentions.py tests/test_cancelled_response_hook.py tests/test_compact_context.py tests/test_workloop_thread_scope.py -n 0 -q`
- `uv run pytest tests/test_multi_agent_bot.py -n 0 -q`
