### PR TITLE
fix: split room cache barriers by thread

### DIFF
--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -51,11 +51,11 @@ class ThreadReadPolicy:
     def _coordinator(self) -> EventCacheWriteCoordinator | None:
         return self.runtime.event_cache_write_coordinator
 
-    async def _wait_for_pending_room_cache_updates(self, room_id: str) -> None:
+    async def _wait_for_pending_thread_cache_updates(self, room_id: str, thread_id: str) -> None:
         coordinator = self._coordinator()
         if coordinator is None:
             return
-        await coordinator.wait_for_room_idle(room_id)
+        await coordinator.wait_for_thread_idle(room_id, thread_id)
 
     def _full_history_result(
         self,
@@ -89,8 +89,9 @@ class ThreadReadPolicy:
             return await load()
         return typing.cast(
             "ThreadHistoryResult",
-            await coordinator.run_room_update(
+            await coordinator.run_thread_update(
                 room_id,
+                thread_id,
                 load,
                 name=name,
             ),
@@ -104,8 +105,8 @@ class ThreadReadPolicy:
         full_history: bool,
         dispatch_safe: bool,
     ) -> ThreadHistoryResult:
-        """Resolve one thread read through the shared barrier and fetch selection path."""
-        await self._wait_for_pending_room_cache_updates(room_id)
+        """Resolve one thread read through the same-thread barrier and fetch selection path."""
+        await self._wait_for_pending_thread_cache_updates(room_id, thread_id)
         if full_history and dispatch_safe:
             return await self._run_thread_read(
                 room_id,
@@ -143,7 +144,7 @@ class ThreadReadPolicy:
         room_id: str,
         thread_id: str,
     ) -> ThreadHistoryResult:
-        """Resolve advisory lightweight thread context for one thread under the room-scoped barrier."""
+        """Resolve advisory lightweight thread context for one thread under the same-thread barrier."""
         return await self.read_thread(
             room_id,
             thread_id,
@@ -169,7 +170,7 @@ class ThreadReadPolicy:
         room_id: str,
         thread_id: str,
     ) -> ThreadHistoryResult:
-        """Resolve strict lightweight thread context for dispatch under the room-scoped barrier."""
+        """Resolve strict lightweight thread context for dispatch under the same-thread barrier."""
         return await self.read_thread(
             room_id,
             thread_id,

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -47,6 +47,23 @@ class ThreadMutationCacheOps:
         coordinator = self.runtime.event_cache_write_coordinator
         return coordinator.queue_room_update(room_id, update_coro_factory, name=name)
 
+    def queue_thread_cache_update(
+        self,
+        room_id: str,
+        thread_id: str,
+        update_coro_factory: Callable[[], Coroutine[Any, Any, object]],
+        *,
+        name: str,
+    ) -> asyncio.Task[object]:
+        """Run one thread-specific cache mutation under the same-thread write barrier."""
+        coordinator = self.runtime.event_cache_write_coordinator
+        return coordinator.queue_thread_update(
+            room_id,
+            thread_id,
+            update_coro_factory,
+            name=name,
+        )
+
     async def store_events_batch(
         self,
         room_id: str,

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -171,7 +171,18 @@ class ThreadOutboundWritePolicy:
         event_info = EventInfo.from_event(event_source)
         if not is_thread_affecting_relation(event_info):
             return
-
+        direct_thread_id = event_info.thread_id or event_info.thread_id_from_edit
+        if direct_thread_id is not None:
+            self._schedule_fail_open_thread_update(
+                room_id,
+                direct_thread_id,
+                lambda: self._apply_outbound_message_notification(room_id, event_id, event_source, event_info),
+                name="matrix_cache_notify_outbound_message",
+                cancelled_message="Ignoring cancelled outbound threaded message cache bookkeeping after successful send",
+                failure_message="Ignoring outbound threaded message cache bookkeeping failure after successful send",
+                log_context={"event_id": event_id, "thread_id": direct_thread_id},
+            )
+            return
         self._schedule_fail_open_room_update(
             room_id,
             lambda: self._apply_outbound_message_notification(room_id, event_id, event_source, event_info),
@@ -283,6 +294,61 @@ class ThreadOutboundWritePolicy:
                 **log_context,
             )
 
+    def _schedule_fail_open_thread_update(
+        self,
+        room_id: str,
+        thread_id: str,
+        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        *,
+        name: str,
+        cancelled_message: str,
+        failure_message: str,
+        log_context: dict[str, object],
+    ) -> None:
+        async def safe_update() -> None:
+            try:
+                await update_coro_factory()
+            except asyncio.CancelledError as exc:
+                self._cache_ops.logger.warning(
+                    cancelled_message,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    error=str(exc),
+                    **log_context,
+                )
+            except Exception as exc:
+                self._cache_ops.logger.warning(
+                    failure_message,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    error=str(exc),
+                    **log_context,
+                )
+
+        try:
+            self._cache_ops.queue_thread_cache_update(
+                room_id,
+                thread_id,
+                safe_update,
+                name=name,
+            )
+        except asyncio.CancelledError as exc:
+            self._cache_ops.logger.warning(
+                cancelled_message,
+                room_id=room_id,
+                thread_id=thread_id,
+                error=str(exc),
+                **log_context,
+            )
+        except Exception as exc:
+            self._cache_ops.logger.warning(
+                failure_message,
+                room_id=room_id,
+                thread_id=thread_id,
+                error=str(exc),
+                **log_context,
+            )
+
 
 class ThreadLiveWritePolicy:
     """Own live-event and live-redaction thread cache mutations."""
@@ -351,8 +417,9 @@ class ThreadLiveWritePolicy:
                 )
             return appended
 
-        await self._cache_ops.queue_room_cache_update(
+        await self._cache_ops.queue_thread_cache_update(
             room_id,
+            thread_id,
             append_and_invalidate,
             name="matrix_cache_append_live_event",
         )
@@ -386,6 +453,14 @@ class ThreadLiveWritePolicy:
             )
             return redacted
 
+        if thread_id is not None:
+            await self._cache_ops.queue_thread_cache_update(
+                room_id,
+                thread_id,
+                redact_and_invalidate,
+                name="matrix_cache_apply_redaction",
+            )
+            return
         await self._cache_ops.queue_room_cache_update(
             room_id,
             redact_and_invalidate,

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -36,8 +36,32 @@ class EventCacheWriteCoordinator(Protocol):
     ) -> object:
         """Run one room-scoped update through the same ordered barrier."""
 
+    def queue_thread_update(
+        self,
+        room_id: str,
+        thread_id: str,
+        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        *,
+        name: str,
+        log_exceptions: bool = True,
+    ) -> asyncio.Task[object]:
+        """Queue one thread-scoped update behind same-thread and room-wide predecessors."""
+
+    async def run_thread_update(
+        self,
+        room_id: str,
+        thread_id: str,
+        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        *,
+        name: str,
+    ) -> object:
+        """Run one thread-scoped update through the ordered thread barrier."""
+
     async def wait_for_room_idle(self, room_id: str) -> None:
         """Wait for one room's queued updates to drain."""
+
+    async def wait_for_thread_idle(self, room_id: str, thread_id: str) -> None:
+        """Wait for room-wide and same-thread queued updates to drain."""
 
     async def close(self) -> None:
         """Drain and tear down the coordinator."""
@@ -50,12 +74,21 @@ class _EventCacheWriteCoordinator:
     logger: structlog.stdlib.BoundLogger
     background_task_owner: object = field(default_factory=object)
     _room_update_tasks: dict[str, asyncio.Task[Any]] = field(default_factory=dict, init=False)
+    _thread_update_tasks: dict[tuple[str, str], asyncio.Task[Any]] = field(default_factory=dict, init=False)
+    _thread_update_tasks_by_room: dict[str, dict[str, asyncio.Task[Any]]] = field(
+        default_factory=dict,
+        init=False,
+    )
     _room_update_predecessors: weakref.WeakKeyDictionary[
         asyncio.Task[Any],
         asyncio.Task[Any] | None,
     ] = field(default_factory=weakref.WeakKeyDictionary, init=False)
+    _thread_update_predecessors: weakref.WeakKeyDictionary[
+        asyncio.Task[Any],
+        asyncio.Task[Any] | None,
+    ] = field(default_factory=weakref.WeakKeyDictionary, init=False)
 
-    def _pending_predecessor(self, task: asyncio.Task[Any]) -> asyncio.Task[Any] | None:
+    def _pending_room_predecessor(self, task: asyncio.Task[Any]) -> asyncio.Task[Any] | None:
         predecessor = self._room_update_predecessors.get(task)
         while predecessor is not None and predecessor.done():
             if not predecessor.cancelled():
@@ -63,21 +96,41 @@ class _EventCacheWriteCoordinator:
             predecessor = self._room_update_predecessors.get(predecessor)
         return predecessor
 
-    async def _await_predecessor(
+    def _pending_thread_predecessor(self, task: asyncio.Task[Any]) -> asyncio.Task[Any] | None:
+        predecessor = self._thread_update_predecessors.get(task)
+        while predecessor is not None and predecessor.done():
+            if not predecessor.cancelled():
+                return None
+            predecessor = self._thread_update_predecessors.get(predecessor)
+        return predecessor
+
+    def _pending_predecessor(self, task: asyncio.Task[Any]) -> asyncio.Task[Any] | None:
+        if task in self._thread_update_predecessors:
+            return self._pending_thread_predecessor(task)
+        return self._pending_room_predecessor(task)
+
+    async def _await_predecessors(
         self,
         room_id: str,
         operation: str,
-        previous_task: asyncio.Task[Any] | None,
+        previous_tasks: tuple[asyncio.Task[Any], ...],
     ) -> None:
-        predecessor = previous_task
-        while predecessor is not None:
+        pending_predecessors = list(previous_tasks)
+        seen_predecessors: set[asyncio.Task[Any]] = set()
+        while pending_predecessors:
+            predecessor = pending_predecessors.pop(0)
+            if predecessor in seen_predecessors:
+                continue
+            seen_predecessors.add(predecessor)
             try:
                 await predecessor
             except asyncio.CancelledError:
                 current_task = asyncio.current_task()
                 if current_task is not None and current_task.cancelling():
                     raise
-                predecessor = self._pending_predecessor(predecessor)
+                replacement_predecessor = self._pending_predecessor(predecessor)
+                if replacement_predecessor is not None:
+                    pending_predecessors.append(replacement_predecessor)
             except Exception as exc:
                 self.logger.debug(
                     "Previous room cache update failed before follow-up update",
@@ -85,18 +138,68 @@ class _EventCacheWriteCoordinator:
                     operation=operation,
                     error=str(exc),
                 )
-                return
-            else:
-                return
 
     def _clear_room_tail(self, room_id: str, done_task: asyncio.Task[object]) -> None:
         if self._room_update_tasks.get(room_id) is not done_task:
             return
-        predecessor = self._pending_predecessor(done_task)
+        predecessor = self._pending_room_predecessor(done_task)
         if done_task.cancelled() and predecessor is not None:
             self._room_update_tasks[room_id] = predecessor
             return
         self._room_update_tasks.pop(room_id, None)
+
+    def _clear_thread_tail(
+        self,
+        room_id: str,
+        thread_id: str,
+        done_task: asyncio.Task[object],
+    ) -> None:
+        key = (room_id, thread_id)
+        if self._thread_update_tasks.get(key) is not done_task:
+            return
+        predecessor = self._pending_thread_predecessor(done_task)
+        if done_task.cancelled() and predecessor is not None:
+            self._thread_update_tasks[key] = predecessor
+            self._thread_update_tasks_by_room.setdefault(room_id, {})[thread_id] = predecessor
+            return
+        self._thread_update_tasks.pop(key, None)
+        room_threads = self._thread_update_tasks_by_room.get(room_id)
+        if room_threads is None:
+            return
+        room_threads.pop(thread_id, None)
+        if not room_threads:
+            self._thread_update_tasks_by_room.pop(room_id, None)
+
+    def _clear_room_thread_tail_if_current(
+        self,
+        room_id: str,
+        done_task: asyncio.Task[object],
+    ) -> None:
+        room_threads = self._thread_update_tasks_by_room.get(room_id)
+        if room_threads is None:
+            return
+        for thread_id, current_task in list(room_threads.items()):
+            if current_task is done_task and done_task.done():
+                self._clear_thread_tail(room_id, thread_id, done_task)
+
+    def _room_predecessors(self, room_id: str) -> tuple[asyncio.Task[Any], ...]:
+        predecessors: list[asyncio.Task[Any]] = []
+        room_task = self._room_update_tasks.get(room_id)
+        if room_task is not None:
+            predecessors.append(room_task)
+        thread_tasks = self._thread_update_tasks_by_room.get(room_id, {})
+        predecessors.extend(thread_tasks.values())
+        return tuple(dict.fromkeys(predecessors))
+
+    def _thread_predecessors(self, room_id: str, thread_id: str) -> tuple[asyncio.Task[Any], ...]:
+        predecessors: list[asyncio.Task[Any]] = []
+        room_task = self._room_update_tasks.get(room_id)
+        if room_task is not None:
+            predecessors.append(room_task)
+        thread_task = self._thread_update_tasks.get((room_id, thread_id))
+        if thread_task is not None:
+            predecessors.append(thread_task)
+        return tuple(dict.fromkeys(predecessors))
 
     def queue_room_update(
         self,
@@ -107,10 +210,11 @@ class _EventCacheWriteCoordinator:
         log_exceptions: bool = True,
     ) -> asyncio.Task[object]:
         """Schedule one room-scoped cache update behind any active predecessor."""
-        previous_task = self._room_update_tasks.get(room_id)
+        previous_room_task = self._room_update_tasks.get(room_id)
+        previous_tasks = self._room_predecessors(room_id)
 
         async def run_after_previous() -> object:
-            await self._await_predecessor(room_id, name, previous_task)
+            await self._await_predecessors(room_id, name, previous_tasks)
             return await update_coro_factory()
 
         task = create_background_task(
@@ -119,7 +223,7 @@ class _EventCacheWriteCoordinator:
             owner=self.background_task_owner,
             log_exceptions=log_exceptions,
         )
-        self._room_update_predecessors[task] = previous_task
+        self._room_update_predecessors[task] = previous_room_task
         self._room_update_tasks[room_id] = task
         task.add_done_callback(lambda done_task: self._clear_room_tail(room_id, done_task))
         return task
@@ -139,30 +243,109 @@ class _EventCacheWriteCoordinator:
             log_exceptions=False,
         )
 
+    def queue_thread_update(
+        self,
+        room_id: str,
+        thread_id: str,
+        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        *,
+        name: str,
+        log_exceptions: bool = True,
+    ) -> asyncio.Task[object]:
+        """Schedule one thread-scoped cache update behind room-wide and same-thread predecessors."""
+        key = (room_id, thread_id)
+        previous_thread_task = self._thread_update_tasks.get(key)
+        previous_tasks = self._thread_predecessors(room_id, thread_id)
+
+        async def run_after_previous() -> object:
+            await self._await_predecessors(room_id, name, previous_tasks)
+            return await update_coro_factory()
+
+        task = create_background_task(
+            run_after_previous(),
+            name=name,
+            owner=self.background_task_owner,
+            log_exceptions=log_exceptions,
+        )
+        self._thread_update_predecessors[task] = previous_thread_task
+        self._thread_update_tasks[key] = task
+        self._thread_update_tasks_by_room.setdefault(room_id, {})[thread_id] = task
+        task.add_done_callback(lambda done_task: self._clear_thread_tail(room_id, thread_id, done_task))
+        return task
+
+    async def run_thread_update(
+        self,
+        room_id: str,
+        thread_id: str,
+        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        *,
+        name: str,
+    ) -> object:
+        """Run one thread-scoped operation through the ordered thread barrier and await its result."""
+        return await self.queue_thread_update(
+            room_id,
+            thread_id,
+            update_coro_factory,
+            name=name,
+            log_exceptions=False,
+        )
+
     async def wait_for_room_idle(self, room_id: str) -> None:
         """Wait for the currently queued same-room update chain to drain."""
         while True:
-            tail_task = self._room_update_tasks.get(room_id)
-            if tail_task is None:
+            pending_tasks = self._room_predecessors(room_id)
+            if not pending_tasks:
                 return
-            try:
-                await tail_task
-            except asyncio.CancelledError:
-                current_task = asyncio.current_task()
-                if current_task is not None and current_task.cancelling():
-                    raise
-            except Exception as exc:
-                self.logger.debug(
-                    "Room cache update failed before room became idle",
-                    room_id=room_id,
-                    error=str(exc),
-                )
-            finally:
-                if self._room_update_tasks.get(room_id) is tail_task and tail_task.done():
-                    self._clear_room_tail(room_id, tail_task)
+            for pending_task in pending_tasks:
+                try:
+                    await pending_task
+                except asyncio.CancelledError:
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise
+                except Exception as exc:
+                    self.logger.debug(
+                        "Room cache update failed before room became idle",
+                        room_id=room_id,
+                        error=str(exc),
+                    )
+                finally:
+                    self._clear_room_thread_tail_if_current(room_id, pending_task)
+                    if self._room_update_tasks.get(room_id) is pending_task and pending_task.done():
+                        self._clear_room_tail(room_id, pending_task)
+
+    async def wait_for_thread_idle(self, room_id: str, thread_id: str) -> None:
+        """Wait for room-wide and same-thread queued updates to drain."""
+        key = (room_id, thread_id)
+        while True:
+            pending_tasks = self._thread_predecessors(room_id, thread_id)
+            if not pending_tasks:
+                return
+            for pending_task in pending_tasks:
+                try:
+                    await pending_task
+                except asyncio.CancelledError:
+                    current_task = asyncio.current_task()
+                    if current_task is not None and current_task.cancelling():
+                        raise
+                except Exception as exc:
+                    self.logger.debug(
+                        "Thread cache update failed before thread became idle",
+                        room_id=room_id,
+                        thread_id=thread_id,
+                        error=str(exc),
+                    )
+                finally:
+                    if self._thread_update_tasks.get(key) is pending_task and pending_task.done():
+                        self._clear_thread_tail(room_id, thread_id, pending_task)
+                    if self._room_update_tasks.get(room_id) is pending_task and pending_task.done():
+                        self._clear_room_tail(room_id, pending_task)
 
     async def close(self) -> None:
         """Drain any queued cache writes for this coordinator."""
         await wait_for_background_tasks(timeout=5.0, owner=self.background_task_owner)
         self._room_update_tasks.clear()
+        self._thread_update_tasks.clear()
+        self._thread_update_tasks_by_room.clear()
         self._room_update_predecessors.clear()
+        self._thread_update_predecessors.clear()

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -3421,8 +3421,8 @@ class TestThreadingBehavior:
             await access.get_thread_history("!test:localhost", "$thread:localhost")
 
     @pytest.mark.asyncio
-    async def test_get_thread_history_refresh_runs_under_room_write_barrier(self) -> None:
-        """Thread refreshes should occupy the same room-scoped barrier used by mutations."""
+    async def test_get_thread_history_refresh_runs_under_same_thread_write_barrier(self) -> None:
+        """Thread refreshes should serialize with same-thread mutations without blocking other threads."""
         access = MatrixConversationCache(
             logger=MagicMock(),
             runtime=_conversation_runtime(),
@@ -3452,8 +3452,9 @@ class TestThreadingBehavior:
         refresh_task = asyncio.create_task(access.get_thread_history("!test:localhost", "$thread:localhost"))
         await asyncio.wait_for(refresh_started.wait(), timeout=1.0)
 
-        access.runtime.event_cache_write_coordinator.queue_room_update(
+        access.runtime.event_cache_write_coordinator.queue_thread_update(
             "!test:localhost",
+            "$thread:localhost",
             lambda: queued_update(),
             name="matrix_cache_follow_up_update",
         )
@@ -3467,8 +3468,8 @@ class TestThreadingBehavior:
         assert queued_update_started.is_set()
 
     @pytest.mark.asyncio
-    async def test_get_thread_snapshot_refresh_runs_under_room_write_barrier(self) -> None:
-        """Snapshot refreshes should occupy the same room-scoped barrier used by mutations."""
+    async def test_get_thread_snapshot_refresh_runs_under_same_thread_write_barrier(self) -> None:
+        """Snapshot refreshes should serialize with same-thread mutations without blocking other threads."""
         access = MatrixConversationCache(
             logger=MagicMock(),
             runtime=_conversation_runtime(),
@@ -3496,8 +3497,9 @@ class TestThreadingBehavior:
         refresh_task = asyncio.create_task(access.get_thread_snapshot("!test:localhost", "$thread:localhost"))
         await asyncio.wait_for(refresh_started.wait(), timeout=1.0)
 
-        access.runtime.event_cache_write_coordinator.queue_room_update(
+        access.runtime.event_cache_write_coordinator.queue_thread_update(
             "!test:localhost",
+            "$thread:localhost",
             lambda: queued_update(),
             name="matrix_cache_follow_up_update",
         )
@@ -3535,7 +3537,7 @@ class TestThreadingBehavior:
         allow_reader_continue = asyncio.Event()
         raw_append_committed = asyncio.Event()
 
-        async def pause_reader(_room_id: str) -> None:
+        async def pause_reader(_room_id: str, _thread_id: str) -> None:
             reader_ready.set()
             await allow_reader_continue.wait()
 
@@ -3583,7 +3585,7 @@ class TestThreadingBehavior:
         event_cache.get_thread_id_for_event = AsyncMock(return_value="$thread:localhost")
         event_cache.mark_thread_stale = AsyncMock(side_effect=mark_thread_stale)
         event_cache.append_event = AsyncMock(side_effect=append_event)
-        access._reads._wait_for_pending_room_cache_updates = AsyncMock(side_effect=pause_reader)
+        access._reads._wait_for_pending_thread_cache_updates = AsyncMock(side_effect=pause_reader)
         access._reads.fetch_thread_history_from_client = AsyncMock(side_effect=fetch_fresh_history)
         new_event_source = {
             "event_id": "$reply-new:localhost",
@@ -3863,6 +3865,91 @@ class TestThreadingBehavior:
         await wait_for_background_tasks(timeout=1.0, owner=owner)
 
         assert second_update_started.is_set()
+
+    @pytest.mark.asyncio
+    async def test_shared_event_cache_write_coordinator_allows_other_thread_updates_while_one_thread_runs(
+        self,
+    ) -> None:
+        """Same-room thread updates should not serialize across unrelated threads."""
+        first_update_started = asyncio.Event()
+        release_first_update = asyncio.Event()
+        second_update_started = asyncio.Event()
+        owner = object()
+        coordinator = _EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=owner,
+        )
+
+        async def first_update() -> None:
+            first_update_started.set()
+            await release_first_update.wait()
+
+        async def second_update() -> None:
+            second_update_started.set()
+
+        coordinator.queue_thread_update(
+            "!test:localhost",
+            "$thread-a:localhost",
+            lambda: first_update(),
+            name="matrix_cache_first_thread_update",
+        )
+        await asyncio.wait_for(first_update_started.wait(), timeout=1.0)
+
+        coordinator.queue_thread_update(
+            "!test:localhost",
+            "$thread-b:localhost",
+            lambda: second_update(),
+            name="matrix_cache_second_thread_update",
+        )
+        await asyncio.sleep(0)
+        assert second_update_started.is_set()
+
+        release_first_update.set()
+        await wait_for_background_tasks(timeout=1.0, owner=owner)
+
+    @pytest.mark.asyncio
+    async def test_get_thread_history_does_not_wait_for_other_thread_update(self) -> None:
+        """Thread reads should not stall behind unrelated thread updates in the same room."""
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(),
+        )
+        other_thread_update_started = asyncio.Event()
+        release_other_thread_update = asyncio.Event()
+        fetch_started = asyncio.Event()
+
+        async def blocking_other_thread_update() -> None:
+            other_thread_update_started.set()
+            await release_other_thread_update.wait()
+
+        async def fetch_history(
+            _room_id: str,
+            _thread_id: str,
+        ) -> ThreadHistoryResult:
+            fetch_started.set()
+            return thread_history_result(
+                [_message(event_id="$thread-a:localhost", body="Root")],
+                is_full_history=True,
+            )
+
+        access._reads.fetch_thread_history_from_client = AsyncMock(side_effect=fetch_history)
+        access.runtime.event_cache_write_coordinator.queue_thread_update(
+            "!test:localhost",
+            "$thread-b:localhost",
+            lambda: blocking_other_thread_update(),
+            name="matrix_cache_blocking_other_thread_update",
+        )
+        await asyncio.wait_for(other_thread_update_started.wait(), timeout=1.0)
+
+        history = await asyncio.wait_for(
+            access.get_thread_history("!test:localhost", "$thread-a:localhost"),
+            timeout=1.0,
+        )
+
+        assert fetch_started.is_set()
+        assert [message.body for message in history] == ["Root"]
+        release_other_thread_update.set()
+        await access.runtime.event_cache_write_coordinator.wait_for_room_idle("!test:localhost")
 
     @pytest.mark.asyncio
     async def test_cancelled_room_cache_update_does_not_start_queued_coro(self) -> None:


### PR DESCRIPTION
## Summary
- add thread-scoped cache coordination so thread reads and writes wait on room-wide work and same-thread work, but not unrelated threads in the same room
- route outbound and live thread mutations through the thread-specific barrier whenever the thread id is known
- add regression coverage for same-thread serialization and cross-thread non-blocking behavior in the shared event cache coordinator

## Test Plan
- [x] uv run pytest
