### PR TITLE
Avoid blocking knowledge API reads on manager initialization

### DIFF
--- a/src/mindroom/api/knowledge.py
+++ b/src/mindroom/api/knowledge.py
@@ -96,16 +96,24 @@ async def _ensure_managers(config: Config, runtime_paths: constants.RuntimePaths
     )
 
 
+def _get_existing_manager(
+    config: Config,
+    base_id: str,
+    runtime_paths: constants.RuntimePaths,
+) -> KnowledgeManager | None:
+    return get_shared_knowledge_manager_for_config(
+        base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+
+
 async def _ensure_manager(
     config: Config,
     base_id: str,
     runtime_paths: constants.RuntimePaths,
 ) -> KnowledgeManager | None:
-    existing = get_shared_knowledge_manager_for_config(
-        base_id,
-        config=config,
-        runtime_paths=runtime_paths,
-    )
+    existing = _get_existing_manager(config, base_id, runtime_paths)
     if existing is not None:
         return existing
     managers = await _ensure_managers(config, runtime_paths)
@@ -155,13 +163,12 @@ async def _stream_upload_to_destination(upload: UploadFile, destination: Path, f
 async def list_knowledge_bases(request: Request) -> dict[str, Any]:
     """List all configured knowledge bases with status summaries."""
     config, runtime_paths = config_lifecycle.read_committed_runtime_config(request)
-    manager_map = await _ensure_managers(config, runtime_paths)
 
     bases: list[dict[str, Any]] = []
     for base_id in sorted(config.knowledge_bases):
         base_config = config.knowledge_bases[base_id]
         root = _knowledge_root(config, base_id, runtime_paths)
-        manager = manager_map.get(base_id)
+        manager = _get_existing_manager(config, base_id, runtime_paths)
         if manager is None:
             file_count = len(_list_file_info(root)[0])
             indexed_count = 0
@@ -177,6 +184,7 @@ async def list_knowledge_bases(request: Request) -> dict[str, Any]:
                 "watch": base_config.watch,
                 "file_count": file_count,
                 "indexed_count": indexed_count,
+                "manager_available": manager is not None,
             },
         )
 
@@ -191,7 +199,7 @@ async def list_knowledge_files(base_id: str, request: Request) -> dict[str, Any]
     """List all managed files currently present in one knowledge base folder."""
     config, runtime_paths = config_lifecycle.read_committed_runtime_config(request)
     root = _knowledge_root(config, base_id, runtime_paths)
-    manager = await _ensure_manager(config, base_id, runtime_paths)
+    manager = _get_existing_manager(config, base_id, runtime_paths)
     files, total_size = _list_file_info(root, manager.list_files() if manager is not None else None)
 
     return {
@@ -199,6 +207,7 @@ async def list_knowledge_files(base_id: str, request: Request) -> dict[str, Any]
         "files": files,
         "total_size": total_size,
         "file_count": len(files),
+        "manager_available": manager is not None,
     }
 
 
@@ -278,7 +287,7 @@ async def knowledge_status(base_id: str, request: Request) -> dict[str, Any]:
     """Return current indexing status for one knowledge base."""
     config, runtime_paths = config_lifecycle.read_committed_runtime_config(request)
     root = _knowledge_root(config, base_id, runtime_paths)
-    manager = await _ensure_manager(config, base_id, runtime_paths)
+    manager = _get_existing_manager(config, base_id, runtime_paths)
 
     if manager is not None:
         manager_status = manager.get_status()
@@ -294,6 +303,7 @@ async def knowledge_status(base_id: str, request: Request) -> dict[str, Any]:
         "watch": config.knowledge_bases[base_id].watch,
         "file_count": file_count,
         "indexed_count": indexed_count,
+        "manager_available": manager is not None,
     }
 
 

--- a/tests/api/test_knowledge_api.py
+++ b/tests/api/test_knowledge_api.py
@@ -67,11 +67,11 @@ def test_client(tmp_path: Path) -> TestClient:
     return TestClient(main.app)
 
 
-def test_knowledge_bases_list_initializes_managers_with_full_reindex(
+def test_knowledge_bases_list_uses_existing_manager_without_initializing(
     test_client: TestClient,
     tmp_path: Path,
 ) -> None:
-    """Base listing should initialize managers with full create-time indexing."""
+    """Base listing should use an existing manager without triggering initialization."""
     config = _knowledge_config(tmp_path)
     manager = MagicMock()
     manager.get_status.return_value = {"indexed_count": 3, "file_count": 4}
@@ -79,8 +79,12 @@ def test_knowledge_bases_list_initializes_managers_with_full_reindex(
 
     with (
         patch(
+            "mindroom.api.knowledge.get_shared_knowledge_manager_for_config",
+            return_value=manager,
+        ) as get_manager,
+        patch(
             "mindroom.api.knowledge.initialize_shared_knowledge_managers",
-            new=AsyncMock(return_value={"research": manager}),
+            new=AsyncMock(),
         ) as init_managers,
     ):
         response = test_client.get("/api/knowledge/bases")
@@ -91,8 +95,9 @@ def test_knowledge_bases_list_initializes_managers_with_full_reindex(
     assert payload["bases"][0]["name"] == "research"
     assert payload["bases"][0]["indexed_count"] == 3
     assert payload["bases"][0]["file_count"] == 4
-    init_managers.assert_awaited_once()
-    assert init_managers.await_args.kwargs["reindex_on_create"] is True
+    assert payload["bases"][0]["manager_available"] is True
+    get_manager.assert_called_once()
+    init_managers.assert_not_awaited()
 
 
 def test_knowledge_root_resolves_relative_path_from_config_dir(
@@ -131,8 +136,12 @@ def test_knowledge_files_list_uses_manager_filters_when_available(
 
     with (
         patch(
+            "mindroom.api.knowledge.get_shared_knowledge_manager_for_config",
+            return_value=manager,
+        ) as get_manager,
+        patch(
             "mindroom.api.knowledge.initialize_shared_knowledge_managers",
-            new=AsyncMock(return_value={"research": manager}),
+            new=AsyncMock(),
         ) as init_managers,
     ):
         response = test_client.get("/api/knowledge/bases/research/files")
@@ -149,8 +158,78 @@ def test_knowledge_files_list_uses_manager_filters_when_available(
             "type": "md",
         },
     ]
-    init_managers.assert_awaited_once()
-    assert init_managers.await_args.kwargs["reindex_on_create"] is True
+    assert payload["manager_available"] is True
+    get_manager.assert_called_once()
+    init_managers.assert_not_awaited()
+
+
+def test_knowledge_status_uses_existing_manager_without_initializing(
+    test_client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """Status should use an existing manager without triggering initialization."""
+    config = _knowledge_config(tmp_path)
+    manager = MagicMock()
+    manager.get_status.return_value = {"indexed_count": 3, "file_count": 4}
+    _publish_committed_runtime_config(test_client.app, config)
+
+    with (
+        patch(
+            "mindroom.api.knowledge.get_shared_knowledge_manager_for_config",
+            return_value=manager,
+        ) as get_manager,
+        patch(
+            "mindroom.api.knowledge.initialize_shared_knowledge_managers",
+            new=AsyncMock(),
+        ) as init_managers,
+    ):
+        response = test_client.get("/api/knowledge/bases/research/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "base_id": "research",
+        "folder_path": str(tmp_path.resolve()),
+        "watch": False,
+        "file_count": 4,
+        "indexed_count": 3,
+        "manager_available": True,
+    }
+    get_manager.assert_called_once()
+    init_managers.assert_not_awaited()
+
+
+def test_knowledge_status_falls_back_without_initializing_when_manager_missing(
+    test_client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """Status should remain fast and best-effort when no manager exists yet."""
+    config = _knowledge_config(tmp_path)
+    (tmp_path / "note.md").write_text("hello", encoding="utf-8")
+    _publish_committed_runtime_config(test_client.app, config)
+
+    with (
+        patch(
+            "mindroom.api.knowledge.get_shared_knowledge_manager_for_config",
+            return_value=None,
+        ) as get_manager,
+        patch(
+            "mindroom.api.knowledge.initialize_shared_knowledge_managers",
+            new=AsyncMock(),
+        ) as init_managers,
+    ):
+        response = test_client.get("/api/knowledge/bases/research/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "base_id": "research",
+        "folder_path": str(tmp_path.resolve()),
+        "watch": False,
+        "file_count": 1,
+        "indexed_count": 0,
+        "manager_available": False,
+    }
+    get_manager.assert_called_once()
+    init_managers.assert_not_awaited()
 
 
 def test_knowledge_upload_rolls_back_on_oversized_file(


### PR DESCRIPTION
## Summary
- keep read-only knowledge API routes best-effort by using an existing shared manager when available
- avoid triggering manager initialization or create-time reindexing from list/status/read routes
- add API tests covering existing-manager and manager-missing behavior

## Testing
- uv run pytest tests/api/test_knowledge_api.py
- uv run ruff check src/mindroom/api/knowledge.py tests/api/test_knowledge_api.py