### PR TITLE
perf: persist durable MXC sidecar text cache

### DIFF
--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -19,13 +19,14 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
     from pathlib import Path
 
-EVENT_CACHE_SCHEMA_VERSION = 7
+EVENT_CACHE_SCHEMA_VERSION = 8
 _EVENT_CACHE_TABLES = (
     "thread_events",
     "events",
     "event_edits",
     "event_threads",
     "redacted_events",
+    "mxc_text_cache",
     "thread_cache_state",
     "room_cache_state",
 )
@@ -124,6 +125,15 @@ async def create_event_cache_schema(db: aiosqlite.Connection) -> None:
             room_id TEXT NOT NULL,
             event_id TEXT NOT NULL,
             PRIMARY KEY (room_id, event_id)
+        )
+        """,
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mxc_text_cache (
+            mxc_url TEXT PRIMARY KEY,
+            text_content TEXT NOT NULL,
+            cached_at REAL NOT NULL
         )
         """,
     )
@@ -366,11 +376,17 @@ class ConversationEventCache(Protocol):
     async def get_latest_edit(self, room_id: str, original_event_id: str) -> dict[str, Any] | None:
         """Return the latest cached edit event for one original event."""
 
+    async def get_mxc_text(self, room_id: str, mxc_url: str) -> str | None:
+        """Return one durably cached MXC text payload when present."""
+
     async def store_event(self, event_id: str, room_id: str, event_data: dict[str, Any]) -> None:
         """Insert or replace one individually cached Matrix event."""
 
     async def store_events_batch(self, events: list[tuple[str, str, dict[str, Any]]]) -> None:
         """Insert or replace a batch of individually cached Matrix events."""
+
+    async def store_mxc_text(self, room_id: str, mxc_url: str, text: str) -> None:
+        """Insert or replace one durably cached MXC text payload."""
 
     async def replace_thread(
         self,
@@ -519,6 +535,18 @@ class _EventCache:
             ),
         )
 
+    async def get_mxc_text(self, room_id: str, mxc_url: str) -> str | None:
+        """Return one durably cached MXC text payload when present."""
+        return await self._read_operation(
+            room_id,
+            operation="get_mxc_text",
+            disabled_result=None,
+            reader=lambda db: event_cache_events.load_mxc_text(
+                db,
+                mxc_url=mxc_url,
+            ),
+        )
+
     async def store_event(self, event_id: str, room_id: str, event_data: dict[str, Any]) -> None:
         """Insert or replace one individually cached Matrix event."""
         await self.store_events_batch([(event_id, room_id, event_data)])
@@ -549,6 +577,20 @@ class _EventCache:
                     cached_at=cached_at,
                 ),
             )
+
+    async def store_mxc_text(self, room_id: str, mxc_url: str, text: str) -> None:
+        """Insert or replace one durably cached MXC text payload."""
+        await self._write_operation(
+            room_id,
+            operation="store_mxc_text",
+            disabled_result=None,
+            writer=lambda db: event_cache_events.persist_mxc_text(
+                db,
+                mxc_url=mxc_url,
+                text=text,
+                cached_at=time.time(),
+            ),
+        )
 
     async def replace_thread(
         self,

--- a/src/mindroom/matrix/cache/event_cache_events.py
+++ b/src/mindroom/matrix/cache/event_cache_events.py
@@ -145,6 +145,42 @@ async def load_latest_edit(
     return None if row is None else json.loads(row[0])
 
 
+async def load_mxc_text(
+    db: aiosqlite.Connection,
+    *,
+    mxc_url: str,
+) -> str | None:
+    """Return one durably cached MXC text payload when present."""
+    cursor = await db.execute(
+        """
+        SELECT text_content
+        FROM mxc_text_cache
+        WHERE mxc_url = ?
+        """,
+        (mxc_url,),
+    )
+    row = await cursor.fetchone()
+    await cursor.close()
+    return None if row is None else str(row[0])
+
+
+async def persist_mxc_text(
+    db: aiosqlite.Connection,
+    *,
+    mxc_url: str,
+    text: str,
+    cached_at: float,
+) -> None:
+    """Insert or replace one durably cached MXC text payload."""
+    await db.execute(
+        """
+        INSERT OR REPLACE INTO mxc_text_cache(mxc_url, text_content, cached_at)
+        VALUES (?, ?, ?)
+        """,
+        (mxc_url, text, cached_at),
+    )
+
+
 async def persist_lookup_events(
     db: aiosqlite.Connection,
     *,

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -1342,9 +1342,11 @@ def _bundled_replacement_source(event_source: Mapping[str, Any]) -> dict[str, An
 async def _resolve_thread_history_from_event_sources_timed(
     client: nio.AsyncClient,
     *,
+    room_id: str,
     thread_id: str,
     event_sources: Sequence[dict[str, Any]],
     hydrate_sidecars: bool = True,
+    event_cache: ConversationEventCache,
 ) -> tuple[list[ResolvedVisibleMessage], float]:
     """Resolve visible thread history and return approximate sidecar hydration time."""
     input_order_by_event_id: dict[str, int] = {}
@@ -1384,7 +1386,14 @@ async def _resolve_thread_history_from_event_sources_timed(
         if event_info.is_edit or event.event_id in messages_by_event_id:
             continue
         messages_by_event_id[event.event_id] = (
-            await _resolve_thread_history_message(event, client) if hydrate_sidecars else _snapshot_message_dict(event)
+            await _resolve_thread_history_message(
+                event,
+                client,
+                event_cache=event_cache,
+                room_id=room_id,
+            )
+            if hydrate_sidecars
+            else _snapshot_message_dict(event)
         )
 
     await _apply_latest_edits_to_messages(
@@ -1392,6 +1401,8 @@ async def _resolve_thread_history_from_event_sources_timed(
         messages_by_event_id=messages_by_event_id,
         latest_edits_by_original_event_id=latest_edits_by_original_event_id,
         required_thread_id=thread_id,
+        event_cache=event_cache,
+        room_id=room_id,
     )
     messages = list(messages_by_event_id.values())
     sort_thread_messages_root_first(
@@ -1473,9 +1484,11 @@ async def _resolve_cached_thread_history(
     try:
         return await _resolve_thread_history_from_event_sources_timed(
             client,
+            room_id=room_id,
             thread_id=thread_id,
             event_sources=cached_event_sources,
             hydrate_sidecars=hydrate_sidecars,
+            event_cache=event_cache,
         )
     except Exception as exc:
         logger.warning(
@@ -1557,6 +1570,7 @@ async def _fetch_thread_history_with_events(
     thread_id: str,
     *,
     hydrate_sidecars: bool,
+    event_cache: ConversationEventCache,
 ) -> _ThreadHistoryFetchResult:
     """Fetch thread history and raw event sources from the homeserver."""
     return await _fetch_thread_history_via_room_messages_with_events(
@@ -1564,6 +1578,7 @@ async def _fetch_thread_history_with_events(
         room_id,
         thread_id,
         hydrate_sidecars=hydrate_sidecars,
+        event_cache=event_cache,
     )
 
 
@@ -1583,6 +1598,7 @@ async def refresh_thread_history_from_source(
             room_id,
             thread_id,
             hydrate_sidecars=hydrate_sidecars,
+            event_cache=event_cache,
         )
     except Exception as exc:
         if allow_stale_fallback:
@@ -1653,10 +1669,18 @@ def _thread_history_fetch_is_cacheable(
 async def _resolve_thread_history_message(
     event: nio.Event,
     client: nio.AsyncClient,
+    *,
+    event_cache: ConversationEventCache,
+    room_id: str,
 ) -> ResolvedVisibleMessage:
     """Resolve one room-message event into the normalized thread-history shape."""
     if isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES):
-        message_data = await extract_and_resolve_message(event, client)
+        message_data = await extract_and_resolve_message(
+            event,
+            client,
+            event_cache=event_cache,
+            room_id=room_id,
+        )
         return ResolvedVisibleMessage.from_message_data(
             message_data,
             thread_id=EventInfo.from_event(event.source).thread_id,
@@ -1666,6 +1690,8 @@ async def _resolve_thread_history_message(
     resolved_event_source = await resolve_event_source_content(
         event.source if isinstance(event.source, dict) else {},
         client,
+        event_cache=event_cache,
+        room_id=room_id,
     )
     content = resolved_event_source.get("content", {})
     normalized_content = content if isinstance(content, dict) else {}
@@ -1717,6 +1743,8 @@ async def _apply_latest_edits_to_messages(
     messages_by_event_id: dict[str, ResolvedVisibleMessage],
     latest_edits_by_original_event_id: dict[str, tuple[nio.RoomMessageText | nio.RoomMessageNotice, str | None]],
     required_thread_id: str | None = None,
+    event_cache: ConversationEventCache | None = None,
+    room_id: str | None = None,
 ) -> None:
     """Apply latest edits to message records and synthesize missing originals when allowed."""
     for original_event_id, (edit_event, edit_thread_id) in latest_edits_by_original_event_id.items():
@@ -1727,7 +1755,12 @@ async def _apply_latest_edits_to_messages(
         if existing_message is None and required_thread_id is not None and edit_thread_id != required_thread_id:
             continue
 
-        edited_body, edited_content = await extract_edit_body(edit_event.source, client)
+        edited_body, edited_content = await extract_edit_body(
+            edit_event.source,
+            client,
+            event_cache=event_cache,
+            room_id=room_id,
+        )
         if edited_body is None:
             continue
 
@@ -1951,15 +1984,18 @@ async def _fetch_thread_history_via_room_messages_with_events(
     thread_id: str,
     *,
     hydrate_sidecars: bool,
+    event_cache: ConversationEventCache,
 ) -> _ThreadHistoryFetchResult:
     """Fetch all thread messages by scanning room history pages."""
     event_sources, _root_message_found = await _fetch_thread_event_sources_via_room_messages(client, room_id, thread_id)
     resolution_started = time.perf_counter()
     history, sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
         client,
+        room_id=room_id,
         thread_id=thread_id,
         event_sources=event_sources,
         hydrate_sidecars=hydrate_sidecars,
+        event_cache=event_cache,
     )
     return _ThreadHistoryFetchResult(
         history=history,

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -174,7 +174,12 @@ async def _apply_cached_latest_edit(
     if latest_edit_source is None:
         return event_source
 
-    edited_body, edited_content = await extract_edit_body(latest_edit_source, client)
+    edited_body, edited_content = await extract_edit_body(
+        latest_edit_source,
+        client,
+        event_cache=event_cache,
+        room_id=room_id,
+    )
     if edited_body is None or edited_content is None:
         return event_source
 

--- a/src/mindroom/matrix/message_content.py
+++ b/src/mindroom/matrix/message_content.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import json
 import time
 from collections import OrderedDict
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import nio
 from nio import crypto
 
 from mindroom.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from mindroom.matrix.cache import ConversationEventCache
 
 logger = get_logger(__name__)
 
@@ -91,10 +94,13 @@ def _sidecar_mxc_url(content: dict[str, Any]) -> str | None:
     return file_url if isinstance(file_url, str) else None
 
 
-async def _download_mxc_text(  # noqa: PLR0911, C901
+async def _download_mxc_text(  # noqa: PLR0911, PLR0912, PLR0915, C901
     client: nio.AsyncClient,
     mxc_url: str,
     file_info: dict[str, Any] | None = None,
+    *,
+    event_cache: ConversationEventCache | None = None,
+    room_id: str | None = None,
 ) -> str | None:
     """Download text content from an MXC URL with caching.
 
@@ -102,6 +108,8 @@ async def _download_mxc_text(  # noqa: PLR0911, C901
         client: Matrix client
         mxc_url: The MXC URL to download from
         file_info: Optional encryption info for E2EE rooms
+        event_cache: Optional durable event cache used for restart-safe MXC text reuse
+        room_id: Room scope for event-cache locking when a durable MXC cache is available
     Returns:
         The downloaded text content, or None if download failed
 
@@ -116,6 +124,19 @@ async def _download_mxc_text(  # noqa: PLR0911, C901
             return content
         # Expired, remove from cache
         del _mxc_cache[mxc_url]
+
+    if event_cache is not None and room_id is not None:
+        try:
+            cached_text = await event_cache.get_mxc_text(room_id, mxc_url)
+        except Exception:
+            logger.exception("Failed to read durable MXC text cache")
+        else:
+            if cached_text is not None:
+                _mxc_cache[mxc_url] = (cached_text, current_time)
+                _mxc_cache.move_to_end(mxc_url)
+                _clean_expired_cache()
+                logger.debug("mxc_text_cache_hit", mxc_url=mxc_url, room_id=room_id)
+                return cached_text
 
     try:
         # Parse MXC URL
@@ -162,6 +183,11 @@ async def _download_mxc_text(  # noqa: PLR0911, C901
         _mxc_cache[mxc_url] = (decoded_text, time.time())
         _mxc_cache.move_to_end(mxc_url)
         logger.debug("mxc_content_cached", mxc_url=mxc_url)
+        if event_cache is not None and room_id is not None:
+            try:
+                await event_cache.store_mxc_text(room_id, mxc_url, decoded_text)
+            except Exception:
+                logger.exception("Failed to persist durable MXC text cache")
 
         if len(_mxc_cache) > _mxc_cache_max_entries:
             _clean_expired_cache()
@@ -176,6 +202,9 @@ async def _download_mxc_text(  # noqa: PLR0911, C901
 async def extract_and_resolve_message(
     event: nio.RoomMessageText | nio.RoomMessageNotice,
     client: nio.AsyncClient | None = None,
+    *,
+    event_cache: ConversationEventCache | None = None,
+    room_id: str | None = None,
 ) -> dict[str, Any]:
     """Extract message data and resolve large message content if needed.
 
@@ -185,6 +214,8 @@ async def extract_and_resolve_message(
     Args:
         event: The Matrix event to extract data from
         client: Optional Matrix client for downloading attachments
+        event_cache: Optional durable event cache used for restart-safe sidecar reuse
+        room_id: Room scope for durable sidecar cache reads and writes
 
     Returns:
         Dict with sender, body, timestamp, event_id, and content fields.
@@ -194,7 +225,12 @@ async def extract_and_resolve_message(
     """
     # Extract basic message data
     preview_content = _normalized_content_dict(event.source.get("content", {}))
-    resolved_content = await _resolve_canonical_content(preview_content, client)
+    resolved_content = await _resolve_canonical_content(
+        preview_content,
+        client,
+        event_cache=event_cache,
+        room_id=room_id,
+    )
     message_data = {
         "sender": event.sender,
         "body": _content_body(resolved_content, event.body),
@@ -211,10 +247,18 @@ async def extract_and_resolve_message(
 async def extract_edit_body(
     event_source: dict[str, Any],
     client: nio.AsyncClient | None = None,
+    *,
+    event_cache: ConversationEventCache | None = None,
+    room_id: str | None = None,
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Extract body/content from an edit event's ``m.new_content`` payload."""
     content = _normalized_content_dict(event_source.get("content", {}))
-    resolved_content = await _resolve_canonical_content(content, client)
+    resolved_content = await _resolve_canonical_content(
+        content,
+        client,
+        event_cache=event_cache,
+        room_id=room_id,
+    )
     new_content = _normalized_content_dict(resolved_content.get("m.new_content"))
 
     body = new_content.get("body")
@@ -226,10 +270,18 @@ async def extract_edit_body(
 async def resolve_event_source_content(
     event_source: dict[str, Any],
     client: nio.AsyncClient | None = None,
+    *,
+    event_cache: ConversationEventCache | None = None,
+    room_id: str | None = None,
 ) -> dict[str, Any]:
     """Return an event source with canonical v2 sidecar content hydrated when available."""
     preview_content = _normalized_content_dict(event_source.get("content", {}))
-    resolved_content = await _resolve_canonical_content(preview_content, client)
+    resolved_content = await _resolve_canonical_content(
+        preview_content,
+        client,
+        event_cache=event_cache,
+        room_id=room_id,
+    )
     if resolved_content is preview_content:
         return event_source
 
@@ -241,6 +293,9 @@ async def resolve_event_source_content(
 async def _resolve_canonical_content(
     content: dict[str, Any],
     client: nio.AsyncClient | None,
+    *,
+    event_cache: ConversationEventCache | None,
+    room_id: str | None,
 ) -> dict[str, Any]:
     """Hydrate canonical event content from a v2 JSON sidecar when available."""
     sidecar_content = _sidecar_content_for_resolution(content)
@@ -257,6 +312,8 @@ async def _resolve_canonical_content(
         client,
         mxc_url,
         sidecar_content.get("file") if isinstance(sidecar_content.get("file"), dict) else None,
+        event_cache=event_cache,
+        room_id=room_id,
     )
     if full_text is None:
         return content

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -209,6 +209,7 @@ def make_event_cache_mock() -> AsyncMock:
     event_cache = AsyncMock(spec=_EventCache)
     event_cache.get_event.return_value = None
     event_cache.get_latest_edit.return_value = None
+    event_cache.get_mxc_text.return_value = None
     event_cache.get_thread_events.return_value = None
     event_cache.get_thread_cache_state.return_value = None
     event_cache.get_thread_id_for_event.return_value = None

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -19,6 +19,7 @@ from mindroom.matrix.cache.event_cache import _EventCache
 from mindroom.matrix.client import fetch_thread_history
 from mindroom.matrix.conversation_cache import _cached_room_get_event as cached_room_get_event
 from mindroom.matrix.event_info import EventInfo
+from mindroom.matrix.message_content import _clear_mxc_cache
 from mindroom.timing import DispatchPipelineTiming
 
 if TYPE_CHECKING:
@@ -1360,6 +1361,113 @@ async def test_fetch_thread_history_cache_miss_does_full_fetch(tmp_path: Path) -
     assert [event["event_id"] for event in cached_events] == ["$thread_root", "$reply"]
     client.room_get_event.assert_not_awaited()
     client.room_messages.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mxc_text_cache_round_trips_across_event_cache_reopen(tmp_path: Path) -> None:
+    """Durable MXC text rows should survive closing and reopening the event cache."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+
+    try:
+        await cache.store_mxc_text("!room:localhost", "mxc://server/sidecar", "Full text sidecar")
+    finally:
+        await cache.close()
+
+    reopened_cache = _EventCache(db_path)
+    await reopened_cache.initialize()
+    try:
+        cached_text = await reopened_cache.get_mxc_text("!room:localhost", "mxc://server/sidecar")
+    finally:
+        await reopened_cache.close()
+
+    assert cached_text == "Full text sidecar"
+
+
+@pytest.mark.asyncio
+async def test_fetch_thread_history_reuses_durable_mxc_text_after_restart(tmp_path: Path) -> None:
+    """Cached full-history reads should reuse durable sidecar text after a restart."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    _clear_mxc_cache()
+
+    root_event = _make_text_event(
+        event_id="$thread_root",
+        sender="@user:localhost",
+        body="Root message",
+        server_timestamp=1000,
+        source_content={"body": "Root message"},
+    )
+    sidecar_reply = _make_text_event(
+        event_id="$reply",
+        sender="@agent:localhost",
+        body="Preview reply",
+        server_timestamp=2000,
+        source_content={
+            "body": "Preview reply",
+            "msgtype": "m.file",
+            "io.mindroom.long_text": {
+                "version": 2,
+                "encoding": "matrix_event_content_json",
+            },
+            "url": "mxc://server/sidecar",
+            "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+        },
+    )
+    canonical_sidecar_content = {"body": "Full reply", "msgtype": "m.text"}
+
+    first_client = MagicMock()
+    first_client.download = AsyncMock(
+        return_value=MagicMock(
+            spec=nio.DownloadResponse,
+            body=json.dumps(canonical_sidecar_content).encode("utf-8"),
+        ),
+    )
+    first_client.room_get_event = AsyncMock()
+    first_client.room_messages = AsyncMock()
+    first_client.room_get_event_relations = MagicMock()
+
+    try:
+        await _seed_thread_cache(
+            cache,
+            room_id="!room:localhost",
+            thread_id="$thread_root",
+            events=[_cache_source(root_event), _cache_source(sidecar_reply)],
+        )
+
+        first_history = await fetch_thread_history(first_client, "!room:localhost", "$thread_root", event_cache=cache)
+    finally:
+        await cache.close()
+
+    _clear_mxc_cache()
+
+    reopened_cache = _EventCache(db_path)
+    await reopened_cache.initialize()
+    second_client = MagicMock()
+    second_client.download = AsyncMock(
+        return_value=MagicMock(spec=nio.DownloadError),
+    )
+    second_client.room_get_event = AsyncMock()
+    second_client.room_messages = AsyncMock()
+    second_client.room_get_event_relations = MagicMock()
+
+    try:
+        second_history = await fetch_thread_history(
+            second_client,
+            "!room:localhost",
+            "$thread_root",
+            event_cache=reopened_cache,
+        )
+    finally:
+        await reopened_cache.close()
+        _clear_mxc_cache()
+
+    assert [message.body for message in first_history] == ["Root message", "Full reply"]
+    assert [message.body for message in second_history] == ["Root message", "Full reply"]
+    first_client.download.assert_awaited_once_with(mxc="mxc://server/sidecar")
+    second_client.download.assert_not_awaited()
 
 
 def test_event_cache_uses_distinct_locks_per_room(tmp_path: Path) -> None:

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -243,6 +243,7 @@ class TestThreadHistory:
             "!room:localhost",
             "$thread_root",
             hydrate_sidecars=True,
+            event_cache=event_cache,
         )
         mock_store.assert_awaited_once_with(
             event_cache,
@@ -1078,6 +1079,7 @@ class TestThreadHistory:
                 "!room:localhost",
                 "$thread_root",
                 hydrate_sidecars=True,
+                event_cache=_event_cache(),
             )
         ).history
         serialized = [message.to_dict() for message in history]
@@ -1136,6 +1138,7 @@ class TestThreadHistory:
                 "!room:localhost",
                 "$thread_root",
                 hydrate_sidecars=True,
+                event_cache=_event_cache(),
             )
         ).history
         serialized = [message.to_dict() for message in history]
@@ -1191,6 +1194,7 @@ class TestThreadHistory:
                 "!room:localhost",
                 "$thread_root",
                 hydrate_sidecars=True,
+                event_cache=_event_cache(),
             )
         ).history
 
@@ -1383,6 +1387,7 @@ class TestThreadHistory:
                 "!room:localhost",
                 "$root",
                 hydrate_sidecars=True,
+                event_cache=_event_cache(),
             )
         ).history
 
@@ -1396,6 +1401,7 @@ class TestThreadHistory:
 
         history, _sidecar_ms = await _resolve_thread_history_from_event_sources_timed(
             client,
+            room_id="!room:localhost",
             thread_id="$root",
             event_sources=[
                 {
@@ -1429,6 +1435,7 @@ class TestThreadHistory:
                 },
             ],
             hydrate_sidecars=True,
+            event_cache=_event_cache(),
         )
 
         assert [message.event_id for message in history] == ["$root", "$zzz_parent", "$aaa_child"]
@@ -1592,8 +1599,10 @@ class TestThreadHistory:
 
         history, _sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
             client,
+            room_id="!room:localhost",
             thread_id="$thread_root",
             event_sources=[_event_source_for_cache(root_event), _event_source_for_cache(edit_only_event)],
+            event_cache=_event_cache(),
         )
 
         assert [message.event_id for message in history] == ["$thread_root"]
@@ -1630,8 +1639,10 @@ class TestThreadHistory:
         with patch("mindroom.matrix.client.extract_edit_body", new_callable=AsyncMock) as mock_extract_edit_body:
             history, _sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
                 client,
+                room_id="!room:localhost",
                 thread_id="$thread_root",
                 event_sources=[_event_source_for_cache(root_event), _event_source_for_cache(unrelated_edit)],
+                event_cache=_event_cache(),
             )
 
         assert [message.event_id for message in history] == ["$thread_root"]
@@ -1672,8 +1683,10 @@ class TestThreadHistory:
 
         history, _sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
             client,
+            room_id="!room:localhost",
             thread_id="$thread_root",
             event_sources=[_event_source_for_cache(root_event), _event_source_for_cache(edit_only_event)],
+            event_cache=_event_cache(),
         )
 
         assert [message.event_id for message in history] == ["$thread_root", "$missing_original"]
@@ -1828,6 +1841,7 @@ class TestThreadHistory:
                 "!room:localhost",
                 "$thread_root",
                 hydrate_sidecars=True,
+                event_cache=_event_cache(),
             )
 
     @pytest.mark.asyncio
@@ -1855,6 +1869,7 @@ class TestThreadHistory:
                 "!room:localhost",
                 "$thread_root",
                 hydrate_sidecars=True,
+                event_cache=_event_cache(),
             )
 
 


### PR DESCRIPTION
## Summary
- upstream only the durable MXC sidecar text cache persistence commit onto current `main`
- keep this PR scoped to the single sidecar-cache persistence change

## Verification
- branch pushed for review
- full `pre-commit --all-files` and `pytest -n auto` still pending before final readiness