### PR TITLE
Fast-path trusted router relays in dispatch prep

### DIFF
--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -440,6 +440,49 @@ class ConversationResolver:
             dispatch_safe=True,
         )
 
+    async def extract_trusted_router_relay_context(
+        self,
+        room: nio.MatrixRoom,
+        event: DispatchEvent,
+    ) -> MessageContext:
+        """Extract minimal context for router relays and defer thread hydration until after lock."""
+        resolved_event_source = await resolve_event_source_content(event.source, self._client())
+        config = self.deps.runtime.config
+
+        if should_skip_mentions(resolved_event_source):
+            mentioned_agents: list[MatrixID] = []
+            am_i_mentioned = False
+            has_non_agent_mentions = False
+        else:
+            mentioned_agents, am_i_mentioned, has_non_agent_mentions = check_agent_mentioned(
+                resolved_event_source,
+                self._matrix_id(),
+                config,
+                self.deps.runtime_paths,
+            )
+
+        if am_i_mentioned:
+            self.deps.logger.info("Mentioned", event_id=event.event_id, room_id=room.room_id)
+
+        event_info = EventInfo.from_event(resolved_event_source)
+        resolved_target = self.build_message_target(
+            room_id=room.room_id,
+            thread_id=event_info.thread_id or event_info.thread_id_from_edit,
+            reply_to_event_id=event.event_id,
+            event_source=resolved_event_source,
+        )
+        resolved_thread_id = resolved_target.resolved_thread_id
+        return MessageContext(
+            am_i_mentioned=am_i_mentioned,
+            is_thread=resolved_thread_id is not None,
+            thread_id=resolved_thread_id,
+            thread_history=(),
+            mentioned_agents=mentioned_agents,
+            has_non_agent_mentions=has_non_agent_mentions,
+            replay_guard_history=(),
+            requires_full_thread_history=resolved_thread_id is not None,
+        )
+
     async def extract_message_context(
         self,
         room: nio.MatrixRoom,

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -465,13 +465,17 @@ class ConversationResolver:
             self.deps.logger.info("Mentioned", event_id=event.event_id, room_id=room.room_id)
 
         event_info = EventInfo.from_event(resolved_event_source)
-        resolved_target = self.build_message_target(
-            room_id=room.room_id,
-            thread_id=event_info.thread_id or event_info.thread_id_from_edit,
-            reply_to_event_id=event.event_id,
-            event_source=resolved_event_source,
-        )
-        resolved_thread_id = resolved_target.resolved_thread_id
+        if (
+            config.get_entity_thread_mode(
+                self.deps.agent_name,
+                self.deps.runtime_paths,
+                room_id=room.room_id,
+            )
+            == "room"
+        ):
+            resolved_thread_id = None
+        else:
+            resolved_thread_id = event_info.thread_id or event_info.thread_id_from_edit
         return MessageContext(
             am_i_mentioned=am_i_mentioned,
             is_thread=resolved_thread_id is not None,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -216,6 +216,17 @@ class TurnController:
         original_sender = content.get(ORIGINAL_SENDER_KEY)
         return isinstance(original_sender, str) and bool(original_sender)
 
+    def _is_trusted_router_relay_event(self, event: _DispatchEvent) -> bool:
+        """Return whether one trusted internal relay originated from the router."""
+        if not self._is_trusted_internal_relay_event(event):
+            return False
+        sender_agent_name = extract_agent_name(
+            event.sender,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
+        return sender_agent_name == ROUTER_AGENT_NAME
+
     def _precheck_event(
         self,
         room: nio.MatrixRoom,
@@ -440,7 +451,10 @@ class TurnController:
         handled_turn: HandledTurnState,
     ) -> PreparedDispatch | None:
         """Build the shared dispatch context for one prepared inbound turn."""
-        context = await self.deps.resolver.extract_dispatch_context(room, event)
+        if self._is_trusted_router_relay_event(event):
+            context = await self.deps.resolver.extract_trusted_router_relay_context(room, event)
+        else:
+            context = await self.deps.resolver.extract_dispatch_context(room, event)
         target = self.deps.resolver.build_message_target(
             room_id=room.room_id,
             thread_id=context.thread_id,

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -682,6 +682,89 @@ async def test_prepare_dispatch_builds_target_via_conversation_resolver(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_prepare_dispatch_uses_trusted_router_context_for_router_relays(tmp_path: Path) -> None:
+    """Router relays should skip the expensive dispatch preview read during preparation."""
+    bot = _agent_bot(tmp_path)
+    room = nio.MatrixRoom(room_id="!room:localhost", own_user_id="@mindroom_code:localhost")
+    event = nio.RoomMessageText.from_dict(
+        {
+            "event_id": "$router-relay",
+            "sender": "@mindroom_router:localhost",
+            "origin_server_ts": 1234567890,
+            "content": {
+                "msgtype": "m.text",
+                "body": "@mindroom_code:localhost please check this thread",
+                ORIGINAL_SENDER_KEY: "@user:localhost",
+                "m.relates_to": {
+                    "event_id": "$thread-root",
+                    "rel_type": "m.thread",
+                },
+            },
+        },
+    )
+    trusted_context = MessageContext(
+        am_i_mentioned=True,
+        is_thread=True,
+        thread_id="$thread-root",
+        thread_history=[],
+        mentioned_agents=[bot.matrix_id],
+        has_non_agent_mentions=False,
+        replay_guard_history=[],
+        requires_full_thread_history=True,
+    )
+    bot._conversation_resolver.extract_trusted_router_relay_context = AsyncMock(return_value=trusted_context)
+    bot._conversation_resolver.extract_dispatch_context = AsyncMock()
+
+    dispatch = await bot._turn_controller._prepare_dispatch(
+        room,
+        event,
+        "@user:localhost",
+        event_label="message",
+        handled_turn=HandledTurnState.from_source_event_id(event.event_id),
+    )
+
+    assert dispatch is not None
+    assert dispatch.context is trusted_context
+    bot._conversation_resolver.extract_trusted_router_relay_context.assert_awaited_once_with(room, event)
+    bot._conversation_resolver.extract_dispatch_context.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_prepare_dispatch_keeps_standard_context_for_non_router_internal_relays(tmp_path: Path) -> None:
+    """Non-router internal relays should keep using the standard dispatch context path."""
+    bot = _agent_bot(tmp_path)
+    room = nio.MatrixRoom(room_id="!room:localhost", own_user_id="@mindroom_code:localhost")
+    event = nio.RoomMessageText.from_dict(
+        {
+            "event_id": "$agent-relay",
+            "sender": "@mindroom_code:localhost",
+            "origin_server_ts": 1234567890,
+            "content": {
+                "msgtype": "m.text",
+                "body": "@mindroom_code:localhost internal follow-up",
+                ORIGINAL_SENDER_KEY: "@user:localhost",
+            },
+        },
+    )
+    standard_context = _dispatch_context(bot)
+    bot._conversation_resolver.extract_trusted_router_relay_context = AsyncMock()
+    bot._conversation_resolver.extract_dispatch_context = AsyncMock(return_value=standard_context)
+
+    dispatch = await bot._turn_controller._prepare_dispatch(
+        room,
+        event,
+        "@user:localhost",
+        event_label="message",
+        handled_turn=HandledTurnState.from_source_event_id(event.event_id),
+    )
+
+    assert dispatch is not None
+    assert dispatch.context is standard_context
+    bot._conversation_resolver.extract_dispatch_context.assert_awaited_once_with(room, event)
+    bot._conversation_resolver.extract_trusted_router_relay_context.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_dispatch_text_message_continues_for_hook_originated_mentions(tmp_path: Path) -> None:
     """Hook-originated messages should continue into normal agent dispatch resolution."""
     bot = _agent_bot(tmp_path)

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -730,6 +730,32 @@ async def test_prepare_dispatch_uses_trusted_router_context_for_router_relays(tm
 
 
 @pytest.mark.asyncio
+async def test_extract_trusted_router_context_does_not_invent_thread_for_room_level_relay(tmp_path: Path) -> None:
+    """Room-level router relays should stay room-level until an explicit thread root is present."""
+    bot = _agent_bot(tmp_path)
+    room = nio.MatrixRoom(room_id="!room:localhost", own_user_id="@mindroom_code:localhost")
+    event = nio.RoomMessageText.from_dict(
+        {
+            "event_id": "$router-relay-room",
+            "sender": "@mindroom_router:localhost",
+            "origin_server_ts": 1234567890,
+            "content": {
+                "msgtype": "m.text",
+                "body": "@mindroom_code:localhost please help",
+                ORIGINAL_SENDER_KEY: "@user:localhost",
+            },
+        },
+    )
+
+    context = await bot._conversation_resolver.extract_trusted_router_relay_context(room, event)
+
+    assert context.is_thread is False
+    assert context.thread_id is None
+    assert list(context.thread_history) == []
+    assert context.requires_full_thread_history is False
+
+
+@pytest.mark.asyncio
 async def test_prepare_dispatch_keeps_standard_context_for_non_router_internal_relays(tmp_path: Path) -> None:
     """Non-router internal relays should keep using the standard dispatch context path."""
     bot = _agent_bot(tmp_path)


### PR DESCRIPTION
## Summary
- fast-path trusted router relays through a minimal dispatch context during preparation
- keep non-router internal relays on the standard dispatch-context path
- preserve room-level relay semantics so the fast path does not invent a thread when the relay itself is room-level

## Verification
- `uv run pytest tests/test_hook_sender.py -x -n 0 --no-cov -q`
- `uv run pre-commit run --files src/mindroom/conversation_resolver.py src/mindroom/turn_controller.py tests/test_hook_sender.py`

## Review
- local zero-tolerance `pr-review`: `APPROVE`
