### PR TITLE
refactor: consolidate matrix thread domain

### DIFF
--- a/src/mindroom/custom_tools/matrix_api.py
+++ b/src/mindroom/custom_tools/matrix_api.py
@@ -13,10 +13,8 @@ from agno.tools import Toolkit
 
 from mindroom.custom_tools.attachment_helpers import room_access_allowed
 from mindroom.logging_config import get_logger
-from mindroom.matrix.thread_membership import (
-    conversation_cache_thread_membership_access_for_client,
+from mindroom.matrix.thread_bookkeeping import (
     event_requires_thread_bookkeeping,
-    fetch_event_info_from_conversation_cache,
     redaction_requires_thread_bookkeeping,
 )
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
@@ -444,13 +442,11 @@ class MatrixApiTools(Toolkit):
 
         try:
             requires_conversation_cache_write = await event_requires_thread_bookkeeping(
+                context.client,
                 room_id=room_id,
                 event_type=normalized_event_type,
                 content=normalized_content,
-                access=conversation_cache_thread_membership_access_for_client(
-                    context.client,
-                    conversation_cache=context.conversation_cache,
-                ),
+                conversation_cache=context.conversation_cache,
             )
         except Exception as exc:
             logger.warning(
@@ -804,20 +800,11 @@ class MatrixApiTools(Toolkit):
         assert normalized_event_id is not None
 
         try:
-            target_event_info = await fetch_event_info_from_conversation_cache(
-                context.conversation_cache,
-                room_id,
-                normalized_event_id,
-                strict=True,
-            )
             requires_conversation_cache_write = await redaction_requires_thread_bookkeeping(
+                context.client,
                 room_id=room_id,
                 event_id=normalized_event_id,
-                access=conversation_cache_thread_membership_access_for_client(
-                    context.client,
-                    conversation_cache=context.conversation_cache,
-                ),
-                target_event_info=target_event_info,
+                conversation_cache=context.conversation_cache,
             )
         except Exception as exc:
             logger.warning(

--- a/src/mindroom/custom_tools/thread_summary.py
+++ b/src/mindroom/custom_tools/thread_summary.py
@@ -6,19 +6,17 @@ import json
 
 from agno.tools import Toolkit
 
-from mindroom.custom_tools.attachment_helpers import resolve_context_thread_id, room_access_allowed
+from mindroom.custom_tools.attachment_helpers import (
+    resolve_context_thread_id,
+    resolve_requested_room_id,
+    room_access_allowed,
+)
 from mindroom.matrix.thread_membership import resolve_thread_root_event_id_for_client
 from mindroom.thread_summary import (
-    THREAD_SUMMARY_MAX_LENGTH,
-    _count_non_summary_messages,
-    normalize_thread_summary_text,
-    send_thread_summary_event,
-    thread_summary_lock,
-    update_last_summary_count,
+    ThreadSummaryWriteError,
+    set_manual_thread_summary,
 )
 from mindroom.tool_system.runtime_context import get_tool_runtime_context
-
-_MAX_THREAD_SUMMARY_LENGTH = THREAD_SUMMARY_MAX_LENGTH
 
 
 class ThreadSummaryTools(Toolkit):
@@ -44,7 +42,7 @@ class ThreadSummaryTools(Toolkit):
             message="Thread summary tool context is unavailable in this runtime path.",
         )
 
-    async def set_thread_summary(  # noqa: C901, PLR0911, PLR0912
+    async def set_thread_summary(  # noqa: PLR0911
         self,
         summary: str,
         thread_id: str | None = None,
@@ -59,17 +57,15 @@ class ThreadSummaryTools(Toolkit):
             return self._context_error()
         conversation_cache = context.conversation_cache
 
-        if room_id is None:
-            resolved_room_id = context.room_id
-        elif not isinstance(room_id, str) or not room_id.strip():
+        resolved_room_id, room_error = resolve_requested_room_id(context, room_id)
+        if room_error is not None:
             return self._payload(
                 "error",
                 action="set",
                 room_id=room_id,
                 message="room_id must be a non-empty string when provided.",
             )
-        else:
-            resolved_room_id = room_id.strip()
+        assert resolved_room_id is not None
 
         if not room_access_allowed(context, resolved_room_id):
             return self._payload(
@@ -86,92 +82,62 @@ class ThreadSummaryTools(Toolkit):
                 room_id=resolved_room_id,
                 message="summary must be a non-empty string.",
             )
-        normalized_summary = normalize_thread_summary_text(summary)
-        if not normalized_summary:
-            return self._payload(
-                "error",
-                action="set",
-                room_id=resolved_room_id,
-                message="summary must be a non-empty string.",
-            )
-        if len(normalized_summary) > _MAX_THREAD_SUMMARY_LENGTH:
-            return self._payload(
-                "error",
-                action="set",
-                room_id=resolved_room_id,
-                message=f"summary must be {_MAX_THREAD_SUMMARY_LENGTH} characters or fewer after whitespace normalization.",
-            )
-
-        error_message: str | None = None
-        error_thread_id: str | None = None
         effective_thread_id = resolve_context_thread_id(
             context,
             room_id=resolved_room_id,
             thread_id=thread_id,
         )
         if effective_thread_id is None:
-            error_message = "thread_id is required when no active thread context is available for the target room."
-        else:
-            try:
-                normalized_thread_id = await resolve_thread_root_event_id_for_client(
-                    context.client,
-                    resolved_room_id,
-                    effective_thread_id,
-                    conversation_cache=context.conversation_cache,
-                )
-            except Exception:
-                error_thread_id = effective_thread_id
-                error_message = "Failed to resolve a canonical thread root for the target event."
-            else:
-                if normalized_thread_id is None:
-                    error_thread_id = effective_thread_id
-                    error_message = "Failed to resolve a canonical thread root for the target event."
-                else:
-                    async with thread_summary_lock(resolved_room_id, normalized_thread_id):
-                        try:
-                            thread_history = await conversation_cache.get_thread_history(
-                                resolved_room_id,
-                                normalized_thread_id,
-                            )
-                        except Exception:
-                            error_thread_id = normalized_thread_id
-                            error_message = "Failed to fetch thread history for the target thread."
-                        else:
-                            message_count = _count_non_summary_messages(thread_history)
-                            try:
-                                event_id = await send_thread_summary_event(
-                                    context.client,
-                                    resolved_room_id,
-                                    normalized_thread_id,
-                                    normalized_summary,
-                                    message_count,
-                                    "manual",
-                                    conversation_cache,
-                                )
-                            except Exception:
-                                error_thread_id = normalized_thread_id
-                                error_message = "Failed to send thread summary event."
-                            else:
-                                if event_id is None:
-                                    error_thread_id = normalized_thread_id
-                                    error_message = "Failed to send thread summary event."
-                                else:
-                                    update_last_summary_count(resolved_room_id, normalized_thread_id, message_count)
-                                    return self._payload(
-                                        "ok",
-                                        action="set",
-                                        room_id=resolved_room_id,
-                                        thread_id=normalized_thread_id,
-                                        event_id=event_id,
-                                        message_count=message_count,
-                                        summary=normalized_summary,
-                                    )
+            return self._payload(
+                "error",
+                action="set",
+                room_id=resolved_room_id,
+                thread_id=None,
+                message="thread_id is required when no active thread context is available for the target room.",
+            )
 
-        assert error_message is not None
+        try:
+            normalized_thread_id = await resolve_thread_root_event_id_for_client(
+                context.client,
+                resolved_room_id,
+                effective_thread_id,
+                conversation_cache=context.conversation_cache,
+            )
+        except Exception:
+            normalized_thread_id = None
+
+        if normalized_thread_id is None:
+            return self._payload(
+                "error",
+                action="set",
+                room_id=resolved_room_id,
+                thread_id=effective_thread_id,
+                message="Failed to resolve a canonical thread root for the target event.",
+            )
+
+        try:
+            result = await set_manual_thread_summary(
+                context.client,
+                resolved_room_id,
+                normalized_thread_id,
+                summary,
+                conversation_cache=conversation_cache,
+            )
+        except ThreadSummaryWriteError as exc:
+            return self._payload(
+                "error",
+                action="set",
+                room_id=resolved_room_id,
+                thread_id=normalized_thread_id,
+                message=str(exc),
+            )
+
         return self._payload(
-            "error",
+            "ok",
             action="set",
             room_id=resolved_room_id,
-            thread_id=error_thread_id,
-            message=error_message,
+            thread_id=normalized_thread_id,
+            event_id=result.event_id,
+            message_count=result.message_count,
+            summary=result.summary,
         )

--- a/src/mindroom/custom_tools/thread_tags.py
+++ b/src/mindroom/custom_tools/thread_tags.py
@@ -22,26 +22,10 @@ from mindroom.thread_tags import (
     remove_thread_tag,
     set_thread_tag,
 )
-from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
+from mindroom.tool_system.runtime_context import get_tool_runtime_context
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-
-
-def _resolve_target_thread_reference(
-    context: ToolRuntimeContext,
-    *,
-    room_id: str,
-    thread_id: str | None,
-    allow_context_fallback: bool = True,
-) -> str | None:
-    """Resolve thread targeting in the order requested by the issue."""
-    return resolve_context_thread_id(
-        context,
-        room_id=room_id,
-        thread_id=thread_id,
-        allow_context_fallback=allow_context_fallback,
-    )
 
 
 def _serialized_tags(tags: Mapping[str, ThreadTagRecord]) -> dict[str, dict[str, object]]:
@@ -138,7 +122,7 @@ class ThreadTagsTools(Toolkit):
                 message=str(exc),
             )
 
-        effective_thread_id = _resolve_target_thread_reference(
+        effective_thread_id = resolve_context_thread_id(
             context,
             room_id=resolved_room_id,
             thread_id=thread_id,
@@ -236,7 +220,7 @@ class ThreadTagsTools(Toolkit):
                 message=str(exc),
             )
 
-        effective_thread_id = _resolve_target_thread_reference(
+        effective_thread_id = resolve_context_thread_id(
             context,
             room_id=resolved_room_id,
             thread_id=thread_id,
@@ -338,7 +322,7 @@ class ThreadTagsTools(Toolkit):
                 message=str(exc),
             )
 
-        effective_thread_id = _resolve_target_thread_reference(
+        effective_thread_id = resolve_context_thread_id(
             context,
             room_id=resolved_room_id,
             thread_id=thread_id,

--- a/src/mindroom/matrix/thread_bookkeeping.py
+++ b/src/mindroom/matrix/thread_bookkeeping.py
@@ -1,0 +1,83 @@
+"""Tool-facing Matrix thread bookkeeping helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.matrix.event_info import EventInfo
+from mindroom.matrix.thread_membership import (
+    conversation_cache_thread_membership_access_for_client,
+    fetch_event_info_for_client,
+    fetch_event_info_from_conversation_cache,
+    resolve_event_thread_id,
+    resolve_related_event_thread_id,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    import nio
+
+    from mindroom.matrix.conversation_cache import ConversationCacheProtocol
+
+
+async def event_requires_thread_bookkeeping(
+    client: nio.AsyncClient,
+    room_id: str,
+    *,
+    event_type: str,
+    content: Mapping[str, object],
+    conversation_cache: ConversationCacheProtocol | None,
+) -> bool:
+    """Return whether one outbound event payload targets a thread."""
+    if event_type != "m.room.message":
+        return False
+    event_info = EventInfo.from_event({"type": event_type, "content": dict(content)})
+    return isinstance(
+        await resolve_event_thread_id(
+            room_id,
+            event_info,
+            access=conversation_cache_thread_membership_access_for_client(
+                client,
+                conversation_cache=conversation_cache,
+            ),
+        ),
+        str,
+    )
+
+
+async def redaction_requires_thread_bookkeeping(
+    client: nio.AsyncClient,
+    room_id: str,
+    *,
+    event_id: str,
+    conversation_cache: ConversationCacheProtocol | None,
+) -> bool:
+    """Return whether one redaction target can affect thread-scoped cache state."""
+    if conversation_cache is None:
+        target_event_info = await fetch_event_info_for_client(
+            client,
+            room_id,
+            event_id,
+            strict=True,
+        )
+    else:
+        target_event_info = await fetch_event_info_from_conversation_cache(
+            conversation_cache,
+            room_id,
+            event_id,
+            strict=True,
+        )
+    if target_event_info is not None and target_event_info.is_reaction:
+        return False
+    return isinstance(
+        await resolve_related_event_thread_id(
+            room_id,
+            event_id,
+            access=conversation_cache_thread_membership_access_for_client(
+                client,
+                conversation_cache=conversation_cache,
+            ),
+        ),
+        str,
+    )

--- a/src/mindroom/matrix/thread_membership.py
+++ b/src/mindroom/matrix/thread_membership.py
@@ -630,47 +630,6 @@ async def resolve_thread_root_event_id_for_client(
     )
 
 
-async def event_requires_thread_bookkeeping(
-    room_id: str,
-    *,
-    event_type: str,
-    content: Mapping[str, object],
-    access: ThreadMembershipAccess,
-) -> bool:
-    """Return whether one outbound event payload targets a thread."""
-    if event_type != "m.room.message":
-        return False
-    event_info = EventInfo.from_event({"type": event_type, "content": dict(content)})
-    return isinstance(
-        await resolve_event_thread_id(
-            room_id,
-            event_info,
-            access=access,
-        ),
-        str,
-    )
-
-
-async def redaction_requires_thread_bookkeeping(
-    room_id: str,
-    *,
-    event_id: str,
-    access: ThreadMembershipAccess,
-    target_event_info: EventInfo | None,
-) -> bool:
-    """Return whether one redaction target can affect thread-scoped cache state."""
-    if target_event_info is not None and target_event_info.is_reaction:
-        return False
-    return isinstance(
-        await resolve_related_event_thread_id(
-            room_id,
-            event_id,
-            access=access,
-        ),
-        str,
-    )
-
-
 async def resolve_thread_ids_for_event_infos(
     room_id: str,
     *,

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import re
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -44,6 +45,19 @@ _PREQUEUE_CONCURRENCY_MARGIN = 2
 # Key: "{room_id}:{thread_id}", value: message count at last summary.
 _last_summary_counts: dict[str, int] = {}
 _thread_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+
+class ThreadSummaryWriteError(RuntimeError):
+    """Raised when a manual thread summary cannot be written."""
+
+
+@dataclass(frozen=True)
+class ThreadSummaryWriteResult:
+    """Successful manual thread summary write details."""
+
+    event_id: str
+    message_count: int
+    summary: str
 
 
 class _ThreadSummary(BaseModel):
@@ -370,6 +384,67 @@ async def send_thread_summary_event(
         return delivered.event_id
     logger.warning("Failed to send thread summary", room_id=room_id, thread_id=thread_id)
     return None
+
+
+async def set_manual_thread_summary(
+    client: nio.AsyncClient,
+    room_id: str,
+    thread_id: str,
+    summary: str,
+    *,
+    conversation_cache: ConversationCacheProtocol,
+) -> ThreadSummaryWriteResult:
+    """Write one validated manual summary for a canonical thread root."""
+    if not isinstance(summary, str) or not summary.strip():
+        msg = "summary must be a non-empty string."
+        raise ThreadSummaryWriteError(msg)
+
+    normalized_summary = normalize_thread_summary_text(summary)
+    if not normalized_summary:
+        msg = "summary must be a non-empty string."
+        raise ThreadSummaryWriteError(msg)
+    if len(normalized_summary) > THREAD_SUMMARY_MAX_LENGTH:
+        msg = (
+            f"summary must be {THREAD_SUMMARY_MAX_LENGTH} characters or fewer "
+            "after whitespace normalization."
+        )
+        raise ThreadSummaryWriteError(msg)
+
+    async with thread_summary_lock(room_id, thread_id):
+        try:
+            thread_history = await _load_thread_history(
+                conversation_cache,
+                room_id,
+                thread_id,
+            )
+        except Exception as exc:
+            msg = "Failed to fetch thread history for the target thread."
+            raise ThreadSummaryWriteError(msg) from exc
+
+        message_count = _count_non_summary_messages(thread_history)
+        try:
+            event_id = await send_thread_summary_event(
+                client,
+                room_id,
+                thread_id,
+                normalized_summary,
+                message_count,
+                "manual",
+                conversation_cache,
+            )
+        except Exception as exc:
+            msg = "Failed to send thread summary event."
+            raise ThreadSummaryWriteError(msg) from exc
+        if event_id is None:
+            msg = "Failed to send thread summary event."
+            raise ThreadSummaryWriteError(msg)
+
+        update_last_summary_count(room_id, thread_id, message_count)
+        return ThreadSummaryWriteResult(
+            event_id=event_id,
+            message_count=message_count,
+            summary=normalized_summary,
+        )
 
 
 async def maybe_generate_thread_summary(

--- a/src/mindroom/thread_tags.py
+++ b/src/mindroom/thread_tags.py
@@ -375,30 +375,6 @@ def _thread_tags_state_from_tags(
     )
 
 
-def _collect_thread_tag_room_state_event(
-    room_id: str,
-    event: Mapping[str, object],
-    *,
-    legacy_tags_by_thread: dict[str, dict[str, ThreadTagRecord]],
-    per_tag_records_by_thread: dict[str, dict[str, ThreadTagRecord]],
-    per_tag_tombstones_by_thread: dict[str, set[str]],
-) -> None:
-    """Parse one room-state event into either legacy or per-tag storage."""
-    if event.get("type") != THREAD_TAGS_EVENT_TYPE:
-        return
-
-    state_key = event.get("state_key")
-    content = event.get("content")
-    _collect_thread_tag_state_entry(
-        room_id,
-        state_key,
-        content,
-        legacy_tags_by_thread=legacy_tags_by_thread,
-        per_tag_records_by_thread=per_tag_records_by_thread,
-        per_tag_tombstones_by_thread=per_tag_tombstones_by_thread,
-    )
-
-
 def _collect_thread_tag_state_entry(
     room_id: str,
     state_key: object,
@@ -645,9 +621,12 @@ async def _get_room_thread_tags_states(
     per_tag_records_by_thread: dict[str, dict[str, ThreadTagRecord]] = {}
     per_tag_tombstones_by_thread: dict[str, set[str]] = {}
     for event in response.events:
-        _collect_thread_tag_room_state_event(
+        if event.get("type") != THREAD_TAGS_EVENT_TYPE:
+            continue
+        _collect_thread_tag_state_entry(
             room_id,
-            event,
+            event.get("state_key"),
+            event.get("content"),
             legacy_tags_by_thread=legacy_tags_by_thread,
             per_tag_records_by_thread=per_tag_records_by_thread,
             per_tag_tombstones_by_thread=per_tag_tombstones_by_thread,

--- a/tests/test_matrix_thread_domain.py
+++ b/tests/test_matrix_thread_domain.py
@@ -1,0 +1,164 @@
+"""Direct tests for Matrix thread resolution and bookkeeping helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import nio
+import pytest
+
+from mindroom.matrix.event_info import EventInfo
+from mindroom.matrix.thread_bookkeeping import (
+    event_requires_thread_bookkeeping,
+    redaction_requires_thread_bookkeeping,
+)
+from mindroom.matrix.thread_membership import (
+    ThreadResolution,
+    map_backed_thread_membership_access,
+    resolve_event_thread_membership,
+)
+
+
+def _message_event_info(content: dict[str, object]) -> EventInfo:
+    return EventInfo.from_event(
+        {
+            "type": "m.room.message",
+            "content": content,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_event_thread_membership_promotes_plain_reply_transitively() -> None:
+    """Plain replies should inherit thread membership from a threaded ancestor."""
+    event_infos = {
+        "$plain-two:localhost": _message_event_info(
+            {
+                "body": "plain two",
+                "msgtype": "m.text",
+                "m.relates_to": {"m.in_reply_to": {"event_id": "$plain-one:localhost"}},
+            },
+        ),
+        "$plain-one:localhost": _message_event_info(
+            {
+                "body": "plain one",
+                "msgtype": "m.text",
+                "m.relates_to": {"m.in_reply_to": {"event_id": "$thread-reply:localhost"}},
+            },
+        ),
+        "$thread-reply:localhost": _message_event_info(
+            {
+                "body": "thread reply",
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": "$thread-root:localhost",
+                },
+            },
+        ),
+    }
+
+    resolution = await resolve_event_thread_membership(
+        "!room:localhost",
+        event_infos["$plain-two:localhost"],
+        access=map_backed_thread_membership_access(
+            event_infos=event_infos,
+            resolved_thread_ids={},
+        ),
+    )
+
+    assert resolution == ThreadResolution.threaded("$thread-root:localhost")
+
+
+@pytest.mark.asyncio
+async def test_resolve_event_thread_membership_proves_current_root_when_allowed() -> None:
+    """A root event should normalize to itself only when descendants prove it is threaded."""
+    event_infos = {
+        "$thread-root:localhost": _message_event_info(
+            {
+                "body": "root",
+                "msgtype": "m.text",
+            },
+        ),
+        "$thread-reply:localhost": _message_event_info(
+            {
+                "body": "thread reply",
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": "$thread-root:localhost",
+                },
+            },
+        ),
+    }
+
+    resolution = await resolve_event_thread_membership(
+        "!room:localhost",
+        event_infos["$thread-root:localhost"],
+        event_id="$thread-root:localhost",
+        allow_current_root=True,
+        access=map_backed_thread_membership_access(
+            event_infos=event_infos,
+            resolved_thread_ids={},
+        ),
+    )
+
+    assert resolution == ThreadResolution.threaded("$thread-root:localhost")
+
+
+@pytest.mark.asyncio
+async def test_event_requires_thread_bookkeeping_uses_shared_thread_resolution() -> None:
+    """Outbound plain replies to threaded events should be classified as thread-scoped."""
+    client = AsyncMock()
+    conversation_cache = AsyncMock()
+    conversation_cache.get_thread_id_for_event.side_effect = (
+        lambda room_id, event_id: "$thread-root:localhost"
+        if (room_id, event_id) == ("!room:localhost", "$thread-reply:localhost")
+        else None
+    )
+
+    requires_thread_bookkeeping = await event_requires_thread_bookkeeping(
+        client,
+        "!room:localhost",
+        event_type="m.room.message",
+        content={
+            "body": "bridged reply",
+            "msgtype": "m.text",
+            "m.relates_to": {"m.in_reply_to": {"event_id": "$thread-reply:localhost"}},
+        },
+        conversation_cache=conversation_cache,
+    )
+
+    assert requires_thread_bookkeeping is True
+
+
+@pytest.mark.asyncio
+async def test_redaction_requires_thread_bookkeeping_ignores_reactions() -> None:
+    """Reaction redactions should stay room-level even when the reaction targets a thread."""
+    client = AsyncMock()
+    conversation_cache = AsyncMock()
+    conversation_cache.get_event.return_value = nio.RoomGetEventResponse.from_dict(
+        {
+            "event_id": "$reaction:localhost",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1,
+            "room_id": "!room:localhost",
+            "type": "m.reaction",
+            "content": {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": "$thread-reply:localhost",
+                    "key": "👍",
+                },
+            },
+        },
+    )
+
+    requires_thread_bookkeeping = await redaction_requires_thread_bookkeeping(
+        client,
+        "!room:localhost",
+        event_id="$reaction:localhost",
+        conversation_cache=conversation_cache,
+    )
+
+    assert requires_thread_bookkeeping is False

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -15,7 +15,9 @@ from mindroom.thread_summary import (
     _MAX_MESSAGES_BEFORE_TRUNCATION,
     _TRUNCATION_SAMPLE_SIZE,
     THREAD_SUMMARY_MAX_LENGTH,
+    ThreadSummaryWriteError,
     _build_conversation_text,
+    _count_non_summary_messages,
     _generate_summary,
     _is_thread_summary_message,
     _last_summary_counts,
@@ -27,6 +29,7 @@ from mindroom.thread_summary import (
     next_thread_summary_threshold,
     normalize_thread_summary_text,
     send_thread_summary_event,
+    set_manual_thread_summary,
     should_queue_thread_summary,
     thread_summary_cache_key,
     thread_summary_message_count_hint,
@@ -1183,6 +1186,85 @@ class TestSendSummaryEvent:
         assert relates_to["event_id"] == "$root1"
         assert relates_to["m.in_reply_to"] == {"event_id": "$root1"}
         conversation_cache.notify_outbound_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestSetManualThreadSummary:
+    """Direct tests for the shared manual summary write path."""
+
+    async def test_sets_summary_and_updates_cache(self) -> None:
+        """Manual summary writes should normalize text, count non-summary messages, and update the cache."""
+        client = _mock_client()
+        conversation_cache = AsyncMock()
+        conversation_cache.get_thread_history.return_value = [
+            *_make_thread_history(3),
+            _make_summary_notice_message("$root1", message_count=2),
+        ]
+
+        with patch(
+            "mindroom.thread_summary.send_thread_summary_event",
+            new=AsyncMock(return_value="$summary1"),
+        ) as mock_send:
+            result = await set_manual_thread_summary(
+                client,
+                "!room:x",
+                "$root1",
+                "  # **Fix** [ISSUE-116](http://example.com)  ",
+                conversation_cache=conversation_cache,
+            )
+
+        assert result.event_id == "$summary1"
+        assert result.summary == "Fix ISSUE-116"
+        assert result.message_count == _count_non_summary_messages(conversation_cache.get_thread_history.return_value)
+        mock_send.assert_awaited_once_with(
+            client,
+            "!room:x",
+            "$root1",
+            "Fix ISSUE-116",
+            3,
+            "manual",
+            conversation_cache,
+        )
+        assert _last_summary_counts[thread_summary_cache_key("!room:x", "$root1")] == 3
+
+    async def test_send_failure_raises_and_leaves_cache_unchanged(self) -> None:
+        """A failed manual summary send should not advance the cached threshold baseline."""
+        client = _mock_client()
+        conversation_cache = AsyncMock()
+        conversation_cache.get_thread_history.return_value = _make_thread_history(5)
+        update_last_summary_count("!room:x", "$root1", 2)
+
+        with (
+            patch(
+                "mindroom.thread_summary.send_thread_summary_event",
+                new=AsyncMock(return_value=None),
+            ),
+            pytest.raises(ThreadSummaryWriteError, match=r"Failed to send thread summary event\."),
+        ):
+            await set_manual_thread_summary(
+                client,
+                "!room:x",
+                "$root1",
+                "failed write",
+                conversation_cache=conversation_cache,
+            )
+
+        assert _last_summary_counts[thread_summary_cache_key("!room:x", "$root1")] == 2
+
+    async def test_fetch_failure_raises_before_send(self) -> None:
+        """A failed history fetch should raise the shared manual-summary fetch error."""
+        client = _mock_client()
+        conversation_cache = AsyncMock()
+        conversation_cache.get_thread_history.side_effect = TimeoutError("timed out")
+
+        with pytest.raises(ThreadSummaryWriteError, match=r"Failed to fetch thread history for the target thread\."):
+            await set_manual_thread_summary(
+                client,
+                "!room:x",
+                "$root1",
+                "done",
+                conversation_cache=conversation_cache,
+            )
 
 
 class TestBuildConversationText:

--- a/tests/test_thread_summary_tool.py
+++ b/tests/test_thread_summary_tool.py
@@ -14,13 +14,10 @@ import mindroom.tools  # noqa: F401
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.custom_tools.thread_summary import ThreadSummaryTools
-from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.thread_summary import (
     THREAD_SUMMARY_MAX_LENGTH,
-    _last_summary_counts,
-    _thread_locks,
-    thread_summary_cache_key,
-    update_last_summary_count,
+    ThreadSummaryWriteError,
+    ThreadSummaryWriteResult,
 )
 from mindroom.tool_system.metadata import TOOL_METADATA, get_tool_by_name
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
@@ -55,40 +52,17 @@ def _make_context(
     )
 
 
-@pytest.fixture(autouse=True)
-def _clear_summary_counts() -> None:
-    """Reset cached summary counts between tests."""
-    _last_summary_counts.clear()
-    _thread_locks.clear()
-
-
-def _thread_history(
-    count: int,
+def _write_result(
     *,
-    summary_count: int = 0,
-) -> list[ResolvedVisibleMessage]:
-    """Build a fake thread history with a fixed number of messages."""
-    messages = [
-        ResolvedVisibleMessage.synthetic(
-            sender=f"@user{i}:localhost",
-            body=f"Message {i}",
-            event_id=f"$event{i}:localhost",
-        )
-        for i in range(count)
-    ]
-    messages.extend(
-        ResolvedVisibleMessage.synthetic(
-            sender="@mindroom:localhost",
-            body=f"Summary {i}",
-            event_id=f"$summary{i}:localhost",
-            content={
-                "body": f"Summary {i}",
-                "io.mindroom.thread_summary": {"version": 1},
-            },
-        )
-        for i in range(summary_count)
+    event_id: str = "$summary-event:localhost",
+    message_count: int = 3,
+    summary: str = "done",
+) -> ThreadSummaryWriteResult:
+    return ThreadSummaryWriteResult(
+        event_id=event_id,
+        message_count=message_count,
+        summary=summary,
     )
-    return messages
 
 
 def test_thread_summary_tool_registered_and_instantiates() -> None:
@@ -122,7 +96,6 @@ async def test_set_thread_summary_defaults_to_context_room_and_thread() -> None:
     """The tool should default to the current room and resolved thread context."""
     tool = ThreadSummaryTools()
     context = _make_context(thread_id="$ctx-thread:localhost")
-    context.conversation_cache.get_thread_history.return_value = _thread_history(3)
 
     with (
         patch(
@@ -130,9 +103,13 @@ async def test_set_thread_summary_defaults_to_context_room_and_thread() -> None:
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ) as mock_normalize,
         patch(
-            "mindroom.custom_tools.thread_summary.send_thread_summary_event",
-            new=AsyncMock(return_value="$summary-event:localhost"),
-        ) as mock_send,
+            "mindroom.custom_tools.thread_summary.set_manual_thread_summary",
+            new=AsyncMock(
+                return_value=_write_result(
+                    summary="🧵 Ready for review",
+                ),
+            ),
+        ) as mock_set,
         tool_runtime_context(context),
     ):
         payload = json.loads(await tool.set_thread_summary("  🧵 Ready\nfor\t review  "))
@@ -153,28 +130,20 @@ async def test_set_thread_summary_defaults_to_context_room_and_thread() -> None:
         "$ctx-thread:localhost",
         conversation_cache=context.conversation_cache,
     )
-    context.conversation_cache.get_thread_history.assert_awaited_once_with(
-        context.room_id,
-        "$ctx-thread:localhost",
-    )
-    mock_send.assert_awaited_once_with(
+    mock_set.assert_awaited_once_with(
         context.client,
         context.room_id,
         "$ctx-thread:localhost",
-        "🧵 Ready for review",
-        3,
-        "manual",
-        context.conversation_cache,
+        "  🧵 Ready\nfor\t review  ",
+        conversation_cache=context.conversation_cache,
     )
-    assert _last_summary_counts[thread_summary_cache_key(context.room_id, "$ctx-thread:localhost")] == 3
 
 
 @pytest.mark.asyncio
-async def test_set_thread_summary_strips_markdown_before_send() -> None:
-    """Manual summaries should remove markdown syntax before they are written."""
+async def test_set_thread_summary_returns_helper_summary() -> None:
+    """The tool should return the normalized summary produced by the shared write helper."""
     tool = ThreadSummaryTools()
     context = _make_context(thread_id="$ctx-thread:localhost")
-    context.conversation_cache.get_thread_history.return_value = _thread_history(3)
 
     with (
         patch(
@@ -182,23 +151,21 @@ async def test_set_thread_summary_strips_markdown_before_send() -> None:
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ),
         patch(
-            "mindroom.custom_tools.thread_summary.send_thread_summary_event",
-            new=AsyncMock(return_value="$summary-event:localhost"),
-        ) as mock_send,
+            "mindroom.custom_tools.thread_summary.set_manual_thread_summary",
+            new=AsyncMock(return_value=_write_result(summary="Fix ISSUE-116")),
+        ) as mock_set,
         tool_runtime_context(context),
     ):
         payload = json.loads(await tool.set_thread_summary("# **Fix** [ISSUE-116](http://example.com)"))
 
     assert payload["status"] == "ok"
     assert payload["summary"] == "Fix ISSUE-116"
-    mock_send.assert_awaited_once_with(
+    mock_set.assert_awaited_once_with(
         context.client,
         context.room_id,
         "$ctx-thread:localhost",
-        "Fix ISSUE-116",
-        3,
-        "manual",
-        context.conversation_cache,
+        "# **Fix** [ISSUE-116](http://example.com)",
+        conversation_cache=context.conversation_cache,
     )
 
 
@@ -221,7 +188,6 @@ async def test_set_thread_summary_normalizes_explicit_thread_id() -> None:
     """Explicit event IDs should be normalized to the canonical thread root."""
     tool = ThreadSummaryTools()
     context = _make_context(thread_id=None)
-    context.conversation_cache.get_thread_history.return_value = _thread_history(4)
 
     with (
         patch(
@@ -229,9 +195,9 @@ async def test_set_thread_summary_normalizes_explicit_thread_id() -> None:
             new=AsyncMock(return_value="$thread-root:localhost"),
         ) as mock_normalize,
         patch(
-            "mindroom.custom_tools.thread_summary.send_thread_summary_event",
-            new=AsyncMock(return_value="$summary-event:localhost"),
-        ),
+            "mindroom.custom_tools.thread_summary.set_manual_thread_summary",
+            new=AsyncMock(return_value=_write_result(message_count=4)),
+        ) as mock_set,
         tool_runtime_context(context),
     ):
         payload = json.loads(await tool.set_thread_summary("done", thread_id="$reply-event:localhost"))
@@ -242,6 +208,13 @@ async def test_set_thread_summary_normalizes_explicit_thread_id() -> None:
         context.client,
         context.room_id,
         "$reply-event:localhost",
+        conversation_cache=context.conversation_cache,
+    )
+    mock_set.assert_awaited_once_with(
+        context.client,
+        context.room_id,
+        "$thread-root:localhost",
+        "done",
         conversation_cache=context.conversation_cache,
     )
 
@@ -329,11 +302,25 @@ async def test_set_thread_summary_rejects_non_string_summary() -> None:
 
 @pytest.mark.asyncio
 async def test_set_thread_summary_rejects_overlong_summary() -> None:
-    """Oversized summaries should fail before any Matrix work starts."""
+    """Oversized summaries should return the helper's validation error."""
     tool = ThreadSummaryTools()
     context = _make_context()
 
-    with tool_runtime_context(context):
+    with (
+        patch(
+            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
+            new=AsyncMock(return_value="$ctx-thread:localhost"),
+        ),
+        patch(
+            "mindroom.custom_tools.thread_summary.set_manual_thread_summary",
+            new=AsyncMock(
+                side_effect=ThreadSummaryWriteError(
+                    f"summary must be {THREAD_SUMMARY_MAX_LENGTH} characters or fewer after whitespace normalization.",
+                ),
+            ),
+        ),
+        tool_runtime_context(context),
+    ):
         payload = json.loads(await tool.set_thread_summary("x" * (THREAD_SUMMARY_MAX_LENGTH + 1)))
 
     assert payload["status"] == "error"
@@ -345,12 +332,10 @@ async def test_set_thread_summary_rejects_overlong_summary() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_thread_summary_send_failure_leaves_cache_unchanged() -> None:
-    """A failed send should not update the last-summary count cache."""
+async def test_set_thread_summary_returns_helper_error_for_send_failure() -> None:
+    """Tool errors should pass through shared manual-summary write failures."""
     tool = ThreadSummaryTools()
     context = _make_context(thread_id="$ctx-thread:localhost")
-    update_last_summary_count(context.room_id, "$ctx-thread:localhost", 2)
-    context.conversation_cache.get_thread_history.return_value = _thread_history(5)
 
     with (
         patch(
@@ -358,8 +343,8 @@ async def test_set_thread_summary_send_failure_leaves_cache_unchanged() -> None:
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ),
         patch(
-            "mindroom.custom_tools.thread_summary.send_thread_summary_event",
-            new=AsyncMock(return_value=None),
+            "mindroom.custom_tools.thread_summary.set_manual_thread_summary",
+            new=AsyncMock(side_effect=ThreadSummaryWriteError("Failed to send thread summary event.")),
         ),
         tool_runtime_context(context),
     ):
@@ -367,40 +352,7 @@ async def test_set_thread_summary_send_failure_leaves_cache_unchanged() -> None:
 
     assert payload["status"] == "error"
     assert payload["thread_id"] == "$ctx-thread:localhost"
-    assert _last_summary_counts[thread_summary_cache_key(context.room_id, "$ctx-thread:localhost")] == 2
-
-
-@pytest.mark.asyncio
-async def test_set_thread_summary_excludes_existing_summary_notices_from_message_count() -> None:
-    """Manual summaries should not count prior summary notices toward the baseline."""
-    tool = ThreadSummaryTools()
-    context = _make_context(thread_id="$ctx-thread:localhost")
-    context.conversation_cache.get_thread_history.return_value = _thread_history(3, summary_count=2)
-
-    with (
-        patch(
-            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
-            new=AsyncMock(return_value="$ctx-thread:localhost"),
-        ),
-        patch(
-            "mindroom.custom_tools.thread_summary.send_thread_summary_event",
-            new=AsyncMock(return_value="$summary-event:localhost"),
-        ) as mock_send,
-        tool_runtime_context(context),
-    ):
-        payload = json.loads(await tool.set_thread_summary("done"))
-
-    assert payload["status"] == "ok"
-    assert payload["message_count"] == 3
-    mock_send.assert_awaited_once_with(
-        context.client,
-        context.room_id,
-        "$ctx-thread:localhost",
-        "done",
-        3,
-        "manual",
-        context.conversation_cache,
-    )
+    assert payload["message"] == "Failed to send thread summary event."
 
 
 @pytest.mark.asyncio
@@ -425,15 +377,18 @@ async def test_set_thread_summary_returns_error_when_normalize_raises() -> None:
 
 @pytest.mark.asyncio
 async def test_set_thread_summary_returns_error_when_fetch_raises() -> None:
-    """History fetch exceptions should return the standard error payload."""
+    """History fetch exceptions should surface through the shared write helper."""
     tool = ThreadSummaryTools()
     context = _make_context(thread_id="$ctx-thread:localhost")
-    context.conversation_cache.get_thread_history.side_effect = TimeoutError("timed out")
 
     with (
         patch(
             "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
             new=AsyncMock(return_value="$ctx-thread:localhost"),
+        ),
+        patch(
+            "mindroom.custom_tools.thread_summary.set_manual_thread_summary",
+            new=AsyncMock(side_effect=ThreadSummaryWriteError("Failed to fetch thread history for the target thread.")),
         ),
         tool_runtime_context(context),
     ):
@@ -446,11 +401,9 @@ async def test_set_thread_summary_returns_error_when_fetch_raises() -> None:
 
 @pytest.mark.asyncio
 async def test_set_thread_summary_returns_error_when_send_raises() -> None:
-    """Send exceptions should return the standard error payload."""
+    """Manual-send exceptions should surface through the shared write helper."""
     tool = ThreadSummaryTools()
     context = _make_context(thread_id="$ctx-thread:localhost")
-    update_last_summary_count(context.room_id, "$ctx-thread:localhost", 2)
-    context.conversation_cache.get_thread_history.return_value = _thread_history(5)
 
     with (
         patch(
@@ -458,8 +411,8 @@ async def test_set_thread_summary_returns_error_when_send_raises() -> None:
             new=AsyncMock(return_value="$ctx-thread:localhost"),
         ),
         patch(
-            "mindroom.custom_tools.thread_summary.send_thread_summary_event",
-            new=AsyncMock(side_effect=TimeoutError("timed out")),
+            "mindroom.custom_tools.thread_summary.set_manual_thread_summary",
+            new=AsyncMock(side_effect=ThreadSummaryWriteError("Failed to send thread summary event.")),
         ),
         tool_runtime_context(context),
     ):
@@ -468,4 +421,3 @@ async def test_set_thread_summary_returns_error_when_send_raises() -> None:
     assert payload["status"] == "error"
     assert payload["thread_id"] == "$ctx-thread:localhost"
     assert payload["message"] == "Failed to send thread summary event."
-    assert _last_summary_counts[thread_summary_cache_key(context.room_id, "$ctx-thread:localhost")] == 2


### PR DESCRIPTION
## Summary
- split thread bookkeeping classification into a focused `thread_bookkeeping.py` module while keeping canonical thread resolution in `thread_membership.py`
- simplify the thread summary and thread tag tools into thinner adapters and move the shared manual summary write flow into `thread_summary.py`
- remove redundant thread-tag relay helpers and add direct tests for the shared thread-domain helpers

## Testing
- uv run ruff check src/mindroom/custom_tools/matrix_api.py src/mindroom/custom_tools/thread_summary.py src/mindroom/custom_tools/thread_tags.py src/mindroom/matrix/thread_membership.py src/mindroom/matrix/thread_bookkeeping.py src/mindroom/thread_summary.py src/mindroom/thread_tags.py tests/test_matrix_thread_domain.py tests/test_thread_summary.py tests/test_thread_summary_tool.py tests/test_thread_tags.py
- uv run pytest tests/test_matrix_thread_domain.py tests/test_matrix_api_tool.py tests/test_thread_tags.py tests/test_thread_tags_tool.py tests/test_thread_summary_tool.py tests/test_thread_summary.py -x -n 0 --no-cov -q