### PR TITLE
refactor: drop cache alias seam

### DIFF
--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -9,7 +9,7 @@ Developer note:
 Package boundary:
 - `mindroom.matrix.cache` is the package-level import surface for cache-facing contracts and shared helpers used above the cache package.
 - `_EventCache` and `_EventCacheWriteCoordinator` remain private concrete implementations used by `runtime_support.py` as the composition-root exception.
-- `MatrixConversationCache` remains the higher-level conversation read/write facade above the cache package and may use cache-internal helper modules through narrow Tach visibility.
+- `MatrixConversationCache` remains the higher-level conversation read/write facade above the cache package and may use specific cache helper submodules through narrow Tach visibility.
 
 Main invariants:
 - Runtime disable and room/db ordering live only in the concrete event-cache implementation.
@@ -30,11 +30,6 @@ from .thread_history_result import (
     ThreadHistoryResult,
     thread_history_result,
 )
-from .thread_reads import ThreadReadPolicy as _ThreadReadPolicy  # noqa: F401
-from .thread_write_cache_ops import ThreadMutationCacheOps as _ThreadMutationCacheOps  # noqa: F401
-from .thread_writes import ThreadLiveWritePolicy as _ThreadLiveWritePolicy  # noqa: F401
-from .thread_writes import ThreadOutboundWritePolicy as _ThreadOutboundWritePolicy  # noqa: F401
-from .thread_writes import ThreadSyncWritePolicy as _ThreadSyncWritePolicy  # noqa: F401
 from .write_coordinator import EventCacheWriteCoordinator, _EventCacheWriteCoordinator
 
 __all__ = [

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -143,39 +143,54 @@ class ThreadOutboundWritePolicy:
         content: dict[str, Any],
     ) -> None:
         """Schedule advisory bookkeeping for one locally sent threaded message or edit."""
-        if not self._cache_ops.cache_runtime_available():
-            return
-        if not isinstance(event_id, str) or not event_id:
-            return
+        try:
+            if not self._cache_ops.cache_runtime_available():
+                return
+            if not isinstance(event_id, str) or not event_id:
+                return
 
-        client = self._require_client()
-        sender = client.user_id if isinstance(client.user_id, str) else None
-        origin_server_ts = int(time.time() * 1000)
-        event_source = normalize_event_source_for_cache(
-            {
-                "type": "m.room.message",
-                "room_id": room_id,
-                "event_id": event_id,
-                "sender": sender,
-                "origin_server_ts": origin_server_ts,
-                "content": dict(content),
-            },
-            event_id=event_id,
-            sender=sender,
-            origin_server_ts=origin_server_ts,
-        )
-        event_info = EventInfo.from_event(event_source)
-        if not is_thread_affecting_relation(event_info):
-            return
+            client = self._require_client()
+            sender = client.user_id if isinstance(client.user_id, str) else None
+            origin_server_ts = int(time.time() * 1000)
+            event_source = normalize_event_source_for_cache(
+                {
+                    "type": "m.room.message",
+                    "room_id": room_id,
+                    "event_id": event_id,
+                    "sender": sender,
+                    "origin_server_ts": origin_server_ts,
+                    "content": dict(content),
+                },
+                event_id=event_id,
+                sender=sender,
+                origin_server_ts=origin_server_ts,
+            )
+            event_info = EventInfo.from_event(event_source)
+            if not is_thread_affecting_relation(event_info):
+                return
 
-        self._schedule_fail_open_room_update(
-            room_id,
-            lambda: self._apply_outbound_message_notification(room_id, event_id, event_source, event_info),
-            name="matrix_cache_notify_outbound_message",
-            cancelled_message="Ignoring cancelled outbound threaded message cache bookkeeping after successful send",
-            failure_message="Ignoring outbound threaded message cache bookkeeping failure after successful send",
-            log_context={"event_id": event_id},
-        )
+            self._schedule_fail_open_room_update(
+                room_id,
+                lambda: self._apply_outbound_message_notification(room_id, event_id, event_source, event_info),
+                name="matrix_cache_notify_outbound_message",
+                cancelled_message="Ignoring cancelled outbound threaded message cache bookkeeping after successful send",
+                failure_message="Ignoring outbound threaded message cache bookkeeping failure after successful send",
+                log_context={"event_id": event_id},
+            )
+        except asyncio.CancelledError as exc:
+            self._cache_ops.logger.warning(
+                "Ignoring cancelled outbound threaded message cache bookkeeping after successful send",
+                room_id=room_id,
+                event_id=event_id,
+                error=str(exc),
+            )
+        except Exception as exc:
+            self._cache_ops.logger.warning(
+                "Ignoring outbound threaded message cache bookkeeping failure after successful send",
+                room_id=room_id,
+                event_id=event_id,
+                error=str(exc),
+            )
 
     async def _apply_outbound_redaction_notification(
         self,
@@ -216,19 +231,34 @@ class ThreadOutboundWritePolicy:
         redacted_event_id: str,
     ) -> None:
         """Schedule advisory bookkeeping for one locally redacted threaded message."""
-        if not self._cache_ops.cache_runtime_available():
-            return
-        if not redacted_event_id:
-            return
+        try:
+            if not self._cache_ops.cache_runtime_available():
+                return
+            if not redacted_event_id:
+                return
 
-        self._schedule_fail_open_room_update(
-            room_id,
-            lambda: self._apply_outbound_redaction_notification(room_id, redacted_event_id),
-            name="matrix_cache_notify_outbound_redaction",
-            cancelled_message="Ignoring cancelled outbound Matrix redaction cache bookkeeping after successful redact",
-            failure_message="Ignoring outbound Matrix redaction cache bookkeeping failure after successful redact",
-            log_context={"redacted_event_id": redacted_event_id},
-        )
+            self._schedule_fail_open_room_update(
+                room_id,
+                lambda: self._apply_outbound_redaction_notification(room_id, redacted_event_id),
+                name="matrix_cache_notify_outbound_redaction",
+                cancelled_message="Ignoring cancelled outbound Matrix redaction cache bookkeeping after successful redact",
+                failure_message="Ignoring outbound Matrix redaction cache bookkeeping failure after successful redact",
+                log_context={"redacted_event_id": redacted_event_id},
+            )
+        except asyncio.CancelledError as exc:
+            self._cache_ops.logger.warning(
+                "Ignoring cancelled outbound Matrix redaction cache bookkeeping after successful redact",
+                room_id=room_id,
+                redacted_event_id=redacted_event_id,
+                error=str(exc),
+            )
+        except Exception as exc:
+            self._cache_ops.logger.warning(
+                "Ignoring outbound Matrix redaction cache bookkeeping failure after successful redact",
+                room_id=room_id,
+                redacted_event_id=redacted_event_id,
+                error=str(exc),
+            )
 
     def _schedule_fail_open_room_update(
         self,

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -15,13 +14,15 @@ from mindroom.logging_config import get_logger
 from mindroom.matrix.cache import (
     ConversationEventCache,
     ThreadHistoryResult,
-    _ThreadLiveWritePolicy,
-    _ThreadMutationCacheOps,
-    _ThreadOutboundWritePolicy,
-    _ThreadReadPolicy,
-    _ThreadSyncWritePolicy,
     normalize_nio_event_for_cache,
     thread_history_result,
+)
+from mindroom.matrix.cache.thread_reads import ThreadReadPolicy
+from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
+from mindroom.matrix.cache.thread_writes import (
+    ThreadLiveWritePolicy,
+    ThreadOutboundWritePolicy,
+    ThreadSyncWritePolicy,
 )
 from mindroom.matrix.client import (
     fetch_dispatch_thread_history,
@@ -34,7 +35,7 @@ from mindroom.matrix.message_content import extract_edit_body
 from mindroom.matrix.thread_bookkeeping import ThreadMutationResolver
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable
+    from collections.abc import AsyncIterator
     from contextlib import AbstractAsyncContextManager
 
     import structlog
@@ -279,15 +280,15 @@ class MatrixConversationCache(ConversationCacheProtocol):
     _turn_thread_read_cache: ContextVar[dict[ThreadReadCacheKey, ThreadReadResult] | None] = field(
         default_factory=lambda: ContextVar("mindroom_turn_thread_read_cache", default=None),
     )
-    _reads: _ThreadReadPolicy = field(init=False, repr=False)
-    _write_cache_ops: _ThreadMutationCacheOps = field(init=False, repr=False)
-    _outbound: _ThreadOutboundWritePolicy = field(init=False, repr=False)
-    _live: _ThreadLiveWritePolicy = field(init=False, repr=False)
-    _sync: _ThreadSyncWritePolicy = field(init=False, repr=False)
+    _reads: ThreadReadPolicy = field(init=False, repr=False)
+    _write_cache_ops: ThreadMutationCacheOps = field(init=False, repr=False)
+    _outbound: ThreadOutboundWritePolicy = field(init=False, repr=False)
+    _live: ThreadLiveWritePolicy = field(init=False, repr=False)
+    _sync: ThreadSyncWritePolicy = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Bind extracted read/write collaborators to this facade."""
-        self._reads = _ThreadReadPolicy(
+        self._reads = ThreadReadPolicy(
             logger_getter=lambda: self.logger,
             runtime=self.runtime,
             fetch_thread_history_from_client=self._fetch_thread_history_from_client,
@@ -300,49 +301,23 @@ class MatrixConversationCache(ConversationCacheProtocol):
             runtime=self.runtime,
             fetch_event_info_for_thread_resolution=self._event_info_for_thread_resolution,
         )
-        self._write_cache_ops = _ThreadMutationCacheOps(
+        self._write_cache_ops = ThreadMutationCacheOps(
             logger_getter=lambda: self.logger,
             runtime=self.runtime,
         )
-        self._outbound = _ThreadOutboundWritePolicy(
+        self._outbound = ThreadOutboundWritePolicy(
             resolver=resolver,
             cache_ops=self._write_cache_ops,
             require_client=self._require_client,
         )
-        self._live = _ThreadLiveWritePolicy(
+        self._live = ThreadLiveWritePolicy(
             resolver=resolver,
             cache_ops=self._write_cache_ops,
         )
-        self._sync = _ThreadSyncWritePolicy(
+        self._sync = ThreadSyncWritePolicy(
             resolver=resolver,
             cache_ops=self._write_cache_ops,
         )
-
-    def _run_fail_open_outbound_write(
-        self,
-        callback: Callable[[], None],
-        *,
-        cancelled_message: str,
-        failure_message: str,
-        room_id: str,
-        **log_context: object,
-    ) -> None:
-        try:
-            callback()
-        except asyncio.CancelledError as exc:
-            self.logger.warning(
-                cancelled_message,
-                room_id=room_id,
-                error=str(exc),
-                **log_context,
-            )
-        except Exception as exc:
-            self.logger.warning(
-                failure_message,
-                room_id=room_id,
-                error=str(exc),
-                **log_context,
-            )
 
     def _require_client(self) -> nio.AsyncClient:
         client = self.runtime.client
@@ -651,23 +626,11 @@ class MatrixConversationCache(ConversationCacheProtocol):
         content: dict[str, Any],
     ) -> None:
         """Schedule one locally sent threaded message or edit for advisory cache bookkeeping."""
-        self._run_fail_open_outbound_write(
-            lambda: self._outbound.notify_outbound_message(room_id, event_id, content),
-            cancelled_message="Ignoring cancelled outbound threaded message cache bookkeeping after successful send",
-            failure_message="Ignoring outbound threaded message cache bookkeeping failure after successful send",
-            room_id=room_id,
-            event_id=event_id,
-        )
+        self._outbound.notify_outbound_message(room_id, event_id, content)
 
     def notify_outbound_redaction(self, room_id: str, redacted_event_id: str) -> None:
         """Schedule one locally redacted threaded message for advisory cache bookkeeping."""
-        self._run_fail_open_outbound_write(
-            lambda: self._outbound.notify_outbound_redaction(room_id, redacted_event_id),
-            cancelled_message="Ignoring cancelled outbound threaded message cache redaction bookkeeping after successful redact",
-            failure_message="Ignoring outbound threaded message cache redaction bookkeeping failure after successful redact",
-            room_id=room_id,
-            redacted_event_id=redacted_event_id,
-        )
+        self._outbound.notify_outbound_redaction(room_id, redacted_event_id)
 
     async def append_live_event(
         self,

--- a/tach.toml
+++ b/tach.toml
@@ -3,11 +3,52 @@ source_roots = ["src"]
 
 [[modules]]
 path = "mindroom.matrix.cache"
+depends_on = [
+    "mindroom.matrix.cache.event_cache_events",
+    "mindroom.matrix.cache.thread_cache_helpers",
+    "mindroom.matrix.cache.thread_history_result",
+]
+
+[[modules]]
+path = "mindroom.matrix.cache.thread_reads"
+depends_on = [
+    "mindroom.matrix.cache.thread_cache_helpers",
+    "mindroom.matrix.cache.thread_history_result",
+]
+
+[[modules]]
+path = "mindroom.matrix.cache.thread_cache_helpers"
 depends_on = []
 
 [[modules]]
+path = "mindroom.matrix.cache.thread_history_result"
+depends_on = []
+
+[[modules]]
+path = "mindroom.matrix.cache.thread_write_cache_ops"
+depends_on = ["mindroom.matrix.cache"]
+
+[[modules]]
+path = "mindroom.matrix.cache.event_cache_events"
+depends_on = []
+
+[[modules]]
+path = "mindroom.matrix.cache.thread_writes"
+depends_on = [
+    "mindroom.matrix.cache.event_cache_events",
+    "mindroom.matrix.cache.thread_write_cache_ops",
+]
+
+[[modules]]
 path = "mindroom.matrix.conversation_cache"
-depends_on = ["mindroom.matrix.cache", "mindroom.matrix.client"]
+depends_on = [
+    "mindroom.matrix.cache",
+    "mindroom.matrix.cache.thread_history_result",
+    "mindroom.matrix.cache.thread_reads",
+    "mindroom.matrix.cache.thread_write_cache_ops",
+    "mindroom.matrix.cache.thread_writes",
+    "mindroom.matrix.client",
+]
 
 [[modules]]
 path = "mindroom.runtime_support"
@@ -19,7 +60,11 @@ depends_on = ["mindroom.matrix.cache"]
 
 [[modules]]
 path = "mindroom.matrix.client"
-depends_on = ["mindroom.matrix.cache", "mindroom.matrix.conversation_cache"]
+depends_on = [
+    "mindroom.matrix.cache",
+    "mindroom.matrix.cache.thread_history_result",
+    "mindroom.matrix.conversation_cache",
+]
 
 [[modules]]
 path = "mindroom.conversation_resolver"
@@ -91,15 +136,32 @@ from = ["mindroom.matrix.cache"]
 expose = [
     "ConversationEventCache",
     "ThreadHistoryResult",
-    "_ThreadReadPolicy",
-    "_ThreadMutationCacheOps",
-    "_ThreadOutboundWritePolicy",
-    "_ThreadLiveWritePolicy",
-    "_ThreadSyncWritePolicy",
     "normalize_nio_event_for_cache",
     "thread_history_result",
 ]
 from = ["mindroom.matrix.cache"]
+visibility = ["mindroom.matrix.conversation_cache"]
+exclusive = true
+
+[[interfaces]]
+expose = ["ThreadReadPolicy"]
+from = ["mindroom.matrix.cache.thread_reads"]
+visibility = ["mindroom.matrix.conversation_cache"]
+exclusive = true
+
+[[interfaces]]
+expose = ["ThreadMutationCacheOps"]
+from = ["mindroom.matrix.cache.thread_write_cache_ops"]
+visibility = ["mindroom.matrix.conversation_cache"]
+exclusive = true
+
+[[interfaces]]
+expose = [
+    "ThreadOutboundWritePolicy",
+    "ThreadLiveWritePolicy",
+    "ThreadSyncWritePolicy",
+]
+from = ["mindroom.matrix.cache.thread_writes"]
 visibility = ["mindroom.matrix.conversation_cache"]
 exclusive = true
 

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -301,6 +301,11 @@ def test_matrix_cache_package_does_not_export_thread_policy_wrappers() -> None:
     assert "ThreadWritePolicy" not in matrix_cache.__all__
     assert not hasattr(matrix_cache, "ThreadReadPolicy")
     assert not hasattr(matrix_cache, "ThreadWritePolicy")
+    assert not hasattr(matrix_cache, "_ThreadReadPolicy")
+    assert not hasattr(matrix_cache, "_ThreadMutationCacheOps")
+    assert not hasattr(matrix_cache, "_ThreadOutboundWritePolicy")
+    assert not hasattr(matrix_cache, "_ThreadLiveWritePolicy")
+    assert not hasattr(matrix_cache, "_ThreadSyncWritePolicy")
 
 
 class TestMatrixConversationCacheThreadReads:
@@ -314,6 +319,7 @@ class TestMatrixConversationCacheThreadReads:
         )
 
         assert not hasattr(access, "_writes")
+        assert not hasattr(access, "_run_fail_open_outbound_write")
 
     @pytest.mark.parametrize(
         "error",
@@ -328,7 +334,7 @@ class TestMatrixConversationCacheThreadReads:
             logger=MagicMock(),
             runtime=_conversation_runtime(),
         )
-        access._outbound.notify_outbound_message = Mock(side_effect=error)
+        access._outbound._require_client = Mock(side_effect=error)
 
         access.notify_outbound_message(
             "!room:localhost",
@@ -349,7 +355,7 @@ class TestMatrixConversationCacheThreadReads:
             logger=MagicMock(),
             runtime=_conversation_runtime(),
         )
-        access._outbound.notify_outbound_redaction = Mock(side_effect=error)
+        access._outbound._schedule_fail_open_room_update = Mock(side_effect=error)
 
         access.notify_outbound_redaction(
             "!room:localhost",


### PR DESCRIPTION
## Why
PR #621 removed the old `ThreadReadPolicy` / `ThreadWritePolicy` exports, but it did not remove the fake cache seam itself.
`mindroom.matrix.cache` was still re-exporting the same helper collaborators under underscore aliases and Tach was still treating those aliases as an official interface for `conversation_cache.py`.
That meant we had only renamed the seam, not deleted it.

It also left the outbound fail-open boundary defined in two places.
`ThreadOutboundWritePolicy` already owned the queued outbound failure handling, but `MatrixConversationCache` added another `_run_fail_open_outbound_write()` wrapper on top.
This follow-up removes that duplication and makes the ownership line honest again.

## Summary
- stop re-exporting cache helper collaborators through `mindroom.matrix.cache` and let `conversation_cache.py` use the real helper submodules directly
- move the outbound fail-open boundary fully into `ThreadOutboundWritePolicy` so `MatrixConversationCache` no longer duplicates that wrapper
- update Tach module/interface declarations and regression tests to lock the real helper-module boundary

## Test Plan
- [x] `uv run pre-commit run --files src/mindroom/matrix/conversation_cache.py src/mindroom/matrix/cache/__init__.py src/mindroom/matrix/cache/thread_reads.py src/mindroom/matrix/cache/thread_cache_helpers.py src/mindroom/matrix/cache/thread_history_result.py src/mindroom/matrix/cache/thread_write_cache_ops.py src/mindroom/matrix/cache/event_cache_events.py src/mindroom/matrix/cache/thread_writes.py src/mindroom/matrix/client.py tests/test_threading_error.py tach.toml`
- [x] `uv run pytest tests/test_threading_error.py -x -n 0 --no-cov -q`