### PR TITLE
fix: add pre-queue gate for thread summary generation (ISSUE-144)

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -164,21 +164,6 @@ _SYNC_TIMEOUT_MS = 30000
 _STOPPING_RESPONSE_TEXT = "⏹️ Stopping generation..."
 
 
-def _thread_summary_message_count_hint(
-    thread_history: Sequence[ResolvedVisibleMessage],
-) -> int:
-    """Return a lower-bound post-response thread size without refetching history.
-
-    The summary task runs only after this bot has already appended one visible
-    reply to the thread, so the hint must account for that new non-summary
-    message. Existing summary notices do not count toward the thresholds.
-    """
-    existing_non_summary_messages = sum(
-        1 for message in thread_history if not isinstance(message.content.get("io.mindroom.thread_summary"), dict)
-    )
-    return existing_non_summary_messages + 1
-
-
 def _create_task_wrapper(
     callback: Callable[..., Awaitable[None]],
     *,
@@ -1714,7 +1699,7 @@ class TeamBot(AgentBot):
 
         media_inputs = media or MediaInputs()
 
-        event_id = await self._generate_team_response_helper(
+        return await self._generate_team_response_helper(
             room_id=room_id,
             reply_to_event_id=reply_to_event_id,
             thread_id=thread_id,
@@ -1751,10 +1736,3 @@ class TeamBot(AgentBot):
             matrix_run_metadata=matrix_run_metadata,
             on_lifecycle_lock_acquired=on_lifecycle_lock_acquired,
         )
-        if thread_id is not None and event_id is not None:
-            self._post_response_effects_support.queue_thread_summary(
-                room_id=room_id,
-                thread_id=thread_id,
-                message_count_hint=_thread_summary_message_count_hint(thread_history),
-            )
-        return event_id

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -9,8 +9,10 @@ from mindroom import interactive
 from mindroom.background_tasks import create_background_task
 from mindroom.delivery_gateway import CompactionNoticeRequest
 from mindroom.message_target import MessageTarget
-from mindroom.thread_summary import maybe_generate_thread_summary
-from mindroom.timing import timed
+from mindroom.thread_summary import (
+    maybe_generate_thread_summary,
+    should_queue_thread_summary as should_queue_thread_summary_check,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
@@ -73,6 +75,7 @@ class PostResponseEffectsDeps:
     strip_transient_enrichment: Callable[[], None] | None = None
     queue_memory_persistence: Callable[[], None] | None = None
     persist_response_event_id: Callable[[str, str], None] | None = None
+    should_queue_thread_summary: Callable[[str, str, int | None], bool] | None = None
     queue_thread_summary: Callable[[str, str, int | None], None] | None = None
 
 
@@ -94,14 +97,19 @@ class PostResponseEffectsSupport:
             raise RuntimeError(msg)
         return client
 
-    @timed("maybe_generate_thread_summary")
-    async def _timed_thread_summary(
+    def should_queue_thread_summary(
         self,
-        *,
-        summary_coro: Awaitable[None],
-    ) -> None:
-        """Run thread-summary generation with duration logging."""
-        await summary_coro
+        room_id: str,
+        thread_id: str,
+        message_count_hint: int | None,
+    ) -> bool:
+        """Return whether a thread-summary check should be queued for this response."""
+        return should_queue_thread_summary_check(
+            room_id=room_id,
+            thread_id=thread_id,
+            config=self.runtime.config,
+            message_count_hint=message_count_hint,
+        )
 
     async def _register_interactive_delivery(
         self,
@@ -161,19 +169,16 @@ class PostResponseEffectsSupport:
         thread_id: str,
         message_count_hint: int | None,
     ) -> None:
-        """Queue background thread summarization with timing instrumentation."""
-        summary_coro = maybe_generate_thread_summary(
-            client=self._client(),
-            room_id=room_id,
-            thread_id=thread_id,
-            config=self.runtime.config,
-            runtime_paths=self.runtime_paths,
-            conversation_access=self.conversation_access,
-            message_count_hint=message_count_hint,
-        )
+        """Queue background thread summarization for one response."""
         create_background_task(
-            self._timed_thread_summary(
-                summary_coro=summary_coro,
+            maybe_generate_thread_summary(
+                client=self._client(),
+                room_id=room_id,
+                thread_id=thread_id,
+                config=self.runtime.config,
+                runtime_paths=self.runtime_paths,
+                conversation_access=self.conversation_access,
+                message_count_hint=message_count_hint,
             ),
             name=f"thread_summary_{room_id}_{thread_id}",
             owner=self.runtime,
@@ -226,6 +231,7 @@ class PostResponseEffectsSupport:
             strip_transient_enrichment=strip_transient_enrichment,
             queue_memory_persistence=queue_memory_persistence,
             persist_response_event_id=persist_response_event_id,
+            should_queue_thread_summary=self.should_queue_thread_summary,
             queue_thread_summary=self.queue_thread_summary,
         )
 
@@ -335,6 +341,14 @@ async def apply_post_response_effects(  # noqa: C901
         and (delivery_result is None or not delivery_result.suppressed)
         and outcome.thread_summary_room_id is not None
         and outcome.thread_summary_thread_id is not None
+        and (
+            deps.should_queue_thread_summary is None
+            or deps.should_queue_thread_summary(
+                outcome.thread_summary_room_id,
+                outcome.thread_summary_thread_id,
+                outcome.thread_summary_message_count_hint,
+            )
+        )
         and deps.queue_thread_summary is not None
     ):
         deps.queue_thread_summary(

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -57,6 +57,7 @@ from mindroom.streaming import (
     build_restart_interrupted_body,
 )
 from mindroom.teams import TeamMode, select_model_for_team, team_response, team_response_stream
+from mindroom.thread_summary import thread_summary_message_count_hint
 from mindroom.timing import DispatchPipelineTiming, timed
 from mindroom.tool_system.runtime_context import resolve_tool_runtime_hook_bindings
 from mindroom.tool_system.worker_routing import (
@@ -215,16 +216,6 @@ def prepare_memory_and_model_context(
         runtime_paths=runtime_paths,
     )
     return prompt, thread_history, model_prompt_text, model_thread_history
-
-
-def _thread_summary_message_count_hint(
-    thread_history: Sequence[ResolvedVisibleMessage],
-) -> int:
-    """Return a lower-bound post-response thread size without refetching history."""
-    existing_non_summary_messages = sum(
-        1 for message in thread_history if not isinstance(message.content.get("io.mindroom.thread_summary"), dict)
-    )
-    return existing_non_summary_messages + 1
 
 
 class _ReplyEventWithSource(Protocol):
@@ -994,6 +985,9 @@ class ResponseRunner:
                     execution_identity=execution_identity,
                     compaction_outcomes=tuple(compaction_outcomes),
                     interactive_target=resolved_target,
+                    thread_summary_room_id=request.room_id if request.thread_id is not None else None,
+                    thread_summary_thread_id=request.thread_id,
+                    thread_summary_message_count_hint=thread_summary_message_count_hint(request.thread_history),
                     strip_transient_enrichment_after_run=request.strip_transient_enrichment_after_run,
                     strip_transient_enrichment_before_effects=True,
                     dispatch_compaction_when_suppressed=True,
@@ -2265,7 +2259,7 @@ class ResponseRunner:
                     interactive_target=resolved_target,
                     thread_summary_room_id=request.room_id if request.thread_id is not None else None,
                     thread_summary_thread_id=request.thread_id,
-                    thread_summary_message_count_hint=_thread_summary_message_count_hint(request.thread_history),
+                    thread_summary_message_count_hint=thread_summary_message_count_hint(request.thread_history),
                     memory_prompt=memory_prompt,
                     memory_thread_history=memory_thread_history,
                     strip_transient_enrichment_after_run=request.strip_transient_enrichment_after_run,

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 
 from mindroom.ai import cached_agent_run, get_model_instance
 from mindroom.logging_config import get_logger
+from mindroom.timing import timed
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -35,6 +36,7 @@ _MARKDOWN_INLINE_CODE_RE = re.compile(r"`([^`]*)`")
 _MARKDOWN_HEADING_RE = re.compile(r"(?m)^\s{0,3}#{1,6}\s+")
 _MARKDOWN_BLOCKQUOTE_RE = re.compile(r"(?m)^\s{0,3}>\s?")
 _MARKDOWN_LIST_ITEM_RE = re.compile(r"(?m)^\s*(?:[-+*]|\d+\.)\s+")
+_PREQUEUE_CONCURRENCY_MARGIN = 2
 
 # In-memory tracking of last summarized message count per thread.
 # Key: "{room_id}:{thread_id}", value: message count at last summary.
@@ -107,6 +109,40 @@ def _is_thread_summary_message(message: ResolvedVisibleMessage) -> bool:
 def _count_non_summary_messages(thread_history: Sequence[ResolvedVisibleMessage]) -> int:
     """Count visible thread messages while excluding summary notices."""
     return sum(1 for message in thread_history if not _is_thread_summary_message(message))
+
+
+def thread_summary_message_count_hint(
+    thread_history: Sequence[ResolvedVisibleMessage],
+) -> int:
+    """Return a lower-bound post-response thread size without refetching history."""
+    return _count_non_summary_messages(thread_history) + 1
+
+
+def next_thread_summary_threshold(
+    room_id: str,
+    thread_id: str,
+    config: Config,
+) -> int:
+    """Return the next summary threshold using the current in-memory baseline."""
+    return _next_threshold(
+        _last_summary_counts.get(thread_summary_cache_key(room_id, thread_id), 0),
+        first_threshold=config.defaults.thread_summary_first_threshold,
+        subsequent_interval=config.defaults.thread_summary_subsequent_interval,
+    )
+
+
+def should_queue_thread_summary(
+    room_id: str,
+    thread_id: str,
+    config: Config,
+    *,
+    message_count_hint: int | None,
+) -> bool:
+    """Return whether the lower-bound hint is close enough to justify a live recheck."""
+    if message_count_hint is None:
+        return True
+    threshold = next_thread_summary_threshold(room_id, thread_id, config)
+    return message_count_hint >= threshold - _PREQUEUE_CONCURRENCY_MARGIN
 
 
 async def _load_thread_history(
@@ -253,6 +289,16 @@ async def _generate_summary(
     return str(content) if content else None
 
 
+@timed("maybe_generate_thread_summary")
+async def _timed_generate_summary(
+    thread_history: Sequence[ResolvedVisibleMessage],
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> str | None:
+    """Run the summary generation attempt with timing instrumentation."""
+    return await _generate_summary(thread_history, config, runtime_paths)
+
+
 async def send_thread_summary_event(
     client: nio.AsyncClient,
     room_id: str,
@@ -322,9 +368,6 @@ async def maybe_generate_thread_summary(
     message_count_hint: int | None = None,
 ) -> None:
     """Generate and send a thread summary if the message count crosses a threshold."""
-    first_threshold = config.defaults.thread_summary_first_threshold
-    subsequent_interval = config.defaults.thread_summary_subsequent_interval
-
     async with thread_summary_lock(room_id, thread_id):
         cache_key = thread_summary_cache_key(room_id, thread_id)
         # Recover from existing summary events on cache miss (e.g., after restart)
@@ -333,12 +376,7 @@ async def maybe_generate_thread_summary(
             if recovered > 0:
                 update_last_summary_count(room_id, thread_id, recovered)
 
-        last_count = _last_summary_counts.get(cache_key, 0)
-        threshold = _next_threshold(
-            last_count,
-            first_threshold=first_threshold,
-            subsequent_interval=subsequent_interval,
-        )
+        threshold = next_thread_summary_threshold(room_id, thread_id, config)
 
         # message_count_hint comes from a pre-send snapshot and is only a
         # lower bound. Other agents or humans can post before this background
@@ -350,7 +388,7 @@ async def maybe_generate_thread_summary(
         if message_count < threshold:
             return
         try:
-            summary = await _generate_summary(thread_history, config, runtime_paths)
+            summary = await _timed_generate_summary(thread_history, config, runtime_paths)
         except Exception:
             logger.exception("Thread summary generation failed", room_id=room_id, thread_id=thread_id)
             # Record current count to prevent retry storms until next threshold

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -32,7 +32,6 @@ from mindroom.bot import (
     AgentBot,
     MultiKnowledgeVectorDb,
     TeamBot,
-    _thread_summary_message_count_hint,
 )
 from mindroom.coalescing import PreparedTextEvent
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig
@@ -95,6 +94,7 @@ from mindroom.response_runner import ResponseRequest, ResponseRunner, _merge_res
 from mindroom.runtime_state import get_runtime_state, reset_runtime_state, set_runtime_ready
 from mindroom.streaming import StreamingDeliveryError
 from mindroom.teams import TeamIntent, TeamMemberStatus, TeamMode, TeamOutcome, TeamResolution, TeamResolutionMember
+from mindroom.thread_summary import thread_summary_message_count_hint
 from mindroom.tool_system.events import ToolTraceEntry
 from mindroom.turn_controller import TurnController, _PrecheckedEvent
 from mindroom.turn_policy import DispatchPlan, PreparedDispatch, ResponseAction, TurnPolicy
@@ -3478,7 +3478,7 @@ class TestAgentBot:
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
     ) -> None:
-        """Threaded agent replies should queue summary generation."""
+        """Threaded agent replies should queue summary generation once the threshold is reached."""
 
         async def fake_store_conversation_memory(*_args: object, **_kwargs: object) -> None:
             return None
@@ -3502,6 +3502,15 @@ class TestAgentBot:
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = AsyncMock()
         bot._knowledge_access_support.for_agent = MagicMock(return_value=None)
+        thread_history = [
+            _visible_message(
+                sender=f"@user{i}:localhost",
+                body=f"Message {i}",
+                event_id=f"$message{i}",
+                timestamp=i,
+            )
+            for i in range(4)
+        ]
 
         with (
             patch("mindroom.response_runner.typing_indicator", _noop_typing_indicator),
@@ -3509,6 +3518,11 @@ class TestAgentBot:
             patch("mindroom.response_runner.ai_response", new_callable=AsyncMock, return_value="ok"),
             patch("mindroom.delivery_gateway.send_message", new=AsyncMock(return_value="$response")),
             patch("mindroom.delivery_gateway.edit_message", new=AsyncMock(return_value=_room_send_response("$edit"))),
+            patch.object(
+                bot._conversation_access,
+                "get_thread_history",
+                new=AsyncMock(return_value=thread_history),
+            ) as mock_get_thread_history,
             patch("mindroom.response_runner.create_background_task", side_effect=schedule_background_task),
             patch("mindroom.post_response_effects.create_background_task", side_effect=schedule_background_task),
             patch(
@@ -3525,13 +3539,14 @@ class TestAgentBot:
                 prompt="Summarize this thread",
                 reply_to_event_id="$event",
                 thread_id="$thread",
-                thread_history=[],
+                thread_history=thread_history,
                 user_id="@alice:localhost",
             )
 
         if scheduled_tasks:
             await asyncio.gather(*scheduled_tasks)
 
+        mock_get_thread_history.assert_awaited_once_with("!test:localhost", "$thread")
         mock_thread_summary.assert_awaited_once_with(
             client=bot.client,
             room_id="!test:localhost",
@@ -3539,7 +3554,7 @@ class TestAgentBot:
             config=config,
             runtime_paths=bot.runtime_paths,
             conversation_access=bot._conversation_access,
-            message_count_hint=1,
+            message_count_hint=5,
         )
         assert "thread_summary_!test:localhost_$thread" in scheduled_names
 
@@ -3692,6 +3707,141 @@ class TestAgentBot:
         assert any(name.startswith("memory_save_team_") for name in scheduled_names)
 
     @pytest.mark.asyncio
+    async def test_team_generate_response_uses_refreshed_thread_history_for_summary_gate(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Team replies should pass the refreshed thread history into the shared summary gate."""
+
+        async def fake_store_conversation_memory(*_args: object, **_kwargs: object) -> None:
+            return None
+
+        async def run_cancellable_response(*_args: object, **kwargs: object) -> str:
+            response_function = cast("Callable[[str | None], Awaitable[None]]", kwargs["response_function"])
+            await response_function(None)
+            return "$response"
+
+        scheduled_tasks: list[asyncio.Task[None]] = []
+
+        def schedule_background_task(
+            coro: Coroutine[Any, Any, None],
+            *,
+            name: str,
+            error_handler: object | None = None,  # noqa: ARG001
+            owner: object | None = None,  # noqa: ARG001
+        ) -> asyncio.Task[None]:
+            task: asyncio.Task[None] = asyncio.create_task(coro, name=name)
+            scheduled_tasks.append(task)
+            return task
+
+        stale_history: list[ResolvedVisibleMessage] = []
+        fresh_history = [
+            _visible_message(
+                sender=f"@user{i}:localhost",
+                body=f"Message {i}",
+                event_id=f"$message{i}",
+                timestamp=i,
+            )
+            for i in range(4)
+        ]
+
+        config = self._config_for_storage(tmp_path)
+        runtime_paths = runtime_paths_for(config)
+        team_member = config.get_ids(runtime_paths)["general"]
+        bot = TeamBot(
+            mock_agent_user,
+            tmp_path,
+            config=config,
+            runtime_paths=runtime_paths,
+            team_agents=[team_member],
+            team_mode="coordinate",
+        )
+        _wrap_extracted_collaborators(bot)
+        bot.client = AsyncMock()
+        bot.orchestrator = MagicMock(
+            current_config=config,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+
+        async def cached_history_refresh(room_id: str, thread_id: str) -> list[ResolvedVisibleMessage]:
+            cache = bot._conversation_access._turn_history_cache.get()
+            assert cache is not None
+            cache[(room_id, thread_id)] = fresh_history
+            return fresh_history
+
+        resolution = TeamResolution(
+            intent=TeamIntent.EXPLICIT_MEMBERS,
+            requested_members=[team_member],
+            member_statuses=[
+                TeamResolutionMember(
+                    agent=team_member,
+                    name="general",
+                    status=TeamMemberStatus.ELIGIBLE,
+                ),
+            ],
+            eligible_members=[team_member],
+            outcome=TeamOutcome.TEAM,
+            mode=TeamMode.COORDINATE,
+        )
+
+        with (
+            patch.object(bot._turn_policy, "materializable_agent_names", return_value={"general"}),
+            patch("mindroom.bot.resolve_configured_team", return_value=resolution),
+            patch.object(
+                bot._conversation_access,
+                "get_thread_history",
+                new=AsyncMock(side_effect=cached_history_refresh),
+            ) as mock_get_thread_history,
+            patch.object(
+                ResponseRunner,
+                "run_cancellable_response",
+                new=AsyncMock(side_effect=run_cancellable_response),
+            ),
+            patch.object(
+                bot._delivery_gateway,
+                "send_text",
+                new=AsyncMock(return_value="$response"),
+            ),
+            patch_response_runner_module(
+                should_use_streaming=AsyncMock(return_value=False),
+                team_response=AsyncMock(return_value="Team reply"),
+            ),
+            patch(
+                "mindroom.response_runner.apply_post_response_effects",
+                new=AsyncMock(),
+            ) as mock_post_effects,
+            patch("mindroom.bot.create_background_task", side_effect=schedule_background_task),
+            patch("mindroom.bot.store_conversation_memory", side_effect=fake_store_conversation_memory),
+        ):
+            async with bot._conversation_resolver.turn_thread_cache_scope():
+                cache = bot._conversation_access._turn_history_cache.get()
+                assert cache is not None
+                cache[("!test:localhost", "$thread")] = stale_history
+
+                await bot._generate_response(
+                    room_id="!test:localhost",
+                    prompt="Team, summarize this thread",
+                    reply_to_event_id="$event",
+                    thread_id="$thread",
+                    thread_history=stale_history,
+                    user_id="@alice:localhost",
+                )
+
+                assert cache[("!test:localhost", "$thread")] == fresh_history
+
+        if scheduled_tasks:
+            await asyncio.gather(*scheduled_tasks)
+
+        mock_get_thread_history.assert_awaited_once_with("!test:localhost", "$thread")
+        assert mock_post_effects.await_count == 1
+        outcome = mock_post_effects.await_args.args[0]
+        assert outcome.thread_summary_room_id == "!test:localhost"
+        assert outcome.thread_summary_thread_id == "$thread"
+        assert outcome.thread_summary_message_count_hint == 5
+
+    @pytest.mark.asyncio
     async def test_team_generate_response_redacts_suppressed_streaming_reply(
         self,
         mock_agent_user: AgentMatrixUser,
@@ -3825,7 +3975,7 @@ class TestAgentBot:
             ),
         )
 
-        assert _thread_summary_message_count_hint(thread_history) == 5
+        assert thread_summary_message_count_hint(thread_history) == 5
 
     @pytest.mark.asyncio
     async def test_generate_team_response_streams_into_placeholder_event(

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -27,6 +27,7 @@ from mindroom.ai import (
     queued_message_signal_context,
     stream_agent_response,
 )
+from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.bot import AgentBot
 from mindroom.coalescing import PreparedTextEvent
 from mindroom.config.agent import AgentConfig
@@ -39,7 +40,13 @@ from mindroom.hooks import MessageEnvelope
 from mindroom.inbound_turn_normalizer import DispatchPayload
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
-from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutcome, apply_post_response_effects
+from mindroom.matrix.client import ResolvedVisibleMessage
+from mindroom.post_response_effects import (
+    PostResponseEffectsDeps,
+    PostResponseEffectsSupport,
+    ResponseOutcome,
+    apply_post_response_effects,
+)
 from mindroom.response_runner import ResponseRequest, ResponseRunner
 from mindroom.teams import TeamMode, _create_team_instance
 from mindroom.turn_controller import _PrecheckedEvent
@@ -54,7 +61,7 @@ from tests.conftest import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Coroutine
     from pathlib import Path
 
 
@@ -264,6 +271,94 @@ async def test_post_response_effects_skip_thread_summary_for_suppressed_delivery
     )
 
     queue_thread_summary.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_response_effects_queues_summary_with_stale_hint_inside_margin(tmp_path: Path) -> None:
+    """A stale hint just below threshold should still reach the live summary check."""
+    config = _config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    client = AsyncMock(spec=nio.AsyncClient)
+    runtime = BotRuntimeState(
+        client=client,
+        config=config,
+        enable_streaming=False,
+        orchestrator=None,
+        event_cache=None,
+        event_cache_write_coordinator=None,
+    )
+    conversation_access = MagicMock()
+    support = PostResponseEffectsSupport(
+        runtime=runtime,
+        logger=MagicMock(),
+        runtime_paths=runtime_paths,
+        delivery_gateway=MagicMock(),
+        conversation_access=conversation_access,
+    )
+    deps = support.build_deps(
+        room_id="!room:localhost",
+        reply_to_event_id="$event",
+        thread_id="$thread",
+        interactive_agent_name="general",
+    )
+    thread_history = [
+        ResolvedVisibleMessage.synthetic(
+            sender=f"@user{i}:localhost",
+            body=f"Message {i}",
+            timestamp=i,
+            event_id=f"$message{i}",
+        )
+        for i in range(5)
+    ]
+    scheduled_tasks: list[asyncio.Task[None]] = []
+
+    def schedule_background_task(
+        coro: Coroutine[object, object, None],
+        *,
+        name: str,
+        error_handler: object | None = None,  # noqa: ARG001
+        owner: object | None = None,  # noqa: ARG001
+    ) -> asyncio.Task[None]:
+        task = asyncio.create_task(coro, name=name)
+        scheduled_tasks.append(task)
+        return task
+
+    with (
+        patch("mindroom.post_response_effects.create_background_task", side_effect=schedule_background_task),
+        patch("mindroom.thread_summary._load_thread_history", new=AsyncMock(return_value=thread_history)) as mock_fetch,
+        patch("mindroom.thread_summary._generate_summary", new=AsyncMock(return_value="Summary")) as mock_generate,
+        patch("mindroom.thread_summary.send_thread_summary_event", new=AsyncMock(return_value="$summary")) as mock_send,
+        patch("mindroom.thread_summary._recover_last_summary_count", new=AsyncMock(return_value=0)),
+    ):
+        await apply_post_response_effects(
+            ResponseOutcome(
+                resolved_event_id="$response",
+                delivery_result=DeliveryResult(
+                    event_id="$response",
+                    response_text="visible",
+                    delivery_kind="sent",
+                    suppressed=False,
+                ),
+                thread_summary_room_id="!room:localhost",
+                thread_summary_thread_id="$thread",
+                thread_summary_message_count_hint=4,
+            ),
+            deps,
+        )
+
+        assert scheduled_tasks
+        await asyncio.gather(*scheduled_tasks)
+
+    mock_fetch.assert_awaited_once_with(conversation_access, "!room:localhost", "$thread")
+    mock_generate.assert_awaited_once_with(thread_history, config, runtime_paths)
+    mock_send.assert_awaited_once_with(
+        client,
+        "!room:localhost",
+        "$thread",
+        "Summary",
+        5,
+        "default",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -24,9 +24,12 @@ from mindroom.thread_summary import (
     _thread_locks,
     _ThreadSummary,
     maybe_generate_thread_summary,
+    next_thread_summary_threshold,
     normalize_thread_summary_text,
     send_thread_summary_event,
+    should_queue_thread_summary,
     thread_summary_cache_key,
+    thread_summary_message_count_hint,
     update_last_summary_count,
 )
 
@@ -333,6 +336,64 @@ def _clear_summary_counts() -> None:
     _thread_locks.clear()
 
 
+class TestThreadSummaryMessageCountHint:
+    """Lower-bound message-count hints used by the pre-queue gate."""
+
+    def test_ignores_existing_summary_notice_and_accounts_for_new_reply(self) -> None:
+        """Summary notices must not count, but the just-sent reply must."""
+        thread_history = [
+            *_make_thread_history(4),
+            _make_summary_notice_message("$thread1", message_count=4),
+        ]
+
+        assert thread_summary_message_count_hint(thread_history) == 5
+
+
+class TestShouldQueueThreadSummary:
+    """Cheap pre-queue gating based on the cached threshold and lower-bound hint."""
+
+    def test_margin_near_first_threshold_queues(self) -> None:
+        """Hints within the concurrency margin should still queue a live recheck."""
+        config = _mock_config()
+
+        assert should_queue_thread_summary(
+            "!room:x",
+            "$thread1",
+            config,
+            message_count_hint=4,
+        )
+
+    def test_far_below_first_threshold_skips_queue(self) -> None:
+        """Hints that are still clearly below threshold should skip queueing."""
+        config = _mock_config()
+
+        assert not should_queue_thread_summary(
+            "!room:x",
+            "$thread1",
+            config,
+            message_count_hint=2,
+        )
+
+    def test_cached_summary_uses_subsequent_threshold(self) -> None:
+        """Once a summary baseline exists, the gate should honor the same margin."""
+        update_last_summary_count("!room:x", "$thread1", 5)
+        config = _mock_config()
+
+        assert next_thread_summary_threshold("!room:x", "$thread1", config) == 15
+        assert not should_queue_thread_summary(
+            "!room:x",
+            "$thread1",
+            config,
+            message_count_hint=12,
+        )
+        assert should_queue_thread_summary(
+            "!room:x",
+            "$thread1",
+            config,
+            message_count_hint=13,
+        )
+
+
 @pytest.mark.asyncio
 class TestMaybeGenerateThreadSummary:
     """Integration tests for the threshold-gated summary pipeline."""
@@ -384,6 +445,30 @@ class TestMaybeGenerateThreadSummary:
 
         mock_fetch.assert_awaited_once()
         mock_gen.assert_not_awaited()
+
+    async def test_below_threshold_skips_timed_generation_helper(self) -> None:
+        """Timing should only wrap actual generation attempts, not early threshold skips."""
+        client = AsyncMock(spec=nio.AsyncClient)
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+
+        with (
+            patch(
+                "mindroom.thread_summary._load_thread_history",
+                return_value=_make_thread_history(3),
+            ),
+            patch(
+                "mindroom.thread_summary._timed_generate_summary",
+                new=AsyncMock(return_value="Summary"),
+            ) as mock_timed_gen,
+            patch(
+                "mindroom.thread_summary._recover_last_summary_count",
+                return_value=0,
+            ),
+        ):
+            await self._maybe_generate(client, config, rp)
+
+        mock_timed_gen.assert_not_awaited()
 
     async def test_at_threshold_generates(self) -> None:
         """LLM is called and event sent when count reaches threshold."""


### PR DESCRIPTION
## Summary
- add a lower-bound pre-queue gate so thread summaries only recheck live history near a summary threshold
- thread the shared summary message-count hint through both agent and team post-response paths
- add coverage for the gating margin, refreshed team-thread history, and queued-notice behavior

## Notes
- direct-to-`main` cut resolved the one `response_runner.py` conflict by applying the `ISSUE-144` thread-summary delta onto the pre-lifecycle code path

## Testing
- `uv run pytest -x -n 0 --no-cov -v tests/test_multi_agent_bot.py tests/test_queued_message_notify.py tests/test_thread_summary.py`