### PR TITLE
fix: wait for joined room cache before welcome send

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -163,6 +163,8 @@ __all__ = ["AgentBot", "MultiKnowledgeVectorDb"]
 # Constants
 _SYNC_TIMEOUT_MS = 30000
 _STOPPING_RESPONSE_TEXT = "⏹️ Stopping generation..."
+_JOINED_ROOM_CACHE_WAIT_ATTEMPTS = 20
+_JOINED_ROOM_CACHE_WAIT_SECONDS = 0.1
 
 
 def _create_task_wrapper(
@@ -1170,6 +1172,12 @@ class AgentBot:
         if not response.chunk:
             # Room is completely empty
             self.logger.info("Room is empty, sending welcome message", room_id=room_id)
+            if not await self._wait_for_joined_room_cache(room_id):
+                self.logger.warning(
+                    "Skipping welcome message because the joined room is not cached yet",
+                    room_id=room_id,
+                )
+                return
 
             # Generate and send the welcome message
             welcome_msg = _generate_welcome_message(room_id, self.config, self.runtime_paths)
@@ -1193,6 +1201,18 @@ class AgentBot:
                 return
             # Otherwise, room has a different message, don't send welcome
         # Room has other messages, don't send welcome
+
+    async def _wait_for_joined_room_cache(self, room_id: str) -> bool:
+        """Wait briefly for a newly joined room to appear in nio's local room cache."""
+        assert self.client is not None
+        if room_id in self.client.rooms:
+            return True
+
+        for _ in range(_JOINED_ROOM_CACHE_WAIT_ATTEMPTS):
+            await asyncio.sleep(_JOINED_ROOM_CACHE_WAIT_SECONDS)
+            if room_id in self.client.rooms:
+                return True
+        return False
 
     def _maybe_start_deferred_overdue_task_drain(self) -> None:
         """Start draining queued overdue tasks once Matrix sync is ready."""

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -5109,6 +5109,49 @@ class TestAgentBot:
         )
 
     @pytest.mark.asyncio
+    async def test_router_welcome_waits_for_joined_room_cache_before_send(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Welcome sends should wait until the joined room is cached locally."""
+        agent_user = AgentMatrixUser(
+            agent_name="router",
+            user_id="@mindroom_router:localhost",
+            display_name="Router Agent",
+            password=TEST_PASSWORD,
+            access_token="mock_test_token",  # noqa: S106
+        )
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = AsyncMock()
+        bot.client.rooms = {}
+        bot.client.room_messages = AsyncMock(
+            return_value=nio.RoomMessagesResponse(
+                room_id="!welcome:localhost",
+                chunk=[],
+                start="",
+                end=None,
+            ),
+        )
+
+        async def fake_send_response(*, room_id: str, **_: object) -> str:
+            assert room_id in bot.client.rooms
+            return "$welcome"
+
+        async def populate_room_cache(_delay: float) -> None:
+            bot.client.rooms["!welcome:localhost"] = MagicMock()
+
+        bot._send_response = AsyncMock(side_effect=fake_send_response)
+        with (
+            patch("mindroom.bot._generate_welcome_message", return_value="Welcome"),
+            patch("mindroom.bot.asyncio.sleep", new=AsyncMock(side_effect=populate_room_cache)) as mock_sleep,
+        ):
+            await bot._send_welcome_message_if_empty("!welcome:localhost")
+
+        mock_sleep.assert_awaited()
+        bot._send_response.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_router_routes_file_messages_with_sender_metadata(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary
- wait briefly for a newly joined Matrix room to appear in nio's local room cache before sending the router welcome message
- add a regression test that reproduces the stale `client.rooms` startup window
- isolate the startup smoke fix from the broader PR #575 work

## Root cause
`Persist Matrix bot sessions for encrypted rooms` (`ceb2de540a50ba9b02de05bc903532f48054adb1`) introduced restored Matrix sessions on startup. In that path, the router could join a room and immediately try to send the welcome message before nio had populated `client.rooms`, which raises `LocalProtocolError: No such room with id ... found` and breaks the smoke stack job.

## Verification
- `UV_PYTHON=3.12 uv run pytest tests/test_multi_agent_bot.py -k "welcome_waits_for_joined_room_cache_before_send" -n 0 --no-cov -v`
- `UV_PYTHON=3.12 uv run pytest tests/test_multi_agent_bot.py -n 0 --no-cov`
- `UV_PYTHON=3.12 uv run pytest -n 0`
- `UV_PYTHON=3.12 uv run pre-commit run --files src/mindroom/bot.py tests/test_multi_agent_bot.py`

## Notes
- `UV_PYTHON=3.12 uv run pre-commit run --all-files` still reports unrelated repository-wide lint debt in untouched files such as `src/mindroom/knowledge/chunking.py`, `src/mindroom/matrix/users.py`, and `tests/test_queued_message_notify.py`.