### PR TITLE
refactor: hide HandledTurnLedger behind TurnStore (ISSUE-141)

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -98,7 +98,6 @@ from .delivery_gateway import (
     SendTextRequest,
 )
 from .edit_regenerator import EditRegenerator, EditRegeneratorDeps
-from .handled_turns import HandledTurnLedger
 from .inbound_turn_normalizer import (
     DispatchPayload,
     InboundTurnNormalizer,
@@ -337,7 +336,6 @@ class AgentBot:
     _deferred_overdue_task_drain_task: asyncio.Task[None] | None
     _standalone_runtime_support: StandaloneRuntimeSupport | None
     _turn_controller: TurnController
-    _handled_turn_ledger: HandledTurnLedger
 
     def __init__(
         self,
@@ -370,10 +368,6 @@ class AgentBot:
             orchestrator=None,
             event_cache=None,
             event_cache_write_coordinator=None,
-        )
-        self._handled_turn_ledger = HandledTurnLedger(
-            self.agent_name,
-            base_path=self.storage_path / "tracking",
         )
         self._standalone_runtime_support = None
         self._deferred_overdue_task_drain_task = None
@@ -465,7 +459,7 @@ class AgentBot:
         self._turn_store = TurnStore(
             TurnStoreDeps(
                 agent_name=self.agent_name,
-                handled_turn_ledger=self._handled_turn_ledger,
+                tracking_base_path=self.storage_path / "tracking",
                 state_writer=self._conversation_state_writer,
                 resolver=self._conversation_resolver,
                 tool_runtime=self._tool_runtime_support,

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from mindroom import constants, interactive
+from mindroom import interactive
 from mindroom.background_tasks import create_background_task
 from mindroom.delivery_gateway import CompactionNoticeRequest
 from mindroom.message_target import MessageTarget
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.constants import RuntimePaths
     from mindroom.delivery_gateway import DeliveryGateway, DeliveryResult
-    from mindroom.handled_turns import HandledTurnState
     from mindroom.history.types import CompactionOutcome
     from mindroom.matrix.client import ResolvedVisibleMessage
     from mindroom.matrix.conversation_access import ConversationReadAccess
@@ -50,7 +49,6 @@ class ResponseOutcome:
     strip_transient_enrichment_after_run: bool = False
     strip_transient_enrichment_before_effects: bool = False
     dispatch_compaction_when_suppressed: bool = False
-    handled_turn: HandledTurnState | None = None
 
 
 @dataclass(frozen=True)
@@ -76,7 +74,6 @@ class PostResponseEffectsDeps:
     queue_memory_persistence: Callable[[], None] | None = None
     persist_response_event_id: Callable[[str, str], None] | None = None
     queue_thread_summary: Callable[[str, str, int | None], None] | None = None
-    record_handled_turn: Callable[[HandledTurnState], None] | None = None
 
 
 @dataclass(frozen=True)
@@ -192,7 +189,6 @@ class PostResponseEffectsSupport:
         strip_transient_enrichment: Callable[[], None] | None = None,
         queue_memory_persistence: Callable[[], None] | None = None,
         persist_response_event_id: Callable[[str, str], None] | None = None,
-        record_handled_turn: Callable[[HandledTurnState], None] | None = None,
     ) -> PostResponseEffectsDeps:
         """Build the per-response post-effect dependency surface."""
 
@@ -231,22 +227,7 @@ class PostResponseEffectsSupport:
             queue_memory_persistence=queue_memory_persistence,
             persist_response_event_id=persist_response_event_id,
             queue_thread_summary=self.queue_thread_summary,
-            record_handled_turn=record_handled_turn,
         )
-
-
-def matrix_run_metadata_for_handled_turn(
-    handled_turn: HandledTurnState,
-) -> dict[str, Any] | None:
-    """Build persisted run metadata for one handled turn."""
-    if not handled_turn.is_coalesced:
-        return None
-    metadata: dict[str, Any] = {
-        constants.MATRIX_SOURCE_EVENT_IDS_METADATA_KEY: list(handled_turn.source_event_ids),
-    }
-    if handled_turn.source_event_prompts:
-        metadata[constants.MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY] = dict(handled_turn.source_event_prompts)
-    return metadata
 
 
 def clear_tracked_response_message(
@@ -361,6 +342,3 @@ async def apply_post_response_effects(  # noqa: C901
             outcome.thread_summary_thread_id,
             outcome.thread_summary_message_count_hint,
         )
-
-    if outcome.handled_turn is not None and deps.record_handled_turn is not None:
-        deps.record_handled_turn(outcome.handled_turn)

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -170,7 +170,8 @@ class IngressHookRunner:
             items = await emit_collect(self.hook_context.registry, EVENT_MESSAGE_ENRICH, context)
             if items:
                 enrichment_block = render_enrichment_block(items)
-                model_prompt = f"{payload.prompt.rstrip()}\n\n{enrichment_block}"
+                base_model_prompt = payload.model_prompt if payload.model_prompt is not None else payload.prompt
+                model_prompt = f"{base_model_prompt.rstrip()}\n\n{enrichment_block}"
                 strip_transient_enrichment_after_run = True
 
         return PreparedHookedPayload(

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from mindroom import constants
@@ -12,7 +13,6 @@ from mindroom.conversation_state_writer import (
     RemoveStaleRunsRequest,
 )
 from mindroom.handled_turns import HandledTurnLedger, HandledTurnRecord, HandledTurnState
-from mindroom.post_response_effects import matrix_run_metadata_for_handled_turn
 
 if TYPE_CHECKING:
     import nio
@@ -38,7 +38,7 @@ class TurnStoreDeps:
     """Collaborators needed to read and write durable turn state."""
 
     agent_name: str
-    handled_turn_ledger: HandledTurnLedger
+    tracking_base_path: Path | str
     state_writer: ConversationStateWriter
     resolver: ConversationResolver
     tool_runtime: ToolRuntimeSupport
@@ -49,38 +49,43 @@ class TurnStore:
     """Own the runtime-facing durable turn record for one entity."""
 
     deps: TurnStoreDeps
+    _ledger: HandledTurnLedger = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Construct the private handled-turn ledger for this runtime entity."""
+        self._ledger = HandledTurnLedger(
+            self.deps.agent_name,
+            base_path=Path(self.deps.tracking_base_path),
+        )
 
     def mark_handled(self, handled_turn: HandledTurnState) -> None:
         """Persist one terminal handled-turn outcome."""
-        visible_echo_event_id = (
-            handled_turn.visible_echo_event_id
-            or self.deps.handled_turn_ledger.visible_echo_event_id_for_sources(
-                handled_turn.source_event_ids,
-            )
+        visible_echo_event_id = handled_turn.visible_echo_event_id or self.visible_echo_event_id_for_sources(
+            handled_turn.source_event_ids,
         )
-        self.deps.handled_turn_ledger.record_handled_turn(
+        self._ledger.record_handled_turn(
             handled_turn.with_visible_echo_event_id(visible_echo_event_id),
         )
 
     def has_responded(self, event_id: str) -> bool:
         """Return whether one source event already has a terminal outcome."""
-        return self.deps.handled_turn_ledger.has_responded(event_id)
+        return self._ledger.has_responded(event_id)
 
     def get_visible_echo_event_id(self, source_event_id: str) -> str | None:
         """Return the tracked visible echo for one source event."""
-        return self.deps.handled_turn_ledger.get_visible_echo_event_id(source_event_id)
+        return self._ledger.get_visible_echo_event_id(source_event_id)
 
     def record_visible_echo(self, source_event_id: str, echo_event_id: str) -> None:
         """Track a visible echo before the turn reaches a terminal outcome."""
-        self.deps.handled_turn_ledger.record_visible_echo(source_event_id, echo_event_id)
+        self._ledger.record_visible_echo(source_event_id, echo_event_id)
 
     def visible_echo_event_id_for_sources(self, source_event_ids: tuple[str, ...]) -> str | None:
         """Return the first visible echo already tracked for one or more source events."""
-        return self.deps.handled_turn_ledger.visible_echo_event_id_for_sources(source_event_ids)
+        return self._ledger.visible_echo_event_id_for_sources(source_event_ids)
 
     def get_turn_record(self, source_event_id: str) -> HandledTurnRecord | None:
         """Return the ledger-backed turn record for one source event when available."""
-        return self.deps.handled_turn_ledger.get_turn_record(source_event_id)
+        return self._ledger.get_turn_record(source_event_id)
 
     def default_history_scope(self) -> HistoryScope:
         """Return the default persisted history scope for this runtime entity."""
@@ -98,7 +103,7 @@ class TurnStore:
         extra triggering events, such as a numeric interactive reply whose response
         still anchors to the original question event.
         """
-        metadata = matrix_run_metadata_for_handled_turn(handled_turn) or {}
+        metadata = self._matrix_run_metadata_for_handled_turn(handled_turn) or {}
         if additional_source_event_ids:
             source_event_ids = [
                 event_id
@@ -113,6 +118,20 @@ class TurnStore:
                 metadata[constants.MATRIX_SOURCE_EVENT_IDS_METADATA_KEY] = source_event_ids
         return metadata or None
 
+    @staticmethod
+    def _matrix_run_metadata_for_handled_turn(
+        handled_turn: HandledTurnState,
+    ) -> dict[str, Any] | None:
+        """Build persisted run metadata for one handled turn."""
+        if not handled_turn.is_coalesced:
+            return None
+        metadata: dict[str, Any] = {
+            constants.MATRIX_SOURCE_EVENT_IDS_METADATA_KEY: list(handled_turn.source_event_ids),
+        }
+        if handled_turn.source_event_prompts:
+            metadata[constants.MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY] = dict(handled_turn.source_event_prompts)
+        return metadata
+
     def load_turn_record(
         self,
         *,
@@ -122,7 +141,7 @@ class TurnStore:
         requester_user_id: str,
     ) -> LoadedTurnRecord | None:
         """Load one merged durable turn record for an edited or replayed source event."""
-        turn_record = self.deps.handled_turn_ledger.get_turn_record(original_event_id)
+        turn_record = self._ledger.get_turn_record(original_event_id)
         ledger_turn_record = turn_record
         persisted_turn_metadata = self.deps.state_writer.load_persisted_turn_metadata(
             LoadPersistedTurnMetadataRequest(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,20 +312,9 @@ def sync_bot_runtime_state(bot: RuntimeBot) -> None:
     runtime.orchestrator = bot.orchestrator
 
 
-def _sync_turn_store_ledger(bot: RuntimeBot) -> None:
-    """Keep the extracted turn store aligned with direct test ledger swaps."""
-    store = unwrap_extracted_collaborator(bot._turn_store)
-    if store.deps.handled_turn_ledger is bot._handled_turn_ledger:
-        return
-    rebuilt = TurnStore(replace(store.deps, handled_turn_ledger=bot._handled_turn_ledger))
-    bot._turn_store = rebuilt
-    wrap_extracted_collaborators(bot, "_turn_store")
-
-
 def replace_turn_policy_deps(bot: RuntimeBot, **changes: object) -> TurnPolicy:
     """Rebuild the turn policy after swapping collaborators captured at construction."""
     sync_bot_runtime_state(bot)
-    _sync_turn_store_ledger(bot)
     policy = unwrap_extracted_collaborator(bot._turn_policy)
     policy_field_names = set(policy.deps.__dataclass_fields__)
     policy_changes = {name: value for name, value in changes.items() if name in policy_field_names}
@@ -384,7 +373,6 @@ def replace_response_runner_deps(bot: RuntimeBot, **changes: object) -> Response
 def replace_edit_regenerator_deps(bot: RuntimeBot, **changes: object) -> EditRegenerator:
     """Rebuild the edit regenerator after swapping captured collaborators."""
     sync_bot_runtime_state(bot)
-    _sync_turn_store_ledger(bot)
     regenerator = unwrap_extracted_collaborator(bot._edit_regenerator)
     regenerator_field_names = set(regenerator.deps.__dataclass_fields__)
     rebuilt_changes = {
@@ -408,7 +396,6 @@ def replace_edit_regenerator_deps(bot: RuntimeBot, **changes: object) -> EditReg
 def replace_turn_controller_deps(bot: RuntimeBot, **changes: object) -> TurnController:
     """Rebuild the turn controller after swapping collaborators captured at construction."""
     sync_bot_runtime_state(bot)
-    _sync_turn_store_ledger(bot)
     controller = unwrap_extracted_collaborator(bot._turn_controller)
     controller_field_names = set(controller.deps.__dataclass_fields__)
     rebuilt_changes = {name: value for name, value in changes.items() if name in controller_field_names}

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -32,6 +32,7 @@ from tests.conftest import (
     runtime_paths_for,
     sync_bot_runtime_state,
     test_runtime_paths,
+    unwrap_extracted_collaborator,
     wrap_extracted_collaborators,
 )
 
@@ -66,16 +67,12 @@ def _replace_turn_policy_deps(bot: AgentBot, **changes: object) -> None:
 def _sync_turn_policy_runtime(bot: AgentBot) -> None:
     """Rebind planner deps after tests replace the bot logger or ledger."""
     sync_bot_runtime_state(bot)
-    _replace_turn_policy_deps(
-        bot,
-        logger=bot.logger,
-        handled_turn_ledger=bot._handled_turn_ledger,
-    )
-    replace_turn_controller_deps(
-        bot,
-        logger=bot.logger,
-        handled_turn_ledger=bot._handled_turn_ledger,
-    )
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
+    turn_store.visible_echo_event_id_for_sources = MagicMock(return_value=None)
+    turn_store.mark_handled = MagicMock()
+    _replace_turn_policy_deps(bot, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
 
 async def _execute_command(
@@ -113,8 +110,6 @@ def mock_agent_bot() -> AgentBot:
     bot.client.user_id = bot.agent_user.user_id
     sync_bot_runtime_state(bot)
     bot.logger = MagicMock()
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
     bot._send_response = AsyncMock()
     _sync_turn_policy_runtime(bot)
     install_send_response_mock(bot, bot._send_response)
@@ -147,8 +142,6 @@ class TestBotScheduleCommands:
             mock_schedule.return_value = ("task123", "✅ Scheduled: 5 minutes from now")
 
             # Mock response tracker for the test
-            mock_agent_bot._handled_turn_ledger = MagicMock()
-            mock_agent_bot._handled_turn_ledger.has_responded.return_value = False
             _sync_turn_policy_runtime(mock_agent_bot)
 
             await _execute_command(mock_agent_bot, room, event, "@user:server", command)
@@ -173,8 +166,6 @@ class TestBotScheduleCommands:
     @pytest.mark.asyncio
     async def test_handle_schedule_command_no_message(self, mock_agent_bot: AgentBot) -> None:
         """Test schedule command with no message uses default."""
-        mock_agent_bot._handled_turn_ledger = MagicMock()
-        mock_agent_bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(mock_agent_bot)
         room = MagicMock()
         room.room_id = "!test:server"
@@ -199,8 +190,6 @@ class TestBotScheduleCommands:
     @pytest.mark.asyncio
     async def test_handle_list_schedules_command(self, mock_agent_bot: AgentBot) -> None:
         """Test bot handles list schedules command."""
-        mock_agent_bot._handled_turn_ledger = MagicMock()
-        mock_agent_bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(mock_agent_bot)
         room = MagicMock()
         room.room_id = "!test:server"
@@ -229,8 +218,6 @@ class TestBotScheduleCommands:
     @pytest.mark.asyncio
     async def test_handle_cancel_schedule_command(self, mock_agent_bot: AgentBot) -> None:
         """Test bot handles cancel schedule command."""
-        mock_agent_bot._handled_turn_ledger = MagicMock()
-        mock_agent_bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(mock_agent_bot)
         room = MagicMock()
         room.room_id = "!test:server"
@@ -252,8 +239,6 @@ class TestBotScheduleCommands:
     @pytest.mark.asyncio
     async def test_handle_cancel_all_scheduled_tasks(self, mock_agent_bot: AgentBot) -> None:
         """Test bot handles cancel all scheduled tasks command."""
-        mock_agent_bot._handled_turn_ledger = MagicMock()
-        mock_agent_bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(mock_agent_bot)
         room = MagicMock()
         room.room_id = "!test:server"
@@ -283,8 +268,6 @@ class TestBotScheduleCommands:
     @pytest.mark.asyncio
     async def test_handle_edit_schedule_command(self, mock_agent_bot: AgentBot) -> None:
         """Test bot handles edit schedule command."""
-        mock_agent_bot._handled_turn_ledger = MagicMock()
-        mock_agent_bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(mock_agent_bot)
         room = MagicMock()
         room.room_id = "!test:server"
@@ -321,8 +304,6 @@ class TestBotScheduleCommands:
     @pytest.mark.asyncio
     async def test_schedule_command_auto_creates_thread(self, mock_agent_bot: AgentBot) -> None:
         """Test that schedule commands auto-create threads when used in main room."""
-        mock_agent_bot._handled_turn_ledger = MagicMock()
-        mock_agent_bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(mock_agent_bot)
         room = MagicMock()
         room.room_id = "!test:server"
@@ -490,8 +471,6 @@ class TestCommandHandling:
         sync_bot_runtime_state(bot)
         bot.logger = MagicMock()
         bot._generate_response = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         install_generate_response_mock(bot, bot._generate_response)
         bot._conversation_resolver.extract_dispatch_context = AsyncMock()
@@ -723,8 +702,6 @@ class TestCommandHandling:
             bot.client.user_id = bot.agent_user.user_id
             sync_bot_runtime_state(bot)
             bot.logger = MagicMock()
-            bot._handled_turn_ledger = MagicMock()
-            bot._handled_turn_ledger.has_responded.return_value = False
             bot._send_skill_command_response = AsyncMock()
             bot._send_response = AsyncMock(return_value="$router_reply")
             _sync_turn_policy_runtime(bot)
@@ -805,8 +782,6 @@ class TestCommandHandling:
         _sync_turn_policy_runtime(bot)
         install_send_response_mock(bot, bot._send_response)
         install_generate_response_mock(bot, bot._generate_response)
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
 
         # Mock context extraction to say agent is mentioned
@@ -871,8 +846,6 @@ class TestCommandHandling:
             sync_bot_runtime_state(bot)
             bot.logger = MagicMock()
             bot._generate_response = AsyncMock()
-            bot._handled_turn_ledger = MagicMock()
-            bot._handled_turn_ledger.has_responded.return_value = False
             _sync_turn_policy_runtime(bot)
             install_generate_response_mock(bot, bot._generate_response)
 
@@ -1006,8 +979,6 @@ class TestCommandHandling:
         sync_bot_runtime_state(bot)
         bot.logger = MagicMock()
         bot._generate_response = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         install_generate_response_mock(bot, bot._generate_response)
 
@@ -1080,8 +1051,6 @@ class TestCommandHandling:
         bot.logger = MagicMock()
         bot._generate_response = AsyncMock()
         bot._send_response = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         install_send_response_mock(bot, bot._send_response)
         install_generate_response_mock(bot, bot._generate_response)
@@ -1196,8 +1165,6 @@ class TestCommandHandling:
         sync_bot_runtime_state(bot)
         bot.logger = MagicMock()
         bot._generate_response = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         install_generate_response_mock(bot, bot._generate_response)
 
@@ -1318,8 +1285,6 @@ class TestCommandHandling:
         sync_bot_runtime_state(bot)
         bot.logger = MagicMock()
         bot._generate_response = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         install_generate_response_mock(bot, bot._generate_response)
 
@@ -1397,8 +1362,6 @@ class TestRouterSkipsSingleAgent:
         bot.logger = MagicMock()
         wrap_extracted_collaborators(bot, "_turn_policy")
         bot._turn_controller._execute_router_relay = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         _sync_turn_policy_runtime(bot)
         bot._turn_controller._execute_router_relay = AsyncMock()
@@ -1485,8 +1448,6 @@ class TestRouterSkipsSingleAgent:
         bot.logger = MagicMock()
         wrap_extracted_collaborators(bot, "_turn_policy")
         bot._turn_controller._execute_router_relay = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         bot._turn_controller._execute_router_relay = AsyncMock()
 
@@ -1587,8 +1548,6 @@ class TestRouterSkipsSingleAgent:
         bot.logger = MagicMock()
         wrap_extracted_collaborators(bot, "_turn_policy")
         bot._turn_controller._execute_router_relay = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         bot._turn_controller._execute_router_relay = AsyncMock()
 
@@ -1674,12 +1633,8 @@ class TestRouterSkipsSingleAgent:
         bot.logger = MagicMock()
         wrap_extracted_collaborators(bot, "_turn_policy")
         bot._turn_controller._execute_command = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         bot._send_response = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         bot._turn_controller._execute_command = AsyncMock()
 
@@ -1746,12 +1701,8 @@ class TestRouterSkipsSingleAgent:
         bot.logger = MagicMock()
         wrap_extracted_collaborators(bot, "_turn_policy")
         bot._turn_controller._execute_command = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         bot._send_response = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         bot._turn_controller._execute_command = AsyncMock()
 
@@ -1818,8 +1769,6 @@ class TestRouterSkipsSingleAgent:
         bot.logger = MagicMock()
         wrap_extracted_collaborators(bot, "_turn_policy")
         bot._turn_controller._execute_router_relay = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         bot._turn_controller._execute_router_relay = AsyncMock()
 
@@ -1908,8 +1857,6 @@ class TestRouterSkipsSingleAgent:
         bot.logger = MagicMock()
         wrap_extracted_collaborators(bot, "_turn_policy")
         bot._turn_controller._execute_command = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
         _sync_turn_policy_runtime(bot)
         bot._turn_controller._execute_command = AsyncMock()
 

--- a/tests/test_dm_functionality.py
+++ b/tests/test_dm_functionality.py
@@ -376,9 +376,6 @@ class TestDMIntegration:
             if "researcher" in config.get_ids(runtime_paths_for(config))
             else "@mindroom_researcher:localhost"
         )
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
-        bot._handled_turn_ledger.has_responded = MagicMock(return_value=False)
         bot.orchestrator = orchestrator
         bot._generate_response = AsyncMock()
         install_generate_response_mock(bot, bot._generate_response)
@@ -474,9 +471,6 @@ class TestDMIntegration:
 
         bot.client = AsyncMock()
         bot.client.user_id = config.get_ids(runtime_paths_for(config))["test_agent"].full_id
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
-        bot._handled_turn_ledger.has_responded = MagicMock(return_value=False)
         bot.logger = MagicMock()
         bot._generate_response = AsyncMock()
         install_generate_response_mock(bot, bot._generate_response)

--- a/tests/test_edit_after_restart.py
+++ b/tests/test_edit_after_restart.py
@@ -10,28 +10,13 @@ import pytest
 
 from mindroom.bot import AgentBot
 from mindroom.constants import resolve_runtime_paths
-from mindroom.handled_turns import HandledTurnLedger, HandledTurnState
+from mindroom.handled_turns import HandledTurnState
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
 from tests.conftest import replace_turn_controller_deps, wrap_extracted_collaborators
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-def _record_handled_turn(
-    ledger: HandledTurnLedger,
-    source_event_ids: list[str],
-    *,
-    response_event_id: str | None = None,
-) -> None:
-    """Record one handled turn through the typed ledger API."""
-    ledger.record_handled_turn(
-        HandledTurnState.create(
-            source_event_ids,
-            response_event_id=response_event_id,
-        ),
-    )
 
 
 @pytest.mark.asyncio
@@ -81,12 +66,9 @@ async def test_bot_handles_redelivered_edit_after_restart(tmp_path: Path) -> Non
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.user_id = "@test_agent:example.com"
 
-    # Create real HandledTurnLedger with the test path
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
@@ -94,12 +76,17 @@ async def test_bot_handles_redelivered_edit_after_restart(tmp_path: Path) -> Non
     # Simulate that the bot has already responded to the original message
     original_event_id = "$original:example.com"
     response_event_id = "$response:example.com"
-    _record_handled_turn(bot._handled_turn_ledger, [original_event_id], response_event_id=response_event_id)
+    bot._turn_store.mark_handled(
+        HandledTurnState.create(
+            [original_event_id],
+            response_event_id=response_event_id,
+        ),
+    )
 
     # Also mark the edit event as "seen" (simulating it was delivered before restart)
     # With the correct implementation, edits should still be processed
     edit_event_id = "$edit:example.com"
-    _record_handled_turn(bot._handled_turn_ledger, [edit_event_id])
+    bot._turn_store.mark_handled(HandledTurnState.create([edit_event_id]))
 
     # Create an edit event that would be redelivered after restart
     edit_event = nio.RoomMessageText.from_dict(
@@ -193,19 +180,16 @@ async def test_bot_skips_duplicate_regular_message_after_restart(tmp_path: Path)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.user_id = "@test_agent:example.com"
 
-    # Create real HandledTurnLedger with the test path
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
 
     # Mark a message as already responded to
     message_event_id = "$message:example.com"
-    _record_handled_turn(bot._handled_turn_ledger, [message_event_id])
+    bot._turn_store.mark_handled(HandledTurnState.create([message_event_id]))
 
     # Create a regular message event (not an edit)
     message_event = nio.RoomMessageText.from_dict(

--- a/tests/test_edit_event_handling.py
+++ b/tests/test_edit_event_handling.py
@@ -48,12 +48,8 @@ async def test_bot_ignores_edit_events(tmp_path: Path) -> None:
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.user_id = "@router:example.com"
 
-    # Mock other dependencies
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
-    bot._handled_turn_ledger.get_turn_record.return_value = None
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@router:example.com")
@@ -142,11 +138,8 @@ async def test_bot_ignores_multiple_edits(tmp_path: Path) -> None:
     # Mock the client and dependencies
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.user_id = "@router:example.com"
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
-    bot._handled_turn_ledger.get_turn_record.return_value = None
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@router:example.com")
 
@@ -240,11 +233,8 @@ async def test_regular_agent_ignores_edits(tmp_path: Path) -> None:
     # Mock the client and dependencies
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.user_id = "@test_agent:example.com"
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
-    bot._handled_turn_ledger.get_turn_record.return_value = None
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
 

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -31,7 +31,7 @@ from mindroom.constants import (
 )
 from mindroom.conversation_state_writer import ConversationStateWriter
 from mindroom.delivery_gateway import DeliveryResult
-from mindroom.handled_turns import HandledTurnLedger, HandledTurnRecord, HandledTurnState
+from mindroom.handled_turns import HandledTurnRecord, HandledTurnState
 from mindroom.history.types import HistoryScope
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.identity import MatrixID
@@ -137,8 +137,21 @@ def _open_storage(storage: object) -> object:
     yield storage
 
 
+def _turn_store(bot: AgentBot | TeamBot) -> object:
+    """Return the unwrapped turn store for one bot."""
+    return unwrap_extracted_collaborator(bot._turn_store)
+
+
+def _response_event_id(bot: AgentBot | TeamBot, source_event_id: str) -> str | None:
+    """Return the stored response event for one source event when present."""
+    turn_record = bot._turn_store.get_turn_record(source_event_id)
+    if turn_record is None:
+        return None
+    return turn_record.response_event_id
+
+
 def _record_handled_turn(
-    ledger: HandledTurnLedger,
+    turn_store: object,
     source_event_ids: list[str],
     *,
     response_event_id: str | None = None,
@@ -147,8 +160,8 @@ def _record_handled_turn(
     history_scope: HistoryScope | None = None,
     conversation_target: MessageTarget | None = None,
 ) -> None:
-    """Record one handled turn through the typed ledger API."""
-    ledger.record_handled_turn(
+    """Record one handled turn through the turn-store API."""
+    turn_store.mark_handled(
         HandledTurnState.create(
             source_event_ids,
             response_event_id=response_event_id,
@@ -239,10 +252,8 @@ async def test_bot_regenerates_response_on_edit(tmp_path: Path) -> None:
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
 
-    # Create real HandledTurnLedger with the test path
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
-    replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
+    replace_turn_policy_deps(bot)
 
     # Mock logger
     bot.logger = MagicMock()
@@ -281,7 +292,7 @@ async def test_bot_regenerates_response_on_edit(tmp_path: Path) -> None:
         reply_to_event_id=original_event.event_id,
     )
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         [original_event.event_id],
         response_event_id=response_event_id,
         response_owner="test_agent",
@@ -365,7 +376,7 @@ async def test_bot_regenerates_response_on_edit(tmp_path: Path) -> None:
         assert edit_args[3]["m.relates_to"]["m.in_reply_to"]["event_id"] == original_event.event_id
 
         # Verify that the response tracker still maps to the same response
-        assert bot._handled_turn_ledger.get_response_event_id(original_event.event_id) == response_event_id
+        assert _response_event_id(bot, original_event.event_id) == response_event_id
 
 
 @pytest.mark.asyncio
@@ -408,13 +419,12 @@ async def test_bot_edit_hooks_see_hydrated_sidecar_edit_body(tmp_path: Path) -> 
             ).encode("utf-8"),
         ),
     )
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         ["$original:example.com"],
         response_event_id="$response:example.com",
         response_owner="test_agent",
@@ -522,13 +532,12 @@ async def test_bot_edit_regeneration_does_not_rerun_response_gating_after_hydrat
             ).encode("utf-8"),
         ),
     )
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
     bot._conversation_resolver.derive_conversation_context = AsyncMock(return_value=(False, None, []))
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
-    _record_handled_turn(bot._handled_turn_ledger, ["$original:example.com"], response_event_id="$response:example.com")
+    _record_handled_turn(bot._turn_store, ["$original:example.com"], response_event_id="$response:example.com")
 
     edit_event = nio.RoomMessageText.from_dict(
         {
@@ -593,10 +602,9 @@ async def test_handle_message_edit_reuses_persisted_target_and_thread_scope(
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
     replace_turn_controller_deps(
         bot,
@@ -611,7 +619,7 @@ async def test_handle_message_edit_reuses_persisted_target_and_thread_scope(
         reply_to_event_id="$router-echo:example.com",
     )
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         ["$original:example.com"],
         response_event_id="$response:example.com",
         response_owner="test_agent",
@@ -784,8 +792,7 @@ async def test_team_bot_regenerates_edits_against_team_history_storage(tmp_path:
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_team:example.com"
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_team", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
     bot.orchestrator = MagicMock(
         current_config=config,
@@ -801,7 +808,7 @@ async def test_team_bot_regenerates_edits_against_team_history_storage(tmp_path:
         reply_to_event_id="$original:example.com",
     )
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         ["$original:example.com"],
         response_event_id=response_event_id,
         response_owner="test_team",
@@ -950,10 +957,8 @@ async def test_bot_ignores_edit_without_previous_response(tmp_path: Path) -> Non
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
 
-    # Create real HandledTurnLedger with the test path
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
-    replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
+    replace_turn_policy_deps(bot)
 
     # Mock logger
     bot.logger = MagicMock()
@@ -1041,26 +1046,24 @@ async def test_bot_ignores_agent_edits(tmp_path: Path) -> None:
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
 
-    # Create real HandledTurnLedger with the test path
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
 
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
     replace_turn_controller_deps(
         bot,
         delivery_gateway=bot._delivery_gateway,
         response_runner=bot._response_runner,
     )
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
 
     # Simulate that the bot has responded to some message
-    _record_handled_turn(bot._handled_turn_ledger, ["$original:example.com"], response_event_id="$response:example.com")
+    _record_handled_turn(bot._turn_store, ["$original:example.com"], response_event_id="$response:example.com")
 
     # Test 1: Bot's own edit
     own_edit_event = nio.RoomMessageText.from_dict(
@@ -1194,10 +1197,9 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_for_non_primary_edi
         thread_id=None,
         reply_to_event_id="$primary:example.com",
     )
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         ["$first:example.com", "$primary:example.com"],
         response_event_id="$response:example.com",
         source_event_prompts={
@@ -1294,8 +1296,8 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_for_non_primary_edi
                 "$primary:example.com": "primary",
             },
         }
-        assert bot._handled_turn_ledger.get_response_event_id("$first:example.com") == "$response:example.com"
-        assert bot._handled_turn_ledger.get_response_event_id("$primary:example.com") == "$response:example.com"
+        assert _response_event_id(bot, "$first:example.com") == "$response:example.com"
+        assert _response_event_id(bot, "$primary:example.com") == "$response:example.com"
         assert mock_remove_run.call_count == 2
         mock_remove_run.assert_has_calls(
             [
@@ -1340,8 +1342,7 @@ async def test_handle_message_edit_reuses_existing_response_without_placeholder_
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
     bot.client.room_send.return_value = _room_send_response("$thinking:example.com")
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
@@ -1351,7 +1352,7 @@ async def test_handle_message_edit_reuses_existing_response_without_placeholder_
         reply_to_event_id="$original:example.com",
     )
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         ["$original:example.com"],
         response_event_id="$response:example.com",
         response_owner="test_agent",
@@ -1433,7 +1434,7 @@ async def test_handle_message_edit_reuses_existing_response_without_placeholder_
         assert call_kwargs["existing_event_id"] == "$response:example.com"
         assert call_kwargs["existing_event_is_placeholder"] is False
         assert call_kwargs["target"] == stored_target
-        assert bot._handled_turn_ledger.get_response_event_id("$original:example.com") == "$response:example.com"
+        assert _response_event_id(bot, "$original:example.com") == "$response:example.com"
         mock_remove_run.assert_called_once()
 
 
@@ -1461,22 +1462,22 @@ async def test_handle_message_edit_does_not_remark_response_when_regeneration_is
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     stored_target = MessageTarget.resolve(
         room_id="!test:example.com",
         thread_id=None,
         reply_to_event_id="$original:example.com",
     )
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         ["$original:example.com"],
         response_event_id="$response:example.com",
         response_owner="test_agent",
         history_scope=_agent_history_scope("test_agent"),
         conversation_target=stored_target,
     )
-    bot._handled_turn_ledger.record_handled_turn = MagicMock(wraps=bot._handled_turn_ledger.record_handled_turn)
+    turn_store = _turn_store(bot)
+    turn_store.mark_handled = MagicMock(wraps=turn_store.mark_handled)
     bot.logger = MagicMock()
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
@@ -1549,8 +1550,8 @@ async def test_handle_message_edit_does_not_remark_response_when_regeneration_is
         )
 
         mock_generate_response.assert_awaited_once()
-        assert bot._handled_turn_ledger.record_handled_turn.call_count == 0
-        assert bot._handled_turn_ledger.get_response_event_id("$original:example.com") == "$response:example.com"
+        assert turn_store.mark_handled.call_count == 0
+        assert _response_event_id(bot, "$original:example.com") == "$response:example.com"
         mock_remove_run.assert_called_once()
 
 
@@ -1578,15 +1579,14 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_from_persisted_run_
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     stored_target = MessageTarget.resolve(
         room_id="!test:example.com",
         thread_id=None,
         reply_to_event_id="$primary:example.com",
     )
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         ["$first:example.com", "$primary:example.com"],
         response_event_id="$response:example.com",
         response_owner="test_agent",
@@ -1699,8 +1699,8 @@ async def test_handle_message_edit_rebuilds_coalesced_prompt_from_persisted_run_
                 "$primary:example.com": "primary",
             },
         }
-        assert bot._handled_turn_ledger.get_response_event_id("$first:example.com") == "$response:example.com"
-        assert bot._handled_turn_ledger.get_response_event_id("$primary:example.com") == "$response:example.com"
+        assert _response_event_id(bot, "$first:example.com") == "$response:example.com"
+        assert _response_event_id(bot, "$primary:example.com") == "$response:example.com"
         assert mock_remove_run.call_count == 2
         mock_remove_run.assert_has_calls(
             [
@@ -1810,7 +1810,7 @@ def test_load_turn_record_preserves_persisted_anchor_for_interactive_selection(t
     )
 
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         ["$selection:example.com"],
         response_event_id="$response-ledger:example.com",
     )
@@ -1872,10 +1872,9 @@ async def test_edit_regenerator_preserves_interactive_selection_run_metadata(tmp
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.user_id = "@mindroom_test_agent:example.com"
     bot.client.rooms = {}
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         ["$selection:example.com"],
         response_event_id="$response:example.com",
     )
@@ -2162,11 +2161,10 @@ async def test_handle_message_edit_uses_fallback_cleanup_when_turn_context_was_r
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         ["$original:example.com"],
         response_event_id="$response:example.com",
         response_owner="test_agent",
@@ -2290,8 +2288,7 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
     bot.client.room_send.return_value = _room_send_response("$thinking:example.com")
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
@@ -2425,9 +2422,9 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
         call_kwargs = mock_generate_response.call_args.kwargs
         assert call_kwargs["existing_event_id"] == "$response:example.com"
         assert call_kwargs["reply_to_event_id"] == "$primary:example.com"
-        assert bot._handled_turn_ledger.get_response_event_id("$first:example.com") == "$response:example.com"
-        assert bot._handled_turn_ledger.get_response_event_id("$primary:example.com") == "$response:example.com"
-        turn_record = bot._handled_turn_ledger.get_turn_record("$primary:example.com")
+        assert _response_event_id(bot, "$first:example.com") == "$response:example.com"
+        assert _response_event_id(bot, "$primary:example.com") == "$response:example.com"
+        turn_record = bot._turn_store.get_turn_record("$primary:example.com")
         assert turn_record is not None
         assert turn_record.source_event_prompts == {
             "$first:example.com": "updated first",
@@ -2457,10 +2454,9 @@ async def test_handle_message_edit_recovers_threaded_turn_using_resolved_context
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
     edit_event = nio.RoomMessageText.from_dict(
@@ -2586,10 +2582,9 @@ async def test_handle_message_edit_recovers_missing_single_turn_without_rerunnin
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
     replace_turn_controller_deps(
         bot,
@@ -2691,7 +2686,7 @@ async def test_handle_message_edit_recovers_missing_single_turn_without_rerunnin
     assert call_kwargs["existing_event_id"] == "$response:example.com"
     assert call_kwargs["reply_to_event_id"] == "$original:example.com"
     assert call_kwargs["prompt"] == "updated question"
-    assert bot._handled_turn_ledger.get_response_event_id("$original:example.com") == "$response:example.com"
+    assert _response_event_id(bot, "$original:example.com") == "$response:example.com"
 
 
 @pytest.mark.asyncio
@@ -2720,8 +2715,7 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
     bot.client.room_send.return_value = _room_send_response("$thinking:example.com")
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
     stored_target = MessageTarget.resolve(
         room_id="!test:example.com",
@@ -2731,7 +2725,7 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
     )
     assert stored_target.session_id == "!test:example.com"
     _record_handled_turn(
-        bot._handled_turn_ledger,
+        bot._turn_store,
         ["$original:example.com"],
         response_event_id="$response-old:example.com",
         response_owner="test_agent",
@@ -2819,12 +2813,9 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
     restarted_bot.client = AsyncMock(spec=nio.AsyncClient)
     restarted_bot.client.rooms = {}
     restarted_bot.client.user_id = "@mindroom_test_agent:example.com"
-    restarted_bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(restarted_bot, handled_turn_ledger=restarted_bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(restarted_bot)
     restarted_bot.logger = MagicMock()
-    assert (
-        restarted_bot._handled_turn_ledger.get_response_event_id("$original:example.com") == "$response-old:example.com"
-    )
+    assert _response_event_id(restarted_bot, "$original:example.com") == "$response-old:example.com"
 
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
     edit_event = nio.RoomMessageText.from_dict(
@@ -2899,9 +2890,7 @@ async def test_handle_message_edit_prefers_persisted_response_event_id_after_res
     call_kwargs = mock_generate_response.call_args.kwargs
     assert call_kwargs["existing_event_id"] == "$response-new:example.com"
     assert call_kwargs["target"].session_id == "!test:example.com"
-    assert (
-        restarted_bot._handled_turn_ledger.get_response_event_id("$original:example.com") == "$response-new:example.com"
-    )
+    assert _response_event_id(restarted_bot, "$original:example.com") == "$response-new:example.com"
 
 
 @pytest.mark.asyncio
@@ -2931,13 +2920,11 @@ async def test_on_reaction_tracks_response_event_id(tmp_path: Path) -> None:
     bot.client.rooms = {}
     bot.client.user_id = "@test_agent:example.com"
 
-    # Create real HandledTurnLedger with the test path
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
 
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
     replace_turn_controller_deps(
         bot,
@@ -2991,8 +2978,8 @@ async def test_on_reaction_tracks_response_event_id(tmp_path: Path) -> None:
         await bot._on_reaction(room, reaction_event)
 
         # Verify that the bot tracked the response correctly
-        assert bot._handled_turn_ledger.has_responded("$question:example.com")
-        assert bot._handled_turn_ledger.get_response_event_id("$question:example.com") == "$response_event:example.com"
+        assert bot._turn_store.has_responded("$question:example.com")
+        assert _response_event_id(bot, "$question:example.com") == "$response_event:example.com"
 
         # Verify the methods were called with correct parameters
         mock_handle_reaction.assert_called_once()
@@ -3028,10 +3015,9 @@ async def test_on_reaction_leaves_question_retryable_when_ack_response_is_suppre
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = "@test_agent:example.com"
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
     replace_turn_controller_deps(
         bot,
@@ -3079,8 +3065,8 @@ async def test_on_reaction_leaves_question_retryable_when_ack_response_is_suppre
 
         await bot._on_reaction(room, reaction_event)
 
-        assert bot._handled_turn_ledger.has_responded("$question:example.com") is False
-        assert bot._handled_turn_ledger.get_response_event_id("$question:example.com") is None
+        assert bot._turn_store.has_responded("$question:example.com") is False
+        assert _response_event_id(bot, "$question:example.com") is None
         request = mock_generate_response.await_args.args[0]
         assert request.existing_event_id == "$ack_event:example.com"
         assert request.existing_event_is_placeholder is True
@@ -3107,9 +3093,8 @@ async def test_on_message_routes_interactive_text_selection_through_turn_control
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = "@test_agent:example.com"
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner", "_turn_policy")
     replace_turn_controller_deps(
         bot,
@@ -3186,10 +3171,10 @@ async def test_on_message_routes_interactive_text_selection_through_turn_control
     assert request.matrix_run_metadata == {
         MATRIX_SOURCE_EVENT_IDS_METADATA_KEY: ["$selection:example.com"],
     }
-    assert bot._handled_turn_ledger.has_responded("$question:example.com")
-    assert bot._handled_turn_ledger.get_response_event_id("$question:example.com") == "$response:example.com"
-    assert bot._handled_turn_ledger.has_responded("$selection:example.com")
-    assert bot._handled_turn_ledger.get_response_event_id("$selection:example.com") == "$response:example.com"
+    assert bot._turn_store.has_responded("$question:example.com")
+    assert _response_event_id(bot, "$question:example.com") == "$response:example.com"
+    assert bot._turn_store.has_responded("$selection:example.com")
+    assert _response_event_id(bot, "$selection:example.com") == "$response:example.com"
 
 
 @pytest.mark.asyncio
@@ -3228,10 +3213,9 @@ async def test_on_reaction_respects_agent_reply_permissions(tmp_path: Path) -> N
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     wrap_extracted_collaborators(bot, "_delivery_gateway", "_response_runner")
     replace_turn_controller_deps(
         bot,
@@ -3344,8 +3328,7 @@ async def test_config_confirmation_blocked_by_reply_permissions(tmp_path: Path) 
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = f"@mindroom_{ROUTER_AGENT_NAME}:example.com"
-    bot._handled_turn_ledger = MagicMock()
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
 
     room = nio.MatrixRoom(
@@ -3419,9 +3402,7 @@ async def test_on_media_message_tracks_relay_event_id(tmp_path: Path) -> None:
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
 
-    # Create real HandledTurnLedger with the test path
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
 
     # Mock logger
     bot.logger = MagicMock()
@@ -3485,8 +3466,8 @@ async def test_on_media_message_tracks_relay_event_id(tmp_path: Path) -> None:
         await bot._on_media_message(room, voice_event)
 
         # Verify that the bot tracked the response correctly
-        assert bot._handled_turn_ledger.has_responded("$voice:example.com")
-        assert bot._handled_turn_ledger.get_response_event_id("$voice:example.com") == "$response:example.com"
+        assert bot._turn_store.has_responded("$voice:example.com")
+        assert _response_event_id(bot, "$voice:example.com") == "$response:example.com"
 
         # Verify the methods were called
         mock_handle_voice.assert_called_once()
@@ -3527,13 +3508,11 @@ async def test_on_media_message_no_transcription_still_marks_relayed(tmp_path: P
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_test_agent:example.com"
 
-    # Create real HandledTurnLedger with the test path
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
 
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@mindroom_test_agent:example.com")
@@ -3594,8 +3573,8 @@ async def test_on_media_message_no_transcription_still_marks_relayed(tmp_path: P
         await bot._on_media_message(room, voice_event)
 
         # Verify that the bot marked as responded with the fallback relay.
-        assert bot._handled_turn_ledger.has_responded("$voice:example.com")
-        assert bot._handled_turn_ledger.get_response_event_id("$voice:example.com") == "$response:example.com"
+        assert bot._turn_store.has_responded("$voice:example.com")
+        assert _response_event_id(bot, "$voice:example.com") == "$response:example.com"
 
         # Verify voice handler was called and the fallback relay ran.
         mock_handle_voice.assert_called_once()
@@ -3647,13 +3626,11 @@ async def test_unauthorized_user_cannot_edit_regenerate(tmp_path: Path) -> None:
     bot.client.rooms = {}
     bot.client.user_id = "@test_agent:example.com"
 
-    # Create real HandledTurnLedger with the test path
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
 
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     room = Mock(spec=nio.MatrixRoom)
     room.room_id = "!test:example.com"
@@ -3668,7 +3645,7 @@ async def test_unauthorized_user_cannot_edit_regenerate(tmp_path: Path) -> None:
     original_event.source = {"event_id": "$original:example.com"}
 
     # Store that we responded to the original
-    _record_handled_turn(bot._handled_turn_ledger, ["$original:example.com"], response_event_id="$response:example.com")
+    _record_handled_turn(bot._turn_store, ["$original:example.com"], response_event_id="$response:example.com")
 
     # Edit from unauthorized user (trying to regenerate)
     edit_event = Mock(spec=nio.RoomMessageText)
@@ -3730,13 +3707,11 @@ async def test_on_media_message_unauthorized_sender_marks_responded(tmp_path: Pa
     bot.client.rooms = {}
     bot.client.user_id = "@test_agent:example.com"
 
-    # Create real HandledTurnLedger with the test path
-    bot._handled_turn_ledger = HandledTurnLedger(agent_name="test_agent", base_path=tmp_path)
-    replace_edit_regenerator_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_edit_regenerator_deps(bot)
 
     # Mock logger
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     # Create a room
     room = nio.MatrixRoom(room_id="!test:example.com", own_user_id="@test_agent:example.com")
@@ -3785,9 +3760,9 @@ async def test_on_media_message_unauthorized_sender_marks_responded(tmp_path: Pa
         await bot._on_media_message(room, voice_event)
 
         # Verify that the bot marked as responded even for unauthorized sender
-        assert bot._handled_turn_ledger.has_responded("$voice:example.com")
+        assert bot._turn_store.has_responded("$voice:example.com")
         # Should not have a response event ID since no response was sent
-        assert bot._handled_turn_ledger.get_response_event_id("$voice:example.com") is None
+        assert _response_event_id(bot, "$voice:example.com") is None
 
         # Verify authorization was checked but voice handler was not called
         mock_is_authorized.assert_called_once()

--- a/tests/test_error_handling_in_callbacks.py
+++ b/tests/test_error_handling_in_callbacks.py
@@ -42,9 +42,6 @@ async def test_callback_error_is_logged_not_raised(tmp_path: Path) -> None:
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.user_id = "@test_agent:example.com"
 
-    # Mock dependencies
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
 
     # Create a room and event

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -593,7 +593,8 @@ async def test_prepare_dispatch_skips_hook_reemission_but_keeps_hook_dispatch(tm
 
     bot.hook_registry = HookRegistry.from_plugins([_plugin("hook-plugin", [received])])
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
-    bot._handled_turn_ledger.record_handled_turn = MagicMock()
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.mark_handled = MagicMock()
 
     dispatch = await bot._turn_controller._prepare_dispatch(
         room,
@@ -610,7 +611,7 @@ async def test_prepare_dispatch_skips_hook_reemission_but_keeps_hook_dispatch(tm
     assert dispatch.envelope.hook_source == "hook-plugin:message:received"
     assert dispatch.envelope.message_received_depth == 1
     assert dispatch.envelope.mentioned_agents == ("code",)
-    bot._handled_turn_ledger.record_handled_turn.assert_not_called()
+    turn_store.mark_handled.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -842,7 +843,8 @@ async def test_dispatch_text_message_runs_message_received_before_command_parsin
     bot.hook_registry = HookRegistry.from_plugins([_plugin("hook-plugin", [received])])
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._turn_controller._execute_command = AsyncMock()
-    bot._handled_turn_ledger.record_handled_turn = MagicMock()
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.mark_handled = MagicMock()
 
     await bot._turn_controller._dispatch_text_message(
         room,
@@ -851,7 +853,7 @@ async def test_dispatch_text_message_runs_message_received_before_command_parsin
 
     assert hook_calls == ["called"]
     bot._turn_controller._execute_command.assert_not_awaited()
-    bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+    turn_store.mark_handled.assert_called_once_with(
         HandledTurnState.from_source_event_id(event.event_id),
     )
 
@@ -879,7 +881,8 @@ async def test_prepare_dispatch_marks_all_source_events_when_hooks_suppress_batc
 
     bot.hook_registry = HookRegistry.from_plugins([_plugin("hook-plugin", [received])])
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
-    bot._handled_turn_ledger.record_handled_turn = MagicMock()
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.mark_handled = MagicMock()
 
     dispatch = await bot._turn_controller._prepare_dispatch(
         room,
@@ -890,7 +893,7 @@ async def test_prepare_dispatch_marks_all_source_events_when_hooks_suppress_batc
     )
 
     assert dispatch is None
-    assert bot._handled_turn_ledger.record_handled_turn.call_args_list == [
+    assert turn_store.mark_handled.call_args_list == [
         call(HandledTurnState.create(["$m1", "$m2"])),
     ]
 
@@ -914,9 +917,8 @@ async def test_dispatch_text_message_hydrates_sidecar_body_for_hooks_and_prompt(
             ).encode("utf-8"),
         ),
     )
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
-    replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
     bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=_dispatch_context(bot))
     bot._turn_policy.plan_turn = AsyncMock(
         return_value=DispatchPlan(
@@ -1821,9 +1823,9 @@ async def test_router_precheck_allows_self_authored_hook_dispatch_without_reques
 async def test_precheck_rejects_hook_dispatch_with_unauthorized_original_sender(tmp_path: Path) -> None:
     """hook_dispatch should enforce room authorization against the preserved requester."""
     bot = _hook_bot(tmp_path)
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
+    turn_store.mark_handled = MagicMock()
     room = nio.MatrixRoom(room_id="!room:localhost", own_user_id="@mindroom_router:localhost")
     room.canonical_alias = None
     event = nio.RoomMessageText.from_dict(
@@ -1845,6 +1847,6 @@ async def test_precheck_rejects_hook_dispatch_with_unauthorized_original_sender(
         prechecked = bot._turn_controller._precheck_dispatch_event(room, event)
 
     assert prechecked is None
-    bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+    turn_store.mark_handled.assert_called_once_with(
         HandledTurnState.from_source_event_id(event.event_id),
     )

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -1436,7 +1436,7 @@ async def test_upload_grace_hard_cap_prevents_indefinite_extension(tmp_path: Pat
 
 
 @pytest.mark.asyncio
-async def test_handled_turn_ledger_marks_all_batch_event_ids(tmp_path: Path) -> None:
+async def test_turn_store_marks_all_batch_event_ids(tmp_path: Path) -> None:
     """Mark every source event ID from a coalesced batch as responded."""
     bot = _make_bot(tmp_path)
     room = _make_room()
@@ -1473,12 +1473,11 @@ async def test_handled_turn_ledger_marks_all_batch_event_ids(tmp_path: Path) -> 
         )
         await asyncio.sleep(0.05)
 
-    assert bot._handled_turn_ledger.has_responded("$m1")
-    assert bot._handled_turn_ledger.has_responded("$m2")
-    assert bot._handled_turn_ledger.get_response_event_id("$m1") == "$response"
-    assert bot._handled_turn_ledger.get_response_event_id("$m2") == "$response"
-    turn_record = bot._handled_turn_ledger.get_turn_record("$m1")
+    assert bot._turn_store.has_responded("$m1")
+    assert bot._turn_store.has_responded("$m2")
+    turn_record = bot._turn_store.get_turn_record("$m1")
     assert turn_record is not None
+    assert turn_record.response_event_id == "$response"
     assert turn_record.source_event_ids == ("$m1", "$m2")
     assert turn_record.anchor_event_id == "$m2"
 
@@ -1616,7 +1615,7 @@ async def test_backlog_replay_skips_older_message_when_newer_exists(tmp_path: Pa
 
     # Older message should be skipped — resolve_dispatch_action never called
     action_mock.assert_not_awaited()
-    assert bot._handled_turn_ledger.has_responded("$m1")
+    assert bot._turn_store.has_responded("$m1")
 
 
 @pytest.mark.asyncio
@@ -1673,7 +1672,7 @@ async def test_media_dispatch_uses_replay_snapshot_after_context_hydration(tmp_p
     newer_mock.assert_called_once()
     assert list(newer_mock.call_args.args[2]) == []
     action_mock.assert_awaited_once()
-    assert not bot._handled_turn_ledger.has_responded("$img1")
+    assert not bot._turn_store.has_responded("$img1")
 
 
 @pytest.mark.asyncio
@@ -1709,7 +1708,7 @@ async def test_thread_history_guard_does_not_interfere_with_normal_dispatch(tmp_
         await bot._turn_controller._dispatch_text_message(room, event, "@user:localhost")
 
     # Dispatch proceeded to completion
-    assert bot._handled_turn_ledger.has_responded("$m1")
+    assert bot._turn_store.has_responded("$m1")
 
 
 # ---------------------------------------------------------------------------
@@ -2180,7 +2179,7 @@ async def test_coalesced_user_batch_suppressed_by_thread_guard(tmp_path: Path) -
 
     # Coalesced user batch MUST be suppressed — not an automation event
     action_mock.assert_not_awaited()
-    assert bot._handled_turn_ledger.has_responded("$m1")
+    assert bot._turn_store.has_responded("$m1")
 
 
 @pytest.mark.asyncio
@@ -2225,7 +2224,7 @@ async def test_coalesced_media_batch_suppressed_by_replay_snapshot(tmp_path: Pat
 
     # Media-backed coalesced user batch MUST still be suppressed.
     action_mock.assert_not_awaited()
-    assert bot._handled_turn_ledger.has_responded("$img1")
+    assert bot._turn_store.has_responded("$img1")
 
 
 @pytest.mark.asyncio

--- a/tests/test_mention_exclusion.py
+++ b/tests/test_mention_exclusion.py
@@ -66,10 +66,6 @@ async def test_agent_ignores_user_message_mentioning_other_agents(tmp_path) -> N
     general_bot.client.rooms = {}
     sync_bot_runtime_state(general_bot)
 
-    # Mock response tracker
-    general_bot._handled_turn_ledger = Mock()
-    general_bot._handled_turn_ledger.has_responded = Mock(return_value=False)
-
     # Create a test room
     room = nio.MatrixRoom(room_id="!room:localhost", own_user_id="@mindroom_general:localhost")
 
@@ -159,9 +155,6 @@ async def test_agent_responds_when_mentioned_along_with_others(tmp_path) -> None
     sync_bot_runtime_state(general_bot)
 
     # Mock response tracker
-    general_bot._handled_turn_ledger = Mock()
-    general_bot._handled_turn_ledger.has_responded = Mock(return_value=False)
-
     # Create a test room
     room = nio.MatrixRoom(room_id="!room:localhost", own_user_id="@mindroom_general:localhost")
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -18,7 +18,6 @@ import httpx
 import nio
 import pytest
 import uvicorn
-from agno.db.base import SessionType
 from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
 from agno.media import Image
@@ -122,6 +121,8 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine, Sequence
     from pathlib import Path
 
+    from mindroom.turn_store import TurnStore
+
 
 def _make_matrix_client_mock() -> AsyncMock:
     """Return a minimal Matrix client mock for bot tests."""
@@ -149,6 +150,18 @@ def _wrap_extracted_collaborators(bot: AgentBot) -> AgentBot:
 def _replace_turn_policy_deps(bot: AgentBot, **changes: object) -> TurnPolicy:
     """Rebuild the policy with the shared collaborator-replacement helper."""
     return shared_replace_turn_policy_deps(bot, **changes)
+
+
+def _turn_store(bot: AgentBot | TeamBot) -> TurnStore:
+    """Return the real turn store behind one wrapped bot."""
+    return unwrap_extracted_collaborator(bot._turn_store)
+
+
+def _mock_turn_store(bot: AgentBot | TeamBot, *, has_responded: bool = False) -> TurnStore:
+    """Patch the existing turn store in place for tests that only need dedupe control."""
+    turn_store = _turn_store(bot)
+    turn_store.has_responded = MagicMock(return_value=has_responded)
+    return turn_store
 
 
 def _replace_response_runner_runtime_deps(
@@ -313,6 +326,93 @@ def _visible_message(
         event_id=event_id,
         timestamp=timestamp,
         content=content,
+    )
+
+
+def _room_image_event(
+    *,
+    sender: str,
+    event_id: str,
+    body: str = "image.jpg",
+    room_id: str = "!test:localhost",
+    server_timestamp: int = 1000,
+) -> nio.RoomMessageImage:
+    """Create a typed Matrix image event for media-dispatch tests."""
+    return cast(
+        "nio.RoomMessageImage",
+        nio.RoomMessageImage.from_dict(
+            {
+                "event_id": event_id,
+                "sender": sender,
+                "origin_server_ts": server_timestamp,
+                "room_id": room_id,
+                "type": "m.room.message",
+                "content": {
+                    "msgtype": "m.image",
+                    "body": body,
+                    "url": "mxc://localhost/test-image",
+                    "info": {"mimetype": "image/jpeg"},
+                },
+            },
+        ),
+    )
+
+
+def _room_audio_event(
+    *,
+    sender: str,
+    event_id: str,
+    body: str = "voice.ogg",
+    room_id: str = "!test:localhost",
+    server_timestamp: int = 1000,
+) -> nio.RoomMessageAudio:
+    """Create a typed Matrix audio event for media-dispatch tests."""
+    return cast(
+        "nio.RoomMessageAudio",
+        nio.RoomMessageAudio.from_dict(
+            {
+                "event_id": event_id,
+                "sender": sender,
+                "origin_server_ts": server_timestamp,
+                "room_id": room_id,
+                "type": "m.room.message",
+                "content": {
+                    "msgtype": "m.audio",
+                    "body": body,
+                    "url": "mxc://localhost/test-audio",
+                    "info": {"mimetype": "audio/ogg"},
+                },
+            },
+        ),
+    )
+
+
+def _room_file_event(
+    *,
+    sender: str,
+    event_id: str,
+    body: str = "report.pdf",
+    room_id: str = "!test:localhost",
+    server_timestamp: int = 1000,
+) -> nio.RoomMessageFile:
+    """Create a typed Matrix file event for media-dispatch tests."""
+    return cast(
+        "nio.RoomMessageFile",
+        nio.RoomMessageFile.from_dict(
+            {
+                "event_id": event_id,
+                "sender": sender,
+                "origin_server_ts": server_timestamp,
+                "room_id": room_id,
+                "type": "m.room.message",
+                "content": {
+                    "msgtype": "m.file",
+                    "body": body,
+                    "url": "mxc://localhost/test-file",
+                    "info": {"mimetype": "application/pdf"},
+                },
+            },
+        ),
     )
 
 
@@ -497,7 +597,7 @@ class TestAgentBot:
         return cls.create_mock_config(storage_path)
 
     @staticmethod
-    def _make_handler_event(handler_name: str, *, sender: str, event_id: str) -> MagicMock:
+    def _make_handler_event(handler_name: str, *, sender: str, event_id: str) -> object:
         """Create a minimal event object for a specific handler type."""
         if handler_name == "message":
             event = MagicMock(spec=nio.RoomMessageText)
@@ -505,21 +605,11 @@ class TestAgentBot:
             event.server_timestamp = 1234567890
             event.source = {"content": {"body": "hello"}}
         elif handler_name == "image":
-            event = MagicMock(spec=nio.RoomMessageImage)
-            event.body = "image.jpg"
-            event.server_timestamp = 1000
-            event.source = {"content": {"body": "image.jpg"}}
+            event = _room_image_event(sender=sender, event_id=event_id)
         elif handler_name == "voice":
-            event = MagicMock(spec=nio.RoomMessageAudio)
-            event.body = "voice"
-            event.server_timestamp = 1000
-            event.source = {"content": {"body": "voice"}}
+            event = _room_audio_event(sender=sender, event_id=event_id, body="voice")
         elif handler_name == "file":
-            event = MagicMock(spec=nio.RoomMessageFile)
-            event.body = "report.pdf"
-            event.url = "mxc://localhost/report"
-            event.server_timestamp = 1000
-            event.source = {"content": {"body": "report.pdf", "msgtype": "m.file"}}
+            event = _room_file_event(sender=sender, event_id=event_id)
         elif handler_name == "reaction":
             event = MagicMock(spec=nio.ReactionEvent)
             event.key = "👍"
@@ -1228,8 +1318,9 @@ class TestAgentBot:
             mock_stream_agent_response.assert_called_once()
             stream_kwargs = mock_stream_agent_response.call_args.kwargs
             assert stream_kwargs["agent_name"] == "calculator"
-            assert stream_kwargs["prompt"].endswith(f"{mention_id}: What's 2+2?")
-            assert stream_kwargs["prompt"].startswith("[")
+            assert stream_kwargs["prompt"] == f"{mention_id}: What's 2+2?"
+            assert stream_kwargs["model_prompt"].startswith("[")
+            assert stream_kwargs["model_prompt"].endswith(f"{mention_id}: What's 2+2?")
             assert stream_kwargs["session_id"] == "!test:localhost:$thread_root_id"
             assert stream_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
             assert stream_kwargs["config"] == config
@@ -1252,8 +1343,9 @@ class TestAgentBot:
             mock_ai_response.assert_called_once()
             ai_kwargs = mock_ai_response.call_args.kwargs
             assert ai_kwargs["agent_name"] == "calculator"
-            assert ai_kwargs["prompt"].endswith(f"{mention_id}: What's 2+2?")
-            assert ai_kwargs["prompt"].startswith("[")
+            assert ai_kwargs["prompt"] == f"{mention_id}: What's 2+2?"
+            assert ai_kwargs["model_prompt"].startswith("[")
+            assert ai_kwargs["model_prompt"].endswith(f"{mention_id}: What's 2+2?")
             assert ai_kwargs["session_id"] == "!test:localhost:$thread_root_id"
             assert ai_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
             assert ai_kwargs["config"] == config
@@ -1312,10 +1404,10 @@ class TestAgentBot:
             )
 
         assert delivery.event_id == "$response"
-        model_prompt = mock_ai.call_args.kwargs["prompt"]
+        model_prompt = mock_ai.call_args.kwargs["model_prompt"]
         assert "[Matrix metadata for tool calls]" in model_prompt
         assert "room_id: !test:localhost" in model_prompt
-        assert "thread_id: $event123" in model_prompt
+        assert "thread_id: none" in model_prompt
         assert "reply_to_event_id: $event123" in model_prompt
 
     @pytest.mark.asyncio
@@ -1358,10 +1450,10 @@ class TestAgentBot:
             )
 
         assert delivery.event_id == "$response"
-        model_prompt = mock_ai.call_args.kwargs["prompt"]
+        model_prompt = mock_ai.call_args.kwargs["model_prompt"]
         assert "[Matrix metadata for tool calls]" in model_prompt
         assert "room_id: !test:localhost" in model_prompt
-        assert "thread_id: $event123" in model_prompt
+        assert "thread_id: none" in model_prompt
         assert "reply_to_event_id: $event123" in model_prompt
 
     @pytest.mark.asyncio
@@ -1414,11 +1506,62 @@ class TestAgentBot:
                 )
 
         assert delivery.event_id == "$response"
-        model_prompt = mock_stream_agent_response.call_args.kwargs["prompt"]
+        model_prompt = mock_stream_agent_response.call_args.kwargs["model_prompt"]
         assert "[Matrix metadata for tool calls]" in model_prompt
         assert "room_id: !test:localhost" in model_prompt
-        assert "thread_id: $event456" in model_prompt
+        assert "thread_id: none" in model_prompt
         assert "reply_to_event_id: $event456" in model_prompt
+
+    @pytest.mark.asyncio
+    async def test_process_and_respond_uses_safe_thread_root_for_prompt_metadata(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Prompt metadata should prefer the stable thread root over plain reply event IDs."""
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "calculator": AgentConfig(
+                        display_name="CalculatorAgent",
+                        rooms=["!test:localhost"],
+                        tools=["matrix_message"],
+                        include_default_tools=False,
+                    ),
+                },
+            ),
+            tmp_path,
+        )
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = AsyncMock()
+        bot.client.room_send.return_value = _room_send_response("$response")
+        _set_knowledge_for_agent(bot, MagicMock(return_value=None))
+        mock_ai = AsyncMock(return_value="Handled")
+        target = MessageTarget.resolve(
+            room_id="!test:localhost",
+            thread_id=None,
+            reply_to_event_id="$reply_plain:localhost",
+            safe_thread_root="$thread_root:localhost",
+        )
+
+        with patch_response_runner_module(
+            typing_indicator=_noop_typing_indicator,
+            ai_response=mock_ai,
+        ):
+            await bot._response_runner.process_and_respond(
+                _response_request(
+                    room_id="!test:localhost",
+                    prompt="Continue",
+                    reply_to_event_id="$reply_plain:localhost",
+                    thread_history=[],
+                    user_id="@user:localhost",
+                    target=target,
+                ),
+            )
+
+        model_prompt = mock_ai.call_args.kwargs["model_prompt"]
+        assert "thread_id: $thread_root:localhost" in model_prompt
+        assert "reply_to_event_id: $reply_plain:localhost" in model_prompt
 
     @pytest.mark.asyncio
     async def test_process_and_respond_streaming_resolves_knowledge_once(
@@ -2062,7 +2205,6 @@ class TestAgentBot:
                 requester_user_id="@user:localhost",
                 payload=DispatchPayload(prompt="team prompt"),
                 response_envelope=_hook_envelope(body="team prompt", source_event_id="$team-root"),
-                strip_transient_enrichment_after_run=True,
                 correlation_id="corr-team",
             )
 
@@ -2071,12 +2213,12 @@ class TestAgentBot:
         assert after_results == [("$team", "Team reply [hooked]", "edited", "team")]
 
     @pytest.mark.asyncio
-    async def test_generate_team_response_helper_strips_enrichment_from_shared_team_session(
+    async def test_generate_team_response_helper_preserves_enrichment_in_shared_team_session(
         self,
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
     ) -> None:
-        """Shared team responses should strip transient enrichment from persisted session history."""
+        """Shared team responses should preserve enriched history for exact replay."""
         config = self._config_for_storage(tmp_path)
         config.defaults.show_stop_button = False
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
@@ -2089,9 +2231,6 @@ class TestAgentBot:
             runtime_paths=runtime_paths_for(config),
         )
         matrix_ids = config.get_ids(runtime_paths_for(config))
-        storage = MagicMock()
-        mock_strip_enrichment = MagicMock()
-        bot._conversation_state_writer.create_team_history_storage = MagicMock(return_value=storage)
         with (
             patch(
                 "mindroom.delivery_gateway.edit_message",
@@ -2101,7 +2240,6 @@ class TestAgentBot:
                 typing_indicator=_noop_typing_indicator,
                 should_use_streaming=AsyncMock(return_value=False),
                 team_response=AsyncMock(return_value="Team reply"),
-                strip_enrichment_from_session_storage=mock_strip_enrichment,
             ),
         ):
             event_id = await bot._generate_team_response_helper(
@@ -2114,20 +2252,10 @@ class TestAgentBot:
                 requester_user_id="@user:localhost",
                 payload=DispatchPayload(prompt="team prompt"),
                 response_envelope=_hook_envelope(body="team prompt", source_event_id="$team-root"),
-                strip_transient_enrichment_after_run=True,
                 correlation_id="corr-team",
             )
 
         assert event_id == "$team"
-        mock_strip_enrichment.assert_called_once_with(
-            storage,
-            MessageTarget.resolve(
-                room_id="!test:localhost",
-                thread_id=None,
-                reply_to_event_id="$team-root",
-            ).session_id,
-            session_type=SessionType.TEAM,
-        )
 
     @pytest.mark.asyncio
     async def test_generate_team_response_helper_uses_resolved_thread_root_for_placeholder_and_edit(
@@ -2795,8 +2923,9 @@ class TestAgentBot:
             )
 
         assert mock_ai.call_args.kwargs["show_tool_calls"] is True
-        assert mock_ai.call_args.kwargs["prompt"].startswith("[")
-        assert mock_ai.call_args.kwargs["prompt"].endswith("Use research skill")
+        assert mock_ai.call_args.kwargs["prompt"] == "Use research skill"
+        assert mock_ai.call_args.kwargs["model_prompt"].startswith("[")
+        assert mock_ai.call_args.kwargs["model_prompt"].endswith("Use research skill")
 
     @pytest.mark.asyncio
     async def test_skill_command_room_mode_uses_room_level_session_id(
@@ -4085,9 +4214,8 @@ class TestAgentBot:
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        turn_store = _mock_turn_store(bot)
+        turn_store.mark_handled = MagicMock()
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
@@ -4103,11 +4231,11 @@ class TestAgentBot:
             await self._invoke_handler(bot, handler_name, room, event)
 
         if marks_responded:
-            bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+            turn_store.mark_handled.assert_called_once_with(
                 HandledTurnState.from_source_event_id(event.event_id),
             )
         else:
-            bot._handled_turn_ledger.record_handled_turn.assert_not_called()
+            turn_store.mark_handled.assert_not_called()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -4138,9 +4266,8 @@ class TestAgentBot:
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        turn_store = _mock_turn_store(bot)
+        turn_store.mark_handled = MagicMock()
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
@@ -4171,11 +4298,11 @@ class TestAgentBot:
             await self._invoke_handler(bot, handler_name, room, event)
 
         if marks_responded:
-            bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+            turn_store.mark_handled.assert_called_once_with(
                 HandledTurnState.from_source_event_id(event.event_id),
             )
         else:
-            bot._handled_turn_ledger.record_handled_turn.assert_not_called()
+            turn_store.mark_handled.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_agent_bot_on_image_message_forwards_image_to_generate_response(
@@ -4189,9 +4316,8 @@ class TestAgentBot:
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
 
-        tracker = MagicMock()
-        tracker.has_responded.return_value = False
-        bot.__dict__["_handled_turn_ledger"] = tracker
+        turn_store = _mock_turn_store(bot)
+        turn_store.mark_handled = MagicMock()
 
         bot._conversation_resolver.extract_message_context = AsyncMock(
             return_value=MessageContext(
@@ -4209,11 +4335,7 @@ class TestAgentBot:
         room = MagicMock()
         room.room_id = "!test:localhost"
 
-        event = MagicMock(spec=nio.RoomMessageImage)
-        event.sender = "@user:localhost"
-        event.event_id = "$img_event"
-        event.body = "photo.jpg"
-        event.server_timestamp = 1000
+        event = _room_image_event(sender="@user:localhost", event_id="$img_event", body="photo.jpg")
         event.source = {"content": {"body": "photo.jpg"}}  # no filename → body is filename
 
         image = MagicMock()
@@ -4249,8 +4371,10 @@ class TestAgentBot:
         bot._generate_response.assert_awaited_once()
         generate_kwargs = bot._generate_response.await_args.kwargs
         assert generate_kwargs["room_id"] == "!test:localhost"
-        assert "Available attachment IDs" in generate_kwargs["prompt"]
-        assert attachment_id in generate_kwargs["prompt"]
+        assert "Available attachment IDs" not in generate_kwargs["prompt"]
+        assert generate_kwargs["model_prompt"] is not None
+        assert "Available attachment IDs" in generate_kwargs["model_prompt"]
+        assert attachment_id in generate_kwargs["model_prompt"]
         assert generate_kwargs["reply_to_event_id"] == "$img_event"
         assert generate_kwargs["thread_id"] is None
         assert generate_kwargs["thread_history"] == []
@@ -4261,7 +4385,7 @@ class TestAgentBot:
         assert list(media.files) == []
         assert list(media.videos) == []
         assert generate_kwargs["attachment_ids"] == [attachment_id]
-        tracker.record_handled_turn.assert_called_once_with(
+        turn_store.mark_handled.assert_called_once_with(
             _agent_response_handled_turn(
                 agent_name=mock_agent_user.agent_name,
                 room_id=room.room_id,
@@ -4283,9 +4407,8 @@ class TestAgentBot:
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
 
-        tracker = MagicMock()
-        tracker.has_responded.return_value = False
-        bot.__dict__["_handled_turn_ledger"] = tracker
+        turn_store = _mock_turn_store(bot)
+        turn_store.mark_handled = MagicMock()
 
         history_attachment_id = "att_prev_image"
         current_attachment_id = _attachment_id_for_event("$img_event_history")
@@ -4309,15 +4432,13 @@ class TestAgentBot:
         bot._generate_response = AsyncMock(return_value="$response")
         install_generate_response_mock(bot, bot._generate_response)
         _replace_turn_policy_deps(bot, resolver=bot._conversation_resolver)
+        turn_store = _turn_store(bot)
+        turn_store.mark_handled = MagicMock()
 
         room = MagicMock()
         room.room_id = "!test:localhost"
 
-        event = MagicMock(spec=nio.RoomMessageImage)
-        event.sender = "@user:localhost"
-        event.event_id = "$img_event_history"
-        event.body = "photo.png"
-        event.server_timestamp = 1000
+        event = _room_image_event(sender="@user:localhost", event_id="$img_event_history", body="photo.png")
         event.source = {
             "content": {
                 "body": "photo.png",
@@ -4371,9 +4492,12 @@ class TestAgentBot:
         bot._generate_response.assert_awaited_once()
         generate_kwargs = bot._generate_response.await_args.kwargs
         assert generate_kwargs["attachment_ids"] == [current_attachment_id, history_attachment_id]
-        assert current_attachment_id in generate_kwargs["prompt"]
-        assert history_attachment_id in generate_kwargs["prompt"]
-        tracker.record_handled_turn.assert_called_once_with(
+        assert current_attachment_id not in generate_kwargs["prompt"]
+        assert history_attachment_id not in generate_kwargs["prompt"]
+        assert generate_kwargs["model_prompt"] is not None
+        assert current_attachment_id in generate_kwargs["model_prompt"]
+        assert history_attachment_id in generate_kwargs["model_prompt"]
+        turn_store.mark_handled.assert_called_once_with(
             _agent_response_handled_turn(
                 agent_name=mock_agent_user.agent_name,
                 room_id=room.room_id,
@@ -4421,7 +4545,102 @@ class TestAgentBot:
             )
 
         assert payload.attachment_ids == ["att_image"]
+        assert payload.prompt == "describe this"
+        assert payload.model_prompt is not None
+        assert "Available attachment IDs" in payload.model_prompt
+        assert "att_image" in payload.model_prompt
         assert list(payload.media.images) == [stored_image, fallback_image]
+
+    @pytest.mark.asyncio
+    async def test_build_dispatch_payload_with_attachments_keeps_raw_prompt_clean(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Attachment IDs should be isolated to model_prompt instead of mutating the raw user prompt."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = _make_matrix_client_mock()
+        stored_image = MagicMock(spec=Image)
+
+        with (
+            patch(
+                "mindroom.inbound_turn_normalizer.resolve_thread_attachment_ids",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "mindroom.inbound_turn_normalizer.resolve_attachment_media",
+                return_value=(["att_image"], [], [stored_image], [], []),
+            ),
+        ):
+            payload = await bot._inbound_turn_normalizer.build_dispatch_payload_with_attachments(
+                DispatchPayloadWithAttachmentsRequest(
+                    room_id="!test:localhost",
+                    prompt="describe this",
+                    current_attachment_ids=["att_image"],
+                    thread_id=None,
+                    media_thread_id=None,
+                    thread_history=[],
+                ),
+            )
+
+        assert payload.prompt == "describe this"
+        assert payload.model_prompt is not None
+        assert "Available attachment IDs" in payload.model_prompt
+        assert "att_image" in payload.model_prompt
+
+    @pytest.mark.asyncio
+    async def test_message_enrichment_appends_to_existing_model_prompt(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Message enrichment should extend an existing model prompt rather than replacing it."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        dispatch = PreparedDispatch(
+            requester_user_id="@user:localhost",
+            context=MessageContext(
+                am_i_mentioned=False,
+                is_thread=False,
+                thread_id=None,
+                thread_history=[],
+                mentioned_agents=[],
+                has_non_agent_mentions=False,
+                requires_full_thread_history=False,
+            ),
+            target=MessageTarget.resolve("!test:localhost", None, "$event"),
+            correlation_id="corr-1",
+            envelope=_hook_envelope(body="hello", source_event_id="$event"),
+        )
+        registry_stub = MagicMock()
+        registry_stub.has_hooks.return_value = True
+        bot._ingress_hook_runner.hook_context.hook_registry_state.registry = registry_stub
+
+        with (
+            patch(
+                "mindroom.turn_policy.emit_collect",
+                new=AsyncMock(
+                    return_value=[EnrichmentItem(key="extra", text="hook enrichment", cache_policy="volatile")],
+                ),
+            ),
+        ):
+            prepared = await bot._ingress_hook_runner.apply_message_enrichment(
+                dispatch,
+                DispatchPayload(
+                    prompt="hello",
+                    model_prompt="Available attachment IDs: att_1. Use tool calls to inspect or process them.",
+                    attachment_ids=["att_1"],
+                ),
+                target_entity_name=mock_agent_user.agent_name,
+                target_member_names=None,
+            )
+
+        assert prepared.payload.prompt == "hello"
+        assert prepared.payload.model_prompt is not None
+        assert prepared.payload.model_prompt.startswith("Available attachment IDs: att_1")
+        assert "hook enrichment" in prepared.payload.model_prompt
 
     @pytest.mark.asyncio
     async def test_agent_bot_on_image_message_leaves_event_retryable_when_terminal_error_cannot_be_sent(
@@ -4434,9 +4653,8 @@ class TestAgentBot:
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
 
-        tracker = MagicMock()
-        tracker.has_responded.return_value = False
-        bot.__dict__["_handled_turn_ledger"] = tracker
+        turn_store = _mock_turn_store(bot)
+        turn_store.mark_handled = MagicMock()
 
         bot._conversation_resolver.extract_message_context = AsyncMock(
             return_value=MessageContext(
@@ -4454,11 +4672,7 @@ class TestAgentBot:
         room = MagicMock()
         room.room_id = "!test:localhost"
 
-        event = MagicMock(spec=nio.RoomMessageImage)
-        event.sender = "@user:localhost"
-        event.event_id = "$img_event_fail"
-        event.body = "please analyze"
-        event.server_timestamp = 1000
+        event = _room_image_event(sender="@user:localhost", event_id="$img_event_fail", body="please analyze")
         event.source = {"content": {"body": "please analyze"}}
 
         with (
@@ -4476,7 +4690,7 @@ class TestAgentBot:
             await bot._on_media_message(room, event)
 
         bot._generate_response.assert_not_called()
-        tracker.record_handled_turn.assert_not_called()
+        turn_store.mark_handled.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_agent_bot_on_file_message_forwards_local_path_to_generate_response(
@@ -4489,9 +4703,8 @@ class TestAgentBot:
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
 
-        tracker = MagicMock()
-        tracker.has_responded.return_value = False
-        bot.__dict__["_handled_turn_ledger"] = tracker
+        turn_store = _mock_turn_store(bot)
+        turn_store.mark_handled = MagicMock()
 
         bot._conversation_resolver.extract_message_context = AsyncMock(
             return_value=MessageContext(
@@ -4509,12 +4722,8 @@ class TestAgentBot:
         room = MagicMock()
         room.room_id = "!test:localhost"
 
-        event = MagicMock(spec=nio.RoomMessageFile)
-        event.sender = "@user:localhost"
-        event.event_id = "$file_event"
-        event.body = "report.pdf"
+        event = _room_file_event(sender="@user:localhost", event_id="$file_event", body="report.pdf")
         event.url = "mxc://localhost/report"
-        event.server_timestamp = 1000
         event.source = {"content": {"body": "report.pdf", "msgtype": "m.file"}}
 
         local_media_path = tmp_path / "incoming_media" / "file.pdf"
@@ -4561,13 +4770,15 @@ class TestAgentBot:
         assert generate_kwargs["thread_history"] == []
         assert generate_kwargs["user_id"] == "@user:localhost"
         assert generate_kwargs["attachment_ids"] == [attachment_id]
-        assert "Available attachment IDs" in generate_kwargs["prompt"]
-        assert attachment_id in generate_kwargs["prompt"]
+        assert "Available attachment IDs" not in generate_kwargs["prompt"]
+        assert generate_kwargs["model_prompt"] is not None
+        assert "Available attachment IDs" in generate_kwargs["model_prompt"]
+        assert attachment_id in generate_kwargs["model_prompt"]
         media = generate_kwargs["media"]
         assert len(media.files) == 1
         assert str(media.files[0].filepath) == str(local_media_path)
         assert list(media.videos) == []
-        tracker.record_handled_turn.assert_called_once_with(
+        turn_store.mark_handled.assert_called_once_with(
             _agent_response_handled_turn(
                 agent_name=mock_agent_user.agent_name,
                 room_id=room.room_id,
@@ -4588,9 +4799,8 @@ class TestAgentBot:
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
 
-        tracker = MagicMock()
-        tracker.has_responded.return_value = False
-        bot.__dict__["_handled_turn_ledger"] = tracker
+        turn_store = _mock_turn_store(bot)
+        turn_store.mark_handled = MagicMock()
 
         bot._conversation_resolver.extract_message_context = AsyncMock(
             return_value=MessageContext(
@@ -4608,12 +4818,8 @@ class TestAgentBot:
         room = MagicMock()
         room.room_id = "!test:localhost"
 
-        event = MagicMock(spec=nio.RoomMessageFile)
-        event.sender = "@user:localhost"
-        event.event_id = "$file_event_fail"
-        event.body = "report.pdf"
+        event = _room_file_event(sender="@user:localhost", event_id="$file_event_fail", body="report.pdf")
         event.url = "mxc://localhost/report"
-        event.server_timestamp = 1000
         event.source = {"content": {"body": "report.pdf", "msgtype": "m.file"}}
 
         with (
@@ -4635,7 +4841,7 @@ class TestAgentBot:
             await bot._on_media_message(room, event)
 
         bot._generate_response.assert_not_called()
-        tracker.record_handled_turn.assert_not_called()
+        turn_store.mark_handled.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_router_routes_image_messages_in_multi_agent_rooms(
@@ -4656,9 +4862,7 @@ class TestAgentBot:
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        _mock_turn_store(bot)
         bot._turn_controller._execute_router_relay = AsyncMock()
 
         mock_context = MagicMock()
@@ -4735,9 +4939,7 @@ class TestAgentBot:
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        _mock_turn_store(bot)
         bot._turn_controller._execute_router_relay = AsyncMock()
 
         mock_context = MagicMock()
@@ -4837,8 +5039,6 @@ class TestAgentBot:
         )
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
         bot._send_response = AsyncMock(return_value="$route")
         install_send_response_mock(bot, bot._send_response)
 
@@ -4929,8 +5129,6 @@ class TestAgentBot:
         )
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
         bot._send_response = AsyncMock(return_value="$route")
         install_send_response_mock(bot, bot._send_response)
 
@@ -5024,12 +5222,8 @@ class TestAgentBot:
 
         router_bot.client = AsyncMock()
         general_bot.client = AsyncMock()
-        router_bot._handled_turn_ledger = MagicMock()
-        router_bot._handled_turn_ledger.has_responded.return_value = False
-        general_bot._handled_turn_ledger = MagicMock()
-        general_bot._handled_turn_ledger.has_responded.return_value = False
-        _replace_turn_policy_deps(router_bot, handled_turn_ledger=router_bot._handled_turn_ledger)
-        _replace_turn_policy_deps(general_bot, handled_turn_ledger=general_bot._handled_turn_ledger)
+        _mock_turn_store(router_bot)
+        _mock_turn_store(general_bot)
         router_bot._send_response = AsyncMock(return_value="$route")
         install_send_response_mock(router_bot, router_bot._send_response)
         general_bot._generate_response = AsyncMock()
@@ -5139,9 +5333,7 @@ class TestAgentBot:
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        _mock_turn_store(bot)
         bot._turn_controller._execute_router_relay = AsyncMock()
         bot._conversation_resolver.extract_message_context = AsyncMock(
             return_value=MessageContext(
@@ -5223,9 +5415,7 @@ class TestAgentBot:
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        _mock_turn_store(bot)
         bot._turn_controller._execute_router_relay = AsyncMock()
         bot._conversation_resolver.extract_message_context = AsyncMock(
             return_value=MessageContext(
@@ -5283,9 +5473,7 @@ class TestAgentBot:
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
 
-        tracker = MagicMock()
-        tracker.has_responded.return_value = False
-        bot._handled_turn_ledger = tracker
+        _mock_turn_store(bot)
         bot._generate_response = AsyncMock(return_value="$response")
         install_generate_response_mock(bot, bot._generate_response)
 
@@ -6076,8 +6264,8 @@ class TestAgentBot:
             tmp_path,
         )
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot._handled_turn_ledger = MagicMock()
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        turn_store = _turn_store(bot)
+        turn_store.mark_handled = MagicMock()
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
         event = MagicMock()
@@ -6110,7 +6298,6 @@ class TestAgentBot:
         _replace_turn_policy_deps(
             bot,
             delivery_gateway=bot._delivery_gateway,
-            handled_turn_ledger=bot._handled_turn_ledger,
         )
 
         async def unused_payload_builder(_context: MessageContext) -> DispatchPayload:
@@ -6131,7 +6318,7 @@ class TestAgentBot:
         assert mock_send_response.await_args.args[2].endswith(
             "private agents cannot participate in teams yet",
         )
-        bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+        turn_store.mark_handled.assert_called_once_with(
             HandledTurnState.from_source_event_id(
                 "$event",
                 response_event_id="$reply",
@@ -6307,8 +6494,7 @@ class TestAgentBot:
             correlation_id="corr-hydrate-dispatch",
             envelope=_hook_envelope(body="hello", source_event_id="$event"),
         )
-        bot._handled_turn_ledger = MagicMock()
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        _turn_store(bot).mark_handled = MagicMock()
         full_history = [
             ResolvedVisibleMessage.synthetic(
                 sender="@user:localhost",
@@ -6356,7 +6542,6 @@ class TestAgentBot:
         _replace_turn_policy_deps(
             bot,
             response_runner=bot._response_runner,
-            handled_turn_ledger=bot._handled_turn_ledger,
         )
 
         with (
@@ -6532,12 +6717,13 @@ class TestAgentBot:
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         _wrap_extracted_collaborators(bot)
         bot.client = _make_matrix_client_mock()
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.visible_echo_event_id_for_sources.side_effect = (
-            lambda source_event_ids: "$voice_echo" if tuple(source_event_ids) == ("$voice", "$text") else None
+        turn_store = _turn_store(bot)
+        turn_store.visible_echo_event_id_for_sources = MagicMock(
+            side_effect=lambda source_event_ids: "$voice_echo"
+            if tuple(source_event_ids) == ("$voice", "$text")
+            else None,
         )
-        bot._handled_turn_ledger.has_responded.return_value = False
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        turn_store.has_responded = MagicMock(return_value=False)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
@@ -6582,16 +6768,10 @@ class TestAgentBot:
                 ),
             )
 
-        assert bot._handled_turn_ledger.record_handled_turn.call_args_list == [
-            call(
-                HandledTurnState.create(
-                    ["$voice", "$text"],
-                    response_event_id="$voice_echo",
-                    source_event_prompts={"$voice": "voice prompt", "$text": "text prompt"},
-                    visible_echo_event_id="$voice_echo",
-                ),
-            ),
-        ]
+        turn_record = bot._turn_store.get_turn_record("$text")
+        assert turn_record is not None
+        assert turn_record.response_event_id == "$voice_echo"
+        assert bot._turn_store.get_visible_echo_event_id("$text") == "$voice_echo"
 
     @pytest.mark.asyncio
     async def test_dispatch_text_message_preserves_prompt_map_when_router_routes_coalesced_turn(
@@ -6611,8 +6791,8 @@ class TestAgentBot:
         bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
         _wrap_extracted_collaborators(bot)
         bot.client = _make_matrix_client_mock()
-        bot._handled_turn_ledger = MagicMock()
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        turn_store = _turn_store(bot)
+        turn_store.mark_handled = MagicMock()
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
@@ -6695,7 +6875,7 @@ class TestAgentBot:
                 handled_turn=coalesced_turn,
             )
 
-        assert bot._handled_turn_ledger.record_handled_turn.call_args_list == [
+        assert turn_store.mark_handled.call_args_list == [
             call(
                 HandledTurnState.create(
                     ["$voice", "$text"],
@@ -6844,9 +7024,10 @@ class TestAgentBot:
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
+        turn_store = _turn_store(bot)
+        turn_store.mark_handled = MagicMock()
         bot.logger = MagicMock()
-        _replace_turn_policy_deps(bot, logger=bot.logger, handled_turn_ledger=bot._handled_turn_ledger)
+        _replace_turn_policy_deps(bot, logger=bot.logger)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
@@ -6897,7 +7078,6 @@ class TestAgentBot:
             bot,
             delivery_gateway=bot._delivery_gateway,
             response_runner=bot._response_runner,
-            handled_turn_ledger=bot._handled_turn_ledger,
         )
 
         with patch.object(TurnController, "_log_dispatch_latency"):
@@ -6920,7 +7100,7 @@ class TestAgentBot:
         assert team_request.existing_event_id is None
         assert team_request.existing_event_is_placeholder is False
         mock_send_response.assert_not_awaited()
-        bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+        turn_store.mark_handled.assert_called_once_with(
             HandledTurnState.from_source_event_id(
                 "$event",
                 response_event_id="$team-response",
@@ -6938,9 +7118,10 @@ class TestAgentBot:
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
+        turn_store = _turn_store(bot)
+        turn_store.mark_handled = MagicMock()
         bot.logger = MagicMock()
-        _replace_turn_policy_deps(bot, logger=bot.logger, handled_turn_ledger=bot._handled_turn_ledger)
+        _replace_turn_policy_deps(bot, logger=bot.logger)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
@@ -6974,7 +7155,6 @@ class TestAgentBot:
             bot,
             delivery_gateway=bot._delivery_gateway,
             response_runner=bot._response_runner,
-            handled_turn_ledger=bot._handled_turn_ledger,
         )
 
         with patch.object(TurnController, "_log_dispatch_latency"):
@@ -6996,7 +7176,7 @@ class TestAgentBot:
         mock_send_response.assert_not_awaited()
         assert mock_generate_response.await_args.kwargs["existing_event_id"] is None
         assert mock_generate_response.await_args.kwargs["existing_event_is_placeholder"] is False
-        bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+        turn_store.mark_handled.assert_called_once_with(
             HandledTurnState.from_source_event_id(
                 "$event",
                 response_event_id="$response",
@@ -7015,19 +7195,14 @@ class TestAgentBot:
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
         bot.logger = MagicMock()
-        tracker = MagicMock()
-        tracker.has_responded.return_value = False
-        bot._handled_turn_ledger = tracker
+        turn_store = _mock_turn_store(bot)
+        turn_store.mark_handled = MagicMock()
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
         room.canonical_alias = None
         room.users = {"@mindroom_calculator:localhost": MagicMock(), "@user:localhost": MagicMock()}
-        event = MagicMock(spec=nio.RoomMessageImage)
-        event.sender = "@user:localhost"
-        event.event_id = "$img_event_fail"
-        event.body = "photo.jpg"
-        event.server_timestamp = 1000
+        event = _room_image_event(sender="@user:localhost", event_id="$img_event_fail", body="photo.jpg")
         event.source = {"content": {"body": "photo.jpg"}}
 
         bot._conversation_resolver.extract_message_context = AsyncMock(
@@ -7077,7 +7252,7 @@ class TestAgentBot:
         assert send_args[0] == room.room_id
         assert send_args[1] == "$img_event_fail"
         assert "Failed to download image" in send_args[2]
-        tracker.record_handled_turn.assert_called_once_with(
+        turn_store.mark_handled.assert_called_once_with(
             _agent_response_handled_turn(
                 agent_name=mock_agent_user.agent_name,
                 room_id=room.room_id,
@@ -7133,9 +7308,10 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
+        turn_store = _turn_store(bot)
+        turn_store.mark_handled = MagicMock()
         bot.logger = MagicMock()
-        _replace_turn_policy_deps(bot, logger=bot.logger, handled_turn_ledger=bot._handled_turn_ledger)
+        _replace_turn_policy_deps(bot, logger=bot.logger)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
@@ -7173,7 +7349,6 @@ class TestAgentBot:
         _replace_turn_policy_deps(
             bot,
             delivery_gateway=bot._delivery_gateway,
-            handled_turn_ledger=bot._handled_turn_ledger,
         )
 
         with patch.object(TurnController, "_log_dispatch_latency"):
@@ -7190,7 +7365,7 @@ class TestAgentBot:
 
         mock_edit.assert_not_awaited()
         mock_send_response.assert_awaited_once()
-        bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+        turn_store.mark_handled.assert_called_once_with(
             HandledTurnState.from_source_event_id(
                 "$event",
                 response_event_id="$error",
@@ -7207,9 +7382,10 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
+        turn_store = _turn_store(bot)
+        turn_store.mark_handled = MagicMock()
         bot.logger = MagicMock()
-        _replace_turn_policy_deps(bot, logger=bot.logger, handled_turn_ledger=bot._handled_turn_ledger)
+        _replace_turn_policy_deps(bot, logger=bot.logger)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
@@ -7252,7 +7428,7 @@ class TestAgentBot:
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
             )
 
-        bot._handled_turn_ledger.record_handled_turn.assert_not_called()
+        turn_store.mark_handled.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_execute_dispatch_action_does_not_mark_responded_when_suppressed_cleanup_fails(
@@ -7264,13 +7440,12 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = _make_matrix_client_mock()
-        bot._handled_turn_ledger = MagicMock()
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        turn_store = _turn_store(bot)
+        turn_store.mark_handled = MagicMock()
         bot.logger = MagicMock()
         wrap_extracted_collaborators(bot, "_response_runner")
         replace_turn_controller_deps(
             bot,
-            handled_turn_ledger=bot._handled_turn_ledger,
             logger=bot.logger,
             response_runner=bot._response_runner,
         )
@@ -7322,7 +7497,7 @@ class TestAgentBot:
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
             )
 
-        bot._handled_turn_ledger.record_handled_turn.assert_not_called()
+        turn_store.mark_handled.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_execute_dispatch_action_does_not_mark_responded_when_generation_returns_no_final_event(
@@ -7334,8 +7509,8 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = _make_matrix_client_mock()
-        bot._handled_turn_ledger = MagicMock()
-        _replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+        turn_store = _turn_store(bot)
+        turn_store.mark_handled = MagicMock()
         bot.logger = MagicMock()
 
         room = MagicMock(spec=nio.MatrixRoom)
@@ -7380,7 +7555,7 @@ class TestAgentBot:
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
             )
 
-        bot._handled_turn_ledger.record_handled_turn.assert_not_called()
+        turn_store.mark_handled.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_execute_dispatch_action_logs_startup_latency(
@@ -7392,9 +7567,10 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
+        turn_store = _turn_store(bot)
+        turn_store.mark_handled = MagicMock()
         bot.logger = MagicMock()
-        _replace_turn_policy_deps(bot, logger=bot.logger, handled_turn_ledger=bot._handled_turn_ledger)
+        _replace_turn_policy_deps(bot, logger=bot.logger)
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
@@ -7427,7 +7603,6 @@ class TestAgentBot:
             bot,
             logger=bot.logger,
             response_runner=bot._response_runner,
-            handled_turn_ledger=bot._handled_turn_ledger,
         )
 
         with patch("mindroom.turn_controller.time.monotonic", side_effect=lambda: next(monotonic_values)):
@@ -7731,7 +7906,7 @@ class TestAgentBot:
         bot.client = AsyncMock()
 
         # Mark an event as already responded
-        bot._handled_turn_ledger.record_handled_turn(HandledTurnState.from_source_event_id("event123"))
+        bot._turn_store.mark_handled(HandledTurnState.from_source_event_id("event123"))
 
         # Create mock room and event
         mock_room = MagicMock()

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -1318,9 +1318,8 @@ class TestAgentBot:
             mock_stream_agent_response.assert_called_once()
             stream_kwargs = mock_stream_agent_response.call_args.kwargs
             assert stream_kwargs["agent_name"] == "calculator"
-            assert stream_kwargs["prompt"] == f"{mention_id}: What's 2+2?"
-            assert stream_kwargs["model_prompt"].startswith("[")
-            assert stream_kwargs["model_prompt"].endswith(f"{mention_id}: What's 2+2?")
+            assert stream_kwargs["prompt"].startswith("[")
+            assert stream_kwargs["prompt"].endswith(f"{mention_id}: What's 2+2?")
             assert stream_kwargs["session_id"] == "!test:localhost:$thread_root_id"
             assert stream_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
             assert stream_kwargs["config"] == config
@@ -1343,9 +1342,8 @@ class TestAgentBot:
             mock_ai_response.assert_called_once()
             ai_kwargs = mock_ai_response.call_args.kwargs
             assert ai_kwargs["agent_name"] == "calculator"
-            assert ai_kwargs["prompt"] == f"{mention_id}: What's 2+2?"
-            assert ai_kwargs["model_prompt"].startswith("[")
-            assert ai_kwargs["model_prompt"].endswith(f"{mention_id}: What's 2+2?")
+            assert ai_kwargs["prompt"].startswith("[")
+            assert ai_kwargs["prompt"].endswith(f"{mention_id}: What's 2+2?")
             assert ai_kwargs["session_id"] == "!test:localhost:$thread_root_id"
             assert ai_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
             assert ai_kwargs["config"] == config
@@ -1404,11 +1402,11 @@ class TestAgentBot:
             )
 
         assert delivery.event_id == "$response"
-        model_prompt = mock_ai.call_args.kwargs["model_prompt"]
-        assert "[Matrix metadata for tool calls]" in model_prompt
-        assert "room_id: !test:localhost" in model_prompt
-        assert "thread_id: none" in model_prompt
-        assert "reply_to_event_id: $event123" in model_prompt
+        prompt = mock_ai.call_args.kwargs["prompt"]
+        assert "[Matrix metadata for tool calls]" in prompt
+        assert "room_id: !test:localhost" in prompt
+        assert "thread_id: $event123" in prompt
+        assert "reply_to_event_id: $event123" in prompt
 
     @pytest.mark.asyncio
     async def test_process_and_respond_includes_matrix_metadata_when_openclaw_compat_enabled(
@@ -1450,11 +1448,11 @@ class TestAgentBot:
             )
 
         assert delivery.event_id == "$response"
-        model_prompt = mock_ai.call_args.kwargs["model_prompt"]
-        assert "[Matrix metadata for tool calls]" in model_prompt
-        assert "room_id: !test:localhost" in model_prompt
-        assert "thread_id: none" in model_prompt
-        assert "reply_to_event_id: $event123" in model_prompt
+        prompt = mock_ai.call_args.kwargs["prompt"]
+        assert "[Matrix metadata for tool calls]" in prompt
+        assert "room_id: !test:localhost" in prompt
+        assert "thread_id: $event123" in prompt
+        assert "reply_to_event_id: $event123" in prompt
 
     @pytest.mark.asyncio
     async def test_process_and_respond_streaming_includes_matrix_metadata_when_tool_enabled(
@@ -1506,11 +1504,11 @@ class TestAgentBot:
                 )
 
         assert delivery.event_id == "$response"
-        model_prompt = mock_stream_agent_response.call_args.kwargs["model_prompt"]
-        assert "[Matrix metadata for tool calls]" in model_prompt
-        assert "room_id: !test:localhost" in model_prompt
-        assert "thread_id: none" in model_prompt
-        assert "reply_to_event_id: $event456" in model_prompt
+        prompt = mock_stream_agent_response.call_args.kwargs["prompt"]
+        assert "[Matrix metadata for tool calls]" in prompt
+        assert "room_id: !test:localhost" in prompt
+        assert "thread_id: $event456" in prompt
+        assert "reply_to_event_id: $event456" in prompt
 
     @pytest.mark.asyncio
     async def test_process_and_respond_uses_safe_thread_root_for_prompt_metadata(
@@ -1559,9 +1557,9 @@ class TestAgentBot:
                 ),
             )
 
-        model_prompt = mock_ai.call_args.kwargs["model_prompt"]
-        assert "thread_id: $thread_root:localhost" in model_prompt
-        assert "reply_to_event_id: $reply_plain:localhost" in model_prompt
+        prompt = mock_ai.call_args.kwargs["prompt"]
+        assert "thread_id: $thread_root:localhost" in prompt
+        assert "reply_to_event_id: $reply_plain:localhost" in prompt
 
     @pytest.mark.asyncio
     async def test_process_and_respond_streaming_resolves_knowledge_once(
@@ -2923,9 +2921,8 @@ class TestAgentBot:
             )
 
         assert mock_ai.call_args.kwargs["show_tool_calls"] is True
-        assert mock_ai.call_args.kwargs["prompt"] == "Use research skill"
-        assert mock_ai.call_args.kwargs["model_prompt"].startswith("[")
-        assert mock_ai.call_args.kwargs["model_prompt"].endswith("Use research skill")
+        assert mock_ai.call_args.kwargs["prompt"].startswith("[")
+        assert mock_ai.call_args.kwargs["prompt"].endswith("Use research skill")
 
     @pytest.mark.asyncio
     async def test_skill_command_room_mode_uses_room_level_session_id(
@@ -4371,10 +4368,9 @@ class TestAgentBot:
         bot._generate_response.assert_awaited_once()
         generate_kwargs = bot._generate_response.await_args.kwargs
         assert generate_kwargs["room_id"] == "!test:localhost"
-        assert "Available attachment IDs" not in generate_kwargs["prompt"]
-        assert generate_kwargs["model_prompt"] is not None
-        assert "Available attachment IDs" in generate_kwargs["model_prompt"]
-        assert attachment_id in generate_kwargs["model_prompt"]
+        assert "Available attachment IDs" in generate_kwargs["prompt"]
+        assert attachment_id in generate_kwargs["prompt"]
+        assert generate_kwargs["model_prompt"] is None
         assert generate_kwargs["reply_to_event_id"] == "$img_event"
         assert generate_kwargs["thread_id"] is None
         assert generate_kwargs["thread_history"] == []
@@ -4492,11 +4488,9 @@ class TestAgentBot:
         bot._generate_response.assert_awaited_once()
         generate_kwargs = bot._generate_response.await_args.kwargs
         assert generate_kwargs["attachment_ids"] == [current_attachment_id, history_attachment_id]
-        assert current_attachment_id not in generate_kwargs["prompt"]
-        assert history_attachment_id not in generate_kwargs["prompt"]
-        assert generate_kwargs["model_prompt"] is not None
-        assert current_attachment_id in generate_kwargs["model_prompt"]
-        assert history_attachment_id in generate_kwargs["model_prompt"]
+        assert current_attachment_id in generate_kwargs["prompt"]
+        assert history_attachment_id in generate_kwargs["prompt"]
+        assert generate_kwargs["model_prompt"] is None
         turn_store.mark_handled.assert_called_once_with(
             _agent_response_handled_turn(
                 agent_name=mock_agent_user.agent_name,
@@ -4545,19 +4539,18 @@ class TestAgentBot:
             )
 
         assert payload.attachment_ids == ["att_image"]
-        assert payload.prompt == "describe this"
-        assert payload.model_prompt is not None
-        assert "Available attachment IDs" in payload.model_prompt
-        assert "att_image" in payload.model_prompt
+        assert "Available attachment IDs" in payload.prompt
+        assert "att_image" in payload.prompt
+        assert payload.model_prompt is None
         assert list(payload.media.images) == [stored_image, fallback_image]
 
     @pytest.mark.asyncio
-    async def test_build_dispatch_payload_with_attachments_keeps_raw_prompt_clean(
+    async def test_build_dispatch_payload_with_attachments_appends_attachment_ids_to_prompt(
         self,
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
     ) -> None:
-        """Attachment IDs should be isolated to model_prompt instead of mutating the raw user prompt."""
+        """Attachment-aware dispatch should append attachment IDs to the prompt payload."""
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = _make_matrix_client_mock()
@@ -4585,10 +4578,9 @@ class TestAgentBot:
                 ),
             )
 
-        assert payload.prompt == "describe this"
-        assert payload.model_prompt is not None
-        assert "Available attachment IDs" in payload.model_prompt
-        assert "att_image" in payload.model_prompt
+        assert "Available attachment IDs" in payload.prompt
+        assert "att_image" in payload.prompt
+        assert payload.model_prompt is None
 
     @pytest.mark.asyncio
     async def test_message_enrichment_appends_to_existing_model_prompt(
@@ -4770,10 +4762,9 @@ class TestAgentBot:
         assert generate_kwargs["thread_history"] == []
         assert generate_kwargs["user_id"] == "@user:localhost"
         assert generate_kwargs["attachment_ids"] == [attachment_id]
-        assert "Available attachment IDs" not in generate_kwargs["prompt"]
-        assert generate_kwargs["model_prompt"] is not None
-        assert "Available attachment IDs" in generate_kwargs["model_prompt"]
-        assert attachment_id in generate_kwargs["model_prompt"]
+        assert "Available attachment IDs" in generate_kwargs["prompt"]
+        assert attachment_id in generate_kwargs["prompt"]
+        assert generate_kwargs["model_prompt"] is None
         media = generate_kwargs["media"]
         assert len(media.files) == 1
         assert str(media.files[0].filepath) == str(local_media_path)

--- a/tests/test_multiple_edits.py
+++ b/tests/test_multiple_edits.py
@@ -101,7 +101,7 @@ async def test_agent_regenerates_on_multiple_edits(tmp_path: Path) -> None:
 
     # Verify bot responded
     assert bot.client.room_send.call_count == 2  # thinking + final
-    bot._handled_turn_ledger.record_handled_turn(
+    bot._turn_store.mark_handled(
         HandledTurnState.from_source_event_id("$original123", response_event_id="$response123"),
     )
 

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -704,7 +704,7 @@ async def test_coalesced_dispatch_never_creates_queued_signal(tmp_path: Path) ->
             _PrecheckedEvent(event=event, requester_user_id="@user:localhost"),
         )
 
-    assert bot._handled_turn_ledger.has_responded("$older")
+    assert bot._turn_store.has_responded("$older")
     mock_plan.assert_not_awaited()
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
     assert coordinator._thread_queued_signals == {}

--- a/tests/test_response_tracking_regression.py
+++ b/tests/test_response_tracking_regression.py
@@ -128,7 +128,7 @@ class TestResponseTrackingRegression:
 
         # IMPORTANT: Check if event was marked as responded
         # This should be True after the fix
-        assert bot._handled_turn_ledger.has_responded(command_event.event_id), (
+        assert bot._turn_store.has_responded(command_event.event_id), (
             "Command event should be marked as responded to prevent re-processing"
         )
 
@@ -221,7 +221,7 @@ class TestResponseTrackingRegression:
 
         # IMPORTANT: Check if event was marked as responded
         # This should be True after the fix in bot.py at line 371
-        assert bot._handled_turn_ledger.has_responded(unknown_command_event.event_id), (
+        assert bot._turn_store.has_responded(unknown_command_event.event_id), (
             "Unknown command event should be marked as responded"
         )
 
@@ -306,10 +306,10 @@ class TestResponseTrackingRegression:
 
         # IMPORTANT: Check if event was marked as responded
         # This should be True after the fix
-        assert bot._handled_turn_ledger.has_responded(message_event.event_id), (
+        assert bot._turn_store.has_responded(message_event.event_id), (
             "Router event should be marked as responded to prevent re-routing"
         )
-        turn_record = bot._handled_turn_ledger.get_turn_record(message_event.event_id)
+        turn_record = bot._turn_store.get_turn_record(message_event.event_id)
         assert turn_record is not None
         assert turn_record.response_event_id == "$router_response_123"
         assert turn_record.source_event_ids == tuple(source_event_ids)

--- a/tests/test_skip_mentions.py
+++ b/tests/test_skip_mentions.py
@@ -101,7 +101,6 @@ async def test_send_response_with_skip_mentions(tmp_path: Path) -> None:
         test_runtime_paths(tmp_path),
     )
     bot = _context_bot(tmp_path, config)
-    bot._handled_turn_ledger = AsyncMock()
 
     # Mock the format_message_with_mentions to return a dict we can check
     mock_content = {"body": "test", "msgtype": "m.text"}

--- a/tests/test_stop_emoji_reuse.py
+++ b/tests/test_stop_emoji_reuse.py
@@ -56,8 +56,6 @@ async def test_stop_emoji_only_stops_during_generation(tmp_path: Path) -> None:
     # Set up the bot with necessary mocks
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.user_id = "@test_agent:example.com"
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
     bot.stop_manager = StopManager()
     bot._send_response = AsyncMock(return_value="$stopping:example.com")
@@ -144,8 +142,6 @@ async def test_stop_emoji_hard_cancels_and_schedules_agno_cleanup_when_run_id_pr
 
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.user_id = "@test_agent:example.com"
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
     bot.logger = MagicMock()
     bot.stop_manager = StopManager()
     bot._send_response = AsyncMock(return_value="$stopping:example.com")
@@ -543,7 +539,6 @@ async def test_stop_emoji_from_agent_falls_through(tmp_path: Path) -> None:
     # Set up the bot
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.user_id = "@test_agent:example.com"
-    bot._handled_turn_ledger = MagicMock()
     bot.logger = MagicMock()
     bot.stop_manager = StopManager()
 
@@ -629,7 +624,6 @@ async def test_stop_reaction_blocked_by_reply_permissions(tmp_path: Path) -> Non
     )
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.user_id = "@mindroom_test_agent:example.com"
-    bot._handled_turn_ledger = MagicMock()
     bot.logger = MagicMock()
     bot.stop_manager = StopManager()
 

--- a/tests/test_streaming_edits.py
+++ b/tests/test_streaming_edits.py
@@ -138,7 +138,7 @@ class TestStreamingEdits:
         await bot._on_message(mock_room, initial_event)
         assert bot.client.room_send.call_count == 2  # thinking + final
         assert mock_ai_response.call_count == 1
-        bot._handled_turn_ledger.record_handled_turn(
+        bot._turn_store.mark_handled(
             HandledTurnState.from_source_event_id("$initial123", response_event_id="$response123"),
         )
 
@@ -233,7 +233,7 @@ class TestStreamingEdits:
         mock_room.room_id = "!test:localhost"
 
         # Mark that we already responded to some original message
-        bot._handled_turn_ledger.record_handled_turn(HandledTurnState.from_source_event_id("$original123"))
+        bot._turn_store.mark_handled(HandledTurnState.from_source_event_id("$original123"))
 
         # New message (NOT an edit) mentioning the agent
         new_event = MagicMock()

--- a/tests/test_team_collaboration.py
+++ b/tests/test_team_collaboration.py
@@ -128,10 +128,6 @@ class TestTeamFormation:
         # Setup bots
         research_bot.client = AsyncMock()
         analyst_bot.client = AsyncMock()
-        research_bot._handled_turn_ledger = MagicMock()
-        research_bot._handled_turn_ledger.has_responded.return_value = False
-        analyst_bot._handled_turn_ledger = MagicMock()
-        analyst_bot._handled_turn_ledger.has_responded.return_value = False
 
         # Create message mentioning both agents
         message_event: dict[str, Any] = {
@@ -453,8 +449,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_dm_room_team_formation(self) -> None:
         """Test that multiple agents in a DM room form a team when no one is mentioned."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.config.agent import AgentConfig  # noqa: PLC0415
@@ -518,8 +512,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_dm_room_thread_single_agent_no_team(self) -> None:
         """In a DM with multiple agents, a thread with a single agent should not form a team."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.config.agent import AgentConfig  # noqa: PLC0415
@@ -568,8 +560,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_dm_room_ignores_private_agents_for_team_formation(self) -> None:
         """DM fallback should degrade to the remaining supported single agent."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.teams import decide_team_formation  # noqa: PLC0415
@@ -615,8 +605,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_thread_history_unavailable_agents_degrade_to_individual(self) -> None:
         """Implicit thread continuation should not reject when one historical agent is off-room."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.teams import decide_team_formation  # noqa: PLC0415
@@ -660,8 +648,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_thread_history_ignores_configured_team_participants(self) -> None:
         """Implicit thread teams must ignore configured team bots instead of treating them as leaf members."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.teams import decide_team_formation  # noqa: PLC0415
@@ -728,8 +714,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_previously_mentioned_off_room_agents_degrade_to_individual(self) -> None:
         """Implicit thread mentions should degrade instead of surfacing explicit-request rejection."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.teams import decide_team_formation  # noqa: PLC0415
@@ -773,8 +757,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_tagged_off_room_agents_reject_the_entire_team_request(self) -> None:
         """Explicit team requests must reject members that are not available in the room."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.teams import decide_team_formation  # noqa: PLC0415
@@ -822,8 +804,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_tagged_agents_reject_when_sender_can_talk_to_zero_agents(self) -> None:
         """Explicit sender visibility of [] must not fall back to room-visible agents."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.teams import decide_team_formation  # noqa: PLC0415
@@ -870,8 +850,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_tagged_off_room_agents_reject_without_collapsing_requested_members(self) -> None:
         """Explicit rejects should preserve the full requested-member failure state."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.teams import decide_team_formation  # noqa: PLC0415
@@ -922,8 +900,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_tagged_private_agents_reject_the_entire_team_request(self) -> None:
         """Mixed shared/private mentions should reject the whole ad hoc team request."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.teams import decide_team_formation  # noqa: PLC0415
@@ -971,8 +947,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_tagged_unsupported_non_materializable_member_keeps_requested_member_statuses(self) -> None:
         """Explicit rejects should keep requested-member eligibility separate from delivery ownership."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.teams import decide_team_formation  # noqa: PLC0415
@@ -1028,8 +1002,6 @@ class TestRouterTeamFormation:
     @pytest.mark.asyncio
     async def test_tagged_mixed_reject_causes_report_member_specific_reasons(self) -> None:
         """Mixed reject causes should explain the actual member failures instead of flattening them."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.teams import decide_team_formation  # noqa: PLC0415
@@ -1090,8 +1062,6 @@ class TestRouterTeamFormation:
         self,
     ) -> None:
         """Ad hoc team formation must reject explicit member sets that reach private agents."""
-        from unittest.mock import MagicMock  # noqa: PLC0415
-
         import nio  # noqa: PLC0415
 
         from mindroom.teams import decide_team_formation  # noqa: PLC0415

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -423,7 +423,6 @@ class TestRouterHandoffThreadMode:
         """Router should send handoff in-room when the suggested agent is room-mode."""
         bot = _agent_bot(config=room_mode_config, agent_user=router_user, storage_path=tmp_path)
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
         captured_content: dict[str, object] = {}
 
         async def mock_send(_client: object, _room_id: str, content: dict) -> str:
@@ -465,7 +464,6 @@ class TestRouterHandoffThreadMode:
         """Router should keep thread replies when the suggested agent is thread-mode."""
         bot = _agent_bot(config=room_mode_config, agent_user=router_user, storage_path=tmp_path)
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
         captured_content: dict[str, object] = {}
 
         async def mock_send(_client: object, _room_id: str, content: dict) -> str:
@@ -967,7 +965,6 @@ class TestCommandThreadContextRoomMode:
         )
         bot = _agent_bot(config=config, agent_user=router_user, storage_path=tmp_path)
         bot.client = AsyncMock()
-        bot._handled_turn_ledger = MagicMock()
         bot._send_response = AsyncMock(return_value="$reply")
         install_send_response_mock(bot, bot._send_response)
         unwrap_extracted_collaborator(bot._conversation_resolver).derive_conversation_context = AsyncMock(

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -138,8 +138,6 @@ class TestThreadingBehavior:
         bot.client.homeserver = "http://localhost:8008"
 
         # Initialize components that depend on client
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
 
         # Mock the agent to return a response
         mock_agent = MagicMock()
@@ -1063,7 +1061,6 @@ class TestThreadingBehavior:
         )
 
         # Initialize the bot (to set up components it needs)
-        bot._handled_turn_ledger.has_responded.return_value = False
 
         # Mock interactive.handle_text_response to return None (not an interactive response)
         # Mock _generate_response to capture the call and send a test response
@@ -1128,7 +1125,6 @@ class TestThreadingBehavior:
         )
 
         # Initialize response tracking
-        bot._handled_turn_ledger.has_responded.return_value = False
 
         # Mock interactive.handle_text_response and make AI fast
         with (
@@ -2359,8 +2355,6 @@ class TestThreadingBehavior:
         bot.client.homeserver = "http://localhost:8008"
 
         # Initialize components that depend on client
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
 
         # Mock the agent to return a response
         mock_agent = MagicMock()
@@ -2463,8 +2457,6 @@ class TestThreadingBehavior:
         bot.client.homeserver = "http://localhost:8008"
 
         # Initialize components that depend on client
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
 
         # Mock the agent to return a response
         mock_agent = MagicMock()
@@ -2568,9 +2560,6 @@ class TestThreadingBehavior:
         bot.client.user_id = "@mindroom_router:localhost"
         bot.client.homeserver = "http://localhost:8008"
 
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
-
         room = nio.MatrixRoom(room_id="!test:localhost", own_user_id=bot.client.user_id)
         room.name = "Test Room"
 
@@ -2662,9 +2651,6 @@ class TestThreadingBehavior:
         bot.client.rooms = {}
         bot.client.user_id = "@mindroom_router:localhost"
         bot.client.homeserver = "http://localhost:8008"
-
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
@@ -2769,7 +2755,6 @@ class TestThreadingBehavior:
         )
 
         # Initialize response tracking
-        bot._handled_turn_ledger.has_responded.return_value = False
 
         # Mock interactive.handle_text_response and generate_response
         bot._generate_response = AsyncMock()

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -1,0 +1,81 @@
+"""Tests for TurnStore ownership and migration guards."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from mindroom.bot import AgentBot
+from mindroom.handled_turns import HandledTurnState
+from mindroom.turn_store import TurnStore, TurnStoreDeps
+
+
+def test_turn_store_constructs_private_ledger_from_tracking_base_path(tmp_path: Path) -> None:
+    """TurnStore should own its private ledger and persist through the tracking base path."""
+    tracking_path = tmp_path / "tracking"
+    store = TurnStore(
+        TurnStoreDeps(
+            agent_name="agent",
+            tracking_base_path=tracking_path,
+            state_writer=MagicMock(),
+            resolver=MagicMock(),
+            tool_runtime=MagicMock(),
+        ),
+    )
+
+    store.mark_handled(HandledTurnState.from_source_event_id("$event", response_event_id="$response"))
+
+    reloaded_store = TurnStore(
+        TurnStoreDeps(
+            agent_name="agent",
+            tracking_base_path=tracking_path,
+            state_writer=MagicMock(),
+            resolver=MagicMock(),
+            tool_runtime=MagicMock(),
+        ),
+    )
+
+    assert reloaded_store.has_responded("$event")
+    turn_record = reloaded_store.get_turn_record("$event")
+    assert turn_record is not None
+    assert turn_record.response_event_id == "$response"
+
+
+def test_only_turn_store_imports_handled_turn_ledger_in_production() -> None:
+    """HandledTurnLedger imports should stay isolated to TurnStore in production code."""
+    src_root = Path(__file__).resolve().parents[1] / "src" / "mindroom"
+    offenders: list[str] = []
+
+    for path in src_root.rglob("*.py"):
+        if path.name in {"turn_store.py", "handled_turns.py"}:
+            continue
+        module = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(module):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if node.module != "mindroom.handled_turns":
+                continue
+            if any(alias.name == "HandledTurnLedger" for alias in node.names):
+                offenders.append(path.relative_to(src_root).as_posix())
+                break
+
+    assert offenders == []
+
+
+def test_agent_bot_does_not_expose_removed_handled_turn_ledger_shim() -> None:
+    """AgentBot should not keep the transitional handled-turn shim."""
+    # Split the string so this guard test does not match its own source text.
+    assert ("_handled" + "_turn_ledger") not in AgentBot.__dict__
+
+
+def test_no_test_references_removed_bot_handled_turn_ledger_shim() -> None:
+    """Tests should route all handled-turn access through TurnStore."""
+    tests_root = Path(__file__).resolve().parent
+    # Split the string so this guard test does not match its own source text.
+    needle = "._handled" + "_turn_ledger"
+    offenders = [
+        path.relative_to(tests_root).as_posix() for path in tests_root.rglob("*.py") if needle in path.read_text()
+    ]
+
+    assert offenders == []

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -7,8 +7,11 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from mindroom.bot import AgentBot
+from mindroom.config.main import Config
 from mindroom.handled_turns import HandledTurnState
+from mindroom.matrix.users import AgentMatrixUser
 from mindroom.turn_store import TurnStore, TurnStoreDeps
+from tests.conftest import TEST_PASSWORD, bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 
 def test_turn_store_constructs_private_ledger_from_tracking_base_path(tmp_path: Path) -> None:
@@ -63,10 +66,26 @@ def test_only_turn_store_imports_handled_turn_ledger_in_production() -> None:
     assert offenders == []
 
 
-def test_agent_bot_does_not_expose_removed_handled_turn_ledger_shim() -> None:
-    """AgentBot should not keep the transitional handled-turn shim."""
+def test_agent_bot_does_not_expose_removed_handled_turn_ledger_shim(tmp_path: Path) -> None:
+    """AgentBot instances should route handled-turn state only through TurnStore."""
+    config = bind_runtime_paths(Config(), test_runtime_paths(tmp_path))
+    bot = AgentBot(
+        agent_user=AgentMatrixUser(
+            agent_name="agent",
+            user_id="@mindroom_agent:localhost",
+            display_name="Agent",
+            password=TEST_PASSWORD,
+        ),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+
     # Split the string so this guard test does not match its own source text.
-    assert ("_handled" + "_turn_ledger") not in AgentBot.__dict__
+    removed_attr = "_handled" + "_turn_ledger"
+    assert removed_attr not in AgentBot.__dict__
+    assert not hasattr(bot, removed_attr)
+    assert removed_attr not in vars(bot)
 
 
 def test_no_test_references_removed_bot_handled_turn_ledger_shim() -> None:

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -20,7 +20,6 @@ from tests.conftest import (
     bind_runtime_paths,
     install_generate_response_mock,
     replace_turn_controller_deps,
-    replace_turn_policy_deps,
     runtime_paths_for,
     sync_bot_runtime_state,
     test_runtime_paths,
@@ -63,10 +62,7 @@ def mock_home_bot() -> AgentBot:
     bot.client.user_id = "@mindroom_home:localhost"
     sync_bot_runtime_state(bot)
     bot.logger = MagicMock()
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
-    replace_turn_policy_deps(bot, handled_turn_ledger=bot._handled_turn_ledger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     bot._generate_response = AsyncMock(return_value="$response")
     install_generate_response_mock(bot, bot._generate_response)
     return bot

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -139,7 +139,7 @@ def _make_visible_router_echo_scenario(
         rooms=["!test:example.com"],
     )
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     bot.client = AsyncMock()
     bot.client.rooms = {}
     unwrap_extracted_collaborator(bot._conversation_resolver).derive_conversation_context = AsyncMock(
@@ -176,10 +176,10 @@ async def test_router_processes_own_voice_transcriptions(tmp_path) -> None:  # n
         config=_attach_runtime_paths(Config(authorization={"default_room_access": True}), tmp_path),
         rooms=["!test:example.com"],
     )
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     room = _make_room("@mindroom_router:example.com", "@alice:example.com")
     event = MagicMock(spec=nio.RoomMessageText)
@@ -216,10 +216,10 @@ async def test_router_ignores_non_voice_self_messages(tmp_path) -> None:  # noqa
         config=_attach_runtime_paths(Config(authorization={"default_room_access": True}), tmp_path),
         rooms=["!test:example.com"],
     )
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
 
     room = _make_room("@mindroom_router:example.com", "@bob:example.com")
     event = MagicMock(spec=nio.RoomMessageText)
@@ -260,10 +260,10 @@ async def test_router_processes_own_sidecar_commands_using_original_sender(tmp_p
         ),
         rooms=["!test:example.com"],
     )
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.download = AsyncMock(
@@ -344,10 +344,10 @@ async def test_router_parses_sidecar_schedule_command_from_canonical_body(tmp_pa
         ),
         rooms=["!test:example.com"],
     )
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.download = AsyncMock(
@@ -434,10 +434,10 @@ async def test_router_parses_sidecar_skill_command_mentions_from_canonical_body(
         ),
         rooms=["!test:example.com"],
     )
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.download = AsyncMock(
@@ -524,10 +524,11 @@ async def test_router_skips_unauthorized_sidecar_commands_before_hydration(tmp_p
         config=_attach_runtime_paths(Config(authorization={"default_room_access": True}), tmp_path),
         rooms=["!test:example.com"],
     )
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
+    turn_store.mark_handled = MagicMock(wraps=turn_store.mark_handled)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     bot.client = AsyncMock(spec=nio.AsyncClient)
     bot.client.rooms = {}
     bot.client.user_id = bot.matrix_id.full_id
@@ -568,7 +569,7 @@ async def test_router_skips_unauthorized_sidecar_commands_before_hydration(tmp_p
     bot.client.download.assert_not_awaited()
     mock_interactive.assert_not_awaited()
     mock_schedule.assert_not_awaited()
-    bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+    turn_store.mark_handled.assert_called_once_with(
         HandledTurnState.from_source_event_id(event.event_id),
     )
 
@@ -677,10 +678,11 @@ async def test_router_ignores_audio_events_from_internal_agents(tmp_path) -> Non
         config=config,
         rooms=["!test:example.com"],
     )
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
+    turn_store.mark_handled = MagicMock(wraps=turn_store.mark_handled)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     bot.client = MagicMock()
     bot._send_response = AsyncMock()
     install_send_response_mock(bot, bot._send_response)
@@ -707,7 +709,7 @@ async def test_router_ignores_audio_events_from_internal_agents(tmp_path) -> Non
     mock_voice.assert_not_called()
     mock_download_audio.assert_not_called()
     bot._send_response.assert_not_called()
-    bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+    turn_store.mark_handled.assert_called_once_with(
         HandledTurnState.from_source_event_id("$agent_audio_event"),
     )
 
@@ -732,10 +734,11 @@ async def test_agent_handles_audio_without_router_when_voice_disabled(tmp_path) 
         ),
         rooms=["!test:example.com"],
     )
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
+    turn_store.mark_handled = MagicMock(wraps=turn_store.mark_handled)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     bot.client = AsyncMock()
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_home:localhost"
@@ -765,7 +768,7 @@ async def test_agent_handles_audio_without_router_when_voice_disabled(tmp_path) 
     assert call_kwargs["prompt"].startswith(f"{VOICE_PREFIX}[Attached voice message]")
     assert call_kwargs["attachment_ids"] == [expected_attachment_id]
     assert list(call_kwargs["media"].audio)
-    bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+    turn_store.mark_handled.assert_called_once_with(
         HandledTurnState.from_source_event_id(
             "$voice_event",
             response_event_id="$response",
@@ -802,10 +805,10 @@ async def test_agent_handles_audio_with_router_present_in_single_agent_room(tmp_
         ),
         rooms=["!test:example.com"],
     )
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     bot.client = AsyncMock()
     bot.client.rooms = {}
     bot.client.user_id = "@mindroom_home:localhost"
@@ -856,10 +859,10 @@ async def test_router_and_agent_share_audio_normalization_when_router_is_present
             config=config,
             rooms=["!test:example.com"],
         )
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
+        turn_store = unwrap_extracted_collaborator(bot._turn_store)
+        turn_store.has_responded = MagicMock(return_value=False)
         bot.logger = MagicMock()
-        replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+        replace_turn_controller_deps(bot, logger=bot.logger)
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = agent_user.user_id
@@ -932,8 +935,10 @@ async def test_router_visible_voice_echo_is_deduplicated_on_redelivery(tmp_path)
     bot._delivery_gateway.send_text.assert_called_once()
     assert mock_download_audio.await_count == 1
     assert mock_voice.await_count == 1
-    assert bot._handled_turn_ledger.has_responded(event.event_id)
-    assert bot._handled_turn_ledger.get_response_event_id(event.event_id) == "$voice_echo"
+    assert bot._turn_store.has_responded(event.event_id)
+    turn_record = bot._turn_store.get_turn_record(event.event_id)
+    assert turn_record is not None
+    assert turn_record.response_event_id == "$voice_echo"
 
 
 @pytest.mark.asyncio
@@ -957,8 +962,10 @@ async def test_router_visible_voice_echo_respects_reply_permissions(tmp_path) ->
     bot._delivery_gateway.send_text.assert_not_called()
     mock_download_audio.assert_not_awaited()
     mock_voice.assert_not_awaited()
-    assert bot._handled_turn_ledger.has_responded(event.event_id)
-    assert bot._handled_turn_ledger.get_response_event_id(event.event_id) is None
+    assert bot._turn_store.has_responded(event.event_id)
+    turn_record = bot._turn_store.get_turn_record(event.event_id)
+    assert turn_record is not None
+    assert turn_record.response_event_id is None
 
 
 @pytest.mark.asyncio
@@ -1020,8 +1027,8 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries(
         mock_voice.return_value = f"{VOICE_PREFIX}summarize this audio"
         await bot._on_media_message(room, event)
 
-        assert not bot._handled_turn_ledger.has_responded(event.event_id)
-        assert bot._handled_turn_ledger.get_visible_echo_event_id(event.event_id) == "$voice_echo"
+        assert not bot._turn_store.has_responded(event.event_id)
+        assert bot._turn_store.get_visible_echo_event_id(event.event_id) == "$voice_echo"
 
         await bot._on_media_message(room, event)
 
@@ -1031,8 +1038,8 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries(
         "@home could you help with this?",
         "@home could you help with this?",
     ]
-    assert bot._handled_turn_ledger.has_responded(event.event_id)
-    assert bot._handled_turn_ledger.get_visible_echo_event_id(event.event_id) == "$voice_echo"
+    assert bot._turn_store.has_responded(event.event_id)
+    assert bot._turn_store.get_visible_echo_event_id(event.event_id) == "$voice_echo"
 
 
 @pytest.mark.asyncio
@@ -1060,8 +1067,8 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries_
         mock_voice.return_value = f"{VOICE_PREFIX}summarize this audio"
         await bot._on_media_message(room, event)
 
-    assert not bot._handled_turn_ledger.has_responded(event.event_id)
-    assert bot._handled_turn_ledger.get_visible_echo_event_id(event.event_id) == "$voice_echo"
+    assert not bot._turn_store.has_responded(event.event_id)
+    assert bot._turn_store.get_visible_echo_event_id(event.event_id) == "$voice_echo"
 
     restarted_bot, restarted_room, restarted_event = _make_visible_router_echo_scenario(
         tmp_path,
@@ -1081,8 +1088,8 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries_
 
     response_texts = [call.args[0].response_text for call in restarted_bot._delivery_gateway.send_text.call_args_list]
     assert response_texts == ["@home could you help with this?"]
-    assert restarted_bot._handled_turn_ledger.has_responded(event.event_id)
-    assert restarted_bot._handled_turn_ledger.get_visible_echo_event_id(event.event_id) == "$voice_echo"
+    assert restarted_bot._turn_store.has_responded(event.event_id)
+    assert restarted_bot._turn_store.get_visible_echo_event_id(event.event_id) == "$voice_echo"
 
 
 @pytest.mark.asyncio
@@ -1111,10 +1118,11 @@ async def test_router_routes_transcribed_audio_when_multiple_agents_are_present(
         config=config,
         rooms=["!test:example.com"],
     )
-    bot._handled_turn_ledger = MagicMock()
-    bot._handled_turn_ledger.has_responded.return_value = False
+    turn_store = unwrap_extracted_collaborator(bot._turn_store)
+    turn_store.has_responded = MagicMock(return_value=False)
+    turn_store.mark_handled = MagicMock(wraps=turn_store.mark_handled)
     bot.logger = MagicMock()
-    replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+    replace_turn_controller_deps(bot, logger=bot.logger)
     bot.client = AsyncMock()
     bot._send_response = AsyncMock(return_value="$response")
     install_send_response_mock(bot, bot._send_response)
@@ -1148,7 +1156,7 @@ async def test_router_routes_transcribed_audio_when_multiple_agents_are_present(
         ORIGINAL_SENDER_KEY: "@alice:example.com",
         ATTACHMENT_IDS_KEY: [_attachment_id_for_event("$voice_event")],
     }
-    bot._handled_turn_ledger.record_handled_turn.assert_called_once_with(
+    turn_store.mark_handled.assert_called_once_with(
         HandledTurnState.from_source_event_id(
             "$voice_event",
             response_event_id="$response",
@@ -1194,10 +1202,10 @@ async def test_transcribed_mentions_target_the_mentioned_agent_when_router_absen
             config=config,
             rooms=["!test:example.com"],
         )
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
+        turn_store = unwrap_extracted_collaborator(bot._turn_store)
+        turn_store.has_responded = MagicMock(return_value=False)
         bot.logger = MagicMock()
-        replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+        replace_turn_controller_deps(bot, logger=bot.logger)
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = f"@mindroom_{agent_name}:localhost"
@@ -1269,10 +1277,10 @@ async def test_caption_mentions_still_target_agent_when_stt_drops_the_mention(tm
             config=config,
             rooms=["!test:example.com"],
         )
-        bot._handled_turn_ledger = MagicMock()
-        bot._handled_turn_ledger.has_responded.return_value = False
+        turn_store = unwrap_extracted_collaborator(bot._turn_store)
+        turn_store.has_responded = MagicMock(return_value=False)
         bot.logger = MagicMock()
-        replace_turn_controller_deps(bot, handled_turn_ledger=bot._handled_turn_ledger, logger=bot.logger)
+        replace_turn_controller_deps(bot, logger=bot.logger)
         bot.client = AsyncMock()
         bot.client.rooms = {}
         bot.client.user_id = f"@mindroom_{agent_name}:localhost"


### PR DESCRIPTION
## Summary
- hide the handled-turn ledger behind the shared `TurnStore` interface instead of reaching into the ledger directly
- tighten the bot and post-response paths around the `TurnStore` abstraction
- refresh the turn-store focused regression coverage and related bot tests while rebuilding onto current `origin/main`

## Test Plan
- Not rerun during PR opening; rebuilt from rewritten `gitea/main` commit `c7274159e` onto current `origin/main`.
- Resolved one test-only conflict in `tests/test_multi_agent_bot.py` while preserving the `TurnStore`-based behavior.