### PR TITLE
Extract turn engine and edit regenerator

### DIFF
--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -1,76 +1,76 @@
-# Bot Runtime Simplification
+# Bot Runtime Simplification Plan
 
-`src/mindroom/bot.py` currently owns too many jobs at once.
-It is the Matrix lifecycle shell, the inbound event normalizer, the conversation resolver, the routing and team policy layer, the response lifecycle coordinator, and part of the persistence layer.
-Today the file is roughly 6,800 lines long, which is a symptom rather than the root problem.
-The root problem is that several core concepts are represented in multiple overlapping ways and are re-derived at different stages of the same turn.
+## Why This Document Exists
 
-This document defines the requirements for the bot runtime and proposes a simpler design.
-The design goal is not to introduce more abstraction for its own sake.
-The goal is to make one turn easy to trace from Matrix ingress to final delivery, with one owner for each concern.
+The previous refactor improved file boundaries, but it did not remove enough conceptual complexity.
+The main risk now is doing another extraction pass that only redistributes the same complexity again.
+This plan exists to keep the next refactor subtractive.
 
-## Current Pain Points
+## Problem Statement
 
-- Conversation identity is represented repeatedly as `EventInfo.thread_id`, `_MessageContext.thread_id`, `MessageTarget.thread_id`, `MessageTarget.resolved_thread_id`, and ad hoc local variables such as `effective_thread_id` and `delivery_thread_id`.
-- Conversation history is loaded through several paths, including full history, lightweight snapshots, reply-chain reconstruction, per-turn caches, and the persistent event cache.
-- Text, audio, sidecar-backed files, routed media, and edits all enter the same pipeline through different normalization paths.
-- Response planning and response mechanics are interleaved, so policy decisions and delivery details are hard to separate.
-- Placeholder messages, queued-message signals, streaming edits, cancellation, and duplicate tracking all mutate the same turn from different layers.
-- Edit regeneration depends on partially reconstructing the original decision path instead of reading a single canonical record for the handled turn.
+One inbound turn is still controlled by multiple places.
+Today the main control flow is split across `AgentBot`, `DispatchPlanner`, `ResponseCoordinator`, and edit-specific code in `bot.py`.
+Planning and execution are still partially mixed.
+Turn persistence still has two overlapping sources of truth.
+Conversation identity is still represented by several near-duplicate shapes.
 
-## Goals
+## Refactor Goal
 
-- Make `AgentBot` a thin Matrix runtime shell.
-- Introduce one canonical turn model for text, media, voice, synthetic hook events, and edits.
-- Introduce one canonical conversation target model for routing, memory, and delivery.
-- Move thread and reply-chain resolution behind one service boundary.
-- Move response lifecycle state behind one service boundary.
-- Preserve current user-visible behavior unless the current behavior is clearly a bug.
-- Keep the number of runtime concepts small enough that a new contributor can trace a turn without reading the entire file.
+Make one turn easy to trace from ingress to final recorded outcome.
+Reduce the number of runtime owners and data models involved in that turn.
+Delete overlapping representations instead of adding better wrappers around them.
 
-## Non-Goals
+## Success Criteria
 
-- This design does not change the external Matrix behavior, the config model, or the tool runtime model.
-- This design does not require a large class hierarchy.
-- This design does not require splitting the code into many tiny files.
-- This design does not redesign reactions or redactions beyond keeping their ownership clear.
+A normal text turn can be traced in one control-flow entrypoint.
+Exactly one component decides whether the turn is ignored, routed, handled as a command, rejected, or answered.
+The planner has no delivery, AI, or persistence side effects.
+Edit regeneration loads one durable turn record instead of reconciling multiple partial records.
+`AgentBot` becomes a runtime shell again rather than a partial controller.
 
-## Functional Requirements
+## Design Rules
 
-1. The bot runtime must accept text, media, voice, synthetic hook dispatches, edits, reactions, and redactions from Matrix.
-2. The runtime must normalize inbound text-like turns exactly once before planning.
-3. The runtime must preserve conversation continuity for native threads, plain replies from non-thread clients, and room-mode agents that intentionally avoid thread metadata.
-4. The runtime must deduplicate already-handled source events before expensive work begins.
-5. The runtime must enforce sender authorization and per-agent reply permissions before planning a response.
-6. The runtime must support commands, router dispatch, direct agent replies, team replies, and explicit rejection responses.
-7. The runtime must preserve attachment and media context across a conversation turn.
-8. The runtime must support coalescing of closely related user turns without creating a second downstream execution model.
-9. The runtime must support both streaming and non-streaming delivery with the same routing, hook, memory, and cancellation semantics.
-10. The runtime must persist enough metadata to regenerate responses for edited source messages.
-11. The runtime must keep the Matrix sync loop non-blocking by pushing expensive work into async tasks or background work.
-12. The runtime must preserve backlog suppression semantics, where an older turn is skipped if a newer unhandled turn from the same requester already exists in the same conversation.
-13. The runtime must preserve hook-ingress behavior for synthetic turns, including hook provenance, message-received depth, and the policy decisions that control reruns, plugin skipping, unmentioned-agent bypass, and deep-relay suppression.
-14. The runtime must preserve the current built-in reaction paths: stop controls, interactive answers, and router config confirmations.
-15. When built-in reaction handling declines a reaction, the runtime must still emit the post-built-in `reaction:received` observer hook.
+### 1. One Turn Owner
 
-## Structural Requirements
+Introduce `TurnEngine` as the only high-level owner of one inbound turn.
+`TurnEngine` must sequence `precheck -> normalize -> resolve -> plan -> execute -> record`.
+`AgentBot` must stop owning turn sequencing.
 
-1. Conversation resolution must happen in one place.
-2. Matrix reply-chain traversal, snapshot loading, full-history loading, and event-cache usage must be hidden behind that one place.
-3. Response delivery target resolution must happen in one place.
-4. The same canonical conversation target must be used for routing, locks, memory session IDs, and duplicate suppression.
-5. Matrix delivery and tool runtime anchoring must derive an explicit delivery target from that canonical conversation target instead of introducing a third ad hoc target shape.
-6. Response lifecycle state such as locks, queued signals, placeholders, and cancellation must have one owner.
-7. Marking a source event as handled must happen in one place after a terminal outcome is known.
-8. Hooks must observe the same normalized envelope regardless of whether the turn started as text, voice, media, or an edit.
-9. A stage must not partially redo work that an earlier stage already performed.
-10. Hook-ingress policy must run before unmentioned-agent gating and before deep synthetic relays are allowed to continue into full dispatch.
+### 2. Pure Planner
 
-## Proposed Shape
+`DispatchPlanner` must become a pure policy stage.
+It may inspect normalized input and resolved context.
+It may return a `TurnPlan`.
+It must not send messages.
+It must not call `ResponseCoordinator`.
+It must not update handled-turn state.
 
-The target design keeps `AgentBot` as the Matrix-facing shell and moves turn handling into a small pipeline.
-The pipeline should be logical first and physical second.
-If some stages live in the same file during migration, that is fine as long as the boundaries are clear.
+### 3. One Durable Turn Record
+
+Replace the current split between `HandledTurnLedger` and persisted run-metadata fallback with one durable `TurnStore`.
+`TurnStore` must be the single source of truth for source-event ownership, response linkage, history scope, conversation target, and coalesced prompt metadata.
+Edit regeneration must read from `TurnStore` first and should not need to reconstruct ownership from current thread state.
+
+### 4. Separate Conversation Scope From Delivery Placement
+
+Replace the overloaded `MessageTarget` role with two concepts.
+`ConversationTarget` should mean stable conversation identity used for locking, session scope, memory, and dedupe.
+`DeliveryTarget` should mean Matrix delivery placement used for send and edit behavior.
+If the old `MessageTarget` remains temporarily, new code should treat it as a migration shim rather than the target design.
+
+### 5. Keep The Good Seams
+
+Keep `InboundTurnNormalizer`.
+Keep `ConversationResolver`.
+Keep `DeliveryGateway`.
+Those modules already map well to real boundaries in the system.
+
+### 6. Do Not Add Classes That Do Not Delete Code
+
+Do not introduce `TurnEngine`, `CommandExecutor`, `RouteExecutor`, or any other type unless it immediately removes duplicated control flow from existing modules.
+A new object must replace an old owner, not sit beside it.
+
+## Target Runtime Shape
 
 ```text
 Matrix callback
@@ -79,297 +79,178 @@ Matrix callback
 AgentBot
     |
     v
-TurnController
+TurnEngine
     |
     +--> InboundTurnNormalizer
-    |
     +--> ConversationResolver
-    |
     +--> DispatchPlanner
-    |
-    +--> RouteExecutor
-    |
-    +--> CommandExecutor
-    |
-    +--> ResponseCoordinator
+    +--> TurnExecutor
             |
+            +--> ResponseCoordinator
             +--> DeliveryGateway
-            +--> AI response engine
-            +--> PostResponseEffects
     |
-    +--> ConversationStateWriter
+    +--> TurnStore
 ```
 
-`AgentBot` should own Matrix client lifecycle, sync start and stop, room joins, room invites, presence, and callback registration.
-It should also keep the callback-to-background-task wrapper that prevents Matrix sync from blocking on event handling.
-`AgentBot` should not decide how to resolve one turn beyond handing the raw event to the pipeline.
+`AgentBot` owns Matrix lifecycle and callback registration.
+`TurnEngine` owns sequencing for one turn.
+`DispatchPlanner` owns policy only.
+`TurnExecutor` owns side effects for the chosen plan.
+`ResponseCoordinator` owns response lifecycle mechanics only.
+`TurnStore` owns durable turn outcome state.
 
-`TurnController` should own the high-level state machine for one inbound event.
-It should be the only place that decides whether a turn is ignored, routed, handled as a command, or completed with a response.
-It should also be the only place that updates the handled-turn ledger.
-It should own sequencing across ingress, planning, and execution phases, but it should not reimplement the logic of any single phase.
-It should apply hook-ingress policy early enough that deep synthetic relays can stop before full dispatch and `hook_dispatch` can bypass the unmentioned-agent gate without leaking special cases into later stages.
+## What Not To Do
 
-`InboundTurnNormalizer` should convert raw Matrix events into one typed `InboundTurn`.
-Voice transcription, file sidecar preview extraction, and coalesced batches should all produce the same normalized shape.
-Commands should still be detectable from the normalized turn.
-Synthetic hook turns must preserve the ingress facts needed to compute hook policy, at minimum hook provenance and message-received depth.
+Do not split `ResponseCoordinator` just to create smaller files.
+Do not add a new abstraction layer if it still depends on the same large request object and the same collaborators.
+Do not preserve both old and new turn-record systems at the end of the refactor.
+Do not optimize for line counts.
+Optimize for fewer control paths and fewer state representations.
 
-`ConversationResolver` should own thread and reply-chain resolution.
-It should be the only component allowed to translate Matrix relations into a canonical conversation target.
-It should also own the turn-scoped history cache, the reply-chain caches, and access to the persistent event cache.
-That includes the per-turn cache scope that deduplicates repeated thread-history fetches inside one turn.
-It should not own send-vs-edit placement rules for already-existing response events.
+## Refactor Order
 
-`DispatchPlanner` should be a mostly pure policy stage.
-It should use the normalized turn and the resolved conversation snapshot to decide between `ignore`, `command`, `route`, `reject`, `respond_individual`, and `respond_team`.
-It should not send messages, edit messages, or touch cancellation state.
-It should operate in two steps when needed: a cheap `preplan(snapshot)` and a `finalize_plan(full_context_if_needed)` step for cases where the current behavior depends on upgraded history before the final action is chosen.
-When the planner returns `command` or `route`, the actual execution should run through dedicated side-effecting executors instead of smuggling transport and persistence work back into the planner.
+### Phase 0
 
-`RouteExecutor` should own router relay behavior.
-That includes routed attachment handling, target selection for the chosen agent or team, visible router echoes, and the terminal bookkeeping for a routed turn.
-
-`CommandExecutor` should own command workflows.
-Commands are planner outcomes, but command execution still needs conversation context, response delivery, AI or tool execution, and memory persistence, so it should be explicit rather than treated as a special planner branch.
-
-`ResponseCoordinator` should own the mechanics of a planned response.
-It should acquire the per-conversation lock, manage queued-message state, manage placeholders, choose streaming versus non-streaming delivery, and wire cancellation and stop-button behavior.
-It should collapse the duplicated agent-response and team-response lock and queued-signal paths into one response lifecycle mechanism.
-Queued placeholders should be generation-scoped tokens with exactly three terminal operations: `adopt`, `complete_and_redact`, and `cancel_and_redact`.
-
-`TeamBot` should use the same inbound pipeline as `AgentBot`.
-The team-specific difference should live at response execution time, not in a second ingress or planning flow.
-
-`DeliveryGateway` should be the only layer that turns a canonical target into Matrix event content.
-It should own send, edit, redact, latest-thread-event compatibility behavior, and response-hook transport around final visible delivery.
-
-`PostResponseEffects` should own memory persistence, interactive-question registration, compaction notices, and thread-summary scheduling.
-Those are downstream consequences of a terminal response, not part of response lifecycle state itself.
-
-`ConversationStateWriter` should own the write side of conversation state.
-That includes sync-time cache seeding, thread-event append behavior, and redaction-driven invalidation for the advisory `EventCache`.
-
-## Canonical Runtime Types
-
-The current code already has useful building blocks such as `MessageEnvelope` and `MessageTarget`.
-The simplification should keep that idea, but reduce the number of adjacent representations.
-
-### `InboundTurn`
-
-`InboundTurn` is the normalized trigger for one turn.
-It should include the source event ID, sender ID, requester ID, normalized body, source kind, attachment references, edit metadata, and the raw relation facts needed by the resolver.
-For synthetic hook turns it must also preserve the ingress facts needed to reproduce current hook behavior, at minimum `hook_source` and `message_received_depth`.
-Raw Matrix relation facts such as the incoming `thread_id` belong here and in the derived conversation context, not in the canonical conversation identity.
-
-### `ConversationTarget`
-
-`ConversationTarget` is the single source of truth for canonical conversation scope.
-It should identify the stable scope used for routing, locks, session IDs, memory, and duplicate suppression.
-For the internal pipeline, the important stable fields are `room_id`, `mode`, `root_event_id`, and `session_id`.
-That list is intentionally about stable conversation identity, not a complete send target.
-
-### `DeliveryTarget`
-
-`DeliveryTarget` is derived from `ConversationTarget` when the runtime actually sends or edits Matrix events.
-It should carry delivery-only fields such as the requested thread shape, `delivery_thread_root_id`, `reply_to_event_id`, and `latest_thread_event_id`.
-This keeps placeholder adoption, existing-event edits, and room-mode delivery quirks out of the canonical conversation object.
-`ConversationTarget` plus `DeliveryTarget` should fully replace today's `MessageTarget` contract.
-The pair must preserve enough thread and reply-anchor information to rebuild tool runtime context without lossy translation.
-
-### `ConversationContext`
-
-`ConversationContext` should contain the canonical target, the conversation history, mention and participant facts, and a history detail level.
-The resolver should return explicit `history_completeness` and `content_hydration` flags because a snapshot fetch may already be full history and cached reply-chain messages may still need sidecar hydration.
-`snapshot` is a request, not a guarantee.
-Only the resolver should be allowed to upgrade a context.
-
-### `HandledTurnRecord`
-
-`HandledTurnRecord` should be the durable record for one terminally handled turn.
-It should persist `owner_entity`, exact `history_scope`, `conversation_target`, `session_id`, `reply_anchor_event_id`, `source_event_ids`, `source_event_prompts` for coalesced turns, `response_event_id`, and any `visible_echo_event_id`.
-It should also persist the terminal outcome state, at minimum distinguishing `visible_echo_sent`, `terminally_handled_without_response`, and `response_completed`.
-The exact `history_scope` matters for team runs because the persisted history lane may be a configured team name or an ad hoc sorted-member scope.
-Edit regeneration should read this record directly instead of re-running router choice or mention-based responder selection.
-
-### `DispatchPlan`
-
-`DispatchPlan` should be the planner output.
-It should say what to do, who owns the response, whether a full history upgrade is required, and what prompt inputs are needed.
-It should not contain transient delivery state.
-
-### `ResponseJob`
-
-`ResponseJob` should be the executor input.
-It should include the final prompt, target, existing response event ID if one exists, hook envelope, and any execution metadata that must be persisted with the run.
-
-## Conversation Resolution
-
-The most important simplification is to make one service own all conversation identity logic.
-Today that logic is spread across `_extract_message_context_impl`, `_derive_conversation_context`, `_derive_conversation_target`, `_fetch_thread_history`, `_resolve_response_thread_root`, and several send and edit paths.
-
-The proposed resolver API is:
-
-```text
-resolve(turn, detail="snapshot") -> ConversationContext
-ensure_full(context) -> ConversationContext
-```
-
-`resolve` should return the canonical target plus the cheapest history that is valid for planning.
-`ensure_full` should upgrade that context only when the planner or executor actually needs complete history.
-No other stage should fetch history directly.
-
-This lets the pipeline express a simple rule.
-Planning starts with a snapshot.
-Some turns may then require a full-history promotion before the final plan is chosen.
-Actual response generation should only start after that promotion decision is settled.
-Reply-only chains from non-thread clients are still treated as one conversation and get a stable canonical root reused for should-respond decisions, session scope, and duplicate suppression.
-
-## Caching And State Ownership
-
-The simplification depends on explicit ownership of caches and mutable state.
-
-### ConversationResolver-owned state
-
-- Reply-chain traversal caches.
-- The turn-scoped thread history cache.
-- Read access to the persistent `EventCache`.
-- Snapshot versus full-history upgrade logic.
-
-`EventCache` is advisory and partial, not authoritative.
-Resolver code must treat cache misses, stale rows, and invalidation as normal fallback cases rather than as correctness failures.
-If a fetch path wants to refresh, repopulate, or invalidate persistent cache entries, the resolver should request that through a writer-owned cache maintenance API instead of mutating `EventCache` directly.
-
-### TurnController-owned state
-
-- The handled-turn ledger, which replaces the current partial `ResponseTracker` role.
-- Source-event to response-event linkage.
-- Source-event to routed-echo linkage.
-- The rule that a source event is only marked handled after a terminal outcome is known.
-- Backlog suppression semantics for older turns in the same conversation.
-
-### ResponseCoordinator-owned state
-
-- Per-conversation lifecycle locks.
-- Queued-message signals.
-- Placeholder lifecycle.
-- Stop-button and cancellation lifecycle.
-- In-flight response counters.
-
-### ConversationStateWriter-owned state
-
-- Sync-time cache seeding from live Matrix events.
-- Cached thread append behavior for threads that are already materialized.
-- Redaction-driven invalidation and cache cleanup.
-- Fetch-path cache invalidation, refresh, and repopulation requested by the resolver after thread-history reads.
-- Exclusive write access to `EventCache`.
-
-Coalescing should be treated as an ingress concern.
-It may emit a combined `InboundTurn`, but it should not create a second response execution model.
-It should only batch events that already passed ingress prechecks and share `(room_id, canonical conversation scope, requester_user_id)`.
-If the canonical conversation root is discovered after the gate opens, retargeting must also transfer queued-signal and placeholder ownership for the same generation.
-If coalescing wants a visible queued state, it should request that through the response coordinator instead of open-coding Matrix sends and redactions from the gate itself.
-
-## Edit Regeneration
-
-Edit handling should become a normal pipeline case instead of a special side path with partial reconstruction.
-The missing abstraction is a handled-turn record that says which agent or team owned the original response, which source events fed it, and which response event was produced.
-
-The requirements for edit regeneration are:
-
-1. Editing a previously handled user message must find the original `HandledTurnRecord`.
-2. Regeneration must reuse the persisted owner, history scope, and target directly.
-3. Regeneration must not re-run router choice or mention-based responder selection.
-4. Coalesced turns must persist the source prompt map needed to rebuild the coalesced prompt.
-5. Regeneration must edit the existing response event in place when possible.
-6. Before storing the replacement run, the runtime must remove or supersede prior persisted runs for every source event in the handled-turn record.
-
-This removes the current special-case limitation where a routed agent may fail to regenerate after the user edits the original message.
-
-## Runtime Invariants
-
-- Native threads use the thread root as canonical conversation scope.
-- Plain reply chains from non-thread clients still collapse to one stable canonical root.
-- Room-mode agents collapse all delivery and session identity to room scope.
-- Conversation scope and delivery scope are related but not identical.
-- History has two dimensions: completeness and hydration.
-- Snapshot resolution must stay cheap and must not fetch full history until promotion is required.
-- Once promoted, full history should be fetched at most once per dispatch.
-- `EventCache` is advisory and partial, so cache misses and stale rows are fallback cases, not correctness failures.
-- Coalescing may only batch events that already passed self-message, duplicate, authorization, and reply-permission checks.
-- If the coalescing gate opens before the canonical root is known, retargeting must transfer queued-signal and placeholder ownership for the same generation.
-- A queued placeholder must end in exactly one terminal state: adopted, completed and redacted, or cancelled and redacted.
-- Duplicate suppression is not only "already handled source event IDs"; it also includes backlog suppression when a newer unhandled turn from the same requester already exists in the same conversation.
-- Hook-ingress policy must evaluate before unmentioned-agent gating and before deep synthetic relays continue into planner and executor stages.
-- Router config-confirmation reactions remain a built-in reaction path and must not be lost while separating stop controls from interactive-answer reactions.
-- If built-in reaction handling declines a reaction, the runtime still emits `reaction:received` observer hooks.
-- `HandledTurnRecord` must persist exact history-scope identity for team runs instead of inferring it later from `owner_entity`.
-- If the runtime does not introduce a durable pre-send reservation or idempotent delivery key, crash-boundary duplicate suppression is best-effort rather than exactly-once.
-
-## Simpler End-To-End Flow
-
-The target steady-state flow for text, voice, media, and edits should be:
-
-1. `AgentBot` receives a Matrix callback and hands it to `TurnController`.
-2. `InboundTurnNormalizer` converts the raw event into `InboundTurn`.
-3. `TurnController` performs cheap prechecks such as self-message skipping, deduplication, authorization, and hook-ingress gating for synthetic relays.
-4. `ConversationResolver.resolve(..., detail="snapshot")` returns the canonical target and planning context.
-5. `DispatchPlanner` returns a `DispatchPlan`, and may request a full-history promotion before the final plan is locked.
-6. If needed, `ConversationResolver.ensure_full(...)` upgrades the context and the planner finalizes the plan.
-7. `TurnController` routes the final plan to `RouteExecutor`, `CommandExecutor`, or `ResponseCoordinator`.
-8. `ResponseCoordinator` executes the response job and delegates send or edit operations to `DeliveryGateway`.
-9. `PostResponseEffects` runs terminal side effects.
-10. `TurnController` records the terminal outcome in the handled-turn ledger.
-
-Control reactions such as stop buttons should remain separate from the turn pipeline.
-Router config-confirmation reactions should also remain a separate built-in reaction path.
-Interactive-answer reactions should be fed back into `TurnController` as synthetic `InboundTurn`s.
-If built-in reaction handling declines the reaction, the runtime should still emit `reaction:received` hooks for plugin observers.
-Redactions remain outside the turn pipeline, but they may notify `ConversationStateWriter` to mutate persistent cache state while resolver-owned turn-scoped caches stay read-side only.
-
-## Migration Plan
-
-The migration should be incremental and behavior-preserving.
-The order matters because the riskiest coupling today lives in terminal outcome recording, response lifecycle state, and edit regeneration metadata.
+Agree on this plan and treat it as the source of truth for the refactor.
+Do not extract more types before agreeing on the end state.
 
 ### Phase 1
 
-Centralize terminal outcome recording first.
-Keep the existing control flow, but make one helper own source-event to response-event linkage, visible-echo linkage, and the durable handled-turn record.
-No behavior changes should happen in this phase.
+Introduce `TurnEngine` with no behavior change.
+Move the existing turn-sequencing logic out of `AgentBot` and into `TurnEngine`.
+Keep `AgentBot` limited to Matrix callback handling, lifecycle, room membership, sync support, and reaction wiring.
+
+#### Phase 1 Checklist
+
+Add a new runtime module for `TurnEngine`.
+Prefer a small file such as `src/mindroom/turn_engine.py`.
+Do not move planner or response code into that file yet.
+Move only sequencing and ingress control flow.
+
+`AgentBot` should keep these responsibilities:
+
+- callback registration in `start()`
+- sync lifecycle and startup or shutdown helpers
+- room joins, invites, presence, welcome messages, and router overdue-task draining
+- redaction handling in `_on_redaction()`
+- reaction handling in `_on_reaction()` and `_handle_reaction_inner()`
+
+`AgentBot` should stop owning these turn-sequencing methods:
+
+- `_enqueue_for_dispatch()` from `src/mindroom/bot.py`
+- `_dispatch_coalesced_batch()` from `src/mindroom/bot.py`
+- `_handle_message_inner()` from `src/mindroom/bot.py`
+- `_dispatch_text_message()` from `src/mindroom/bot.py`
+- `_handle_media_message_inner()` from `src/mindroom/bot.py`
+- `_dispatch_special_media_as_text()` from `src/mindroom/bot.py`
+- `_dispatch_file_sidecar_text_preview()` from `src/mindroom/bot.py`
+- `_on_audio_media_message()` from `src/mindroom/bot.py`
+- `_handle_command()` from `src/mindroom/bot.py`
+
+Phase 1 should also move these small ingress helpers if they are only used by turn sequencing:
+
+- `_precheck_event()`
+- `_precheck_dispatch_event()`
+- `_requester_user_id()`
+- `_requester_user_id_for_event()`
+- `_is_trusted_internal_relay_event()`
+- `_should_bypass_coalescing_for_active_thread_follow_up()`
+- `_has_newer_unresponded_in_thread()`
+- `_should_skip_deep_synthetic_full_dispatch()`
+
+Phase 1 should not move edit regeneration yet.
+Keep `_handle_message_edit()` in `AgentBot` for now.
+It is too entangled with the current dual persistence model and should be handled after `TurnStore` work.
+
+The temporary `TurnEngine` constructor should receive already-extracted collaborators from `AgentBot`:
+
+- `ConversationResolver`
+- `InboundTurnNormalizer`
+- `DispatchPlanner`
+- `ResponseCoordinator`
+- `DeliveryGateway`
+- `ConversationStateWriter`
+- `HandledTurnLedger`
+- `ToolRuntimeSupport`
+- `MatrixConversationAccess`
+- logger, config, runtime paths, and agent name
+
+The target call shape for Phase 1 is:
+
+```text
+_on_message() -> TurnEngine.handle_text_event()
+_on_media_message() -> TurnEngine.handle_media_event()
+CoalescingGate.flush() -> TurnEngine.handle_coalesced_batch()
+```
+
+The target internal flow for `TurnEngine.handle_text_event()` in Phase 1 is:
+
+1. Append the live event to conversation access.
+2. Skip streamed or invalid text events.
+3. Run ingress precheck.
+4. Branch edits to the existing `AgentBot._handle_message_edit()` callback.
+5. Normalize text.
+6. Apply deep synthetic relay gating and interactive text handling.
+7. Decide whether to bypass coalescing.
+8. Either enqueue into the gate or call the existing dispatch path.
+
+The target internal flow for `TurnEngine.dispatch_text_message()` in Phase 1 is:
+
+1. Normalize the raw or prechecked event into one prepared text event.
+2. Call `DispatchPlanner.prepare_dispatch()`.
+3. Handle command detection at the turn-engine layer, not in `AgentBot`.
+4. Apply backlog suppression and deep synthetic relay suppression.
+5. Call `DispatchPlanner.plan_dispatch()`.
+6. Branch on the returned plan.
+7. For now, call the existing side-effecting planner executor methods.
+8. Record handled-turn outcomes exactly as today.
+
+The explicit non-goal for Phase 1 is purity.
+It is acceptable that `DispatchPlanner` still executes commands, router relays, and response actions during this phase.
+The goal is only to make `AgentBot` stop being the turn controller.
 
 ### Phase 2
 
-Extract `ResponseCoordinator`, `DeliveryGateway`, and `PostResponseEffects`.
-Move locks, queued signals, placeholders, cancellation, send and edit operations, and visible delivery behind one response boundary.
-Move memory persistence, interactive registration, compaction notices, and thread-summary side effects into post-response effects.
-Because Phase 2 lands before conversation resolution is fully extracted, it may need a temporary shim for thread-root resolution that Phase 3 later removes.
+Make `DispatchPlanner` pure.
+Remove `execute_command`, `execute_router_relay`, and `execute_response_action` from `DispatchPlanner`.
+Return a `TurnPlan` that is rich enough for a separate executor to perform those actions.
 
 ### Phase 3
 
-Extract `InboundTurnNormalizer`, `ConversationResolver`, and `ConversationStateWriter` together.
-Preserve snapshot and full-history upgrades, merged plain-reply context, sidecar hydration, hook provenance, coalescing thread-key resolution, sync-time cache seeding, and redaction invalidation.
+Introduce `TurnStore`.
+Move durable turn recording, response linkage, visible echo linkage, source prompt maps, and edit-regeneration lookup behind that one store.
+Delete fallback reconciliation between handled-turn records and persisted run metadata once `TurnStore` is sufficient.
 
 ### Phase 4
 
-Extract `DispatchPlanner`.
-Represent command handling and router relay delivery as explicit executor paths instead of planner-owned side effects.
+Split conversation identity from delivery placement.
+Introduce `ConversationTarget` and `DeliveryTarget`, or make an equivalent simplification that removes the overloaded role of `MessageTarget`.
+Update locking, session scope, memory scope, and delivery code to use the correct target type.
 
 ### Phase 5
 
-Move edit regeneration onto the same pipeline using the handled-turn record.
-Remove special-case code paths that only exist because earlier stages were not explicit enough.
+Re-evaluate `ResponseCoordinator`.
+Only split it further if that split deletes duplicated lifecycle paths or collapses the current request-shuffling between team and individual responses.
+If no real deletion happens, leave it as one module.
 
-## Reliability Note
+### Phase 6
 
-Duplicate suppression should be described honestly.
-Unless the runtime introduces a durable pre-send reservation or an idempotent delivery key, duplicate suppression across crash boundaries is best-effort rather than exactly-once.
+Delete stale paths, update docs and diagrams, and remove migration shims.
+The refactor is not done until the old owners are gone.
 
-## Result
+## Review Checklist
 
-After the refactor, `bot.py` should read like a runtime shell.
-The file should answer questions such as when the bot starts, what callbacks are registered, and which pipeline handles each event type.
-It should not be the place where a contributor has to understand every detail of thread resolution, routing, placeholder state, streaming, and edit regeneration all at once.
+When reviewing each phase, ask these questions.
 
-The key simplification is not smaller methods.
-The key simplification is one canonical turn, one canonical conversation target, one conversation resolver, and one response coordinator.
+Can one normal text turn be traced in one place.
+Is there one owner for turn sequencing.
+Is the planner side-effect free.
+Is there one durable turn record.
+Can edit regeneration use the same core execution path as a normal response.
+Did the change delete an old owner, or only add a new one.
+
+## Practical Note
+
+A short plan document is the right first step.
+The document must be brief, current, and tied to code deletion.
+It must not become another architecture essay that the implementation no longer follows.

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import time
-from dataclasses import dataclass, replace
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 import nio
@@ -22,11 +21,7 @@ from mindroom.hooks import (
     ReactionReceivedContext,
     emit,
 )
-from mindroom.hooks.ingress import (
-    hook_ingress_policy,
-    is_automation_source_kind,
-    should_handle_interactive_text_response,
-)
+from mindroom.hooks.ingress import is_automation_source_kind
 from mindroom.hooks.registry import HookRegistryState
 from mindroom.hooks.sender import send_hook_message
 from mindroom.hooks.types import EVENT_AGENT_STARTED, EVENT_AGENT_STOPPED, EVENT_BOT_READY, EVENT_REACTION_RECEIVED
@@ -42,10 +37,6 @@ from mindroom.matrix.identity import (
     extract_agent_name,
     is_agent_id,
 )
-from mindroom.matrix.message_content import (
-    extract_edit_body,
-    is_v2_sidecar_text_preview,
-)
 from mindroom.matrix.presence import build_agent_status_message, set_presence_status
 from mindroom.matrix.room_cleanup import cleanup_all_orphaned_bots
 from mindroom.matrix.rooms import leave_non_dm_rooms, resolve_room_aliases
@@ -59,20 +50,10 @@ from mindroom.memory import store_conversation_memory
 from mindroom.message_target import MessageTarget  # noqa: TC001
 from mindroom.post_response_effects import (
     PostResponseEffectsSupport,
-    matrix_run_metadata_for_handled_turn,
     record_handled_turn,
 )
 from mindroom.stop import StopManager
 from mindroom.teams import TeamMode, TeamOutcome, resolve_configured_team
-from mindroom.thread_utils import (
-    should_agent_respond,
-)
-from mindroom.timing import (
-    attach_dispatch_pipeline_timing,
-    create_dispatch_pipeline_timing,
-    get_dispatch_pipeline_timing,
-)
-from mindroom.timing import timing_scope as timing_scope_context
 from mindroom.tool_system.runtime_context import ToolRuntimeSupport
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
@@ -84,38 +65,21 @@ from . import constants, interactive
 from .agents import (
     create_agent,
     get_rooms_for_entity,
-    remove_run_by_event_id,
     show_tool_calls_for_agent,
 )
-from .attachments import (
-    merge_attachment_ids,
-    parse_attachment_ids_from_event_source,
-)
 from .authorization import (
-    get_effective_sender_id_for_reply_permissions,
     is_authorized_sender,
 )
 from .background_tasks import create_background_task, wait_for_background_tasks
 from .coalescing import (
     CoalescedBatch,
     CoalescingGate,
-    CoalescingKey,
-    PendingEvent,
-    PreparedTextEvent,
-    build_batch_dispatch_event,
-    coalesced_prompt,
+    PreparedTextEvent,  # noqa: F401
 )
 from .commands import config_confirmation
-from .commands.handler import CommandEvent, _generate_welcome_message
-from .commands.parsing import Command, command_parser
+from .commands.handler import _generate_welcome_message
 from .constants import (
-    ATTACHMENT_IDS_KEY,
-    ORIGINAL_SENDER_KEY,
     ROUTER_AGENT_NAME,
-    STREAM_STATUS_KEY,
-    STREAM_STATUS_PENDING,
-    STREAM_STATUS_STREAMING,
-    VOICE_RAW_AUDIO_FALLBACK_KEY,
     RuntimePaths,
     resolve_avatar_path,
 )
@@ -127,9 +91,6 @@ from .conversation_resolver import (
 from .conversation_state_writer import (
     ConversationStateWriter,
     ConversationStateWriterDeps,
-    LoadPersistedTurnMetadataRequest,
-    PersistedTurnMetadata,
-    RemoveStaleRunsRequest,
 )
 from .delivery_gateway import (
     DeliveryGateway,
@@ -145,22 +106,15 @@ from .dispatch_planner import (
     DispatchHookService,
     DispatchPlanner,
     DispatchPlannerDeps,
-    ResponseAction,
 )
-from .handled_turns import HandledTurnLedger, HandledTurnRecord, HandledTurnState
+from .edit_regenerator import EditRegenerator, EditRegeneratorDeps
+from .handled_turns import HandledTurnLedger, HandledTurnState
 from .inbound_turn_normalizer import (
-    BatchMediaAttachmentRequest,
     DispatchPayload,
-    DispatchPayloadWithAttachmentsRequest,
     InboundTurnNormalizer,
     InboundTurnNormalizerDeps,
-    TextNormalizationRequest,
-    VoiceNormalizationRequest,
 )
-from .knowledge.utils import (
-    KnowledgeAccessSupport,
-    MultiKnowledgeVectorDb,
-)
+from .knowledge.utils import KnowledgeAccessSupport, MultiKnowledgeVectorDb
 from .logging_config import get_logger
 from .matrix.avatar import check_and_set_avatar
 from .matrix.client import (
@@ -188,6 +142,7 @@ from .scheduling import (
     has_deferred_overdue_tasks,
     restore_scheduled_tasks,
 )
+from .turn_engine import TurnEngine, TurnEngineDeps
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
@@ -196,10 +151,8 @@ if TYPE_CHECKING:
 
     import structlog
     from agno.agent import Agent
-    from agno.media import Image
 
     from mindroom.config.main import Config
-    from mindroom.history.types import HistoryScope
     from mindroom.matrix.client import ResolvedVisibleMessage
     from mindroom.matrix.event_cache import ConversationEventCache
     from mindroom.matrix.event_cache_write_coordinator import EventCacheWriteCoordinator
@@ -345,25 +298,8 @@ type _MediaDispatchEvent = (
     | nio.RoomMessageVideo
     | nio.RoomEncryptedVideo
 )
-type _InboundMediaEvent = _MediaDispatchEvent | nio.RoomMessageAudio | nio.RoomEncryptedAudio
-
-type _TextDispatchEvent = nio.RoomMessageText | PreparedTextEvent
-
-type _DispatchEvent = _TextDispatchEvent | _MediaDispatchEvent
 
 type _MessageContext = MessageContext
-
-
-@dataclass(frozen=True)
-class _PrecheckedEvent[T]:
-    """A raw or prepared event that has already passed ingress prechecks."""
-
-    event: T
-    requester_user_id: str
-
-
-type _PrecheckedTextDispatchEvent = _PrecheckedEvent[_TextDispatchEvent]
-type _PrecheckedMediaDispatchEvent = _PrecheckedEvent[_MediaDispatchEvent]
 
 
 class AgentBot:
@@ -401,6 +337,7 @@ class AgentBot:
     _knowledge_access_support: KnowledgeAccessSupport
     _deferred_overdue_task_drain_task: asyncio.Task[None] | None
     _standalone_runtime_support: StandaloneRuntimeSupport | None
+    _turn_engine: TurnEngine
 
     def __init__(
         self,
@@ -438,11 +375,12 @@ class AgentBot:
 
     def _init_runtime_components(self) -> None:
         """Initialize runtime-only helpers that depend on bound instance methods."""
-        stable_matrix_id = MatrixID.from_agent(
-            self.agent_name,
-            self.config.get_domain(self.runtime_paths),
-            self.runtime_paths,
-        )
+        runtime_matrix_id = self.config.get_ids(self.runtime_paths).get(self.agent_name)
+        if self.agent_user.user_id:
+            runtime_matrix_id = self.matrix_id
+        elif runtime_matrix_id is None:
+            msg = f"Missing Matrix ID for {self.agent_name!r} during runtime initialization"
+            raise KeyError(msg)
         self._coalescing_gate = CoalescingGate(
             dispatch_batch=self._dispatch_coalesced_batch,
             enabled=self._coalescing_enabled,
@@ -481,7 +419,7 @@ class AgentBot:
                 logger=self.logger,
                 runtime_paths=self.runtime_paths,
                 agent_name=self.agent_name,
-                matrix_id=stable_matrix_id,
+                matrix_id=runtime_matrix_id,
                 conversation_access=self._conversation_access,
             ),
         )
@@ -491,7 +429,7 @@ class AgentBot:
                 logger=self.logger,
                 storage_path=self.storage_path,
                 runtime_paths=self.runtime_paths,
-                sender_domain=stable_matrix_id.domain,
+                sender_domain=runtime_matrix_id.domain,
                 conversation_resolver=self._conversation_resolver,
             ),
         )
@@ -501,7 +439,7 @@ class AgentBot:
                 runtime_paths=self.runtime_paths,
                 agent_name=self.agent_name,
                 logger=self.logger,
-                sender_domain=stable_matrix_id.domain,
+                sender_domain=runtime_matrix_id.domain,
                 resolver=self._conversation_resolver,
                 redact_message_event=self._redact_message_event,
                 response_hooks=ResponseHookService(
@@ -515,7 +453,7 @@ class AgentBot:
             runtime_paths=self.runtime_paths,
             storage_path=self.storage_path,
             agent_name=self.agent_name,
-            matrix_id=stable_matrix_id,
+            matrix_id=runtime_matrix_id,
             resolver=self._conversation_resolver,
             hook_context=self._hook_context_support,
         )
@@ -534,7 +472,7 @@ class AgentBot:
                 runtime_paths=self.runtime_paths,
                 storage_path=self.storage_path,
                 agent_name=self.agent_name,
-                matrix_full_id=stable_matrix_id.full_id,
+                matrix_full_id=runtime_matrix_id.full_id,
                 resolver=self._conversation_resolver,
                 tool_runtime=self._tool_runtime_support,
                 knowledge_access=self._knowledge_access_support,
@@ -546,6 +484,20 @@ class AgentBot:
         self._dispatch_hook_service = DispatchHookService(
             hook_context=self._hook_context_support,
         )
+        self._edit_regenerator = EditRegenerator(
+            EditRegeneratorDeps(
+                runtime=self._runtime_view,
+                get_logger=lambda: self.logger,
+                runtime_paths=self.runtime_paths,
+                agent_name=self.agent_name,
+                get_handled_turn_ledger=lambda: self.handled_turn_ledger,
+                resolver=self._conversation_resolver,
+                state_writer=self._conversation_state_writer,
+                tool_runtime=self._tool_runtime_support,
+                dispatch_hook_service=self._dispatch_hook_service,
+                generate_response=lambda **kwargs: self._generate_response(**kwargs),
+            ),
+        )
         self._dispatch_planner = DispatchPlanner(
             DispatchPlannerDeps(
                 runtime=self._runtime_view,
@@ -554,13 +506,32 @@ class AgentBot:
                 runtime_paths=self.runtime_paths,
                 storage_path=self.storage_path,
                 agent_name=self.agent_name,
-                matrix_id=stable_matrix_id,
+                matrix_id=runtime_matrix_id,
                 normalizer=self._inbound_turn_normalizer,
                 resolver=self._conversation_resolver,
                 delivery_gateway=self._delivery_gateway,
                 response_coordinator=self._response_coordinator,
                 hook_service=self._dispatch_hook_service,
                 tool_runtime=self._tool_runtime_support,
+            ),
+        )
+        self._turn_engine = TurnEngine(
+            TurnEngineDeps(
+                runtime=self._runtime_view,
+                logger=self.logger,
+                runtime_paths=self.runtime_paths,
+                agent_name=self.agent_name,
+                matrix_id=runtime_matrix_id,
+                handled_turn_ledger=self.handled_turn_ledger,
+                conversation_access=self._conversation_access,
+                resolver=self._conversation_resolver,
+                normalizer=self._inbound_turn_normalizer,
+                dispatch_planner=self._dispatch_planner,
+                response_coordinator=self._response_coordinator,
+                delivery_gateway=self._delivery_gateway,
+                state_writer=self._conversation_state_writer,
+                coalescing_gate=self._coalescing_gate,
+                edit_regenerator=self._edit_regenerator,
             ),
         )
 
@@ -699,181 +670,6 @@ class AgentBot:
     ) -> None:
         """Mark one or more source events as handled by the same response."""
         record_handled_turn(self.handled_turn_ledger, handled_turn)
-
-    def _dispatch_matrix_run_metadata(
-        self,
-        handled_turn: HandledTurnState,
-    ) -> dict[str, Any] | None:
-        """Build run metadata extras for one dispatch turn."""
-        return matrix_run_metadata_for_handled_turn(handled_turn)
-
-    def _response_history_scope_for_action(
-        self,
-        response_action: ResponseAction,
-    ) -> HistoryScope | None:
-        """Return the persisted history scope used by one response action."""
-        if response_action.kind == "team":
-            assert response_action.form_team is not None
-            return self._conversation_state_writer.team_history_scope(response_action.form_team.eligible_members)
-        if response_action.kind == "individual":
-            return self._conversation_state_writer.history_scope()
-        return None
-
-    def _handled_turn_with_response_context(
-        self,
-        handled_turn: HandledTurnState,
-        *,
-        history_scope: HistoryScope | None,
-        conversation_target: MessageTarget | None,
-    ) -> HandledTurnState:
-        """Attach the persisted regeneration context for one response."""
-        return handled_turn.with_response_context(
-            response_owner=self.agent_name,
-            history_scope=history_scope,
-            conversation_target=conversation_target,
-        )
-
-    def _load_persisted_turn_metadata(
-        self,
-        *,
-        room: nio.MatrixRoom,
-        thread_id: str | None,
-        original_event_id: str,
-        requester_user_id: str,
-    ) -> PersistedTurnMetadata | None:
-        """Load persisted run metadata for one edited turn when available."""
-        return self._conversation_state_writer.load_persisted_turn_metadata(
-            LoadPersistedTurnMetadataRequest(
-                room=room,
-                thread_id=thread_id,
-                original_event_id=original_event_id,
-                requester_user_id=requester_user_id,
-            ),
-            build_message_target=self._conversation_resolver.build_message_target,
-            build_tool_execution_identity=self._tool_runtime_support.build_execution_identity,
-        )
-
-    async def _edit_regeneration_context(
-        self,
-        room: nio.MatrixRoom,
-        event: _DispatchEvent,
-        *,
-        conversation_target: MessageTarget | None,
-    ) -> MessageContext:
-        """Return edit context, reusing the recorded thread root when available."""
-        context = await self._conversation_resolver.extract_message_context(room, event)
-        if conversation_target is None or conversation_target.resolved_thread_id is None:
-            return context
-        if context.thread_id == conversation_target.resolved_thread_id:
-            return context
-        assert self.client is not None
-        return MessageContext(
-            am_i_mentioned=context.am_i_mentioned,
-            is_thread=True,
-            thread_id=conversation_target.resolved_thread_id,
-            thread_history=await self._conversation_resolver.fetch_thread_history(
-                self.client,
-                room.room_id,
-                conversation_target.resolved_thread_id,
-            ),
-            mentioned_agents=context.mentioned_agents,
-            has_non_agent_mentions=context.has_non_agent_mentions,
-            requires_full_thread_history=context.requires_full_thread_history,
-        )
-
-    def _remove_stale_runs_for_turn_record(
-        self,
-        *,
-        turn_record: HandledTurnRecord,
-        recorded_turn_context_available: bool,
-        room: nio.MatrixRoom,
-        thread_id: str | None,
-        original_event_id: str,
-        requester_user_id: str,
-    ) -> None:
-        """Remove stale persisted runs using the recorded turn context when possible."""
-        if (
-            recorded_turn_context_available
-            and turn_record.conversation_target is not None
-            and turn_record.history_scope is not None
-        ):
-            self._conversation_state_writer.remove_stale_runs_for_turn_record(
-                turn_record=turn_record,
-                requester_user_id=requester_user_id,
-                build_tool_execution_identity=self._tool_runtime_support.build_execution_identity,
-                remove_run_by_event_id_fn=remove_run_by_event_id,
-            )
-            return
-        self._remove_stale_runs_for_edited_message(
-            room=room,
-            thread_id=thread_id,
-            original_event_id=original_event_id,
-            requester_user_id=requester_user_id,
-        )
-
-    def _has_newer_unresponded_in_thread(
-        self,
-        event: _TextDispatchEvent,
-        requester_user_id: str,
-        thread_history: Sequence[ResolvedVisibleMessage],
-    ) -> bool:
-        """Return True when a newer unresponded message from the same sender exists.
-
-        Guards against duplicate replies during backlog replay: if the bot
-        restarts and processes an older message while a newer one from the
-        same sender is already visible in the thread, the older dispatch
-        should be skipped.
-
-        Automation events (scheduled tasks, hooks) are always independent
-        actions and must never be suppressed.  Command messages (``!help``,
-        etc.) are also excluded — they are handled separately and should
-        not suppress earlier questions.
-        """
-        # Automation events (scheduled tasks, hooks) are independent — never suppress.
-        # User-originated synthetics (coalesced batches, voice) must still be guarded.
-        if isinstance(event, PreparedTextEvent) and is_automation_source_kind(event.source_kind_override or ""):
-            return False
-        event_ts = event.server_timestamp
-        if event_ts is None or not thread_history:
-            return False
-        for msg in thread_history:
-            if msg.sender != requester_user_id:
-                continue
-            if msg.timestamp is None or msg.timestamp <= event_ts:
-                continue
-            if msg.event_id == event.event_id:
-                continue
-            if self.handled_turn_ledger.has_responded(msg.event_id):
-                continue
-            # Commands are handled independently — skip them as suppression candidates.
-            if msg.body and isinstance(msg.body, str) and command_parser.parse(msg.body.strip()) is not None:
-                continue
-            self.logger.info(
-                "Skipping older message — newer unresponded message from same sender in thread",
-                skipped_event_id=event.event_id,
-                newer_event_id=msg.event_id,
-            )
-            return True
-        return False
-
-    def _should_skip_deep_synthetic_full_dispatch(
-        self,
-        *,
-        event_id: str,
-        envelope: MessageEnvelope,
-    ) -> bool:
-        """Return True when a deep synthetic hook relay must stop before dispatch."""
-        ingress_policy = hook_ingress_policy(envelope)
-        if ingress_policy.allow_full_dispatch:
-            return False
-        self.logger.debug(
-            "Ignoring deep synthetic hook relay before command/response dispatch",
-            event_id=event_id,
-            source_kind=envelope.source_kind,
-            hook_source=envelope.hook_source,
-            message_received_depth=envelope.message_received_depth,
-        )
-        return True
 
     async def _emit_reaction_received_hooks(
         self,
@@ -1486,406 +1282,13 @@ class AgentBot:
         else:
             self.logger.error("Failed to join room", room_id=room.room_id)
 
-    async def _coalescing_key_for_event(
-        self,
-        room: nio.MatrixRoom,
-        event: _DispatchEvent,
-        requester_user_id: str,
-    ) -> CoalescingKey:
-        """Return the sender/thread-scoped dispatch key for one event."""
-        return (
-            room.room_id,
-            await self._conversation_resolver.coalescing_thread_id(room, event),
-            requester_user_id,
-        )
-
-    async def _enqueue_for_dispatch(
-        self,
-        event: _DispatchEvent,
-        room: nio.MatrixRoom,
-        *,
-        source_kind: str,
-        requester_user_id: str | None = None,
-        coalescing_key: CoalescingKey | None = None,
-    ) -> None:
-        """Route one inbound event through the live coalescing gate."""
-        dispatch_timing = get_dispatch_pipeline_timing(event.source)
-        if dispatch_timing is not None:
-            dispatch_timing.mark("gate_enter")
-        effective_requester_user_id = requester_user_id or self._requester_user_id(
-            sender=event.sender,
-            source=event.source,
-        )
-        if self._is_trusted_internal_relay_event(event):
-            if dispatch_timing is not None:
-                dispatch_timing.note(coalescing_bypassed=True, coalescing_bypass_reason="trusted_internal_relay")
-                dispatch_timing.mark("gate_exit")
-            trusted_relay_event = cast("_TextDispatchEvent", event)
-            await self._dispatch_text_message(
-                room,
-                trusted_relay_event,
-                effective_requester_user_id,
-            )
-            return
-        await self._coalescing_gate.enqueue(
-            coalescing_key or await self._coalescing_key_for_event(room, event, effective_requester_user_id),
-            PendingEvent(
-                event=event,
-                room=room,
-                source_kind=source_kind,
-            ),
-        )
-
     async def _dispatch_coalesced_batch(self, batch: CoalescedBatch) -> None:
-        """Dispatch one flushed batch through the normal text pipeline."""
-        dispatch_event = build_batch_dispatch_event(batch)
-        dispatch_timing = get_dispatch_pipeline_timing(dispatch_event.source)
-        if dispatch_timing is not None:
-            dispatch_timing.mark("gate_exit")
-        batch_coalescing_key = await self._coalescing_key_for_event(
-            batch.room,
-            batch.primary_event,
-            batch.requester_user_id,
-        )
-        # The first room message opens the gate with thread_id=None, but dispatch
-        # resolves that turn into a new thread rooted at the source event ID.
-        canonical_key = (
-            batch.room.room_id,
-            self._conversation_resolver.build_message_target(
-                room_id=batch.room.room_id,
-                thread_id=batch_coalescing_key[1],
-                reply_to_event_id=dispatch_event.event_id,
-                event_source=dispatch_event.source,
-            ).resolved_thread_id,
-            batch.requester_user_id,
-        )
-        self._coalescing_gate.retarget(batch_coalescing_key, canonical_key)
-        async with self._conversation_resolver.turn_thread_cache_scope():
-            await self._dispatch_text_message(
-                batch.room,
-                dispatch_event,
-                batch.requester_user_id,
-                media_events=batch.media_events or None,
-                handled_turn=HandledTurnState.create(
-                    batch.source_event_ids,
-                    source_event_prompts=batch.source_event_prompts,
-                ),
-            )
+        """Delegate one flushed coalesced batch to the turn engine."""
+        await self._turn_engine.handle_coalesced_batch(batch)
 
     async def _on_message(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
-        async with self._conversation_resolver.turn_thread_cache_scope():
-            await self._handle_message_inner(room, event)
-
-    async def _handle_message_inner(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
-        """Handle one text message inside the per-turn thread-history cache scope."""
-        event_info = EventInfo.from_event(event.source)
-        assert self.client is not None
-        ingress_thread_id = await self._conversation_resolver.coalescing_thread_id(room, event)
-        self.logger.info(
-            "Received message",
-            event_id=event.event_id,
-            room_id=room.room_id,
-            sender=event.sender,
-            thread_id=ingress_thread_id,
-        )
-        dispatch_timing = create_dispatch_pipeline_timing(
-            event_id=event.event_id,
-            room_id=room.room_id,
-        )
-        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
-        await self._conversation_access.append_live_event(room.room_id, event, event_info=event_info)
-        if not isinstance(event.body, str):
-            return
-        # Skip messages that are still being streamed (use metadata, not text pattern)
-        event_content = event.source.get("content") if isinstance(event.source, dict) else None
-        if isinstance(event_content, dict) and event_content.get(STREAM_STATUS_KEY) in {
-            STREAM_STATUS_PENDING,
-            STREAM_STATUS_STREAMING,
-        }:
-            return
-
-        prechecked_event = self._precheck_dispatch_event(room, event, is_edit=event_info.is_edit)
-        if prechecked_event is None:
-            return
-
-        if event_info.is_edit:
-            await self._handle_message_edit(
-                room,
-                prechecked_event.event,
-                event_info,
-                requester_user_id=prechecked_event.requester_user_id,
-            )
-            return
-
-        prepared_event = await self._inbound_turn_normalizer.resolve_text_event(
-            TextNormalizationRequest(event=prechecked_event.event),
-        )
-        attach_dispatch_pipeline_timing(prepared_event.source, dispatch_timing)
-        envelope = self._conversation_resolver.build_ingress_envelope(
-            room_id=room.room_id,
-            event=prepared_event,
-            requester_user_id=prechecked_event.requester_user_id,
-        )
-        if self._should_skip_deep_synthetic_full_dispatch(
-            event_id=prepared_event.event_id,
-            envelope=envelope,
-        ):
-            return
-        if should_handle_interactive_text_response(envelope):
-            await interactive.handle_text_response(self.client, room, prepared_event, self.agent_name)
-        coalescing_thread_id = await self._conversation_resolver.coalescing_thread_id(room, prepared_event)
-        target = self._conversation_resolver.build_message_target(
-            room_id=room.room_id,
-            thread_id=coalescing_thread_id,
-            reply_to_event_id=prepared_event.event_id,
-            event_source=prepared_event.source,
-        )
-        if self._should_bypass_coalescing_for_active_thread_follow_up(
-            target=target,
-            source_kind=envelope.source_kind,
-            sender_id=prepared_event.sender,
-        ):
-            if dispatch_timing is not None:
-                dispatch_timing.mark("gate_enter")
-                dispatch_timing.note(
-                    coalescing_bypassed=True,
-                    coalescing_bypass_reason="active_thread_follow_up",
-                )
-                dispatch_timing.mark("gate_exit")
-            await self._dispatch_text_message(
-                room,
-                prepared_event,
-                prechecked_event.requester_user_id,
-            )
-            return
-        await self._enqueue_for_dispatch(
-            prechecked_event.event,
-            room,
-            source_kind="message",
-            requester_user_id=prechecked_event.requester_user_id,
-            coalescing_key=(room.room_id, coalescing_thread_id, prechecked_event.requester_user_id),
-        )
-
-    def _should_bypass_coalescing_for_active_thread_follow_up(
-        self,
-        *,
-        target: MessageTarget,
-        source_kind: str,
-        sender_id: str,
-    ) -> bool:
-        """Return whether one human thread follow-up should skip IN_FLIGHT coalescing."""
-        if target.resolved_thread_id is None:
-            return False
-        if is_automation_source_kind(source_kind):
-            return False
-        if is_agent_id(sender_id, self.config, self.runtime_paths):
-            return False
-        return self._response_coordinator.has_active_response_for_target(target)
-
-    async def _dispatch_text_message(  # noqa: C901, PLR0912, PLR0915
-        self,
-        room: nio.MatrixRoom,
-        event: _TextDispatchEvent | _PrecheckedTextDispatchEvent,
-        requester_user_id: str | None = None,
-        *,
-        media_events: list[_MediaDispatchEvent] | None = None,
-        handled_turn: HandledTurnState | None = None,
-    ) -> None:
-        """Run the normal text/command dispatch pipeline for a prepared text event."""
-        raw_event: _TextDispatchEvent
-        if isinstance(event, _PrecheckedEvent):
-            requester_user_id = event.requester_user_id
-            raw_event = cast("_TextDispatchEvent", event.event)
-        else:
-            raw_event = event
-        if requester_user_id is None:
-            msg = "requester_user_id is required when dispatching a raw event"
-            raise TypeError(msg)
-        router_event: _DispatchEvent = raw_event
-        event = await self._inbound_turn_normalizer.resolve_text_event(
-            TextNormalizationRequest(event=raw_event),
-        )
-        dispatch_timing = get_dispatch_pipeline_timing(raw_event.source)
-        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
-        timing_scope_token = timing_scope_context.set(event.event_id[:20] if event.event_id else "unknown")
-        try:
-            if dispatch_timing is not None:
-                dispatch_timing.mark("dispatch_start")
-            dispatch_started_at = time.monotonic()
-            handled_turn = handled_turn or HandledTurnState.from_source_event_id(event.event_id)
-
-            if dispatch_timing is not None:
-                dispatch_timing.mark("dispatch_prepare_start")
-            dispatch = await self._dispatch_planner.prepare_dispatch(
-                room,
-                event,
-                requester_user_id,
-                event_label="message",
-                handled_turn=handled_turn,
-            )
-            if dispatch_timing is not None:
-                dispatch_timing.mark("dispatch_prepare_ready")
-            if dispatch is None:
-                return
-
-            # Commands always dispatch and bypass thread-history suppression.
-            command = command_parser.parse(event.body) if not media_events else None
-            if command:
-                if self.agent_name == ROUTER_AGENT_NAME:
-                    await self._handle_command(
-                        room,
-                        _PrecheckedEvent(
-                            event=event,
-                            requester_user_id=requester_user_id,
-                        ),
-                        command,
-                        source_envelope=dispatch.envelope,
-                    )
-                return
-
-            if self._has_newer_unresponded_in_thread(
-                event,
-                requester_user_id,
-                dispatch.context.thread_history,
-            ):
-                self._mark_source_events_responded(handled_turn)
-                return
-            if self._should_skip_deep_synthetic_full_dispatch(
-                event_id=event.event_id,
-                envelope=dispatch.envelope,
-            ):
-                return
-            if dispatch.context.requires_full_thread_history:
-                await self._conversation_resolver.hydrate_dispatch_context(room, event, dispatch.context)
-            content = event.source.get("content") if isinstance(event.source, dict) else None
-            message_attachment_ids = parse_attachment_ids_from_event_source(event.source)
-            message_extra_content: dict[str, Any] = {}
-            if message_attachment_ids:
-                message_extra_content[ATTACHMENT_IDS_KEY] = message_attachment_ids
-            if isinstance(content, dict):
-                original_sender = content.get(ORIGINAL_SENDER_KEY)
-                if isinstance(original_sender, str):
-                    message_extra_content[ORIGINAL_SENDER_KEY] = original_sender
-                raw_audio_fallback = content.get(VOICE_RAW_AUDIO_FALLBACK_KEY)
-                if isinstance(raw_audio_fallback, bool) and raw_audio_fallback:
-                    message_extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] = True
-            router_extra_content = dict(message_extra_content)
-            if media_events and ORIGINAL_SENDER_KEY not in router_extra_content:
-                router_extra_content[ORIGINAL_SENDER_KEY] = requester_user_id
-            if dispatch_timing is not None:
-                dispatch_timing.mark("dispatch_plan_start")
-            plan = await self._dispatch_planner.plan_dispatch(
-                room,
-                event,
-                dispatch,
-                extra_content=router_extra_content or None,
-                media_events=media_events,
-                handled_turn=handled_turn,
-                router_event=media_events[0]
-                if media_events and len(handled_turn.source_event_ids) == 1
-                else router_event,
-            )
-            if dispatch_timing is not None:
-                dispatch_timing.mark("dispatch_plan_ready")
-            if plan.kind == "ignore":
-                if plan.handled_turn_outcome is not None:
-                    self._mark_source_events_responded(plan.handled_turn_outcome)
-                return
-            if plan.kind == "route":
-                route_event = plan.router_event or event
-                single_direct_media_route = (
-                    isinstance(
-                        route_event,
-                        nio.RoomMessageFile
-                        | nio.RoomEncryptedFile
-                        | nio.RoomMessageVideo
-                        | nio.RoomEncryptedVideo
-                        | nio.RoomMessageImage
-                        | nio.RoomEncryptedImage,
-                    )
-                    and media_events == [route_event]
-                    and handled_turn.source_event_ids == (event.event_id,)
-                )
-                routing_kwargs: dict[str, Any] = {
-                    "message": event.body if media_events else plan.router_message,
-                    "requester_user_id": dispatch.requester_user_id,
-                    "extra_content": plan.extra_content,
-                }
-                if plan.media_events is not None and not single_direct_media_route:
-                    routing_kwargs["media_events"] = plan.media_events
-                if (
-                    plan.handled_turn is not None
-                    and list(plan.handled_turn.source_event_ids) != [route_event.event_id]
-                    and not single_direct_media_route
-                ):
-                    routing_kwargs["handled_turn"] = self._handled_turn_with_response_context(
-                        plan.handled_turn,
-                        history_scope=None,
-                        conversation_target=dispatch.target,
-                    )
-                await self._handle_ai_routing(
-                    room,
-                    route_event,
-                    dispatch.context.thread_history,
-                    dispatch.context.thread_id,
-                    **routing_kwargs,
-                )
-                return
-            assert plan.response_action is not None
-            handled_turn = self._handled_turn_with_response_context(
-                handled_turn,
-                history_scope=self._response_history_scope_for_action(plan.response_action),
-                conversation_target=dispatch.target,
-            )
-            matrix_run_metadata = self._dispatch_matrix_run_metadata(handled_turn)
-
-            async def build_payload(context: MessageContext) -> DispatchPayload:
-                effective_thread_id = self._conversation_resolver.build_message_target(
-                    room_id=room.room_id,
-                    thread_id=context.thread_id,
-                    reply_to_event_id=event.event_id,
-                    event_source=event.source,
-                ).resolved_thread_id
-                media_attachment_ids: list[str] = []
-                fallback_images: list[Image] | None = None
-                if media_events:
-                    media_result = await self._inbound_turn_normalizer.register_batch_media_attachments(
-                        BatchMediaAttachmentRequest(
-                            room_id=room.room_id,
-                            thread_id=effective_thread_id,
-                            media_events=media_events,
-                        ),
-                    )
-                    media_attachment_ids = media_result.attachment_ids
-                    fallback_images = media_result.fallback_images
-                return await self._inbound_turn_normalizer.build_dispatch_payload_with_attachments(
-                    DispatchPayloadWithAttachmentsRequest(
-                        room_id=room.room_id,
-                        prompt=event.body,
-                        current_attachment_ids=merge_attachment_ids(
-                            message_attachment_ids,
-                            media_attachment_ids,
-                        ),
-                        thread_id=context.thread_id,
-                        media_thread_id=effective_thread_id,
-                        thread_history=context.thread_history,
-                        fallback_images=fallback_images,
-                    ),
-                )
-
-            await self._dispatch_planner.execute_response_action(
-                room,
-                event,
-                dispatch,
-                plan.response_action,
-                build_payload,
-                processing_log="Processing",
-                dispatch_started_at=dispatch_started_at,
-                handled_turn=handled_turn,
-                matrix_run_metadata=matrix_run_metadata,
-            )
-        finally:
-            timing_scope_context.reset(timing_scope_token)
+        """Delegate one inbound text event to the turn engine."""
+        await self._turn_engine.handle_text_event(room, event)
 
     async def _on_redaction(self, room: nio.MatrixRoom, event: nio.RedactionEvent) -> None:
         """Keep cached thread history consistent when Matrix redactions arrive."""
@@ -2003,280 +1406,13 @@ class AgentBot:
                 ),
             )
 
-    async def _on_audio_media_message(
-        self,
-        room: nio.MatrixRoom,
-        prechecked_event: _PrecheckedEvent[nio.RoomMessageAudio | nio.RoomEncryptedAudio],
-    ) -> None:
-        """Normalize audio into a synthetic text event and reuse text dispatch."""
-        assert self.client is not None
-        event = prechecked_event.event
-
-        if is_agent_id(event.sender, self.config, self.runtime_paths):
-            self.logger.debug(
-                "Ignoring agent audio event for voice transcription",
-                event_id=event.event_id,
-                sender=event.sender,
-            )
-            self._mark_source_events_responded(HandledTurnState.from_source_event_id(event.event_id))
-            return
-
-        normalized_voice = await self._inbound_turn_normalizer.prepare_voice_event(
-            VoiceNormalizationRequest(
-                room=room,
-                event=event,
-            ),
-        )
-        if normalized_voice is None:
-            self._mark_source_events_responded(HandledTurnState.from_source_event_id(event.event_id))
-            return
-
-        await self._maybe_send_visible_voice_echo(
-            room,
-            event,
-            text=normalized_voice.event.body,
-            thread_id=normalized_voice.effective_thread_id,
-        )
-
-        await self._enqueue_for_dispatch(
-            normalized_voice.event,
-            room,
-            source_kind="voice",
-            requester_user_id=prechecked_event.requester_user_id,
-        )
-
-    async def _maybe_send_visible_voice_echo(
-        self,
-        room: nio.MatrixRoom,
-        event: nio.RoomMessageAudio | nio.RoomEncryptedAudio,
-        *,
-        text: str,
-        thread_id: str | None,
-    ) -> str | None:
-        """Optionally post a display-only router echo for normalized audio."""
-        if self.agent_name != ROUTER_AGENT_NAME or not self.config.voice.visible_router_echo:
-            return None
-
-        existing_visible_echo_event_id = self.handled_turn_ledger.get_visible_echo_event_id(event.event_id)
-        if existing_visible_echo_event_id is not None:
-            return existing_visible_echo_event_id
-
-        visible_echo_event_id = await self._send_response(
-            room_id=room.room_id,
-            reply_to_event_id=event.event_id,
-            response_text=text,
-            thread_id=thread_id,
-            skip_mentions=True,
-        )
-        if visible_echo_event_id is not None:
-            self.handled_turn_ledger.record_visible_echo(event.event_id, visible_echo_event_id)
-        return visible_echo_event_id
-
     async def _on_media_message(
         self,
         room: nio.MatrixRoom,
         event: _MediaDispatchEvent,
     ) -> None:
-        """Handle image/file/video/audio events and dispatch media-aware responses."""
-        async with self._conversation_resolver.turn_thread_cache_scope():
-            await self._handle_media_message_inner(room, event)
-
-    async def _handle_media_message_inner(
-        self,
-        room: nio.MatrixRoom,
-        event: _MediaDispatchEvent,
-    ) -> None:
-        """Handle one media event inside the per-turn thread-history cache scope."""
-        assert self.client is not None
-
-        prechecked_event = self._precheck_dispatch_event(room, event)
-        if prechecked_event is None:
-            return
-
-        if await self._dispatch_special_media_as_text(room, prechecked_event):
-            return
-        event = prechecked_event.event
-        await self._enqueue_for_dispatch(
-            event,
-            room,
-            source_kind="image" if isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage) else "media",
-            requester_user_id=prechecked_event.requester_user_id,
-        )
-
-    async def _dispatch_special_media_as_text(
-        self,
-        room: nio.MatrixRoom,
-        prechecked_event: _PrecheckedMediaDispatchEvent,
-    ) -> bool:
-        """Handle media events that normalize into the text dispatch pipeline."""
-        event = prechecked_event.event
-        if isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio):
-            await self._on_audio_media_message(
-                room,
-                _PrecheckedEvent(
-                    event=event,
-                    requester_user_id=prechecked_event.requester_user_id,
-                ),
-            )
-            return True
-        if isinstance(event, nio.RoomMessageFile | nio.RoomEncryptedFile):
-            return await self._dispatch_file_sidecar_text_preview(
-                room,
-                _PrecheckedEvent(
-                    event=event,
-                    requester_user_id=prechecked_event.requester_user_id,
-                ),
-            )
-        return False
-
-    async def _dispatch_file_sidecar_text_preview(
-        self,
-        room: nio.MatrixRoom,
-        prechecked_event: _PrecheckedEvent[nio.RoomMessageFile | nio.RoomEncryptedFile],
-    ) -> bool:
-        """Dispatch one sidecar-backed file preview through the normal text pipeline."""
-        event = prechecked_event.event
-        if not is_v2_sidecar_text_preview(event.source):
-            return False
-
-        prepared_text_event = await self._inbound_turn_normalizer.prepare_file_sidecar_text_event(event)
-        assert prepared_text_event is not None
-        assert self.client is not None
-        envelope = self._conversation_resolver.build_ingress_envelope(
-            room_id=room.room_id,
-            event=prepared_text_event,
-            requester_user_id=prechecked_event.requester_user_id,
-        )
-        if self._should_skip_deep_synthetic_full_dispatch(
-            event_id=prepared_text_event.event_id,
-            envelope=envelope,
-        ):
-            return True
-        if should_handle_interactive_text_response(envelope):
-            await interactive.handle_text_response(self.client, room, prepared_text_event, self.agent_name)
-        await self._dispatch_text_message(
-            room,
-            _PrecheckedEvent(
-                event=prepared_text_event,
-                requester_user_id=prechecked_event.requester_user_id,
-            ),
-        )
-        return True
-
-    def _requester_user_id(
-        self,
-        *,
-        sender: str,
-        source: object,
-    ) -> str:
-        """Return the effective requester for reply-permission checks."""
-        source_dict = cast("dict[str, Any] | None", source if isinstance(source, dict) else None)
-        content = source_dict.get("content") if source_dict is not None else None
-        if (
-            sender == self.matrix_id.full_id
-            and isinstance(content, dict)
-            and isinstance(content.get(ORIGINAL_SENDER_KEY), str)
-        ):
-            return content[ORIGINAL_SENDER_KEY]
-        return get_effective_sender_id_for_reply_permissions(
-            sender,
-            source_dict,
-            self.config,
-            self.runtime_paths,
-        )
-
-    def _requester_user_id_for_event(
-        self,
-        event: CommandEvent,
-    ) -> str:
-        """Return the effective requester for per-user reply checks."""
-        return self._requester_user_id(
-            sender=event.sender,
-            source=event.source,
-        )
-
-    def _is_trusted_internal_relay_event(self, event: _DispatchEvent) -> bool:
-        """Return whether one agent-authored relay should bypass user-turn coalescing."""
-        if not isinstance(event, nio.RoomMessageText | PreparedTextEvent):
-            return False
-        if extract_agent_name(event.sender, self.config, self.runtime_paths) is None:
-            return False
-        content = event.source.get("content") if isinstance(event.source, dict) else None
-        if not isinstance(content, dict):
-            return False
-        if content.get("com.mindroom.source_kind") == "scheduled":
-            return False
-        original_sender = content.get(ORIGINAL_SENDER_KEY)
-        return isinstance(original_sender, str) and bool(original_sender)
-
-    def _precheck_event(
-        self,
-        room: nio.MatrixRoom,
-        event: _DispatchEvent | _InboundMediaEvent,
-        *,
-        is_edit: bool = False,
-    ) -> str | None:
-        """Common early-exit checks shared by text/media/voice handlers.
-
-        Returns the effective requester user ID when the event should be
-        processed, or ``None`` when the event should be skipped.
-
-        Checks (in order): self-authored, already processed (skipped for
-        edits so restart recovery works), effective requester
-        authorization, and per-agent reply permissions.
-        """
-        content = event.source.get("content") if isinstance(event.source, dict) else None
-        source_kind = content.get("com.mindroom.source_kind") if isinstance(content, dict) else None
-        requester_user_id = self._requester_user_id(
-            sender=event.sender,
-            source=event.source,
-        )
-
-        if requester_user_id == self.matrix_id.full_id and source_kind != "hook_dispatch":
-            return None
-
-        # Edits bypass the dedup check: if an edit is redelivered after a
-        # restart the bot should still regenerate the response.
-        if not is_edit and self.handled_turn_ledger.has_responded(event.event_id):
-            return None
-
-        if not is_authorized_sender(
-            requester_user_id,
-            self.config,
-            room.room_id,
-            self.runtime_paths,
-            room_alias=room.canonical_alias,
-        ):
-            self._mark_source_events_responded(HandledTurnState.from_source_event_id(event.event_id))
-            return None
-
-        if not self._dispatch_planner.can_reply_to_sender(requester_user_id):
-            self._mark_source_events_responded(HandledTurnState.from_source_event_id(event.event_id))
-            return None
-
-        return requester_user_id
-
-    def _precheck_dispatch_event[T: _DispatchEvent](
-        self,
-        room: nio.MatrixRoom,
-        event: T,
-        *,
-        is_edit: bool = False,
-    ) -> _PrecheckedEvent[T] | None:
-        """Return a typed prechecked event for ingress handlers.
-
-        Raw Matrix handlers must call this once before dispatch so downstream
-        helpers never need to guess whether requester resolution and sender
-        gating already happened.
-        """
-        requester_user_id = self._precheck_event(room, event, is_edit=is_edit)
-        if requester_user_id is None:
-            return None
-        return _PrecheckedEvent(event=event, requester_user_id=requester_user_id)
-
-    async def _resolve_text_dispatch_event(self, event: _TextDispatchEvent) -> PreparedTextEvent:
-        """Return one canonical text event for hooks, routing, and command handling."""
-        return await self._dispatch_planner.resolve_text_dispatch_event(event)
+        """Delegate one inbound media event to the turn engine."""
+        await self._turn_engine.handle_media_event(room, event)
 
     def _should_queue_follow_up_in_active_response_thread(
         self,
@@ -2539,310 +1675,6 @@ class AgentBot:
             self.logger.error("Failed to redact message", event_id=event_id, error=str(response))
             return False
         return True
-
-    async def _handle_ai_routing(
-        self,
-        room: nio.MatrixRoom,
-        event: _DispatchEvent,
-        thread_history: Sequence[ResolvedVisibleMessage],
-        thread_id: str | None = None,
-        message: str | None = None,
-        *,
-        requester_user_id: str,
-        extra_content: dict[str, Any] | None = None,
-        media_events: list[_MediaDispatchEvent] | None = None,
-        handled_turn: HandledTurnState | None = None,
-    ) -> None:
-        await self._dispatch_planner.execute_router_relay(
-            room,
-            event,
-            thread_history,
-            thread_id,
-            message=message,
-            requester_user_id=requester_user_id,
-            extra_content=extra_content,
-            media_events=media_events,
-            handled_turn=handled_turn,
-        )
-
-    async def _handle_message_edit(  # noqa: C901, PLR0911, PLR0912, PLR0915
-        self,
-        room: nio.MatrixRoom,
-        event: nio.RoomMessageText,
-        event_info: EventInfo,
-        *,
-        requester_user_id: str,
-    ) -> None:
-        """Handle an edited message by regenerating the agent's response.
-
-        Args:
-            room: The Matrix room
-            event: The edited message event
-            event_info: Information about the edit event
-            requester_user_id: Effective requester resolved during raw-event precheck
-
-        """
-        if not event_info.original_event_id:
-            self.logger.debug("Edit event has no original event ID")
-            return
-        original_event_id = event_info.original_event_id
-
-        # Skip edits from other agents
-        sender_agent_name = extract_agent_name(event.sender, self.config, self.runtime_paths)
-        if sender_agent_name:
-            self.logger.debug("ignoring_edit_from_other_agent", agent=sender_agent_name)
-            return
-
-        # Known limitations for edit regeneration (ISSUE-110 Phase 5):
-        # - Team-scoped responses regenerate with canonical history scope, not recorded scope.
-        # - Router relay edits regenerate as AI responses instead of re-running router dispatch.
-        # - Missing-ledger recovery loses response_owner/history_scope/conversation_target metadata.
-        # These are acceptable because these edge cases do not occur in current usage.
-        turn_record = self.handled_turn_ledger.get_turn_record(original_event_id)
-        context = await self._edit_regeneration_context(
-            room,
-            event,
-            conversation_target=turn_record.conversation_target if turn_record is not None else None,
-        )
-        persisted_turn_metadata = self._load_persisted_turn_metadata(
-            room=room,
-            thread_id=context.thread_id,
-            original_event_id=original_event_id,
-            requester_user_id=requester_user_id,
-        )
-        if turn_record is None:
-            if persisted_turn_metadata is None:
-                self.logger.debug(
-                    "No handled turn record found for edited message",
-                    original_event_id=original_event_id,
-                )
-                return
-            turn_record = HandledTurnRecord(
-                anchor_event_id=persisted_turn_metadata.anchor_event_id,
-                source_event_ids=persisted_turn_metadata.source_event_ids,
-                response_event_id=persisted_turn_metadata.response_event_id,
-                source_event_prompts=persisted_turn_metadata.source_event_prompts,
-            )
-        recorded_turn_context_available = bool(
-            turn_record.conversation_target is not None and turn_record.history_scope is not None,
-        )
-        response_owner_missing = turn_record.response_owner is None
-        if response_owner_missing and persisted_turn_metadata is not None:
-            turn_record = replace(turn_record, response_owner=self.agent_name)
-        response_event_id = (
-            persisted_turn_metadata.response_event_id
-            if persisted_turn_metadata is not None and persisted_turn_metadata.response_event_id is not None
-            else turn_record.response_event_id
-        )
-        if response_event_id is None:
-            self.logger.debug("missing_previous_response_for_edit", event_id=original_event_id)
-            return
-        regeneration_target = turn_record.conversation_target or self._conversation_resolver.build_message_target(
-            room_id=room.room_id,
-            thread_id=context.thread_id,
-            reply_to_event_id=turn_record.anchor_event_id,
-        )
-        regeneration_history_scope = turn_record.history_scope or self._conversation_state_writer.history_scope()
-        regeneration_response_owner = turn_record.response_owner or self.agent_name
-        if regeneration_response_owner != self.agent_name:
-            self.logger.debug(
-                "Ignoring edited message for turn owned by another entity",
-                original_event_id=original_event_id,
-                response_owner=regeneration_response_owner,
-            )
-            return
-        needs_turn_record_backfill = (
-            turn_record.response_event_id != response_event_id
-            or response_owner_missing
-            or turn_record.history_scope is None
-            or turn_record.conversation_target is None
-            or (
-                turn_record.is_coalesced
-                and turn_record.source_event_prompts is None
-                and persisted_turn_metadata is not None
-                and persisted_turn_metadata.source_event_prompts is not None
-            )
-        )
-        coalesced_source_event_prompts = turn_record.source_event_prompts
-        if (
-            coalesced_source_event_prompts is None
-            and persisted_turn_metadata is not None
-            and persisted_turn_metadata.is_coalesced
-        ):
-            coalesced_source_event_prompts = persisted_turn_metadata.source_event_prompts
-
-        self.logger.info(
-            "Regenerating response for edited message",
-            original_event_id=original_event_id,
-            response_event_id=response_event_id,
-        )
-
-        edited_content, _ = await extract_edit_body(event.source, self.client)
-        if edited_content is None:
-            self.logger.debug("Edited message missing resolved body", event_id=event.event_id)
-            return
-        regeneration_handled_turn = HandledTurnState.create(
-            turn_record.source_event_ids,
-            response_event_id=response_event_id,
-            response_owner=regeneration_response_owner,
-            history_scope=regeneration_history_scope,
-            conversation_target=regeneration_target,
-        )
-        regeneration_turn_record = replace(
-            turn_record,
-            response_event_id=response_event_id,
-            response_owner=regeneration_response_owner,
-            history_scope=regeneration_history_scope,
-            conversation_target=regeneration_target,
-        )
-        if regeneration_turn_record.is_coalesced:
-            if coalesced_source_event_prompts is None:
-                self.logger.warning(
-                    "Skipping edited coalesced turn regeneration without persisted source prompts",
-                    original_event_id=original_event_id,
-                    anchor_event_id=regeneration_turn_record.anchor_event_id,
-                )
-                return
-            updated_prompt_map = dict(coalesced_source_event_prompts)
-            updated_prompt_map[original_event_id] = edited_content
-            rebuilt_prompt_parts: list[str] = []
-            for source_event_id in regeneration_turn_record.source_event_ids:
-                prompt_part = updated_prompt_map.get(source_event_id)
-                if prompt_part is None:
-                    self.logger.warning(
-                        "Skipping edited coalesced turn regeneration with incomplete prompt map",
-                        original_event_id=original_event_id,
-                        missing_source_event_id=source_event_id,
-                        anchor_event_id=regeneration_turn_record.anchor_event_id,
-                    )
-                    return
-                rebuilt_prompt_parts.append(prompt_part)
-            regeneration_prompt = coalesced_prompt(rebuilt_prompt_parts)
-            regeneration_handled_turn = HandledTurnState.create(
-                regeneration_turn_record.source_event_ids,
-                response_event_id=response_event_id,
-                source_event_prompts=updated_prompt_map,
-                response_owner=regeneration_response_owner,
-                history_scope=regeneration_history_scope,
-                conversation_target=regeneration_target,
-            )
-            regeneration_turn_record = replace(regeneration_turn_record, source_event_prompts=updated_prompt_map)
-            regeneration_matrix_run_metadata = self._dispatch_matrix_run_metadata(regeneration_handled_turn)
-        else:
-            regeneration_prompt = edited_content
-            regeneration_matrix_run_metadata = None
-        envelope = self._conversation_resolver.build_message_envelope(
-            room_id=room.room_id,
-            event=event,
-            requester_user_id=requester_user_id,
-            context=context,
-            target=regeneration_target,
-            body=edited_content,
-            source_kind="edit",
-        )
-        ingress_policy = hook_ingress_policy(envelope)
-        if await self._dispatch_hook_service.emit_message_received_hooks(
-            envelope=envelope,
-            correlation_id=event.event_id,
-            policy=ingress_policy,
-        ):
-            self._mark_source_events_responded(regeneration_handled_turn)
-            return
-
-        if turn_record.response_owner is None:
-            should_respond = should_agent_respond(
-                agent_name=self.agent_name,
-                am_i_mentioned=context.am_i_mentioned,
-                is_thread=context.is_thread,
-                room=room,
-                thread_history=context.thread_history,
-                config=self.config,
-                runtime_paths=self.runtime_paths,
-                mentioned_agents=context.mentioned_agents,
-                has_non_agent_mentions=context.has_non_agent_mentions,
-                sender_id=requester_user_id,
-            )
-            if not should_respond and not regeneration_turn_record.is_coalesced:
-                self.logger.debug("Agent should not respond to edited message")
-                if needs_turn_record_backfill:
-                    self._mark_source_events_responded(regeneration_handled_turn)
-                return
-
-        # Generate new response
-        regenerated_event_id = await self._generate_response(
-            room_id=room.room_id,
-            prompt=regeneration_prompt,
-            reply_to_event_id=regeneration_turn_record.anchor_event_id,
-            thread_id=regeneration_target.thread_id,
-            target=regeneration_target,
-            thread_history=context.thread_history,
-            existing_event_id=response_event_id,
-            existing_event_is_placeholder=False,
-            user_id=requester_user_id,
-            response_envelope=envelope,
-            correlation_id=event.event_id,
-            matrix_run_metadata=regeneration_matrix_run_metadata,
-            on_lifecycle_lock_acquired=lambda: self._remove_stale_runs_for_turn_record(
-                turn_record=regeneration_turn_record,
-                recorded_turn_context_available=recorded_turn_context_available,
-                room=room,
-                thread_id=context.thread_id,
-                original_event_id=original_event_id,
-                requester_user_id=requester_user_id,
-            ),
-        )
-
-        # Update the handled-turn ledger linkage for the edited source turn.
-        if regenerated_event_id is not None:
-            self._mark_source_events_responded(
-                regeneration_handled_turn.with_response_event_id(regenerated_event_id),
-            )
-            self.logger.info("Successfully regenerated response for edited message")
-        else:
-            if needs_turn_record_backfill:
-                self._mark_source_events_responded(regeneration_handled_turn)
-            self.logger.info(
-                "Suppressed regeneration left existing response unchanged",
-                original_event_id=original_event_id,
-                response_event_id=response_event_id,
-            )
-
-    def _remove_stale_runs_for_edited_message(
-        self,
-        *,
-        room: nio.MatrixRoom,
-        thread_id: str | None,
-        original_event_id: str,
-        requester_user_id: str,
-    ) -> None:
-        """Remove persisted runs tied to the pre-edit message before regenerating."""
-        self._conversation_state_writer.remove_stale_runs_for_edited_message(
-            RemoveStaleRunsRequest(
-                room=room,
-                thread_id=thread_id,
-                original_event_id=original_event_id,
-                requester_user_id=requester_user_id,
-            ),
-            build_message_target=self._conversation_resolver.build_message_target,
-            build_tool_execution_identity=self._tool_runtime_support.build_execution_identity,
-            remove_run_by_event_id_fn=remove_run_by_event_id,
-        )
-
-    async def _handle_command(
-        self,
-        room: nio.MatrixRoom,
-        prechecked_event: _PrecheckedTextDispatchEvent,
-        command: Command,
-        *,
-        source_envelope: MessageEnvelope | None = None,
-    ) -> None:
-        await self._dispatch_planner.execute_command(
-            room=room,
-            event=prechecked_event.event,
-            requester_user_id=prechecked_event.requester_user_id,
-            command=command,
-            source_envelope=source_envelope,
-        )
 
 
 class TeamBot(AgentBot):

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -1,0 +1,424 @@
+"""Edit-triggered response regeneration for previously handled turns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any, Protocol
+
+from mindroom.agents import remove_run_by_event_id
+from mindroom.coalescing import coalesced_prompt
+from mindroom.conversation_resolver import MessageContext
+from mindroom.conversation_state_writer import (
+    LoadPersistedTurnMetadataRequest,
+    PersistedTurnMetadata,
+    RemoveStaleRunsRequest,
+)
+from mindroom.handled_turns import HandledTurnLedger, HandledTurnRecord, HandledTurnState
+from mindroom.hooks.ingress import hook_ingress_policy
+from mindroom.matrix.identity import extract_agent_name
+from mindroom.matrix.message_content import extract_edit_body
+from mindroom.post_response_effects import matrix_run_metadata_for_handled_turn, record_handled_turn
+from mindroom.thread_utils import should_agent_respond
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    import nio
+    import structlog
+
+    from mindroom.bot_runtime_view import BotRuntimeView
+    from mindroom.constants import RuntimePaths
+    from mindroom.conversation_resolver import ConversationResolver
+    from mindroom.conversation_state_writer import ConversationStateWriter
+    from mindroom.dispatch_planner import DispatchHookService
+    from mindroom.hooks import MessageEnvelope
+    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.event_info import EventInfo
+    from mindroom.message_target import MessageTarget
+    from mindroom.tool_system.runtime_context import ToolRuntimeSupport
+
+
+class _GenerateResponse(Protocol):
+    """Minimal response-generation surface needed for edit regeneration."""
+
+    async def __call__(
+        self,
+        *,
+        room_id: str,
+        prompt: str,
+        reply_to_event_id: str,
+        thread_id: str | None,
+        thread_history: Sequence[ResolvedVisibleMessage],
+        existing_event_id: str | None = None,
+        existing_event_is_placeholder: bool = False,
+        user_id: str | None = None,
+        response_envelope: MessageEnvelope | None = None,
+        correlation_id: str | None = None,
+        target: MessageTarget | None = None,
+        matrix_run_metadata: dict[str, Any] | None = None,
+        on_lifecycle_lock_acquired: Callable[[], None] | None = None,
+    ) -> str | None:
+        """Generate or regenerate a response for one handled turn."""
+
+
+@dataclass(frozen=True)
+class EditRegeneratorDeps:
+    """Collaborators needed for edit-triggered regeneration."""
+
+    runtime: BotRuntimeView
+    get_logger: Callable[[], structlog.stdlib.BoundLogger]
+    runtime_paths: RuntimePaths
+    agent_name: str
+    get_handled_turn_ledger: Callable[[], HandledTurnLedger]
+    resolver: ConversationResolver
+    state_writer: ConversationStateWriter
+    tool_runtime: ToolRuntimeSupport
+    dispatch_hook_service: DispatchHookService
+    generate_response: _GenerateResponse
+
+
+@dataclass
+class EditRegenerator:
+    """Own edit-triggered response regeneration for previously handled turns."""
+
+    deps: EditRegeneratorDeps
+
+    def _logger(self) -> structlog.stdlib.BoundLogger:
+        return self.deps.get_logger()
+
+    def _handled_turn_ledger(self) -> HandledTurnLedger:
+        return self.deps.get_handled_turn_ledger()
+
+    def _client(self) -> nio.AsyncClient:
+        client = self.deps.runtime.client
+        if client is None:
+            msg = "Matrix client is not ready for edit regeneration"
+            raise RuntimeError(msg)
+        return client
+
+    def _mark_source_events_responded(self, handled_turn: HandledTurnState) -> None:
+        """Mark one or more source events as handled by the same response."""
+        record_handled_turn(self._handled_turn_ledger(), handled_turn)
+
+    def load_persisted_turn_metadata(
+        self,
+        *,
+        room: nio.MatrixRoom,
+        thread_id: str | None,
+        original_event_id: str,
+        requester_user_id: str,
+    ) -> PersistedTurnMetadata | None:
+        """Load persisted run metadata for one edited turn when available."""
+        return self.deps.state_writer.load_persisted_turn_metadata(
+            LoadPersistedTurnMetadataRequest(
+                room=room,
+                thread_id=thread_id,
+                original_event_id=original_event_id,
+                requester_user_id=requester_user_id,
+            ),
+            build_message_target=self.deps.resolver.build_message_target,
+            build_tool_execution_identity=self.deps.tool_runtime.build_execution_identity,
+        )
+
+    async def edit_regeneration_context(
+        self,
+        room: nio.MatrixRoom,
+        event: nio.RoomMessageText,
+        *,
+        conversation_target: MessageTarget | None,
+    ) -> MessageContext:
+        """Return edit context, reusing the recorded thread root when available."""
+        context = await self.deps.resolver.extract_message_context(room, event)
+        if conversation_target is None or conversation_target.resolved_thread_id is None:
+            return context
+        if context.thread_id == conversation_target.resolved_thread_id:
+            return context
+        return MessageContext(
+            am_i_mentioned=context.am_i_mentioned,
+            is_thread=True,
+            thread_id=conversation_target.resolved_thread_id,
+            thread_history=await self.deps.resolver.fetch_thread_history(
+                self._client(),
+                room.room_id,
+                conversation_target.resolved_thread_id,
+            ),
+            mentioned_agents=context.mentioned_agents,
+            has_non_agent_mentions=context.has_non_agent_mentions,
+            requires_full_thread_history=context.requires_full_thread_history,
+        )
+
+    def remove_stale_runs_for_turn_record(
+        self,
+        *,
+        turn_record: HandledTurnRecord,
+        recorded_turn_context_available: bool,
+        room: nio.MatrixRoom,
+        thread_id: str | None,
+        original_event_id: str,
+        requester_user_id: str,
+    ) -> None:
+        """Remove stale persisted runs using the recorded turn context when possible."""
+        if (
+            recorded_turn_context_available
+            and turn_record.conversation_target is not None
+            and turn_record.history_scope is not None
+        ):
+            self.deps.state_writer.remove_stale_runs_for_turn_record(
+                turn_record=turn_record,
+                requester_user_id=requester_user_id,
+                build_tool_execution_identity=self.deps.tool_runtime.build_execution_identity,
+                remove_run_by_event_id_fn=remove_run_by_event_id,
+            )
+            return
+        self.remove_stale_runs_for_edited_message(
+            room=room,
+            thread_id=thread_id,
+            original_event_id=original_event_id,
+            requester_user_id=requester_user_id,
+        )
+
+    def remove_stale_runs_for_edited_message(
+        self,
+        *,
+        room: nio.MatrixRoom,
+        thread_id: str | None,
+        original_event_id: str,
+        requester_user_id: str,
+    ) -> None:
+        """Remove persisted runs tied to the pre-edit message before regenerating."""
+        self.deps.state_writer.remove_stale_runs_for_edited_message(
+            RemoveStaleRunsRequest(
+                room=room,
+                thread_id=thread_id,
+                original_event_id=original_event_id,
+                requester_user_id=requester_user_id,
+            ),
+            build_message_target=self.deps.resolver.build_message_target,
+            build_tool_execution_identity=self.deps.tool_runtime.build_execution_identity,
+            remove_run_by_event_id_fn=remove_run_by_event_id,
+        )
+
+    async def handle_message_edit(  # noqa: C901, PLR0911, PLR0912, PLR0915
+        self,
+        room: nio.MatrixRoom,
+        event: nio.RoomMessageText,
+        event_info: EventInfo,
+        requester_user_id: str,
+    ) -> None:
+        """Handle an edited message by regenerating the owned response."""
+        if not event_info.original_event_id:
+            self._logger().debug("Edit event has no original event ID")
+            return
+        original_event_id = event_info.original_event_id
+
+        sender_agent_name = extract_agent_name(event.sender, self.deps.runtime.config, self.deps.runtime_paths)
+        if sender_agent_name:
+            self._logger().debug("ignoring_edit_from_other_agent", agent=sender_agent_name)
+            return
+
+        turn_record = self._handled_turn_ledger().get_turn_record(original_event_id)
+        context = await self.edit_regeneration_context(
+            room,
+            event,
+            conversation_target=turn_record.conversation_target if turn_record is not None else None,
+        )
+        persisted_turn_metadata = self.load_persisted_turn_metadata(
+            room=room,
+            thread_id=context.thread_id,
+            original_event_id=original_event_id,
+            requester_user_id=requester_user_id,
+        )
+        if turn_record is None:
+            if persisted_turn_metadata is None:
+                self._logger().debug(
+                    "No handled turn record found for edited message",
+                    original_event_id=original_event_id,
+                )
+                return
+            turn_record = HandledTurnRecord(
+                anchor_event_id=persisted_turn_metadata.anchor_event_id,
+                source_event_ids=persisted_turn_metadata.source_event_ids,
+                response_event_id=persisted_turn_metadata.response_event_id,
+                source_event_prompts=persisted_turn_metadata.source_event_prompts,
+            )
+        recorded_turn_context_available = bool(
+            turn_record.conversation_target is not None and turn_record.history_scope is not None,
+        )
+        response_owner_missing = turn_record.response_owner is None
+        if response_owner_missing and persisted_turn_metadata is not None:
+            turn_record = replace(turn_record, response_owner=self.deps.agent_name)
+        response_event_id = (
+            persisted_turn_metadata.response_event_id
+            if persisted_turn_metadata is not None and persisted_turn_metadata.response_event_id is not None
+            else turn_record.response_event_id
+        )
+        if response_event_id is None:
+            self._logger().debug("missing_previous_response_for_edit", event_id=original_event_id)
+            return
+        regeneration_target = turn_record.conversation_target or self.deps.resolver.build_message_target(
+            room_id=room.room_id,
+            thread_id=context.thread_id,
+            reply_to_event_id=turn_record.anchor_event_id,
+        )
+        regeneration_history_scope = turn_record.history_scope or self.deps.state_writer.history_scope()
+        regeneration_response_owner = turn_record.response_owner or self.deps.agent_name
+        if regeneration_response_owner != self.deps.agent_name:
+            self._logger().debug(
+                "Ignoring edited message for turn owned by another entity",
+                original_event_id=original_event_id,
+                response_owner=regeneration_response_owner,
+            )
+            return
+        needs_turn_record_backfill = (
+            turn_record.response_event_id != response_event_id
+            or response_owner_missing
+            or turn_record.history_scope is None
+            or turn_record.conversation_target is None
+            or (
+                turn_record.is_coalesced
+                and turn_record.source_event_prompts is None
+                and persisted_turn_metadata is not None
+                and persisted_turn_metadata.source_event_prompts is not None
+            )
+        )
+        coalesced_source_event_prompts = turn_record.source_event_prompts
+        if (
+            coalesced_source_event_prompts is None
+            and persisted_turn_metadata is not None
+            and persisted_turn_metadata.is_coalesced
+        ):
+            coalesced_source_event_prompts = persisted_turn_metadata.source_event_prompts
+
+        self._logger().info(
+            "Regenerating response for edited message",
+            original_event_id=original_event_id,
+            response_event_id=response_event_id,
+        )
+
+        edited_content, _ = await extract_edit_body(event.source, self._client())
+        if edited_content is None:
+            self._logger().debug("Edited message missing resolved body", event_id=event.event_id)
+            return
+        regeneration_handled_turn = HandledTurnState.create(
+            turn_record.source_event_ids,
+            response_event_id=response_event_id,
+            response_owner=regeneration_response_owner,
+            history_scope=regeneration_history_scope,
+            conversation_target=regeneration_target,
+        )
+        regeneration_turn_record = replace(
+            turn_record,
+            response_event_id=response_event_id,
+            response_owner=regeneration_response_owner,
+            history_scope=regeneration_history_scope,
+            conversation_target=regeneration_target,
+        )
+        if regeneration_turn_record.is_coalesced:
+            if coalesced_source_event_prompts is None:
+                self._logger().warning(
+                    "Skipping edited coalesced turn regeneration without persisted source prompts",
+                    original_event_id=original_event_id,
+                    anchor_event_id=regeneration_turn_record.anchor_event_id,
+                )
+                return
+            updated_prompt_map = dict(coalesced_source_event_prompts)
+            updated_prompt_map[original_event_id] = edited_content
+            rebuilt_prompt_parts: list[str] = []
+            for source_event_id in regeneration_turn_record.source_event_ids:
+                prompt_part = updated_prompt_map.get(source_event_id)
+                if prompt_part is None:
+                    self._logger().warning(
+                        "Skipping edited coalesced turn regeneration with incomplete prompt map",
+                        original_event_id=original_event_id,
+                        missing_source_event_id=source_event_id,
+                        anchor_event_id=regeneration_turn_record.anchor_event_id,
+                    )
+                    return
+                rebuilt_prompt_parts.append(prompt_part)
+            regeneration_prompt = coalesced_prompt(rebuilt_prompt_parts)
+            regeneration_handled_turn = HandledTurnState.create(
+                regeneration_turn_record.source_event_ids,
+                response_event_id=response_event_id,
+                source_event_prompts=updated_prompt_map,
+                response_owner=regeneration_response_owner,
+                history_scope=regeneration_history_scope,
+                conversation_target=regeneration_target,
+            )
+            regeneration_turn_record = replace(regeneration_turn_record, source_event_prompts=updated_prompt_map)
+            regeneration_matrix_run_metadata = matrix_run_metadata_for_handled_turn(regeneration_handled_turn)
+        else:
+            regeneration_prompt = edited_content
+            regeneration_matrix_run_metadata = None
+        envelope = self.deps.resolver.build_message_envelope(
+            room_id=room.room_id,
+            event=event,
+            requester_user_id=requester_user_id,
+            context=context,
+            target=regeneration_target,
+            body=edited_content,
+            source_kind="edit",
+        )
+        ingress_policy = hook_ingress_policy(envelope)
+        if await self.deps.dispatch_hook_service.emit_message_received_hooks(
+            envelope=envelope,
+            correlation_id=event.event_id,
+            policy=ingress_policy,
+        ):
+            self._mark_source_events_responded(regeneration_handled_turn)
+            return
+
+        if turn_record.response_owner is None:
+            should_respond = should_agent_respond(
+                agent_name=self.deps.agent_name,
+                am_i_mentioned=context.am_i_mentioned,
+                is_thread=context.is_thread,
+                room=room,
+                thread_history=context.thread_history,
+                config=self.deps.runtime.config,
+                runtime_paths=self.deps.runtime_paths,
+                mentioned_agents=context.mentioned_agents,
+                has_non_agent_mentions=context.has_non_agent_mentions,
+                sender_id=requester_user_id,
+            )
+            if not should_respond and not regeneration_turn_record.is_coalesced:
+                self._logger().debug("Agent should not respond to edited message")
+                if needs_turn_record_backfill:
+                    self._mark_source_events_responded(regeneration_handled_turn)
+                return
+
+        regenerated_event_id = await self.deps.generate_response(
+            room_id=room.room_id,
+            prompt=regeneration_prompt,
+            reply_to_event_id=regeneration_turn_record.anchor_event_id,
+            thread_id=regeneration_target.thread_id,
+            target=regeneration_target,
+            thread_history=context.thread_history,
+            existing_event_id=response_event_id,
+            existing_event_is_placeholder=False,
+            user_id=requester_user_id,
+            response_envelope=envelope,
+            correlation_id=event.event_id,
+            matrix_run_metadata=regeneration_matrix_run_metadata,
+            on_lifecycle_lock_acquired=lambda: self.remove_stale_runs_for_turn_record(
+                turn_record=regeneration_turn_record,
+                recorded_turn_context_available=recorded_turn_context_available,
+                room=room,
+                thread_id=context.thread_id,
+                original_event_id=original_event_id,
+                requester_user_id=requester_user_id,
+            ),
+        )
+
+        if regenerated_event_id is not None:
+            self._mark_source_events_responded(
+                regeneration_handled_turn.with_response_event_id(regenerated_event_id),
+            )
+            self._logger().info("Successfully regenerated response for edited message")
+        else:
+            if needs_turn_record_backfill:
+                self._mark_source_events_responded(regeneration_handled_turn)
+            self._logger().info(
+                "Suppressed regeneration left existing response unchanged",
+                original_event_id=original_event_id,
+                response_event_id=response_event_id,
+            )

--- a/src/mindroom/turn_engine.py
+++ b/src/mindroom/turn_engine.py
@@ -1,0 +1,878 @@
+"""Turn sequencing extracted from the Matrix bot runtime shell."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+import nio
+
+from mindroom import interactive
+from mindroom.attachments import merge_attachment_ids, parse_attachment_ids_from_event_source
+from mindroom.authorization import (
+    get_effective_sender_id_for_reply_permissions,
+    is_authorized_sender,
+)
+from mindroom.coalescing import (
+    CoalescedBatch,
+    CoalescingGate,
+    CoalescingKey,
+    PendingEvent,
+    PreparedTextEvent,
+    build_batch_dispatch_event,
+)
+from mindroom.commands.parsing import command_parser
+from mindroom.constants import (
+    ATTACHMENT_IDS_KEY,
+    ORIGINAL_SENDER_KEY,
+    ROUTER_AGENT_NAME,
+    STREAM_STATUS_KEY,
+    STREAM_STATUS_PENDING,
+    STREAM_STATUS_STREAMING,
+    VOICE_RAW_AUDIO_FALLBACK_KEY,
+    RuntimePaths,
+)
+from mindroom.delivery_gateway import SendTextRequest
+from mindroom.handled_turns import HandledTurnLedger, HandledTurnState
+from mindroom.hooks.ingress import (
+    hook_ingress_policy,
+    is_automation_source_kind,
+    should_handle_interactive_text_response,
+)
+from mindroom.inbound_turn_normalizer import (
+    BatchMediaAttachmentRequest,
+    DispatchPayload,
+    DispatchPayloadWithAttachmentsRequest,
+    InboundTurnNormalizer,
+    TextNormalizationRequest,
+    VoiceNormalizationRequest,
+)
+from mindroom.matrix.event_info import EventInfo
+from mindroom.matrix.identity import extract_agent_name, is_agent_id
+from mindroom.matrix.message_content import is_v2_sidecar_text_preview
+from mindroom.post_response_effects import matrix_run_metadata_for_handled_turn, record_handled_turn
+from mindroom.timing import (
+    attach_dispatch_pipeline_timing,
+    create_dispatch_pipeline_timing,
+    get_dispatch_pipeline_timing,
+)
+from mindroom.timing import timing_scope as timing_scope_context
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import structlog
+    from agno.media import Image
+
+    from mindroom.bot_runtime_view import BotRuntimeView
+    from mindroom.conversation_resolver import ConversationResolver, MessageContext
+    from mindroom.conversation_state_writer import ConversationStateWriter
+    from mindroom.delivery_gateway import DeliveryGateway
+    from mindroom.dispatch_planner import DispatchPlanner, ResponseAction
+    from mindroom.history.types import HistoryScope
+    from mindroom.hooks import MessageEnvelope
+    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.conversation_access import MatrixConversationAccess
+    from mindroom.matrix.identity import MatrixID
+    from mindroom.message_target import MessageTarget
+    from mindroom.response_coordinator import ResponseCoordinator
+
+type _MediaDispatchEvent = (
+    nio.RoomMessageImage
+    | nio.RoomEncryptedImage
+    | nio.RoomMessageFile
+    | nio.RoomEncryptedFile
+    | nio.RoomMessageVideo
+    | nio.RoomEncryptedVideo
+)
+type _InboundMediaEvent = _MediaDispatchEvent | nio.RoomMessageAudio | nio.RoomEncryptedAudio
+type _TextDispatchEvent = nio.RoomMessageText | PreparedTextEvent
+type _DispatchEvent = _TextDispatchEvent | _MediaDispatchEvent
+
+
+class _EditRegenerator(Protocol):
+    """Minimal edit-regeneration surface needed by turn sequencing."""
+
+    async def handle_message_edit(
+        self,
+        room: nio.MatrixRoom,
+        event: nio.RoomMessageText,
+        event_info: EventInfo,
+        requester_user_id: str,
+    ) -> None:
+        """Regenerate the owned response for one edited user turn."""
+
+
+@dataclass(frozen=True)
+class _PrecheckedEvent[T]:
+    """A raw or prepared event that already passed ingress prechecks."""
+
+    event: T
+    requester_user_id: str
+
+
+type _PrecheckedTextDispatchEvent = _PrecheckedEvent[_TextDispatchEvent]
+type _PrecheckedMediaDispatchEvent = _PrecheckedEvent[_MediaDispatchEvent]
+
+
+@dataclass(frozen=True)
+class TurnEngineDeps:
+    """Collaborators needed for Phase 1 turn sequencing."""
+
+    runtime: BotRuntimeView
+    logger: structlog.stdlib.BoundLogger
+    runtime_paths: RuntimePaths
+    agent_name: str
+    matrix_id: MatrixID
+    handled_turn_ledger: HandledTurnLedger
+    conversation_access: MatrixConversationAccess
+    resolver: ConversationResolver
+    normalizer: InboundTurnNormalizer
+    dispatch_planner: DispatchPlanner
+    response_coordinator: ResponseCoordinator
+    delivery_gateway: DeliveryGateway
+    state_writer: ConversationStateWriter
+    coalescing_gate: CoalescingGate
+    edit_regenerator: _EditRegenerator
+
+
+@dataclass
+class TurnEngine:
+    """Own sequencing for one inbound text or media turn."""
+
+    deps: TurnEngineDeps
+
+    def _client(self) -> nio.AsyncClient:
+        client = self.deps.runtime.client
+        if client is None:
+            msg = "Matrix client is not ready for turn execution"
+            raise RuntimeError(msg)
+        return client
+
+    def _requester_user_id(
+        self,
+        *,
+        sender: str,
+        source: object,
+    ) -> str:
+        """Return the effective requester for reply-permission checks."""
+        source_dict = cast("dict[str, Any] | None", source if isinstance(source, dict) else None)
+        content = source_dict.get("content") if source_dict is not None else None
+        if (
+            sender == self.deps.matrix_id.full_id
+            and isinstance(content, dict)
+            and isinstance(content.get(ORIGINAL_SENDER_KEY), str)
+        ):
+            return content[ORIGINAL_SENDER_KEY]
+        return get_effective_sender_id_for_reply_permissions(
+            sender,
+            source_dict,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
+
+    def _is_trusted_internal_relay_event(self, event: _DispatchEvent) -> bool:
+        """Return whether one agent-authored relay should bypass user-turn coalescing."""
+        if not isinstance(event, nio.RoomMessageText | PreparedTextEvent):
+            return False
+        if extract_agent_name(event.sender, self.deps.runtime.config, self.deps.runtime_paths) is None:
+            return False
+        content = event.source.get("content") if isinstance(event.source, dict) else None
+        if not isinstance(content, dict):
+            return False
+        if content.get("com.mindroom.source_kind") == "scheduled":
+            return False
+        original_sender = content.get(ORIGINAL_SENDER_KEY)
+        return isinstance(original_sender, str) and bool(original_sender)
+
+    def _precheck_event(
+        self,
+        room: nio.MatrixRoom,
+        event: _DispatchEvent | _InboundMediaEvent,
+        *,
+        is_edit: bool = False,
+    ) -> str | None:
+        """Run shared early-exit checks for inbound text and media events."""
+        content = event.source.get("content") if isinstance(event.source, dict) else None
+        source_kind = content.get("com.mindroom.source_kind") if isinstance(content, dict) else None
+        requester_user_id = self._requester_user_id(
+            sender=event.sender,
+            source=event.source,
+        )
+
+        if requester_user_id == self.deps.matrix_id.full_id and source_kind != "hook_dispatch":
+            return None
+
+        if not is_edit and self.deps.handled_turn_ledger.has_responded(event.event_id):
+            return None
+
+        if not is_authorized_sender(
+            requester_user_id,
+            self.deps.runtime.config,
+            room.room_id,
+            self.deps.runtime_paths,
+            room_alias=room.canonical_alias,
+        ):
+            self._mark_source_events_responded(HandledTurnState.from_source_event_id(event.event_id))
+            return None
+
+        if not self.deps.dispatch_planner.can_reply_to_sender(requester_user_id):
+            self._mark_source_events_responded(HandledTurnState.from_source_event_id(event.event_id))
+            return None
+
+        return requester_user_id
+
+    def _precheck_dispatch_event[T: _DispatchEvent](
+        self,
+        room: nio.MatrixRoom,
+        event: T,
+        *,
+        is_edit: bool = False,
+    ) -> _PrecheckedEvent[T] | None:
+        """Return a typed prechecked event for turn dispatch."""
+        requester_user_id = self._precheck_event(room, event, is_edit=is_edit)
+        if requester_user_id is None:
+            return None
+        return _PrecheckedEvent(event=event, requester_user_id=requester_user_id)
+
+    def _mark_source_events_responded(self, handled_turn: HandledTurnState) -> None:
+        """Mark one or more source events as handled by the same terminal outcome."""
+        record_handled_turn(self.deps.handled_turn_ledger, handled_turn)
+
+    def _response_history_scope_for_action(
+        self,
+        response_action: ResponseAction,
+    ) -> HistoryScope | None:
+        """Return the persisted history scope used by one response action."""
+        if response_action.kind == "team":
+            assert response_action.form_team is not None
+            return self.deps.state_writer.team_history_scope(response_action.form_team.eligible_members)
+        if response_action.kind == "individual":
+            return self.deps.state_writer.history_scope()
+        return None
+
+    def _handled_turn_with_response_context(
+        self,
+        handled_turn: HandledTurnState,
+        *,
+        history_scope: HistoryScope | None,
+        conversation_target: MessageTarget | None,
+    ) -> HandledTurnState:
+        """Attach the persisted regeneration context for one response."""
+        return handled_turn.with_response_context(
+            response_owner=self.deps.agent_name,
+            history_scope=history_scope,
+            conversation_target=conversation_target,
+        )
+
+    def _has_newer_unresponded_in_thread(
+        self,
+        event: _TextDispatchEvent,
+        requester_user_id: str,
+        thread_history: Sequence[ResolvedVisibleMessage],
+    ) -> bool:
+        """Return True when a newer unresponded message from the same sender exists."""
+        if isinstance(event, PreparedTextEvent) and is_automation_source_kind(event.source_kind_override or ""):
+            return False
+        event_ts = event.server_timestamp
+        if event_ts is None or not thread_history:
+            return False
+        for message in thread_history:
+            if message.sender != requester_user_id:
+                continue
+            if message.timestamp is None or message.timestamp <= event_ts:
+                continue
+            if message.event_id == event.event_id:
+                continue
+            if self.deps.handled_turn_ledger.has_responded(message.event_id):
+                continue
+            if (
+                message.body
+                and isinstance(message.body, str)
+                and command_parser.parse(message.body.strip()) is not None
+            ):
+                continue
+            self.deps.logger.info(
+                "Skipping older message — newer unresponded message from same sender in thread",
+                skipped_event_id=event.event_id,
+                newer_event_id=message.event_id,
+            )
+            return True
+        return False
+
+    def _should_skip_deep_synthetic_full_dispatch(
+        self,
+        *,
+        event_id: str,
+        envelope: MessageEnvelope,
+    ) -> bool:
+        """Return True when a deep synthetic hook relay must stop before dispatch."""
+        resolved_policy = hook_ingress_policy(envelope)
+        if resolved_policy.allow_full_dispatch:
+            return False
+        self.deps.logger.debug(
+            "Ignoring deep synthetic hook relay before command/response dispatch",
+            event_id=event_id,
+            source_kind=envelope.source_kind,
+            hook_source=envelope.hook_source,
+            message_received_depth=envelope.message_received_depth,
+        )
+        return True
+
+    def _should_bypass_coalescing_for_active_thread_follow_up(
+        self,
+        *,
+        target: MessageTarget,
+        source_kind: str,
+        sender_id: str,
+    ) -> bool:
+        """Return whether one human thread follow-up should skip in-flight coalescing."""
+        if target.resolved_thread_id is None:
+            return False
+        if is_automation_source_kind(source_kind):
+            return False
+        if is_agent_id(sender_id, self.deps.runtime.config, self.deps.runtime_paths):
+            return False
+        return self.deps.response_coordinator.has_active_response_for_target(target)
+
+    async def _coalescing_key_for_event(
+        self,
+        room: nio.MatrixRoom,
+        event: _DispatchEvent,
+        requester_user_id: str,
+    ) -> CoalescingKey:
+        """Return the sender or thread scoped dispatch key for one event."""
+        return (
+            room.room_id,
+            await self.deps.resolver.coalescing_thread_id(room, event),
+            requester_user_id,
+        )
+
+    async def _enqueue_for_dispatch(
+        self,
+        event: _DispatchEvent,
+        room: nio.MatrixRoom,
+        *,
+        source_kind: str,
+        requester_user_id: str | None = None,
+        coalescing_key: CoalescingKey | None = None,
+    ) -> None:
+        """Route one inbound event through the live coalescing gate."""
+        dispatch_timing = get_dispatch_pipeline_timing(event.source)
+        if dispatch_timing is not None:
+            dispatch_timing.mark("gate_enter")
+        effective_requester_user_id = requester_user_id or self._requester_user_id(
+            sender=event.sender,
+            source=event.source,
+        )
+        if self._is_trusted_internal_relay_event(event):
+            if dispatch_timing is not None:
+                dispatch_timing.note(coalescing_bypassed=True, coalescing_bypass_reason="trusted_internal_relay")
+                dispatch_timing.mark("gate_exit")
+            trusted_relay_event = cast("_TextDispatchEvent", event)
+            await self._dispatch_text_message(
+                room,
+                trusted_relay_event,
+                effective_requester_user_id,
+            )
+            return
+        await self.deps.coalescing_gate.enqueue(
+            coalescing_key or await self._coalescing_key_for_event(room, event, effective_requester_user_id),
+            PendingEvent(
+                event=event,
+                room=room,
+                source_kind=source_kind,
+            ),
+        )
+
+    async def _maybe_send_visible_voice_echo(
+        self,
+        room: nio.MatrixRoom,
+        event: nio.RoomMessageAudio | nio.RoomEncryptedAudio,
+        *,
+        text: str,
+        thread_id: str | None,
+    ) -> str | None:
+        """Optionally post a display-only router echo for normalized audio."""
+        if self.deps.agent_name != ROUTER_AGENT_NAME or not self.deps.runtime.config.voice.visible_router_echo:
+            return None
+
+        existing_visible_echo_event_id = self.deps.handled_turn_ledger.get_visible_echo_event_id(event.event_id)
+        if existing_visible_echo_event_id is not None:
+            return existing_visible_echo_event_id
+
+        target = self.deps.resolver.build_message_target(
+            room_id=room.room_id,
+            thread_id=thread_id,
+            reply_to_event_id=event.event_id,
+            event_source=event.source,
+        )
+        visible_echo_event_id = await self.deps.delivery_gateway.send_text(
+            SendTextRequest(
+                target=target,
+                response_text=text,
+                skip_mentions=True,
+            ),
+        )
+        if visible_echo_event_id is not None:
+            self.deps.handled_turn_ledger.record_visible_echo(event.event_id, visible_echo_event_id)
+        return visible_echo_event_id
+
+    async def handle_coalesced_batch(self, batch: CoalescedBatch) -> None:
+        """Dispatch one flushed batch through the normal text pipeline."""
+        dispatch_event = build_batch_dispatch_event(batch)
+        dispatch_timing = get_dispatch_pipeline_timing(dispatch_event.source)
+        if dispatch_timing is not None:
+            dispatch_timing.mark("gate_exit")
+        batch_coalescing_key = await self._coalescing_key_for_event(
+            batch.room,
+            batch.primary_event,
+            batch.requester_user_id,
+        )
+        canonical_key = (
+            batch.room.room_id,
+            self.deps.resolver.build_message_target(
+                room_id=batch.room.room_id,
+                thread_id=batch_coalescing_key[1],
+                reply_to_event_id=dispatch_event.event_id,
+                event_source=dispatch_event.source,
+            ).resolved_thread_id,
+            batch.requester_user_id,
+        )
+        self.deps.coalescing_gate.retarget(batch_coalescing_key, canonical_key)
+        async with self.deps.resolver.turn_thread_cache_scope():
+            await self._dispatch_text_message(
+                batch.room,
+                dispatch_event,
+                batch.requester_user_id,
+                media_events=batch.media_events or None,
+                handled_turn=HandledTurnState.create(
+                    batch.source_event_ids,
+                    source_event_prompts=batch.source_event_prompts,
+                ),
+            )
+
+    async def handle_text_event(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
+        """Handle one inbound text event."""
+        async with self.deps.resolver.turn_thread_cache_scope():
+            await self._handle_message_inner(room, event)
+
+    async def _handle_message_inner(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
+        """Handle one text message inside the per-turn thread-history cache scope."""
+        ingress_thread_id = await self.deps.resolver.coalescing_thread_id(room, event)
+        self.deps.logger.info(
+            "Received message",
+            event_id=event.event_id,
+            room_id=room.room_id,
+            sender=event.sender,
+            thread_id=ingress_thread_id,
+        )
+        dispatch_timing = create_dispatch_pipeline_timing(
+            event_id=event.event_id,
+            room_id=room.room_id,
+        )
+        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
+        event_info = EventInfo.from_event(event.source)
+        await self.deps.conversation_access.append_live_event(room.room_id, event, event_info=event_info)
+        if not isinstance(event.body, str):
+            return
+        event_content = event.source.get("content") if isinstance(event.source, dict) else None
+        if isinstance(event_content, dict) and event_content.get(STREAM_STATUS_KEY) in {
+            STREAM_STATUS_PENDING,
+            STREAM_STATUS_STREAMING,
+        }:
+            return
+
+        prechecked_event = self._precheck_dispatch_event(room, event, is_edit=event_info.is_edit)
+        if prechecked_event is None:
+            return
+
+        if event_info.is_edit:
+            await self.deps.edit_regenerator.handle_message_edit(
+                room,
+                prechecked_event.event,
+                event_info,
+                prechecked_event.requester_user_id,
+            )
+            return
+
+        prepared_event = await self.deps.normalizer.resolve_text_event(
+            TextNormalizationRequest(event=prechecked_event.event),
+        )
+        attach_dispatch_pipeline_timing(prepared_event.source, dispatch_timing)
+        envelope = self.deps.resolver.build_ingress_envelope(
+            room_id=room.room_id,
+            event=prepared_event,
+            requester_user_id=prechecked_event.requester_user_id,
+        )
+        if self._should_skip_deep_synthetic_full_dispatch(
+            event_id=prepared_event.event_id,
+            envelope=envelope,
+        ):
+            return
+        if should_handle_interactive_text_response(envelope):
+            await interactive.handle_text_response(self._client(), room, prepared_event, self.deps.agent_name)
+        coalescing_thread_id = await self.deps.resolver.coalescing_thread_id(room, prepared_event)
+        target = self.deps.resolver.build_message_target(
+            room_id=room.room_id,
+            thread_id=coalescing_thread_id,
+            reply_to_event_id=prepared_event.event_id,
+            event_source=prepared_event.source,
+        )
+        if self._should_bypass_coalescing_for_active_thread_follow_up(
+            target=target,
+            source_kind=envelope.source_kind,
+            sender_id=prepared_event.sender,
+        ):
+            if dispatch_timing is not None:
+                dispatch_timing.mark("gate_enter")
+                dispatch_timing.note(
+                    coalescing_bypassed=True,
+                    coalescing_bypass_reason="active_thread_follow_up",
+                )
+                dispatch_timing.mark("gate_exit")
+            await self._dispatch_text_message(
+                room,
+                prepared_event,
+                prechecked_event.requester_user_id,
+            )
+            return
+        await self._enqueue_for_dispatch(
+            prechecked_event.event,
+            room,
+            source_kind="message",
+            requester_user_id=prechecked_event.requester_user_id,
+            coalescing_key=(room.room_id, coalescing_thread_id, prechecked_event.requester_user_id),
+        )
+
+    async def _dispatch_text_message(  # noqa: C901, PLR0912, PLR0915
+        self,
+        room: nio.MatrixRoom,
+        event: _TextDispatchEvent | _PrecheckedTextDispatchEvent,
+        requester_user_id: str | None = None,
+        *,
+        media_events: list[_MediaDispatchEvent] | None = None,
+        handled_turn: HandledTurnState | None = None,
+    ) -> None:
+        """Run the normal text or command dispatch pipeline for a prepared text event."""
+        raw_event: _TextDispatchEvent
+        if isinstance(event, _PrecheckedEvent):
+            requester_user_id = event.requester_user_id
+            raw_event = cast("_TextDispatchEvent", event.event)
+        else:
+            raw_event = event
+        if requester_user_id is None:
+            msg = "requester_user_id is required when dispatching a raw event"
+            raise TypeError(msg)
+        router_event: _DispatchEvent = raw_event
+        event = await self.deps.normalizer.resolve_text_event(
+            TextNormalizationRequest(event=raw_event),
+        )
+        dispatch_timing = get_dispatch_pipeline_timing(raw_event.source)
+        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
+        timing_scope_token = timing_scope_context.set(event.event_id[:20] if event.event_id else "unknown")
+        try:
+            if dispatch_timing is not None:
+                dispatch_timing.mark("dispatch_start")
+            dispatch_started_at = time.monotonic()
+            handled_turn = handled_turn or HandledTurnState.from_source_event_id(event.event_id)
+
+            if dispatch_timing is not None:
+                dispatch_timing.mark("dispatch_prepare_start")
+            dispatch = await self.deps.dispatch_planner.prepare_dispatch(
+                room,
+                event,
+                requester_user_id,
+                event_label="message",
+                handled_turn=handled_turn,
+            )
+            if dispatch_timing is not None:
+                dispatch_timing.mark("dispatch_prepare_ready")
+            if dispatch is None:
+                return
+
+            command = command_parser.parse(event.body) if not media_events else None
+            if command:
+                if self.deps.agent_name == ROUTER_AGENT_NAME:
+                    await self.deps.dispatch_planner.execute_command(
+                        room=room,
+                        event=event,
+                        requester_user_id=requester_user_id,
+                        command=command,
+                        source_envelope=dispatch.envelope,
+                    )
+                return
+
+            if self._has_newer_unresponded_in_thread(
+                event,
+                requester_user_id,
+                dispatch.context.thread_history,
+            ):
+                self._mark_source_events_responded(handled_turn)
+                return
+            if self._should_skip_deep_synthetic_full_dispatch(
+                event_id=event.event_id,
+                envelope=dispatch.envelope,
+            ):
+                return
+            if dispatch.context.requires_full_thread_history:
+                await self.deps.resolver.hydrate_dispatch_context(room, event, dispatch.context)
+            content = event.source.get("content") if isinstance(event.source, dict) else None
+            message_attachment_ids = parse_attachment_ids_from_event_source(event.source)
+            message_extra_content: dict[str, Any] = {}
+            if message_attachment_ids:
+                message_extra_content[ATTACHMENT_IDS_KEY] = message_attachment_ids
+            if isinstance(content, dict):
+                original_sender = content.get(ORIGINAL_SENDER_KEY)
+                if isinstance(original_sender, str):
+                    message_extra_content[ORIGINAL_SENDER_KEY] = original_sender
+                raw_audio_fallback = content.get(VOICE_RAW_AUDIO_FALLBACK_KEY)
+                if isinstance(raw_audio_fallback, bool) and raw_audio_fallback:
+                    message_extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] = True
+            router_extra_content = dict(message_extra_content)
+            if media_events and ORIGINAL_SENDER_KEY not in router_extra_content:
+                router_extra_content[ORIGINAL_SENDER_KEY] = requester_user_id
+            if dispatch_timing is not None:
+                dispatch_timing.mark("dispatch_plan_start")
+            plan = await self.deps.dispatch_planner.plan_dispatch(
+                room,
+                event,
+                dispatch,
+                extra_content=router_extra_content or None,
+                media_events=media_events,
+                handled_turn=handled_turn,
+                router_event=media_events[0]
+                if media_events and len(handled_turn.source_event_ids) == 1
+                else router_event,
+            )
+            if dispatch_timing is not None:
+                dispatch_timing.mark("dispatch_plan_ready")
+            if plan.kind == "ignore":
+                if plan.handled_turn_outcome is not None:
+                    self._mark_source_events_responded(plan.handled_turn_outcome)
+                return
+            if plan.kind == "route":
+                route_event = plan.router_event or event
+                single_direct_media_route = (
+                    isinstance(
+                        route_event,
+                        nio.RoomMessageFile
+                        | nio.RoomEncryptedFile
+                        | nio.RoomMessageVideo
+                        | nio.RoomEncryptedVideo
+                        | nio.RoomMessageImage
+                        | nio.RoomEncryptedImage,
+                    )
+                    and media_events == [route_event]
+                    and handled_turn.source_event_ids == (event.event_id,)
+                )
+                routing_kwargs: dict[str, Any] = {
+                    "message": event.body if media_events else plan.router_message,
+                    "requester_user_id": dispatch.requester_user_id,
+                    "extra_content": plan.extra_content,
+                }
+                if plan.media_events is not None and not single_direct_media_route:
+                    routing_kwargs["media_events"] = plan.media_events
+                if (
+                    plan.handled_turn is not None
+                    and list(plan.handled_turn.source_event_ids) != [route_event.event_id]
+                    and not single_direct_media_route
+                ):
+                    routing_kwargs["handled_turn"] = self._handled_turn_with_response_context(
+                        plan.handled_turn,
+                        history_scope=None,
+                        conversation_target=dispatch.target,
+                    )
+                await self.deps.dispatch_planner.execute_router_relay(
+                    room,
+                    route_event,
+                    dispatch.context.thread_history,
+                    dispatch.context.thread_id,
+                    **routing_kwargs,
+                )
+                return
+            assert plan.response_action is not None
+            handled_turn = self._handled_turn_with_response_context(
+                handled_turn,
+                history_scope=self._response_history_scope_for_action(plan.response_action),
+                conversation_target=dispatch.target,
+            )
+            matrix_run_metadata = matrix_run_metadata_for_handled_turn(handled_turn)
+
+            async def build_payload(context: MessageContext) -> DispatchPayload:
+                effective_thread_id = self.deps.resolver.build_message_target(
+                    room_id=room.room_id,
+                    thread_id=context.thread_id,
+                    reply_to_event_id=event.event_id,
+                    event_source=event.source,
+                ).resolved_thread_id
+                media_attachment_ids: list[str] = []
+                fallback_images: list[Image] | None = None
+                if media_events:
+                    media_result = await self.deps.normalizer.register_batch_media_attachments(
+                        BatchMediaAttachmentRequest(
+                            room_id=room.room_id,
+                            thread_id=effective_thread_id,
+                            media_events=media_events,
+                        ),
+                    )
+                    media_attachment_ids = media_result.attachment_ids
+                    fallback_images = media_result.fallback_images
+                return await self.deps.normalizer.build_dispatch_payload_with_attachments(
+                    DispatchPayloadWithAttachmentsRequest(
+                        room_id=room.room_id,
+                        prompt=event.body,
+                        current_attachment_ids=merge_attachment_ids(
+                            message_attachment_ids,
+                            media_attachment_ids,
+                        ),
+                        thread_id=context.thread_id,
+                        media_thread_id=effective_thread_id,
+                        thread_history=context.thread_history,
+                        fallback_images=fallback_images,
+                    ),
+                )
+
+            await self.deps.dispatch_planner.execute_response_action(
+                room,
+                event,
+                dispatch,
+                plan.response_action,
+                build_payload,
+                processing_log="Processing",
+                dispatch_started_at=dispatch_started_at,
+                handled_turn=handled_turn,
+                matrix_run_metadata=matrix_run_metadata,
+            )
+        finally:
+            timing_scope_context.reset(timing_scope_token)
+
+    async def handle_media_event(
+        self,
+        room: nio.MatrixRoom,
+        event: _MediaDispatchEvent,
+    ) -> None:
+        """Handle one inbound media event."""
+        async with self.deps.resolver.turn_thread_cache_scope():
+            await self._handle_media_message_inner(room, event)
+
+    async def _handle_media_message_inner(
+        self,
+        room: nio.MatrixRoom,
+        event: _MediaDispatchEvent,
+    ) -> None:
+        """Handle one media event inside the per-turn thread-history cache scope."""
+        prechecked_event = self._precheck_dispatch_event(room, event)
+        if prechecked_event is None:
+            return
+
+        if await self._dispatch_special_media_as_text(room, prechecked_event):
+            return
+        event = prechecked_event.event
+        await self._enqueue_for_dispatch(
+            event,
+            room,
+            source_kind="image" if isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage) else "media",
+            requester_user_id=prechecked_event.requester_user_id,
+        )
+
+    async def _dispatch_special_media_as_text(
+        self,
+        room: nio.MatrixRoom,
+        prechecked_event: _PrecheckedMediaDispatchEvent,
+    ) -> bool:
+        """Handle media events that normalize into the text dispatch pipeline."""
+        event = prechecked_event.event
+        if isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio):
+            await self._on_audio_media_message(
+                room,
+                _PrecheckedEvent(
+                    event=event,
+                    requester_user_id=prechecked_event.requester_user_id,
+                ),
+            )
+            return True
+        if isinstance(event, nio.RoomMessageFile | nio.RoomEncryptedFile):
+            return await self._dispatch_file_sidecar_text_preview(
+                room,
+                _PrecheckedEvent(
+                    event=event,
+                    requester_user_id=prechecked_event.requester_user_id,
+                ),
+            )
+        return False
+
+    async def _on_audio_media_message(
+        self,
+        room: nio.MatrixRoom,
+        prechecked_event: _PrecheckedEvent[nio.RoomMessageAudio | nio.RoomEncryptedAudio],
+    ) -> None:
+        """Normalize audio into a synthetic text event and reuse text dispatch."""
+        event = prechecked_event.event
+
+        if is_agent_id(event.sender, self.deps.runtime.config, self.deps.runtime_paths):
+            self.deps.logger.debug(
+                "Ignoring agent audio event for voice transcription",
+                event_id=event.event_id,
+                sender=event.sender,
+            )
+            self._mark_source_events_responded(HandledTurnState.from_source_event_id(event.event_id))
+            return
+
+        normalized_voice = await self.deps.normalizer.prepare_voice_event(
+            VoiceNormalizationRequest(
+                room=room,
+                event=event,
+            ),
+        )
+        if normalized_voice is None:
+            self._mark_source_events_responded(HandledTurnState.from_source_event_id(event.event_id))
+            return
+
+        await self._maybe_send_visible_voice_echo(
+            room,
+            event,
+            text=normalized_voice.event.body,
+            thread_id=normalized_voice.effective_thread_id,
+        )
+
+        await self._enqueue_for_dispatch(
+            normalized_voice.event,
+            room,
+            source_kind="voice",
+            requester_user_id=prechecked_event.requester_user_id,
+        )
+
+    async def _dispatch_file_sidecar_text_preview(
+        self,
+        room: nio.MatrixRoom,
+        prechecked_event: _PrecheckedEvent[nio.RoomMessageFile | nio.RoomEncryptedFile],
+    ) -> bool:
+        """Dispatch one sidecar-backed file preview through the normal text pipeline."""
+        event = prechecked_event.event
+        if not is_v2_sidecar_text_preview(event.source):
+            return False
+
+        prepared_text_event = await self.deps.normalizer.prepare_file_sidecar_text_event(event)
+        assert prepared_text_event is not None
+        envelope = self.deps.resolver.build_ingress_envelope(
+            room_id=room.room_id,
+            event=prepared_text_event,
+            requester_user_id=prechecked_event.requester_user_id,
+        )
+        if self._should_skip_deep_synthetic_full_dispatch(
+            event_id=prepared_text_event.event_id,
+            envelope=envelope,
+        ):
+            return True
+        if should_handle_interactive_text_response(envelope):
+            await interactive.handle_text_response(self._client(), room, prepared_text_event, self.deps.agent_name)
+        await self._dispatch_text_message(
+            room,
+            _PrecheckedEvent(
+                event=prepared_text_event,
+                requester_user_id=prechecked_event.requester_user_id,
+            ),
+        )
+        return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,10 @@ from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.delivery_gateway import DeliveryGateway, EditTextRequest, SendTextRequest
 from mindroom.dispatch_planner import DispatchPlanner
+from mindroom.edit_regenerator import EditRegenerator
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.response_coordinator import ResponseCoordinator, ResponseRequest
+from mindroom.turn_engine import TurnEngine
 
 __all__ = [
     "TEST_ACCESS_TOKEN",
@@ -41,7 +43,9 @@ __all__ = [
     "patch_response_coordinator_module",
     "replace_delivery_gateway_deps",
     "replace_dispatch_planner_deps",
+    "replace_edit_regenerator_deps",
     "replace_response_coordinator_deps",
+    "replace_turn_engine_deps",
     "resolve_response_thread_root_for_test",
     "runtime_paths_for",
     "sync_bot_runtime_state",
@@ -279,6 +283,7 @@ def wrap_extracted_collaborators(bot: object, *names: str) -> object:
         "_dispatch_planner",
         "_delivery_gateway",
         "_response_coordinator",
+        "_edit_regenerator",
         "_inbound_turn_normalizer",
         "_conversation_resolver",
         "_conversation_state_writer",
@@ -309,6 +314,8 @@ def replace_dispatch_planner_deps(bot: object, **changes: object) -> DispatchPla
     rebuilt = DispatchPlanner(replace(planner.deps, **changes))
     bot._dispatch_planner = rebuilt
     wrap_extracted_collaborators(bot, "_dispatch_planner")
+    if hasattr(bot, "_turn_engine"):
+        replace_turn_engine_deps(bot, dispatch_planner=bot._dispatch_planner)
     return rebuilt
 
 
@@ -319,6 +326,8 @@ def replace_delivery_gateway_deps(bot: object, **changes: object) -> DeliveryGat
     rebuilt = DeliveryGateway(replace(gateway.deps, **changes))
     bot._delivery_gateway = rebuilt
     wrap_extracted_collaborators(bot, "_delivery_gateway")
+    if hasattr(bot, "_turn_engine"):
+        replace_turn_engine_deps(bot, delivery_gateway=bot._delivery_gateway)
     if hasattr(bot, "_response_coordinator"):
         replace_response_coordinator_deps(bot, delivery_gateway=bot._delivery_gateway)
     elif hasattr(bot, "_dispatch_planner"):
@@ -333,11 +342,53 @@ def replace_response_coordinator_deps(bot: object, **changes: object) -> Respons
     rebuilt = ResponseCoordinator(replace(coordinator.deps, **changes))
     bot._response_coordinator = rebuilt
     wrap_extracted_collaborators(bot, "_response_coordinator")
+    if hasattr(bot, "_turn_engine"):
+        replace_turn_engine_deps(bot, response_coordinator=bot._response_coordinator)
     if hasattr(bot, "_dispatch_planner"):
         planner_changes: dict[str, object] = {"response_coordinator": bot._response_coordinator}
         if "delivery_gateway" in changes:
             planner_changes["delivery_gateway"] = changes["delivery_gateway"]
         replace_dispatch_planner_deps(bot, **planner_changes)
+    return rebuilt
+
+
+def replace_edit_regenerator_deps(bot: object, **changes: object) -> EditRegenerator:
+    """Rebuild the edit regenerator after swapping captured collaborators."""
+    sync_bot_runtime_state(bot)
+    regenerator = unwrap_extracted_collaborator(cast("EditRegenerator", bot._edit_regenerator))
+    rebuilt_changes = dict(changes)
+    if "logger" in rebuilt_changes:
+        logger = rebuilt_changes.pop("logger")
+        rebuilt_changes["get_logger"] = lambda logger=logger: logger
+    if "handled_turn_ledger" in rebuilt_changes:
+        handled_turn_ledger = rebuilt_changes.pop("handled_turn_ledger")
+        rebuilt_changes["get_handled_turn_ledger"] = lambda handled_turn_ledger=handled_turn_ledger: handled_turn_ledger
+    rebuilt = EditRegenerator(replace(regenerator.deps, **rebuilt_changes))
+    bot._edit_regenerator = rebuilt
+    wrap_extracted_collaborators(bot, "_edit_regenerator")
+    if hasattr(bot, "_turn_engine"):
+        replace_turn_engine_deps(bot, edit_regenerator=bot._edit_regenerator)
+    return rebuilt
+
+
+def replace_turn_engine_deps(bot: object, **changes: object) -> TurnEngine:
+    """Rebuild the turn engine after swapping collaborators captured at construction."""
+    sync_bot_runtime_state(bot)
+    engine = unwrap_extracted_collaborator(cast("TurnEngine", bot._turn_engine))
+    rebuilt_changes = dict(changes)
+    if hasattr(bot, "_edit_regenerator") and "edit_regenerator" not in rebuilt_changes:
+        rebuilt_changes["edit_regenerator"] = bot._edit_regenerator
+    rebuilt = TurnEngine(replace(engine.deps, **rebuilt_changes))
+    bot._turn_engine = rebuilt
+    if hasattr(bot, "_edit_regenerator"):
+        edit_changes = {
+            name: value
+            for name, value in changes.items()
+            if name
+            in unwrap_extracted_collaborator(cast("EditRegenerator", bot._edit_regenerator)).deps.__dataclass_fields__
+        }
+        if edit_changes:
+            replace_edit_regenerator_deps(bot, **edit_changes)
     return rebuilt
 
 
@@ -369,6 +420,8 @@ def install_send_response_mock(bot: object, send_response: AsyncMock) -> None:
         )
 
     bot._delivery_gateway.send_text = AsyncMock(side_effect=_send_text)
+    if hasattr(bot, "_turn_engine"):
+        replace_turn_engine_deps(bot, delivery_gateway=bot._delivery_gateway)
     if hasattr(bot, "_response_coordinator"):
         replace_response_coordinator_deps(bot, delivery_gateway=bot._delivery_gateway)
     if hasattr(bot, "_dispatch_planner"):
@@ -406,6 +459,8 @@ def install_generate_response_mock(bot: object, generate_response: AsyncMock) ->
         )
 
     bot._response_coordinator.generate_response = AsyncMock(side_effect=_generate)
+    if hasattr(bot, "_turn_engine"):
+        replace_turn_engine_deps(bot, response_coordinator=bot._response_coordinator)
     if hasattr(bot, "_dispatch_planner"):
         replace_dispatch_planner_deps(
             bot,
@@ -429,6 +484,8 @@ def install_edit_message_mock(bot: object, edit_message: AsyncMock) -> None:
         )
 
     bot._delivery_gateway.edit_text = AsyncMock(side_effect=_edit_text)
+    if hasattr(bot, "_turn_engine"):
+        replace_turn_engine_deps(bot, delivery_gateway=bot._delivery_gateway)
     if hasattr(bot, "_response_coordinator"):
         replace_response_coordinator_deps(bot, delivery_gateway=bot._delivery_gateway)
     if hasattr(bot, "_dispatch_planner"):
@@ -443,6 +500,8 @@ def install_send_skill_command_response_mock(bot: object, send_skill_command_res
     """Route skill-command dispatch through one test mock on the real owner."""
     wrap_extracted_collaborators(bot, "_response_coordinator")
     bot._response_coordinator.send_skill_command_response = send_skill_command_response
+    if hasattr(bot, "_turn_engine"):
+        replace_turn_engine_deps(bot, response_coordinator=bot._response_coordinator)
     if hasattr(bot, "_dispatch_planner"):
         replace_dispatch_planner_deps(
             bot,
@@ -524,5 +583,8 @@ def bypass_authorization(request: pytest.FixtureRequest) -> Generator[None, None
     if "test_authorization" in request.node.parent.name:
         yield
     else:
-        with patch("mindroom.bot.is_authorized_sender", return_value=True):
+        with (
+            patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        ):
             yield

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 
-from mindroom.bot import AgentBot, _PrecheckedEvent
+from mindroom.bot import AgentBot
 from mindroom.commands.parsing import Command, CommandType
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
@@ -18,6 +18,7 @@ from mindroom.constants import ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME, VOICE_PRE
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.thread_utils import should_agent_respond
+from mindroom.turn_engine import _PrecheckedEvent
 from tests.conftest import (
     TEST_ACCESS_TOKEN,
     TEST_PASSWORD,
@@ -27,6 +28,7 @@ from tests.conftest import (
     install_send_response_mock,
     install_send_skill_command_response_mock,
     replace_dispatch_planner_deps,
+    replace_turn_engine_deps,
     runtime_paths_for,
     sync_bot_runtime_state,
     test_runtime_paths,
@@ -69,6 +71,22 @@ def _sync_dispatch_planner_runtime(bot: AgentBot) -> None:
         logger=bot.logger,
         handled_turn_ledger=bot.handled_turn_ledger,
     )
+    replace_turn_engine_deps(
+        bot,
+        logger=bot.logger,
+        handled_turn_ledger=bot.handled_turn_ledger,
+    )
+
+
+async def _execute_command(
+    bot: AgentBot,
+    room: object,
+    event: object,
+    requester_user_id: str,
+    command: Command,
+) -> None:
+    """Execute one command through the current planner owner."""
+    await bot._dispatch_planner.execute_command(room, event, requester_user_id, command)
 
 
 @pytest.fixture
@@ -82,14 +100,14 @@ def mock_agent_bot() -> AgentBot:
         access_token=TEST_ACCESS_TOKEN,
     )
     config = _runtime_bound_config(Config())
-    with tempfile.TemporaryDirectory() as tmpdir:
-        bot = AgentBot(
-            agent_user=agent_user,
-            storage_path=Path(tmpdir),
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            rooms=["!test:server"],
-        )
+    tmpdir = Path(tempfile.mkdtemp())
+    bot = AgentBot(
+        agent_user=agent_user,
+        storage_path=tmpdir,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        rooms=["!test:server"],
+    )
     wrap_extracted_collaborators(bot)
     bot.client = AsyncMock()
     bot.client.user_id = bot.agent_user.user_id
@@ -133,11 +151,7 @@ class TestBotScheduleCommands:
             mock_agent_bot.handled_turn_ledger.has_responded.return_value = False
             _sync_dispatch_planner_runtime(mock_agent_bot)
 
-            await mock_agent_bot._handle_command(
-                room,
-                _PrecheckedEvent(event=event, requester_user_id="@user:server"),
-                command,
-            )
+            await _execute_command(mock_agent_bot, room, event, "@user:server", command)
 
             # Verify schedule_task was called correctly
             mock_schedule.assert_called_once()
@@ -176,11 +190,7 @@ class TestBotScheduleCommands:
         with patch("mindroom.commands.handler.schedule_task") as mock_schedule:
             mock_schedule.return_value = ("task456", "✅ Scheduled for tomorrow")
 
-            await mock_agent_bot._handle_command(
-                room,
-                _PrecheckedEvent(event=event, requester_user_id="@user:server"),
-                command,
-            )
+            await _execute_command(mock_agent_bot, room, event, "@user:server", command)
 
             # Verify the full text was passed
             call_args = mock_schedule.call_args
@@ -205,11 +215,7 @@ class TestBotScheduleCommands:
         with patch("mindroom.commands.handler.list_scheduled_tasks") as mock_list:
             mock_list.return_value = "**Scheduled Tasks:**\n• task123 - Tomorrow: Test"
 
-            await mock_agent_bot._handle_command(
-                room,
-                _PrecheckedEvent(event=event, requester_user_id="@user:server"),
-                command,
-            )
+            await _execute_command(mock_agent_bot, room, event, "@user:server", command)
 
             mock_list.assert_called_once_with(
                 client=mock_agent_bot.client,
@@ -239,11 +245,7 @@ class TestBotScheduleCommands:
         with patch("mindroom.commands.handler.cancel_scheduled_task") as mock_cancel:
             mock_cancel.return_value = "✅ Cancelled task `task123`"
 
-            await mock_agent_bot._handle_command(
-                room,
-                _PrecheckedEvent(event=event, requester_user_id="@user:server"),
-                command,
-            )
+            await _execute_command(mock_agent_bot, room, event, "@user:server", command)
 
             mock_cancel.assert_called_once_with(client=mock_agent_bot.client, room_id="!test:server", task_id="task123")
 
@@ -270,11 +272,7 @@ class TestBotScheduleCommands:
         with patch("mindroom.commands.handler.cancel_all_scheduled_tasks") as mock_cancel_all:
             mock_cancel_all.return_value = "✅ Cancelled 3 scheduled task(s)"
 
-            await mock_agent_bot._handle_command(
-                room,
-                _PrecheckedEvent(event=event, requester_user_id="@user:server"),
-                command,
-            )
+            await _execute_command(mock_agent_bot, room, event, "@user:server", command)
 
             mock_cancel_all.assert_called_once_with(client=mock_agent_bot.client, room_id="!test:server")
 
@@ -306,11 +304,7 @@ class TestBotScheduleCommands:
         with patch("mindroom.commands.handler.edit_scheduled_task") as mock_edit:
             mock_edit.return_value = "✅ Updated task `task123`."
 
-            await mock_agent_bot._handle_command(
-                room,
-                _PrecheckedEvent(event=event, requester_user_id="@user:server"),
-                command,
-            )
+            await _execute_command(mock_agent_bot, room, event, "@user:server", command)
 
             mock_edit.assert_called_once()
             edit_kwargs = mock_edit.call_args.kwargs
@@ -345,11 +339,7 @@ class TestBotScheduleCommands:
         with patch("mindroom.commands.handler.schedule_task") as mock_schedule:
             mock_schedule.return_value = ("task123", "✅ Scheduled: 5 minutes from now")
 
-            await mock_agent_bot._handle_command(
-                room,
-                _PrecheckedEvent(event=event, requester_user_id="@user:server"),
-                command,
-            )
+            await _execute_command(mock_agent_bot, room, event, "@user:server", command)
 
         # Should successfully schedule the task (auto-creates thread)
         mock_agent_bot._send_response.assert_called_once()
@@ -549,7 +539,9 @@ class TestCommandHandling:
             bot.client = AsyncMock()
             bot.client.user_id = bot.agent_user.user_id
             bot.logger = MagicMock()
-            bot._handle_command = AsyncMock()
+            wrap_extracted_collaborators(bot, "_dispatch_planner")
+            _sync_dispatch_planner_runtime(bot)
+            bot._dispatch_planner.execute_command = AsyncMock()
 
             # Create a room and event with thread info
             room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
@@ -570,7 +562,7 @@ class TestCommandHandling:
                 await bot._on_message(room, event)
 
             # Verify the command was handled
-            bot._handle_command.assert_called_once()
+            bot._dispatch_planner.execute_command.assert_called_once()
             bot.logger.info.assert_any_call(
                 "Received message",
                 event_id="$event123",
@@ -603,7 +595,9 @@ class TestCommandHandling:
             bot.client = AsyncMock()
             bot.client.user_id = bot.agent_user.user_id
             bot.logger = MagicMock()
-            bot._handle_command = AsyncMock()
+            wrap_extracted_collaborators(bot, "_dispatch_planner")
+            _sync_dispatch_planner_runtime(bot)
+            bot._dispatch_planner.execute_command = AsyncMock()
             bot._conversation_resolver.coalescing_thread_id = AsyncMock(return_value="$thread-root")
 
             room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
@@ -623,7 +617,7 @@ class TestCommandHandling:
             with patch("mindroom.constants.ROUTER_AGENT_NAME", "router"):
                 await bot._on_message(room, event)
 
-            bot._handle_command.assert_called_once()
+            bot._dispatch_planner.execute_command.assert_called_once()
             bot.logger.info.assert_any_call(
                 "Received message",
                 event_id="$event123",
@@ -664,7 +658,9 @@ class TestCommandHandling:
             bot.client = AsyncMock()
             bot.client.user_id = bot.agent_user.user_id
             bot.logger = MagicMock()
-            bot._handle_command = AsyncMock()
+            wrap_extracted_collaborators(bot, "_dispatch_planner")
+            _sync_dispatch_planner_runtime(bot)
+            bot._dispatch_planner.execute_command = AsyncMock()
 
             room = nio.MatrixRoom(room_id="!test:server", own_user_id=bot.client.user_id)
             event = nio.RoomMessageText.from_dict(
@@ -681,7 +677,7 @@ class TestCommandHandling:
 
             await bot._on_message(room, event)
 
-            bot._handle_command.assert_not_called()
+            bot._dispatch_planner.execute_command.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_router_skill_command_respects_target_reply_permissions(self) -> None:
@@ -1395,11 +1391,13 @@ class TestRouterSkipsSingleAgent:
         bot.client = AsyncMock()
         bot.client.user_id = bot.agent_user.user_id
         bot.logger = MagicMock()
-        bot._handle_ai_routing = AsyncMock()
+        wrap_extracted_collaborators(bot, "_dispatch_planner")
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         _sync_dispatch_planner_runtime(bot)
         _sync_dispatch_planner_runtime(bot)
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
 
         # Create context with no mentions and no agents in thread
         mock_context = MagicMock()
@@ -1442,7 +1440,7 @@ class TestRouterSkipsSingleAgent:
             await bot._on_message(room, event)
 
         # Verify router didn't attempt to route
-        bot._handle_ai_routing.assert_not_called()
+        bot._dispatch_planner.execute_router_relay.assert_not_called()
 
         # Verify it logged that it's skipping routing
         info_calls = [call[0][0] for call in bot.logger.info.call_args_list]
@@ -1481,10 +1479,12 @@ class TestRouterSkipsSingleAgent:
         bot.client = AsyncMock()
         bot.client.user_id = bot.agent_user.user_id
         bot.logger = MagicMock()
-        bot._handle_ai_routing = AsyncMock()
+        wrap_extracted_collaborators(bot, "_dispatch_planner")
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         _sync_dispatch_planner_runtime(bot)
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
 
         # Create context with no mentions and no agents in thread
         mock_context = MagicMock()
@@ -1531,8 +1531,8 @@ class TestRouterSkipsSingleAgent:
             await bot._on_message(room, event)
 
         # Verify router DID attempt to route
-        bot._handle_ai_routing.assert_called_once()
-        routed_call = bot._handle_ai_routing.call_args
+        bot._dispatch_planner.execute_router_relay.assert_called_once()
+        routed_call = bot._dispatch_planner.execute_router_relay.call_args
         assert routed_call.args[0] is room
         routed_event = routed_call.args[1]
         assert routed_event.event_id == event.event_id
@@ -1581,10 +1581,12 @@ class TestRouterSkipsSingleAgent:
         bot.client = AsyncMock()
         bot.client.user_id = bot.agent_user.user_id
         bot.logger = MagicMock()
-        bot._handle_ai_routing = AsyncMock()
+        wrap_extracted_collaborators(bot, "_dispatch_planner")
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         _sync_dispatch_planner_runtime(bot)
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
 
         mock_context = MagicMock()
         mock_context.am_i_mentioned = False
@@ -1627,12 +1629,12 @@ class TestRouterSkipsSingleAgent:
                 config.get_ids(runtime_paths_for(config))["general"],
                 config.get_ids(runtime_paths_for(config))["calculator"],
             ]
-            await bot._dispatch_text_message(
+            await bot._turn_engine._dispatch_text_message(
                 room,
                 _PrecheckedEvent(event=event, requester_user_id="@alice:localhost"),
             )
 
-        bot._handle_ai_routing.assert_not_called()
+        bot._dispatch_planner.execute_router_relay.assert_not_called()
         info_calls = [call[0][0] for call in bot.logger.info.call_args_list]
         assert "Skipping routing: multiple non-agent users in thread (mention required)" in info_calls
 
@@ -1666,7 +1668,8 @@ class TestRouterSkipsSingleAgent:
         bot.client = AsyncMock()
         bot.client.user_id = bot.agent_user.user_id
         bot.logger = MagicMock()
-        bot._handle_command = AsyncMock()
+        wrap_extracted_collaborators(bot, "_dispatch_planner")
+        bot._dispatch_planner.execute_command = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         _sync_dispatch_planner_runtime(bot)
@@ -1674,6 +1677,7 @@ class TestRouterSkipsSingleAgent:
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         _sync_dispatch_planner_runtime(bot)
+        bot._dispatch_planner.execute_command = AsyncMock()
 
         # Room with router + one agent + a human
         room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
@@ -1702,7 +1706,7 @@ class TestRouterSkipsSingleAgent:
 
         # Router should handle the command even with a single agent
         # This ensures commands work properly in single-agent rooms
-        bot._handle_command.assert_called_once()
+        bot._dispatch_planner.execute_command.assert_called_once()
         # Router should not send a response for unknown commands (handled by _handle_command)
         bot._send_response.assert_not_called()
 
@@ -1736,7 +1740,8 @@ class TestRouterSkipsSingleAgent:
         bot.client = AsyncMock()
         bot.client.user_id = bot.agent_user.user_id
         bot.logger = MagicMock()
-        bot._handle_command = AsyncMock()
+        wrap_extracted_collaborators(bot, "_dispatch_planner")
+        bot._dispatch_planner.execute_command = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         _sync_dispatch_planner_runtime(bot)
@@ -1744,6 +1749,7 @@ class TestRouterSkipsSingleAgent:
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         _sync_dispatch_planner_runtime(bot)
+        bot._dispatch_planner.execute_command = AsyncMock()
 
         # Room with router + one agent + a human
         room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
@@ -1772,9 +1778,9 @@ class TestRouterSkipsSingleAgent:
 
         # Router MUST handle schedule commands even with a single agent
         # This is a regression test to ensure commands work in single-agent rooms
-        bot._handle_command.assert_called_once()
-        args = bot._handle_command.call_args[0]
-        assert args[2].type.value == "schedule", "Router should handle schedule command"
+        bot._dispatch_planner.execute_command.assert_called_once()
+        kwargs = bot._dispatch_planner.execute_command.call_args.kwargs
+        assert kwargs["command"].type.value == "schedule", "Router should handle schedule command"
 
     @pytest.mark.asyncio
     async def test_router_handles_voice_transcription_in_single_agent_room(self) -> None:
@@ -1806,10 +1812,12 @@ class TestRouterSkipsSingleAgent:
         bot.client = AsyncMock()
         bot.client.user_id = bot.agent_user.user_id
         bot.logger = MagicMock()
-        bot._handle_ai_routing = AsyncMock()
+        wrap_extracted_collaborators(bot, "_dispatch_planner")
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         _sync_dispatch_planner_runtime(bot)
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
 
         # Room with router + one agent + a human
         room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
@@ -1855,7 +1863,9 @@ class TestRouterSkipsSingleAgent:
 
         # Voice transcriptions should work: router skips routing but doesn't interfere
         # This is a regression test to ensure voice works in single-agent rooms
-        assert not bot._handle_ai_routing.called, "Router should skip routing for voice in single-agent room"
+        assert not bot._dispatch_planner.execute_router_relay.called, (
+            "Router should skip routing for voice in single-agent room"
+        )
         info_calls = [call[0][0] for call in bot.logger.info.call_args_list]
         assert "Skipping routing: only one agent present" in info_calls
 
@@ -1892,10 +1902,12 @@ class TestRouterSkipsSingleAgent:
         bot.client = AsyncMock()
         bot.client.user_id = bot.agent_user.user_id
         bot.logger = MagicMock()
-        bot._handle_command = AsyncMock()
+        wrap_extracted_collaborators(bot, "_dispatch_planner")
+        bot._dispatch_planner.execute_command = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         _sync_dispatch_planner_runtime(bot)
+        bot._dispatch_planner.execute_command = AsyncMock()
 
         # Room with router + two agents + a human
         room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
@@ -1926,4 +1938,4 @@ class TestRouterSkipsSingleAgent:
             ]
             await bot._on_message(room, event)
 
-        bot._handle_command.assert_called_once()
+        bot._dispatch_planner.execute_command.assert_called_once()

--- a/tests/test_edit_after_restart.py
+++ b/tests/test_edit_after_restart.py
@@ -11,8 +11,9 @@ import pytest
 from mindroom.bot import AgentBot
 from mindroom.constants import resolve_runtime_paths
 from mindroom.handled_turns import HandledTurnLedger, HandledTurnState
+from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
-from tests.conftest import wrap_extracted_collaborators
+from tests.conftest import replace_turn_engine_deps, wrap_extracted_collaborators
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -58,7 +59,7 @@ async def test_bot_handles_redelivered_edit_after_restart(tmp_path: Path) -> Non
     config = Mock()
     config.agents = {"test_agent": Mock()}
     config.get_agent_knowledge_base_ids.return_value = []
-    config.get_ids.return_value = {}
+    config.get_ids.return_value = {"test_agent": MatrixID.parse("@test_agent:example.com")}
     config.get_mindroom_user_id.return_value = "@mindroom:example.com"
     config.authorization.agent_reply_permissions = {}
 
@@ -85,6 +86,8 @@ async def test_bot_handles_redelivered_edit_after_restart(tmp_path: Path) -> Non
 
     # Mock logger
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
@@ -140,8 +143,8 @@ async def test_bot_handles_redelivered_edit_after_restart(tmp_path: Path) -> Non
 
     # Mock the methods needed for regeneration
     with (
-        patch.object(bot, "_handle_message_edit", new_callable=AsyncMock) as mock_handle_edit,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch.object(bot._edit_regenerator, "handle_message_edit", new_callable=AsyncMock) as mock_handle_edit,
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
     ):
         # Process the redelivered edit event
         await bot._on_message(room, edit_event)
@@ -169,7 +172,7 @@ async def test_bot_skips_duplicate_regular_message_after_restart(tmp_path: Path)
     config = Mock()
     config.agents = {"test_agent": Mock()}
     config.get_agent_knowledge_base_ids.return_value = []
-    config.get_ids.return_value = {}
+    config.get_ids.return_value = {"test_agent": MatrixID.parse("@test_agent:example.com")}
     config.get_mindroom_user_id.return_value = "@mindroom:example.com"
     config.authorization.agent_reply_permissions = {}
 
@@ -196,6 +199,7 @@ async def test_bot_skips_duplicate_regular_message_after_restart(tmp_path: Path)
 
     # Mock logger
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
@@ -229,8 +233,8 @@ async def test_bot_skips_duplicate_regular_message_after_restart(tmp_path: Path)
 
     # Mock methods
     with (
-        patch.object(bot, "_dispatch_text_message", new_callable=AsyncMock) as mock_dispatch,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch.object(bot._turn_engine, "_dispatch_text_message", new_callable=AsyncMock) as mock_dispatch,
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
     ):
         # Process the redelivered message
         await bot._on_message(room, message_event)

--- a/tests/test_edit_event_handling.py
+++ b/tests/test_edit_event_handling.py
@@ -11,7 +11,8 @@ import pytest
 from mindroom.bot import AgentBot
 from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
 from mindroom.matrix.users import AgentMatrixUser
-from tests.conftest import wrap_extracted_collaborators
+from mindroom.turn_engine import _PrecheckedEvent
+from tests.conftest import replace_turn_engine_deps, wrap_extracted_collaborators
 
 
 @pytest.mark.asyncio
@@ -52,32 +53,10 @@ async def test_bot_ignores_edit_events(tmp_path: Path) -> None:
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.handled_turn_ledger.get_turn_record.return_value = None
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@router:example.com")
-
-    # Create an original message event
-    original_event = nio.RoomMessageText.from_dict(
-        {
-            "content": {
-                "body": "Original message",
-                "msgtype": "m.text",
-            },
-            "event_id": "$original:example.com",
-            "sender": "@user:example.com",
-            "origin_server_ts": 1000000,
-            "type": "m.room.message",
-            "room_id": "!test:example.com",
-        },
-    )
-    original_event.source = {
-        "content": {
-            "body": "Original message",
-            "msgtype": "m.text",
-        },
-        "event_id": "$original:example.com",
-        "sender": "@user:example.com",
-    }
 
     # Create an edit event - this is what Matrix sends when a message is edited
     edit_event = nio.RoomMessageText.from_dict(
@@ -120,23 +99,20 @@ async def test_bot_ignores_edit_events(tmp_path: Path) -> None:
 
     # Mock the routing method that would be called for the router
     with (
-        patch.object(bot, "_handle_ai_routing", new_callable=AsyncMock) as mock_routing,
-        patch.object(bot._dispatch_planner, "can_reply_to_sender", return_value=True),
-        patch.object(bot, "_load_persisted_turn_metadata", return_value=None),
+        patch.object(
+            bot._turn_engine,
+            "_precheck_dispatch_event",
+            return_value=_PrecheckedEvent(event=edit_event, requester_user_id="@user:example.com"),
+        ),
+        patch.object(bot._turn_engine, "_dispatch_text_message", new_callable=AsyncMock) as mock_dispatch,
+        patch.object(bot._edit_regenerator, "handle_message_edit", new_callable=AsyncMock) as mock_handle_edit,
+        patch.object(bot._edit_regenerator, "load_persisted_turn_metadata", return_value=None),
     ):
-        # Process the original message - this should trigger routing
-        await bot._on_message(room, original_event)
-
-        # The router should have attempted to route the original message
-        assert mock_routing.called, "Router should process original messages"
-        mock_routing.reset_mock()
-
-        # Process the edit event - this should NOT trigger routing
+        # Process the edit event - this should not re-enter normal dispatch.
         await bot._on_message(room, edit_event)
 
-        # The router should NOT have attempted to route the edit
-        # This assertion will FAIL with the current code and PASS once fixed
-        assert not mock_routing.called, "Router should NOT process edit events as new messages"
+        mock_dispatch.assert_not_awaited()
+        mock_handle_edit.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -171,6 +147,7 @@ async def test_bot_ignores_multiple_edits(tmp_path: Path) -> None:
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.handled_turn_ledger.get_turn_record.return_value = None
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@router:example.com")
 
@@ -218,18 +195,23 @@ async def test_bot_ignores_multiple_edits(tmp_path: Path) -> None:
 
     # Mock the routing method
     with (
-        patch.object(bot, "_handle_ai_routing", new_callable=AsyncMock) as mock_routing,
-        patch.object(bot, "_load_persisted_turn_metadata", return_value=None),
+        patch.object(
+            bot._turn_engine,
+            "_precheck_dispatch_event",
+            side_effect=[
+                _PrecheckedEvent(event=edit_event, requester_user_id="@user:example.com") for edit_event in edit_events
+            ],
+        ),
+        patch.object(bot._turn_engine, "_dispatch_text_message", new_callable=AsyncMock) as mock_dispatch,
+        patch.object(bot._edit_regenerator, "handle_message_edit", new_callable=AsyncMock) as mock_handle_edit,
+        patch.object(bot._edit_regenerator, "load_persisted_turn_metadata", return_value=None),
     ):
         # Process all edit events
         for edit_event in edit_events:
             await bot._on_message(room, edit_event)
 
-        # None of the edits should have triggered routing
-        # This will FAIL with current code (it will be called 3 times)
-        assert not mock_routing.called, (
-            f"Router should not process any edit events, but was called {mock_routing.call_count} times"
-        )
+        assert not mock_dispatch.called
+        assert mock_handle_edit.await_count == len(edit_events)
 
 
 @pytest.mark.asyncio
@@ -264,6 +246,7 @@ async def test_regular_agent_ignores_edits(tmp_path: Path) -> None:
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.handled_turn_ledger.get_turn_record.return_value = None
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
 
@@ -309,7 +292,7 @@ async def test_regular_agent_ignores_edits(tmp_path: Path) -> None:
     # Mock the generate_response method
     with (
         patch.object(bot, "_generate_response", new_callable=AsyncMock) as mock_generate,
-        patch.object(bot, "_load_persisted_turn_metadata", return_value=None),
+        patch.object(bot._edit_regenerator, "load_persisted_turn_metadata", return_value=None),
     ):
         # Process the edit event
         await bot._on_message(room, edit_event)

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -40,6 +40,8 @@ from tests.conftest import (
     install_generate_response_mock,
     patch_response_coordinator_module,
     replace_dispatch_planner_deps,
+    replace_edit_regenerator_deps,
+    replace_turn_engine_deps,
     runtime_paths_for,
     unwrap_extracted_collaborator,
 )
@@ -327,7 +329,7 @@ async def test_bot_regenerates_response_on_edit(tmp_path: Path) -> None:
             ai_response=mock_ai_response,
         ),
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
-        patch("mindroom.bot.should_agent_respond") as mock_should_respond,
+        patch("mindroom.edit_regenerator.should_agent_respond") as mock_should_respond,
         patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(return_value="$edit")) as mock_edit,
     ):
         # Setup mocks
@@ -454,7 +456,7 @@ async def test_bot_edit_hooks_see_hydrated_sidecar_edit_body(tmp_path: Path) -> 
             "emit_message_received_hooks",
             new_callable=AsyncMock,
         ) as mock_emit_hooks,
-        patch("mindroom.bot.should_agent_respond", return_value=False) as mock_should_respond,
+        patch("mindroom.edit_regenerator.should_agent_respond", return_value=False) as mock_should_respond,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=True,
@@ -558,7 +560,7 @@ async def test_bot_edit_regeneration_uses_hydrated_mentions_for_response_gating(
             "emit_message_received_hooks",
             new_callable=AsyncMock,
         ) as mock_emit_hooks,
-        patch("mindroom.bot.should_agent_respond", return_value=False) as mock_should_respond,
+        patch("mindroom.edit_regenerator.should_agent_respond", return_value=False) as mock_should_respond,
     ):
         mock_emit_hooks.return_value = False
 
@@ -657,7 +659,7 @@ async def test_handle_message_edit_reuses_persisted_target_and_thread_scope(
             new_callable=AsyncMock,
             return_value=[],
         ) as mock_fetch_history,
-        patch("mindroom.bot.should_agent_respond") as mock_should_respond,
+        patch("mindroom.edit_regenerator.should_agent_respond") as mock_should_respond,
         patch.object(
             bot._conversation_state_writer,
             "remove_stale_runs_for_turn_record",
@@ -679,7 +681,7 @@ async def test_handle_message_edit_reuses_persisted_target_and_thread_scope(
             has_non_agent_mentions=False,
         )
 
-        await bot._handle_message_edit(
+        await bot._edit_regenerator.handle_message_edit(
             room,
             edit_event,
             EventInfo.from_event(edit_event.source),
@@ -890,7 +892,7 @@ async def test_team_bot_regenerates_edits_against_team_history_storage(tmp_path:
             "create_storage_for_history_scope",
             return_value=storage,
         ),
-        patch("mindroom.bot.remove_run_by_event_id", return_value=True) as mock_remove_run,
+        patch("mindroom.edit_regenerator.remove_run_by_event_id", return_value=True) as mock_remove_run,
     ):
         mock_context.return_value = MagicMock(
             am_i_mentioned=True,
@@ -1038,6 +1040,7 @@ async def test_bot_ignores_agent_edits(tmp_path: Path) -> None:
 
     # Mock logger
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
@@ -1233,12 +1236,12 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_for_non_primary_edi
 
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
-        patch("mindroom.bot.should_agent_respond", return_value=False) as mock_should_respond,
+        patch("mindroom.edit_regenerator.should_agent_respond", return_value=False) as mock_should_respond,
         patch.object(
             bot._conversation_state_writer,
             "create_history_scope_storage",
         ) as mock_create_storage,
-        patch("mindroom.bot.remove_run_by_event_id", return_value=True) as mock_remove_run,
+        patch("mindroom.edit_regenerator.remove_run_by_event_id", return_value=True) as mock_remove_run,
         patch.object(
             bot,
             "_generate_response",
@@ -1255,7 +1258,7 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_for_non_primary_edi
             has_non_agent_mentions=False,
         )
 
-        await bot._handle_message_edit(
+        await bot._edit_regenerator.handle_message_edit(
             room,
             edit_event,
             EventInfo.from_event(edit_event.source),
@@ -1383,12 +1386,12 @@ async def test_handle_message_edit_reuses_existing_response_without_placeholder_
 
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
-        patch("mindroom.bot.should_agent_respond", return_value=True) as mock_should_respond,
+        patch("mindroom.edit_regenerator.should_agent_respond", return_value=True) as mock_should_respond,
         patch.object(
             bot._conversation_state_writer,
             "create_history_scope_storage",
         ) as mock_create_storage,
-        patch("mindroom.bot.remove_run_by_event_id", return_value=False) as mock_remove_run,
+        patch("mindroom.edit_regenerator.remove_run_by_event_id", return_value=False) as mock_remove_run,
         patch.object(
             bot,
             "_generate_response",
@@ -1405,7 +1408,7 @@ async def test_handle_message_edit_reuses_existing_response_without_placeholder_
             has_non_agent_mentions=False,
         )
 
-        await bot._handle_message_edit(
+        await bot._edit_regenerator.handle_message_edit(
             room,
             edit_event,
             EventInfo.from_event(edit_event.source),
@@ -1506,12 +1509,12 @@ async def test_handle_message_edit_does_not_remark_response_when_regeneration_is
 
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
-        patch("mindroom.bot.should_agent_respond", return_value=True) as mock_should_respond,
+        patch("mindroom.edit_regenerator.should_agent_respond", return_value=True) as mock_should_respond,
         patch.object(
             bot._conversation_state_writer,
             "create_history_scope_storage",
         ) as mock_create_storage,
-        patch("mindroom.bot.remove_run_by_event_id", return_value=False) as mock_remove_run,
+        patch("mindroom.edit_regenerator.remove_run_by_event_id", return_value=False) as mock_remove_run,
         patch.object(
             bot,
             "_generate_response",
@@ -1528,7 +1531,7 @@ async def test_handle_message_edit_does_not_remark_response_when_regeneration_is
             has_non_agent_mentions=False,
         )
 
-        await bot._handle_message_edit(
+        await bot._edit_regenerator.handle_message_edit(
             room,
             edit_event,
             EventInfo.from_event(edit_event.source),
@@ -1643,13 +1646,13 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_from_persisted_run_
 
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
-        patch("mindroom.bot.should_agent_respond", return_value=False) as mock_should_respond,
+        patch("mindroom.edit_regenerator.should_agent_respond", return_value=False) as mock_should_respond,
         patch.object(
             bot._conversation_state_writer,
             "create_history_scope_storage",
             return_value=storage,
         ) as mock_create_storage,
-        patch("mindroom.bot.remove_run_by_event_id", return_value=True) as mock_remove_run,
+        patch("mindroom.edit_regenerator.remove_run_by_event_id", return_value=True) as mock_remove_run,
         patch.object(
             bot,
             "_generate_response",
@@ -1666,7 +1669,7 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_from_persisted_run_
             has_non_agent_mentions=False,
         )
 
-        await bot._handle_message_edit(
+        await bot._edit_regenerator.handle_message_edit(
             room,
             edit_event,
             EventInfo.from_event(edit_event.source),
@@ -1768,7 +1771,7 @@ def test_load_persisted_turn_metadata_prefers_newest_matching_run(tmp_path: Path
         "create_history_scope_storage",
         return_value=storage,
     ):
-        metadata = bot._load_persisted_turn_metadata(
+        metadata = bot._edit_regenerator.load_persisted_turn_metadata(
             room=room,
             thread_id=None,
             original_event_id="$first:example.com",
@@ -1851,7 +1854,7 @@ def test_load_persisted_turn_metadata_prefers_newest_match_across_thread_and_roo
         "create_history_scope_storage",
         side_effect=[threaded_storage, room_storage],
     ):
-        metadata = bot._load_persisted_turn_metadata(
+        metadata = bot._edit_regenerator.load_persisted_turn_metadata(
             room=room,
             thread_id="$thread:example.com",
             original_event_id="$first:example.com",
@@ -1892,6 +1895,11 @@ def test_remove_stale_runs_for_edited_message_uses_internal_state_writer_helpers
         replace(state_writer.deps, logger=captured_logger),
     )
     bot.logger = rebound_logger
+    replace_edit_regenerator_deps(
+        bot,
+        state_writer=bot._conversation_state_writer,
+        logger=bot.logger,
+    )
 
     storage = MagicMock()
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
@@ -1907,9 +1915,9 @@ def test_remove_stale_runs_for_edited_message_uses_internal_state_writer_helpers
             "create_history_scope_storage",
             return_value=storage,
         ) as mock_create_history_scope_storage,
-        patch("mindroom.bot.remove_run_by_event_id", return_value=True),
+        patch("mindroom.edit_regenerator.remove_run_by_event_id", return_value=True),
     ):
-        bot._remove_stale_runs_for_edited_message(
+        bot._edit_regenerator.remove_stale_runs_for_edited_message(
             room=room,
             thread_id=None,
             original_event_id="$original:example.com",
@@ -2009,7 +2017,7 @@ async def test_handle_message_edit_uses_fallback_cleanup_when_turn_context_was_r
 
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
-        patch.object(bot, "_remove_stale_runs_for_edited_message") as mock_fallback_cleanup,
+        patch.object(bot._edit_regenerator, "remove_stale_runs_for_edited_message") as mock_fallback_cleanup,
         patch.object(
             bot._conversation_state_writer,
             "remove_stale_runs_for_turn_record",
@@ -2030,7 +2038,7 @@ async def test_handle_message_edit_uses_fallback_cleanup_when_turn_context_was_r
             has_non_agent_mentions=False,
         )
 
-        await bot._handle_message_edit(
+        await bot._edit_regenerator.handle_message_edit(
             room,
             edit_event,
             EventInfo.from_event(edit_event.source),
@@ -2180,13 +2188,13 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
 
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
-        patch("mindroom.bot.should_agent_respond", return_value=False),
+        patch("mindroom.edit_regenerator.should_agent_respond", return_value=False),
         patch.object(
             bot._conversation_state_writer,
             "create_history_scope_storage",
             return_value=storage,
         ),
-        patch("mindroom.bot.remove_run_by_event_id", return_value=True),
+        patch("mindroom.edit_regenerator.remove_run_by_event_id", return_value=True),
         patch.object(bot, "_generate_response", new_callable=AsyncMock, return_value=None) as mock_generate_response,
     ):
         mock_context.return_value = MagicMock(
@@ -2198,7 +2206,7 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
             has_non_agent_mentions=False,
         )
 
-        await bot._handle_message_edit(
+        await bot._edit_regenerator.handle_message_edit(
             room,
             edit_event,
             EventInfo.from_event(edit_event.source),
@@ -2307,13 +2315,13 @@ async def test_handle_message_edit_recovers_missing_single_turn_without_rerunnin
 
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
-        patch("mindroom.bot.should_agent_respond", return_value=False) as mock_should_respond,
+        patch("mindroom.edit_regenerator.should_agent_respond", return_value=False) as mock_should_respond,
         patch.object(
             bot._conversation_state_writer,
             "create_history_scope_storage",
             return_value=storage,
         ),
-        patch("mindroom.bot.remove_run_by_event_id", return_value=True),
+        patch("mindroom.edit_regenerator.remove_run_by_event_id", return_value=True),
         patch.object(
             bot,
             "_generate_response",
@@ -2330,7 +2338,7 @@ async def test_handle_message_edit_recovers_missing_single_turn_without_rerunnin
             has_non_agent_mentions=False,
         )
 
-        await bot._handle_message_edit(
+        await bot._edit_regenerator.handle_message_edit(
             room,
             edit_event,
             EventInfo.from_event(edit_event.source),
@@ -2521,8 +2529,8 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
             "extract_message_context",
             new_callable=AsyncMock,
         ) as mock_context,
-        patch("mindroom.bot.should_agent_respond", return_value=True) as mock_should_respond,
-        patch("mindroom.bot.remove_run_by_event_id", return_value=True),
+        patch("mindroom.edit_regenerator.should_agent_respond", return_value=True) as mock_should_respond,
+        patch("mindroom.edit_regenerator.remove_run_by_event_id", return_value=True),
         patch.object(
             restarted_bot,
             "_generate_response",
@@ -2539,7 +2547,7 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
             has_non_agent_mentions=False,
         )
 
-        await restarted_bot._handle_message_edit(
+        await restarted_bot._edit_regenerator.handle_message_edit(
             room,
             edit_event,
             EventInfo.from_event(edit_event.source),
@@ -2984,7 +2992,7 @@ async def test_on_media_message_tracks_relay_event_id(tmp_path: Path) -> None:
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_handle_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         # Setup mocks
@@ -3042,6 +3050,7 @@ async def test_on_media_message_no_transcription_still_marks_relayed(tmp_path: P
 
     # Mock logger
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
@@ -3091,7 +3100,7 @@ async def test_on_media_message_no_transcription_still_marks_relayed(tmp_path: P
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_handle_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         # Setup mocks
@@ -3160,6 +3169,7 @@ async def test_unauthorized_user_cannot_edit_regenerate(tmp_path: Path) -> None:
 
     # Mock logger
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     room = Mock(spec=nio.MatrixRoom)
     room.room_id = "!test:example.com"
@@ -3193,8 +3203,8 @@ async def test_unauthorized_user_cannot_edit_regenerate(tmp_path: Path) -> None:
 
     # Test that authorization check works
     with (
-        patch("mindroom.bot.is_authorized_sender", return_value=False) as mock_is_auth,
-        patch.object(bot, "_handle_message_edit") as mock_handle_edit,
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=False) as mock_is_auth,
+        patch.object(bot._edit_regenerator, "handle_message_edit") as mock_handle_edit,
     ):
         await bot._on_message(room, edit_event)
         # Verify authorization was checked
@@ -3241,6 +3251,7 @@ async def test_on_media_message_unauthorized_sender_marks_responded(tmp_path: Pa
 
     # Mock logger
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
@@ -3282,7 +3293,7 @@ async def test_on_media_message_unauthorized_sender_marks_responded(tmp_path: Pa
 
     # Mock is_authorized_sender to return False
     with (
-        patch("mindroom.bot.is_authorized_sender", return_value=False) as mock_is_authorized,
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=False) as mock_is_authorized,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_handle_voice,
     ):
         # Process the voice event

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -11,7 +11,7 @@ import pytest
 
 from mindroom import interactive
 from mindroom.authorization import is_authorized_sender as real_is_authorized_sender
-from mindroom.bot import AgentBot, _PrecheckedEvent
+from mindroom.bot import AgentBot
 from mindroom.coalescing import PreparedTextEvent
 from mindroom.commands.parsing import Command, CommandType
 from mindroom.config.agent import AgentConfig
@@ -46,12 +46,14 @@ from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestrator import MultiAgentOrchestrator
 from mindroom.tool_system.skills import _SkillCommandDispatch, _SkillCommandSpec
+from mindroom.turn_engine import _PrecheckedEvent
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
     install_send_skill_command_response_mock,
     orchestrator_runtime_paths,
     replace_dispatch_planner_deps,
+    replace_turn_engine_deps,
     runtime_paths_for,
     sync_bot_runtime_state,
     test_runtime_paths,
@@ -173,6 +175,15 @@ def _hook_bot(tmp_path: Path) -> AgentBot:
         response_coordinator=bot._response_coordinator,
         delivery_gateway=bot._delivery_gateway,
     )
+    replace_turn_engine_deps(
+        bot,
+        resolver=bot._conversation_resolver,
+        normalizer=bot._inbound_turn_normalizer,
+        dispatch_planner=bot._dispatch_planner,
+        response_coordinator=bot._response_coordinator,
+        delivery_gateway=bot._delivery_gateway,
+        state_writer=bot._conversation_state_writer,
+    )
     return bot
 
 
@@ -198,6 +209,15 @@ def _agent_bot(tmp_path: Path, *, agent_name: str = "code") -> AgentBot:
         resolver=bot._conversation_resolver,
         response_coordinator=bot._response_coordinator,
         delivery_gateway=bot._delivery_gateway,
+    )
+    replace_turn_engine_deps(
+        bot,
+        resolver=bot._conversation_resolver,
+        normalizer=bot._inbound_turn_normalizer,
+        dispatch_planner=bot._dispatch_planner,
+        response_coordinator=bot._response_coordinator,
+        delivery_gateway=bot._delivery_gateway,
+        state_writer=bot._conversation_state_writer,
     )
     return bot
 
@@ -681,7 +701,7 @@ async def test_dispatch_text_message_continues_for_hook_originated_mentions(tmp_
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock(return_value=DispatchPlan(kind="ignore"))
 
-    await bot._dispatch_text_message(
+    await bot._turn_engine._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
@@ -745,7 +765,7 @@ async def test_user_message_cannot_spoof_hook_origin_to_bypass_message_received_
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock(return_value=DispatchPlan(kind="ignore"))
 
-    await bot._dispatch_text_message(
+    await bot._turn_engine._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
     )
@@ -854,16 +874,16 @@ async def test_dispatch_text_message_runs_message_received_before_command_parsin
 
     bot.hook_registry = HookRegistry.from_plugins([_plugin("hook-plugin", [received])])
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
-    bot._handle_command = AsyncMock()
+    bot._dispatch_planner.execute_command = AsyncMock()
     bot.handled_turn_ledger.record_handled_turn = MagicMock()
 
-    await bot._dispatch_text_message(
+    await bot._turn_engine._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
     )
 
     assert hook_calls == ["called"]
-    bot._handle_command.assert_not_awaited()
+    bot._dispatch_planner.execute_command.assert_not_awaited()
     bot.handled_turn_ledger.record_handled_turn.assert_called_once_with(
         HandledTurnState.from_source_event_id(event.event_id),
     )
@@ -952,6 +972,7 @@ async def test_dispatch_text_message_hydrates_sidecar_body_for_hooks_and_prompt(
     )
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
+    replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock(
         return_value=DispatchPlan(
@@ -1303,7 +1324,7 @@ async def test_deep_hook_dispatch_stops_before_command_or_response_dispatch(tmp_
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock()
 
-    await bot._dispatch_text_message(
+    await bot._turn_engine._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
@@ -1337,12 +1358,12 @@ async def test_deep_hook_dispatch_does_not_consume_interactive_answer_on_message
         options={"1": "first"},
         creator_agent=bot.agent_name,
     )
-    bot._precheck_dispatch_event = MagicMock(
+    bot._turn_engine._precheck_dispatch_event = MagicMock(
         return_value=_PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
     bot._inbound_turn_normalizer.resolve_text_event = AsyncMock(return_value=event)
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
-    bot._dispatch_text_message = AsyncMock()
+    bot._turn_engine._dispatch_text_message = AsyncMock()
 
     try:
         await bot._on_message(room, event)
@@ -1350,7 +1371,7 @@ async def test_deep_hook_dispatch_does_not_consume_interactive_answer_on_message
         assert "$question123" in interactive._active_questions
         interactive._active_questions.clear()
 
-    bot._dispatch_text_message.assert_not_awaited()
+    bot._turn_engine._dispatch_text_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1379,12 +1400,12 @@ async def test_first_hop_hook_dispatch_does_not_consume_interactive_answer_on_me
         options={"1": "first"},
         creator_agent=bot.agent_name,
     )
-    bot._precheck_dispatch_event = MagicMock(
+    bot._turn_engine._precheck_dispatch_event = MagicMock(
         return_value=_PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
     bot._inbound_turn_normalizer.resolve_text_event = AsyncMock(return_value=event)
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
-    bot._dispatch_text_message = AsyncMock()
+    bot._turn_engine._dispatch_text_message = AsyncMock()
 
     try:
         await bot._on_message(room, event)
@@ -1392,7 +1413,7 @@ async def test_first_hop_hook_dispatch_does_not_consume_interactive_answer_on_me
         assert "$question123" in interactive._active_questions
         interactive._active_questions.clear()
 
-    bot._dispatch_text_message.assert_awaited_once()
+    bot._turn_engine._dispatch_text_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1425,7 +1446,7 @@ async def test_first_hop_plain_hook_from_non_message_hook_still_dispatches(tmp_p
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock(return_value=DispatchPlan(kind="ignore"))
 
-    await bot._dispatch_text_message(
+    await bot._turn_engine._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
@@ -1476,7 +1497,7 @@ async def test_first_hop_hook_dispatch_sidecar_preview_skips_interactive_answer_
     )
     bot._inbound_turn_normalizer.prepare_file_sidecar_text_event = AsyncMock(return_value=prepared_text_event)
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
-    bot._dispatch_text_message = AsyncMock()
+    bot._turn_engine._dispatch_text_message = AsyncMock()
     interactive._active_questions.clear()
     interactive._active_questions["$question123"] = interactive._InteractiveQuestion(
         room_id=room.room_id,
@@ -1488,7 +1509,7 @@ async def test_first_hop_hook_dispatch_sidecar_preview_skips_interactive_answer_
     try:
         with patch.object(interactive, "handle_text_response", new=AsyncMock()) as mock_handle_text_response:
             assert isinstance(sidecar_event, nio.RoomMessageFile)
-            handled = await bot._dispatch_file_sidecar_text_preview(
+            handled = await bot._turn_engine._dispatch_file_sidecar_text_preview(
                 room,
                 _PrecheckedEvent(
                     event=sidecar_event,
@@ -1499,7 +1520,7 @@ async def test_first_hop_hook_dispatch_sidecar_preview_skips_interactive_answer_
         assert handled is True
         assert "$question123" in interactive._active_questions
         mock_handle_text_response.assert_not_awaited()
-        bot._dispatch_text_message.assert_awaited_once()
+        bot._turn_engine._dispatch_text_message.assert_awaited_once()
     finally:
         interactive._active_questions.clear()
 
@@ -1544,11 +1565,11 @@ async def test_deep_hook_dispatch_sidecar_preview_stops_before_interactive_or_di
     )
     bot._inbound_turn_normalizer.prepare_file_sidecar_text_event = AsyncMock(return_value=prepared_text_event)
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
-    bot._dispatch_text_message = AsyncMock()
+    bot._turn_engine._dispatch_text_message = AsyncMock()
 
     with patch.object(interactive, "handle_text_response", new=AsyncMock()) as mock_handle_text_response:
         assert isinstance(sidecar_event, nio.RoomMessageFile)
-        handled = await bot._dispatch_file_sidecar_text_preview(
+        handled = await bot._turn_engine._dispatch_file_sidecar_text_preview(
             room,
             _PrecheckedEvent(
                 event=sidecar_event,
@@ -1558,7 +1579,7 @@ async def test_deep_hook_dispatch_sidecar_preview_stops_before_interactive_or_di
 
     assert handled is True
     mock_handle_text_response.assert_not_awaited()
-    bot._dispatch_text_message.assert_not_awaited()
+    bot._turn_engine._dispatch_text_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1584,7 +1605,7 @@ async def test_first_hop_prepared_text_hook_dispatch_still_reaches_dispatch(tmp_
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock(return_value=DispatchPlan(kind="ignore"))
 
-    await bot._dispatch_text_message(
+    await bot._turn_engine._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
@@ -1618,7 +1639,7 @@ async def test_deep_prepared_text_hook_dispatch_stops_before_dispatch(tmp_path: 
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock()
 
-    await bot._dispatch_text_message(
+    await bot._turn_engine._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
@@ -1680,7 +1701,7 @@ async def test_hook_dispatch_skill_command_preserves_source_envelope_in_runtime(
         )
 
     with patch("mindroom.dispatch_planner.handle_command", new=fake_handle_command):
-        await bot._dispatch_text_message(
+        await bot._turn_engine._dispatch_text_message(
             room,
             _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
         )
@@ -1740,10 +1761,11 @@ async def test_hook_dispatch_skill_tool_command_builds_full_tool_runtime_context
             new=AsyncMock(side_effect=fake_run_skill_command_tool),
         ),
     ):
-        await bot._handle_command(
-            room,
-            _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
-            command,
+        await bot._dispatch_planner.execute_command(
+            room=room,
+            event=event,
+            requester_user_id="@mindroom_router:localhost",
+            command=command,
             source_envelope=_synthetic_envelope(agent_name="router"),
         )
 
@@ -1825,7 +1847,7 @@ async def test_router_precheck_allows_self_authored_hook_dispatch_without_reques
         ),
     )
 
-    prechecked = bot._precheck_dispatch_event(room, event)
+    prechecked = bot._turn_engine._precheck_dispatch_event(room, event)
 
     assert prechecked is not None
     assert prechecked.requester_user_id == "@mindroom_router:localhost"
@@ -1849,6 +1871,7 @@ async def test_precheck_rejects_hook_dispatch_with_unauthorized_original_sender(
     bot = _hook_bot(tmp_path)
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
     room = nio.MatrixRoom(room_id="!room:localhost", own_user_id="@mindroom_router:localhost")
     room.canonical_alias = None
     event = nio.RoomMessageText.from_dict(
@@ -1866,8 +1889,8 @@ async def test_precheck_rejects_hook_dispatch_with_unauthorized_original_sender(
         },
     )
 
-    with patch("mindroom.bot.is_authorized_sender", side_effect=real_is_authorized_sender):
-        prechecked = bot._precheck_dispatch_event(room, event)
+    with patch("mindroom.turn_engine.is_authorized_sender", side_effect=real_is_authorized_sender):
+        prechecked = bot._turn_engine._precheck_dispatch_event(room, event)
 
     assert prechecked is None
     bot.handled_turn_ledger.record_handled_turn.assert_called_once_with(

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -36,6 +36,7 @@ from tests.conftest import (
     bind_runtime_paths,
     install_generate_response_mock,
     install_send_response_mock,
+    replace_turn_engine_deps,
     runtime_paths_for,
     test_runtime_paths,
     wrap_extracted_collaborators,
@@ -92,6 +93,15 @@ def _make_bot(
     )
     bot = AgentBot(agent_user, tmp_path, config, runtime_paths_for(config), rooms=["!room:localhost"])
     wrap_extracted_collaborators(bot)
+    replace_turn_engine_deps(
+        bot,
+        dispatch_planner=bot._dispatch_planner,
+        delivery_gateway=bot._delivery_gateway,
+        response_coordinator=bot._response_coordinator,
+        resolver=bot._conversation_resolver,
+        normalizer=bot._inbound_turn_normalizer,
+        state_writer=bot._conversation_state_writer,
+    )
     return bot
 
 
@@ -263,8 +273,13 @@ async def test_single_message_dispatches_after_debounce_window(tmp_path: Path) -
         _ = handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn), media_events or []))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(event, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         assert calls == []
         await asyncio.sleep(0.03)
 
@@ -291,9 +306,19 @@ async def test_two_rapid_text_messages_dispatch_one_combined_turn(tmp_path: Path
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(first, room, source_kind="message", requester_user_id="@user:localhost")
-        await bot._enqueue_for_dispatch(second, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            first,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
+        await bot._turn_engine._enqueue_for_dispatch(
+            second,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
 
     assert calls == [
@@ -313,9 +338,19 @@ async def test_two_rapid_text_messages_forward_prompt_map_to_dispatch(tmp_path: 
     first = _text_event(event_id="$m1", body="first", server_timestamp=1000)
     second = _text_event(event_id="$m2", body="second", server_timestamp=1001)
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch:
-        await bot._enqueue_for_dispatch(first, room, source_kind="message", requester_user_id="@user:localhost")
-        await bot._enqueue_for_dispatch(second, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch:
+        await bot._turn_engine._enqueue_for_dispatch(
+            first,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
+        await bot._turn_engine._enqueue_for_dispatch(
+            second,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
 
     assert mock_dispatch.await_count == 1
@@ -347,9 +382,19 @@ async def test_image_and_text_coalesce_into_single_dispatch(tmp_path: Path) -> N
         _ = handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn), len(media_events or [])))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(image_event, room, source_kind="image", requester_user_id="@user:localhost")
-        await bot._enqueue_for_dispatch(text_event, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            image_event,
+            room,
+            source_kind="image",
+            requester_user_id="@user:localhost",
+        )
+        await bot._turn_engine._enqueue_for_dispatch(
+            text_event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
 
     assert calls == [
@@ -382,13 +427,23 @@ async def test_text_first_image_during_grace_dispatches_once(tmp_path: Path) -> 
         _ = handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn), len(media_events or [])))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(text_event, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            text_event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         # Wait for debounce to fire (10ms) so gate enters upload grace
         await asyncio.sleep(0.02)
         assert calls == []
 
-        await bot._enqueue_for_dispatch(image_event, room, source_kind="image", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            image_event,
+            room,
+            source_kind="image",
+            requester_user_id="@user:localhost",
+        )
         await _wait_for(lambda: len(calls) == 1)
 
     assert calls == [
@@ -422,15 +477,30 @@ async def test_text_first_multiple_images_during_grace_dispatch_once(tmp_path: P
         _ = handled_turn
         calls.append((_handled_turn_source_event_ids(handled_turn), len(media_events or [])))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(text_event, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            text_event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         # Wait for debounce to fire (10ms) so gate enters upload grace
         await asyncio.sleep(0.02)
         assert calls == []
 
-        await bot._enqueue_for_dispatch(first_image, room, source_kind="image", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            first_image,
+            room,
+            source_kind="image",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.01)
-        await bot._enqueue_for_dispatch(second_image, room, source_kind="image", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            second_image,
+            room,
+            source_kind="image",
+            requester_user_id="@user:localhost",
+        )
         await _wait_for(lambda: len(calls) == 1)
 
     assert calls == [(["$m1", "$img1", "$img2"], 2)]
@@ -456,13 +526,23 @@ async def test_text_during_upload_grace_flushes_pending_batch_and_starts_new_tur
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(first, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            first,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         # Wait for debounce to fire (40ms) so gate enters upload grace
         await asyncio.sleep(0.06)
         assert calls == []
 
-        await bot._enqueue_for_dispatch(second, room, source_kind="message", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            second,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
 
         assert calls == [("first turn", ["$m1"])]
 
@@ -494,11 +574,21 @@ async def test_image_after_grace_expires_dispatches_as_second_batch(tmp_path: Pa
         _ = handled_turn
         calls.append((_handled_turn_source_event_ids(handled_turn), len(media_events or [])))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(text_event, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            text_event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await _wait_for(lambda: len(calls) == 1)
 
-        await bot._enqueue_for_dispatch(image_event, room, source_kind="image", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            image_event,
+            room,
+            source_kind="image",
+            requester_user_id="@user:localhost",
+        )
         await _wait_for(lambda: len(calls) == 2)
 
     assert calls == [
@@ -527,9 +617,19 @@ async def test_different_senders_dispatch_separately(tmp_path: Path) -> None:
         _ = media_events, handled_turn
         calls.append(_handled_turn_source_event_ids(handled_turn))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(alice, room, source_kind="message", requester_user_id="@alice:localhost")
-        await bot._enqueue_for_dispatch(bob, room, source_kind="message", requester_user_id="@bob:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            alice,
+            room,
+            source_kind="message",
+            requester_user_id="@alice:localhost",
+        )
+        await bot._turn_engine._enqueue_for_dispatch(
+            bob,
+            room,
+            source_kind="message",
+            requester_user_id="@bob:localhost",
+        )
         await asyncio.sleep(0.03)
 
     assert sorted(calls) == [["$m1"], ["$m2"]]
@@ -642,9 +742,19 @@ async def test_same_sender_different_threads_dispatch_separately(tmp_path: Path)
         _ = media_events, handled_turn
         calls.append(_handled_turn_source_event_ids(handled_turn))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(thread_a, room, source_kind="message", requester_user_id="@user:localhost")
-        await bot._enqueue_for_dispatch(thread_b, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            thread_a,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
+        await bot._turn_engine._enqueue_for_dispatch(
+            thread_b,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
 
     assert sorted(calls) == [["$m1"], ["$m2"]]
@@ -670,9 +780,19 @@ async def test_command_mid_batch_flushes_pending_then_processes_command(tmp_path
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(first, room, source_kind="message", requester_user_id="@user:localhost")
-        await bot._enqueue_for_dispatch(command, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            first,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
+        await bot._turn_engine._enqueue_for_dispatch(
+            command,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
 
     assert calls == [
         ("tell me more", ["$m1"]),
@@ -701,12 +821,27 @@ async def test_command_flush_does_not_leave_stale_timer_for_next_message(tmp_pat
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(first, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            first,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.01)
-        await bot._enqueue_for_dispatch(command, room, source_kind="message", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            command,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.005)
-        await bot._enqueue_for_dispatch(second, room, source_kind="message", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            second,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
 
         assert calls == [
@@ -743,13 +878,23 @@ async def test_command_during_upload_grace_flushes_immediately(tmp_path: Path) -
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(text_event, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            text_event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         # Wait for debounce to fire (10ms) so gate enters upload grace
         await asyncio.sleep(0.02)
         assert calls == []
 
-        await bot._enqueue_for_dispatch(command_event, room, source_kind="message", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            command_event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
 
     assert calls == [
         ("first", ["$m1"]),
@@ -783,13 +928,28 @@ async def test_messages_during_active_response_wait_and_batch_after_completion(t
             entered_first_dispatch.set()
             await release_first_dispatch.wait()
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(first, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            first,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
         await entered_first_dispatch.wait()
 
-        await bot._enqueue_for_dispatch(second, room, source_kind="message", requester_user_id="@user:localhost")
-        await bot._enqueue_for_dispatch(third, room, source_kind="message", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            second,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
+        await bot._turn_engine._enqueue_for_dispatch(
+            third,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
 
         assert calls == [["$m1"]]
@@ -831,8 +991,13 @@ async def test_coalescing_exempt_source_kinds_bypass_gate(tmp_path: Path, source
         _ = media_events, handled_turn
         calls.append(dispatched_event.body)
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(event, room, source_kind=source_kind, requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            event,
+            room,
+            source_kind=source_kind,
+            requester_user_id="@user:localhost",
+        )
 
     assert calls == [f"{source_kind} task"]
 
@@ -878,12 +1043,22 @@ async def test_overlapping_scheduled_checkins_coalesce(tmp_path: Path) -> None:
             entered_first_dispatch.set()
             await release_first_dispatch.wait()
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(first, room, source_kind="scheduled", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            first,
+            room,
+            source_kind="scheduled",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
         await entered_first_dispatch.wait()
 
-        await bot._enqueue_for_dispatch(second, room, source_kind="scheduled", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            second,
+            room,
+            source_kind="scheduled",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
 
         assert calls == [["$m1"]]
@@ -917,8 +1092,13 @@ async def test_prepare_for_sync_shutdown_waits_for_active_flush_task(tmp_path: P
         entered_dispatch.set()
         await release_dispatch.wait()
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(event, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
         await entered_dispatch.wait()
 
@@ -952,8 +1132,13 @@ async def test_prepare_for_sync_shutdown_drains_pending_debounced_messages(tmp_p
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(event, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await bot.prepare_for_sync_shutdown()
 
     assert calls == [("hello", ["$m1"])]
@@ -979,8 +1164,13 @@ async def test_prepare_for_sync_shutdown_drains_pending_upload_grace(tmp_path: P
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(event, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         # Wait for debounce to fire (10ms) so gate enters upload grace
         await asyncio.sleep(0.02)
         assert calls == []
@@ -1016,13 +1206,23 @@ async def test_shutdown_during_in_flight_dispatch_does_not_start_grace(tmp_path:
             entered_dispatch.set()
             await release_dispatch.wait()
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(first, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            first,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
         await entered_dispatch.wait()
 
         # Enqueue another message while first is in-flight
-        await bot._enqueue_for_dispatch(second, room, source_kind="message", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            second,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
 
         # Start shutdown — should wait for in-flight, then flush remaining without grace
         shutdown_task = asyncio.create_task(bot.prepare_for_sync_shutdown())
@@ -1064,9 +1264,14 @@ async def test_first_turn_thread_resolution_retargets_in_flight_gate(tmp_path: P
             entered_dispatch.set()
             await release_first_dispatch.wait()
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
         first_task = asyncio.create_task(
-            bot._enqueue_for_dispatch(first, room, source_kind="message", requester_user_id="@user:localhost"),
+            bot._turn_engine._enqueue_for_dispatch(
+                first,
+                room,
+                source_kind="message",
+                requester_user_id="@user:localhost",
+            ),
         )
         await entered_dispatch.wait()
 
@@ -1075,7 +1280,12 @@ async def test_first_turn_thread_resolution_retargets_in_flight_gate(tmp_path: P
         assert bot._coalescing_gate._gates[retargeted_key].phase is GatePhase.IN_FLIGHT
 
         for followup in followups:
-            await bot._enqueue_for_dispatch(followup, room, source_kind="message", requester_user_id="@user:localhost")
+            await bot._turn_engine._enqueue_for_dispatch(
+                followup,
+                room,
+                source_kind="message",
+                requester_user_id="@user:localhost",
+            )
 
         gate = bot._coalescing_gate._gates[retargeted_key]
         assert gate.phase is GatePhase.IN_FLIGHT
@@ -1098,11 +1308,16 @@ async def test_cleanup_drains_pending_debounce_tasks(tmp_path: Path) -> None:
     event = _text_event(event_id="$m1", body="hello")
 
     with (
-        patch.object(bot, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
+        patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
         patch("mindroom.bot.get_joined_rooms", new=AsyncMock(return_value=[])),
         patch("mindroom.bot.wait_for_background_tasks", new=AsyncMock()),
     ):
-        await bot._enqueue_for_dispatch(event, room, source_kind="message", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         assert not bot._coalescing_gate.is_idle()
 
         await bot.cleanup()
@@ -1138,16 +1353,26 @@ async def test_upload_grace_hard_cap_prevents_indefinite_extension(tmp_path: Pat
         _ = media_events, handled_turn
         calls.append(_handled_turn_source_event_ids(handled_turn))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
         started_at = time.monotonic()
-        await bot._enqueue_for_dispatch(text_event, room, source_kind="message", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            text_event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         # Wait for debounce to fire (10ms) so gate enters upload grace
         await asyncio.sleep(0.02)
         assert calls == []
 
         for delay, image_event in zip((0.01, 0.01, 0.01, 0.01), image_events, strict=True):
             await asyncio.sleep(delay)
-            await bot._enqueue_for_dispatch(image_event, room, source_kind="image", requester_user_id="@user:localhost")
+            await bot._turn_engine._enqueue_for_dispatch(
+                image_event,
+                room,
+                source_kind="image",
+                requester_user_id="@user:localhost",
+            )
         await _wait_for(lambda: len(calls) == 1, deadline_seconds=0.5)
 
     assert calls == [["$m1", "$img1", "$img2", "$img3", "$img4"]]
@@ -1179,8 +1404,18 @@ async def test_handled_turn_ledger_marks_all_batch_event_ids(tmp_path: Path) -> 
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._enqueue_for_dispatch(first, room, source_kind="message", requester_user_id="@user:localhost")
-        await bot._enqueue_for_dispatch(second, room, source_kind="message", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            first,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
+        await bot._turn_engine._enqueue_for_dispatch(
+            second,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.05)
 
     assert bot.handled_turn_ledger.has_responded("$m1")
@@ -1212,8 +1447,13 @@ async def test_zero_debounce_dispatches_immediately(tmp_path: Path) -> None:
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(event, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         # Zero debounce flushes synchronously — should already be dispatched
         await asyncio.sleep(0.01)
 
@@ -1241,9 +1481,19 @@ async def test_multiple_commands_each_dispatch_independently(tmp_path: Path) -> 
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._enqueue_for_dispatch(first_cmd, room, source_kind="message", requester_user_id="@user:localhost")
-        await bot._enqueue_for_dispatch(second_cmd, room, source_kind="message", requester_user_id="@user:localhost")
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_engine._enqueue_for_dispatch(
+            first_cmd,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
+        await bot._turn_engine._enqueue_for_dispatch(
+            second_cmd,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
 
     assert calls == [
         ("!help", ["$c1"]),
@@ -1258,9 +1508,14 @@ async def test_gate_entry_removed_after_dispatch_with_no_pending(tmp_path: Path)
     room = _make_room()
     event = _text_event(event_id="$m1", body="hello")
 
-    with patch.object(bot, "_dispatch_text_message", new=AsyncMock()):
+    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock()):
         assert bot._coalescing_gate.is_idle()
-        await bot._enqueue_for_dispatch(event, room, source_kind="message", requester_user_id="@user:localhost")
+        await bot._turn_engine._enqueue_for_dispatch(
+            event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+        )
         await asyncio.sleep(0.03)
 
     assert bot._coalescing_gate.is_idle()
@@ -1302,7 +1557,7 @@ async def test_backlog_replay_skips_older_message_when_newer_exists(tmp_path: Pa
         patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
         patch.object(bot._dispatch_planner, "plan_dispatch", new=action_mock),
     ):
-        await bot._dispatch_text_message(room, older_event, "@user:localhost")
+        await bot._turn_engine._dispatch_text_message(room, older_event, "@user:localhost")
 
     # Older message should be skipped — resolve_dispatch_action never called
     action_mock.assert_not_awaited()
@@ -1339,7 +1594,7 @@ async def test_thread_history_guard_does_not_interfere_with_normal_dispatch(tmp_
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._dispatch_text_message(room, event, "@user:localhost")
+        await bot._turn_engine._dispatch_text_message(room, event, "@user:localhost")
 
     # Dispatch proceeded to completion
     assert bot.handled_turn_ledger.has_responded("$m1")
@@ -1565,7 +1820,7 @@ async def test_newer_command_does_not_suppress_older_message(tmp_path: Path) -> 
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._dispatch_text_message(room, older_event, "@user:localhost")
+        await bot._turn_engine._dispatch_text_message(room, older_event, "@user:localhost")
 
     # The older message must NOT be suppressed — dispatch action should be called
     action_mock.assert_awaited_once()
@@ -1612,7 +1867,7 @@ async def test_newer_command_with_whitespace_does_not_suppress(tmp_path: Path) -
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._dispatch_text_message(room, older_event, "@user:localhost")
+        await bot._turn_engine._dispatch_text_message(room, older_event, "@user:localhost")
 
     action_mock.assert_awaited_once()
 
@@ -1668,7 +1923,7 @@ async def test_scheduled_event_not_suppressed(tmp_path: Path) -> None:
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._dispatch_text_message(room, scheduled_event, "@mindroom_test_agent:localhost")
+        await bot._turn_engine._dispatch_text_message(room, scheduled_event, "@mindroom_test_agent:localhost")
 
     action_mock.assert_awaited_once()
 
@@ -1716,7 +1971,7 @@ async def test_hook_event_not_suppressed(tmp_path: Path) -> None:
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._dispatch_text_message(room, hook_event, "@mindroom_test_agent:localhost")
+        await bot._turn_engine._dispatch_text_message(room, hook_event, "@mindroom_test_agent:localhost")
 
     action_mock.assert_awaited_once()
 
@@ -1766,7 +2021,7 @@ async def test_multiple_scheduled_fires_not_suppressed(tmp_path: Path) -> None:
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._dispatch_text_message(room, first_fire, "@mindroom_test_agent:localhost")
+        await bot._turn_engine._dispatch_text_message(room, first_fire, "@mindroom_test_agent:localhost")
 
     # First fire must NOT be suppressed
     action_mock.assert_awaited_once()
@@ -1809,7 +2064,7 @@ async def test_coalesced_user_batch_suppressed_by_thread_guard(tmp_path: Path) -
         patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
         patch.object(bot._dispatch_planner, "plan_dispatch", new=action_mock),
     ):
-        await bot._dispatch_text_message(room, coalesced_event, "@user:localhost")
+        await bot._turn_engine._dispatch_text_message(room, coalesced_event, "@user:localhost")
 
     # Coalesced user batch MUST be suppressed — not an automation event
     action_mock.assert_not_awaited()
@@ -1850,7 +2105,7 @@ async def test_voice_synthetic_suppressed_by_thread_guard(tmp_path: Path) -> Non
         patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
         patch.object(bot._dispatch_planner, "plan_dispatch", new=action_mock),
     ):
-        await bot._dispatch_text_message(room, voice_event, "@user:localhost")
+        await bot._turn_engine._dispatch_text_message(room, voice_event, "@user:localhost")
 
     # Voice synthetic MUST be suppressed — not an automation event
     action_mock.assert_not_awaited()
@@ -1890,9 +2145,9 @@ async def test_older_command_not_suppressed_during_replay(tmp_path: Path) -> Non
     handle_cmd_mock = AsyncMock()
     with (
         patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
-        patch.object(bot, "_handle_command", new=handle_cmd_mock),
+        patch.object(bot._dispatch_planner, "execute_command", new=handle_cmd_mock),
     ):
-        await bot._dispatch_text_message(room, cmd_event, "@user:localhost")
+        await bot._turn_engine._dispatch_text_message(room, cmd_event, "@user:localhost")
 
     # Command must have been dispatched, not suppressed
     handle_cmd_mock.assert_awaited_once()

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -33,7 +33,6 @@ from mindroom.bot import (
     MultiKnowledgeVectorDb,
     PreparedTextEvent,
     TeamBot,
-    _PrecheckedEvent,
     _thread_summary_message_count_hint,
 )
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig
@@ -98,6 +97,7 @@ from mindroom.runtime_state import get_runtime_state, reset_runtime_state, set_r
 from mindroom.streaming import StreamingDeliveryError
 from mindroom.teams import TeamIntent, TeamMemberStatus, TeamMode, TeamOutcome, TeamResolution, TeamResolutionMember
 from mindroom.tool_system.events import ToolTraceEntry
+from mindroom.turn_engine import _PrecheckedEvent
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
@@ -107,6 +107,7 @@ from tests.conftest import (
     patch_response_coordinator_module,
     replace_delivery_gateway_deps,
     replace_response_coordinator_deps,
+    replace_turn_engine_deps,
     runtime_paths_for,
     test_runtime_paths,
     unwrap_extracted_collaborator,
@@ -128,7 +129,17 @@ def _make_matrix_client_mock() -> AsyncMock:
 
 def _wrap_extracted_collaborators(bot: AgentBot) -> AgentBot:
     """Wrap frozen extracted collaborators so tests can patch their methods."""
-    return cast("AgentBot", wrap_extracted_collaborators(bot))
+    wrapped_bot = cast("AgentBot", wrap_extracted_collaborators(bot))
+    replace_turn_engine_deps(
+        wrapped_bot,
+        resolver=wrapped_bot._conversation_resolver,
+        normalizer=wrapped_bot._inbound_turn_normalizer,
+        dispatch_planner=wrapped_bot._dispatch_planner,
+        response_coordinator=wrapped_bot._response_coordinator,
+        delivery_gateway=wrapped_bot._delivery_gateway,
+        state_writer=wrapped_bot._conversation_state_writer,
+    )
+    return wrapped_bot
 
 
 def _replace_dispatch_planner_deps(bot: AgentBot, **changes: object) -> DispatchPlanner:
@@ -137,6 +148,26 @@ def _replace_dispatch_planner_deps(bot: AgentBot, **changes: object) -> Dispatch
     updated_planner = DispatchPlanner(replace(planner.deps, **changes))
     bot._dispatch_planner = updated_planner
     wrap_extracted_collaborators(bot, "_dispatch_planner")
+    engine_changes = {
+        name: value
+        for name, value in changes.items()
+        if name
+        in {
+            "logger",
+            "handled_turn_ledger",
+            "resolver",
+            "normalizer",
+            "response_coordinator",
+            "delivery_gateway",
+            "state_writer",
+            "coalescing_gate",
+        }
+    }
+    replace_turn_engine_deps(
+        bot,
+        dispatch_planner=bot._dispatch_planner,
+        **engine_changes,
+    )
     return updated_planner
 
 
@@ -4064,6 +4095,7 @@ class TestAgentBot:
         bot.client = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
+        _replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
@@ -4072,7 +4104,10 @@ class TestAgentBot:
 
         event = self._make_handler_event(handler_name, sender="@user:localhost", event_id=f"${handler_name}_unauth")
 
-        with patch("mindroom.bot.is_authorized_sender", return_value=False):
+        with (
+            patch("mindroom.bot.is_authorized_sender", return_value=False),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=False),
+        ):
             await self._invoke_handler(bot, handler_name, room, event)
 
         if marks_responded:
@@ -4109,9 +4144,11 @@ class TestAgentBot:
             tmp_path,
         )
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
+        _replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
@@ -4135,6 +4172,7 @@ class TestAgentBot:
         wrap_extracted_collaborators(bot, "_dispatch_planner")
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch.object(bot._dispatch_planner, "can_reply_to_sender", return_value=False),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
         ):
@@ -4195,6 +4233,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -4302,6 +4341,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -4431,6 +4471,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -4503,6 +4544,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -4584,6 +4626,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -4618,11 +4661,13 @@ class TestAgentBot:
 
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._handle_ai_routing = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
+        _replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
 
         mock_context = MagicMock()
         mock_context.am_i_mentioned = False
@@ -4660,7 +4705,7 @@ class TestAgentBot:
             patch("mindroom.dispatch_planner.get_agents_in_thread", return_value=[]),
             patch("mindroom.dispatch_planner.has_multiple_non_agent_users_in_thread", return_value=False),
             patch("mindroom.dispatch_planner.get_available_agents_for_sender") as mock_get_available,
-            patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch("mindroom.coalescing.extract_media_caption", return_value="[Attached image]"),
         ):
             mock_get_available.return_value = [
@@ -4669,7 +4714,7 @@ class TestAgentBot:
             ]
             await bot._on_media_message(room, event)
 
-        bot._handle_ai_routing.assert_called_once_with(
+        bot._dispatch_planner.execute_router_relay.assert_called_once_with(
             room,
             event,
             [],
@@ -4695,11 +4740,13 @@ class TestAgentBot:
 
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._handle_ai_routing = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
+        _replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
 
         mock_context = MagicMock()
         mock_context.am_i_mentioned = False
@@ -4753,7 +4800,7 @@ class TestAgentBot:
             patch("mindroom.dispatch_planner.get_agents_in_thread", return_value=[]),
             patch("mindroom.dispatch_planner.has_multiple_non_agent_users_in_thread", return_value=False),
             patch("mindroom.dispatch_planner.get_available_agents_for_sender") as mock_get_available,
-            patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch(
                 "mindroom.inbound_turn_normalizer.register_file_or_video_attachment",
                 new_callable=AsyncMock,
@@ -4766,9 +4813,9 @@ class TestAgentBot:
             ]
             await bot._on_media_message(room, event)
 
-        bot._handle_ai_routing.assert_called_once()
+        bot._dispatch_planner.execute_router_relay.assert_called_once()
         mock_register_file.assert_not_awaited()
-        call_kwargs = bot._handle_ai_routing.call_args.kwargs
+        call_kwargs = bot._dispatch_planner.execute_router_relay.call_args.kwargs
         assert call_kwargs["message"] == "[Attached file]"
         assert call_kwargs["requester_user_id"] == "@user:localhost"
         assert call_kwargs["extra_content"] == {ORIGINAL_SENDER_KEY: "@user:localhost"}
@@ -4799,6 +4846,7 @@ class TestAgentBot:
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
+        _replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
         bot._send_response = AsyncMock(return_value="$route")
         install_send_response_mock(bot, bot._send_response)
 
@@ -4849,7 +4897,7 @@ class TestAgentBot:
                 return_value=attachment_record,
             ) as mock_register_file,
         ):
-            await bot._handle_ai_routing(
+            await bot._dispatch_planner.execute_router_relay(
                 room=room,
                 event=event,
                 thread_history=[],
@@ -4890,6 +4938,7 @@ class TestAgentBot:
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
+        _replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
         bot._send_response = AsyncMock(return_value="$route")
         install_send_response_mock(bot, bot._send_response)
 
@@ -4927,7 +4976,7 @@ class TestAgentBot:
                 return_value=attachment_record,
             ) as mock_register_image,
         ):
-            await bot._handle_ai_routing(
+            await bot._dispatch_planner.execute_router_relay(
                 room=room,
                 event=event,
                 thread_history=[],
@@ -4987,6 +5036,8 @@ class TestAgentBot:
         router_bot.handled_turn_ledger.has_responded.return_value = False
         general_bot.handled_turn_ledger = MagicMock()
         general_bot.handled_turn_ledger.has_responded.return_value = False
+        _replace_dispatch_planner_deps(router_bot, handled_turn_ledger=router_bot.handled_turn_ledger)
+        _replace_dispatch_planner_deps(general_bot, handled_turn_ledger=general_bot.handled_turn_ledger)
         router_bot._send_response = AsyncMock(return_value="$route")
         install_send_response_mock(router_bot, router_bot._send_response)
         general_bot._generate_response = AsyncMock()
@@ -5047,6 +5098,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -5093,10 +5145,12 @@ class TestAgentBot:
             tmp_path,
         )
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
-        bot._handle_ai_routing = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
+        _replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
         bot._conversation_resolver.extract_message_context = AsyncMock(
             return_value=MessageContext(
                 am_i_mentioned=False,
@@ -5137,7 +5191,7 @@ class TestAgentBot:
                     config.get_ids(runtime_paths_for(config))["general"],
                 ],
             ),
-            patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.coalescing.extract_media_caption", return_value="[Attached image]"),
             patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock, return_value=None),
@@ -5145,9 +5199,9 @@ class TestAgentBot:
             await bot._on_message(room, text_event)
             await bot._on_media_message(room, image_event)
 
-        assert bot._handle_ai_routing.await_count == 2
-        first_call = bot._handle_ai_routing.await_args_list[0].kwargs
-        second_call = bot._handle_ai_routing.await_args_list[1].kwargs
+        assert bot._dispatch_planner.execute_router_relay.await_count == 2
+        first_call = bot._dispatch_planner.execute_router_relay.await_args_list[0].kwargs
+        second_call = bot._dispatch_planner.execute_router_relay.await_args_list[1].kwargs
         assert first_call["requester_user_id"] == "@user:localhost"
         assert first_call["message"] is None
         assert second_call["requester_user_id"] == "@user:localhost"
@@ -5171,10 +5225,12 @@ class TestAgentBot:
             tmp_path,
         )
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
-        bot._handle_ai_routing = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
+        _replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
+        bot._dispatch_planner.execute_router_relay = AsyncMock()
         bot._conversation_resolver.extract_message_context = AsyncMock(
             return_value=MessageContext(
                 am_i_mentioned=False,
@@ -5206,7 +5262,7 @@ class TestAgentBot:
                 "mindroom.dispatch_planner.get_available_agents_for_sender",
                 return_value=[config.get_ids(runtime_paths_for(config))["calculator"]],
             ),
-            patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.coalescing.extract_media_caption", return_value="[Attached image]"),
             patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock, return_value=None),
@@ -5214,7 +5270,7 @@ class TestAgentBot:
             await bot._on_message(room, text_event)
             await bot._on_media_message(room, image_event)
 
-        bot._handle_ai_routing.assert_not_awaited()
+        bot._dispatch_planner.execute_router_relay.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_agent_receives_images_from_thread_root_after_routing(
@@ -5265,6 +5321,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.extract_agent_name", return_value="router"),
             patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch("mindroom.bot.interactive.handle_text_response"),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.dispatch_planner.get_agents_in_thread", return_value=[]),
@@ -6015,6 +6072,7 @@ class TestAgentBot:
         )
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.handled_turn_ledger = MagicMock()
+        _replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
         event = MagicMock()
@@ -6245,6 +6303,7 @@ class TestAgentBot:
             envelope=_hook_envelope(body="hello", source_event_id="$event"),
         )
         bot.handled_turn_ledger = MagicMock()
+        _replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
         full_history = [
             ResolvedVisibleMessage.synthetic(
                 sender="@user:localhost",
@@ -6310,7 +6369,7 @@ class TestAgentBot:
             ),
             patch.object(bot._dispatch_planner, "log_dispatch_latency"),
         ):
-            await bot._dispatch_text_message(
+            await bot._turn_engine._dispatch_text_message(
                 room,
                 _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
             )
@@ -6374,7 +6433,7 @@ class TestAgentBot:
             ) as mock_build_payload,
             patch.object(bot._dispatch_planner, "execute_response_action", new=AsyncMock()) as mock_execute,
         ):
-            await bot._dispatch_text_message(
+            await bot._turn_engine._dispatch_text_message(
                 room,
                 _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
             )
@@ -6442,10 +6501,10 @@ class TestAgentBot:
         with (
             patch.object(bot._inbound_turn_normalizer, "resolve_text_event", new=AsyncMock(return_value=event)),
             patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
-            patch.object(bot, "_has_newer_unresponded_in_thread", return_value=False),
-            patch.object(bot, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
+            patch.object(bot._turn_engine, "_has_newer_unresponded_in_thread", return_value=False),
+            patch.object(bot._turn_engine, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
         ):
-            await bot._dispatch_text_message(
+            await bot._turn_engine._dispatch_text_message(
                 room,
                 _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
                 handled_turn=HandledTurnState.create(
@@ -6559,10 +6618,10 @@ class TestAgentBot:
                 "execute_router_relay",
                 new=AsyncMock(side_effect=fake_execute_router_relay),
             ),
-            patch.object(bot, "_has_newer_unresponded_in_thread", return_value=False),
-            patch.object(bot, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
+            patch.object(bot._turn_engine, "_has_newer_unresponded_in_thread", return_value=False),
+            patch.object(bot._turn_engine, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
         ):
-            await bot._dispatch_text_message(
+            await bot._turn_engine._dispatch_text_message(
                 room,
                 _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
                 handled_turn=coalesced_turn,
@@ -6609,10 +6668,10 @@ class TestAgentBot:
         )
 
         with (
-            patch.object(bot, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
+            patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
             patch.object(bot._coalescing_gate, "enqueue", new=AsyncMock()) as mock_enqueue,
         ):
-            await bot._enqueue_for_dispatch(event, room, source_kind="message")
+            await bot._turn_engine._enqueue_for_dispatch(event, room, source_kind="message")
 
         mock_dispatch.assert_awaited_once_with(room, event, "@user:localhost")
         mock_enqueue.assert_not_awaited()
@@ -6671,7 +6730,7 @@ class TestAgentBot:
 
         with (
             patch.object(
-                bot,
+                bot._turn_engine,
                 "_precheck_dispatch_event",
                 return_value=_PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
             ),
@@ -6683,8 +6742,8 @@ class TestAgentBot:
                 "mindroom.conversation_resolver.ConversationResolver.build_ingress_envelope",
                 return_value=envelope,
             ),
-            patch.object(bot, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
-            patch("mindroom.bot.should_handle_interactive_text_response", return_value=False),
+            patch.object(bot._turn_engine, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
+            patch("mindroom.turn_engine.should_handle_interactive_text_response", return_value=False),
             patch.object(
                 bot._conversation_resolver,
                 "coalescing_thread_id",
@@ -6695,7 +6754,7 @@ class TestAgentBot:
                 "has_active_response_for_target",
                 return_value=True,
             ) as mock_has_active_response,
-            patch.object(bot, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
+            patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
             patch.object(bot._coalescing_gate, "enqueue", new=AsyncMock()) as mock_enqueue,
         ):
             await bot._on_message(room, event)
@@ -6719,6 +6778,7 @@ class TestAgentBot:
         bot.client = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.logger = MagicMock()
+        _replace_dispatch_planner_deps(bot, logger=bot.logger, handled_turn_ledger=bot.handled_turn_ledger)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
@@ -6812,6 +6872,7 @@ class TestAgentBot:
         bot.client = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.logger = MagicMock()
+        _replace_dispatch_planner_deps(bot, logger=bot.logger, handled_turn_ledger=bot.handled_turn_ledger)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
@@ -6928,6 +6989,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -7005,6 +7067,7 @@ class TestAgentBot:
         bot.client = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.logger = MagicMock()
+        _replace_dispatch_planner_deps(bot, logger=bot.logger, handled_turn_ledger=bot.handled_turn_ledger)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
@@ -7078,6 +7141,7 @@ class TestAgentBot:
         bot.client = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.logger = MagicMock()
+        _replace_dispatch_planner_deps(bot, logger=bot.logger, handled_turn_ledger=bot.handled_turn_ledger)
         _replace_dispatch_planner_deps(bot, logger=bot.logger, handled_turn_ledger=bot.handled_turn_ledger)
 
         room = MagicMock(spec=nio.MatrixRoom)
@@ -7256,6 +7320,7 @@ class TestAgentBot:
         bot.client = AsyncMock()
         bot.handled_turn_ledger = MagicMock()
         bot.logger = MagicMock()
+        _replace_dispatch_planner_deps(bot, logger=bot.logger, handled_turn_ledger=bot.handled_turn_ledger)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"

--- a/tests/test_multiple_edits.py
+++ b/tests/test_multiple_edits.py
@@ -38,6 +38,7 @@ async def test_agent_regenerates_on_multiple_edits(tmp_path: Path) -> None:
             room_models={},
             models={"default": ModelConfig(provider="ollama", id="test-model")},
             router=RouterConfig(model="default"),
+            authorization={"default_room_access": True},
         ),
         test_runtime_paths(tmp_path),
     )

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -26,7 +26,7 @@ from mindroom.ai import (
     queued_message_signal_context,
     stream_agent_response,
 )
-from mindroom.bot import AgentBot, _PrecheckedEvent
+from mindroom.bot import AgentBot
 from mindroom.coalescing import PreparedTextEvent
 from mindroom.config.agent import AgentConfig
 from mindroom.config.auth import AuthorizationConfig
@@ -42,6 +42,7 @@ from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutcome, apply_post_response_effects
 from mindroom.response_coordinator import ResponseCoordinator, ResponseRequest
 from mindroom.teams import TeamMode, _create_team_instance
+from mindroom.turn_engine import _PrecheckedEvent
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
@@ -668,14 +669,14 @@ async def test_coalesced_dispatch_never_creates_queued_signal(tmp_path: Path) ->
         patch.object(bot._inbound_turn_normalizer, "resolve_text_event", new=AsyncMock(return_value=event)),
         patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
-        patch.object(bot, "_has_newer_unresponded_in_thread", return_value=True),
+        patch.object(bot._turn_engine, "_has_newer_unresponded_in_thread", return_value=True),
         patch.object(
             bot._dispatch_planner,
             "plan_dispatch",
             new=AsyncMock(return_value=DispatchPlan(kind="ignore")),
         ) as mock_plan,
     ):
-        await bot._dispatch_text_message(
+        await bot._turn_engine._dispatch_text_message(
             room,
             _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
         )

--- a/tests/test_response_tracking_regression.py
+++ b/tests/test_response_tracking_regression.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 
-from mindroom.bot import AgentBot, _PrecheckedEvent
+from mindroom.bot import AgentBot
 from mindroom.commands.parsing import Command, CommandType
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
@@ -116,9 +116,10 @@ class TestResponseTrackingRegression:
         mock_room.room_id = test_room_id
 
         # Process command first time
-        await bot._handle_command(
+        await bot._dispatch_planner.execute_command(
             mock_room,
-            _PrecheckedEvent(event=command_event, requester_user_id="@user:localhost"),
+            command_event,
+            "@user:localhost",
             command,
         )
 
@@ -135,9 +136,10 @@ class TestResponseTrackingRegression:
         bot.client.room_send.reset_mock()
 
         # Process same command again (simulating restart)
-        await bot._handle_command(
+        await bot._dispatch_planner.execute_command(
             mock_room,
-            _PrecheckedEvent(event=command_event, requester_user_id="@user:localhost"),
+            command_event,
+            "@user:localhost",
             command,
         )
 
@@ -288,7 +290,7 @@ class TestResponseTrackingRegression:
         }
 
         # Process routing
-        await bot._handle_ai_routing(
+        await bot._dispatch_planner.execute_router_relay(
             mock_room,
             message_event,
             [],
@@ -318,7 +320,7 @@ class TestResponseTrackingRegression:
         mock_suggest_agent.reset_mock()
 
         # Process same message again (simulating restart)
-        await bot._handle_ai_routing(
+        await bot._dispatch_planner.execute_router_relay(
             mock_room,
             message_event,
             [],

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -303,10 +303,11 @@ class TestAIRouting:
         with patch("mindroom.dispatch_planner.suggest_agent_for_message") as mock_suggest:
             # Should raise AssertionError since general is not the router agent
             with pytest.raises(AssertionError):
-                await bot._handle_ai_routing(
+                await bot._dispatch_planner.execute_router_relay(
                     mock_room,
                     mock_event,
                     [],
+                    None,
                     requester_user_id="@user:localhost",
                 )
 

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -207,6 +207,7 @@ class TestRoutingRegression:
                 room_models={},
                 models={"default": ModelConfig(provider="test", id="test-model")},
                 router=RouterConfig(model="default"),
+                authorization={"default_room_access": True},
             ),
             tmp_path,
         )
@@ -345,10 +346,11 @@ class TestRoutingRegression:
             },
         }
 
-        await router_bot._handle_ai_routing(
+        await router_bot._dispatch_planner.execute_router_relay(
             mock_room,
             message_event,
-            thread_history=[],
+            [],
+            None,
             requester_user_id="@bob:localhost",
         )
 
@@ -647,6 +649,7 @@ class TestRoutingRegression:
                 teams={},
                 room_models={},
                 models={"default": ModelConfig(provider="anthropic", id="claude-3-5-haiku-latest")},
+                authorization={"default_room_access": True},
             ),
             tmp_path,
         )

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -13,7 +13,7 @@ import nio
 import pytest
 from pydantic import ValidationError
 
-from mindroom.bot import AgentBot, _PrecheckedEvent
+from mindroom.bot import AgentBot
 from mindroom.commands.parsing import Command, CommandType
 from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
@@ -445,11 +445,11 @@ class TestRouterHandoffThreadMode:
                 new_callable=AsyncMock,
             ) as mock_get_latest,
         ):
-            await bot._handle_ai_routing(
+            await bot._dispatch_planner.execute_router_relay(
                 room,
                 self._routing_event(),
-                thread_history=[],
-                thread_id="$thread_root",
+                [],
+                "$thread_root",
                 requester_user_id="@user:localhost",
             )
         mock_get_latest.assert_not_called()
@@ -485,11 +485,11 @@ class TestRouterHandoffThreadMode:
                 return_value="$latest",
             ) as mock_get_latest,
         ):
-            await bot._handle_ai_routing(
+            await bot._dispatch_planner.execute_router_relay(
                 room,
                 self._routing_event(),
-                thread_history=[],
-                thread_id="$thread_root",
+                [],
+                "$thread_root",
                 requester_user_id="@user:localhost",
             )
         mock_get_latest.assert_awaited_once()
@@ -999,10 +999,11 @@ class TestCommandThreadContextRoomMode:
                 return_value=("task123", "scheduled"),
             ) as mock_schedule,
         ):
-            await bot._handle_command(
-                room,
-                _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
-                command,
+            await bot._dispatch_planner.execute_command(
+                room=room,
+                event=event,
+                requester_user_id="@user:localhost",
+                command=command,
             )
 
         assert mock_schedule.await_args.kwargs["thread_id"] is None

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -2713,7 +2713,7 @@ class TestThreadingBehavior:
                 AsyncMock(return_value="$router_response:localhost"),
             ) as mock_send,
         ):
-            await bot._handle_ai_routing(
+            await bot._dispatch_planner.execute_router_relay(
                 room,
                 event,
                 thread_history=[],

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -20,6 +20,7 @@ from tests.conftest import (
     bind_runtime_paths,
     install_generate_response_mock,
     replace_dispatch_planner_deps,
+    replace_turn_engine_deps,
     runtime_paths_for,
     sync_bot_runtime_state,
     test_runtime_paths,
@@ -42,6 +43,7 @@ def _agent_bot(*, agent_user: AgentMatrixUser, storage_path: Path, config: Confi
 @pytest.fixture
 def mock_home_bot() -> AgentBot:
     """Create a single-agent bot for audio threading tests."""
+    tmpdir = Path(tempfile.mkdtemp())
     agent_user = AgentMatrixUser(
         agent_name="home",
         user_id="@mindroom_home:localhost",
@@ -53,9 +55,8 @@ def mock_home_bot() -> AgentBot:
         agents={"home": {"display_name": "HomeAssistant", "rooms": ["!test:server"]}},
         authorization={"default_room_access": True},
     )
-    config = bind_runtime_paths(config, test_runtime_paths(Path(tempfile.mkdtemp())))
-    with tempfile.TemporaryDirectory() as tmpdir:
-        bot = _agent_bot(agent_user=agent_user, storage_path=Path(tmpdir), config=config, rooms=["!test:server"])
+    config = bind_runtime_paths(config, test_runtime_paths(tmpdir))
+    bot = _agent_bot(agent_user=agent_user, storage_path=tmpdir, config=config, rooms=["!test:server"])
     wrap_extracted_collaborators(bot)
     bot.client = AsyncMock()
     bot.client.rooms = {}
@@ -64,6 +65,7 @@ def mock_home_bot() -> AgentBot:
     bot.logger = MagicMock()
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
     bot._generate_response = AsyncMock(return_value="$response")
     install_generate_response_mock(bot, bot._generate_response)
@@ -106,7 +108,7 @@ async def test_voice_message_in_main_room_creates_thread(mock_home_bot: AgentBot
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", return_value="🎤 what is the weather"),
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -147,7 +149,7 @@ async def test_voice_message_in_thread_continues_thread(mock_home_bot: AgentBot)
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", return_value="🎤 show me the forecast"),
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -203,7 +205,7 @@ async def test_voice_plain_reply_to_thread_message_uses_thread_root(mock_home_bo
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", return_value="🎤 continue the same thread"),
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -33,7 +33,7 @@ from tests.conftest import (
     install_send_response_mock,
     install_send_skill_command_response_mock,
     orchestrator_runtime_paths,
-    replace_response_coordinator_deps,
+    replace_turn_engine_deps,
     runtime_paths_for,
     unwrap_extracted_collaborator,
     wrap_extracted_collaborators,
@@ -139,16 +139,18 @@ def _make_visible_router_echo_scenario(
         rooms=["!test:example.com"],
     )
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock()
     bot.client.rooms = {}
     unwrap_extracted_collaborator(bot._conversation_resolver).derive_conversation_context = AsyncMock(
         return_value=(False, None, []),
     )
+    bot._send_response = AsyncMock()
     if send_response_side_effect is not None:
-        bot._delivery_gateway.send_text = AsyncMock(side_effect=send_response_side_effect)
+        bot._send_response.side_effect = send_response_side_effect
     else:
-        bot._delivery_gateway.send_text = AsyncMock(return_value=send_response_return)
-    replace_response_coordinator_deps(bot, delivery_gateway=bot._delivery_gateway)
+        bot._send_response.return_value = send_response_return
+    install_send_response_mock(bot, bot._send_response)
 
     room_user_ids = [
         "@mindroom_router:localhost",
@@ -177,6 +179,7 @@ async def test_router_processes_own_voice_transcriptions(tmp_path) -> None:  # n
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     room = _make_room("@mindroom_router:example.com", "@alice:example.com")
     event = MagicMock(spec=nio.RoomMessageText)
@@ -187,7 +190,7 @@ async def test_router_processes_own_voice_transcriptions(tmp_path) -> None:  # n
     event.source = {"content": {"body": "🎤 !schedule daily", ORIGINAL_SENDER_KEY: "@alice:example.com"}}
 
     with (
-        patch.object(bot, "_handle_command", new_callable=AsyncMock) as mock_handle,
+        patch("mindroom.dispatch_planner.DispatchPlanner.execute_command", new_callable=AsyncMock) as mock_handle,
         patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock),
         patch("mindroom.dispatch_planner.is_dm_room", return_value=False),
     ):
@@ -195,7 +198,7 @@ async def test_router_processes_own_voice_transcriptions(tmp_path) -> None:  # n
         await bot._on_message(room, event)
 
     mock_handle.assert_called_once()
-    command = mock_handle.call_args[0][2]
+    command = mock_handle.await_args.kwargs["command"]
     assert command.type.value == "schedule"
 
 
@@ -216,6 +219,7 @@ async def test_router_ignores_non_voice_self_messages(tmp_path) -> None:  # noqa
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     room = _make_room("@mindroom_router:example.com", "@bob:example.com")
     event = MagicMock(spec=nio.RoomMessageText)
@@ -226,7 +230,7 @@ async def test_router_ignores_non_voice_self_messages(tmp_path) -> None:  # noqa
     event.source = {"content": {"body": "Regular message from router"}}
 
     with (
-        patch.object(bot, "_handle_command", new_callable=AsyncMock) as mock_handle,
+        patch("mindroom.dispatch_planner.DispatchPlanner.execute_command", new_callable=AsyncMock) as mock_handle,
         patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock),
         patch("mindroom.dispatch_planner.is_dm_room", return_value=False),
     ):
@@ -259,6 +263,7 @@ async def test_router_processes_own_sidecar_commands_using_original_sender(tmp_p
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.download = AsyncMock(
@@ -338,6 +343,7 @@ async def test_router_parses_sidecar_schedule_command_from_canonical_body(tmp_pa
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.download = AsyncMock(
@@ -423,6 +429,7 @@ async def test_router_parses_sidecar_skill_command_mentions_from_canonical_body(
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.download = AsyncMock(
@@ -508,6 +515,7 @@ async def test_router_skips_unauthorized_sidecar_commands_before_hydration(tmp_p
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.download = AsyncMock()
 
@@ -533,7 +541,7 @@ async def test_router_skips_unauthorized_sidecar_commands_before_hydration(tmp_p
 
     with (
         patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock) as mock_interactive,
-        patch("mindroom.bot.is_authorized_sender", return_value=False),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=False),
         patch("mindroom.commands.handler.schedule_task", new_callable=AsyncMock) as mock_schedule,
     ):
         assert isinstance(event, nio.RoomMessageFile)
@@ -654,6 +662,7 @@ async def test_router_ignores_audio_events_from_internal_agents(tmp_path) -> Non
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = MagicMock()
     bot._send_response = AsyncMock()
     install_send_response_mock(bot, bot._send_response)
@@ -673,7 +682,7 @@ async def test_router_ignores_audio_events_from_internal_agents(tmp_path) -> Non
     with (
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
     ):
         await bot._on_media_message(room, event)
 
@@ -708,6 +717,7 @@ async def test_agent_handles_audio_without_router_when_voice_disabled(tmp_path) 
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock()
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_home:localhost"
@@ -723,7 +733,7 @@ async def test_agent_handles_audio_without_router_when_voice_disabled(tmp_path) 
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -777,6 +787,7 @@ async def test_agent_handles_audio_with_router_present_in_single_agent_room(tmp_
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock()
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_home:localhost"
@@ -792,7 +803,7 @@ async def test_agent_handles_audio_with_router_present_in_single_agent_room(tmp_
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -830,6 +841,7 @@ async def test_router_and_agent_share_audio_normalization_when_router_is_present
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         bot.logger = MagicMock()
+        replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = agent_user.user_id
@@ -848,7 +860,7 @@ async def test_router_and_agent_share_audio_normalization_when_router_is_present
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -870,7 +882,7 @@ async def test_router_posts_visible_voice_echo_when_enabled(tmp_path) -> None:  
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         mock_voice.return_value = f"{VOICE_PREFIX}@home turn on the lights"
@@ -892,7 +904,7 @@ async def test_router_visible_voice_echo_is_deduplicated_on_redelivery(tmp_path)
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         mock_voice.return_value = f"{VOICE_PREFIX}@home turn on the lights"
@@ -920,7 +932,7 @@ async def test_router_visible_voice_echo_respects_reply_permissions(tmp_path) ->
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
     ):
         await bot._on_media_message(room, event)
 
@@ -946,7 +958,7 @@ async def test_router_visible_voice_echo_keeps_multi_agent_handoff(tmp_path) -> 
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.suggest_agent_for_message", new_callable=AsyncMock, return_value="home"),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -983,7 +995,7 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries(
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.suggest_agent_for_message", new_callable=AsyncMock, return_value="home"),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -1023,7 +1035,7 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries_
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.suggest_agent_for_message", new_callable=AsyncMock, return_value="home"),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -1042,7 +1054,7 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries_
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.suggest_agent_for_message", new_callable=AsyncMock, return_value="home"),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -1084,6 +1096,7 @@ async def test_router_routes_transcribed_audio_when_multiple_agents_are_present(
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
+    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock()
     bot._send_response = AsyncMock(return_value="$response")
     install_send_response_mock(bot, bot._send_response)
@@ -1102,7 +1115,7 @@ async def test_router_routes_transcribed_audio_when_multiple_agents_are_present(
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.suggest_agent_for_message", new_callable=AsyncMock, return_value="home"),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -1166,6 +1179,7 @@ async def test_transcribed_mentions_target_the_mentioned_agent_when_router_absen
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         bot.logger = MagicMock()
+        replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = f"@mindroom_{agent_name}:localhost"
@@ -1179,7 +1193,7 @@ async def test_transcribed_mentions_target_the_mentioned_agent_when_router_absen
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -1240,6 +1254,7 @@ async def test_caption_mentions_still_target_agent_when_stt_drops_the_mention(tm
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         bot.logger = MagicMock()
+        replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = f"@mindroom_{agent_name}:localhost"
@@ -1253,7 +1268,7 @@ async def test_caption_mentions_still_target_agent_when_stt_drops_the_mention(tm
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.bot.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")


### PR DESCRIPTION
## Summary
- extract normal turn sequencing out of `bot.py` into `turn_engine.py`
- extract edit regeneration into `edit_regenerator.py`
- migrate the affected tests to the real current owners instead of stale bot seams

## Why
This is the first subtractive runtime refactor step.
It removes `AgentBot` as the owner of normal turn sequencing and edit regeneration instead of just wrapping the old methods.

## Testing
- `uv run pytest -x -n 0 --no-cov`
- `uv run pre-commit run --all-files`

## Stack
This is the first PR in a stacked runtime-simplification series.