### PR TITLE
fix: handle stale nio room cache during sends

### DIFF
--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -9,7 +9,7 @@ import json
 import mimetypes
 import ssl as ssl_module
 import time
-from collections.abc import AsyncGenerator, Iterable, Mapping, Sequence
+from collections.abc import AsyncGenerator, Iterable, Mapping, MutableMapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -870,7 +870,7 @@ async def join_room(client: nio.AsyncClient, room_id: str) -> bool:
     response = await client.join(room_id)
     if isinstance(response, nio.JoinResponse):
         rooms = client.rooms
-        if isinstance(rooms, dict) and response.room_id not in rooms:
+        if isinstance(rooms, MutableMapping) and response.room_id not in rooms:
             rooms[response.room_id] = nio.MatrixRoom(
                 room_id=response.room_id,
                 own_user_id=client.user_id or "",
@@ -980,10 +980,10 @@ def cached_room(client: nio.AsyncClient, room_id: str) -> nio.MatrixRoom | None:
     return cached_rooms(client).get(room_id)
 
 
-def cached_rooms(client: nio.AsyncClient) -> dict[str, nio.MatrixRoom]:
+def cached_rooms(client: nio.AsyncClient) -> Mapping[str, nio.MatrixRoom]:
     """Return the client room cache when nio has initialized it."""
     rooms = client.rooms
-    return rooms if isinstance(rooms, dict) else {}
+    return rooms if isinstance(rooms, Mapping) else {}
 
 
 def _can_send_to_encrypted_room(client: nio.AsyncClient, room_id: str, *, operation: str) -> bool:
@@ -1023,8 +1023,8 @@ async def send_message_result(
         return None
 
     rooms = client.rooms
-    room = rooms.get(room_id) if isinstance(rooms, dict) else None
-    cache_bypass = isinstance(rooms, dict) and room is None
+    room = rooms.get(room_id) if isinstance(rooms, Mapping) else None
+    cache_bypass = isinstance(rooms, Mapping) and room is None
     if cache_bypass:
         encryption_state = await client.room_get_state_event(room_id, "m.room.encryption")
         if isinstance(encryption_state, nio.RoomGetStateEventResponse):
@@ -1109,8 +1109,7 @@ async def _upload_file_as_mxc(
         return None, None
 
     info: dict[str, Any] = {"size": len(file_bytes), "mimetype": mimetype}
-    rooms = client.rooms
-    room = rooms.get(room_id) if isinstance(rooms, dict) else None
+    room = cached_room(client, room_id)
     if room is None:
         logger.error("Cannot determine encryption state for unknown room", room_id=room_id)
         return None, None

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -1022,20 +1022,13 @@ async def send_message_result(
     if not _can_send_to_encrypted_room(client, room_id, operation="send_message"):
         return None
 
-    content_sent = await prepare_large_message(client, room_id, content)
-    cache_bypass = False
-    try:
-        response = await client.room_send(
-            room_id=room_id,
-            message_type="m.room.message",
-            content=content_sent,
-        )
-    except nio.LocalProtocolError as exc:
-        if "No such room with id" not in str(exc):
-            raise
+    rooms = client.rooms
+    room = rooms.get(room_id) if isinstance(rooms, dict) else None
+    cache_bypass = isinstance(rooms, dict) and room is None
+    if cache_bypass:
         encryption_state = await client.room_get_state_event(room_id, "m.room.encryption")
         if isinstance(encryption_state, nio.RoomGetStateEventResponse):
-            logger.exception(
+            logger.error(
                 "matrix_encrypted_room_send_requires_synced_room_cache",
                 room_id=room_id,
                 operation="send_message",
@@ -1045,17 +1038,20 @@ async def send_message_result(
         if not (
             isinstance(encryption_state, nio.RoomGetStateEventError) and encryption_state.status_code == "M_NOT_FOUND"
         ):
-            logger.exception(
+            logger.error(
                 "matrix_room_send_requires_known_encryption_state",
                 room_id=room_id,
                 operation="send_message",
                 hint="Unable to determine whether the room is encrypted while nio's room cache is empty.",
             )
             return None
+
+    content_sent = await prepare_large_message(client, room_id, content)
+    if cache_bypass:
         access_token = client.access_token
         if not access_token:
             msg = "Matrix client access token is required to send a message."
-            raise nio.LocalProtocolError(msg) from exc
+            raise nio.LocalProtocolError(msg)
         method, path, data = Api.room_send(
             access_token,
             room_id,
@@ -1070,7 +1066,12 @@ async def send_message_result(
             data,
             response_data=(room_id,),
         )
-        cache_bypass = True
+    else:
+        response = await client.room_send(
+            room_id=room_id,
+            message_type="m.room.message",
+            content=content_sent,
+        )
     if isinstance(response, nio.RoomSendResponse):
         logger.debug(
             "matrix_message_sent",
@@ -1086,12 +1087,6 @@ async def send_message_result(
         cache_bypass=cache_bypass,
     )
     return None
-
-
-async def send_message(client: nio.AsyncClient, room_id: str, content: dict[str, Any]) -> str | None:
-    """Send a message to a Matrix room and return its event id."""
-    delivered = await send_message_result(client, room_id, content)
-    return delivered.event_id if delivered is not None else None
 
 
 def _guess_mimetype(file_path: Path) -> str:

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -14,10 +14,12 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 import nio
 from aiohttp import ClientError
 from nio import crypto
+from nio.api import Api
 from nio.responses import RoomThreadsResponse
 
 from mindroom.constants import STREAM_STATUS_KEY, RuntimePaths, encryption_keys_dir, runtime_matrix_ssl_verify
@@ -998,6 +1000,57 @@ def _can_send_to_encrypted_room(client: nio.AsyncClient, room_id: str, *, operat
     return False
 
 
+async def _room_uses_encryption_state(client: nio.AsyncClient, room_id: str) -> bool | None:
+    """Return whether the room is encrypted, falling back to remote state when nio cache is stale."""
+    room = cached_room(client, room_id)
+    if room is not None:
+        return room.encrypted
+
+    response = await client.room_get_state_event(room_id, "m.room.encryption")
+    if isinstance(response, nio.RoomGetStateEventResponse):
+        return True
+    if isinstance(response, nio.RoomGetStateEventError) and response.status_code == "M_NOT_FOUND":
+        return False
+    logger.warning(
+        "matrix_room_encryption_state_lookup_failed",
+        room_id=room_id,
+        error=str(response),
+    )
+    return None
+
+
+async def _raw_room_send_unencrypted(
+    client: nio.AsyncClient,
+    room_id: str,
+    content: dict[str, Any],
+) -> str | None:
+    """Send one unencrypted room message through nio's private transport helper."""
+    access_token = client.access_token
+    if not access_token:
+        msg = "Matrix client access token is required to send a message."
+        raise nio.LocalProtocolError(msg)
+
+    method, path, data = Api.room_send(
+        access_token,
+        room_id,
+        "m.room.message",
+        content,
+        uuid4(),
+    )
+    response = await client._send(
+        nio.RoomSendResponse,
+        method,
+        path,
+        data,
+        response_data=(room_id,),
+    )
+    if isinstance(response, nio.RoomSendResponse):
+        logger.debug("matrix_message_sent", room_id=room_id, event_id=str(response.event_id), cache_bypass=True)
+        return str(response.event_id)
+    logger.error("matrix_message_send_failed", room_id=room_id, error=str(response), cache_bypass=True)
+    return None
+
+
 async def send_message_result(
     client: nio.AsyncClient,
     room_id: str,
@@ -1021,17 +1074,47 @@ async def send_message_result(
         return None
 
     content_sent = await prepare_large_message(client, room_id, content)
-
-    response = await client.room_send(
-        room_id=room_id,
-        message_type="m.room.message",
-        content=content_sent,
-    )
+    try:
+        response = await client.room_send(
+            room_id=room_id,
+            message_type="m.room.message",
+            content=content_sent,
+        )
+    except nio.LocalProtocolError as exc:
+        if "No such room with id" not in str(exc):
+            raise
+        room_encrypted = await _room_uses_encryption_state(client, room_id)
+        if room_encrypted is True:
+            logger.exception(
+                "matrix_encrypted_room_send_requires_synced_room_cache",
+                room_id=room_id,
+                operation="send_message",
+                hint="Wait for initial sync to populate nio's room cache before sending to encrypted rooms.",
+            )
+            return None
+        if room_encrypted is None:
+            logger.exception(
+                "matrix_room_send_requires_known_encryption_state",
+                room_id=room_id,
+                operation="send_message",
+                hint="Unable to determine whether the room is encrypted while nio's room cache is empty.",
+            )
+            return None
+        raw_event_id = await _raw_room_send_unencrypted(client, room_id, content_sent)
+        if raw_event_id is None:
+            return None
+        return DeliveredMatrixEvent(event_id=raw_event_id, content_sent=content_sent)
     if isinstance(response, nio.RoomSendResponse):
         logger.debug("matrix_message_sent", room_id=room_id, event_id=str(response.event_id))
         return DeliveredMatrixEvent(event_id=str(response.event_id), content_sent=content_sent)
     logger.error("matrix_message_send_failed", room_id=room_id, error=str(response))
     return None
+
+
+async def send_message(client: nio.AsyncClient, room_id: str, content: dict[str, Any]) -> str | None:
+    """Send a message to a Matrix room and return its event id."""
+    delivered = await send_message_result(client, room_id, content)
+    return delivered.event_id if delivered is not None else None
 
 
 def _guess_mimetype(file_path: Path) -> str:

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -1000,57 +1000,6 @@ def _can_send_to_encrypted_room(client: nio.AsyncClient, room_id: str, *, operat
     return False
 
 
-async def _room_uses_encryption_state(client: nio.AsyncClient, room_id: str) -> bool | None:
-    """Return whether the room is encrypted, falling back to remote state when nio cache is stale."""
-    room = cached_room(client, room_id)
-    if room is not None:
-        return room.encrypted
-
-    response = await client.room_get_state_event(room_id, "m.room.encryption")
-    if isinstance(response, nio.RoomGetStateEventResponse):
-        return True
-    if isinstance(response, nio.RoomGetStateEventError) and response.status_code == "M_NOT_FOUND":
-        return False
-    logger.warning(
-        "matrix_room_encryption_state_lookup_failed",
-        room_id=room_id,
-        error=str(response),
-    )
-    return None
-
-
-async def _raw_room_send_unencrypted(
-    client: nio.AsyncClient,
-    room_id: str,
-    content: dict[str, Any],
-) -> str | None:
-    """Send one unencrypted room message through nio's private transport helper."""
-    access_token = client.access_token
-    if not access_token:
-        msg = "Matrix client access token is required to send a message."
-        raise nio.LocalProtocolError(msg)
-
-    method, path, data = Api.room_send(
-        access_token,
-        room_id,
-        "m.room.message",
-        content,
-        uuid4(),
-    )
-    response = await client._send(
-        nio.RoomSendResponse,
-        method,
-        path,
-        data,
-        response_data=(room_id,),
-    )
-    if isinstance(response, nio.RoomSendResponse):
-        logger.debug("matrix_message_sent", room_id=room_id, event_id=str(response.event_id), cache_bypass=True)
-        return str(response.event_id)
-    logger.error("matrix_message_send_failed", room_id=room_id, error=str(response), cache_bypass=True)
-    return None
-
-
 async def send_message_result(
     client: nio.AsyncClient,
     room_id: str,
@@ -1074,6 +1023,7 @@ async def send_message_result(
         return None
 
     content_sent = await prepare_large_message(client, room_id, content)
+    cache_bypass = False
     try:
         response = await client.room_send(
             room_id=room_id,
@@ -1083,8 +1033,8 @@ async def send_message_result(
     except nio.LocalProtocolError as exc:
         if "No such room with id" not in str(exc):
             raise
-        room_encrypted = await _room_uses_encryption_state(client, room_id)
-        if room_encrypted is True:
+        encryption_state = await client.room_get_state_event(room_id, "m.room.encryption")
+        if isinstance(encryption_state, nio.RoomGetStateEventResponse):
             logger.exception(
                 "matrix_encrypted_room_send_requires_synced_room_cache",
                 room_id=room_id,
@@ -1092,7 +1042,9 @@ async def send_message_result(
                 hint="Wait for initial sync to populate nio's room cache before sending to encrypted rooms.",
             )
             return None
-        if room_encrypted is None:
+        if not (
+            isinstance(encryption_state, nio.RoomGetStateEventError) and encryption_state.status_code == "M_NOT_FOUND"
+        ):
             logger.exception(
                 "matrix_room_send_requires_known_encryption_state",
                 room_id=room_id,
@@ -1100,14 +1052,39 @@ async def send_message_result(
                 hint="Unable to determine whether the room is encrypted while nio's room cache is empty.",
             )
             return None
-        raw_event_id = await _raw_room_send_unencrypted(client, room_id, content_sent)
-        if raw_event_id is None:
-            return None
-        return DeliveredMatrixEvent(event_id=raw_event_id, content_sent=content_sent)
+        access_token = client.access_token
+        if not access_token:
+            msg = "Matrix client access token is required to send a message."
+            raise nio.LocalProtocolError(msg) from exc
+        method, path, data = Api.room_send(
+            access_token,
+            room_id,
+            "m.room.message",
+            content_sent,
+            uuid4(),
+        )
+        response = await client._send(
+            nio.RoomSendResponse,
+            method,
+            path,
+            data,
+            response_data=(room_id,),
+        )
+        cache_bypass = True
     if isinstance(response, nio.RoomSendResponse):
-        logger.debug("matrix_message_sent", room_id=room_id, event_id=str(response.event_id))
+        logger.debug(
+            "matrix_message_sent",
+            room_id=room_id,
+            event_id=str(response.event_id),
+            cache_bypass=cache_bypass,
+        )
         return DeliveredMatrixEvent(event_id=str(response.event_id), content_sent=content_sent)
-    logger.error("matrix_message_send_failed", room_id=room_id, error=str(response))
+    logger.error(
+        "matrix_message_send_failed",
+        room_id=room_id,
+        error=str(response),
+        cache_bypass=cache_bypass,
+    )
     return None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import os
 import re
-from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Mapping
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Iterator, Mapping, MutableMapping
 from contextlib import ExitStack, contextmanager
 from dataclasses import replace
 from itertools import count
@@ -104,11 +104,41 @@ def _make_room_get_event_response(event_id: str) -> nio.RoomGetEventResponse:
     return response
 
 
+class _AutoRoomCache(MutableMapping[str, nio.MatrixRoom]):
+    """Mutable test room cache that lazily vends joined unencrypted rooms."""
+
+    def __init__(self, own_user_id: str) -> None:
+        self._own_user_id = own_user_id
+        self._rooms: dict[str, nio.MatrixRoom] = {}
+
+    def __getitem__(self, room_id: str) -> nio.MatrixRoom:
+        room = self._rooms.get(room_id)
+        if room is not None:
+            return room
+        if not room_id.startswith("!"):
+            raise KeyError(room_id)
+        room = nio.MatrixRoom(room_id, self._own_user_id)
+        self._rooms[room_id] = room
+        return room
+
+    def __setitem__(self, room_id: str, room: nio.MatrixRoom) -> None:
+        self._rooms[room_id] = room
+
+    def __delitem__(self, room_id: str) -> None:
+        del self._rooms[room_id]
+
+    def __iter__(self) -> Iterator[str]:
+        yield from self._rooms
+
+    def __len__(self) -> int:
+        return len(self._rooms)
+
+
 def make_matrix_client_mock(*, user_id: str = "@mindroom_test:example.com") -> AsyncMock:
     """Return an AsyncClient-shaped mock with safe defaults for sync nio APIs."""
     client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
     client.user_id = user_id
+    client.rooms = _AutoRoomCache(user_id)
     client.next_batch = "s_test_token"
     presence_response = MagicMock()
     presence_response.presence = "offline"

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -27,7 +27,12 @@ class MockClient:
     """Mock Matrix client for testing."""
 
     def __init__(self, should_upload_succeed: bool = True) -> None:
-        self.rooms = {}
+        room = MagicMock()
+        room.encrypted = False
+        self.rooms = {
+            "!room:server": room,
+            "!test:room": room,
+        }
         self.messages_sent = []
         self.uploads: list[dict] = []
         self.should_upload_succeed = should_upload_succeed

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -27,6 +27,7 @@ def _mock_client(*, encrypted: bool = False) -> AsyncMock:
     room = MagicMock()
     room.encrypted = encrypted
     client.rooms = {"!room:localhost": room}
+    client.olm = None
     return client
 
 
@@ -443,6 +444,32 @@ class TestSendMessageResult:
         assert result is None
         mock_prepare.assert_not_awaited()
         client.room_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_raw_send_when_room_missing_from_cache_but_room_is_unencrypted(self) -> None:
+        """Unencrypted sends should not depend on nio's room cache."""
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.rooms = {}
+        client.access_token = "token"  # noqa: S105
+        client.room_send.side_effect = nio.LocalProtocolError("No such room with id !room:localhost found.")
+        client.room_get_state_event.return_value = nio.RoomGetStateEventError(
+            "not found",
+            status_code="M_NOT_FOUND",
+        )
+        client._send.return_value = nio.RoomSendResponse("$evt:localhost", "!room:localhost")
+
+        prepared_content = {"body": "hello", "msgtype": "m.text"}
+        with patch("mindroom.matrix.client.prepare_large_message", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.return_value = prepared_content
+            result = await send_message_result(client, "!room:localhost", {"body": "hello", "msgtype": "m.text"})
+
+        assert result is not None
+        assert result.event_id == "$evt:localhost"
+        assert result.content_sent == prepared_content
+        mock_prepare.assert_awaited_once()
+        client.room_get_state_event.assert_awaited_once_with("!room:localhost", "m.room.encryption")
+        client.room_send.assert_awaited_once()
+        client._send.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_treats_non_dict_room_cache_as_unknown_room(self) -> None:

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -450,8 +450,9 @@ class TestSendMessageResult:
         """Unencrypted sends should not depend on nio's room cache."""
         client = AsyncMock(spec=nio.AsyncClient)
         client.rooms = {}
+        client.olm = None
         client.access_token = "token"  # noqa: S105
-        client.room_send.side_effect = nio.LocalProtocolError("No such room with id !room:localhost found.")
+        client.room_send.return_value = nio.RoomSendResponse("$wrong:localhost", "!room:localhost")
         client.room_get_state_event.return_value = nio.RoomGetStateEventError(
             "not found",
             status_code="M_NOT_FOUND",
@@ -468,8 +469,34 @@ class TestSendMessageResult:
         assert result.content_sent == prepared_content
         mock_prepare.assert_awaited_once()
         client.room_get_state_event.assert_awaited_once_with("!room:localhost", "m.room.encryption")
-        client.room_send.assert_awaited_once()
+        client.room_send.assert_not_awaited()
         client._send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_uncached_encrypted_room_without_olm(self) -> None:
+        """Encrypted sends should fail closed until nio has synced the room cache."""
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.rooms = {}
+        client.olm = None
+        client.access_token = "token"  # noqa: S105
+        client.room_send.return_value = nio.RoomSendResponse("$wrong:localhost", "!room:localhost")
+        client.room_get_state_event.return_value = nio.RoomGetStateEventResponse(
+            {"algorithm": "m.megolm.v1.aes-sha2"},
+            "m.room.encryption",
+            "",
+            "!room:localhost",
+        )
+
+        with patch(
+            "mindroom.matrix.client.prepare_large_message",
+            new=AsyncMock(side_effect=lambda *_: {"body": "hello", "msgtype": "m.text"}),
+        ):
+            result = await send_message_result(client, "!room:localhost", {"body": "hello", "msgtype": "m.text"})
+
+        assert result is None
+        client.room_get_state_event.assert_awaited_once_with("!room:localhost", "m.room.encryption")
+        client.room_send.assert_not_awaited()
+        client._send.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_treats_non_dict_room_cache_as_unknown_room(self) -> None:

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -131,6 +131,11 @@ def _make_reaction_event(
     return event
 
 
+def _joined_room_cache(room_id: str = ROOM_ID, *, own_user_id: str = BOT_USER_ID) -> dict[str, nio.MatrixRoom]:
+    room = nio.MatrixRoom(room_id, own_user_id)
+    return {room_id: room}
+
+
 def _room_messages_response(*events: object, end: str | None = None) -> nio.RoomMessagesResponse:
     response = MagicMock()
     response.__class__ = nio.RoomMessagesResponse
@@ -1364,7 +1369,7 @@ async def test_cleanup_repairs_pending_stream_status_on_restart_note_messages(tm
     """Restart-note messages should still get a metadata-only repair when status is pending."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
+    client.rooms = _joined_room_cache()
     interrupted_body = build_restart_interrupted_body("Working ⋯")
     client.room_messages.return_value = _room_messages_response(
         _make_message_event(
@@ -1403,7 +1408,7 @@ async def test_cleanup_preserves_tool_trace_and_ai_run_metadata(tmp_path: Path) 
     """Cleanup edits should preserve Cinny-facing run metadata in both edit payload layers."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
+    client.rooms = _joined_room_cache()
     client.room_messages.return_value = _room_messages_response(
         _make_message_event(
             event_id="$message",
@@ -1437,7 +1442,7 @@ async def test_cleanup_preserves_multiple_mindroom_metadata_keys(tmp_path: Path)
     """Cleanup edits should preserve every io.mindroom.* key, not just one special case."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
+    client.rooms = _joined_room_cache()
     input_keys = {
         "io.mindroom.stream_status": "streaming",
         "io.mindroom.compaction": {"version": 1, "compacted": False},
@@ -1467,7 +1472,7 @@ async def test_cleanup_prefers_latest_mindroom_metadata_from_edit_chain(tmp_path
     """Cleanup should use the canonical io.mindroom.* keys from the newest edit's m.new_content."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
+    client.rooms = _joined_room_cache()
     original = _make_message_event(
         event_id="$original",
         body="Initial partial ⋯",
@@ -1508,7 +1513,7 @@ async def test_cleanup_sets_terminal_stream_status(tmp_path: Path) -> None:
     config = _make_config(tmp_path)
 
     client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
+    client.rooms = _joined_room_cache()
     client.room_messages.return_value = _room_messages_response(
         _make_message_event(
             event_id="$msg-streaming",
@@ -1534,7 +1539,7 @@ async def test_cleanup_sets_terminal_stream_status(tmp_path: Path) -> None:
     assert new_content["io.mindroom.tool_trace"] == {"version": 1}
 
     client2 = AsyncMock(spec=nio.AsyncClient)
-    client2.rooms = {}
+    client2.rooms = _joined_room_cache()
     client2.room_messages.return_value = _room_messages_response(
         _make_message_event(
             event_id="$msg-pending",
@@ -1562,7 +1567,7 @@ async def test_cleanup_preserves_tool_trace_from_v2_sidecar(tmp_path: Path) -> N
     """Cleanup should hydrate a v2 sidecar and preserve metadata that only exists there."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
+    client.rooms = _joined_room_cache()
 
     sidecar_tool_trace = {"version": 1, "events": [{"tool": "web_search"}]}
     sidecar_payload = {
@@ -1612,7 +1617,7 @@ async def test_cleanup_does_not_hydrate_sidecars_for_unrelated_user_messages(tmp
     """Cleanup should resolve visible message state only for the current bot's messages."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
+    client.rooms = _joined_room_cache()
 
     user_sidecar_event = _make_message_event(
         event_id="$user-preview",
@@ -1651,7 +1656,7 @@ async def test_cleanup_sidecar_hydration_failure_falls_back_gracefully(tmp_path:
     """Cleanup should still work when sidecar hydration fails."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
+    client.rooms = _joined_room_cache()
 
     preview_event = _make_message_event(
         event_id="$message",
@@ -1693,7 +1698,7 @@ async def test_cleanup_preserves_sidecar_tool_trace_from_edit_chain(tmp_path: Pa
     """For edit-based sidecars, tool_trace should come from the latest edit sidecar."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
+    client.rooms = _joined_room_cache()
 
     sidecar_tool_trace = {"version": 1, "events": [{"tool": "shell"}, {"tool": "file"}]}
     sidecar_inner = {

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -40,6 +40,7 @@ from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
     install_runtime_cache_support,
+    make_matrix_client_mock,
     patch_response_runner_module,
     replace_response_runner_deps,
     runtime_paths_for,
@@ -58,11 +59,7 @@ async def _aiter(*events: object) -> AsyncIterator[object]:
 
 
 def _make_matrix_client_mock() -> AsyncMock:
-    client = AsyncMock()
-    client.rooms = {}
-    client.next_batch = "s_test_token"
-    client.add_event_callback = MagicMock()
-    client.add_response_callback = MagicMock()
+    client = make_matrix_client_mock(user_id="@mindroom_streaming:localhost")
     client.room_get_event_relations = MagicMock(return_value=_aiter())
     return client
 

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -32,6 +32,7 @@ from mindroom.thread_summary import (
     thread_summary_message_count_hint,
     update_last_summary_count,
 )
+from tests.conftest import make_matrix_client_mock
 
 
 def _make_thread_history(count: int) -> list[ResolvedVisibleMessage]:
@@ -81,9 +82,7 @@ def _make_summary_notice_message(
 
 def _mock_client() -> AsyncMock:
     """Return a typed AsyncClient mock with an initialized room cache."""
-    client = AsyncMock(spec=nio.AsyncClient)
-    client.rooms = {}
-    return client
+    return make_matrix_client_mock()
 
 
 # -- model validation --


### PR DESCRIPTION
## Summary
- handle the `No such room with id ... found` `nio.LocalProtocolError` path that appears when a room exists remotely but has not populated `client.rooms` yet
- keep encrypted-room sends on the existing guarded path, and only fall back to a raw unencrypted send after confirming the room is not encrypted
- add a regression test covering the unencrypted stale-room-cache send path

## Test Plan
- `uv run pre-commit run --files src/mindroom/matrix/client.py tests/test_send_file_message.py`
- `uv run pytest -n 0`
- `git diff --quiet optional-olm HEAD --` (confirmed the follow-up branch tree matches the fully verified commit)
- `uv run pytest tests/test_send_file_message.py tests/test_large_messages_integration.py -n 0 --no-cov -v`
