### PR TITLE
fix: kill subprocess on cancellation in run_shell_command (ISSUE-125)

### DIFF
--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -334,49 +334,63 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
 
             stdout_buf: deque[str] = deque(maxlen=_MAX_OUTPUT_LINES)
             stderr_buf: deque[str] = deque(maxlen=_MAX_OUTPUT_LINES)
+            background_handle: str | None = None
+            background_monitor_task: asyncio.Task[None] | None = None
 
             stdout_reader = asyncio.create_task(_read_stream(process.stdout, stdout_buf))
             stderr_reader = asyncio.create_task(_read_stream(process.stderr, stderr_buf))
 
             try:
-                await asyncio.wait_for(process.wait(), timeout=timeout)
-            except TimeoutError:
-                active = sum(1 for r in self._processes.values() if not r.finished)
-                if active >= _MAX_BACKGROUNDED:
-                    with contextlib.suppress(ProcessLookupError, PermissionError):
-                        os.killpg(process.pid, signal.SIGKILL)
-                    for task in (stdout_reader, stderr_reader):
-                        task.cancel()
-                        with contextlib.suppress(asyncio.CancelledError):
-                            await task
-                    return (
-                        f"Error: Too many backgrounded processes ({active}/{_MAX_BACKGROUNDED}). "
-                        "Kill or wait for existing ones before running more."
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=timeout)
+                except TimeoutError:
+                    active = sum(1 for r in self._processes.values() if not r.finished)
+                    if active >= _MAX_BACKGROUNDED:
+                        with contextlib.suppress(ProcessLookupError, PermissionError):
+                            os.killpg(process.pid, signal.SIGKILL)
+                        await _cancel_pending_tasks(stdout_reader, stderr_reader)
+                        return (
+                            f"Error: Too many backgrounded processes ({active}/{_MAX_BACKGROUNDED}). "
+                            "Kill or wait for existing ones before running more."
+                        )
+                    handle = f"shell:{uuid.uuid4().hex[:8]}"
+                    record = _ProcessRecord(
+                        namespace=self._handle_namespace,
+                        handle=handle,
+                        pid=process.pid,
+                        args=args,
+                        process=process,
+                        stdout_buf=stdout_buf,
+                        stderr_buf=stderr_buf,
+                        tail=tail,
                     )
-                handle = f"shell:{uuid.uuid4().hex[:8]}"
-                record = _ProcessRecord(
-                    namespace=self._handle_namespace,
-                    handle=handle,
-                    pid=process.pid,
-                    args=args,
-                    process=process,
-                    stdout_buf=stdout_buf,
-                    stderr_buf=stderr_buf,
-                    tail=tail,
-                )
-                record._monitor_task = asyncio.create_task(
-                    _monitor_process(self._processes, handle, process, stdout_reader, stderr_reader),
-                )
-                self._processes[handle] = record
-                return (
-                    f"Command timed out after {timeout}s. Still running (PID {process.pid}).\n"
-                    f"Handle: {handle}\n"
-                    f"Use check_shell_command('{handle}') to poll or "
-                    f"kill_shell_command('{handle}') to stop."
-                )
+                    record._monitor_task = asyncio.create_task(
+                        _monitor_process(self._processes, handle, process, stdout_reader, stderr_reader),
+                    )
+                    self._processes[handle] = record
+                    background_handle = handle
+                    background_monitor_task = record._monitor_task
+                    await asyncio.sleep(0)
+                    return (
+                        f"Command timed out after {timeout}s. Still running (PID {process.pid}).\n"
+                        f"Handle: {handle}\n"
+                        f"Use check_shell_command('{handle}') to poll or "
+                        f"kill_shell_command('{handle}') to stop."
+                    )
 
-            await stdout_reader
-            await stderr_reader
+                await stdout_reader
+                await stderr_reader
+            except asyncio.CancelledError:
+                if background_handle is not None:
+                    self._processes.pop(background_handle, None)
+                if background_monitor_task is not None:
+                    background_monitor_task.cancel()
+                await _terminate_process_group(process)
+                await _cancel_pending_tasks(stdout_reader, stderr_reader)
+                if background_monitor_task is not None:
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await background_monitor_task
+                raise
 
             if process.returncode != 0:
                 return f"Error: {chr(10).join(stderr_buf)}"
@@ -479,6 +493,42 @@ async def _read_stream(stream: asyncio.StreamReader | None, buf: deque[str]) -> 
         buf.append(line.decode(errors="replace").rstrip("\n"))
 
 
+async def _cancel_pending_tasks(*tasks: asyncio.Task[None]) -> None:
+    """Cancel any pending tasks and wait for them to finish."""
+    pending_tasks = [task for task in tasks if not task.done()]
+    for task in pending_tasks:
+        task.cancel()
+    for task in pending_tasks:
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def _terminate_process_group(
+    process: asyncio.subprocess.Process,
+    *,
+    grace_period: float = 0.5,
+) -> None:
+    """Terminate a subprocess process group, escalating to SIGKILL if needed."""
+    if process.returncode is not None:
+        return
+
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(process.pid, signal.SIGTERM)
+
+    try:
+        await asyncio.wait_for(process.wait(), timeout=grace_period)
+    except TimeoutError:
+        pass
+    else:
+        return
+
+    if process.returncode is None:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(process.pid, signal.SIGKILL)
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(process.wait(), timeout=grace_period)
+
+
 async def _monitor_process(
     registry: dict[str, _ProcessRecord],
     handle: str,
@@ -491,11 +541,7 @@ async def _monitor_process(
         await process.wait()
     finally:
         await asyncio.wait([stdout_reader, stderr_reader], timeout=2.0)
-        for task in (stdout_reader, stderr_reader):
-            if not task.done():
-                task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
+        await _cancel_pending_tasks(stdout_reader, stderr_reader)
         record = registry.get(handle)
         if record is not None:
             record.finished = True

--- a/tests/test_shell_cancel.py
+++ b/tests/test_shell_cancel.py
@@ -1,0 +1,181 @@
+"""Regression tests for shell subprocess cancellation."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+import sys
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from mindroom.constants import RuntimePaths, resolve_runtime_paths
+from mindroom.tool_system.metadata import get_tool_by_name
+from mindroom.tools.shell import _process_registry
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Iterator
+    from pathlib import Path
+
+
+def _make_runtime_paths(tmp_path: Path) -> RuntimePaths:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    return resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+
+
+def _get_run_shell_command(tmp_path: Path) -> Callable[..., Awaitable[str]]:
+    runtime_paths = _make_runtime_paths(tmp_path)
+    tool = get_tool_by_name("shell", runtime_paths, disable_sandbox_proxy=True, worker_target=None)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+    return entrypoint
+
+
+async def _wait_for_pid(pid_file: Path) -> int:
+    for _ in range(50):
+        if pid_file.exists():
+            return int(pid_file.read_text(encoding="utf-8").strip())
+        await asyncio.sleep(0.05)
+    message = f"PID file was not written: {pid_file}"
+    raise AssertionError(message)
+
+
+async def _assert_pid_dead(pid: int) -> None:
+    for _ in range(20):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        await asyncio.sleep(0.05)
+    message = f"Subprocess {pid} is still alive"
+    raise AssertionError(message)
+
+
+@pytest.fixture(autouse=True)
+def clear_process_registry() -> Iterator[None]:
+    """Ensure subprocess registry state does not leak between tests."""
+    _process_registry.clear()
+    yield
+    for record in list(_process_registry.values()):
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(record.pid, signal.SIGKILL)
+    _process_registry.clear()
+
+
+@pytest.mark.asyncio
+async def test_run_shell_command_cancellation_kills_subprocess(tmp_path: Path) -> None:
+    """Cancelling run_shell_command should kill the local subprocess and re-raise."""
+    run_shell_command = _get_run_shell_command(tmp_path)
+    pid_file = tmp_path / "sleep.pid"
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "import os, pathlib, sys, time; "
+            "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()), encoding='utf-8'); "
+            "time.sleep(300)"
+        ),
+        str(pid_file),
+    ]
+
+    task = asyncio.create_task(run_shell_command(command, timeout=120))
+    pid = await _wait_for_pid(pid_file)
+    await asyncio.sleep(0.1)
+
+    started_cancel = time.perf_counter()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    elapsed = time.perf_counter() - started_cancel
+
+    await _assert_pid_dead(pid)
+    assert elapsed < 2.0
+    assert _process_registry == {}
+
+
+@pytest.mark.asyncio
+async def test_run_shell_command_cancellation_cleans_up_reader_tasks(tmp_path: Path) -> None:
+    """Cancellation should stop a noisy subprocess without leaking a background handle."""
+    run_shell_command = _get_run_shell_command(tmp_path)
+    pid_file = tmp_path / "stream.pid"
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "import os, pathlib, sys, time; "
+            "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()), encoding='utf-8'); "
+            "i = 0\n"
+            "while True:\n"
+            "    print(f'out-{i}', flush=True)\n"
+            "    print(f'err-{i}', file=sys.stderr, flush=True)\n"
+            "    i += 1\n"
+            "    time.sleep(0.05)\n"
+        ),
+        str(pid_file),
+    ]
+
+    task = asyncio.create_task(run_shell_command(command, timeout=120))
+    pid = await _wait_for_pid(pid_file)
+    await asyncio.sleep(0.2)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await _assert_pid_dead(pid)
+    assert _process_registry == {}
+
+
+@pytest.mark.asyncio
+async def test_run_shell_command_cancellation_cleans_up_background_handle(tmp_path: Path) -> None:
+    """Cancellation after timeout backgrounding should drop the unusable handle."""
+    run_shell_command = _get_run_shell_command(tmp_path)
+    pid_file = tmp_path / "background.pid"
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "import os, pathlib, sys, time; "
+            "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()), encoding='utf-8'); "
+            "time.sleep(300)"
+        ),
+        str(pid_file),
+    ]
+
+    real_sleep = asyncio.sleep
+    background_registered = asyncio.Event()
+    release_background_sleep = asyncio.Event()
+
+    async def controlled_sleep(delay: float) -> None:
+        if delay == 0 and not background_registered.is_set():
+            background_registered.set()
+            await release_background_sleep.wait()
+            return
+        await real_sleep(delay)
+
+    with patch("mindroom.tools.shell.asyncio.sleep", new=controlled_sleep):
+        task = asyncio.create_task(run_shell_command(command, timeout=0))
+        pid = await _wait_for_pid(pid_file)
+        await background_registered.wait()
+        assert len(_process_registry) == 1
+
+        task.cancel()
+        release_background_sleep.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    await _assert_pid_dead(pid)
+    assert _process_registry == {}


### PR DESCRIPTION
## Summary
- kill the subprocess tree when `run_shell_command` is cancelled instead of leaving child processes behind
- harden shell cancellation handling in the tool implementation
- add dedicated regression coverage for shell cancellation cleanup

## Test Plan
- Not rerun during branch refresh; this PR was rebuilt from rewritten `gitea/main` commit `45e5b0d8` onto current `origin/main`.