### PR TITLE
fix: prewarm threads by local cache recency

### DIFF
--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -367,6 +367,9 @@ class ConversationEventCache(Protocol):
     async def get_thread_events(self, room_id: str, thread_id: str) -> list[dict[str, Any]] | None:
         """Return cached events for one thread sorted by timestamp."""
 
+    async def get_recent_room_thread_ids(self, room_id: str, *, limit: int) -> list[str]:
+        """Return locally known thread IDs for one room ordered by newest cached activity."""
+
     async def get_thread_cache_state(self, room_id: str, thread_id: str) -> ThreadCacheState | None:
         """Return durable freshness metadata for one cached thread."""
 
@@ -517,6 +520,19 @@ class _EventCache:
                 db,
                 room_id=room_id,
                 thread_id=thread_id,
+            ),
+        )
+
+    async def get_recent_room_thread_ids(self, room_id: str, *, limit: int) -> list[str]:
+        """Return locally known thread IDs for one room ordered by newest cached activity."""
+        return await self._read_operation(
+            room_id,
+            operation="get_recent_room_thread_ids",
+            disabled_result=[],
+            reader=lambda db: event_cache_threads.load_recent_room_thread_ids(
+                db,
+                room_id=room_id,
+                limit=limit,
             ),
         )
 

--- a/src/mindroom/matrix/cache/event_cache_threads.py
+++ b/src/mindroom/matrix/cache/event_cache_threads.py
@@ -87,7 +87,7 @@ async def load_recent_room_thread_ids(
     )
     rows = await cursor.fetchall()
     await cursor.close()
-    return [str(row[0]) for row in rows if row and isinstance(row[0], str)]
+    return [str(row[0]) for row in rows]
 
 
 async def load_thread_cache_state_row(

--- a/src/mindroom/matrix/cache/event_cache_threads.py
+++ b/src/mindroom/matrix/cache/event_cache_threads.py
@@ -67,6 +67,29 @@ async def load_thread_events(
     return [json.loads(row[0]) for row in rows]
 
 
+async def load_recent_room_thread_ids(
+    db: aiosqlite.Connection,
+    *,
+    room_id: str,
+    limit: int,
+) -> list[str]:
+    """Return thread IDs for one room ordered by the newest locally cached event timestamp."""
+    cursor = await db.execute(
+        """
+        SELECT thread_id
+        FROM thread_events
+        WHERE room_id = ?
+        GROUP BY thread_id
+        ORDER BY MAX(origin_server_ts) DESC, thread_id ASC
+        LIMIT ?
+        """,
+        (room_id, limit),
+    )
+    rows = await cursor.fetchall()
+    await cursor.close()
+    return [str(row[0]) for row in rows if row and isinstance(row[0], str)]
+
+
 async def load_thread_cache_state_row(
     db: aiosqlite.Connection,
     *,

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -549,6 +549,40 @@ class MatrixConversationCache(ConversationCacheProtocol):
             cache_write_guard_started_at=fetch_started_at,
         )
 
+    async def _startup_thread_prewarm_ids(
+        self,
+        room_id: str,
+    ) -> list[str] | None:
+        """Return startup-prewarm thread IDs using local recency first and /threads as a top-up."""
+        thread_ids = await self.runtime.event_cache.get_recent_room_thread_ids(room_id, limit=20)
+        if len(thread_ids) >= 20:
+            return thread_ids
+        try:
+            thread_roots, _next_batch = await get_room_threads_page(
+                self._require_client(),
+                room_id,
+                limit=20,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if not thread_ids:
+                self.logger.warning(
+                    "startup_thread_prewarm_room_threads_failed",
+                    room_id=room_id,
+                    error=str(exc),
+                )
+                return None
+            return thread_ids
+
+        for thread_root in thread_roots:
+            thread_id = thread_root.event_id.strip()
+            if thread_id and thread_id not in thread_ids:
+                thread_ids.append(thread_id)
+            if len(thread_ids) >= 20:
+                break
+        return thread_ids
+
     async def prewarm_recent_room_threads(
         self,
         room_id: str,
@@ -559,28 +593,14 @@ class MatrixConversationCache(ConversationCacheProtocol):
         started_at = time.perf_counter()
         threads_warmed = 0
         threads_failed = 0
-
-        try:
-            thread_roots, _next_batch = await get_room_threads_page(
-                self._require_client(),
-                room_id,
-                limit=20,
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            self.logger.warning(
-                "startup_thread_prewarm_room_threads_failed",
-                room_id=room_id,
-                error=str(exc),
-            )
+        thread_ids = await self._startup_thread_prewarm_ids(room_id)
+        if thread_ids is None:
             return False
 
-        for thread_root in thread_roots:
+        for thread_id in thread_ids:
             if is_shutting_down():
                 return False
 
-            thread_id = thread_root.event_id.strip()
             if not thread_id:
                 threads_failed += 1
                 self.logger.warning(

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -578,7 +578,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 error=str(exc),
                 local_thread_count=len(thread_ids),
             )
-            return thread_ids if thread_ids else None
+            return thread_ids or None
 
         for thread_root in thread_roots:
             thread_id = thread_root.event_id.strip()

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -71,6 +71,9 @@ __all__ = [
 ]
 
 
+_STARTUP_PREWARM_THREAD_LIMIT = 20
+
+
 class ConversationCacheProtocol(Protocol):
     """Conversation-data reads available to resolver and related callers."""
 
@@ -554,32 +557,34 @@ class MatrixConversationCache(ConversationCacheProtocol):
         room_id: str,
     ) -> list[str] | None:
         """Return startup-prewarm thread IDs using local recency first and /threads as a top-up."""
-        thread_ids = await self.runtime.event_cache.get_recent_room_thread_ids(room_id, limit=20)
-        if len(thread_ids) >= 20:
+        thread_ids = await self.runtime.event_cache.get_recent_room_thread_ids(
+            room_id,
+            limit=_STARTUP_PREWARM_THREAD_LIMIT,
+        )
+        if len(thread_ids) >= _STARTUP_PREWARM_THREAD_LIMIT:
             return thread_ids
         try:
             thread_roots, _next_batch = await get_room_threads_page(
                 self._require_client(),
                 room_id,
-                limit=20,
+                limit=_STARTUP_PREWARM_THREAD_LIMIT,
             )
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            if not thread_ids:
-                self.logger.warning(
-                    "startup_thread_prewarm_room_threads_failed",
-                    room_id=room_id,
-                    error=str(exc),
-                )
-                return None
-            return thread_ids
+            self.logger.warning(
+                "startup_thread_prewarm_room_threads_failed",
+                room_id=room_id,
+                error=str(exc),
+                local_thread_count=len(thread_ids),
+            )
+            return thread_ids if thread_ids else None
 
         for thread_root in thread_roots:
             thread_id = thread_root.event_id.strip()
             if thread_id and thread_id not in thread_ids:
                 thread_ids.append(thread_id)
-            if len(thread_ids) >= 20:
+            if len(thread_ids) >= _STARTUP_PREWARM_THREAD_LIMIT:
                 break
         return thread_ids
 

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -556,7 +556,12 @@ class MatrixConversationCache(ConversationCacheProtocol):
         self,
         room_id: str,
     ) -> list[str] | None:
-        """Return startup-prewarm thread IDs using local recency first and /threads as a top-up."""
+        """Return startup-prewarm thread IDs using local recency first and /threads as a top-up.
+
+        Tuwunel does not currently order /threads by latest thread activity, so the local cache is the
+        best available recency signal for startup prewarm. /threads is only used to fill any remaining
+        slots when we have fewer than the target number of locally known threads.
+        """
         thread_ids = await self.runtime.event_cache.get_recent_room_thread_ids(
             room_id,
             limit=_STARTUP_PREWARM_THREAD_LIMIT,
@@ -578,6 +583,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 error=str(exc),
                 local_thread_count=len(thread_ids),
             )
+            # Partial local prewarm is still useful here because /threads is only a best-effort top-up.
             return thread_ids or None
 
         for thread_root in thread_roots:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,6 +211,7 @@ def make_event_cache_mock() -> AsyncMock:
     event_cache.get_event.return_value = None
     event_cache.get_latest_edit.return_value = None
     event_cache.get_mxc_text.return_value = None
+    event_cache.get_recent_room_thread_ids.return_value = []
     event_cache.get_thread_events.return_value = None
     event_cache.get_thread_cache_state.return_value = None
     event_cache.get_thread_id_for_event.return_value = None

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -596,6 +596,46 @@ async def test_bot_ready_prefers_locally_recent_threads_for_startup_prewarm(tmp_
 
 
 @pytest.mark.asyncio
+async def test_bot_ready_falls_back_to_local_threads_when_threads_api_fails(tmp_path: Path) -> None:
+    """Startup prewarm should still warm local thread IDs when /threads errors but local cache has entries."""
+    bot = _agent_bot(tmp_path)
+    bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id or "@mindroom_code:localhost")
+    bot.client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=["!room:localhost"])
+    bot.event_cache.get_recent_room_thread_ids.return_value = [
+        "$thread-local-a:localhost",
+        "$thread-local-b:localhost",
+    ]
+    bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
+        return_value=thread_history_result([], is_full_history=False),
+    )
+    bot._conversation_cache.logger = MagicMock()
+
+    with (
+        patch("mindroom.bot.mark_matrix_sync_success", return_value=datetime.now(UTC)),
+        patch(
+            "mindroom.matrix.conversation_cache.get_room_threads_page",
+            new=AsyncMock(side_effect=RuntimeError("threads_api_unavailable")),
+        ),
+    ):
+        await bot._on_sync_response(MagicMock())
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    assert [
+        call.args
+        for call in bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm.await_args_list
+    ] == [
+        ("!room:localhost", "$thread-local-a:localhost"),
+        ("!room:localhost", "$thread-local-b:localhost"),
+    ]
+    bot._conversation_cache.logger.warning.assert_any_call(
+        "startup_thread_prewarm_room_threads_failed",
+        room_id="!room:localhost",
+        error="threads_api_unavailable",
+        local_thread_count=2,
+    )
+
+
+@pytest.mark.asyncio
 async def test_bot_ready_skips_threads_api_when_local_recent_cache_is_sufficient(tmp_path: Path) -> None:
     """Startup prewarm should avoid /threads when local cache already supplies the full prewarm set."""
     bot = _agent_bot(tmp_path)
@@ -817,6 +857,7 @@ async def test_room_thread_listing_failure_releases_claim_for_later_joined_bot(t
         "startup_thread_prewarm_room_threads_failed",
         room_id="!room:localhost",
         error="boom",
+        local_thread_count=0,
     )
     assert [
         call.args

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -549,6 +549,82 @@ async def test_bot_ready_starts_background_startup_thread_prewarm(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_bot_ready_prefers_locally_recent_threads_for_startup_prewarm(tmp_path: Path) -> None:
+    """Startup prewarm should use locally recent thread IDs before topping up from /threads."""
+    bot = _agent_bot(tmp_path)
+    bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id or "@mindroom_code:localhost")
+    bot.client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=["!room:localhost"])
+    bot.event_cache.get_recent_room_thread_ids.return_value = [
+        "$thread-local-a:localhost",
+        "$thread-local-b:localhost",
+    ]
+    bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
+        return_value=thread_history_result([], is_full_history=False),
+    )
+
+    thread_roots = [
+        _thread_root_event("$thread-local-b:localhost", body="Thread B", origin_server_ts=2),
+        _thread_root_event("$thread-api-c:localhost", body="Thread C", origin_server_ts=3),
+        _thread_root_event("$thread-api-d:localhost", body="Thread D", origin_server_ts=4),
+    ]
+
+    with (
+        patch("mindroom.bot.mark_matrix_sync_success", return_value=datetime.now(UTC)),
+        patch(
+            "mindroom.matrix.conversation_cache.get_room_threads_page",
+            new=AsyncMock(return_value=(thread_roots, None)),
+        ) as mock_get_room_threads_page,
+    ):
+        await bot._on_sync_response(MagicMock())
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    bot.event_cache.get_recent_room_thread_ids.assert_awaited_once_with("!room:localhost", limit=20)
+    mock_get_room_threads_page.assert_awaited_once_with(
+        bot.client,
+        "!room:localhost",
+        limit=20,
+    )
+    assert [
+        call.args
+        for call in bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm.await_args_list
+    ] == [
+        ("!room:localhost", "$thread-local-a:localhost"),
+        ("!room:localhost", "$thread-local-b:localhost"),
+        ("!room:localhost", "$thread-api-c:localhost"),
+        ("!room:localhost", "$thread-api-d:localhost"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bot_ready_skips_threads_api_when_local_recent_cache_is_sufficient(tmp_path: Path) -> None:
+    """Startup prewarm should avoid /threads when local cache already supplies the full prewarm set."""
+    bot = _agent_bot(tmp_path)
+    bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id or "@mindroom_code:localhost")
+    bot.client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=["!room:localhost"])
+    local_thread_ids = [f"$thread-{index}:localhost" for index in range(20)]
+    bot.event_cache.get_recent_room_thread_ids.return_value = local_thread_ids
+    bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm = AsyncMock(
+        return_value=thread_history_result([], is_full_history=False),
+    )
+
+    with (
+        patch("mindroom.bot.mark_matrix_sync_success", return_value=datetime.now(UTC)),
+        patch(
+            "mindroom.matrix.conversation_cache.get_room_threads_page",
+            new=AsyncMock(side_effect=AssertionError("/threads should not be called when local recency is sufficient")),
+        ),
+    ):
+        await bot._on_sync_response(MagicMock())
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    bot.event_cache.get_recent_room_thread_ids.assert_awaited_once_with("!room:localhost", limit=20)
+    assert [
+        call.args[1]
+        for call in bot._conversation_cache._refresh_dispatch_thread_snapshot_for_startup_prewarm.await_args_list
+    ] == local_thread_ids
+
+
+@pytest.mark.asyncio
 async def test_startup_thread_prewarm_joined_rooms_failure_is_fail_open(tmp_path: Path) -> None:
     """Startup thread prewarm should log and stop cleanly when joined room lookup fails."""
     bot = _agent_bot(tmp_path)

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -255,6 +255,82 @@ async def test_event_cache_store_and_retrieve(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_recent_room_thread_ids_orders_by_latest_event_in_each_thread(tmp_path: Path) -> None:
+    """Recent thread IDs should be ordered by the freshest cached event per thread, not by root timestamp."""
+    cache = _EventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+
+    try:
+        await _seed_thread_cache(
+            cache,
+            room_id="!room:localhost",
+            thread_id="$thread_old_root_recent_reply",
+            events=[
+                {
+                    "event_id": "$thread_old_root_recent_reply",
+                    "sender": "@user:localhost",
+                    "origin_server_ts": 1000,
+                    "type": "m.room.message",
+                    "content": {"body": "Old root", "msgtype": "m.text"},
+                },
+                {
+                    "event_id": "$recent_reply",
+                    "sender": "@agent:localhost",
+                    "origin_server_ts": 9000,
+                    "type": "m.room.message",
+                    "content": {
+                        "body": "Recent reply",
+                        "msgtype": "m.text",
+                        "m.relates_to": {
+                            "rel_type": "m.thread",
+                            "event_id": "$thread_old_root_recent_reply",
+                        },
+                    },
+                },
+            ],
+        )
+        await _seed_thread_cache(
+            cache,
+            room_id="!room:localhost",
+            thread_id="$thread_recent_root_no_replies",
+            events=[
+                {
+                    "event_id": "$thread_recent_root_no_replies",
+                    "sender": "@user:localhost",
+                    "origin_server_ts": 5000,
+                    "type": "m.room.message",
+                    "content": {"body": "Recent root", "msgtype": "m.text"},
+                },
+            ],
+        )
+        await _seed_thread_cache(
+            cache,
+            room_id="!other_room:localhost",
+            thread_id="$thread_other_room",
+            events=[
+                {
+                    "event_id": "$thread_other_room",
+                    "sender": "@user:localhost",
+                    "origin_server_ts": 99999,
+                    "type": "m.room.message",
+                    "content": {"body": "Other room root", "msgtype": "m.text"},
+                },
+            ],
+        )
+
+        all_recent = await cache.get_recent_room_thread_ids("!room:localhost", limit=10)
+        first_only = await cache.get_recent_room_thread_ids("!room:localhost", limit=1)
+    finally:
+        await cache.close()
+
+    assert all_recent == [
+        "$thread_old_root_recent_reply",
+        "$thread_recent_root_no_replies",
+    ]
+    assert first_only == ["$thread_old_root_recent_reply"]
+
+
+@pytest.mark.asyncio
 async def test_event_cache_preserves_insertion_order_for_same_timestamp_events(tmp_path: Path) -> None:
     """Cached reads should preserve the stored order when timestamps tie."""
     cache = _EventCache(tmp_path / "event_cache.db")


### PR DESCRIPTION
## Summary
- Startup thread prewarm now seeds candidates from the local event cache (newest first) before falling back to the `/threads` API.
- Skips the `/threads` round-trip entirely when the local cache already supplies the full prewarm set (20 threads), and uses the API only to top up when local data is sparse.
- Falls back to local IDs when `/threads` errors so prewarm still progresses; only fully fails when both sources yield nothing.

## Test plan
- [ ] `uv run pytest tests/test_bot_ready_hook.py -x -n 0 --no-cov -v`