### PR TITLE
refactor: unify event cache lifecycle

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -121,10 +121,9 @@ from .response_runner import (
     prepare_memory_and_model_context,
 )
 from .runtime_support import (
-    StandaloneRuntimeSupport,
-    close_standalone_runtime_support,
-    create_standalone_runtime_support,
-    initialize_standalone_runtime_support,
+    OwnedRuntimeSupport,
+    close_owned_runtime_support,
+    sync_owned_runtime_support,
 )
 from .scheduling import (
     cancel_all_running_scheduled_tasks,
@@ -150,8 +149,9 @@ if TYPE_CHECKING:
     from agno.agent import Agent
 
     from mindroom.config.main import Config
+    from mindroom.matrix.cache.event_cache import ConversationEventCache
+    from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
     from mindroom.matrix.client import ResolvedVisibleMessage
-    from mindroom.matrix.conversation_cache import ConversationEventCache, EventCacheWriteCoordinator
     from mindroom.orchestrator import MultiAgentOrchestrator
     from mindroom.tool_system.events import ToolTraceEntry
 
@@ -320,7 +320,7 @@ class AgentBot:
     _hook_context_support: HookContextSupport
     _knowledge_access_support: KnowledgeAccessSupport
     _deferred_overdue_task_drain_task: asyncio.Task[None] | None
-    _standalone_runtime_support: StandaloneRuntimeSupport | None
+    _standalone_runtime_support: OwnedRuntimeSupport | None
     _turn_controller: TurnController
 
     def __init__(
@@ -956,21 +956,17 @@ class AgentBot:
             msg = self._partial_runtime_support_injection_error()
             raise RuntimeError(msg)
         self._runtime_view.mark_runtime_started()
-        if binding_state == "uninitialized":
-            support = await create_standalone_runtime_support(
-                config=self.config,
-                runtime_paths=self.runtime_paths,
-                logger=self.logger,
-                background_task_owner=self._runtime_view,
-            )
-            self._standalone_runtime_support = support
-            self.event_cache = support.event_cache
-            self.event_cache_write_coordinator = support.event_cache_write_coordinator
-            return
-        support = self._standalone_runtime_support
-        assert support is not None
-        support.event_cache_write_coordinator.background_task_owner = self._runtime_view
-        await initialize_standalone_runtime_support(support, logger=self.logger)
+        support = await sync_owned_runtime_support(
+            self._standalone_runtime_support,
+            db_path=self.config.cache.resolve_db_path(self.runtime_paths),
+            logger=self.logger,
+            background_task_owner=self._runtime_view,
+            init_failure_reason_prefix="standalone_runtime_init_failed",
+            log_db_path_change=False,
+        )
+        self._standalone_runtime_support = support
+        self.event_cache = support.event_cache
+        self.event_cache_write_coordinator = support.event_cache_write_coordinator
 
     async def _close_runtime_support_services(self) -> None:
         """Close standalone-owned services and detach any injected shared support."""
@@ -984,7 +980,7 @@ class AgentBot:
             return
         support = self._standalone_runtime_support
         assert support is not None
-        await close_standalone_runtime_support(support, logger=self.logger)
+        await close_owned_runtime_support(support, logger=self.logger)
         self.event_cache = None
         self.event_cache_write_coordinator = None
         self._standalone_runtime_support = None

--- a/src/mindroom/bot_runtime_view.py
+++ b/src/mindroom/bot_runtime_view.py
@@ -10,7 +10,8 @@ if TYPE_CHECKING:
     import nio
 
     from mindroom.config.main import Config
-    from mindroom.matrix.conversation_cache import ConversationEventCache, EventCacheWriteCoordinator
+    from mindroom.matrix.cache.event_cache import ConversationEventCache
+    from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
     from mindroom.orchestrator import MultiAgentOrchestrator
 
 

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -19,8 +19,8 @@ if TYPE_CHECKING:
     import structlog
 
     from mindroom.bot_runtime_view import BotRuntimeView
+    from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
     from mindroom.matrix.client import ResolvedVisibleMessage
-    from mindroom.matrix.conversation_cache import EventCacheWriteCoordinator
 
 
 class ThreadReadPolicy:

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -6,12 +6,41 @@ import asyncio
 import typing
 import weakref
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from mindroom.background_tasks import create_background_task, wait_for_background_tasks
 
 if TYPE_CHECKING:
     import structlog
+
+
+class EventCacheWriteCoordinator(Protocol):
+    """Runtime-facing coordinator contract for ordered advisory cache writes."""
+
+    def queue_room_update(
+        self,
+        room_id: str,
+        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        *,
+        name: str,
+        log_exceptions: bool = True,
+    ) -> asyncio.Task[object]:
+        """Queue one room-scoped update behind any active predecessor."""
+
+    async def run_room_update(
+        self,
+        room_id: str,
+        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        *,
+        name: str,
+    ) -> object:
+        """Run one room-scoped update through the same ordered barrier."""
+
+    async def wait_for_room_idle(self, room_id: str) -> None:
+        """Wait for one room's queued updates to drain."""
+
+    async def close(self) -> None:
+        """Drain and tear down the coordinator."""
 
 
 @dataclass

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -16,15 +16,9 @@ from mindroom.matrix.cache.event_cache import (
     ConversationEventCache,
     normalize_nio_event_for_cache,
 )
-from mindroom.matrix.cache.event_cache import (
-    _EventCache as EventCache,
-)
 from mindroom.matrix.cache.thread_history_result import ThreadHistoryResult
 from mindroom.matrix.cache.thread_reads import ThreadReadPolicy
 from mindroom.matrix.cache.thread_writes import ThreadWritePolicy
-from mindroom.matrix.cache.write_coordinator import (
-    _EventCacheWriteCoordinator as EventCacheWriteCoordinator,
-)
 from mindroom.matrix.client import (
     fetch_dispatch_thread_history,
     fetch_dispatch_thread_snapshot,
@@ -61,8 +55,6 @@ class _TurnEventLookup:
 __all__ = [
     "ConversationCacheProtocol",
     "ConversationEventCache",
-    "EventCache",
-    "EventCacheWriteCoordinator",
     "EventLookupResult",
     "MatrixConversationCache",
     "ThreadReadResult",

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -35,12 +35,6 @@ from mindroom.matrix.client import (
     get_room_members,
     invite_to_room,
 )
-from mindroom.matrix.conversation_cache import (
-    EventCache as _EventCache,
-)
-from mindroom.matrix.conversation_cache import (
-    EventCacheWriteCoordinator as _EventCacheWriteCoordinator,
-)
 from mindroom.matrix.health import reset_matrix_sync_health
 from mindroom.matrix.identity import MatrixID, extract_server_name_from_homeserver
 from mindroom.matrix.rooms import (
@@ -103,6 +97,12 @@ from .orchestration.runtime import (
     stop_entities,
     sync_forever_with_restart,
     wait_for_matrix_homeserver,
+)
+from .runtime_support import (
+    OwnedRuntimeSupport,
+    build_owned_runtime_support,
+    close_owned_runtime_support,
+    sync_owned_runtime_support,
 )
 
 if TYPE_CHECKING:
@@ -217,8 +217,7 @@ class MultiAgentOrchestrator:
     _config_reload_requested_at: float | None = field(default=None, init=False)
     _mcp_manager: MCPServerManager | None = field(default=None, init=False)
     _mcp_catalog_change_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
-    _event_cache: _EventCache = field(init=False)
-    _event_cache_write_coordinator: _EventCacheWriteCoordinator = field(init=False)
+    _runtime_support: OwnedRuntimeSupport = field(init=False)
     _event_cache_write_task_owner: object = field(default_factory=object, init=False)
     hook_registry: HookRegistry = field(default_factory=HookRegistry.empty, init=False)
 
@@ -226,8 +225,8 @@ class MultiAgentOrchestrator:
         """Store canonical derived paths from the explicit runtime context."""
         self.storage_path = self.runtime_paths.storage_root
         self.config_path = self.runtime_paths.config_path
-        self._event_cache = _EventCache(self.storage_path / "event_cache.db")
-        self._event_cache_write_coordinator = _EventCacheWriteCoordinator(
+        self._runtime_support = build_owned_runtime_support(
+            db_path=self.storage_path / "event_cache.db",
             logger=logger,
             background_task_owner=self._event_cache_write_task_owner,
         )
@@ -269,8 +268,8 @@ class MultiAgentOrchestrator:
 
     def _bind_runtime_support_services(self, bot: AgentBot | TeamBot) -> None:
         """Bind the current runtime support services to one managed bot."""
-        bot.event_cache = self._event_cache
-        bot.event_cache_write_coordinator = self._event_cache_write_coordinator
+        bot.event_cache = self._runtime_support.event_cache
+        bot.event_cache_write_coordinator = self._runtime_support.event_cache_write_coordinator
 
     def _rebind_runtime_support_services(self) -> None:
         """Rebind the current runtime support services to every managed bot."""
@@ -279,36 +278,19 @@ class MultiAgentOrchestrator:
 
     async def _sync_event_cache_service(self, config: Config) -> None:
         """Ensure the runtime has one initialized shared event-cache service."""
-        desired_db_path = config.cache.resolve_db_path(self.runtime_paths)
-        cache = self._event_cache
-        if not cache.is_initialized and cache.db_path != desired_db_path:
-            cache = _EventCache(desired_db_path)
-            self._event_cache = cache
-        elif cache.db_path != desired_db_path:
-            logger.info(
-                "Event cache db_path change will apply after restart",
-                active_db_path=str(cache.db_path),
-                configured_db_path=str(desired_db_path),
-            )
-        if not cache.is_initialized:
-            try:
-                await cache.initialize()
-            except Exception as exc:
-                cache.disable(f"shared_runtime_init_failed:{exc}")
-                logger.warning(
-                    "Shared event cache init failed; continuing without advisory cache",
-                    db_path=str(cache.db_path),
-                    error=str(exc),
-                )
+        self._runtime_support = await sync_owned_runtime_support(
+            self._runtime_support,
+            db_path=config.cache.resolve_db_path(self.runtime_paths),
+            logger=logger,
+            background_task_owner=self._event_cache_write_task_owner,
+            init_failure_reason_prefix="shared_runtime_init_failed",
+            log_db_path_change=True,
+        )
         self._rebind_runtime_support_services()
 
-    async def _close_event_cache_write_coordinator(self) -> None:
-        """Drain the shared event-cache write coordinator."""
-        await self._event_cache_write_coordinator.close()
-
-    async def _close_event_cache(self) -> None:
-        """Close the shared event cache."""
-        await self._event_cache.close()
+    async def _close_runtime_support_services(self) -> None:
+        """Close the shared runtime-owned cache services."""
+        await close_owned_runtime_support(self._runtime_support, logger=logger)
 
     async def _ensure_user_account(self, config: Config) -> None:
         """Ensure a user account exists, creating one if necessary.
@@ -1513,8 +1495,7 @@ class MultiAgentOrchestrator:
 
         stop_tasks = [bot.stop(reason="shutdown") for bot in self.agent_bots.values()]
         await asyncio.gather(*stop_tasks)
-        await self._close_event_cache_write_coordinator()
-        await self._close_event_cache()
+        await self._close_runtime_support_services()
         logger.info("All agent bots stopped")
 
 

--- a/src/mindroom/runtime_support.py
+++ b/src/mindroom/runtime_support.py
@@ -1,38 +1,36 @@
-"""Standalone runtime support service lifecycle helpers."""
+"""Shared ownership and lifecycle helpers for runtime Matrix event-cache services."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from mindroom.matrix.conversation_cache import EventCache as _EventCache
-from mindroom.matrix.conversation_cache import EventCacheWriteCoordinator as _EventCacheWriteCoordinator
+from mindroom.matrix.cache.event_cache import _EventCache
+from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
 
 if TYPE_CHECKING:
-    import structlog
+    from pathlib import Path
 
-    from mindroom.config.main import Config
-    from mindroom.constants import RuntimePaths
+    import structlog
 
 
 @dataclass(slots=True)
-class StandaloneRuntimeSupport:
-    """Concrete standalone-owned runtime support services for one bot."""
+class OwnedRuntimeSupport:
+    """Concrete event-cache services owned by one runtime lifecycle."""
 
     event_cache: _EventCache
     event_cache_write_coordinator: _EventCacheWriteCoordinator
 
 
-def _build_standalone_runtime_support(
+def build_owned_runtime_support(
     *,
-    config: Config,
-    runtime_paths: RuntimePaths,
+    db_path: Path,
     logger: structlog.stdlib.BoundLogger,
     background_task_owner: object,
-) -> StandaloneRuntimeSupport:
-    """Build standalone runtime support without initializing the event cache."""
-    return StandaloneRuntimeSupport(
-        event_cache=_EventCache(config.cache.resolve_db_path(runtime_paths)),
+) -> OwnedRuntimeSupport:
+    """Build one owned runtime-support bundle without initializing the cache."""
+    return OwnedRuntimeSupport(
+        event_cache=_EventCache(db_path),
         event_cache_write_coordinator=_EventCacheWriteCoordinator(
             logger=logger,
             background_task_owner=background_task_owner,
@@ -40,71 +38,64 @@ def _build_standalone_runtime_support(
     )
 
 
-async def initialize_standalone_runtime_support(
-    support: StandaloneRuntimeSupport,
+async def sync_owned_runtime_support(
+    support: OwnedRuntimeSupport | None,
     *,
+    db_path: Path,
     logger: structlog.stdlib.BoundLogger,
-) -> None:
-    """Initialize the standalone-owned event cache, degrading to no-cache on SQLite errors."""
+    background_task_owner: object,
+    init_failure_reason_prefix: str,
+    log_db_path_change: bool,
+) -> OwnedRuntimeSupport:
+    """Build, rebind, and initialize one owned runtime-support bundle."""
+    if support is None:
+        support = build_owned_runtime_support(
+            db_path=db_path,
+            logger=logger,
+            background_task_owner=background_task_owner,
+        )
+    else:
+        support.event_cache_write_coordinator.background_task_owner = background_task_owner
+        if not support.event_cache.is_initialized and support.event_cache.db_path != db_path:
+            support = build_owned_runtime_support(
+                db_path=db_path,
+                logger=logger,
+                background_task_owner=background_task_owner,
+            )
+        elif support.event_cache.db_path != db_path and log_db_path_change:
+            logger.info(
+                "Event cache db_path change will apply after restart",
+                active_db_path=str(support.event_cache.db_path),
+                configured_db_path=str(db_path),
+            )
+
+    if support.event_cache.is_initialized:
+        return support
+
     try:
         await support.event_cache.initialize()
     except Exception as exc:
-        support.event_cache.disable(f"standalone_runtime_init_failed:{exc}")
+        support.event_cache.disable(f"{init_failure_reason_prefix}:{exc}")
         logger.warning(
             "Event cache init failed; continuing without advisory cache",
             db_path=str(support.event_cache.db_path),
             error=str(exc),
         )
-
-
-async def create_standalone_runtime_support(
-    *,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    logger: structlog.stdlib.BoundLogger,
-    background_task_owner: object,
-) -> StandaloneRuntimeSupport:
-    """Build and initialize the standalone runtime support services for one direct bot runtime."""
-    support = _build_standalone_runtime_support(
-        config=config,
-        runtime_paths=runtime_paths,
-        logger=logger,
-        background_task_owner=background_task_owner,
-    )
-    await initialize_standalone_runtime_support(support, logger=logger)
     return support
 
 
-async def close_standalone_runtime_support(
-    support: StandaloneRuntimeSupport,
+async def close_owned_runtime_support(
+    support: OwnedRuntimeSupport,
     *,
     logger: structlog.stdlib.BoundLogger,
 ) -> None:
-    """Close one standalone-owned runtime support bundle in dependency order."""
-    await _close_standalone_event_cache_write_coordinator(
-        support.event_cache_write_coordinator,
-        logger=logger,
-    )
-    await _close_standalone_event_cache(support.event_cache, logger=logger)
-
-
-async def _close_standalone_event_cache_write_coordinator(
-    event_cache_write_coordinator: _EventCacheWriteCoordinator,
-    *,
-    logger: structlog.stdlib.BoundLogger,
-) -> None:
+    """Close one owned runtime-support bundle in dependency order."""
     try:
-        await event_cache_write_coordinator.close()
+        await support.event_cache_write_coordinator.close()
     except Exception as exc:
         logger.warning("Failed to close event cache write coordinator", error=str(exc))
 
-
-async def _close_standalone_event_cache(
-    event_cache: _EventCache,
-    *,
-    logger: structlog.stdlib.BoundLogger,
-) -> None:
     try:
-        await event_cache.close()
+        await support.event_cache.close()
     except Exception as exc:
         logger.warning("Failed to close event cache", error=str(exc))

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, replace
 from datetime import datetime
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Self, cast
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 from zoneinfo import ZoneInfo
 
 import httpx
@@ -8991,14 +8991,63 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.load_plugins", return_value=[]),
             patch.object(orchestrator, "_prepare_user_account", new=AsyncMock()),
             patch.object(orchestrator, "_sync_mcp_manager", new=AsyncMock(return_value=set())),
-            patch("mindroom.orchestrator._EventCache.initialize", new=AsyncMock(side_effect=RuntimeError("boom"))),
+            patch("mindroom.runtime_support._EventCache.initialize", new=AsyncMock(side_effect=RuntimeError("boom"))),
             patch.object(MultiAgentOrchestrator, "_create_managed_bot") as mock_create_managed_bot,
         ):
             await orchestrator.initialize()
 
         assert orchestrator.config is config
         assert mock_create_managed_bot.call_count == 2
-        assert orchestrator._event_cache.is_initialized is False
+        assert orchestrator._runtime_support.event_cache.is_initialized is False
+
+    @pytest.mark.asyncio
+    async def test_sync_event_cache_service_uses_shared_runtime_support_sync(self, tmp_path: Path) -> None:
+        """Shared runtime cache lifecycle should route through the shared sync helper."""
+        orchestrator = MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": {
+                        "display_name": "GeneralAgent",
+                        "role": "General assistant",
+                        "model": "default",
+                        "rooms": ["lobby"],
+                    },
+                },
+                models={"default": {"provider": "test", "id": "test-model"}},
+            ),
+            tmp_path,
+        )
+        router_bot = _mock_managed_bot(config)
+        general_bot = _mock_managed_bot(config)
+        orchestrator.agent_bots = {"router": router_bot, "general": general_bot}
+        initial_support = orchestrator._runtime_support
+        synced_support = SimpleNamespace(
+            event_cache=make_event_cache_mock(),
+            event_cache_write_coordinator=make_event_cache_write_coordinator_mock(),
+        )
+
+        with patch(
+            "mindroom.orchestrator.sync_owned_runtime_support",
+            new=AsyncMock(return_value=synced_support),
+            create=True,
+        ) as sync_owned_runtime_support:
+            await orchestrator._sync_event_cache_service(config)
+
+        sync_owned_runtime_support.assert_awaited_once()
+        assert sync_owned_runtime_support.await_args.args == (initial_support,)
+        assert sync_owned_runtime_support.await_args.kwargs == {
+            "db_path": config.cache.resolve_db_path(orchestrator.runtime_paths),
+            "logger": ANY,
+            "background_task_owner": orchestrator._event_cache_write_task_owner,
+            "init_failure_reason_prefix": "shared_runtime_init_failed",
+            "log_db_path_change": True,
+        }
+        assert orchestrator._runtime_support is synced_support
+        assert router_bot.event_cache is synced_support.event_cache
+        assert general_bot.event_cache is synced_support.event_cache
+        assert router_bot.event_cache_write_coordinator is synced_support.event_cache_write_coordinator
+        assert general_bot.event_cache_write_coordinator is synced_support.event_cache_write_coordinator
 
     @pytest.mark.asyncio
     async def test_initialize_does_not_activate_hook_runtime_before_user_account_succeeds(
@@ -9771,13 +9820,18 @@ class TestMultiAgentOrchestrator:
             try:
                 updated = await orchestrator.update_config()
                 assert updated is False
-                assert router_bot.event_cache is orchestrator._event_cache
-                assert general_bot.event_cache is orchestrator._event_cache
-                assert router_bot.event_cache_write_coordinator is orchestrator._event_cache_write_coordinator
-                assert general_bot.event_cache_write_coordinator is orchestrator._event_cache_write_coordinator
+                assert router_bot.event_cache is orchestrator._runtime_support.event_cache
+                assert general_bot.event_cache is orchestrator._runtime_support.event_cache
+                assert (
+                    router_bot.event_cache_write_coordinator
+                    is orchestrator._runtime_support.event_cache_write_coordinator
+                )
+                assert (
+                    general_bot.event_cache_write_coordinator
+                    is orchestrator._runtime_support.event_cache_write_coordinator
+                )
             finally:
-                await orchestrator._close_event_cache_write_coordinator()
-                await orchestrator._close_event_cache()
+                await orchestrator._close_runtime_support_services()
 
     @pytest.mark.asyncio
     async def test_update_config_keeps_shared_event_cache_when_db_path_changes(self, tmp_path: Path) -> None:
@@ -9821,7 +9875,7 @@ class TestMultiAgentOrchestrator:
         general_bot = _mock_managed_bot(old_config)
         orchestrator.agent_bots = {"router": router_bot, "general": general_bot}
         await orchestrator._sync_event_cache_service(old_config)
-        old_cache = orchestrator._event_cache
+        old_cache = orchestrator._runtime_support.event_cache
         assert old_cache is not None
 
         with (
@@ -9834,16 +9888,21 @@ class TestMultiAgentOrchestrator:
             try:
                 updated = await orchestrator.update_config()
                 assert updated is False
-                assert orchestrator._event_cache is old_cache
+                assert orchestrator._runtime_support.event_cache is old_cache
                 assert old_cache.db_path == old_config.cache.resolve_db_path(orchestrator.runtime_paths)
                 assert router_bot.event_cache is old_cache
                 assert general_bot.event_cache is old_cache
-                assert orchestrator._event_cache_write_coordinator is not None
-                assert router_bot.event_cache_write_coordinator is orchestrator._event_cache_write_coordinator
-                assert general_bot.event_cache_write_coordinator is orchestrator._event_cache_write_coordinator
+                assert orchestrator._runtime_support.event_cache_write_coordinator is not None
+                assert (
+                    router_bot.event_cache_write_coordinator
+                    is orchestrator._runtime_support.event_cache_write_coordinator
+                )
+                assert (
+                    general_bot.event_cache_write_coordinator
+                    is orchestrator._runtime_support.event_cache_write_coordinator
+                )
             finally:
-                await orchestrator._close_event_cache_write_coordinator()
-                await orchestrator._close_event_cache()
+                await orchestrator._close_runtime_support_services()
 
     @pytest.mark.asyncio
     async def test_update_config_keeps_failed_new_bot_and_schedules_retry(self, tmp_path: Path) -> None:

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import time
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
@@ -65,6 +66,7 @@ from tests.conftest import (
     bind_runtime_paths,
     install_generate_response_mock,
     make_event_cache_mock,
+    make_event_cache_write_coordinator_mock,
     make_matrix_client_mock,
     runtime_paths_for,
     test_runtime_paths,
@@ -922,6 +924,36 @@ class TestThreadingBehavior:
         assert bot._runtime_view.event_cache is None
         assert bot._runtime_view.event_cache_write_coordinator is None
         start_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_standalone_runtime_support_uses_shared_sync_flow(self, bot: AgentBot) -> None:
+        """Standalone startup should delegate ownership lifecycle to the shared sync helper."""
+        bot.event_cache = None
+        bot.event_cache_write_coordinator = None
+        synced_support = SimpleNamespace(
+            event_cache=make_event_cache_mock(),
+            event_cache_write_coordinator=make_event_cache_write_coordinator_mock(owner=bot._runtime_view),
+        )
+
+        with patch(
+            "mindroom.bot.sync_owned_runtime_support",
+            new=AsyncMock(return_value=synced_support),
+            create=True,
+        ) as sync_owned_runtime_support:
+            await bot._initialize_runtime_support_services()
+
+        sync_owned_runtime_support.assert_awaited_once()
+        assert sync_owned_runtime_support.await_args.args == (None,)
+        assert sync_owned_runtime_support.await_args.kwargs == {
+            "db_path": bot.config.cache.resolve_db_path(bot.runtime_paths),
+            "logger": bot.logger,
+            "background_task_owner": bot._runtime_view,
+            "init_failure_reason_prefix": "standalone_runtime_init_failed",
+            "log_db_path_change": False,
+        }
+        assert bot._standalone_runtime_support is synced_support
+        assert bot._runtime_view.event_cache is synced_support.event_cache
+        assert bot._runtime_view.event_cache_write_coordinator is synced_support.event_cache_write_coordinator
 
     @pytest.mark.asyncio
     async def test_injected_shared_event_cache_stays_open_for_other_bots(self, bot: AgentBot, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- centralize owned event-cache construction, init degradation, and shutdown in `runtime_support.py`
- route both standalone bot startup and orchestrator-owned shared cache wiring through the same lifecycle helper
- tighten the cache boundary so runtime-facing code uses protocols instead of concrete cache/coordinator re-exports

## Tests
- `uv run pytest tests/test_threading_error.py -k 'runtime_support or injected_shared_event_cache or standalone_runtime_support or start_and_stop_manage_persistent_event_cache' -x -n 0 --no-cov -v`
- `uv run pytest tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_sync_event_cache_service_uses_shared_runtime_support_sync tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_initialize_degrades_when_shared_event_cache_init_fails tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_update_config_initializes_shared_event_cache_for_unchanged_bots tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_update_config_keeps_shared_event_cache_when_db_path_changes -x -n 0 --no-cov -v`
- `uv run ruff check src/mindroom/matrix/conversation_cache.py src/mindroom/matrix/cache/thread_reads.py src/mindroom/runtime_support.py src/mindroom/orchestrator.py src/mindroom/bot.py src/mindroom/bot_runtime_view.py src/mindroom/matrix/cache/write_coordinator.py tests/test_threading_error.py tests/test_multi_agent_bot.py`
- `uv run ty check src/mindroom/runtime_support.py src/mindroom/orchestrator.py src/mindroom/bot.py src/mindroom/bot_runtime_view.py src/mindroom/matrix/cache/write_coordinator.py src/mindroom/matrix/cache/thread_reads.py src/mindroom/matrix/conversation_cache.py tests/test_threading_error.py tests/test_multi_agent_bot.py`

## Notes
- `uv sync --all-extras` currently fails in this environment because `python-olm==3.2.16` does not build with the installed CMake policy setup.
- `uv run pre-commit run --all-files` still reports unrelated existing optional-dependency import resolution failures in untouched modules (`google_auth_oauthlib`, `playwright`, `claude_agent_sdk`, `composio_agno`).
