### PR TITLE
Disable Chroma telemetry globally

### DIFF
--- a/src/mindroom/__init__.py
+++ b/src/mindroom/__init__.py
@@ -5,8 +5,9 @@ from importlib.metadata import version
 
 from mindroom.constants import patch_chromadb_for_python314
 
-# MindRoom should never emit Agno network telemetry, even if a user .env enables it.
+# MindRoom should never emit vendor network telemetry, even if a user .env enables it.
 os.environ["AGNO_TELEMETRY"] = "false"
+os.environ["ANONYMIZED_TELEMETRY"] = "false"
 
 patch_chromadb_for_python314()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,19 @@
+"""Tests for package-level import side effects."""
+
+import importlib
+import os
+
+import pytest
+
+import mindroom
+
+
+def test_package_init_disables_vendor_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MindRoom should force vendor telemetry off at import time."""
+    monkeypatch.setenv("AGNO_TELEMETRY", "true")
+    monkeypatch.setenv("ANONYMIZED_TELEMETRY", "true")
+
+    importlib.reload(mindroom)
+
+    assert os.environ["AGNO_TELEMETRY"] == "false"
+    assert os.environ["ANONYMIZED_TELEMETRY"] == "false"


### PR DESCRIPTION
## Summary
- force Chroma anonymized telemetry off at MindRoom package import time, alongside the existing Agno override
- keep the override process-wide so user `.env` settings cannot re-enable vendor telemetry
- add a regression test that reloads `mindroom` and verifies both telemetry env vars are forced to `false`

## Verification
- `uv run pytest tests/test_init.py -x -n 0 --no-cov -v`
- `uv sync --all-extras`
- `uv run pytest`
- `uv run pre-commit run --all-files`
