### PR TITLE
Avoid pathological knowledge micro-chunking

### DIFF
--- a/src/mindroom/knowledge/chunking.py
+++ b/src/mindroom/knowledge/chunking.py
@@ -1,0 +1,68 @@
+"""MindRoom-specific chunking helpers."""
+
+from __future__ import annotations
+
+from agno.knowledge.chunking.fixed import FixedSizeChunking
+from agno.knowledge.document.base import Document
+
+
+class SafeFixedSizeChunking(FixedSizeChunking):
+    """Avoid pathological micro-chunks when whitespace is far from the boundary."""
+
+    def __init__(
+        self,
+        chunk_size: int = 5000,
+        overlap: int = 0,
+        *,
+        min_chunk_fill_ratio: float = 0.5,
+    ) -> None:
+        super().__init__(chunk_size=chunk_size, overlap=overlap)
+        if not 0 < min_chunk_fill_ratio <= 1:
+            msg = "min_chunk_fill_ratio must be in the range (0, 1]"
+            raise ValueError(msg)
+        self.min_chunk_fill_ratio = min_chunk_fill_ratio
+
+    def chunk(self, document: Document) -> list[Document]:
+        content = self.clean_text(document.content)
+        content_length = len(content)
+        chunked_documents: list[Document] = []
+        chunk_number = 1
+        min_chunk_size = max(1, int(self.chunk_size * self.min_chunk_fill_ratio))
+        start = 0
+
+        while start < content_length:
+            raw_end = min(start + self.chunk_size, content_length)
+            end = raw_end
+
+            if raw_end < content_length:
+                while end > start and content[end] not in [" ", "\n", "\r", "\t"]:
+                    end -= 1
+
+                # Prefer a hard split over tiny overlap-driven fragments when the
+                # nearest whitespace is too far from the target boundary.
+                if end == start or (end - start) < min_chunk_size:
+                    end = raw_end
+
+            chunk = content[start:end]
+            meta_data = (document.meta_data or {}).copy()
+            meta_data["chunk"] = chunk_number
+            meta_data["chunk_size"] = len(chunk)
+            chunked_documents.append(
+                Document(
+                    id=self._generate_chunk_id(document, chunk_number, chunk),
+                    name=document.name,
+                    meta_data=meta_data,
+                    content=chunk,
+                )
+            )
+
+            if end >= content_length:
+                break
+
+            next_start = end - self.overlap
+            if next_start <= start:
+                next_start = end
+            start = next_start
+            chunk_number += 1
+
+        return chunked_documents

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import quote, urlparse, urlunparse
 
-from agno.knowledge.chunking.fixed import FixedSizeChunking
 from agno.knowledge.embedder.ollama import OllamaEmbedder
 from agno.knowledge.knowledge import Knowledge
 from agno.knowledge.reader import ReaderFactory
@@ -33,6 +32,7 @@ from mindroom.embeddings import (
     create_sentence_transformers_embedder,
     effective_knowledge_embedder_signature,
 )
+from mindroom.knowledge.chunking import SafeFixedSizeChunking
 from mindroom.logging_config import get_logger
 from mindroom.runtime_resolution import ResolvedKnowledgeBinding, resolve_knowledge_binding
 
@@ -797,7 +797,7 @@ class KnowledgeManager:
         configured_reader = deepcopy(reader)
         configured_reader.chunk = True
         configured_reader.chunk_size = base_config.chunk_size
-        configured_reader.chunking_strategy = FixedSizeChunking(
+        configured_reader.chunking_strategy = SafeFixedSizeChunking(
             chunk_size=base_config.chunk_size,
             overlap=base_config.chunk_overlap,
         )

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -11,10 +11,13 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import pytest
 from pydantic import ValidationError
 
+from agno.knowledge.chunking.fixed import FixedSizeChunking
+from agno.knowledge.document.base import Document
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig, AgentPrivateKnowledgeConfig
 from mindroom.config.knowledge import KnowledgeBaseConfig, KnowledgeGitConfig
 from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
+from mindroom.knowledge.chunking import SafeFixedSizeChunking
 from mindroom.knowledge.manager import (
     _FAILED_SIGNATURE_RETRY_NS,
     _MAX_CONCURRENT_KNOWLEDGE_FILE_INDEXES,
@@ -498,8 +501,26 @@ async def test_index_file_uses_configured_chunk_settings(
     assert getattr(reader, "chunk_size", None) == 640
     chunking_strategy = getattr(reader, "chunking_strategy", None)
     assert chunking_strategy is not None
+    assert isinstance(chunking_strategy, SafeFixedSizeChunking)
     assert getattr(chunking_strategy, "chunk_size", None) == 640
     assert getattr(chunking_strategy, "overlap", None) == 32
+
+
+def test_safe_fixed_size_chunking_avoids_micro_chunk_explosion() -> None:
+    """Whitespace backtracking should not degrade into one-character progress."""
+    document = Document(
+        id="doc-1",
+        name="doc",
+        content=("a " + "x" * 30 + " ") * 4,
+        meta_data={},
+    )
+
+    original_chunks = FixedSizeChunking(chunk_size=20, overlap=5).chunk(document)
+    safe_chunks = SafeFixedSizeChunking(chunk_size=20, overlap=5).chunk(document)
+
+    assert any(len(chunk.content) <= 5 for chunk in original_chunks)
+    assert len(safe_chunks) < len(original_chunks)
+    assert all(len(chunk.content) >= 10 for chunk in safe_chunks[:-1])
 
 
 def test_knowledge_base_chunk_overlap_must_be_smaller_than_chunk_size() -> None:


### PR DESCRIPTION
## Summary
- add a MindRoom-specific fixed-size chunker that avoids tiny overlap-driven fragments when whitespace-aware backtracking finds a boundary far before the target size
- use that chunker for knowledge file readers while preserving configured chunk size and overlap
- add a regression test that covers the pathological case

## Testing
- .venv/bin/pytest -q tests/test_knowledge_manager.py -k "safe_fixed_size_chunking or test_index_file_uses_configured_chunk_settings"