### PR TITLE
refactor: shrink matrix tool surfaces

### DIFF
--- a/src/mindroom/custom_tools/matrix_api.py
+++ b/src/mindroom/custom_tools/matrix_api.py
@@ -10,16 +10,14 @@ from typing import ClassVar
 
 import nio
 from agno.tools import Toolkit
-from nio.responses import RoomGetEventError
 
 from mindroom.custom_tools.attachment_helpers import room_access_allowed
 from mindroom.logging_config import get_logger
-from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.thread_membership import (
-    ThreadMembershipAccess,
-    resolve_event_thread_id,
-    resolve_related_event_thread_id,
-    room_scan_thread_membership_access_for_client,
+    conversation_cache_thread_membership_access_for_client,
+    event_requires_thread_bookkeeping,
+    fetch_event_info_from_conversation_cache,
+    redaction_requires_thread_bookkeeping,
 )
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
 
@@ -390,103 +388,6 @@ class MatrixApiTools(Toolkit):
         return None
 
     @staticmethod
-    async def _get_thread_id_for_event(
-        context: ToolRuntimeContext,
-        *,
-        room_id: str,
-        event_id: str,
-    ) -> str | None:
-        """Resolve one event's cached thread root through the public conversation cache when available."""
-        return await context.conversation_cache.get_thread_id_for_event(room_id, event_id)
-
-    @staticmethod
-    async def _event_info_for_event(
-        context: ToolRuntimeContext,
-        *,
-        room_id: str,
-        event_id: str,
-    ) -> EventInfo | None:
-        response = await context.conversation_cache.get_event(room_id, event_id)
-        if isinstance(response, nio.RoomGetEventResponse):
-            return EventInfo.from_event(response.event.source)
-        if isinstance(response, RoomGetEventError) and response.status_code == "M_NOT_FOUND":
-            return None
-        detail = response.message if isinstance(response, RoomGetEventError) else "unknown error"
-        msg = f"Failed to resolve Matrix event {event_id}: {detail}"
-        raise RuntimeError(msg)
-
-    @staticmethod
-    async def _requires_conversation_cache_write(
-        context: ToolRuntimeContext,
-        *,
-        room_id: str,
-        event_type: str,
-        content: dict[str, object],
-    ) -> bool:
-        """Return whether one send_event payload must update threaded conversation cache state."""
-        if event_type != "m.room.message":
-            return False
-        event_info = EventInfo.from_event({"type": event_type, "content": content})
-        access = MatrixApiTools._thread_membership_access(context)
-        return isinstance(
-            await resolve_event_thread_id(
-                room_id,
-                event_info,
-                access=access,
-            ),
-            str,
-        )
-
-    @staticmethod
-    async def _redaction_requires_conversation_cache_write(
-        context: ToolRuntimeContext,
-        *,
-        room_id: str,
-        event_id: str,
-    ) -> bool:
-        """Return whether one redact payload must update threaded conversation cache state."""
-        target_event_info = await MatrixApiTools._event_info_for_event(
-            context,
-            room_id=room_id,
-            event_id=event_id,
-        )
-        if target_event_info is not None and target_event_info.is_reaction:
-            return False
-        access = MatrixApiTools._thread_membership_access(context)
-        return isinstance(
-            await resolve_related_event_thread_id(
-                room_id,
-                event_id,
-                access=access,
-            ),
-            str,
-        )
-
-    @staticmethod
-    def _thread_membership_access(context: ToolRuntimeContext) -> ThreadMembershipAccess:
-        """Return the shared thread-membership accessors for Matrix API classification."""
-
-        async def lookup_thread_id(lookup_room_id: str, lookup_event_id: str) -> str | None:
-            return await MatrixApiTools._get_thread_id_for_event(
-                context,
-                room_id=lookup_room_id,
-                event_id=lookup_event_id,
-            )
-
-        async def fetch_event_info(lookup_room_id: str, lookup_event_id: str) -> EventInfo | None:
-            return await MatrixApiTools._event_info_for_event(
-                context,
-                room_id=lookup_room_id,
-                event_id=lookup_event_id,
-            )
-
-        return room_scan_thread_membership_access_for_client(
-            context.client,
-            lookup_thread_id=lookup_thread_id,
-            fetch_event_info=fetch_event_info,
-        )
-
-    @staticmethod
     async def _record_send_event_outbound_cache_write(
         context: ToolRuntimeContext,
         *,
@@ -542,11 +443,14 @@ class MatrixApiTools(Toolkit):
             return policy_error
 
         try:
-            requires_conversation_cache_write = await self._requires_conversation_cache_write(
-                context,
+            requires_conversation_cache_write = await event_requires_thread_bookkeeping(
                 room_id=room_id,
                 event_type=normalized_event_type,
                 content=normalized_content,
+                access=conversation_cache_thread_membership_access_for_client(
+                    context.client,
+                    conversation_cache=context.conversation_cache,
+                ),
             )
         except Exception as exc:
             logger.warning(
@@ -900,10 +804,20 @@ class MatrixApiTools(Toolkit):
         assert normalized_event_id is not None
 
         try:
-            requires_conversation_cache_write = await self._redaction_requires_conversation_cache_write(
-                context,
+            target_event_info = await fetch_event_info_from_conversation_cache(
+                context.conversation_cache,
+                room_id,
+                normalized_event_id,
+                strict=True,
+            )
+            requires_conversation_cache_write = await redaction_requires_thread_bookkeeping(
                 room_id=room_id,
                 event_id=normalized_event_id,
+                access=conversation_cache_thread_membership_access_for_client(
+                    context.client,
+                    conversation_cache=context.conversation_cache,
+                ),
+                target_event_info=target_event_info,
             )
         except Exception as exc:
             logger.warning(

--- a/src/mindroom/custom_tools/thread_summary.py
+++ b/src/mindroom/custom_tools/thread_summary.py
@@ -7,6 +7,7 @@ import json
 from agno.tools import Toolkit
 
 from mindroom.custom_tools.attachment_helpers import resolve_context_thread_id, room_access_allowed
+from mindroom.matrix.thread_membership import resolve_thread_root_event_id_for_client
 from mindroom.thread_summary import (
     THREAD_SUMMARY_MAX_LENGTH,
     _count_non_summary_messages,
@@ -15,7 +16,6 @@ from mindroom.thread_summary import (
     thread_summary_lock,
     update_last_summary_count,
 )
-from mindroom.thread_tags import normalize_thread_root_event_id
 from mindroom.tool_system.runtime_context import get_tool_runtime_context
 
 _MAX_THREAD_SUMMARY_LENGTH = THREAD_SUMMARY_MAX_LENGTH
@@ -113,11 +113,11 @@ class ThreadSummaryTools(Toolkit):
             error_message = "thread_id is required when no active thread context is available for the target room."
         else:
             try:
-                normalized_thread_id = await normalize_thread_root_event_id(
+                normalized_thread_id = await resolve_thread_root_event_id_for_client(
                     context.client,
                     resolved_room_id,
                     effective_thread_id,
-                    context.conversation_cache,
+                    conversation_cache=context.conversation_cache,
                 )
             except Exception:
                 error_thread_id = effective_thread_id

--- a/src/mindroom/custom_tools/thread_tags.py
+++ b/src/mindroom/custom_tools/thread_tags.py
@@ -12,13 +12,13 @@ from mindroom.custom_tools.attachment_helpers import (
     resolve_requested_room_id,
     room_access_allowed,
 )
+from mindroom.matrix.thread_membership import resolve_thread_root_event_id_for_client
 from mindroom.thread_tags import (
     ThreadTagRecord,
     ThreadTagsError,
     get_thread_tags,
     list_tagged_threads,
     normalize_tag_name,
-    normalize_thread_root_event_id,
     remove_thread_tag,
     set_thread_tag,
 )
@@ -152,11 +152,11 @@ class ThreadTagsTools(Toolkit):
                 message="thread_id is required when no active thread context is available for the target room.",
             )
 
-        normalized_thread_id = await normalize_thread_root_event_id(
+        normalized_thread_id = await resolve_thread_root_event_id_for_client(
             context.client,
             resolved_room_id,
             effective_thread_id,
-            context.conversation_cache,
+            conversation_cache=context.conversation_cache,
         )
         if normalized_thread_id is None:
             return self._payload(
@@ -253,11 +253,11 @@ class ThreadTagsTools(Toolkit):
         if canonical:
             target_thread_id = effective_thread_id
         else:
-            target_thread_id = await normalize_thread_root_event_id(
+            target_thread_id = await resolve_thread_root_event_id_for_client(
                 context.client,
                 resolved_room_id,
                 effective_thread_id,
-                context.conversation_cache,
+                conversation_cache=context.conversation_cache,
             )
             if target_thread_id is None:
                 return self._payload(
@@ -385,11 +385,11 @@ class ThreadTagsTools(Toolkit):
                 },
             )
 
-        normalized_thread_id = await normalize_thread_root_event_id(
+        normalized_thread_id = await resolve_thread_root_event_id_for_client(
             context.client,
             resolved_room_id,
             effective_thread_id,
-            context.conversation_cache,
+            conversation_cache=context.conversation_cache,
         )
         if normalized_thread_id is None:
             return self._payload(

--- a/src/mindroom/matrix/thread_membership.py
+++ b/src/mindroom/matrix/thread_membership.py
@@ -7,10 +7,12 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Protocol
 
+import nio
+
 from mindroom.matrix.event_info import EventInfo
 
 if TYPE_CHECKING:
-    import nio
+    from mindroom.matrix.conversation_cache import ConversationCacheProtocol
 
 type ThreadIdLookup = Callable[[str, str], Awaitable[str | None]]
 type EventInfoLookup = Callable[[str, str], Awaitable[EventInfo | None]]
@@ -487,6 +489,187 @@ def room_scan_thread_membership_access_for_client(
         lookup_thread_id=lookup_thread_id,
         fetch_event_info=fetch_event_info,
         fetch_thread_event_sources=fetch_thread_event_sources,
+    )
+
+
+async def lookup_thread_id_from_conversation_cache(
+    conversation_cache: ConversationCacheProtocol | None,
+    room_id: str,
+    event_id: str,
+) -> str | None:
+    """Return one cached thread root when a conversation cache is available."""
+    if conversation_cache is None:
+        return None
+    return await conversation_cache.get_thread_id_for_event(room_id, event_id)
+
+
+def _event_info_from_lookup_response(
+    response: object,
+    *,
+    event_id: str,
+    strict: bool,
+) -> EventInfo | None:
+    """Normalize one room-get-event style response into EventInfo when available."""
+    if isinstance(response, nio.RoomGetEventResponse):
+        return EventInfo.from_event(response.event.source)
+    if not strict:
+        return None
+    if isinstance(response, nio.RoomGetEventError) and response.status_code == "M_NOT_FOUND":
+        return None
+    detail = response.message if isinstance(response, nio.RoomGetEventError) else "unknown error"
+    msg = f"Failed to resolve Matrix event {event_id}: {detail}"
+    raise RuntimeError(msg)
+
+
+async def fetch_event_info_from_conversation_cache(
+    conversation_cache: ConversationCacheProtocol,
+    room_id: str,
+    event_id: str,
+    *,
+    strict: bool,
+) -> EventInfo | None:
+    """Fetch one event through the conversation cache and parse its relation metadata."""
+    response = await conversation_cache.get_event(room_id, event_id)
+    return _event_info_from_lookup_response(
+        response,
+        event_id=event_id,
+        strict=strict,
+    )
+
+
+async def fetch_event_info_for_client(
+    client: nio.AsyncClient,
+    room_id: str,
+    event_id: str,
+    *,
+    strict: bool,
+) -> EventInfo | None:
+    """Fetch one event directly from Matrix and parse its relation metadata."""
+    response = await client.room_get_event(room_id, event_id)
+    return _event_info_from_lookup_response(
+        response,
+        event_id=event_id,
+        strict=strict,
+    )
+
+
+def conversation_cache_thread_membership_access_for_client(
+    client: nio.AsyncClient,
+    *,
+    conversation_cache: ConversationCacheProtocol | None,
+    fetch_event_info: EventInfoLookup | None = None,
+    strict_event_fetch: bool = True,
+) -> ThreadMembershipAccess:
+    """Build room-scan membership access backed by conversation-cache lookups when available."""
+
+    async def lookup_thread_id(lookup_room_id: str, lookup_event_id: str) -> str | None:
+        return await lookup_thread_id_from_conversation_cache(
+            conversation_cache,
+            lookup_room_id,
+            lookup_event_id,
+        )
+
+    async def resolved_fetch_event_info(lookup_room_id: str, lookup_event_id: str) -> EventInfo | None:
+        if fetch_event_info is not None:
+            return await fetch_event_info(lookup_room_id, lookup_event_id)
+        if conversation_cache is None:
+            return None
+        return await fetch_event_info_from_conversation_cache(
+            conversation_cache,
+            lookup_room_id,
+            lookup_event_id,
+            strict=strict_event_fetch,
+        )
+
+    return room_scan_thread_membership_access_for_client(
+        client,
+        lookup_thread_id=lookup_thread_id,
+        fetch_event_info=resolved_fetch_event_info,
+    )
+
+
+async def resolve_thread_root_event_id_for_client(
+    client: nio.AsyncClient,
+    room_id: str,
+    event_id: str,
+    *,
+    conversation_cache: ConversationCacheProtocol | None = None,
+) -> str | None:
+    """Resolve one event ID into a canonical thread root when thread membership can prove one."""
+    normalized_event_id = event_id.strip() if isinstance(event_id, str) else ""
+    if not normalized_event_id:
+        return None
+
+    event_info = await fetch_event_info_for_client(
+        client,
+        room_id,
+        normalized_event_id,
+        strict=False,
+    )
+    if event_info is None:
+        return await lookup_thread_id_from_conversation_cache(
+            conversation_cache,
+            room_id,
+            normalized_event_id,
+        )
+
+    return await resolve_event_thread_id(
+        room_id,
+        event_info,
+        event_id=normalized_event_id,
+        allow_current_root=True,
+        access=conversation_cache_thread_membership_access_for_client(
+            client,
+            conversation_cache=conversation_cache,
+            fetch_event_info=lambda lookup_room_id, lookup_event_id: fetch_event_info_for_client(
+                client,
+                lookup_room_id,
+                lookup_event_id,
+                strict=False,
+            ),
+            strict_event_fetch=False,
+        ),
+    )
+
+
+async def event_requires_thread_bookkeeping(
+    room_id: str,
+    *,
+    event_type: str,
+    content: Mapping[str, object],
+    access: ThreadMembershipAccess,
+) -> bool:
+    """Return whether one outbound event payload targets a thread."""
+    if event_type != "m.room.message":
+        return False
+    event_info = EventInfo.from_event({"type": event_type, "content": dict(content)})
+    return isinstance(
+        await resolve_event_thread_id(
+            room_id,
+            event_info,
+            access=access,
+        ),
+        str,
+    )
+
+
+async def redaction_requires_thread_bookkeeping(
+    room_id: str,
+    *,
+    event_id: str,
+    access: ThreadMembershipAccess,
+    target_event_info: EventInfo | None,
+) -> bool:
+    """Return whether one redaction target can affect thread-scoped cache state."""
+    if target_event_info is not None and target_event_info.is_reaction:
+        return False
+    return isinstance(
+        await resolve_related_event_thread_id(
+            room_id,
+            event_id,
+            access=access,
+        ),
+        str,
     )
 
 

--- a/src/mindroom/matrix/thread_membership.py
+++ b/src/mindroom/matrix/thread_membership.py
@@ -558,7 +558,6 @@ def conversation_cache_thread_membership_access_for_client(
     *,
     conversation_cache: ConversationCacheProtocol | None,
     fetch_event_info: EventInfoLookup | None = None,
-    strict_event_fetch: bool = True,
 ) -> ThreadMembershipAccess:
     """Build room-scan membership access backed by conversation-cache lookups when available."""
 
@@ -578,7 +577,7 @@ def conversation_cache_thread_membership_access_for_client(
             conversation_cache,
             lookup_room_id,
             lookup_event_id,
-            strict=strict_event_fetch,
+            strict=True,
         )
 
     return room_scan_thread_membership_access_for_client(
@@ -627,7 +626,6 @@ async def resolve_thread_root_event_id_for_client(
                 lookup_event_id,
                 strict=False,
             ),
-            strict_event_fetch=False,
         ),
     )
 

--- a/src/mindroom/thread_tags.py
+++ b/src/mindroom/thread_tags.py
@@ -7,20 +7,10 @@ import math
 import re
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 import nio
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
-
-from mindroom.matrix.event_info import EventInfo
-from mindroom.matrix.thread_membership import (
-    ThreadMembershipAccess,
-    resolve_event_thread_id,
-    room_scan_thread_membership_access_for_client,
-)
-
-if TYPE_CHECKING:
-    from mindroom.matrix.conversation_cache import ConversationCacheProtocol
 
 THREAD_TAGS_EVENT_TYPE = "com.mindroom.thread.tags"
 POWER_LEVELS_EVENT_TYPE = "m.room.power_levels"
@@ -139,18 +129,6 @@ def _normalize_non_empty_string(value: object) -> str | None:
     if not normalized_value:
         return None
     return normalized_value
-
-
-async def _event_info_for_event_id(
-    client: nio.AsyncClient,
-    room_id: str,
-    event_id: str,
-) -> EventInfo | None:
-    """Fetch one event and return parsed relation metadata when available."""
-    response = await client.room_get_event(room_id, event_id)
-    if not isinstance(response, nio.RoomGetEventResponse):
-        return None
-    return EventInfo.from_event(response.event.source)
 
 
 def _require_non_empty_string(value: object, *, field_name: str) -> str:
@@ -764,71 +742,6 @@ async def _assert_thread_tags_write_allowed(
         subject_label="the requester",
         user_id=normalized_requester_user_id,
     )
-
-
-async def normalize_thread_root_event_id(
-    client: nio.AsyncClient,
-    room_id: str,
-    event_id: str,
-    conversation_cache: ConversationCacheProtocol | None = None,
-) -> str | None:
-    """Resolve one event ID to an explicit thread root when possible."""
-    normalized_event_id = _normalize_non_empty_string(event_id)
-    if not normalized_event_id:
-        return None
-
-    event_info = await _event_info_for_event_id(client, room_id, normalized_event_id)
-    if event_info is None:
-        return await _lookup_thread_id_from_cache(conversation_cache, room_id, normalized_event_id)
-
-    return await resolve_event_thread_id(
-        room_id,
-        event_info,
-        event_id=normalized_event_id,
-        allow_current_root=True,
-        access=_thread_membership_access(
-            client,
-            conversation_cache=conversation_cache,
-        ),
-    )
-
-
-def _thread_membership_access(
-    client: nio.AsyncClient,
-    *,
-    conversation_cache: ConversationCacheProtocol | None,
-) -> ThreadMembershipAccess:
-    """Return the shared thread-membership accessors for thread-tag normalization."""
-
-    async def lookup_thread_id(lookup_room_id: str, lookup_event_id: str) -> str | None:
-        return await _lookup_thread_id_from_cache(
-            conversation_cache,
-            lookup_room_id,
-            lookup_event_id,
-        )
-
-    async def fetch_event_info(lookup_room_id: str, lookup_event_id: str) -> EventInfo | None:
-        return await _event_info_for_event_id(
-            client,
-            lookup_room_id,
-            lookup_event_id,
-        )
-
-    return room_scan_thread_membership_access_for_client(
-        client,
-        lookup_thread_id=lookup_thread_id,
-        fetch_event_info=fetch_event_info,
-    )
-
-
-async def _lookup_thread_id_from_cache(
-    conversation_cache: ConversationCacheProtocol | None,
-    room_id: str,
-    event_id: str,
-) -> str | None:
-    if conversation_cache is None:
-        return None
-    return await conversation_cache.get_thread_id_for_event(room_id, event_id)
 
 
 async def get_thread_tags(

--- a/tests/test_matrix_api_tool.py
+++ b/tests/test_matrix_api_tool.py
@@ -337,6 +337,35 @@ async def test_matrix_api_send_event_plain_reply_to_threaded_target_records_thre
 
 
 @pytest.mark.asyncio
+async def test_matrix_api_send_event_delegates_thread_classification_to_shared_helper() -> None:
+    """send_event should call the shared thread-membership helper instead of inlining cache policy."""
+    tool = MatrixApiTools()
+    ctx = _make_context()
+    ctx.client.room_send.return_value = nio.RoomSendResponse(
+        event_id="$send:localhost",
+        room_id=ctx.room_id,
+    )
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_api.event_requires_thread_bookkeeping",
+            new=AsyncMock(return_value=True),
+        ) as mock_requires_thread_bookkeeping,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_api(
+                action="send_event",
+                event_type="m.room.message",
+                content={"body": "hello", "msgtype": "m.text"},
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    mock_requires_thread_bookkeeping.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_matrix_api_send_event_room_message_preserves_matrix_error_details() -> None:
     """Low-level m.room.message send errors should surface the actual homeserver failure."""
     tool = MatrixApiTools()
@@ -597,6 +626,35 @@ async def test_matrix_api_redact_happy_path() -> None:
         reason="cleanup",
     )
     ctx.conversation_cache.notify_outbound_redaction.assert_called_once_with(ctx.room_id, "$target:localhost")
+
+
+@pytest.mark.asyncio
+async def test_matrix_api_redact_delegates_thread_classification_to_shared_helper() -> None:
+    """Redact should call the shared thread-membership helper instead of inlining cache policy."""
+    tool = MatrixApiTools()
+    ctx = _make_context()
+    ctx.client.room_redact.return_value = nio.RoomRedactResponse(
+        event_id="$redaction:localhost",
+        room_id=ctx.room_id,
+    )
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_api.redaction_requires_thread_bookkeeping",
+            new=AsyncMock(return_value=True),
+        ) as mock_requires_thread_bookkeeping,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_api(
+                action="redact",
+                event_id="$target:localhost",
+                reason="cleanup",
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    mock_requires_thread_bookkeeping.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_summary_tool.py
+++ b/tests/test_thread_summary_tool.py
@@ -126,7 +126,7 @@ async def test_set_thread_summary_defaults_to_context_room_and_thread() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_summary.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ) as mock_normalize,
         patch(
@@ -151,7 +151,7 @@ async def test_set_thread_summary_defaults_to_context_room_and_thread() -> None:
         context.client,
         context.room_id,
         "$ctx-thread:localhost",
-        context.conversation_cache,
+        conversation_cache=context.conversation_cache,
     )
     context.conversation_cache.get_thread_history.assert_awaited_once_with(
         context.room_id,
@@ -178,7 +178,7 @@ async def test_set_thread_summary_strips_markdown_before_send() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_summary.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ),
         patch(
@@ -225,7 +225,7 @@ async def test_set_thread_summary_normalizes_explicit_thread_id() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_summary.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$thread-root:localhost"),
         ) as mock_normalize,
         patch(
@@ -242,7 +242,7 @@ async def test_set_thread_summary_normalizes_explicit_thread_id() -> None:
         context.client,
         context.room_id,
         "$reply-event:localhost",
-        context.conversation_cache,
+        conversation_cache=context.conversation_cache,
     )
 
 
@@ -354,7 +354,7 @@ async def test_set_thread_summary_send_failure_leaves_cache_unchanged() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_summary.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ),
         patch(
@@ -379,7 +379,7 @@ async def test_set_thread_summary_excludes_existing_summary_notices_from_message
 
     with (
         patch(
-            "mindroom.custom_tools.thread_summary.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ),
         patch(
@@ -411,7 +411,7 @@ async def test_set_thread_summary_returns_error_when_normalize_raises() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_summary.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
             new=AsyncMock(side_effect=TimeoutError("timed out")),
         ),
         tool_runtime_context(context),
@@ -432,7 +432,7 @@ async def test_set_thread_summary_returns_error_when_fetch_raises() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_summary.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ),
         tool_runtime_context(context),
@@ -454,7 +454,7 @@ async def test_set_thread_summary_returns_error_when_send_raises() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_summary.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ),
         patch(

--- a/tests/test_thread_tags.py
+++ b/tests/test_thread_tags.py
@@ -10,12 +10,12 @@ from unittest.mock import AsyncMock, MagicMock
 import nio
 import pytest
 
+from mindroom.matrix.thread_membership import resolve_thread_root_event_id_for_client
 from mindroom.thread_tags import (
     THREAD_TAGS_EVENT_TYPE,
     ThreadTagsError,
     get_thread_tags,
     list_tagged_threads,
-    normalize_thread_root_event_id,
     remove_thread_tag,
     set_thread_tag,
 )
@@ -1397,7 +1397,7 @@ async def test_get_thread_tags_raises_for_non_missing_state_fetch_error() -> Non
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_returns_root_for_root_event() -> None:
+async def test_resolve_thread_root_event_id_for_client_returns_root_for_root_event() -> None:
     """A proven thread root should normalize to itself."""
     client = AsyncMock()
     client.room_get_event.return_value = _message_event_response(
@@ -1439,7 +1439,7 @@ async def test_normalize_thread_root_event_id_returns_root_for_root_event() -> N
     room_messages_response.end = None
     client.room_messages = AsyncMock(return_value=room_messages_response)
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$thread-root:localhost",
@@ -1450,7 +1450,7 @@ async def test_normalize_thread_root_event_id_returns_root_for_root_event() -> N
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_returns_none_for_unproven_root_event() -> None:
+async def test_resolve_thread_root_event_id_for_client_returns_none_for_unproven_root_event() -> None:
     """Unproven room-level roots should not normalize as canonical thread IDs."""
     client = AsyncMock()
     client.room_get_event.return_value = _message_event_response(
@@ -1476,7 +1476,7 @@ async def test_normalize_thread_root_event_id_returns_none_for_unproven_root_eve
     room_messages_response.end = None
     client.room_messages = AsyncMock(return_value=room_messages_response)
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$thread-root:localhost",
@@ -1486,7 +1486,7 @@ async def test_normalize_thread_root_event_id_returns_none_for_unproven_root_eve
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_returns_thread_root_for_thread_reply() -> None:
+async def test_resolve_thread_root_event_id_for_client_returns_thread_root_for_thread_reply() -> None:
     """Native thread replies should normalize to their thread root."""
     client = AsyncMock()
     client.room_get_event = AsyncMock(
@@ -1505,7 +1505,7 @@ async def test_normalize_thread_root_event_id_returns_thread_root_for_thread_rep
         ],
     )
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$thread-reply:localhost",
@@ -1517,11 +1517,11 @@ async def test_normalize_thread_root_event_id_returns_thread_root_for_thread_rep
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("event_id", ["", "   "])
-async def test_normalize_thread_root_event_id_returns_none_for_blank_input(event_id: str) -> None:
+async def test_resolve_thread_root_event_id_for_client_returns_none_for_blank_input(event_id: str) -> None:
     """Blank event IDs should be rejected before any event lookup."""
     client = AsyncMock()
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         event_id,
@@ -1532,7 +1532,7 @@ async def test_normalize_thread_root_event_id_returns_none_for_blank_input(event
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_returns_thread_root_for_plain_reply_to_thread_reply() -> None:
+async def test_resolve_thread_root_event_id_for_client_returns_thread_root_for_plain_reply_to_thread_reply() -> None:
     """Plain replies to explicit thread messages should normalize to the existing thread root."""
     client = AsyncMock()
     client.room_get_event = AsyncMock(
@@ -1559,7 +1559,7 @@ async def test_normalize_thread_root_event_id_returns_thread_root_for_plain_repl
         ],
     )
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$plain-reply:localhost",
@@ -1571,7 +1571,7 @@ async def test_normalize_thread_root_event_id_returns_thread_root_for_plain_repl
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_walks_transitively_to_threaded_ancestor() -> None:
+async def test_resolve_thread_root_event_id_for_client_walks_transitively_to_threaded_ancestor() -> None:
     """Plain replies should normalize transitively when the reply chain eventually reaches a threaded ancestor."""
     client = AsyncMock()
     client.room_get_event = AsyncMock(
@@ -1603,7 +1603,7 @@ async def test_normalize_thread_root_event_id_walks_transitively_to_threaded_anc
         ],
     )
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$plain-reply-2:localhost",
@@ -1617,7 +1617,7 @@ async def test_normalize_thread_root_event_id_walks_transitively_to_threaded_anc
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_returns_thread_root_for_plain_reply_to_thread_root() -> None:
+async def test_resolve_thread_root_event_id_for_client_returns_thread_root_for_plain_reply_to_thread_root() -> None:
     """Plain replies to the actual thread root should normalize back to that root."""
     client = AsyncMock()
     client.room_get_event = AsyncMock(
@@ -1674,7 +1674,7 @@ async def test_normalize_thread_root_event_id_returns_thread_root_for_plain_repl
     room_messages_response.end = None
     client.room_messages = AsyncMock(return_value=room_messages_response)
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$plain-reply:localhost",
@@ -1685,7 +1685,7 @@ async def test_normalize_thread_root_event_id_returns_thread_root_for_plain_repl
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_returns_none_for_plain_reply_to_plain_root_message() -> None:
+async def test_resolve_thread_root_event_id_for_client_returns_none_for_plain_reply_to_plain_root_message() -> None:
     """Plain replies to unrelated room roots should not normalize as threads."""
     client = AsyncMock()
     client.room_get_event = AsyncMock(
@@ -1725,7 +1725,7 @@ async def test_normalize_thread_root_event_id_returns_none_for_plain_reply_to_pl
     room_messages_response.end = None
     client.room_messages = AsyncMock(return_value=room_messages_response)
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$plain-reply:localhost",
@@ -1738,7 +1738,7 @@ async def test_normalize_thread_root_event_id_returns_none_for_plain_reply_to_pl
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_returns_none_for_plain_reply() -> None:
+async def test_resolve_thread_root_event_id_for_client_returns_none_for_plain_reply() -> None:
     """Plain replies should no longer be promoted into synthetic thread roots."""
     client = AsyncMock()
     client.room_get_event = AsyncMock(
@@ -1776,7 +1776,7 @@ async def test_normalize_thread_root_event_id_returns_none_for_plain_reply() -> 
     room_messages_response.end = None
     client.room_messages = AsyncMock(return_value=room_messages_response)
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$reply-two:localhost",
@@ -1789,12 +1789,12 @@ async def test_normalize_thread_root_event_id_returns_none_for_plain_reply() -> 
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_returns_none_when_lookup_fails() -> None:
+async def test_resolve_thread_root_event_id_for_client_returns_none_when_lookup_fails() -> None:
     """Missing or unreadable events should not guess a thread root."""
     client = AsyncMock()
     client.room_get_event = AsyncMock(return_value=object())
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$reply-one:localhost",
@@ -1804,14 +1804,14 @@ async def test_normalize_thread_root_event_id_returns_none_when_lookup_fails() -
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_uses_cache_when_event_lookup_misses() -> None:
+async def test_resolve_thread_root_event_id_for_client_uses_cache_when_event_lookup_misses() -> None:
     """Cache-backed normalization should still work when the homeserver lookup misses."""
     client = AsyncMock()
     client.room_get_event = AsyncMock(return_value=object())
     conversation_cache = MagicMock()
     conversation_cache.get_thread_id_for_event = AsyncMock(return_value="$thread-root:localhost")
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$fresh-local-reply:localhost",
@@ -1826,7 +1826,7 @@ async def test_normalize_thread_root_event_id_uses_cache_when_event_lookup_misse
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_resolves_thread_edit_via_original_event() -> None:
+async def test_resolve_thread_root_event_id_for_client_resolves_thread_edit_via_original_event() -> None:
     """Thread edits should normalize directly from explicit thread metadata."""
     client = AsyncMock()
     client.room_get_event = AsyncMock(
@@ -1851,7 +1851,7 @@ async def test_normalize_thread_root_event_id_resolves_thread_edit_via_original_
         ),
     )
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$edit:localhost",
@@ -1862,7 +1862,7 @@ async def test_normalize_thread_root_event_id_resolves_thread_edit_via_original_
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_resolves_thread_reply_edit_via_original_event_without_nested_thread_metadata() -> (
+async def test_resolve_thread_root_event_id_for_client_resolves_thread_reply_edit_via_original_event_without_nested_thread_metadata() -> (
     None
 ):
     """Edits of thread replies should fall back through the original event when nested thread metadata is absent."""
@@ -1898,7 +1898,7 @@ async def test_normalize_thread_root_event_id_resolves_thread_reply_edit_via_ori
         ],
     )
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$edit:localhost",
@@ -1910,7 +1910,9 @@ async def test_normalize_thread_root_event_id_resolves_thread_reply_edit_via_ori
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_resolves_edit_of_promoted_plain_reply_via_original_reply_target() -> None:
+async def test_resolve_thread_root_event_id_for_client_resolves_edit_of_promoted_plain_reply_via_original_reply_target() -> (
+    None
+):
     """Edits of promoted plain replies should reuse the same transitive thread inheritance."""
     client = AsyncMock()
     client.room_get_event = AsyncMock(
@@ -1952,7 +1954,7 @@ async def test_normalize_thread_root_event_id_resolves_edit_of_promoted_plain_re
         ],
     )
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$edit:localhost",
@@ -1965,7 +1967,7 @@ async def test_normalize_thread_root_event_id_resolves_edit_of_promoted_plain_re
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_resolves_thread_root_edit_via_original_event() -> None:
+async def test_resolve_thread_root_event_id_for_client_resolves_thread_root_edit_via_original_event() -> None:
     """Edits of thread-root messages should normalize back to the original root event."""
     client = AsyncMock()
     client.room_get_event = AsyncMock(
@@ -2026,7 +2028,7 @@ async def test_normalize_thread_root_event_id_resolves_thread_root_edit_via_orig
     room_messages_response.end = None
     client.room_messages = AsyncMock(return_value=room_messages_response)
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$edit:localhost",
@@ -2039,7 +2041,7 @@ async def test_normalize_thread_root_event_id_resolves_thread_root_edit_via_orig
 
 
 @pytest.mark.asyncio
-async def test_normalize_thread_root_event_id_returns_none_for_cyclic_edit_chain() -> None:
+async def test_resolve_thread_root_event_id_for_client_returns_none_for_cyclic_edit_chain() -> None:
     """Cyclic edit chains should fail closed instead of recursing until crash."""
     client = AsyncMock()
     responses = {
@@ -2066,7 +2068,7 @@ async def test_normalize_thread_root_event_id_returns_none_for_cyclic_edit_chain
         side_effect=lambda _room_id, event_id: responses[event_id],
     )
 
-    normalized = await normalize_thread_root_event_id(
+    normalized = await resolve_thread_root_event_id_for_client(
         client,
         "!room:localhost",
         "$edit-a:localhost",

--- a/tests/test_thread_tags_tool.py
+++ b/tests/test_thread_tags_tool.py
@@ -122,7 +122,7 @@ async def test_tag_thread_defaults_to_context_thread_id() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ) as mock_normalize,
         patch(
@@ -140,7 +140,7 @@ async def test_tag_thread_defaults_to_context_thread_id() -> None:
         context.client,
         context.room_id,
         "$ctx-thread:localhost",
-        context.conversation_cache,
+        conversation_cache=context.conversation_cache,
     )
     mock_set.assert_awaited_once_with(
         context.client,
@@ -161,7 +161,7 @@ async def test_tag_thread_explicit_thread_id_overrides_same_room_context() -> No
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$explicit-thread:localhost"),
         ) as mock_normalize,
         patch(
@@ -178,7 +178,7 @@ async def test_tag_thread_explicit_thread_id_overrides_same_room_context() -> No
         context.client,
         context.room_id,
         "$explicit-event:localhost",
-        context.conversation_cache,
+        conversation_cache=context.conversation_cache,
     )
     mock_set.assert_awaited_once_with(
         context.client,
@@ -199,7 +199,7 @@ async def test_tag_thread_explicit_same_room_id_keeps_context_thread_fallback() 
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ) as mock_normalize,
         patch(
@@ -216,7 +216,7 @@ async def test_tag_thread_explicit_same_room_id_keeps_context_thread_fallback() 
         context.client,
         context.room_id,
         "$ctx-thread:localhost",
-        context.conversation_cache,
+        conversation_cache=context.conversation_cache,
     )
     mock_set.assert_awaited_once_with(
         context.client,
@@ -237,7 +237,7 @@ async def test_untag_thread_defaults_to_context_thread_id() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ) as mock_normalize,
         patch(
@@ -256,7 +256,7 @@ async def test_untag_thread_defaults_to_context_thread_id() -> None:
         context.client,
         context.room_id,
         "$ctx-thread:localhost",
-        context.conversation_cache,
+        conversation_cache=context.conversation_cache,
     )
     mock_remove.assert_awaited_once_with(
         context.client,
@@ -275,7 +275,7 @@ async def test_untag_thread_explicit_thread_id_overrides_same_room_context() -> 
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$explicit-thread:localhost"),
         ) as mock_normalize,
         patch(
@@ -292,7 +292,7 @@ async def test_untag_thread_explicit_thread_id_overrides_same_room_context() -> 
         context.client,
         context.room_id,
         "$explicit-event:localhost",
-        context.conversation_cache,
+        conversation_cache=context.conversation_cache,
     )
     mock_remove.assert_awaited_once_with(
         context.client,
@@ -311,7 +311,7 @@ async def test_untag_thread_explicit_same_room_id_keeps_context_thread_fallback(
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ) as mock_normalize,
         patch(
@@ -328,7 +328,7 @@ async def test_untag_thread_explicit_same_room_id_keeps_context_thread_fallback(
         context.client,
         context.room_id,
         "$ctx-thread:localhost",
-        context.conversation_cache,
+        conversation_cache=context.conversation_cache,
     )
     mock_remove.assert_awaited_once_with(
         context.client,
@@ -347,7 +347,7 @@ async def test_list_thread_tags_defaults_to_context_thread_id() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ) as mock_normalize,
         patch(
@@ -366,7 +366,7 @@ async def test_list_thread_tags_defaults_to_context_thread_id() -> None:
         context.client,
         context.room_id,
         "$ctx-thread:localhost",
-        context.conversation_cache,
+        conversation_cache=context.conversation_cache,
     )
     mock_get.assert_awaited_once_with(
         context.client,
@@ -383,7 +383,7 @@ async def test_list_thread_tags_explicit_thread_id_overrides_same_room_context()
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$explicit-thread:localhost"),
         ) as mock_normalize,
         patch(
@@ -401,7 +401,7 @@ async def test_list_thread_tags_explicit_thread_id_overrides_same_room_context()
         context.client,
         context.room_id,
         "$explicit-event:localhost",
-        context.conversation_cache,
+        conversation_cache=context.conversation_cache,
     )
     mock_get.assert_awaited_once_with(
         context.client,
@@ -515,7 +515,7 @@ async def test_tag_thread_normalizes_explicit_thread_id_before_write() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$thread-root:localhost"),
         ) as mock_normalize,
         patch(
@@ -543,7 +543,7 @@ async def test_tag_thread_normalizes_explicit_thread_id_before_write() -> None:
         context.client,
         context.room_id,
         "$reply-event:localhost",
-        context.conversation_cache,
+        conversation_cache=context.conversation_cache,
     )
     mock_set.assert_awaited_once_with(
         context.client,
@@ -564,7 +564,7 @@ async def test_tag_thread_returns_error_when_normalization_fails() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value=None),
         ),
         tool_runtime_context(context),
@@ -585,7 +585,7 @@ async def test_tag_thread_surfaces_write_failures() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$thread:localhost"),
         ),
         patch(
@@ -924,7 +924,7 @@ async def test_list_thread_tags_explicit_same_room_target_can_list_room_wide_fro
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(),
         ) as mock_normalize,
         patch(
@@ -989,7 +989,7 @@ async def test_list_thread_tags_filters_thread_specific_payload() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ),
         patch(
@@ -1020,7 +1020,7 @@ async def test_list_thread_tags_thread_specific_include_exclude_filters() -> Non
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ),
         patch(
@@ -1067,7 +1067,7 @@ async def test_untag_thread_canonical_skips_normalization() -> None:
 
     with (
         patch(
-            "mindroom.custom_tools.thread_tags.normalize_thread_root_event_id",
+            "mindroom.custom_tools.thread_tags.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value=None),
         ) as mock_normalize,
         patch(


### PR DESCRIPTION
## Summary
- move Matrix thread classification and conversation-cache helpers into `matrix.thread_membership`
- remove the leftover `thread_tags.normalize_thread_root_event_id` wrapper and have tool wrappers call the shared helper directly
- update the `thread_summary` tool and regression tests to use the shared helper after the wrapper removal

## Review follow-up
- fixed the remaining tool-surface blocker from review: `thread_tags.py` no longer keeps a pass-through thread-resolution wrapper
- removed the dead `strict_event_fetch` option from the shared thread-membership access helper so its surface matches actual behavior
- kept wrapper responsibilities limited to input validation, auth/policy, Matrix calls, and response shaping

## Testing
- `uv run pytest tests/test_matrix_api_tool.py tests/test_thread_tags.py tests/test_thread_tags_tool.py tests/test_thread_summary_tool.py -x -n 0 --no-cov -v`
- `uv run pre-commit run --all-files`
- `uv run pytest -x -n 0 --no-cov`
