### PR TITLE
refactor: collapse runtime dispatch contracts

### DIFF
--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -65,6 +65,15 @@ It no longer sends messages, runs AI, or writes persistence state.
 `TurnController` and `EditRegenerator` read and write through `TurnStore` instead of owning their own persistence helpers.
 Command handling now records terminal outcomes through `TurnStore` as well.
 
+## Tool Dispatch Contracts
+
+There are now four active runtime contracts for tool and scheduling dispatch.
+`ToolRuntimeContext` is the live Matrix runtime object with client, caches, hook bindings, and attachment scope.
+`LiveToolDispatchContext` is the strict live contract that pairs one `ToolRuntimeContext` with a matching `ToolExecutionIdentity`.
+`ToolDispatchContext` is the detached contract for cases that only have a serializable execution identity and no live Matrix runtime.
+`SchedulingRuntime` is the explicit live scheduling contract consumed by command and tool scheduling entrypoints.
+Hook bridges and response execution now consume these contracts directly instead of rebuilding identity from partial nullable fields.
+
 `AgentBot` is closer to a runtime shell again.
 It still needs more cleanup, but normal turn control, edit regeneration, and interactive selection execution no longer live in the bot class itself.
 

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -34,6 +34,7 @@ from mindroom.timing import timed
 from mindroom.tool_system.dynamic_toolkits import DynamicToolkitSelection, resolve_dynamic_toolkit_selection
 from mindroom.tool_system.metadata import TOOL_METADATA, get_tool_by_name
 from mindroom.tool_system.plugins import load_plugins
+from mindroom.tool_system.runtime_context import ToolDispatchContext
 from mindroom.tool_system.skills import build_agent_skills
 from mindroom.tool_system.tool_hooks import build_tool_hook_bridge, prepend_tool_hook_bridge
 from mindroom.tool_system.worker_routing import (
@@ -889,7 +890,7 @@ def _build_agent_tool_hook_bridge(
     hook_registry: HookRegistry | None,
     plugins: list[_Plugin],
     agent_name: str,
-    execution_identity: ToolExecutionIdentity | None,
+    dispatch_context: ToolDispatchContext | None,
     config: Config,
     runtime_paths: constants.RuntimePaths,
 ) -> Callable[..., Any] | None:
@@ -897,7 +898,7 @@ def _build_agent_tool_hook_bridge(
     return build_tool_hook_bridge(
         active_hook_registry,
         agent_name=agent_name,
-        execution_identity=execution_identity,
+        dispatch_context=dispatch_context,
         config=config,
         runtime_paths=runtime_paths,
     )
@@ -1009,7 +1010,9 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         hook_registry=hook_registry,
         plugins=plugins,
         agent_name=agent_name,
-        execution_identity=execution_identity,
+        dispatch_context=(
+            ToolDispatchContext(execution_identity=execution_identity) if execution_identity is not None else None
+        ),
         config=config,
         runtime_paths=runtime_paths,
     )

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -25,7 +25,6 @@ from mindroom.scheduling import (
 )
 from mindroom.thread_utils import check_agent_mentioned, get_configured_agents_for_room
 from mindroom.tool_system.runtime_context import (
-    LiveToolDispatchContext,
     ToolDispatchContext,
     runtime_context_from_dispatch_context,
     tool_runtime_context,
@@ -50,7 +49,6 @@ if TYPE_CHECKING:
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol, ConversationEventCache
     from mindroom.matrix.identity import MatrixID
     from mindroom.message_target import MessageTarget
-    from mindroom.tool_system.runtime_context import ToolRuntimeContext
 
 logger = get_logger(__name__)
 
@@ -407,29 +405,6 @@ async def _maybe_await(value: object) -> object:
     if inspect.isawaitable(value):
         return await value
     return value
-
-
-def skill_tool_dispatch_context_from_target(
-    *,
-    agent_name: str,
-    runtime_paths: RuntimePaths,
-    requester_user_id: str | None,
-    target: MessageTarget | None,
-) -> ToolDispatchContext:
-    """Build the non-live dispatch shape from an explicit Matrix target."""
-    return ToolDispatchContext.from_target(
-        agent_name=agent_name,
-        runtime_paths=runtime_paths,
-        requester_user_id=requester_user_id,
-        target=target,
-    )
-
-
-def skill_tool_dispatch_context_from_runtime_context(
-    runtime_context: ToolRuntimeContext,
-) -> LiveToolDispatchContext:
-    """Build the live dispatch shape from one bound runtime context."""
-    return LiveToolDispatchContext.from_runtime_context(runtime_context)
 
 
 async def _run_skill_command_tool(

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -24,11 +24,15 @@ from mindroom.scheduling import (
     schedule_task,
 )
 from mindroom.thread_utils import check_agent_mentioned, get_configured_agents_for_room
-from mindroom.tool_system.runtime_context import build_execution_identity_from_runtime_context, tool_runtime_context
+from mindroom.tool_system.runtime_context import (
+    LiveToolDispatchContext,
+    ToolDispatchContext,
+    runtime_context_from_dispatch_context,
+    tool_runtime_context,
+)
 from mindroom.tool_system.skills import resolve_skill_command_spec
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
-    build_tool_execution_identity,
     tool_execution_identity,
 )
 
@@ -343,14 +347,6 @@ class _ToolCallArguments:
     error: str | None = None
 
 
-@dataclass(frozen=True)
-class SkillToolDispatchContext:
-    """One explicit runtime shape for tool-dispatched skill execution."""
-
-    execution_identity: ToolExecutionIdentity
-    runtime_context: ToolRuntimeContext | None
-
-
 def _prepare_tool_call_arguments(  # noqa: PLR0911
     entrypoint: Callable[..., object] | None,
     base_args: Mapping[str, object],
@@ -419,31 +415,21 @@ def skill_tool_dispatch_context_from_target(
     runtime_paths: RuntimePaths,
     requester_user_id: str | None,
     target: MessageTarget | None,
-) -> SkillToolDispatchContext:
+) -> ToolDispatchContext:
     """Build the non-live dispatch shape from an explicit Matrix target."""
-    return SkillToolDispatchContext(
-        execution_identity=build_tool_execution_identity(
-            channel="matrix",
-            agent_name=agent_name,
-            runtime_paths=runtime_paths,
-            requester_id=requester_user_id,
-            room_id=target.room_id if target is not None else None,
-            thread_id=target.resolved_thread_id if target is not None else None,
-            resolved_thread_id=target.resolved_thread_id if target is not None else None,
-            session_id=target.session_id if target is not None else None,
-        ),
-        runtime_context=None,
+    return ToolDispatchContext.from_target(
+        agent_name=agent_name,
+        runtime_paths=runtime_paths,
+        requester_user_id=requester_user_id,
+        target=target,
     )
 
 
 def skill_tool_dispatch_context_from_runtime_context(
     runtime_context: ToolRuntimeContext,
-) -> SkillToolDispatchContext:
+) -> LiveToolDispatchContext:
     """Build the live dispatch shape from one bound runtime context."""
-    return SkillToolDispatchContext(
-        execution_identity=build_execution_identity_from_runtime_context(runtime_context),
-        runtime_context=runtime_context,
-    )
+    return LiveToolDispatchContext.from_runtime_context(runtime_context)
 
 
 async def _run_skill_command_tool(
@@ -455,7 +441,7 @@ async def _run_skill_command_tool(
     command_tool: str,
     skill_name: str,
     args_text: str,
-    dispatch_context: SkillToolDispatchContext,
+    dispatch_context: ToolDispatchContext,
     command_name: str = "skill",
 ) -> str:
     effective_runtime_paths = (
@@ -466,7 +452,7 @@ async def _run_skill_command_tool(
 
     try:
         with (
-            tool_runtime_context(dispatch_context.runtime_context),
+            tool_runtime_context(runtime_context_from_dispatch_context(dispatch_context)),
             tool_execution_identity(
                 dispatch_context.execution_identity,
             ),

--- a/src/mindroom/custom_tools/scheduler.py
+++ b/src/mindroom/custom_tools/scheduler.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from agno.tools import Toolkit
 
 from mindroom.scheduling import (
-    SchedulingRuntime,
     cancel_scheduled_task,
     edit_scheduled_task,
     list_scheduled_tasks,
     schedule_task,
 )
-from mindroom.tool_system.runtime_context import get_tool_runtime_context
+from mindroom.tool_system.runtime_context import (
+    build_scheduling_runtime_from_tool_runtime_context,
+    get_tool_runtime_context,
+)
 
 
 class SchedulerTools(Toolkit):
@@ -44,14 +46,7 @@ class SchedulerTools(Toolkit):
         if context is None or context.room is None:
             return "❌ Scheduler tool is unavailable in this context."
 
-        runtime = SchedulingRuntime(
-            client=context.client,
-            config=context.config,
-            runtime_paths=context.runtime_paths,
-            room=context.room,
-            conversation_cache=context.conversation_cache,
-            event_cache=context.event_cache,
-        )
+        runtime = build_scheduling_runtime_from_tool_runtime_context(context)
         _, response_text = await schedule_task(
             runtime=runtime,
             room_id=context.room_id,
@@ -77,14 +72,7 @@ class SchedulerTools(Toolkit):
         if context is None or context.room is None:
             return "❌ Scheduler tool is unavailable in this context."
 
-        runtime = SchedulingRuntime(
-            client=context.client,
-            config=context.config,
-            runtime_paths=context.runtime_paths,
-            room=context.room,
-            conversation_cache=context.conversation_cache,
-            event_cache=context.event_cache,
-        )
+        runtime = build_scheduling_runtime_from_tool_runtime_context(context)
         return await edit_scheduled_task(
             runtime=runtime,
             room_id=context.room_id,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -58,7 +58,11 @@ from mindroom.streaming import (
 from mindroom.teams import TeamMode, select_model_for_team, team_response, team_response_stream
 from mindroom.thread_summary import thread_summary_message_count_hint
 from mindroom.timing import DispatchPipelineTiming, timed
-from mindroom.tool_system.runtime_context import resolve_tool_runtime_hook_bindings
+from mindroom.tool_system.runtime_context import (
+    ToolDispatchContext,
+    resolve_tool_runtime_hook_bindings,
+    runtime_context_from_dispatch_context,
+)
 from mindroom.tool_system.worker_routing import (
     run_with_tool_execution_identity,
     stream_with_tool_execution_identity,
@@ -335,8 +339,7 @@ class _PreparedResponseRuntime:
     media_inputs: MediaInputs
     session_id: str
     model_prompt: str
-    tool_context: ToolRuntimeContext | None
-    execution_identity: ToolExecutionIdentity
+    tool_dispatch: ToolDispatchContext
     request_knowledge_managers: dict[str, Any]
     room_mode: bool = False
 
@@ -423,15 +426,14 @@ class ResponseRunner:
     async def _run_in_tool_context(
         self,
         *,
-        execution_identity: ToolExecutionIdentity | None,
-        tool_context: ToolRuntimeContext | None,
+        tool_dispatch: ToolDispatchContext,
         operation: Callable[[], Awaitable[_ToolContextResult]],
     ) -> _ToolContextResult:
         """Execute one operation inside the response-owned execution and tool context."""
         return await self.deps.tool_runtime.run_in_context(
-            tool_context=tool_context,
+            tool_context=runtime_context_from_dispatch_context(tool_dispatch),
             operation=lambda: run_with_tool_execution_identity(
-                execution_identity,
+                tool_dispatch.execution_identity,
                 operation=operation,
             ),
         )
@@ -439,15 +441,14 @@ class ResponseRunner:
     def _stream_in_tool_context(
         self,
         *,
-        execution_identity: ToolExecutionIdentity | None,
-        tool_context: ToolRuntimeContext | None,
+        tool_dispatch: ToolDispatchContext,
         stream_factory: Callable[[], AsyncIterator[_ToolStreamChunk]],
     ) -> AsyncIterator[_ToolStreamChunk]:
         """Wrap one stream inside the response-owned execution and tool context."""
         return self.deps.tool_runtime.stream_in_context(
-            tool_context=tool_context,
+            tool_context=runtime_context_from_dispatch_context(tool_dispatch),
             stream_factory=lambda: stream_with_tool_execution_identity(
-                execution_identity,
+                tool_dispatch.execution_identity,
                 stream_factory=stream_factory,
             ),
         )
@@ -975,7 +976,7 @@ class ResponseRunner:
         )
         delivery_request_base = replace(resolved_request, target=delivery_target)
         session_id = resolved_target.session_id
-        tool_context = self.deps.tool_runtime.build_context(
+        tool_dispatch = self.deps.tool_runtime.build_dispatch_context(
             resolved_target,
             user_id=requester_user_id,
             active_model_name=model_name,
@@ -984,19 +985,14 @@ class ResponseRunner:
             correlation_id=resolved_correlation_id,
             source_envelope=request.response_envelope,
         )
-        execution_identity = self.deps.tool_runtime.build_execution_identity(
-            target=resolved_target,
-            user_id=requester_user_id,
-            session_id=session_id,
-        )
         session_scope = self.deps.state_writer.team_history_scope(list(team_request.team_agents))
         session_type = self.deps.state_writer.session_type_for_scope(session_scope)
 
         def team_storage_factory() -> SqliteDb:
-            return self.deps.state_writer.create_storage(execution_identity, scope=session_scope)
+            return self.deps.state_writer.create_storage(tool_dispatch.execution_identity, scope=session_scope)
 
         session_started_watch = lifecycle.setup_session_watch(
-            tool_context=tool_context,
+            tool_context=runtime_context_from_dispatch_context(tool_dispatch),
             session_id=session_id,
             session_type=session_type,
             scope=session_scope,
@@ -1045,7 +1041,7 @@ class ResponseRunner:
                             agent_ids=list(team_request.team_agents),
                             message=model_message,
                             orchestrator=orchestrator,
-                            execution_identity=execution_identity,
+                            execution_identity=tool_dispatch.execution_identity,
                             mode=mode,
                             thread_history=model_thread_history,
                             model_name=model_name,
@@ -1068,8 +1064,7 @@ class ResponseRunner:
                         )
 
                     response_stream = self._stream_in_tool_context(
-                        execution_identity=execution_identity,
-                        tool_context=tool_context,
+                        tool_dispatch=tool_dispatch,
                         stream_factory=build_response_stream,
                     )
 
@@ -1133,7 +1128,7 @@ class ResponseRunner:
                                     mode=mode,
                                     message=model_message,
                                     orchestrator=orchestrator,
-                                    execution_identity=execution_identity,
+                                    execution_identity=tool_dispatch.execution_identity,
                                     thread_history=model_thread_history,
                                     model_name=model_name,
                                     media=resolved_request.media,
@@ -1154,8 +1149,7 @@ class ResponseRunner:
                                 )
 
                             response_text = await self._run_in_tool_context(
-                                execution_identity=execution_identity,
-                                tool_context=tool_context,
+                                tool_dispatch=tool_dispatch,
                                 operation=build_response_text,
                             )
                     finally:
@@ -1253,7 +1247,7 @@ class ResponseRunner:
                 response_run_id=response_run_id,
                 session_id=session_id,
                 session_type=SessionType.TEAM,
-                execution_identity=execution_identity,
+                execution_identity=tool_dispatch.execution_identity,
                 compaction_outcomes=tuple(compaction_outcomes),
                 interactive_target=resolved_target,
                 thread_summary_room_id=(request.room_id if resolved_target.resolved_thread_id is not None else None),
@@ -1407,7 +1401,7 @@ class ResponseRunner:
             target=resolved_target,
             include_context=_agent_has_matrix_messaging_tool(self.deps.runtime.config, self.deps.agent_name),
         )
-        tool_context = self.deps.tool_runtime.build_context(
+        tool_dispatch = self.deps.tool_runtime.build_dispatch_context(
             resolved_target,
             user_id=request.user_id,
             session_id=session_id,
@@ -1415,14 +1409,9 @@ class ResponseRunner:
             correlation_id=request.correlation_id,
             source_envelope=request.response_envelope,
         )
-        execution_identity = self.deps.tool_runtime.build_execution_identity(
-            target=resolved_target,
-            user_id=request.user_id,
-            session_id=session_id,
-        )
         request_knowledge_managers = await self._ensure_request_knowledge_managers(
             [self.deps.agent_name],
-            execution_identity,
+            tool_dispatch.execution_identity,
         )
         return _PreparedResponseRuntime(
             resolved_target=resolved_target,
@@ -1430,8 +1419,7 @@ class ResponseRunner:
             media_inputs=media_inputs,
             session_id=session_id,
             model_prompt=resolved_model_prompt,
-            tool_context=tool_context,
-            execution_identity=execution_identity,
+            tool_dispatch=tool_dispatch,
             request_knowledge_managers=request_knowledge_managers,
             room_mode=room_mode,
         )
@@ -1510,7 +1498,7 @@ class ResponseRunner:
                 show_tool_calls=self._show_tool_calls(),
                 tool_trace_collector=tool_trace,
                 run_metadata_collector=run_metadata_content,
-                execution_identity=runtime.execution_identity,
+                execution_identity=runtime.tool_dispatch.execution_identity,
                 compaction_outcomes_collector=compaction_outcomes,
                 matrix_run_metadata=matrix_run_metadata,
                 system_enrichment_items=request.system_enrichment_items,
@@ -1519,8 +1507,7 @@ class ResponseRunner:
 
         async with typing_indicator(self._client(), request.room_id):
             return await self._run_in_tool_context(
-                execution_identity=runtime.execution_identity,
-                tool_context=runtime.tool_context,
+                tool_dispatch=runtime.tool_dispatch,
                 operation=build_response_text,
             )
 
@@ -1564,7 +1551,7 @@ class ResponseRunner:
             active_event_ids=active_event_ids,
             show_tool_calls=self._show_tool_calls(),
             run_metadata_collector=run_metadata_content,
-            execution_identity=runtime.execution_identity,
+            execution_identity=runtime.tool_dispatch.execution_identity,
             compaction_outcomes_collector=compaction_outcomes,
             matrix_run_metadata=matrix_run_metadata,
             system_enrichment_items=request.system_enrichment_items,
@@ -1573,8 +1560,7 @@ class ResponseRunner:
 
         async with typing_indicator(self._client(), request.room_id):
             wrapped_response_stream = self._stream_in_tool_context(
-                execution_identity=runtime.execution_identity,
-                tool_context=runtime.tool_context,
+                tool_dispatch=runtime.tool_dispatch,
                 stream_factory=lambda: response_stream,
             )
             response_extra_content = _merge_response_extra_content(
@@ -1630,10 +1616,10 @@ class ResponseRunner:
         session_type = self.deps.state_writer.session_type_for_scope(session_scope)
 
         def history_storage_factory() -> SqliteDb:
-            return self.deps.state_writer.create_storage(runtime.execution_identity, scope=session_scope)
+            return self.deps.state_writer.create_storage(runtime.tool_dispatch.execution_identity, scope=session_scope)
 
         session_started_watch = lifecycle.setup_session_watch(
-            tool_context=runtime.tool_context,
+            tool_context=runtime_context_from_dispatch_context(runtime.tool_dispatch),
             session_id=runtime.session_id,
             session_type=session_type,
             scope=session_scope,
@@ -1748,10 +1734,10 @@ class ResponseRunner:
         session_type = self.deps.state_writer.session_type_for_scope(session_scope)
 
         def history_storage_factory() -> SqliteDb:
-            return self.deps.state_writer.create_storage(runtime.execution_identity, scope=session_scope)
+            return self.deps.state_writer.create_storage(runtime.tool_dispatch.execution_identity, scope=session_scope)
 
         session_started_watch = lifecycle.setup_session_watch(
-            tool_context=runtime.tool_context,
+            tool_context=runtime_context_from_dispatch_context(runtime.tool_dispatch),
             session_id=runtime.session_id,
             session_type=session_type,
             scope=session_scope,
@@ -1936,18 +1922,12 @@ class ResponseRunner:
             target=resolved_target,
             include_context=_agent_has_matrix_messaging_tool(self.deps.runtime.config, agent_name),
         )
-        tool_context = self.deps.tool_runtime.build_context(
+        tool_dispatch = self.deps.tool_runtime.build_dispatch_context(
             resolved_target,
             user_id=user_id,
             session_id=session_id,
             agent_name=agent_name,
             source_envelope=source_envelope,
-        )
-        execution_identity = self.deps.tool_runtime.build_execution_identity(
-            target=resolved_target,
-            user_id=user_id,
-            session_id=session_id,
-            agent_name=agent_name,
         )
         skill_request = ResponseRequest(
             room_id=room_id,
@@ -1968,10 +1948,10 @@ class ResponseRunner:
         session_scope = HistoryScope(kind="agent", scope_id=agent_name)
 
         def history_storage_factory() -> SqliteDb:
-            return self.deps.state_writer.create_storage(execution_identity, scope=session_scope)
+            return self.deps.state_writer.create_storage(tool_dispatch.execution_identity, scope=session_scope)
 
         session_started_watch = lifecycle.setup_session_watch(
-            tool_context=tool_context,
+            tool_context=runtime_context_from_dispatch_context(tool_dispatch),
             session_id=session_id,
             session_type=self.deps.state_writer.session_type_for_scope(session_scope),
             scope=session_scope,
@@ -1979,14 +1959,17 @@ class ResponseRunner:
             thread_id=resolved_target.resolved_thread_id,
             create_storage=history_storage_factory,
         )
-        request_knowledge_managers = await self._ensure_request_knowledge_managers([agent_name], execution_identity)
+        request_knowledge_managers = await self._ensure_request_knowledge_managers(
+            [agent_name],
+            tool_dispatch.execution_identity,
+        )
         reprioritize_auto_flush_sessions(
             self.deps.storage_path,
             self.deps.runtime.config,
             self.deps.runtime_paths,
             agent_name=agent_name,
             active_session_id=session_id,
-            execution_identity=execution_identity,
+            execution_identity=tool_dispatch.execution_identity,
         )
         show_tool_calls = self._show_tool_calls(agent_name)
         tool_trace: list[Any] = []
@@ -2013,13 +1996,12 @@ class ResponseRunner:
                     show_tool_calls=show_tool_calls,
                     tool_trace_collector=tool_trace,
                     run_metadata_collector=run_metadata_content,
-                    execution_identity=execution_identity,
+                    execution_identity=tool_dispatch.execution_identity,
                 )
 
             try:
                 response_text = await self._run_in_tool_context(
-                    execution_identity=execution_identity,
-                    tool_context=tool_context,
+                    tool_dispatch=tool_dispatch,
                     operation=build_response_text,
                 )
             finally:
@@ -2044,7 +2026,7 @@ class ResponseRunner:
                     self.deps.runtime_paths,
                     agent_name=agent_name,
                     session_id=session_id,
-                    execution_identity=execution_identity,
+                    execution_identity=tool_dispatch.execution_identity,
                 )
                 if self.deps.runtime.config.get_agent_memory_backend(agent_name) == "mem0":
                     create_background_task(
@@ -2057,7 +2039,7 @@ class ResponseRunner:
                             self.deps.runtime_paths,
                             memory_thread_history,
                             user_id,
-                            execution_identity=execution_identity,
+                            execution_identity=tool_dispatch.execution_identity,
                         ),
                         name=f"memory_save_{agent_name}_{session_id}",
                         owner=self.deps.runtime,
@@ -2078,7 +2060,7 @@ class ResponseRunner:
                 ),
                 session_id=session_id,
                 session_type=SessionType.AGENT,
-                execution_identity=execution_identity,
+                execution_identity=tool_dispatch.execution_identity,
                 interactive_target=resolved_target,
                 memory_prompt=memory_prompt,
                 memory_thread_history=memory_thread_history,

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from mindroom.hooks.types import HookRoomStatePutter, HookRoomStateQuerier
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol, ConversationEventCache
     from mindroom.matrix.identity import MatrixID
+    from mindroom.scheduling import SchedulingRuntime
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 _ToolContextReturn = TypeVar("_ToolContextReturn")
@@ -87,6 +88,57 @@ class ToolRuntimeContext:
     room_state_querier: HookRoomStateQuerier | None = None
     room_state_putter: HookRoomStatePutter | None = None
     message_received_depth: int = 0
+
+
+@dataclass(frozen=True)
+class ToolDispatchContext:
+    """Detached execution identity for tool dispatch outside a live Matrix runtime."""
+
+    execution_identity: ToolExecutionIdentity
+
+    @classmethod
+    def from_target(
+        cls,
+        *,
+        agent_name: str,
+        runtime_paths: RuntimePaths,
+        requester_user_id: str | None,
+        target: MessageTarget | None,
+    ) -> ToolDispatchContext:
+        """Build the detached dispatch contract for one explicit Matrix target."""
+        return cls(
+            execution_identity=build_tool_execution_identity(
+                channel="matrix",
+                agent_name=agent_name,
+                runtime_paths=runtime_paths,
+                requester_id=requester_user_id,
+                room_id=target.room_id if target is not None else None,
+                thread_id=target.resolved_thread_id if target is not None else None,
+                resolved_thread_id=target.resolved_thread_id if target is not None else None,
+                session_id=target.session_id if target is not None else None,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class LiveToolDispatchContext(ToolDispatchContext):
+    """Execution identity paired with one matching live Matrix runtime context."""
+
+    runtime_context: ToolRuntimeContext
+
+    def __post_init__(self) -> None:
+        """Validate that the detached identity and live runtime represent the same dispatch."""
+        if not execution_identity_matches_tool_runtime_context(self.execution_identity, self.runtime_context):
+            msg = "Live tool dispatch execution_identity must match the provided tool runtime context"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_runtime_context(cls, runtime_context: ToolRuntimeContext) -> LiveToolDispatchContext:
+        """Build the live dispatch contract represented by one tool runtime context."""
+        return cls(
+            execution_identity=build_execution_identity_from_runtime_context(runtime_context),
+            runtime_context=runtime_context,
+        )
 
 
 @dataclass(frozen=True)
@@ -147,7 +199,7 @@ class ToolRuntimeSupport:
             conversation_cache=self.resolver.deps.conversation_cache,
             event_cache=event_cache,
             active_model_name=active_model_name,
-            session_id=session_id,
+            session_id=session_id or target.session_id,
             room=self.resolver.cached_room(target_room_id),
             reply_to_event_id=target_reply_to_event_id,
             storage_path=self.storage_path,
@@ -187,6 +239,64 @@ class ToolRuntimeSupport:
             msg = "Live Matrix tool dispatch requires initialized tool runtime support"
             raise RuntimeError(msg)
         return context
+
+    def build_dispatch_context(
+        self,
+        target: MessageTarget,
+        *,
+        user_id: str | None,
+        session_id: str | None = None,
+        agent_name: str | None = None,
+        active_model_name: str | None = None,
+        attachment_ids: list[str] | tuple[str, ...] | None = None,
+        correlation_id: str | None = None,
+        source_envelope: MessageEnvelope | None = None,
+    ) -> ToolDispatchContext:
+        """Build the canonical detached or live dispatch contract for one tool call."""
+        execution_identity = self.build_execution_identity(
+            target=target,
+            user_id=user_id,
+            session_id=session_id or target.session_id,
+            agent_name=agent_name,
+        )
+        context = self.build_context(
+            target,
+            user_id=user_id,
+            session_id=session_id,
+            agent_name=agent_name,
+            active_model_name=active_model_name,
+            attachment_ids=attachment_ids,
+            correlation_id=correlation_id,
+            source_envelope=source_envelope,
+        )
+        if context is None:
+            return ToolDispatchContext(execution_identity=execution_identity)
+        return LiveToolDispatchContext.from_runtime_context(context)
+
+    def build_required_live_dispatch_context(
+        self,
+        target: MessageTarget,
+        *,
+        user_id: str | None,
+        session_id: str | None = None,
+        agent_name: str | None = None,
+        active_model_name: str | None = None,
+        attachment_ids: list[str] | tuple[str, ...] | None = None,
+        correlation_id: str | None = None,
+        source_envelope: MessageEnvelope | None = None,
+    ) -> LiveToolDispatchContext:
+        """Build one live Matrix dispatch contract or fail fast if runtime support is unavailable."""
+        context = self.build_required_context(
+            target,
+            user_id=user_id,
+            session_id=session_id,
+            agent_name=agent_name,
+            active_model_name=active_model_name,
+            attachment_ids=attachment_ids,
+            correlation_id=correlation_id,
+            source_envelope=source_envelope,
+        )
+        return LiveToolDispatchContext.from_runtime_context(context)
 
     def build_execution_identity(
         self,
@@ -295,6 +405,50 @@ def build_execution_identity_from_runtime_context(context: ToolRuntimeContext) -
         thread_id=target.resolved_thread_id,
         resolved_thread_id=target.resolved_thread_id,
         session_id=target.session_id,
+    )
+
+
+def execution_identity_matches_tool_runtime_context(
+    execution_identity: ToolExecutionIdentity,
+    context: ToolRuntimeContext,
+) -> bool:
+    """Return whether one execution identity represents the same live Matrix tool runtime."""
+    target = MessageTarget.from_runtime_context(context)
+    valid_thread_ids = {target.source_thread_id, target.resolved_thread_id}
+    return (
+        execution_identity.channel == "matrix"
+        and execution_identity.agent_name == context.agent_name
+        and execution_identity.requester_id == context.requester_id
+        and execution_identity.room_id == context.room_id
+        and execution_identity.thread_id in valid_thread_ids
+        and execution_identity.resolved_thread_id == target.resolved_thread_id
+        and execution_identity.session_id == target.session_id
+        and execution_identity.tenant_id == context.runtime_paths.env_value("CUSTOMER_ID")
+        and execution_identity.account_id == context.runtime_paths.env_value("ACCOUNT_ID")
+    )
+
+
+def runtime_context_from_dispatch_context(dispatch_context: ToolDispatchContext) -> ToolRuntimeContext | None:
+    """Return the live runtime context when one dispatch contract is runtime-bound."""
+    if isinstance(dispatch_context, LiveToolDispatchContext):
+        return dispatch_context.runtime_context
+    return None
+
+
+def build_scheduling_runtime_from_tool_runtime_context(context: ToolRuntimeContext) -> SchedulingRuntime:
+    """Build the canonical live scheduling runtime for one Matrix tool context."""
+    from mindroom.scheduling import SchedulingRuntime  # noqa: PLC0415
+
+    if context.room is None:
+        msg = "Scheduling runtime requires a cached Matrix room in tool runtime context"
+        raise RuntimeError(msg)
+    return SchedulingRuntime(
+        client=context.client,
+        config=context.config,
+        runtime_paths=context.runtime_paths,
+        room=context.room,
+        conversation_cache=context.conversation_cache,
+        event_cache=context.event_cache,
     )
 
 

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -45,8 +45,6 @@ if TYPE_CHECKING:
     from mindroom.hooks.registry import HookRegistry
     from mindroom.hooks.types import HookMessageSender, HookRoomStatePutter, HookRoomStateQuerier
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
-    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
-
 _DECLINED_RESULT_TEMPLATE = (
     "[TOOL CALL DECLINED]\n"
     "Tool: {tool_name}\n"
@@ -128,17 +126,19 @@ def _ambient_tool_dispatch_context() -> ToolDispatchContext | None:
 
 
 def _explicit_bridge_dispatch_context(
-    execution_identity: ToolExecutionIdentity | None,
+    dispatch_context: ToolDispatchContext | None,
 ) -> ToolDispatchContext | None:
-    if execution_identity is None:
+    if dispatch_context is None:
         return None
+    if isinstance(dispatch_context, LiveToolDispatchContext):
+        return dispatch_context
     runtime_context = get_tool_runtime_context()
     if runtime_context is not None and execution_identity_matches_tool_runtime_context(
-        execution_identity,
+        dispatch_context.execution_identity,
         runtime_context,
     ):
         return LiveToolDispatchContext.from_runtime_context(runtime_context)
-    return ToolDispatchContext(execution_identity=execution_identity)
+    return dispatch_context
 
 
 def _resolve_tool_context(
@@ -281,16 +281,14 @@ async def _execute_bridge(
     func: Callable[..., Any],
     args: dict[str, Any],
     agent_name: str | None,
-    execution_identity: ToolExecutionIdentity | None,
+    dispatch_context: ToolDispatchContext | None,
     config: Config | None,
     runtime_paths: RuntimePaths | None,
     has_before_hooks: bool,
     has_after_hooks: bool,
 ) -> ToolHookResult:
     started_at = time.perf_counter()
-    effective_dispatch_context = (
-        _explicit_bridge_dispatch_context(execution_identity) or _ambient_tool_dispatch_context()
-    )
+    effective_dispatch_context = _explicit_bridge_dispatch_context(dispatch_context) or _ambient_tool_dispatch_context()
     bridge_context = _ToolHookBridgeContext(
         agent_name=agent_name,
         config=config,
@@ -394,7 +392,7 @@ async def _execute_bridge(
 def build_tool_hook_bridge(
     hook_registry: HookRegistry,
     agent_name: str | None,
-    execution_identity: ToolExecutionIdentity | None = None,
+    dispatch_context: ToolDispatchContext | None = None,
     config: Config | None = None,
     runtime_paths: RuntimePaths | None = None,
 ) -> Callable[..., Any]:
@@ -409,7 +407,7 @@ def build_tool_hook_bridge(
             func=func,
             args=args,
             agent_name=agent_name,
-            execution_identity=execution_identity,
+            dispatch_context=dispatch_context,
             config=config,
             runtime_paths=runtime_paths,
             has_before_hooks=has_before_hooks,
@@ -425,7 +423,7 @@ def build_tool_hook_bridge(
                     func=func,
                     args=args,
                     agent_name=agent_name,
-                    execution_identity=execution_identity,
+                    dispatch_context=dispatch_context,
                     config=config,
                     runtime_paths=runtime_paths,
                     has_before_hooks=has_before_hooks,
@@ -439,7 +437,7 @@ def build_tool_hook_bridge(
                 func=func,
                 args=args,
                 agent_name=agent_name,
-                execution_identity=execution_identity,
+                dispatch_context=dispatch_context,
                 config=config,
                 runtime_paths=runtime_paths,
                 has_before_hooks=has_before_hooks,

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -24,7 +24,13 @@ from mindroom.hooks import (
 )
 from mindroom.hooks.types import EVENT_TOOL_AFTER_CALL, EVENT_TOOL_BEFORE_CALL
 from mindroom.logging_config import get_logger
-from mindroom.tool_system.runtime_context import get_tool_runtime_context, resolve_tool_runtime_hook_bindings
+from mindroom.tool_system.runtime_context import (
+    LiveToolDispatchContext,
+    ToolDispatchContext,
+    execution_identity_matches_tool_runtime_context,
+    get_tool_runtime_context,
+    resolve_tool_runtime_hook_bindings,
+)
 from mindroom.tool_system.tool_failures import record_tool_failure
 from mindroom.tool_system.worker_routing import active_tool_execution_identity
 
@@ -95,53 +101,103 @@ class _ResolvedToolContext:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class _ToolHookBridgeContext:
+    """Static hook-bridge inputs that remain valid across live and detached calls."""
+
+    agent_name: str | None
+    config: Config | None
+    runtime_paths: RuntimePaths | None
+    dispatch_context: ToolDispatchContext | None
+
+
 def _correlation_id_for_runtime_context(runtime_context: ToolRuntimeContext | None) -> str:
     if runtime_context is not None and runtime_context.correlation_id:
         return runtime_context.correlation_id
     return "tool-hook:" + uuid4().hex
 
 
+def _ambient_tool_dispatch_context() -> ToolDispatchContext | None:
+    runtime_context = get_tool_runtime_context()
+    if runtime_context is not None:
+        return LiveToolDispatchContext.from_runtime_context(runtime_context)
+    execution_identity = active_tool_execution_identity(None)
+    if execution_identity is not None:
+        return ToolDispatchContext(execution_identity=execution_identity)
+    return None
+
+
+def _explicit_bridge_dispatch_context(
+    execution_identity: ToolExecutionIdentity | None,
+) -> ToolDispatchContext | None:
+    if execution_identity is None:
+        return None
+    runtime_context = get_tool_runtime_context()
+    if runtime_context is not None and execution_identity_matches_tool_runtime_context(
+        execution_identity,
+        runtime_context,
+    ):
+        return LiveToolDispatchContext.from_runtime_context(runtime_context)
+    return ToolDispatchContext(execution_identity=execution_identity)
+
+
 def _resolve_tool_context(
     *,
-    agent_name: str | None,
-    execution_identity: ToolExecutionIdentity | None,
-    config: Config | None,
-    runtime_paths: RuntimePaths | None,
+    bridge_context: _ToolHookBridgeContext,
 ) -> _ResolvedToolContext:
-    runtime_context = get_tool_runtime_context()
-    resolved_execution_identity = active_tool_execution_identity(execution_identity)
-    bindings = resolve_tool_runtime_hook_bindings(runtime_context) if runtime_context is not None else None
-    if resolved_execution_identity is not None:
+    dispatch_context = bridge_context.dispatch_context
+    if isinstance(dispatch_context, LiveToolDispatchContext):
+        runtime_context = dispatch_context.runtime_context
+        bindings = resolve_tool_runtime_hook_bindings(runtime_context)
         return _ResolvedToolContext(
-            agent_name=agent_name or resolved_execution_identity.agent_name,
-            room_id=resolved_execution_identity.room_id,
-            thread_id=resolved_execution_identity.resolved_thread_id or resolved_execution_identity.thread_id,
-            requester_id=resolved_execution_identity.requester_id,
-            session_id=resolved_execution_identity.session_id,
-            channel=resolved_execution_identity.channel,
-            config=runtime_context.config if runtime_context is not None else config,
-            runtime_paths=runtime_context.runtime_paths if runtime_context is not None else runtime_paths,
+            agent_name=bridge_context.agent_name or dispatch_context.execution_identity.agent_name,
+            room_id=dispatch_context.execution_identity.room_id,
+            thread_id=dispatch_context.execution_identity.resolved_thread_id
+            or dispatch_context.execution_identity.thread_id,
+            requester_id=dispatch_context.execution_identity.requester_id,
+            session_id=dispatch_context.execution_identity.session_id,
+            channel=dispatch_context.execution_identity.channel,
+            config=runtime_context.config,
+            runtime_paths=runtime_context.runtime_paths,
             correlation_id=_correlation_id_for_runtime_context(runtime_context),
-            message_sender=bindings.message_sender if bindings is not None else None,
-            room_state_querier=bindings.room_state_querier if bindings is not None else None,
-            room_state_putter=bindings.room_state_putter if bindings is not None else None,
-            message_received_depth=bindings.message_received_depth if bindings is not None else 0,
+            message_sender=bindings.message_sender,
+            room_state_querier=bindings.room_state_querier,
+            room_state_putter=bindings.room_state_putter,
+            message_received_depth=bindings.message_received_depth,
+        )
+
+    if dispatch_context is not None:
+        return _ResolvedToolContext(
+            agent_name=bridge_context.agent_name or dispatch_context.execution_identity.agent_name,
+            room_id=dispatch_context.execution_identity.room_id,
+            thread_id=dispatch_context.execution_identity.resolved_thread_id
+            or dispatch_context.execution_identity.thread_id,
+            requester_id=dispatch_context.execution_identity.requester_id,
+            session_id=dispatch_context.execution_identity.session_id,
+            channel=dispatch_context.execution_identity.channel,
+            config=bridge_context.config,
+            runtime_paths=bridge_context.runtime_paths,
+            correlation_id=_correlation_id_for_runtime_context(None),
+            message_sender=None,
+            room_state_querier=None,
+            room_state_putter=None,
+            message_received_depth=0,
         )
 
     return _ResolvedToolContext(
-        agent_name=agent_name or (runtime_context.agent_name if runtime_context is not None else ""),
-        room_id=runtime_context.room_id if runtime_context is not None else None,
-        thread_id=runtime_context.resolved_thread_id if runtime_context is not None else None,
-        requester_id=runtime_context.requester_id if runtime_context is not None else None,
-        session_id=runtime_context.session_id if runtime_context is not None else None,
+        agent_name=bridge_context.agent_name or "",
+        room_id=None,
+        thread_id=None,
+        requester_id=None,
+        session_id=None,
         channel=None,
-        config=runtime_context.config if runtime_context is not None else config,
-        runtime_paths=runtime_context.runtime_paths if runtime_context is not None else runtime_paths,
-        correlation_id=_correlation_id_for_runtime_context(runtime_context),
-        message_sender=bindings.message_sender if bindings is not None else None,
-        room_state_querier=bindings.room_state_querier if bindings is not None else None,
-        room_state_putter=bindings.room_state_putter if bindings is not None else None,
-        message_received_depth=bindings.message_received_depth if bindings is not None else 0,
+        config=bridge_context.config,
+        runtime_paths=bridge_context.runtime_paths,
+        correlation_id=_correlation_id_for_runtime_context(None),
+        message_sender=None,
+        room_state_querier=None,
+        room_state_putter=None,
+        message_received_depth=0,
     )
 
 
@@ -232,11 +288,17 @@ async def _execute_bridge(
     has_after_hooks: bool,
 ) -> ToolHookResult:
     started_at = time.perf_counter()
-    resolved_context = _resolve_tool_context(
+    effective_dispatch_context = (
+        _explicit_bridge_dispatch_context(execution_identity) or _ambient_tool_dispatch_context()
+    )
+    bridge_context = _ToolHookBridgeContext(
         agent_name=agent_name,
-        execution_identity=execution_identity,
         config=config,
         runtime_paths=runtime_paths,
+        dispatch_context=effective_dispatch_context,
+    )
+    resolved_context = _resolve_tool_context(
+        bridge_context=bridge_context,
     )
     hook_arguments = deepcopy(args) if has_before_hooks or has_after_hooks else None
 
@@ -281,7 +343,9 @@ async def _execute_bridge(
                 requester_id=resolved_context.requester_id,
                 session_id=resolved_context.session_id,
                 correlation_id=resolved_context.correlation_id,
-                execution_identity=active_tool_execution_identity(execution_identity),
+                execution_identity=(
+                    effective_dispatch_context.execution_identity if effective_dispatch_context is not None else None
+                ),
                 runtime_paths=resolved_context.runtime_paths,
             )
             logger.warning(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -29,7 +29,6 @@ from mindroom.commands.handler import (
     CommandHandlerContext,
     _run_skill_command_tool,
     handle_command,
-    skill_tool_dispatch_context_from_runtime_context,
 )
 from mindroom.commands.parsing import command_parser
 from mindroom.constants import (
@@ -559,7 +558,7 @@ class TurnController:
                 reply_to_event_id=event.event_id,
                 event_source=event.source,
             )
-            runtime_context = self.deps.tool_runtime.build_required_context(
+            dispatch_context = self.deps.tool_runtime.build_required_live_dispatch_context(
                 target,
                 user_id=requester_user_id,
                 agent_name=agent_name,
@@ -573,7 +572,7 @@ class TurnController:
                 command_tool=command_tool,
                 skill_name=skill_name,
                 args_text=args_text,
-                dispatch_context=skill_tool_dispatch_context_from_runtime_context(runtime_context),
+                dispatch_context=dispatch_context,
             )
 
         context = CommandHandlerContext(

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -71,7 +71,12 @@ from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsSupport
 from mindroom.response_runner import ResponseRequest, ResponseRunner, ResponseRunnerDeps
 from mindroom.streaming import StreamingDeliveryError
-from mindroom.tool_system.runtime_context import ToolRuntimeSupport, get_tool_runtime_context, tool_runtime_context
+from mindroom.tool_system.runtime_context import (
+    LiveToolDispatchContext,
+    ToolRuntimeSupport,
+    get_tool_runtime_context,
+    tool_runtime_context,
+)
 from mindroom.tool_system.worker_routing import (
     build_tool_execution_identity,
     get_tool_execution_identity,
@@ -1918,8 +1923,7 @@ class TestUserIdPassthrough:
                 )
 
         stream = coordinator._stream_in_tool_context(
-            execution_identity=execution_identity,
-            tool_context=tool_context,
+            tool_dispatch=LiveToolDispatchContext.from_runtime_context(tool_context),
             stream_factory=source,
         )
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -12,7 +12,6 @@ from agno.tools import Toolkit
 
 import mindroom.tool_system.skills as skills_module
 from mindroom.commands.handler import (
-    SkillToolDispatchContext,
     _collect_agent_toolkits,
     _run_skill_command_tool,
     skill_tool_dispatch_context_from_runtime_context,
@@ -33,7 +32,12 @@ from mindroom.tool_system.metadata import (
     ToolStatus,
     register_tool_with_metadata,
 )
-from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
+from mindroom.tool_system.runtime_context import (
+    LiveToolDispatchContext,
+    ToolDispatchContext,
+    ToolRuntimeContext,
+    get_tool_runtime_context,
+)
 from mindroom.tool_system.skills import build_agent_skills, resolve_skill_command_spec
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
@@ -64,7 +68,7 @@ def _skill_dispatch_context(
     requester_user_id: str | None = None,
     room_id: str | None = None,
     thread_id: str | None = None,
-) -> SkillToolDispatchContext:
+) -> ToolDispatchContext:
     target = (
         MessageTarget.resolve(room_id=room_id, thread_id=thread_id, reply_to_event_id=None)
         if room_id is not None
@@ -1088,6 +1092,38 @@ async def test_skill_command_tool_dispatch_context_from_runtime_context_preserve
         tenant_id=runtime_paths.env_value("CUSTOMER_ID"),
         account_id=runtime_paths.env_value("ACCOUNT_ID"),
     )
+
+
+def test_live_skill_dispatch_context_rejects_mismatched_execution_identity() -> None:
+    """Live dispatch contracts should reject identities that do not match the runtime context."""
+    config = _base_config(["dispatch"])
+    runtime_paths = resolve_runtime_paths()
+    runtime_context = ToolRuntimeContext(
+        agent_name="code",
+        room_id="!room:example.org",
+        thread_id="$thread",
+        resolved_thread_id="$thread",
+        requester_id="@alice:example.org",
+        client=AsyncMock(),
+        config=config,
+        runtime_paths=runtime_paths,
+        event_cache=make_event_cache_mock(),
+        conversation_cache=make_conversation_cache_mock(),
+    )
+
+    with pytest.raises(ValueError, match="must match the provided tool runtime context"):
+        LiveToolDispatchContext(
+            runtime_context=runtime_context,
+            execution_identity=ToolExecutionIdentity(
+                channel="matrix",
+                agent_name="other-agent",
+                requester_id="@bob:example.org",
+                room_id="!other:example.org",
+                thread_id="$other-thread",
+                resolved_thread_id="$other-thread",
+                session_id="!other:example.org:$other-thread",
+            ),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -14,8 +14,6 @@ import mindroom.tool_system.skills as skills_module
 from mindroom.commands.handler import (
     _collect_agent_toolkits,
     _run_skill_command_tool,
-    skill_tool_dispatch_context_from_runtime_context,
-    skill_tool_dispatch_context_from_target,
 )
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig
 from mindroom.config.main import Config
@@ -74,7 +72,7 @@ def _skill_dispatch_context(
         if room_id is not None
         else None
     )
-    return skill_tool_dispatch_context_from_target(
+    return ToolDispatchContext.from_target(
         agent_name=agent_name,
         runtime_paths=runtime_paths,
         requester_user_id=requester_user_id,
@@ -878,7 +876,7 @@ async def test_skill_command_tool_dispatch_uses_canonical_runtime_thread_identit
             command_tool="demo",
             skill_name="dispatch",
             args_text="hello",
-            dispatch_context=skill_tool_dispatch_context_from_runtime_context(runtime_context),
+            dispatch_context=LiveToolDispatchContext.from_runtime_context(runtime_context),
         )
     finally:
         _TOOL_REGISTRY.clear()
@@ -940,7 +938,7 @@ async def test_skill_command_tool_dispatch_ignores_raw_room_mode_thread_id() -> 
             command_tool="demo",
             skill_name="dispatch",
             args_text="hello",
-            dispatch_context=skill_tool_dispatch_context_from_runtime_context(runtime_context),
+            dispatch_context=LiveToolDispatchContext.from_runtime_context(runtime_context),
         )
     finally:
         _TOOL_REGISTRY.clear()
@@ -1022,7 +1020,7 @@ async def test_skill_command_tool_dispatch_installs_explicit_tool_runtime_contex
             command_tool="demo",
             skill_name="dispatch",
             args_text="hello",
-            dispatch_context=skill_tool_dispatch_context_from_runtime_context(runtime_context),
+            dispatch_context=LiveToolDispatchContext.from_runtime_context(runtime_context),
         )
     finally:
         _TOOL_REGISTRY.clear()
@@ -1073,7 +1071,7 @@ async def test_skill_command_tool_dispatch_context_from_runtime_context_preserve
             conversation_cache=make_conversation_cache_mock(),
         )
 
-        dispatch_context = skill_tool_dispatch_context_from_runtime_context(runtime_context)
+        dispatch_context = LiveToolDispatchContext.from_runtime_context(runtime_context)
     finally:
         _TOOL_REGISTRY.clear()
         _TOOL_REGISTRY.update(original_registry)

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -42,6 +42,7 @@ from mindroom.message_target import MessageTarget
 from mindroom.orchestrator import MultiAgentOrchestrator
 from mindroom.tool_system.metadata import _TOOL_REGISTRY, TOOL_METADATA, ToolCategory, register_tool_with_metadata
 from mindroom.tool_system.runtime_context import (
+    ToolDispatchContext,
     ToolRuntimeContext,
     emit_custom_event,
     get_plugin_state_root,
@@ -203,6 +204,14 @@ def _execution_identity() -> ToolExecutionIdentity:
         resolved_thread_id="$resolved-thread",
         session_id=_SESSION_ID,
     )
+
+
+def _dispatch_context(
+    execution_identity: ToolExecutionIdentity | None = None,
+) -> ToolDispatchContext | None:
+    if execution_identity is None:
+        return None
+    return ToolDispatchContext(execution_identity=execution_identity)
 
 
 def _agent_bot(tmp_path: Path, *, config: Config, agent_name: str = "code") -> AgentBot:
@@ -386,7 +395,7 @@ async def test_tool_hook_bridge_records_failures_without_registered_hooks(tmp_pa
     bridge = build_tool_hook_bridge(
         HookRegistry.empty(),
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
         runtime_paths=runtime_context.runtime_paths,
     )
     error = ValueError("boom {'api_key': 'secret'} https://alice:secret@example.com/private")
@@ -464,7 +473,7 @@ async def test_tool_hook_bridge_preserves_original_error_when_failure_recording_
     bridge = build_tool_hook_bridge(
         HookRegistry.from_plugins([_plugin("tool-policy", [after])]),
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
         runtime_paths=runtime_context.runtime_paths,
     )
     error = ValueError("boom")
@@ -510,7 +519,7 @@ def test_sync_function_call_execute_runs_tool_hooks(tmp_path: Path) -> None:
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -560,7 +569,7 @@ async def test_sync_tool_function_call_aexecute_runs_tool_hooks(tmp_path: Path) 
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -628,7 +637,7 @@ async def test_tool_hook_bridge_allows_call_and_populates_contexts(tmp_path: Pat
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -676,7 +685,7 @@ async def test_tool_after_call_hooks_cannot_mutate_returned_result(tmp_path: Pat
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -703,7 +712,7 @@ async def test_tool_after_call_hooks_cannot_mutate_non_deepcopyable_result(tmp_p
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -759,7 +768,7 @@ async def test_tool_hook_context_send_message_uses_bound_sender(tmp_path: Path) 
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -828,7 +837,7 @@ async def test_tool_hook_context_send_message_advances_existing_message_received
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -891,7 +900,7 @@ async def test_tool_hook_context_room_state_helpers_use_runtime_client(tmp_path:
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -969,7 +978,7 @@ async def test_agent_bot_tool_runtime_context_room_state_helpers_fallback_to_rou
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=execution_identity,
+        dispatch_context=_dispatch_context(execution_identity),
     )
     assert bridge is not None
 
@@ -1038,7 +1047,7 @@ async def test_sync_tool_aexecute_send_message_uses_request_loop(tmp_path: Path)
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -1097,14 +1106,16 @@ async def test_tool_hook_bridge_prefers_bridge_agent_name_over_nested_runtime_co
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="child-agent",
-        execution_identity=ToolExecutionIdentity(
-            channel="matrix",
-            agent_name="child-agent",
-            requester_id="@user:localhost",
-            room_id="!room:localhost",
-            thread_id="$thread",
-            resolved_thread_id="$resolved-thread",
-            session_id=_SESSION_ID,
+        dispatch_context=_dispatch_context(
+            ToolExecutionIdentity(
+                channel="matrix",
+                agent_name="child-agent",
+                requester_id="@user:localhost",
+                room_id="!room:localhost",
+                thread_id="$thread",
+                resolved_thread_id="$resolved-thread",
+                session_id=_SESSION_ID,
+            ),
         ),
     )
     assert bridge is not None
@@ -1137,14 +1148,16 @@ async def test_tool_hook_bridge_does_not_merge_explicit_identity_with_ambient_id
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="child-agent",
-        execution_identity=ToolExecutionIdentity(
-            channel="matrix",
-            agent_name="child-agent",
-            requester_id=None,
-            room_id=None,
-            thread_id=None,
-            resolved_thread_id=None,
-            session_id=None,
+        dispatch_context=_dispatch_context(
+            ToolExecutionIdentity(
+                channel="matrix",
+                agent_name="child-agent",
+                requester_id=None,
+                room_id=None,
+                thread_id=None,
+                resolved_thread_id=None,
+                session_id=None,
+            ),
         ),
     )
     assert bridge is not None
@@ -1174,14 +1187,16 @@ async def test_tool_hook_bridge_does_not_merge_explicit_identity_with_ambient_ru
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="child-agent",
-        execution_identity=ToolExecutionIdentity(
-            channel="matrix",
-            agent_name="child-agent",
-            requester_id=None,
-            room_id=None,
-            thread_id=None,
-            resolved_thread_id=None,
-            session_id=None,
+        dispatch_context=_dispatch_context(
+            ToolExecutionIdentity(
+                channel="matrix",
+                agent_name="child-agent",
+                requester_id=None,
+                room_id=None,
+                thread_id=None,
+                resolved_thread_id=None,
+                session_id=None,
+            ),
         ),
     )
     assert bridge is not None
@@ -1214,7 +1229,7 @@ async def test_tool_hook_bridge_declines_and_skips_real_tool(tmp_path: Path) -> 
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -1245,7 +1260,7 @@ async def test_tool_hook_bridge_reraises_tool_errors_after_after_call(tmp_path: 
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -1282,7 +1297,7 @@ async def test_tool_after_call_hooks_cannot_mutate_reraised_non_deepcopyable_err
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 
@@ -1518,7 +1533,7 @@ async def test_tool_hook_bridge_fails_open_when_before_hook_raises(tmp_path: Pat
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        dispatch_context=_dispatch_context(_execution_identity()),
     )
     assert bridge is not None
 

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -67,6 +67,8 @@ type SyncBridgeEvent = (
     | tuple[Literal["after"], str, bool, str]
 )
 
+_SESSION_ID = "!room:localhost:$resolved-thread"
+
 
 class NonDeepcopyableResult:
     """Mutable result object that deliberately breaks deepcopy()."""
@@ -152,7 +154,7 @@ def _before_context(
         room_id=room_id,
         thread_id="$thread",
         requester_id="@user:localhost",
-        session_id="session-1",
+        session_id=_SESSION_ID,
         config=config,
         runtime_paths=runtime_paths_for(config),
         correlation_id="corr-tool",
@@ -181,6 +183,7 @@ def _tool_runtime_context(
         runtime_paths=runtime_paths_for(config),
         event_cache=make_event_cache_mock(),
         conversation_cache=make_conversation_cache_mock(),
+        session_id=_SESSION_ID,
         correlation_id="corr-runtime",
         hook_registry=hook_registry or HookRegistry.empty(),
         hook_message_sender=hook_message_sender,
@@ -198,7 +201,7 @@ def _execution_identity() -> ToolExecutionIdentity:
         room_id="!room:localhost",
         thread_id="$thread",
         resolved_thread_id="$resolved-thread",
-        session_id="session-1",
+        session_id=_SESSION_ID,
     )
 
 
@@ -254,7 +257,7 @@ def test_tool_before_call_context_decline_helper() -> None:
         room_id="!room:localhost",
         thread_id="$thread",
         requester_id="@user:localhost",
-        session_id="session-1",
+        session_id=_SESSION_ID,
     )
 
     context.decline("blocked")
@@ -436,7 +439,7 @@ async def test_tool_hook_bridge_records_failures_without_registered_hooks(tmp_pa
     assert records[0]["room_id"] == "!room:localhost"
     assert records[0]["thread_id"] == "$resolved-thread"
     assert records[0]["requester_id"] == "@user:localhost"
-    assert records[0]["session_id"] == "session-1"
+    assert records[0]["session_id"] == _SESSION_ID
     assert records[0]["correlation_id"] == "corr-runtime"
     assert records[0]["error_type"] == "ValueError"
     assert records[0]["arguments"] == {
@@ -644,7 +647,7 @@ async def test_tool_hook_bridge_allows_call_and_populates_contexts(tmp_path: Pat
             "!room:localhost",
             "$resolved-thread",
             "@user:localhost",
-            "session-1",
+            _SESSION_ID,
         ),
     ]
     assert after_seen == [
@@ -655,7 +658,7 @@ async def test_tool_hook_bridge_allows_call_and_populates_contexts(tmp_path: Pat
             "!room:localhost",
             "$resolved-thread",
             "@user:localhost",
-            "session-1",
+            _SESSION_ID,
         ),
     ]
 
@@ -957,23 +960,26 @@ async def test_agent_bot_tool_runtime_context_room_state_helpers_fallback_to_rou
         seen.append((query_result, put_result))
 
     registry = HookRegistry.from_plugins([_plugin("tool-policy", [before])])
+    target = MessageTarget.resolve("!room:localhost", "$thread", None)
+    execution_identity = bot._tool_runtime_support.build_execution_identity(
+        target=target,
+        user_id="@user:localhost",
+        session_id=target.session_id,
+    )
     bridge = build_tool_hook_bridge(
         registry,
         agent_name="code",
-        execution_identity=_execution_identity(),
+        execution_identity=execution_identity,
     )
     assert bridge is not None
 
     async def next_func(**kwargs: object) -> dict[str, object]:
         return {"echo": kwargs["path"]}
 
-    runtime_context = bot._tool_runtime_support.build_context(
-        MessageTarget.resolve("!room:localhost", "$thread", None),
-        user_id="@user:localhost",
-    )
+    runtime_context = bot._tool_runtime_support.build_context(target, user_id="@user:localhost")
     assert runtime_context is not None
 
-    with tool_runtime_context(runtime_context), tool_execution_identity(_execution_identity()):
+    with tool_runtime_context(runtime_context), tool_execution_identity(execution_identity):
         result = await bridge("read_file", next_func, {"path": "notes.txt"})
 
     assert result == {"echo": "notes.txt"}
@@ -1098,7 +1104,7 @@ async def test_tool_hook_bridge_prefers_bridge_agent_name_over_nested_runtime_co
             room_id="!room:localhost",
             thread_id="$thread",
             resolved_thread_id="$resolved-thread",
-            session_id="session-1",
+            session_id=_SESSION_ID,
         ),
     )
     assert bridge is not None
@@ -1378,7 +1384,7 @@ async def test_agent_bot_tool_runtime_context_routes_custom_events_from_tool_hoo
             execution_identity = bot._tool_runtime_support.build_execution_identity(
                 target=target,
                 user_id="@user:localhost",
-                session_id="session-1",
+                session_id=target.session_id,
             )
             toolkit = next(tool for tool in bot.agent.tools if tool.name == "tool-hooks-runtime-demo")
             function = _first_function(toolkit)
@@ -1389,7 +1395,7 @@ async def test_agent_bot_tool_runtime_context_routes_custom_events_from_tool_hoo
         assert result.status == "success"
         assert result.result == "HI"
         assert before_seen == [
-            ("!room:localhost", "$thread", "@user:localhost", "session-1"),
+            ("!room:localhost", "$thread", "@user:localhost", target.session_id),
         ]
         assert seen == [
             (


### PR DESCRIPTION
## Summary
- collapse runtime and dispatch handling around explicit live and detached contracts
- thread the canonical dispatch contract through response execution, skill commands, hook bridges, and scheduler tools
- update tests and add a short runtime-contract note for developers

## Verification
- uv run pytest tests/test_tool_hooks.py tests/test_skills.py tests/test_hook_sender.py tests/test_bot_scheduling.py tests/test_scheduler_tool.py tests/test_schedule_agent_validation.py tests/test_scheduling.py tests/test_workflow_scheduling.py -x -n 0 --no-cov -v
- uv run pytest tests/test_ai_user_id.py -k streaming_tool_context_cleanup_survives_cross_task_close -x -n 0 --no-cov -v
- uv run ruff check src/mindroom/tool_system/runtime_context.py src/mindroom/tool_system/tool_hooks.py tests/test_ai_user_id.py tests/test_skills.py
- uv run ruff format --check src/mindroom/tool_system/runtime_context.py src/mindroom/tool_system/tool_hooks.py tests/test_ai_user_id.py tests/test_skills.py