### PR TITLE
Tighten scheduling runtime and skill tool dispatch context

### DIFF
--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -894,20 +894,10 @@ def _build_agent_tool_hook_bridge(
     runtime_paths: constants.RuntimePaths,
 ) -> Callable[..., Any] | None:
     active_hook_registry = hook_registry if hook_registry is not None else HookRegistry.from_plugins(plugins)
-    hook_execution_identity = execution_identity
-    if (
-        hook_execution_identity is not None
-        and hook_execution_identity.requester_id is None
-        and hook_execution_identity.room_id is None
-        and hook_execution_identity.thread_id is None
-        and hook_execution_identity.resolved_thread_id is None
-        and hook_execution_identity.session_id is None
-    ):
-        hook_execution_identity = None
     return build_tool_hook_bridge(
         active_hook_registry,
         agent_name=agent_name,
-        execution_identity=hook_execution_identity,
+        execution_identity=execution_identity,
         config=config,
         runtime_paths=runtime_paths,
     )

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -56,8 +56,6 @@ from mindroom.stop import StopManager
 from mindroom.teams import TeamMode, TeamOutcome, resolve_configured_team
 from mindroom.tool_system.runtime_context import ToolRuntimeSupport
 from mindroom.tool_system.worker_routing import (
-    ToolExecutionIdentity,
-    build_tool_execution_identity,
     tool_execution_identity,
 )
 
@@ -707,19 +705,6 @@ class AgentBot:
         """Whether to show tool call details inline in responses."""
         return show_tool_calls_for_agent(self.config, self.agent_name)
 
-    def _build_shared_execution_identity(self) -> ToolExecutionIdentity:
-        """Build a non-request execution identity for shared agent materialization."""
-        return build_tool_execution_identity(
-            channel="matrix",
-            agent_name=self.agent_name,
-            runtime_paths=self.runtime_paths,
-            requester_id=None,
-            room_id=None,
-            thread_id=None,
-            resolved_thread_id=None,
-            session_id=None,
-        )
-
     @property  # Not cached_property because Team mutates it!
     def agent(self) -> Agent:
         """Get the Agno Agent instance for this bot."""
@@ -729,14 +714,13 @@ class AgentBot:
                 f"Private agent '{self.agent_name}' requires an explicit execution identity."
             )
             raise ValueError(msg)
-        execution_identity = self._build_shared_execution_identity()
         knowledge = self._knowledge_access_support.for_agent(self.agent_name)
         return create_agent(
             agent_name=self.agent_name,
             config=self.config,
             runtime_paths=self.runtime_paths,
             knowledge=knowledge,
-            execution_identity=execution_identity,
+            execution_identity=None,
             hook_registry=self.hook_registry,
         )
 

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -15,8 +15,8 @@ from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths
 from mindroom.handled_turns import HandledTurnState
 from mindroom.logging_config import get_logger
 from mindroom.matrix.event_info import EventInfo
-from mindroom.message_target import MessageTarget
 from mindroom.scheduling import (
+    SchedulingRuntime,
     cancel_all_scheduled_tasks,
     cancel_scheduled_task,
     edit_scheduled_task,
@@ -24,7 +24,7 @@ from mindroom.scheduling import (
     schedule_task,
 )
 from mindroom.thread_utils import check_agent_mentioned, get_configured_agents_for_room
-from mindroom.tool_system.runtime_context import tool_runtime_context
+from mindroom.tool_system.runtime_context import build_execution_identity_from_runtime_context, tool_runtime_context
 from mindroom.tool_system.skills import resolve_skill_command_spec
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
@@ -45,9 +45,22 @@ if TYPE_CHECKING:
     from mindroom.matrix.client import ResolvedVisibleMessage
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol, ConversationEventCache
     from mindroom.matrix.identity import MatrixID
+    from mindroom.message_target import MessageTarget
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
 
 logger = get_logger(__name__)
+
+
+def _scheduling_runtime(context: CommandHandlerContext, room: nio.MatrixRoom) -> SchedulingRuntime:
+    """Collapse active scheduling collaborators into one explicit live runtime object."""
+    return SchedulingRuntime(
+        client=context.client,
+        config=context.config,
+        runtime_paths=context.runtime_paths,
+        room=room,
+        conversation_cache=context.conversation_cache,
+        event_cache=context.event_cache,
+    )
 
 
 class CommandEvent(Protocol):
@@ -331,13 +344,10 @@ class _ToolCallArguments:
 
 
 @dataclass(frozen=True)
-class _SkillToolDispatchTarget:
-    """One valid runtime shape for tool-dispatched skill execution."""
+class SkillToolDispatchContext:
+    """One explicit runtime shape for tool-dispatched skill execution."""
 
-    requester_user_id: str | None
-    room_id: str | None
-    resolved_thread_id: str | None
-    session_id: str | None
+    execution_identity: ToolExecutionIdentity
     runtime_context: ToolRuntimeContext | None
 
 
@@ -403,46 +413,36 @@ async def _maybe_await(value: object) -> object:
     return value
 
 
-def _resolve_skill_tool_dispatch_target(
+def skill_tool_dispatch_context_from_target(
     *,
+    agent_name: str,
+    runtime_paths: RuntimePaths,
     requester_user_id: str | None,
-    room_id: str | None,
-    thread_id: str | None,
-    runtime_context: ToolRuntimeContext | None,
-) -> _SkillToolDispatchTarget:
-    if runtime_context is not None:
-        if requester_user_id is not None or room_id is not None or thread_id is not None:
-            msg = "Skill tool dispatch accepts either runtime_context or raw Matrix coordinates."
-            raise ValueError(msg)
-
-        target = MessageTarget.from_runtime_context(runtime_context)
-        return _SkillToolDispatchTarget(
-            requester_user_id=runtime_context.requester_id,
-            room_id=target.room_id,
-            resolved_thread_id=target.resolved_thread_id,
-            session_id=target.session_id,
-            runtime_context=runtime_context,
-        )
-
-    if thread_id is not None and room_id is None:
-        msg = "Skill tool dispatch thread_id requires room_id."
-        raise ValueError(msg)
-
-    target = (
-        MessageTarget.resolve(
-            room_id=room_id,
-            thread_id=thread_id,
-            reply_to_event_id=None,
-        )
-        if room_id is not None
-        else None
-    )
-    return _SkillToolDispatchTarget(
-        requester_user_id=requester_user_id,
-        room_id=target.room_id if target is not None else None,
-        resolved_thread_id=target.resolved_thread_id if target is not None else None,
-        session_id=target.session_id if target is not None else None,
+    target: MessageTarget | None,
+) -> SkillToolDispatchContext:
+    """Build the non-live dispatch shape from an explicit Matrix target."""
+    return SkillToolDispatchContext(
+        execution_identity=build_tool_execution_identity(
+            channel="matrix",
+            agent_name=agent_name,
+            runtime_paths=runtime_paths,
+            requester_id=requester_user_id,
+            room_id=target.room_id if target is not None else None,
+            thread_id=target.resolved_thread_id if target is not None else None,
+            resolved_thread_id=target.resolved_thread_id if target is not None else None,
+            session_id=target.session_id if target is not None else None,
+        ),
         runtime_context=None,
+    )
+
+
+def skill_tool_dispatch_context_from_runtime_context(
+    runtime_context: ToolRuntimeContext,
+) -> SkillToolDispatchContext:
+    """Build the live dispatch shape from one bound runtime context."""
+    return SkillToolDispatchContext(
+        execution_identity=build_execution_identity_from_runtime_context(runtime_context),
+        runtime_context=runtime_context,
     )
 
 
@@ -455,28 +455,9 @@ async def _run_skill_command_tool(
     command_tool: str,
     skill_name: str,
     args_text: str,
+    dispatch_context: SkillToolDispatchContext,
     command_name: str = "skill",
-    requester_user_id: str | None = None,
-    room_id: str | None = None,
-    thread_id: str | None = None,
-    runtime_context: ToolRuntimeContext | None = None,
 ) -> str:
-    dispatch_target = _resolve_skill_tool_dispatch_target(
-        requester_user_id=requester_user_id,
-        room_id=room_id,
-        thread_id=thread_id,
-        runtime_context=runtime_context,
-    )
-    execution_identity = build_tool_execution_identity(
-        channel="matrix",
-        agent_name=agent_name,
-        runtime_paths=runtime_paths,
-        requester_id=dispatch_target.requester_user_id,
-        room_id=dispatch_target.room_id,
-        thread_id=dispatch_target.resolved_thread_id,
-        resolved_thread_id=dispatch_target.resolved_thread_id,
-        session_id=dispatch_target.session_id,
-    )
     effective_runtime_paths = (
         runtime_paths
         if storage_path is None or storage_path == runtime_paths.storage_root
@@ -484,12 +465,17 @@ async def _run_skill_command_tool(
     )
 
     try:
-        with tool_runtime_context(dispatch_target.runtime_context), tool_execution_identity(execution_identity):
+        with (
+            tool_runtime_context(dispatch_context.runtime_context),
+            tool_execution_identity(
+                dispatch_context.execution_identity,
+            ),
+        ):
             toolkits = _collect_agent_toolkits(
                 config,
                 agent_name,
                 effective_runtime_paths,
-                execution_identity=execution_identity,
+                execution_identity=dispatch_context.execution_identity,
             )
             function, toolkit, error = _resolve_tool_dispatch_target(toolkits, command_tool)
             if error:
@@ -573,16 +559,11 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
         mentioned_agents, _, _ = check_agent_mentioned(event.source, None, context.config, context.runtime_paths)
 
         _, response_text = await schedule_task(
-            client=context.client,
+            runtime=_scheduling_runtime(context, room),
             room_id=room.room_id,
             thread_id=effective_thread_id,
             scheduled_by=requester_user_id,
             full_text=full_text,
-            config=context.config,
-            runtime_paths=context.runtime_paths,
-            room=room,
-            conversation_cache=context.conversation_cache,
-            event_cache=context.event_cache,
             mentioned_agents=mentioned_agents,
         )
 
@@ -616,16 +597,11 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
         task_id = command.args["task_id"]
         full_text = command.args["full_text"]
         response_text = await edit_scheduled_task(
-            client=context.client,
+            runtime=_scheduling_runtime(context, room),
             room_id=room.room_id,
             task_id=task_id,
             full_text=full_text,
             scheduled_by=requester_user_id,
-            config=context.config,
-            runtime_paths=context.runtime_paths,
-            room=room,
-            conversation_cache=context.conversation_cache,
-            event_cache=context.event_cache,
             thread_id=effective_thread_id,
         )
 

--- a/src/mindroom/custom_tools/scheduler.py
+++ b/src/mindroom/custom_tools/scheduler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from agno.tools import Toolkit
 
 from mindroom.scheduling import (
+    SchedulingRuntime,
     cancel_scheduled_task,
     edit_scheduled_task,
     list_scheduled_tasks,
@@ -43,17 +44,20 @@ class SchedulerTools(Toolkit):
         if context is None or context.room is None:
             return "❌ Scheduler tool is unavailable in this context."
 
-        _, response_text = await schedule_task(
+        runtime = SchedulingRuntime(
             client=context.client,
-            room_id=context.room_id,
-            thread_id=context.resolved_thread_id,
-            scheduled_by=context.requester_id,
-            full_text=request,
             config=context.config,
             runtime_paths=context.runtime_paths,
             room=context.room,
             conversation_cache=context.conversation_cache,
             event_cache=context.event_cache,
+        )
+        _, response_text = await schedule_task(
+            runtime=runtime,
+            room_id=context.room_id,
+            thread_id=context.resolved_thread_id,
+            scheduled_by=context.requester_id,
+            full_text=request,
             new_thread=new_thread,
         )
         return response_text
@@ -73,17 +77,20 @@ class SchedulerTools(Toolkit):
         if context is None or context.room is None:
             return "❌ Scheduler tool is unavailable in this context."
 
-        return await edit_scheduled_task(
+        runtime = SchedulingRuntime(
             client=context.client,
-            room_id=context.room_id,
-            task_id=task_id,
-            full_text=request,
-            scheduled_by=context.requester_id,
             config=context.config,
             runtime_paths=context.runtime_paths,
             room=context.room,
             conversation_cache=context.conversation_cache,
             event_cache=context.event_cache,
+        )
+        return await edit_scheduled_task(
+            runtime=runtime,
+            room_id=context.room_id,
+            task_id=task_id,
+            full_text=request,
+            scheduled_by=context.requester_id,
             thread_id=context.resolved_thread_id,
         )
 

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -150,6 +150,18 @@ class ScheduledTaskRecord:
     workflow: ScheduledWorkflow
 
 
+@dataclass(frozen=True)
+class SchedulingRuntime:
+    """Live scheduling collaborators required to create or edit running tasks."""
+
+    client: nio.AsyncClient
+    config: Config
+    runtime_paths: RuntimePaths
+    room: nio.MatrixRoom
+    conversation_cache: ConversationCacheProtocol
+    event_cache: ConversationEventCache
+
+
 @dataclass
 class _DeferredOverdueTaskStart:
     """A one-time scheduled task that should start after Matrix sync is live."""
@@ -1192,16 +1204,11 @@ def _extract_mentioned_agents_from_text(
 
 
 async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
-    client: nio.AsyncClient,
+    runtime: SchedulingRuntime,
     room_id: str,
     thread_id: str | None,
     scheduled_by: str,
     full_text: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    room: nio.MatrixRoom,
-    conversation_cache: ConversationCacheProtocol,
-    event_cache: ConversationEventCache,
     new_thread: bool = False,
     mentioned_agents: list[MatrixID] | None = None,
     task_id: str | None = None,
@@ -1213,6 +1220,13 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
         Tuple of (task_id, response_message)
 
     """
+    client = runtime.client
+    config = runtime.config
+    runtime_paths = runtime.runtime_paths
+    room = runtime.room
+    conversation_cache = runtime.conversation_cache
+    event_cache = runtime.event_cache
+
     if mentioned_agents is None:
         mentioned_agents = _extract_mentioned_agents_from_text(full_text, config, runtime_paths)
 
@@ -1349,19 +1363,15 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
 
 async def edit_scheduled_task(
-    client: nio.AsyncClient,
+    runtime: SchedulingRuntime,
     room_id: str,
     task_id: str,
     full_text: str,
     scheduled_by: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    room: nio.MatrixRoom,
-    conversation_cache: ConversationCacheProtocol,
-    event_cache: ConversationEventCache,
     thread_id: str | None = None,
 ) -> str:
     """Edit an existing scheduled task by replacing its workflow details."""
+    client = runtime.client
     existing_task = await get_scheduled_task(client=client, room_id=room_id, task_id=task_id)
     if not existing_task:
         return f"❌ Task `{task_id}` not found."
@@ -1372,16 +1382,11 @@ async def edit_scheduled_task(
     target_thread_id = None if target_new_thread else existing_task.workflow.thread_id or thread_id
 
     edited_task_id, response_text = await schedule_task(
-        client=client,
+        runtime=runtime,
         room_id=room_id,
         thread_id=target_thread_id,
         scheduled_by=scheduled_by,
         full_text=full_text,
-        config=config,
-        runtime_paths=runtime_paths,
-        room=room,
-        conversation_cache=conversation_cache,
-        event_cache=event_cache,
         new_thread=target_new_thread,
         task_id=task_id,
         existing_task=existing_task,

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -20,6 +20,7 @@ from mindroom.hooks import (
 )
 from mindroom.hooks.types import validate_event_name
 from mindroom.logging_config import get_logger
+from mindroom.message_target import MessageTarget
 from mindroom.tool_system.plugin_identity import validate_plugin_name
 from mindroom.tool_system.worker_routing import build_tool_execution_identity
 
@@ -38,7 +39,6 @@ if TYPE_CHECKING:
     from mindroom.hooks.types import HookRoomStatePutter, HookRoomStateQuerier
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol, ConversationEventCache
     from mindroom.matrix.identity import MatrixID
-    from mindroom.message_target import MessageTarget
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 _ToolContextReturn = TypeVar("_ToolContextReturn")
@@ -160,6 +160,34 @@ class ToolRuntimeSupport:
             message_received_depth=(source_envelope.message_received_depth if source_envelope is not None else 0),
         )
 
+    def build_required_context(
+        self,
+        target: MessageTarget,
+        *,
+        user_id: str | None,
+        session_id: str | None = None,
+        agent_name: str | None = None,
+        active_model_name: str | None = None,
+        attachment_ids: list[str] | tuple[str, ...] | None = None,
+        correlation_id: str | None = None,
+        source_envelope: MessageEnvelope | None = None,
+    ) -> ToolRuntimeContext:
+        """Build one live Matrix tool runtime context or fail fast if runtime support is unavailable."""
+        context = self.build_context(
+            target,
+            user_id=user_id,
+            session_id=session_id,
+            agent_name=agent_name,
+            active_model_name=active_model_name,
+            attachment_ids=attachment_ids,
+            correlation_id=correlation_id,
+            source_envelope=source_envelope,
+        )
+        if context is None:
+            msg = "Live Matrix tool dispatch requires initialized tool runtime support"
+            raise RuntimeError(msg)
+        return context
+
     def build_execution_identity(
         self,
         *,
@@ -253,6 +281,21 @@ def resolve_current_session_id(
         return resolved_runtime_context.session_id
 
     return None
+
+
+def build_execution_identity_from_runtime_context(context: ToolRuntimeContext) -> ToolExecutionIdentity:
+    """Build the canonical execution identity represented by one live runtime context."""
+    target = MessageTarget.from_runtime_context(context)
+    return build_tool_execution_identity(
+        channel="matrix",
+        agent_name=context.agent_name,
+        runtime_paths=context.runtime_paths,
+        requester_id=context.requester_id,
+        room_id=target.room_id,
+        thread_id=target.resolved_thread_id,
+        resolved_thread_id=target.resolved_thread_id,
+        session_id=target.session_id,
+    )
 
 
 def attachment_id_available_in_tool_runtime_context(

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -61,20 +61,6 @@ class _DeferredAsyncToolHookResult:
     awaitable: Awaitable[ToolHookResult]
 
 
-def _resolved_thread_id(
-    default_thread_id: str | None,
-    execution_identity: ToolExecutionIdentity | None,
-    runtime_context: ToolRuntimeContext | None,
-) -> str | None:
-    if runtime_context is not None and runtime_context.resolved_thread_id is not None:
-        return runtime_context.resolved_thread_id
-
-    if execution_identity is not None and execution_identity.resolved_thread_id is not None:
-        return execution_identity.resolved_thread_id
-
-    return default_thread_id
-
-
 @dataclass(frozen=True, slots=True)
 class _ResolvedToolContext:
     agent_name: str
@@ -109,61 +95,49 @@ class _ResolvedToolContext:
         }
 
 
-def _coalesce(*values: str | None) -> str | None:
-    for value in values:
-        if value is not None:
-            return value
-    return None
+def _correlation_id_for_runtime_context(runtime_context: ToolRuntimeContext | None) -> str:
+    if runtime_context is not None and runtime_context.correlation_id:
+        return runtime_context.correlation_id
+    return "tool-hook:" + uuid4().hex
 
 
 def _resolve_tool_context(
     *,
     agent_name: str | None,
-    room_id: str | None,
-    thread_id: str | None,
-    requester_id: str | None,
-    session_id: str | None,
     execution_identity: ToolExecutionIdentity | None,
     config: Config | None,
     runtime_paths: RuntimePaths | None,
 ) -> _ResolvedToolContext:
     runtime_context = get_tool_runtime_context()
     resolved_execution_identity = active_tool_execution_identity(execution_identity)
-    request_runtime_context = runtime_context if execution_identity is None else None
     bindings = resolve_tool_runtime_hook_bindings(runtime_context) if runtime_context is not None else None
+    if resolved_execution_identity is not None:
+        return _ResolvedToolContext(
+            agent_name=agent_name or resolved_execution_identity.agent_name,
+            room_id=resolved_execution_identity.room_id,
+            thread_id=resolved_execution_identity.resolved_thread_id or resolved_execution_identity.thread_id,
+            requester_id=resolved_execution_identity.requester_id,
+            session_id=resolved_execution_identity.session_id,
+            channel=resolved_execution_identity.channel,
+            config=runtime_context.config if runtime_context is not None else config,
+            runtime_paths=runtime_context.runtime_paths if runtime_context is not None else runtime_paths,
+            correlation_id=_correlation_id_for_runtime_context(runtime_context),
+            message_sender=bindings.message_sender if bindings is not None else None,
+            room_state_querier=bindings.room_state_querier if bindings is not None else None,
+            room_state_putter=bindings.room_state_putter if bindings is not None else None,
+            message_received_depth=bindings.message_received_depth if bindings is not None else 0,
+        )
+
     return _ResolvedToolContext(
-        agent_name=(
-            _coalesce(
-                agent_name,
-                runtime_context.agent_name if runtime_context is not None else None,
-                resolved_execution_identity.agent_name if resolved_execution_identity is not None else None,
-            )
-            or ""
-        ),
-        room_id=_coalesce(
-            room_id,
-            request_runtime_context.room_id if request_runtime_context is not None else None,
-            resolved_execution_identity.room_id if resolved_execution_identity is not None else None,
-        ),
-        thread_id=_resolved_thread_id(thread_id, resolved_execution_identity, request_runtime_context),
-        requester_id=_coalesce(
-            requester_id,
-            request_runtime_context.requester_id if request_runtime_context is not None else None,
-            resolved_execution_identity.requester_id if resolved_execution_identity is not None else None,
-        ),
-        session_id=_coalesce(
-            session_id,
-            request_runtime_context.session_id if request_runtime_context is not None else None,
-            resolved_execution_identity.session_id if resolved_execution_identity is not None else None,
-        ),
-        channel=resolved_execution_identity.channel if resolved_execution_identity is not None else None,
+        agent_name=agent_name or (runtime_context.agent_name if runtime_context is not None else ""),
+        room_id=runtime_context.room_id if runtime_context is not None else None,
+        thread_id=runtime_context.resolved_thread_id if runtime_context is not None else None,
+        requester_id=runtime_context.requester_id if runtime_context is not None else None,
+        session_id=runtime_context.session_id if runtime_context is not None else None,
+        channel=None,
         config=runtime_context.config if runtime_context is not None else config,
         runtime_paths=runtime_context.runtime_paths if runtime_context is not None else runtime_paths,
-        correlation_id=(
-            runtime_context.correlation_id
-            if runtime_context is not None and runtime_context.correlation_id
-            else "tool-hook:" + uuid4().hex
-        ),
+        correlation_id=_correlation_id_for_runtime_context(runtime_context),
         message_sender=bindings.message_sender if bindings is not None else None,
         room_state_querier=bindings.room_state_querier if bindings is not None else None,
         room_state_putter=bindings.room_state_putter if bindings is not None else None,
@@ -251,10 +225,6 @@ async def _execute_bridge(
     func: Callable[..., Any],
     args: dict[str, Any],
     agent_name: str | None,
-    room_id: str | None,
-    thread_id: str | None,
-    requester_id: str | None,
-    session_id: str | None,
     execution_identity: ToolExecutionIdentity | None,
     config: Config | None,
     runtime_paths: RuntimePaths | None,
@@ -264,10 +234,6 @@ async def _execute_bridge(
     started_at = time.perf_counter()
     resolved_context = _resolve_tool_context(
         agent_name=agent_name,
-        room_id=room_id,
-        thread_id=thread_id,
-        requester_id=requester_id,
-        session_id=session_id,
         execution_identity=execution_identity,
         config=config,
         runtime_paths=runtime_paths,
@@ -364,10 +330,6 @@ async def _execute_bridge(
 def build_tool_hook_bridge(
     hook_registry: HookRegistry,
     agent_name: str | None,
-    room_id: str | None = None,
-    thread_id: str | None = None,
-    requester_id: str | None = None,
-    session_id: str | None = None,
     execution_identity: ToolExecutionIdentity | None = None,
     config: Config | None = None,
     runtime_paths: RuntimePaths | None = None,
@@ -383,10 +345,6 @@ def build_tool_hook_bridge(
             func=func,
             args=args,
             agent_name=agent_name,
-            room_id=room_id,
-            thread_id=thread_id,
-            requester_id=requester_id,
-            session_id=session_id,
             execution_identity=execution_identity,
             config=config,
             runtime_paths=runtime_paths,
@@ -403,10 +361,6 @@ def build_tool_hook_bridge(
                     func=func,
                     args=args,
                     agent_name=agent_name,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    requester_id=requester_id,
-                    session_id=session_id,
                     execution_identity=execution_identity,
                     config=config,
                     runtime_paths=runtime_paths,
@@ -421,10 +375,6 @@ def build_tool_hook_bridge(
                 func=func,
                 args=args,
                 agent_name=agent_name,
-                room_id=room_id,
-                thread_id=thread_id,
-                requester_id=requester_id,
-                session_id=session_id,
                 execution_identity=execution_identity,
                 config=config,
                 runtime_paths=runtime_paths,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -29,6 +29,7 @@ from mindroom.commands.handler import (
     CommandHandlerContext,
     _run_skill_command_tool,
     handle_command,
+    skill_tool_dispatch_context_from_runtime_context,
 )
 from mindroom.commands.parsing import command_parser
 from mindroom.constants import (
@@ -548,23 +549,22 @@ class TurnController:
             command_tool: str,
             skill_name: str,
             args_text: str,
-            requester_user_id: str | None = None,
-            room_id: str | None = None,
+            requester_user_id: str,
+            room_id: str,
             thread_id: str | None = None,
         ) -> str:
-            runtime_context = None
-            if room_id is not None:
-                runtime_context = self.deps.tool_runtime.build_context(
-                    self.deps.resolver.build_message_target(
-                        room_id=room_id,
-                        thread_id=thread_id,
-                        reply_to_event_id=event.event_id,
-                        event_source=event.source,
-                    ),
-                    user_id=requester_user_id,
-                    agent_name=agent_name,
-                    source_envelope=source_envelope,
-                )
+            target = self.deps.resolver.build_message_target(
+                room_id=room_id,
+                thread_id=thread_id,
+                reply_to_event_id=event.event_id,
+                event_source=event.source,
+            )
+            runtime_context = self.deps.tool_runtime.build_required_context(
+                target,
+                user_id=requester_user_id,
+                agent_name=agent_name,
+                source_envelope=source_envelope,
+            )
             return await _run_skill_command_tool(
                 config=self.deps.runtime.config,
                 runtime_paths=self.deps.runtime_paths,
@@ -573,7 +573,7 @@ class TurnController:
                 command_tool=command_tool,
                 skill_name=skill_name,
                 args_text=args_text,
-                runtime_context=runtime_context,
+                dispatch_context=skill_tool_dispatch_context_from_runtime_context(runtime_context),
             )
 
         context = CommandHandlerContext(

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -161,13 +161,14 @@ class TestBotScheduleCommands:
             # Verify schedule_task was called correctly
             mock_schedule.assert_called_once()
             call_kwargs = mock_schedule.call_args.kwargs
-            assert call_kwargs["client"] is mock_agent_bot.client
+            runtime = call_kwargs["runtime"]
+            assert runtime.client is mock_agent_bot.client
+            assert runtime.config is mock_agent_bot.config
+            assert runtime.room is room
             assert call_kwargs["room_id"] == "!test:server"
             assert call_kwargs["thread_id"] == "$thread123"
             assert call_kwargs["scheduled_by"] == "@user:server"
             assert call_kwargs["full_text"] == "in 5 minutes Check deployment"
-            assert call_kwargs["config"] is mock_agent_bot.config
-            assert call_kwargs["room"] is room
             assert call_kwargs["mentioned_agents"] == []
 
             # Verify response was sent
@@ -303,6 +304,10 @@ class TestBotScheduleCommands:
 
             mock_edit.assert_called_once()
             edit_kwargs = mock_edit.call_args.kwargs
+            runtime = edit_kwargs["runtime"]
+            assert runtime.client is mock_agent_bot.client
+            assert runtime.config is mock_agent_bot.config
+            assert runtime.room is room
             assert edit_kwargs["room_id"] == "!test:server"
             assert edit_kwargs["task_id"] == "task123"
             assert edit_kwargs["full_text"] == "in 30 minutes Check deployment"

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -1703,7 +1703,8 @@ async def test_hook_dispatch_skill_tool_command_builds_full_tool_runtime_context
 
     async def fake_run_skill_command_tool(**kwargs: object) -> str:
         nonlocal captured_runtime_context
-        captured_runtime_context = kwargs["runtime_context"]
+        dispatch_context = kwargs["dispatch_context"]
+        captured_runtime_context = dispatch_context.runtime_context
         return "tool-result"
 
     spec = _SkillCommandSpec(

--- a/tests/test_schedule_agent_validation.py
+++ b/tests/test_schedule_agent_validation.py
@@ -13,7 +13,7 @@ import pytest
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import RouterConfig
-from mindroom.scheduling import ScheduledWorkflow, schedule_task
+from mindroom.scheduling import ScheduledWorkflow, SchedulingRuntime, schedule_task
 from tests.conftest import bind_runtime_paths, make_event_cache_mock, runtime_paths_for, test_runtime_paths
 
 
@@ -43,6 +43,22 @@ def _conversation_cache(thread_history: list[object] | None = None) -> MagicMock
 
 def _event_cache() -> AsyncMock:
     return make_event_cache_mock()
+
+
+def _scheduling_runtime(
+    *,
+    client: AsyncMock,
+    config: Config,
+    room: nio.MatrixRoom,
+) -> SchedulingRuntime:
+    return SchedulingRuntime(
+        client=client,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        room=room,
+        conversation_cache=_conversation_cache(),
+        event_cache=_event_cache(),
+    )
 
 
 @pytest.mark.asyncio
@@ -89,16 +105,11 @@ async def test_schedule_validates_agents_in_room() -> None:
 
         # Try to schedule a task mentioning calculator in test_room (where it's not configured)
         task_id, response = await schedule_task(
-            client=client,
+            runtime=_scheduling_runtime(client=client, config=config, room=room),
             room_id="test_room",
             thread_id=None,
             scheduled_by="@user:localhost",
             full_text="in 5 minutes ask calculator to calculate",
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            event_cache=_event_cache(),
-            room=room,
-            conversation_cache=_conversation_cache(),
         )
 
         # Should fail because calculator is not in test_room
@@ -154,16 +165,11 @@ async def test_schedule_validates_agents_in_thread() -> None:
 
         # Try to schedule in a thread
         task_id, response = await schedule_task(
-            client=client,
+            runtime=_scheduling_runtime(client=client, config=config, room=room),
             room_id="test_room",
             thread_id="$thread123",
             scheduled_by="@user:localhost",
             full_text="in 5 minutes ask calculator to calculate",
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            event_cache=_event_cache(),
-            room=room,
-            conversation_cache=_conversation_cache(),
         )
 
         # Should fail because calculator is not in the room
@@ -224,16 +230,18 @@ async def test_schedule_allows_agents_in_room() -> None:
 
         # Try to schedule in a thread where calculator is in the room
         task_id, response = await schedule_task(
-            client=client,
+            runtime=SchedulingRuntime(
+                client=client,
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                room=room,
+                conversation_cache=conversation_cache,
+                event_cache=_event_cache(),
+            ),
             room_id="test_room",
             thread_id="$thread123",
             scheduled_by="@user:localhost",
             full_text="in 5 minutes ask calculator to calculate",
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            event_cache=_event_cache(),
-            room=room,
-            conversation_cache=conversation_cache,
         )
 
         # Should succeed because calculator is in the room
@@ -293,16 +301,11 @@ async def test_schedule_with_multiple_agents_validation() -> None:
         mock_parse.return_value = mock_workflow
 
         task_id, response = await schedule_task(
-            client=client,
+            runtime=_scheduling_runtime(client=client, config=config, room=room),
             room_id="test_room",
             thread_id=None,
             scheduled_by="@user:localhost",
             full_text="in 5 minutes research and calculate",
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            event_cache=_event_cache(),
-            room=room,
-            conversation_cache=_conversation_cache(),
         )
 
         # Should fail because calculator is not in room
@@ -362,16 +365,18 @@ async def test_schedule_with_no_agent_mentions() -> None:
         conversation_cache = _conversation_cache()
 
         task_id, response = await schedule_task(
-            client=client,
+            runtime=SchedulingRuntime(
+                client=client,
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                room=room,
+                conversation_cache=conversation_cache,
+                event_cache=_event_cache(),
+            ),
             room_id="test_room",
             thread_id="$thread123",
             scheduled_by="@user:localhost",
             full_text="in 5 minutes remind me about deployment",
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            event_cache=_event_cache(),
-            room=room,
-            conversation_cache=conversation_cache,
             new_thread=True,
         )
 
@@ -428,16 +433,11 @@ async def test_schedule_validation_respects_sender_reply_permissions() -> None:
         mock_parse.return_value = mock_workflow
 
         task_id, response = await schedule_task(
-            client=client,
+            runtime=_scheduling_runtime(client=client, config=config, room=room),
             room_id="test_room",
             thread_id=None,
             scheduled_by="@blocked:localhost",
             full_text="in 5 minutes ask calculator to calculate",
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            event_cache=_event_cache(),
-            room=room,
-            conversation_cache=_conversation_cache(),
         )
 
     assert task_id is None
@@ -482,16 +482,11 @@ async def test_schedule_with_nonexistent_agent() -> None:
         mock_parse.return_value = mock_workflow
 
         task_id, _response = await schedule_task(
-            client=client,
+            runtime=_scheduling_runtime(client=client, config=config, room=room),
             room_id="test_room",
             thread_id=None,
             scheduled_by="@user:localhost",
             full_text="in 5 minutes ask imaginary agent",
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            event_cache=_event_cache(),
-            room=room,
-            conversation_cache=_conversation_cache(),
         )
 
         # Should succeed if imaginary_agent is not recognized as a valid agent

--- a/tests/test_scheduler_tool.py
+++ b/tests/test_scheduler_tool.py
@@ -13,7 +13,7 @@ from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.custom_tools.scheduler import SchedulerTools
 from mindroom.matrix.identity import MatrixID
-from mindroom.scheduling import _extract_mentioned_agents_from_text
+from mindroom.scheduling import SchedulingRuntime, _extract_mentioned_agents_from_text
 from mindroom.tool_system.metadata import TOOL_METADATA
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 from tests.conftest import bind_runtime_paths, make_event_cache_mock, runtime_paths_for, test_runtime_paths
@@ -87,30 +87,30 @@ async def test_scheduler_tool_uses_shared_backend() -> None:
     assert result == "✅ Scheduled"
     assert new_thread_result == "✅ Scheduled"
     assert mock_schedule.await_count == 2
-    assert mock_schedule.await_args_list[0].kwargs == {
-        "client": context.client,
+    first_call = mock_schedule.await_args_list[0].kwargs
+    second_call = mock_schedule.await_args_list[1].kwargs
+    expected_runtime = SchedulingRuntime(
+        client=context.client,
+        config=context.config,
+        runtime_paths=context.runtime_paths,
+        room=context.room,
+        conversation_cache=context.conversation_cache,
+        event_cache=context.event_cache,
+    )
+    assert first_call == {
+        "runtime": expected_runtime,
         "room_id": context.room_id,
         "thread_id": context.resolved_thread_id,
         "scheduled_by": context.requester_id,
         "full_text": "tomorrow at 3pm check deployment",
-        "config": context.config,
-        "runtime_paths": context.runtime_paths,
-        "room": context.room,
-        "conversation_cache": context.conversation_cache,
-        "event_cache": context.event_cache,
         "new_thread": False,
     }
-    assert mock_schedule.await_args_list[1].kwargs == {
-        "client": context.client,
+    assert second_call == {
+        "runtime": expected_runtime,
         "room_id": context.room_id,
         "thread_id": context.resolved_thread_id,
         "scheduled_by": context.requester_id,
         "full_text": "tomorrow at 4pm check deployment",
-        "config": context.config,
-        "runtime_paths": context.runtime_paths,
-        "room": context.room,
-        "conversation_cache": context.conversation_cache,
-        "event_cache": context.event_cache,
         "new_thread": True,
     }
 
@@ -141,16 +141,18 @@ async def test_edit_schedule_tool_calls_backend() -> None:
 
     assert "Updated" in result
     mock_edit.assert_awaited_once_with(
-        client=context.client,
+        runtime=SchedulingRuntime(
+            client=context.client,
+            config=context.config,
+            runtime_paths=context.runtime_paths,
+            room=context.room,
+            conversation_cache=context.conversation_cache,
+            event_cache=context.event_cache,
+        ),
         room_id=context.room_id,
         task_id="task123",
         full_text="tomorrow at 9am check deployment",
         scheduled_by=context.requester_id,
-        config=context.config,
-        runtime_paths=context.runtime_paths,
-        room=context.room,
-        conversation_cache=context.conversation_cache,
-        event_cache=context.event_cache,
         thread_id=context.resolved_thread_id,
     )
 

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -17,6 +17,7 @@ from mindroom.scheduling import (
     CronSchedule,
     ScheduledTaskRecord,
     ScheduledWorkflow,
+    SchedulingRuntime,
     _run_cron_task,
     _run_once_task,
     cancel_all_scheduled_tasks,
@@ -53,6 +54,24 @@ def _conversation_cache(
     access.get_latest_thread_event_id_if_needed = AsyncMock(return_value=latest_thread_event_id)
     access.notify_outbound_message = Mock()
     return access
+
+
+def _scheduling_runtime(
+    *,
+    client: AsyncMock | None = None,
+    config: object | None = None,
+    room: object | None = None,
+    conversation_cache: AsyncMock | None = None,
+    event_cache: AsyncMock | None = None,
+) -> SchedulingRuntime:
+    return SchedulingRuntime(
+        client=client or AsyncMock(),
+        config=config or MagicMock(),
+        runtime_paths=_runtime_paths(),
+        room=room or MagicMock(),
+        conversation_cache=conversation_cache or _conversation_cache(),
+        event_cache=event_cache or _event_cache(),
+    )
 
 
 def _record(
@@ -1164,29 +1183,24 @@ async def test_edit_scheduled_task_reuses_existing_thread() -> None:
         new=AsyncMock(return_value=("task123", "✅ Scheduled")),
     ) as mock_schedule:
         result = await edit_scheduled_task(
-            client=client,
+            runtime=_scheduling_runtime(client=client, config=config, room=room),
             room_id="!test:server",
             task_id="task123",
             full_text="tomorrow at 9am updated task",
             scheduled_by="@user:server",
-            config=config,
-            runtime_paths=_runtime_paths(),
-            event_cache=_event_cache(),
-            room=room,
-            conversation_cache=_conversation_cache(),
             thread_id="$fallback_thread",
         )
 
     assert "✅ Updated task `task123`." in result
     mock_schedule.assert_awaited_once()
     call_kwargs = mock_schedule.await_args.kwargs
-    assert call_kwargs["client"] is client
+    assert call_kwargs["runtime"].client is client
     assert call_kwargs["room_id"] == "!test:server"
     assert call_kwargs["thread_id"] == "$original_thread"
     assert call_kwargs["scheduled_by"] == "@user:server"
     assert call_kwargs["full_text"] == "tomorrow at 9am updated task"
-    assert call_kwargs["config"] is config
-    assert call_kwargs["room"] is room
+    assert call_kwargs["runtime"].config is config
+    assert call_kwargs["runtime"].room is room
     assert call_kwargs["new_thread"] is False
     assert call_kwargs["task_id"] == "task123"
     assert call_kwargs["existing_task"].task_id == "task123"
@@ -1221,16 +1235,11 @@ async def test_edit_scheduled_task_preserves_new_thread_mode() -> None:
         new=AsyncMock(return_value=("task123", "✅ Scheduled")),
     ) as mock_schedule:
         result = await edit_scheduled_task(
-            client=client,
+            runtime=_scheduling_runtime(client=client, config=config, room=room),
             room_id="!test:server",
             task_id="task123",
             full_text="tomorrow at 9am updated task",
             scheduled_by="@user:server",
-            config=config,
-            runtime_paths=_runtime_paths(),
-            event_cache=_event_cache(),
-            room=room,
-            conversation_cache=_conversation_cache(),
             thread_id="$fallback_thread",
         )
 
@@ -1254,16 +1263,11 @@ async def test_edit_scheduled_task_rejects_non_pending() -> None:
     client.room_get_state_event = AsyncMock(return_value=state_response)
 
     result = await edit_scheduled_task(
-        client=client,
+        runtime=_scheduling_runtime(client=client, room=room),
         room_id="!test:server",
         task_id="task123",
         full_text="tomorrow at 9am updated task",
         scheduled_by="@user:server",
-        config=MagicMock(),
-        runtime_paths=_runtime_paths(),
-        event_cache=_event_cache(),
-        room=room,
-        conversation_cache=_conversation_cache(),
         thread_id="$thread123",
     )
 
@@ -1411,16 +1415,11 @@ async def test_schedule_task_returns_error_when_sender_blocked_from_all_agents()
         ),
     ):
         task_id, message = await schedule_task(
-            client=client,
+            runtime=_scheduling_runtime(client=client, config=config, room=room),
             room_id="!test:server",
             thread_id=None,
             scheduled_by="@blocked:server",
             full_text="remind me in 5 minutes to check logs",
-            config=config,
-            runtime_paths=_runtime_paths(),
-            event_cache=_event_cache(),
-            room=room,
-            conversation_cache=_conversation_cache(),
         )
 
     assert task_id is None
@@ -1445,16 +1444,11 @@ async def test_schedule_task_blocked_sender_new_thread_returns_error() -> None:
         ),
     ):
         task_id, message = await schedule_task(
-            client=client,
+            runtime=_scheduling_runtime(client=client, config=config, room=room),
             room_id="!test:server",
             thread_id=None,
             scheduled_by="@blocked:server",
             full_text="remind me in 5 minutes",
-            config=config,
-            runtime_paths=_runtime_paths(),
-            event_cache=_event_cache(),
-            room=room,
-            conversation_cache=_conversation_cache(),
             new_thread=True,
         )
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -11,10 +11,17 @@ import pytest
 from agno.tools import Toolkit
 
 import mindroom.tool_system.skills as skills_module
-from mindroom.commands.handler import _collect_agent_toolkits, _run_skill_command_tool
+from mindroom.commands.handler import (
+    SkillToolDispatchContext,
+    _collect_agent_toolkits,
+    _run_skill_command_tool,
+    skill_tool_dispatch_context_from_runtime_context,
+    skill_tool_dispatch_context_from_target,
+)
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig
 from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
+from mindroom.message_target import MessageTarget
 from mindroom.runtime_resolution import resolve_agent_runtime
 from mindroom.thread_utils import create_session_id
 from mindroom.tool_system.metadata import (
@@ -47,6 +54,27 @@ def _runtime_paths(storage_path: Path, *, config_path: Path | None = None) -> Ru
     return resolve_runtime_paths(
         config_path=config_path or storage_path / "config.yaml",
         storage_path=storage_path,
+    )
+
+
+def _skill_dispatch_context(
+    *,
+    agent_name: str,
+    runtime_paths: RuntimePaths,
+    requester_user_id: str | None = None,
+    room_id: str | None = None,
+    thread_id: str | None = None,
+) -> SkillToolDispatchContext:
+    target = (
+        MessageTarget.resolve(room_id=room_id, thread_id=thread_id, reply_to_event_id=None)
+        if room_id is not None
+        else None
+    )
+    return skill_tool_dispatch_context_from_target(
+        agent_name=agent_name,
+        runtime_paths=runtime_paths,
+        requester_user_id=requester_user_id,
+        target=target,
     )
 
 
@@ -449,9 +477,13 @@ async def test_skill_command_tool_dispatch_uses_runtime_storage_path_for_workspa
         command_tool="shell.demo",
         skill_name="dispatch",
         args_text="hello",
-        requester_user_id="@alice:example.org",
-        room_id="!room:example.org",
-        thread_id="$thread",
+        dispatch_context=_skill_dispatch_context(
+            agent_name="code",
+            runtime_paths=_runtime_paths(runtime_storage_path),
+            requester_user_id="@alice:example.org",
+            room_id="!room:example.org",
+            thread_id="$thread",
+        ),
     )
 
     identity = ToolExecutionIdentity(
@@ -523,9 +555,13 @@ async def test_skill_command_tool_dispatch_preserves_runtime_env_when_storage_ro
             command_tool="demo",
             skill_name="dispatch",
             args_text="hello",
-            requester_user_id="@alice:example.org",
-            room_id="!room:example.org",
-            thread_id="$thread",
+            dispatch_context=_skill_dispatch_context(
+                agent_name="code",
+                runtime_paths=original_runtime_paths,
+                requester_user_id="@alice:example.org",
+                room_id="!room:example.org",
+                thread_id="$thread",
+            ),
         )
 
     assert result == "skill:dispatch:hello"
@@ -664,6 +700,10 @@ async def test_skill_command_tool_dispatch() -> None:
             command_tool="demo",
             skill_name="dispatch",
             args_text="hello",
+            dispatch_context=_skill_dispatch_context(
+                agent_name="code",
+                runtime_paths=resolve_runtime_paths(),
+            ),
         )
     finally:
         _TOOL_REGISTRY.clear()
@@ -709,6 +749,10 @@ async def test_skill_command_tool_dispatch_uses_default_tools() -> None:
             command_tool="demo",
             skill_name="dispatch",
             args_text="hello",
+            dispatch_context=_skill_dispatch_context(
+                agent_name="code",
+                runtime_paths=resolve_runtime_paths(),
+            ),
         )
     finally:
         _TOOL_REGISTRY.clear()
@@ -760,9 +804,13 @@ async def test_skill_command_tool_dispatch_sets_execution_identity() -> None:
             command_tool="demo",
             skill_name="dispatch",
             args_text="hello",
-            requester_user_id="@alice:example.org",
-            room_id="!room:example.org",
-            thread_id="$thread",
+            dispatch_context=_skill_dispatch_context(
+                agent_name="code",
+                runtime_paths=resolve_runtime_paths(),
+                requester_user_id="@alice:example.org",
+                room_id="!room:example.org",
+                thread_id="$thread",
+            ),
         )
     finally:
         _TOOL_REGISTRY.clear()
@@ -826,7 +874,7 @@ async def test_skill_command_tool_dispatch_uses_canonical_runtime_thread_identit
             command_tool="demo",
             skill_name="dispatch",
             args_text="hello",
-            runtime_context=runtime_context,
+            dispatch_context=skill_tool_dispatch_context_from_runtime_context(runtime_context),
         )
     finally:
         _TOOL_REGISTRY.clear()
@@ -888,7 +936,7 @@ async def test_skill_command_tool_dispatch_ignores_raw_room_mode_thread_id() -> 
             command_tool="demo",
             skill_name="dispatch",
             args_text="hello",
-            runtime_context=runtime_context,
+            dispatch_context=skill_tool_dispatch_context_from_runtime_context(runtime_context),
         )
     finally:
         _TOOL_REGISTRY.clear()
@@ -970,7 +1018,7 @@ async def test_skill_command_tool_dispatch_installs_explicit_tool_runtime_contex
             command_tool="demo",
             skill_name="dispatch",
             args_text="hello",
-            runtime_context=runtime_context,
+            dispatch_context=skill_tool_dispatch_context_from_runtime_context(runtime_context),
         )
     finally:
         _TOOL_REGISTRY.clear()
@@ -982,8 +1030,8 @@ async def test_skill_command_tool_dispatch_installs_explicit_tool_runtime_contex
 
 
 @pytest.mark.asyncio
-async def test_skill_command_tool_dispatch_rejects_mixed_runtime_shapes() -> None:
-    """Skill tool dispatch should accept either raw Matrix coordinates or a runtime context, not both."""
+async def test_skill_command_tool_dispatch_context_from_runtime_context_preserves_live_shape() -> None:
+    """Live skill dispatch should derive execution identity from one full runtime context."""
 
     class DemoTools(Toolkit):
         def __init__(self) -> None:
@@ -1021,24 +1069,25 @@ async def test_skill_command_tool_dispatch_rejects_mixed_runtime_shapes() -> Non
             conversation_cache=make_conversation_cache_mock(),
         )
 
-        with pytest.raises(ValueError, match="either runtime_context or raw Matrix coordinates"):
-            await _run_skill_command_tool(
-                config=config,
-                runtime_paths=runtime_paths,
-                agent_name="code",
-                command_tool="demo",
-                skill_name="dispatch",
-                args_text="hello",
-                requester_user_id="@alice:example.org",
-                room_id="!room:example.org",
-                thread_id="$thread",
-                runtime_context=runtime_context,
-            )
+        dispatch_context = skill_tool_dispatch_context_from_runtime_context(runtime_context)
     finally:
         _TOOL_REGISTRY.clear()
         _TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
+
+    assert dispatch_context.runtime_context is runtime_context
+    assert dispatch_context.execution_identity == ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="code",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id="$thread",
+        resolved_thread_id="$thread",
+        session_id=create_session_id("!room:example.org", "$thread"),
+        tenant_id=runtime_paths.env_value("CUSTOMER_ID"),
+        account_id=runtime_paths.env_value("ACCOUNT_ID"),
+    )
 
 
 @pytest.mark.asyncio
@@ -1084,9 +1133,13 @@ async def test_skill_command_tool_dispatch_preserves_tenant_scoped_worker_key() 
                 command_tool="demo",
                 skill_name="dispatch",
                 args_text="hello",
-                requester_user_id="@alice:example.org",
-                room_id="!room:example.org",
-                thread_id="$thread",
+                dispatch_context=_skill_dispatch_context(
+                    agent_name="code",
+                    runtime_paths=resolve_runtime_paths(),
+                    requester_user_id="@alice:example.org",
+                    room_id="!room:example.org",
+                    thread_id="$thread",
+                ),
             )
     finally:
         _TOOL_REGISTRY.clear()
@@ -1114,6 +1167,10 @@ async def test_skill_command_tool_dispatch_threads_config_path_to_self_config(tm
         command_tool="get_own_config",
         skill_name="dispatch",
         args_text="",
+        dispatch_context=_skill_dispatch_context(
+            agent_name="code",
+            runtime_paths=_runtime_paths(tmp_path, config_path=config_path),
+        ),
     )
 
     assert "Skill Config Writer" in result
@@ -1199,9 +1256,13 @@ async def test_skill_command_tool_dispatch_loads_worker_scoped_config_field_cred
             command_tool="lookup",
             skill_name="dispatch",
             args_text="hello",
-            requester_user_id="@alice:example.org",
-            room_id="!room:example.org",
-            thread_id="$thread",
+            dispatch_context=_skill_dispatch_context(
+                agent_name="code",
+                runtime_paths=resolve_runtime_paths(),
+                requester_user_id="@alice:example.org",
+                room_id="!room:example.org",
+                thread_id="$thread",
+            ),
         )
     finally:
         _TOOL_REGISTRY.clear()

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -22,6 +22,7 @@ from mindroom.message_target import MessageTarget
 from mindroom.scheduling import (
     CronSchedule,
     ScheduledWorkflow,
+    SchedulingRuntime,
     _execute_scheduled_workflow,
     _parse_workflow_schedule,
     _validate_conditional_workflow,
@@ -733,16 +734,18 @@ class TestIntegrationWithScheduling:
 
         with patch("mindroom.scheduling._run_cron_task", new=AsyncMock()):
             task_id, message = await schedule_task(
-                client=client,
+                runtime=SchedulingRuntime(
+                    client=client,
+                    config=config,
+                    runtime_paths=runtime_paths_for(config),
+                    room=room,
+                    conversation_cache=_conversation_cache(),
+                    event_cache=_event_cache(),
+                ),
                 room_id="!room:server",
                 thread_id="$thread123",
                 scheduled_by="@user:server",
                 full_text="Daily at 9am, research AI news",
-                config=config,
-                runtime_paths=runtime_paths_for(config),
-                event_cache=_event_cache(),
-                room=room,
-                conversation_cache=_conversation_cache(),
             )
 
             assert task_id is not None


### PR DESCRIPTION
## Summary
- collapse scheduling entrypoint dependencies into an explicit `SchedulingRuntime` and keep schedule edits as state-only Matrix writes
- carry a single skill tool dispatch context so live runtime dispatch preserves canonical execution identity and hook bindings
- stop merging ambient execution identity into explicit hook bridge identities and cover the behavior with regression tests

## Verification
- `uv run pytest -x -n 0 --no-cov -v tests/test_tool_hooks.py tests/test_skills.py tests/test_scheduling.py tests/test_scheduler_tool.py tests/test_schedule_agent_validation.py tests/test_bot_scheduling.py tests/test_hook_sender.py tests/test_workflow_scheduling.py tests/api/test_schedules_api.py`
- `uv run ruff check src/mindroom/commands/handler.py src/mindroom/tool_system/runtime_context.py`
- `uv run --active pre-commit run --all-files`
