### PR TITLE
Scope sandbox runner plugins to worker runtime

### DIFF
--- a/.github/workflows/smoke-stacks.yml
+++ b/.github/workflows/smoke-stacks.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: Set up kind
         uses: engineerd/setup-kind@v0.6.2
+        with:
+          skipClusterCreation: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/smoke-stacks.yml
+++ b/.github/workflows/smoke-stacks.yml
@@ -63,6 +63,8 @@ jobs:
         uses: engineerd/setup-kind@v0.6.2
         with:
           skipClusterCreation: true
+          skipClusterDeletion: true
+          skipClusterLogsExport: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/docs/superpowers/plans/2026-04-15-worker-tool-validation-snapshot.md
+++ b/docs/superpowers/plans/2026-04-15-worker-tool-validation-snapshot.md
@@ -1,0 +1,186 @@
+# Worker Tool Validation Snapshot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split tool validation from tool executability so the primary runtime owns config validity and workers only own local execution.
+
+**Architecture:** Introduce a validation-only tool snapshot derived from the primary runtime's resolved tool surface, make config validation depend on that snapshot instead of executable runtime metadata, and pass the snapshot to workers at startup instead of ad hoc allowed-name lists. This removes the worker-side placeholder metadata path and restores a single source of truth for authored tool validation.
+
+**Tech Stack:** Python, Pydantic, FastAPI sandbox runner, Kubernetes worker backend, pytest
+
+---
+
+### Task 1: Capture the new worker contract in tests
+
+**Files:**
+- Modify: `tests/api/test_sandbox_runner_api.py`
+- Modify: `tests/test_kubernetes_worker_backend.py`
+- Modify: `tests/test_tools_metadata.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests that assert:
+- worker startup accepts tools validated upstream without fabricating `ToolMetadata`
+- unknown tools are still rejected from the worker runtime
+- Kubernetes worker env contains a validation snapshot payload instead of `MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON`
+- the validation snapshot preserves authored override schema and MCP-specific validation behavior
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run:
+```bash
+PYTHONPATH=/home/basnijholt/Work/dev/mindroom/.worktrees/pr-594-review/src \
+/home/basnijholt/Work/dev/mindroom/.venv/bin/pytest \
+tests/api/test_sandbox_runner_api.py \
+tests/test_kubernetes_worker_backend.py \
+tests/test_tools_metadata.py \
+-k 'validation_snapshot or worker_runtime or mcp' -x -n 0 --no-cov -v
+```
+
+Expected:
+- failures referring to missing validation snapshot helpers or old allowed-tool-name env wiring
+
+### Task 2: Add a validation-only tool snapshot
+
+**Files:**
+- Modify: `src/mindroom/tool_system/metadata.py`
+- Modify: `src/mindroom/mcp/registry.py` if needed for explicit MCP validation markers
+- Test: `tests/test_tools_metadata.py`
+
+- [ ] **Step 1: Add the failing metadata test if Task 1 did not already cover it**
+
+Add a test that builds a runtime validation snapshot and asserts it contains:
+- known tool names
+- config-field schema used by authored overrides
+- explicit MCP override-validation semantics without depending on runtime factories
+
+- [ ] **Step 2: Implement the minimal metadata changes**
+
+Add:
+- a validation-only dataclass for one tool's authored-config validation surface
+- a runtime snapshot builder that returns validation data separate from executable registry state
+- serialization helpers for worker startup payloads
+
+Keep `ToolMetadata` for runtime/UI concerns only.
+
+- [ ] **Step 3: Run metadata-focused tests**
+
+Run:
+```bash
+PYTHONPATH=/home/basnijholt/Work/dev/mindroom/.worktrees/pr-594-review/src \
+/home/basnijholt/Work/dev/mindroom/.venv/bin/pytest \
+tests/test_tools_metadata.py -x -n 0 --no-cov -v
+```
+
+Expected:
+- PASS
+
+### Task 3: Make config validation depend on the snapshot
+
+**Files:**
+- Modify: `src/mindroom/config/main.py`
+- Modify: `src/mindroom/tool_system/metadata.py`
+- Test: `tests/api/test_sandbox_runner_api.py`
+
+- [ ] **Step 1: Write or extend the failing config-validation tests**
+
+Assert that authored tool validation succeeds when the upstream snapshot says a missing worker plugin tool is valid, and fails when the tool is not present in that snapshot.
+
+- [ ] **Step 2: Implement the minimal config-validation changes**
+
+Change config validation to consume the validation snapshot instead of executable registry plus `ToolMetadata`.
+
+That includes:
+- replacing `_validate_authored_tool_entries_with_state(...)` with a snapshot-based entrypoint
+- removing MCP validation's dependence on runtime factory markers during config validation
+
+- [ ] **Step 3: Run the sandbox-runner validation tests**
+
+Run:
+```bash
+PYTHONPATH=/home/basnijholt/Work/dev/mindroom/.worktrees/pr-594-review/src \
+/home/basnijholt/Work/dev/mindroom/.venv/bin/pytest \
+tests/api/test_sandbox_runner_api.py \
+-k 'skips_unavailable_plugins_for_worker_runtime or rejects_invalid_tools' \
+-x -n 0 --no-cov -v
+```
+
+Expected:
+- PASS
+
+### Task 4: Replace the worker startup side channel
+
+**Files:**
+- Modify: `src/mindroom/api/sandbox_runner.py`
+- Modify: `src/mindroom/workers/backends/kubernetes_resources.py`
+- Test: `tests/test_kubernetes_worker_backend.py`
+- Test: `tests/api/test_sandbox_runner_api.py`
+
+- [ ] **Step 1: Write or extend the failing worker payload tests**
+
+Assert that:
+- Kubernetes sends the serialized validation snapshot into worker env
+- sandbox runner reads that snapshot from env
+- worker startup no longer uses placeholder tool factories or placeholder metadata
+
+- [ ] **Step 2: Implement the minimal runtime changes**
+
+Replace:
+- `MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON`
+- `_validation_placeholder_tool_factory()`
+- `_placeholder_tool_metadata()`
+- `_tool_state_with_upstream_allowed_names()`
+
+With:
+- one serialized validation snapshot env payload
+- one env loader in the sandbox runner
+- snapshot-based config validation during worker startup
+
+- [ ] **Step 3: Run focused worker tests**
+
+Run:
+```bash
+PYTHONPATH=/home/basnijholt/Work/dev/mindroom/.worktrees/pr-594-review/src \
+/home/basnijholt/Work/dev/mindroom/.venv/bin/pytest \
+tests/api/test_sandbox_runner_api.py \
+tests/test_kubernetes_worker_backend.py \
+-x -n 0 --no-cov -v
+```
+
+Expected:
+- PASS
+
+### Task 5: Final cleanup, verification, and push
+
+**Files:**
+- Modify only the files touched above
+
+- [ ] **Step 1: Remove obsolete helpers and dead imports**
+
+Delete the old allowed-name plumbing and any no-longer-needed compatibility helpers.
+
+- [ ] **Step 2: Run full focused verification**
+
+Run:
+```bash
+PYTHONPATH=/home/basnijholt/Work/dev/mindroom/.worktrees/pr-594-review/src \
+/home/basnijholt/Work/dev/mindroom/.venv/bin/pytest \
+tests/api/test_sandbox_runner_api.py \
+tests/test_kubernetes_worker_backend.py \
+tests/test_tools_metadata.py \
+-x -n 0 --no-cov -v
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 3: Commit and push**
+
+Run:
+```bash
+git add docs/superpowers/plans/2026-04-15-worker-tool-validation-snapshot.md
+git add tests/api/test_sandbox_runner_api.py tests/test_kubernetes_worker_backend.py tests/test_tools_metadata.py
+git add src/mindroom/tool_system/metadata.py src/mindroom/config/main.py src/mindroom/api/sandbox_runner.py src/mindroom/workers/backends/kubernetes_resources.py
+git commit -m "refactor: split worker tool validation from execution"
+git push
+```

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -25,6 +25,7 @@ from mindroom.api.config_lifecycle import api_runtime_paths as api_request_runti
 from mindroom.api.config_lifecycle import load_config_into_app as load_api_config_into_app
 from mindroom.api.config_lifecycle import raise_for_config_load_result as raise_api_config_load_result
 from mindroom.api.config_lifecycle import read_app_committed_config as read_api_app_committed_config
+from mindroom.api.config_lifecycle import read_app_committed_runtime_config as read_api_app_committed_runtime_config
 from mindroom.api.config_lifecycle import read_committed_config as read_api_committed_config
 from mindroom.api.config_lifecycle import read_raw_config_source as read_api_raw_config_source
 from mindroom.api.config_lifecycle import replace_committed_config as replace_api_committed_config
@@ -54,7 +55,12 @@ from mindroom.orchestration.runtime import matrix_sync_startup_timeout_seconds
 from mindroom.runtime_state import get_runtime_state
 from mindroom.tool_system.dependencies import auto_install_enabled, auto_install_tool_extra
 from mindroom.tool_system.sandbox_proxy import sandbox_proxy_config
-from mindroom.workers.runtime import get_primary_worker_manager, primary_worker_backend_available
+from mindroom.workers.runtime import (
+    get_primary_worker_manager,
+    primary_worker_backend_available,
+    primary_worker_backend_name,
+    serialized_kubernetes_worker_validation_snapshot,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable
@@ -143,7 +149,11 @@ def _worker_cleanup_interval_seconds(runtime_paths: constants.RuntimePaths) -> f
     return max(0.0, interval)
 
 
-def _cleanup_workers_once(runtime_paths: constants.RuntimePaths) -> int:
+def _cleanup_workers_once(
+    runtime_paths: constants.RuntimePaths,
+    *,
+    runtime_config: Config | None = None,
+) -> int:
     """Run one idle-worker cleanup pass when a backend is configured."""
     proxy_config = sandbox_proxy_config(runtime_paths)
     if not primary_worker_backend_available(
@@ -153,11 +163,18 @@ def _cleanup_workers_once(runtime_paths: constants.RuntimePaths) -> int:
     ):
         return 0
 
+    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
+    if runtime_config is not None and primary_worker_backend_name(runtime_paths) == "kubernetes":
+        kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
+            runtime_paths,
+            runtime_config=runtime_config,
+        )
     worker_manager = get_primary_worker_manager(
         runtime_paths,
         proxy_url=proxy_config.proxy_url,
         proxy_token=proxy_config.proxy_token,
         storage_root=runtime_paths.storage_root,
+        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
     )
     cleaned_workers = worker_manager.cleanup_idle_workers()
     if cleaned_workers:
@@ -190,7 +207,19 @@ async def _worker_cleanup_loop(
             break
         except TimeoutError:
             try:
-                await asyncio.to_thread(_cleanup_workers_once, _app_runtime_paths(api_app))
+                try:
+                    runtime_config, runtime_paths = read_api_app_committed_runtime_config(api_app)
+                except HTTPException:
+                    runtime_config = None
+                    runtime_paths = _app_runtime_paths(api_app)
+                if runtime_config is None:
+                    await asyncio.to_thread(_cleanup_workers_once, runtime_paths)
+                else:
+                    await asyncio.to_thread(
+                        _cleanup_workers_once,
+                        runtime_paths,
+                        runtime_config=runtime_config,
+                    )
             except Exception:
                 logger.exception("Background worker cleanup failed")
 

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -163,6 +163,9 @@ def _cleanup_workers_once(
     ):
         return 0
 
+    if runtime_config is None and primary_worker_backend_name(runtime_paths) == "kubernetes":
+        return 0
+
     kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
     if runtime_config is not None and primary_worker_backend_name(runtime_paths) == "kubernetes":
         kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -29,8 +29,12 @@ from mindroom.logging_config import get_logger
 from mindroom.tool_system import sandbox_proxy
 from mindroom.tool_system.metadata import (
     TOOL_METADATA,
+    ToolCategory,
     ToolConfigOverrideError,
     ToolInitOverrideError,
+    ToolMetadata,
+    ToolStatus,
+    SetupType,
     ensure_tool_registry_loaded,
     get_tool_by_name,
     sanitize_tool_init_overrides,
@@ -58,6 +62,7 @@ logger = get_logger(__name__)
 _SUBPROCESS_WORKER_ARG = "--sandbox-subprocess-worker"
 _STARTUP_RUNTIME_PATHS_ENV = "MINDROOM_RUNTIME_PATHS_JSON"
 _RUNNER_TOKEN_ENV = "MINDROOM_SANDBOX_PROXY_TOKEN"  # noqa: S105
+_ALLOWED_TOOL_NAMES_ENV = "MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON"
 
 
 def _startup_runtime_paths_from_env() -> RuntimePaths:
@@ -100,6 +105,54 @@ def _startup_runner_token_from_env() -> str | None:
     return raw_token or None
 
 
+def _upstream_allowed_tool_names_from_env() -> frozenset[str]:
+    raw_payload = os.environ.get(_ALLOWED_TOOL_NAMES_ENV, "").strip()
+    if not raw_payload:
+        return frozenset()
+    payload = json.loads(raw_payload)
+    if not isinstance(payload, list) or any(not isinstance(item, str) for item in payload):
+        msg = f"{_ALLOWED_TOOL_NAMES_ENV} must contain a JSON array of tool names."
+        raise TypeError(msg)
+    return frozenset(item.strip() for item in payload if item.strip())
+
+
+def _validation_placeholder_tool_factory() -> type[Toolkit]:
+    """Fail fast if a validation-only placeholder ever reaches runtime execution."""
+    msg = "Validation placeholder tool factory should never be instantiated."
+    raise RuntimeError(msg)
+
+
+def _placeholder_tool_metadata(tool_name: str) -> ToolMetadata:
+    """Return metadata for an upstream-validated tool unavailable in this worker."""
+    return ToolMetadata(
+        name=tool_name,
+        display_name=tool_name,
+        description="Tool validated in the primary runtime but unavailable in this worker runtime.",
+        category=ToolCategory.INTEGRATIONS,
+        status=ToolStatus.AVAILABLE,
+        setup_type=SetupType.NONE,
+        factory=_validation_placeholder_tool_factory,
+    )
+
+
+def _tool_state_with_upstream_allowed_names(
+    tool_registry: dict[str, Callable[[], type[Toolkit]]],
+    tool_metadata: dict[str, ToolMetadata],
+    *,
+    allowed_tool_names: frozenset[str],
+) -> tuple[dict[str, Callable[[], type[Toolkit]]], dict[str, ToolMetadata]]:
+    """Augment worker-visible tool state with upstream-approved missing tool names."""
+    if not allowed_tool_names:
+        return tool_registry, tool_metadata
+
+    augmented_registry = tool_registry.copy()
+    augmented_metadata = tool_metadata.copy()
+    for tool_name in sorted(allowed_tool_names - set(augmented_metadata)):
+        augmented_registry[tool_name] = _validation_placeholder_tool_factory
+        augmented_metadata[tool_name] = _placeholder_tool_metadata(tool_name)
+    return augmented_registry, augmented_metadata
+
+
 def _runtime_config_or_empty(runtime_paths: RuntimePaths) -> Config:
     """Return the worker runtime config visible inside one sandbox runner.
 
@@ -119,9 +172,10 @@ def _runtime_config_or_empty(runtime_paths: RuntimePaths) -> Config:
             context={"runtime_paths": runtime_paths},
         )
         config = _config_with_available_plugins(config, runtime_paths)
+        allowed_tool_names = _upstream_allowed_tool_names_from_env()
 
-        # Still reject malformed plugins and registry collisions for the
-        # plugin/tool surface that is actually visible inside this worker.
+        # Validate authored tool references against the worker-visible registry
+        # plus the upstream-approved tool names from the primary runtime.
         from mindroom.tool_system.metadata import (  # noqa: PLC0415
             ToolConfigOverrideError,
             ToolMetadataValidationError,
@@ -130,7 +184,16 @@ def _runtime_config_or_empty(runtime_paths: RuntimePaths) -> Config:
         from mindroom.tool_system.plugins import PluginValidationError  # noqa: PLC0415
 
         try:
-            resolved_tool_state_for_runtime(runtime_paths, config)
+            tool_registry, tool_metadata = resolved_tool_state_for_runtime(runtime_paths, config)
+            validated_registry, validated_metadata = _tool_state_with_upstream_allowed_names(
+                tool_registry,
+                tool_metadata,
+                allowed_tool_names=allowed_tool_names,
+            )
+            config._validate_authored_tool_entries_with_state(
+                tool_registry=validated_registry,
+                tool_metadata=validated_metadata,
+            )
         except (PluginValidationError, ToolConfigOverrideError, ToolMetadataValidationError) as exc:
             raise ConfigRuntimeValidationError(str(exc)) from exc
         return config

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -29,17 +29,17 @@ from mindroom.logging_config import get_logger
 from mindroom.tool_system import sandbox_proxy
 from mindroom.tool_system.metadata import (
     TOOL_METADATA,
-    ToolCategory,
     ToolConfigOverrideError,
     ToolInitOverrideError,
-    ToolMetadata,
-    ToolStatus,
-    SetupType,
+    ToolMetadataValidationError,
+    deserialize_tool_validation_snapshot,
     ensure_tool_registry_loaded,
     get_tool_by_name,
+    resolved_tool_validation_snapshot_for_runtime,
     sanitize_tool_init_overrides,
     validate_authored_overrides,
 )
+from mindroom.tool_system.plugins import PluginValidationError
 from mindroom.tool_system.sandbox_proxy import to_json_compatible
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
@@ -62,7 +62,7 @@ logger = get_logger(__name__)
 _SUBPROCESS_WORKER_ARG = "--sandbox-subprocess-worker"
 _STARTUP_RUNTIME_PATHS_ENV = "MINDROOM_RUNTIME_PATHS_JSON"
 _RUNNER_TOKEN_ENV = "MINDROOM_SANDBOX_PROXY_TOKEN"  # noqa: S105
-_ALLOWED_TOOL_NAMES_ENV = "MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON"
+_TOOL_VALIDATION_SNAPSHOT_ENV = "MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON"
 
 
 def _startup_runtime_paths_from_env() -> RuntimePaths:
@@ -105,52 +105,11 @@ def _startup_runner_token_from_env() -> str | None:
     return raw_token or None
 
 
-def _upstream_allowed_tool_names_from_env() -> frozenset[str]:
-    raw_payload = os.environ.get(_ALLOWED_TOOL_NAMES_ENV, "").strip()
+def _upstream_tool_validation_snapshot_from_env() -> dict[str, object]:
+    raw_payload = os.environ.get(_TOOL_VALIDATION_SNAPSHOT_ENV, "").strip()
     if not raw_payload:
-        return frozenset()
-    payload = json.loads(raw_payload)
-    if not isinstance(payload, list) or any(not isinstance(item, str) for item in payload):
-        msg = f"{_ALLOWED_TOOL_NAMES_ENV} must contain a JSON array of tool names."
-        raise TypeError(msg)
-    return frozenset(item.strip() for item in payload if item.strip())
-
-
-def _validation_placeholder_tool_factory() -> type[Toolkit]:
-    """Fail fast if a validation-only placeholder ever reaches runtime execution."""
-    msg = "Validation placeholder tool factory should never be instantiated."
-    raise RuntimeError(msg)
-
-
-def _placeholder_tool_metadata(tool_name: str) -> ToolMetadata:
-    """Return metadata for an upstream-validated tool unavailable in this worker."""
-    return ToolMetadata(
-        name=tool_name,
-        display_name=tool_name,
-        description="Tool validated in the primary runtime but unavailable in this worker runtime.",
-        category=ToolCategory.INTEGRATIONS,
-        status=ToolStatus.AVAILABLE,
-        setup_type=SetupType.NONE,
-        factory=_validation_placeholder_tool_factory,
-    )
-
-
-def _tool_state_with_upstream_allowed_names(
-    tool_registry: dict[str, Callable[[], type[Toolkit]]],
-    tool_metadata: dict[str, ToolMetadata],
-    *,
-    allowed_tool_names: frozenset[str],
-) -> tuple[dict[str, Callable[[], type[Toolkit]]], dict[str, ToolMetadata]]:
-    """Augment worker-visible tool state with upstream-approved missing tool names."""
-    if not allowed_tool_names:
-        return tool_registry, tool_metadata
-
-    augmented_registry = tool_registry.copy()
-    augmented_metadata = tool_metadata.copy()
-    for tool_name in sorted(allowed_tool_names - set(augmented_metadata)):
-        augmented_registry[tool_name] = _validation_placeholder_tool_factory
-        augmented_metadata[tool_name] = _placeholder_tool_metadata(tool_name)
-    return augmented_registry, augmented_metadata
+        return {}
+    return deserialize_tool_validation_snapshot(json.loads(raw_payload))
 
 
 def _runtime_config_or_empty(runtime_paths: RuntimePaths) -> Config:
@@ -172,29 +131,24 @@ def _runtime_config_or_empty(runtime_paths: RuntimePaths) -> Config:
             context={"runtime_paths": runtime_paths},
         )
         config = _config_with_available_plugins(config, runtime_paths)
-        allowed_tool_names = _upstream_allowed_tool_names_from_env()
-
-        # Validate authored tool references against the worker-visible registry
-        # plus the upstream-approved tool names from the primary runtime.
-        from mindroom.tool_system.metadata import (  # noqa: PLC0415
-            ToolConfigOverrideError,
-            ToolMetadataValidationError,
-            resolved_tool_state_for_runtime,
-        )
-        from mindroom.tool_system.plugins import PluginValidationError  # noqa: PLC0415
 
         try:
-            tool_registry, tool_metadata = resolved_tool_state_for_runtime(runtime_paths, config)
-            validated_registry, validated_metadata = _tool_state_with_upstream_allowed_names(
-                tool_registry,
-                tool_metadata,
-                allowed_tool_names=allowed_tool_names,
+            tool_validation_snapshot = _upstream_tool_validation_snapshot_from_env()
+            if not tool_validation_snapshot:
+                tool_validation_snapshot = resolved_tool_validation_snapshot_for_runtime(
+                    runtime_paths,
+                    config,
+                )
+            config._validate_authored_tool_entries_with_snapshot(
+                tool_validation_snapshot=tool_validation_snapshot,
             )
-            config._validate_authored_tool_entries_with_state(
-                tool_registry=validated_registry,
-                tool_metadata=validated_metadata,
-            )
-        except (PluginValidationError, ToolConfigOverrideError, ToolMetadataValidationError) as exc:
+        except (
+            PluginValidationError,
+            ToolConfigOverrideError,
+            ToolMetadataValidationError,
+            TypeError,
+            ValueError,
+        ) as exc:
             raise ConfigRuntimeValidationError(str(exc)) from exc
         return config
     return Config.validate_with_runtime({}, runtime_paths)

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -17,12 +17,13 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Annotated, Any
 
+import yaml
 from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request
 from pydantic import BaseModel, Field, ValidationError
 
 from mindroom import constants
 from mindroom.api import sandbox_exec, sandbox_protocol, sandbox_worker_prep
-from mindroom.config.main import Config, load_config
+from mindroom.config.main import Config, ConfigRuntimeValidationError, _normalized_config_data
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager
 from mindroom.logging_config import get_logger
 from mindroom.tool_system import sandbox_proxy
@@ -100,10 +101,75 @@ def _startup_runner_token_from_env() -> str | None:
 
 
 def _runtime_config_or_empty(runtime_paths: RuntimePaths) -> Config:
-    """Return the active runtime config, or an explicit empty config if none exists."""
+    """Return the worker runtime config visible inside one sandbox runner.
+
+    Dedicated workers should load only the plugin surface that is actually
+    installed inside the worker runtime. They should not fail startup because
+    the primary deployment config references plugins that are mounted only in
+    the main app pod.
+    """
     if runtime_paths.config_path.exists():
-        return load_config(runtime_paths)
+        with runtime_paths.config_path.open() as f:
+            data = yaml.safe_load(f) or {}
+
+        # Worker runtimes only need the authored config shape plus the subset
+        # of plugin entries that actually exist in that runtime filesystem.
+        config = Config.model_validate(
+            _normalized_config_data(data),
+            context={"runtime_paths": runtime_paths},
+        )
+        config = _config_with_available_plugins(config, runtime_paths)
+
+        # Still reject malformed plugins and registry collisions for the
+        # plugin/tool surface that is actually visible inside this worker.
+        from mindroom.tool_system.metadata import (  # noqa: PLC0415
+            ToolConfigOverrideError,
+            ToolMetadataValidationError,
+            resolved_tool_state_for_runtime,
+        )
+        from mindroom.tool_system.plugins import PluginValidationError  # noqa: PLC0415
+
+        try:
+            resolved_tool_state_for_runtime(runtime_paths, config)
+        except (PluginValidationError, ToolConfigOverrideError, ToolMetadataValidationError) as exc:
+            raise ConfigRuntimeValidationError(str(exc)) from exc
+        return config
     return Config.validate_with_runtime({}, runtime_paths)
+
+
+def _config_with_available_plugins(config: Config, runtime_paths: RuntimePaths) -> Config:
+    """Return one config snapshot filtered to plugin entries visible in this runtime."""
+    if not config.plugins:
+        return config
+
+    from mindroom.tool_system import plugins as plugin_module  # noqa: PLC0415
+
+    available_plugins = []
+    skipped_plugin_paths: list[str] = []
+    for plugin_entry in config.plugins:
+        if not plugin_entry.enabled:
+            available_plugins.append(plugin_entry)
+            continue
+
+        try:
+            plugin_root = plugin_module._resolve_plugin_root(plugin_entry.path, runtime_paths)
+        except Exception:
+            skipped_plugin_paths.append(plugin_entry.path)
+            continue
+
+        if plugin_root.exists() and plugin_root.is_dir():
+            available_plugins.append(plugin_entry)
+        else:
+            skipped_plugin_paths.append(plugin_entry.path)
+
+    if not skipped_plugin_paths:
+        return config
+
+    logger.info(
+        "sandbox_runner_skipping_unavailable_plugins",
+        plugin_paths=sorted(skipped_plugin_paths),
+    )
+    return config.model_copy(update={"plugins": available_plugins}, deep=True)
 
 
 def _load_config_from_startup_runtime() -> tuple[RuntimePaths, Config]:

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from mindroom import constants
 from mindroom.api import sandbox_exec, sandbox_protocol, sandbox_worker_prep
-from mindroom.config.main import Config, ConfigRuntimeValidationError, _normalized_config_data
+from mindroom.config.main import Config, ConfigRuntimeValidationError, _normalized_config_data, load_config
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager
 from mindroom.logging_config import get_logger
 from mindroom.tool_system import sandbox_proxy
@@ -35,9 +35,8 @@ from mindroom.tool_system.metadata import (
     deserialize_tool_validation_snapshot,
     ensure_tool_registry_loaded,
     get_tool_by_name,
-    resolved_tool_validation_snapshot_for_runtime,
     sanitize_tool_init_overrides,
-    validate_authored_overrides,
+    validate_authored_tool_entry_overrides,
 )
 from mindroom.tool_system.plugins import PluginValidationError
 from mindroom.tool_system.sandbox_proxy import to_json_compatible
@@ -113,45 +112,45 @@ def _upstream_tool_validation_snapshot_from_env() -> dict[str, object]:
 
 
 def _runtime_config_or_empty(runtime_paths: RuntimePaths) -> Config:
-    """Return the worker runtime config visible inside one sandbox runner.
-
-    Dedicated workers should load only the plugin surface that is actually
-    installed inside the worker runtime. They should not fail startup because
-    the primary deployment config references plugins that are mounted only in
-    the main app pod.
-    """
+    """Return the runtime config visible inside one sandbox runner."""
     if runtime_paths.config_path.exists():
-        with runtime_paths.config_path.open() as f:
-            data = yaml.safe_load(f) or {}
-
-        # Worker runtimes only need the authored config shape plus the subset
-        # of plugin entries that actually exist in that runtime filesystem.
-        config = Config.model_validate(
-            _normalized_config_data(data),
-            context={"runtime_paths": runtime_paths},
-        )
-        config = _config_with_available_plugins(config, runtime_paths)
-
-        try:
-            tool_validation_snapshot = _upstream_tool_validation_snapshot_from_env()
-            if not tool_validation_snapshot:
-                tool_validation_snapshot = resolved_tool_validation_snapshot_for_runtime(
-                    runtime_paths,
-                    config,
-                )
-            config._validate_authored_tool_entries_with_snapshot(
-                tool_validation_snapshot=tool_validation_snapshot,
-            )
-        except (
-            PluginValidationError,
-            ToolConfigOverrideError,
-            ToolMetadataValidationError,
-            TypeError,
-            ValueError,
-        ) as exc:
-            raise ConfigRuntimeValidationError(str(exc)) from exc
-        return config
+        if not sandbox_exec.runner_uses_dedicated_worker(runtime_paths):
+            return load_config(runtime_paths)
+        return _dedicated_worker_runtime_config_or_empty(runtime_paths)
     return Config.validate_with_runtime({}, runtime_paths)
+
+
+def _dedicated_worker_runtime_config_or_empty(runtime_paths: RuntimePaths) -> Config:
+    """Return dedicated-worker config, tolerating plugins unavailable in that worker image."""
+    with runtime_paths.config_path.open() as f:
+        data = yaml.safe_load(f) or {}
+
+    tool_validation_snapshot = _upstream_tool_validation_snapshot_from_env()
+    if not tool_validation_snapshot:
+        return load_config(runtime_paths)
+
+    # Dedicated workers only need the authored config shape plus the subset of
+    # plugin entries that actually exist in that runtime filesystem. Upstream
+    # validation remains authoritative for the full configured tool surface.
+    config = Config.model_validate(
+        _normalized_config_data(data),
+        context={"runtime_paths": runtime_paths},
+    )
+    config = _config_with_available_plugins(config, runtime_paths)
+
+    try:
+        config._validate_authored_tool_entries_with_snapshot(
+            tool_validation_snapshot=tool_validation_snapshot,
+        )
+    except (
+        PluginValidationError,
+        ToolConfigOverrideError,
+        ToolMetadataValidationError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise ConfigRuntimeValidationError(str(exc)) from exc
+    return config
 
 
 def _config_with_available_plugins(config: Config, runtime_paths: RuntimePaths) -> Config:
@@ -781,7 +780,7 @@ def _validate_execute_request_payload(
             raise HTTPException(status_code=400, detail=str(exc)) from exc
     if payload.tool_config_overrides:
         try:
-            payload.tool_config_overrides = validate_authored_overrides(
+            payload.tool_config_overrides = validate_authored_tool_entry_overrides(
                 payload.tool_name,
                 payload.tool_config_overrides,
                 config_path_prefix="request.tool_config_overrides",

--- a/src/mindroom/api/workers.py
+++ b/src/mindroom/api/workers.py
@@ -7,8 +7,14 @@ from typing import TYPE_CHECKING
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from mindroom.api import config_lifecycle
 from mindroom.tool_system.sandbox_proxy import sandbox_proxy_config
-from mindroom.workers.runtime import get_primary_worker_manager, primary_worker_backend_available
+from mindroom.workers.runtime import (
+    get_primary_worker_manager,
+    primary_worker_backend_available,
+    primary_worker_backend_name,
+    serialized_kubernetes_worker_validation_snapshot,
+)
 
 if TYPE_CHECKING:
     from mindroom.workers.manager import WorkerManager
@@ -68,9 +74,7 @@ def _serialize_worker(worker: WorkerHandle) -> WorkerResponse:
 
 
 def _worker_manager(request: Request) -> WorkerManager:
-    from mindroom.api.main import api_runtime_paths  # noqa: PLC0415
-
-    runtime_paths = api_runtime_paths(request)
+    runtime_config, runtime_paths = config_lifecycle.read_committed_runtime_config(request)
     proxy_config = sandbox_proxy_config(runtime_paths)
     if not primary_worker_backend_available(
         runtime_paths,
@@ -78,11 +82,18 @@ def _worker_manager(request: Request) -> WorkerManager:
         proxy_token=proxy_config.proxy_token,
     ):
         raise HTTPException(status_code=503, detail="Worker backend is not configured.")
+    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
+    if primary_worker_backend_name(runtime_paths) == "kubernetes":
+        kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
+            runtime_paths,
+            runtime_config=runtime_config,
+        )
     return get_primary_worker_manager(
         runtime_paths,
         proxy_url=proxy_config.proxy_url,
         proxy_token=proxy_config.proxy_token,
         storage_root=runtime_paths.storage_root,
+        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
     )
 
 

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -56,19 +56,16 @@ from mindroom.mcp.config import MCPServerConfig, normalize_mcp_server_id
 from mindroom.tool_system.metadata import (
     ToolConfigOverrideError,
     ToolMetadataValidationError,
-    resolved_tool_state_for_runtime,
+    ToolValidationInfo,
+    resolved_tool_validation_snapshot_for_runtime,
+    validate_authored_tool_entry_overrides,
 )
 from mindroom.tool_system.plugins import PluginValidationError
 from mindroom.tool_system.worker_routing import unsupported_shared_only_integration_names
 from mindroom.workspaces import validate_workspace_template_dir
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
-    from agno.tools.toolkit import Toolkit
-
     from mindroom.matrix.identity import MatrixID
-    from mindroom.tool_system.metadata import ToolMetadata
     from mindroom.tool_system.worker_routing import WorkerScope
 
 _AGENT_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_]+$")
@@ -1209,29 +1206,19 @@ class Config(BaseModel):
         entry: ToolConfigEntry,
         *,
         config_path_prefix: str,
-        tool_registry: dict[str, Any],
-        tool_metadata: dict[str, Any],
+        tool_validation_snapshot: dict[str, ToolValidationInfo],
     ) -> None:
-        """Validate one authored tool entry against the loaded tool metadata."""
-        from mindroom.mcp.registry import _MCP_TOOL_FACTORY_MARKER, validate_mcp_agent_overrides  # noqa: PLC0415
-        from mindroom.tool_system.metadata import validate_authored_overrides  # noqa: PLC0415
-
-        if entry.name not in tool_metadata and not self.is_tool_preset(entry.name):
+        """Validate one authored tool entry against the resolved validation snapshot."""
+        if entry.name not in tool_validation_snapshot and not self.is_tool_preset(entry.name):
             msg = f"{config_path_prefix}.{entry.name}: Unknown tool '{entry.name}'."
             raise ToolConfigOverrideError(msg)
 
-        validated_overrides = validate_authored_overrides(
+        validate_authored_tool_entry_overrides(
             entry.name,
             entry.overrides,
             config_path_prefix=config_path_prefix,
-            tool_metadata=tool_metadata,
+            tool_metadata=tool_validation_snapshot,
         )
-        tool_factory = tool_registry.get(entry.name)
-        if tool_factory is not None and getattr(tool_factory, _MCP_TOOL_FACTORY_MARKER, False):
-            try:
-                validate_mcp_agent_overrides(entry.name, validated_overrides)
-            except ValueError as exc:
-                raise ToolConfigOverrideError(str(exc)) from exc
 
     def _validate_authored_tool_entries(
         self,
@@ -1239,38 +1226,34 @@ class Config(BaseModel):
         *,
         tolerate_plugin_load_errors: bool = False,
     ) -> None:
-        """Validate defaults and per-agent authored tool overrides with runtime metadata loaded."""
-        tool_registry, tool_metadata = resolved_tool_state_for_runtime(
+        """Validate authored tool references against one resolved validation snapshot."""
+        tool_validation_snapshot = resolved_tool_validation_snapshot_for_runtime(
             runtime_paths,
             self,
             tolerate_plugin_load_errors=tolerate_plugin_load_errors,
         )
-        self._validate_authored_tool_entries_with_state(
-            tool_registry=tool_registry,
-            tool_metadata=tool_metadata,
+        self._validate_authored_tool_entries_with_snapshot(
+            tool_validation_snapshot=tool_validation_snapshot,
         )
 
-    def _validate_authored_tool_entries_with_state(
+    def _validate_authored_tool_entries_with_snapshot(
         self,
         *,
-        tool_registry: dict[str, Callable[[], type[Toolkit]]],
-        tool_metadata: dict[str, ToolMetadata],
+        tool_validation_snapshot: dict[str, ToolValidationInfo],
     ) -> None:
-        """Validate authored tool references against one already-resolved tool state."""
+        """Validate authored tool references against one already-resolved validation snapshot."""
         for index, entry in enumerate(self.defaults.tools):
             self._validate_authored_tool_entry(
                 entry,
                 config_path_prefix=f"defaults.tools[{index}]",
-                tool_registry=tool_registry,
-                tool_metadata=tool_metadata,
+                tool_validation_snapshot=tool_validation_snapshot,
             )
         for agent_name, agent_config in self.agents.items():
             for index, entry in enumerate(agent_config.tools):
                 self._validate_authored_tool_entry(
                     entry,
                     config_path_prefix=f"agents.{agent_name}.tools[{index}]",
-                    tool_registry=tool_registry,
-                    tool_metadata=tool_metadata,
+                    tool_validation_snapshot=tool_validation_snapshot,
                 )
         for toolkit_name, toolkit in self.toolkits.items():
             for index, entry in enumerate(toolkit.tools):
@@ -1281,7 +1264,8 @@ class Config(BaseModel):
                         f"control-plane tool '{entry.name}'."
                     )
                     raise ValueError(msg)
-                if entry.name not in tool_registry:
+                validation_info = tool_validation_snapshot.get(entry.name)
+                if validation_info is None or not validation_info.runtime_loadable:
                     msg = (
                         f"{config_path_prefix}.{entry.name}: Toolkit tools must resolve through the normal "
                         f"tool registry; '{entry.name}' is not supported."
@@ -1290,8 +1274,7 @@ class Config(BaseModel):
                 self._validate_authored_tool_entry(
                     entry,
                     config_path_prefix=config_path_prefix,
-                    tool_registry=tool_registry,
-                    tool_metadata=tool_metadata,
+                    tool_validation_snapshot=tool_validation_snapshot,
                 )
 
     def get_toolkit_tool_configs(self, toolkit_name: str) -> list[ResolvedToolConfig]:

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -59,7 +59,12 @@ from mindroom.tool_system.worker_routing import unsupported_shared_only_integrat
 from mindroom.workspaces import validate_workspace_template_dir
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from agno.tools.toolkit import Toolkit
+
     from mindroom.matrix.identity import MatrixID
+    from mindroom.tool_system.metadata import ToolMetadata
     from mindroom.tool_system.worker_routing import WorkerScope
 
 _AGENT_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_]+$")
@@ -1238,6 +1243,18 @@ class Config(BaseModel):
             self,
             tolerate_plugin_load_errors=tolerate_plugin_load_errors,
         )
+        self._validate_authored_tool_entries_with_state(
+            tool_registry=tool_registry,
+            tool_metadata=tool_metadata,
+        )
+
+    def _validate_authored_tool_entries_with_state(
+        self,
+        *,
+        tool_registry: dict[str, Callable[[], type[Toolkit]]],
+        tool_metadata: dict[str, ToolMetadata],
+    ) -> None:
+        """Validate authored tool references against one already-resolved tool state."""
         for index, entry in enumerate(self.defaults.tools):
             self._validate_authored_tool_entry(
                 entry,

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -53,7 +53,11 @@ from mindroom.matrix.identity import (
     managed_space_alias_localpart,
 )
 from mindroom.mcp.config import MCPServerConfig, normalize_mcp_server_id
-from mindroom.tool_system.metadata import ToolConfigOverrideError, ToolMetadataValidationError
+from mindroom.tool_system.metadata import (
+    ToolConfigOverrideError,
+    ToolMetadataValidationError,
+    resolved_tool_state_for_runtime,
+)
 from mindroom.tool_system.plugins import PluginValidationError
 from mindroom.tool_system.worker_routing import unsupported_shared_only_integration_names
 from mindroom.workspaces import validate_workspace_template_dir
@@ -1236,8 +1240,6 @@ class Config(BaseModel):
         tolerate_plugin_load_errors: bool = False,
     ) -> None:
         """Validate defaults and per-agent authored tool overrides with runtime metadata loaded."""
-        from mindroom.tool_system.metadata import resolved_tool_state_for_runtime  # noqa: PLC0415
-
         tool_registry, tool_metadata = resolved_tool_state_for_runtime(
             runtime_paths,
             self,

--- a/src/mindroom/mcp/registry.py
+++ b/src/mindroom/mcp/registry.py
@@ -10,6 +10,7 @@ from mindroom.tool_system.metadata import (
     TOOL_METADATA,
     ConfigField,
     SetupType,
+    ToolAuthoredOverrideValidator,
     ToolCategory,
     ToolMetadata,
     ToolStatus,
@@ -122,6 +123,7 @@ def _tool_metadata(server_id: str, server_config: MCPServerConfig) -> ToolMetada
         setup_type=SetupType.NONE,
         config_fields=_tool_override_fields(),
         agent_override_fields=_tool_override_fields(),
+        authored_override_validator=ToolAuthoredOverrideValidator.MCP,
     )
 
 

--- a/src/mindroom/tool_system/dynamic_toolkits.py
+++ b/src/mindroom/tool_system/dynamic_toolkits.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from mindroom.config.models import ResolvedToolConfig
 from mindroom.logging_config import get_logger
+from mindroom.tool_system.metadata import validate_authored_tool_entry_overrides
 
 if TYPE_CHECKING:
     from mindroom.config.main import Config
@@ -112,9 +113,7 @@ def _normalize_effective_tool_config_overrides(
     tool_name: str,
     overrides: dict[str, object],
 ) -> dict[str, object]:
-    from mindroom.tool_system.metadata import validate_authored_overrides  # noqa: PLC0415
-
-    return validate_authored_overrides(tool_name, overrides)
+    return validate_authored_tool_entry_overrides(tool_name, overrides)
 
 
 def get_loaded_toolkits_for_session(

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -1223,6 +1223,10 @@ def deserialize_tool_validation_snapshot(payload: object) -> dict[str, ToolValid
                 f"authored_override_validator '{raw_validator}'."
             )
             raise TypeError(msg) from exc
+        raw_runtime_loadable = raw_info.get("runtime_loadable", True)
+        if not isinstance(raw_runtime_loadable, bool):
+            msg = f"Tool validation snapshot entry for '{tool_name}' must set runtime_loadable to a boolean."
+            raise TypeError(msg)
         snapshot[tool_name] = ToolValidationInfo(
             name=tool_name,
             config_fields=_deserialize_tool_validation_fields(
@@ -1234,7 +1238,7 @@ def deserialize_tool_validation_snapshot(payload: object) -> dict[str, ToolValid
                 field_name=f"{tool_name}.agent_override_fields",
             ),
             authored_override_validator=authored_override_validator,
-            runtime_loadable=bool(raw_info.get("runtime_loadable", True)),
+            runtime_loadable=raw_runtime_loadable,
         )
     return snapshot
 

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -64,6 +64,13 @@ class ToolMetadataValidationError(ValueError):
     """Raised when runtime tool metadata derived from authored config is invalid."""
 
 
+class ToolAuthoredOverrideValidator(str, Enum):
+    """Explicit authored-override validation modes for a tool."""
+
+    DEFAULT = "default"
+    MCP = "mcp"
+
+
 @dataclass(frozen=True)
 class _ToolRegistrySnapshot:
     registry: dict[str, Callable[[], type[Toolkit]]]
@@ -271,7 +278,7 @@ def _agent_override_field(
     tool_name: str,
     field_name: str,
     *,
-    tool_metadata: dict[str, ToolMetadata] | None = None,
+    tool_metadata: Mapping[str, ToolMetadata | ToolValidationInfo] | None = None,
 ) -> ConfigField | None:
     """Return one tool's agent override field metadata when it exists."""
     metadata_by_name = TOOL_METADATA if tool_metadata is None else tool_metadata
@@ -287,7 +294,7 @@ def _validate_text_authored_override_value(
     value: object,
     *,
     full_path: str,
-    tool_metadata: dict[str, ToolMetadata] | None = None,
+    tool_metadata: Mapping[str, ToolMetadata | ToolValidationInfo] | None = None,
 ) -> object:
     """Validate one authored override for a text-like config field."""
     agent_override_field = _agent_override_field(tool_name, field.name, tool_metadata=tool_metadata)
@@ -313,7 +320,7 @@ def _validate_authored_override_value(
     value: object,
     *,
     full_path: str,
-    tool_metadata: dict[str, ToolMetadata] | None = None,
+    tool_metadata: Mapping[str, ToolMetadata | ToolValidationInfo] | None = None,
 ) -> object:
     """Validate one authored override value against its declared config field type."""
     if is_authored_override_inherit(value):
@@ -354,7 +361,7 @@ def validate_authored_overrides(
     overrides: dict[str, object] | None,
     *,
     config_path_prefix: str | None = None,
-    tool_metadata: dict[str, ToolMetadata] | None = None,
+    tool_metadata: Mapping[str, ToolMetadata | ToolValidationInfo] | None = None,
 ) -> dict[str, object]:
     """Validate authored YAML overrides against one tool's declared config fields."""
     if not overrides:
@@ -393,6 +400,53 @@ def validate_authored_overrides(
             tool_metadata=tool_metadata,
         )
     return validated
+
+
+def _run_authored_override_validator(
+    tool_name: str,
+    overrides: dict[str, object],
+    *,
+    validator: ToolAuthoredOverrideValidator,
+) -> None:
+    """Run one tool-specific authored-override validator against normalized overrides."""
+    if not overrides or validator == ToolAuthoredOverrideValidator.DEFAULT:
+        return
+    if validator == ToolAuthoredOverrideValidator.MCP:
+        from mindroom.mcp.registry import validate_mcp_agent_overrides  # noqa: PLC0415
+
+        validate_mcp_agent_overrides(tool_name, overrides)
+        return
+    msg = f"Unsupported authored override validator '{validator}'."
+    raise ValueError(msg)
+
+
+def validate_authored_tool_entry_overrides(
+    tool_name: str,
+    overrides: dict[str, object] | None,
+    *,
+    config_path_prefix: str | None = None,
+    tool_metadata: Mapping[str, ToolMetadata | ToolValidationInfo] | None = None,
+) -> dict[str, object]:
+    """Validate authored overrides, including any tool-specific validation mode."""
+    validated_overrides = validate_authored_overrides(
+        tool_name,
+        overrides,
+        config_path_prefix=config_path_prefix,
+        tool_metadata=tool_metadata,
+    )
+    metadata_by_name = TOOL_METADATA if tool_metadata is None else tool_metadata
+    metadata = metadata_by_name.get(tool_name)
+    if metadata is None:
+        return validated_overrides
+    try:
+        _run_authored_override_validator(
+            tool_name,
+            validated_overrides,
+            validator=metadata.authored_override_validator,
+        )
+    except ValueError as exc:
+        raise ToolConfigOverrideError(str(exc)) from exc
+    return validated_overrides
 
 
 def sanitize_tool_init_overrides(
@@ -712,6 +766,17 @@ class ConfigField:
     authored_override: bool = True
 
 
+@dataclass(frozen=True)
+class ToolValidationInfo:
+    """Validation-only metadata for authored tool references."""
+
+    name: str
+    config_fields: tuple[ConfigField, ...] = ()
+    agent_override_fields: tuple[ConfigField, ...] = ()
+    authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT
+    runtime_loadable: bool = True
+
+
 @dataclass
 class ToolMetadata:
     """Complete metadata for a tool."""
@@ -727,6 +792,7 @@ class ToolMetadata:
     icon_color: str | None = None  # Tailwind color class like "text-blue-500"
     config_fields: list[ConfigField] | None = None  # Detailed field definitions
     agent_override_fields: list[ConfigField] | None = None  # Safe per-agent override field definitions
+    authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT
     dependencies: list[str] | None = None  # Required pip packages
     auth_provider: str | None = None  # Name of integration that provides auth (e.g., "google")
     docs_url: str | None = None  # Documentation URL
@@ -752,6 +818,7 @@ def register_tool_with_metadata(
     icon_color: str | None = None,
     config_fields: list[ConfigField] | None = None,
     agent_override_fields: list[ConfigField] | None = None,
+    authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT,
     dependencies: list[str] | None = None,
     auth_provider: str | None = None,
     docs_url: str | None = None,
@@ -775,6 +842,7 @@ def register_tool_with_metadata(
         icon_color: CSS color class for the icon
         config_fields: List of configuration fields
         agent_override_fields: Safe per-agent override fields serialized via config.yaml
+        authored_override_validator: Explicit authored-override validation mode for the tool
         dependencies: Required Python packages
         auth_provider: Name of integration that provides authentication
         docs_url: Link to documentation
@@ -800,6 +868,7 @@ def register_tool_with_metadata(
             icon_color=icon_color,
             config_fields=config_fields,
             agent_override_fields=agent_override_fields,
+            authored_override_validator=authored_override_validator,
             dependencies=dependencies,
             auth_provider=auth_provider,
             docs_url=docs_url,
@@ -1068,6 +1137,108 @@ def resolved_tool_metadata_for_runtime(
     return desired_metadata
 
 
+def tool_validation_snapshot_from_state(
+    tool_registry: Mapping[str, Callable[[], type[Toolkit]]],
+    tool_metadata: Mapping[str, ToolMetadata],
+) -> dict[str, ToolValidationInfo]:
+    """Project runtime tool state into a validation-only snapshot."""
+    return {
+        tool_name: ToolValidationInfo(
+            name=tool_name,
+            config_fields=tuple(metadata.config_fields or ()),
+            agent_override_fields=tuple(metadata.agent_override_fields or ()),
+            authored_override_validator=metadata.authored_override_validator,
+            runtime_loadable=tool_name in tool_registry,
+        )
+        for tool_name, metadata in tool_metadata.items()
+    }
+
+
+def resolved_tool_validation_snapshot_for_runtime(
+    runtime_paths: RuntimePaths,
+    config: Config,
+    *,
+    tolerate_plugin_load_errors: bool = False,
+) -> dict[str, ToolValidationInfo]:
+    """Return validation-only tool state visible for one runtime config."""
+    tool_registry, desired_metadata = resolved_tool_state_for_runtime(
+        runtime_paths,
+        config,
+        tolerate_plugin_load_errors=tolerate_plugin_load_errors,
+    )
+    return tool_validation_snapshot_from_state(tool_registry, desired_metadata)
+
+
+def serialize_tool_validation_snapshot(
+    tool_validation_snapshot: Mapping[str, ToolValidationInfo],
+) -> dict[str, dict[str, object]]:
+    """Export one validation snapshot as a JSON-serializable object."""
+    return {
+        tool_name: {
+            "config_fields": [asdict(field) for field in info.config_fields],
+            "agent_override_fields": [asdict(field) for field in info.agent_override_fields],
+            "authored_override_validator": info.authored_override_validator.value,
+            "runtime_loadable": info.runtime_loadable,
+        }
+        for tool_name, info in sorted(tool_validation_snapshot.items())
+    }
+
+
+def _deserialize_tool_validation_fields(raw_fields: object, *, field_name: str) -> tuple[ConfigField, ...]:
+    """Deserialize one serialized config-field list from a validation snapshot."""
+    if raw_fields is None:
+        return ()
+    if not isinstance(raw_fields, list):
+        msg = f"{field_name} must be a list of config field objects."
+        raise TypeError(msg)
+    fields: list[ConfigField] = []
+    for index, raw_field in enumerate(raw_fields):
+        if not isinstance(raw_field, dict):
+            msg = f"{field_name}[{index}] must be an object."
+            raise TypeError(msg)
+        fields.append(ConfigField(**raw_field))
+    return tuple(fields)
+
+
+def deserialize_tool_validation_snapshot(payload: object) -> dict[str, ToolValidationInfo]:
+    """Deserialize one JSON payload into validation-only tool metadata."""
+    if not isinstance(payload, dict) or any(not isinstance(tool_name, str) for tool_name in payload):
+        msg = "Tool validation snapshot must be a JSON object keyed by tool name."
+        raise TypeError(msg)
+
+    snapshot: dict[str, ToolValidationInfo] = {}
+    for tool_name, raw_info in payload.items():
+        if not isinstance(raw_info, dict):
+            msg = f"Tool validation snapshot entry for '{tool_name}' must be an object."
+            raise TypeError(msg)
+        raw_validator = raw_info.get(
+            "authored_override_validator",
+            ToolAuthoredOverrideValidator.DEFAULT.value,
+        )
+        try:
+            authored_override_validator = ToolAuthoredOverrideValidator(raw_validator)
+        except ValueError as exc:
+            msg = (
+                f"Tool validation snapshot entry for '{tool_name}' has unsupported "
+                f"authored_override_validator '{raw_validator}'."
+            )
+            raise TypeError(msg) from exc
+        snapshot[tool_name] = ToolValidationInfo(
+            name=tool_name,
+            config_fields=_deserialize_tool_validation_fields(
+                raw_info.get("config_fields", []),
+                field_name=f"{tool_name}.config_fields",
+            ),
+            agent_override_fields=_deserialize_tool_validation_fields(
+                raw_info.get("agent_override_fields", []),
+                field_name=f"{tool_name}.agent_override_fields",
+            ),
+            authored_override_validator=authored_override_validator,
+            runtime_loadable=bool(raw_info.get("runtime_loadable", True)),
+        )
+    return snapshot
+
+
 def default_worker_routed_tools(tool_names: list[str]) -> list[str]:
     """Return the tool names that default to worker execution."""
     selected_tools: list[str] = []
@@ -1089,6 +1260,7 @@ def export_tools_metadata(tool_metadata: dict[str, ToolMetadata] | None = None) 
         tool_dict["status"] = metadata.status.value
         tool_dict["setup_type"] = metadata.setup_type.value
         tool_dict["default_execution_target"] = metadata.default_execution_target.value
+        tool_dict.pop("authored_override_validator", None)
         tool_dict.pop("managed_init_args", None)
         tool_dict.pop("factory", None)
         tools.append(tool_dict)
@@ -1175,12 +1347,11 @@ def normalize_authored_tool_overrides(tool_name: str, overrides: dict[str, objec
             raise ValueError(msg) from exc
         if normalized_value is not None:
             normalized[field_name] = normalized_value
-
-    from mindroom.mcp.registry import _MCP_TOOL_FACTORY_MARKER, validate_mcp_agent_overrides  # noqa: PLC0415
-
-    tool_factory = _TOOL_REGISTRY.get(tool_name)
-    if tool_factory is not None and getattr(tool_factory, _MCP_TOOL_FACTORY_MARKER, False):
-        validate_mcp_agent_overrides(tool_name, normalized)
+    _run_authored_override_validator(
+        tool_name,
+        normalized,
+        validator=metadata.authored_override_validator,
+    )
     return normalized
 
 

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -596,7 +596,7 @@ def _build_tool_instance(
     ) or {}
     if credential_overrides:
         credentials = {**credentials, **credential_overrides}
-    validated_tool_config_overrides = validate_authored_overrides(tool_name, tool_config_overrides)
+    validated_tool_config_overrides = validate_authored_tool_entry_overrides(tool_name, tool_config_overrides)
     safe_tool_init_overrides = sanitize_tool_init_overrides(tool_name, tool_init_overrides)
     init_kwargs = _build_tool_config_init_kwargs(
         metadata,

--- a/src/mindroom/tool_system/sandbox_proxy.py
+++ b/src/mindroom/tool_system/sandbox_proxy.py
@@ -27,6 +27,7 @@ from mindroom.workers.runtime import (
     get_primary_worker_manager,
     primary_worker_backend_available,
     primary_worker_backend_name,
+    serialized_kubernetes_worker_validation_snapshot,
 )
 
 if TYPE_CHECKING:
@@ -360,11 +361,18 @@ def _get_worker_manager(
     storage_root = (
         context.storage_path if context is not None and context.storage_path is not None else runtime_paths.storage_root
     )
+    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
+    if context is not None and primary_worker_backend_name(runtime_paths) == "kubernetes":
+        kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
+            runtime_paths,
+            runtime_config=context.config,
+        )
     return get_primary_worker_manager(
         runtime_paths,
         proxy_url=proxy_config.proxy_url,
         proxy_token=proxy_config.proxy_token,
         storage_root=storage_root,
+        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
     )
 
 

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -38,6 +38,7 @@ class KubernetesWorkerBackend:
         config: _KubernetesWorkerBackendConfig,
         auth_token: str | None,
         storage_root: Path,
+        tool_validation_snapshot: dict[str, dict[str, object]],
     ) -> None:
         self.runtime_paths = runtime_paths
         self.config = config
@@ -49,6 +50,7 @@ class KubernetesWorkerBackend:
             config=config,
             auth_token=auth_token,
             storage_root=self.storage_root,
+            tool_validation_snapshot=tool_validation_snapshot,
         )
         self._worker_locks: dict[str, threading.Lock] = {}
         self._worker_locks_lock = threading.Lock()
@@ -60,6 +62,7 @@ class KubernetesWorkerBackend:
         *,
         auth_token: str | None,
         storage_root: Path,
+        tool_validation_snapshot: dict[str, dict[str, object]],
     ) -> KubernetesWorkerBackend:
         """Construct a backend instance from one explicit runtime context."""
         return cls(
@@ -67,6 +70,7 @@ class KubernetesWorkerBackend:
             config=_KubernetesWorkerBackendConfig.from_runtime(runtime_paths),
             auth_token=auth_token,
             storage_root=storage_root,
+            tool_validation_snapshot=tool_validation_snapshot,
         )
 
     def ensure_worker(self, spec: WorkerSpec, *, now: float | None = None) -> WorkerHandle:

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -58,7 +58,7 @@ _DEDICATED_WORKER_KEY_ENV = "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY"
 _DEDICATED_WORKER_ROOT_ENV = "MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT"
 _SHARED_STORAGE_ROOT_ENV = "MINDROOM_SANDBOX_SHARED_STORAGE_ROOT"
 _STARTUP_RUNTIME_PATHS_ENV = "MINDROOM_RUNTIME_PATHS_JSON"
-_ALLOWED_TOOL_NAMES_ENV = "MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON"
+_TOOL_VALIDATION_SNAPSHOT_ENV = "MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON"
 _DEFAULT_CONTAINER_PATH = "/app/.venv/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 
@@ -249,7 +249,7 @@ class KubernetesResourceManager:
         self._control_plane_node_name_loaded = False
         self._owner_reference: dict[str, object] | None = None
         self._owner_reference_loaded = False
-        self._worker_allowed_tool_names: list[str] | None = None
+        self._worker_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
 
     @property
     def _apps(self) -> _AppsApiProtocol:
@@ -605,8 +605,12 @@ class KubernetesResourceManager:
                 ),
             },
             {
-                "name": _ALLOWED_TOOL_NAMES_ENV,
-                "value": json.dumps(self._validated_worker_tool_names(), separators=(",", ":")),
+                "name": _TOOL_VALIDATION_SNAPSHOT_ENV,
+                "value": json.dumps(
+                    self._worker_validation_snapshot(),
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
             },
             {"name": "MINDROOM_CONFIG_PATH", "value": self.config.config_path},
             {"name": "MINDROOM_STORAGE_PATH", "value": dedicated_root},
@@ -643,22 +647,25 @@ class KubernetesResourceManager:
             env.append({"name": name, "value": value})
         return env
 
-    def _validated_worker_tool_names(self) -> list[str]:
-        """Return the sorted tool names already validated in the primary runtime."""
-        if self._worker_allowed_tool_names is not None:
-            return self._worker_allowed_tool_names
+    def _worker_validation_snapshot(self) -> dict[str, dict[str, object]]:
+        """Return the serialized validation snapshot already accepted in the primary runtime."""
+        if self._worker_tool_validation_snapshot is not None:
+            return self._worker_tool_validation_snapshot
 
         from mindroom.config.main import load_config  # noqa: PLC0415
-        from mindroom.tool_system.metadata import resolved_tool_state_for_runtime  # noqa: PLC0415
+        from mindroom.tool_system.metadata import (  # noqa: PLC0415
+            resolved_tool_validation_snapshot_for_runtime,
+            serialize_tool_validation_snapshot,
+        )
 
         if not self.runtime_paths.config_path.exists():
-            self._worker_allowed_tool_names = []
-            return self._worker_allowed_tool_names
+            self._worker_tool_validation_snapshot = {}
+            return self._worker_tool_validation_snapshot
 
         config = load_config(self.runtime_paths)
-        _, tool_metadata = resolved_tool_state_for_runtime(self.runtime_paths, config)
-        self._worker_allowed_tool_names = sorted(tool_metadata)
-        return self._worker_allowed_tool_names
+        snapshot = resolved_tool_validation_snapshot_for_runtime(self.runtime_paths, config)
+        self._worker_tool_validation_snapshot = serialize_tool_validation_snapshot(snapshot)
+        return self._worker_tool_validation_snapshot
 
     def _worker_google_application_credentials_path(
         self,

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -58,6 +58,7 @@ _DEDICATED_WORKER_KEY_ENV = "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY"
 _DEDICATED_WORKER_ROOT_ENV = "MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT"
 _SHARED_STORAGE_ROOT_ENV = "MINDROOM_SANDBOX_SHARED_STORAGE_ROOT"
 _STARTUP_RUNTIME_PATHS_ENV = "MINDROOM_RUNTIME_PATHS_JSON"
+_ALLOWED_TOOL_NAMES_ENV = "MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON"
 _DEFAULT_CONTAINER_PATH = "/app/.venv/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 
@@ -248,6 +249,7 @@ class KubernetesResourceManager:
         self._control_plane_node_name_loaded = False
         self._owner_reference: dict[str, object] | None = None
         self._owner_reference_loaded = False
+        self._worker_allowed_tool_names: list[str] | None = None
 
     @property
     def _apps(self) -> _AppsApiProtocol:
@@ -602,6 +604,10 @@ class KubernetesResourceManager:
                     sort_keys=True,
                 ),
             },
+            {
+                "name": _ALLOWED_TOOL_NAMES_ENV,
+                "value": json.dumps(self._validated_worker_tool_names(), separators=(",", ":")),
+            },
             {"name": "MINDROOM_CONFIG_PATH", "value": self.config.config_path},
             {"name": "MINDROOM_STORAGE_PATH", "value": dedicated_root},
             {"name": _SHARED_STORAGE_ROOT_ENV, "value": self.config.storage_mount_path},
@@ -636,6 +642,23 @@ class KubernetesResourceManager:
         for name, value in sorted(self.config.extra_env.items()):
             env.append({"name": name, "value": value})
         return env
+
+    def _validated_worker_tool_names(self) -> list[str]:
+        """Return the sorted tool names already validated in the primary runtime."""
+        if self._worker_allowed_tool_names is not None:
+            return self._worker_allowed_tool_names
+
+        from mindroom.config.main import load_config  # noqa: PLC0415
+        from mindroom.tool_system.metadata import resolved_tool_state_for_runtime  # noqa: PLC0415
+
+        if not self.runtime_paths.config_path.exists():
+            self._worker_allowed_tool_names = []
+            return self._worker_allowed_tool_names
+
+        config = load_config(self.runtime_paths)
+        _, tool_metadata = resolved_tool_state_for_runtime(self.runtime_paths, config)
+        self._worker_allowed_tool_names = sorted(tool_metadata)
+        return self._worker_allowed_tool_names
 
     def _worker_google_application_credentials_path(
         self,

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -236,12 +236,14 @@ class KubernetesResourceManager:
         config: _KubernetesWorkerBackendConfig,
         auth_token: str | None,
         storage_root: Path,
+        tool_validation_snapshot: dict[str, dict[str, object]],
     ) -> None:
         """Initialize one resource manager for a concrete backend configuration."""
         self.runtime_paths = runtime_paths
         self.config = config
         self.auth_token = auth_token
         self.storage_root = storage_root.expanduser().resolve()
+        self.tool_validation_snapshot = tool_validation_snapshot
         self.apps_api: _AppsApiProtocol | None = None
         self.core_api: _CoreApiProtocol | None = None
         self.api_exception_cls: type[_ApiStatusError] | None = None
@@ -249,7 +251,6 @@ class KubernetesResourceManager:
         self._control_plane_node_name_loaded = False
         self._owner_reference: dict[str, object] | None = None
         self._owner_reference_loaded = False
-        self._worker_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
 
     @property
     def _apps(self) -> _AppsApiProtocol:
@@ -607,7 +608,7 @@ class KubernetesResourceManager:
             {
                 "name": _TOOL_VALIDATION_SNAPSHOT_ENV,
                 "value": json.dumps(
-                    self._worker_validation_snapshot(),
+                    self.tool_validation_snapshot,
                     separators=(",", ":"),
                     sort_keys=True,
                 ),
@@ -646,26 +647,6 @@ class KubernetesResourceManager:
         for name, value in sorted(self.config.extra_env.items()):
             env.append({"name": name, "value": value})
         return env
-
-    def _worker_validation_snapshot(self) -> dict[str, dict[str, object]]:
-        """Return the serialized validation snapshot already accepted in the primary runtime."""
-        if self._worker_tool_validation_snapshot is not None:
-            return self._worker_tool_validation_snapshot
-
-        from mindroom.config.main import load_config  # noqa: PLC0415
-        from mindroom.tool_system.metadata import (  # noqa: PLC0415
-            resolved_tool_validation_snapshot_for_runtime,
-            serialize_tool_validation_snapshot,
-        )
-
-        if not self.runtime_paths.config_path.exists():
-            self._worker_tool_validation_snapshot = {}
-            return self._worker_tool_validation_snapshot
-
-        config = load_config(self.runtime_paths)
-        snapshot = resolved_tool_validation_snapshot_for_runtime(self.runtime_paths, config)
-        self._worker_tool_validation_snapshot = serialize_tool_validation_snapshot(snapshot)
-        return self._worker_tool_validation_snapshot
 
     def _worker_google_application_credentials_path(
         self,

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -14,6 +14,7 @@ from mindroom.workers.manager import WorkerManager
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
 
 _PRIMARY_WORKER_BACKEND_ENV = "MINDROOM_WORKER_BACKEND"
@@ -22,8 +23,10 @@ _PRIMARY_WORKER_MANAGER_CONFIG: tuple[str, ...] | None = None
 _PRIMARY_WORKER_MANAGER_LOCK = threading.Lock()
 
 
-def _serialized_kubernetes_worker_validation_snapshot(
+def serialized_kubernetes_worker_validation_snapshot(
     runtime_paths: RuntimePaths,
+    *,
+    runtime_config: Config | None = None,
 ) -> dict[str, dict[str, object]]:
     """Build the authoritative worker validation snapshot in the primary runtime."""
     from mindroom.config.main import load_config  # noqa: PLC0415
@@ -32,8 +35,10 @@ def _serialized_kubernetes_worker_validation_snapshot(
         serialize_tool_validation_snapshot,
     )
 
-    config = load_config(runtime_paths)
-    snapshot = resolved_tool_validation_snapshot_for_runtime(runtime_paths, config)
+    snapshot = resolved_tool_validation_snapshot_for_runtime(
+        runtime_paths,
+        runtime_config or load_config(runtime_paths),
+    )
     return serialize_tool_validation_snapshot(snapshot)
 
 
@@ -98,7 +103,9 @@ def _primary_worker_backend_config_signature(
         return _static_runner_backend_config_signature(proxy_url=proxy_url, proxy_token=proxy_token)
     if backend_name == "kubernetes":
         if kubernetes_tool_validation_snapshot is None:
-            kubernetes_tool_validation_snapshot = _serialized_kubernetes_worker_validation_snapshot(runtime_paths)
+            kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
+                runtime_paths,
+            )
         return (
             *kubernetes_backend_config_signature(
                 runtime_paths,
@@ -132,7 +139,9 @@ def _build_primary_worker_manager(
             msg = "Kubernetes worker backend requires an explicit runtime storage root."
             raise WorkerBackendError(msg)
         if kubernetes_tool_validation_snapshot is None:
-            kubernetes_tool_validation_snapshot = _serialized_kubernetes_worker_validation_snapshot(runtime_paths)
+            kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
+                runtime_paths,
+            )
         return WorkerManager(
             KubernetesWorkerBackend.from_runtime(
                 runtime_paths,
@@ -151,13 +160,13 @@ def get_primary_worker_manager(
     proxy_url: str | None,
     proxy_token: str | None,
     storage_root: Path | None = None,
+    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
 ) -> WorkerManager:
     """Return the primary-runtime worker manager for the current backend config."""
     global _PRIMARY_WORKER_MANAGER, _PRIMARY_WORKER_MANAGER_CONFIG
 
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
-    if primary_worker_backend_name(runtime_paths) == "kubernetes":
-        kubernetes_tool_validation_snapshot = _serialized_kubernetes_worker_validation_snapshot(runtime_paths)
+    if primary_worker_backend_name(runtime_paths) == "kubernetes" and kubernetes_tool_validation_snapshot is None:
+        kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(runtime_paths)
 
     config_signature = _primary_worker_backend_config_signature(
         runtime_paths,

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import threading
 from typing import TYPE_CHECKING
 
@@ -19,6 +20,21 @@ _PRIMARY_WORKER_BACKEND_ENV = "MINDROOM_WORKER_BACKEND"
 _PRIMARY_WORKER_MANAGER: WorkerManager | None = None
 _PRIMARY_WORKER_MANAGER_CONFIG: tuple[str, ...] | None = None
 _PRIMARY_WORKER_MANAGER_LOCK = threading.Lock()
+
+
+def _serialized_kubernetes_worker_validation_snapshot(
+    runtime_paths: RuntimePaths,
+) -> dict[str, dict[str, object]]:
+    """Build the authoritative worker validation snapshot in the primary runtime."""
+    from mindroom.config.main import load_config  # noqa: PLC0415
+    from mindroom.tool_system.metadata import (  # noqa: PLC0415
+        resolved_tool_validation_snapshot_for_runtime,
+        serialize_tool_validation_snapshot,
+    )
+
+    config = load_config(runtime_paths)
+    snapshot = resolved_tool_validation_snapshot_for_runtime(runtime_paths, config)
+    return serialize_tool_validation_snapshot(snapshot)
 
 
 def _normalize_backend_name(raw_value: str | None) -> str:
@@ -75,12 +91,22 @@ def _primary_worker_backend_config_signature(
     proxy_url: str | None,
     proxy_token: str | None,
     storage_root: Path | None,
+    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
 ) -> tuple[str, ...]:
     backend_name = primary_worker_backend_name(runtime_paths)
     if backend_name == "static_runner":
         return _static_runner_backend_config_signature(proxy_url=proxy_url, proxy_token=proxy_token)
     if backend_name == "kubernetes":
-        return kubernetes_backend_config_signature(runtime_paths, auth_token=proxy_token, storage_root=storage_root)
+        if kubernetes_tool_validation_snapshot is None:
+            kubernetes_tool_validation_snapshot = _serialized_kubernetes_worker_validation_snapshot(runtime_paths)
+        return (
+            *kubernetes_backend_config_signature(
+                runtime_paths,
+                auth_token=proxy_token,
+                storage_root=storage_root,
+            ),
+            json.dumps(kubernetes_tool_validation_snapshot, separators=(",", ":"), sort_keys=True),
+        )
     msg = f"Unsupported worker backend: {backend_name}"
     raise WorkerBackendError(msg)
 
@@ -91,6 +117,7 @@ def _build_primary_worker_manager(
     proxy_url: str | None,
     proxy_token: str | None,
     storage_root: Path | None,
+    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
 ) -> WorkerManager:
     backend_name = primary_worker_backend_name(runtime_paths)
     if backend_name == "static_runner":
@@ -104,11 +131,14 @@ def _build_primary_worker_manager(
         if storage_root is None:
             msg = "Kubernetes worker backend requires an explicit runtime storage root."
             raise WorkerBackendError(msg)
+        if kubernetes_tool_validation_snapshot is None:
+            kubernetes_tool_validation_snapshot = _serialized_kubernetes_worker_validation_snapshot(runtime_paths)
         return WorkerManager(
             KubernetesWorkerBackend.from_runtime(
                 runtime_paths,
                 auth_token=proxy_token,
                 storage_root=storage_root,
+                tool_validation_snapshot=kubernetes_tool_validation_snapshot,
             ),
         )
     msg = f"Unsupported worker backend: {backend_name}"
@@ -125,11 +155,16 @@ def get_primary_worker_manager(
     """Return the primary-runtime worker manager for the current backend config."""
     global _PRIMARY_WORKER_MANAGER, _PRIMARY_WORKER_MANAGER_CONFIG
 
+    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
+    if primary_worker_backend_name(runtime_paths) == "kubernetes":
+        kubernetes_tool_validation_snapshot = _serialized_kubernetes_worker_validation_snapshot(runtime_paths)
+
     config_signature = _primary_worker_backend_config_signature(
         runtime_paths,
         proxy_url=proxy_url,
         proxy_token=proxy_token,
         storage_root=storage_root,
+        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
     )
     with _PRIMARY_WORKER_MANAGER_LOCK:
         if _PRIMARY_WORKER_MANAGER is None or config_signature != _PRIMARY_WORKER_MANAGER_CONFIG:
@@ -138,6 +173,7 @@ def get_primary_worker_manager(
                 proxy_url=proxy_url,
                 proxy_token=proxy_token,
                 storage_root=storage_root,
+                kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
             )
             _PRIMARY_WORKER_MANAGER_CONFIG = config_signature
     return _PRIMARY_WORKER_MANAGER

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -78,6 +78,15 @@ def primary_worker_backend_available(
     return False
 
 
+def _require_kubernetes_tool_validation_snapshot(
+    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None,
+) -> dict[str, dict[str, object]]:
+    if kubernetes_tool_validation_snapshot is None:
+        msg = "Kubernetes worker backend requires an explicit tool validation snapshot."
+        raise WorkerBackendError(msg)
+    return kubernetes_tool_validation_snapshot
+
+
 def _static_runner_backend_config_signature(
     *,
     proxy_url: str | None,
@@ -102,10 +111,9 @@ def _primary_worker_backend_config_signature(
     if backend_name == "static_runner":
         return _static_runner_backend_config_signature(proxy_url=proxy_url, proxy_token=proxy_token)
     if backend_name == "kubernetes":
-        if kubernetes_tool_validation_snapshot is None:
-            kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
-                runtime_paths,
-            )
+        kubernetes_tool_validation_snapshot = _require_kubernetes_tool_validation_snapshot(
+            kubernetes_tool_validation_snapshot,
+        )
         return (
             *kubernetes_backend_config_signature(
                 runtime_paths,
@@ -138,10 +146,9 @@ def _build_primary_worker_manager(
         if storage_root is None:
             msg = "Kubernetes worker backend requires an explicit runtime storage root."
             raise WorkerBackendError(msg)
-        if kubernetes_tool_validation_snapshot is None:
-            kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
-                runtime_paths,
-            )
+        kubernetes_tool_validation_snapshot = _require_kubernetes_tool_validation_snapshot(
+            kubernetes_tool_validation_snapshot,
+        )
         return WorkerManager(
             KubernetesWorkerBackend.from_runtime(
                 runtime_paths,
@@ -164,9 +171,6 @@ def get_primary_worker_manager(
 ) -> WorkerManager:
     """Return the primary-runtime worker manager for the current backend config."""
     global _PRIMARY_WORKER_MANAGER, _PRIMARY_WORKER_MANAGER_CONFIG
-
-    if primary_worker_backend_name(runtime_paths) == "kubernetes" and kubernetes_tool_validation_snapshot is None:
-        kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(runtime_paths)
 
     config_signature = _primary_worker_backend_config_signature(
         runtime_paths,

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -974,10 +974,23 @@ def test_worker_cleanup_once_cleans_workers(monkeypatch: pytest.MonkeyPatch) -> 
                 ),
             ]
 
+    monkeypatch.setenv("MINDROOM_WORKER_BACKEND", "kubernetes")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_IMAGE", "ghcr.io/mindroom-ai/mindroom:latest")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME", "mindroom-storage")
     monkeypatch.setattr(main, "primary_worker_backend_available", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(main, "get_primary_worker_manager", lambda *_args, **_kwargs: _FakeWorkerManager())
+    monkeypatch.setattr(main, "primary_worker_backend_name", lambda *_args, **_kwargs: "kubernetes")
+    captured_kwargs: dict[str, object] = {}
 
-    assert main._cleanup_workers_once(main._app_runtime_paths(main.app)) == 1
+    def _fake_get_primary_worker_manager(*_args: object, **kwargs: object) -> _FakeWorkerManager:
+        captured_kwargs.update(kwargs)
+        return _FakeWorkerManager()
+
+    monkeypatch.setattr(main, "get_primary_worker_manager", _fake_get_primary_worker_manager)
+
+    runtime_paths = main._app_runtime_paths(main.app)
+    runtime_config = Config.validate_with_runtime({}, runtime_paths)
+    assert main._cleanup_workers_once(runtime_paths, runtime_config=runtime_config) == 1
+    assert captured_kwargs["kubernetes_tool_validation_snapshot"] is not None
 
 
 def test_list_workers_endpoint(test_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1000,11 +1013,21 @@ def test_list_workers_endpoint(test_client: TestClient, monkeypatch: pytest.Monk
                 ),
             ]
 
+    monkeypatch.setenv("MINDROOM_WORKER_BACKEND", "kubernetes")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_IMAGE", "ghcr.io/mindroom-ai/mindroom:latest")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME", "mindroom-storage")
     monkeypatch.setattr(workers_api, "primary_worker_backend_available", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(workers_api, "primary_worker_backend_name", lambda *_args, **_kwargs: "kubernetes")
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_get_primary_worker_manager(*_args: object, **kwargs: object) -> _FakeWorkerManager:
+        captured_kwargs.update(kwargs)
+        return _FakeWorkerManager()
+
     monkeypatch.setattr(
         workers_api,
         "get_primary_worker_manager",
-        lambda *_args, **_kwargs: _FakeWorkerManager(),
+        _fake_get_primary_worker_manager,
     )
 
     response = test_client.get("/api/workers")
@@ -1012,6 +1035,7 @@ def test_list_workers_endpoint(test_client: TestClient, monkeypatch: pytest.Monk
     assert response.status_code == 200
     assert response.json()["workers"][0]["worker_key"] == "worker-key"
     assert response.json()["workers"][0]["backend_name"] == "kubernetes"
+    assert captured_kwargs["kubernetes_tool_validation_snapshot"] is not None
 
 
 def test_cleanup_workers_endpoint(test_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -954,6 +954,22 @@ def test_worker_cleanup_once_skips_when_backend_unavailable(monkeypatch: pytest.
     assert main._cleanup_workers_once(main._app_runtime_paths(main.app)) == 0
 
 
+def test_worker_cleanup_once_skips_kubernetes_without_committed_runtime_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Kubernetes cleanup should skip the cycle when no committed runtime config is available."""
+    monkeypatch.setattr(main, "primary_worker_backend_available", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(main, "primary_worker_backend_name", lambda *_args, **_kwargs: "kubernetes")
+
+    def _unexpected_get_primary_worker_manager(*_args: object, **_kwargs: object) -> object:
+        msg = "cleanup should not build a Kubernetes worker manager without a committed snapshot"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(main, "get_primary_worker_manager", _unexpected_get_primary_worker_manager)
+
+    assert main._cleanup_workers_once(main._app_runtime_paths(main.app)) == 0
+
+
 def test_worker_cleanup_once_cleans_workers(monkeypatch: pytest.MonkeyPatch) -> None:
     """Background worker cleanup should delegate to the configured worker manager."""
 

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -107,6 +107,11 @@ def _set_sandbox_token(monkeypatch: pytest.MonkeyPatch) -> None:
     _refresh_runner_app_from_env()
 
 
+def _set_allowed_worker_tool_names(monkeypatch: pytest.MonkeyPatch, *tool_names: str) -> None:
+    """Set the upstream-approved tool names visible to one worker runtime."""
+    monkeypatch.setenv("MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON", json.dumps(list(tool_names)))
+
+
 def _refresh_runner_app_from_env() -> tuple[RuntimePaths, Config]:
     runtime_paths = resolve_primary_runtime_paths(process_env=dict(os.environ))
     config = sandbox_runner_module._runtime_config_or_empty(runtime_paths)
@@ -161,6 +166,36 @@ def _missing_plugin_path_config_path(tmp_path: Path) -> Path:
         "    include_default_tools: false\n"
         "    tools:\n"
         "      - agentspace_slack_search\n"
+        "router:\n"
+        "  model: default\n"
+        "plugins:\n"
+        "  - ./plugins/agentspace-slack-search\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _missing_plugin_path_with_invalid_tool_config_path(tmp_path: Path) -> Path:
+    """Write one config that mixes a missing worker plugin with an unknown tool."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n"
+        "  default:\n"
+        "    provider: openai\n"
+        "    id: gpt-5.4\n"
+        "agents:\n"
+        "  broken:\n"
+        "    display_name: Broken\n"
+        "    model: default\n"
+        "    include_default_tools: false\n"
+        "    tools:\n"
+        "      - agentspace_slack_search\n"
+        "  broken:\n"
+        "    display_name: Broken\n"
+        "    model: default\n"
+        "    include_default_tools: false\n"
+        "    tools:\n"
+        "      - definitely_not_a_tool\n"
         "router:\n"
         "  model: default\n"
         "plugins:\n"
@@ -702,6 +737,7 @@ def test_sandbox_runner_skips_unavailable_plugins_for_worker_runtime(
     tmp_path: Path,
 ) -> None:
     """Worker startup should not fail on plugin paths missing from the worker filesystem."""
+    _set_allowed_worker_tool_names(monkeypatch, "agentspace_slack_search")
     _set_sandbox_token(monkeypatch)
     monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(_missing_plugin_path_config_path(tmp_path)))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
@@ -726,6 +762,24 @@ def test_sandbox_runner_skips_unavailable_plugins_for_worker_runtime(
     assert response.status_code == 200
     assert response.json()["ok"] is True
     assert '"result": 3' in response.json()["result"]
+
+
+def test_sandbox_runner_still_rejects_invalid_tools_after_skipping_worker_plugins(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Worker plugin filtering must not weaken authored tool validation."""
+    _set_allowed_worker_tool_names(monkeypatch, "agentspace_slack_search")
+    _set_sandbox_token(monkeypatch)
+    monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(_missing_plugin_path_with_invalid_tool_config_path(tmp_path)))
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
+
+    with pytest.raises(ConfigRuntimeValidationError) as exc_info:
+        _refresh_runner_app_from_env()
+
+    assert str(exc_info.value) == (
+        "agents.broken.tools[0].definitely_not_a_tool: Unknown tool 'definitely_not_a_tool'."
+    )
 
 
 def test_sandbox_runner_execute_uses_committed_startup_config_until_explicit_refresh(

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -140,6 +140,36 @@ def _invalid_plugin_config_path(tmp_path: Path) -> Path:
     return config_path
 
 
+def _missing_plugin_path_config_path(tmp_path: Path) -> Path:
+    """Write one config that references a plugin unavailable in the worker runtime."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n"
+        "  default:\n"
+        "    provider: openai\n"
+        "    id: gpt-5.4\n"
+        "agents:\n"
+        "  mind:\n"
+        "    display_name: Mind\n"
+        "    model: default\n"
+        "    include_default_tools: false\n"
+        "    tools:\n"
+        "      - shell\n"
+        "  saguaro:\n"
+        "    display_name: Saguaro\n"
+        "    model: default\n"
+        "    include_default_tools: false\n"
+        "    tools:\n"
+        "      - agentspace_slack_search\n"
+        "router:\n"
+        "  model: default\n"
+        "plugins:\n"
+        "  - ./plugins/agentspace-slack-search\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
 def test_startup_runtime_keeps_runner_token_outside_runtime_paths(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -665,6 +695,37 @@ def test_sandbox_runner_execute_returns_422_for_invalid_runtime_config(
         "Invalid plugin name: 'BadName'. Plugin names must use lowercase ASCII letters, digits, "
         "hyphens, or underscores. (" + str((tmp_path / "plugins" / "bad-name" / "mindroom.plugin.json").resolve()) + ")"
     )
+
+
+def test_sandbox_runner_skips_unavailable_plugins_for_worker_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Worker startup should not fail on plugin paths missing from the worker filesystem."""
+    _set_sandbox_token(monkeypatch)
+    monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(_missing_plugin_path_config_path(tmp_path)))
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
+
+    runtime_paths, config = _refresh_runner_app_from_env()
+
+    assert runtime_paths.config_path.exists()
+    assert config.plugins == []
+
+    with TestClient(sandbox_runner_app) as client:
+        response = client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "calculator",
+                "function_name": "add",
+                "args": [1, 2],
+                "kwargs": {},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert '"result": 3' in response.json()["result"]
 
 
 def test_sandbox_runner_execute_uses_committed_startup_config_until_explicit_refresh(

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
-import yaml
 from fastapi.testclient import TestClient
 
 import mindroom.api.sandbox_exec as sandbox_exec_module
@@ -112,11 +111,7 @@ def _set_sandbox_token(monkeypatch: pytest.MonkeyPatch) -> None:
 def _set_worker_tool_validation_snapshot(monkeypatch: pytest.MonkeyPatch, *tool_names: str) -> None:
     """Set the upstream-authored validation snapshot visible to one worker runtime."""
     runtime_paths = resolve_primary_runtime_paths(process_env=dict(os.environ))
-    config = Config.validate_with_runtime({}, runtime_paths) if not runtime_paths.config_path.exists() else None
-    if config is None:
-        with runtime_paths.config_path.open(encoding="utf-8") as f:
-            data = yaml.safe_load(f) or {}
-        config = Config.validate_with_runtime(data, runtime_paths)
+    config = Config.validate_with_runtime({}, runtime_paths)
     snapshot = serialize_tool_validation_snapshot(
         resolved_tool_validation_snapshot_for_runtime(runtime_paths, config),
     )
@@ -210,8 +205,8 @@ def _missing_plugin_path_with_invalid_tool_config_path(tmp_path: Path) -> Path:
         "    include_default_tools: false\n"
         "    tools:\n"
         "      - agentspace_slack_search\n"
-        "  broken:\n"
-        "    display_name: Broken\n"
+        "  invalid:\n"
+        "    display_name: Invalid\n"
         "    model: default\n"
         "    include_default_tools: false\n"
         "    tools:\n"
@@ -757,10 +752,11 @@ def test_sandbox_runner_skips_unavailable_plugins_for_worker_runtime(
     tmp_path: Path,
 ) -> None:
     """Worker startup should not fail on plugin paths missing from the worker filesystem."""
+    config_path = _missing_plugin_path_config_path(tmp_path)
+    monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
     _set_worker_tool_validation_snapshot(monkeypatch, "agentspace_slack_search")
     _set_sandbox_token(monkeypatch)
-    monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(_missing_plugin_path_config_path(tmp_path)))
-    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
 
     runtime_paths, config = _refresh_runner_app_from_env()
 
@@ -789,16 +785,17 @@ def test_sandbox_runner_still_rejects_invalid_tools_after_skipping_worker_plugin
     tmp_path: Path,
 ) -> None:
     """Worker plugin filtering must not weaken authored tool validation."""
-    _set_worker_tool_validation_snapshot(monkeypatch, "agentspace_slack_search")
-    _set_sandbox_token(monkeypatch)
-    monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(_missing_plugin_path_with_invalid_tool_config_path(tmp_path)))
+    config_path = _missing_plugin_path_with_invalid_tool_config_path(tmp_path)
+    monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
+    _set_worker_tool_validation_snapshot(monkeypatch, "agentspace_slack_search")
+    monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", SANDBOX_TOKEN)
 
     with pytest.raises(ConfigRuntimeValidationError) as exc_info:
         _refresh_runner_app_from_env()
 
     assert str(exc_info.value) == (
-        "agents.broken.tools[0].definitely_not_a_tool: Unknown tool 'definitely_not_a_tool'."
+        "agents.invalid.tools[0].definitely_not_a_tool: Unknown tool 'definitely_not_a_tool'."
     )
 
 

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -220,6 +220,35 @@ def _missing_plugin_path_with_invalid_tool_config_path(tmp_path: Path) -> Path:
     return config_path
 
 
+def _mcp_demo_config_path(tmp_path: Path) -> Path:
+    """Write one config that exposes a valid MCP-backed tool assignment."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n"
+        "  default:\n"
+        "    provider: openai\n"
+        "    id: gpt-5.4\n"
+        "router:\n"
+        "  model: default\n"
+        "mcp_servers:\n"
+        "  demo:\n"
+        "    transport: stdio\n"
+        "    command: python\n"
+        "    args:\n"
+        "      - -c\n"
+        "      - print(0)\n"
+        "agents:\n"
+        "  code:\n"
+        "    display_name: Code\n"
+        "    role: test\n"
+        "    model: default\n"
+        "    tools:\n"
+        "      - mcp_demo\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
 def test_startup_runtime_keeps_runner_token_outside_runtime_paths(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -755,6 +784,7 @@ def test_sandbox_runner_skips_unavailable_plugins_for_worker_runtime(
     config_path = _missing_plugin_path_config_path(tmp_path)
     monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
+    monkeypatch.setenv("MINDROOM_SANDBOX_DEDICATED_WORKER_KEY", "worker-a")
     _set_worker_tool_validation_snapshot(monkeypatch, "agentspace_slack_search")
     _set_sandbox_token(monkeypatch)
 
@@ -763,7 +793,10 @@ def test_sandbox_runner_skips_unavailable_plugins_for_worker_runtime(
     assert runtime_paths.config_path.exists()
     assert config.plugins == []
 
-    with TestClient(sandbox_runner_app) as client:
+    with (
+        patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=_fake_local_worker_venv_create),
+        TestClient(sandbox_runner_app) as client,
+    ):
         response = client.post(
             "/api/sandbox-runner/execute",
             headers=SANDBOX_HEADERS,
@@ -780,6 +813,21 @@ def test_sandbox_runner_skips_unavailable_plugins_for_worker_runtime(
     assert '"result": 3' in response.json()["result"]
 
 
+def test_sandbox_runner_shared_startup_still_rejects_missing_plugins(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Shared runner startup must keep canonical plugin validation semantics."""
+    config_path = _missing_plugin_path_config_path(tmp_path)
+    monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
+    _set_worker_tool_validation_snapshot(monkeypatch, "agentspace_slack_search")
+    monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", SANDBOX_TOKEN)
+
+    with pytest.raises(ConfigRuntimeValidationError, match="Configured plugin path does not exist"):
+        _refresh_runner_app_from_env()
+
+
 def test_sandbox_runner_still_rejects_invalid_tools_after_skipping_worker_plugins(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -788,6 +836,7 @@ def test_sandbox_runner_still_rejects_invalid_tools_after_skipping_worker_plugin
     config_path = _missing_plugin_path_with_invalid_tool_config_path(tmp_path)
     monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
+    monkeypatch.setenv("MINDROOM_SANDBOX_DEDICATED_WORKER_KEY", "worker-a")
     _set_worker_tool_validation_snapshot(monkeypatch, "agentspace_slack_search")
     monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", SANDBOX_TOKEN)
 
@@ -797,6 +846,37 @@ def test_sandbox_runner_still_rejects_invalid_tools_after_skipping_worker_plugin
     assert str(exc_info.value) == (
         "agents.invalid.tools[0].definitely_not_a_tool: Unknown tool 'definitely_not_a_tool'."
     )
+
+
+def test_sandbox_runner_execute_rejects_invalid_mcp_tool_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Execute requests should use the same MCP-specific override validation as config loading."""
+    config_path = _mcp_demo_config_path(tmp_path)
+    monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
+    _set_sandbox_token(monkeypatch)
+    _refresh_runner_app_from_env()
+
+    with TestClient(sandbox_runner_app) as client:
+        response = client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "mcp_demo",
+                "function_name": "demo",
+                "args": [],
+                "kwargs": {},
+                "tool_config_overrides": {
+                    "include_tools": ["echo"],
+                    "exclude_tools": ["echo"],
+                },
+            },
+        )
+
+    assert response.status_code == 400
+    assert "include_tools and exclude_tools overlap" in response.json()["detail"]
 
 
 def test_sandbox_runner_execute_uses_committed_startup_config_until_explicit_refresh(

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+import yaml
 from fastapi.testclient import TestClient
 
 import mindroom.api.sandbox_exec as sandbox_exec_module
@@ -23,7 +24,7 @@ import mindroom.api.sandbox_worker_prep as sandbox_worker_prep_module
 import mindroom.credentials as credentials_module
 import mindroom.tool_system.metadata as metadata_module
 from mindroom.api.sandbox_runner_app import app as sandbox_runner_app
-from mindroom.config.main import ConfigRuntimeValidationError
+from mindroom.config.main import Config, ConfigRuntimeValidationError
 from mindroom.constants import (
     resolve_primary_runtime_paths,
     resolve_runtime_paths,
@@ -40,6 +41,8 @@ from mindroom.tool_system.metadata import (
     ToolStatus,
     ensure_tool_registry_loaded,
     get_tool_by_name,
+    resolved_tool_validation_snapshot_for_runtime,
+    serialize_tool_validation_snapshot,
 )
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
@@ -54,7 +57,6 @@ from mindroom.workers.models import WorkerSpec
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
 
 SANDBOX_TOKEN = "secret-token"  # noqa: S105
@@ -107,9 +109,27 @@ def _set_sandbox_token(monkeypatch: pytest.MonkeyPatch) -> None:
     _refresh_runner_app_from_env()
 
 
-def _set_allowed_worker_tool_names(monkeypatch: pytest.MonkeyPatch, *tool_names: str) -> None:
-    """Set the upstream-approved tool names visible to one worker runtime."""
-    monkeypatch.setenv("MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON", json.dumps(list(tool_names)))
+def _set_worker_tool_validation_snapshot(monkeypatch: pytest.MonkeyPatch, *tool_names: str) -> None:
+    """Set the upstream-authored validation snapshot visible to one worker runtime."""
+    runtime_paths = resolve_primary_runtime_paths(process_env=dict(os.environ))
+    config = Config.validate_with_runtime({}, runtime_paths) if not runtime_paths.config_path.exists() else None
+    if config is None:
+        with runtime_paths.config_path.open(encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        config = Config.validate_with_runtime(data, runtime_paths)
+    snapshot = serialize_tool_validation_snapshot(
+        resolved_tool_validation_snapshot_for_runtime(runtime_paths, config),
+    )
+    for tool_name in tool_names:
+        snapshot[tool_name] = {
+            "config_fields": [],
+            "agent_override_fields": [],
+            "authored_override_validator": "default",
+        }
+    monkeypatch.setenv(
+        "MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON",
+        json.dumps(snapshot, separators=(",", ":"), sort_keys=True),
+    )
 
 
 def _refresh_runner_app_from_env() -> tuple[RuntimePaths, Config]:
@@ -737,7 +757,7 @@ def test_sandbox_runner_skips_unavailable_plugins_for_worker_runtime(
     tmp_path: Path,
 ) -> None:
     """Worker startup should not fail on plugin paths missing from the worker filesystem."""
-    _set_allowed_worker_tool_names(monkeypatch, "agentspace_slack_search")
+    _set_worker_tool_validation_snapshot(monkeypatch, "agentspace_slack_search")
     _set_sandbox_token(monkeypatch)
     monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(_missing_plugin_path_config_path(tmp_path)))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
@@ -769,7 +789,7 @@ def test_sandbox_runner_still_rejects_invalid_tools_after_skipping_worker_plugin
     tmp_path: Path,
 ) -> None:
     """Worker plugin filtering must not weaken authored tool validation."""
-    _set_allowed_worker_tool_names(monkeypatch, "agentspace_slack_search")
+    _set_worker_tool_validation_snapshot(monkeypatch, "agentspace_slack_search")
     _set_sandbox_token(monkeypatch)
     monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(_missing_plugin_path_with_invalid_tool_config_path(tmp_path)))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -32,6 +32,7 @@ from mindroom.tool_system.dynamic_toolkits import (
     merge_runtime_tool_configs,
     save_loaded_toolkits_for_session,
 )
+from mindroom.tool_system.metadata import ToolConfigOverrideError, ensure_tool_registry_loaded
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 if TYPE_CHECKING:
@@ -320,6 +321,30 @@ def test_config_rejects_invalid_mcp_server_name(tmp_path: Path) -> None:
         Config.validate_with_runtime(raw, _runtime_paths(tmp_path))
 
     assert "filesystem-server" in str(exc_info.value)
+
+
+def test_dynamic_toolkit_override_normalization_uses_mcp_specific_validation(tmp_path: Path) -> None:
+    """Dynamic toolkit merging should reject invalid MCP override payloads consistently."""
+    raw = _base_config_data()
+    raw["mcp_servers"] = {
+        "demo": {
+            "transport": "stdio",
+            "command": "python",
+            "args": ["-c", "print(0)"],
+        },
+    }
+    raw["agents"]["code"]["tools"] = ["mcp_demo"]
+    config = _validated_config(tmp_path, raw)
+    ensure_tool_registry_loaded(_runtime_paths(tmp_path), config)
+
+    with pytest.raises(ToolConfigOverrideError, match="include_tools and exclude_tools overlap"):
+        dynamic_toolkits_module._normalize_effective_tool_config_overrides(
+            "mcp_demo",
+            {
+                "include_tools": ["echo"],
+                "exclude_tools": ["echo"],
+            },
+        )
 
 
 def test_dynamic_toolkit_session_initializes_from_initial_toolkits(tmp_path: Path) -> None:

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -260,6 +260,7 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:
     assert "MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT" in env_names
     assert "MINDROOM_STORAGE_PATH" in env_names
     assert "MINDROOM_RUNTIME_PATHS_JSON" in env_names
+    assert "MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON" in env_names
     assert "MINDROOM_SANDBOX_SHARED_STORAGE_ROOT" in env_names
     assert "VIRTUAL_ENV" in env_names
     assert "PATH" in env_names
@@ -267,6 +268,7 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:
     assert "MINDROOM_SANDBOX_PROXY_TOKEN" in env_names
     assert env_values["MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE"] == "subprocess"
     assert env_values["MINDROOM_SANDBOX_RUNNER_PORT"] == "8766"
+    assert isinstance(json.loads(env_values["MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON"]), list)
     expected_dedicated_root = f"/app/worker/workers/{worker_dir_name(worker_key)}"
     committed_runtime = deserialize_runtime_paths(json.loads(env_values["MINDROOM_RUNTIME_PATHS_JSON"]))
     assert env_values["MINDROOM_STORAGE_PATH"] == expected_dedicated_root

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -235,7 +235,7 @@ def _backend(
     return backend, apps_api, core_api
 
 
-def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:
+def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:  # noqa: PLR0915
     """Ensuring one worker should create a service/deployment pair on shared storage."""
     backend, apps_api, core_api = _backend(owner_deployment_name="mindroom-demo")
     worker_key = _TEST_SCOPED_WORKER_KEY_A
@@ -260,7 +260,8 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:
     assert "MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT" in env_names
     assert "MINDROOM_STORAGE_PATH" in env_names
     assert "MINDROOM_RUNTIME_PATHS_JSON" in env_names
-    assert "MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON" in env_names
+    assert "MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON" in env_names
+    assert "MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON" not in env_names
     assert "MINDROOM_SANDBOX_SHARED_STORAGE_ROOT" in env_names
     assert "VIRTUAL_ENV" in env_names
     assert "PATH" in env_names
@@ -268,7 +269,10 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:
     assert "MINDROOM_SANDBOX_PROXY_TOKEN" in env_names
     assert env_values["MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE"] == "subprocess"
     assert env_values["MINDROOM_SANDBOX_RUNNER_PORT"] == "8766"
-    assert isinstance(json.loads(env_values["MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON"]), list)
+    validation_snapshot = json.loads(env_values["MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON"])
+    assert isinstance(validation_snapshot, dict)
+    assert "calculator" in validation_snapshot
+    assert validation_snapshot["calculator"]["authored_override_validator"] == "default"
     expected_dedicated_root = f"/app/worker/workers/{worker_dir_name(worker_key)}"
     committed_runtime = deserialize_runtime_paths(json.loads(env_values["MINDROOM_RUNTIME_PATHS_JSON"]))
     assert env_values["MINDROOM_STORAGE_PATH"] == expected_dedicated_root

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -31,6 +31,14 @@ _TEST_TOKEN_SECRET_KEY = "sandbox_proxy_token"  # noqa: S105
 _TEST_AUTH_TOKEN = "test-token"  # noqa: S105
 _TEST_SCOPED_WORKER_KEY_A = "v1:tenant-123:shared:code"
 _TEST_SCOPED_WORKER_KEY_B = "v1:tenant-123:shared:research"
+_TEST_TOOL_VALIDATION_SNAPSHOT = {
+    "calculator": {
+        "config_fields": [],
+        "agent_override_fields": [],
+        "authored_override_validator": "default",
+        "runtime_loadable": True,
+    },
+}
 
 
 class _FakeApiError(Exception):
@@ -181,6 +189,7 @@ def _backend(
     name_prefix: str = "mindroom-worker",
     owner_deployment_name: str | None = None,
     runtime_paths: RuntimePaths | None = None,
+    tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
 ) -> tuple[KubernetesWorkerBackend, _FakeAppsApi, _FakeCoreApi]:
     config = _KubernetesWorkerBackendConfig(
         namespace="chat",
@@ -214,6 +223,7 @@ def _backend(
         config=config,
         auth_token=_TEST_AUTH_TOKEN,
         storage_root=resolved_runtime_paths.storage_root,
+        tool_validation_snapshot=tool_validation_snapshot or deepcopy(_TEST_TOOL_VALIDATION_SNAPSHOT),
     )
     apps_api = _FakeAppsApi()
     core_api = _FakeCoreApi()
@@ -270,9 +280,7 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:  # 
     assert env_values["MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE"] == "subprocess"
     assert env_values["MINDROOM_SANDBOX_RUNNER_PORT"] == "8766"
     validation_snapshot = json.loads(env_values["MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON"])
-    assert isinstance(validation_snapshot, dict)
-    assert "calculator" in validation_snapshot
-    assert validation_snapshot["calculator"]["authored_override_validator"] == "default"
+    assert validation_snapshot == _TEST_TOOL_VALIDATION_SNAPSHOT
     expected_dedicated_root = f"/app/worker/workers/{worker_dir_name(worker_key)}"
     committed_runtime = deserialize_runtime_paths(json.loads(env_values["MINDROOM_RUNTIME_PATHS_JSON"]))
     assert env_values["MINDROOM_STORAGE_PATH"] == expected_dedicated_root
@@ -389,6 +397,30 @@ def test_kubernetes_backend_commits_parent_runtime_env_into_worker_payload(tmp_p
     assert committed_runtime.env_value("MINDROOM_SANDBOX_PROXY_TOKEN") is None
     assert committed_runtime.env_value("MINDROOM_LOCAL_CLIENT_SECRET") is None
     assert local_credentials_path.read_text(encoding="utf-8") == '{"type":"service_account"}\n'
+
+
+def test_kubernetes_backend_uses_provided_validation_snapshot() -> None:
+    """Worker env should reflect the authoritative snapshot passed into the backend."""
+    custom_snapshot = {
+        "worker_only": {
+            "config_fields": [],
+            "agent_override_fields": [],
+            "authored_override_validator": "default",
+            "runtime_loadable": False,
+        },
+    }
+    backend, apps_api, _core_api = _backend(
+        owner_deployment_name="mindroom-demo",
+        tool_validation_snapshot=custom_snapshot,
+    )
+
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
+
+    deployment = apps_api.created_bodies[0]
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    env_values = {env["name"]: env.get("value") for env in container["env"]}
+
+    assert json.loads(env_values["MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON"]) == custom_snapshot
 
 
 def test_kubernetes_backend_drops_host_local_adc_path_when_not_mounted(tmp_path: Path) -> None:

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -1371,6 +1371,115 @@ def test_get_worker_manager_singleton_creation_is_thread_safe(monkeypatch: pytes
     workers_runtime_module._reset_primary_worker_manager()
 
 
+def test_get_worker_manager_rebuilds_kubernetes_backend_when_validation_snapshot_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Kubernetes worker-manager caching should track the authoritative validation snapshot."""
+    workers_runtime_module._reset_primary_worker_manager()
+    monkeypatch.setenv("MINDROOM_WORKER_BACKEND", "kubernetes")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_IMAGE", "ghcr.io/mindroom-ai/mindroom:latest")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME", "mindroom-storage")
+    runtime_paths = _configure_proxy_runtime(
+        monkeypatch,
+        proxy_url=None,
+        proxy_token=_TEST_AUTH_TOKEN,
+        execution_mode="off",
+    )
+    first_snapshot = {
+        "calculator": {
+            "config_fields": [],
+            "agent_override_fields": [],
+            "authored_override_validator": "default",
+            "runtime_loadable": True,
+        },
+    }
+    second_snapshot = {
+        "calculator": {
+            "config_fields": [],
+            "agent_override_fields": [],
+            "authored_override_validator": "default",
+            "runtime_loadable": True,
+        },
+        "worker_only": {
+            "config_fields": [],
+            "agent_override_fields": [],
+            "authored_override_validator": "default",
+            "runtime_loadable": False,
+        },
+    }
+    snapshots = iter([first_snapshot, second_snapshot])
+    captured_snapshots: list[dict[str, dict[str, object]]] = []
+
+    class FakeKubernetesBackend:
+        backend_name = "kubernetes"
+        idle_timeout_seconds = 60.0
+
+        @classmethod
+        def from_runtime(
+            cls,
+            runtime_paths: RuntimePaths,
+            *,
+            auth_token: str | None,
+            storage_root: Path,
+            tool_validation_snapshot: dict[str, dict[str, object]],
+        ) -> Self:
+            del runtime_paths, auth_token, storage_root
+            captured_snapshots.append(tool_validation_snapshot)
+            return cls()
+
+        def ensure_worker(self, spec: WorkerSpec, *, now: float | None = None) -> object:
+            raise NotImplementedError
+
+        def get_worker(self, worker_key: str, *, now: float | None = None) -> object:
+            raise NotImplementedError
+
+        def touch_worker(self, worker_key: str, *, now: float | None = None) -> object:
+            raise NotImplementedError
+
+        def list_workers(self, *, include_idle: bool = True, now: float | None = None) -> list[object]:
+            raise NotImplementedError
+
+        def evict_worker(
+            self,
+            worker_key: str,
+            *,
+            preserve_state: bool = True,
+            now: float | None = None,
+        ) -> object:
+            raise NotImplementedError
+
+        def cleanup_idle_workers(self, *, now: float | None = None) -> list[object]:
+            raise NotImplementedError
+
+        def record_failure(self, worker_key: str, failure_reason: str, *, now: float | None = None) -> object:
+            raise NotImplementedError
+
+    monkeypatch.setattr(
+        workers_runtime_module,
+        "_serialized_kubernetes_worker_validation_snapshot",
+        lambda _runtime_paths: next(snapshots),
+    )
+    monkeypatch.setattr(workers_runtime_module, "KubernetesWorkerBackend", FakeKubernetesBackend)
+
+    first_manager = workers_runtime_module.get_primary_worker_manager(
+        runtime_paths,
+        proxy_url=None,
+        proxy_token=_TEST_AUTH_TOKEN,
+        storage_root=tmp_path,
+    )
+    second_manager = workers_runtime_module.get_primary_worker_manager(
+        runtime_paths,
+        proxy_url=None,
+        proxy_token=_TEST_AUTH_TOKEN,
+        storage_root=tmp_path,
+    )
+
+    assert first_manager is not second_manager
+    assert captured_snapshots == [first_snapshot, second_snapshot]
+    workers_runtime_module._reset_primary_worker_manager()
+
+
 def test_worker_tools_override_can_use_kubernetes_backend_without_proxy_url(monkeypatch: pytest.MonkeyPatch) -> None:
     """Worker-routed tools should stay proxy-enabled when the Kubernetes backend provides worker handles directly."""
     monkeypatch.setenv("MINDROOM_WORKER_BACKEND", "kubernetes")

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -1412,7 +1412,6 @@ def test_get_worker_manager_rebuilds_kubernetes_backend_when_validation_snapshot
             "runtime_loadable": False,
         },
     }
-    snapshots = iter([first_snapshot, second_snapshot])
     captured_snapshots: list[dict[str, dict[str, object]]] = []
 
     class FakeKubernetesBackend:
@@ -1459,11 +1458,6 @@ def test_get_worker_manager_rebuilds_kubernetes_backend_when_validation_snapshot
         def record_failure(self, worker_key: str, failure_reason: str, *, now: float | None = None) -> object:
             raise NotImplementedError
 
-    monkeypatch.setattr(
-        workers_runtime_module,
-        "serialized_kubernetes_worker_validation_snapshot",
-        lambda _runtime_paths: next(snapshots),
-    )
     monkeypatch.setattr(workers_runtime_module, "KubernetesWorkerBackend", FakeKubernetesBackend)
 
     first_manager = workers_runtime_module.get_primary_worker_manager(
@@ -1471,16 +1465,48 @@ def test_get_worker_manager_rebuilds_kubernetes_backend_when_validation_snapshot
         proxy_url=None,
         proxy_token=_TEST_AUTH_TOKEN,
         storage_root=tmp_path,
+        kubernetes_tool_validation_snapshot=first_snapshot,
     )
     second_manager = workers_runtime_module.get_primary_worker_manager(
         runtime_paths,
         proxy_url=None,
         proxy_token=_TEST_AUTH_TOKEN,
         storage_root=tmp_path,
+        kubernetes_tool_validation_snapshot=second_snapshot,
     )
 
     assert first_manager is not second_manager
     assert captured_snapshots == [first_snapshot, second_snapshot]
+    workers_runtime_module._reset_primary_worker_manager()
+
+
+def test_get_primary_worker_manager_requires_explicit_snapshot_for_kubernetes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Kubernetes worker-manager lookup should require the caller to provide a committed snapshot."""
+    workers_runtime_module._reset_primary_worker_manager()
+    monkeypatch.setenv("MINDROOM_WORKER_BACKEND", "kubernetes")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_IMAGE", "ghcr.io/mindroom-ai/mindroom:latest")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME", "mindroom-storage")
+    runtime_paths = _configure_proxy_runtime(
+        monkeypatch,
+        proxy_url=None,
+        proxy_token=_TEST_AUTH_TOKEN,
+        execution_mode="off",
+    )
+
+    with pytest.raises(
+        WorkerBackendError,
+        match="requires an explicit tool validation snapshot",
+    ):
+        workers_runtime_module.get_primary_worker_manager(
+            runtime_paths,
+            proxy_url=None,
+            proxy_token=_TEST_AUTH_TOKEN,
+            storage_root=tmp_path,
+        )
+
     workers_runtime_module._reset_primary_worker_manager()
 
 

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -19,7 +19,7 @@ import mindroom.tool_system.sandbox_proxy as sandbox_proxy_module
 import mindroom.tools  # noqa: F401
 import mindroom.tools.shell as shell_tool_module
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig
-from mindroom.config.main import Config
+from mindroom.config.main import Config, load_config
 from mindroom.constants import (
     RuntimePaths,
     resolve_runtime_paths,
@@ -35,6 +35,8 @@ from mindroom.tool_system.metadata import (
     ToolInitOverrideError,
     get_tool_by_name,
     register_tool_with_metadata,
+    resolved_tool_validation_snapshot_for_runtime,
+    serialize_tool_validation_snapshot,
 )
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 from mindroom.tool_system.worker_routing import (
@@ -941,11 +943,13 @@ def test_get_worker_manager_falls_back_to_runtime_storage_root_without_tool_cont
         proxy_url: str | None,
         proxy_token: str | None,
         storage_root: Path | None = None,
+        kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
     ) -> str:
         captured["runtime_paths"] = runtime_paths_arg
         captured["proxy_url"] = proxy_url
         captured["proxy_token"] = proxy_token
         captured["storage_root"] = storage_root
+        captured["kubernetes_tool_validation_snapshot"] = kubernetes_tool_validation_snapshot
         return "manager"
 
     monkeypatch.setattr(sandbox_proxy_module, "get_primary_worker_manager", _fake_get_primary_worker_manager)
@@ -1457,7 +1461,7 @@ def test_get_worker_manager_rebuilds_kubernetes_backend_when_validation_snapshot
 
     monkeypatch.setattr(
         workers_runtime_module,
-        "_serialized_kubernetes_worker_validation_snapshot",
+        "serialized_kubernetes_worker_validation_snapshot",
         lambda _runtime_paths: next(snapshots),
     )
     monkeypatch.setattr(workers_runtime_module, "KubernetesWorkerBackend", FakeKubernetesBackend)
@@ -1478,6 +1482,136 @@ def test_get_worker_manager_rebuilds_kubernetes_backend_when_validation_snapshot
     assert first_manager is not second_manager
     assert captured_snapshots == [first_snapshot, second_snapshot]
     workers_runtime_module._reset_primary_worker_manager()
+
+
+def test_get_primary_worker_manager_reuses_cached_manager_without_rereading_disk_when_snapshot_is_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Explicit validation snapshots should keep manager lookups independent from later disk drift."""
+    workers_runtime_module._reset_primary_worker_manager()
+    monkeypatch.setenv("MINDROOM_WORKER_BACKEND", "kubernetes")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_IMAGE", "ghcr.io/mindroom-ai/mindroom:latest")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME", "mindroom-storage")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nrouter:\n  model: default\nagents: {}\n",
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "storage",
+        process_env=dict(os.environ),
+    )
+    runtime_config = load_config(runtime_paths)
+    tool_validation_snapshot = serialize_tool_validation_snapshot(
+        resolved_tool_validation_snapshot_for_runtime(runtime_paths, runtime_config),
+    )
+
+    class FakeKubernetesBackend:
+        backend_name = "kubernetes"
+        idle_timeout_seconds = 60.0
+
+        @classmethod
+        def from_runtime(
+            cls,
+            runtime_paths: RuntimePaths,
+            *,
+            auth_token: str | None,
+            storage_root: Path,
+            tool_validation_snapshot: dict[str, dict[str, object]],
+        ) -> Self:
+            del runtime_paths, auth_token, storage_root, tool_validation_snapshot
+            return cls()
+
+        def ensure_worker(self, spec: WorkerSpec, *, now: float | None = None) -> object:
+            raise NotImplementedError
+
+        def get_worker(self, worker_key: str, *, now: float | None = None) -> object:
+            raise NotImplementedError
+
+        def touch_worker(self, worker_key: str, *, now: float | None = None) -> object:
+            raise NotImplementedError
+
+        def list_workers(self, *, include_idle: bool = True, now: float | None = None) -> list[object]:
+            raise NotImplementedError
+
+        def evict_worker(
+            self,
+            worker_key: str,
+            *,
+            preserve_state: bool = True,
+            now: float | None = None,
+        ) -> object:
+            raise NotImplementedError
+
+        def cleanup_idle_workers(self, *, now: float | None = None) -> list[object]:
+            raise NotImplementedError
+
+        def record_failure(self, worker_key: str, failure_reason: str, *, now: float | None = None) -> object:
+            raise NotImplementedError
+
+    monkeypatch.setattr(workers_runtime_module, "KubernetesWorkerBackend", FakeKubernetesBackend)
+
+    first_manager = workers_runtime_module.get_primary_worker_manager(
+        runtime_paths,
+        proxy_url=None,
+        proxy_token=_TEST_AUTH_TOKEN,
+        storage_root=tmp_path,
+        kubernetes_tool_validation_snapshot=tool_validation_snapshot,
+    )
+    config_path.write_text("models: [\n", encoding="utf-8")
+    second_manager = workers_runtime_module.get_primary_worker_manager(
+        runtime_paths,
+        proxy_url=None,
+        proxy_token=_TEST_AUTH_TOKEN,
+        storage_root=tmp_path,
+        kubernetes_tool_validation_snapshot=tool_validation_snapshot,
+    )
+
+    assert first_manager is second_manager
+    workers_runtime_module._reset_primary_worker_manager()
+
+
+def test_get_worker_manager_passes_committed_snapshot_from_tool_runtime_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sandbox proxy worker routing should use the committed tool-runtime config snapshot."""
+    monkeypatch.setenv("MINDROOM_WORKER_BACKEND", "kubernetes")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_IMAGE", "ghcr.io/mindroom-ai/mindroom:latest")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME", "mindroom-storage")
+    runtime_paths = _configure_proxy_runtime(
+        monkeypatch,
+        proxy_url=None,
+        proxy_token=_TEST_AUTH_TOKEN,
+        execution_mode="off",
+    )
+    runtime_config = load_config(runtime_paths)
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_get_primary_worker_manager(*_args: object, **kwargs: object) -> object:
+        captured_kwargs.update(kwargs)
+        return object()
+
+    runtime_context = ToolRuntimeContext(
+        agent_name="code",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        requester_id="@user:example.org",
+        client=object(),
+        config=runtime_config,
+        runtime_paths=runtime_paths,
+        event_cache=make_event_cache_mock(),
+        conversation_cache=make_conversation_cache_mock(),
+    )
+    proxy_config = sandbox_proxy_module.sandbox_proxy_config(runtime_paths)
+    monkeypatch.setattr(sandbox_proxy_module, "get_primary_worker_manager", _fake_get_primary_worker_manager)
+
+    with tool_runtime_context(runtime_context):
+        sandbox_proxy_module._get_worker_manager(runtime_paths, proxy_config)
+
+    assert captured_kwargs["kubernetes_tool_validation_snapshot"] is not None
 
 
 def test_worker_tools_override_can_use_kubernetes_backend_without_proxy_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -9,7 +9,7 @@ from agno.tools import Toolkit
 
 # Import tools to trigger tool registration
 import mindroom.tools  # noqa: F401
-from mindroom.config.main import Config
+from mindroom.config.main import Config, load_config
 from mindroom.constants import resolve_runtime_paths
 from mindroom.tool_system.metadata import (
     _TOOL_REGISTRY,
@@ -21,6 +21,7 @@ from mindroom.tool_system.metadata import (
     ToolConfigOverrideError,
     ToolManagedInitArg,
     deserialize_tool_validation_snapshot,
+    ensure_tool_registry_loaded,
     export_tools_metadata,
     get_tool_by_name,
     register_tool_with_metadata,
@@ -481,6 +482,49 @@ def test_deserialize_tool_validation_snapshot_rejects_non_boolean_runtime_loadab
                     "runtime_loadable": "yes",
                 },
             },
+        )
+
+
+def test_get_tool_by_name_rejects_invalid_mcp_assignment_overrides(tmp_path: Path) -> None:
+    """Direct tool construction must enforce the same MCP-specific override rules as config loading."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n"
+        "  default:\n"
+        "    provider: openai\n"
+        "    id: gpt-5.4\n"
+        "router:\n"
+        "  model: default\n"
+        "mcp_servers:\n"
+        "  demo:\n"
+        "    transport: stdio\n"
+        "    command: python\n"
+        "    args:\n"
+        "      - -c\n"
+        "      - print(0)\n"
+        "agents:\n"
+        "  code:\n"
+        "    display_name: Code\n"
+        "    role: test\n"
+        "    model: default\n"
+        "    tools:\n"
+        "      - mcp_demo\n",
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(config_path=config_path, storage_path=tmp_path / "storage")
+    config = load_config(runtime_paths)
+    ensure_tool_registry_loaded(runtime_paths, config)
+
+    with pytest.raises(ToolConfigOverrideError, match="include_tools and exclude_tools overlap"):
+        get_tool_by_name(
+            "mcp_demo",
+            runtime_paths,
+            tool_config_overrides={
+                "include_tools": ["echo"],
+                "exclude_tools": ["echo"],
+            },
+            disable_sandbox_proxy=True,
+            worker_target=None,
         )
 
 

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -469,6 +469,21 @@ def test_tool_validation_snapshot_round_trips_mcp_override_validation(tmp_path: 
     assert restored_snapshot["mcp_demo"].agent_override_fields is not None
 
 
+def test_deserialize_tool_validation_snapshot_rejects_non_boolean_runtime_loadable() -> None:
+    """Validation snapshot payloads should type-check runtime_loadable strictly."""
+    with pytest.raises(TypeError, match="runtime_loadable to a boolean"):
+        deserialize_tool_validation_snapshot(
+            {
+                "shell": {
+                    "config_fields": [],
+                    "agent_override_fields": [],
+                    "authored_override_validator": "default",
+                    "runtime_loadable": "yes",
+                },
+            },
+        )
+
+
 def test_secret_like_config_fields_are_marked_password() -> None:
     """Secret-like tool config fields should be declared as password inputs."""
     suspicious_suffixes = ("_api_key", "_password", "_secret", "_token")

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -9,18 +9,23 @@ from agno.tools import Toolkit
 
 # Import tools to trigger tool registration
 import mindroom.tools  # noqa: F401
+from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
 from mindroom.tool_system.metadata import (
     _TOOL_REGISTRY,
     AUTHORED_OVERRIDE_INHERIT,
     TOOL_METADATA,
     ConfigField,
+    ToolAuthoredOverrideValidator,
     ToolCategory,
     ToolConfigOverrideError,
     ToolManagedInitArg,
+    deserialize_tool_validation_snapshot,
     export_tools_metadata,
     get_tool_by_name,
     register_tool_with_metadata,
+    resolved_tool_validation_snapshot_for_runtime,
+    serialize_tool_validation_snapshot,
     validate_authored_overrides,
 )
 from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, resolve_worker_target
@@ -430,6 +435,38 @@ def test_validate_authored_overrides_rejects_bad_types_and_password_fields() -> 
     finally:
         _TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
+
+
+def test_tool_validation_snapshot_round_trips_mcp_override_validation(tmp_path: Path) -> None:
+    """Validation snapshots should preserve explicit MCP override-validator semantics."""
+    runtime_paths = resolve_runtime_paths(config_path=tmp_path / "config.yaml")
+    config = Config.model_validate(
+        {
+            "models": {
+                "default": {
+                    "provider": "openai",
+                    "id": "gpt-5.4",
+                },
+            },
+            "agents": {},
+            "router": {"model": "default"},
+            "mcp_servers": {
+                "demo": {
+                    "transport": "stdio",
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-everything"],
+                },
+            },
+        },
+        context={"runtime_paths": runtime_paths},
+    )
+
+    snapshot = resolved_tool_validation_snapshot_for_runtime(runtime_paths, config)
+    payload = serialize_tool_validation_snapshot(snapshot)
+    restored_snapshot = deserialize_tool_validation_snapshot(payload)
+
+    assert restored_snapshot["mcp_demo"].authored_override_validator == ToolAuthoredOverrideValidator.MCP
+    assert restored_snapshot["mcp_demo"].agent_override_fields is not None
 
 
 def test_secret_like_config_fields_are_marked_password() -> None:


### PR DESCRIPTION
## Summary
- scope sandbox runner plugin loading to the plugin paths actually available in the current worker runtime
- skip unavailable plugin paths for dedicated workers instead of failing runtime initialization
- add regression coverage for worker-runtime plugin filtering and invalid runtime configs

## Testing
- `PYTEST_ADDOPTS='' .venv/bin/pytest -q tests/api/test_sandbox_runner_api.py -k 'skips_unavailable_plugins_for_worker_runtime or invalid_runtime_config or executes_tool_call or unknown_tool_returns_404'`
