### PR TITLE
fix: preserve hot thread cache across stop-button cleanup

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1317,7 +1317,11 @@ class AgentBot:
                     message_id=event.reacts_to,
                     requested_by=event.sender,
                 )
-                await self.stop_manager.remove_stop_button(self.client, event.reacts_to)
+                await self.stop_manager.remove_stop_button(
+                    self.client,
+                    event.reacts_to,
+                    notify_outbound_redaction=self._conversation_cache.notify_outbound_redaction,
+                )
                 await self._send_response(room.room_id, event.reacts_to, _STOPPING_RESPONSE_TEXT, None)
                 return
 

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -413,6 +413,15 @@ class ConversationEventCache(Protocol):
     async def append_event(self, room_id: str, thread_id: str, event: dict[str, Any]) -> bool:
         """Append one event when the thread already has cached data."""
 
+    async def revalidate_thread_after_incremental_update(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        runtime_started_at: float,
+    ) -> bool:
+        """Refresh thread validation after a safe incremental update in the current runtime."""
+
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
         """Return the cached thread ID for one event."""
 
@@ -679,6 +688,28 @@ class _EventCache:
                     room_id=room_id,
                     thread_id=thread_id,
                     normalized_event=normalized_event,
+                ),
+            ),
+        )
+
+    async def revalidate_thread_after_incremental_update(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        runtime_started_at: float,
+    ) -> bool:
+        """Refresh one thread's validated timestamp after a safe incremental update."""
+        return bool(
+            await self._write_operation(
+                room_id,
+                operation="revalidate_thread_after_incremental_update",
+                disabled_result=False,
+                writer=lambda db: event_cache_threads.revalidate_thread_after_incremental_update_locked(
+                    db,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    runtime_started_at=runtime_started_at,
                 ),
             ),
         )

--- a/src/mindroom/matrix/cache/event_cache_threads.py
+++ b/src/mindroom/matrix/cache/event_cache_threads.py
@@ -35,6 +35,15 @@ class ThreadCacheState:
     room_invalidation_reason: str | None
 
 
+_INCREMENTAL_THREAD_REVALIDATION_REASONS = frozenset(
+    {
+        "live_thread_mutation",
+        "sync_thread_mutation",
+        "outbound_thread_mutation",
+    },
+)
+
+
 async def load_thread_events(
     db: aiosqlite.Connection,
     *,
@@ -340,6 +349,41 @@ async def mark_thread_stale_locked(
         """,
         (room_id, thread_id, time.time(), reason),
     )
+
+
+async def revalidate_thread_after_incremental_update_locked(
+    db: aiosqlite.Connection,
+    *,
+    room_id: str,
+    thread_id: str,
+    runtime_started_at: float,
+) -> bool:
+    """Mark one thread cache fresh after a safe incremental update in the current runtime."""
+    row = await load_thread_cache_state_row(
+        db,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    if row is None:
+        return False
+    validated_at, invalidated_at, invalidation_reason, room_invalidated_at, _room_invalidation_reason = row
+    if validated_at is None or validated_at < runtime_started_at:
+        return False
+    if invalidated_at is None or invalidation_reason not in _INCREMENTAL_THREAD_REVALIDATION_REASONS:
+        return False
+    if invalidated_at < runtime_started_at:
+        return False
+    if room_invalidated_at is not None and room_invalidated_at >= validated_at:
+        return False
+    await db.execute(
+        """
+        UPDATE thread_cache_state
+        SET validated_at = ?, invalidated_at = NULL, invalidation_reason = NULL
+        WHERE room_id = ? AND thread_id = ?
+        """,
+        (time.time(), room_id, thread_id),
+    )
+    return True
 
 
 async def mark_room_stale_locked(

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -107,7 +107,7 @@ class ThreadMutationCacheOps:
                 reason=success_reason if redacted else failure_reason,
             )
             return
-        if impact.state is MutationThreadImpactState.UNKNOWN:
+        if impact.state is MutationThreadImpactState.UNKNOWN and redacted:
             await self.invalidate_room_threads(room_id, reason=lookup_unavailable_reason)
 
     async def invalidate_known_thread(
@@ -187,7 +187,23 @@ class ThreadMutationCacheOps:
                 event_id=event_id,
                 context=context,
             )
-        return bool(appended)
+            return False
+        try:
+            await self.runtime.event_cache.revalidate_thread_after_incremental_update(
+                room_id,
+                thread_id,
+                runtime_started_at=self.runtime.runtime_started_at,
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "Failed to refresh thread cache validation after incremental update",
+                room_id=room_id,
+                thread_id=thread_id,
+                event_id=event_id,
+                context=context,
+                error=str(exc),
+            )
+        return True
 
     def _disable_cache_after_fail_closed_invalidation(
         self,

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -155,15 +155,21 @@ class ThreadOutboundWritePolicy:
             normalized_event_source = self._normalize_outbound_event_source(room_id, event_source)
             if normalized_event_source is None:
                 return
-            event_id = normalized_event_source["event_id"]
+            event_id_value = normalized_event_source.get("event_id")
+            if not isinstance(event_id_value, str) or not event_id_value:
+                return
+            event_id = typing.cast("str", event_id_value)
 
             event_info = EventInfo.from_event(normalized_event_source)
             if event_info.is_reaction:
+                persisted_batch: list[tuple[str, str, dict[str, object]]] = [
+                    (event_id, room_id, normalized_event_source),
+                ]
                 self._schedule_fail_open_room_update(
                     room_id,
                     lambda: self._cache_ops.store_events_batch(
                         room_id,
-                        [(event_id, room_id, normalized_event_source)],
+                        persisted_batch,
                         failure_message="Failed to persist outbound reaction lookup to cache",
                     ),
                     name="matrix_cache_notify_outbound_event",
@@ -188,19 +194,19 @@ class ThreadOutboundWritePolicy:
                 log_context={"event_id": event_id},
             )
         except asyncio.CancelledError as exc:
-            event_id = event_source.get("event_id")
+            raw_event_id = event_source.get("event_id")
             self._cache_ops.logger.warning(
                 "Ignoring cancelled outbound cache bookkeeping after successful send",
                 room_id=room_id,
-                event_id=event_id if isinstance(event_id, str) else None,
+                event_id=raw_event_id if isinstance(raw_event_id, str) else None,
                 error=str(exc),
             )
         except Exception as exc:
-            event_id = event_source.get("event_id")
+            raw_event_id = event_source.get("event_id")
             self._cache_ops.logger.warning(
                 "Ignoring outbound cache bookkeeping failure after successful send",
                 room_id=room_id,
-                event_id=event_id if isinstance(event_id, str) else None,
+                event_id=raw_event_id if isinstance(raw_event_id, str) else None,
                 error=str(exc),
             )
 
@@ -230,21 +236,24 @@ class ThreadOutboundWritePolicy:
         self,
         room_id: str,
         event_source: dict[str, Any],
-    ) -> dict[str, Any] | None:
+    ) -> dict[str, object] | None:
         """Return one outbound event payload normalized for durable cache storage."""
         event_id = event_source.get("event_id")
         if not isinstance(event_id, str) or not event_id:
             return None
         client = self._require_client()
         sender = client.user_id if isinstance(client.user_id, str) else None
-        return normalize_event_source_for_cache(
-            {
-                **event_source,
-                "room_id": room_id,
-            },
-            event_id=event_id,
-            sender=sender,
-            origin_server_ts=int(time.time() * 1000),
+        return typing.cast(
+            "dict[str, object]",
+            normalize_event_source_for_cache(
+                {
+                    **event_source,
+                    "room_id": room_id,
+                },
+                event_id=event_id,
+                sender=sender,
+                origin_server_ts=int(time.time() * 1000),
+            ),
         )
 
     async def _apply_outbound_redaction_notification(

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -96,7 +96,7 @@ class ThreadOutboundWritePolicy:
         self._cache_ops = cache_ops
         self._require_client = require_client
 
-    async def _apply_outbound_message_notification(
+    async def _apply_outbound_event_notification(
         self,
         room_id: str,
         event_id: str,
@@ -110,8 +110,15 @@ class ThreadOutboundWritePolicy:
             context="outbound",
         )
         if impact.state is MutationThreadImpactState.ROOM_LEVEL:
+            if event_info.is_reaction:
+                await self._cache_ops.store_events_batch(
+                    room_id,
+                    [(event_id, room_id, event_source)],
+                    failure_message="Failed to persist outbound reaction lookup to cache",
+                )
+                return
             self._cache_ops.logger.debug(
-                "Skipping outbound thread cache bookkeeping for non-threaded message mutation",
+                "Skipping outbound thread cache bookkeeping for non-threaded event mutation",
                 room_id=room_id,
                 event_id=event_id,
                 original_event_id=event_info.original_event_id,
@@ -136,6 +143,67 @@ class ThreadOutboundWritePolicy:
             context="outbound",
         )
 
+    def notify_outbound_event(
+        self,
+        room_id: str,
+        event_source: dict[str, Any],
+    ) -> None:
+        """Schedule advisory bookkeeping for one locally sent outbound event."""
+        try:
+            if not self._cache_ops.cache_runtime_available():
+                return
+            normalized_event_source = self._normalize_outbound_event_source(room_id, event_source)
+            if normalized_event_source is None:
+                return
+            event_id = normalized_event_source["event_id"]
+
+            event_info = EventInfo.from_event(normalized_event_source)
+            if event_info.is_reaction:
+                self._schedule_fail_open_room_update(
+                    room_id,
+                    lambda: self._cache_ops.store_events_batch(
+                        room_id,
+                        [(event_id, room_id, normalized_event_source)],
+                        failure_message="Failed to persist outbound reaction lookup to cache",
+                    ),
+                    name="matrix_cache_notify_outbound_event",
+                    cancelled_message="Ignoring cancelled outbound cache bookkeeping after successful send",
+                    failure_message="Ignoring outbound cache bookkeeping failure after successful send",
+                    log_context={"event_id": event_id},
+                )
+                return
+            if not is_thread_affecting_relation(event_info):
+                return
+            self._schedule_fail_open_room_update(
+                room_id,
+                lambda: self._apply_outbound_event_notification(
+                    room_id,
+                    event_id,
+                    normalized_event_source,
+                    event_info,
+                ),
+                name="matrix_cache_notify_outbound_event",
+                cancelled_message="Ignoring cancelled outbound cache bookkeeping after successful send",
+                failure_message="Ignoring outbound cache bookkeeping failure after successful send",
+                log_context={"event_id": event_id},
+            )
+        except asyncio.CancelledError as exc:
+            event_id = event_source.get("event_id")
+            self._cache_ops.logger.warning(
+                "Ignoring cancelled outbound cache bookkeeping after successful send",
+                room_id=room_id,
+                event_id=event_id if isinstance(event_id, str) else None,
+                error=str(exc),
+            )
+        except Exception as exc:
+            event_id = event_source.get("event_id")
+            self._cache_ops.logger.warning(
+                "Ignoring outbound cache bookkeeping failure after successful send",
+                room_id=room_id,
+                event_id=event_id if isinstance(event_id, str) else None,
+                error=str(exc),
+            )
+
     def notify_outbound_message(
         self,
         room_id: str,
@@ -143,54 +211,41 @@ class ThreadOutboundWritePolicy:
         content: dict[str, Any],
     ) -> None:
         """Schedule advisory bookkeeping for one locally sent threaded message or edit."""
-        try:
-            if not self._cache_ops.cache_runtime_available():
-                return
-            if not isinstance(event_id, str) or not event_id:
-                return
+        if not self._cache_ops.cache_runtime_available():
+            return
+        if not isinstance(event_id, str) or not event_id:
+            return
 
-            client = self._require_client()
-            sender = client.user_id if isinstance(client.user_id, str) else None
-            origin_server_ts = int(time.time() * 1000)
-            event_source = normalize_event_source_for_cache(
-                {
-                    "type": "m.room.message",
-                    "room_id": room_id,
-                    "event_id": event_id,
-                    "sender": sender,
-                    "origin_server_ts": origin_server_ts,
-                    "content": dict(content),
-                },
-                event_id=event_id,
-                sender=sender,
-                origin_server_ts=origin_server_ts,
-            )
-            event_info = EventInfo.from_event(event_source)
-            if not is_thread_affecting_relation(event_info):
-                return
+        self.notify_outbound_event(
+            room_id,
+            {
+                "type": "m.room.message",
+                "room_id": room_id,
+                "event_id": event_id,
+                "content": dict(content),
+            },
+        )
 
-            self._schedule_fail_open_room_update(
-                room_id,
-                lambda: self._apply_outbound_message_notification(room_id, event_id, event_source, event_info),
-                name="matrix_cache_notify_outbound_message",
-                cancelled_message="Ignoring cancelled outbound threaded message cache bookkeeping after successful send",
-                failure_message="Ignoring outbound threaded message cache bookkeeping failure after successful send",
-                log_context={"event_id": event_id},
-            )
-        except asyncio.CancelledError as exc:
-            self._cache_ops.logger.warning(
-                "Ignoring cancelled outbound threaded message cache bookkeeping after successful send",
-                room_id=room_id,
-                event_id=event_id,
-                error=str(exc),
-            )
-        except Exception as exc:
-            self._cache_ops.logger.warning(
-                "Ignoring outbound threaded message cache bookkeeping failure after successful send",
-                room_id=room_id,
-                event_id=event_id,
-                error=str(exc),
-            )
+    def _normalize_outbound_event_source(
+        self,
+        room_id: str,
+        event_source: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Return one outbound event payload normalized for durable cache storage."""
+        event_id = event_source.get("event_id")
+        if not isinstance(event_id, str) or not event_id:
+            return None
+        client = self._require_client()
+        sender = client.user_id if isinstance(client.user_id, str) else None
+        return normalize_event_source_for_cache(
+            {
+                **event_source,
+                "room_id": room_id,
+            },
+            event_id=event_id,
+            sender=sender,
+            origin_server_ts=int(time.time() * 1000),
+        )
 
     async def _apply_outbound_redaction_notification(
         self,
@@ -507,7 +562,7 @@ class ThreadSyncWritePolicy:
                 failure_message="Failed to apply sync redaction to cache",
             )
             if impact.state is MutationThreadImpactState.UNKNOWN:
-                if not room_threads_invalidated:
+                if redacted and not room_threads_invalidated:
                     await self._cache_ops.invalidate_room_threads(
                         room_id,
                         reason="sync_redaction_lookup_unavailable",

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -139,6 +139,9 @@ class ConversationCacheProtocol(Protocol):
         Callers should treat Matrix delivery as complete before this local cache work runs.
         """
 
+    def notify_outbound_event(self, room_id: str, event_source: dict[str, Any]) -> None:
+        """Schedule one locally sent outbound event for advisory cache bookkeeping."""
+
     def notify_outbound_redaction(self, room_id: str, redacted_event_id: str) -> None:
         """Schedule one locally redacted threaded message for advisory cache bookkeeping.
 
@@ -632,6 +635,21 @@ class MatrixConversationCache(ConversationCacheProtocol):
     ) -> None:
         """Schedule one locally sent threaded message or edit for advisory cache bookkeeping."""
         self._outbound.notify_outbound_message(room_id, event_id, content)
+
+    def notify_outbound_event(
+        self,
+        room_id: str,
+        event_source: dict[str, Any],
+    ) -> None:
+        """Schedule one locally sent outbound event for advisory cache bookkeeping."""
+        event_id = event_source.get("event_id")
+        self._run_fail_open_outbound_write(
+            lambda: self._outbound.notify_outbound_event(room_id, event_source),
+            cancelled_message="Ignoring cancelled outbound cache bookkeeping after successful send",
+            failure_message="Ignoring outbound cache bookkeeping failure after successful send",
+            room_id=room_id,
+            event_id=event_id if isinstance(event_id, str) else None,
+        )
 
     def notify_outbound_redaction(self, room_id: str, redacted_event_id: str) -> None:
         """Schedule one locally redacted threaded message for advisory cache bookkeeping."""

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -642,14 +642,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
         event_source: dict[str, Any],
     ) -> None:
         """Schedule one locally sent outbound event for advisory cache bookkeeping."""
-        event_id = event_source.get("event_id")
-        self._run_fail_open_outbound_write(
-            lambda: self._outbound.notify_outbound_event(room_id, event_source),
-            cancelled_message="Ignoring cancelled outbound cache bookkeeping after successful send",
-            failure_message="Ignoring outbound cache bookkeeping failure after successful send",
-            room_id=room_id,
-            event_id=event_id if isinstance(event_id, str) else None,
-        )
+        self._outbound.notify_outbound_event(room_id, event_source)
 
     def notify_outbound_redaction(self, room_id: str, redacted_event_id: str) -> None:
         """Schedule one locally redacted threaded message for advisory cache bookkeeping."""

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     from mindroom.history.types import CompactionOutcome
     from mindroom.matrix.client import ResolvedVisibleMessage
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol
-    from mindroom.stop import StopManager
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 
@@ -247,25 +246,6 @@ class PostResponseEffectsSupport:
             should_queue_thread_summary=self.should_queue_thread_summary,
             queue_thread_summary=self.queue_thread_summary,
         )
-
-
-def clear_tracked_response_message(
-    stop_manager: StopManager,
-    client: nio.AsyncClient,
-    tracked_message_id: str,
-    *,
-    show_stop_button: bool,
-    notify_outbound_redaction: Callable[[str, str], None] | None = None,
-) -> None:
-    """Clear one tracked response and redact the stop button when still present."""
-    tracked = stop_manager.tracked_messages.get(tracked_message_id)
-    button_already_removed = tracked is None or tracked.reaction_event_id is None
-    stop_manager.clear_message(
-        tracked_message_id,
-        client=client,
-        remove_button=show_stop_button and not button_already_removed,
-        notify_outbound_redaction=notify_outbound_redaction,
-    )
 
 
 async def apply_post_response_effects(  # noqa: C901

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -255,6 +255,7 @@ def clear_tracked_response_message(
     tracked_message_id: str,
     *,
     show_stop_button: bool,
+    notify_outbound_redaction: Callable[[str, str], None] | None = None,
 ) -> None:
     """Clear one tracked response and redact the stop button when still present."""
     tracked = stop_manager.tracked_messages.get(tracked_message_id)
@@ -263,6 +264,7 @@ def clear_tracked_response_message(
         tracked_message_id,
         client=client,
         remove_button=show_stop_button and not button_already_removed,
+        notify_outbound_redaction=notify_outbound_redaction,
     )
 
 

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -47,7 +47,6 @@ from mindroom.orchestration.runtime import is_sync_restart_cancel
 from mindroom.post_response_effects import (
     PostResponseEffectsSupport,
     ResponseOutcome,
-    clear_tracked_response_message,
 )
 from mindroom.streaming import (
     ReplacementStreamingResponse,
@@ -1366,12 +1365,15 @@ class ResponseRunner:
                     self.deps.logger.exception("Error during response generation", error=str(error))
                     raise
                 finally:
-                    clear_tracked_response_message(
-                        self.deps.stop_manager,
-                        self._client(),
+                    tracked = self.deps.stop_manager.tracked_messages.get(tracked_message_id)
+                    button_already_removed = tracked is None or tracked.reaction_event_id is None
+                    self.deps.stop_manager.clear_message(
                         tracked_message_id,
-                        show_stop_button=show_stop_button,
-                        notify_outbound_redaction=self.deps.post_response_effects.conversation_cache.notify_outbound_redaction,
+                        client=self._client(),
+                        remove_button=show_stop_button and not button_already_removed,
+                        notify_outbound_redaction=(
+                            self.deps.post_response_effects.conversation_cache.notify_outbound_redaction
+                        ),
                     )
 
                 return message_id

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1342,7 +1342,11 @@ class ResponseRunner:
 
                     if show_stop_button:
                         self.deps.logger.info("Adding stop button", message_id=message_to_track)
-                        await self.deps.stop_manager.add_stop_button(self._client(), message_to_track)
+                        await self.deps.stop_manager.add_stop_button(
+                            self._client(),
+                            message_to_track,
+                            notify_outbound_event=self.deps.resolver.deps.conversation_cache.notify_outbound_event,
+                        )
 
                 try:
                     await task
@@ -1367,6 +1371,7 @@ class ResponseRunner:
                         self._client(),
                         tracked_message_id,
                         show_stop_button=show_stop_button,
+                        notify_outbound_redaction=self.deps.post_response_effects.conversation_cache.notify_outbound_redaction,
                     )
 
                 return message_id

--- a/src/mindroom/stop.py
+++ b/src/mindroom/stop.py
@@ -13,6 +13,8 @@ from agno.run.cancel import acancel_run
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from nio import AsyncClient
 
     from mindroom.message_target import MessageTarget
@@ -227,6 +229,7 @@ class StopManager:
         client: AsyncClient,
         remove_button: bool = True,
         delay: float = 5.0,
+        notify_outbound_redaction: Callable[[str, str], None] | None = None,
     ) -> None:
         """Clear tracking for a specific message and optionally remove stop button."""
 
@@ -235,6 +238,7 @@ class StopManager:
             if remove_button and message_id in self.tracked_messages:
                 tracked = self.tracked_messages[message_id]
                 if tracked.reaction_event_id:
+                    reaction_event_id = tracked.reaction_event_id
                     logger.info(
                         "Removing stop button in cleanup",
                         message_id=message_id,
@@ -243,10 +247,12 @@ class StopManager:
                     try:
                         await client.room_redact(
                             room_id=tracked.target.room_id,
-                            event_id=tracked.reaction_event_id,
+                            event_id=reaction_event_id,
                             reason="Response completed",
                         )
                         tracked.reaction_event_id = None
+                        if notify_outbound_redaction is not None:
+                            notify_outbound_redaction(tracked.target.room_id, reaction_event_id)
                     except Exception as e:
                         logger.warning(
                             "stop_button_cleanup_failed",
@@ -331,7 +337,13 @@ class StopManager:
             logger.warning("Stop reaction for untracked message", message_id=message_id)
         return False
 
-    async def add_stop_button(self, client: AsyncClient, message_id: str) -> str | None:
+    async def add_stop_button(
+        self,
+        client: AsyncClient,
+        message_id: str,
+        *,
+        notify_outbound_event: Callable[[str, dict[str, object]], None] | None = None,
+    ) -> str | None:
         """Add a stop button reaction to a tracked message."""
         tracked = self.tracked_messages.get(message_id)
         if tracked is None:
@@ -364,6 +376,23 @@ class StopManager:
                     **self._log_target(tracked.target),
                 )
                 tracked.reaction_event_id = event_id
+                if notify_outbound_event is not None:
+                    notify_outbound_event(
+                        tracked.target.room_id,
+                        {
+                            "type": "m.reaction",
+                            "room_id": tracked.target.room_id,
+                            "event_id": event_id,
+                            "sender": client.user_id if isinstance(client.user_id, str) else None,
+                            "content": {
+                                "m.relates_to": {
+                                    "rel_type": "m.annotation",
+                                    "event_id": message_id,
+                                    "key": "🛑",
+                                },
+                            },
+                        },
+                    )
                 return event_id
             logger.warning(
                 "Failed to add stop button - no event_id in response",
@@ -378,24 +407,33 @@ class StopManager:
             )
         return None
 
-    async def remove_stop_button(self, client: AsyncClient, message_id: str | None = None) -> None:
+    async def remove_stop_button(
+        self,
+        client: AsyncClient,
+        message_id: str | None = None,
+        *,
+        notify_outbound_redaction: Callable[[str, str], None] | None = None,
+    ) -> None:
         """Remove the stop button reaction immediately when user clicks it."""
         if message_id and message_id in self.tracked_messages:
             tracked = self.tracked_messages[message_id]
             if tracked.reaction_event_id:
+                reaction_event_id = tracked.reaction_event_id
                 logger.info(
                     "Removing stop button immediately (user clicked)",
                     message_id=message_id,
-                    reaction_event_id=tracked.reaction_event_id,
+                    reaction_event_id=reaction_event_id,
                     **self._log_target(tracked.target),
                 )
                 try:
                     await client.room_redact(
                         room_id=tracked.target.room_id,
-                        event_id=tracked.reaction_event_id,
+                        event_id=reaction_event_id,
                         reason="User clicked stop",
                     )
                     tracked.reaction_event_id = None
+                    if notify_outbound_redaction is not None:
+                        notify_outbound_redaction(tracked.target.room_id, reaction_event_id)
                     logger.info("Stop button removed successfully", **self._log_target(tracked.target))
                 except Exception as e:
                     logger.exception(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,6 +253,7 @@ def make_conversation_cache_mock() -> AsyncMock:
     conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(return_value=None)
     conversation_cache.append_live_event = AsyncMock()
     conversation_cache.notify_outbound_message = MagicMock()
+    conversation_cache.notify_outbound_event = MagicMock()
     conversation_cache.notify_outbound_redaction = MagicMock()
     return conversation_cache
 

--- a/tests/test_stop_emoji_reuse.py
+++ b/tests/test_stop_emoji_reuse.py
@@ -224,6 +224,59 @@ async def test_stop_manager_force_cancels_task_when_run_never_becomes_cancellabl
 
 
 @pytest.mark.asyncio
+async def test_stop_manager_add_and_remove_button_notifies_cache_bookkeeping() -> None:
+    """Stop-button add/remove should preserve cache bookkeeping for the synthetic reaction."""
+    stop_manager = StopManager()
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.user_id = "@agent:example.com"
+    client.room_send = AsyncMock(
+        return_value=nio.RoomSendResponse(room_id="!test:example.com", event_id="$reaction:example.com"),
+    )
+    client.room_redact = AsyncMock(return_value=MagicMock())
+    notify_outbound_event = MagicMock()
+    notify_outbound_redaction = MagicMock()
+    task = MagicMock()
+    task.done = MagicMock(return_value=False)
+    stop_manager.set_current(
+        message_id="$message:example.com",
+        target=MessageTarget.resolve("!test:example.com", "$thread:example.com", "$message:example.com"),
+        task=task,
+    )
+
+    added_event_id = await stop_manager.add_stop_button(
+        client,
+        "$message:example.com",
+        notify_outbound_event=notify_outbound_event,
+    )
+
+    assert added_event_id == "$reaction:example.com"
+    notify_outbound_event.assert_called_once_with(
+        "!test:example.com",
+        {
+            "type": "m.reaction",
+            "room_id": "!test:example.com",
+            "event_id": "$reaction:example.com",
+            "sender": "@agent:example.com",
+            "content": {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": "$message:example.com",
+                    "key": "🛑",
+                },
+            },
+        },
+    )
+
+    await stop_manager.remove_stop_button(
+        client,
+        "$message:example.com",
+        notify_outbound_redaction=notify_outbound_redaction,
+    )
+
+    notify_outbound_redaction.assert_called_once_with("!test:example.com", "$reaction:example.com")
+
+
+@pytest.mark.asyncio
 async def test_stop_manager_force_cancels_task_when_graceful_cancel_errors() -> None:
     """Cancellation-manager failures must not disable the hard-cancel fallback."""
     stop_manager = StopManager(graceful_cancel_fallback_seconds=0.01)

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -2631,3 +2631,102 @@ class TestThreadHistoryCache:
         history = await fetch_thread_history(client, "!room:localhost", "$thread_root", event_cache=broken_cache)
         assert [message.event_id for message in history] == ["$thread_root", "$reply"]
         broken_cache.replace_thread.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_incremental_thread_revalidation_does_not_bypass_runtime_or_room_staleness(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Incremental append refresh must not bless pre-runtime or room-invalidated cache."""
+        cache = _EventCache(tmp_path / "event_cache.db")
+        await cache.initialize()
+
+        root_event = self._make_text_event(
+            event_id="$thread_root",
+            sender="@user:localhost",
+            body="Root message",
+            server_timestamp=1000,
+            source_content={"body": "Root message"},
+        )
+        cached_reply = self._make_text_event(
+            event_id="$reply1",
+            sender="@agent:localhost",
+            body="Cached reply",
+            server_timestamp=2000,
+            source_content={
+                "body": "Cached reply",
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+        )
+        appended_reply = self._make_text_event(
+            event_id="$reply2",
+            sender="@agent:localhost",
+            body="Incremental reply",
+            server_timestamp=3000,
+            source_content={
+                "body": "Incremental reply",
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+        )
+        runtime_started_at = time.time() - 1
+
+        await cache.replace_thread(
+            "!room:localhost",
+            "$thread_root",
+            [self._cache_source(root_event), self._cache_source(cached_reply)],
+            validated_at=runtime_started_at - 100,
+        )
+        await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="sync_thread_mutation")
+        pre_runtime_appended = await cache.append_event(
+            "!room:localhost",
+            "$thread_root",
+            self._cache_source(appended_reply),
+        )
+        pre_runtime_revalidated = await cache.revalidate_thread_after_incremental_update(
+            "!room:localhost",
+            "$thread_root",
+            runtime_started_at=runtime_started_at,
+        )
+
+        await cache.replace_thread(
+            "!room:localhost",
+            "$thread_root",
+            [self._cache_source(root_event), self._cache_source(cached_reply)],
+            validated_at=time.time(),
+        )
+        await cache.mark_room_threads_stale("!room:localhost", reason="sync_redaction_lookup_unavailable")
+        await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="sync_thread_mutation")
+        room_stale_appended = await cache.append_event(
+            "!room:localhost",
+            "$thread_root",
+            self._cache_source(appended_reply),
+        )
+        room_stale_revalidated = await cache.revalidate_thread_after_incremental_update(
+            "!room:localhost",
+            "$thread_root",
+            runtime_started_at=runtime_started_at,
+        )
+
+        client = MagicMock()
+        page = MagicMock(spec=nio.RoomMessagesResponse)
+        page.chunk = [appended_reply, cached_reply, root_event]
+        page.end = None
+        client.room_messages = AsyncMock(return_value=page)
+
+        try:
+            history = await matrix_client_module.fetch_dispatch_thread_history(
+                client,
+                "!room:localhost",
+                "$thread_root",
+                event_cache=cache,
+                runtime_started_at=runtime_started_at,
+            )
+        finally:
+            await cache.close()
+
+        assert pre_runtime_appended is True
+        assert pre_runtime_revalidated is False
+        assert room_stale_appended is True
+        assert room_stale_revalidated is False
+        assert [message.event_id for message in history] == ["$thread_root", "$reply1", "$reply2"]
+        assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_HOMESERVER

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -393,8 +393,10 @@ class TestMatrixConversationCacheThreadReads:
         event_cache.append_event.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_notify_outbound_redaction_lookup_miss_invalidates_room_threads(self) -> None:
-        """Plain redactions should fail closed when mutation lookup cannot prove room-level state."""
+    async def test_notify_outbound_redaction_lookup_miss_without_cached_target_does_not_invalidate_room_threads(
+        self,
+    ) -> None:
+        """Unknown redactions should not poison room caches when nothing was actually removed."""
         event_cache = _runtime_event_cache()
         event_cache.get_thread_id_for_event = AsyncMock(return_value=None)
         access = MatrixConversationCache(
@@ -405,12 +407,63 @@ class TestMatrixConversationCacheThreadReads:
         access.notify_outbound_redaction("!room:localhost", "$room-message:localhost")
         await access.runtime.event_cache_write_coordinator.wait_for_room_idle("!room:localhost")
 
-        event_cache.mark_room_threads_stale.assert_awaited_once_with(
-            "!room:localhost",
-            reason="outbound_redaction_lookup_unavailable",
-        )
+        event_cache.mark_room_threads_stale.assert_not_awaited()
         event_cache.mark_thread_stale.assert_not_awaited()
         event_cache.redact_event.assert_awaited_once_with("!room:localhost", "$room-message:localhost")
+
+    @pytest.mark.asyncio
+    async def test_notify_outbound_reaction_persists_lookup_without_thread_invalidation(self) -> None:
+        """Outbound reactions should be cached for later redaction lookups without staling thread history."""
+        event_cache = _runtime_event_cache()
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.user_id = "@agent:localhost"
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(client=client, event_cache=event_cache),
+        )
+
+        access.notify_outbound_event(
+            "!room:localhost",
+            {
+                "type": "m.reaction",
+                "room_id": "!room:localhost",
+                "event_id": "$reaction:localhost",
+                "sender": "@agent:localhost",
+                "content": {
+                    "m.relates_to": {
+                        "rel_type": "m.annotation",
+                        "event_id": "$thread-reply:localhost",
+                        "key": "🛑",
+                    },
+                },
+            },
+        )
+        await access.runtime.event_cache_write_coordinator.wait_for_room_idle("!room:localhost")
+
+        event_cache.store_events_batch.assert_awaited_once()
+        stored_batch = event_cache.store_events_batch.await_args.args[0]
+        assert stored_batch == [
+            (
+                "$reaction:localhost",
+                "!room:localhost",
+                {
+                    "type": "m.reaction",
+                    "room_id": "!room:localhost",
+                    "event_id": "$reaction:localhost",
+                    "sender": "@agent:localhost",
+                    "content": {
+                        "m.relates_to": {
+                            "rel_type": "m.annotation",
+                            "event_id": "$thread-reply:localhost",
+                            "key": "🛑",
+                        },
+                    },
+                },
+            ),
+        ]
+        event_cache.mark_thread_stale.assert_not_awaited()
+        event_cache.mark_room_threads_stale.assert_not_awaited()
+        event_cache.append_event.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_notify_outbound_message_plain_reply_to_threaded_target_updates_thread_cache(self) -> None:
@@ -1675,6 +1728,47 @@ class TestThreadingBehavior:
             reason="sync_thread_lookup_unavailable",
         )
         event_cache.append_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sync_reaction_redaction_lookup_miss_without_cached_target_does_not_invalidate_room_threads(
+        self,
+        bot: AgentBot,
+    ) -> None:
+        """Sync redaction lookup misses should not poison the room when the target was already removed."""
+        event_cache = _runtime_event_cache()
+        event_cache.store_events_batch = AsyncMock()
+        event_cache.redact_event = AsyncMock(return_value=False)
+        event_cache.get_thread_id_for_event = AsyncMock(return_value=None)
+        event_cache.get_event = AsyncMock(return_value=None)
+        bot.event_cache = event_cache
+        _install_runtime_write_coordinator(bot)
+
+        redaction_event = MagicMock(spec=nio.RedactionEvent)
+        redaction_event.event_id = "$redaction:localhost"
+        redaction_event.redacts = "$reaction:localhost"
+        redaction_event.sender = "@user:localhost"
+        redaction_event.server_timestamp = 1234567891
+        redaction_event.source = {
+            "content": {},
+            "event_id": "$redaction:localhost",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1234567891,
+            "redacts": "$reaction:localhost",
+            "room_id": "!test:localhost",
+            "type": "m.room.redaction",
+        }
+        sync_response = MagicMock()
+        sync_response.__class__ = nio.SyncResponse
+        sync_response.rooms = MagicMock()
+        sync_response.rooms.join = {
+            "!test:localhost": MagicMock(timeline=MagicMock(events=[redaction_event])),
+        }
+
+        bot._conversation_cache.cache_sync_timeline(sync_response)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+        event_cache.redact_event.assert_awaited_once_with("!test:localhost", "$reaction:localhost")
+        event_cache.mark_room_threads_stale.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_cache_sync_timeline_unknown_thread_mutations_invalidate_room_threads_once_without_room_scan(
@@ -3625,7 +3719,7 @@ class TestThreadingBehavior:
         read_task = asyncio.create_task(access.get_thread_history("!room:localhost", "$thread:localhost"))
         await asyncio.wait_for(reader_ready.wait(), timeout=1.0)
         write_task = asyncio.create_task(
-            access._outbound._apply_outbound_message_notification(
+            access._outbound._apply_outbound_event_notification(
                 "!room:localhost",
                 "$reply-new:localhost",
                 new_event_source,

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -1400,7 +1400,12 @@ class TestThreadingBehavior:
         sync_error = MagicMock(spec=nio.SyncError)
         bot._first_sync_done = True
 
-        with patch("mindroom.bot.time.monotonic", side_effect=[100.0, 200.0]):
+        monotonic_values = iter([100.0, 200.0])
+
+        def monotonic_side_effect() -> float:
+            return next(monotonic_values, 200.0)
+
+        with patch("mindroom.bot.time.monotonic", side_effect=monotonic_side_effect):
             await bot._on_sync_response(sync_response)
             await bot._on_sync_error(sync_error)
 

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -442,9 +442,38 @@ class TestMatrixConversationCacheThreadReads:
 
         event_cache.store_events_batch.assert_awaited_once()
         stored_batch = event_cache.store_events_batch.await_args.args[0]
-        assert stored_batch == [
-            (
-                "$reaction:localhost",
+        assert len(stored_batch) == 1
+        stored_event_id, stored_room_id, stored_event_source = stored_batch[0]
+        assert stored_event_id == "$reaction:localhost"
+        assert stored_room_id == "!room:localhost"
+        assert stored_event_source["type"] == "m.reaction"
+        assert stored_event_source["room_id"] == "!room:localhost"
+        assert stored_event_source["event_id"] == "$reaction:localhost"
+        assert stored_event_source["sender"] == "@agent:localhost"
+        assert stored_event_source["content"]["m.relates_to"]["event_id"] == "$thread-reply:localhost"
+        assert stored_event_source["content"]["m.relates_to"]["key"] == "🛑"
+        assert isinstance(stored_event_source.get("origin_server_ts"), int)
+        event_cache.mark_thread_stale.assert_not_awaited()
+        event_cache.mark_room_threads_stale.assert_not_awaited()
+        event_cache.append_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_notify_outbound_reaction_normalizes_event_for_real_cache(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Synthetic outbound reactions should be normalized before durable cache persistence."""
+        event_cache = _EventCache(tmp_path / "event_cache.db")
+        await event_cache.initialize()
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.user_id = "@agent:localhost"
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(client=client, event_cache=event_cache),
+        )
+
+        try:
+            access.notify_outbound_event(
                 "!room:localhost",
                 {
                     "type": "m.reaction",
@@ -459,11 +488,17 @@ class TestMatrixConversationCacheThreadReads:
                         },
                     },
                 },
-            ),
-        ]
-        event_cache.mark_thread_stale.assert_not_awaited()
-        event_cache.mark_room_threads_stale.assert_not_awaited()
-        event_cache.append_event.assert_not_awaited()
+            )
+            await access.runtime.event_cache_write_coordinator.wait_for_room_idle("!room:localhost")
+
+            cached_event = await event_cache.get_event("!room:localhost", "$reaction:localhost")
+        finally:
+            await event_cache.close()
+
+        assert cached_event is not None
+        assert cached_event["event_id"] == "$reaction:localhost"
+        assert cached_event["content"]["m.relates_to"]["key"] == "🛑"
+        assert isinstance(cached_event.get("origin_server_ts"), int)
 
     @pytest.mark.asyncio
     async def test_notify_outbound_message_plain_reply_to_threaded_target_updates_thread_cache(self) -> None:


### PR DESCRIPTION
## Summary
- preserve hot thread cache validity across stop-button reaction add/remove bookkeeping
- persist outbound stop reactions so cleanup redactions do not degrade into room-wide unknown invalidations
- tighten incremental thread cache revalidation so only same-runtime append-style invalidations can be healed

## Verification
- `uv run pre-commit run --all-files`
- `uv run pytest tests/test_thread_history.py tests/test_threading_error.py tests/test_stop_emoji_reuse.py -x -n 0 --no-cov -q`
- `uv run pytest -n auto --no-cov`