### PR TITLE
Persist Matrix bot sessions for encrypted rooms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "humanize>=4.12.3",
   "json5>=0.13",
   "markdown-it-py>=4",
-  "matrix-nio>=0.25",
+  "matrix-nio[e2e]>=0.25",
   "mcp[cli]>=1.12.4",
   "mem0ai>=0.1.115",
   "openai",

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -383,6 +383,28 @@ async def login(
     raise matrix_startup_error(msg, response=response)
 
 
+async def restore_login(
+    homeserver: str,
+    user_id: str,
+    device_id: str,
+    access_token: str,
+    runtime_paths: RuntimePaths,
+) -> nio.AsyncClient:
+    """Restore one authenticated Matrix session without creating a new device."""
+    runtime_paths = _require_runtime_paths_arg(runtime_paths)
+    client = _create_matrix_client(homeserver, runtime_paths, user_id, access_token)
+    client.restore_login(user_id, device_id, access_token)
+
+    response = await client.whoami()
+    if isinstance(response, nio.WhoamiResponse):
+        logger.info("matrix_login_restored", user_id=user_id, device_id=device_id)
+        return client
+
+    await client.close()
+    msg = f"Failed to restore Matrix login for {user_id}: {response}"
+    raise matrix_startup_error(msg, response=response)
+
+
 async def invite_to_room(
     client: nio.AsyncClient,
     room_id: str,

--- a/src/mindroom/matrix/state.py
+++ b/src/mindroom/matrix/state.py
@@ -14,6 +14,8 @@ class _MatrixAccount(BaseModel):
 
     username: str
     password: str
+    device_id: str | None = None
+    access_token: str | None = None
 
 
 class MatrixRoom(BaseModel):
@@ -63,9 +65,22 @@ class MatrixState(BaseModel):
         """Get an account by key."""
         return self.accounts.get(key)
 
-    def add_account(self, key: str, username: str, password: str) -> None:
+    def add_account(
+        self,
+        key: str,
+        username: str,
+        password: str,
+        *,
+        device_id: str | None = None,
+        access_token: str | None = None,
+    ) -> None:
         """Add or update an account."""
-        self.accounts[key] = _MatrixAccount(username=username, password=password)
+        self.accounts[key] = _MatrixAccount(
+            username=username,
+            password=password,
+            device_id=device_id,
+            access_token=access_token,
+        )
 
     def get_room(self, key: str) -> MatrixRoom | None:
         """Get a room by key."""

--- a/src/mindroom/matrix/users.py
+++ b/src/mindroom/matrix/users.py
@@ -15,6 +15,7 @@ from mindroom.matrix.client import (
     login,
     matrix_client,
     matrix_startup_error,
+    restore_login,
 )
 from mindroom.matrix.identity import MatrixID, agent_username_localpart, extract_server_name_from_homeserver
 from mindroom.matrix.state import MatrixState
@@ -51,6 +52,7 @@ class AgentMatrixUser:
     user_id: str
     display_name: str
     password: str
+    device_id: str | None = None
     access_token: str | None = None
 
     @cached_property
@@ -62,7 +64,7 @@ class AgentMatrixUser:
 def _get_agent_credentials(
     agent_name: str,
     runtime_paths: RuntimePaths,
-) -> dict[str, str] | None:
+) -> dict[str, str | None] | None:
     """Get credentials for a specific agent from matrix_state.yaml.
 
     Args:
@@ -77,7 +79,12 @@ def _get_agent_credentials(
     agent_key = _account_key_for_agent(agent_name)
     account = state.get_account(agent_key)
     if account:
-        return {"username": account.username, "password": account.password}
+        return {
+            "username": account.username,
+            "password": account.password,
+            "device_id": account.device_id,
+            "access_token": account.access_token,
+        }
     return None
 
 
@@ -86,6 +93,9 @@ def _save_agent_credentials(
     username: str,
     password: str,
     runtime_paths: RuntimePaths,
+    *,
+    device_id: str | None = None,
+    access_token: str | None = None,
 ) -> None:
     """Save credentials for a specific agent to matrix_state.yaml.
 
@@ -98,9 +108,41 @@ def _save_agent_credentials(
     """
     state = MatrixState.load(runtime_paths=runtime_paths)
     agent_key = _account_key_for_agent(agent_name)
-    state.add_account(agent_key, username, password)
+    state.add_account(
+        agent_key,
+        username,
+        password,
+        device_id=device_id,
+        access_token=access_token,
+    )
     state.save(runtime_paths=runtime_paths)
     logger.info("agent_credentials_saved", agent=agent_name)
+
+
+def _persist_agent_session(
+    agent_name: str,
+    username: str,
+    password: str,
+    *,
+    device_id: str | None,
+    access_token: str | None,
+    runtime_paths: RuntimePaths,
+) -> None:
+    """Persist one agent session so restarts can reuse the same Matrix device."""
+    _save_agent_credentials(
+        agent_name,
+        username,
+        password,
+        runtime_paths,
+        device_id=device_id,
+        access_token=access_token,
+    )
+    logger.info(
+        "agent_session_persisted",
+        agent=agent_name,
+        device_id=device_id,
+        has_access_token=bool(access_token),
+    )
 
 
 async def _homeserver_requires_registration_token(
@@ -614,14 +656,23 @@ async def create_agent_user(
         raise matrix_startup_error(msg, permanent=True)
 
     if existing_creds and (preferred_username is None or existing_creds["username"] == preferred_username):
-        matrix_username = existing_creds["username"]
-        password = existing_creds["password"]
+        username_value = existing_creds["username"]
+        password_value = existing_creds["password"]
+        if username_value is None or password_value is None:
+            msg = f"Stored Matrix credentials for {agent_name} are incomplete"
+            raise matrix_startup_error(msg, permanent=True)
+        matrix_username = username_value
+        password = password_value
+        existing_device_id = existing_creds["device_id"]
+        existing_access_token = existing_creds["access_token"]
         logger.info("agent_credentials_loaded", agent=agent_name)
         registration_needed = False
     else:
         # Generate new credentials
         matrix_username = preferred_username or agent_username_localpart(agent_name, runtime_paths=runtime_paths)
         password = secrets.token_urlsafe(24)
+        existing_device_id = None
+        existing_access_token = None
         logger.info("agent_credentials_generated", agent=agent_name)
         registration_needed = True
 
@@ -637,27 +688,6 @@ async def create_agent_user(
             display_name=agent_display_name,
             runtime_paths=runtime_paths,
         )
-    else:
-        login_response = await _login_existing_user(
-            homeserver=homeserver,
-            user_id=user_id,
-            password=password,
-            display_name=agent_display_name,
-            runtime_paths=runtime_paths,
-        )
-        if not isinstance(login_response, nio.LoginResponse):
-            logger.info(
-                "Existing Matrix credentials failed login; attempting registration to recover account",
-                agent_name=agent_name,
-                user_id=user_id,
-            )
-            await _register_user(
-                homeserver=homeserver,
-                username=matrix_username,
-                password=password,
-                display_name=agent_display_name,
-                runtime_paths=runtime_paths,
-            )
 
     # Save credentials only after registration/verification succeeds.
     if registration_needed:
@@ -669,6 +699,8 @@ async def create_agent_user(
         user_id=user_id,
         display_name=agent_display_name,
         password=password,
+        device_id=existing_device_id,
+        access_token=existing_access_token,
     )
 
 
@@ -691,12 +723,39 @@ async def login_agent_user(
         ValueError: If login fails
 
     """
+    if agent_user.access_token and agent_user.device_id:
+        try:
+            client = await restore_login(
+                homeserver,
+                agent_user.user_id,
+                agent_user.device_id,
+                agent_user.access_token,
+                runtime_paths=runtime_paths,
+            )
+            return client
+        except ValueError:
+            logger.warning(
+                "matrix_login_restore_failed_falling_back_to_password",
+                agent=agent_user.agent_name,
+                user_id=agent_user.user_id,
+                device_id=agent_user.device_id,
+            )
+
     client = await login(
         homeserver,
         agent_user.user_id,
         agent_user.password,
         runtime_paths=runtime_paths,
     )
+    _persist_agent_session(
+        agent_user.agent_name,
+        agent_user.matrix_id.localpart,
+        agent_user.password,
+        device_id=client.device_id,
+        access_token=client.access_token,
+        runtime_paths=runtime_paths,
+    )
+    agent_user.device_id = client.device_id
     agent_user.access_token = client.access_token
     return client
 

--- a/src/mindroom/matrix/users.py
+++ b/src/mindroom/matrix/users.py
@@ -749,7 +749,7 @@ async def login_agent_user(
     )
     _persist_agent_session(
         agent_user.agent_name,
-        agent_user.matrix_id.localpart,
+        agent_user.matrix_id.username,
         agent_user.password,
         device_id=client.device_id,
         access_token=client.access_token,

--- a/src/mindroom/matrix/users.py
+++ b/src/mindroom/matrix/users.py
@@ -663,8 +663,9 @@ async def create_agent_user(
             raise matrix_startup_error(msg, permanent=True)
         matrix_username = username_value
         password = password_value
-        existing_device_id = existing_creds["device_id"]
-        existing_access_token = existing_creds["access_token"]
+        # Older persisted credentials may not include session fields yet.
+        existing_device_id = existing_creds.get("device_id")
+        existing_access_token = existing_creds.get("access_token")
         logger.info("agent_credentials_loaded", agent=agent_name)
         registration_needed = False
     else:

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -365,6 +365,8 @@ class TestBotTaskRestoration:
                 mock_client = AsyncMock()
                 mock_client.add_event_callback = MagicMock()
                 mock_client.add_response_callback = MagicMock()
+                mock_client.device_id = "TEST_DEVICE"
+                mock_client.access_token = TEST_ACCESS_TOKEN
                 mock_login.return_value = mock_client
 
                 # Mock the client.join method to return JoinResponse
@@ -413,6 +415,8 @@ class TestBotTaskRestoration:
                 mock_client = AsyncMock()
                 mock_client.add_event_callback = MagicMock()
                 mock_client.add_response_callback = MagicMock()
+                mock_client.device_id = "TEST_DEVICE"
+                mock_client.access_token = TEST_ACCESS_TOKEN
                 mock_login.return_value = mock_client
 
                 # Mock the client.join method to return JoinResponse

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -180,7 +180,7 @@ class TestUserAccountManagement:
         tmp_path: Path,
         mock_matrix_client: tuple[MagicMock, AsyncMock],
     ) -> None:
-        """Existing stored credentials should be used via direct login."""
+        """Existing stored credentials should be reused without re-registration."""
         mock_context, mock_client = mock_matrix_client
 
         # Create existing config with internal user account
@@ -189,13 +189,6 @@ class TestUserAccountManagement:
 
         runtime_paths = _runtime_paths(tmp_path)
         state.save(runtime_paths=runtime_paths)
-
-        mock_client.login.return_value = nio.LoginResponse(
-            user_id=f"@{DEFAULT_INTERNAL_USERNAME}:localhost",
-            device_id="TEST_DEVICE",
-            access_token=TEST_ACCESS_TOKEN,
-        )
-        mock_client.set_displayname.return_value = AsyncMock()
 
         with (
             patch("mindroom.matrix.users.matrix_client", return_value=mock_context),
@@ -216,8 +209,8 @@ class TestUserAccountManagement:
             assert result_config.accounts[INTERNAL_USER_ACCOUNT_KEY].password == "existing_password"  # noqa: S105
 
             mock_client.register.assert_not_called()
-            mock_client.login.assert_called_once_with("existing_password")
-            mock_client.set_displayname.assert_called_once_with(DEFAULT_INTERNAL_DISPLAY_NAME)
+            mock_client.login.assert_not_called()
+            mock_client.set_displayname.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_ensure_user_account_recreates_account_when_stored_login_fails(
@@ -225,7 +218,7 @@ class TestUserAccountManagement:
         tmp_path: Path,
         mock_matrix_client: tuple[MagicMock, AsyncMock],
     ) -> None:
-        """Failed login with stored credentials should retry registration."""
+        """Stored credentials should be preserved until an explicit login happens."""
         mock_context, mock_client = mock_matrix_client
 
         # Create existing config with invalid credentials
@@ -234,20 +227,6 @@ class TestUserAccountManagement:
 
         runtime_paths = _runtime_paths(tmp_path)
         state.save(runtime_paths=runtime_paths)
-
-        # Mock failed login
-        mock_client.login.return_value = nio.LoginError(
-            message="Invalid username or password",
-            status_code="M_FORBIDDEN",
-        )
-
-        # Mock successful registration for the recreated account.
-        mock_client.register.return_value = nio.RegisterResponse(
-            user_id=f"@{DEFAULT_INTERNAL_USERNAME}:localhost",
-            device_id="TEST_DEVICE",
-            access_token=TEST_ACCESS_TOKEN,
-        )
-        mock_client.set_displayname.return_value = AsyncMock()
 
         with (
             patch("mindroom.matrix.users.matrix_client", return_value=mock_context),
@@ -267,12 +246,11 @@ class TestUserAccountManagement:
             result_config = MatrixState.load(runtime_paths=runtime_paths)
             assert INTERNAL_USER_ACCOUNT_KEY in result_config.accounts
             assert result_config.accounts[INTERNAL_USER_ACCOUNT_KEY].username == DEFAULT_INTERNAL_USERNAME
-            # Password stays the same - create_agent_user reuses existing credentials
             assert result_config.accounts[INTERNAL_USER_ACCOUNT_KEY].password == "wrong_password"  # noqa: S105
 
-            mock_client.login.assert_called_once_with("wrong_password")
-            mock_client.register.assert_called_once()
-            mock_client.set_displayname.assert_called_once_with(DEFAULT_INTERNAL_DISPLAY_NAME)
+            mock_client.login.assert_not_called()
+            mock_client.register.assert_not_called()
+            mock_client.set_displayname.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_ensure_user_account_uses_configured_identity(

--- a/tests/test_matrix_agent_manager.py
+++ b/tests/test_matrix_agent_manager.py
@@ -786,41 +786,34 @@ class TestAgentUserCreation:
     @patch("mindroom.matrix.users.matrix_client")
     @patch("mindroom.matrix.users._save_agent_credentials")
     @patch("mindroom.matrix.users._get_agent_credentials")
-    async def test_create_agent_user_existing_credentials_log_in_directly(
+    async def test_create_agent_user_existing_credentials_reuses_stored_credentials(
         self,
         mock_get_creds: MagicMock,
         mock_save_creds: MagicMock,
         mock_matrix_client: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Existing credentials should be reused via login without re-registration."""
+        """Existing credentials should be reused without re-registration."""
         mock_get_creds.return_value = {
             "username": "mindroom_calculator",
             "password": "existing_pass",
         }
-        mock_client = AsyncMock()
-        mock_client.login.return_value = MagicMock(spec=nio.LoginResponse)
-        mock_matrix_client.return_value.__aenter__.return_value = mock_client
 
         runtime_paths = _runtime_paths(tmp_path)
         agent_user = await create_agent_user("http://localhost:8008", "calculator", "CalculatorAgent", runtime_paths)
 
         assert agent_user.password == "existing_pass"  # noqa: S105
+        assert agent_user.device_id is None
+        assert agent_user.access_token is None  # noqa: S105
         mock_save_creds.assert_not_called()  # Should not save again
-        mock_matrix_client.assert_called_once_with(
-            "http://localhost:8008",
-            user_id="@mindroom_calculator:localhost",
-            runtime_paths=runtime_paths,
-        )
-        mock_client.login.assert_called_once_with("existing_pass")
-        mock_client.set_displayname.assert_called_once_with("CalculatorAgent")
+        mock_matrix_client.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("mindroom.matrix.users._register_user")
     @patch("mindroom.matrix.users.matrix_client")
     @patch("mindroom.matrix.users._save_agent_credentials")
     @patch("mindroom.matrix.users._get_agent_credentials")
-    async def test_create_agent_user_existing_credentials_retry_registration_on_login_failure(
+    async def test_create_agent_user_existing_credentials_preserves_session_fields(
         self,
         mock_get_creds: MagicMock,
         mock_save_creds: MagicMock,
@@ -828,29 +821,23 @@ class TestAgentUserCreation:
         mock_register: AsyncMock,
         tmp_path: Path,
     ) -> None:
-        """Existing credentials should retry registration when login no longer works."""
+        """Existing credentials should preserve stored session fields."""
         mock_get_creds.return_value = {
             "username": "mindroom_calculator",
             "password": "stale_pass",
+            "device_id": "stored_device",
+            "access_token": "stored_token",
         }
-        mock_client = AsyncMock()
-        mock_client.login.return_value = MagicMock(spec=nio.LoginError)
-        mock_matrix_client.return_value.__aenter__.return_value = mock_client
-        mock_register.return_value = "@mindroom_calculator:localhost"
 
         runtime_paths = _runtime_paths(tmp_path)
         agent_user = await create_agent_user("http://localhost:8008", "calculator", "CalculatorAgent", runtime_paths)
 
         assert agent_user.password == "stale_pass"  # noqa: S105
+        assert agent_user.device_id == "stored_device"
+        assert agent_user.access_token == "stored_token"  # noqa: S105
         mock_save_creds.assert_not_called()
-        mock_client.login.assert_called_once_with("stale_pass")
-        mock_register.assert_called_once_with(
-            homeserver="http://localhost:8008",
-            username="mindroom_calculator",
-            password="stale_pass",  # noqa: S106
-            display_name="CalculatorAgent",
-            runtime_paths=runtime_paths,
-        )
+        mock_matrix_client.assert_not_called()
+        mock_register.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("mindroom.matrix.users._register_user")
@@ -897,12 +884,14 @@ class TestAgentLogin:
         with patch("mindroom.matrix.users.login") as mock_login:
             mock_client = AsyncMock()
             mock_client.access_token = "new_token"  # noqa: S105
+            mock_client.device_id = "new_device"
             mock_login.return_value = mock_client
 
             client = await login_agent_user("http://localhost:8008", agent_user, runtime_paths)
 
             assert client == mock_client
             assert agent_user.access_token == "new_token"  # noqa: S105
+            assert agent_user.device_id == "new_device"
             mock_login.assert_called_once_with(
                 "http://localhost:8008",
                 agent_user.user_id,

--- a/uv.lock
+++ b/uv.lock
@@ -390,6 +390,12 @@ wheels = [
 ]
 
 [[package]]
+name = "atomicwrites"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c01095a89f16dbcda021c609ddb42dd6d7c0528236fb2/atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11", size = 14227, upload-time = "2022-07-08T18:31:40.459Z" }
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -629,6 +635,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/1c/23e33405a7c9eac261dff640926b8b5adaed6a6eb3e1767d441ed611d0c0/build-1.3.0.tar.gz", hash = "sha256:698edd0ea270bde950f53aed21f3a0135672206f3911e0176261a31e0e07b397", size = 48544, upload-time = "2025-08-01T21:27:09.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl", hash = "sha256:7145f0b5061ba90a1500d60bd1b13ca0a8a4cebdd0cc16ed8adf1c0e739f43b4", size = 23382, upload-time = "2025-08-01T21:27:07.844Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "5.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
 ]
 
 [[package]]
@@ -3115,6 +3130,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/0f/8b958d46e23ed4f69d2cffd63b46bb097a1155524e2e7f5c4279c8691c4a/matrix_nio-0.25.2-py3-none-any.whl", hash = "sha256:9c2880004b0e475db874456c0f79b7dd2b6285073a7663bcaca29e0754a67495", size = 181982, upload-time = "2024-10-04T07:51:39.451Z" },
 ]
 
+[package.optional-dependencies]
+e2e = [
+    { name = "atomicwrites" },
+    { name = "cachetools" },
+    { name = "peewee" },
+    { name = "python-olm" },
+]
+
 [[package]]
 name = "matty"
 version = "0.9.0"
@@ -3209,7 +3232,7 @@ dependencies = [
     { name = "humanize" },
     { name = "json5" },
     { name = "markdown-it-py" },
-    { name = "matrix-nio" },
+    { name = "matrix-nio", extra = ["e2e"] },
     { name = "mcp", extra = ["cli"] },
     { name = "mem0ai" },
     { name = "openai" },
@@ -3566,9 +3589,9 @@ requires-dist = [
     { name = "agentql", marker = "extra == 'agentql'" },
     { name = "agno", extras = ["anthropic", "google", "ollama", "openai"], specifier = "==2.5.13" },
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "aiosqlite", specifier = ">=0.20" },
     { name = "anthropic", specifier = ">=0.70" },
-    { name = "anyio", specifier = ">=4.10.0" },
+    { name = "anyio", specifier = ">=4.10" },
     { name = "apify-client", marker = "platform_machine != 'aarch64' and extra == 'apify'", specifier = ">=1.12.2" },
     { name = "arxiv", marker = "extra == 'arxiv'" },
     { name = "atlassian-python-api", marker = "extra == 'confluence'" },
@@ -3637,7 +3660,7 @@ requires-dist = [
     { name = "lxml-html-clean", marker = "extra == 'newspaper'" },
     { name = "markdown-it-py", specifier = ">=4" },
     { name = "matplotlib", marker = "extra == 'visualization'" },
-    { name = "matrix-nio", specifier = ">=0.25" },
+    { name = "matrix-nio", extras = ["e2e"], specifier = ">=0.25" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.4" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
@@ -5935,6 +5958,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+]
+
+[[package]]
+name = "python-olm"
+version = "3.2.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/eb/23ca73cbdc8c7466a774e515dfd917d9fbe747c1257059246fdc63093f04/python-olm-3.2.16.tar.gz", hash = "sha256:a1c47fce2505b7a16841e17694cbed4ed484519646ede96ee9e89545a49643c9", size = 2705522, upload-time = "2023-11-28T19:26:40.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/56/652349f97dc2ce6d1aed43481d179c775f565e68796517836406fb7794c7/python_olm-3.2.16-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16bbb209d43d62135450696526ed0a811150e9de9df32ed91542bf9434e79030", size = 293671, upload-time = "2023-11-28T19:25:21.525Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ee/1e15304ac67d3a7ebecbcac417d6479abb7186aad73c6a035647938eaa8e/python_olm-3.2.16-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45e76b3f5060a5cf8451140d6c7e3b438f972ff432b6f39d0ca2c7f2296509bb", size = 301030, upload-time = "2023-11-28T19:25:26.634Z" },
+    { url = "https://files.pythonhosted.org/packages/79/93/f6729f10149305262194774d6c8b438c0b084740cf239f48ab97b4df02fa/python_olm-3.2.16-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:10a5e68a2f4b5a2bfa5fdb5dbfa22396a551730df6c4a572235acaa96e997d3f", size = 297000, upload-time = "2023-11-28T19:25:31.045Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add the Matrix E2EE extras required for encrypted-room support
- persist Matrix bot device sessions so existing logins can be restored across restarts
- handle older stored credentials that do not yet include session fields
- update Matrix agent-manager tests to cover the current session-persistence behavior

## Testing
- python3 -m compileall src/mindroom/matrix
- .venv/bin/pytest -q tests/test_matrix_agent_manager.py -k 'create_agent_user or login_agent_user'
