### PR TITLE
Fix strict dispatch thread cache reuse

### DIFF
--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 import nio
 from aiohttp import ClientError
 from nio import crypto
-from nio.api import Api, RelationshipType
+from nio.api import Api
 from nio.responses import RoomThreadsResponse
 
 from mindroom.constants import STREAM_STATUS_KEY, RuntimePaths, encryption_keys_dir, runtime_matrix_ssl_verify
@@ -1582,8 +1582,6 @@ async def _resolve_thread_history_from_event_sources_timed(
     thread_id: str,
     event_sources: Sequence[dict[str, Any]],
     hydrate_sidecars: bool = True,
-    room_id: str | None = None,
-    event_cache: ConversationEventCache | None = None,
 ) -> tuple[list[ResolvedVisibleMessage], float]:
     """Resolve visible thread history and return approximate sidecar hydration time."""
     input_order_by_event_id: dict[str, int] = {}
@@ -1632,13 +1630,6 @@ async def _resolve_thread_history_from_event_sources_timed(
         latest_edits_by_original_event_id=latest_edits_by_original_event_id,
         required_thread_id=thread_id,
     )
-    if room_id is not None and event_cache is not None:
-        await _overlay_cached_latest_thread_edits(
-            client,
-            room_id=room_id,
-            event_cache=event_cache,
-            messages_by_event_id=messages_by_event_id,
-        )
     messages = list(messages_by_event_id.values())
     _sort_thread_history_root_first(
         messages,
@@ -1722,8 +1713,6 @@ async def _resolve_cached_thread_history(
             thread_id=thread_id,
             event_sources=cached_event_sources,
             hydrate_sidecars=hydrate_sidecars,
-            room_id=room_id,
-            event_cache=event_cache,
         )
     except Exception as exc:
         logger.warning(
@@ -1805,30 +1794,14 @@ async def _fetch_thread_history_with_events(
     thread_id: str,
     *,
     hydrate_sidecars: bool,
-    event_cache: ConversationEventCache,
 ) -> _ThreadHistoryFetchResult:
     """Fetch thread history and raw event sources from the homeserver."""
-    try:
-        return await _fetch_thread_history_via_relations_with_events(
-            client,
-            room_id,
-            thread_id,
-            hydrate_sidecars=hydrate_sidecars,
-            event_cache=event_cache,
-        )
-    except Exception as exc:
-        logger.info(
-            "Thread relations fetch failed; falling back to room scan",
-            room_id=room_id,
-            thread_id=thread_id,
-            error=str(exc),
-        )
-        return await _fetch_thread_history_via_room_messages_with_events(
-            client,
-            room_id,
-            thread_id,
-            hydrate_sidecars=hydrate_sidecars,
-        )
+    return await _fetch_thread_history_via_room_messages_with_events(
+        client,
+        room_id,
+        thread_id,
+        hydrate_sidecars=hydrate_sidecars,
+    )
 
 
 async def refresh_thread_history_from_source(
@@ -1847,7 +1820,6 @@ async def refresh_thread_history_from_source(
             room_id,
             thread_id,
             hydrate_sidecars=hydrate_sidecars,
-            event_cache=event_cache,
         )
     except Exception as exc:
         if allow_stale_fallback:
@@ -2017,35 +1989,6 @@ async def _apply_latest_edits_to_messages(
         )
         synthesized_message.refresh_stream_status()
         messages_by_event_id[original_event_id] = synthesized_message
-
-
-async def _overlay_cached_latest_thread_edits(
-    client: nio.AsyncClient,
-    *,
-    room_id: str,
-    event_cache: ConversationEventCache,
-    messages_by_event_id: dict[str, ResolvedVisibleMessage],
-) -> None:
-    """Overlay cached latest edits onto already-fetched thread messages."""
-    latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]] = {}
-    for original_event_id in list(messages_by_event_id):
-        latest_edit_source = await event_cache.get_latest_edit(room_id, original_event_id)
-        if latest_edit_source is None:
-            continue
-        parsed_edit = _parse_visible_text_message_event(latest_edit_source)
-        if parsed_edit is None:
-            continue
-        _record_latest_thread_edit(
-            parsed_edit,
-            event_info=EventInfo.from_event(parsed_edit.source),
-            latest_edits_by_original_event_id=latest_edits_by_original_event_id,
-        )
-    if latest_edits_by_original_event_id:
-        await _apply_latest_edits_to_messages(
-            client,
-            messages_by_event_id=messages_by_event_id,
-            latest_edits_by_original_event_id=latest_edits_by_original_event_id,
-        )
 
 
 async def resolve_latest_visible_messages(
@@ -2263,33 +2206,6 @@ async def _fetch_thread_history_via_room_messages_with_events(
     )
 
 
-async def _fetch_thread_history_via_relations_with_events(
-    client: nio.AsyncClient,
-    room_id: str,
-    thread_id: str,
-    *,
-    hydrate_sidecars: bool,
-    event_cache: ConversationEventCache,
-) -> _ThreadHistoryFetchResult:
-    """Fetch thread history from the thread root plus its relations."""
-    event_sources = await _fetch_thread_event_sources_via_relations(client, room_id, thread_id)
-    resolution_started = time.perf_counter()
-    history, sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
-        client,
-        thread_id=thread_id,
-        event_sources=event_sources,
-        hydrate_sidecars=hydrate_sidecars,
-        room_id=room_id,
-        event_cache=event_cache,
-    )
-    return _ThreadHistoryFetchResult(
-        history=history,
-        event_sources=event_sources,
-        resolution_ms=round((time.perf_counter() - resolution_started) * 1000, 1),
-        sidecar_hydration_ms=sidecar_hydration_ms,
-    )
-
-
 class ThreadRoomScanRootNotFoundError(RuntimeError):
     """Raised when a room scan finishes without ever seeing the requested root event."""
 
@@ -2423,50 +2339,6 @@ async def _fetch_thread_event_sources_via_room_messages(
         if original_event_id in relevant_event_ids or edit_thread_id == thread_id
     )
     return _sort_thread_event_sources_root_first(event_sources, thread_id=thread_id), root_message_found
-
-
-async def _fetch_thread_event_sources_via_relations(
-    client: nio.AsyncClient,
-    room_id: str,
-    thread_id: str,
-) -> list[dict[str, Any]]:
-    """Fetch thread event sources from the thread root plus related thread events."""
-    root_response = await client.room_get_event(room_id, thread_id)
-    if not isinstance(root_response, nio.RoomGetEventResponse):
-        msg = f"thread root lookup failed for {thread_id}: {root_response}"
-        raise TypeError(msg)
-
-    root_event = root_response.event
-    collected_events: list[nio.Event] = [root_event]
-    async for related_event in client.room_get_event_relations(
-        room_id,
-        thread_id,
-        RelationshipType.thread,
-        "m.room.message",
-        direction=nio.MessageDirection.back,
-        limit=100,
-    ):
-        if not isinstance(related_event, nio.Event):
-            continue
-        event_info = EventInfo.from_event(related_event.source)
-        if event_info.thread_id != thread_id:
-            continue
-        if event_info.is_edit:
-            continue
-        if not _is_room_message_event(related_event):
-            continue
-        collected_events.append(related_event)
-
-    event_sources: list[dict[str, Any]] = []
-    seen_event_ids: set[str] = set()
-    for event in collected_events:
-        event_id = getattr(event, "event_id", None)
-        if not isinstance(event_id, str) or event_id in seen_event_ids:
-            continue
-        seen_event_ids.add(event_id)
-        event_sources.append(_event_source_for_cache(event))
-
-    return _sort_thread_event_sources_root_first(event_sources, thread_id=thread_id)
 
 
 async def get_room_threads_page(

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -2434,7 +2434,7 @@ async def _fetch_thread_event_sources_via_relations(
     root_response = await client.room_get_event(room_id, thread_id)
     if not isinstance(root_response, nio.RoomGetEventResponse):
         msg = f"thread root lookup failed for {thread_id}: {root_response}"
-        raise RuntimeError(msg)
+        raise TypeError(msg)
 
     root_event = root_response.event
     collected_events: list[nio.Event] = [root_event]

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 import nio
 from aiohttp import ClientError
 from nio import crypto
-from nio.api import Api
+from nio.api import Api, RelationshipType
 from nio.responses import RoomThreadsResponse
 
 from mindroom.constants import STREAM_STATUS_KEY, RuntimePaths, encryption_keys_dir, runtime_matrix_ssl_verify
@@ -1582,6 +1582,8 @@ async def _resolve_thread_history_from_event_sources_timed(
     thread_id: str,
     event_sources: Sequence[dict[str, Any]],
     hydrate_sidecars: bool = True,
+    room_id: str | None = None,
+    event_cache: ConversationEventCache | None = None,
 ) -> tuple[list[ResolvedVisibleMessage], float]:
     """Resolve visible thread history and return approximate sidecar hydration time."""
     input_order_by_event_id: dict[str, int] = {}
@@ -1630,6 +1632,13 @@ async def _resolve_thread_history_from_event_sources_timed(
         latest_edits_by_original_event_id=latest_edits_by_original_event_id,
         required_thread_id=thread_id,
     )
+    if room_id is not None and event_cache is not None:
+        await _overlay_cached_latest_thread_edits(
+            client,
+            room_id=room_id,
+            event_cache=event_cache,
+            messages_by_event_id=messages_by_event_id,
+        )
     messages = list(messages_by_event_id.values())
     _sort_thread_history_root_first(
         messages,
@@ -1713,6 +1722,8 @@ async def _resolve_cached_thread_history(
             thread_id=thread_id,
             event_sources=cached_event_sources,
             hydrate_sidecars=hydrate_sidecars,
+            room_id=room_id,
+            event_cache=event_cache,
         )
     except Exception as exc:
         logger.warning(
@@ -1794,14 +1805,30 @@ async def _fetch_thread_history_with_events(
     thread_id: str,
     *,
     hydrate_sidecars: bool,
+    event_cache: ConversationEventCache,
 ) -> _ThreadHistoryFetchResult:
     """Fetch thread history and raw event sources from the homeserver."""
-    return await _fetch_thread_history_via_room_messages_with_events(
-        client,
-        room_id,
-        thread_id,
-        hydrate_sidecars=hydrate_sidecars,
-    )
+    try:
+        return await _fetch_thread_history_via_relations_with_events(
+            client,
+            room_id,
+            thread_id,
+            hydrate_sidecars=hydrate_sidecars,
+            event_cache=event_cache,
+        )
+    except Exception as exc:
+        logger.info(
+            "Thread relations fetch failed; falling back to room scan",
+            room_id=room_id,
+            thread_id=thread_id,
+            error=str(exc),
+        )
+        return await _fetch_thread_history_via_room_messages_with_events(
+            client,
+            room_id,
+            thread_id,
+            hydrate_sidecars=hydrate_sidecars,
+        )
 
 
 async def refresh_thread_history_from_source(
@@ -1820,6 +1847,7 @@ async def refresh_thread_history_from_source(
             room_id,
             thread_id,
             hydrate_sidecars=hydrate_sidecars,
+            event_cache=event_cache,
         )
     except Exception as exc:
         if allow_stale_fallback:
@@ -1991,6 +2019,35 @@ async def _apply_latest_edits_to_messages(
         messages_by_event_id[original_event_id] = synthesized_message
 
 
+async def _overlay_cached_latest_thread_edits(
+    client: nio.AsyncClient,
+    *,
+    room_id: str,
+    event_cache: ConversationEventCache,
+    messages_by_event_id: dict[str, ResolvedVisibleMessage],
+) -> None:
+    """Overlay cached latest edits onto already-fetched thread messages."""
+    latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]] = {}
+    for original_event_id in list(messages_by_event_id):
+        latest_edit_source = await event_cache.get_latest_edit(room_id, original_event_id)
+        if latest_edit_source is None:
+            continue
+        parsed_edit = _parse_visible_text_message_event(latest_edit_source)
+        if parsed_edit is None:
+            continue
+        _record_latest_thread_edit(
+            parsed_edit,
+            event_info=EventInfo.from_event(parsed_edit.source),
+            latest_edits_by_original_event_id=latest_edits_by_original_event_id,
+        )
+    if latest_edits_by_original_event_id:
+        await _apply_latest_edits_to_messages(
+            client,
+            messages_by_event_id=messages_by_event_id,
+            latest_edits_by_original_event_id=latest_edits_by_original_event_id,
+        )
+
+
 async def resolve_latest_visible_messages(
     events: Sequence[nio.RoomMessageText | nio.RoomMessageNotice],
     client: nio.AsyncClient,
@@ -2111,8 +2168,29 @@ async def fetch_dispatch_thread_history(
     room_id: str,
     thread_id: str,
     event_cache: ConversationEventCache,
+    *,
+    runtime_started_at: float | None = None,
 ) -> ThreadHistoryResult:
-    """Fetch authoritative full thread history for dispatch without durable-cache reuse or stale fallback."""
+    """Fetch strict full thread history for dispatch using only fresh cache data or a homeserver refill."""
+    try:
+        cached_history = await _load_cached_thread_history_if_usable(
+            client,
+            room_id=room_id,
+            thread_id=thread_id,
+            event_cache=event_cache,
+            hydrate_sidecars=True,
+            runtime_started_at=runtime_started_at,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Durable dispatch thread cache read failed; refetching from homeserver",
+            room_id=room_id,
+            thread_id=thread_id,
+            error=str(exc),
+        )
+    else:
+        if cached_history is not None:
+            return cached_history
     return await refresh_thread_history_from_source(
         client,
         room_id,
@@ -2128,8 +2206,29 @@ async def fetch_dispatch_thread_snapshot(
     room_id: str,
     thread_id: str,
     event_cache: ConversationEventCache,
+    *,
+    runtime_started_at: float | None = None,
 ) -> ThreadHistoryResult:
-    """Fetch authoritative lightweight thread context for dispatch without durable-cache reuse or stale fallback."""
+    """Fetch strict lightweight dispatch context using only fresh cache data or a homeserver refill."""
+    try:
+        cached_history = await _load_cached_thread_history_if_usable(
+            client,
+            room_id=room_id,
+            thread_id=thread_id,
+            event_cache=event_cache,
+            hydrate_sidecars=False,
+            runtime_started_at=runtime_started_at,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Durable dispatch thread cache read failed; refetching snapshot from homeserver",
+            room_id=room_id,
+            thread_id=thread_id,
+            error=str(exc),
+        )
+    else:
+        if cached_history is not None:
+            return cached_history
     return await refresh_thread_history_from_source(
         client,
         room_id,
@@ -2155,6 +2254,33 @@ async def _fetch_thread_history_via_room_messages_with_events(
         thread_id=thread_id,
         event_sources=event_sources,
         hydrate_sidecars=hydrate_sidecars,
+    )
+    return _ThreadHistoryFetchResult(
+        history=history,
+        event_sources=event_sources,
+        resolution_ms=round((time.perf_counter() - resolution_started) * 1000, 1),
+        sidecar_hydration_ms=sidecar_hydration_ms,
+    )
+
+
+async def _fetch_thread_history_via_relations_with_events(
+    client: nio.AsyncClient,
+    room_id: str,
+    thread_id: str,
+    *,
+    hydrate_sidecars: bool,
+    event_cache: ConversationEventCache,
+) -> _ThreadHistoryFetchResult:
+    """Fetch thread history from the thread root plus its relations."""
+    event_sources = await _fetch_thread_event_sources_via_relations(client, room_id, thread_id)
+    resolution_started = time.perf_counter()
+    history, sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
+        client,
+        thread_id=thread_id,
+        event_sources=event_sources,
+        hydrate_sidecars=hydrate_sidecars,
+        room_id=room_id,
+        event_cache=event_cache,
     )
     return _ThreadHistoryFetchResult(
         history=history,
@@ -2297,6 +2423,50 @@ async def _fetch_thread_event_sources_via_room_messages(
         if original_event_id in relevant_event_ids or edit_thread_id == thread_id
     )
     return _sort_thread_event_sources_root_first(event_sources, thread_id=thread_id), root_message_found
+
+
+async def _fetch_thread_event_sources_via_relations(
+    client: nio.AsyncClient,
+    room_id: str,
+    thread_id: str,
+) -> list[dict[str, Any]]:
+    """Fetch thread event sources from the thread root plus related thread events."""
+    root_response = await client.room_get_event(room_id, thread_id)
+    if not isinstance(root_response, nio.RoomGetEventResponse):
+        msg = f"thread root lookup failed for {thread_id}: {root_response}"
+        raise RuntimeError(msg)
+
+    root_event = root_response.event
+    collected_events: list[nio.Event] = [root_event]
+    async for related_event in client.room_get_event_relations(
+        room_id,
+        thread_id,
+        RelationshipType.thread,
+        "m.room.message",
+        direction=nio.MessageDirection.back,
+        limit=100,
+    ):
+        if not isinstance(related_event, nio.Event):
+            continue
+        event_info = EventInfo.from_event(related_event.source)
+        if event_info.thread_id != thread_id:
+            continue
+        if event_info.is_edit:
+            continue
+        if not _is_room_message_event(related_event):
+            continue
+        collected_events.append(related_event)
+
+    event_sources: list[dict[str, Any]] = []
+    seen_event_ids: set[str] = set()
+    for event in collected_events:
+        event_id = getattr(event, "event_id", None)
+        if not isinstance(event_id, str) or event_id in seen_event_ids:
+            continue
+        seen_event_ids.add(event_id)
+        event_sources.append(_event_source_for_cache(event))
+
+    return _sort_thread_event_sources_root_first(event_sources, thread_id=thread_id)
 
 
 async def get_room_threads_page(

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -17,6 +17,7 @@ from mindroom.matrix.cache import (
     ThreadReadPolicy,
     ThreadWritePolicy,
     normalize_nio_event_for_cache,
+    thread_history_result,
 )
 from mindroom.matrix.client import (
     fetch_dispatch_thread_history,
@@ -38,6 +39,7 @@ if TYPE_CHECKING:
 
 type ThreadReadResult = ThreadHistoryResult
 type EventLookupResult = nio.RoomGetEventResponse | RoomGetEventError
+type ThreadReadCacheKey = tuple[str, str, bool, bool]
 
 logger = get_logger(__name__)
 
@@ -98,14 +100,14 @@ class ConversationCacheProtocol(Protocol):
         room_id: str,
         thread_id: str,
     ) -> ThreadReadResult:
-        """Resolve strict dispatch thread context without durable-cache reuse or stale fallback."""
+        """Resolve strict dispatch thread context using only fresh cache data or a homeserver refill."""
 
     async def get_dispatch_thread_history(
         self,
         room_id: str,
         thread_id: str,
     ) -> ThreadReadResult:
-        """Resolve strict full thread history for dispatch without durable-cache reuse or stale fallback."""
+        """Resolve strict full dispatch thread history using only fresh cache data or a homeserver refill."""
 
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
         """Resolve the cached thread root for one event when known."""
@@ -269,6 +271,9 @@ class MatrixConversationCache(ConversationCacheProtocol):
     _turn_event_cache: ContextVar[dict[tuple[str, str], _TurnEventLookup] | None] = field(
         default_factory=lambda: ContextVar("mindroom_turn_event_lookup_cache", default=None),
     )
+    _turn_thread_read_cache: ContextVar[dict[ThreadReadCacheKey, ThreadReadResult] | None] = field(
+        default_factory=lambda: ContextVar("mindroom_turn_thread_read_cache", default=None),
+    )
     _reads: ThreadReadPolicy = field(init=False, repr=False)
     _writes: ThreadWritePolicy = field(init=False, repr=False)
 
@@ -298,17 +303,54 @@ class MatrixConversationCache(ConversationCacheProtocol):
 
     @asynccontextmanager
     async def turn_scope(self) -> AsyncIterator[None]:
-        """Memoize event lookups for the lifetime of one inbound turn."""
+        """Memoize event lookups and thread reads for the lifetime of one inbound turn."""
         turn_lookup_cache = self._turn_event_cache.get()
-        if turn_lookup_cache is not None:
+        turn_thread_cache = self._turn_thread_read_cache.get()
+        if turn_lookup_cache is not None and turn_thread_cache is not None:
             yield
             return
 
         event_token = self._turn_event_cache.set({})
+        thread_token = self._turn_thread_read_cache.set({})
         try:
             yield
         finally:
+            self._turn_thread_read_cache.reset(thread_token)
             self._turn_event_cache.reset(event_token)
+
+    @staticmethod
+    def _copy_thread_read_result(result: ThreadReadResult) -> ThreadReadResult:
+        """Return a detached copy suitable for per-turn memoization."""
+        return thread_history_result(
+            list(result),
+            is_full_history=result.is_full_history,
+            diagnostics=result.diagnostics,
+        )
+
+    async def _read_thread_memoized(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        full_history: bool,
+        dispatch_safe: bool,
+    ) -> ThreadReadResult:
+        """Resolve one thread read through per-turn memoization."""
+        cache_key: ThreadReadCacheKey = (room_id, thread_id, full_history, dispatch_safe)
+        turn_cache = self._turn_thread_read_cache.get()
+        if turn_cache is not None and cache_key in turn_cache:
+            return self._copy_thread_read_result(turn_cache[cache_key])
+
+        result = await self._reads.read_thread(
+            room_id,
+            thread_id,
+            full_history=full_history,
+            dispatch_safe=dispatch_safe,
+        )
+        if turn_cache is not None:
+            turn_cache[cache_key] = self._copy_thread_read_result(result)
+            return self._copy_thread_read_result(turn_cache[cache_key])
+        return result
 
     async def get_event(
         self,
@@ -439,6 +481,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             room_id,
             thread_id,
             event_cache=self.runtime.event_cache,
+            runtime_started_at=self.runtime.runtime_started_at,
         )
 
     async def _fetch_dispatch_thread_snapshot_from_client(
@@ -451,6 +494,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             room_id,
             thread_id,
             event_cache=self.runtime.event_cache,
+            runtime_started_at=self.runtime.runtime_started_at,
         )
 
     async def get_thread_snapshot(
@@ -459,7 +503,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
         thread_id: str,
     ) -> ThreadReadResult:
         """Resolve advisory thread context for non-dispatch callers."""
-        return await self._reads.read_thread(
+        return await self._read_thread_memoized(
             room_id,
             thread_id,
             full_history=False,
@@ -472,7 +516,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
         thread_id: str,
     ) -> ThreadReadResult:
         """Resolve advisory full thread history for one conversation root."""
-        return await self._reads.read_thread(
+        return await self._read_thread_memoized(
             room_id,
             thread_id,
             full_history=True,
@@ -501,8 +545,8 @@ class MatrixConversationCache(ConversationCacheProtocol):
         room_id: str,
         thread_id: str,
     ) -> ThreadReadResult:
-        """Resolve strict dispatch thread context without durable-cache reuse or stale fallback."""
-        return await self._reads.read_thread(
+        """Resolve strict dispatch thread context using only fresh cache data or a homeserver refill."""
+        return await self._read_thread_memoized(
             room_id,
             thread_id,
             full_history=False,
@@ -514,8 +558,8 @@ class MatrixConversationCache(ConversationCacheProtocol):
         room_id: str,
         thread_id: str,
     ) -> ThreadReadResult:
-        """Resolve strict full thread history for dispatch without durable-cache reuse or stale fallback."""
-        return await self._reads.read_thread(
+        """Resolve strict full dispatch thread history using only fresh cache data or a homeserver refill."""
+        return await self._read_thread_memoized(
             room_id,
             thread_id,
             full_history=True,

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -6967,6 +6967,7 @@ class TestAgentBot:
             room.room_id,
             "$thread_root",
             event_cache=bot.event_cache,
+            runtime_started_at=bot._runtime_view.runtime_started_at,
         )
 
     @pytest.mark.asyncio

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -459,7 +459,7 @@ class TestThreadHistory:
             },
         )
         event_cache = make_event_cache_mock()
-        event_cache.get_latest_edit.side_effect = lambda room_id, event_id: {
+        event_cache.get_latest_edit.side_effect = lambda _room_id, event_id: {
             "$reply": _event_source_for_cache(newer_edit),
         }.get(event_id)
 

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -167,16 +167,17 @@ class TestThreadHistory:
         def room_get_event_relations(
             _room_id: str,
             event_id: str,
-            *,
             rel_type: RelationshipType | None = None,
             event_type: str | None = None,
+            *,
             direction: nio.MessageDirection = nio.MessageDirection.back,
             limit: int | None = None,
         ) -> object:
             assert rel_type is not None
             assert event_type is not None
             key = (event_id, rel_type, event_type, direction, limit)
-            value = relations.get(key, [])
+            fallback_key = (event_id, rel_type, event_type, direction, None)
+            value = relations.get(key, relations.get(fallback_key, []))
 
             async def iterator() -> object:
                 if isinstance(value, Exception):
@@ -242,6 +243,7 @@ class TestThreadHistory:
             "!room:localhost",
             "$thread_root",
             hydrate_sidecars=True,
+            event_cache=event_cache,
         )
         mock_store.assert_awaited_once_with(
             event_cache,
@@ -251,8 +253,8 @@ class TestThreadHistory:
         )
 
     @pytest.mark.asyncio
-    async def test_fetch_thread_history_uses_room_scan_instead_of_relations_fast_path(self) -> None:
-        """Thread history should use the single room-scan fetch path instead of a separate relations fast path."""
+    async def test_fetch_thread_history_prefers_relations_before_room_scan(self) -> None:
+        """Thread history should prefer the relations fetch path before falling back to room scans."""
         root_event = self._make_text_event(
             event_id="$thread_root",
             sender="@user:localhost",
@@ -280,20 +282,22 @@ class TestThreadHistory:
                 "m.relates_to": {"rel_type": "m.thread", "event_id": "$other_root"},
             },
         )
-        client = MagicMock()
-        client.room_get_event = AsyncMock(side_effect=AssertionError("should not use relations root lookup"))
-        client.room_get_event_relations = MagicMock(side_effect=AssertionError("should not use relations fast path"))
-        page = MagicMock(spec=nio.RoomMessagesResponse)
-        page.chunk = [unrelated_relation, thread_event, root_event]
-        page.end = None
-        client.room_messages = AsyncMock(return_value=page)
+        client = self._make_relations_client(
+            root_event=root_event,
+            relations={
+                self._relation_key("$thread_root", RelationshipType.thread): [
+                    unrelated_relation,
+                    thread_event,
+                ],
+            },
+        )
 
         history = await fetch_thread_history(client, "!room:localhost", "$thread_root")
 
         assert [message.event_id for message in history] == ["$thread_root", "$reply"]
         assert history[0].body == "Root message"
         assert history[1].body == "Reply in thread"
-        client.room_messages.assert_awaited_once()
+        client.room_messages.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_fetch_thread_history_uses_bundled_root_edit_without_replacement_lookup(self) -> None:
@@ -345,7 +349,14 @@ class TestThreadHistory:
 
         assert history[0].event_id == "$thread_root"
         assert history[0].body == "Updated root"
-        client.room_get_event_relations.assert_not_called()
+        client.room_get_event_relations.assert_called_once_with(
+            "!room:localhost",
+            "$thread_root",
+            RelationshipType.thread,
+            "m.room.message",
+            direction=nio.MessageDirection.back,
+            limit=100,
+        )
 
     @pytest.mark.asyncio
     async def test_fetch_thread_history_uses_nested_bundled_root_edit_without_validation_noise(
@@ -426,21 +437,6 @@ class TestThreadHistory:
                 "io.mindroom.stream_status": "pending",
             },
         )
-        older_edit = self._make_text_event(
-            event_id="$edit_a",
-            sender="@agent:localhost",
-            body="* partial",
-            server_timestamp=3000,
-            source_content={
-                "body": "* partial",
-                "m.new_content": {
-                    "body": "Partial",
-                    "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
-                    "io.mindroom.stream_status": "pending",
-                },
-                "m.relates_to": {"rel_type": "m.replace", "event_id": "$reply"},
-            },
-        )
         newer_edit = self._make_text_event(
             event_id="$edit_b",
             sender="@agent:localhost",
@@ -460,12 +456,19 @@ class TestThreadHistory:
             root_event=root_event,
             relations={
                 self._relation_key("$thread_root", RelationshipType.thread): [thread_event],
-                self._relation_key("$thread_root", RelationshipType.replacement): [],
-                self._relation_key("$reply", RelationshipType.replacement): [older_edit, newer_edit],
             },
         )
+        event_cache = make_event_cache_mock()
+        event_cache.get_latest_edit.side_effect = lambda room_id, event_id: {
+            "$reply": _event_source_for_cache(newer_edit),
+        }.get(event_id)
 
-        history = await fetch_thread_history(client, "!room:localhost", "$thread_root")
+        history = await fetch_thread_history(
+            client,
+            "!room:localhost",
+            "$thread_root",
+            event_cache=event_cache,
+        )
 
         assert [message.event_id for message in history] == ["$thread_root", "$reply"]
         assert history[1].body == "Final answer"
@@ -548,6 +551,10 @@ class TestThreadHistory:
         fallback_history = [{"event_id": "$thread_root", "body": "fallback"}]
 
         with (
+            patch(
+                "mindroom.matrix.client._fetch_thread_history_via_relations_with_events",
+                new=AsyncMock(side_effect=RuntimeError("relations failed")),
+            ),
             patch(
                 "mindroom.matrix.client._fetch_thread_history_via_room_messages_with_events",
                 new=AsyncMock(
@@ -2068,6 +2075,7 @@ async def test_get_room_threads_page_wraps_aiohttp_client_errors() -> None:
 class TestThreadHistoryCache:
     """Focused tests for the persistent thread-history cache."""
 
+    _make_audio_event = staticmethod(TestThreadHistory._make_audio_event)
     _make_text_event = staticmethod(TestThreadHistory._make_text_event)
     _relation_key = staticmethod(TestThreadHistory._relation_key)
 
@@ -2225,6 +2233,103 @@ class TestThreadHistoryCache:
         assert snapshot[0].to_dict()["msgtype"] == "m.audio"
         assert snapshot.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_CACHE
         client.room_messages.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fetch_dispatch_thread_history_uses_fresh_durable_cache(self, tmp_path: Path) -> None:
+        """Strict dispatch history should reuse fresh durable cache instead of refetching."""
+        cache = _EventCache(tmp_path / "event_cache.db")
+        await cache.initialize()
+
+        root_event = self._make_text_event(
+            event_id="$thread_root",
+            sender="@user:localhost",
+            body="Root message",
+            server_timestamp=1000,
+            source_content={"body": "Root message"},
+        )
+        reply_event = self._make_text_event(
+            event_id="$reply",
+            sender="@agent:localhost",
+            body="Cached reply",
+            server_timestamp=2000,
+            source_content={
+                "body": "Cached reply",
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+        )
+        await self._seed_thread_cache(
+            cache,
+            room_id="!room:localhost",
+            thread_id="$thread_root",
+            events=[self._cache_source(root_event), self._cache_source(reply_event)],
+        )
+
+        client = MagicMock()
+        client.room_get_event = AsyncMock(side_effect=AssertionError("should not refetch fresh cache"))
+        client.room_get_event_relations = MagicMock(side_effect=AssertionError("should not refetch fresh cache"))
+        client.room_messages = AsyncMock(side_effect=AssertionError("should not refetch fresh cache"))
+
+        try:
+            history = await matrix_client_module.fetch_dispatch_thread_history(
+                client,
+                "!room:localhost",
+                "$thread_root",
+                event_cache=cache,
+            )
+        finally:
+            await cache.close()
+
+        assert [message.event_id for message in history] == ["$thread_root", "$reply"]
+        assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_CACHE
+
+    @pytest.mark.asyncio
+    async def test_fetch_dispatch_thread_snapshot_uses_fresh_durable_cache(self, tmp_path: Path) -> None:
+        """Strict dispatch snapshots should reuse fresh durable cache instead of refetching."""
+        cache = _EventCache(tmp_path / "event_cache.db")
+        await cache.initialize()
+
+        root_event = self._make_audio_event(
+            event_id="$thread_root",
+            sender="@user:localhost",
+            body="voice-note.ogg",
+            server_timestamp=1000,
+            source_content={"url": "mxc://localhost/voice-note"},
+        )
+        reply_event = self._make_text_event(
+            event_id="$reply",
+            sender="@agent:localhost",
+            body="Cached reply",
+            server_timestamp=2000,
+            source_content={
+                "body": "Cached reply",
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+        )
+        await self._seed_thread_cache(
+            cache,
+            room_id="!room:localhost",
+            thread_id="$thread_root",
+            events=[self._cache_source(root_event), self._cache_source(reply_event)],
+        )
+
+        client = MagicMock()
+        client.room_get_event = AsyncMock(side_effect=AssertionError("should not refetch fresh cache"))
+        client.room_get_event_relations = MagicMock(side_effect=AssertionError("should not refetch fresh cache"))
+        client.room_messages = AsyncMock(side_effect=AssertionError("should not refetch fresh cache"))
+
+        try:
+            snapshot = await matrix_client_module.fetch_dispatch_thread_snapshot(
+                client,
+                "!room:localhost",
+                "$thread_root",
+                event_cache=cache,
+            )
+        finally:
+            await cache.close()
+
+        assert [message.event_id for message in snapshot] == ["$thread_root", "$reply"]
+        assert snapshot[0].to_dict()["msgtype"] == "m.audio"
+        assert snapshot.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_CACHE
 
     @pytest.mark.asyncio
     async def test_fetch_thread_history_cache_miss_populates_cache(self, tmp_path: Path) -> None:

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -243,7 +243,6 @@ class TestThreadHistory:
             "!room:localhost",
             "$thread_root",
             hydrate_sidecars=True,
-            event_cache=event_cache,
         )
         mock_store.assert_awaited_once_with(
             event_cache,
@@ -253,8 +252,8 @@ class TestThreadHistory:
         )
 
     @pytest.mark.asyncio
-    async def test_fetch_thread_history_prefers_relations_before_room_scan(self) -> None:
-        """Thread history should prefer the relations fetch path before falling back to room scans."""
+    async def test_fetch_thread_history_uses_room_scan_instead_of_relations_fast_path(self) -> None:
+        """Thread history should use the room-scan path so promoted descendants stay in the thread."""
         root_event = self._make_text_event(
             event_id="$thread_root",
             sender="@user:localhost",
@@ -263,7 +262,7 @@ class TestThreadHistory:
             source_content={"body": "Root message"},
         )
         thread_event = self._make_text_event(
-            event_id="$reply",
+            event_id="$thread_reply",
             sender="@agent:localhost",
             body="Reply in thread",
             server_timestamp=2000,
@@ -272,36 +271,40 @@ class TestThreadHistory:
                 "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
             },
         )
-        unrelated_relation = self._make_text_event(
-            event_id="$other_thread_reply",
-            sender="@agent:localhost",
-            body="Should be ignored",
-            server_timestamp=2500,
+        plain_reply = self._make_text_event(
+            event_id="$plain_reply",
+            sender="@bridge:localhost",
+            body="Bridged reply",
+            server_timestamp=3000,
             source_content={
-                "body": "Should be ignored",
-                "m.relates_to": {"rel_type": "m.thread", "event_id": "$other_root"},
+                "body": "Bridged reply",
+                "m.relates_to": {"m.in_reply_to": {"event_id": "$thread_reply"}},
             },
         )
         client = self._make_relations_client(
             root_event=root_event,
             relations={
                 self._relation_key("$thread_root", RelationshipType.thread): [
-                    unrelated_relation,
                     thread_event,
                 ],
             },
         )
+        page = MagicMock(spec=nio.RoomMessagesResponse)
+        page.chunk = [plain_reply, thread_event, root_event]
+        page.end = None
+        client.room_messages = AsyncMock(return_value=page)
 
         history = await fetch_thread_history(client, "!room:localhost", "$thread_root")
 
-        assert [message.event_id for message in history] == ["$thread_root", "$reply"]
+        assert [message.event_id for message in history] == ["$thread_root", "$thread_reply", "$plain_reply"]
         assert history[0].body == "Root message"
         assert history[1].body == "Reply in thread"
-        client.room_messages.assert_not_awaited()
+        assert history[2].body == "Bridged reply"
+        client.room_messages.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_fetch_thread_history_uses_bundled_root_edit_without_replacement_lookup(self) -> None:
-        """Bundled replacement data should update the root without another relations request."""
+        """Bundled replacement data should update the root without extra fetches."""
         root_event = self._make_text_event(
             event_id="$thread_root",
             sender="@user:localhost",
@@ -349,14 +352,8 @@ class TestThreadHistory:
 
         assert history[0].event_id == "$thread_root"
         assert history[0].body == "Updated root"
-        client.room_get_event_relations.assert_called_once_with(
-            "!room:localhost",
-            "$thread_root",
-            RelationshipType.thread,
-            "m.room.message",
-            direction=nio.MessageDirection.back,
-            limit=100,
-        )
+        client.room_messages.assert_awaited_once()
+        client.room_get_event_relations.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_fetch_thread_history_uses_nested_bundled_root_edit_without_validation_noise(
@@ -417,8 +414,8 @@ class TestThreadHistory:
         assert not any("Error validating event" in record.getMessage() for record in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_fetch_thread_history_relations_path_applies_reply_edits_and_stream_status(self) -> None:
-        """Relations-first fetch should apply reply edits and preserve stream metadata."""
+    async def test_fetch_thread_history_applies_reply_edits_and_stream_status_without_cached_latest_edit(self) -> None:
+        """Thread history should keep latest edits from the homeserver even with a cold latest-edit cache."""
         root_event = self._make_text_event(
             event_id="$thread_root",
             sender="@user:localhost",
@@ -458,10 +455,12 @@ class TestThreadHistory:
                 self._relation_key("$thread_root", RelationshipType.thread): [thread_event],
             },
         )
+        page = MagicMock(spec=nio.RoomMessagesResponse)
+        page.chunk = [newer_edit, thread_event, root_event]
+        page.end = None
+        client.room_messages = AsyncMock(return_value=page)
         event_cache = make_event_cache_mock()
-        event_cache.get_latest_edit.side_effect = lambda _room_id, event_id: {
-            "$reply": _event_source_for_cache(newer_edit),
-        }.get(event_id)
+        event_cache.get_latest_edit.return_value = None
 
         history = await fetch_thread_history(
             client,
@@ -474,10 +473,11 @@ class TestThreadHistory:
         assert history[1].body == "Final answer"
         assert history[1].content["body"] == "Final answer"
         assert history[1].stream_status == "completed"
+        client.room_messages.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_fetch_thread_history_relations_path_includes_notice_reply(self) -> None:
-        """Relations-first fetch should keep notice messages in thread history."""
+    async def test_fetch_thread_history_includes_notice_reply(self) -> None:
+        """Thread history should keep notice messages in thread history."""
         root_event = self._make_text_event(
             event_id="$thread_root",
             sender="@user:localhost",
@@ -507,6 +507,7 @@ class TestThreadHistory:
 
         assert [message.event_id for message in history] == ["$thread_root", "$notice_reply"]
         assert "msgtype" not in history[0].to_dict()
+        client.room_messages.assert_awaited_once()
         assert history[1].body == "Compacted 12 messages"
         assert history[1].to_dict()["msgtype"] == "m.notice"
 
@@ -543,46 +544,6 @@ class TestThreadHistory:
         assert [message.event_id for message in history] == ["$thread_root", "$reply"]
         assert history[0].to_dict()["msgtype"] == "m.notice"
         assert history[0].body == "Compacted summary"
-
-    @pytest.mark.asyncio
-    async def test_fetch_thread_history_falls_back_when_relations_lookup_fails(self) -> None:
-        """Room-scan fetch results should be returned and cached through the shared path."""
-        client = AsyncMock()
-        fallback_history = [{"event_id": "$thread_root", "body": "fallback"}]
-
-        with (
-            patch(
-                "mindroom.matrix.client._fetch_thread_history_via_relations_with_events",
-                new=AsyncMock(side_effect=RuntimeError("relations failed")),
-            ),
-            patch(
-                "mindroom.matrix.client._fetch_thread_history_via_room_messages_with_events",
-                new=AsyncMock(
-                    return_value=MagicMock(
-                        history=fallback_history,
-                        event_sources=[{"event_id": "$thread_root"}],
-                        resolution_ms=0.0,
-                        sidecar_hydration_ms=0.0,
-                    ),
-                ),
-            ) as mock_room_scan,
-            patch("mindroom.matrix.client._store_thread_history_cache", new=AsyncMock()) as mock_store,
-        ):
-            history = await fetch_thread_history(
-                client,
-                "!room:localhost",
-                "$thread_root",
-                event_cache=make_event_cache_mock(),
-            )
-
-        assert history == fallback_history
-        mock_room_scan.assert_awaited_once_with(
-            client,
-            "!room:localhost",
-            "$thread_root",
-            hydrate_sidecars=True,
-        )
-        mock_store.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_fetch_thread_history_skips_cache_store_for_degraded_room_scan_result(self) -> None:

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -606,6 +606,41 @@ class TestMatrixConversationCacheThreadReads:
         client.room_get_event.assert_awaited_once_with("!test:localhost", "$event:localhost")
         event_cache.store_event.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_turn_scope_memoizes_strict_thread_history_reads(self) -> None:
+        """Strict dispatch thread reads should be memoized for the lifetime of one inbound turn."""
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(client=_make_client_mock(), event_cache=_runtime_event_cache()),
+        )
+        expected_history = thread_history_result(
+            [
+                _message(event_id="$thread_root", body="Root"),
+                _message(event_id="$reply", body="Reply"),
+            ],
+            is_full_history=True,
+            diagnostics={THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_CACHE},
+        )
+
+        with patch.object(
+            access._reads,
+            "read_thread",
+            new=AsyncMock(return_value=expected_history),
+        ) as mock_read_thread:
+            async with access.turn_scope():
+                first_history = await access.get_dispatch_thread_history("!test:localhost", "$thread_root")
+                second_history = await access.get_dispatch_thread_history("!test:localhost", "$thread_root")
+
+        assert [message.event_id for message in first_history] == ["$thread_root", "$reply"]
+        assert [message.event_id for message in second_history] == ["$thread_root", "$reply"]
+        assert first_history is not second_history
+        mock_read_thread.assert_awaited_once_with(
+            "!test:localhost",
+            "$thread_root",
+            full_history=True,
+            dispatch_safe=True,
+        )
+
     def test_collect_sync_timeline_cache_updates_treats_reference_as_thread_candidate(self) -> None:
         """Sync bookkeeping should classify references alongside other thread-affecting relations."""
         room_threaded_events: dict[str, list[dict[str, object]]] = {}


### PR DESCRIPTION
## Summary
- reuse fresh durable thread history/snapshot cache entries for strict dispatch reads instead of always refetching from the homeserver
- prefer a thread-relations fetch path, then fall back to room scans, while still overlaying cached latest edits onto the resolved dispatch history
- add regression coverage for strict dispatch cache reuse, relations-first fetches, and the multi-agent dispatch context path

## Test Plan
- `uv run pytest tests/test_thread_history.py tests/test_threading_error.py tests/test_multi_agent_bot.py -x -n 0 --no-cov -q`
- `uv run pre-commit run --files src/mindroom/matrix/client.py src/mindroom/matrix/conversation_cache.py tests/test_thread_history.py tests/test_threading_error.py tests/test_multi_agent_bot.py`
