### PR TITLE
Reduce repeated MessageTarget resolution

### DIFF
--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -1392,13 +1392,8 @@ async def _refresh_cached_thread_event_sources(
         )
         if new_event_sources:
             await event_cache.store_thread_events(room_id, thread_id, new_event_sources)
-        for redacted_event_id, redaction_event in redactions:
-            await event_cache.redact_event(
-                room_id,
-                redacted_event_id,
-                thread_id=thread_id,
-                redaction_event=redaction_event,
-            )
+        for redacted_event_id, _ in redactions:
+            await event_cache.redact_event(room_id, redacted_event_id)
         if not new_event_sources and not redactions:
             return cached_event_sources
 

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -1393,7 +1393,7 @@ async def _refresh_cached_thread_event_sources(
         if new_event_sources:
             await event_cache.store_thread_events(room_id, thread_id, new_event_sources)
         for redacted_event_id, _ in redactions:
-            await event_cache.redact_event(room_id, redacted_event_id, thread_id=thread_id)
+            await event_cache.redact_event(room_id, redacted_event_id)
         if not new_event_sources and not redactions:
             return cached_event_sources
 

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -1393,7 +1393,7 @@ async def _refresh_cached_thread_event_sources(
         if new_event_sources:
             await event_cache.store_thread_events(room_id, thread_id, new_event_sources)
         for redacted_event_id, _ in redactions:
-            await event_cache.redact_event(room_id, redacted_event_id)
+            await event_cache.redact_event(room_id, redacted_event_id, thread_id=thread_id)
         if not new_event_sources and not redactions:
             return cached_event_sources
 

--- a/src/mindroom/matrix/conversation_access.py
+++ b/src/mindroom/matrix/conversation_access.py
@@ -316,7 +316,7 @@ class MatrixConversationAccess(ConversationReadAccess):
         try:
             await self._queue_room_cache_update(
                 room_id,
-                lambda: event_cache.redact_event(room_id, event.redacts, thread_id=thread_id),
+                lambda: event_cache.redact_event(room_id, event.redacts),
                 name="matrix_cache_apply_redaction",
             )
         except Exception as exc:

--- a/src/mindroom/matrix/conversation_access.py
+++ b/src/mindroom/matrix/conversation_access.py
@@ -316,7 +316,7 @@ class MatrixConversationAccess(ConversationReadAccess):
         try:
             await self._queue_room_cache_update(
                 room_id,
-                lambda: event_cache.redact_event(room_id, event.redacts),
+                lambda: event_cache.redact_event(room_id, event.redacts, thread_id=thread_id),
                 name="matrix_cache_apply_redaction",
             )
         except Exception as exc:

--- a/src/mindroom/matrix/conversation_access.py
+++ b/src/mindroom/matrix/conversation_access.py
@@ -313,24 +313,10 @@ class MatrixConversationAccess(ConversationReadAccess):
             )
             thread_id = None
 
-        server_timestamp = event.server_timestamp
-        redaction_source = normalize_event_source_for_cache(
-            event.source,
-            event_id=event.event_id,
-            sender=event.sender,
-            origin_server_ts=server_timestamp
-            if isinstance(server_timestamp, int) and not isinstance(server_timestamp, bool)
-            else None,
-        )
         try:
             await self._queue_room_cache_update(
                 room_id,
-                lambda: event_cache.redact_event(
-                    room_id,
-                    event.redacts,
-                    thread_id=thread_id,
-                    redaction_event=redaction_source,
-                ),
+                lambda: event_cache.redact_event(room_id, event.redacts),
                 name="matrix_cache_apply_redaction",
             )
         except Exception as exc:

--- a/src/mindroom/matrix/event_cache.py
+++ b/src/mindroom/matrix/event_cache.py
@@ -84,6 +84,8 @@ class ConversationEventCache(Protocol):
         self,
         room_id: str,
         event_id: str,
+        *,
+        thread_id: str | None = None,
     ) -> bool:
         """Delete one cached event after a redaction."""
 
@@ -534,8 +536,11 @@ class EventCache:
         self,
         room_id: str,
         event_id: str,
+        *,
+        thread_id: str | None = None,
     ) -> bool:
         """Delete one cached event after a redaction."""
+        del thread_id
         async with self._acquire_db_operation(room_id, operation="redact_event") as db:
             dependent_edit_ids = await _dependent_edit_event_ids(db, room_id, original_event_id=event_id)
             removed_event_ids = list(dict.fromkeys([event_id, *dependent_edit_ids]))

--- a/src/mindroom/matrix/event_cache.py
+++ b/src/mindroom/matrix/event_cache.py
@@ -84,8 +84,6 @@ class ConversationEventCache(Protocol):
         self,
         room_id: str,
         event_id: str,
-        *,
-        thread_id: str | None = None,
     ) -> bool:
         """Delete one cached event after a redaction."""
 
@@ -536,11 +534,8 @@ class EventCache:
         self,
         room_id: str,
         event_id: str,
-        *,
-        thread_id: str | None = None,
     ) -> bool:
         """Delete one cached event after a redaction."""
-        del thread_id
         async with self._acquire_db_operation(room_id, operation="redact_event") as db:
             dependent_edit_ids = await _dependent_edit_event_ids(db, room_id, original_event_id=event_id)
             removed_event_ids = list(dict.fromkeys([event_id, *dependent_edit_ids]))

--- a/src/mindroom/matrix/event_cache.py
+++ b/src/mindroom/matrix/event_cache.py
@@ -84,9 +84,6 @@ class ConversationEventCache(Protocol):
         self,
         room_id: str,
         event_id: str,
-        *,
-        thread_id: str | None = None,
-        redaction_event: dict[str, Any] | None = None,
     ) -> bool:
         """Delete one cached event after a redaction."""
 
@@ -537,13 +534,8 @@ class EventCache:
         self,
         room_id: str,
         event_id: str,
-        *,
-        thread_id: str | None = None,
-        redaction_event: dict[str, Any] | None = None,
     ) -> bool:
         """Delete one cached event after a redaction."""
-        del redaction_event, thread_id
-
         async with self._acquire_db_operation(room_id, operation="redact_event") as db:
             dependent_edit_ids = await _dependent_edit_event_ids(db, room_id, original_event_id=event_id)
             removed_event_ids = list(dict.fromkeys([event_id, *dependent_edit_ids]))

--- a/src/mindroom/message_target.py
+++ b/src/mindroom/message_target.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from mindroom.config.main import Config
-    from mindroom.constants import RuntimePaths
     from mindroom.scheduling import ScheduledWorkflow
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
 
@@ -41,16 +39,12 @@ class MessageTarget:
     def for_scheduled_task(
         cls,
         workflow: ScheduledWorkflow,
-        *,
-        config: Config,
-        runtime_paths: RuntimePaths,
     ) -> MessageTarget:
         """Resolve the delivery target for one scheduled workflow execution."""
         if workflow.room_id is None:
             msg = "Scheduled workflows require room_id to resolve a MessageTarget"
             raise ValueError(msg)
 
-        del config, runtime_paths
         return cls.resolve(
             room_id=workflow.room_id,
             thread_id=None if workflow.new_thread else workflow.thread_id,

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -101,11 +101,9 @@ class PostResponseEffectsSupport:
     async def _timed_thread_summary(
         self,
         *,
-        thread_id: str,
         summary_coro: Awaitable[None],
     ) -> None:
         """Run thread-summary generation with duration logging."""
-        del thread_id
         await summary_coro
 
     async def _register_interactive_delivery(
@@ -178,7 +176,6 @@ class PostResponseEffectsSupport:
         )
         create_background_task(
             self._timed_thread_summary(
-                thread_id=thread_id,
                 summary_coro=summary_coro,
             ),
             name=f"thread_summary_{room_id}_{thread_id}",

--- a/src/mindroom/response_coordinator.py
+++ b/src/mindroom/response_coordinator.py
@@ -1165,15 +1165,7 @@ class ResponseCoordinator:
         existing_event_uses_thread_id: bool,
         room_mode: bool,
     ) -> _PreparedResponseRuntime:
-        resolved_target = request.target or (
-            request.response_envelope.target
-            if request.response_envelope is not None
-            else self.deps.resolver.build_message_target(
-                room_id=request.room_id,
-                thread_id=request.thread_id,
-                reply_to_event_id=request.reply_to_event_id,
-            )
-        )
+        resolved_target = self._resolve_request_target(request)
         response_thread_id = (
             resolved_target.resolved_thread_id
             if request.target is not None

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -403,20 +403,6 @@ def _cleanup_task_if_current(task_id: str, running_tasks: dict[str, asyncio.Task
         del running_tasks[task_id]
 
 
-def _scheduled_workflow_target(
-    workflow: ScheduledWorkflow,
-    *,
-    config: Config,
-    runtime_paths: RuntimePaths,
-) -> MessageTarget:
-    """Return the canonical target for one scheduled workflow snapshot."""
-    return MessageTarget.for_scheduled_task(
-        workflow,
-        config=config,
-        runtime_paths=runtime_paths,
-    )
-
-
 def _parse_task_records_from_state(
     room_id: str,
     state_response: nio.RoomGetStateResponse,
@@ -754,8 +740,6 @@ async def _execute_scheduled_workflow(
 
     target = MessageTarget.for_scheduled_task(
         workflow,
-        config=config,
-        runtime_paths=runtime_paths,
     )
 
     with bound_log_context(**target.log_context):
@@ -834,7 +818,7 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
         logger.error("No room_id provided for recurring task", task_id=task_id)
         return
 
-    current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
+    current_target = MessageTarget.for_scheduled_task(workflow)
     try:
         while True:
             latest_task = await _get_pending_task_record(client=client, room_id=workflow.room_id, task_id=task_id)
@@ -845,7 +829,7 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
             latest_workflow = latest_task.workflow
             workflow = latest_workflow
-            current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
+            current_target = MessageTarget.for_scheduled_task(workflow)
             with bound_log_context(**current_target.log_context):
                 cron_schedule = latest_workflow.cron_schedule
                 if not cron_schedule:
@@ -878,11 +862,7 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
                     if _workflows_differ(workflow, refreshed_workflow):
                         workflow = refreshed_workflow
-                        current_target = _scheduled_workflow_target(
-                            workflow,
-                            config=config,
-                            runtime_paths=runtime_paths,
-                        )
+                        current_target = MessageTarget.for_scheduled_task(workflow)
                         workflow_changed = True
                         break
 
@@ -904,7 +884,7 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     return
                 if _workflows_differ(workflow, latest_workflow):
                     workflow = latest_workflow
-                    current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
+                    current_target = MessageTarget.for_scheduled_task(workflow)
                     continue
 
                 await _execute_scheduled_workflow(client, workflow, config, runtime_paths, task_id=task_id)
@@ -943,7 +923,7 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
         logger.error("No room_id provided for one-time task", task_id=task_id)
         return
 
-    current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
+    current_target = MessageTarget.for_scheduled_task(workflow)
     latest_pending_task: ScheduledTaskRecord | None = None
     try:
         while True:
@@ -955,7 +935,7 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
 
             latest_workflow = latest_task.workflow
             workflow = latest_workflow
-            current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
+            current_target = MessageTarget.for_scheduled_task(workflow)
             with bound_log_context(**current_target.log_context):
                 execute_at = latest_workflow.execute_at
                 if not execute_at:
@@ -980,7 +960,7 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
         latest_workflow = latest_before_execute.workflow
         latest_pending_task = latest_before_execute
         workflow = latest_workflow
-        current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
+        current_target = MessageTarget.for_scheduled_task(workflow)
         with bound_log_context(**current_target.log_context):
             if not latest_workflow.execute_at:
                 logger.error("No execution time provided for one-time task", task_id=task_id)
@@ -1012,14 +992,14 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
     except asyncio.CancelledError:
         if latest_pending_task is not None and latest_pending_task.workflow is not workflow:
             workflow = latest_pending_task.workflow
-            current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
+            current_target = MessageTarget.for_scheduled_task(workflow)
         with bound_log_context(**current_target.log_context):
             logger.info("one_time_task_cancelled", task_id=task_id)
         raise
     except Exception as e:
         if latest_pending_task is not None and latest_pending_task.workflow is not workflow:
             workflow = latest_pending_task.workflow
-            current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
+            current_target = MessageTarget.for_scheduled_task(workflow)
         with bound_log_context(**current_target.log_context):
             logger.exception("one_time_task_failed", task_id=task_id)
             if workflow.room_id:

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -403,6 +403,20 @@ def _cleanup_task_if_current(task_id: str, running_tasks: dict[str, asyncio.Task
         del running_tasks[task_id]
 
 
+def _scheduled_workflow_target(
+    workflow: ScheduledWorkflow,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> MessageTarget:
+    """Return the canonical target for one scheduled workflow snapshot."""
+    return MessageTarget.for_scheduled_task(
+        workflow,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+
+
 def _parse_task_records_from_state(
     room_id: str,
     state_response: nio.RoomGetStateResponse,
@@ -820,23 +834,18 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
         logger.error("No room_id provided for recurring task", task_id=task_id)
         return
 
+    current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
     try:
         while True:
             latest_task = await _get_pending_task_record(client=client, room_id=workflow.room_id, task_id=task_id)
             if not latest_task:
-                with bound_log_context(
-                    **MessageTarget.for_scheduled_task(
-                        workflow,
-                        config=config,
-                        runtime_paths=runtime_paths,
-                    ).log_context,
-                ):
+                with bound_log_context(**current_target.log_context):
                     logger.info("Recurring task is no longer pending, stopping", task_id=task_id)
                 return
 
             latest_workflow = latest_task.workflow
             workflow = latest_workflow
-            current_target = MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths)
+            current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
             with bound_log_context(**current_target.log_context):
                 cron_schedule = latest_workflow.cron_schedule
                 if not cron_schedule:
@@ -869,6 +878,11 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
                     if _workflows_differ(workflow, refreshed_workflow):
                         workflow = refreshed_workflow
+                        current_target = _scheduled_workflow_target(
+                            workflow,
+                            config=config,
+                            runtime_paths=runtime_paths,
+                        )
                         workflow_changed = True
                         break
 
@@ -890,6 +904,7 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     return
                 if _workflows_differ(workflow, latest_workflow):
                     workflow = latest_workflow
+                    current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
                     continue
 
                 await _execute_scheduled_workflow(client, workflow, config, runtime_paths, task_id=task_id)
@@ -897,21 +912,18 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     logger.info("scheduled_task_missing_from_running_tasks", task_id=task_id)
                     return
     except asyncio.CancelledError:
-        with bound_log_context(
-            **MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths).log_context,
-        ):
+        with bound_log_context(**current_target.log_context):
             logger.info("cron_task_cancelled", task_id=task_id)
         raise
     except Exception as e:
-        target = MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths)
-        with bound_log_context(**target.log_context):
+        with bound_log_context(**current_target.log_context):
             logger.exception("cron_task_failed", task_id=task_id)
             if workflow.room_id:
                 error_message = f"❌ Recurring task failed: {workflow.description}\nTask ID: {task_id}\nError: {e!s}"
                 error_content = await _build_scheduled_failure_content(
                     client,
                     workflow,
-                    target,
+                    current_target,
                     error_message,
                 )
                 await send_message(client, workflow.room_id, error_content)
@@ -931,24 +943,19 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
         logger.error("No room_id provided for one-time task", task_id=task_id)
         return
 
+    current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
     latest_pending_task: ScheduledTaskRecord | None = None
     try:
         while True:
             latest_task = await _get_pending_task_record(client=client, room_id=workflow.room_id, task_id=task_id)
             if not latest_task:
-                with bound_log_context(
-                    **MessageTarget.for_scheduled_task(
-                        workflow,
-                        config=config,
-                        runtime_paths=runtime_paths,
-                    ).log_context,
-                ):
+                with bound_log_context(**current_target.log_context):
                     logger.info("One-time task is no longer pending, stopping", task_id=task_id)
                 return
 
             latest_workflow = latest_task.workflow
             workflow = latest_workflow
-            current_target = MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths)
+            current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
             with bound_log_context(**current_target.log_context):
                 execute_at = latest_workflow.execute_at
                 if not execute_at:
@@ -966,16 +973,14 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
             task_id=task_id,
         )
         if not latest_before_execute:
-            with bound_log_context(
-                **MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths).log_context,
-            ):
+            with bound_log_context(**current_target.log_context):
                 logger.info("One-time task was cancelled before execution, stopping", task_id=task_id)
             return
 
         latest_workflow = latest_before_execute.workflow
         latest_pending_task = latest_before_execute
         workflow = latest_workflow
-        current_target = MessageTarget.for_scheduled_task(workflow, config=config, runtime_paths=runtime_paths)
+        current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
         with bound_log_context(**current_target.log_context):
             if not latest_workflow.execute_at:
                 logger.error("No execution time provided for one-time task", task_id=task_id)
@@ -1005,27 +1010,24 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
                     status=final_status,
                 )
     except asyncio.CancelledError:
-        current_workflow = latest_pending_task.workflow if latest_pending_task is not None else workflow
-        with bound_log_context(
-            **MessageTarget.for_scheduled_task(
-                current_workflow,
-                config=config,
-                runtime_paths=runtime_paths,
-            ).log_context,
-        ):
+        if latest_pending_task is not None and latest_pending_task.workflow is not workflow:
+            workflow = latest_pending_task.workflow
+            current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
+        with bound_log_context(**current_target.log_context):
             logger.info("one_time_task_cancelled", task_id=task_id)
         raise
     except Exception as e:
-        current_workflow = latest_pending_task.workflow if latest_pending_task is not None else workflow
-        target = MessageTarget.for_scheduled_task(current_workflow, config=config, runtime_paths=runtime_paths)
-        with bound_log_context(**target.log_context):
+        if latest_pending_task is not None and latest_pending_task.workflow is not workflow:
+            workflow = latest_pending_task.workflow
+            current_target = _scheduled_workflow_target(workflow, config=config, runtime_paths=runtime_paths)
+        with bound_log_context(**current_target.log_context):
             logger.exception("one_time_task_failed", task_id=task_id)
             if workflow.room_id:
                 error_message = f"❌ One-time task failed: {workflow.description}\nTask ID: {task_id}\nError: {e!s}"
                 error_content = await _build_scheduled_failure_content(
                     client,
                     workflow,
-                    target,
+                    current_target,
                     error_message,
                 )
                 await send_message(client, workflow.room_id, error_content)

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -575,7 +575,6 @@ def _build_tool_instance(
         credentials_manager=resolved_credentials_manager,
         tool_init_overrides=proxy_tool_init_overrides or None,
         tool_config_overrides=validated_tool_config_overrides,
-        runtime_overrides=runtime_overrides,
         extra_env_passthrough=extra_env_passthrough if isinstance(extra_env_passthrough, str) else None,
         worker_tools_override=worker_tools_override,
         shared_storage_root_path=shared_storage_root_path,

--- a/src/mindroom/tool_system/sandbox_proxy.py
+++ b/src/mindroom/tool_system/sandbox_proxy.py
@@ -656,7 +656,6 @@ def maybe_wrap_toolkit_for_sandbox_proxy(
     shared_storage_root_path: Path | None = None,
     tool_config_overrides: dict[str, object] | None = None,
     tool_init_overrides: dict[str, object] | None = None,
-    runtime_overrides: dict[str, object] | None = None,
     extra_env_passthrough: str | None = None,
     worker_tools_override: list[str] | None = None,
     worker_target: ResolvedWorkerTarget | None = None,
@@ -666,8 +665,6 @@ def maybe_wrap_toolkit_for_sandbox_proxy(
     Note: mutates ``toolkit.functions`` and ``toolkit.async_functions`` in place.
     Callers must pass a freshly-created toolkit (``get_tool_by_name`` does this).
     """
-    del runtime_overrides
-
     if not _sandbox_proxy_enabled_for_tool(
         tool_name,
         runtime_paths=runtime_paths,

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -679,7 +679,7 @@ async def test_redaction_removes_individual_event_cache_entry(tmp_path: Path) ->
             [_cache_source(root_event), _cache_source(reply_event)],
         )
         assert await cache.get_event("!room:localhost", "$reply") is not None
-        redacted = await cache.redact_event("!room:localhost", "$reply", thread_id="$thread_root")
+        redacted = await cache.redact_event("!room:localhost", "$reply")
         cached_event = await cache.get_event("!room:localhost", "$reply")
     finally:
         await cache.close()
@@ -739,7 +739,7 @@ async def test_redacting_original_removes_dependent_cached_edits_from_thread_his
         )
         history_before = await fetch_thread_history(client, "!room:localhost", "$thread_root", event_cache=cache)
 
-        redacted = await cache.redact_event("!room:localhost", "$reply", thread_id="$thread_root")
+        redacted = await cache.redact_event("!room:localhost", "$reply")
         latest_edit = await cache.get_latest_edit("!room:localhost", "$reply")
         cached_edit = await cache.get_event("!room:localhost", "$reply_edit")
         history_after = await fetch_thread_history(client, "!room:localhost", "$thread_root", event_cache=cache)

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -750,8 +750,7 @@ class TestThreadingBehavior:
         await bot._conversation_access.apply_redaction("!test:localhost", redaction_event)
 
         event_cache.get_thread_id_for_event.assert_awaited_once_with("!test:localhost", "$thread_msg:localhost")
-        event_cache.redact_event.assert_awaited_once()
-        assert event_cache.redact_event.await_args.kwargs["thread_id"] is None
+        event_cache.redact_event.assert_awaited_once_with("!test:localhost", "$thread_msg:localhost")
 
     @pytest.mark.asyncio
     async def test_live_event_cache_update_recovers_after_same_room_failure(self) -> None:

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -117,8 +117,6 @@ class TestScheduledWorkflow:
 
     def test_message_target_for_scheduled_task_uses_persisted_thread_id(self) -> None:
         """Scheduled workflows should honor the persisted thread even if live routing is room mode."""
-        config = MagicMock()
-        config.get_entity_thread_mode.return_value = "room"
         workflow = ScheduledWorkflow(
             schedule_type="once",
             execute_at=datetime.now(UTC),
@@ -129,15 +127,10 @@ class TestScheduledWorkflow:
             new_thread=False,
         )
 
-        target = MessageTarget.for_scheduled_task(
-            workflow,
-            config=config,
-            runtime_paths=MagicMock(),
-        )
+        target = MessageTarget.for_scheduled_task(workflow)
 
         assert target.resolved_thread_id == "$thread-root"
         assert target.session_id == "!room:server:$thread-root"
-        config.get_entity_thread_mode.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reduce repeated `MessageTarget` resolution in scheduled task runners by carrying a `current_target` alongside the latest workflow snapshot
- reuse the existing `_resolve_request_target(...)` helper inside `ResponseCoordinator._prepare_response_runtime_common(...)` instead of duplicating the same resolution expression
- keep behavior unchanged while trimming avoidable target recomputation and duplicate logic

## Test Plan
- uv run pytest -q tests/test_hook_schedule.py
- uv run pytest -q tests/test_queued_message_notify.py
- uv run pre-commit run --all-files
