### PR TITLE
Avoid Chroma count() during knowledge startup

### DIFF
--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -497,7 +497,9 @@ class KnowledgeManager:
         if not isinstance(vector_db, ChromaDb) or not vector_db.exists():
             return False
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
-        return collection.count() > 0
+        result = collection.get(limit=1, include=[])
+        ids = result.get("ids", []) or []
+        return bool(ids)
 
     def _startup_index_mode(self) -> Literal["full_reindex", "resume", "incremental"]:
         persisted_state = self._load_persisted_indexing_state()
@@ -816,15 +818,11 @@ class KnowledgeManager:
             return {}
 
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
-        total_count = collection.count()
-        if total_count == 0:
-            return {}
-
         indexed_files: dict[str, tuple[int, int] | None] = {}
         offset = 0
         batch_size = 1_000
 
-        while offset < total_count:
+        while True:
             result = collection.get(
                 limit=batch_size,
                 offset=offset,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -53,6 +53,9 @@ class _DummyVectorDb:
 
 class _DummyCollection:
     def count(self) -> int:
+        if _DummyChromaDb.raise_on_count:
+            msg = "count() should not be called in this test"
+            raise AssertionError(msg)
         return len(_DummyChromaDb.metadatas)
 
     def get(
@@ -115,6 +118,7 @@ class _DummyKnowledge:
 
 class _DummyChromaDb:
     metadatas: ClassVar[list[object]] = []
+    raise_on_count: ClassVar[bool] = False
 
     def __init__(self, **_: object) -> None:
         self.collection_name = "mindroom_knowledge"
@@ -520,6 +524,23 @@ async def test_load_indexed_files_recovers_source_paths(dummy_manager: Knowledge
     assert indexed_count == 2
     status = dummy_manager.get_status()
     assert status["indexed_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_load_indexed_files_does_not_use_collection_count(dummy_manager: KnowledgeManager) -> None:
+    """Loading indexed files should page via get() without relying on collection.count()."""
+    _DummyChromaDb.metadatas = [
+        {"source_path": "docs/a.txt"},
+        {"source_path": "notes/b.md"},
+    ]
+    _DummyChromaDb.raise_on_count = True
+
+    try:
+        indexed_count = await dummy_manager.load_indexed_files()
+    finally:
+        _DummyChromaDb.raise_on_count = False
+
+    assert indexed_count == 2
 
 
 @pytest.mark.asyncio
@@ -2269,6 +2290,29 @@ async def test_initialize_shared_knowledge_managers_resumes_partial_git_index_wi
         assert initialize_calls == 0
     finally:
         await shutdown_shared_knowledge_managers()
+
+
+def test_startup_index_mode_does_not_use_collection_count_for_existing_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup index mode should detect existing vectors via get(), not collection.count()."""
+    _DummyChromaDb.metadatas = [{"source_path": "doc.md"}]
+    _DummyChromaDb.raise_on_count = True
+    monkeypatch.setattr("mindroom.knowledge.manager.ChromaDb", _DummyChromaDb)
+    monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _DummyKnowledge)
+
+    manager = KnowledgeManager(
+        base_id="research",
+        config=_make_config(tmp_path / "knowledge"),
+        runtime_paths=_runtime_paths(tmp_path / "config.yaml", tmp_path / "storage"),
+    )
+    manager._save_persisted_indexing_state("indexing")
+
+    try:
+        assert manager._startup_index_mode() == "resume"
+    finally:
+        _DummyChromaDb.raise_on_count = False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- stop using `collection.count()` when checking whether a persisted knowledge collection has entries
- page through collection metadata with `get()` until empty when rebuilding in-memory indexed-file state
- add regression coverage that fails if startup or load paths touch `count()`

## Testing
- uv run ruff check src/mindroom/knowledge/manager.py tests/test_knowledge_manager.py
- uv run pytest tests/test_knowledge_manager.py