### PR TITLE
feat: add include_tag/exclude_tag filters to list_thread_tags (ISSUE-142)

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -74,6 +74,7 @@ Tools like `matrix_message`, `matrix_room`, `thread_tags`, and `matrix_api` use 
 `thread_tags.tag_thread()` and `thread_tags.untag_thread()` still use the active thread when the caller explicitly repeats the current `room_id`.
 `thread_tags.list_thread_tags()` uses the active thread by default, but passing `room_id` without `thread_id` forces room-wide listing even from inside an active thread.
 `thread_tags.list_thread_tags(tag=...)` narrows both thread-specific and room-wide responses to the requested tag only.
+`thread_tags.list_thread_tags(include_tag=..., exclude_tag=...)` filters which threads are returned: `include_tag` keeps only threads with that tag, `exclude_tag` removes threads with that tag. Both can be combined. Unlike `tag` (which narrows the output payload), these filter which threads appear at all.
 `thread_tags` also validates and normalizes predefined payload schemas for `blocked.data.blocked_by`, `waiting.data.waiting_on`, `priority.data.level`, and `due.data.deadline`.
 `thread_tags` intentionally replaces the removed experimental `thread_resolution` tool and does not auto-read old `com.mindroom.thread.resolution` markers.
 `matrix_api` defaults `room_id` to the active room, supports authorized cross-room targeting, and never infers event IDs or state keys from thread context.

--- a/src/mindroom/custom_tools/thread_tags.py
+++ b/src/mindroom/custom_tools/thread_tags.py
@@ -58,6 +58,21 @@ def _serialized_tags_for_output(
     return {tag: serialized[tag]} if tag in serialized else {}
 
 
+def _thread_matches_tag_filters(
+    tags: Mapping[str, ThreadTagRecord],
+    *,
+    tag: str | None,
+    include_tag: str | None,
+    exclude_tag: str | None,
+) -> bool:
+    """Return whether one tagged thread matches the requested list filters."""
+    if tag is not None and tag not in tags:
+        return False
+    if include_tag is not None and include_tag not in tags:
+        return False
+    return exclude_tag is None or exclude_tag not in tags
+
+
 class ThreadTagsTools(Toolkit):
     """Tools for tagging Matrix threads via shared room state."""
 
@@ -273,8 +288,10 @@ class ThreadTagsTools(Toolkit):
         thread_id: str | None = None,
         room_id: str | None = None,
         tag: str | None = None,
+        include_tag: str | None = None,
+        exclude_tag: str | None = None,
     ) -> str:
-        """List tags for one thread or all tagged threads in one room."""
+        """List tags for one thread or all tagged threads in one room, with optional tag filters."""
         context = get_tool_runtime_context()
         if context is None:
             return self._context_error()
@@ -293,6 +310,8 @@ class ThreadTagsTools(Toolkit):
 
         try:
             normalized_tag = normalize_tag_name(tag) if tag is not None else None
+            normalized_include_tag = normalize_tag_name(include_tag) if include_tag is not None else None
+            normalized_exclude_tag = normalize_tag_name(exclude_tag) if exclude_tag is not None else None
         except ThreadTagsError as exc:
             return self._payload(
                 "error",
@@ -308,11 +327,14 @@ class ThreadTagsTools(Toolkit):
             allow_context_fallback=room_id is None,
         )
         if effective_thread_id is None:
+            room_wide_tag = (
+                normalized_tag if normalized_include_tag is None and normalized_exclude_tag is None else None
+            )
             try:
                 threads = await list_tagged_threads(
                     context.client,
                     resolved_room_id,
-                    tag=normalized_tag,
+                    tag=room_wide_tag,
                 )
             except ThreadTagsError as exc:
                 return self._payload(
@@ -320,6 +342,8 @@ class ThreadTagsTools(Toolkit):
                     action="list",
                     room_id=resolved_room_id,
                     tag=normalized_tag,
+                    include_tag=normalized_include_tag,
+                    exclude_tag=normalized_exclude_tag,
                     message=str(exc),
                 )
 
@@ -329,9 +353,17 @@ class ThreadTagsTools(Toolkit):
                 room_id=resolved_room_id,
                 room_wide=True,
                 tag=normalized_tag,
+                include_tag=normalized_include_tag,
+                exclude_tag=normalized_exclude_tag,
                 threads={
                     thread_root_id: _serialized_tags_for_output(state.tags, tag=normalized_tag)
                     for thread_root_id, state in threads.items()
+                    if _thread_matches_tag_filters(
+                        state.tags,
+                        tag=None if room_wide_tag is not None else normalized_tag,
+                        include_tag=normalized_include_tag,
+                        exclude_tag=normalized_exclude_tag,
+                    )
                 },
             )
 
@@ -348,6 +380,8 @@ class ThreadTagsTools(Toolkit):
                 room_id=resolved_room_id,
                 thread_id=effective_thread_id,
                 tag=normalized_tag,
+                include_tag=normalized_include_tag,
+                exclude_tag=normalized_exclude_tag,
                 message="Failed to resolve a canonical thread root for the target event.",
             )
 
@@ -364,10 +398,19 @@ class ThreadTagsTools(Toolkit):
                 room_id=resolved_room_id,
                 thread_id=normalized_thread_id,
                 tag=normalized_tag,
+                include_tag=normalized_include_tag,
+                exclude_tag=normalized_exclude_tag,
                 message=str(exc),
             )
 
-        tags = _serialized_tags_for_output(state.tags, tag=normalized_tag) if state is not None else {}
+        tags = {}
+        if state is not None and _thread_matches_tag_filters(
+            state.tags,
+            tag=normalized_tag,
+            include_tag=normalized_include_tag,
+            exclude_tag=normalized_exclude_tag,
+        ):
+            tags = _serialized_tags_for_output(state.tags, tag=normalized_tag)
 
         return self._payload(
             "ok",
@@ -375,5 +418,7 @@ class ThreadTagsTools(Toolkit):
             room_id=resolved_room_id,
             thread_id=normalized_thread_id,
             tag=normalized_tag,
+            include_tag=normalized_include_tag,
+            exclude_tag=normalized_exclude_tag,
             tags=tags,
         )

--- a/tests/test_thread_tags_tool.py
+++ b/tests/test_thread_tags_tool.py
@@ -616,6 +616,253 @@ async def test_list_thread_tags_lists_room_wide_when_no_thread_is_available() ->
 
 
 @pytest.mark.asyncio
+async def test_list_thread_tags_room_wide_filters_by_include_tag_only() -> None:
+    """Room-wide listing should keep only threads that carry the included tag."""
+    tool = ThreadTagsTools()
+    context = _make_context(thread_id=None, reply_to_event_id=None)
+
+    with (
+        patch(
+            "mindroom.custom_tools.thread_tags.list_tagged_threads",
+            new=AsyncMock(
+                return_value={
+                    "$thread-one:localhost": _state(
+                        "$thread-one:localhost",
+                        blocked=_record(data={"blocked_by": ["$other:localhost"]}),
+                    ),
+                    "$thread-two:localhost": _state(
+                        "$thread-two:localhost",
+                        resolved=_record(note="done"),
+                    ),
+                    "$thread-three:localhost": _state(
+                        "$thread-three:localhost",
+                        blocked=_record(data={"blocked_by": ["$other:localhost"]}),
+                        resolved=_record(note="done"),
+                    ),
+                },
+            ),
+        ) as mock_list,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await tool.list_thread_tags(include_tag="blocked"))
+
+    assert payload["status"] == "ok"
+    assert payload["room_wide"] is True
+    assert payload["include_tag"] == "blocked"
+    assert payload["exclude_tag"] is None
+    assert list(payload["threads"]) == ["$thread-one:localhost", "$thread-three:localhost"]
+    assert set(payload["threads"]["$thread-one:localhost"]) == {"blocked"}
+    assert set(payload["threads"]["$thread-three:localhost"]) == {"blocked", "resolved"}
+    mock_list.assert_awaited_once_with(
+        context.client,
+        context.room_id,
+        tag=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_thread_tags_room_wide_requires_tag_and_include_tag_together() -> None:
+    """Room-wide listing should require both tag filters when tag and include_tag are combined."""
+    tool = ThreadTagsTools()
+    context = _make_context(thread_id=None, reply_to_event_id=None)
+
+    with (
+        patch(
+            "mindroom.custom_tools.thread_tags.list_tagged_threads",
+            new=AsyncMock(
+                return_value={
+                    "$thread-one:localhost": _state(
+                        "$thread-one:localhost",
+                        blocked=_record(data={"blocked_by": ["$other:localhost"]}),
+                    ),
+                    "$thread-two:localhost": _state(
+                        "$thread-two:localhost",
+                        blocked=_record(data={"blocked_by": ["$other:localhost"]}),
+                        waiting=_record(data={"waiting_on": ["@owner:localhost"]}),
+                    ),
+                    "$thread-three:localhost": _state(
+                        "$thread-three:localhost",
+                        waiting=_record(data={"waiting_on": ["@owner:localhost"]}),
+                    ),
+                },
+            ),
+        ) as mock_list,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await tool.list_thread_tags(tag="blocked", include_tag="waiting"))
+
+    assert payload["status"] == "ok"
+    assert payload["room_wide"] is True
+    assert payload["tag"] == "blocked"
+    assert payload["include_tag"] == "waiting"
+    assert list(payload["threads"]) == ["$thread-two:localhost"]
+    assert list(payload["threads"]["$thread-two:localhost"]) == ["blocked"]
+    mock_list.assert_awaited_once_with(
+        context.client,
+        context.room_id,
+        tag=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_thread_tags_room_wide_requires_tag_without_excluded_tag() -> None:
+    """Room-wide listing should keep threads with the tag unless they also carry the excluded tag."""
+    tool = ThreadTagsTools()
+    context = _make_context(thread_id=None, reply_to_event_id=None)
+
+    with (
+        patch(
+            "mindroom.custom_tools.thread_tags.list_tagged_threads",
+            new=AsyncMock(
+                return_value={
+                    "$thread-one:localhost": _state(
+                        "$thread-one:localhost",
+                        blocked=_record(data={"blocked_by": ["$other:localhost"]}),
+                    ),
+                    "$thread-two:localhost": _state(
+                        "$thread-two:localhost",
+                        blocked=_record(data={"blocked_by": ["$other:localhost"]}),
+                        resolved=_record(note="done"),
+                    ),
+                    "$thread-three:localhost": _state(
+                        "$thread-three:localhost",
+                        waiting=_record(data={"waiting_on": ["@owner:localhost"]}),
+                    ),
+                },
+            ),
+        ) as mock_list,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await tool.list_thread_tags(tag="blocked", exclude_tag="resolved"))
+
+    assert payload["status"] == "ok"
+    assert payload["room_wide"] is True
+    assert payload["tag"] == "blocked"
+    assert payload["exclude_tag"] == "resolved"
+    assert list(payload["threads"]) == ["$thread-one:localhost"]
+    assert list(payload["threads"]["$thread-one:localhost"]) == ["blocked"]
+    mock_list.assert_awaited_once_with(
+        context.client,
+        context.room_id,
+        tag=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_thread_tags_room_wide_returns_empty_when_include_tag_matches_nothing() -> None:
+    """Room-wide listing should return an empty result when no thread has the included tag."""
+    tool = ThreadTagsTools()
+    context = _make_context(thread_id=None, reply_to_event_id=None)
+
+    with (
+        patch(
+            "mindroom.custom_tools.thread_tags.list_tagged_threads",
+            new=AsyncMock(
+                return_value={
+                    "$thread-one:localhost": _state(
+                        "$thread-one:localhost",
+                        blocked=_record(data={"blocked_by": ["$other:localhost"]}),
+                    ),
+                    "$thread-two:localhost": _state(
+                        "$thread-two:localhost",
+                        resolved=_record(note="done"),
+                    ),
+                },
+            ),
+        ) as mock_list,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await tool.list_thread_tags(include_tag="nonexistent"))
+
+    assert payload["status"] == "ok"
+    assert payload["room_wide"] is True
+    assert payload["include_tag"] == "nonexistent"
+    assert payload["threads"] == {}
+    mock_list.assert_awaited_once_with(
+        context.client,
+        context.room_id,
+        tag=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_thread_tags_room_wide_returns_empty_when_exclude_tag_filters_all_threads() -> None:
+    """Room-wide listing should return an empty result when every thread has the excluded tag."""
+    tool = ThreadTagsTools()
+    context = _make_context(thread_id=None, reply_to_event_id=None)
+
+    with (
+        patch(
+            "mindroom.custom_tools.thread_tags.list_tagged_threads",
+            new=AsyncMock(
+                return_value={
+                    "$thread-one:localhost": _state(
+                        "$thread-one:localhost",
+                        blocked=_record(data={"blocked_by": ["$other:localhost"]}),
+                        resolved=_record(note="done"),
+                    ),
+                    "$thread-two:localhost": _state(
+                        "$thread-two:localhost",
+                        resolved=_record(note="done"),
+                    ),
+                },
+            ),
+        ) as mock_list,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await tool.list_thread_tags(exclude_tag="resolved"))
+
+    assert payload["status"] == "ok"
+    assert payload["room_wide"] is True
+    assert payload["exclude_tag"] == "resolved"
+    assert payload["threads"] == {}
+    mock_list.assert_awaited_once_with(
+        context.client,
+        context.room_id,
+        tag=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_thread_tags_room_wide_normalizes_mixed_case_include_and_exclude_tags() -> None:
+    """Room-wide listing should normalize include and exclude tag inputs before filtering."""
+    tool = ThreadTagsTools()
+    context = _make_context(thread_id=None, reply_to_event_id=None)
+
+    with (
+        patch(
+            "mindroom.custom_tools.thread_tags.list_tagged_threads",
+            new=AsyncMock(
+                return_value={
+                    "$thread-one:localhost": _state(
+                        "$thread-one:localhost",
+                        blocked=_record(data={"blocked_by": ["$other:localhost"]}),
+                    ),
+                    "$thread-two:localhost": _state(
+                        "$thread-two:localhost",
+                        blocked=_record(data={"blocked_by": ["$other:localhost"]}),
+                        resolved=_record(note="done"),
+                    ),
+                },
+            ),
+        ) as mock_list,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await tool.list_thread_tags(include_tag="BloCked", exclude_tag="ReSoLved"))
+
+    assert payload["status"] == "ok"
+    assert payload["room_wide"] is True
+    assert payload["include_tag"] == "blocked"
+    assert payload["exclude_tag"] == "resolved"
+    assert list(payload["threads"]) == ["$thread-one:localhost"]
+    mock_list.assert_awaited_once_with(
+        context.client,
+        context.room_id,
+        tag=None,
+    )
+
+
+@pytest.mark.asyncio
 async def test_list_thread_tags_explicit_same_room_target_can_list_room_wide_from_thread_context() -> None:
     """An explicit same-room target should disable thread fallback and allow room-wide listing."""
     tool = ThreadTagsTools()
@@ -709,6 +956,53 @@ async def test_list_thread_tags_filters_thread_specific_payload() -> None:
     assert payload["tags"]["blocked"]["data"] == {"blocked_by": ["$other:localhost"]}
     assert payload["tags"]["blocked"]["set_by"] == "@user:localhost"
     assert datetime.fromisoformat(payload["tags"]["blocked"]["set_at"]).tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_list_thread_tags_thread_specific_include_exclude_filters() -> None:
+    """Thread-specific listing should respect include_tag and exclude_tag filters."""
+    tool = ThreadTagsTools()
+    context = _make_context(thread_id="$ctx-thread:localhost")
+
+    with (
+        patch(
+            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            new=AsyncMock(return_value="$ctx-thread:localhost"),
+        ),
+        patch(
+            "mindroom.custom_tools.thread_tags.get_thread_tags",
+            new=AsyncMock(
+                return_value=_state(
+                    "$ctx-thread:localhost",
+                    resolved=_record(),
+                    blocked=_record(data={"blocked_by": ["$other:localhost"]}),
+                ),
+            ),
+        ),
+        tool_runtime_context(context),
+    ):
+        # include_tag matches → thread returned with all tags
+        payload = json.loads(await tool.list_thread_tags(include_tag="blocked"))
+        assert payload["status"] == "ok"
+        assert "blocked" in payload["tags"]
+        assert "resolved" in payload["tags"]
+
+        # exclude_tag matches → thread excluded (empty tags)
+        payload = json.loads(await tool.list_thread_tags(exclude_tag="resolved"))
+        assert payload["status"] == "ok"
+        assert payload["tags"] == {}
+
+        # include_tag matches but exclude_tag also matches → excluded
+        payload = json.loads(
+            await tool.list_thread_tags(include_tag="blocked", exclude_tag="resolved"),
+        )
+        assert payload["status"] == "ok"
+        assert payload["tags"] == {}
+
+        # include_tag doesn't match → excluded
+        payload = json.loads(await tool.list_thread_tags(include_tag="nonexistent"))
+        assert payload["status"] == "ok"
+        assert payload["tags"] == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `include_tag` and `exclude_tag` filters to `list_thread_tags`
- document the new filters and add regression coverage for the tool behavior

## Test Plan
- Not rerun during PR opening; rebuilt from `gitea/main` commit `e357a6c4c` onto current `origin/main`.