### PR TITLE
refactor: collapse Kubernetes worker snapshot plumbing

### DIFF
--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -57,9 +57,9 @@ from mindroom.tool_system.dependencies import auto_install_enabled, auto_install
 from mindroom.tool_system.sandbox_proxy import sandbox_proxy_config
 from mindroom.workers.runtime import (
     get_primary_worker_manager,
+    maybe_serialized_kubernetes_worker_validation_snapshot,
     primary_worker_backend_available,
     primary_worker_backend_name,
-    serialized_kubernetes_worker_validation_snapshot,
 )
 
 if TYPE_CHECKING:
@@ -156,6 +156,7 @@ def _cleanup_workers_once(
 ) -> int:
     """Run one idle-worker cleanup pass when a backend is configured."""
     proxy_config = sandbox_proxy_config(runtime_paths)
+    backend_name = primary_worker_backend_name(runtime_paths)
     if not primary_worker_backend_available(
         runtime_paths,
         proxy_url=proxy_config.proxy_url,
@@ -163,21 +164,18 @@ def _cleanup_workers_once(
     ):
         return 0
 
-    if runtime_config is None and primary_worker_backend_name(runtime_paths) == "kubernetes":
+    if runtime_config is None and backend_name == "kubernetes":
         return 0
 
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
-    if runtime_config is not None and primary_worker_backend_name(runtime_paths) == "kubernetes":
-        kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
-            runtime_paths,
-            runtime_config=runtime_config,
-        )
     worker_manager = get_primary_worker_manager(
         runtime_paths,
         proxy_url=proxy_config.proxy_url,
         proxy_token=proxy_config.proxy_token,
         storage_root=runtime_paths.storage_root,
-        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
+        kubernetes_tool_validation_snapshot=maybe_serialized_kubernetes_worker_validation_snapshot(
+            runtime_paths,
+            runtime_config=runtime_config,
+        ),
     )
     cleaned_workers = worker_manager.cleanup_idle_workers()
     if cleaned_workers:

--- a/src/mindroom/api/workers.py
+++ b/src/mindroom/api/workers.py
@@ -11,9 +11,8 @@ from mindroom.api import config_lifecycle
 from mindroom.tool_system.sandbox_proxy import sandbox_proxy_config
 from mindroom.workers.runtime import (
     get_primary_worker_manager,
+    maybe_serialized_kubernetes_worker_validation_snapshot,
     primary_worker_backend_available,
-    primary_worker_backend_name,
-    serialized_kubernetes_worker_validation_snapshot,
 )
 
 if TYPE_CHECKING:
@@ -82,18 +81,15 @@ def _worker_manager(request: Request) -> WorkerManager:
         proxy_token=proxy_config.proxy_token,
     ):
         raise HTTPException(status_code=503, detail="Worker backend is not configured.")
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
-    if primary_worker_backend_name(runtime_paths) == "kubernetes":
-        kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
-            runtime_paths,
-            runtime_config=runtime_config,
-        )
     return get_primary_worker_manager(
         runtime_paths,
         proxy_url=proxy_config.proxy_url,
         proxy_token=proxy_config.proxy_token,
         storage_root=runtime_paths.storage_root,
-        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
+        kubernetes_tool_validation_snapshot=maybe_serialized_kubernetes_worker_validation_snapshot(
+            runtime_paths,
+            runtime_config=runtime_config,
+        ),
     )
 
 

--- a/src/mindroom/tool_system/sandbox_proxy.py
+++ b/src/mindroom/tool_system/sandbox_proxy.py
@@ -25,9 +25,9 @@ from mindroom.tool_system.worker_routing import (
 from mindroom.workers.models import WorkerHandle, WorkerSpec, worker_api_endpoint
 from mindroom.workers.runtime import (
     get_primary_worker_manager,
+    maybe_serialized_kubernetes_worker_validation_snapshot,
     primary_worker_backend_available,
     primary_worker_backend_name,
-    serialized_kubernetes_worker_validation_snapshot,
 )
 
 if TYPE_CHECKING:
@@ -361,18 +361,15 @@ def _get_worker_manager(
     storage_root = (
         context.storage_path if context is not None and context.storage_path is not None else runtime_paths.storage_root
     )
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
-    if context is not None and primary_worker_backend_name(runtime_paths) == "kubernetes":
-        kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
-            runtime_paths,
-            runtime_config=context.config,
-        )
     return get_primary_worker_manager(
         runtime_paths,
         proxy_url=proxy_config.proxy_url,
         proxy_token=proxy_config.proxy_token,
         storage_root=storage_root,
-        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
+        kubernetes_tool_validation_snapshot=maybe_serialized_kubernetes_worker_validation_snapshot(
+            runtime_paths,
+            runtime_config=context.config if context is not None else None,
+        ),
     )
 
 

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -26,19 +26,15 @@ _PRIMARY_WORKER_MANAGER_LOCK = threading.Lock()
 def serialized_kubernetes_worker_validation_snapshot(
     runtime_paths: RuntimePaths,
     *,
-    runtime_config: Config | None = None,
+    runtime_config: Config,
 ) -> dict[str, dict[str, object]]:
     """Build the authoritative worker validation snapshot in the primary runtime."""
-    from mindroom.config.main import load_config  # noqa: PLC0415
     from mindroom.tool_system.metadata import (  # noqa: PLC0415
         resolved_tool_validation_snapshot_for_runtime,
         serialize_tool_validation_snapshot,
     )
 
-    snapshot = resolved_tool_validation_snapshot_for_runtime(
-        runtime_paths,
-        runtime_config or load_config(runtime_paths),
-    )
+    snapshot = resolved_tool_validation_snapshot_for_runtime(runtime_paths, runtime_config)
     return serialize_tool_validation_snapshot(snapshot)
 
 
@@ -76,6 +72,20 @@ def primary_worker_backend_available(
             return False
         return True
     return False
+
+
+def maybe_serialized_kubernetes_worker_validation_snapshot(
+    runtime_paths: RuntimePaths,
+    *,
+    runtime_config: Config | None,
+) -> dict[str, dict[str, object]] | None:
+    """Return the committed Kubernetes validation snapshot when one is available."""
+    if runtime_config is None or primary_worker_backend_name(runtime_paths) != "kubernetes":
+        return None
+    return serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=runtime_config,
+    )
 
 
 def _require_kubernetes_tool_validation_snapshot(

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -121,15 +121,16 @@ def _primary_worker_backend_config_signature(
     if backend_name == "static_runner":
         return _static_runner_backend_config_signature(proxy_url=proxy_url, proxy_token=proxy_token)
     if backend_name == "kubernetes":
+        backend_signature = kubernetes_backend_config_signature(
+            runtime_paths,
+            auth_token=proxy_token,
+            storage_root=storage_root,
+        )
         kubernetes_tool_validation_snapshot = _require_kubernetes_tool_validation_snapshot(
             kubernetes_tool_validation_snapshot,
         )
         return (
-            *kubernetes_backend_config_signature(
-                runtime_paths,
-                auth_token=proxy_token,
-                storage_root=storage_root,
-            ),
+            *backend_signature,
             json.dumps(kubernetes_tool_validation_snapshot, separators=(",", ":"), sort_keys=True),
         )
     msg = f"Unsupported worker backend: {backend_name}"

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -995,6 +995,11 @@ def test_worker_cleanup_once_cleans_workers(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME", "mindroom-storage")
     monkeypatch.setattr(main, "primary_worker_backend_available", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(main, "primary_worker_backend_name", lambda *_args, **_kwargs: "kubernetes")
+    monkeypatch.setattr(
+        main,
+        "maybe_serialized_kubernetes_worker_validation_snapshot",
+        lambda *_args, **_kwargs: {"calculator": {"runtime_loadable": True}},
+    )
     captured_kwargs: dict[str, object] = {}
 
     def _fake_get_primary_worker_manager(*_args: object, **kwargs: object) -> _FakeWorkerManager:
@@ -1033,7 +1038,11 @@ def test_list_workers_endpoint(test_client: TestClient, monkeypatch: pytest.Monk
     monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_IMAGE", "ghcr.io/mindroom-ai/mindroom:latest")
     monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME", "mindroom-storage")
     monkeypatch.setattr(workers_api, "primary_worker_backend_available", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(workers_api, "primary_worker_backend_name", lambda *_args, **_kwargs: "kubernetes")
+    monkeypatch.setattr(
+        workers_api,
+        "maybe_serialized_kubernetes_worker_validation_snapshot",
+        lambda *_args, **_kwargs: {"calculator": {"runtime_loadable": True}},
+    )
     captured_kwargs: dict[str, object] = {}
 
     def _fake_get_primary_worker_manager(*_args: object, **kwargs: object) -> _FakeWorkerManager:

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -1480,6 +1480,27 @@ def test_get_worker_manager_rebuilds_kubernetes_backend_when_validation_snapshot
     workers_runtime_module._reset_primary_worker_manager()
 
 
+def test_maybe_serialized_kubernetes_worker_validation_snapshot_skips_without_runtime_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Optional snapshot helper should no-op until the caller has a committed runtime config."""
+    monkeypatch.setenv("MINDROOM_WORKER_BACKEND", "kubernetes")
+    runtime_paths = _configure_proxy_runtime(
+        monkeypatch,
+        proxy_url=None,
+        proxy_token=_TEST_AUTH_TOKEN,
+        execution_mode="off",
+    )
+
+    assert (
+        workers_runtime_module.maybe_serialized_kubernetes_worker_validation_snapshot(
+            runtime_paths,
+            runtime_config=None,
+        )
+        is None
+    )
+
+
 def test_get_primary_worker_manager_requires_explicit_snapshot_for_kubernetes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- remove the remaining disk-loading fallback from the Kubernetes worker validation snapshot helper
- collapse repeated Kubernetes snapshot construction in the API, sandbox proxy, and cleanup paths into one shared helper
- extend regression coverage for the optional snapshot helper and the stricter caller boundary

## Test Plan
- `uv run pytest tests/api/test_sandbox_runner_api.py tests/test_dynamic_toolkits.py tests/test_kubernetes_worker_backend.py tests/test_sandbox_proxy.py tests/test_tools_metadata.py tests/api/test_api.py -k 'worker_runtime or missing_plugins or mcp or validation_snapshot or rereading_disk or committed_snapshot or get_worker_manager or cleanup_workers_once or get_tool_by_name_rejects_invalid_mcp_assignment_overrides or maybe_serialized_kubernetes_worker_validation_snapshot' -x -n 0 --no-cov -q`
