### PR TITLE
test: stabilize Matrix client mocks across bot integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from itertools import count
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import nio
 import pytest
 import pytest_asyncio
 from aioresponses import aioresponses
@@ -38,6 +39,7 @@ __all__ = [
     "install_generate_response_mock",
     "install_send_response_mock",
     "install_send_skill_command_response_mock",
+    "make_matrix_client_mock",
     "make_visible_message",
     "normalize_console_output",
     "orchestrator_runtime_paths",
@@ -61,6 +63,49 @@ _VISIBLE_MESSAGE_IDS = count(1)
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 _SOFT_WRAP_RE = re.compile(r"(?<=\S)\n(?=\S)")
 RuntimeBot = AgentBot | TeamBot
+
+
+async def _empty_async_iterator() -> AsyncGenerator[object, None]:
+    """Yield nothing while preserving async-iterator semantics for nio relations APIs."""
+    if False:
+        yield None
+
+
+def _make_room_get_event_response(event_id: str) -> nio.RoomGetEventResponse:
+    """Return a minimal RoomGetEventResponse containing one visible text event."""
+    event = MagicMock(spec=nio.RoomMessageText)
+    event.event_id = event_id
+    event.sender = "@user:localhost"
+    event.body = event_id
+    event.server_timestamp = 0
+    event.source = {
+        "type": "m.room.message",
+        "content": {
+            "msgtype": "m.text",
+            "body": event_id,
+        },
+    }
+    response = nio.RoomGetEventResponse()
+    response.event = event
+    return response
+
+
+def make_matrix_client_mock(*, user_id: str = "@mindroom_test:example.com") -> AsyncMock:
+    """Return an AsyncClient-shaped mock with safe defaults for sync nio APIs."""
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.rooms = {}
+    client.user_id = user_id
+    presence_response = MagicMock()
+    presence_response.presence = "offline"
+    presence_response.last_active_ago = 3_600_000
+    room_messages_response = nio.RoomMessagesResponse(room_id="!test:localhost", chunk=[], start="", end=None)
+    client.add_event_callback = MagicMock()
+    client.add_response_callback = MagicMock()
+    client.get_presence = AsyncMock(return_value=presence_response)
+    client.room_get_event = AsyncMock(side_effect=lambda _room_id, event_id: _make_room_get_event_response(event_id))
+    client.room_get_event_relations = MagicMock(return_value=_empty_async_iterator())
+    client.room_messages = AsyncMock(return_value=room_messages_response)
+    return client
 
 
 def normalize_console_output(text: str) -> str:

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -363,6 +363,8 @@ class TestBotTaskRestoration:
                 patch("mindroom.bot.restore_scheduled_tasks", new_callable=AsyncMock) as mock_restore,
             ):
                 mock_client = AsyncMock()
+                mock_client.add_event_callback = MagicMock()
+                mock_client.add_response_callback = MagicMock()
                 mock_login.return_value = mock_client
 
                 # Mock the client.join method to return JoinResponse
@@ -409,6 +411,8 @@ class TestBotTaskRestoration:
                 patch("mindroom.bot.AgentBot._set_presence_with_model_info", new_callable=AsyncMock),
             ):
                 mock_client = AsyncMock()
+                mock_client.add_event_callback = MagicMock()
+                mock_client.add_response_callback = MagicMock()
                 mock_login.return_value = mock_client
 
                 # Mock the client.join method to return JoinResponse

--- a/tests/test_interactive_thread_fix.py
+++ b/tests/test_interactive_thread_fix.py
@@ -21,7 +21,7 @@ from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.matrix.users import AgentMatrixUser
-from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
+from tests.conftest import bind_runtime_paths, make_matrix_client_mock, runtime_paths_for, test_runtime_paths
 
 
 def _room_send_response(event_id: str) -> MagicMock:
@@ -97,7 +97,7 @@ async def test_interactive_question_preserves_thread_root_in_streaming(tmp_path:
         )
 
         # Mock client
-        client = AsyncMock()
+        client = make_matrix_client_mock(user_id="@mindroom_general:localhost")
         client.user_id = "@mindroom_general:localhost"
         client.room_send.return_value = _room_send_response("$agent_message_id")
         bot.client = client
@@ -191,7 +191,7 @@ async def test_interactive_question_preserves_thread_root_in_non_streaming(tmp_p
             rooms=["!test:localhost"],
         )
 
-        client = AsyncMock()
+        client = make_matrix_client_mock(user_id="@mindroom_general:localhost")
         client.user_id = "@mindroom_general:localhost"
         client.room_send.return_value = _room_send_response("$agent_response_id")
         bot.client = client

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -109,9 +109,13 @@ from tests.conftest import (
     replace_response_runner_deps,
     replace_turn_controller_deps,
     runtime_paths_for,
+    sync_bot_runtime_state,
     test_runtime_paths,
     unwrap_extracted_collaborator,
     wrap_extracted_collaborators,
+)
+from tests.conftest import (
+    make_matrix_client_mock as _base_make_matrix_client_mock,
 )
 from tests.conftest import (
     replace_turn_policy_deps as shared_replace_turn_policy_deps,
@@ -126,10 +130,7 @@ if TYPE_CHECKING:
 
 def _make_matrix_client_mock() -> AsyncMock:
     """Return a minimal Matrix client mock for bot tests."""
-    client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
-    client.user_id = "@mindroom_test:example.com"
-    return client
+    return _base_make_matrix_client_mock()
 
 
 def _wrap_extracted_collaborators(bot: AgentBot) -> AgentBot:
@@ -967,6 +968,7 @@ class TestAgentBot:
         mock_client = AsyncMock()
         # add_event_callback is a sync method, not async
         mock_client.add_event_callback = MagicMock()
+        mock_client.add_response_callback = MagicMock()
         mock_login.return_value = mock_client
 
         # Mock ensure_user_account to not change the agent_user
@@ -1004,6 +1006,7 @@ class TestAgentBot:
         call_order: list[str] = []
         mock_client = AsyncMock()
         mock_client.add_event_callback = MagicMock()
+        mock_client.add_response_callback = MagicMock()
 
         async def _sync_forever(*_args: object, **_kwargs: object) -> None:
             call_order.append("sync")
@@ -1152,7 +1155,7 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
 
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         bot.running = True
 
         await bot.stop()
@@ -1166,7 +1169,7 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
 
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
 
         mock_room = MagicMock()
         mock_room.room_id = "!test:localhost"
@@ -1184,7 +1187,7 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
 
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
 
         mock_room = MagicMock()
         mock_event = MagicMock()
@@ -1205,7 +1208,7 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
 
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
 
         mock_room = MagicMock()
         mock_event = MagicMock()
@@ -1266,7 +1269,7 @@ class TestAgentBot:
             config=config,
             runtime_paths=runtime_paths_for(config),
         )
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
 
         # Mock presence check to return user online when streaming is enabled
         # We need to create a proper mock response that will be returned by get_presence
@@ -1383,7 +1386,7 @@ class TestAgentBot:
             tmp_path,
         )
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         bot.client.room_send.return_value = _room_send_response("$response")
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         mock_ai = AsyncMock(return_value="Handled")
@@ -1429,7 +1432,7 @@ class TestAgentBot:
             tmp_path,
         )
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         bot.client.room_send.return_value = _room_send_response("$response")
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         mock_ai = AsyncMock(return_value="Handled")
@@ -1478,7 +1481,7 @@ class TestAgentBot:
             tmp_path,
         )
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         bot._handle_interactive_question = AsyncMock()
         mock_stream_agent_response = AsyncMock()
@@ -1531,7 +1534,7 @@ class TestAgentBot:
             tmp_path,
         )
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         bot.client.room_send.return_value = _room_send_response("$response")
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         mock_ai = AsyncMock(return_value="Handled")
@@ -1584,7 +1587,7 @@ class TestAgentBot:
             tmp_path,
         )
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         bot._handle_interactive_question = AsyncMock()
         mock_stream_agent_response = AsyncMock(return_value=mock_streaming_response())
@@ -1623,7 +1626,8 @@ class TestAgentBot:
         """Non-streaming responses should persist attachment IDs in message metadata."""
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
+        sync_bot_runtime_state(bot)
         bot.client.room_send.return_value = _room_send_response("$response")
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
 
@@ -1661,7 +1665,7 @@ class TestAgentBot:
         """Streaming responses should persist attachment IDs in message metadata."""
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         bot._handle_interactive_question = AsyncMock()
 
@@ -1748,7 +1752,7 @@ class TestAgentBot:
         """Metadata populated during generator iteration must appear in extra_content via mutable reference."""
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         bot._handle_interactive_question = AsyncMock()
 
@@ -1807,7 +1811,7 @@ class TestAgentBot:
         """CancelledError during streaming must still carry io.mindroom.ai_run in extra_content."""
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         bot._handle_interactive_question = AsyncMock()
 
@@ -1874,7 +1878,7 @@ class TestAgentBot:
 
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         bot._handle_interactive_question = AsyncMock()
         mock_stream_agent_response = AsyncMock(return_value=mock_streaming_response())
@@ -2154,6 +2158,17 @@ class TestAgentBot:
         """Team final output should use the same before/after hook flow."""
         after_results: list[tuple[str, str, str, str]] = []
 
+        def discard_background_task(
+            coro: object,
+            *,
+            name: str,  # noqa: ARG001
+            error_handler: object | None = None,  # noqa: ARG001
+            owner: object | None = None,  # noqa: ARG001
+        ) -> None:
+            close = getattr(coro, "close", None)
+            if callable(close):
+                close()
+
         @hook(EVENT_MESSAGE_BEFORE_RESPONSE)
         async def before_hook(ctx: BeforeResponseContext) -> None:
             ctx.draft.response_text = f"{ctx.draft.response_text} [hooked]"
@@ -2172,7 +2187,8 @@ class TestAgentBot:
         config = self._config_for_storage(tmp_path)
         config.defaults.show_stop_button = False
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
+        sync_bot_runtime_state(bot)
         bot._send_response = AsyncMock(return_value="$team")
         install_send_response_mock(bot, bot._send_response)
         bot.hook_registry = HookRegistry.from_plugins([_hook_plugin("hooked", [before_hook, after_hook])])
@@ -2187,10 +2203,15 @@ class TestAgentBot:
                 "mindroom.delivery_gateway.edit_message",
                 new=AsyncMock(return_value=_room_send_response("$edit")),
             ) as mock_edit_message,
+            patch(
+                "mindroom.delivery_gateway.build_threaded_edit_content",
+                new=AsyncMock(return_value={"msgtype": "m.text", "body": "Team reply [hooked]"}),
+            ),
             patch_response_runner_module(
                 typing_indicator=_noop_typing_indicator,
                 should_use_streaming=AsyncMock(return_value=False),
                 team_response=AsyncMock(return_value="Team reply"),
+                create_background_task=MagicMock(side_effect=discard_background_task),
             ),
         ):
             event_id = await bot._generate_team_response_helper(
@@ -2630,10 +2651,23 @@ class TestAgentBot:
         tmp_path: Path,
     ) -> None:
         """Team interactive questions should be owned by the real bot agent name."""
+
+        def discard_background_task(
+            coro: object,
+            *,
+            name: str,  # noqa: ARG001
+            error_handler: object | None = None,  # noqa: ARG001
+            owner: object | None = None,  # noqa: ARG001
+        ) -> None:
+            close = getattr(coro, "close", None)
+            if callable(close):
+                close()
+
         config = self._config_for_storage(tmp_path)
         config.defaults.show_stop_button = False
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
+        sync_bot_runtime_state(bot)
         bot._send_response = AsyncMock(return_value="$team")
         install_send_response_mock(bot, bot._send_response)
         bot.orchestrator = MagicMock(
@@ -2650,6 +2684,11 @@ class TestAgentBot:
                 typing_indicator=_noop_typing_indicator,
                 should_use_streaming=AsyncMock(return_value=False),
                 team_response=AsyncMock(return_value=interactive_response),
+                create_background_task=MagicMock(side_effect=discard_background_task),
+            ),
+            patch(
+                "mindroom.delivery_gateway.build_threaded_edit_content",
+                new=AsyncMock(return_value={"msgtype": "m.text", "body": "Interactive team reply"}),
             ),
             patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(return_value=_room_send_response("$edit"))),
             patch("mindroom.bot.interactive.register_interactive_question") as mock_register,
@@ -2899,7 +2938,8 @@ class TestAgentBot:
             tmp_path,
         )
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
+        sync_bot_runtime_state(bot)
         bot._knowledge_access_support.for_agent = MagicMock(return_value=None)
         bot._send_response = AsyncMock(return_value="$response")
         install_send_response_mock(bot, bot._send_response)
@@ -3500,7 +3540,7 @@ class TestAgentBot:
 
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         bot._knowledge_access_support.for_agent = MagicMock(return_value=None)
 
         with (
@@ -3511,6 +3551,7 @@ class TestAgentBot:
             patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(return_value=_room_send_response("$edit"))),
             patch("mindroom.response_runner.create_background_task", side_effect=schedule_background_task),
             patch("mindroom.post_response_effects.create_background_task", side_effect=schedule_background_task),
+            patch("mindroom.bot.store_conversation_memory", side_effect=fake_store_conversation_memory),
             patch(
                 "mindroom.response_runner.store_conversation_memory",
                 side_effect=fake_store_conversation_memory,
@@ -7656,6 +7697,10 @@ class TestAgentBot:
         tmp_path: Path,
     ) -> None:
         """Test agent bot thread response behavior based on agent participation."""
+
+        async def fake_store_conversation_memory(*_args: object, **_kwargs: object) -> None:
+            return None
+
         # Use the helper method to create mock config
         config = self._config_for_storage(tmp_path)
         mock_load_config.return_value = config
@@ -7680,7 +7725,7 @@ class TestAgentBot:
             rooms=["!test:localhost"],
             enable_streaming=enable_streaming,
         )
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
 
         # Mock orchestrator with agent_bots
         mock_orchestrator = MagicMock()
@@ -7778,111 +7823,119 @@ class TestAgentBot:
             },
         }
 
-        await bot._on_message(mock_room, mock_event)
-
-        # Should respond as only agent in thread
-        if enable_streaming:
-            mock_stream_agent_response.assert_called_once()
-            mock_ai_response.assert_not_called()
-            # With streaming and stop button support
-            assert bot.client.room_send.call_count >= 2
-        else:
-            mock_ai_response.assert_called_once()
-            mock_stream_agent_response.assert_not_called()
-            # With stop button support: initial + reaction + final
-            assert bot.client.room_send.call_count >= 2
-
-        # Reset mocks
-        mock_stream_agent_response.reset_mock()
-        mock_ai_response.reset_mock()
-        mock_team_arun.reset_mock()
-        bot.client.room_send.reset_mock()
-        mock_fetch_history.reset_mock()
-
-        # Test 2: Thread with multiple agents - should NOT respond without mention
-        test2_history = [
-            _visible_message(sender="@user:localhost", body="Previous message", timestamp=123, event_id="prev1"),
-            _visible_message(sender=mock_agent_user.user_id, body="My response", timestamp=124, event_id="prev2"),
-            _visible_message(
-                sender=config.get_ids(runtime_paths_for(config))["general"].full_id
-                if "general" in config.get_ids(runtime_paths_for(config))
-                else "@mindroom_general:localhost",
-                body="Another agent response",
-                timestamp=125,
-                event_id="prev3",
+        with (
+            patch("mindroom.bot.store_conversation_memory", side_effect=fake_store_conversation_memory),
+            patch(
+                "mindroom.response_runner.store_conversation_memory",
+                side_effect=fake_store_conversation_memory,
             ),
-        ]
-        mock_fetch_history.return_value = test2_history
-        mock_fetch_snapshot.return_value = test2_history
+            patch("mindroom.post_response_effects.maybe_generate_thread_summary", new=AsyncMock()),
+        ):
+            await bot._on_message(mock_room, mock_event)
 
-        # Create a new event with a different ID for Test 2
-        mock_event_2 = MagicMock()
-        mock_event_2.sender = "@user:localhost"
-        mock_event_2.body = "Thread message without mention"
-        mock_event_2.event_id = "event456"  # Different event ID
-        mock_event_2.server_timestamp = 127
-        mock_event_2.source = {
-            "content": {
-                "m.relates_to": {
-                    "rel_type": "m.thread",
-                    "event_id": "thread_root",
+            # Should respond as only agent in thread
+            if enable_streaming:
+                mock_stream_agent_response.assert_called_once()
+                mock_ai_response.assert_not_called()
+                # With streaming and stop button support
+                assert bot.client.room_send.call_count >= 2
+            else:
+                mock_ai_response.assert_called_once()
+                mock_stream_agent_response.assert_not_called()
+                # With stop button support: initial + reaction + final
+                assert bot.client.room_send.call_count >= 2
+
+            # Reset mocks
+            mock_stream_agent_response.reset_mock()
+            mock_ai_response.reset_mock()
+            mock_team_arun.reset_mock()
+            bot.client.room_send.reset_mock()
+            mock_fetch_history.reset_mock()
+
+            # Test 2: Thread with multiple agents - should NOT respond without mention
+            test2_history = [
+                _visible_message(sender="@user:localhost", body="Previous message", timestamp=123, event_id="prev1"),
+                _visible_message(sender=mock_agent_user.user_id, body="My response", timestamp=124, event_id="prev2"),
+                _visible_message(
+                    sender=config.get_ids(runtime_paths_for(config))["general"].full_id
+                    if "general" in config.get_ids(runtime_paths_for(config))
+                    else "@mindroom_general:localhost",
+                    body="Another agent response",
+                    timestamp=125,
+                    event_id="prev3",
+                ),
+            ]
+            mock_fetch_history.return_value = test2_history
+            mock_fetch_snapshot.return_value = test2_history
+
+            # Create a new event with a different ID for Test 2
+            mock_event_2 = MagicMock()
+            mock_event_2.sender = "@user:localhost"
+            mock_event_2.body = "Thread message without mention"
+            mock_event_2.event_id = "event456"  # Different event ID
+            mock_event_2.server_timestamp = 127
+            mock_event_2.source = {
+                "content": {
+                    "m.relates_to": {
+                        "rel_type": "m.thread",
+                        "event_id": "thread_root",
+                    },
                 },
-            },
-        }
+            }
 
-        await bot._on_message(mock_room, mock_event_2)
+            await bot._on_message(mock_room, mock_event_2)
 
-        # Should form team and send a structured streaming team response
-        mock_stream_agent_response.assert_not_called()
-        mock_ai_response.assert_not_called()
-        mock_team_arun.assert_called_once()
-        # Structured streaming sends an initial message and one or more edits
-        assert bot.client.room_send.call_count >= 1
-
-        # Reset mocks
-        mock_stream_agent_response.reset_mock()
-        mock_ai_response.reset_mock()
-        mock_team_arun.reset_mock()
-        bot.client.room_send.reset_mock()
-
-        # Test 3: Thread with multiple agents WITH mention - should respond
-        mock_event_with_mention = MagicMock()
-        mock_event_with_mention.sender = "@user:localhost"
-        mock_event_with_mention.body = "@mindroom_calculator:localhost What's 2+2?"
-        mock_event_with_mention.event_id = "event789"  # Unique event ID for Test 3
-        mock_event_with_mention.server_timestamp = 128
-        mock_event_with_mention.source = {
-            "content": {
-                "body": "@mindroom_calculator:localhost What's 2+2?",
-                "m.relates_to": {
-                    "rel_type": "m.thread",
-                    "event_id": "thread_root",
-                },
-                "m.mentions": {"user_ids": ["@mindroom_calculator:localhost"]},
-            },
-        }
-
-        # Set up fresh async generator for the second call
-        async def mock_streaming_response2() -> AsyncGenerator[str, None]:
-            yield "Mentioned"
-            yield " response"
-
-        mock_stream_agent_response.return_value = mock_streaming_response2()
-        mock_ai_response.return_value = "Mentioned response"
-
-        await bot._on_message(mock_room, mock_event_with_mention)
-
-        # Should respond when explicitly mentioned
-        if enable_streaming:
-            mock_stream_agent_response.assert_called_once()
-            mock_ai_response.assert_not_called()
-            # With streaming and stop button support
-            assert bot.client.room_send.call_count >= 2
-        else:
-            mock_ai_response.assert_called_once()
+            # Should form team and send a structured streaming team response
             mock_stream_agent_response.assert_not_called()
-            # With stop button support: initial + reaction + final
-            assert bot.client.room_send.call_count >= 2
+            mock_ai_response.assert_not_called()
+            mock_team_arun.assert_called_once()
+            # Structured streaming sends an initial message and one or more edits
+            assert bot.client.room_send.call_count >= 1
+
+            # Reset mocks
+            mock_stream_agent_response.reset_mock()
+            mock_ai_response.reset_mock()
+            mock_team_arun.reset_mock()
+            bot.client.room_send.reset_mock()
+
+            # Test 3: Thread with multiple agents WITH mention - should respond
+            mock_event_with_mention = MagicMock()
+            mock_event_with_mention.sender = "@user:localhost"
+            mock_event_with_mention.body = "@mindroom_calculator:localhost What's 2+2?"
+            mock_event_with_mention.event_id = "event789"  # Unique event ID for Test 3
+            mock_event_with_mention.server_timestamp = 128
+            mock_event_with_mention.source = {
+                "content": {
+                    "body": "@mindroom_calculator:localhost What's 2+2?",
+                    "m.relates_to": {
+                        "rel_type": "m.thread",
+                        "event_id": "thread_root",
+                    },
+                    "m.mentions": {"user_ids": ["@mindroom_calculator:localhost"]},
+                },
+            }
+
+            # Set up fresh async generator for the second call
+            async def mock_streaming_response2() -> AsyncGenerator[str, None]:
+                yield "Mentioned"
+                yield " response"
+
+            mock_stream_agent_response.return_value = mock_streaming_response2()
+            mock_ai_response.return_value = "Mentioned response"
+
+            await bot._on_message(mock_room, mock_event_with_mention)
+
+            # Should respond when explicitly mentioned
+            if enable_streaming:
+                mock_stream_agent_response.assert_called_once()
+                mock_ai_response.assert_not_called()
+                # With streaming and stop button support
+                assert bot.client.room_send.call_count >= 2
+            else:
+                mock_ai_response.assert_called_once()
+                mock_stream_agent_response.assert_not_called()
+                # With stop button support: initial + reaction + final
+                assert bot.client.room_send.call_count >= 2
 
     @pytest.mark.asyncio
     async def test_agent_bot_skips_already_responded_messages(

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -23,6 +23,7 @@ from tests.conftest import (
     TEST_ACCESS_TOKEN,
     TEST_PASSWORD,
     bind_runtime_paths,
+    make_matrix_client_mock,
     patch_response_runner_module,
     runtime_paths_for,
 )
@@ -39,7 +40,7 @@ def _runtime_paths(storage_path: Path) -> RuntimePaths:
 
 
 def _make_config(storage_path: Path) -> Config:
-    return bind_runtime_paths(
+    config = bind_runtime_paths(
         Config(
             agents={
                 "calculator": AgentConfig(display_name="CalculatorAgent", rooms=["!test:localhost"]),
@@ -51,6 +52,8 @@ def _make_config(storage_path: Path) -> Config:
         ),
         _runtime_paths(storage_path),
     )
+    config.memory.backend = "file"
+    return config
 
 
 def _visible_message(*, sender: str, body: str, event_id: str, timestamp: int) -> ResolvedVisibleMessage:
@@ -106,6 +109,7 @@ async def test_agent_processes_direct_mention(
         # Mock the client
         mock_client = AsyncMock()
         mock_client.add_event_callback = MagicMock()
+        mock_client.add_response_callback = MagicMock()
         mock_client.user_id = mock_calculator_agent.user_id
         mock_client.access_token = mock_calculator_agent.access_token
         mock_login.return_value = mock_client
@@ -195,8 +199,7 @@ async def test_agent_ignores_other_agents(
     test_room_id = "!test:localhost"
 
     with patch("mindroom.bot.login_agent_user") as mock_login:
-        mock_client = AsyncMock()
-        mock_client.add_event_callback = MagicMock()
+        mock_client = make_matrix_client_mock(user_id=mock_calculator_agent.user_id)
         mock_client.user_id = mock_calculator_agent.user_id
         mock_login.return_value = mock_client
 
@@ -266,8 +269,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
         patch("mindroom.config.main.Config.from_yaml", return_value=mock_config),
         patch("mindroom.teams._select_team_mode", new=AsyncMock()) as mock_select_mode,
     ):
-        mock_client = AsyncMock()
-        mock_client.add_event_callback = MagicMock()
+        mock_client = make_matrix_client_mock(user_id=mock_calculator_agent.user_id)
         mock_client.user_id = mock_calculator_agent.user_id
         mock_login.return_value = mock_client
         mock_select_mode.return_value = TeamMode.COLLABORATE
@@ -572,6 +574,7 @@ async def test_orchestrator_manages_multiple_agents(tmp_path: Path) -> None:
         ):
             mock_client = AsyncMock()
             mock_client.add_event_callback = MagicMock()
+            mock_client.add_response_callback = MagicMock()
             mock_client.user_id = "@mindroom_calculator:localhost"
             mock_client.join = AsyncMock(return_value=nio.JoinResponse(room_id="!test:localhost"))
             # Don't run sync_forever, just verify setup
@@ -595,8 +598,7 @@ async def test_agent_handles_room_invite(mock_calculator_agent: AgentMatrixUser,
     invite_room = "!invite:localhost"
 
     with patch("mindroom.bot.login_agent_user") as mock_login:
-        mock_client = AsyncMock()
-        mock_client.add_event_callback = MagicMock()
+        mock_client = make_matrix_client_mock(user_id=mock_calculator_agent.user_id)
         mock_client.user_id = mock_calculator_agent.user_id
         mock_login.return_value = mock_client
 

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -57,6 +57,8 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from pathlib import Path
 
+    from agno.session.team import TeamSession
+
 
 def _config(tmp_path: Path) -> Config:
     return bind_runtime_paths(

--- a/tests/test_routing_integration.py
+++ b/tests/test_routing_integration.py
@@ -17,7 +17,13 @@ from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.matrix.users import AgentMatrixUser
-from tests.conftest import TEST_PASSWORD, bind_runtime_paths, runtime_paths_for, test_runtime_paths
+from tests.conftest import (
+    TEST_PASSWORD,
+    bind_runtime_paths,
+    make_matrix_client_mock,
+    runtime_paths_for,
+    test_runtime_paths,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -98,7 +104,7 @@ class TestRoutingIntegration:
 
         # Mock clients
         for bot in [research_bot, news_bot]:
-            bot.client = AsyncMock()
+            bot.client = make_matrix_client_mock(user_id=bot.matrix_id)
 
             # Mock orchestrator
             mock_orchestrator = MagicMock()

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -23,6 +23,7 @@ from mindroom.matrix.users import AgentMatrixUser
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
+    make_matrix_client_mock,
     make_visible_message,
     runtime_paths_for,
     test_runtime_paths,
@@ -75,7 +76,7 @@ def setup_test_bot(
         rooms=[room_id],
         enable_streaming=enable_streaming,
     )
-    bot.client = AsyncMock()
+    bot.client = make_matrix_client_mock(user_id=agent.user_id)
     return bot
 
 

--- a/tests/test_streaming_e2e.py
+++ b/tests/test_streaming_e2e.py
@@ -29,6 +29,13 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+def _matrix_client_mock() -> AsyncMock:
+    client = AsyncMock()
+    client.add_event_callback = MagicMock()
+    client.add_response_callback = MagicMock()
+    return client
+
+
 @pytest.mark.asyncio
 @pytest.mark.e2e  # Mark as end-to-end test
 @pytest.mark.requires_matrix  # Requires real Matrix server for streaming e2e test
@@ -113,8 +120,8 @@ async def test_streaming_edits_e2e(  # noqa: C901, PLR0915
     calc_events: list[dict[str, object]] = []
 
     # Create mock clients for each agent
-    helper_client = AsyncMock()
-    calc_client = AsyncMock()
+    helper_client = _matrix_client_mock()
+    calc_client = _matrix_client_mock()
 
     # Configure login to return appropriate clients
     def login_side_effect(_homeserver: str, agent_user: object) -> object:
@@ -125,11 +132,11 @@ async def test_streaming_edits_e2e(  # noqa: C901, PLR0915
                 return calc_client
             if agent_user.agent_name == "router":
                 # Return a mock client for the router
-                router_client = AsyncMock()
+                router_client = _matrix_client_mock()
                 router_client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=[test_room_id])
                 router_client.sync_forever = AsyncMock()
                 return router_client
-        return AsyncMock()  # Default mock client
+        return _matrix_client_mock()  # Default mock client
 
     mock_login.side_effect = login_side_effect
 
@@ -385,7 +392,7 @@ async def test_user_edits_with_mentions_e2e(tmp_path: Path) -> None:
 
     # Mock login
     with patch("mindroom.bot.login_agent_user") as mock_login:
-        mock_client = AsyncMock()
+        mock_client = _matrix_client_mock()
         mock_login.return_value = mock_client
 
         # Track events

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -25,6 +25,7 @@ from mindroom.matrix.client import (
     get_room_threads_page,
 )
 from mindroom.matrix.event_cache import EventCache
+from tests.conftest import make_matrix_client_mock
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -808,7 +809,7 @@ class TestThreadHistory:
     @pytest.mark.asyncio
     async def test_latest_thread_event_id_returns_thread_root_on_history_failure(self) -> None:
         """The helper should degrade to the thread root when visible-history lookup fails."""
-        client = AsyncMock()
+        client = make_matrix_client_mock()
 
         with patch(
             "mindroom.matrix.client.fetch_thread_history",

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -27,7 +27,7 @@ from mindroom.scheduling import (
     _WorkflowParseError,
     schedule_task,
 )
-from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
+from tests.conftest import bind_runtime_paths, make_matrix_client_mock, runtime_paths_for, test_runtime_paths
 
 
 def _mid(name: str) -> MatrixID:
@@ -489,7 +489,7 @@ class TestExecuteScheduledWorkflow:
 
     async def test_execute_workflow_error_handling(self) -> None:
         """Test error handling in execute_scheduled_workflow."""
-        client = AsyncMock()
+        client = make_matrix_client_mock()
         config = _runtime_bound_config(Config())
         workflow = ScheduledWorkflow(
             schedule_type="once",


### PR DESCRIPTION
## Summary
- tighten shared Matrix client mock setup in the integration-heavy bot test suite
- remove brittle per-test mock wiring that drifted across files
- keep the existing response, routing, scheduling, and thread-history expectations stable across tests

## Testing
- `uv run pytest -x -n 0 --no-cov -v tests/test_bot_scheduling.py tests/test_interactive_thread_fix.py tests/test_multi_agent_bot.py tests/test_multi_agent_e2e.py tests/test_queued_message_notify.py tests/test_routing_integration.py tests/test_routing_regression.py tests/test_streaming_e2e.py tests/test_thread_history.py tests/test_workflow_scheduling.py`