### PR TITLE
refactor: shrink matrix cache thread policy surface

### DIFF
--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -9,7 +9,7 @@ Developer note:
 Package boundary:
 - `mindroom.matrix.cache` is the package-level import surface for cache-facing contracts and shared helpers used above the cache package.
 - `_EventCache` and `_EventCacheWriteCoordinator` remain private concrete implementations used by `runtime_support.py` as the composition-root exception.
-- `MatrixConversationCache` remains the higher-level conversation read/write facade above the cache package.
+- `MatrixConversationCache` remains the higher-level conversation read/write facade above the cache package and may use cache-internal helper modules through narrow Tach visibility.
 
 Main invariants:
 - Runtime disable and room/db ordering live only in the concrete event-cache implementation.
@@ -30,8 +30,11 @@ from .thread_history_result import (
     ThreadHistoryResult,
     thread_history_result,
 )
-from .thread_reads import ThreadReadPolicy
-from .thread_writes import ThreadWritePolicy
+from .thread_reads import ThreadReadPolicy as _ThreadReadPolicy  # noqa: F401
+from .thread_write_cache_ops import ThreadMutationCacheOps as _ThreadMutationCacheOps  # noqa: F401
+from .thread_writes import ThreadLiveWritePolicy as _ThreadLiveWritePolicy  # noqa: F401
+from .thread_writes import ThreadOutboundWritePolicy as _ThreadOutboundWritePolicy  # noqa: F401
+from .thread_writes import ThreadSyncWritePolicy as _ThreadSyncWritePolicy  # noqa: F401
 from .write_coordinator import EventCacheWriteCoordinator, _EventCacheWriteCoordinator
 
 __all__ = [
@@ -45,8 +48,6 @@ __all__ = [
     "EventCacheWriteCoordinator",
     "ThreadCacheState",
     "ThreadHistoryResult",
-    "ThreadReadPolicy",
-    "ThreadWritePolicy",
     "_EventCache",
     "_EventCacheWriteCoordinator",
     "normalize_nio_event_for_cache",

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -138,58 +138,6 @@ class ThreadReadPolicy:
             full_history=False,
         )
 
-    async def get_thread_snapshot(
-        self,
-        room_id: str,
-        thread_id: str,
-    ) -> ThreadHistoryResult:
-        """Resolve advisory lightweight thread context for one thread under the room-scoped barrier."""
-        return await self.read_thread(
-            room_id,
-            thread_id,
-            full_history=False,
-            dispatch_safe=False,
-        )
-
-    async def get_thread_history(
-        self,
-        room_id: str,
-        thread_id: str,
-    ) -> ThreadHistoryResult:
-        """Resolve advisory full thread history for one conversation root."""
-        return await self.read_thread(
-            room_id,
-            thread_id,
-            full_history=True,
-            dispatch_safe=False,
-        )
-
-    async def get_dispatch_thread_snapshot(
-        self,
-        room_id: str,
-        thread_id: str,
-    ) -> ThreadHistoryResult:
-        """Resolve strict lightweight thread context for dispatch under the room-scoped barrier."""
-        return await self.read_thread(
-            room_id,
-            thread_id,
-            full_history=False,
-            dispatch_safe=True,
-        )
-
-    async def get_dispatch_thread_history(
-        self,
-        room_id: str,
-        thread_id: str,
-    ) -> ThreadHistoryResult:
-        """Resolve strict full thread history for dispatch."""
-        return await self.read_thread(
-            room_id,
-            thread_id,
-            full_history=True,
-            dispatch_safe=True,
-        )
-
     async def get_latest_thread_event_id_if_needed(
         self,
         room_id: str,

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -13,7 +13,6 @@ from mindroom.matrix.cache.event_cache_events import (
     normalize_event_source_for_cache,
     normalize_nio_event_for_cache,
 )
-from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.thread_bookkeeping import (
     MutationResolutionContext,
@@ -23,12 +22,9 @@ from mindroom.matrix.thread_bookkeeping import (
 )
 
 if TYPE_CHECKING:
-    import structlog
+    from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
 
-    from mindroom.bot_runtime_view import BotRuntimeView
-
-
-__all__ = ["ThreadWritePolicy", "_collect_sync_timeline_cache_updates"]
+__all__ = ["_collect_sync_timeline_cache_updates"]
 
 
 def _collect_sync_timeline_cache_updates(
@@ -589,108 +585,4 @@ class ThreadSyncWritePolicy:
                     redacted_event_ids,
                 ),
                 name="matrix_cache_sync_timeline",
-            )
-
-
-class ThreadWritePolicy:
-    """Own the public thread-write boundary for one conversation cache."""
-
-    def __init__(
-        self,
-        *,
-        logger_getter: typing.Callable[[], structlog.stdlib.BoundLogger],
-        runtime: BotRuntimeView,
-        require_client: typing.Callable[[], nio.AsyncClient],
-        fetch_event_info_for_thread_resolution: typing.Callable[[str, str], typing.Awaitable[EventInfo | None]],
-    ) -> None:
-        self._resolver = ThreadMutationResolver(
-            logger_getter=logger_getter,
-            runtime=runtime,
-            fetch_event_info_for_thread_resolution=fetch_event_info_for_thread_resolution,
-        )
-        self._cache_ops = ThreadMutationCacheOps(
-            logger_getter=logger_getter,
-            runtime=runtime,
-        )
-        self._outbound = ThreadOutboundWritePolicy(
-            resolver=self._resolver,
-            cache_ops=self._cache_ops,
-            require_client=require_client,
-        )
-        self._live = ThreadLiveWritePolicy(
-            resolver=self._resolver,
-            cache_ops=self._cache_ops,
-        )
-        self._sync = ThreadSyncWritePolicy(
-            resolver=self._resolver,
-            cache_ops=self._cache_ops,
-        )
-
-    def notify_outbound_message(
-        self,
-        room_id: str,
-        event_id: str | None,
-        content: dict[str, Any],
-    ) -> None:
-        """Schedule one locally sent threaded message or edit and fail open on bookkeeping errors."""
-        self._run_fail_open_outbound_write(
-            lambda: self._outbound.notify_outbound_message(room_id, event_id, content),
-            cancelled_message="Ignoring cancelled outbound threaded message cache bookkeeping after successful send",
-            failure_message="Ignoring outbound threaded message cache bookkeeping failure after successful send",
-            room_id=room_id,
-            event_id=event_id,
-        )
-
-    def notify_outbound_redaction(self, room_id: str, redacted_event_id: str) -> None:
-        """Schedule one locally redacted threaded message and fail open on bookkeeping errors."""
-        self._run_fail_open_outbound_write(
-            lambda: self._outbound.notify_outbound_redaction(room_id, redacted_event_id),
-            cancelled_message="Ignoring cancelled outbound threaded message cache redaction bookkeeping after successful redact",
-            failure_message="Ignoring outbound threaded message cache redaction bookkeeping failure after successful redact",
-            room_id=room_id,
-            redacted_event_id=redacted_event_id,
-        )
-
-    async def append_live_event(
-        self,
-        room_id: str,
-        event: nio.RoomMessage,
-        *,
-        event_info: EventInfo,
-    ) -> None:
-        """Append one live threaded event into the advisory cache when the thread is known."""
-        await self._live.append_live_event(room_id, event, event_info=event_info)
-
-    async def apply_redaction(self, room_id: str, event: nio.RedactionEvent) -> None:
-        """Apply one redaction to the advisory cache when the affected thread is known."""
-        await self._live.apply_redaction(room_id, event)
-
-    def cache_sync_timeline(self, response: nio.SyncResponse) -> None:
-        """Queue sync timeline persistence through the room-ordered cache barrier."""
-        self._sync.cache_sync_timeline(response)
-
-    def _run_fail_open_outbound_write(
-        self,
-        callback: typing.Callable[[], None],
-        *,
-        cancelled_message: str,
-        failure_message: str,
-        room_id: str,
-        **log_context: object,
-    ) -> None:
-        try:
-            callback()
-        except asyncio.CancelledError as exc:
-            self._cache_ops.logger.warning(
-                cancelled_message,
-                room_id=room_id,
-                error=str(exc),
-                **log_context,
-            )
-        except Exception as exc:
-            self._cache_ops.logger.warning(
-                failure_message,
-                room_id=room_id,
-                error=str(exc),
-                **log_context,
             )

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -14,8 +15,11 @@ from mindroom.logging_config import get_logger
 from mindroom.matrix.cache import (
     ConversationEventCache,
     ThreadHistoryResult,
-    ThreadReadPolicy,
-    ThreadWritePolicy,
+    _ThreadLiveWritePolicy,
+    _ThreadMutationCacheOps,
+    _ThreadOutboundWritePolicy,
+    _ThreadReadPolicy,
+    _ThreadSyncWritePolicy,
     normalize_nio_event_for_cache,
     thread_history_result,
 )
@@ -27,9 +31,10 @@ from mindroom.matrix.client import (
 )
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.message_content import extract_edit_body
+from mindroom.matrix.thread_bookkeeping import ThreadMutationResolver
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Callable
     from contextlib import AbstractAsyncContextManager
 
     import structlog
@@ -274,18 +279,15 @@ class MatrixConversationCache(ConversationCacheProtocol):
     _turn_thread_read_cache: ContextVar[dict[ThreadReadCacheKey, ThreadReadResult] | None] = field(
         default_factory=lambda: ContextVar("mindroom_turn_thread_read_cache", default=None),
     )
-    _reads: ThreadReadPolicy = field(init=False, repr=False)
-    _writes: ThreadWritePolicy = field(init=False, repr=False)
+    _reads: _ThreadReadPolicy = field(init=False, repr=False)
+    _write_cache_ops: _ThreadMutationCacheOps = field(init=False, repr=False)
+    _outbound: _ThreadOutboundWritePolicy = field(init=False, repr=False)
+    _live: _ThreadLiveWritePolicy = field(init=False, repr=False)
+    _sync: _ThreadSyncWritePolicy = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        """Bind extracted read/write policy collaborators to this facade."""
-        self._writes = ThreadWritePolicy(
-            logger_getter=lambda: self.logger,
-            runtime=self.runtime,
-            require_client=self._require_client,
-            fetch_event_info_for_thread_resolution=self._event_info_for_thread_resolution,
-        )
-        self._reads = ThreadReadPolicy(
+        """Bind extracted read/write collaborators to this facade."""
+        self._reads = _ThreadReadPolicy(
             logger_getter=lambda: self.logger,
             runtime=self.runtime,
             fetch_thread_history_from_client=self._fetch_thread_history_from_client,
@@ -293,6 +295,54 @@ class MatrixConversationCache(ConversationCacheProtocol):
             fetch_dispatch_thread_history_from_client=self._fetch_dispatch_thread_history_from_client,
             fetch_dispatch_thread_snapshot_from_client=self._fetch_dispatch_thread_snapshot_from_client,
         )
+        resolver = ThreadMutationResolver(
+            logger_getter=lambda: self.logger,
+            runtime=self.runtime,
+            fetch_event_info_for_thread_resolution=self._event_info_for_thread_resolution,
+        )
+        self._write_cache_ops = _ThreadMutationCacheOps(
+            logger_getter=lambda: self.logger,
+            runtime=self.runtime,
+        )
+        self._outbound = _ThreadOutboundWritePolicy(
+            resolver=resolver,
+            cache_ops=self._write_cache_ops,
+            require_client=self._require_client,
+        )
+        self._live = _ThreadLiveWritePolicy(
+            resolver=resolver,
+            cache_ops=self._write_cache_ops,
+        )
+        self._sync = _ThreadSyncWritePolicy(
+            resolver=resolver,
+            cache_ops=self._write_cache_ops,
+        )
+
+    def _run_fail_open_outbound_write(
+        self,
+        callback: Callable[[], None],
+        *,
+        cancelled_message: str,
+        failure_message: str,
+        room_id: str,
+        **log_context: object,
+    ) -> None:
+        try:
+            callback()
+        except asyncio.CancelledError as exc:
+            self.logger.warning(
+                cancelled_message,
+                room_id=room_id,
+                error=str(exc),
+                **log_context,
+            )
+        except Exception as exc:
+            self.logger.warning(
+                failure_message,
+                room_id=room_id,
+                error=str(exc),
+                **log_context,
+            )
 
     def _require_client(self) -> nio.AsyncClient:
         client = self.runtime.client
@@ -601,11 +651,23 @@ class MatrixConversationCache(ConversationCacheProtocol):
         content: dict[str, Any],
     ) -> None:
         """Schedule one locally sent threaded message or edit for advisory cache bookkeeping."""
-        self._writes.notify_outbound_message(room_id, event_id, content)
+        self._run_fail_open_outbound_write(
+            lambda: self._outbound.notify_outbound_message(room_id, event_id, content),
+            cancelled_message="Ignoring cancelled outbound threaded message cache bookkeeping after successful send",
+            failure_message="Ignoring outbound threaded message cache bookkeeping failure after successful send",
+            room_id=room_id,
+            event_id=event_id,
+        )
 
     def notify_outbound_redaction(self, room_id: str, redacted_event_id: str) -> None:
         """Schedule one locally redacted threaded message for advisory cache bookkeeping."""
-        self._writes.notify_outbound_redaction(room_id, redacted_event_id)
+        self._run_fail_open_outbound_write(
+            lambda: self._outbound.notify_outbound_redaction(room_id, redacted_event_id),
+            cancelled_message="Ignoring cancelled outbound threaded message cache redaction bookkeeping after successful redact",
+            failure_message="Ignoring outbound threaded message cache redaction bookkeeping failure after successful redact",
+            room_id=room_id,
+            redacted_event_id=redacted_event_id,
+        )
 
     async def append_live_event(
         self,
@@ -615,12 +677,12 @@ class MatrixConversationCache(ConversationCacheProtocol):
         event_info: EventInfo,
     ) -> None:
         """Append one live threaded event into the advisory cache when the thread is known."""
-        await self._writes.append_live_event(room_id, event, event_info=event_info)
+        await self._live.append_live_event(room_id, event, event_info=event_info)
 
     async def apply_redaction(self, room_id: str, event: nio.RedactionEvent) -> None:
         """Apply one redaction to the advisory cache when the affected thread is known."""
-        await self._writes.apply_redaction(room_id, event)
+        await self._live.apply_redaction(room_id, event)
 
     def cache_sync_timeline(self, response: nio.SyncResponse) -> None:
         """Queue sync timeline persistence through the room-ordered cache barrier."""
-        self._writes.cache_sync_timeline(response)
+        self._sync.cache_sync_timeline(response)

--- a/tach.toml
+++ b/tach.toml
@@ -81,13 +81,27 @@ expose = [
     "THREAD_HISTORY_SOURCE_STALE_CACHE",
     "ThreadCacheState",
     "ThreadHistoryResult",
-    "ThreadReadPolicy",
-    "ThreadWritePolicy",
     "normalize_nio_event_for_cache",
     "thread_cache_state_is_usable",
     "thread_history_result",
 ]
 from = ["mindroom.matrix.cache"]
+
+[[interfaces]]
+expose = [
+    "ConversationEventCache",
+    "ThreadHistoryResult",
+    "_ThreadReadPolicy",
+    "_ThreadMutationCacheOps",
+    "_ThreadOutboundWritePolicy",
+    "_ThreadLiveWritePolicy",
+    "_ThreadSyncWritePolicy",
+    "normalize_nio_event_for_cache",
+    "thread_history_result",
+]
+from = ["mindroom.matrix.cache"]
+visibility = ["mindroom.matrix.conversation_cache"]
+exclusive = true
 
 [[interfaces]]
 expose = ["_EventCache", "_EventCacheWriteCoordinator"]

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -21,6 +21,7 @@ import pytest
 import pytest_asyncio
 from nio.api import RelationshipType
 
+import mindroom.matrix.cache as matrix_cache
 from mindroom.background_tasks import create_background_task, wait_for_background_tasks
 from mindroom.bot import AgentBot
 from mindroom.bot_runtime_view import BotRuntimeState
@@ -294,8 +295,25 @@ def _install_runtime_write_coordinator(bot: AgentBot) -> _EventCacheWriteCoordin
     return coordinator
 
 
+def test_matrix_cache_package_does_not_export_thread_policy_wrappers() -> None:
+    """Thread policy wrappers should not remain on the public cache package surface."""
+    assert "ThreadReadPolicy" not in matrix_cache.__all__
+    assert "ThreadWritePolicy" not in matrix_cache.__all__
+    assert not hasattr(matrix_cache, "ThreadReadPolicy")
+    assert not hasattr(matrix_cache, "ThreadWritePolicy")
+
+
 class TestMatrixConversationCacheThreadReads:
     """Targeted read-path tests for invalidate-and-refetch behavior."""
+
+    def test_conversation_cache_does_not_keep_write_policy_wrapper(self) -> None:
+        """Conversation cache should own write collaborators directly, not through a write-policy façade."""
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(),
+        )
+
+        assert not hasattr(access, "_writes")
 
     @pytest.mark.parametrize(
         "error",
@@ -310,7 +328,7 @@ class TestMatrixConversationCacheThreadReads:
             logger=MagicMock(),
             runtime=_conversation_runtime(),
         )
-        access._writes._outbound.notify_outbound_message = Mock(side_effect=error)
+        access._outbound.notify_outbound_message = Mock(side_effect=error)
 
         access.notify_outbound_message(
             "!room:localhost",
@@ -331,7 +349,7 @@ class TestMatrixConversationCacheThreadReads:
             logger=MagicMock(),
             runtime=_conversation_runtime(),
         )
-        access._writes._outbound.notify_outbound_redaction = Mock(side_effect=error)
+        access._outbound.notify_outbound_redaction = Mock(side_effect=error)
 
         access.notify_outbound_redaction(
             "!room:localhost",
@@ -713,7 +731,7 @@ class TestMatrixConversationCacheThreadReads:
             runtime=_conversation_runtime(event_cache=event_cache),
         )
 
-        await access._writes._cache_ops.invalidate_known_thread(
+        await access._write_cache_ops.invalidate_known_thread(
             "!room:localhost",
             "$thread:localhost",
             reason="test_failure",
@@ -731,7 +749,7 @@ class TestMatrixConversationCacheThreadReads:
             runtime=_conversation_runtime(event_cache=event_cache),
         )
 
-        await access._writes._cache_ops.invalidate_room_threads(
+        await access._write_cache_ops.invalidate_room_threads(
             "!room:localhost",
             reason="test_failure",
         )
@@ -3601,7 +3619,7 @@ class TestThreadingBehavior:
         read_task = asyncio.create_task(access.get_thread_history("!room:localhost", "$thread:localhost"))
         await asyncio.wait_for(reader_ready.wait(), timeout=1.0)
         write_task = asyncio.create_task(
-            access._writes._outbound._apply_outbound_message_notification(
+            access._outbound._apply_outbound_message_notification(
                 "!room:localhost",
                 "$reply-new:localhost",
                 new_event_source,


### PR DESCRIPTION
## Summary
- remove `ThreadWritePolicy` from the public `mindroom.matrix.cache` surface and keep conversation-cache write coordination direct
- trim dead thread-read convenience wrappers while keeping the helper modules in place
- tighten Tach and regression tests so the cache package no longer exports the old thread policy wrappers

## Test Plan
- [x] `uv run pre-commit run --files src/mindroom/matrix/conversation_cache.py src/mindroom/matrix/cache/__init__.py src/mindroom/matrix/cache/thread_reads.py src/mindroom/matrix/cache/thread_writes.py src/mindroom/matrix/cache/thread_write_cache_ops.py tests/test_threading_error.py tach.toml`
- [x] `uv run pytest tests/test_threading_error.py -x -n 0 --no-cov -q`