### PR TITLE
chore: disable mem0 telemetry

### DIFF
--- a/src/mindroom/__init__.py
+++ b/src/mindroom/__init__.py
@@ -8,6 +8,7 @@ from mindroom.constants import patch_chromadb_for_python314
 # MindRoom should never emit vendor network telemetry, even if a user .env enables it.
 os.environ["AGNO_TELEMETRY"] = "false"
 os.environ["ANONYMIZED_TELEMETRY"] = "false"
+os.environ["MEM0_TELEMETRY"] = "false"
 
 patch_chromadb_for_python314()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,8 +12,10 @@ def test_package_init_disables_vendor_telemetry(monkeypatch: pytest.MonkeyPatch)
     """MindRoom should force vendor telemetry off at import time."""
     monkeypatch.setenv("AGNO_TELEMETRY", "true")
     monkeypatch.setenv("ANONYMIZED_TELEMETRY", "true")
+    monkeypatch.setenv("MEM0_TELEMETRY", "true")
 
     importlib.reload(mindroom)
 
     assert os.environ["AGNO_TELEMETRY"] == "false"
     assert os.environ["ANONYMIZED_TELEMETRY"] == "false"
+    assert os.environ["MEM0_TELEMETRY"] == "false"


### PR DESCRIPTION
## Summary
- force `MEM0_TELEMETRY=false` at MindRoom package import time
- extend the existing vendor-telemetry import test to cover Mem0 too
- mirror the existing Chroma telemetry shutdown pattern from #620

## Verification
- `env -u VIRTUAL_ENV uv run pytest tests/test_init.py -q`
- `env -u VIRTUAL_ENV uv run pre-commit run --files src/mindroom/__init__.py tests/test_init.py`
