### PR TITLE
fix: re-enable compaction summary injection into agent prompt (ISSUE-145)

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -1232,6 +1232,7 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         knowledge=knowledge if knowledge_enabled else None,
         search_knowledge=knowledge_enabled,
         add_history_to_context=True,
+        add_session_summary_to_context=True,
         num_history_runs=num_history_runs,
         num_history_messages=num_history_messages,
         # Keep persisted runs raw even though Agno replays history natively.

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1181,6 +1181,7 @@ def _create_team_instance(
         # Team-owned replay should come from the shared TeamSession, not from
         # each member independently replaying their own session state.
         agent.add_history_to_context = False
+        agent.add_session_summary_to_context = False
 
     team = Team(
         members=agents,  # type: ignore[arg-type]
@@ -1190,6 +1191,7 @@ def _create_team_instance(
         db=history_storage,
         delegate_to_all_members=mode == TeamMode.COLLABORATE,
         add_history_to_context=True,
+        add_session_summary_to_context=True,
         num_history_runs=history_settings.policy.limit if history_settings.policy.mode == "runs" else None,
         num_history_messages=history_settings.policy.limit if history_settings.policy.mode == "messages" else None,
         max_tool_calls_from_history=history_settings.max_tool_calls_from_history,


### PR DESCRIPTION
## Summary
- re-enable compaction summary injection for agent prompt assembly
- keep the same summary injection behavior aligned for team prompt assembly

## Test Plan
- Not rerun during PR opening; rebuilt from `gitea/main` commit `86465c617` onto current `origin/main`.