### PR TITLE
Strip nested Matrix relations from edit replacements

### DIFF
--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -2372,6 +2372,10 @@ def build_edit_event_content(
 ) -> dict[str, Any]:
     """Wrap replacement content in one Matrix m.replace edit envelope."""
     replacement_content = dict(new_content)
+    # Matrix applies m.new_content over the original event while preserving the
+    # original event's relationship metadata, so nested relations in the
+    # replacement payload are redundant and can confuse clients.
+    replacement_content.pop("m.relates_to", None)
     edit_content = {
         "msgtype": "m.text",
         "body": f"* {new_text}",

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -184,6 +184,37 @@ async def test_large_edit_preserves_mindroom_metadata_in_both_payload_layers() -
         assert uploaded_payload["m.new_content"][key] == value
 
 
+@pytest.mark.asyncio
+async def test_threaded_edit_strips_nested_relations_from_replacement_payload() -> None:
+    """Threaded edits should keep the top-level replacement relation only."""
+    client = MockClient()
+    content = {
+        "body": "Updated reply",
+        "msgtype": "m.text",
+        "formatted_body": "<p>Updated reply</p>",
+        "m.relates_to": {
+            "rel_type": "m.thread",
+            "event_id": "$thread_root",
+            "m.in_reply_to": {"event_id": "$latest"},
+        },
+    }
+
+    await edit_message_result(
+        client,
+        "!room:server",
+        "$original",
+        content,
+        "Updated reply",
+    )
+
+    assert len(client.messages_sent) == 1
+    sent_content = client.messages_sent[0][2]
+    assert sent_content["m.relates_to"] == {"rel_type": "m.replace", "event_id": "$original"}
+    assert sent_content["m.new_content"]["body"] == "Updated reply"
+    assert sent_content["m.new_content"]["msgtype"] == "m.text"
+    assert "m.relates_to" not in sent_content["m.new_content"]
+
+
 # ============================================================================
 # Streaming Tests
 # ============================================================================

--- a/tests/test_skip_mentions.py
+++ b/tests/test_skip_mentions.py
@@ -413,7 +413,8 @@ async def test_delivery_gateway_edit_text_records_threaded_outbound_edit(tmp_pat
     assert record_args[0] == "!test:server"
     assert record_args[1] == "$edit-event"
     assert record_args[2]["m.relates_to"]["rel_type"] == "m.replace"
-    assert record_args[2]["m.new_content"]["m.relates_to"]["event_id"] == "$thread"
+    assert record_args[2]["m.relates_to"]["event_id"] == "$original"
+    assert "m.relates_to" not in record_args[2]["m.new_content"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep DM reply flows thread-based
- strip nested relation metadata from `m.new_content` when sending Matrix edit events
- add a regression test covering threaded edit payloads

## Testing
- `PYTEST_ADDOPTS= .venv/bin/pytest -q tests/test_large_messages_integration.py -k "threaded_edit_strips_nested_relations_from_replacement_payload or large_edit_preserves_mindroom_metadata_in_both_payload_layers"`
- `PYTEST_ADDOPTS= .venv/bin/pytest -q -n0 tests/test_streaming_behavior.py::TestStreamingBehavior::test_streaming_first_send_uses_resolved_thread_root`