### PR TITLE
Ignore fallback thread metadata in Matrix DMs

### DIFF
--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -22,6 +22,7 @@ from mindroom.matrix.reply_chain import (
     derive_conversation_target,
 )
 from mindroom.matrix.room_cache import cached_room
+from mindroom.matrix.rooms import is_dm_room
 from mindroom.message_target import MessageTarget
 from mindroom.thread_utils import check_agent_mentioned
 
@@ -100,6 +101,18 @@ class ConversationResolver:
 
     def _matrix_id(self) -> MatrixID:
         return self.deps.matrix_id
+
+    async def _should_use_room_mode(self, room_id: str) -> bool:
+        """Return whether inbound events in this room should ignore thread metadata."""
+        config_prefers_room_mode = (
+            self.deps.runtime.config.get_entity_thread_mode(
+                self.deps.agent_name,
+                self.deps.runtime_paths,
+                room_id=room_id,
+            )
+            == "room"
+        )
+        return config_prefers_room_mode or await is_dm_room(self._client(), room_id)
 
     def _envelope_ingress_metadata(
         self,
@@ -274,15 +287,7 @@ class ConversationResolver:
         event: DispatchEvent,
     ) -> str | None:
         """Return the coalescing thread scope for one inbound event."""
-        config = self.deps.runtime.config
-        if (
-            config.get_entity_thread_mode(
-                self.deps.agent_name,
-                self.deps.runtime_paths,
-                room_id=room.room_id,
-            )
-            == "room"
-        ):
+        if await self._should_use_room_mode(room.room_id):
             return None
         event_info = EventInfo.from_event(event.source)
         if event_info.thread_id:
@@ -378,14 +383,7 @@ class ConversationResolver:
             self.deps.logger.info("Mentioned", event_id=event.event_id, room_id=room.room_id)
 
         event_info = EventInfo.from_event(resolved_event_source)
-        if (
-            config.get_entity_thread_mode(
-                self.deps.agent_name,
-                self.deps.runtime_paths,
-                room_id=room.room_id,
-            )
-            == "room"
-        ):
+        if await self._should_use_room_mode(room.room_id):
             is_thread = False
             thread_id = None
             thread_history: list[ResolvedVisibleMessage] = []

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -19,6 +19,7 @@ from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.conversation_resolver import MessageContext
+from mindroom.handled_turns import HandledTurnState
 from mindroom.matrix.users import AgentMatrixUser
 from tests.conftest import (
     TEST_PASSWORD,
@@ -176,6 +177,69 @@ class TestRoutingRegression:
         assert news_bot.client.room_send.call_count == 0
         # Router should NOT have been called
         assert mock_suggest_agent.call_count == 0
+
+    @pytest.mark.asyncio
+    @patch("mindroom.conversation_resolver.is_dm_room", new_callable=AsyncMock, return_value=True)
+    async def test_dm_fallback_thread_message_is_routed_in_room_mode(
+        self,
+        mock_is_dm_room: AsyncMock,
+        mock_research_agent: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """DM follow-ups with fallback thread metadata should stay in room mode."""
+        test_room_id = "!dm:localhost"
+        thread_root = "$thread_root"
+
+        research_bot = setup_test_bot(mock_research_agent, tmp_path, test_room_id)
+
+        mock_room = MagicMock()
+        mock_room.room_id = test_room_id
+        mock_room.users = {
+            "@user:localhost": MagicMock(),
+            mock_research_agent.user_id: MagicMock(),
+        }
+
+        message_event = MagicMock(spec=nio.RoomMessageText)
+        message_event.sender = "@user:localhost"
+        message_event.body = "followup"
+        message_event.event_id = "$user_msg_456"
+        message_event.server_timestamp = 1000
+        message_event.source = {
+            "content": {
+                "body": "followup",
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    "event_id": thread_root,
+                    "rel_type": "m.thread",
+                    "is_falling_back": True,
+                    "m.in_reply_to": {"event_id": thread_root},
+                },
+            },
+        }
+
+        coalescing_thread_id = await research_bot._conversation_resolver.coalescing_thread_id(
+            mock_room,
+            message_event,
+        )
+        context = await research_bot._conversation_resolver.extract_dispatch_context(
+            mock_room,
+            message_event,
+        )
+        dispatch = await research_bot._turn_controller._prepare_dispatch(
+            mock_room,
+            message_event,
+            message_event.sender,
+            event_label="message",
+            handled_turn=HandledTurnState.from_source_event_id(message_event.event_id),
+        )
+
+        assert coalescing_thread_id is None
+        assert context.is_thread is False
+        assert context.thread_id is None
+        assert dispatch is not None
+        assert dispatch.target.thread_id is None
+        assert dispatch.target.reply_to_event_id == message_event.event_id
+        assert mock_is_dm_room.await_count >= 1
 
     @pytest.mark.asyncio
     @patch("mindroom.response_runner.ai_response")


### PR DESCRIPTION
## Summary
- ignore fallback `m.thread` metadata on inbound Matrix DM follow-up messages
- keep DM follow-up routing in room scope instead of treating fallback metadata as a real thread
- add a regression test covering DM follow-ups that include fallback thread metadata

## Testing
- `.venv/bin/pytest -q tests/test_routing_regression.py -k 'dm_fallback_thread_message_is_routed_in_room_mode'`