### PR TITLE
Rename runtime collaborators

### DIFF
--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -1,256 +1,137 @@
-# Bot Runtime Simplification Plan
+# Bot Runtime Simplification Roadmap
 
-## Why This Document Exists
+## Purpose
 
-The previous refactor improved file boundaries, but it did not remove enough conceptual complexity.
-The main risk now is doing another extraction pass that only redistributes the same complexity again.
-This plan exists to keep the next refactor subtractive.
+This document is the source of truth for the next runtime simplification.
+The goal is to make the remaining abstractions concrete, honest, and easy to trace.
 
-## Problem Statement
+## Good Boundaries To Keep
 
-One inbound turn is still controlled by multiple places.
-Today the main control flow is split across `AgentBot`, `DispatchPlanner`, `ResponseCoordinator`, and edit-specific code in `bot.py`.
-Planning and execution are still partially mixed.
-Turn persistence still has two overlapping sources of truth.
-Conversation identity is still represented by several near-duplicate shapes.
+`AgentBot` is the Matrix runtime shell.
+It should own lifecycle, callback registration, sync, room membership, presence, and startup or shutdown.
 
-## Refactor Goal
+`InboundTurnNormalizer` owns raw input shaping.
+It should turn text, voice, sidecars, and media into canonical turn inputs before policy or execution runs.
 
-Make one turn easy to trace from ingress to final recorded outcome.
-Reduce the number of runtime owners and data models involved in that turn.
-Delete overlapping representations instead of adding better wrappers around them.
+`ConversationResolver` owns conversation identity.
+It should resolve thread roots, reply chains, history, mentions, and normalized ingress envelopes.
 
-## Success Criteria
+`DeliveryGateway` owns Matrix transport.
+It should send, edit, redact, and finalize already-generated responses.
 
-A normal text turn can be traced in one control-flow entrypoint.
-Exactly one component decides whether the turn is ignored, routed, handled as a command, rejected, or answered.
-The planner has no delivery, AI, or persistence side effects.
-Edit regeneration loads one durable turn record instead of reconciling multiple partial records.
-`AgentBot` becomes a runtime shell again rather than a partial controller.
+`EditRegenerator` owns the edited-message replay workflow.
+It is still coupled to the current persistence split, but its workflow boundary is real.
 
-## Design Rules
+## Current Problems
 
-### 1. One Turn Owner
+`TurnController` is the real turn owner now, but the name is vague.
+`DispatchPlanner` still mixes policy with command execution, router relay, and response execution.
+`ResponseRunner` still mixes lifecycle mechanics with actual response running.
+`IngressHookRunner` is a thin hook adapter with a vague name.
+`HandledTurnLedger` and persisted run metadata still split durable turn truth.
+`MessageTarget` still combines conversation identity and delivery placement.
 
-Introduce `TurnEngine` as the only high-level owner of one inbound turn.
-`TurnEngine` must sequence `precheck -> normalize -> resolve -> plan -> execute -> record`.
-`AgentBot` must stop owning turn sequencing.
+## Target Runtime Vocabulary
 
-### 2. Pure Planner
-
-`DispatchPlanner` must become a pure policy stage.
-It may inspect normalized input and resolved context.
-It may return a `TurnPlan`.
-It must not send messages.
-It must not call `ResponseCoordinator`.
-It must not update handled-turn state.
-
-### 3. One Durable Turn Record
-
-Replace the current split between `HandledTurnLedger` and persisted run-metadata fallback with one durable `TurnStore`.
-`TurnStore` must be the single source of truth for source-event ownership, response linkage, history scope, conversation target, and coalesced prompt metadata.
-Edit regeneration must read from `TurnStore` first and should not need to reconstruct ownership from current thread state.
-
-### 4. Separate Conversation Scope From Delivery Placement
-
-Replace the overloaded `MessageTarget` role with two concepts.
-`ConversationTarget` should mean stable conversation identity used for locking, session scope, memory, and dedupe.
-`DeliveryTarget` should mean Matrix delivery placement used for send and edit behavior.
-If the old `MessageTarget` remains temporarily, new code should treat it as a migration shim rather than the target design.
-
-### 5. Keep The Good Seams
-
-Keep `InboundTurnNormalizer`.
-Keep `ConversationResolver`.
-Keep `DeliveryGateway`.
-Those modules already map well to real boundaries in the system.
-
-### 6. Do Not Add Classes That Do Not Delete Code
-
-Do not introduce `TurnEngine`, `CommandExecutor`, `RouteExecutor`, or any other type unless it immediately removes duplicated control flow from existing modules.
-A new object must replace an old owner, not sit beside it.
-
-## Target Runtime Shape
+The target runtime should read like this:
 
 ```text
 Matrix callback
-    |
-    v
-AgentBot
-    |
-    v
-TurnEngine
-    |
-    +--> InboundTurnNormalizer
-    +--> ConversationResolver
-    +--> DispatchPlanner
-    +--> TurnExecutor
-            |
-            +--> ResponseCoordinator
-            +--> DeliveryGateway
-    |
-    +--> TurnStore
+  -> AgentBot
+  -> TurnController
+       -> InboundTurnNormalizer
+       -> ConversationResolver
+       -> TurnPolicy
+       -> ResponseRunner
+       -> TurnStore
+       -> DeliveryGateway
 ```
 
-`AgentBot` owns Matrix lifecycle and callback registration.
-`TurnEngine` owns sequencing for one turn.
-`DispatchPlanner` owns policy only.
-`TurnExecutor` owns side effects for the chosen plan.
-`ResponseCoordinator` owns response lifecycle mechanics only.
-`TurnStore` owns durable turn outcome state.
+`AgentBot` owns Matrix lifecycle only.
+`TurnController` owns one inbound turn from ingress to recorded outcome.
+`TurnPolicy` owns pure decision logic only.
+`ResponseRunner` owns response execution and lifecycle only.
+`TurnStore` owns durable turn truth.
+`DeliveryGateway` owns Matrix transport only.
 
-## What Not To Do
+## Rename-Only PR
 
-Do not split `ResponseCoordinator` just to create smaller files.
-Do not add a new abstraction layer if it still depends on the same large request object and the same collaborators.
-Do not preserve both old and new turn-record systems at the end of the refactor.
+The first PR should be rename-only.
+It should improve the honesty of the current names without changing behavior.
+
+### Rename Set
+
+Rename `TurnController` to `TurnController`.
+Rename `ResponseRunner` to `ResponseRunner`.
+Rename `IngressHookRunner` to `IngressHookRunner`.
+
+Do not rename `DispatchPlanner` in this PR.
+Any better name for it depends on first making it pure.
+Renaming it early would either be dishonest or create churn.
+
+### Rules
+
+Do not change behavior.
+Do not move logic across modules.
+Do not change persistence.
+Do not add wrappers or compatibility shims.
+Only change names, imports, docstrings, tests, and architecture docs.
+
+### Acceptance Criteria
+
+The diff should be mostly symbol renames and documentation updates.
+The full test suite must stay green.
+`pre-commit` must stay green.
+
+## Behavioral Simplification PR
+
+The second PR should do the actual simplification work.
+It should reduce the number of orchestration objects and remove overlapping truth.
+
+### Scope
+
+Make `DispatchPlanner` pure.
+Rename the pure result to `TurnPolicy`.
+Move command execution, router relay, and response branching out of the planner.
+
+Keep `TurnController` as the only owner of turn sequencing.
+It should sequence `precheck -> normalize -> resolve -> decide -> execute -> record`.
+
+Narrow `ResponseRunner` to actual response execution and lifecycle.
+It should own placeholders, locking, streaming, cancellation, AI or team runs, and post-response effects.
+
+Introduce `TurnStore` as the single durable turn boundary.
+It may wrap current storage first, but it must present one source of truth to the runtime.
+
+Move `EditRegenerator` to read and write through `TurnStore`.
+It should stop reconciling `HandledTurnLedger` and persisted run metadata directly.
+
+### Non-Goals
+
+Do not split `MessageTarget` yet unless the rest of the refactor is already stable.
+Do not create a new abstraction unless it deletes an old owner immediately.
 Do not optimize for line counts.
 Optimize for fewer control paths and fewer state representations.
 
-## Refactor Order
+### Acceptance Criteria
 
-### Phase 0
+A normal text turn can be traced through one controller entrypoint.
+The policy layer has no delivery, AI, or persistence side effects.
+Edit regeneration reads one durable turn record.
+`AgentBot` stays a runtime shell instead of a partial controller.
 
-Agree on this plan and treat it as the source of truth for the refactor.
-Do not extract more types before agreeing on the end state.
+## Follow-Up After The Behavioral PR
 
-### Phase 1
+Only after the behavioral refactor lands should we revisit `MessageTarget`.
+That follow-up can split conversation identity from delivery placement.
 
-Introduce `TurnEngine` with no behavior change.
-Move the existing turn-sequencing logic out of `AgentBot` and into `TurnEngine`.
-Keep `AgentBot` limited to Matrix callback handling, lifecycle, room membership, sync support, and reaction wiring.
+At that point we can decide whether `EditRegenerator` should remain a separate peer or collapse into a `TurnController` path backed by `TurnStore`.
 
-#### Phase 1 Checklist
+## Review Questions
 
-Add a new runtime module for `TurnEngine`.
-Prefer a small file such as `src/mindroom/turn_engine.py`.
-Do not move planner or response code into that file yet.
-Move only sequencing and ingress control flow.
+When reviewing either PR, ask these questions.
 
-`AgentBot` should keep these responsibilities:
-
-- callback registration in `start()`
-- sync lifecycle and startup or shutdown helpers
-- room joins, invites, presence, welcome messages, and router overdue-task draining
-- redaction handling in `_on_redaction()`
-- reaction handling in `_on_reaction()` and `_handle_reaction_inner()`
-
-`AgentBot` should stop owning these turn-sequencing methods:
-
-- `_enqueue_for_dispatch()` from `src/mindroom/bot.py`
-- `_dispatch_coalesced_batch()` from `src/mindroom/bot.py`
-- `_handle_message_inner()` from `src/mindroom/bot.py`
-- `_dispatch_text_message()` from `src/mindroom/bot.py`
-- `_handle_media_message_inner()` from `src/mindroom/bot.py`
-- `_dispatch_special_media_as_text()` from `src/mindroom/bot.py`
-- `_dispatch_file_sidecar_text_preview()` from `src/mindroom/bot.py`
-- `_on_audio_media_message()` from `src/mindroom/bot.py`
-- `_handle_command()` from `src/mindroom/bot.py`
-
-Phase 1 should also move these small ingress helpers if they are only used by turn sequencing:
-
-- `_precheck_event()`
-- `_precheck_dispatch_event()`
-- `_requester_user_id()`
-- `_requester_user_id_for_event()`
-- `_is_trusted_internal_relay_event()`
-- `_should_bypass_coalescing_for_active_thread_follow_up()`
-- `_has_newer_unresponded_in_thread()`
-- `_should_skip_deep_synthetic_full_dispatch()`
-
-Phase 1 should not move edit regeneration yet.
-Keep `_handle_message_edit()` in `AgentBot` for now.
-It is too entangled with the current dual persistence model and should be handled after `TurnStore` work.
-
-The temporary `TurnEngine` constructor should receive already-extracted collaborators from `AgentBot`:
-
-- `ConversationResolver`
-- `InboundTurnNormalizer`
-- `DispatchPlanner`
-- `ResponseCoordinator`
-- `DeliveryGateway`
-- `ConversationStateWriter`
-- `HandledTurnLedger`
-- `ToolRuntimeSupport`
-- `MatrixConversationAccess`
-- logger, config, runtime paths, and agent name
-
-The target call shape for Phase 1 is:
-
-```text
-_on_message() -> TurnEngine.handle_text_event()
-_on_media_message() -> TurnEngine.handle_media_event()
-CoalescingGate.flush() -> TurnEngine.handle_coalesced_batch()
-```
-
-The target internal flow for `TurnEngine.handle_text_event()` in Phase 1 is:
-
-1. Append the live event to conversation access.
-2. Skip streamed or invalid text events.
-3. Run ingress precheck.
-4. Branch edits to the existing `AgentBot._handle_message_edit()` callback.
-5. Normalize text.
-6. Apply deep synthetic relay gating and interactive text handling.
-7. Decide whether to bypass coalescing.
-8. Either enqueue into the gate or call the existing dispatch path.
-
-The target internal flow for `TurnEngine.dispatch_text_message()` in Phase 1 is:
-
-1. Normalize the raw or prechecked event into one prepared text event.
-2. Call `DispatchPlanner.prepare_dispatch()`.
-3. Handle command detection at the turn-engine layer, not in `AgentBot`.
-4. Apply backlog suppression and deep synthetic relay suppression.
-5. Call `DispatchPlanner.plan_dispatch()`.
-6. Branch on the returned plan.
-7. For now, call the existing side-effecting planner executor methods.
-8. Record handled-turn outcomes exactly as today.
-
-The explicit non-goal for Phase 1 is purity.
-It is acceptable that `DispatchPlanner` still executes commands, router relays, and response actions during this phase.
-The goal is only to make `AgentBot` stop being the turn controller.
-
-### Phase 2
-
-Make `DispatchPlanner` pure.
-Remove `execute_command`, `execute_router_relay`, and `execute_response_action` from `DispatchPlanner`.
-Return a `TurnPlan` that is rich enough for a separate executor to perform those actions.
-
-### Phase 3
-
-Introduce `TurnStore`.
-Move durable turn recording, response linkage, visible echo linkage, source prompt maps, and edit-regeneration lookup behind that one store.
-Delete fallback reconciliation between handled-turn records and persisted run metadata once `TurnStore` is sufficient.
-
-### Phase 4
-
-Split conversation identity from delivery placement.
-Introduce `ConversationTarget` and `DeliveryTarget`, or make an equivalent simplification that removes the overloaded role of `MessageTarget`.
-Update locking, session scope, memory scope, and delivery code to use the correct target type.
-
-### Phase 5
-
-Re-evaluate `ResponseCoordinator`.
-Only split it further if that split deletes duplicated lifecycle paths or collapses the current request-shuffling between team and individual responses.
-If no real deletion happens, leave it as one module.
-
-### Phase 6
-
-Delete stale paths, update docs and diagrams, and remove migration shims.
-The refactor is not done until the old owners are gone.
-
-## Review Checklist
-
-When reviewing each phase, ask these questions.
-
-Can one normal text turn be traced in one place.
-Is there one owner for turn sequencing.
-Is the planner side-effect free.
-Is there one durable turn record.
-Can edit regeneration use the same core execution path as a normal response.
-Did the change delete an old owner, or only add a new one.
-
-## Practical Note
-
-A short plan document is the right first step.
-The document must be brief, current, and tied to code deletion.
-It must not become another architecture essay that the implementation no longer follows.
+Does each abstraction own a concrete thing rather than a vague place in the pipeline.
+Did the change delete an old owner instead of adding a second one.
+Can one inbound turn be traced without jumping between multiple coordinators.
+Is the durable turn truth singular.

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1,4 +1,4 @@
-"""Multi-agent bot implementation where each agent has its own Matrix user account."""
+"""Matrix runtime shell for agents, teams, and the router."""
 
 from __future__ import annotations
 
@@ -103,9 +103,9 @@ from .delivery_gateway import (
     SuppressedPlaceholderCleanupError as _SuppressedPlaceholderCleanupError,
 )
 from .dispatch_planner import (
-    DispatchHookService,
     DispatchPlanner,
     DispatchPlannerDeps,
+    IngressHookRunner,
 )
 from .edit_regenerator import EditRegenerator, EditRegeneratorDeps
 from .handled_turns import HandledTurnLedger, HandledTurnState
@@ -124,10 +124,10 @@ from .matrix.client import (
     join_room,
 )
 from .media_inputs import MediaInputs
-from .response_coordinator import (
-    ResponseCoordinator,
-    ResponseCoordinatorDeps,
+from .response_runner import (
     ResponseRequest,
+    ResponseRunner,
+    ResponseRunnerDeps,
     prepare_memory_and_model_context,
 )
 from .runtime_support import (
@@ -142,7 +142,7 @@ from .scheduling import (
     has_deferred_overdue_tasks,
     restore_scheduled_tasks,
 )
-from .turn_engine import TurnEngine, TurnEngineDeps
+from .turn_controller import TurnController, TurnControllerDeps
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
@@ -303,7 +303,7 @@ type _MessageContext = MessageContext
 
 
 class AgentBot:
-    """Represents a single agent bot with its own Matrix account."""
+    """Matrix lifecycle shell for one configured agent or router entity."""
 
     # Construction inputs
     agent_user: AgentMatrixUser
@@ -329,15 +329,15 @@ class AgentBot:
     _conversation_state_writer: ConversationStateWriter
     _conversation_access: MatrixConversationAccess
     _delivery_gateway: DeliveryGateway
-    _response_coordinator: ResponseCoordinator
+    _response_runner: ResponseRunner
     _tool_runtime_support: ToolRuntimeSupport
     _post_response_effects_support: PostResponseEffectsSupport
-    _dispatch_hook_service: DispatchHookService
+    _ingress_hook_runner: IngressHookRunner
     _hook_context_support: HookContextSupport
     _knowledge_access_support: KnowledgeAccessSupport
     _deferred_overdue_task_drain_task: asyncio.Task[None] | None
     _standalone_runtime_support: StandaloneRuntimeSupport | None
-    _turn_engine: TurnEngine
+    _turn_controller: TurnController
 
     def __init__(
         self,
@@ -464,8 +464,8 @@ class AgentBot:
             delivery_gateway=self._delivery_gateway,
             conversation_access=self._conversation_access,
         )
-        self._response_coordinator = ResponseCoordinator(
-            ResponseCoordinatorDeps(
+        self._response_runner = ResponseRunner(
+            ResponseRunnerDeps(
                 runtime=self._runtime_view,
                 logger=self.logger,
                 stop_manager=self.stop_manager,
@@ -481,7 +481,7 @@ class AgentBot:
                 state_writer=self._conversation_state_writer,
             ),
         )
-        self._dispatch_hook_service = DispatchHookService(
+        self._ingress_hook_runner = IngressHookRunner(
             hook_context=self._hook_context_support,
         )
         self._edit_regenerator = EditRegenerator(
@@ -494,7 +494,7 @@ class AgentBot:
                 resolver=self._conversation_resolver,
                 state_writer=self._conversation_state_writer,
                 tool_runtime=self._tool_runtime_support,
-                dispatch_hook_service=self._dispatch_hook_service,
+                dispatch_hook_service=self._ingress_hook_runner,
                 generate_response=lambda **kwargs: self._generate_response(**kwargs),
             ),
         )
@@ -510,13 +510,13 @@ class AgentBot:
                 normalizer=self._inbound_turn_normalizer,
                 resolver=self._conversation_resolver,
                 delivery_gateway=self._delivery_gateway,
-                response_coordinator=self._response_coordinator,
-                hook_service=self._dispatch_hook_service,
+                response_runner=self._response_runner,
+                hook_service=self._ingress_hook_runner,
                 tool_runtime=self._tool_runtime_support,
             ),
         )
-        self._turn_engine = TurnEngine(
-            TurnEngineDeps(
+        self._turn_controller = TurnController(
+            TurnControllerDeps(
                 runtime=self._runtime_view,
                 logger=self.logger,
                 runtime_paths=self.runtime_paths,
@@ -527,7 +527,7 @@ class AgentBot:
                 resolver=self._conversation_resolver,
                 normalizer=self._inbound_turn_normalizer,
                 dispatch_planner=self._dispatch_planner,
-                response_coordinator=self._response_coordinator,
+                response_runner=self._response_runner,
                 delivery_gateway=self._delivery_gateway,
                 state_writer=self._conversation_state_writer,
                 coalescing_gate=self._coalescing_gate,
@@ -608,12 +608,12 @@ class AgentBot:
     @property
     def in_flight_response_count(self) -> int:
         """Return the number of active response lifecycles."""
-        return self._response_coordinator.in_flight_response_count
+        return self._response_runner.in_flight_response_count
 
     @in_flight_response_count.setter
     def in_flight_response_count(self, value: int) -> None:
         """Update the number of active response lifecycles."""
-        self._response_coordinator.in_flight_response_count = value
+        self._response_runner.in_flight_response_count = value
 
     @property
     def agent_name(self) -> str:
@@ -640,7 +640,7 @@ class AgentBot:
 
     def has_active_response_for_target(self, target: MessageTarget) -> bool:
         """Return whether one canonical conversation target currently has an active turn."""
-        return self._response_coordinator.has_active_response_for_target(target)
+        return self._response_runner.has_active_response_for_target(target)
 
     def _coalescing_enabled(self) -> bool:
         """Return whether live coalescing is enabled for this bot."""
@@ -1284,11 +1284,11 @@ class AgentBot:
 
     async def _dispatch_coalesced_batch(self, batch: CoalescedBatch) -> None:
         """Delegate one flushed coalesced batch to the turn engine."""
-        await self._turn_engine.handle_coalesced_batch(batch)
+        await self._turn_controller.handle_coalesced_batch(batch)
 
     async def _on_message(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
         """Delegate one inbound text event to the turn engine."""
-        await self._turn_engine.handle_text_event(room, event)
+        await self._turn_controller.handle_text_event(room, event)
 
     async def _on_redaction(self, room: nio.MatrixRoom, event: nio.RedactionEvent) -> None:
         """Keep cached thread history consistent when Matrix redactions arrive."""
@@ -1412,7 +1412,7 @@ class AgentBot:
         event: _MediaDispatchEvent,
     ) -> None:
         """Delegate one inbound media event to the turn engine."""
-        await self._turn_engine.handle_media_event(room, event)
+        await self._turn_controller.handle_media_event(room, event)
 
     def _should_queue_follow_up_in_active_response_thread(
         self,
@@ -1465,7 +1465,7 @@ class AgentBot:
         on_lifecycle_lock_acquired: Callable[[], None] | None = None,
     ) -> str | None:
         """Generate a team response (shared between preformed teams and TeamBot)."""
-        return await self._response_coordinator.generate_team_response_helper(
+        return await self._response_runner.generate_team_response_helper(
             ResponseRequest(
                 room_id=room_id,
                 reply_to_event_id=reply_to_event_id,
@@ -1544,7 +1544,7 @@ class AgentBot:
             Event ID of the response message, or None if failed
 
         """
-        return await self._response_coordinator.generate_response(
+        return await self._response_runner.generate_response(
             ResponseRequest(
                 room_id=room_id,
                 reply_to_event_id=reply_to_event_id,

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -1,4 +1,4 @@
-"""Conversation resolution and envelope assembly for bot dispatch."""
+"""Own conversation identity and ingress envelope assembly for inbound turns."""
 
 from __future__ import annotations
 
@@ -85,7 +85,7 @@ class ConversationResolverDeps:
 
 @dataclass
 class ConversationResolver:
-    """Resolve conversation targets, context, and normalized envelopes."""
+    """Resolve thread roots, reply-chain context, history, mentions, and ingress envelopes."""
 
     deps: ConversationResolverDeps
     reply_chain: ReplyChainCaches = field(default_factory=ReplyChainCaches)

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -1,4 +1,4 @@
-"""Matrix delivery transport for bot responses."""
+"""Own visible Matrix delivery for already-generated responses."""
 
 from __future__ import annotations
 
@@ -251,7 +251,7 @@ class FinalizeStreamedResponseRequest:
 
 @dataclass(frozen=True)
 class DeliveryGateway:
-    """Own the visible Matrix send/edit transport for responses."""
+    """Send, edit, redact, and finalize visible Matrix responses."""
 
     deps: DeliveryGatewayDeps
 

--- a/src/mindroom/dispatch_planner.py
+++ b/src/mindroom/dispatch_planner.py
@@ -66,7 +66,7 @@ from mindroom.matrix.identity import MatrixID, extract_agent_name, is_agent_id
 from mindroom.matrix.rooms import is_dm_room
 from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import record_handled_turn
-from mindroom.response_coordinator import ResponseCoordinator, ResponseRequest
+from mindroom.response_runner import ResponseRequest, ResponseRunner
 from mindroom.routing import suggest_agent_for_message
 from mindroom.team_runtime_resolution import resolve_live_shared_agent_names
 from mindroom.teams import (
@@ -120,7 +120,7 @@ class _ResolvedPreparedHookedPayload:
 
 
 @dataclass
-class DispatchHookService:
+class IngressHookRunner:
     """Own planner-facing hook ingress and enrichment behavior."""
 
     hook_context: HookContextSupport
@@ -268,8 +268,8 @@ class DispatchPlannerDeps:
     normalizer: InboundTurnNormalizer
     resolver: ConversationResolver
     delivery_gateway: DeliveryGateway
-    response_coordinator: ResponseCoordinator
-    hook_service: DispatchHookService
+    response_runner: ResponseRunner
+    hook_service: IngressHookRunner
     tool_runtime: ToolRuntimeSupport
 
 
@@ -722,7 +722,7 @@ class DispatchPlanner:
             return False
         if is_agent_id(source_envelope.sender_id, self.deps.runtime.config, self.deps.runtime_paths):
             return False
-        return self.deps.response_coordinator.has_active_response_for_target(target)
+        return self.deps.response_runner.has_active_response_for_target(target)
 
     async def execute_command(
         self,
@@ -747,7 +747,7 @@ class DispatchPlanner:
             user_id: str | None,
             reply_to_event: nio.RoomMessageText | None = None,
         ) -> str | None:
-            return await self.deps.response_coordinator.send_skill_command_response(
+            return await self.deps.response_runner.send_skill_command_response(
                 room_id=room_id,
                 reply_to_event_id=reply_to_event_id,
                 thread_id=thread_id,
@@ -1087,7 +1087,7 @@ class DispatchPlanner:
             if action.kind == "team":
                 assert action.form_team is not None
                 assert action.form_team.mode is not None
-                response_event_id = await self.deps.response_coordinator.generate_team_response_helper(
+                response_event_id = await self.deps.response_runner.generate_team_response_helper(
                     ResponseRequest(
                         room_id=room.room_id,
                         reply_to_event_id=event.event_id,
@@ -1110,7 +1110,7 @@ class DispatchPlanner:
                     team_mode=action.form_team.mode.value,
                 )
             else:
-                response_event_id = await self.deps.response_coordinator.generate_response(
+                response_event_id = await self.deps.response_runner.generate_response(
                     ResponseRequest(
                         room_id=room.room_id,
                         reply_to_event_id=event.event_id,

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -1,4 +1,4 @@
-"""Edit-triggered response regeneration for previously handled turns."""
+"""Own the edited-message regeneration workflow for previously handled turns."""
 
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.conversation_resolver import ConversationResolver
     from mindroom.conversation_state_writer import ConversationStateWriter
-    from mindroom.dispatch_planner import DispatchHookService
+    from mindroom.dispatch_planner import IngressHookRunner
     from mindroom.hooks import MessageEnvelope
     from mindroom.matrix.client import ResolvedVisibleMessage
     from mindroom.matrix.event_info import EventInfo
@@ -73,13 +73,13 @@ class EditRegeneratorDeps:
     resolver: ConversationResolver
     state_writer: ConversationStateWriter
     tool_runtime: ToolRuntimeSupport
-    dispatch_hook_service: DispatchHookService
+    dispatch_hook_service: IngressHookRunner
     generate_response: _GenerateResponse
 
 
 @dataclass
 class EditRegenerator:
-    """Own edit-triggered response regeneration for previously handled turns."""
+    """Re-run the owned response for one edited user turn."""
 
     deps: EditRegeneratorDeps
 

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -1,4 +1,4 @@
-"""Inbound text, voice, and media normalization for bot dispatch."""
+"""Own raw input shaping for inbound Matrix turns."""
 
 from __future__ import annotations
 
@@ -127,7 +127,7 @@ class InboundTurnNormalizerDeps:
 
 @dataclass(frozen=True)
 class InboundTurnNormalizer:
-    """Normalize raw inbound events into dispatch-ready forms."""
+    """Turn raw text, voice, sidecar, and media events into canonical turn inputs."""
 
     deps: InboundTurnNormalizerDeps
 

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1,4 +1,4 @@
-"""Response lifecycle coordination extracted from ``bot.py``."""
+"""Response lifecycle execution extracted from ``bot.py``."""
 
 from __future__ import annotations
 
@@ -302,7 +302,7 @@ class TeamResponseRequest:
 
 
 @dataclass(frozen=True)
-class ResponseCoordinatorDeps:
+class ResponseRunnerDeps:
     """Explicit collaborators for the response lifecycle."""
 
     runtime: BotRuntimeView
@@ -336,10 +336,10 @@ class _PreparedResponseRuntime:
 
 
 @dataclass
-class ResponseCoordinator:
-    """Coordinate one response lifecycle while keeping bot seams patchable."""
+class ResponseRunner:
+    """Run one response lifecycle while keeping bot seams patchable."""
 
-    deps: ResponseCoordinatorDeps
+    deps: ResponseRunnerDeps
     _response_lifecycle_locks: dict[tuple[str, str | None], asyncio.Lock] = field(default_factory=dict, init=False)
     _thread_queued_signals: dict[tuple[str, str | None], _QueuedMessageState] = field(default_factory=dict, init=False)
     _in_flight_response_count: int = field(default=0, init=False)

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1,4 +1,4 @@
-"""Turn sequencing extracted from the Matrix bot runtime shell."""
+"""Control one inbound turn from ingress to recorded outcome."""
 
 from __future__ import annotations
 
@@ -76,7 +76,7 @@ if TYPE_CHECKING:
     from mindroom.matrix.conversation_access import MatrixConversationAccess
     from mindroom.matrix.identity import MatrixID
     from mindroom.message_target import MessageTarget
-    from mindroom.response_coordinator import ResponseCoordinator
+    from mindroom.response_runner import ResponseRunner
 
 type _MediaDispatchEvent = (
     nio.RoomMessageImage
@@ -117,7 +117,7 @@ type _PrecheckedMediaDispatchEvent = _PrecheckedEvent[_MediaDispatchEvent]
 
 
 @dataclass(frozen=True)
-class TurnEngineDeps:
+class TurnControllerDeps:
     """Collaborators needed for Phase 1 turn sequencing."""
 
     runtime: BotRuntimeView
@@ -130,7 +130,7 @@ class TurnEngineDeps:
     resolver: ConversationResolver
     normalizer: InboundTurnNormalizer
     dispatch_planner: DispatchPlanner
-    response_coordinator: ResponseCoordinator
+    response_runner: ResponseRunner
     delivery_gateway: DeliveryGateway
     state_writer: ConversationStateWriter
     coalescing_gate: CoalescingGate
@@ -138,10 +138,10 @@ class TurnEngineDeps:
 
 
 @dataclass
-class TurnEngine:
+class TurnController:
     """Own sequencing for one inbound text or media turn."""
 
-    deps: TurnEngineDeps
+    deps: TurnControllerDeps
 
     def _client(self) -> nio.AsyncClient:
         client = self.deps.runtime.client
@@ -334,7 +334,7 @@ class TurnEngine:
             return False
         if is_agent_id(sender_id, self.deps.runtime.config, self.deps.runtime_paths):
             return False
-        return self.deps.response_coordinator.has_active_response_for_target(target)
+        return self.deps.response_runner.has_active_response_for_target(target)
 
     async def _coalescing_key_for_event(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,8 @@ from mindroom.delivery_gateway import DeliveryGateway, EditTextRequest, SendText
 from mindroom.dispatch_planner import DispatchPlanner
 from mindroom.edit_regenerator import EditRegenerator
 from mindroom.matrix.client import ResolvedVisibleMessage
-from mindroom.response_coordinator import ResponseCoordinator, ResponseRequest
-from mindroom.turn_engine import TurnEngine
+from mindroom.response_runner import ResponseRequest, ResponseRunner
+from mindroom.turn_controller import TurnController
 
 __all__ = [
     "TEST_ACCESS_TOKEN",
@@ -40,12 +40,12 @@ __all__ = [
     "make_visible_message",
     "normalize_console_output",
     "orchestrator_runtime_paths",
-    "patch_response_coordinator_module",
+    "patch_response_runner_module",
     "replace_delivery_gateway_deps",
     "replace_dispatch_planner_deps",
     "replace_edit_regenerator_deps",
-    "replace_response_coordinator_deps",
-    "replace_turn_engine_deps",
+    "replace_response_runner_deps",
+    "replace_turn_controller_deps",
     "resolve_response_thread_root_for_test",
     "runtime_paths_for",
     "sync_bot_runtime_state",
@@ -282,7 +282,7 @@ def wrap_extracted_collaborators(bot: object, *names: str) -> object:
     collaborator_names = names or (
         "_dispatch_planner",
         "_delivery_gateway",
-        "_response_coordinator",
+        "_response_runner",
         "_edit_regenerator",
         "_inbound_turn_normalizer",
         "_conversation_resolver",
@@ -314,8 +314,8 @@ def replace_dispatch_planner_deps(bot: object, **changes: object) -> DispatchPla
     rebuilt = DispatchPlanner(replace(planner.deps, **changes))
     bot._dispatch_planner = rebuilt
     wrap_extracted_collaborators(bot, "_dispatch_planner")
-    if hasattr(bot, "_turn_engine"):
-        replace_turn_engine_deps(bot, dispatch_planner=bot._dispatch_planner)
+    if hasattr(bot, "_turn_controller"):
+        replace_turn_controller_deps(bot, dispatch_planner=bot._dispatch_planner)
     return rebuilt
 
 
@@ -326,26 +326,26 @@ def replace_delivery_gateway_deps(bot: object, **changes: object) -> DeliveryGat
     rebuilt = DeliveryGateway(replace(gateway.deps, **changes))
     bot._delivery_gateway = rebuilt
     wrap_extracted_collaborators(bot, "_delivery_gateway")
-    if hasattr(bot, "_turn_engine"):
-        replace_turn_engine_deps(bot, delivery_gateway=bot._delivery_gateway)
-    if hasattr(bot, "_response_coordinator"):
-        replace_response_coordinator_deps(bot, delivery_gateway=bot._delivery_gateway)
+    if hasattr(bot, "_turn_controller"):
+        replace_turn_controller_deps(bot, delivery_gateway=bot._delivery_gateway)
+    if hasattr(bot, "_response_runner"):
+        replace_response_runner_deps(bot, delivery_gateway=bot._delivery_gateway)
     elif hasattr(bot, "_dispatch_planner"):
         replace_dispatch_planner_deps(bot, delivery_gateway=bot._delivery_gateway)
     return rebuilt
 
 
-def replace_response_coordinator_deps(bot: object, **changes: object) -> ResponseCoordinator:
+def replace_response_runner_deps(bot: object, **changes: object) -> ResponseRunner:
     """Rebuild the response coordinator after swapping captured collaborators."""
     sync_bot_runtime_state(bot)
-    coordinator = unwrap_extracted_collaborator(cast("ResponseCoordinator", bot._response_coordinator))
-    rebuilt = ResponseCoordinator(replace(coordinator.deps, **changes))
-    bot._response_coordinator = rebuilt
-    wrap_extracted_collaborators(bot, "_response_coordinator")
-    if hasattr(bot, "_turn_engine"):
-        replace_turn_engine_deps(bot, response_coordinator=bot._response_coordinator)
+    coordinator = unwrap_extracted_collaborator(cast("ResponseRunner", bot._response_runner))
+    rebuilt = ResponseRunner(replace(coordinator.deps, **changes))
+    bot._response_runner = rebuilt
+    wrap_extracted_collaborators(bot, "_response_runner")
+    if hasattr(bot, "_turn_controller"):
+        replace_turn_controller_deps(bot, response_runner=bot._response_runner)
     if hasattr(bot, "_dispatch_planner"):
-        planner_changes: dict[str, object] = {"response_coordinator": bot._response_coordinator}
+        planner_changes: dict[str, object] = {"response_runner": bot._response_runner}
         if "delivery_gateway" in changes:
             planner_changes["delivery_gateway"] = changes["delivery_gateway"]
         replace_dispatch_planner_deps(bot, **planner_changes)
@@ -366,20 +366,20 @@ def replace_edit_regenerator_deps(bot: object, **changes: object) -> EditRegener
     rebuilt = EditRegenerator(replace(regenerator.deps, **rebuilt_changes))
     bot._edit_regenerator = rebuilt
     wrap_extracted_collaborators(bot, "_edit_regenerator")
-    if hasattr(bot, "_turn_engine"):
-        replace_turn_engine_deps(bot, edit_regenerator=bot._edit_regenerator)
+    if hasattr(bot, "_turn_controller"):
+        replace_turn_controller_deps(bot, edit_regenerator=bot._edit_regenerator)
     return rebuilt
 
 
-def replace_turn_engine_deps(bot: object, **changes: object) -> TurnEngine:
+def replace_turn_controller_deps(bot: object, **changes: object) -> TurnController:
     """Rebuild the turn engine after swapping collaborators captured at construction."""
     sync_bot_runtime_state(bot)
-    engine = unwrap_extracted_collaborator(cast("TurnEngine", bot._turn_engine))
+    engine = unwrap_extracted_collaborator(cast("TurnController", bot._turn_controller))
     rebuilt_changes = dict(changes)
     if hasattr(bot, "_edit_regenerator") and "edit_regenerator" not in rebuilt_changes:
         rebuilt_changes["edit_regenerator"] = bot._edit_regenerator
-    rebuilt = TurnEngine(replace(engine.deps, **rebuilt_changes))
-    bot._turn_engine = rebuilt
+    rebuilt = TurnController(replace(engine.deps, **rebuilt_changes))
+    bot._turn_controller = rebuilt
     if hasattr(bot, "_edit_regenerator"):
         edit_changes = {
             name: value
@@ -393,11 +393,11 @@ def replace_turn_engine_deps(bot: object, **changes: object) -> TurnEngine:
 
 
 @contextmanager
-def patch_response_coordinator_module(**changes: object) -> Generator[None, None, None]:
+def patch_response_runner_module(**changes: object) -> Generator[None, None, None]:
     """Patch module-level response coordinator seams on the real current owner."""
     with ExitStack() as stack:
         for name, replacement in changes.items():
-            stack.enter_context(patch(f"mindroom.response_coordinator.{name}", new=replacement))
+            stack.enter_context(patch(f"mindroom.response_runner.{name}", new=replacement))
         yield
 
 
@@ -420,10 +420,10 @@ def install_send_response_mock(bot: object, send_response: AsyncMock) -> None:
         )
 
     bot._delivery_gateway.send_text = AsyncMock(side_effect=_send_text)
-    if hasattr(bot, "_turn_engine"):
-        replace_turn_engine_deps(bot, delivery_gateway=bot._delivery_gateway)
-    if hasattr(bot, "_response_coordinator"):
-        replace_response_coordinator_deps(bot, delivery_gateway=bot._delivery_gateway)
+    if hasattr(bot, "_turn_controller"):
+        replace_turn_controller_deps(bot, delivery_gateway=bot._delivery_gateway)
+    if hasattr(bot, "_response_runner"):
+        replace_response_runner_deps(bot, delivery_gateway=bot._delivery_gateway)
     if hasattr(bot, "_dispatch_planner"):
         replace_dispatch_planner_deps(
             bot,
@@ -434,7 +434,7 @@ def install_send_response_mock(bot: object, send_response: AsyncMock) -> None:
 
 def install_generate_response_mock(bot: object, generate_response: AsyncMock) -> None:
     """Route response execution through one legacy-style generate-response mock."""
-    wrap_extracted_collaborators(bot, "_response_coordinator")
+    wrap_extracted_collaborators(bot, "_response_runner")
 
     async def _generate(request: ResponseRequest) -> str | None:
         attachment_ids = list(request.attachment_ids) if request.attachment_ids is not None else None
@@ -458,13 +458,13 @@ def install_generate_response_mock(bot: object, generate_response: AsyncMock) ->
             matrix_run_metadata=request.matrix_run_metadata,
         )
 
-    bot._response_coordinator.generate_response = AsyncMock(side_effect=_generate)
-    if hasattr(bot, "_turn_engine"):
-        replace_turn_engine_deps(bot, response_coordinator=bot._response_coordinator)
+    bot._response_runner.generate_response = AsyncMock(side_effect=_generate)
+    if hasattr(bot, "_turn_controller"):
+        replace_turn_controller_deps(bot, response_runner=bot._response_runner)
     if hasattr(bot, "_dispatch_planner"):
         replace_dispatch_planner_deps(
             bot,
-            response_coordinator=bot._response_coordinator,
+            response_runner=bot._response_runner,
             handled_turn_ledger=bot.handled_turn_ledger,
         )
 
@@ -484,10 +484,10 @@ def install_edit_message_mock(bot: object, edit_message: AsyncMock) -> None:
         )
 
     bot._delivery_gateway.edit_text = AsyncMock(side_effect=_edit_text)
-    if hasattr(bot, "_turn_engine"):
-        replace_turn_engine_deps(bot, delivery_gateway=bot._delivery_gateway)
-    if hasattr(bot, "_response_coordinator"):
-        replace_response_coordinator_deps(bot, delivery_gateway=bot._delivery_gateway)
+    if hasattr(bot, "_turn_controller"):
+        replace_turn_controller_deps(bot, delivery_gateway=bot._delivery_gateway)
+    if hasattr(bot, "_response_runner"):
+        replace_response_runner_deps(bot, delivery_gateway=bot._delivery_gateway)
     if hasattr(bot, "_dispatch_planner"):
         replace_dispatch_planner_deps(
             bot,
@@ -498,14 +498,14 @@ def install_edit_message_mock(bot: object, edit_message: AsyncMock) -> None:
 
 def install_send_skill_command_response_mock(bot: object, send_skill_command_response: AsyncMock) -> None:
     """Route skill-command dispatch through one test mock on the real owner."""
-    wrap_extracted_collaborators(bot, "_response_coordinator")
-    bot._response_coordinator.send_skill_command_response = send_skill_command_response
-    if hasattr(bot, "_turn_engine"):
-        replace_turn_engine_deps(bot, response_coordinator=bot._response_coordinator)
+    wrap_extracted_collaborators(bot, "_response_runner")
+    bot._response_runner.send_skill_command_response = send_skill_command_response
+    if hasattr(bot, "_turn_controller"):
+        replace_turn_controller_deps(bot, response_runner=bot._response_runner)
     if hasattr(bot, "_dispatch_planner"):
         replace_dispatch_planner_deps(
             bot,
-            response_coordinator=bot._response_coordinator,
+            response_runner=bot._response_runner,
             handled_turn_ledger=bot.handled_turn_ledger,
         )
 
@@ -585,6 +585,6 @@ def bypass_authorization(request: pytest.FixtureRequest) -> Generator[None, None
     else:
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         ):
             yield

--- a/tests/test_ai_error_message_display.py
+++ b/tests/test_ai_error_message_display.py
@@ -20,13 +20,13 @@ from mindroom.hooks import HookRegistry
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestration.runtime import SYNC_RESTART_CANCEL_MSG
-from mindroom.response_coordinator import ResponseRequest
+from mindroom.response_runner import ResponseRequest
 from mindroom.streaming import build_restart_interrupted_body
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
     replace_delivery_gateway_deps,
-    replace_response_coordinator_deps,
+    replace_response_runner_deps,
     resolve_response_thread_root_for_test,
     runtime_paths_for,
     test_runtime_paths,
@@ -84,14 +84,14 @@ def _mock_bot(tmp_path: Path) -> AgentBot:
     return bot
 
 
-def _build_response_coordinator(bot: AgentBot) -> None:
+def _build_response_runner(bot: AgentBot) -> None:
     """Rebuild extracted collaborators after tests replace bot-facing dependencies."""
     replace_delivery_gateway_deps(
         bot,
         logger=bot.logger,
         resolver=bot._conversation_resolver,
     )
-    replace_response_coordinator_deps(
+    replace_response_runner_deps(
         bot,
         logger=bot.logger,
         resolver=bot._conversation_resolver,
@@ -140,14 +140,14 @@ class TestAIErrorDisplay:
             return "$edit"
 
         with (
-            patch("mindroom.response_coordinator.ai_response") as mock_ai,
+            patch("mindroom.response_runner.ai_response") as mock_ai,
             patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(side_effect=mock_gateway_edit_message)),
         ):
-            _build_response_coordinator(bot)
+            _build_response_runner(bot)
             error_msg = "[test_agent] 🔴 Authentication failed. Please check your API key configuration."
             mock_ai.return_value = error_msg
 
-            await bot._response_coordinator.process_and_respond(
+            await bot._response_runner.process_and_respond(
                 _response_request(existing_event_id="$thinking_msg"),
             )
 
@@ -178,7 +178,7 @@ class TestAIErrorDisplay:
         bot._handle_interactive_question = AsyncMock()
 
         # Mock stream_agent_response to yield an error message
-        with patch("mindroom.response_coordinator.stream_agent_response") as mock_stream:
+        with patch("mindroom.response_runner.stream_agent_response") as mock_stream:
 
             async def error_stream() -> AsyncIterator[str]:
                 yield "[test_agent] 🔴 Rate limited. Please wait before trying again."
@@ -187,12 +187,12 @@ class TestAIErrorDisplay:
 
             # Mock send_streaming_response to return the accumulated text
             with patch("mindroom.delivery_gateway.send_streaming_response") as mock_send_streaming:
-                _build_response_coordinator(bot)
+                _build_response_runner(bot)
                 error_text = "[test_agent] 🔴 Rate limited. Please wait before trying again."
                 mock_send_streaming.return_value = ("$msg_id", error_text)
 
                 # Call the method with an existing_event_id
-                await bot._response_coordinator.process_and_respond_streaming(
+                await bot._response_runner.process_and_respond_streaming(
                     _response_request(existing_event_id="$thinking_msg"),
                 )
 
@@ -217,15 +217,15 @@ class TestAIErrorDisplay:
 
         # Mock ai_response to raise CancelledError
         with (
-            patch("mindroom.response_coordinator.ai_response") as mock_ai,
+            patch("mindroom.response_runner.ai_response") as mock_ai,
             patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(side_effect=mock_gateway_edit_message)),
         ):
-            _build_response_coordinator(bot)
+            _build_response_runner(bot)
             mock_ai.side_effect = asyncio.CancelledError()
 
             # Call the method and expect it to raise CancelledError
             with pytest.raises(asyncio.CancelledError):
-                await bot._response_coordinator.process_and_respond(
+                await bot._response_runner.process_and_respond(
                     _response_request(existing_event_id="$thinking_msg"),
                 )
 
@@ -264,13 +264,13 @@ class TestAIErrorDisplay:
             edited_messages.clear()
 
             with (
-                patch("mindroom.response_coordinator.ai_response") as mock_ai,
+                patch("mindroom.response_runner.ai_response") as mock_ai,
                 patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(side_effect=mock_gateway_edit_message)),
             ):
-                _build_response_coordinator(bot)
+                _build_response_runner(bot)
                 mock_ai.return_value = error_msg
 
-                await bot._response_coordinator.process_and_respond(
+                await bot._response_runner.process_and_respond(
                     _response_request(
                         prompt="Help me",
                         existing_event_id=f"$thinking_{error_messages.index(error_msg)}",
@@ -312,14 +312,14 @@ class TestAIErrorDisplay:
             return "$edit"
 
         with (
-            patch("mindroom.response_coordinator.ai_response") as mock_ai,
+            patch("mindroom.response_runner.ai_response") as mock_ai,
             patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(side_effect=mock_gateway_edit_message)),
         ):
-            _build_response_coordinator(bot)
+            _build_response_runner(bot)
             mock_ai.side_effect = asyncio.CancelledError(SYNC_RESTART_CANCEL_MSG)
 
             with pytest.raises(asyncio.CancelledError):
-                await bot._response_coordinator.process_and_respond(
+                await bot._response_runner.process_and_respond(
                     _response_request(existing_event_id="$thinking_msg"),
                 )
 
@@ -337,17 +337,17 @@ class TestAIErrorDisplay:
 
         with (
             patch(
-                "mindroom.response_coordinator.ensure_request_knowledge_managers",
+                "mindroom.response_runner.ensure_request_knowledge_managers",
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("knowledge init failed"),
             ),
-            patch("mindroom.response_coordinator.ai_response", new_callable=AsyncMock) as mock_ai,
+            patch("mindroom.response_runner.ai_response", new_callable=AsyncMock) as mock_ai,
             patch("mindroom.delivery_gateway.send_message", new=AsyncMock(return_value="$response_id")),
         ):
-            _build_response_coordinator(bot)
+            _build_response_runner(bot)
             mock_ai.return_value = "Response without knowledge"
 
-            delivery = await bot._response_coordinator.process_and_respond(
+            delivery = await bot._response_runner.process_and_respond(
                 _response_request(),
             )
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -48,7 +48,7 @@ from mindroom.hooks.registry import HookRegistryState
 from mindroom.media_inputs import MediaInputs
 from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsSupport
-from mindroom.response_coordinator import ResponseCoordinator, ResponseCoordinatorDeps, ResponseRequest
+from mindroom.response_runner import ResponseRequest, ResponseRunner, ResponseRunnerDeps
 from mindroom.tool_system.runtime_context import ToolRuntimeSupport, get_tool_runtime_context, tool_runtime_context
 from mindroom.tool_system.worker_routing import (
     build_tool_execution_identity,
@@ -100,14 +100,14 @@ def _prepared_prompt_result(
     return agent, prompt, [], PreparedHistoryState()
 
 
-def _build_response_coordinator(
+def _build_response_runner(
     bot: MagicMock,
     *,
     config: Config,
     runtime_paths: RuntimePaths,
     storage_path: Path,
     requester_id: str,  # noqa: ARG001
-) -> ResponseCoordinator:
+) -> ResponseRunner:
     """Build a real response coordinator for one bot-shaped test double."""
     bot.matrix_id = MagicMock(full_id="@mindroom_general:localhost", domain="localhost")
     bot.enable_streaming = True
@@ -170,8 +170,8 @@ def _build_response_coordinator(
     )
     bot._knowledge_access_support = SimpleNamespace(for_agent=MagicMock(return_value=None))
 
-    return ResponseCoordinator(
-        ResponseCoordinatorDeps(
+    return ResponseRunner(
+        ResponseRunnerDeps(
             runtime=runtime,
             logger=bot.logger,
             stop_manager=bot.stop_manager,
@@ -229,10 +229,10 @@ class TestUserIdPassthrough:
         bot._knowledge_access_support.for_agent = MagicMock(return_value=None)
         bot._send_response = AsyncMock(return_value="$response_id")
         with (
-            patch("mindroom.response_coordinator.ensure_request_knowledge_managers", new=AsyncMock(return_value={})),
-            patch("mindroom.response_coordinator.ai_response") as mock_ai,
+            patch("mindroom.response_runner.ensure_request_knowledge_managers", new=AsyncMock(return_value={})),
+            patch("mindroom.response_runner.ai_response") as mock_ai,
         ):
-            coordinator = _build_response_coordinator(
+            coordinator = _build_response_runner(
                 bot,
                 config=config,
                 runtime_paths=runtime_paths,
@@ -278,10 +278,10 @@ class TestUserIdPassthrough:
         bot._knowledge_access_support.for_agent = MagicMock(return_value=None)
         bot._handle_interactive_question = AsyncMock()
         with (
-            patch("mindroom.response_coordinator.ensure_request_knowledge_managers", new=AsyncMock(return_value={})),
-            patch("mindroom.response_coordinator.stream_agent_response") as mock_stream,
+            patch("mindroom.response_runner.ensure_request_knowledge_managers", new=AsyncMock(return_value={})),
+            patch("mindroom.response_runner.stream_agent_response") as mock_stream,
         ):
-            coordinator = _build_response_coordinator(
+            coordinator = _build_response_runner(
                 bot,
                 config=config,
                 runtime_paths=runtime_paths,
@@ -332,7 +332,7 @@ class TestUserIdPassthrough:
         bot.config = config
         bot.runtime_paths = runtime_paths
 
-        coordinator = _build_response_coordinator(
+        coordinator = _build_response_runner(
             bot,
             config=config,
             runtime_paths=runtime_paths,
@@ -418,7 +418,7 @@ class TestUserIdPassthrough:
         bot.config = config
         bot.runtime_paths = runtime_paths
 
-        coordinator = _build_response_coordinator(
+        coordinator = _build_response_runner(
             bot,
             config=config,
             runtime_paths=runtime_paths,

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -18,7 +18,7 @@ from mindroom.constants import ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME, VOICE_PRE
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.thread_utils import should_agent_respond
-from mindroom.turn_engine import _PrecheckedEvent
+from mindroom.turn_controller import _PrecheckedEvent
 from tests.conftest import (
     TEST_ACCESS_TOKEN,
     TEST_PASSWORD,
@@ -28,7 +28,7 @@ from tests.conftest import (
     install_send_response_mock,
     install_send_skill_command_response_mock,
     replace_dispatch_planner_deps,
-    replace_turn_engine_deps,
+    replace_turn_controller_deps,
     runtime_paths_for,
     sync_bot_runtime_state,
     test_runtime_paths,
@@ -71,7 +71,7 @@ def _sync_dispatch_planner_runtime(bot: AgentBot) -> None:
         logger=bot.logger,
         handled_turn_ledger=bot.handled_turn_ledger,
     )
-    replace_turn_engine_deps(
+    replace_turn_controller_deps(
         bot,
         logger=bot.logger,
         handled_turn_ledger=bot.handled_turn_ledger,
@@ -1144,7 +1144,7 @@ class TestCommandHandling:
         with (
             patch("mindroom.bot.interactive") as mock_interactive,
             patch("mindroom.dispatch_planner.extract_agent_name") as mock_extract,
-            patch("mindroom.response_coordinator.team_response") as mock_team,
+            patch("mindroom.response_runner.team_response") as mock_team,
         ):
             mock_interactive.handle_text_response = AsyncMock()
             mock_extract.side_effect = (
@@ -1629,7 +1629,7 @@ class TestRouterSkipsSingleAgent:
                 config.get_ids(runtime_paths_for(config))["general"],
                 config.get_ids(runtime_paths_for(config))["calculator"],
             ]
-            await bot._turn_engine._dispatch_text_message(
+            await bot._turn_controller._dispatch_text_message(
                 room,
                 _PrecheckedEvent(event=event, requester_user_id="@alice:localhost"),
             )

--- a/tests/test_config_discovery.py
+++ b/tests/test_config_discovery.py
@@ -51,7 +51,7 @@ _AMBIENT_EXECUTION_IDENTITY_ALLOWLIST = {
     "src/mindroom/api/sandbox_runner.py",
     "src/mindroom/bot.py",
     "src/mindroom/commands/handler.py",
-    "src/mindroom/response_coordinator.py",
+    "src/mindroom/response_runner.py",
     "src/mindroom/tool_system/worker_routing.py",
 }
 _EXPLICIT_RUNTIME_SCOPE_KEYWORDS = {

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -131,7 +131,7 @@ async def test_queued_config_reload_waits_for_in_flight_response_without_event_i
         await release_response.wait()
 
     response_task = asyncio.create_task(
-        bot._response_coordinator.run_cancellable_response(
+        bot._response_runner.run_cancellable_response(
             room_id="!room:localhost",
             reply_to_event_id="$reply",
             thread_id=None,
@@ -1155,7 +1155,7 @@ async def test_in_flight_response_count_nonzero_during_send_response(
         pass
 
     task = asyncio.create_task(
-        bot._response_coordinator.run_cancellable_response(
+        bot._response_runner.run_cancellable_response(
             room_id="!room:localhost",
             reply_to_event_id="$reply",
             thread_id=None,
@@ -1207,7 +1207,7 @@ async def test_run_cancellable_response_does_not_depend_on_current_task_lookup(
     async def response_function(message_id: str | None) -> None:
         assert message_id is None
 
-    await bot._response_coordinator.run_cancellable_response(
+    await bot._response_runner.run_cancellable_response(
         room_id="!room:localhost",
         reply_to_event_id="$reply",
         thread_id=None,
@@ -1268,7 +1268,7 @@ async def test_run_cancellable_response_marks_thinking_placeholder_pending(
     async def response_function(message_id: str | None) -> None:
         assert message_id == "$thinking"
 
-    await bot._response_coordinator.run_cancellable_response(
+    await bot._response_runner.run_cancellable_response(
         room_id="!room:localhost",
         reply_to_event_id="$reply",
         thread_id=None,

--- a/tests/test_edit_after_restart.py
+++ b/tests/test_edit_after_restart.py
@@ -13,7 +13,7 @@ from mindroom.constants import resolve_runtime_paths
 from mindroom.handled_turns import HandledTurnLedger, HandledTurnState
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
-from tests.conftest import replace_turn_engine_deps, wrap_extracted_collaborators
+from tests.conftest import replace_turn_controller_deps, wrap_extracted_collaborators
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -86,8 +86,8 @@ async def test_bot_handles_redelivered_edit_after_restart(tmp_path: Path) -> Non
 
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
@@ -144,7 +144,7 @@ async def test_bot_handles_redelivered_edit_after_restart(tmp_path: Path) -> Non
     # Mock the methods needed for regeneration
     with (
         patch.object(bot._edit_regenerator, "handle_message_edit", new_callable=AsyncMock) as mock_handle_edit,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
     ):
         # Process the redelivered edit event
         await bot._on_message(room, edit_event)
@@ -199,7 +199,7 @@ async def test_bot_skips_duplicate_regular_message_after_restart(tmp_path: Path)
 
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
@@ -233,8 +233,8 @@ async def test_bot_skips_duplicate_regular_message_after_restart(tmp_path: Path)
 
     # Mock methods
     with (
-        patch.object(bot._turn_engine, "_dispatch_text_message", new_callable=AsyncMock) as mock_dispatch,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch.object(bot._turn_controller, "_dispatch_text_message", new_callable=AsyncMock) as mock_dispatch,
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
     ):
         # Process the redelivered message
         await bot._on_message(room, message_event)

--- a/tests/test_edit_event_handling.py
+++ b/tests/test_edit_event_handling.py
@@ -11,8 +11,8 @@ import pytest
 from mindroom.bot import AgentBot
 from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
 from mindroom.matrix.users import AgentMatrixUser
-from mindroom.turn_engine import _PrecheckedEvent
-from tests.conftest import replace_turn_engine_deps, wrap_extracted_collaborators
+from mindroom.turn_controller import _PrecheckedEvent
+from tests.conftest import replace_turn_controller_deps, wrap_extracted_collaborators
 
 
 @pytest.mark.asyncio
@@ -53,7 +53,7 @@ async def test_bot_ignores_edit_events(tmp_path: Path) -> None:
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.handled_turn_ledger.get_turn_record.return_value = None
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@router:example.com")
@@ -100,11 +100,11 @@ async def test_bot_ignores_edit_events(tmp_path: Path) -> None:
     # Mock the routing method that would be called for the router
     with (
         patch.object(
-            bot._turn_engine,
+            bot._turn_controller,
             "_precheck_dispatch_event",
             return_value=_PrecheckedEvent(event=edit_event, requester_user_id="@user:example.com"),
         ),
-        patch.object(bot._turn_engine, "_dispatch_text_message", new_callable=AsyncMock) as mock_dispatch,
+        patch.object(bot._turn_controller, "_dispatch_text_message", new_callable=AsyncMock) as mock_dispatch,
         patch.object(bot._edit_regenerator, "handle_message_edit", new_callable=AsyncMock) as mock_handle_edit,
         patch.object(bot._edit_regenerator, "load_persisted_turn_metadata", return_value=None),
     ):
@@ -147,7 +147,7 @@ async def test_bot_ignores_multiple_edits(tmp_path: Path) -> None:
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.handled_turn_ledger.get_turn_record.return_value = None
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@router:example.com")
 
@@ -196,13 +196,13 @@ async def test_bot_ignores_multiple_edits(tmp_path: Path) -> None:
     # Mock the routing method
     with (
         patch.object(
-            bot._turn_engine,
+            bot._turn_controller,
             "_precheck_dispatch_event",
             side_effect=[
                 _PrecheckedEvent(event=edit_event, requester_user_id="@user:example.com") for edit_event in edit_events
             ],
         ),
-        patch.object(bot._turn_engine, "_dispatch_text_message", new_callable=AsyncMock) as mock_dispatch,
+        patch.object(bot._turn_controller, "_dispatch_text_message", new_callable=AsyncMock) as mock_dispatch,
         patch.object(bot._edit_regenerator, "handle_message_edit", new_callable=AsyncMock) as mock_handle_edit,
         patch.object(bot._edit_regenerator, "load_persisted_turn_metadata", return_value=None),
     ):
@@ -246,7 +246,7 @@ async def test_regular_agent_ignores_edits(tmp_path: Path) -> None:
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.handled_turn_ledger.get_turn_record.return_value = None
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
 

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -38,10 +38,10 @@ from mindroom.thread_utils import create_session_id
 from tests.conftest import (
     bind_runtime_paths,
     install_generate_response_mock,
-    patch_response_coordinator_module,
+    patch_response_runner_module,
     replace_dispatch_planner_deps,
     replace_edit_regenerator_deps,
-    replace_turn_engine_deps,
+    replace_turn_controller_deps,
     runtime_paths_for,
     unwrap_extracted_collaborator,
 )
@@ -324,7 +324,7 @@ async def test_bot_regenerates_response_on_edit(tmp_path: Path) -> None:
     mock_streaming = AsyncMock(return_value=False)
     mock_ai_response = AsyncMock(return_value="The answer is 6")
     with (
-        patch_response_coordinator_module(
+        patch_response_runner_module(
             should_use_streaming=mock_streaming,
             ai_response=mock_ai_response,
         ),
@@ -452,7 +452,7 @@ async def test_bot_edit_hooks_see_hydrated_sidecar_edit_body(tmp_path: Path) -> 
     with (
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
         patch.object(
-            bot._dispatch_hook_service,
+            bot._ingress_hook_runner,
             "emit_message_received_hooks",
             new_callable=AsyncMock,
         ) as mock_emit_hooks,
@@ -556,7 +556,7 @@ async def test_bot_edit_regeneration_uses_hydrated_mentions_for_response_gating(
 
     with (
         patch.object(
-            bot._dispatch_hook_service,
+            bot._ingress_hook_runner,
             "emit_message_received_hooks",
             new_callable=AsyncMock,
         ) as mock_emit_hooks,
@@ -868,17 +868,17 @@ async def test_team_bot_regenerates_edits_against_team_history_storage(tmp_path:
         patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
         patch("mindroom.bot.store_conversation_memory", side_effect=fake_store_conversation_memory),
         patch("mindroom.bot.create_background_task", side_effect=schedule_background_task),
-        patch_response_coordinator_module(
+        patch_response_runner_module(
             team_response=mock_team_response,
             should_use_streaming=AsyncMock(return_value=False),
             typing_indicator=noop_typing_indicator,
         ),
         patch(
-            "mindroom.response_coordinator.apply_post_response_effects",
+            "mindroom.response_runner.apply_post_response_effects",
             new=AsyncMock(),
         ),
         patch(
-            "mindroom.response_coordinator.DeliveryGateway.deliver_final",
+            "mindroom.response_runner.DeliveryGateway.deliver_final",
             new=AsyncMock(
                 return_value=DeliveryResult(
                     event_id=response_event_id,
@@ -1040,7 +1040,7 @@ async def test_bot_ignores_agent_edits(tmp_path: Path) -> None:
 
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
@@ -2154,13 +2154,13 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
     with (
         patch.object(bot._conversation_state_writer, "create_history_scope_storage", return_value=storage),
         patch(
-            "mindroom.response_coordinator.ResponseCoordinator.process_and_respond",
+            "mindroom.response_runner.ResponseRunner.process_and_respond",
             new=AsyncMock(side_effect=process_and_respond),
         ),
-        patch("mindroom.response_coordinator.reprioritize_auto_flush_sessions"),
-        patch("mindroom.response_coordinator.mark_auto_flush_dirty_session"),
+        patch("mindroom.response_runner.reprioritize_auto_flush_sessions"),
+        patch("mindroom.response_runner.mark_auto_flush_dirty_session"),
         patch.object(Config, "get_agent_memory_backend", return_value="none"),
-        patch_response_coordinator_module(
+        patch_response_runner_module(
             should_use_streaming=AsyncMock(return_value=False),
         ),
     ):
@@ -2434,13 +2434,13 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
         )
 
     with (
-        patch("mindroom.response_coordinator.should_use_streaming", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=False),
         patch(
-            "mindroom.response_coordinator.ResponseCoordinator.process_and_respond",
+            "mindroom.response_runner.ResponseRunner.process_and_respond",
             new=AsyncMock(side_effect=process_and_respond),
         ),
-        patch("mindroom.response_coordinator.reprioritize_auto_flush_sessions"),
-        patch("mindroom.response_coordinator.mark_auto_flush_dirty_session"),
+        patch("mindroom.response_runner.reprioritize_auto_flush_sessions"),
+        patch("mindroom.response_runner.mark_auto_flush_dirty_session"),
         patch.object(Config, "get_agent_memory_backend", return_value="none"),
     ):
         response_event_id = await bot._generate_response(
@@ -2992,7 +2992,7 @@ async def test_on_media_message_tracks_relay_event_id(tmp_path: Path) -> None:
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_handle_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         # Setup mocks
@@ -3050,7 +3050,7 @@ async def test_on_media_message_no_transcription_still_marks_relayed(tmp_path: P
 
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
@@ -3100,7 +3100,7 @@ async def test_on_media_message_no_transcription_still_marks_relayed(tmp_path: P
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_handle_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         # Setup mocks
@@ -3169,7 +3169,7 @@ async def test_unauthorized_user_cannot_edit_regenerate(tmp_path: Path) -> None:
 
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     room = Mock(spec=nio.MatrixRoom)
     room.room_id = "!test:example.com"
@@ -3203,7 +3203,7 @@ async def test_unauthorized_user_cannot_edit_regenerate(tmp_path: Path) -> None:
 
     # Test that authorization check works
     with (
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=False) as mock_is_auth,
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=False) as mock_is_auth,
         patch.object(bot._edit_regenerator, "handle_message_edit") as mock_handle_edit,
     ):
         await bot._on_message(room, edit_event)
@@ -3251,7 +3251,7 @@ async def test_on_media_message_unauthorized_sender_marks_responded(tmp_path: Pa
 
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
@@ -3293,7 +3293,7 @@ async def test_on_media_message_unauthorized_sender_marks_responded(tmp_path: Pa
 
     # Mock is_authorized_sender to return False
     with (
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=False) as mock_is_authorized,
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=False) as mock_is_authorized,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_handle_voice,
     ):
         # Process the voice event

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -46,14 +46,14 @@ from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestrator import MultiAgentOrchestrator
 from mindroom.tool_system.skills import _SkillCommandDispatch, _SkillCommandSpec
-from mindroom.turn_engine import _PrecheckedEvent
+from mindroom.turn_controller import _PrecheckedEvent
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
     install_send_skill_command_response_mock,
     orchestrator_runtime_paths,
     replace_dispatch_planner_deps,
-    replace_turn_engine_deps,
+    replace_turn_controller_deps,
     runtime_paths_for,
     sync_bot_runtime_state,
     test_runtime_paths,
@@ -172,15 +172,15 @@ def _hook_bot(tmp_path: Path) -> AgentBot:
     replace_dispatch_planner_deps(
         bot,
         resolver=bot._conversation_resolver,
-        response_coordinator=bot._response_coordinator,
+        response_runner=bot._response_runner,
         delivery_gateway=bot._delivery_gateway,
     )
-    replace_turn_engine_deps(
+    replace_turn_controller_deps(
         bot,
         resolver=bot._conversation_resolver,
         normalizer=bot._inbound_turn_normalizer,
         dispatch_planner=bot._dispatch_planner,
-        response_coordinator=bot._response_coordinator,
+        response_runner=bot._response_runner,
         delivery_gateway=bot._delivery_gateway,
         state_writer=bot._conversation_state_writer,
     )
@@ -207,15 +207,15 @@ def _agent_bot(tmp_path: Path, *, agent_name: str = "code") -> AgentBot:
     replace_dispatch_planner_deps(
         bot,
         resolver=bot._conversation_resolver,
-        response_coordinator=bot._response_coordinator,
+        response_runner=bot._response_runner,
         delivery_gateway=bot._delivery_gateway,
     )
-    replace_turn_engine_deps(
+    replace_turn_controller_deps(
         bot,
         resolver=bot._conversation_resolver,
         normalizer=bot._inbound_turn_normalizer,
         dispatch_planner=bot._dispatch_planner,
-        response_coordinator=bot._response_coordinator,
+        response_runner=bot._response_runner,
         delivery_gateway=bot._delivery_gateway,
         state_writer=bot._conversation_state_writer,
     )
@@ -701,7 +701,7 @@ async def test_dispatch_text_message_continues_for_hook_originated_mentions(tmp_
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock(return_value=DispatchPlan(kind="ignore"))
 
-    await bot._turn_engine._dispatch_text_message(
+    await bot._turn_controller._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
@@ -726,7 +726,7 @@ async def test_apply_message_enrichment_preserves_hook_chain_metadata(tmp_path: 
         envelope=_synthetic_envelope(),
     )
 
-    prepared = await bot._dispatch_hook_service.apply_message_enrichment(
+    prepared = await bot._ingress_hook_runner.apply_message_enrichment(
         dispatch,
         DispatchPayload(prompt="hello"),
         target_entity_name="code",
@@ -765,7 +765,7 @@ async def test_user_message_cannot_spoof_hook_origin_to_bypass_message_received_
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock(return_value=DispatchPlan(kind="ignore"))
 
-    await bot._turn_engine._dispatch_text_message(
+    await bot._turn_controller._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
     )
@@ -877,7 +877,7 @@ async def test_dispatch_text_message_runs_message_received_before_command_parsin
     bot._dispatch_planner.execute_command = AsyncMock()
     bot.handled_turn_ledger.record_handled_turn = MagicMock()
 
-    await bot._turn_engine._dispatch_text_message(
+    await bot._turn_controller._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
     )
@@ -1324,7 +1324,7 @@ async def test_deep_hook_dispatch_stops_before_command_or_response_dispatch(tmp_
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock()
 
-    await bot._turn_engine._dispatch_text_message(
+    await bot._turn_controller._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
@@ -1358,12 +1358,12 @@ async def test_deep_hook_dispatch_does_not_consume_interactive_answer_on_message
         options={"1": "first"},
         creator_agent=bot.agent_name,
     )
-    bot._turn_engine._precheck_dispatch_event = MagicMock(
+    bot._turn_controller._precheck_dispatch_event = MagicMock(
         return_value=_PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
     bot._inbound_turn_normalizer.resolve_text_event = AsyncMock(return_value=event)
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
-    bot._turn_engine._dispatch_text_message = AsyncMock()
+    bot._turn_controller._dispatch_text_message = AsyncMock()
 
     try:
         await bot._on_message(room, event)
@@ -1371,7 +1371,7 @@ async def test_deep_hook_dispatch_does_not_consume_interactive_answer_on_message
         assert "$question123" in interactive._active_questions
         interactive._active_questions.clear()
 
-    bot._turn_engine._dispatch_text_message.assert_not_awaited()
+    bot._turn_controller._dispatch_text_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1400,12 +1400,12 @@ async def test_first_hop_hook_dispatch_does_not_consume_interactive_answer_on_me
         options={"1": "first"},
         creator_agent=bot.agent_name,
     )
-    bot._turn_engine._precheck_dispatch_event = MagicMock(
+    bot._turn_controller._precheck_dispatch_event = MagicMock(
         return_value=_PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
     bot._inbound_turn_normalizer.resolve_text_event = AsyncMock(return_value=event)
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
-    bot._turn_engine._dispatch_text_message = AsyncMock()
+    bot._turn_controller._dispatch_text_message = AsyncMock()
 
     try:
         await bot._on_message(room, event)
@@ -1413,7 +1413,7 @@ async def test_first_hop_hook_dispatch_does_not_consume_interactive_answer_on_me
         assert "$question123" in interactive._active_questions
         interactive._active_questions.clear()
 
-    bot._turn_engine._dispatch_text_message.assert_awaited_once()
+    bot._turn_controller._dispatch_text_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1446,7 +1446,7 @@ async def test_first_hop_plain_hook_from_non_message_hook_still_dispatches(tmp_p
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock(return_value=DispatchPlan(kind="ignore"))
 
-    await bot._turn_engine._dispatch_text_message(
+    await bot._turn_controller._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
@@ -1497,7 +1497,7 @@ async def test_first_hop_hook_dispatch_sidecar_preview_skips_interactive_answer_
     )
     bot._inbound_turn_normalizer.prepare_file_sidecar_text_event = AsyncMock(return_value=prepared_text_event)
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
-    bot._turn_engine._dispatch_text_message = AsyncMock()
+    bot._turn_controller._dispatch_text_message = AsyncMock()
     interactive._active_questions.clear()
     interactive._active_questions["$question123"] = interactive._InteractiveQuestion(
         room_id=room.room_id,
@@ -1509,7 +1509,7 @@ async def test_first_hop_hook_dispatch_sidecar_preview_skips_interactive_answer_
     try:
         with patch.object(interactive, "handle_text_response", new=AsyncMock()) as mock_handle_text_response:
             assert isinstance(sidecar_event, nio.RoomMessageFile)
-            handled = await bot._turn_engine._dispatch_file_sidecar_text_preview(
+            handled = await bot._turn_controller._dispatch_file_sidecar_text_preview(
                 room,
                 _PrecheckedEvent(
                     event=sidecar_event,
@@ -1520,7 +1520,7 @@ async def test_first_hop_hook_dispatch_sidecar_preview_skips_interactive_answer_
         assert handled is True
         assert "$question123" in interactive._active_questions
         mock_handle_text_response.assert_not_awaited()
-        bot._turn_engine._dispatch_text_message.assert_awaited_once()
+        bot._turn_controller._dispatch_text_message.assert_awaited_once()
     finally:
         interactive._active_questions.clear()
 
@@ -1565,11 +1565,11 @@ async def test_deep_hook_dispatch_sidecar_preview_stops_before_interactive_or_di
     )
     bot._inbound_turn_normalizer.prepare_file_sidecar_text_event = AsyncMock(return_value=prepared_text_event)
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
-    bot._turn_engine._dispatch_text_message = AsyncMock()
+    bot._turn_controller._dispatch_text_message = AsyncMock()
 
     with patch.object(interactive, "handle_text_response", new=AsyncMock()) as mock_handle_text_response:
         assert isinstance(sidecar_event, nio.RoomMessageFile)
-        handled = await bot._turn_engine._dispatch_file_sidecar_text_preview(
+        handled = await bot._turn_controller._dispatch_file_sidecar_text_preview(
             room,
             _PrecheckedEvent(
                 event=sidecar_event,
@@ -1579,7 +1579,7 @@ async def test_deep_hook_dispatch_sidecar_preview_stops_before_interactive_or_di
 
     assert handled is True
     mock_handle_text_response.assert_not_awaited()
-    bot._turn_engine._dispatch_text_message.assert_not_awaited()
+    bot._turn_controller._dispatch_text_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1605,7 +1605,7 @@ async def test_first_hop_prepared_text_hook_dispatch_still_reaches_dispatch(tmp_
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock(return_value=DispatchPlan(kind="ignore"))
 
-    await bot._turn_engine._dispatch_text_message(
+    await bot._turn_controller._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
@@ -1639,7 +1639,7 @@ async def test_deep_prepared_text_hook_dispatch_stops_before_dispatch(tmp_path: 
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._dispatch_planner.plan_dispatch = AsyncMock()
 
-    await bot._turn_engine._dispatch_text_message(
+    await bot._turn_controller._dispatch_text_message(
         room,
         _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
     )
@@ -1701,7 +1701,7 @@ async def test_hook_dispatch_skill_command_preserves_source_envelope_in_runtime(
         )
 
     with patch("mindroom.dispatch_planner.handle_command", new=fake_handle_command):
-        await bot._turn_engine._dispatch_text_message(
+        await bot._turn_controller._dispatch_text_message(
             room,
             _PrecheckedEvent(event=event, requester_user_id="@mindroom_router:localhost"),
         )
@@ -1847,7 +1847,7 @@ async def test_router_precheck_allows_self_authored_hook_dispatch_without_reques
         ),
     )
 
-    prechecked = bot._turn_engine._precheck_dispatch_event(room, event)
+    prechecked = bot._turn_controller._precheck_dispatch_event(room, event)
 
     assert prechecked is not None
     assert prechecked.requester_user_id == "@mindroom_router:localhost"
@@ -1871,7 +1871,7 @@ async def test_precheck_rejects_hook_dispatch_with_unauthorized_original_sender(
     bot = _hook_bot(tmp_path)
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
     room = nio.MatrixRoom(room_id="!room:localhost", own_user_id="@mindroom_router:localhost")
     room.canonical_alias = None
     event = nio.RoomMessageText.from_dict(
@@ -1889,8 +1889,8 @@ async def test_precheck_rejects_hook_dispatch_with_unauthorized_original_sender(
         },
     )
 
-    with patch("mindroom.turn_engine.is_authorized_sender", side_effect=real_is_authorized_sender):
-        prechecked = bot._turn_engine._precheck_dispatch_event(room, event)
+    with patch("mindroom.turn_controller.is_authorized_sender", side_effect=real_is_authorized_sender):
+        prechecked = bot._turn_controller._precheck_dispatch_event(room, event)
 
     assert prechecked is None
     bot.handled_turn_ledger.record_handled_turn.assert_called_once_with(

--- a/tests/test_interactive_thread_fix.py
+++ b/tests/test_interactive_thread_fix.py
@@ -49,8 +49,8 @@ async def test_interactive_question_preserves_thread_root_in_streaming(tmp_path:
         return task
 
     with (
-        patch("mindroom.response_coordinator.stream_agent_response") as mock_ai_response,
-        patch("mindroom.response_coordinator.should_use_streaming", new_callable=AsyncMock, return_value=True),
+        patch("mindroom.response_runner.stream_agent_response") as mock_ai_response,
+        patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=True),
         patch(
             "mindroom.delivery_gateway.send_streaming_response",
             new_callable=AsyncMock,
@@ -59,7 +59,7 @@ async def test_interactive_question_preserves_thread_root_in_streaming(tmp_path:
         patch("mindroom.bot.interactive.register_interactive_question") as mock_register,
         patch("mindroom.bot.interactive.add_reaction_buttons", new_callable=AsyncMock),
         patch("mindroom.post_response_effects.maybe_generate_thread_summary", new_callable=AsyncMock),
-        patch("mindroom.response_coordinator.create_background_task", side_effect=schedule_background_task),
+        patch("mindroom.response_runner.create_background_task", side_effect=schedule_background_task),
         patch("mindroom.post_response_effects.create_background_task", side_effect=schedule_background_task),
     ):
 
@@ -149,14 +149,14 @@ async def test_interactive_question_preserves_thread_root_in_non_streaming(tmp_p
         return task
 
     with (
-        patch("mindroom.response_coordinator.ai_response") as mock_ai_response,
-        patch("mindroom.response_coordinator.should_use_streaming", new_callable=AsyncMock, return_value=False),
+        patch("mindroom.response_runner.ai_response") as mock_ai_response,
+        patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=False),
         patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(return_value=_room_send_response("$edit"))),
         patch("mindroom.bot.interactive.parse_and_format_interactive") as mock_parse,
         patch("mindroom.bot.interactive.register_interactive_question") as mock_register,
         patch("mindroom.bot.interactive.add_reaction_buttons", new_callable=AsyncMock),
         patch("mindroom.post_response_effects.maybe_generate_thread_summary", new_callable=AsyncMock),
-        patch("mindroom.response_coordinator.create_background_task", side_effect=schedule_background_task),
+        patch("mindroom.response_runner.create_background_task", side_effect=schedule_background_task),
         patch("mindroom.post_response_effects.create_background_task", side_effect=schedule_background_task),
     ):
         mock_ai_response.return_value = "Test interactive response"
@@ -229,8 +229,8 @@ async def test_interactive_question_preserves_thread_root_in_non_streaming(tmp_p
 async def test_interactive_question_without_thread_streaming(tmp_path: Path) -> None:
     """Streaming interactive replies without a thread should use the response event as the root."""
     with (
-        patch("mindroom.response_coordinator.stream_agent_response") as mock_ai_response,
-        patch("mindroom.response_coordinator.should_use_streaming", new_callable=AsyncMock, return_value=True),
+        patch("mindroom.response_runner.stream_agent_response") as mock_ai_response,
+        patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=True),
         patch(
             "mindroom.delivery_gateway.send_streaming_response",
             new_callable=AsyncMock,

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -36,7 +36,7 @@ from tests.conftest import (
     bind_runtime_paths,
     install_generate_response_mock,
     install_send_response_mock,
-    replace_turn_engine_deps,
+    replace_turn_controller_deps,
     runtime_paths_for,
     test_runtime_paths,
     wrap_extracted_collaborators,
@@ -93,11 +93,11 @@ def _make_bot(
     )
     bot = AgentBot(agent_user, tmp_path, config, runtime_paths_for(config), rooms=["!room:localhost"])
     wrap_extracted_collaborators(bot)
-    replace_turn_engine_deps(
+    replace_turn_controller_deps(
         bot,
         dispatch_planner=bot._dispatch_planner,
         delivery_gateway=bot._delivery_gateway,
-        response_coordinator=bot._response_coordinator,
+        response_runner=bot._response_runner,
         resolver=bot._conversation_resolver,
         normalizer=bot._inbound_turn_normalizer,
         state_writer=bot._conversation_state_writer,
@@ -273,8 +273,8 @@ async def test_single_message_dispatches_after_debounce_window(tmp_path: Path) -
         _ = handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn), media_events or []))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             event,
             room,
             source_kind="message",
@@ -306,14 +306,14 @@ async def test_two_rapid_text_messages_dispatch_one_combined_turn(tmp_path: Path
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             first,
             room,
             source_kind="message",
             requester_user_id="@user:localhost",
         )
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             second,
             room,
             source_kind="message",
@@ -338,14 +338,14 @@ async def test_two_rapid_text_messages_forward_prompt_map_to_dispatch(tmp_path: 
     first = _text_event(event_id="$m1", body="first", server_timestamp=1000)
     second = _text_event(event_id="$m2", body="second", server_timestamp=1001)
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch:
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch:
+        await bot._turn_controller._enqueue_for_dispatch(
             first,
             room,
             source_kind="message",
             requester_user_id="@user:localhost",
         )
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             second,
             room,
             source_kind="message",
@@ -382,14 +382,14 @@ async def test_image_and_text_coalesce_into_single_dispatch(tmp_path: Path) -> N
         _ = handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn), len(media_events or [])))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             image_event,
             room,
             source_kind="image",
             requester_user_id="@user:localhost",
         )
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             text_event,
             room,
             source_kind="message",
@@ -427,8 +427,8 @@ async def test_text_first_image_during_grace_dispatches_once(tmp_path: Path) -> 
         _ = handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn), len(media_events or [])))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             text_event,
             room,
             source_kind="message",
@@ -438,7 +438,7 @@ async def test_text_first_image_during_grace_dispatches_once(tmp_path: Path) -> 
         await asyncio.sleep(0.02)
         assert calls == []
 
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             image_event,
             room,
             source_kind="image",
@@ -477,8 +477,8 @@ async def test_text_first_multiple_images_during_grace_dispatch_once(tmp_path: P
         _ = handled_turn
         calls.append((_handled_turn_source_event_ids(handled_turn), len(media_events or [])))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             text_event,
             room,
             source_kind="message",
@@ -488,14 +488,14 @@ async def test_text_first_multiple_images_during_grace_dispatch_once(tmp_path: P
         await asyncio.sleep(0.02)
         assert calls == []
 
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             first_image,
             room,
             source_kind="image",
             requester_user_id="@user:localhost",
         )
         await asyncio.sleep(0.01)
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             second_image,
             room,
             source_kind="image",
@@ -526,8 +526,8 @@ async def test_text_during_upload_grace_flushes_pending_batch_and_starts_new_tur
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             first,
             room,
             source_kind="message",
@@ -537,7 +537,7 @@ async def test_text_during_upload_grace_flushes_pending_batch_and_starts_new_tur
         await asyncio.sleep(0.06)
         assert calls == []
 
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             second,
             room,
             source_kind="message",
@@ -574,8 +574,8 @@ async def test_image_after_grace_expires_dispatches_as_second_batch(tmp_path: Pa
         _ = handled_turn
         calls.append((_handled_turn_source_event_ids(handled_turn), len(media_events or [])))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             text_event,
             room,
             source_kind="message",
@@ -583,7 +583,7 @@ async def test_image_after_grace_expires_dispatches_as_second_batch(tmp_path: Pa
         )
         await _wait_for(lambda: len(calls) == 1)
 
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             image_event,
             room,
             source_kind="image",
@@ -617,14 +617,14 @@ async def test_different_senders_dispatch_separately(tmp_path: Path) -> None:
         _ = media_events, handled_turn
         calls.append(_handled_turn_source_event_ids(handled_turn))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             alice,
             room,
             source_kind="message",
             requester_user_id="@alice:localhost",
         )
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             bob,
             room,
             source_kind="message",
@@ -742,14 +742,14 @@ async def test_same_sender_different_threads_dispatch_separately(tmp_path: Path)
         _ = media_events, handled_turn
         calls.append(_handled_turn_source_event_ids(handled_turn))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             thread_a,
             room,
             source_kind="message",
             requester_user_id="@user:localhost",
         )
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             thread_b,
             room,
             source_kind="message",
@@ -780,14 +780,14 @@ async def test_command_mid_batch_flushes_pending_then_processes_command(tmp_path
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             first,
             room,
             source_kind="message",
             requester_user_id="@user:localhost",
         )
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             command,
             room,
             source_kind="message",
@@ -821,22 +821,22 @@ async def test_command_flush_does_not_leave_stale_timer_for_next_message(tmp_pat
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             first,
             room,
             source_kind="message",
             requester_user_id="@user:localhost",
         )
         await asyncio.sleep(0.01)
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             command,
             room,
             source_kind="message",
             requester_user_id="@user:localhost",
         )
         await asyncio.sleep(0.005)
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             second,
             room,
             source_kind="message",
@@ -878,8 +878,8 @@ async def test_command_during_upload_grace_flushes_immediately(tmp_path: Path) -
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             text_event,
             room,
             source_kind="message",
@@ -889,7 +889,7 @@ async def test_command_during_upload_grace_flushes_immediately(tmp_path: Path) -
         await asyncio.sleep(0.02)
         assert calls == []
 
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             command_event,
             room,
             source_kind="message",
@@ -928,8 +928,8 @@ async def test_messages_during_active_response_wait_and_batch_after_completion(t
             entered_first_dispatch.set()
             await release_first_dispatch.wait()
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             first,
             room,
             source_kind="message",
@@ -938,13 +938,13 @@ async def test_messages_during_active_response_wait_and_batch_after_completion(t
         await asyncio.sleep(0.03)
         await entered_first_dispatch.wait()
 
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             second,
             room,
             source_kind="message",
             requester_user_id="@user:localhost",
         )
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             third,
             room,
             source_kind="message",
@@ -991,8 +991,8 @@ async def test_coalescing_exempt_source_kinds_bypass_gate(tmp_path: Path, source
         _ = media_events, handled_turn
         calls.append(dispatched_event.body)
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             event,
             room,
             source_kind=source_kind,
@@ -1043,8 +1043,8 @@ async def test_overlapping_scheduled_checkins_coalesce(tmp_path: Path) -> None:
             entered_first_dispatch.set()
             await release_first_dispatch.wait()
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             first,
             room,
             source_kind="scheduled",
@@ -1053,7 +1053,7 @@ async def test_overlapping_scheduled_checkins_coalesce(tmp_path: Path) -> None:
         await asyncio.sleep(0.03)
         await entered_first_dispatch.wait()
 
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             second,
             room,
             source_kind="scheduled",
@@ -1092,8 +1092,8 @@ async def test_prepare_for_sync_shutdown_waits_for_active_flush_task(tmp_path: P
         entered_dispatch.set()
         await release_dispatch.wait()
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             event,
             room,
             source_kind="message",
@@ -1132,8 +1132,8 @@ async def test_prepare_for_sync_shutdown_drains_pending_debounced_messages(tmp_p
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             event,
             room,
             source_kind="message",
@@ -1164,8 +1164,8 @@ async def test_prepare_for_sync_shutdown_drains_pending_upload_grace(tmp_path: P
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             event,
             room,
             source_kind="message",
@@ -1206,8 +1206,8 @@ async def test_shutdown_during_in_flight_dispatch_does_not_start_grace(tmp_path:
             entered_dispatch.set()
             await release_dispatch.wait()
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             first,
             room,
             source_kind="message",
@@ -1217,7 +1217,7 @@ async def test_shutdown_during_in_flight_dispatch_does_not_start_grace(tmp_path:
         await entered_dispatch.wait()
 
         # Enqueue another message while first is in-flight
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             second,
             room,
             source_kind="message",
@@ -1264,9 +1264,9 @@ async def test_first_turn_thread_resolution_retargets_in_flight_gate(tmp_path: P
             entered_dispatch.set()
             await release_first_dispatch.wait()
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
         first_task = asyncio.create_task(
-            bot._turn_engine._enqueue_for_dispatch(
+            bot._turn_controller._enqueue_for_dispatch(
                 first,
                 room,
                 source_kind="message",
@@ -1280,7 +1280,7 @@ async def test_first_turn_thread_resolution_retargets_in_flight_gate(tmp_path: P
         assert bot._coalescing_gate._gates[retargeted_key].phase is GatePhase.IN_FLIGHT
 
         for followup in followups:
-            await bot._turn_engine._enqueue_for_dispatch(
+            await bot._turn_controller._enqueue_for_dispatch(
                 followup,
                 room,
                 source_kind="message",
@@ -1308,11 +1308,11 @@ async def test_cleanup_drains_pending_debounce_tasks(tmp_path: Path) -> None:
     event = _text_event(event_id="$m1", body="hello")
 
     with (
-        patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
+        patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
         patch("mindroom.bot.get_joined_rooms", new=AsyncMock(return_value=[])),
         patch("mindroom.bot.wait_for_background_tasks", new=AsyncMock()),
     ):
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             event,
             room,
             source_kind="message",
@@ -1353,9 +1353,9 @@ async def test_upload_grace_hard_cap_prevents_indefinite_extension(tmp_path: Pat
         _ = media_events, handled_turn
         calls.append(_handled_turn_source_event_ids(handled_turn))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
         started_at = time.monotonic()
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             text_event,
             room,
             source_kind="message",
@@ -1367,7 +1367,7 @@ async def test_upload_grace_hard_cap_prevents_indefinite_extension(tmp_path: Pat
 
         for delay, image_event in zip((0.01, 0.01, 0.01, 0.01), image_events, strict=True):
             await asyncio.sleep(delay)
-            await bot._turn_engine._enqueue_for_dispatch(
+            await bot._turn_controller._enqueue_for_dispatch(
                 image_event,
                 room,
                 source_kind="image",
@@ -1404,13 +1404,13 @@ async def test_handled_turn_ledger_marks_all_batch_event_ids(tmp_path: Path) -> 
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             first,
             room,
             source_kind="message",
             requester_user_id="@user:localhost",
         )
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             second,
             room,
             source_kind="message",
@@ -1447,8 +1447,8 @@ async def test_zero_debounce_dispatches_immediately(tmp_path: Path) -> None:
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             event,
             room,
             source_kind="message",
@@ -1481,14 +1481,14 @@ async def test_multiple_commands_each_dispatch_independently(tmp_path: Path) -> 
         _ = media_events, handled_turn
         calls.append((dispatched_event.body, _handled_turn_source_event_ids(handled_turn)))
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
-        await bot._turn_engine._enqueue_for_dispatch(
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
+        await bot._turn_controller._enqueue_for_dispatch(
             first_cmd,
             room,
             source_kind="message",
             requester_user_id="@user:localhost",
         )
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             second_cmd,
             room,
             source_kind="message",
@@ -1508,9 +1508,9 @@ async def test_gate_entry_removed_after_dispatch_with_no_pending(tmp_path: Path)
     room = _make_room()
     event = _text_event(event_id="$m1", body="hello")
 
-    with patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock()):
+    with patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock()):
         assert bot._coalescing_gate.is_idle()
-        await bot._turn_engine._enqueue_for_dispatch(
+        await bot._turn_controller._enqueue_for_dispatch(
             event,
             room,
             source_kind="message",
@@ -1557,7 +1557,7 @@ async def test_backlog_replay_skips_older_message_when_newer_exists(tmp_path: Pa
         patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
         patch.object(bot._dispatch_planner, "plan_dispatch", new=action_mock),
     ):
-        await bot._turn_engine._dispatch_text_message(room, older_event, "@user:localhost")
+        await bot._turn_controller._dispatch_text_message(room, older_event, "@user:localhost")
 
     # Older message should be skipped — resolve_dispatch_action never called
     action_mock.assert_not_awaited()
@@ -1594,7 +1594,7 @@ async def test_thread_history_guard_does_not_interfere_with_normal_dispatch(tmp_
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._turn_engine._dispatch_text_message(room, event, "@user:localhost")
+        await bot._turn_controller._dispatch_text_message(room, event, "@user:localhost")
 
     # Dispatch proceeded to completion
     assert bot.handled_turn_ledger.has_responded("$m1")
@@ -1820,7 +1820,7 @@ async def test_newer_command_does_not_suppress_older_message(tmp_path: Path) -> 
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._turn_engine._dispatch_text_message(room, older_event, "@user:localhost")
+        await bot._turn_controller._dispatch_text_message(room, older_event, "@user:localhost")
 
     # The older message must NOT be suppressed — dispatch action should be called
     action_mock.assert_awaited_once()
@@ -1867,7 +1867,7 @@ async def test_newer_command_with_whitespace_does_not_suppress(tmp_path: Path) -
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._turn_engine._dispatch_text_message(room, older_event, "@user:localhost")
+        await bot._turn_controller._dispatch_text_message(room, older_event, "@user:localhost")
 
     action_mock.assert_awaited_once()
 
@@ -1923,7 +1923,7 @@ async def test_scheduled_event_not_suppressed(tmp_path: Path) -> None:
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._turn_engine._dispatch_text_message(room, scheduled_event, "@mindroom_test_agent:localhost")
+        await bot._turn_controller._dispatch_text_message(room, scheduled_event, "@mindroom_test_agent:localhost")
 
     action_mock.assert_awaited_once()
 
@@ -1971,7 +1971,7 @@ async def test_hook_event_not_suppressed(tmp_path: Path) -> None:
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._turn_engine._dispatch_text_message(room, hook_event, "@mindroom_test_agent:localhost")
+        await bot._turn_controller._dispatch_text_message(room, hook_event, "@mindroom_test_agent:localhost")
 
     action_mock.assert_awaited_once()
 
@@ -2021,7 +2021,7 @@ async def test_multiple_scheduled_fires_not_suppressed(tmp_path: Path) -> None:
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
         patch.object(bot._dispatch_planner, "log_dispatch_latency"),
     ):
-        await bot._turn_engine._dispatch_text_message(room, first_fire, "@mindroom_test_agent:localhost")
+        await bot._turn_controller._dispatch_text_message(room, first_fire, "@mindroom_test_agent:localhost")
 
     # First fire must NOT be suppressed
     action_mock.assert_awaited_once()
@@ -2064,7 +2064,7 @@ async def test_coalesced_user_batch_suppressed_by_thread_guard(tmp_path: Path) -
         patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
         patch.object(bot._dispatch_planner, "plan_dispatch", new=action_mock),
     ):
-        await bot._turn_engine._dispatch_text_message(room, coalesced_event, "@user:localhost")
+        await bot._turn_controller._dispatch_text_message(room, coalesced_event, "@user:localhost")
 
     # Coalesced user batch MUST be suppressed — not an automation event
     action_mock.assert_not_awaited()
@@ -2105,7 +2105,7 @@ async def test_voice_synthetic_suppressed_by_thread_guard(tmp_path: Path) -> Non
         patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
         patch.object(bot._dispatch_planner, "plan_dispatch", new=action_mock),
     ):
-        await bot._turn_engine._dispatch_text_message(room, voice_event, "@user:localhost")
+        await bot._turn_controller._dispatch_text_message(room, voice_event, "@user:localhost")
 
     # Voice synthetic MUST be suppressed — not an automation event
     action_mock.assert_not_awaited()
@@ -2147,7 +2147,7 @@ async def test_older_command_not_suppressed_during_replay(tmp_path: Path) -> Non
         patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
         patch.object(bot._dispatch_planner, "execute_command", new=handle_cmd_mock),
     ):
-        await bot._turn_engine._dispatch_text_message(room, cmd_event, "@user:localhost")
+        await bot._turn_controller._dispatch_text_message(room, cmd_event, "@user:localhost")
 
     # Command must have been dispatched, not suppressed
     handle_cmd_mock.assert_awaited_once()

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -92,22 +92,22 @@ from mindroom.orchestrator import (
     _SignalAwareUvicornServer,
     main,
 )
-from mindroom.response_coordinator import ResponseCoordinator, ResponseRequest, _merge_response_extra_content
+from mindroom.response_runner import ResponseRequest, ResponseRunner, _merge_response_extra_content
 from mindroom.runtime_state import get_runtime_state, reset_runtime_state, set_runtime_ready
 from mindroom.streaming import StreamingDeliveryError
 from mindroom.teams import TeamIntent, TeamMemberStatus, TeamMode, TeamOutcome, TeamResolution, TeamResolutionMember
 from mindroom.tool_system.events import ToolTraceEntry
-from mindroom.turn_engine import _PrecheckedEvent
+from mindroom.turn_controller import _PrecheckedEvent
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
     install_edit_message_mock,
     install_generate_response_mock,
     install_send_response_mock,
-    patch_response_coordinator_module,
+    patch_response_runner_module,
     replace_delivery_gateway_deps,
-    replace_response_coordinator_deps,
-    replace_turn_engine_deps,
+    replace_response_runner_deps,
+    replace_turn_controller_deps,
     runtime_paths_for,
     test_runtime_paths,
     unwrap_extracted_collaborator,
@@ -130,12 +130,12 @@ def _make_matrix_client_mock() -> AsyncMock:
 def _wrap_extracted_collaborators(bot: AgentBot) -> AgentBot:
     """Wrap frozen extracted collaborators so tests can patch their methods."""
     wrapped_bot = cast("AgentBot", wrap_extracted_collaborators(bot))
-    replace_turn_engine_deps(
+    replace_turn_controller_deps(
         wrapped_bot,
         resolver=wrapped_bot._conversation_resolver,
         normalizer=wrapped_bot._inbound_turn_normalizer,
         dispatch_planner=wrapped_bot._dispatch_planner,
-        response_coordinator=wrapped_bot._response_coordinator,
+        response_runner=wrapped_bot._response_runner,
         delivery_gateway=wrapped_bot._delivery_gateway,
         state_writer=wrapped_bot._conversation_state_writer,
     )
@@ -157,13 +157,13 @@ def _replace_dispatch_planner_deps(bot: AgentBot, **changes: object) -> Dispatch
             "handled_turn_ledger",
             "resolver",
             "normalizer",
-            "response_coordinator",
+            "response_runner",
             "delivery_gateway",
             "state_writer",
             "coalescing_gate",
         }
     }
-    replace_turn_engine_deps(
+    replace_turn_controller_deps(
         bot,
         dispatch_planner=bot._dispatch_planner,
         **engine_changes,
@@ -171,12 +171,12 @@ def _replace_dispatch_planner_deps(bot: AgentBot, **changes: object) -> Dispatch
     return updated_planner
 
 
-def _replace_response_coordinator_runtime_deps(
+def _replace_response_runner_runtime_deps(
     bot: AgentBot,
     **changes: object,
-) -> ResponseCoordinator:
+) -> ResponseRunner:
     """Rebuild the response coordinator with updated runtime-captured deps."""
-    return replace_response_coordinator_deps(bot, **changes)
+    return replace_response_runner_deps(bot, **changes)
 
 
 def _set_knowledge_for_agent(bot: AgentBot, knowledge_for_agent: MagicMock) -> MagicMock:
@@ -1149,10 +1149,10 @@ class TestAgentBot:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("enable_streaming", [True, False])
     @patch("mindroom.delivery_gateway.get_latest_thread_event_id_if_needed")
-    @patch("mindroom.response_coordinator.ai_response")
-    @patch("mindroom.response_coordinator.stream_agent_response")
+    @patch("mindroom.response_runner.ai_response")
+    @patch("mindroom.response_runner.stream_agent_response")
     @patch("mindroom.conversation_resolver.ConversationResolver.fetch_thread_history")
-    @patch("mindroom.response_coordinator.should_use_streaming")
+    @patch("mindroom.response_runner.should_use_streaming")
     async def test_agent_bot_on_message_mentioned(  # noqa: PLR0915
         self,
         mock_should_use_streaming: AsyncMock,
@@ -1317,11 +1317,11 @@ class TestAgentBot:
         bot.client.room_send.return_value = _room_send_response("$response")
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         mock_ai = AsyncMock(return_value="Handled")
-        with patch_response_coordinator_module(
+        with patch_response_runner_module(
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._response_coordinator.process_and_respond(
+            delivery = await bot._response_runner.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -1363,11 +1363,11 @@ class TestAgentBot:
         bot.client.room_send.return_value = _room_send_response("$response")
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         mock_ai = AsyncMock(return_value="Handled")
-        with patch_response_coordinator_module(
+        with patch_response_runner_module(
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._response_coordinator.process_and_respond(
+            delivery = await bot._response_runner.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -1419,11 +1419,11 @@ class TestAgentBot:
         ) as mock_send_streaming_response:
             mock_stream_agent_response.return_value = mock_streaming_response()
             mock_send_streaming_response.return_value = ("$response", "chunk")
-            with patch_response_coordinator_module(
+            with patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                delivery = await bot._response_coordinator.process_and_respond_streaming(
+                delivery = await bot._response_runner.process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Please reply in thread",
@@ -1472,11 +1472,11 @@ class TestAgentBot:
             new_callable=AsyncMock,
         ) as mock_send_streaming_response:
             mock_send_streaming_response.return_value = ("$response", "chunk")
-            with patch_response_coordinator_module(
+            with patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                delivery = await bot._response_coordinator.process_and_respond_streaming(
+                delivery = await bot._response_runner.process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Hello",
@@ -1512,11 +1512,11 @@ class TestAgentBot:
 
         mock_ai = AsyncMock(side_effect=fake_ai_response)
         attachment_ids = ["att_image", "att_zip"]
-        with patch_response_coordinator_module(
+        with patch_response_runner_module(
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            await bot._response_coordinator.process_and_respond(
+            await bot._response_runner.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please inspect attachments",
@@ -1570,12 +1570,12 @@ class TestAgentBot:
                 new_callable=AsyncMock,
                 side_effect=_consuming_send_streaming,
             ) as mock_send_streaming_response,
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=fake_stream_agent_response,
             ),
         ):
-            await bot._response_coordinator.process_and_respond_streaming(
+            await bot._response_runner.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please inspect attachments",
@@ -1655,12 +1655,12 @@ class TestAgentBot:
                 new_callable=AsyncMock,
                 side_effect=_consuming_send_streaming,
             ) as mock_send_streaming_response,
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=fake_stream_agent_response,
             ),
         ):
-            await bot._response_coordinator.process_and_respond_streaming(
+            await bot._response_runner.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Hello",
@@ -1719,12 +1719,12 @@ class TestAgentBot:
                 side_effect=_consuming_send_streaming,
             ),
             pytest.raises(asyncio.CancelledError),
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=fake_stream_agent_response,
             ),
         ):
-            await bot._response_coordinator.process_and_respond_streaming(
+            await bot._response_runner.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Cancel me",
@@ -1768,12 +1768,12 @@ class TestAgentBot:
                     tool_trace=[],
                 ),
             ),
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ),
         ):
-            delivery = await bot._response_coordinator.process_and_respond_streaming(
+            delivery = await bot._response_runner.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please continue",
@@ -1822,11 +1822,11 @@ class TestAgentBot:
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         bot.hook_registry = HookRegistry.from_plugins([_hook_plugin("hooked", [before_hook, after_hook])])
         mock_ai = AsyncMock(return_value="Handled")
-        with patch_response_coordinator_module(
+        with patch_response_runner_module(
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._response_coordinator.process_and_respond(
+            delivery = await bot._response_runner.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -1875,11 +1875,11 @@ class TestAgentBot:
 
         try:
             mock_ai_response = AsyncMock(return_value="Handled")
-            with patch_response_coordinator_module(
+            with patch_response_runner_module(
                 typing_indicator=noop_typing_indicator,
                 ai_response=mock_ai_response,
             ):
-                await bot._response_coordinator.process_and_respond(
+                await bot._response_runner.process_and_respond(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Please continue",
@@ -1943,11 +1943,11 @@ class TestAgentBot:
             ) as mock_edit_message,
         ):
             mock_send_streaming_response.return_value = ("$response", "chunk")
-            with patch_response_coordinator_module(
+            with patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                delivery = await bot._response_coordinator.process_and_respond_streaming(
+                delivery = await bot._response_runner.process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Please reply in thread",
@@ -2004,11 +2004,11 @@ class TestAgentBot:
                 new_callable=AsyncMock,
             ) as mock_send_streaming_response:
                 mock_send_streaming_response.return_value = ("$response", "chunk")
-                with patch_response_coordinator_module(
+                with patch_response_runner_module(
                     typing_indicator=noop_typing_indicator,
                     stream_agent_response=mock_stream,
                 ):
-                    await bot._response_coordinator.process_and_respond_streaming(
+                    await bot._response_runner.process_and_respond_streaming(
                         _response_request(
                             room_id="!test:localhost",
                             prompt="Please continue",
@@ -2066,7 +2066,7 @@ class TestAgentBot:
                 "mindroom.delivery_gateway.edit_message",
                 new=AsyncMock(return_value=_room_send_response("$edit")),
             ) as mock_edit_message,
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 should_use_streaming=AsyncMock(return_value=False),
                 team_response=AsyncMock(return_value="Team reply"),
@@ -2117,7 +2117,7 @@ class TestAgentBot:
                 "mindroom.delivery_gateway.edit_message",
                 new=AsyncMock(return_value=_room_send_response("$edit")),
             ),
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 should_use_streaming=AsyncMock(return_value=False),
                 team_response=AsyncMock(return_value="Team reply"),
@@ -2200,7 +2200,7 @@ class TestAgentBot:
                 "mindroom.delivery_gateway.edit_message",
                 new=AsyncMock(return_value=_room_send_response("$edit")),
             ) as mock_edit_message,
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 should_use_streaming=AsyncMock(return_value=False),
                 team_response=AsyncMock(return_value="Team reply"),
@@ -2285,7 +2285,7 @@ class TestAgentBot:
             reason="Suppressed placeholder response",
         )
         assert (
-            unwrap_extracted_collaborator(bot._response_coordinator).resolve_response_event_id(
+            unwrap_extracted_collaborator(bot._response_runner).resolve_response_event_id(
                 delivery_result=delivery,
                 tracked_event_id="$placeholder",
                 existing_event_id="$placeholder",
@@ -2348,7 +2348,7 @@ class TestAgentBot:
         assert delivery.event_id is None
         redact_message_event.assert_not_awaited()
         assert (
-            unwrap_extracted_collaborator(bot._response_coordinator).resolve_response_event_id(
+            unwrap_extracted_collaborator(bot._response_runner).resolve_response_event_id(
                 delivery_result=delivery,
                 tracked_event_id="$existing",
                 existing_event_id="$existing",
@@ -2455,8 +2455,8 @@ class TestAgentBot:
         )
 
         with (
-            patch("mindroom.response_coordinator.typing_indicator", _noop_typing_indicator),
-            patch("mindroom.response_coordinator.stream_agent_response") as mock_stream_agent_response,
+            patch("mindroom.response_runner.typing_indicator", _noop_typing_indicator),
+            patch("mindroom.response_runner.stream_agent_response") as mock_stream_agent_response,
             patch(
                 "mindroom.delivery_gateway.send_streaming_response",
                 new_callable=AsyncMock,
@@ -2464,7 +2464,7 @@ class TestAgentBot:
         ):
             mock_stream_agent_response.return_value = mock_streaming_response()
             mock_send_streaming_response.return_value = ("$streaming", "chunk")
-            delivery = await bot._response_coordinator.process_and_respond_streaming(
+            delivery = await bot._response_runner.process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please reply in thread",
@@ -2488,7 +2488,7 @@ class TestAgentBot:
             reason="Suppressed streamed response",
         )
         assert (
-            unwrap_extracted_collaborator(bot._response_coordinator).resolve_response_event_id(
+            unwrap_extracted_collaborator(bot._response_runner).resolve_response_event_id(
                 delivery_result=delivery,
                 tracked_event_id="$streaming",
                 existing_event_id=None,
@@ -2504,10 +2504,10 @@ class TestAgentBot:
             delivery_kind=None,
             suppressed=False,
         )
-        coordinator = MagicMock(spec=ResponseCoordinator)
+        coordinator = MagicMock(spec=ResponseRunner)
 
         assert (
-            ResponseCoordinator.resolve_response_event_id(
+            ResponseRunner.resolve_response_event_id(
                 coordinator,
                 delivery_result=delivery,
                 tracked_event_id="$placeholder",
@@ -2540,7 +2540,7 @@ class TestAgentBot:
 {"question":"Choose","options":[{"emoji":"✅","label":"Yes","value":"yes"}]}
 ```"""
         with (
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 should_use_streaming=AsyncMock(return_value=False),
                 team_response=AsyncMock(return_value=interactive_response),
@@ -2728,11 +2728,11 @@ class TestAgentBot:
             return "Hidden tool call output"
 
         mock_ai = AsyncMock(side_effect=fake_ai_response)
-        with patch_response_coordinator_module(
+        with patch_response_runner_module(
             typing_indicator=noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            delivery = await bot._response_coordinator.process_and_respond(
+            delivery = await bot._response_runner.process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Summarize README",
@@ -2787,12 +2787,12 @@ class TestAgentBot:
         bot._send_response = AsyncMock(return_value="$response")
         install_send_response_mock(bot, bot._send_response)
         mock_ai = AsyncMock(return_value="Skill response")
-        with patch_response_coordinator_module(
+        with patch_response_runner_module(
             typing_indicator=noop_typing_indicator,
             ai_response=mock_ai,
             create_background_task=MagicMock(side_effect=discard_background_task),
         ):
-            await bot._response_coordinator.send_skill_command_response(
+            await bot._response_runner.send_skill_command_response(
                 room_id="!test:localhost",
                 reply_to_event_id="$event",
                 thread_id=None,
@@ -2843,14 +2843,14 @@ class TestAgentBot:
         install_send_response_mock(bot, bot._send_response)
         mock_ai = AsyncMock(return_value="Skill response")
         mock_reprioritize = MagicMock()
-        with patch_response_coordinator_module(
+        with patch_response_runner_module(
             typing_indicator=noop_typing_indicator,
             ai_response=mock_ai,
             reprioritize_auto_flush_sessions=mock_reprioritize,
             mark_auto_flush_dirty_session=MagicMock(),
             create_background_task=MagicMock(),
         ):
-            await bot._response_coordinator.send_skill_command_response(
+            await bot._response_runner.send_skill_command_response(
                 room_id="!test:localhost",
                 reply_to_event_id="$event",
                 thread_id=None,
@@ -2918,7 +2918,7 @@ class TestAgentBot:
 
         with (
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
                     return_value=DeliveryResult(
@@ -2929,17 +2929,17 @@ class TestAgentBot:
                 ),
             ) as mock_process,
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
-            patch("mindroom.response_coordinator.should_use_streaming", new_callable=AsyncMock, return_value=False),
-            patch("mindroom.response_coordinator.create_background_task", side_effect=schedule_background_task),
+            patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.response_runner.create_background_task", side_effect=schedule_background_task),
             patch(
-                "mindroom.response_coordinator.store_conversation_memory",
+                "mindroom.response_runner.store_conversation_memory",
                 side_effect=fake_store_conversation_memory,
             ),
-            patch("mindroom.response_coordinator.datetime") as mock_datetime,
+            patch("mindroom.response_runner.datetime") as mock_datetime,
             patch.object(
                 bot._conversation_resolver,
                 "fetch_thread_history",
@@ -3030,7 +3030,7 @@ class TestAgentBot:
 
         with (
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
                     return_value=DeliveryResult(
@@ -3041,12 +3041,12 @@ class TestAgentBot:
                 ),
             ) as mock_process,
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
-            patch("mindroom.response_coordinator.datetime") as mock_datetime,
-            patch_response_coordinator_module(
+            patch("mindroom.response_runner.datetime") as mock_datetime,
+            patch_response_runner_module(
                 should_use_streaming=AsyncMock(return_value=False),
                 create_background_task=schedule_background_task,
                 store_conversation_memory=fake_store_conversation_memory,
@@ -3121,7 +3121,7 @@ class TestAgentBot:
 
         with (
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "process_and_respond_streaming",
                 new=AsyncMock(
                     return_value=DeliveryResult(
@@ -3132,11 +3132,11 @@ class TestAgentBot:
                 ),
             ) as mock_process,
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 should_use_streaming=AsyncMock(return_value=True),
                 create_background_task=schedule_background_task,
                 store_conversation_memory=fake_store_conversation_memory,
@@ -3213,7 +3213,7 @@ class TestAgentBot:
 
         with (
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
                     return_value=DeliveryResult(
@@ -3224,7 +3224,7 @@ class TestAgentBot:
                 ),
             ) as mock_process,
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
@@ -3233,7 +3233,7 @@ class TestAgentBot:
                 "get_thread_history",
                 new=AsyncMock(side_effect=cached_history_refresh),
             ) as mock_get_thread_history,
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 should_use_streaming=AsyncMock(return_value=False),
                 prepare_memory_and_model_context=passthrough_prepare_context,
                 reprioritize_auto_flush_sessions=MagicMock(),
@@ -3313,7 +3313,7 @@ class TestAgentBot:
 
         with (
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
                     return_value=DeliveryResult(
@@ -3323,10 +3323,10 @@ class TestAgentBot:
                     ),
                 ),
             ),
-            patch("mindroom.response_coordinator.should_use_streaming", new_callable=AsyncMock, return_value=False),
-            patch("mindroom.response_coordinator.create_background_task", side_effect=schedule_background_task),
+            patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.response_runner.create_background_task", side_effect=schedule_background_task),
             patch(
-                "mindroom.response_coordinator.store_conversation_memory",
+                "mindroom.response_runner.store_conversation_memory",
                 side_effect=fake_store_conversation_memory,
             ),
             patch(
@@ -3387,14 +3387,14 @@ class TestAgentBot:
         bot._knowledge_access_support.for_agent = MagicMock(return_value=None)
 
         with (
-            patch("mindroom.response_coordinator.typing_indicator", _noop_typing_indicator),
-            patch("mindroom.response_coordinator.should_use_streaming", new_callable=AsyncMock, return_value=False),
-            patch("mindroom.response_coordinator.ai_response", new_callable=AsyncMock, return_value="ok"),
+            patch("mindroom.response_runner.typing_indicator", _noop_typing_indicator),
+            patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.response_runner.ai_response", new_callable=AsyncMock, return_value="ok"),
             patch("mindroom.delivery_gateway.send_message", new=AsyncMock(return_value="$response")),
-            patch("mindroom.response_coordinator.create_background_task", side_effect=schedule_background_task),
+            patch("mindroom.response_runner.create_background_task", side_effect=schedule_background_task),
             patch("mindroom.post_response_effects.create_background_task", side_effect=schedule_background_task),
             patch(
-                "mindroom.response_coordinator.store_conversation_memory",
+                "mindroom.response_runner.store_conversation_memory",
                 side_effect=fake_store_conversation_memory,
             ),
             patch(
@@ -3451,7 +3451,7 @@ class TestAgentBot:
 
         with (
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
                     return_value=DeliveryResult(
@@ -3462,13 +3462,13 @@ class TestAgentBot:
                 ),
             ),
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
-            patch("mindroom.response_coordinator.should_use_streaming", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=False),
             patch(
-                "mindroom.response_coordinator.apply_post_response_effects",
+                "mindroom.response_runner.apply_post_response_effects",
                 new=AsyncMock(side_effect=fake_post_effects),
             ),
         ):
@@ -3641,7 +3641,7 @@ class TestAgentBot:
         )
 
         with (
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 should_use_streaming=AsyncMock(return_value=True),
                 typing_indicator=_noop_typing_indicator,
                 team_response_stream=lambda *_args, **_kwargs: fake_team_response_stream(),
@@ -3652,7 +3652,7 @@ class TestAgentBot:
                 "mindroom.delivery_gateway.send_streaming_response",
                 new=AsyncMock(return_value=("$team-response", "Team reply")),
             ),
-            patch("mindroom.response_coordinator.create_background_task", side_effect=schedule_background_task),
+            patch("mindroom.response_runner.create_background_task", side_effect=schedule_background_task),
             patch("mindroom.post_response_effects.create_background_task", side_effect=schedule_background_task),
             patch("mindroom.bot.store_conversation_memory", side_effect=fake_store_conversation_memory),
             patch(
@@ -3736,14 +3736,14 @@ class TestAgentBot:
         bot.orchestrator = MagicMock()
         mock_team_response = AsyncMock()
         with (
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 should_use_streaming=AsyncMock(return_value=True),
                 typing_indicator=noop_typing_indicator,
                 team_response_stream=fake_team_response_stream,
                 team_response=mock_team_response,
             ),
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
@@ -3808,7 +3808,7 @@ class TestAgentBot:
 
         with (
             patch.object(
-                unwrap_extracted_collaborator(bot._response_coordinator),
+                unwrap_extracted_collaborator(bot._response_runner),
                 "run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
@@ -3816,7 +3816,7 @@ class TestAgentBot:
                 "mindroom.delivery_gateway.send_streaming_response",
                 new=AsyncMock(return_value=("$placeholder", "stream chunk")),
             ),
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 should_use_streaming=AsyncMock(return_value=True),
                 typing_indicator=noop_typing_indicator,
                 team_response_stream=fake_team_response_stream,
@@ -3865,7 +3865,7 @@ class TestAgentBot:
         replace_delivery_gateway_deps(bot, redact_message_event=bot._redact_message_event)
 
         with (
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 should_use_streaming=AsyncMock(return_value=False),
                 typing_indicator=_noop_typing_indicator,
                 team_response=AsyncMock(return_value="Team handled"),
@@ -4060,7 +4060,7 @@ class TestAgentBot:
             reply_to_event_id="$root_b",
         )
 
-        coordinator = unwrap_extracted_collaborator(bot._response_coordinator)
+        coordinator = unwrap_extracted_collaborator(bot._response_runner)
         assert coordinator._response_lifecycle_lock(first) is coordinator._response_lifecycle_lock(first)
         assert coordinator._response_lifecycle_lock(first) is not coordinator._response_lifecycle_lock(second)
 
@@ -4106,7 +4106,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=False),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=False),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=False),
         ):
             await self._invoke_handler(bot, handler_name, room, event)
 
@@ -4172,7 +4172,7 @@ class TestAgentBot:
         wrap_extracted_collaborators(bot, "_dispatch_planner")
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch.object(bot._dispatch_planner, "can_reply_to_sender", return_value=False),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
         ):
@@ -4233,7 +4233,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -4341,7 +4341,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -4471,7 +4471,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -4544,7 +4544,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -4626,7 +4626,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -4705,7 +4705,7 @@ class TestAgentBot:
             patch("mindroom.dispatch_planner.get_agents_in_thread", return_value=[]),
             patch("mindroom.dispatch_planner.has_multiple_non_agent_users_in_thread", return_value=False),
             patch("mindroom.dispatch_planner.get_available_agents_for_sender") as mock_get_available,
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.coalescing.extract_media_caption", return_value="[Attached image]"),
         ):
             mock_get_available.return_value = [
@@ -4800,7 +4800,7 @@ class TestAgentBot:
             patch("mindroom.dispatch_planner.get_agents_in_thread", return_value=[]),
             patch("mindroom.dispatch_planner.has_multiple_non_agent_users_in_thread", return_value=False),
             patch("mindroom.dispatch_planner.get_available_agents_for_sender") as mock_get_available,
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch(
                 "mindroom.inbound_turn_normalizer.register_file_or_video_attachment",
                 new_callable=AsyncMock,
@@ -5098,7 +5098,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -5191,7 +5191,7 @@ class TestAgentBot:
                     config.get_ids(runtime_paths_for(config))["general"],
                 ],
             ),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.coalescing.extract_media_caption", return_value="[Attached image]"),
             patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock, return_value=None),
@@ -5262,7 +5262,7 @@ class TestAgentBot:
                 "mindroom.dispatch_planner.get_available_agents_for_sender",
                 return_value=[config.get_ids(runtime_paths_for(config))["calculator"]],
             ),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.coalescing.extract_media_caption", return_value="[Attached image]"),
             patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock, return_value=None),
@@ -5321,7 +5321,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.extract_agent_name", return_value="router"),
             patch("mindroom.bot.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.bot.interactive.handle_text_response"),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.dispatch_planner.get_agents_in_thread", return_value=[]),
@@ -6036,7 +6036,7 @@ class TestAgentBot:
             ),
             patch("mindroom.dispatch_planner.should_agent_respond", return_value=False) as mock_should_respond,
             patch.object(
-                bot._response_coordinator,
+                bot._response_runner,
                 "has_active_response_for_target",
                 return_value=True,
             ) as mock_has_active_response,
@@ -6350,7 +6350,7 @@ class TestAgentBot:
         install_generate_response_mock(bot, generate_response)
         _replace_dispatch_planner_deps(
             bot,
-            response_coordinator=bot._response_coordinator,
+            response_runner=bot._response_runner,
             handled_turn_ledger=bot.handled_turn_ledger,
         )
 
@@ -6369,7 +6369,7 @@ class TestAgentBot:
             ),
             patch.object(bot._dispatch_planner, "log_dispatch_latency"),
         ):
-            await bot._turn_engine._dispatch_text_message(
+            await bot._turn_controller._dispatch_text_message(
                 room,
                 _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
             )
@@ -6433,7 +6433,7 @@ class TestAgentBot:
             ) as mock_build_payload,
             patch.object(bot._dispatch_planner, "execute_response_action", new=AsyncMock()) as mock_execute,
         ):
-            await bot._turn_engine._dispatch_text_message(
+            await bot._turn_controller._dispatch_text_message(
                 room,
                 _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
             )
@@ -6501,10 +6501,10 @@ class TestAgentBot:
         with (
             patch.object(bot._inbound_turn_normalizer, "resolve_text_event", new=AsyncMock(return_value=event)),
             patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
-            patch.object(bot._turn_engine, "_has_newer_unresponded_in_thread", return_value=False),
-            patch.object(bot._turn_engine, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
+            patch.object(bot._turn_controller, "_has_newer_unresponded_in_thread", return_value=False),
+            patch.object(bot._turn_controller, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
         ):
-            await bot._turn_engine._dispatch_text_message(
+            await bot._turn_controller._dispatch_text_message(
                 room,
                 _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
                 handled_turn=HandledTurnState.create(
@@ -6618,10 +6618,10 @@ class TestAgentBot:
                 "execute_router_relay",
                 new=AsyncMock(side_effect=fake_execute_router_relay),
             ),
-            patch.object(bot._turn_engine, "_has_newer_unresponded_in_thread", return_value=False),
-            patch.object(bot._turn_engine, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
+            patch.object(bot._turn_controller, "_has_newer_unresponded_in_thread", return_value=False),
+            patch.object(bot._turn_controller, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
         ):
-            await bot._turn_engine._dispatch_text_message(
+            await bot._turn_controller._dispatch_text_message(
                 room,
                 _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
                 handled_turn=coalesced_turn,
@@ -6668,10 +6668,10 @@ class TestAgentBot:
         )
 
         with (
-            patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
+            patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
             patch.object(bot._coalescing_gate, "enqueue", new=AsyncMock()) as mock_enqueue,
         ):
-            await bot._turn_engine._enqueue_for_dispatch(event, room, source_kind="message")
+            await bot._turn_controller._enqueue_for_dispatch(event, room, source_kind="message")
 
         mock_dispatch.assert_awaited_once_with(room, event, "@user:localhost")
         mock_enqueue.assert_not_awaited()
@@ -6730,7 +6730,7 @@ class TestAgentBot:
 
         with (
             patch.object(
-                bot._turn_engine,
+                bot._turn_controller,
                 "_precheck_dispatch_event",
                 return_value=_PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
             ),
@@ -6742,19 +6742,19 @@ class TestAgentBot:
                 "mindroom.conversation_resolver.ConversationResolver.build_ingress_envelope",
                 return_value=envelope,
             ),
-            patch.object(bot._turn_engine, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
-            patch("mindroom.turn_engine.should_handle_interactive_text_response", return_value=False),
+            patch.object(bot._turn_controller, "_should_skip_deep_synthetic_full_dispatch", return_value=False),
+            patch("mindroom.turn_controller.should_handle_interactive_text_response", return_value=False),
             patch.object(
                 bot._conversation_resolver,
                 "coalescing_thread_id",
                 new=AsyncMock(return_value="$thread_root"),
             ),
             patch.object(
-                bot._response_coordinator,
+                bot._response_runner,
                 "has_active_response_for_target",
                 return_value=True,
             ) as mock_has_active_response,
-            patch.object(bot._turn_engine, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
+            patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock()) as mock_dispatch,
             patch.object(bot._coalescing_gate, "enqueue", new=AsyncMock()) as mock_enqueue,
         ):
             await bot._on_message(room, event)
@@ -6824,11 +6824,11 @@ class TestAgentBot:
         mock_send_response = AsyncMock()
         mock_generate_team_response = AsyncMock(return_value="$team-response")
         install_send_response_mock(bot, mock_send_response)
-        bot._response_coordinator.generate_team_response_helper = mock_generate_team_response
+        bot._response_runner.generate_team_response_helper = mock_generate_team_response
         _replace_dispatch_planner_deps(
             bot,
             delivery_gateway=bot._delivery_gateway,
-            response_coordinator=bot._response_coordinator,
+            response_runner=bot._response_runner,
             handled_turn_ledger=bot.handled_turn_ledger,
         )
 
@@ -6860,7 +6860,7 @@ class TestAgentBot:
         )
 
     @pytest.mark.asyncio
-    async def test_execute_dispatch_action_does_not_send_placeholder_before_response_coordinator(
+    async def test_execute_dispatch_action_does_not_send_placeholder_before_response_runner(
         self,
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
@@ -6905,7 +6905,7 @@ class TestAgentBot:
         _replace_dispatch_planner_deps(
             bot,
             delivery_gateway=bot._delivery_gateway,
-            response_coordinator=bot._response_coordinator,
+            response_runner=bot._response_runner,
             handled_turn_ledger=bot.handled_turn_ledger,
         )
 
@@ -6989,7 +6989,7 @@ class TestAgentBot:
 
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
-            patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch(
                 "mindroom.dispatch_planner.decide_team_formation",
@@ -7230,7 +7230,7 @@ class TestAgentBot:
 
         with (
             patch.object(
-                bot._response_coordinator,
+                bot._response_runner,
                 "generate_response",
                 new=AsyncMock(side_effect=SuppressedPlaceholderCleanupError("failed cleanup")),
             ),
@@ -7292,7 +7292,7 @@ class TestAgentBot:
             return DispatchPayload(prompt="help me")
 
         with (
-            patch.object(bot._response_coordinator, "generate_response", new=AsyncMock(return_value=None)),
+            patch.object(bot._response_runner, "generate_response", new=AsyncMock(return_value=None)),
             patch.object(bot._dispatch_planner, "log_dispatch_latency", create=True),
         ):
             await bot._dispatch_planner.execute_response_action(
@@ -7352,7 +7352,7 @@ class TestAgentBot:
         _replace_dispatch_planner_deps(
             bot,
             logger=bot.logger,
-            response_coordinator=bot._response_coordinator,
+            response_runner=bot._response_runner,
             handled_turn_ledger=bot.handled_turn_ledger,
         )
 
@@ -7392,11 +7392,11 @@ class TestAgentBot:
     @patch("mindroom.teams.create_agent")
     @patch("mindroom.teams.get_model_instance")
     @patch("mindroom.teams.Team.arun")
-    @patch("mindroom.response_coordinator.ai_response")
-    @patch("mindroom.response_coordinator.stream_agent_response")
+    @patch("mindroom.response_runner.ai_response")
+    @patch("mindroom.response_runner.stream_agent_response")
     @patch("mindroom.matrix.conversation_access.MatrixConversationAccess.get_thread_snapshot")
     @patch("mindroom.matrix.conversation_access.MatrixConversationAccess.get_thread_history")
-    @patch("mindroom.response_coordinator.should_use_streaming")
+    @patch("mindroom.response_runner.should_use_streaming")
     @patch("mindroom.delivery_gateway.get_latest_thread_event_id_if_needed")
     async def test_agent_bot_thread_response(  # noqa: PLR0915
         self,

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -23,7 +23,7 @@ from tests.conftest import (
     TEST_ACCESS_TOKEN,
     TEST_PASSWORD,
     bind_runtime_paths,
-    patch_response_coordinator_module,
+    patch_response_runner_module,
     runtime_paths_for,
 )
 
@@ -150,7 +150,7 @@ async def test_agent_processes_direct_mention(
                 "mindroom.delivery_gateway.send_streaming_response",
                 new_callable=AsyncMock,
             ) as mock_send_streaming_response,
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 stream_agent_response=mock_ai,
                 should_use_streaming=AsyncMock(return_value=True),
             ),
@@ -223,7 +223,7 @@ async def test_agent_ignores_other_agents(
         room = nio.MatrixRoom(test_room_id, mock_calculator_agent.user_id)
 
         mock_ai = AsyncMock()
-        with patch("mindroom.response_coordinator.stream_agent_response", new=mock_ai):
+        with patch("mindroom.response_runner.stream_agent_response", new=mock_ai):
             await bot._on_message(room, message_event)
 
             # Should not process the message
@@ -344,7 +344,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             mock_fetch_snapshot.return_value = thread_history
 
             mock_ai = AsyncMock(return_value="20% of 300 is 60")
-            with patch_response_coordinator_module(
+            with patch_response_runner_module(
                 ai_response=mock_ai,
                 should_use_streaming=AsyncMock(return_value=False),
             ):
@@ -412,7 +412,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
 
             mock_ai = AsyncMock()
             mock_team_response = AsyncMock(return_value="Team response")
-            with patch_response_coordinator_module(
+            with patch_response_runner_module(
                 ai_response=mock_ai,
                 team_response=mock_team_response,
                 should_use_streaming=AsyncMock(return_value=False),
@@ -484,7 +484,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             mock_fetch_snapshot.return_value = thread_history
 
             mock_ai = AsyncMock(return_value="20% of 300 is 60")
-            with patch_response_coordinator_module(
+            with patch_response_runner_module(
                 ai_response=mock_ai,
                 should_use_streaming=AsyncMock(return_value=False),
             ):

--- a/tests/test_multiple_edits.py
+++ b/tests/test_multiple_edits.py
@@ -96,7 +96,7 @@ async def test_agent_regenerates_on_multiple_edits(tmp_path: Path) -> None:
     original_event.source = original_event.__dict__["source"]
 
     # Process original message with mocked AI response
-    with patch("mindroom.response_coordinator.ai_response", AsyncMock(return_value="Original: 4")):
+    with patch("mindroom.response_runner.ai_response", AsyncMock(return_value="Original: 4")):
         await bot._on_message(room, original_event)
 
     # Verify bot responded

--- a/tests/test_preformed_team_routing.py
+++ b/tests/test_preformed_team_routing.py
@@ -26,7 +26,7 @@ from mindroom.tool_system.worker_routing import get_tool_execution_identity
 from tests.conftest import (
     bind_runtime_paths,
     make_visible_message,
-    patch_response_coordinator_module,
+    patch_response_runner_module,
     runtime_paths_for,
     test_runtime_paths,
 )
@@ -180,7 +180,7 @@ async def test_preformed_team_bot_responds_when_mentioned(config_with_team: Conf
         nio.RoomSendResponse.from_dict({"event_id": "$placeholder"}, room.room_id),
         nio.RoomSendResponse.from_dict({"event_id": "$edit"}, room.room_id),
     ]
-    with patch_response_coordinator_module(
+    with patch_response_runner_module(
         team_response=fake_team_response,
         should_use_streaming=AsyncMock(return_value=False),
         typing_indicator=_noop_typing_indicator,
@@ -256,7 +256,7 @@ async def test_preformed_team_bot_schedules_memory_save_for_all_file_members(
         return task
 
     with (
-        patch_response_coordinator_module(
+        patch_response_runner_module(
             should_use_streaming=AsyncMock(return_value=False),
             typing_indicator=_noop_typing_indicator,
             team_response=AsyncMock(return_value="team response"),
@@ -405,7 +405,7 @@ async def test_preformed_team_reply_chain_uses_existing_thread_root(config_with_
         return "🤝 Team Response (a1, a2):\n\n**a1**: ok\n\n**a2**: ok"
 
     with (
-        patch_response_coordinator_module(
+        patch_response_runner_module(
             team_response=fake_team_response,
             should_use_streaming=AsyncMock(return_value=False),
             typing_indicator=_noop_typing_indicator,
@@ -468,7 +468,7 @@ async def test_team_does_not_respond_to_different_domain_mention(config_with_tea
     room = _mock_room("!room:localhost", [team_user.user_id, "@user:localhost"])
     event = _mock_event_with_team_mention(mentioned_id, body=f"{mentioned_id} ping")
 
-    with patch_response_coordinator_module(
+    with patch_response_runner_module(
         team_response=fake_team_response,
         should_use_streaming=AsyncMock(return_value=False),
         typing_indicator=_noop_typing_indicator,

--- a/tests/test_presence_based_streaming.py
+++ b/tests/test_presence_based_streaming.py
@@ -241,8 +241,8 @@ class TestBotIntegration:
     """Test bot integration with presence-based streaming."""
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.ai_response")
-    @patch("mindroom.response_coordinator.stream_agent_response")
+    @patch("mindroom.response_runner.ai_response")
+    @patch("mindroom.response_runner.stream_agent_response")
     @patch("mindroom.matrix.presence.is_user_online")
     async def test_bot_uses_streaming_when_user_online(
         self,
@@ -310,8 +310,8 @@ class TestBotIntegration:
         mock_ai_response.assert_not_called()
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.ai_response")
-    @patch("mindroom.response_coordinator.stream_agent_response")
+    @patch("mindroom.response_runner.ai_response")
+    @patch("mindroom.response_runner.stream_agent_response")
     @patch("mindroom.matrix.presence.is_user_online")
     async def test_bot_uses_non_streaming_when_user_offline(
         self,

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -40,9 +40,9 @@ from mindroom.inbound_turn_normalizer import DispatchPayload
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutcome, apply_post_response_effects
-from mindroom.response_coordinator import ResponseCoordinator, ResponseRequest
+from mindroom.response_runner import ResponseRequest, ResponseRunner
 from mindroom.teams import TeamMode, _create_team_instance
-from mindroom.turn_engine import _PrecheckedEvent
+from mindroom.turn_controller import _PrecheckedEvent
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
@@ -249,14 +249,14 @@ async def test_generate_response_sets_queued_signal_for_human_ingress(tmp_path: 
     bot = _bot(tmp_path)
     response_envelope = _envelope()
     response_target = response_envelope.target
-    coordinator = unwrap_extracted_collaborator(bot._response_coordinator)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
     queued_signal = coordinator._get_or_create_queued_signal(response_target)
     await lifecycle_lock.acquire()
 
     try:
         with patch.object(
-            ResponseCoordinator,
+            ResponseRunner,
             "generate_response_locked",
             new=AsyncMock(return_value="$response"),
         ) as mock_locked:
@@ -288,14 +288,14 @@ async def test_generate_response_skips_signal_for_automation_ingress(tmp_path: P
     bot = _bot(tmp_path)
     response_envelope = _envelope(source_kind="scheduled")
     response_target = response_envelope.target
-    coordinator = unwrap_extracted_collaborator(bot._response_coordinator)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
     queued_signal = coordinator._get_or_create_queued_signal(response_target)
     await lifecycle_lock.acquire()
 
     try:
         with patch.object(
-            ResponseCoordinator,
+            ResponseRunner,
             "generate_response_locked",
             new=AsyncMock(return_value="$response"),
         ):
@@ -325,14 +325,14 @@ async def test_generate_response_skips_signal_for_automation_ingress(tmp_path: P
 async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_path: Path) -> None:
     """A second human turn should queue even before the first acquires the lifecycle lock."""
     bot = _bot(tmp_path)
-    coordinator = unwrap_extracted_collaborator(bot._response_coordinator)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lock = _PrelockBarrierLock()
     response_envelope = _envelope()
     response_target = response_envelope.target
     observed_pending: dict[str, int] = {}
 
     async def fake_generate_response_locked(
-        _self: ResponseCoordinator,
+        _self: ResponseRunner,
         request: ResponseRequest,
         *,
         resolved_target: MessageTarget,
@@ -345,7 +345,7 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
 
     with (
         patch.object(coordinator, "_response_lifecycle_lock", return_value=lock),
-        patch.object(ResponseCoordinator, "generate_response_locked", new=fake_generate_response_locked),
+        patch.object(ResponseRunner, "generate_response_locked", new=fake_generate_response_locked),
     ):
         first_task = asyncio.create_task(
             bot._generate_response(
@@ -387,7 +387,7 @@ async def test_generate_response_waits_for_lock_before_starting_placeholder_life
     bot = _bot(tmp_path)
     response_envelope = _envelope(source_kind="scheduled")
     response_target = response_envelope.target
-    coordinator = unwrap_extracted_collaborator(bot._response_coordinator)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
     await lifecycle_lock.acquire()
     lifecycle_started = asyncio.Event()
@@ -401,7 +401,7 @@ async def test_generate_response_waits_for_lock_before_starting_placeholder_life
     try:
         with (
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "process_and_respond",
                 new=AsyncMock(
                     return_value=DeliveryResult(
@@ -412,13 +412,13 @@ async def test_generate_response_waits_for_lock_before_starting_placeholder_life
                 ),
             ),
             patch.object(
-                ResponseCoordinator,
+                ResponseRunner,
                 "run_cancellable_response",
                 new=AsyncMock(side_effect=fake_run_cancellable_response),
             ) as mock_run_cancellable_response,
-            patch("mindroom.response_coordinator.should_use_streaming", new_callable=AsyncMock, return_value=False),
-            patch("mindroom.response_coordinator.reprioritize_auto_flush_sessions", new=MagicMock()),
-            patch("mindroom.response_coordinator.apply_post_response_effects", new=AsyncMock()),
+            patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=False),
+            patch("mindroom.response_runner.reprioritize_auto_flush_sessions", new=MagicMock()),
+            patch("mindroom.response_runner.apply_post_response_effects", new=AsyncMock()),
         ):
             task = asyncio.create_task(
                 bot._generate_response(
@@ -446,7 +446,7 @@ async def test_generate_response_waits_for_lock_before_starting_placeholder_life
 async def test_refresh_thread_history_after_lock_refreshes_empty_thread_history(tmp_path: Path) -> None:
     """Threaded turns with an empty cached history should still refresh after lock handoff."""
     bot = _bot(tmp_path)
-    coordinator = unwrap_extracted_collaborator(bot._response_coordinator)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
     resolver = unwrap_extracted_collaborator(coordinator.deps.resolver)
     fresh_history = [SimpleNamespace(event_id="$reply", body="updated")]
 
@@ -476,14 +476,14 @@ async def test_generate_team_response_helper_sets_queued_signal(tmp_path: Path) 
     bot = _bot(tmp_path)
     response_envelope = _envelope()
     response_target = response_envelope.target
-    coordinator = unwrap_extracted_collaborator(bot._response_coordinator)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
     queued_signal = coordinator._get_or_create_queued_signal(response_target)
     await lifecycle_lock.acquire()
 
     try:
         with patch.object(
-            ResponseCoordinator,
+            ResponseRunner,
             "generate_team_response_helper_locked",
             new=AsyncMock(return_value="$team-response"),
         ) as mock_locked:
@@ -517,14 +517,14 @@ async def test_generate_response_preserves_later_queued_human_message(tmp_path: 
     bot = _bot(tmp_path)
     response_envelope = _envelope()
     response_target = response_envelope.target
-    coordinator = unwrap_extracted_collaborator(bot._response_coordinator)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
     queued_signal = coordinator._get_or_create_queued_signal(response_target)
     observed_pending: list[bool] = []
     second_turn_started = asyncio.Event()
     allow_turns_to_finish = asyncio.Event()
 
-    async def fake_locked(_self: ResponseCoordinator, *_args: object, **_kwargs: object) -> str:
+    async def fake_locked(_self: ResponseRunner, *_args: object, **_kwargs: object) -> str:
         observed_pending.append(queued_signal.has_pending_human_messages())
         if len(observed_pending) == 1:
             second_turn_started.set()
@@ -533,7 +533,7 @@ async def test_generate_response_preserves_later_queued_human_message(tmp_path: 
 
     await lifecycle_lock.acquire()
     try:
-        with patch.object(ResponseCoordinator, "generate_response_locked", new=fake_locked):
+        with patch.object(ResponseRunner, "generate_response_locked", new=fake_locked):
             task_b = asyncio.create_task(
                 bot._generate_response(
                     room_id="!room:localhost",
@@ -584,14 +584,14 @@ async def test_generate_team_response_preserves_later_queued_human_message(tmp_p
     bot = _bot(tmp_path)
     response_envelope = _envelope()
     response_target = response_envelope.target
-    coordinator = unwrap_extracted_collaborator(bot._response_coordinator)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
     queued_signal = coordinator._get_or_create_queued_signal(response_target)
     observed_pending: list[bool] = []
     second_turn_started = asyncio.Event()
     allow_turns_to_finish = asyncio.Event()
 
-    async def fake_locked(_self: ResponseCoordinator, *_args: object, **_kwargs: object) -> str:
+    async def fake_locked(_self: ResponseRunner, *_args: object, **_kwargs: object) -> str:
         observed_pending.append(queued_signal.has_pending_human_messages())
         if len(observed_pending) == 1:
             second_turn_started.set()
@@ -600,7 +600,7 @@ async def test_generate_team_response_preserves_later_queued_human_message(tmp_p
 
     await lifecycle_lock.acquire()
     try:
-        with patch.object(ResponseCoordinator, "generate_team_response_helper_locked", new=fake_locked):
+        with patch.object(ResponseRunner, "generate_team_response_helper_locked", new=fake_locked):
             task_b = asyncio.create_task(
                 bot._generate_team_response_helper(
                     room_id="!room:localhost",
@@ -669,21 +669,21 @@ async def test_coalesced_dispatch_never_creates_queued_signal(tmp_path: Path) ->
         patch.object(bot._inbound_turn_normalizer, "resolve_text_event", new=AsyncMock(return_value=event)),
         patch.object(bot._dispatch_planner, "prepare_dispatch", new=AsyncMock(return_value=dispatch)),
         patch.object(bot._conversation_resolver, "hydrate_dispatch_context", new=AsyncMock()),
-        patch.object(bot._turn_engine, "_has_newer_unresponded_in_thread", return_value=True),
+        patch.object(bot._turn_controller, "_has_newer_unresponded_in_thread", return_value=True),
         patch.object(
             bot._dispatch_planner,
             "plan_dispatch",
             new=AsyncMock(return_value=DispatchPlan(kind="ignore")),
         ) as mock_plan,
     ):
-        await bot._turn_engine._dispatch_text_message(
+        await bot._turn_controller._dispatch_text_message(
             room,
             _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
         )
 
     assert bot.handled_turn_ledger.has_responded("$older")
     mock_plan.assert_not_awaited()
-    coordinator = unwrap_extracted_collaborator(bot._response_coordinator)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
     assert coordinator._thread_queued_signals == {}
 
 

--- a/tests/test_routing_integration.py
+++ b/tests/test_routing_integration.py
@@ -28,7 +28,7 @@ class TestRoutingIntegration:
     """Integration tests for routing behavior with multiple agents."""
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.stream_agent_response")
+    @patch("mindroom.response_runner.stream_agent_response")
     @patch("mindroom.dispatch_planner.suggest_agent_for_message")
     async def test_real_scenario_research_channel(
         self,

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -105,8 +105,8 @@ class TestRoutingRegression:
     """Regression tests for routing behavior."""
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.is_user_online")
-    @patch("mindroom.response_coordinator.ai_response")
+    @patch("mindroom.response_runner.is_user_online")
+    @patch("mindroom.response_runner.ai_response")
     @patch("mindroom.dispatch_planner.suggest_agent_for_message")
     async def test_router_does_not_respond_when_agent_mentioned(
         self,
@@ -177,7 +177,7 @@ class TestRoutingRegression:
         assert mock_suggest_agent.call_count == 0
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.ai_response")
+    @patch("mindroom.response_runner.ai_response")
     @patch("mindroom.dispatch_planner.suggest_agent_for_message")
     async def test_router_activates_when_no_agent_mentioned(
         self,
@@ -623,7 +623,7 @@ class TestRoutingRegression:
     @patch("mindroom.teams.get_agent_knowledge")
     @patch("mindroom.teams.create_agent")
     @patch("mindroom.teams.Team.arun")
-    @patch("mindroom.response_coordinator.ai_response")
+    @patch("mindroom.response_runner.ai_response")
     @patch("mindroom.teams.get_model_instance")
     @patch("mindroom.config.main.Config.from_yaml")
     async def test_multiple_mentions_each_responds_once(
@@ -736,8 +736,8 @@ class TestRoutingRegression:
         assert mock_team_arun.call_count == 1  # Team formed once
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.is_user_online")
-    @patch("mindroom.response_coordinator.ai_response")
+    @patch("mindroom.response_runner.is_user_online")
+    @patch("mindroom.response_runner.ai_response")
     async def test_router_message_has_completion_marker(
         self,
         mock_ai_response: AsyncMock,

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -23,7 +23,7 @@ from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestration.runtime import SYNC_RESTART_CANCEL_MSG
-from mindroom.response_coordinator import ResponseRequest
+from mindroom.response_runner import ResponseRequest
 from mindroom.streaming import (
     CANCELLED_RESPONSE_NOTE,
     PROGRESS_PLACEHOLDER,
@@ -38,8 +38,8 @@ from mindroom.streaming import (
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
-    patch_response_coordinator_module,
-    replace_response_coordinator_deps,
+    patch_response_runner_module,
+    replace_response_runner_deps,
     runtime_paths_for,
     test_runtime_paths,
 )
@@ -107,9 +107,9 @@ class TestStreamingBehavior:
         )
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.ai_response")
-    @patch("mindroom.response_coordinator.stream_agent_response")
-    @patch("mindroom.response_coordinator.should_use_streaming")
+    @patch("mindroom.response_runner.ai_response")
+    @patch("mindroom.response_runner.stream_agent_response")
+    @patch("mindroom.response_runner.should_use_streaming")
     async def test_streaming_agent_mentions_another_agent(  # noqa: PLR0915
         self,
         mock_should_use_streaming: AsyncMock,
@@ -269,7 +269,7 @@ class TestStreamingBehavior:
         assert mock_ai_response.call_count == 1
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.ai_response")
+    @patch("mindroom.response_runner.ai_response")
     async def test_agent_responds_only_to_final_message(
         self,
         mock_ai_response: AsyncMock,
@@ -817,7 +817,7 @@ class TestStreamingBehavior:
         )
         bot.client = MagicMock(rooms={})
         bot._knowledge_access_support.for_agent = MagicMock(return_value=None)
-        replace_response_coordinator_deps(
+        replace_response_runner_deps(
             bot,
             knowledge_access=bot._knowledge_access_support,
         )
@@ -856,13 +856,13 @@ class TestStreamingBehavior:
             patch("mindroom.streaming.get_latest_thread_event_id_if_needed", new=no_latest_thread_event),
             patch("mindroom.streaming.send_message", new=record_send),
             patch("mindroom.streaming.edit_message", new=record_edit),
-            patch_response_coordinator_module(
+            patch_response_runner_module(
                 ensure_request_knowledge_managers=empty_request_knowledge_managers,
                 stream_agent_response=MagicMock(return_value=response_stream()),
                 typing_indicator=noop_typing,
             ),
         ):
-            delivery = await bot._response_coordinator.process_and_respond_streaming(
+            delivery = await bot._response_runner.process_and_respond_streaming(
                 ResponseRequest(
                     room_id="!test:localhost",
                     reply_to_event_id="$reply_plain:localhost",

--- a/tests/test_streaming_e2e.py
+++ b/tests/test_streaming_e2e.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 @pytest.mark.e2e  # Mark as end-to-end test
 @pytest.mark.requires_matrix  # Requires real Matrix server for streaming e2e test
 @pytest.mark.timeout(10)  # Add timeout to prevent hanging on real server connection
-@patch("mindroom.response_coordinator.is_user_online")
+@patch("mindroom.response_runner.is_user_online")
 @patch("mindroom.matrix.users._ensure_all_agent_users")
 @patch("mindroom.bot.login_agent_user")
 @patch("mindroom.bot.AgentBot.ensure_user_account")
@@ -246,7 +246,7 @@ async def test_streaming_edits_e2e(  # noqa: C901, PLR0915
         }
 
         # Mock AI response for helper (streaming)
-        with patch("mindroom.response_coordinator.stream_agent_response") as mock_streaming:
+        with patch("mindroom.response_runner.stream_agent_response") as mock_streaming:
 
             async def stream_response(
                 _agent_name: str,
@@ -332,7 +332,7 @@ async def test_streaming_edits_e2e(  # noqa: C901, PLR0915
         }
 
         # Mock AI response for calculator (non-streaming)
-        with patch("mindroom.response_coordinator.ai_response") as mock_ai:
+        with patch("mindroom.response_runner.ai_response") as mock_ai:
             mock_ai.return_value = "The answer is 4"
 
             # Also mock that calculator is mentioned
@@ -478,7 +478,7 @@ async def test_user_edits_with_mentions_e2e(tmp_path: Path) -> None:
         }
 
         # Mock AI response
-        with patch("mindroom.response_coordinator.ai_response") as mock_ai:
+        with patch("mindroom.response_runner.ai_response") as mock_ai:
             mock_ai.return_value = "2+2 equals 4"
 
             # Mock that calculator is mentioned

--- a/tests/test_streaming_edits.py
+++ b/tests/test_streaming_edits.py
@@ -97,8 +97,8 @@ class TestStreamingEdits:
         )
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.ai_response")
-    @patch("mindroom.response_coordinator.stream_agent_response")
+    @patch("mindroom.response_runner.ai_response")
+    @patch("mindroom.response_runner.stream_agent_response")
     async def test_agent_regenerates_on_user_edits(
         self,
         mock_stream_agent_response: AsyncMock,  # noqa: ARG002
@@ -209,7 +209,7 @@ class TestStreamingEdits:
         assert mock_generate_response.await_count == 1
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.ai_response")
+    @patch("mindroom.response_runner.ai_response")
     async def test_agent_responds_to_new_messages_after_edits(
         self,
         mock_ai_response: AsyncMock,
@@ -253,7 +253,7 @@ class TestStreamingEdits:
         assert mock_ai_response.call_count == 1
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.ai_response")
+    @patch("mindroom.response_runner.ai_response")
     async def test_agent_ignores_all_edits_from_agents(
         self,
         mock_ai_response: AsyncMock,
@@ -321,7 +321,7 @@ class TestStreamingEdits:
         assert mock_ai_response.call_count == 0
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.ai_response")
+    @patch("mindroom.response_runner.ai_response")
     async def test_agent_responds_to_user_edits_with_new_mentions(
         self,
         mock_ai_response: AsyncMock,

--- a/tests/test_system_enrich.py
+++ b/tests/test_system_enrich.py
@@ -45,13 +45,13 @@ from mindroom.hooks.types import RESERVED_EVENT_NAMESPACES, default_timeout_ms_f
 from mindroom.logging_config import get_logger
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
-from mindroom.response_coordinator import ResponseRequest
+from mindroom.response_runner import ResponseRequest
 from mindroom.team_runtime_resolution import ResolvedExactTeamMembers
 from mindroom.teams import TeamMode, build_materialized_team_instance, prepare_materialized_team_execution
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
-    patch_response_coordinator_module,
+    patch_response_runner_module,
     runtime_paths_for,
     test_runtime_paths,
 )
@@ -545,13 +545,13 @@ async def test_process_and_respond_threads_system_enrichment_items(tmp_path: Pat
                 ),
             ),
         ),
-        patch_response_coordinator_module(
+        patch_response_runner_module(
             ensure_request_knowledge_managers=AsyncMock(return_value={}),
             typing_indicator=_noop_typing_indicator,
             ai_response=AsyncMock(side_effect=fake_ai_response),
         ),
     ):
-        delivery = await bot._response_coordinator.process_and_respond(
+        delivery = await bot._response_runner.process_and_respond(
             ResponseRequest(
                 room_id="!room:localhost",
                 reply_to_event_id="$event",
@@ -590,12 +590,12 @@ async def test_process_and_respond_streaming_threads_system_enrichment_items(tmp
             "mindroom.delivery_gateway.send_streaming_response",
             new=AsyncMock(side_effect=fake_send_streaming_response),
         ),
-        patch_response_coordinator_module(
+        patch_response_runner_module(
             typing_indicator=_noop_typing_indicator,
             stream_agent_response=fake_stream_agent_response,
         ),
     ):
-        delivery = await bot._response_coordinator.process_and_respond_streaming(
+        delivery = await bot._response_runner.process_and_respond_streaming(
             ResponseRequest(
                 room_id="!room:localhost",
                 reply_to_event_id="$event",

--- a/tests/test_team_collaboration.py
+++ b/tests/test_team_collaboration.py
@@ -195,7 +195,7 @@ class TestTeamCollaboration:
     """Test team collaboration behaviors."""
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.stream_agent_response")
+    @patch("mindroom.response_runner.stream_agent_response")
     async def test_team_coordinate_mode(
         self,
         mock_stream_agent_response: AsyncMock,  # noqa: ARG002

--- a/tests/test_team_coordination.py
+++ b/tests/test_team_coordination.py
@@ -96,7 +96,7 @@ We have different recommendations:
         assert "Recommended approach" in expected_resolution
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_coordinator.ai_response")
+    @patch("mindroom.response_runner.ai_response")
     async def test_team_handoff_mechanism(
         self,
         mock_ai_response: AsyncMock,  # noqa: ARG002

--- a/tests/test_team_scheduler_context.py
+++ b/tests/test_team_scheduler_context.py
@@ -20,7 +20,7 @@ from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestration.runtime import SYNC_RESTART_CANCEL_MSG
-from mindroom.response_coordinator import ResponseCoordinator
+from mindroom.response_runner import ResponseRunner
 from mindroom.streaming import build_restart_interrupted_body
 from mindroom.tool_system.runtime_context import get_tool_runtime_context
 from tests.conftest import (
@@ -28,7 +28,7 @@ from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
     install_edit_message_mock,
-    patch_response_coordinator_module,
+    patch_response_runner_module,
     runtime_paths_for,
     test_runtime_paths,
 )
@@ -128,12 +128,12 @@ async def test_team_non_streaming_has_scheduler_context(tmp_path: Path) -> None:
 
     with (
         patch.object(
-            ResponseCoordinator,
+            ResponseRunner,
             "run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
-        patch("mindroom.response_coordinator.typing_indicator", new=_noop_typing_indicator),
-        patch_response_coordinator_module(
+        patch("mindroom.response_runner.typing_indicator", new=_noop_typing_indicator),
+        patch_response_runner_module(
             should_use_streaming=AsyncMock(return_value=False),
             team_response=fake_team_response,
         ),
@@ -183,12 +183,12 @@ async def test_team_non_streaming_cancellation_edits_placeholder(tmp_path: Path)
 
     with (
         patch.object(
-            ResponseCoordinator,
+            ResponseRunner,
             "run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
-        patch("mindroom.response_coordinator.typing_indicator", new=_noop_typing_indicator),
-        patch_response_coordinator_module(
+        patch("mindroom.response_runner.typing_indicator", new=_noop_typing_indicator),
+        patch_response_runner_module(
             should_use_streaming=AsyncMock(return_value=False),
             team_response=fake_team_response,
         ),
@@ -246,12 +246,12 @@ async def test_team_non_streaming_sync_restart_edits_placeholder_with_restart_no
 
     with (
         patch.object(
-            ResponseCoordinator,
+            ResponseRunner,
             "run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
-        patch("mindroom.response_coordinator.typing_indicator", new=_noop_typing_indicator),
-        patch_response_coordinator_module(
+        patch("mindroom.response_runner.typing_indicator", new=_noop_typing_indicator),
+        patch_response_runner_module(
             should_use_streaming=AsyncMock(return_value=False),
             team_response=fake_team_response,
         ),
@@ -319,16 +319,16 @@ async def test_team_streaming_has_scheduler_context(tmp_path: Path) -> None:
 
     with (
         patch.object(
-            ResponseCoordinator,
+            ResponseRunner,
             "run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
-        patch("mindroom.response_coordinator.typing_indicator", new=_noop_typing_indicator),
+        patch("mindroom.response_runner.typing_indicator", new=_noop_typing_indicator),
         patch(
             "mindroom.delivery_gateway.send_streaming_response",
             new=AsyncMock(side_effect=fake_send_streaming_response),
         ),
-        patch_response_coordinator_module(
+        patch_response_runner_module(
             should_use_streaming=AsyncMock(return_value=True),
             team_response_stream=fake_team_response_stream,
         ),

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -1420,7 +1420,7 @@ class TestConversationAccessArchitecture:
             "src/mindroom/conversation_resolver.py",
             "src/mindroom/dispatch_planner.py",
             "src/mindroom/matrix/reply_chain.py",
-            "src/mindroom/response_coordinator.py",
+            "src/mindroom/response_runner.py",
         ):
             file_text = (repo_root / relative_path).read_text()
             for banned_call in banned_calls:
@@ -1437,7 +1437,7 @@ class TestConversationAccessArchitecture:
             "src/mindroom/conversation_resolver.py",
             "src/mindroom/dispatch_planner.py",
             "src/mindroom/matrix/reply_chain.py",
-            "src/mindroom/response_coordinator.py",
+            "src/mindroom/response_runner.py",
         ):
             file_text = (repo_root / relative_path).read_text()
             for banned_token in banned_tokens:

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -1133,7 +1133,7 @@ class TestThreadingBehavior:
         # Mock interactive.handle_text_response and make AI fast
         with (
             patch("mindroom.bot.interactive.handle_text_response", AsyncMock(return_value=None)),
-            patch("mindroom.response_coordinator.ai_response", AsyncMock(return_value="OK")),
+            patch("mindroom.response_runner.ai_response", AsyncMock(return_value="OK")),
             patch(
                 "mindroom.delivery_gateway.get_latest_thread_event_id_if_needed",
                 AsyncMock(return_value="latest_thread_event"),

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -20,7 +20,7 @@ from tests.conftest import (
     bind_runtime_paths,
     install_generate_response_mock,
     replace_dispatch_planner_deps,
-    replace_turn_engine_deps,
+    replace_turn_controller_deps,
     runtime_paths_for,
     sync_bot_runtime_state,
     test_runtime_paths,
@@ -65,7 +65,7 @@ def mock_home_bot() -> AgentBot:
     bot.logger = MagicMock()
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     replace_dispatch_planner_deps(bot, handled_turn_ledger=bot.handled_turn_ledger)
     bot._generate_response = AsyncMock(return_value="$response")
     install_generate_response_mock(bot, bot._generate_response)
@@ -108,7 +108,7 @@ async def test_voice_message_in_main_room_creates_thread(mock_home_bot: AgentBot
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", return_value="🎤 what is the weather"),
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -149,7 +149,7 @@ async def test_voice_message_in_thread_continues_thread(mock_home_bot: AgentBot)
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", return_value="🎤 show me the forecast"),
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -205,7 +205,7 @@ async def test_voice_plain_reply_to_thread_message_uses_thread_root(mock_home_bo
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", return_value="🎤 continue the same thread"),
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -33,7 +33,7 @@ from tests.conftest import (
     install_send_response_mock,
     install_send_skill_command_response_mock,
     orchestrator_runtime_paths,
-    replace_turn_engine_deps,
+    replace_turn_controller_deps,
     runtime_paths_for,
     unwrap_extracted_collaborator,
     wrap_extracted_collaborators,
@@ -139,7 +139,7 @@ def _make_visible_router_echo_scenario(
         rooms=["!test:example.com"],
     )
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock()
     bot.client.rooms = {}
     unwrap_extracted_collaborator(bot._conversation_resolver).derive_conversation_context = AsyncMock(
@@ -179,7 +179,7 @@ async def test_router_processes_own_voice_transcriptions(tmp_path) -> None:  # n
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     room = _make_room("@mindroom_router:example.com", "@alice:example.com")
     event = MagicMock(spec=nio.RoomMessageText)
@@ -219,7 +219,7 @@ async def test_router_ignores_non_voice_self_messages(tmp_path) -> None:  # noqa
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
 
     room = _make_room("@mindroom_router:example.com", "@bob:example.com")
     event = MagicMock(spec=nio.RoomMessageText)
@@ -263,7 +263,7 @@ async def test_router_processes_own_sidecar_commands_using_original_sender(tmp_p
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.download = AsyncMock(
@@ -343,7 +343,7 @@ async def test_router_parses_sidecar_schedule_command_from_canonical_body(tmp_pa
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.download = AsyncMock(
@@ -429,7 +429,7 @@ async def test_router_parses_sidecar_skill_command_mentions_from_canonical_body(
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.download = AsyncMock(
@@ -515,7 +515,7 @@ async def test_router_skips_unauthorized_sidecar_commands_before_hydration(tmp_p
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.download = AsyncMock()
 
@@ -541,7 +541,7 @@ async def test_router_skips_unauthorized_sidecar_commands_before_hydration(tmp_p
 
     with (
         patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock) as mock_interactive,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=False),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=False),
         patch("mindroom.commands.handler.schedule_task", new_callable=AsyncMock) as mock_schedule,
     ):
         assert isinstance(event, nio.RoomMessageFile)
@@ -662,7 +662,7 @@ async def test_router_ignores_audio_events_from_internal_agents(tmp_path) -> Non
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = MagicMock()
     bot._send_response = AsyncMock()
     install_send_response_mock(bot, bot._send_response)
@@ -682,7 +682,7 @@ async def test_router_ignores_audio_events_from_internal_agents(tmp_path) -> Non
     with (
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
     ):
         await bot._on_media_message(room, event)
 
@@ -717,7 +717,7 @@ async def test_agent_handles_audio_without_router_when_voice_disabled(tmp_path) 
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock()
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_home:localhost"
@@ -733,7 +733,7 @@ async def test_agent_handles_audio_without_router_when_voice_disabled(tmp_path) 
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -787,7 +787,7 @@ async def test_agent_handles_audio_with_router_present_in_single_agent_room(tmp_
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock()
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_home:localhost"
@@ -803,7 +803,7 @@ async def test_agent_handles_audio_with_router_present_in_single_agent_room(tmp_
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -841,7 +841,7 @@ async def test_router_and_agent_share_audio_normalization_when_router_is_present
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         bot.logger = MagicMock()
-        replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+        replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = agent_user.user_id
@@ -860,7 +860,7 @@ async def test_router_and_agent_share_audio_normalization_when_router_is_present
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -882,7 +882,7 @@ async def test_router_posts_visible_voice_echo_when_enabled(tmp_path) -> None:  
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         mock_voice.return_value = f"{VOICE_PREFIX}@home turn on the lights"
@@ -904,7 +904,7 @@ async def test_router_visible_voice_echo_is_deduplicated_on_redelivery(tmp_path)
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
         mock_voice.return_value = f"{VOICE_PREFIX}@home turn on the lights"
@@ -932,7 +932,7 @@ async def test_router_visible_voice_echo_respects_reply_permissions(tmp_path) ->
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
     ):
         await bot._on_media_message(room, event)
 
@@ -958,7 +958,7 @@ async def test_router_visible_voice_echo_keeps_multi_agent_handoff(tmp_path) -> 
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.suggest_agent_for_message", new_callable=AsyncMock, return_value="home"),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -995,7 +995,7 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries(
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.suggest_agent_for_message", new_callable=AsyncMock, return_value="home"),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -1035,7 +1035,7 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries_
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.suggest_agent_for_message", new_callable=AsyncMock, return_value="home"),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -1054,7 +1054,7 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries_
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.suggest_agent_for_message", new_callable=AsyncMock, return_value="home"),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -1096,7 +1096,7 @@ async def test_router_routes_transcribed_audio_when_multiple_agents_are_present(
     bot.handled_turn_ledger = MagicMock()
     bot.handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
-    replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
     bot.client = AsyncMock()
     bot._send_response = AsyncMock(return_value="$response")
     install_send_response_mock(bot, bot._send_response)
@@ -1115,7 +1115,7 @@ async def test_router_routes_transcribed_audio_when_multiple_agents_are_present(
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.suggest_agent_for_message", new_callable=AsyncMock, return_value="home"),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -1179,7 +1179,7 @@ async def test_transcribed_mentions_target_the_mentioned_agent_when_router_absen
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         bot.logger = MagicMock()
-        replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+        replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = f"@mindroom_{agent_name}:localhost"
@@ -1193,7 +1193,7 @@ async def test_transcribed_mentions_target_the_mentioned_agent_when_router_absen
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
@@ -1254,7 +1254,7 @@ async def test_caption_mentions_still_target_agent_when_stt_drops_the_mention(tm
         bot.handled_turn_ledger = MagicMock()
         bot.handled_turn_ledger.has_responded.return_value = False
         bot.logger = MagicMock()
-        replace_turn_engine_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
+        replace_turn_controller_deps(bot, handled_turn_ledger=bot.handled_turn_ledger, logger=bot.logger)
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = f"@mindroom_{agent_name}:localhost"
@@ -1268,7 +1268,7 @@ async def test_caption_mentions_still_target_agent_when_stt_drops_the_mention(tm
     with (
         patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
         patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
-        patch("mindroom.turn_engine.is_authorized_sender", return_value=True),
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
         patch("mindroom.dispatch_planner.is_dm_room", new_callable=AsyncMock, return_value=False),
     ):
         mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")


### PR DESCRIPTION
## Summary
- rename `turn_engine.py` to `turn_controller.py`
- rename `response_coordinator.py` to `response_runner.py`
- update docs and tests to use the renamed runtime collaborators

## Why
The previous extraction left generic or misleading names in place.
This PR narrows the vocabulary before the next behavior-changing simplification step.

## Testing
- `uv run pytest -x -n 0 --no-cov`
- `uv run pre-commit run --all-files`

## Stack
This PR stacks on #559 and should be reviewed commit-to-commit.