### PR TITLE
Bind thread log context across response flows

### DIFF
--- a/src/mindroom/dispatch_planner.py
+++ b/src/mindroom/dispatch_planner.py
@@ -61,6 +61,7 @@ from mindroom.hooks import (
 )
 from mindroom.hooks.ingress import HookIngressPolicy, hook_ingress_policy, is_automation_source_kind
 from mindroom.inbound_turn_normalizer import DispatchPayload, InboundTurnNormalizer, TextNormalizationRequest
+from mindroom.logging_config import bound_log_context
 from mindroom.matrix.identity import MatrixID, extract_agent_name, is_agent_id
 from mindroom.matrix.rooms import is_dm_room
 from mindroom.message_target import MessageTarget
@@ -870,7 +871,8 @@ class DispatchPlanner:
             )
             return
 
-        self.deps.logger.info("Handling AI routing", event_id=event.event_id)
+        with bound_log_context(room_id=room.room_id, thread_id=thread_id):
+            self.deps.logger.info("Handling AI routing", event_id=event.event_id)
 
         routing_text = message or event.body
         suggested_agent = await suggest_agent_for_message(
@@ -886,7 +888,8 @@ class DispatchPlanner:
                 "⚠️ I couldn't determine which agent should help with this. "
                 "Please try mentioning an agent directly with @ or rephrase your request."
             )
-            self.deps.logger.warning("Router failed to determine agent")
+            with bound_log_context(room_id=room.room_id, thread_id=thread_id):
+                self.deps.logger.warning("Router failed to determine agent")
         else:
             response_text = f"@{suggested_agent} could you help with this?"
 
@@ -956,15 +959,16 @@ class DispatchPlanner:
             history_scope=None,
             conversation_target=resolved_target,
         )
-        if event_id:
-            self.deps.logger.info("Routed to agent", suggested_agent=suggested_agent)
-            self._mark_source_events_responded(
-                tracked_handled_turn.with_response_event_id(
-                    event_id,
-                ),
-            )
-        else:
-            self.deps.logger.error("Failed to route to agent", agent=suggested_agent)
+        with bound_log_context(**resolved_target.log_context):
+            if event_id:
+                self.deps.logger.info("Routed to agent", suggested_agent=suggested_agent)
+                self._mark_source_events_responded(
+                    tracked_handled_turn.with_response_event_id(
+                        event_id,
+                    ),
+                )
+            else:
+                self.deps.logger.error("Failed to route to agent", agent=suggested_agent)
 
     def _effective_response_action(self, action: ResponseAction) -> ResponseAction:
         """Apply configured-team execution behavior before running one response action."""
@@ -1010,7 +1014,8 @@ class DispatchPlanner:
             return
 
         if not dispatch.context.am_i_mentioned:
-            self.deps.logger.info("Will respond: only agent in thread")
+            with bound_log_context(**dispatch.target.log_context):
+                self.deps.logger.info("Will respond: only agent in thread")
 
         target_member_names: tuple[str, ...] | None = None
         if action.kind == "team":
@@ -1067,15 +1072,17 @@ class DispatchPlanner:
                     dispatch_timing.emit_summary(self.deps.logger, outcome="dispatch_failure")
             return
 
-        self.log_dispatch_latency(
-            event_id=event.event_id,
-            action_kind=action.kind,
-            dispatch_started_at=dispatch_started_at,
-            context_ready_monotonic=context_ready_monotonic,
-            payload_ready_monotonic=payload_ready_monotonic,
-        )
+        with bound_log_context(**dispatch.target.log_context):
+            self.log_dispatch_latency(
+                event_id=event.event_id,
+                action_kind=action.kind,
+                dispatch_started_at=dispatch_started_at,
+                context_ready_monotonic=context_ready_monotonic,
+                payload_ready_monotonic=payload_ready_monotonic,
+            )
 
-        self.deps.logger.info(processing_log, event_id=event.event_id)
+        with bound_log_context(**dispatch.target.log_context):
+            self.deps.logger.info(processing_log, event_id=event.event_id)
         try:
             if action.kind == "team":
                 assert action.form_team is not None
@@ -1124,11 +1131,12 @@ class DispatchPlanner:
                     ),
                 )
         except SuppressedPlaceholderCleanupError:
-            self.deps.logger.warning(
-                "Suppressed response cleanup failed",
-                source_event_id=event.event_id,
-                correlation_id=dispatch.correlation_id,
-            )
+            with bound_log_context(**dispatch.target.log_context):
+                self.deps.logger.warning(
+                    "Suppressed response cleanup failed",
+                    source_event_id=event.event_id,
+                    correlation_id=dispatch.correlation_id,
+                )
             raise
         if response_event_id is not None:
             self._mark_source_events_responded(

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -18,6 +18,7 @@ from mindroom.attachments import (
     resolve_thread_attachment_ids,
 )
 from mindroom.coalescing import PreparedTextEvent
+from mindroom.logging_config import bound_log_context
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.image_handler import download_image
 from mindroom.matrix.message_content import (
@@ -166,37 +167,38 @@ class InboundTurnNormalizer:
             reply_to_event_id=request.event.event_id,
             event_source=request.event.source,
         ).resolved_thread_id
-        prepared_voice = await prepare_voice_message(
-            client,
-            self.deps.storage_path,
-            request.room,
-            request.event,
-            self.deps.runtime.config,
-            runtime_paths=self.deps.runtime_paths,
-            sender_domain=self.deps.sender_domain,
-            thread_id=effective_thread_id,
-        )
-        if prepared_voice is None:
-            return None
+        with bound_log_context(room_id=request.room.room_id, thread_id=effective_thread_id):
+            prepared_voice = await prepare_voice_message(
+                client,
+                self.deps.storage_path,
+                request.room,
+                request.event,
+                self.deps.runtime.config,
+                runtime_paths=self.deps.runtime_paths,
+                sender_domain=self.deps.sender_domain,
+                thread_id=effective_thread_id,
+            )
+            if prepared_voice is None:
+                return None
 
-        return VoiceNormalizationResult(
-            event=PreparedTextEvent(
-                sender=request.event.sender,
-                event_id=request.event.event_id,
-                body=prepared_voice.text,
-                source={
-                    **prepared_voice.source,
-                    "content": {
-                        **prepared_voice.source.get("content", {}),
-                        "com.mindroom.source_kind": "voice",
+            return VoiceNormalizationResult(
+                event=PreparedTextEvent(
+                    sender=request.event.sender,
+                    event_id=request.event.event_id,
+                    body=prepared_voice.text,
+                    source={
+                        **prepared_voice.source,
+                        "content": {
+                            **prepared_voice.source.get("content", {}),
+                            "com.mindroom.source_kind": "voice",
+                        },
                     },
-                },
-                server_timestamp=request.event.server_timestamp,
-                is_synthetic=True,
-                source_kind_override="voice",
-            ),
-            effective_thread_id=effective_thread_id,
-        )
+                    server_timestamp=request.event.server_timestamp,
+                    is_synthetic=True,
+                    source_kind_override="voice",
+                ),
+                effective_thread_id=effective_thread_id,
+            )
 
     async def prepare_file_sidecar_text_event(
         self,

--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, cast
 
 import nio
 
-from mindroom.logging_config import get_logger
+from mindroom.logging_config import bound_log_context, get_logger
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.identity import is_agent_id
 
@@ -432,12 +432,13 @@ async def handle_reaction(
 
         selected_value = question.options[reaction_key]
 
-        logger.info(
-            "Received answer via reaction",
-            user=event.sender,
-            reaction=reaction_key,
-            value=selected_value,
-        )
+        with bound_log_context(room_id=question.room_id, thread_id=question.thread_id):
+            logger.info(
+                "Received answer via reaction",
+                user=event.sender,
+                reaction=reaction_key,
+                value=selected_value,
+            )
 
         # The emoji reaction itself is the user's response, so just consume the question.
         if _remove_active_question_locked(event.reacts_to):
@@ -507,12 +508,13 @@ def _handle_text_response_locked(
             continue
 
         selected_value = question.options[message_text]
-        logger.info(
-            "Received answer via text",
-            user=sender,
-            text=message_text,
-            value=selected_value,
-        )
+        with bound_log_context(room_id=room_id, thread_id=thread_id):
+            logger.info(
+                "Received answer via text",
+                user=sender,
+                text=message_text,
+                value=selected_value,
+            )
         if _remove_active_question_locked(question_event_id):
             _save_active_questions_locked()
         return (selected_value, question.thread_id)
@@ -626,16 +628,22 @@ def register_interactive_question(
             ),
         )
         _save_active_questions_locked()
-    logger.info("Registered interactive question", event_id=event_id, options=len(option_map))
+    with bound_log_context(room_id=room_id, thread_id=thread_id):
+        logger.info("Registered interactive question", event_id=event_id, options=len(option_map))
 
 
 def clear_interactive_question(event_id: str) -> None:
     """Remove one tracked interactive question when its message is edited away."""
     with _thread_lock:
+        question = _active_questions.get(event_id)
         if not _remove_active_question_locked(event_id):
             return
         _save_active_questions_locked()
-    logger.info("Cleared interactive question", event_id=event_id)
+    with bound_log_context(
+        room_id=question.room_id if question is not None else None,
+        thread_id=question.thread_id if question is not None else None,
+    ):
+        logger.info("Cleared interactive question", event_id=event_id)
 
 
 async def add_reaction_buttons(

--- a/src/mindroom/logging_config.py
+++ b/src/mindroom/logging_config.py
@@ -11,9 +11,11 @@ from typing import TYPE_CHECKING
 import structlog
 
 if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
     from mindroom.constants import RuntimePaths
 
-__all__ = ["get_logger", "setup_logging"]
+__all__ = ["bound_log_context", "get_logger", "setup_logging"]
 
 
 class _NioValidationFilter(logging.Filter):
@@ -189,3 +191,8 @@ def get_logger(name: str = __name__) -> structlog.stdlib.BoundLogger:
 
     """
     return structlog.get_logger(name)
+
+
+def bound_log_context(**context: object) -> AbstractContextManager[None]:
+    """Temporarily bind structured log fields for the current async/task scope."""
+    return structlog.contextvars.bound_contextvars(**context)

--- a/src/mindroom/response_coordinator.py
+++ b/src/mindroom/response_coordinator.py
@@ -27,6 +27,7 @@ from mindroom.constants import (
 from mindroom.hooks import EnrichmentItem, MessageEnvelope, strip_enrichment_from_session_storage
 from mindroom.hooks.ingress import is_automation_source_kind
 from mindroom.knowledge.utils import KnowledgeAccessSupport, ensure_request_knowledge_managers
+from mindroom.logging_config import bound_log_context
 from mindroom.matrix.client import replace_visible_message
 from mindroom.matrix.identity import is_agent_id
 from mindroom.matrix.presence import is_user_online, should_use_streaming
@@ -1041,7 +1042,8 @@ class ResponseCoordinator:
                 existing_event_id=request.existing_event_id,
                 existing_event_is_placeholder=request.existing_event_is_placeholder,
             )
-        await finalize_post_response_effects(tracked_event_id)
+        with bound_log_context(**delivery_target.log_context):
+            await finalize_post_response_effects(tracked_event_id)
         outcome = "no_visible_response"
         if delivery_result is not None and delivery_result.suppressed:
             outcome = "suppressed"
@@ -1077,82 +1079,82 @@ class ResponseCoordinator:
 
         try:
             self.in_flight_response_count += 1
-
-            initial_message_id = None
-            if thinking_message:
-                assert not existing_event_id
-                initial_message_id = await self.deps.delivery_gateway.send_text(
-                    SendTextRequest(
-                        target=resolved_target,
-                        response_text=thinking_message,
-                        extra_content={STREAM_STATUS_KEY: STREAM_STATUS_PENDING},
-                    ),
-                )
-                if initial_message_id is not None and pipeline_timing is not None:
-                    pipeline_timing.mark("placeholder_sent")
-                    pipeline_timing.mark_first_visible_reply("placeholder")
-
-            message_id = existing_event_id or initial_message_id
-            task: asyncio.Task[None] = asyncio.create_task(response_function(message_id))
-
-            message_to_track = existing_event_id or initial_message_id
-            tracked_message_id = message_to_track or f"__pending_response__:{id(task)}"
-            show_stop_button = False
-
-            self.deps.stop_manager.set_current(
-                tracked_message_id,
-                resolved_target,
-                task,
-                None,
-                run_id=run_id,
-            )
-
-            if message_to_track:
-                show_stop_button = self.deps.runtime.config.defaults.show_stop_button
-                if show_stop_button and user_id:
-                    user_is_online = await is_user_online(
-                        self._client(),
-                        user_id,
-                        room_id=room_id,
+            with bound_log_context(**resolved_target.log_context):
+                initial_message_id = None
+                if thinking_message:
+                    assert not existing_event_id
+                    initial_message_id = await self.deps.delivery_gateway.send_text(
+                        SendTextRequest(
+                            target=resolved_target,
+                            response_text=thinking_message,
+                            extra_content={STREAM_STATUS_KEY: STREAM_STATUS_PENDING},
+                        ),
                     )
-                    show_stop_button = user_is_online
-                    self.deps.logger.info(
-                        "Stop button decision",
-                        message_id=message_to_track,
-                        user_online=user_is_online,
-                        show_button=show_stop_button,
-                    )
+                    if initial_message_id is not None and pipeline_timing is not None:
+                        pipeline_timing.mark("placeholder_sent")
+                        pipeline_timing.mark_first_visible_reply("placeholder")
 
-                if show_stop_button:
-                    self.deps.logger.info("Adding stop button", message_id=message_to_track)
-                    await self.deps.stop_manager.add_stop_button(self._client(), message_to_track)
+                message_id = existing_event_id or initial_message_id
+                task: asyncio.Task[None] = asyncio.create_task(response_function(message_id))
 
-            try:
-                await task
-            except asyncio.CancelledError as exc:
-                if is_sync_restart_cancel(exc):
-                    self.deps.logger.info(
-                        "Response interrupted by sync restart",
-                        message_id=message_to_track or tracked_message_id,
-                    )
-                else:
-                    self.deps.logger.warning(
-                        "Response cancelled — traceback for diagnosis",
-                        message_id=message_to_track or tracked_message_id,
-                        exc_info=True,
-                    )
-            except Exception as error:
-                self.deps.logger.exception("Error during response generation", error=str(error))
-                raise
-            finally:
-                clear_tracked_response_message(
-                    self.deps.stop_manager,
-                    self._client(),
+                message_to_track = existing_event_id or initial_message_id
+                tracked_message_id = message_to_track or f"__pending_response__:{id(task)}"
+                show_stop_button = False
+
+                self.deps.stop_manager.set_current(
                     tracked_message_id,
-                    show_stop_button=show_stop_button,
+                    resolved_target,
+                    task,
+                    None,
+                    run_id=run_id,
                 )
 
-            return message_id
+                if message_to_track:
+                    show_stop_button = self.deps.runtime.config.defaults.show_stop_button
+                    if show_stop_button and user_id:
+                        user_is_online = await is_user_online(
+                            self._client(),
+                            user_id,
+                            room_id=room_id,
+                        )
+                        show_stop_button = user_is_online
+                        self.deps.logger.info(
+                            "Stop button decision",
+                            message_id=message_to_track,
+                            user_online=user_is_online,
+                            show_button=show_stop_button,
+                        )
+
+                    if show_stop_button:
+                        self.deps.logger.info("Adding stop button", message_id=message_to_track)
+                        await self.deps.stop_manager.add_stop_button(self._client(), message_to_track)
+
+                try:
+                    await task
+                except asyncio.CancelledError as exc:
+                    if is_sync_restart_cancel(exc):
+                        self.deps.logger.info(
+                            "Response interrupted by sync restart",
+                            message_id=message_to_track or tracked_message_id,
+                        )
+                    else:
+                        self.deps.logger.warning(
+                            "Response cancelled — traceback for diagnosis",
+                            message_id=message_to_track or tracked_message_id,
+                            exc_info=True,
+                        )
+                except Exception as error:
+                    self.deps.logger.exception("Error during response generation", error=str(error))
+                    raise
+                finally:
+                    clear_tracked_response_message(
+                        self.deps.stop_manager,
+                        self._client(),
+                        tracked_message_id,
+                        show_stop_button=show_stop_button,
+                    )
+
+                return message_id
         finally:
             self.in_flight_response_count -= 1
 
@@ -1751,31 +1753,32 @@ class ResponseCoordinator:
             except Exception:  # pragma: no cover
                 self.deps.logger.debug("Skipping memory storage due to configuration error")
 
-        await apply_post_response_effects(
-            ResponseOutcome(
-                resolved_event_id=event_id,
-                delivery_result=DeliveryResult(
-                    event_id=event_id,
-                    response_text=response.formatted_text,
-                    delivery_kind="sent" if event_id is not None else None,
-                    option_map=response.option_map,
-                    options_list=response.options_list,
+        with bound_log_context(**resolved_target.log_context):
+            await apply_post_response_effects(
+                ResponseOutcome(
+                    resolved_event_id=event_id,
+                    delivery_result=DeliveryResult(
+                        event_id=event_id,
+                        response_text=response.formatted_text,
+                        delivery_kind="sent" if event_id is not None else None,
+                        option_map=response.option_map,
+                        options_list=response.options_list,
+                    ),
+                    session_id=session_id,
+                    session_type=SessionType.AGENT,
+                    execution_identity=execution_identity,
+                    interactive_target=resolved_target,
+                    memory_prompt=memory_prompt,
+                    memory_thread_history=memory_thread_history,
                 ),
-                session_id=session_id,
-                session_type=SessionType.AGENT,
-                execution_identity=execution_identity,
-                interactive_target=resolved_target,
-                memory_prompt=memory_prompt,
-                memory_thread_history=memory_thread_history,
-            ),
-            self.deps.post_response_effects.build_deps(
-                room_id=room_id,
-                reply_to_event_id=reply_to_event_id,
-                thread_id=thread_id,
-                interactive_agent_name=agent_name,
-                queue_memory_persistence=queue_memory_persistence,
-            ),
-        )
+                self.deps.post_response_effects.build_deps(
+                    room_id=room_id,
+                    reply_to_event_id=reply_to_event_id,
+                    thread_id=thread_id,
+                    interactive_agent_name=agent_name,
+                    queue_memory_persistence=queue_memory_persistence,
+                ),
+            )
 
         return event_id
 
@@ -1806,7 +1809,7 @@ class ResponseCoordinator:
             ),
         )
 
-    async def generate_response_locked(  # noqa: C901
+    async def generate_response_locked(  # noqa: C901, PLR0915
         self,
         request: ResponseRequest,
         *,
@@ -1979,11 +1982,12 @@ class ResponseCoordinator:
                 existing_event_id=request.existing_event_id,
                 existing_event_is_placeholder=request.existing_event_is_placeholder,
             )
-        await self._await_post_response_effects(
-            finalize_effects=finalize_post_response_effects,
-            tracked_event_id=tracked_event_id,
-            swallow_late_cancellation=True,
-        )
+        with bound_log_context(**resolved_target.log_context):
+            await self._await_post_response_effects(
+                finalize_effects=finalize_post_response_effects,
+                tracked_event_id=tracked_event_id,
+                swallow_late_cancellation=True,
+            )
         outcome = "no_visible_response"
         if delivery_result is not None and delivery_result.suppressed:
             outcome = "suppressed"

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING, NoReturn
 import pytest
 
 from mindroom.constants import RuntimePaths
-from mindroom.logging_config import get_logger, setup_logging
+from mindroom.logging_config import bound_log_context, get_logger, setup_logging
+from mindroom.message_target import MessageTarget
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -59,6 +60,38 @@ def test_setup_logging_json_mode_emits_expected_fields(
     assert payload["logger"] == "tests.logging"
     assert payload["room_id"] == "!room:example.org"
     assert "timestamp" in payload
+
+
+def test_bound_log_context_from_message_target_binds_and_restores_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Scoped log context should include target fields only within the active scope."""
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=_runtime_paths(tmp_path))
+    capsys.readouterr()
+
+    target = MessageTarget.resolve(
+        room_id="!room:example.org",
+        thread_id="$thread",
+        reply_to_event_id="$reply",
+    )
+
+    with bound_log_context(**target.log_context):
+        get_logger("tests.logging").info("scoped_event")
+    get_logger("tests.logging").info("outside_scope")
+
+    lines = capsys.readouterr().err.strip().splitlines()
+    scoped_payload = json.loads(lines[0])
+    outside_payload = json.loads(lines[1])
+
+    assert scoped_payload["event"] == "scoped_event"
+    assert scoped_payload["room_id"] == "!room:example.org"
+    assert scoped_payload["thread_id"] == "$thread"
+    assert outside_payload["event"] == "outside_scope"
+    assert "room_id" not in outside_payload
+    assert "thread_id" not in outside_payload
 
 
 def test_setup_logging_json_mode_includes_logger_for_foreign_logger(


### PR DESCRIPTION
## Summary
- add a small `bound_log_context` helper on top of `structlog.contextvars`
- bind canonical room/thread fields across response generation, routing, voice normalization, and interactive response logs
- add a focused logging regression test proving target-scoped context is applied and restored

## Testing
- uv run pre-commit run --all-files
- uv run pytest tests/test_logging_config.py tests/test_voice_command_processing.py tests/test_stop_emoji_reuse.py -n 0 -q
- uv run pytest -n 0 -q
