### PR TITLE
refactor: collapse thread read mode matrix

### DIFF
--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -334,19 +334,31 @@ class ConversationResolver:
         dispatch_safe: bool,
     ) -> ThreadMembershipAccess:
         """Return the shared thread-membership accessors for this resolver."""
-        fetch_thread_messages = (
-            self.deps.conversation_cache.get_dispatch_thread_history
-            if full_history and dispatch_safe
-            else self.deps.conversation_cache.get_thread_history
-            if full_history
-            else self.deps.conversation_cache.get_dispatch_thread_snapshot
-            if dispatch_safe
-            else self.deps.conversation_cache.get_thread_snapshot
-        )
         return thread_messages_thread_membership_access(
             lookup_thread_id=self.deps.conversation_cache.get_thread_id_for_event,
             fetch_event_info=self._event_info_for_event_id,
-            fetch_thread_messages=fetch_thread_messages,
+            fetch_thread_messages=lambda room_id, thread_id: self._read_thread_messages(
+                room_id,
+                thread_id,
+                full_history=full_history,
+                dispatch_safe=dispatch_safe,
+            ),
+        )
+
+    async def _read_thread_messages(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        full_history: bool,
+        dispatch_safe: bool,
+    ) -> list[ResolvedVisibleMessage]:
+        """Resolve one thread read through the shared cache entrypoint."""
+        return await self.deps.conversation_cache.get_thread_messages(
+            room_id,
+            thread_id,
+            full_history=full_history,
+            dispatch_safe=dispatch_safe,
         )
 
     async def _event_info_for_event_id(
@@ -404,22 +416,16 @@ class ConversationResolver:
         if thread_id is None:
             return False, None, [], False
 
-        if full_history:
-            fetch_history = (
-                self.deps.conversation_cache.get_dispatch_thread_history
-                if dispatch_safe
-                else self.deps.conversation_cache.get_thread_history
-            )
-            thread_history = await fetch_history(room_id, thread_id)
-            return True, thread_id, list(thread_history), False
-
-        fetch_snapshot = (
-            self.deps.conversation_cache.get_dispatch_thread_snapshot
-            if dispatch_safe
-            else self.deps.conversation_cache.get_thread_snapshot
+        thread_messages = await self._read_thread_messages(
+            room_id,
+            thread_id,
+            full_history=full_history,
+            dispatch_safe=dispatch_safe,
         )
-        snapshot = await fetch_snapshot(room_id, thread_id)
-        return True, thread_id, list(snapshot), not snapshot.is_full_history
+        if full_history:
+            return True, thread_id, list(thread_messages), False
+
+        return True, thread_id, list(thread_messages), not thread_messages.is_full_history
 
     async def extract_dispatch_context(
         self,
@@ -555,4 +561,9 @@ class ConversationResolver:
         thread_id: str,
     ) -> list[ResolvedVisibleMessage]:
         """Fetch strict post-lock thread history through the shared conversation-cache policy."""
-        return await self.deps.conversation_cache.get_dispatch_thread_history(room_id, thread_id)
+        return await self._read_thread_messages(
+            room_id,
+            thread_id,
+            full_history=True,
+            dispatch_safe=True,
+        )

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -104,23 +104,79 @@ class ThreadReadPolicy:
             ),
         )
 
+    def _read_fetcher(
+        self,
+        *,
+        full_history: bool,
+        dispatch_safe: bool,
+    ) -> tuple[
+        typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
+        str,
+    ]:
+        if dispatch_safe:
+            if full_history:
+                return (
+                    self.fetch_dispatch_thread_history_from_client,
+                    "matrix_cache_refresh_dispatch_thread_history",
+                )
+            return (
+                self.fetch_dispatch_thread_snapshot_from_client,
+                "matrix_cache_refresh_dispatch_thread_snapshot",
+            )
+        if full_history:
+            return (
+                self.fetch_thread_history_from_client,
+                "matrix_cache_refresh_thread_history",
+            )
+        return (
+            self.fetch_thread_snapshot_from_client,
+            "matrix_cache_refresh_thread_snapshot",
+        )
+
+    async def read_thread(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        full_history: bool,
+        dispatch_safe: bool,
+    ) -> ThreadHistoryResult:
+        """Resolve one thread read through the shared barrier and fetch selection path."""
+        await self._wait_for_pending_room_cache_updates(room_id)
+        fetcher, name = self._read_fetcher(
+            full_history=full_history,
+            dispatch_safe=dispatch_safe,
+        )
+        if full_history:
+            return await self._load_thread_history_under_room_barrier(
+                room_id,
+                thread_id,
+                fetcher=fetcher,
+                name=name,
+            )
+        coordinator = self._coordinator()
+        if coordinator is None:
+            return await fetcher(room_id, thread_id)
+        return typing.cast(
+            "ThreadHistoryResult",
+            await coordinator.run_room_update(
+                room_id,
+                lambda: fetcher(room_id, thread_id),
+                name=name,
+            ),
+        )
+
     async def get_thread_snapshot(
         self,
         room_id: str,
         thread_id: str,
     ) -> ThreadHistoryResult:
         """Resolve advisory lightweight thread context for one thread under the room-scoped barrier."""
-        await self._wait_for_pending_room_cache_updates(room_id)
-        coordinator = self._coordinator()
-        if coordinator is None:
-            return await self.fetch_thread_snapshot_from_client(room_id, thread_id)
-        return typing.cast(
-            "ThreadHistoryResult",
-            await coordinator.run_room_update(
-                room_id,
-                lambda: self.fetch_thread_snapshot_from_client(room_id, thread_id),
-                name="matrix_cache_refresh_thread_snapshot",
-            ),
+        return await self.read_thread(
+            room_id,
+            thread_id,
+            full_history=False,
+            dispatch_safe=False,
         )
 
     async def get_thread_history(
@@ -129,12 +185,11 @@ class ThreadReadPolicy:
         thread_id: str,
     ) -> ThreadHistoryResult:
         """Resolve advisory full thread history for one conversation root."""
-        await self._wait_for_pending_room_cache_updates(room_id)
-        return await self._load_thread_history_under_room_barrier(
+        return await self.read_thread(
             room_id,
             thread_id,
-            fetcher=self.fetch_thread_history_from_client,
-            name="matrix_cache_refresh_thread_history",
+            full_history=True,
+            dispatch_safe=False,
         )
 
     async def get_dispatch_thread_snapshot(
@@ -143,17 +198,11 @@ class ThreadReadPolicy:
         thread_id: str,
     ) -> ThreadHistoryResult:
         """Resolve strict lightweight thread context for dispatch under the room-scoped barrier."""
-        await self._wait_for_pending_room_cache_updates(room_id)
-        coordinator = self._coordinator()
-        if coordinator is None:
-            return await self.fetch_dispatch_thread_snapshot_from_client(room_id, thread_id)
-        return typing.cast(
-            "ThreadHistoryResult",
-            await coordinator.run_room_update(
-                room_id,
-                lambda: self.fetch_dispatch_thread_snapshot_from_client(room_id, thread_id),
-                name="matrix_cache_refresh_dispatch_thread_snapshot",
-            ),
+        return await self.read_thread(
+            room_id,
+            thread_id,
+            full_history=False,
+            dispatch_safe=True,
         )
 
     async def get_dispatch_thread_history(
@@ -162,12 +211,11 @@ class ThreadReadPolicy:
         thread_id: str,
     ) -> ThreadHistoryResult:
         """Resolve strict full thread history for dispatch."""
-        await self._wait_for_pending_room_cache_updates(room_id)
-        return await self._load_thread_history_under_room_barrier(
+        return await self.read_thread(
             room_id,
             thread_id,
-            fetcher=self.fetch_dispatch_thread_history_from_client,
-            name="matrix_cache_refresh_dispatch_thread_history",
+            full_history=True,
+            dispatch_safe=True,
         )
 
     async def get_latest_thread_event_id_if_needed(
@@ -181,7 +229,12 @@ class ThreadReadPolicy:
         if thread_id is None or existing_event_id is not None or reply_to_event_id is not None:
             return None
         try:
-            thread_history = await self.get_thread_history(room_id, thread_id)
+            thread_history = await self.read_thread(
+                room_id,
+                thread_id,
+                full_history=True,
+                dispatch_safe=False,
+            )
         except Exception as exc:
             self.logger.warning(
                 "Failed to refresh latest thread event ID; falling back to thread root",

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -69,68 +69,31 @@ class ThreadReadPolicy:
             )
         return thread_history_result(list(history), is_full_history=True)
 
-    async def _load_full_thread_history(
-        self,
-        room_id: str,
-        thread_id: str,
-        *,
-        fetcher: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
-    ) -> ThreadHistoryResult:
-        return self._full_history_result(
-            await fetcher(room_id, thread_id),
-        )
-
-    async def _load_thread_history_under_room_barrier(
+    async def _run_thread_read(
         self,
         room_id: str,
         thread_id: str,
         *,
         fetcher: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
         name: str,
+        full_history: bool,
     ) -> ThreadHistoryResult:
+        async def load() -> ThreadHistoryResult:
+            thread_history = await fetcher(room_id, thread_id)
+            if full_history:
+                return self._full_history_result(thread_history)
+            return thread_history
+
         coordinator = self._coordinator()
         if coordinator is None:
-            return await self._load_full_thread_history(
-                room_id,
-                thread_id,
-                fetcher=fetcher,
-            )
+            return await load()
         return typing.cast(
             "ThreadHistoryResult",
             await coordinator.run_room_update(
                 room_id,
-                lambda: self._load_full_thread_history(room_id, thread_id, fetcher=fetcher),
+                load,
                 name=name,
             ),
-        )
-
-    def _read_fetcher(
-        self,
-        *,
-        full_history: bool,
-        dispatch_safe: bool,
-    ) -> tuple[
-        typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
-        str,
-    ]:
-        if dispatch_safe:
-            if full_history:
-                return (
-                    self.fetch_dispatch_thread_history_from_client,
-                    "matrix_cache_refresh_dispatch_thread_history",
-                )
-            return (
-                self.fetch_dispatch_thread_snapshot_from_client,
-                "matrix_cache_refresh_dispatch_thread_snapshot",
-            )
-        if full_history:
-            return (
-                self.fetch_thread_history_from_client,
-                "matrix_cache_refresh_thread_history",
-            )
-        return (
-            self.fetch_thread_snapshot_from_client,
-            "matrix_cache_refresh_thread_snapshot",
         )
 
     async def read_thread(
@@ -143,27 +106,36 @@ class ThreadReadPolicy:
     ) -> ThreadHistoryResult:
         """Resolve one thread read through the shared barrier and fetch selection path."""
         await self._wait_for_pending_room_cache_updates(room_id)
-        fetcher, name = self._read_fetcher(
-            full_history=full_history,
-            dispatch_safe=dispatch_safe,
-        )
-        if full_history:
-            return await self._load_thread_history_under_room_barrier(
+        if full_history and dispatch_safe:
+            return await self._run_thread_read(
                 room_id,
                 thread_id,
-                fetcher=fetcher,
-                name=name,
+                fetcher=self.fetch_dispatch_thread_history_from_client,
+                name="matrix_cache_refresh_dispatch_thread_history",
+                full_history=True,
             )
-        coordinator = self._coordinator()
-        if coordinator is None:
-            return await fetcher(room_id, thread_id)
-        return typing.cast(
-            "ThreadHistoryResult",
-            await coordinator.run_room_update(
+        if full_history:
+            return await self._run_thread_read(
                 room_id,
-                lambda: fetcher(room_id, thread_id),
-                name=name,
-            ),
+                thread_id,
+                fetcher=self.fetch_thread_history_from_client,
+                name="matrix_cache_refresh_thread_history",
+                full_history=True,
+            )
+        if dispatch_safe:
+            return await self._run_thread_read(
+                room_id,
+                thread_id,
+                fetcher=self.fetch_dispatch_thread_snapshot_from_client,
+                name="matrix_cache_refresh_dispatch_thread_snapshot",
+                full_history=False,
+            )
+        return await self._run_thread_read(
+            room_id,
+            thread_id,
+            fetcher=self.fetch_thread_snapshot_from_client,
+            name="matrix_cache_refresh_thread_snapshot",
+            full_history=False,
         )
 
     async def get_thread_snapshot(

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -78,6 +78,16 @@ class ConversationCacheProtocol(Protocol):
     async def get_event(self, room_id: str, event_id: str) -> EventLookupResult:
         """Resolve one Matrix event by ID."""
 
+    async def get_thread_messages(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        full_history: bool,
+        dispatch_safe: bool,
+    ) -> ThreadReadResult:
+        """Resolve thread context using explicit history and dispatch-safety flags."""
+
     async def get_thread_snapshot(
         self,
         room_id: str,
@@ -458,7 +468,12 @@ class MatrixConversationCache(ConversationCacheProtocol):
         thread_id: str,
     ) -> ThreadReadResult:
         """Resolve advisory thread context for non-dispatch callers."""
-        return await self._reads.get_thread_snapshot(room_id, thread_id)
+        return await self._reads.read_thread(
+            room_id,
+            thread_id,
+            full_history=False,
+            dispatch_safe=False,
+        )
 
     async def get_thread_history(
         self,
@@ -466,7 +481,29 @@ class MatrixConversationCache(ConversationCacheProtocol):
         thread_id: str,
     ) -> ThreadReadResult:
         """Resolve advisory full thread history for one conversation root."""
-        return await self._reads.get_thread_history(room_id, thread_id)
+        return await self._reads.read_thread(
+            room_id,
+            thread_id,
+            full_history=True,
+            dispatch_safe=False,
+        )
+
+    async def get_thread_messages(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        full_history: bool,
+        dispatch_safe: bool,
+    ) -> ThreadReadResult:
+        """Resolve thread context using one explicit read-mode entrypoint."""
+        if dispatch_safe:
+            if full_history:
+                return await self.get_dispatch_thread_history(room_id, thread_id)
+            return await self.get_dispatch_thread_snapshot(room_id, thread_id)
+        if full_history:
+            return await self.get_thread_history(room_id, thread_id)
+        return await self.get_thread_snapshot(room_id, thread_id)
 
     async def get_dispatch_thread_snapshot(
         self,
@@ -474,7 +511,12 @@ class MatrixConversationCache(ConversationCacheProtocol):
         thread_id: str,
     ) -> ThreadReadResult:
         """Resolve strict dispatch thread context without durable-cache reuse or stale fallback."""
-        return await self._reads.get_dispatch_thread_snapshot(room_id, thread_id)
+        return await self._reads.read_thread(
+            room_id,
+            thread_id,
+            full_history=False,
+            dispatch_safe=True,
+        )
 
     async def get_dispatch_thread_history(
         self,
@@ -482,7 +524,12 @@ class MatrixConversationCache(ConversationCacheProtocol):
         thread_id: str,
     ) -> ThreadReadResult:
         """Resolve strict full thread history for dispatch without durable-cache reuse or stale fallback."""
-        return await self._reads.get_dispatch_thread_history(room_id, thread_id)
+        return await self._reads.read_thread(
+            room_id,
+            thread_id,
+            full_history=True,
+            dispatch_safe=True,
+        )
 
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
         """Resolve the cached thread root for one event when known."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,6 +201,23 @@ def make_conversation_cache_mock() -> AsyncMock:
         return_value=thread_history_result([], is_full_history=False),
     )
     conversation_cache.get_dispatch_thread_history = AsyncMock(return_value=[])
+
+    async def _get_thread_messages(
+        room_id: str,
+        thread_id: str,
+        *,
+        full_history: bool,
+        dispatch_safe: bool,
+    ) -> object:
+        if dispatch_safe:
+            if full_history:
+                return await conversation_cache.get_dispatch_thread_history(room_id, thread_id)
+            return await conversation_cache.get_dispatch_thread_snapshot(room_id, thread_id)
+        if full_history:
+            return await conversation_cache.get_thread_history(room_id, thread_id)
+        return await conversation_cache.get_thread_snapshot(room_id, thread_id)
+
+    conversation_cache.get_thread_messages = AsyncMock(side_effect=_get_thread_messages)
     conversation_cache.get_thread_id_for_event = AsyncMock(return_value=None)
     conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(return_value=None)
     conversation_cache.append_live_event = AsyncMock()

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -3657,6 +3657,35 @@ class TestThreadingBehavior:
             await access.get_dispatch_thread_snapshot("!test:localhost", "$thread:localhost")
 
     @pytest.mark.asyncio
+    async def test_get_thread_messages_routes_through_collapsed_read_primitive(self) -> None:
+        """Thread reads should route through one internal primitive with explicit mode flags."""
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(),
+        )
+        expected = thread_history_result(
+            [_message(event_id="$thread:localhost", body="Root")],
+            is_full_history=True,
+        )
+
+        access._reads.read_thread = AsyncMock(return_value=expected)
+
+        result = await access.get_thread_messages(
+            "!test:localhost",
+            "$thread:localhost",
+            full_history=True,
+            dispatch_safe=True,
+        )
+
+        assert result == expected
+        access._reads.read_thread.assert_awaited_once_with(
+            "!test:localhost",
+            "$thread:localhost",
+            full_history=True,
+            dispatch_safe=True,
+        )
+
+    @pytest.mark.asyncio
     async def test_live_event_cache_update_recovers_after_same_room_failure(self) -> None:
         """A failed same-room cache update should not block the next queued write."""
         first_update_started = asyncio.Event()
@@ -5071,6 +5100,62 @@ class TestThreadingBehavior:
             mock_lookup.assert_awaited_once_with(room.room_id, "$plain1:localhost")
             mock_snapshot.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
             mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_extract_dispatch_context_routes_preview_reads_through_single_cache_entrypoint(
+        self,
+        bot: AgentBot,
+    ) -> None:
+        """Dispatch preview resolution should select read mode through one cache helper."""
+        room = MagicMock(spec=nio.MatrixRoom)
+        room.room_id = "!test:localhost"
+        room.name = "Test Room"
+        event = nio.RoomMessageText.from_dict(
+            {
+                "content": {
+                    "body": "plain reply",
+                    "msgtype": "m.text",
+                    "m.relates_to": {"m.in_reply_to": {"event_id": "$plain1:localhost"}},
+                },
+                "event_id": "$event:localhost",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "room_id": room.room_id,
+                "type": "m.room.message",
+            },
+        )
+        preview_snapshot = ThreadHistoryResult(
+            [
+                _message(event_id="$thread_root:localhost", body="Root"),
+                _message(event_id="$plain1:localhost", body="Preview"),
+            ],
+            is_full_history=False,
+        )
+
+        with (
+            patch.object(
+                bot._conversation_cache,
+                "get_thread_id_for_event",
+                AsyncMock(return_value="$thread_root:localhost"),
+            ),
+            patch.object(
+                bot._conversation_cache,
+                "get_thread_messages",
+                AsyncMock(return_value=preview_snapshot),
+                create=True,
+            ) as mock_read,
+        ):
+            context = await bot._conversation_resolver.extract_dispatch_context(room, event)
+
+        assert context.is_thread is True
+        assert context.thread_id == "$thread_root:localhost"
+        assert context.requires_full_thread_history is True
+        mock_read.assert_awaited_once_with(
+            room.room_id,
+            "$thread_root:localhost",
+            full_history=False,
+            dispatch_safe=True,
+        )
 
     @pytest.mark.asyncio
     async def test_full_history_thread_resolution_uses_full_history_to_prove_root(


### PR DESCRIPTION
## Summary
- collapse the internal Matrix thread read surface onto one flag-driven `read_thread` primitive
- add a single `get_thread_messages(...)` cache entrypoint and route resolver reads through it
- tighten test coverage for the collapsed read path and keep the shared conversation-cache mock aligned with snapshot vs full-history semantics

## Test Plan
- uv run pytest tests/test_thread_history.py tests/test_threading_error.py -k 'dispatch_thread or get_thread_history or get_thread_snapshot' -x -n 0 --no-cov -v
- uv run pytest tests/test_thread_mode.py -k 'requires_full_thread_history or dispatch_preview or get_dispatch_thread_snapshot or get_dispatch_thread_history' -x -n 0 --no-cov -v
- git diff --check
