### PR TITLE
Unify interactive selection execution

### DIFF
--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -63,10 +63,13 @@ It no longer sends messages, runs AI, or writes persistence state.
 
 `TurnStore` is now the main durable turn boundary for the extracted runtime flows.
 `TurnController` and `EditRegenerator` read and write through `TurnStore` instead of owning their own persistence helpers.
-Some legacy command and bot paths still write to `HandledTurnLedger` directly.
+Command handling now records terminal outcomes through `TurnStore` as well.
 
 `AgentBot` is closer to a runtime shell again.
-It still needs more cleanup, but normal turn control and edit regeneration no longer live in the bot class itself.
+It still needs more cleanup, but normal turn control, edit regeneration, and interactive selection execution no longer live in the bot class itself.
+
+Interactive reactions and numeric text selections now share the same controller-owned execution path.
+That path sends the acknowledgment, runs response generation, and records the handled turn once.
 
 ## Next Simplification Work
 
@@ -75,9 +78,6 @@ It should keep placeholder, locking, streaming, cancellation, AI or team executi
 
 Revisit `IngressHookRunner`.
 It may stay as a helper, but it should not grow into another top-level orchestration object.
-
-Keep simplifying durable turn state.
-`TurnStore` is the right runtime boundary, but the backing storage model is still split between `HandledTurnLedger` and persisted run metadata.
 
 Only after those steps should we revisit `MessageTarget`.
 That follow-up can split conversation identity from delivery placement if the runtime still needs it.

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -50,7 +50,6 @@ from mindroom.memory import store_conversation_memory
 from mindroom.message_target import MessageTarget  # noqa: TC001
 from mindroom.post_response_effects import (
     PostResponseEffectsSupport,
-    record_handled_turn,
 )
 from mindroom.stop import StopManager
 from mindroom.teams import TeamMode, TeamOutcome, resolve_configured_team
@@ -98,11 +97,8 @@ from .delivery_gateway import (
     ResponseHookService,
     SendTextRequest,
 )
-from .delivery_gateway import (
-    SuppressedPlaceholderCleanupError as _SuppressedPlaceholderCleanupError,
-)
 from .edit_regenerator import EditRegenerator, EditRegeneratorDeps
-from .handled_turns import HandledTurnLedger, HandledTurnState
+from .handled_turns import HandledTurnLedger
 from .inbound_turn_normalizer import (
     DispatchPayload,
     InboundTurnNormalizer,
@@ -671,13 +667,6 @@ class AgentBot:
         if not isinstance(upload_grace_ms, int | float):
             return 0.0
         return max(float(upload_grace_ms), 0.0) / 1000
-
-    def _mark_source_events_responded(
-        self,
-        handled_turn: HandledTurnState,
-    ) -> None:
-        """Mark one or more source events as handled by the same response."""
-        record_handled_turn(self._handled_turn_ledger, handled_turn)
 
     async def _emit_reaction_received_hooks(
         self,
@@ -1343,7 +1332,11 @@ class AgentBot:
             self.runtime_paths,
         )
         if result:
-            await self._handle_interactive_reaction_result(room, event, result)
+            await self._turn_controller.handle_interactive_selection(
+                room,
+                selection=result,
+                user_id=event.sender,
+            )
             return
 
         await self._emit_reaction_received_hooks(
@@ -1351,61 +1344,6 @@ class AgentBot:
             event=event,
             correlation_id=event.event_id,
         )
-
-    async def _handle_interactive_reaction_result(
-        self,
-        room: nio.MatrixRoom,
-        event: nio.ReactionEvent,
-        result: tuple[str, str | None],
-    ) -> None:
-        """Handle one validated interactive reaction selection."""
-        assert self.client is not None
-        selected_value, thread_id = result
-        thread_history = (
-            await self._conversation_resolver.fetch_thread_history(self.client, room.room_id, thread_id)
-            if thread_id
-            else []
-        )
-
-        ack_text = f"You selected: {event.key} {selected_value}\n\nProcessing your response..."
-        # Matrix doesn't allow reply relations to events that already have relations (reactions).
-        # In threads, omit reply_to_event_id; the thread_id ensures correct placement.
-        ack_event_id = await self._send_response(
-            room.room_id,
-            None if thread_id else event.reacts_to,
-            ack_text,
-            thread_id,
-        )
-        if not ack_event_id:
-            self.logger.error("Failed to send acknowledgment for reaction")
-            return
-
-        prompt = f"The user selected: {selected_value}"
-        try:
-            response_event_id = await self._generate_response(
-                room_id=room.room_id,
-                prompt=prompt,
-                reply_to_event_id=event.reacts_to,
-                thread_id=thread_id,
-                thread_history=thread_history,
-                existing_event_id=ack_event_id,
-                existing_event_is_placeholder=True,
-                user_id=event.sender,
-            )
-        except _SuppressedPlaceholderCleanupError:
-            self.logger.warning(
-                "Suppressed interactive acknowledgment cleanup failed",
-                source_event_id=event.reacts_to,
-                acknowledgment_event_id=ack_event_id,
-            )
-            return
-        if response_event_id is not None:
-            self._mark_source_events_responded(
-                HandledTurnState.from_source_event_id(
-                    event.reacts_to,
-                    response_event_id=response_event_id,
-                ),
-            )
 
     async def _on_media_message(
         self,

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
     from agno.tools.toolkit import Toolkit
 
     from mindroom.config.main import Config
-    from mindroom.handled_turns import HandledTurnLedger
     from mindroom.matrix.client import ResolvedVisibleMessage
     from mindroom.matrix.conversation_access import ConversationReadAccess
     from mindroom.matrix.identity import MatrixID
@@ -69,7 +68,6 @@ class CommandHandlerContext:
     runtime_paths: RuntimePaths
     storage_path: Path
     logger: structlog.stdlib.BoundLogger
-    handled_turn_ledger: HandledTurnLedger
     derive_conversation_context: Callable[
         [str, EventInfo],
         Awaitable[tuple[bool, str | None, list[ResolvedVisibleMessage]]],
@@ -77,6 +75,7 @@ class CommandHandlerContext:
     conversation_access: ConversationReadAccess
     requester_user_id_for_event: Callable[[CommandEvent], str]
     build_message_target: Callable[..., MessageTarget]
+    record_handled_turn: Callable[[HandledTurnState], None]
     send_response: Callable[..., Awaitable[str | None]]
     send_skill_command_response: Callable[..., Awaitable[str | None]]
     run_skill_command_tool: Callable[..., Awaitable[str]]
@@ -595,7 +594,7 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
             )
 
             if response_event_id:
-                context.handled_turn_ledger.record_handled_turn(handled_turn)
+                context.record_handled_turn(handled_turn)
                 # Register the pending change
                 config_confirmation.register_pending_change(
                     event_id=response_event_id,
@@ -626,7 +625,7 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
                 )
 
             if response_event_id is None:
-                context.handled_turn_ledger.record_handled_turn(handled_turn)
+                context.record_handled_turn(handled_turn)
             return  # Exit early since we've handled the response
 
     elif command.type == CommandType.SKILL:
@@ -689,7 +688,7 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
                         response_event_id=_normalized_response_event_id(raw_event_id),
                     )
                     if handled_turn.response_event_id is not None:
-                        context.handled_turn_ledger.record_handled_turn(handled_turn)
+                        context.record_handled_turn(handled_turn)
                     return
 
     elif command.type == CommandType.UNKNOWN:
@@ -705,7 +704,7 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
             reply_to_event=event,
             skip_mentions=True,
         )
-        context.handled_turn_ledger.record_handled_turn(
+        context.record_handled_turn(
             HandledTurnState.from_source_event_id(
                 event.event_id,
                 response_event_id=_normalized_response_event_id(raw_response_event_id),

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -233,10 +233,22 @@ class EditRegenerator:
                 conversation_target=regeneration_target,
             )
             regeneration_turn_record = replace(regeneration_turn_record, source_event_prompts=updated_prompt_map)
-            regeneration_matrix_run_metadata = self.deps.turn_store.matrix_run_metadata(regeneration_handled_turn)
         else:
             regeneration_prompt = edited_content
-            regeneration_matrix_run_metadata = None
+        regeneration_metadata_turn = (
+            regeneration_handled_turn
+            if regeneration_turn_record.is_coalesced
+            else HandledTurnState.from_source_event_id(regeneration_turn_record.anchor_event_id)
+        )
+        regeneration_matrix_run_metadata = self.deps.turn_store.matrix_run_metadata(
+            regeneration_metadata_turn,
+            additional_source_event_ids=(
+                (original_event_id,)
+                if not regeneration_turn_record.is_coalesced
+                and original_event_id != regeneration_turn_record.anchor_event_id
+                else ()
+            ),
+        )
         envelope = self.deps.resolver.build_message_envelope(
             room_id=room.room_id,
             event=event,

--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -54,6 +54,16 @@ class _InteractiveResponse(NamedTuple):
     options_list: list[dict[str, str]] | None
 
 
+@dataclass(frozen=True, slots=True)
+class InteractiveSelection:
+    """One validated interactive question selection ready for execution."""
+
+    question_event_id: str
+    selection_key: str
+    selected_value: str
+    thread_id: str | None
+
+
 # Track active interactive questions by event_id
 _active_questions: dict[str, _InteractiveQuestion] = {}
 _persistence_file: Path | None = None
@@ -384,7 +394,7 @@ async def handle_reaction(
     agent_name: str,
     config: Config,
     runtime_paths: RuntimePaths,
-) -> tuple[str, str | None] | None:
+) -> InteractiveSelection | None:
     """Handle a reaction event that might be an answer to a question.
 
     Args:
@@ -395,7 +405,7 @@ async def handle_reaction(
         runtime_paths: Explicit runtime context for agent detection
 
     Returns:
-        Tuple of (selected_value, thread_id) if this was a valid response, None otherwise
+        Interactive selection details if this was a valid response, None otherwise
 
     """
     with _thread_lock:
@@ -444,7 +454,12 @@ async def handle_reaction(
         if _remove_active_question_locked(event.reacts_to):
             _save_active_questions_locked()
 
-        return (selected_value, question.thread_id)
+        return InteractiveSelection(
+            question_event_id=event.reacts_to,
+            selection_key=reaction_key,
+            selected_value=selected_value,
+            thread_id=question.thread_id,
+        )
 
 
 async def handle_text_response(
@@ -452,7 +467,7 @@ async def handle_text_response(
     room: nio.MatrixRoom,
     event: TextResponseEvent,
     agent_name: str,
-) -> tuple[str, str | None] | None:
+) -> InteractiveSelection | None:
     """Handle text responses to interactive questions (e.g., "1", "2", "3").
 
     Args:
@@ -462,7 +477,7 @@ async def handle_text_response(
         agent_name: The name of the agent handling this
 
     Returns:
-        Tuple of (selected_value, thread_id) if this was a valid response, None otherwise
+        Interactive selection details if this was a valid response, None otherwise
 
     """
     message_text = event.body.strip()
@@ -497,7 +512,7 @@ def _handle_text_response_locked(
     sender: str,
     client_user_id: str | None,
     agent_name: str,
-) -> tuple[str, str | None] | None:
+) -> InteractiveSelection | None:
     """Handle a numeric reply while holding ``_thread_lock``."""
     for question_event_id, question in list(_active_questions.items()):
         if question.room_id != room_id or question.thread_id != thread_id:
@@ -517,7 +532,12 @@ def _handle_text_response_locked(
             )
         if _remove_active_question_locked(question_event_id):
             _save_active_questions_locked()
-        return (selected_value, question.thread_id)
+        return InteractiveSelection(
+            question_event_id=question_event_id,
+            selection_key=message_text,
+            selected_value=selected_value,
+            thread_id=question.thread_id,
+        )
     return None
 
 

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.constants import RuntimePaths
     from mindroom.delivery_gateway import DeliveryGateway, DeliveryResult
-    from mindroom.handled_turns import HandledTurnLedger, HandledTurnState
+    from mindroom.handled_turns import HandledTurnState
     from mindroom.history.types import CompactionOutcome
     from mindroom.matrix.client import ResolvedVisibleMessage
     from mindroom.matrix.conversation_access import ConversationReadAccess
@@ -233,19 +233,6 @@ class PostResponseEffectsSupport:
             queue_thread_summary=self.queue_thread_summary,
             record_handled_turn=record_handled_turn,
         )
-
-
-def record_handled_turn(
-    handled_turn_ledger: HandledTurnLedger,
-    handled_turn: HandledTurnState,
-) -> None:
-    """Record a handled turn while preserving any prior visible echo linkage."""
-    visible_echo_event_id = handled_turn.visible_echo_event_id or handled_turn_ledger.visible_echo_event_id_for_sources(
-        handled_turn.source_event_ids,
-    )
-    handled_turn_ledger.record_handled_turn(
-        handled_turn.with_visible_echo_event_id(visible_echo_event_id),
-    )
 
 
 def matrix_run_metadata_for_handled_turn(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -596,11 +596,11 @@ class TurnController:
             runtime_paths=self.deps.runtime_paths,
             storage_path=self.deps.storage_path,
             logger=self.deps.logger,
-            handled_turn_ledger=self.deps.turn_store.deps.handled_turn_ledger,
             derive_conversation_context=self.deps.resolver.derive_conversation_context,
             conversation_access=self.deps.resolver.deps.conversation_access,
             requester_user_id_for_event=self._requester_user_id_for_event,
             build_message_target=self.deps.resolver.build_message_target,
+            record_handled_turn=self.deps.turn_store.mark_handled,
             send_response=send_response,
             send_skill_command_response=send_skill_command_response,
             run_skill_command_tool=run_skill_command_tool,
@@ -612,6 +612,76 @@ class TurnController:
             command=command,
             requester_user_id=requester_user_id,
         )
+
+    async def handle_interactive_selection(
+        self,
+        room: nio.MatrixRoom,
+        *,
+        selection: interactive.InteractiveSelection,
+        user_id: str,
+        source_event_id: str | None = None,
+    ) -> None:
+        """Execute one validated interactive selection through the normal response path."""
+        thread_history = (
+            await self.deps.resolver.fetch_thread_history(self._client(), room.room_id, selection.thread_id)
+            if selection.thread_id
+            else []
+        )
+        ack_target = self.deps.resolver.build_message_target(
+            room_id=room.room_id,
+            thread_id=selection.thread_id,
+            reply_to_event_id=None if selection.thread_id else selection.question_event_id,
+        )
+        ack_event_id = await self.deps.delivery_gateway.send_text(
+            SendTextRequest(
+                target=ack_target,
+                response_text=(
+                    f"You selected: {selection.selection_key} {selection.selected_value}\n\nProcessing your response..."
+                ),
+            ),
+        )
+        if not ack_event_id:
+            self.deps.logger.error(
+                "Failed to send acknowledgment for interactive selection",
+                source_event_id=selection.question_event_id,
+            )
+            return
+
+        try:
+            response_event_id = await self.deps.response_runner.generate_response(
+                ResponseRequest(
+                    room_id=room.room_id,
+                    prompt=f"The user selected: {selection.selected_value}",
+                    reply_to_event_id=selection.question_event_id,
+                    thread_id=selection.thread_id,
+                    thread_history=thread_history,
+                    existing_event_id=ack_event_id,
+                    existing_event_is_placeholder=True,
+                    user_id=user_id,
+                    target=ack_target,
+                ),
+            )
+        except SuppressedPlaceholderCleanupError:
+            self.deps.logger.warning(
+                "Suppressed interactive acknowledgment cleanup failed",
+                source_event_id=selection.question_event_id,
+                acknowledgment_event_id=ack_event_id,
+            )
+            return
+        if response_event_id is not None:
+            self._mark_source_events_responded(
+                HandledTurnState.from_source_event_id(
+                    selection.question_event_id,
+                    response_event_id=response_event_id,
+                ),
+            )
+            if source_event_id is not None and source_event_id != selection.question_event_id:
+                self._mark_source_events_responded(
+                    HandledTurnState.from_source_event_id(
+                        source_event_id,
+                        response_event_id=response_event_id,
+                    ),
+                )
 
     async def _execute_router_relay(
         self,
@@ -1057,7 +1127,20 @@ class TurnController:
         ):
             return
         if should_handle_interactive_text_response(envelope):
-            await interactive.handle_text_response(self._client(), room, prepared_event, self.deps.agent_name)
+            selection = await interactive.handle_text_response(
+                self._client(),
+                room,
+                prepared_event,
+                self.deps.agent_name,
+            )
+            if selection is not None:
+                await self.handle_interactive_selection(
+                    room,
+                    selection=selection,
+                    user_id=prepared_event.sender,
+                    source_event_id=prepared_event.event_id,
+                )
+                return
         coalescing_thread_id = await self.deps.resolver.coalescing_thread_id(room, prepared_event)
         target = self.deps.resolver.build_message_target(
             room_id=room.room_id,
@@ -1082,14 +1165,14 @@ class TurnController:
                 prepared_event,
                 prechecked_event.requester_user_id,
             )
-            return
-        await self._enqueue_for_dispatch(
-            prechecked_event.event,
-            room,
-            source_kind="message",
-            requester_user_id=prechecked_event.requester_user_id,
-            coalescing_key=(room.room_id, coalescing_thread_id, prechecked_event.requester_user_id),
-        )
+        else:
+            await self._enqueue_for_dispatch(
+                prechecked_event.event,
+                room,
+                source_kind="message",
+                requester_user_id=prechecked_event.requester_user_id,
+                coalescing_key=(room.room_id, coalescing_thread_id, prechecked_event.requester_user_id),
+            )
 
     async def _dispatch_text_message(  # noqa: C901, PLR0912, PLR0915
         self,
@@ -1420,7 +1503,20 @@ class TurnController:
         ):
             return True
         if should_handle_interactive_text_response(envelope):
-            await interactive.handle_text_response(self._client(), room, prepared_text_event, self.deps.agent_name)
+            selection = await interactive.handle_text_response(
+                self._client(),
+                room,
+                prepared_text_event,
+                self.deps.agent_name,
+            )
+            if selection is not None:
+                await self.handle_interactive_selection(
+                    room,
+                    selection=selection,
+                    user_id=prepared_text_event.sender,
+                    source_event_id=prepared_text_event.event_id,
+                )
+                return True
         await self._dispatch_text_message(
             room,
             _PrecheckedEvent(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -646,6 +646,14 @@ class TurnController:
                 source_event_id=selection.question_event_id,
             )
             return
+        selection_matrix_run_metadata = self.deps.turn_store.matrix_run_metadata(
+            HandledTurnState.from_source_event_id(selection.question_event_id),
+            additional_source_event_ids=(
+                (source_event_id,)
+                if source_event_id is not None and source_event_id != selection.question_event_id
+                else ()
+            ),
+        )
 
         try:
             response_event_id = await self.deps.response_runner.generate_response(
@@ -659,6 +667,7 @@ class TurnController:
                     existing_event_is_placeholder=True,
                     user_id=user_id,
                     target=ack_target,
+                    matrix_run_metadata=selection_matrix_run_metadata,
                 ),
             )
         except SuppressedPlaceholderCleanupError:

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -11,7 +11,7 @@ from mindroom.conversation_state_writer import (
     RemoveStaleRunsRequest,
 )
 from mindroom.handled_turns import HandledTurnLedger, HandledTurnRecord, HandledTurnState
-from mindroom.post_response_effects import matrix_run_metadata_for_handled_turn, record_handled_turn
+from mindroom.post_response_effects import matrix_run_metadata_for_handled_turn
 
 if TYPE_CHECKING:
     import nio
@@ -51,7 +51,15 @@ class TurnStore:
 
     def mark_handled(self, handled_turn: HandledTurnState) -> None:
         """Persist one terminal handled-turn outcome."""
-        record_handled_turn(self.deps.handled_turn_ledger, handled_turn)
+        visible_echo_event_id = (
+            handled_turn.visible_echo_event_id
+            or self.deps.handled_turn_ledger.visible_echo_event_id_for_sources(
+                handled_turn.source_event_ids,
+            )
+        )
+        self.deps.handled_turn_ledger.record_handled_turn(
+            handled_turn.with_visible_echo_event_id(visible_echo_event_id),
+        )
 
     def has_responded(self, event_id: str) -> bool:
         """Return whether one source event already has a terminal outcome."""

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
+from mindroom import constants
 from mindroom.agents import remove_run_by_event_id
 from mindroom.conversation_state_writer import (
     LoadPersistedTurnMetadataRequest,
@@ -85,9 +86,32 @@ class TurnStore:
         """Return the default persisted history scope for this runtime entity."""
         return self.deps.state_writer.history_scope()
 
-    def matrix_run_metadata(self, handled_turn: HandledTurnState) -> dict[str, Any] | None:
-        """Return run metadata for one handled turn when regeneration needs it."""
-        return matrix_run_metadata_for_handled_turn(handled_turn)
+    def matrix_run_metadata(
+        self,
+        handled_turn: HandledTurnState,
+        *,
+        additional_source_event_ids: tuple[str, ...] = (),
+    ) -> dict[str, Any] | None:
+        """Return persisted run metadata for one handled turn.
+
+        ``additional_source_event_ids`` lets one anchored run stay discoverable by
+        extra triggering events, such as a numeric interactive reply whose response
+        still anchors to the original question event.
+        """
+        metadata = matrix_run_metadata_for_handled_turn(handled_turn) or {}
+        if additional_source_event_ids:
+            source_event_ids = [
+                event_id
+                for event_id in metadata.get(constants.MATRIX_SOURCE_EVENT_IDS_METADATA_KEY, [])
+                if isinstance(event_id, str) and event_id
+            ]
+            for event_id in additional_source_event_ids:
+                if not event_id or event_id in source_event_ids:
+                    continue
+                source_event_ids.append(event_id)
+            if source_event_ids:
+                metadata[constants.MATRIX_SOURCE_EVENT_IDS_METADATA_KEY] = source_event_ids
+        return metadata or None
 
     def load_turn_record(
         self,
@@ -136,6 +160,7 @@ class TurnStore:
             merged_prompt_map = persisted_turn_metadata.source_event_prompts
         merged_turn_record = replace(
             turn_record,
+            anchor_event_id=persisted_turn_metadata.anchor_event_id,
             response_event_id=persisted_turn_metadata.response_event_id or turn_record.response_event_id,
             source_event_prompts=merged_prompt_map,
         )

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -752,7 +752,11 @@ class TestCommandHandling:
             )
 
             with (
-                patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock),
+                patch(
+                    "mindroom.turn_controller.interactive.handle_text_response",
+                    new_callable=AsyncMock,
+                    return_value=None,
+                ),
                 patch("mindroom.turn_controller.is_dm_room", return_value=False),
                 patch("mindroom.commands.handler.resolve_skill_command_spec") as mock_resolve_spec,
             ):
@@ -899,7 +903,7 @@ class TestCommandHandling:
 
             # Mock interactive.handle_text_response and extract_agent_name
             with (
-                patch("mindroom.bot.interactive.handle_text_response"),
+                patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
                 patch("mindroom.turn_controller.extract_agent_name") as mock_extract,
             ):
                 # Make extract_agent_name return "router" for the router agent sender
@@ -1033,7 +1037,7 @@ class TestCommandHandling:
         )
 
         with (
-            patch("mindroom.bot.interactive.handle_text_response"),
+            patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_controller.extract_agent_name", return_value="router"),
         ):
             await bot._on_message(room, event)
@@ -1146,7 +1150,7 @@ class TestCommandHandling:
             patch("mindroom.turn_controller.extract_agent_name") as mock_extract,
             patch("mindroom.response_runner.team_response") as mock_team,
         ):
-            mock_interactive.handle_text_response = AsyncMock()
+            mock_interactive.handle_text_response = AsyncMock(return_value=None)
             mock_extract.side_effect = (
                 lambda x, config, runtime_paths: "router"  # noqa: ARG005
                 if "router" in x
@@ -1274,7 +1278,7 @@ class TestCommandHandling:
             patch("mindroom.bot.interactive") as mock_interactive,
             patch("mindroom.turn_controller.extract_agent_name") as mock_extract,
         ):
-            mock_interactive.handle_text_response = AsyncMock()
+            mock_interactive.handle_text_response = AsyncMock(return_value=None)
             mock_extract.side_effect = (
                 lambda x, config, runtime_paths: "router" if "router" in x else ("finance" if "finance" in x else None)  # noqa: ARG005
             )
@@ -1343,7 +1347,7 @@ class TestCommandHandling:
 
         # Mock interactive.handle_text_response and extract_agent_name
         with (
-            patch("mindroom.bot.interactive.handle_text_response"),
+            patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_controller.extract_agent_name") as mock_extract,
         ):
             # Make extract_agent_name return "router" for the router agent sender
@@ -1429,7 +1433,7 @@ class TestRouterSkipsSingleAgent:
         )
 
         with (
-            patch("mindroom.bot.interactive.handle_text_response"),
+            patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_controller.extract_agent_name", return_value=None),  # User message
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
@@ -1517,7 +1521,7 @@ class TestRouterSkipsSingleAgent:
         )
 
         with (
-            patch("mindroom.bot.interactive.handle_text_response"),
+            patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_controller.extract_agent_name", return_value=None),  # User message
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
@@ -1620,7 +1624,7 @@ class TestRouterSkipsSingleAgent:
         )
 
         with (
-            patch("mindroom.bot.interactive.handle_text_response"),
+            patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_controller.extract_agent_name", return_value=None),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
@@ -1698,7 +1702,7 @@ class TestRouterSkipsSingleAgent:
         )
 
         with (
-            patch("mindroom.bot.interactive.handle_text_response"),
+            patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
         ):
             mock_get_available.return_value = [config.get_ids(runtime_paths_for(config))["general"]]
@@ -1770,7 +1774,7 @@ class TestRouterSkipsSingleAgent:
         )
 
         with (
-            patch("mindroom.bot.interactive.handle_text_response"),
+            patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
         ):
             mock_get_available.return_value = [config.get_ids(runtime_paths_for(config))["general"]]
@@ -1853,7 +1857,7 @@ class TestRouterSkipsSingleAgent:
         bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=mock_context)
 
         with (
-            patch("mindroom.bot.interactive.handle_text_response"),
+            patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
             patch("mindroom.turn_policy.get_agents_in_thread") as mock_agents_in_thread,
         ):
@@ -1929,7 +1933,7 @@ class TestRouterSkipsSingleAgent:
         )
 
         with (
-            patch("mindroom.bot.interactive.handle_text_response"),
+            patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
         ):
             mock_get_available.return_value = [

--- a/tests/test_config_commands.py
+++ b/tests/test_config_commands.py
@@ -240,11 +240,11 @@ async def test_handle_command_threads_config_path_to_config_commands(tmp_path: P
         runtime_paths=resolve_runtime_paths(config_path=config_path, storage_path=tmp_path),
         storage_path=tmp_path,
         logger=MagicMock(),
-        handled_turn_ledger=MagicMock(),
         derive_conversation_context=AsyncMock(return_value=(False, None, [])),
         conversation_access=MagicMock(),
         requester_user_id_for_event=MagicMock(return_value="@alice:example.org"),
         build_message_target=MagicMock(return_value=MessageTarget.resolve("!room:example.org", None, "$event")),
+        record_handled_turn=MagicMock(),
         send_response=AsyncMock(return_value=None),
         send_skill_command_response=AsyncMock(return_value=None),
         run_skill_command_tool=AsyncMock(return_value=""),
@@ -281,11 +281,11 @@ async def test_handle_command_records_response_event_id_for_standard_reply(tmp_p
         runtime_paths=resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path),
         storage_path=tmp_path,
         logger=MagicMock(),
-        handled_turn_ledger=MagicMock(),
         derive_conversation_context=AsyncMock(return_value=(False, None, [])),
         conversation_access=MagicMock(),
         requester_user_id_for_event=MagicMock(return_value="@alice:example.org"),
         build_message_target=MagicMock(return_value=MessageTarget.resolve("!room:example.org", None, "$event")),
+        record_handled_turn=MagicMock(),
         send_response=AsyncMock(return_value="$reply"),
         send_skill_command_response=AsyncMock(return_value=None),
         run_skill_command_tool=AsyncMock(return_value=""),
@@ -306,7 +306,7 @@ async def test_handle_command_records_response_event_id_for_standard_reply(tmp_p
         requester_user_id="@alice:example.org",
     )
 
-    context.handled_turn_ledger.record_handled_turn.assert_called_once_with(
+    context.record_handled_turn.assert_called_once_with(
         HandledTurnState.from_source_event_id(
             "$event",
             response_event_id="$reply",
@@ -323,11 +323,11 @@ async def test_handle_command_config_set_confirmation_records_preview_event_id(t
         runtime_paths=resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path),
         storage_path=tmp_path,
         logger=MagicMock(),
-        handled_turn_ledger=MagicMock(),
         derive_conversation_context=AsyncMock(return_value=(False, None, [])),
         conversation_access=MagicMock(),
         requester_user_id_for_event=MagicMock(return_value="@alice:example.org"),
         build_message_target=MagicMock(return_value=MessageTarget.resolve("!room:example.org", None, "$event")),
+        record_handled_turn=MagicMock(),
         send_response=AsyncMock(return_value="$preview"),
         send_skill_command_response=AsyncMock(return_value=None),
         run_skill_command_tool=AsyncMock(return_value=""),
@@ -389,7 +389,7 @@ async def test_handle_command_config_set_confirmation_records_preview_event_id(t
     mock_get_pending.assert_called_once_with("$preview")
     mock_store_pending.assert_awaited_once_with(context.client, "$preview", pending_change)
     mock_add_reactions.assert_awaited_once_with(context.client, "!room:example.org", "$preview")
-    context.handled_turn_ledger.record_handled_turn.assert_called_once_with(
+    context.record_handled_turn.assert_called_once_with(
         HandledTurnState.from_source_event_id(
             "$event",
             response_event_id="$preview",
@@ -406,11 +406,11 @@ async def test_handle_command_config_set_records_preview_before_post_send_failur
         runtime_paths=resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path),
         storage_path=tmp_path,
         logger=MagicMock(),
-        handled_turn_ledger=MagicMock(),
         derive_conversation_context=AsyncMock(return_value=(False, None, [])),
         conversation_access=MagicMock(),
         requester_user_id_for_event=MagicMock(return_value="@alice:example.org"),
         build_message_target=MagicMock(return_value=MessageTarget.resolve("!room:example.org", None, "$event")),
+        record_handled_turn=MagicMock(),
         send_response=AsyncMock(return_value="$preview"),
         send_skill_command_response=AsyncMock(return_value=None),
         run_skill_command_tool=AsyncMock(return_value=""),
@@ -461,7 +461,7 @@ async def test_handle_command_config_set_records_preview_before_post_send_failur
             requester_user_id="@alice:example.org",
         )
 
-    context.handled_turn_ledger.record_handled_turn.assert_called_once_with(
+    context.record_handled_turn.assert_called_once_with(
         HandledTurnState.from_source_event_id(
             "$event",
             response_event_id="$preview",

--- a/tests/test_dm_functionality.py
+++ b/tests/test_dm_functionality.py
@@ -394,7 +394,7 @@ class TestDMIntegration:
             patch("mindroom.conversation_resolver.should_skip_mentions", return_value=False),
             patch("mindroom.turn_controller.extract_agent_name", return_value=None),  # User is not an agent
             patch("mindroom.turn_controller.is_dm_room", return_value=True),  # This is a DM room
-            patch("mindroom.bot.interactive.handle_text_response", new=mock_handle),
+            patch("mindroom.turn_controller.interactive.handle_text_response", new=mock_handle),
         ):
             # Mock thread info to return no thread
             mock_thread_info.return_value = EventInfo(
@@ -491,7 +491,7 @@ class TestDMIntegration:
             patch("mindroom.conversation_resolver.should_skip_mentions", return_value=False),
             patch("mindroom.turn_controller.extract_agent_name", return_value=None),
             patch("mindroom.turn_controller.is_dm_room", return_value=True),  # This is a DM room
-            patch("mindroom.bot.interactive.handle_text_response", new=mock_handle),
+            patch("mindroom.turn_controller.interactive.handle_text_response", new=mock_handle),
         ):
             # Mock thread info to return no thread
             mock_thread_info.return_value = EventInfo(

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -46,6 +46,7 @@ from tests.conftest import (
     replace_turn_store_deps,
     runtime_paths_for,
     unwrap_extracted_collaborator,
+    wrap_extracted_collaborators,
 )
 
 if TYPE_CHECKING:
@@ -591,6 +592,13 @@ async def test_handle_message_edit_reuses_persisted_target_and_thread_scope(
     bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
     replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
     bot.logger = MagicMock()
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
+    replace_turn_controller_deps(
+        bot,
+        delivery_gateway=bot._delivery_gateway,
+        response_runner=bot._response_runner,
+    )
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
     stored_target = MessageTarget.resolve(
@@ -1035,6 +1043,13 @@ async def test_bot_ignores_agent_edits(tmp_path: Path) -> None:
 
     # Mock logger
     bot.logger = MagicMock()
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
+    replace_turn_controller_deps(
+        bot,
+        delivery_gateway=bot._delivery_gateway,
+        response_runner=bot._response_runner,
+    )
     replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
 
     # Create a room
@@ -2253,6 +2268,7 @@ async def test_handle_message_edit_recovers_threaded_turn_using_resolved_context
     bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
     replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
     bot.logger = MagicMock()
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
     edit_event = nio.RoomMessageText.from_dict(
@@ -2381,6 +2397,13 @@ async def test_handle_message_edit_recovers_missing_single_turn_without_rerunnin
     bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
     replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
     bot.logger = MagicMock()
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
+    replace_turn_controller_deps(
+        bot,
+        delivery_gateway=bot._delivery_gateway,
+        response_runner=bot._response_runner,
+    )
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
     edit_event = nio.RoomMessageText.from_dict(
@@ -2722,6 +2745,13 @@ async def test_on_reaction_tracks_response_event_id(tmp_path: Path) -> None:
 
     # Mock logger
     bot.logger = MagicMock()
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
+    replace_turn_controller_deps(
+        bot,
+        delivery_gateway=bot._delivery_gateway,
+        response_runner=bot._response_runner,
+    )
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
@@ -2750,16 +2780,19 @@ async def test_on_reaction_tracks_response_event_id(tmp_path: Path) -> None:
     with (
         patch("mindroom.bot.interactive.handle_reaction", new_callable=AsyncMock) as mock_handle_reaction,
         patch("mindroom.bot.is_authorized_sender", return_value=True),
-        patch.object(bot, "_send_response", new_callable=AsyncMock) as mock_send_response,
-        patch.object(bot, "_generate_response", new_callable=AsyncMock) as mock_generate_response,
-        patch("mindroom.matrix.conversation_access.fetch_thread_history", new_callable=AsyncMock) as mock_fetch_history,
+        patch.object(bot._delivery_gateway, "send_text", new_callable=AsyncMock) as mock_send_text,
+        patch.object(bot._response_runner, "generate_response", new_callable=AsyncMock) as mock_generate_response,
+        patch.object(bot._conversation_resolver, "fetch_thread_history", new_callable=AsyncMock) as mock_fetch_history,
     ):
         # Setup mocks
-        mock_handle_reaction.return_value = ("Option 1", "thread_id")  # selected_value, thread_id
-        mock_send_response.return_value = "$ack_event:example.com"  # Acknowledgment event ID
-        mock_generate_response.return_value = (
-            "$response_event:example.com"  # Response event ID (same as ack since we edit)
+        mock_handle_reaction.return_value = interactive.InteractiveSelection(
+            question_event_id="$question:example.com",
+            selection_key="1️⃣",
+            selected_value="Option 1",
+            thread_id="thread_id",
         )
+        mock_send_text.return_value = "$ack_event:example.com"
+        mock_generate_response.return_value = "$response_event:example.com"
         mock_fetch_history.return_value = []
 
         # Process the reaction event
@@ -2771,13 +2804,14 @@ async def test_on_reaction_tracks_response_event_id(tmp_path: Path) -> None:
 
         # Verify the methods were called with correct parameters
         mock_handle_reaction.assert_called_once()
-        mock_send_response.assert_called_once()
+        mock_send_text.assert_called_once()
         mock_generate_response.assert_called_once()
 
-        # Verify that _generate_response was called with the acknowledgment event ID for editing
-        call_kwargs = mock_generate_response.call_args.kwargs
-        assert call_kwargs["existing_event_id"] == "$ack_event:example.com"
-        assert call_kwargs["existing_event_is_placeholder"] is True
+        request = mock_generate_response.await_args.args[0]
+        assert request.existing_event_id == "$ack_event:example.com"
+        assert request.existing_event_is_placeholder is True
+        assert request.reply_to_event_id == "$question:example.com"
+        assert request.thread_id == "thread_id"
 
 
 @pytest.mark.asyncio
@@ -2805,6 +2839,13 @@ async def test_on_reaction_leaves_question_retryable_when_ack_response_is_suppre
     bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
     replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
     bot.logger = MagicMock()
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
+    replace_turn_controller_deps(
+        bot,
+        delivery_gateway=bot._delivery_gateway,
+        response_runner=bot._response_runner,
+    )
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
 
@@ -2830,12 +2871,17 @@ async def test_on_reaction_leaves_question_retryable_when_ack_response_is_suppre
     with (
         patch("mindroom.bot.interactive.handle_reaction", new_callable=AsyncMock) as mock_handle_reaction,
         patch("mindroom.bot.is_authorized_sender", return_value=True),
-        patch.object(bot, "_send_response", new_callable=AsyncMock) as mock_send_response,
-        patch.object(bot, "_generate_response", new_callable=AsyncMock) as mock_generate_response,
+        patch.object(bot._delivery_gateway, "send_text", new_callable=AsyncMock) as mock_send_text,
+        patch.object(bot._response_runner, "generate_response", new_callable=AsyncMock) as mock_generate_response,
         patch.object(bot._conversation_resolver, "fetch_thread_history", new_callable=AsyncMock) as mock_fetch_history,
     ):
-        mock_handle_reaction.return_value = ("Option 1", "thread_id")
-        mock_send_response.return_value = "$ack_event:example.com"
+        mock_handle_reaction.return_value = interactive.InteractiveSelection(
+            question_event_id="$question:example.com",
+            selection_key="1️⃣",
+            selected_value="Option 1",
+            thread_id="thread_id",
+        )
+        mock_send_text.return_value = "$ack_event:example.com"
         mock_generate_response.return_value = None
         mock_fetch_history.return_value = []
 
@@ -2843,9 +2889,112 @@ async def test_on_reaction_leaves_question_retryable_when_ack_response_is_suppre
 
         assert bot._handled_turn_ledger.has_responded("$question:example.com") is False
         assert bot._handled_turn_ledger.get_response_event_id("$question:example.com") is None
-        call_kwargs = mock_generate_response.call_args.kwargs
-        assert call_kwargs["existing_event_id"] == "$ack_event:example.com"
-        assert call_kwargs["existing_event_is_placeholder"] is True
+        request = mock_generate_response.await_args.args[0]
+        assert request.existing_event_id == "$ack_event:example.com"
+        assert request.existing_event_is_placeholder is True
+
+
+@pytest.mark.asyncio
+async def test_on_message_routes_interactive_text_selection_through_turn_controller(tmp_path: Path) -> None:
+    """Numeric interactive replies should run the controller-owned selection workflow."""
+    agent_user = AgentMatrixUser(
+        agent_name="test_agent",
+        user_id="@mindroom_test_agent:example.com",
+        display_name="Test Agent",
+        password="test_password",  # noqa: S106
+    )
+
+    config = _test_config(tmp_path)
+    bot = AgentBot(
+        agent_user=agent_user,
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        rooms=["!test:example.com"],
+    )
+    bot.client = AsyncMock(spec=nio.AsyncClient)
+    bot.client.rooms = {}
+    bot.client.user_id = "@test_agent:example.com"
+    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
+    bot.logger = MagicMock()
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner", "_turn_policy")
+    replace_turn_controller_deps(
+        bot,
+        delivery_gateway=bot._delivery_gateway,
+        response_runner=bot._response_runner,
+        turn_policy=bot._turn_policy,
+    )
+
+    room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
+    message_event = nio.RoomMessageText.from_dict(
+        {
+            "content": {
+                "body": "1",
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": "$thread:example.com",
+                },
+            },
+            "event_id": "$selection:example.com",
+            "sender": "@user:example.com",
+            "origin_server_ts": 1000000,
+            "type": "m.room.message",
+            "room_id": "!test:example.com",
+        },
+    )
+    message_event.source = {
+        "content": {
+            "body": "1",
+            "msgtype": "m.text",
+            "m.relates_to": {
+                "rel_type": "m.thread",
+                "event_id": "$thread:example.com",
+            },
+        },
+        "event_id": "$selection:example.com",
+        "sender": "@user:example.com",
+        "room_id": "!test:example.com",
+        "origin_server_ts": 1000000,
+        "type": "m.room.message",
+    }
+
+    with (
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
+        patch.object(bot._turn_policy, "can_reply_to_sender", return_value=True),
+        patch(
+            "mindroom.turn_controller.interactive.handle_text_response",
+            new_callable=AsyncMock,
+            return_value=interactive.InteractiveSelection(
+                question_event_id="$question:example.com",
+                selection_key="1",
+                selected_value="Option 1",
+                thread_id="$thread:example.com",
+            ),
+        ) as mock_handle_text_response,
+        patch.object(bot._delivery_gateway, "send_text", new_callable=AsyncMock, return_value="$ack:example.com"),
+        patch.object(
+            bot._response_runner,
+            "generate_response",
+            new_callable=AsyncMock,
+            return_value="$response:example.com",
+        ) as mock_generate_response,
+        patch.object(bot._conversation_resolver, "fetch_thread_history", new_callable=AsyncMock, return_value=[]),
+        patch.object(bot._turn_controller, "_dispatch_text_message", new_callable=AsyncMock) as mock_dispatch_text,
+    ):
+        await bot._on_message(room, message_event)
+
+    mock_handle_text_response.assert_awaited_once()
+    mock_dispatch_text.assert_not_awaited()
+    request = mock_generate_response.await_args.args[0]
+    assert request.reply_to_event_id == "$question:example.com"
+    assert request.thread_id == "$thread:example.com"
+    assert request.existing_event_id == "$ack:example.com"
+    assert bot._handled_turn_ledger.has_responded("$question:example.com")
+    assert bot._handled_turn_ledger.get_response_event_id("$question:example.com") == "$response:example.com"
+    assert bot._handled_turn_ledger.has_responded("$selection:example.com")
+    assert bot._handled_turn_ledger.get_response_event_id("$selection:example.com") == "$response:example.com"
 
 
 @pytest.mark.asyncio
@@ -2887,6 +3036,13 @@ async def test_on_reaction_respects_agent_reply_permissions(tmp_path: Path) -> N
     bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
     replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
     bot.logger = MagicMock()
+    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
+    replace_turn_controller_deps(
+        bot,
+        delivery_gateway=bot._delivery_gateway,
+        response_runner=bot._response_runner,
+    )
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
     interactive._active_questions.clear()
@@ -2939,21 +3095,21 @@ async def test_on_reaction_respects_agent_reply_permissions(tmp_path: Path) -> N
     with (
         patch("mindroom.bot.is_authorized_sender", return_value=True),
         patch("mindroom.bot.config_confirmation.get_pending_change", return_value=None),
-        patch.object(bot, "_send_response", new_callable=AsyncMock) as mock_send_response,
-        patch.object(bot, "_generate_response", new_callable=AsyncMock) as mock_generate_response,
+        patch.object(bot._delivery_gateway, "send_text", new_callable=AsyncMock) as mock_send_text,
+        patch.object(bot._response_runner, "generate_response", new_callable=AsyncMock) as mock_generate_response,
     ):
-        mock_send_response.return_value = "$ack_event:example.com"
+        mock_send_text.return_value = "$ack_event:example.com"
         mock_generate_response.return_value = "$response_event:example.com"
 
         await bot._on_reaction(room, disallowed_reaction)
-        mock_send_response.assert_not_called()
+        mock_send_text.assert_not_called()
         mock_generate_response.assert_not_called()
 
         await bot._on_reaction(room, allowed_reaction)
 
     interactive._active_questions.clear()
 
-    mock_send_response.assert_called_once()
+    mock_send_text.assert_called_once()
     mock_generate_response.assert_called_once()
 
 

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -24,7 +24,11 @@ from mindroom.agents import get_agent_session, remove_run_by_event_id
 from mindroom.bot import AgentBot, TeamBot
 from mindroom.commands import config_confirmation
 from mindroom.config.main import Config
-from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
+from mindroom.constants import (
+    MATRIX_SOURCE_EVENT_IDS_METADATA_KEY,
+    ROUTER_AGENT_NAME,
+    resolve_runtime_paths,
+)
 from mindroom.conversation_state_writer import ConversationStateWriter
 from mindroom.delivery_gateway import DeliveryResult
 from mindroom.handled_turns import HandledTurnLedger, HandledTurnRecord, HandledTurnState
@@ -1788,6 +1792,194 @@ def test_load_turn_record_prefers_newest_matching_run(tmp_path: Path) -> None:
     }
 
 
+def test_load_turn_record_preserves_persisted_anchor_for_interactive_selection(tmp_path: Path) -> None:
+    """Selection-triggered runs should keep the original question anchor when reloaded."""
+    agent_user = AgentMatrixUser(
+        agent_name="test_agent",
+        user_id="@mindroom_test_agent:example.com",
+        display_name="Test Agent",
+        password="test_password",  # noqa: S106
+    )
+    config = _test_config(tmp_path)
+    bot = AgentBot(
+        agent_user=agent_user,
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        rooms=["!test:example.com"],
+    )
+
+    _record_handled_turn(
+        bot._handled_turn_ledger,
+        ["$selection:example.com"],
+        response_event_id="$response-ledger:example.com",
+    )
+
+    session_id = create_session_id("!test:example.com", None)
+    storage = MagicMock()
+    storage.get_session.return_value = AgentSession(
+        session_id=session_id,
+        runs=[
+            RunOutput(
+                run_id="run-selection",
+                session_id=session_id,
+                metadata={
+                    "matrix_event_id": "$question:example.com",
+                    "matrix_source_event_ids": ["$selection:example.com"],
+                    "matrix_response_event_id": "$response-persisted:example.com",
+                },
+            ),
+        ],
+    )
+    room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
+
+    with patch.object(
+        bot._conversation_state_writer,
+        "create_history_scope_storage",
+        return_value=storage,
+    ):
+        loaded_turn = bot._turn_store.load_turn_record(
+            room=room,
+            thread_id=None,
+            original_event_id="$selection:example.com",
+            requester_user_id="@user:example.com",
+        )
+
+    assert loaded_turn is not None
+    assert loaded_turn.record.anchor_event_id == "$question:example.com"
+    assert loaded_turn.record.source_event_ids == ("$selection:example.com",)
+    assert loaded_turn.record.response_event_id == "$response-persisted:example.com"
+    assert loaded_turn.requires_backfill is True
+
+
+@pytest.mark.asyncio
+async def test_edit_regenerator_preserves_interactive_selection_run_metadata(tmp_path: Path) -> None:
+    """Editing a numeric selection should keep the original question anchor and selection lookup metadata."""
+    agent_user = AgentMatrixUser(
+        agent_name="test_agent",
+        user_id="@mindroom_test_agent:example.com",
+        display_name="Test Agent",
+        password="test_password",  # noqa: S106
+    )
+    config = _test_config(tmp_path)
+    bot = AgentBot(
+        agent_user=agent_user,
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        rooms=["!test:example.com"],
+    )
+    bot.client = AsyncMock(spec=nio.AsyncClient)
+    bot.client.user_id = "@mindroom_test_agent:example.com"
+    bot.client.rooms = {}
+    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
+    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    _record_handled_turn(
+        bot._handled_turn_ledger,
+        ["$selection:example.com"],
+        response_event_id="$response:example.com",
+    )
+
+    room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
+    edit_event = nio.RoomMessageText.from_dict(
+        {
+            "content": {
+                "body": "* 2",
+                "msgtype": "m.text",
+                "m.new_content": {
+                    "body": "2",
+                    "msgtype": "m.text",
+                },
+                "m.relates_to": {
+                    "rel_type": "m.replace",
+                    "event_id": "$selection:example.com",
+                },
+            },
+            "event_id": "$edit:example.com",
+            "sender": "@user:example.com",
+            "origin_server_ts": 1000000,
+            "type": "m.room.message",
+            "room_id": "!test:example.com",
+        },
+    )
+    edit_event.source = {
+        "content": {
+            "body": "* 2",
+            "msgtype": "m.text",
+            "m.new_content": {
+                "body": "2",
+                "msgtype": "m.text",
+            },
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": "$selection:example.com",
+            },
+        },
+        "event_id": "$edit:example.com",
+        "sender": "@user:example.com",
+        "origin_server_ts": 1000000,
+        "type": "m.room.message",
+        "room_id": "!test:example.com",
+    }
+
+    session_id = create_session_id("!test:example.com", None)
+    storage = MagicMock()
+    storage.get_session.return_value = AgentSession(
+        session_id=session_id,
+        runs=[
+            RunOutput(
+                run_id="run-selection",
+                session_id=session_id,
+                metadata={
+                    "matrix_event_id": "$question:example.com",
+                    "matrix_source_event_ids": ["$selection:example.com"],
+                    "matrix_response_event_id": "$response:example.com",
+                },
+            ),
+        ],
+    )
+    generate_response = AsyncMock(return_value="$response-new:example.com")
+    replace_edit_regenerator_deps(bot, generate_response=generate_response)
+
+    with (
+        patch.object(bot._conversation_resolver, "extract_message_context", new_callable=AsyncMock) as mock_context,
+        patch.object(
+            bot._conversation_state_writer,
+            "create_history_scope_storage",
+            return_value=storage,
+        ),
+        patch.object(
+            bot._ingress_hook_runner,
+            "emit_message_received_hooks",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        mock_context.return_value = MagicMock(
+            am_i_mentioned=False,
+            is_thread=False,
+            thread_id=None,
+            thread_history=[],
+            mentioned_agents=[],
+            has_non_agent_mentions=False,
+            requires_full_thread_history=False,
+        )
+
+        await bot._edit_regenerator.handle_message_edit(
+            room,
+            edit_event,
+            EventInfo.from_event(edit_event.source),
+            requester_user_id=edit_event.sender,
+        )
+
+    generate_response.assert_awaited_once()
+    call_kwargs = generate_response.call_args.kwargs
+    assert call_kwargs["reply_to_event_id"] == "$question:example.com"
+    assert call_kwargs["matrix_run_metadata"] == {
+        MATRIX_SOURCE_EVENT_IDS_METADATA_KEY: ["$selection:example.com"],
+    }
+
+
 def test_load_turn_record_prefers_newest_match_across_thread_and_room_sessions(tmp_path: Path) -> None:
     """TurnStore should compare matching persisted runs across thread and room scopes."""
     agent_user = AgentMatrixUser(
@@ -2991,6 +3183,9 @@ async def test_on_message_routes_interactive_text_selection_through_turn_control
     assert request.reply_to_event_id == "$question:example.com"
     assert request.thread_id == "$thread:example.com"
     assert request.existing_event_id == "$ack:example.com"
+    assert request.matrix_run_metadata == {
+        MATRIX_SOURCE_EVENT_IDS_METADATA_KEY: ["$selection:example.com"],
+    }
     assert bot._handled_turn_ledger.has_responded("$question:example.com")
     assert bot._handled_turn_ledger.get_response_event_id("$question:example.com") == "$response:example.com"
     assert bot._handled_turn_ledger.has_responded("$selection:example.com")

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -1511,7 +1511,11 @@ async def test_first_hop_hook_dispatch_sidecar_preview_skips_interactive_answer_
     )
 
     try:
-        with patch.object(interactive, "handle_text_response", new=AsyncMock()) as mock_handle_text_response:
+        with patch.object(
+            interactive,
+            "handle_text_response",
+            new=AsyncMock(return_value=None),
+        ) as mock_handle_text_response:
             assert isinstance(sidecar_event, nio.RoomMessageFile)
             handled = await bot._turn_controller._dispatch_file_sidecar_text_preview(
                 room,
@@ -1571,7 +1575,11 @@ async def test_deep_hook_dispatch_sidecar_preview_stops_before_interactive_or_di
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._turn_controller._dispatch_text_message = AsyncMock()
 
-    with patch.object(interactive, "handle_text_response", new=AsyncMock()) as mock_handle_text_response:
+    with patch.object(
+        interactive,
+        "handle_text_response",
+        new=AsyncMock(return_value=None),
+    ) as mock_handle_text_response:
         assert isinstance(sidecar_event, nio.RoomMessageFile)
         handled = await bot._turn_controller._dispatch_file_sidecar_text_preview(
             room,

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -392,8 +392,12 @@ Based on your choice, I'll proceed accordingly."""
             runtime_paths_for(self.config),
         )
 
-        # Should return the selected value and thread_id
-        assert result == ("fast", "$thread123")
+        assert result == interactive.InteractiveSelection(
+            question_event_id="$question123",
+            selection_key="🚀",
+            selected_value="fast",
+            thread_id="$thread123",
+        )
 
         # Should NOT send confirmation (user's reaction is the response)
         mock_client.room_send.assert_not_called()
@@ -426,7 +430,12 @@ Based on your choice, I'll proceed accordingly."""
             runtime_paths_for(self.config),
         )
 
-        assert result == ("fast", "$thread123")
+        assert result == interactive.InteractiveSelection(
+            question_event_id="$question123",
+            selection_key="🚀",
+            selected_value="fast",
+            thread_id="$thread123",
+        )
         assert "$question123" not in interactive._active_questions
 
     @pytest.mark.asyncio
@@ -548,7 +557,12 @@ Based on your choice, I'll proceed accordingly."""
 
         result = await interactive.handle_text_response(mock_client, room, event, "test_agent")
 
-        assert result == ("first", "$thread123")
+        assert result == interactive.InteractiveSelection(
+            question_event_id="$question123",
+            selection_key="1",
+            selected_value="first",
+            thread_id="$thread123",
+        )
         assert "$question123" not in interactive._active_questions
 
     @pytest.mark.asyncio
@@ -753,8 +767,12 @@ Just let me know your preference!"""
             runtime_paths_for(self.config),
         )
 
-        # Verify reaction was processed
-        assert result == ("detailed", "$thread123")  # Thread ID from the question
+        assert result == interactive.InteractiveSelection(
+            question_event_id=event_id,
+            selection_key="🔍",
+            selected_value="detailed",
+            thread_id="$thread123",
+        )
         assert event_id not in interactive._active_questions
 
     @pytest.mark.asyncio
@@ -857,7 +875,12 @@ Just let me know your preference!"""
             runtime_paths_for(self.config),
         )
 
-        assert result == ("yes", "$thread123")
+        assert result == interactive.InteractiveSelection(
+            question_event_id="$question123",
+            selection_key="✅",
+            selected_value="yes",
+            thread_id="$thread123",
+        )
         assert interactive._active_questions == {}
         assert json.loads(persistence_file.read_text()) == {}
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -26,6 +26,7 @@ from agno.models.ollama import Ollama
 from agno.run.agent import RunContentEvent
 from agno.run.team import TeamRunOutput
 
+from mindroom import interactive
 from mindroom.attachments import _attachment_id_for_event, register_local_attachment
 from mindroom.authorization import is_authorized_sender as is_authorized_sender_for_test
 from mindroom.bot import (
@@ -2630,15 +2631,26 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = MagicMock()
-        bot._send_response = AsyncMock(return_value="$ack")
-        bot._generate_response = AsyncMock(return_value="$reply")
         bot.hook_registry = HookRegistry.from_plugins([_hook_plugin("hooked", [record_reaction])])
         room = MagicMock()
         room.room_id = "!test:localhost"
         room.canonical_alias = None
         event = self._make_handler_event("reaction", sender="@user:localhost", event_id="$reaction")
 
-        with patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=("Selected", None))):
+        with (
+            patch(
+                "mindroom.bot.interactive.handle_reaction",
+                new=AsyncMock(
+                    return_value=interactive.InteractiveSelection(
+                        question_event_id="$question",
+                        selection_key="1",
+                        selected_value="Selected",
+                        thread_id=None,
+                    ),
+                ),
+            ),
+            patch.object(bot._turn_controller, "handle_interactive_selection", new=AsyncMock()),
+        ):
             await bot._on_reaction(room, event)
 
         assert seen == []
@@ -5173,7 +5185,11 @@ class TestAgentBot:
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.coalescing.extract_media_caption", return_value="[Attached image]"),
-            patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock, return_value=None),
+            patch(
+                "mindroom.turn_controller.interactive.handle_text_response",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             await bot._on_message(room, text_event)
             await bot._on_media_message(room, image_event)
@@ -5244,7 +5260,11 @@ class TestAgentBot:
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.coalescing.extract_media_caption", return_value="[Attached image]"),
-            patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock, return_value=None),
+            patch(
+                "mindroom.turn_controller.interactive.handle_text_response",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             await bot._on_message(room, text_event)
             await bot._on_media_message(room, image_event)
@@ -5301,7 +5321,11 @@ class TestAgentBot:
             patch("mindroom.bot.extract_agent_name", return_value="router"),
             patch("mindroom.bot.is_authorized_sender", return_value=True),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
-            patch("mindroom.bot.interactive.handle_text_response"),
+            patch(
+                "mindroom.turn_controller.interactive.handle_text_response",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
             patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.get_available_agents_for_sender", return_value=[]),
@@ -6640,7 +6664,7 @@ class TestAgentBot:
             assert media_events is None
             assert handled_turn is not None
             assert handled_turn.source_event_prompts == {"$voice": "voice prompt", "$text": "hello"}
-            bot._mark_source_events_responded(handled_turn.with_response_event_id("$route"))
+            bot._turn_controller._mark_source_events_responded(handled_turn.with_response_event_id("$route"))
 
         with (
             patch.object(bot._inbound_turn_normalizer, "resolve_text_event", new=AsyncMock(return_value=event)),
@@ -7242,6 +7266,13 @@ class TestAgentBot:
         bot._handled_turn_ledger = MagicMock()
         _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
         bot.logger = MagicMock()
+        wrap_extracted_collaborators(bot, "_response_runner")
+        replace_turn_controller_deps(
+            bot,
+            handled_turn_ledger=bot._handled_turn_ledger,
+            logger=bot.logger,
+            response_runner=bot._response_runner,
+        )
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -328,7 +328,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             patch.object(bot._conversation_access, "get_thread_snapshot") as mock_fetch_snapshot,
             patch.object(bot._conversation_access, "get_thread_history") as mock_fetch,
             patch("mindroom.turn_controller.is_dm_room", return_value=False),  # Not a DM room
-            patch("mindroom.bot.interactive.handle_text_response", new=AsyncMock()),  # Mock interactive handler
+            patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
         ):
             # Only this agent in the thread
             thread_history = [
@@ -385,7 +385,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             patch.object(bot._conversation_access, "get_thread_snapshot") as mock_fetch_snapshot,
             patch.object(bot._conversation_access, "get_thread_history") as mock_fetch,
             patch("mindroom.turn_controller.is_dm_room", return_value=False),  # Not a DM room
-            patch("mindroom.bot.interactive.handle_text_response", new=AsyncMock()),  # Mock interactive handler
+            patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
         ):
             # Multiple agents in the thread
             thread_history = [
@@ -463,7 +463,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             patch.object(bot._conversation_access, "get_thread_snapshot") as mock_fetch_snapshot,
             patch.object(bot._conversation_access, "get_thread_history") as mock_fetch,
             patch("mindroom.turn_controller.is_dm_room", return_value=False),  # Not a DM room
-            patch("mindroom.bot.interactive.handle_text_response", new=AsyncMock()),  # Mock interactive handler
+            patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
         ):
             thread_history = [
                 _visible_message(sender=test_user_id, body="What's 10% of 100?", timestamp=123, event_id="msg1"),

--- a/tests/test_stop_emoji_reuse.py
+++ b/tests/test_stop_emoji_reuse.py
@@ -84,9 +84,9 @@ async def test_stop_emoji_only_stops_during_generation(tmp_path: Path) -> None:
         },
     )
 
-    # Mock interactive.handle_reaction to simulate it being an interactive question
+    # Mock interactive.handle_reaction so the test only exercises stop-vs-fallthrough behavior.
     with patch("mindroom.bot.interactive.handle_reaction") as mock_handle_reaction:
-        mock_handle_reaction.return_value = ("stop_option", None)  # Simulate selecting a stop option
+        mock_handle_reaction.return_value = None
 
         # Case 1: Message is NOT being generated - should handle as interactive
         await bot._on_reaction(room, reaction_event)

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -1070,7 +1070,7 @@ class TestThreadingBehavior:
         bot._generate_response = AsyncMock()
         install_generate_response_mock(bot, bot._generate_response)
         with (
-            patch("mindroom.bot.interactive.handle_text_response", AsyncMock(return_value=None)),
+            patch("mindroom.turn_controller.interactive.handle_text_response", AsyncMock(return_value=None)),
         ):
             # Process the message
             await bot._on_message(room, event)
@@ -1132,7 +1132,7 @@ class TestThreadingBehavior:
 
         # Mock interactive.handle_text_response and make AI fast
         with (
-            patch("mindroom.bot.interactive.handle_text_response", AsyncMock(return_value=None)),
+            patch("mindroom.turn_controller.interactive.handle_text_response", AsyncMock(return_value=None)),
             patch("mindroom.response_runner.ai_response", AsyncMock(return_value="OK")),
             patch(
                 "mindroom.delivery_gateway.get_latest_thread_event_id_if_needed",
@@ -2774,7 +2774,7 @@ class TestThreadingBehavior:
         # Mock interactive.handle_text_response and generate_response
         bot._generate_response = AsyncMock()
         install_generate_response_mock(bot, bot._generate_response)
-        with patch("mindroom.bot.interactive.handle_text_response", AsyncMock(return_value=None)):
+        with patch("mindroom.turn_controller.interactive.handle_text_response", AsyncMock(return_value=None)):
             # Process the message
             await bot._on_message(room, event)
 

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -191,7 +191,7 @@ async def test_router_processes_own_voice_transcriptions(tmp_path) -> None:  # n
 
     with (
         patch("mindroom.turn_controller.TurnController._execute_command", new_callable=AsyncMock) as mock_handle,
-        patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock),
+        patch("mindroom.turn_controller.interactive.handle_text_response", new_callable=AsyncMock, return_value=None),
         patch("mindroom.turn_controller.is_dm_room", return_value=False),
     ):
         bot.client = MagicMock()
@@ -231,7 +231,7 @@ async def test_router_ignores_non_voice_self_messages(tmp_path) -> None:  # noqa
 
     with (
         patch("mindroom.turn_controller.TurnController._execute_command", new_callable=AsyncMock) as mock_handle,
-        patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock),
+        patch("mindroom.turn_controller.interactive.handle_text_response", new_callable=AsyncMock, return_value=None),
         patch("mindroom.turn_controller.is_dm_room", return_value=False),
     ):
         bot.client = MagicMock()
@@ -306,7 +306,11 @@ async def test_router_processes_own_sidecar_commands_using_original_sender(tmp_p
     )
 
     with (
-        patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock) as mock_interactive,
+        patch(
+            "mindroom.turn_controller.interactive.handle_text_response",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_interactive,
         patch(
             "mindroom.commands.handler.schedule_task",
             new_callable=AsyncMock,
@@ -385,7 +389,11 @@ async def test_router_parses_sidecar_schedule_command_from_canonical_body(tmp_pa
     )
 
     with (
-        patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock) as mock_interactive,
+        patch(
+            "mindroom.turn_controller.interactive.handle_text_response",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_interactive,
         patch(
             "mindroom.commands.handler.schedule_task",
             new_callable=AsyncMock,
@@ -478,7 +486,11 @@ async def test_router_parses_sidecar_skill_command_mentions_from_canonical_body(
     )
 
     with (
-        patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock) as mock_interactive,
+        patch(
+            "mindroom.turn_controller.interactive.handle_text_response",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_interactive,
         patch(
             "mindroom.commands.handler.resolve_skill_command_spec",
             return_value=SimpleNamespace(
@@ -542,7 +554,11 @@ async def test_router_skips_unauthorized_sidecar_commands_before_hydration(tmp_p
     )
 
     with (
-        patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock) as mock_interactive,
+        patch(
+            "mindroom.turn_controller.interactive.handle_text_response",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_interactive,
         patch("mindroom.turn_controller.is_authorized_sender", return_value=False),
         patch("mindroom.commands.handler.schedule_task", new_callable=AsyncMock) as mock_schedule,
     ):

--- a/tests/test_voice_thread_agent_response.py
+++ b/tests/test_voice_thread_agent_response.py
@@ -295,7 +295,7 @@ async def test_agent_ignores_visible_router_voice_echo(mock_home_bot: AgentBot) 
 
     with (
         patch("mindroom.bot.extract_agent_name") as mock_extract_agent,
-        patch("mindroom.bot.interactive.handle_text_response", new_callable=AsyncMock),
+        patch("mindroom.turn_controller.interactive.handle_text_response", new_callable=AsyncMock, return_value=None),
     ):
         mock_extract_agent.side_effect = _extract_agent_side_effect
         await bot._on_message(room, router_voice_echo)


### PR DESCRIPTION
## Summary
- move interactive selection execution into TurnController so AgentBot no longer owns the ack/generate/record workflow
- route command handled-turn recording through TurnStore instead of direct ledger writes
- make interactive reactions and numeric text selections share the same controller-owned path

## Testing
- uv run pytest -x -n 0 --no-cov
- uv run pre-commit run --all-files