### PR TITLE
refactor: tighten active runtime optionality

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -80,6 +80,9 @@ timezone: America/Los_Angeles
 ## Persistence
 
 Schedules are stored in Matrix room state and persist across restarts.
+New schedules use the live runtime to start their in-memory runners immediately.
+Edits are state-only Matrix writes.
+Running tasks pick up edited state on their next poll instead of relying on caller-supplied cache or restart hooks.
 Past one-time tasks are automatically skipped during restoration.
 Only the router restores persisted schedules after startup — individual agents do not restore their own.
 On shutdown, the router cancels its in-memory scheduled tasks before exiting.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -9793,7 +9793,7 @@ timezone: America/Los_Angeles
 
 ## Persistence
 
-Schedules are stored in Matrix room state and persist across restarts. Past one-time tasks are automatically skipped during restoration. Only the router restores persisted schedules after startup — individual agents do not restore their own. On shutdown, the router cancels its in-memory scheduled tasks before exiting.
+Schedules are stored in Matrix room state and persist across restarts. New schedules use the live runtime to start their in-memory runners immediately. Edits are state-only Matrix writes. Running tasks pick up edited state on their next poll instead of relying on caller-supplied cache or restart hooks. Past one-time tasks are automatically skipped during restoration. Only the router restores persisted schedules after startup — individual agents do not restore their own. On shutdown, the router cancels its in-memory scheduled tasks before exiting.
 
 # Authorization
 

--- a/skills/mindroom-docs/references/page__scheduling__index.md
+++ b/skills/mindroom-docs/references/page__scheduling__index.md
@@ -73,4 +73,4 @@ timezone: America/Los_Angeles
 
 ## Persistence
 
-Schedules are stored in Matrix room state and persist across restarts. Past one-time tasks are automatically skipped during restoration. Only the router restores persisted schedules after startup — individual agents do not restore their own. On shutdown, the router cancels its in-memory scheduled tasks before exiting.
+Schedules are stored in Matrix room state and persist across restarts. New schedules use the live runtime to start their in-memory runners immediately. Edits are state-only Matrix writes. Running tasks pick up edited state on their next poll instead of relying on caller-supplied cache or restart hooks. Past one-time tasks are automatically skipped during restoration. Only the router restores persisted schedules after startup — individual agents do not restore their own. On shutdown, the router cancels its in-memory scheduled tasks before exiting.

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -894,10 +894,20 @@ def _build_agent_tool_hook_bridge(
     runtime_paths: constants.RuntimePaths,
 ) -> Callable[..., Any] | None:
     active_hook_registry = hook_registry if hook_registry is not None else HookRegistry.from_plugins(plugins)
+    hook_execution_identity = execution_identity
+    if (
+        hook_execution_identity is not None
+        and hook_execution_identity.requester_id is None
+        and hook_execution_identity.room_id is None
+        and hook_execution_identity.thread_id is None
+        and hook_execution_identity.resolved_thread_id is None
+        and hook_execution_identity.session_id is None
+    ):
+        hook_execution_identity = None
     return build_tool_hook_bridge(
         active_hook_registry,
         agent_name=agent_name,
-        execution_identity=execution_identity,
+        execution_identity=hook_execution_identity,
         config=config,
         runtime_paths=runtime_paths,
     )

--- a/src/mindroom/api/schedules.py
+++ b/src/mindroom/api/schedules.py
@@ -300,12 +300,7 @@ async def update_schedule(
                 room_id=resolved_room_id,
                 task_id=task_id,
                 workflow=updated_workflow,
-                config=runtime_config,
-                runtime_paths=runtime_paths,
-                event_cache=None,
-                conversation_cache=None,
                 existing_task=existing_task,
-                restart_task=False,
             )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=f"{e!s}") from e

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -330,6 +330,17 @@ class _ToolCallArguments:
     error: str | None = None
 
 
+@dataclass(frozen=True)
+class _SkillToolDispatchTarget:
+    """One valid runtime shape for tool-dispatched skill execution."""
+
+    requester_user_id: str | None
+    room_id: str | None
+    resolved_thread_id: str | None
+    session_id: str | None
+    runtime_context: ToolRuntimeContext | None
+
+
 def _prepare_tool_call_arguments(  # noqa: PLR0911
     entrypoint: Callable[..., object] | None,
     base_args: Mapping[str, object],
@@ -392,6 +403,49 @@ async def _maybe_await(value: object) -> object:
     return value
 
 
+def _resolve_skill_tool_dispatch_target(
+    *,
+    requester_user_id: str | None,
+    room_id: str | None,
+    thread_id: str | None,
+    runtime_context: ToolRuntimeContext | None,
+) -> _SkillToolDispatchTarget:
+    if runtime_context is not None:
+        if requester_user_id is not None or room_id is not None or thread_id is not None:
+            msg = "Skill tool dispatch accepts either runtime_context or raw Matrix coordinates."
+            raise ValueError(msg)
+
+        target = MessageTarget.from_runtime_context(runtime_context)
+        return _SkillToolDispatchTarget(
+            requester_user_id=runtime_context.requester_id,
+            room_id=target.room_id,
+            resolved_thread_id=target.resolved_thread_id,
+            session_id=target.session_id,
+            runtime_context=runtime_context,
+        )
+
+    if thread_id is not None and room_id is None:
+        msg = "Skill tool dispatch thread_id requires room_id."
+        raise ValueError(msg)
+
+    target = (
+        MessageTarget.resolve(
+            room_id=room_id,
+            thread_id=thread_id,
+            reply_to_event_id=None,
+        )
+        if room_id is not None
+        else None
+    )
+    return _SkillToolDispatchTarget(
+        requester_user_id=requester_user_id,
+        room_id=target.room_id if target is not None else None,
+        resolved_thread_id=target.resolved_thread_id if target is not None else None,
+        session_id=target.session_id if target is not None else None,
+        runtime_context=None,
+    )
+
+
 async def _run_skill_command_tool(
     *,
     config: Config,
@@ -407,30 +461,21 @@ async def _run_skill_command_tool(
     thread_id: str | None = None,
     runtime_context: ToolRuntimeContext | None = None,
 ) -> str:
-    target = (
-        MessageTarget.from_runtime_context(runtime_context)
-        if runtime_context is not None
-        else MessageTarget.resolve(
-            room_id=room_id,
-            thread_id=thread_id,
-            reply_to_event_id=None,
-        )
-        if room_id is not None
-        else None
+    dispatch_target = _resolve_skill_tool_dispatch_target(
+        requester_user_id=requester_user_id,
+        room_id=room_id,
+        thread_id=thread_id,
+        runtime_context=runtime_context,
     )
-    resolved_requester_user_id = runtime_context.requester_id if runtime_context is not None else requester_user_id
-    resolved_room_id = target.room_id if target is not None else room_id
-    resolved_thread_id = target.resolved_thread_id if target is not None else thread_id
-    session_id = target.session_id if target is not None else None
     execution_identity = build_tool_execution_identity(
         channel="matrix",
         agent_name=agent_name,
         runtime_paths=runtime_paths,
-        requester_id=resolved_requester_user_id,
-        room_id=resolved_room_id,
-        thread_id=resolved_thread_id,
-        resolved_thread_id=resolved_thread_id,
-        session_id=session_id,
+        requester_id=dispatch_target.requester_user_id,
+        room_id=dispatch_target.room_id,
+        thread_id=dispatch_target.resolved_thread_id,
+        resolved_thread_id=dispatch_target.resolved_thread_id,
+        session_id=dispatch_target.session_id,
     )
     effective_runtime_paths = (
         runtime_paths
@@ -439,7 +484,7 @@ async def _run_skill_command_tool(
     )
 
     try:
-        with tool_runtime_context(runtime_context), tool_execution_identity(execution_identity):
+        with tool_runtime_context(dispatch_target.runtime_context), tool_execution_identity(execution_identity):
             toolkits = _collect_agent_toolkits(
                 config,
                 agent_name,

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -493,56 +493,24 @@ async def _get_pending_task_record(
     return task_record
 
 
-async def _save_one_time_task_status(
-    client: nio.AsyncClient,
-    task: ScheduledTaskRecord,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    event_cache: ConversationEventCache,
-    status: str,
-) -> None:
-    """Persist the terminal status for a one-time task without restarting it."""
-    await _save_scheduled_task(
-        client=client,
-        room_id=task.room_id,
-        task_id=task.task_id,
-        workflow=task.workflow,
-        config=config,
-        runtime_paths=runtime_paths,
-        event_cache=event_cache,
-        status=status,
-        created_at=task.created_at,
-        restart_task=False,
-    )
+def _serialize_scheduled_task_created_at(created_at: datetime | str | None) -> str:
+    """Normalize persisted scheduled-task timestamps."""
+    if isinstance(created_at, datetime):
+        return created_at.isoformat()
+    if isinstance(created_at, str) and created_at:
+        return created_at
+    return datetime.now(UTC).isoformat()
 
 
-async def _save_scheduled_task(
+async def _persist_scheduled_task_state(
     client: nio.AsyncClient,
     room_id: str,
     task_id: str,
     workflow: ScheduledWorkflow,
-    config: Config | None = None,
-    runtime_paths: RuntimePaths | None = None,
-    event_cache: ConversationEventCache | None = None,
-    conversation_cache: ConversationCacheProtocol | None = None,
     status: str = "pending",
     created_at: datetime | str | None = None,
-    restart_task: bool = True,
 ) -> None:
-    """Persist scheduled task state and optionally restart its in-memory task runner."""
-    if restart_task:
-        if config is None or runtime_paths is None or event_cache is None or conversation_cache is None:
-            msg = "Scheduled task runtime context is required when restart_task=True"
-            raise ValueError(msg)
-        _cancel_running_task(task_id)
-
-    if isinstance(created_at, datetime):
-        created_at_value = created_at.isoformat()
-    elif isinstance(created_at, str) and created_at:
-        created_at_value = created_at
-    else:
-        created_at_value = datetime.now(UTC).isoformat()
-
+    """Persist scheduled task state to Matrix."""
     await client.room_put_state(
         room_id=room_id,
         event_type=_SCHEDULED_TASK_EVENT_TYPE,
@@ -550,18 +518,52 @@ async def _save_scheduled_task(
             "task_id": task_id,
             "workflow": workflow.model_dump_json(),
             "status": status,
-            "created_at": created_at_value,
+            "created_at": _serialize_scheduled_task_created_at(created_at),
             "updated_at": datetime.now(UTC).isoformat(),
         },
         state_key=task_id,
     )
 
-    if restart_task and status == "pending":
-        assert config is not None
-        assert runtime_paths is not None
-        assert event_cache is not None
-        assert conversation_cache is not None
-        _start_scheduled_task(client, task_id, workflow, config, runtime_paths, event_cache, conversation_cache)
+
+async def _save_pending_scheduled_task(
+    client: nio.AsyncClient,
+    room_id: str,
+    task_id: str,
+    workflow: ScheduledWorkflow,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    event_cache: ConversationEventCache,
+    conversation_cache: ConversationCacheProtocol,
+    *,
+    created_at: datetime | str | None = None,
+) -> None:
+    """Persist one pending task and start or replace its in-memory runner."""
+    _cancel_running_task(task_id)
+    await _persist_scheduled_task_state(
+        client=client,
+        room_id=room_id,
+        task_id=task_id,
+        workflow=workflow,
+        status="pending",
+        created_at=created_at,
+    )
+    _start_scheduled_task(client, task_id, workflow, config, runtime_paths, event_cache, conversation_cache)
+
+
+async def _save_one_time_task_status(
+    client: nio.AsyncClient,
+    task: ScheduledTaskRecord,
+    status: str,
+) -> None:
+    """Persist the terminal status for a one-time task without restarting it."""
+    await _persist_scheduled_task_state(
+        client=client,
+        room_id=task.room_id,
+        task_id=task.task_id,
+        workflow=task.workflow,
+        status=status,
+        created_at=task.created_at,
+    )
 
 
 async def save_edited_scheduled_task(
@@ -569,14 +571,9 @@ async def save_edited_scheduled_task(
     room_id: str,
     task_id: str,
     workflow: ScheduledWorkflow,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    event_cache: ConversationEventCache | None,
-    conversation_cache: ConversationCacheProtocol | None,
     existing_task: ScheduledTaskRecord,
-    restart_task: bool = False,
 ) -> ScheduledTaskRecord:
-    """Persist edits to an existing task using shared validation semantics."""
+    """Persist edits to an existing task without touching runtime task runners."""
     if existing_task.status != "pending":
         msg = f"Task `{task_id}` cannot be edited because it is `{existing_task.status}`."
         raise ValueError(msg)
@@ -584,18 +581,13 @@ async def save_edited_scheduled_task(
     if workflow.schedule_type != existing_task.workflow.schedule_type:
         raise ValueError(SCHEDULE_TYPE_CHANGE_NOT_SUPPORTED_ERROR)
 
-    await _save_scheduled_task(
+    await _persist_scheduled_task_state(
         client=client,
         room_id=room_id,
         task_id=task_id,
         workflow=workflow,
-        config=config,
-        runtime_paths=runtime_paths,
-        event_cache=event_cache,
-        conversation_cache=conversation_cache,
         status="pending",
         created_at=existing_task.created_at,
-        restart_task=restart_task,
     )
 
     return ScheduledTaskRecord(
@@ -1001,7 +993,7 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
     workflow: ScheduledWorkflow,
     config: Config,
     runtime_paths: RuntimePaths,
-    event_cache: ConversationEventCache,
+    _event_cache: ConversationEventCache,
     conversation_cache: ConversationCacheProtocol,
 ) -> None:
     """Run a one-time scheduled task."""
@@ -1066,9 +1058,6 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
                 await _save_one_time_task_status(
                     client=client,
                     task=latest_pending_task,
-                    config=config,
-                    runtime_paths=runtime_paths,
-                    event_cache=event_cache,
                     status=final_status,
                 )
             except Exception:
@@ -1110,9 +1099,6 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
                     await _save_one_time_task_status(
                         client=client,
                         task=latest_pending_task,
-                        config=config,
-                        runtime_paths=runtime_paths,
-                        event_cache=event_cache,
                         status="failed",
                     )
                 except Exception:
@@ -1220,7 +1206,6 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
     mentioned_agents: list[MatrixID] | None = None,
     task_id: str | None = None,
     existing_task: ScheduledTaskRecord | None = None,
-    restart_task: bool = True,
 ) -> tuple[str | None, str]:
     """Schedule a workflow from natural language request.
 
@@ -1323,15 +1308,10 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 room_id=room_id,
                 task_id=task_id,
                 workflow=workflow_result,
-                config=config,
-                runtime_paths=runtime_paths,
-                event_cache=event_cache,
                 existing_task=existing_task,
-                restart_task=restart_task,
-                conversation_cache=conversation_cache,
             )
         else:
-            await _save_scheduled_task(
+            await _save_pending_scheduled_task(
                 client=client,
                 room_id=room_id,
                 task_id=task_id,
@@ -1340,9 +1320,7 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 runtime_paths=runtime_paths,
                 event_cache=event_cache,
                 conversation_cache=conversation_cache,
-                status="pending",
                 created_at=datetime.now(UTC).isoformat(),
-                restart_task=restart_task,
             )
     except ValueError as e:
         return (None, f"❌ Failed to schedule: {e!s}")
@@ -1407,7 +1385,6 @@ async def edit_scheduled_task(
         new_thread=target_new_thread,
         task_id=task_id,
         existing_task=existing_task,
-        restart_task=False,
     )
 
     if edited_task_id is None:
@@ -1625,18 +1602,13 @@ async def restore_scheduled_tasks(  # noqa: C901, PLR0912
                             missed_by_seconds=missed_by,
                         )
                         try:
-                            await _save_scheduled_task(
+                            await _persist_scheduled_task_state(
                                 client=client,
                                 room_id=room_id,
                                 task_id=task_id,
                                 workflow=workflow,
-                                config=config,
-                                runtime_paths=runtime_paths,
-                                event_cache=event_cache,
-                                conversation_cache=conversation_cache,
                                 status="failed",
                                 created_at=content.get("created_at"),
-                                restart_task=False,
                             )
                         except Exception:
                             logger.exception("Failed to mark ancient task as failed", task_id=task_id)

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -64,7 +64,6 @@ class _DeferredAsyncToolHookResult:
 def _resolved_thread_id(
     default_thread_id: str | None,
     execution_identity: ToolExecutionIdentity | None,
-    request_execution_identity: ToolExecutionIdentity | None,
     runtime_context: ToolRuntimeContext | None,
 ) -> str | None:
     if runtime_context is not None and runtime_context.resolved_thread_id is not None:
@@ -72,9 +71,6 @@ def _resolved_thread_id(
 
     if execution_identity is not None and execution_identity.resolved_thread_id is not None:
         return execution_identity.resolved_thread_id
-
-    if request_execution_identity is not None and request_execution_identity.resolved_thread_id is not None:
-        return request_execution_identity.resolved_thread_id
 
     return default_thread_id
 
@@ -132,9 +128,7 @@ def _resolve_tool_context(
     runtime_paths: RuntimePaths | None,
 ) -> _ResolvedToolContext:
     runtime_context = get_tool_runtime_context()
-    request_execution_identity = active_tool_execution_identity(None)
-
-    resolved_execution_identity = execution_identity or request_execution_identity
+    resolved_execution_identity = active_tool_execution_identity(execution_identity)
     bindings = resolve_tool_runtime_hook_bindings(runtime_context) if runtime_context is not None else None
     return _ResolvedToolContext(
         agent_name=(
@@ -148,21 +142,18 @@ def _resolve_tool_context(
         room_id=_coalesce(
             room_id,
             runtime_context.room_id if runtime_context is not None else None,
-            execution_identity.room_id if execution_identity is not None else None,
-            request_execution_identity.room_id if request_execution_identity is not None else None,
+            resolved_execution_identity.room_id if resolved_execution_identity is not None else None,
         ),
-        thread_id=_resolved_thread_id(thread_id, execution_identity, request_execution_identity, runtime_context),
+        thread_id=_resolved_thread_id(thread_id, resolved_execution_identity, runtime_context),
         requester_id=_coalesce(
             requester_id,
             runtime_context.requester_id if runtime_context is not None else None,
-            execution_identity.requester_id if execution_identity is not None else None,
-            request_execution_identity.requester_id if request_execution_identity is not None else None,
+            resolved_execution_identity.requester_id if resolved_execution_identity is not None else None,
         ),
         session_id=_coalesce(
             session_id,
-            execution_identity.session_id if execution_identity is not None else None,
-            request_execution_identity.session_id if request_execution_identity is not None else None,
             runtime_context.session_id if runtime_context is not None else None,
+            resolved_execution_identity.session_id if resolved_execution_identity is not None else None,
         ),
         channel=resolved_execution_identity.channel if resolved_execution_identity is not None else None,
         config=runtime_context.config if runtime_context is not None else config,
@@ -323,7 +314,7 @@ async def _execute_bridge(
                 requester_id=resolved_context.requester_id,
                 session_id=resolved_context.session_id,
                 correlation_id=resolved_context.correlation_id,
-                execution_identity=execution_identity or active_tool_execution_identity(None),
+                execution_identity=active_tool_execution_identity(execution_identity),
                 runtime_paths=resolved_context.runtime_paths,
             )
             logger.warning(

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -129,6 +129,7 @@ def _resolve_tool_context(
 ) -> _ResolvedToolContext:
     runtime_context = get_tool_runtime_context()
     resolved_execution_identity = active_tool_execution_identity(execution_identity)
+    request_runtime_context = runtime_context if execution_identity is None else None
     bindings = resolve_tool_runtime_hook_bindings(runtime_context) if runtime_context is not None else None
     return _ResolvedToolContext(
         agent_name=(
@@ -141,18 +142,18 @@ def _resolve_tool_context(
         ),
         room_id=_coalesce(
             room_id,
-            runtime_context.room_id if runtime_context is not None else None,
+            request_runtime_context.room_id if request_runtime_context is not None else None,
             resolved_execution_identity.room_id if resolved_execution_identity is not None else None,
         ),
-        thread_id=_resolved_thread_id(thread_id, resolved_execution_identity, runtime_context),
+        thread_id=_resolved_thread_id(thread_id, resolved_execution_identity, request_runtime_context),
         requester_id=_coalesce(
             requester_id,
-            runtime_context.requester_id if runtime_context is not None else None,
+            request_runtime_context.requester_id if request_runtime_context is not None else None,
             resolved_execution_identity.requester_id if resolved_execution_identity is not None else None,
         ),
         session_id=_coalesce(
             session_id,
-            runtime_context.session_id if runtime_context is not None else None,
+            request_runtime_context.session_id if request_runtime_context is not None else None,
             resolved_execution_identity.session_id if resolved_execution_identity is not None else None,
         ),
         channel=resolved_execution_identity.channel if resolved_execution_identity is not None else None,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -573,9 +573,6 @@ class TurnController:
                 command_tool=command_tool,
                 skill_name=skill_name,
                 args_text=args_text,
-                requester_user_id=requester_user_id,
-                room_id=room_id,
-                thread_id=thread_id,
                 runtime_context=runtime_context,
             )
 

--- a/tests/api/test_schedules_api.py
+++ b/tests/api/test_schedules_api.py
@@ -187,7 +187,6 @@ def test_update_schedule_once_success(test_client: TestClient) -> None:
     save_mock.assert_awaited_once()
     assert save_mock.await_args.kwargs["task_id"] == "abc12345"
     assert save_mock.await_args.kwargs["room_id"] == "test_room"
-    assert save_mock.await_args.kwargs["restart_task"] is False
     assert save_mock.await_args.kwargs["workflow"].new_thread is True
 
 
@@ -250,8 +249,6 @@ async def test_update_schedule_does_not_resolve_cache_path_when_not_restarting()
         )
 
     runtime_config.cache.resolve_db_path.assert_not_called()
-    assert save_mock.await_args.kwargs["event_cache"] is None
-    assert save_mock.await_args.kwargs["restart_task"] is False
     assert response.task_id == "abc12345"
 
 

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -1189,7 +1189,6 @@ async def test_edit_scheduled_task_reuses_existing_thread() -> None:
     assert call_kwargs["room"] is room
     assert call_kwargs["new_thread"] is False
     assert call_kwargs["task_id"] == "task123"
-    assert call_kwargs["restart_task"] is False
     assert call_kwargs["existing_task"].task_id == "task123"
     assert call_kwargs["existing_task"].workflow.thread_id == "$original_thread"
 
@@ -1305,12 +1304,7 @@ async def test_save_edited_scheduled_task_preserves_created_at() -> None:
         room_id="!test:server",
         task_id="task123",
         workflow=updated_workflow,
-        config=MagicMock(),
-        runtime_paths=_runtime_paths(),
-        event_cache=_event_cache(),
-        conversation_cache=_conversation_cache(),
         existing_task=existing_task,
-        restart_task=False,
     )
 
     assert updated_task.created_at == created_at
@@ -1320,8 +1314,8 @@ async def test_save_edited_scheduled_task_preserves_created_at() -> None:
 
 
 @pytest.mark.asyncio
-async def test_save_edited_scheduled_task_allows_persist_only_without_event_cache() -> None:
-    """State-only edits should not require a runtime event cache."""
+async def test_save_edited_scheduled_task_is_state_only() -> None:
+    """State-only edits should not require runtime-only scheduling collaborators."""
     client = AsyncMock()
     created_at = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
     existing_task = ScheduledTaskRecord(
@@ -1352,12 +1346,7 @@ async def test_save_edited_scheduled_task_allows_persist_only_without_event_cach
         room_id="!test:server",
         task_id="task123",
         workflow=updated_workflow,
-        config=MagicMock(),
-        runtime_paths=_runtime_paths(),
-        event_cache=None,
-        conversation_cache=None,
         existing_task=existing_task,
-        restart_task=False,
     )
 
     assert updated_task.created_at == created_at
@@ -1398,12 +1387,7 @@ async def test_save_edited_scheduled_task_rejects_schedule_type_change() -> None
             room_id="!test:server",
             task_id="task123",
             workflow=updated_workflow,
-            config=MagicMock(),
-            runtime_paths=_runtime_paths(),
-            event_cache=_event_cache(),
-            conversation_cache=_conversation_cache(),
             existing_task=existing_task,
-            restart_task=False,
         )
 
     client.room_put_state.assert_not_called()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -970,9 +970,6 @@ async def test_skill_command_tool_dispatch_installs_explicit_tool_runtime_contex
             command_tool="demo",
             skill_name="dispatch",
             args_text="hello",
-            requester_user_id="@alice:example.org",
-            room_id="!room:example.org",
-            thread_id="$thread",
             runtime_context=runtime_context,
         )
     finally:
@@ -982,6 +979,66 @@ async def test_skill_command_tool_dispatch_installs_explicit_tool_runtime_contex
         TOOL_METADATA.update(original_metadata)
 
     assert result == "1:True:True:True"
+
+
+@pytest.mark.asyncio
+async def test_skill_command_tool_dispatch_rejects_mixed_runtime_shapes() -> None:
+    """Skill tool dispatch should accept either raw Matrix coordinates or a runtime context, not both."""
+
+    class DemoTools(Toolkit):
+        def __init__(self) -> None:
+            super().__init__(name="demo_tools", tools=[self.demo])
+
+        def demo(self, command: str, commandName: str, skillName: str) -> str:  # noqa: ARG002, N803
+            return "ok"
+
+    original_registry = _TOOL_REGISTRY.copy()
+    original_metadata = TOOL_METADATA.copy()
+    try:
+
+        @register_tool_with_metadata(
+            name="demo_toolkit",
+            display_name="Demo",
+            description="Demo tool",
+            category=ToolCategory.DEVELOPMENT,
+        )
+        def demo_toolkit() -> type[Toolkit]:
+            return DemoTools
+
+        config = _base_config(["dispatch"])
+        config.agents["code"].tools = ["demo_toolkit"]
+        runtime_paths = resolve_runtime_paths()
+        runtime_context = ToolRuntimeContext(
+            agent_name="code",
+            room_id="!room:example.org",
+            thread_id="$thread",
+            resolved_thread_id="$thread",
+            requester_id="@alice:example.org",
+            client=AsyncMock(),
+            config=config,
+            runtime_paths=runtime_paths,
+            event_cache=make_event_cache_mock(),
+            conversation_cache=make_conversation_cache_mock(),
+        )
+
+        with pytest.raises(ValueError, match="either runtime_context or raw Matrix coordinates"):
+            await _run_skill_command_tool(
+                config=config,
+                runtime_paths=runtime_paths,
+                agent_name="code",
+                command_tool="demo",
+                skill_name="dispatch",
+                args_text="hello",
+                requester_user_id="@alice:example.org",
+                room_id="!room:example.org",
+                thread_id="$thread",
+                runtime_context=runtime_context,
+            )
+    finally:
+        _TOOL_REGISTRY.clear()
+        _TOOL_REGISTRY.update(original_registry)
+        TOOL_METADATA.clear()
+        TOOL_METADATA.update(original_metadata)
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -1119,6 +1119,41 @@ async def test_tool_hook_bridge_prefers_bridge_agent_name_over_nested_runtime_co
 
 
 @pytest.mark.asyncio
+async def test_tool_hook_bridge_does_not_merge_explicit_identity_with_ambient_identity() -> None:
+    """An explicit bridge identity should not backfill missing fields from ambient execution state."""
+    seen: list[tuple[str | None, str | None, str | None, str | None]] = []
+
+    @hook(EVENT_TOOL_BEFORE_CALL)
+    async def before(ctx: ToolBeforeCallContext) -> None:
+        seen.append((ctx.room_id, ctx.thread_id, ctx.requester_id, ctx.session_id))
+
+    registry = HookRegistry.from_plugins([_plugin("tool-policy", [before])])
+    bridge = build_tool_hook_bridge(
+        registry,
+        agent_name="child-agent",
+        execution_identity=ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="child-agent",
+            requester_id=None,
+            room_id=None,
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+        ),
+    )
+    assert bridge is not None
+
+    async def next_func(**kwargs: object) -> str:
+        return str(kwargs["path"])
+
+    with tool_execution_identity(_execution_identity()):
+        result = await bridge("read_file", next_func, {"path": "notes.txt"})
+
+    assert result == "notes.txt"
+    assert seen == [(None, None, None, None)]
+
+
+@pytest.mark.asyncio
 async def test_tool_hook_bridge_declines_and_skips_real_tool(tmp_path: Path) -> None:
     """A declined before-call hook should return a synthetic result and not call the real tool."""
     after_seen: list[tuple[bool, object | None, BaseException | None]] = []

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -1154,6 +1154,43 @@ async def test_tool_hook_bridge_does_not_merge_explicit_identity_with_ambient_id
 
 
 @pytest.mark.asyncio
+async def test_tool_hook_bridge_does_not_merge_explicit_identity_with_ambient_runtime_context(
+    tmp_path: Path,
+) -> None:
+    """An explicit bridge identity should not backfill missing fields from ambient runtime context."""
+    seen: list[tuple[str | None, str | None, str | None, str | None]] = []
+
+    @hook(EVENT_TOOL_BEFORE_CALL)
+    async def before(ctx: ToolBeforeCallContext) -> None:
+        seen.append((ctx.room_id, ctx.thread_id, ctx.requester_id, ctx.session_id))
+
+    registry = HookRegistry.from_plugins([_plugin("tool-policy", [before])])
+    bridge = build_tool_hook_bridge(
+        registry,
+        agent_name="child-agent",
+        execution_identity=ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="child-agent",
+            requester_id=None,
+            room_id=None,
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+        ),
+    )
+    assert bridge is not None
+
+    async def next_func(**kwargs: object) -> str:
+        return str(kwargs["path"])
+
+    with tool_runtime_context(_tool_runtime_context(tmp_path, agent_name="parent-agent")):
+        result = await bridge("read_file", next_func, {"path": "notes.txt"})
+
+    assert result == "notes.txt"
+    assert seen == [(None, None, None, None)]
+
+
+@pytest.mark.asyncio
 async def test_tool_hook_bridge_declines_and_skips_real_tool(tmp_path: Path) -> None:
     """A declined before-call hook should return a synthetic result and not call the real tool."""
     after_seen: list[tuple[bool, object | None, BaseException | None]] = []


### PR DESCRIPTION
## Summary
- split scheduler persistence from runtime-backed task startup so active edit paths are state-only and new pending tasks use explicit runtime wiring
- tighten skill command dispatch to accept one valid runtime shape at a time and propagate canonical runtime identity from `ToolRuntimeContext`
- stop tool-hook bridges from backfilling explicit identities with ambient request state, and document the scheduler contract update

## Review
- Reviewed the diff against `origin/main`
- Blocker findings: none

## Verification
- `uv run pytest tests/test_threading_error.py tests/test_multi_agent_bot.py tests/test_scheduler_tool.py tests/test_hook_execution.py tests/test_scheduling.py tests/test_tool_hooks.py tests/test_skills.py tests/api/test_schedules_api.py tests/test_schedule_agent_validation.py tests/test_workflow_scheduling.py tests/test_hook_sender.py -x -n 0 --no-cov -v`
- `uv run pre-commit run --all-files` *(repo-wide `ty` unresolved-import failures for optional dependencies outside this branch: `google_auth_oauthlib.flow`, `playwright.async_api`, `claude_agent_sdk`, `composio_agno`)*
- `uv run pre-commit run --files docs/scheduling.md skills/mindroom-docs/references/llms-full.txt skills/mindroom-docs/references/page__scheduling__index.md src/mindroom/agents.py src/mindroom/api/schedules.py src/mindroom/commands/handler.py src/mindroom/scheduling.py src/mindroom/tool_system/tool_hooks.py src/mindroom/turn_controller.py tests/api/test_schedules_api.py tests/test_scheduling.py tests/test_skills.py tests/test_tool_hooks.py` *(same repo-wide `ty` failures only)*