### PR TITLE
Fix remaining thread log context gaps

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1578,14 +1578,20 @@ class AgentBot:
 
     async def _handle_message_inner(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
         """Handle one text message inside the per-turn thread-history cache scope."""
-        self.logger.info("Received message", event_id=event.event_id, room_id=room.room_id, sender=event.sender)
+        event_info = EventInfo.from_event(event.source)
+        self.logger.info(
+            "Received message",
+            event_id=event.event_id,
+            room_id=room.room_id,
+            sender=event.sender,
+            thread_id=event_info.thread_id or event_info.thread_id_from_edit,
+        )
         assert self.client is not None
         dispatch_timing = create_dispatch_pipeline_timing(
             event_id=event.event_id,
             room_id=room.room_id,
         )
         attach_dispatch_pipeline_timing(event.source, dispatch_timing)
-        event_info = EventInfo.from_event(event.source)
         await self._conversation_access.append_live_event(room.room_id, event, event_info=event_info)
         if not isinstance(event.body, str):
             return

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1579,14 +1579,15 @@ class AgentBot:
     async def _handle_message_inner(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
         """Handle one text message inside the per-turn thread-history cache scope."""
         event_info = EventInfo.from_event(event.source)
+        assert self.client is not None
+        ingress_thread_id = await self._conversation_resolver.coalescing_thread_id(room, event)
         self.logger.info(
             "Received message",
             event_id=event.event_id,
             room_id=room.room_id,
             sender=event.sender,
-            thread_id=event_info.thread_id or event_info.thread_id_from_edit,
+            thread_id=ingress_thread_id,
         )
-        assert self.client is not None
         dispatch_timing = create_dispatch_pipeline_timing(
             event_id=event.event_id,
             room_id=room.room_id,

--- a/src/mindroom/logging_config.py
+++ b/src/mindroom/logging_config.py
@@ -64,6 +64,7 @@ def setup_logging(
     # Shared processors that don't affect output format
     timestamper = structlog.processors.TimeStamper(fmt="iso")
     pre_chain = [
+        structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
         timestamper,

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -824,89 +824,102 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
         while True:
             latest_task = await _get_pending_task_record(client=client, room_id=workflow.room_id, task_id=task_id)
             if not latest_task:
-                logger.info("Recurring task is no longer pending, stopping", task_id=task_id)
+                with bound_log_context(
+                    **MessageTarget.for_scheduled_task(
+                        workflow,
+                        config=config,
+                        runtime_paths=runtime_paths,
+                    ).log_context,
+                ):
+                    logger.info("Recurring task is no longer pending, stopping", task_id=task_id)
                 return
 
             latest_workflow = latest_task.workflow
-
-            cron_schedule = latest_workflow.cron_schedule
-            if not cron_schedule:
-                logger.error("No cron schedule provided for recurring task", task_id=task_id)
-                return
-
             workflow = latest_workflow
-            cron_string = cron_schedule.to_cron_string()
-            next_run = croniter(cron_string, datetime.now(UTC)).get_next(datetime)
-            workflow_changed = False
+            current_target = MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths)
+            with bound_log_context(**current_target.log_context):
+                cron_schedule = latest_workflow.cron_schedule
+                if not cron_schedule:
+                    logger.error("No cron schedule provided for recurring task", task_id=task_id)
+                    return
 
-            while True:
-                delay = (next_run - datetime.now(UTC)).total_seconds()
-                if delay <= 0:
-                    break
-                await asyncio.sleep(min(delay, _TASK_STATE_POLL_INTERVAL_SECONDS))
+                cron_string = cron_schedule.to_cron_string()
+                next_run = croniter(cron_string, datetime.now(UTC)).get_next(datetime)
+                workflow_changed = False
 
-                refreshed_task = await _get_pending_task_record(
+                while True:
+                    delay = (next_run - datetime.now(UTC)).total_seconds()
+                    if delay <= 0:
+                        break
+                    await asyncio.sleep(min(delay, _TASK_STATE_POLL_INTERVAL_SECONDS))
+
+                    refreshed_task = await _get_pending_task_record(
+                        client=client,
+                        room_id=workflow.room_id,
+                        task_id=task_id,
+                    )
+                    if not refreshed_task:
+                        logger.info("Recurring task cancelled while waiting, stopping", task_id=task_id)
+                        return
+
+                    refreshed_workflow = refreshed_task.workflow
+                    if not refreshed_workflow.cron_schedule:
+                        logger.error("No cron schedule provided for recurring task", task_id=task_id)
+                        return
+
+                    if _workflows_differ(workflow, refreshed_workflow):
+                        workflow = refreshed_workflow
+                        workflow_changed = True
+                        break
+
+                if workflow_changed:
+                    continue
+
+                latest_before_execute = await _get_pending_task_record(
                     client=client,
                     room_id=workflow.room_id,
                     task_id=task_id,
                 )
-                if not refreshed_task:
-                    logger.info("Recurring task cancelled while waiting, stopping", task_id=task_id)
+                if not latest_before_execute:
+                    logger.info("Recurring task cancelled before execution, stopping", task_id=task_id)
                     return
 
-                refreshed_workflow = refreshed_task.workflow
-                if not refreshed_workflow.cron_schedule:
+                latest_workflow = latest_before_execute.workflow
+                if not latest_workflow.cron_schedule:
                     logger.error("No cron schedule provided for recurring task", task_id=task_id)
                     return
+                if _workflows_differ(workflow, latest_workflow):
+                    workflow = latest_workflow
+                    continue
 
-                if _workflows_differ(workflow, refreshed_workflow):
-                    workflow = refreshed_workflow
-                    workflow_changed = True
-                    break
-
-            if workflow_changed:
-                continue
-
-            latest_before_execute = await _get_pending_task_record(
-                client=client,
-                room_id=workflow.room_id,
-                task_id=task_id,
-            )
-            if not latest_before_execute:
-                logger.info("Recurring task cancelled before execution, stopping", task_id=task_id)
-                return
-
-            latest_workflow = latest_before_execute.workflow
-            if not latest_workflow.cron_schedule:
-                logger.error("No cron schedule provided for recurring task", task_id=task_id)
-                return
-            if _workflows_differ(workflow, latest_workflow):
-                workflow = latest_workflow
-                continue
-
-            await _execute_scheduled_workflow(client, workflow, config, runtime_paths, task_id=task_id)
-            if task_id not in running_tasks:
-                logger.info("scheduled_task_missing_from_running_tasks", task_id=task_id)
-                return
+                await _execute_scheduled_workflow(client, workflow, config, runtime_paths, task_id=task_id)
+                if task_id not in running_tasks:
+                    logger.info("scheduled_task_missing_from_running_tasks", task_id=task_id)
+                    return
     except asyncio.CancelledError:
-        logger.info("cron_task_cancelled", task_id=task_id)
+        with bound_log_context(
+            **MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths).log_context,
+        ):
+            logger.info("cron_task_cancelled", task_id=task_id)
         raise
     except Exception as e:
-        logger.exception("cron_task_failed", task_id=task_id)
-        if workflow.room_id:
-            error_message = f"❌ Recurring task failed: {workflow.description}\nTask ID: {task_id}\nError: {e!s}"
-            error_content = await _build_scheduled_failure_content(
-                client,
-                workflow,
-                MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths),
-                error_message,
-            )
-            await send_message(client, workflow.room_id, error_content)
+        target = MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths)
+        with bound_log_context(**target.log_context):
+            logger.exception("cron_task_failed", task_id=task_id)
+            if workflow.room_id:
+                error_message = f"❌ Recurring task failed: {workflow.description}\nTask ID: {task_id}\nError: {e!s}"
+                error_content = await _build_scheduled_failure_content(
+                    client,
+                    workflow,
+                    target,
+                    error_message,
+                )
+                await send_message(client, workflow.room_id, error_content)
     finally:
         _cleanup_task_if_current(task_id, running_tasks)
 
 
-async def _run_once_task(  # noqa: C901, PLR0912
+async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
     client: nio.AsyncClient,
     task_id: str,
     workflow: ScheduledWorkflow,
@@ -923,21 +936,29 @@ async def _run_once_task(  # noqa: C901, PLR0912
         while True:
             latest_task = await _get_pending_task_record(client=client, room_id=workflow.room_id, task_id=task_id)
             if not latest_task:
-                logger.info("One-time task is no longer pending, stopping", task_id=task_id)
+                with bound_log_context(
+                    **MessageTarget.for_scheduled_task(
+                        workflow,
+                        config=config,
+                        runtime_paths=runtime_paths,
+                    ).log_context,
+                ):
+                    logger.info("One-time task is no longer pending, stopping", task_id=task_id)
                 return
 
             latest_workflow = latest_task.workflow
-
-            execute_at = latest_workflow.execute_at
-            if not execute_at:
-                logger.error("No execution time provided for one-time task", task_id=task_id)
-                return
-
             workflow = latest_workflow
-            delay = (execute_at - datetime.now(UTC)).total_seconds()
-            if delay <= 0:
-                break
-            await asyncio.sleep(min(delay, _TASK_STATE_POLL_INTERVAL_SECONDS))
+            current_target = MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths)
+            with bound_log_context(**current_target.log_context):
+                execute_at = latest_workflow.execute_at
+                if not execute_at:
+                    logger.error("No execution time provided for one-time task", task_id=task_id)
+                    return
+
+                delay = (execute_at - datetime.now(UTC)).total_seconds()
+                if delay <= 0:
+                    break
+                await asyncio.sleep(min(delay, _TASK_STATE_POLL_INTERVAL_SECONDS))
 
         latest_before_execute = await _get_pending_task_record(
             client=client,
@@ -945,63 +966,80 @@ async def _run_once_task(  # noqa: C901, PLR0912
             task_id=task_id,
         )
         if not latest_before_execute:
-            logger.info("One-time task was cancelled before execution, stopping", task_id=task_id)
+            with bound_log_context(
+                **MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths).log_context,
+            ):
+                logger.info("One-time task was cancelled before execution, stopping", task_id=task_id)
             return
 
         latest_workflow = latest_before_execute.workflow
         latest_pending_task = latest_before_execute
-        if not latest_workflow.execute_at:
-            logger.error("No execution time provided for one-time task", task_id=task_id)
-            return
+        workflow = latest_workflow
+        current_target = MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths)
+        with bound_log_context(**current_target.log_context):
+            if not latest_workflow.execute_at:
+                logger.error("No execution time provided for one-time task", task_id=task_id)
+                return
 
-        execution_succeeded = await _execute_scheduled_workflow(
-            client,
-            latest_workflow,
-            config,
-            runtime_paths,
-            task_id=task_id,
-        )
-        final_status = "completed" if execution_succeeded else "failed"
-
-        try:
-            await _save_one_time_task_status(
-                client=client,
-                task=latest_pending_task,
+            execution_succeeded = await _execute_scheduled_workflow(
+                client,
+                latest_workflow,
                 config=config,
                 runtime_paths=runtime_paths,
-                status=final_status,
-            )
-        except Exception:
-            logger.exception(
-                "Failed to persist one-time task final state",
                 task_id=task_id,
-                status=final_status,
             )
-    except asyncio.CancelledError:
-        logger.info("one_time_task_cancelled", task_id=task_id)
-        raise
-    except Exception as e:
-        logger.exception("one_time_task_failed", task_id=task_id)
-        if workflow.room_id:
-            error_message = f"❌ One-time task failed: {workflow.description}\nTask ID: {task_id}\nError: {e!s}"
-            error_content = await _build_scheduled_failure_content(
-                client,
-                workflow,
-                MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths),
-                error_message,
-            )
-            await send_message(client, workflow.room_id, error_content)
-        if latest_pending_task is not None:
+            final_status = "completed" if execution_succeeded else "failed"
+
             try:
                 await _save_one_time_task_status(
                     client=client,
                     task=latest_pending_task,
                     config=config,
                     runtime_paths=runtime_paths,
-                    status="failed",
+                    status=final_status,
                 )
             except Exception:
-                logger.exception("Failed to mark one-time task as failed", task_id=task_id)
+                logger.exception(
+                    "Failed to persist one-time task final state",
+                    task_id=task_id,
+                    status=final_status,
+                )
+    except asyncio.CancelledError:
+        current_workflow = latest_pending_task.workflow if latest_pending_task is not None else workflow
+        with bound_log_context(
+            **MessageTarget.for_scheduled_task(
+                current_workflow,
+                config=config,
+                runtime_paths=runtime_paths,
+            ).log_context,
+        ):
+            logger.info("one_time_task_cancelled", task_id=task_id)
+        raise
+    except Exception as e:
+        current_workflow = latest_pending_task.workflow if latest_pending_task is not None else workflow
+        target = MessageTarget.for_scheduled_task(current_workflow, config=config, runtime_paths=runtime_paths)
+        with bound_log_context(**target.log_context):
+            logger.exception("one_time_task_failed", task_id=task_id)
+            if workflow.room_id:
+                error_message = f"❌ One-time task failed: {workflow.description}\nTask ID: {task_id}\nError: {e!s}"
+                error_content = await _build_scheduled_failure_content(
+                    client,
+                    workflow,
+                    target,
+                    error_message,
+                )
+                await send_message(client, workflow.room_id, error_content)
+            if latest_pending_task is not None:
+                try:
+                    await _save_one_time_task_status(
+                        client=client,
+                        task=latest_pending_task,
+                        config=config,
+                        runtime_paths=runtime_paths,
+                        status="failed",
+                    )
+                except Exception:
+                    logger.exception("Failed to mark one-time task as failed", task_id=task_id)
     finally:
         _cleanup_task_if_current(task_id, _running_tasks)
 

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -31,7 +31,7 @@ from mindroom.hooks import (
 )
 from mindroom.hooks.sender import build_hook_message_sender
 from mindroom.hooks.types import EVENT_SCHEDULE_FIRED
-from mindroom.logging_config import get_logger
+from mindroom.logging_config import bound_log_context, get_logger
 from mindroom.matrix.client import (
     get_latest_thread_event_id_if_needed,
     send_message,
@@ -744,66 +744,67 @@ async def _execute_scheduled_workflow(
         runtime_paths=runtime_paths,
     )
 
-    try:
-        message_text = workflow.message
-        if _ACTIVE_HOOK_REGISTRY.has_hooks(EVENT_SCHEDULE_FIRED):
-            context = ScheduleFiredContext(
-                event_name=EVENT_SCHEDULE_FIRED,
-                plugin_name="",
-                settings={},
-                config=config,
-                runtime_paths=runtime_paths,
-                logger=logger.bind(event_name=EVENT_SCHEDULE_FIRED),
-                correlation_id=f"{EVENT_SCHEDULE_FIRED}:{task_id}",
-                message_sender=build_hook_message_sender(client, config, runtime_paths),
-                room_state_querier=build_hook_room_state_querier(client),
-                room_state_putter=build_hook_room_state_putter(client),
-                task_id=task_id,
-                workflow=workflow,
-                room_id=workflow.room_id,
-                thread_id=target.resolved_thread_id,
-                created_by=workflow.created_by,
-                message_text=message_text,
-            )
-            await emit(_ACTIVE_HOOK_REGISTRY, EVENT_SCHEDULE_FIRED, context)
-            if context.suppress:
-                logger.info("Scheduled workflow suppressed by hook", task_id=task_id, room_id=workflow.room_id)
-                return False
-            message_text = context.message_text
+    with bound_log_context(**target.log_context):
+        try:
+            message_text = workflow.message
+            if _ACTIVE_HOOK_REGISTRY.has_hooks(EVENT_SCHEDULE_FIRED):
+                context = ScheduleFiredContext(
+                    event_name=EVENT_SCHEDULE_FIRED,
+                    plugin_name="",
+                    settings={},
+                    config=config,
+                    runtime_paths=runtime_paths,
+                    logger=logger.bind(event_name=EVENT_SCHEDULE_FIRED),
+                    correlation_id=f"{EVENT_SCHEDULE_FIRED}:{task_id}",
+                    message_sender=build_hook_message_sender(client, config, runtime_paths),
+                    room_state_querier=build_hook_room_state_querier(client),
+                    room_state_putter=build_hook_room_state_putter(client),
+                    task_id=task_id,
+                    workflow=workflow,
+                    room_id=workflow.room_id,
+                    thread_id=target.resolved_thread_id,
+                    created_by=workflow.created_by,
+                    message_text=message_text,
+                )
+                await emit(_ACTIVE_HOOK_REGISTRY, EVENT_SCHEDULE_FIRED, context)
+                if context.suppress:
+                    logger.info("Scheduled workflow suppressed by hook", task_id=task_id, room_id=workflow.room_id)
+                    return False
+                message_text = context.message_text
 
-        content = await _build_workflow_message_content(
-            client,
-            workflow,
-            target,
-            config,
-            runtime_paths,
-            message_text,
-        )
-        if workflow.created_by:
-            content[ORIGINAL_SENDER_KEY] = workflow.created_by
-        content["com.mindroom.source_kind"] = "scheduled"
-        event_id = await send_message(client, workflow.room_id, content)
-        if event_id is None:
-            _raise_scheduled_workflow_send_error()
-        logger.info(
-            "Executed scheduled workflow",
-            description=workflow.description,
-            thread_id=target.resolved_thread_id,
-            new_thread=workflow.new_thread,
-            event_id=event_id,
-        )
-    except Exception as e:
-        logger.exception("Failed to execute scheduled workflow")
-        if workflow.room_id:
-            error_message = f"❌ Scheduled task failed: {workflow.description}\nError: {e!s}"
-            error_content = await _build_scheduled_failure_content(client, workflow, target, error_message)
-            try:
-                await send_message(client, workflow.room_id, error_content)
-            except Exception:
-                logger.exception("Failed to send scheduled workflow failure message")
-        return False
-    else:
-        return True
+            content = await _build_workflow_message_content(
+                client,
+                workflow,
+                target,
+                config,
+                runtime_paths,
+                message_text,
+            )
+            if workflow.created_by:
+                content[ORIGINAL_SENDER_KEY] = workflow.created_by
+            content["com.mindroom.source_kind"] = "scheduled"
+            event_id = await send_message(client, workflow.room_id, content)
+            if event_id is None:
+                _raise_scheduled_workflow_send_error()
+            logger.info(
+                "Executed scheduled workflow",
+                description=workflow.description,
+                thread_id=target.resolved_thread_id,
+                new_thread=workflow.new_thread,
+                event_id=event_id,
+            )
+        except Exception as e:
+            logger.exception("Failed to execute scheduled workflow")
+            if workflow.room_id:
+                error_message = f"❌ Scheduled task failed: {workflow.description}\nError: {e!s}"
+                error_content = await _build_scheduled_failure_content(client, workflow, target, error_message)
+                try:
+                    await send_message(client, workflow.room_id, error_content)
+                except Exception:
+                    logger.exception("Failed to send scheduled workflow failure message")
+            return False
+        else:
+            return True
 
 
 async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -580,6 +580,59 @@ class TestCommandHandling:
             )
 
     @pytest.mark.asyncio
+    async def test_router_agent_logs_canonical_thread_scope_for_plain_reply_commands(self) -> None:
+        """Router command ingress logs should use the resolved thread scope, not only raw m.thread metadata."""
+        agent_user = AgentMatrixUser(
+            agent_name="router",
+            user_id="@mindroom_router:localhost",
+            display_name="Router Agent",
+            password=TEST_PASSWORD,
+            access_token=TEST_ACCESS_TOKEN,
+        )
+
+        config = _runtime_bound_config(Config(router=RouterConfig(model="default")))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bot = AgentBot(
+                agent_user=agent_user,
+                storage_path=Path(tmpdir),
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                rooms=["!test:server"],
+            )
+            bot.client = AsyncMock()
+            bot.client.user_id = bot.agent_user.user_id
+            bot.logger = MagicMock()
+            bot._handle_command = AsyncMock()
+            bot._conversation_resolver.coalescing_thread_id = AsyncMock(return_value="$thread-root")
+
+            room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
+            event = nio.RoomMessageText.from_dict(
+                {
+                    "event_id": "$event123",
+                    "sender": "@user:server",
+                    "origin_server_ts": 1234567890,
+                    "content": {
+                        "msgtype": "m.text",
+                        "body": "!schedule in 5 minutes test",
+                        "m.relates_to": {"m.in_reply_to": {"event_id": "$reply123"}},
+                    },
+                },
+            )
+
+            with patch("mindroom.constants.ROUTER_AGENT_NAME", "router"):
+                await bot._on_message(room, event)
+
+            bot._handle_command.assert_called_once()
+            bot.logger.info.assert_any_call(
+                "Received message",
+                event_id="$event123",
+                room_id="!test:server",
+                sender="@user:server",
+                thread_id="$thread-root",
+            )
+
+    @pytest.mark.asyncio
     async def test_router_command_blocked_by_reply_permissions(self) -> None:
         """Router should ignore commands from senders disallowed by router reply rules."""
         agent_user = AgentMatrixUser(

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -571,6 +571,13 @@ class TestCommandHandling:
 
             # Verify the command was handled
             bot._handle_command.assert_called_once()
+            bot.logger.info.assert_any_call(
+                "Received message",
+                event_id="$event123",
+                room_id="!test:server",
+                sender="@user:server",
+                thread_id="$thread123",
+            )
 
     @pytest.mark.asyncio
     async def test_router_command_blocked_by_reply_permissions(self) -> None:

--- a/tests/test_hook_schedule.py
+++ b/tests/test_hook_schedule.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
-from datetime import UTC, datetime
+from contextlib import suppress
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
@@ -13,7 +15,14 @@ import pytest
 from mindroom.config.main import Config
 from mindroom.hooks import EVENT_SCHEDULE_FIRED, HookRegistry, ScheduleFiredContext, hook
 from mindroom.logging_config import setup_logging
-from mindroom.scheduling import ScheduledWorkflow, _execute_scheduled_workflow, set_scheduling_hook_registry
+from mindroom.scheduling import (
+    CronSchedule,
+    ScheduledWorkflow,
+    _execute_scheduled_workflow,
+    _run_cron_task,
+    _run_once_task,
+    set_scheduling_hook_registry,
+)
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 if TYPE_CHECKING:
@@ -130,6 +139,84 @@ async def test_schedule_hook_suppression_log_includes_workflow_thread_context(
 
     assert suppression_payload["room_id"] == "!room:localhost"
     assert suppression_payload["thread_id"] == "$thread"
+
+
+@pytest.mark.asyncio
+async def test_one_time_task_cancel_log_includes_workflow_thread_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Runner cancellation logs should include one-time workflow room/thread context."""
+    config = _config(tmp_path)
+    workflow = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(seconds=30),
+        message="Later",
+        description="cancelled one-time",
+        room_id="!room:localhost",
+        thread_id="$thread",
+        created_by="@user:localhost",
+    )
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=runtime_paths_for(config))
+    capsys.readouterr()
+
+    async def fake_get_pending_task_record(**_: object) -> SimpleNamespace:
+        return SimpleNamespace(workflow=workflow)
+
+    with patch("mindroom.scheduling._get_pending_task_record", new=fake_get_pending_task_record):
+        task = asyncio.create_task(_run_once_task(AsyncMock(), "task-1", workflow, config, runtime_paths_for(config)))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    payloads = [json.loads(line) for line in capsys.readouterr().err.strip().splitlines()]
+    cancel_payload = next(payload for payload in payloads if payload["event"] == "one_time_task_cancelled")
+
+    assert cancel_payload["room_id"] == "!room:localhost"
+    assert cancel_payload["thread_id"] == "$thread"
+
+
+@pytest.mark.asyncio
+async def test_cron_task_cancel_log_includes_workflow_thread_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Runner cancellation logs should include recurring workflow room/thread context."""
+    config = _config(tmp_path)
+    workflow = ScheduledWorkflow(
+        schedule_type="cron",
+        cron_schedule=CronSchedule(),
+        message="Recurring",
+        description="cancelled recurring",
+        room_id="!room:localhost",
+        thread_id="$thread",
+        created_by="@user:localhost",
+    )
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=runtime_paths_for(config))
+    capsys.readouterr()
+
+    async def fake_get_pending_task_record(**_: object) -> SimpleNamespace:
+        return SimpleNamespace(workflow=workflow)
+
+    with patch("mindroom.scheduling._get_pending_task_record", new=fake_get_pending_task_record):
+        task = asyncio.create_task(
+            _run_cron_task(AsyncMock(), "task-1", workflow, {}, config, runtime_paths_for(config)),
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    payloads = [json.loads(line) for line in capsys.readouterr().err.strip().splitlines()]
+    cancel_payload = next(payload for payload in payloads if payload["event"] == "cron_task_cancelled")
+
+    assert cancel_payload["room_id"] == "!room:localhost"
+    assert cancel_payload["thread_id"] == "$thread"
 
 
 @pytest.mark.asyncio

--- a/tests/test_hook_schedule.py
+++ b/tests/test_hook_schedule.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -11,6 +12,7 @@ import pytest
 
 from mindroom.config.main import Config
 from mindroom.hooks import EVENT_SCHEDULE_FIRED, HookRegistry, ScheduleFiredContext, hook
+from mindroom.logging_config import setup_logging
 from mindroom.scheduling import ScheduledWorkflow, _execute_scheduled_workflow, set_scheduling_hook_registry
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
@@ -98,6 +100,36 @@ async def test_schedule_hook_can_suppress_synthetic_message(tmp_path: Path) -> N
         await _execute_scheduled_workflow(AsyncMock(), _workflow("Do not send"), config, runtime_paths_for(config))
 
     mock_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_hook_suppression_log_includes_workflow_thread_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Suppression logs should carry the workflow room/thread context."""
+
+    @hook(EVENT_SCHEDULE_FIRED)
+    async def suppress(ctx: ScheduleFiredContext) -> None:
+        ctx.suppress = True
+
+    config = _config(tmp_path)
+    set_scheduling_hook_registry(HookRegistry.from_plugins([_plugin("schedule-plugin", [suppress])]))
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=runtime_paths_for(config))
+    capsys.readouterr()
+
+    with patch("mindroom.scheduling.send_message", new=AsyncMock()):
+        await _execute_scheduled_workflow(AsyncMock(), _workflow("Do not send"), config, runtime_paths_for(config))
+
+    payloads = [json.loads(line) for line in capsys.readouterr().err.strip().splitlines()]
+    suppression_payload = next(
+        payload for payload in payloads if payload["event"] == "Scheduled workflow suppressed by hook"
+    )
+
+    assert suppression_payload["room_id"] == "!room:localhost"
+    assert suppression_payload["thread_id"] == "$thread"
 
 
 @pytest.mark.asyncio

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -114,6 +114,27 @@ def test_setup_logging_json_mode_includes_logger_for_foreign_logger(
     assert "timestamp" in payload
 
 
+def test_setup_logging_json_mode_foreign_logger_inherits_bound_log_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Foreign loggers should include active structured room/thread context."""
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=_runtime_paths(tmp_path))
+    capsys.readouterr()
+
+    with bound_log_context(room_id="!room:example.org", thread_id="$thread:example.org"):
+        logging.getLogger("test.foreign").info("foreign scoped message")
+
+    payload = _last_stderr_payload(capsys)
+
+    assert payload["event"] == "foreign scoped message"
+    assert payload["logger"] == "test.foreign"
+    assert payload["room_id"] == "!room:example.org"
+    assert payload["thread_id"] == "$thread:example.org"
+
+
 def test_setup_logging_text_mode_does_not_emit_json(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_skip_mentions.py
+++ b/tests/test_skip_mentions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,8 +15,9 @@ from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.conversation_resolver import should_skip_mentions
-from mindroom.delivery_gateway import DeliveryGateway, DeliveryGatewayDeps, FinalDeliveryRequest
+from mindroom.delivery_gateway import DeliveryGateway, DeliveryGatewayDeps, FinalDeliveryRequest, SendTextRequest
 from mindroom.hooks import MessageEnvelope, ResponseDraft
+from mindroom.logging_config import get_logger, setup_logging
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
@@ -298,6 +301,39 @@ def _delivery_envelope() -> MessageEnvelope:
         agent_name="email_agent",
         source_kind="message",
     )
+
+
+@pytest.mark.asyncio
+async def test_delivery_gateway_send_text_logs_target_thread_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Direct send logs should include the resolved target room/thread."""
+    gateway, _, _ = _gateway_with_mocks(tmp_path)
+    config = gateway.deps.runtime.config
+    target = MessageTarget.resolve("!test:server", "$thread", "$event123")
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=runtime_paths_for(config))
+    capsys.readouterr()
+    gateway = DeliveryGateway(replace(gateway.deps, logger=get_logger("tests.delivery")))
+
+    with (
+        patch("mindroom.delivery_gateway.get_latest_thread_event_id_if_needed", new=AsyncMock(return_value="$latest")),
+        patch("mindroom.delivery_gateway.send_message", new=AsyncMock(return_value="$response")),
+    ):
+        event_id = await gateway.send_text(
+            SendTextRequest(
+                target=target,
+                response_text="formatted response",
+            ),
+        )
+
+    payload = json.loads(capsys.readouterr().err.strip().splitlines()[-1])
+    assert event_id == "$response"
+    assert payload["event"] == "Sent response"
+    assert payload["room_id"] == "!test:server"
+    assert payload["thread_id"] == "$thread"
 
 
 @pytest.mark.asyncio

--- a/tests/test_stop_emoji_reuse.py
+++ b/tests/test_stop_emoji_reuse.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path  # noqa: TC003
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,10 +13,11 @@ import pytest
 from mindroom.bot import AgentBot
 from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
+from mindroom.logging_config import setup_logging
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.stop import StopManager
-from tests.conftest import bind_runtime_paths, orchestrator_runtime_paths, runtime_paths_for
+from tests.conftest import bind_runtime_paths, orchestrator_runtime_paths, runtime_paths_for, test_runtime_paths
 
 
 async def _drain_stop_cleanup(stop_manager: StopManager) -> None:
@@ -257,6 +259,39 @@ async def test_stop_manager_force_cancels_task_when_graceful_cancel_errors() -> 
 
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.asyncio
+async def test_stop_manager_logs_tracked_thread_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Stop-manager logs should include tracked room/thread metadata."""
+    monkeypatch.setenv("MINDROOM_LOG_FORMAT", "json")
+    setup_logging(level="INFO", runtime_paths=test_runtime_paths(tmp_path))
+    capsys.readouterr()
+
+    stop_manager = StopManager()
+    task = MagicMock()
+    task.done.return_value = False
+    target = MessageTarget.resolve("!room:example.org", "$thread:example.org", "$message:example.org")
+
+    stop_manager.set_current(
+        message_id="$message:example.org",
+        target=target,
+        task=task,
+    )
+    assert await stop_manager.handle_stop_reaction("$message:example.org") is True
+
+    payloads = [json.loads(line) for line in capsys.readouterr().err.strip().splitlines()]
+    tracking_payload = next(payload for payload in payloads if payload["event"] == "Tracking message generation")
+    stop_payload = next(payload for payload in payloads if payload["event"] == "Handling stop reaction")
+
+    assert tracking_payload["room_id"] == "!room:example.org"
+    assert tracking_payload["thread_id"] == "$thread:example.org"
+    assert stop_payload["room_id"] == "!room:example.org"
+    assert stop_payload["thread_id"] == "$thread:example.org"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- follow up to #556 with the remaining current-main thread log context fixes called out from the #554 discussion
- merge bound contextvars into the foreign logger JSON processor chain and bind scheduled workflow execution to the target room/thread context
- include the inbound bot receive log in thread context coverage and add regression tests for bot, scheduler, foreign logger, delivery, and stop-manager logging paths

## Test Plan
- uv run pre-commit run --all-files
- uv run pytest -n 0 -q