### PR TITLE
fix: make matrix olm optional

### DIFF
--- a/.github/scripts/check_tool_extras_sync.py
+++ b/.github/scripts/check_tool_extras_sync.py
@@ -17,7 +17,7 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 TOOLS_DIR = REPO_ROOT / "src" / "mindroom" / "tools"
 
 # Groups that are not tool registrations (meta-groups, aggregates, etc.)
-IGNORED_GROUPS: set[str] = {"sentence_transformers", "supabase"}
+IGNORED_GROUPS: set[str] = {"matrix_e2ee", "sentence_transformers", "supabase"}
 
 
 def _normalize_dep(spec: str) -> str:

--- a/README.md
+++ b/README.md
@@ -188,10 +188,11 @@ See [Hosted Matrix deployment guide](docs/deployment/hosted-matrix.md) for full 
 # Clone and install
 git clone https://github.com/mindroom-ai/mindroom
 cd mindroom
-uv sync --all-extras
+uv sync
 ```
 
 MindRoom auto-installs the fully local sentence-transformers embedder runtime on first use when `memory.embedder.provider: sentence_transformers` is configured.
+Install `uv sync --extra matrix_e2ee` if you need Matrix E2EE support in encrypted rooms.
 
 ```bash
 # Start MindRoom (agents + API + web dashboard)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "humanize>=4.12.3",
   "json5>=0.13",
   "markdown-it-py>=4",
-  "matrix-nio[e2e]>=0.25",
+  "matrix-nio>=0.25",
   "mcp[cli]>=1.12.4",
   "mem0ai>=0.1.115",
   "openai",
@@ -235,6 +235,9 @@ optional-dependencies.lumalabs = [
   "lumaai",
 ]
 optional-dependencies.matrix_api = [  ]
+optional-dependencies.matrix_e2ee = [
+  "matrix-nio[e2e]>=0.25",
+]
 optional-dependencies.matrix_message = [  ]
 optional-dependencies.matrix_room = [  ]
 optional-dependencies.mem0 = [

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -965,6 +965,20 @@ async def leave_room(client: nio.AsyncClient, room_id: str) -> bool:
     return False
 
 
+def _can_send_to_encrypted_room(client: nio.AsyncClient, room_id: str, *, operation: str) -> bool:
+    """Return whether one outbound room operation can proceed with current nio E2EE support."""
+    room = cached_room(client, room_id)
+    if room is None or not room.encrypted or crypto.ENCRYPTION_ENABLED:
+        return True
+    logger.error(
+        "matrix_e2ee_support_required",
+        room_id=room_id,
+        operation=operation,
+        hint="Install `mindroom[matrix_e2ee]` or `matrix-nio[e2e]` to use encrypted Matrix rooms.",
+    )
+    return False
+
+
 async def send_message(client: nio.AsyncClient, room_id: str, content: dict[str, Any]) -> str | None:
     """Send a message to a Matrix room.
 
@@ -980,6 +994,9 @@ async def send_message(client: nio.AsyncClient, room_id: str, content: dict[str,
         The event ID of the sent message, or None if sending failed
 
     """
+    if not _can_send_to_encrypted_room(client, room_id, operation="send_message"):
+        return None
+
     # Handle large messages if needed
     content = await prepare_large_message(client, room_id, content)
 
@@ -1098,6 +1115,8 @@ async def send_file_message(
     resolved_path = Path(file_path).expanduser().resolve()
     if not resolved_path.is_file():
         logger.error("Cannot send non-file attachment", path=str(resolved_path))
+        return None
+    if not _can_send_to_encrypted_room(client, room_id, operation="send_file_message"):
         return None
 
     mimetype = _guess_mimetype(resolved_path)

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 
-from mindroom.matrix.client import _msgtype_for_mimetype, _upload_file_as_mxc, send_file_message
+from mindroom.matrix.client import _msgtype_for_mimetype, _upload_file_as_mxc, send_file_message, send_message
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -183,6 +183,7 @@ class TestSendFileMessage:
         file.write_bytes(b"\x00" * 8)
 
         with (
+            patch("mindroom.matrix.client.crypto.ENCRYPTION_ENABLED", True),
             patch(
                 "mindroom.matrix.client.crypto.attachments.encrypt_attachment",
                 return_value=(
@@ -251,6 +252,23 @@ class TestSendFileMessage:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_returns_none_for_encrypted_room_when_e2ee_support_is_unavailable(self, tmp_path: Path) -> None:
+        """Encrypted-room file sends should fail early when nio E2EE support is disabled."""
+        client = _mock_client(encrypted=True)
+
+        file = tmp_path / "secret.bin"
+        file.write_bytes(b"\x00" * 8)
+
+        with (
+            patch("mindroom.matrix.client.crypto.ENCRYPTION_ENABLED", False),
+            patch("mindroom.matrix.client._upload_file_as_mxc", new_callable=AsyncMock) as mock_upload,
+        ):
+            result = await send_file_message(client, "!room:localhost", file)
+
+        assert result is None
+        mock_upload.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_caption_overrides_body(self, tmp_path: Path) -> None:
         """When caption is set, body should use it instead of filename."""
         client = _mock_client(encrypted=False)
@@ -296,6 +314,25 @@ class TestMsgtypeForMimetype:
     def test_mimetype_mapping(self, mimetype: str, expected: str) -> None:
         """Verify MIME type to Matrix msgtype mapping."""
         assert _msgtype_for_mimetype(mimetype) == expected
+
+
+class TestSendMessage:
+    """Tests for send_message."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_encrypted_room_when_e2ee_support_is_unavailable(self) -> None:
+        """Encrypted-room text sends should fail before sidecar prep when nio E2EE support is disabled."""
+        client = _mock_client(encrypted=True)
+
+        with (
+            patch("mindroom.matrix.client.crypto.ENCRYPTION_ENABLED", False),
+            patch("mindroom.matrix.client.prepare_large_message", new_callable=AsyncMock) as mock_prepare,
+        ):
+            result = await send_message(client, "!room:localhost", {"body": "hello", "msgtype": "m.text"})
+
+        assert result is None
+        mock_prepare.assert_not_awaited()
+        client.room_send.assert_not_called()
 
 
 class TestSendFileMessageMsgtype:

--- a/uv.lock
+++ b/uv.lock
@@ -3232,7 +3232,7 @@ dependencies = [
     { name = "humanize" },
     { name = "json5" },
     { name = "markdown-it-py" },
-    { name = "matrix-nio", extra = ["e2e"] },
+    { name = "matrix-nio" },
     { name = "mcp", extra = ["cli"] },
     { name = "mem0ai" },
     { name = "openai" },
@@ -3422,6 +3422,9 @@ linkup = [
 ]
 lumalabs = [
     { name = "lumaai" },
+]
+matrix-e2ee = [
+    { name = "matrix-nio", extra = ["e2e"] },
 ]
 mem0 = [
     { name = "mem0ai" },
@@ -3660,7 +3663,8 @@ requires-dist = [
     { name = "lxml-html-clean", marker = "extra == 'newspaper'" },
     { name = "markdown-it-py", specifier = ">=4" },
     { name = "matplotlib", marker = "extra == 'visualization'" },
-    { name = "matrix-nio", extras = ["e2e"], specifier = ">=0.25" },
+    { name = "matrix-nio", specifier = ">=0.25" },
+    { name = "matrix-nio", extras = ["e2e"], marker = "extra == 'matrix-e2ee'", specifier = ">=0.25" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.4" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
@@ -3737,7 +3741,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'" },
     { name = "zep-cloud", marker = "extra == 'zep'", specifier = ">=3.3" },
 ]
-provides-extras = ["agentql", "airflow", "apify", "arxiv", "attachments", "aws-lambda", "aws-ses", "baidusearch", "bitbucket", "brandfetch", "brightdata", "browser", "browserbase", "cal-com", "calculator", "cartesia", "claude-agent", "clickup", "coding", "compact-context", "composio", "config-manager", "confluence", "crawl4ai", "csv", "custom-api", "dalle", "daytona", "delegate", "desi-vocal", "discord", "docker", "duckdb", "duckduckgo", "dynamic-tools", "e2b", "eleven-labs", "email", "exa", "fal", "file", "file-generation", "financial-datasets-api", "firecrawl", "gemini", "giphy", "github", "gmail", "google-bigquery", "google-calendar", "google-maps", "google-sheets", "googlesearch", "groq", "hackernews", "homeassistant", "jina", "jira", "linear", "linkup", "lumalabs", "matrix-api", "matrix-message", "matrix-room", "mem0", "memory", "modelslabs", "moviepy-video-tools", "neo4j", "newspaper", "notion", "openai", "openbb", "openclaw-compat", "openweather", "oxylabs", "pandas", "postgres", "pubmed", "python", "reasoning", "reddit", "redshift", "replicate", "resend", "scheduler", "scrapegraph", "searxng", "self-config", "sentence-transformers", "serpapi", "serper", "shell", "shopify", "slack", "sleep", "spider", "spotify", "sql", "subagents", "supabase", "tavily", "telegram", "thread-summary", "thread-tags", "todoist", "trafilatura", "trello", "twilio", "unsplash", "visualization", "web-browser-tools", "webex", "website", "whatsapp", "wikipedia", "x", "yfinance", "youtube", "zendesk", "zep", "zoom"]
+provides-extras = ["agentql", "airflow", "apify", "arxiv", "attachments", "aws-lambda", "aws-ses", "baidusearch", "bitbucket", "brandfetch", "brightdata", "browser", "browserbase", "cal-com", "calculator", "cartesia", "claude-agent", "clickup", "coding", "compact-context", "composio", "config-manager", "confluence", "crawl4ai", "csv", "custom-api", "dalle", "daytona", "delegate", "desi-vocal", "discord", "docker", "duckdb", "duckduckgo", "dynamic-tools", "e2b", "eleven-labs", "email", "exa", "fal", "file", "file-generation", "financial-datasets-api", "firecrawl", "gemini", "giphy", "github", "gmail", "google-bigquery", "google-calendar", "google-maps", "google-sheets", "googlesearch", "groq", "hackernews", "homeassistant", "jina", "jira", "linear", "linkup", "lumalabs", "matrix-api", "matrix-e2ee", "matrix-message", "matrix-room", "mem0", "memory", "modelslabs", "moviepy-video-tools", "neo4j", "newspaper", "notion", "openai", "openbb", "openclaw-compat", "openweather", "oxylabs", "pandas", "postgres", "pubmed", "python", "reasoning", "reddit", "redshift", "replicate", "resend", "scheduler", "scrapegraph", "searxng", "self-config", "sentence-transformers", "serpapi", "serper", "shell", "shopify", "slack", "sleep", "spider", "spotify", "sql", "subagents", "supabase", "tavily", "telegram", "thread-summary", "thread-tags", "todoist", "trafilatura", "trello", "twilio", "unsplash", "visualization", "web-browser-tools", "webex", "website", "whatsapp", "wikipedia", "x", "yfinance", "youtube", "zendesk", "zep", "zoom"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- switch the base dependency from `matrix-nio[e2e]` to plain `matrix-nio` and move encrypted-room support behind a new `matrix_e2ee` extra
- fail fast with a clear log hint when a plain install tries to send a text or file message into an encrypted Matrix room
- document the new install flow and cover the encrypted-room guard with send-path tests

## Test Plan
- `uv run pre-commit run --files .github/scripts/check_tool_extras_sync.py README.md pyproject.toml src/mindroom/matrix/client.py tests/test_send_file_message.py uv.lock`
- `uv run pytest -n 0`
