### PR TITLE
fix: move worker startup state into startup manifest

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -118,7 +118,7 @@ def _startup_runner_token_from_env() -> str | None:
 
 
 def _upstream_tool_validation_snapshot(runtime_paths: RuntimePaths) -> dict[str, ToolValidationInfo]:
-    startup_manifest_path = runtime_paths.storage_root / ".runtime" / "startup_manifest.json"
+    startup_manifest_path = constants.sandbox_startup_manifest_path(runtime_paths.storage_root)
     if not startup_manifest_path.exists():
         return {}
     startup_runtime_paths, tool_validation_snapshot = constants.deserialize_startup_manifest(

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
+from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -60,30 +61,39 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _SUBPROCESS_WORKER_ARG = "--sandbox-subprocess-worker"
-_STARTUP_RUNTIME_PATHS_ENV = "MINDROOM_RUNTIME_PATHS_JSON"
 _RUNNER_TOKEN_ENV = "MINDROOM_SANDBOX_PROXY_TOKEN"  # noqa: S105
-_TOOL_VALIDATION_SNAPSHOT_ENV = "MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON"
+
+
+def _startup_manifest_path_from_env() -> Path:
+    raw_path = os.environ.get(constants.SANDBOX_STARTUP_MANIFEST_PATH_ENV, "").strip()
+    if not raw_path:
+        msg = f"{constants.SANDBOX_STARTUP_MANIFEST_PATH_ENV} must be set for sandbox runner startup."
+        raise RuntimeError(msg)
+    return Path(raw_path).expanduser()
+
+
+def _startup_manifest_from_env() -> dict[str, object]:
+    payload = json.loads(_startup_manifest_path_from_env().read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        msg = f"{constants.SANDBOX_STARTUP_MANIFEST_PATH_ENV} must point to a JSON object."
+        raise TypeError(msg)
+    return payload
 
 
 def _startup_runtime_paths_from_env() -> RuntimePaths:
-    """Read the committed sandbox-runner runtime payload from startup env."""
-    raw_payload = os.environ.get(_STARTUP_RUNTIME_PATHS_ENV, "").strip()
-    if not raw_payload:
-        msg = f"{_STARTUP_RUNTIME_PATHS_ENV} must be set for sandbox runner startup."
-        raise RuntimeError(msg)
-    payload = json.loads(raw_payload)
-    if not isinstance(payload, dict):
-        msg = f"{_STARTUP_RUNTIME_PATHS_ENV} must contain a JSON object."
-        raise TypeError(msg)
-    if not isinstance(payload.get("process_env"), dict):
-        msg = f"{_STARTUP_RUNTIME_PATHS_ENV} is missing process_env."
-        raise TypeError(msg)
-    startup_runtime_paths = constants.deserialize_runtime_paths(payload)
+    """Read the committed sandbox-runner runtime payload from the startup manifest."""
+    startup_runtime_paths, _tool_validation_snapshot = constants.deserialize_startup_manifest(
+        _startup_manifest_from_env(),
+    )
     if sandbox_exec.runner_uses_dedicated_worker(startup_runtime_paths):
         return startup_runtime_paths
     process_env = dict(startup_runtime_paths.process_env)
     process_env.update(
-        {key: value for key, value in os.environ.items() if key not in {_RUNNER_TOKEN_ENV, _STARTUP_RUNTIME_PATHS_ENV}},
+        {
+            key: value
+            for key, value in os.environ.items()
+            if key not in {_RUNNER_TOKEN_ENV, constants.SANDBOX_STARTUP_MANIFEST_PATH_ENV}
+        },
     )
     resolved_runtime_paths = constants.resolve_primary_runtime_paths(
         config_path=startup_runtime_paths.config_path,
@@ -107,11 +117,17 @@ def _startup_runner_token_from_env() -> str | None:
     return raw_token or None
 
 
-def _upstream_tool_validation_snapshot_from_env() -> dict[str, ToolValidationInfo]:
-    raw_payload = os.environ.get(_TOOL_VALIDATION_SNAPSHOT_ENV, "").strip()
-    if not raw_payload:
+def _upstream_tool_validation_snapshot(runtime_paths: RuntimePaths) -> dict[str, ToolValidationInfo]:
+    startup_manifest_path = runtime_paths.storage_root / ".runtime" / "startup_manifest.json"
+    if not startup_manifest_path.exists():
         return {}
-    return deserialize_tool_validation_snapshot(json.loads(raw_payload))
+    startup_runtime_paths, tool_validation_snapshot = constants.deserialize_startup_manifest(
+        json.loads(startup_manifest_path.read_text(encoding="utf-8")),
+    )
+    if startup_runtime_paths.storage_root != runtime_paths.storage_root:
+        msg = "Sandbox startup manifest storage_root does not match runtime storage_root."
+        raise RuntimeError(msg)
+    return deserialize_tool_validation_snapshot(tool_validation_snapshot)
 
 
 def _runtime_config_or_empty(runtime_paths: RuntimePaths) -> Config:
@@ -128,7 +144,7 @@ def _dedicated_worker_runtime_config_or_empty(runtime_paths: RuntimePaths) -> Co
     with runtime_paths.config_path.open() as f:
         data = yaml.safe_load(f) or {}
 
-    tool_validation_snapshot = _upstream_tool_validation_snapshot_from_env()
+    tool_validation_snapshot = _upstream_tool_validation_snapshot(runtime_paths)
     if not tool_validation_snapshot:
         return load_config(runtime_paths)
 

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -24,6 +24,7 @@ ROUTER_AGENT_NAME = "router"
 # Search order for existing files: env var > ./config.yaml > ~/.mindroom/config.yaml
 _CONFIG_SEARCH_PATHS = [Path("config.yaml"), Path.home() / ".mindroom" / "config.yaml"]
 _RUNTIME_PATH_ENV_KEYS = frozenset({"MINDROOM_CONFIG_PATH", "MINDROOM_STORAGE_PATH"})
+SANDBOX_STARTUP_MANIFEST_PATH_ENV = "MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH"
 _CONFIG_PATH_PLACEHOLDER_PATTERN = re.compile(r"\$(?:\{(?P<braced>[A-Z0-9_]+)\}|(?P<bare>[A-Z0-9_]+))")
 _RUNTIME_STARTUP_ENV_PREFIXES = ("MINDROOM_", "MATRIX_", "BROWSER_")
 _RUNTIME_STARTUP_ENV_EXTRA_KEYS = frozenset(
@@ -60,7 +61,7 @@ _EXECUTION_RUNTIME_EXCLUDED_NAMES = frozenset(
         *_RUNTIME_STARTUP_EXCLUDED_NAMES,
         "MINDROOM_API_KEY",
         "MINDROOM_LOCAL_CLIENT_SECRET",
-        "MINDROOM_RUNTIME_PATHS_JSON",
+        SANDBOX_STARTUP_MANIFEST_PATH_ENV,
     },
 )
 _SHELL_EXTRA_ENV_EXCLUDED_NAMES = frozenset({*_EXECUTION_RUNTIME_EXCLUDED_NAMES, "CI_JOB_TOKEN"})
@@ -292,6 +293,22 @@ def serialize_public_runtime_paths(runtime_paths: RuntimePaths) -> dict[str, obj
     }
 
 
+def serialize_startup_manifest(
+    runtime_paths: RuntimePaths,
+    *,
+    tool_validation_snapshot: Mapping[str, object] | None = None,
+    public_runtime: bool = False,
+) -> dict[str, object]:
+    """Return one JSON-compatible startup manifest for sandbox runners."""
+    serialized_runtime = (
+        serialize_public_runtime_paths(runtime_paths) if public_runtime else serialize_runtime_paths(runtime_paths)
+    )
+    return {
+        "runtime_paths": serialized_runtime,
+        "tool_validation_snapshot": dict(tool_validation_snapshot or {}),
+    }
+
+
 def deserialize_runtime_paths(payload: Mapping[str, object]) -> RuntimePaths:
     """Build one RuntimePaths object from an explicit serialized payload."""
     raw_config_path = payload.get("config_path")
@@ -326,6 +343,25 @@ def deserialize_runtime_paths(payload: Mapping[str, object]) -> RuntimePaths:
         process_env=cast("Mapping[str, str]", MappingProxyType(process_env)),
         env_file_values=cast("Mapping[str, str]", MappingProxyType(env_file_values)),
     )
+
+
+def deserialize_startup_manifest(payload: Mapping[str, object]) -> tuple[RuntimePaths, dict[str, object]]:
+    """Build one startup manifest from explicit serialized payload."""
+    raw_runtime_paths = payload.get("runtime_paths")
+    raw_tool_validation_snapshot = payload.get("tool_validation_snapshot", {})
+    if not isinstance(raw_runtime_paths, Mapping):
+        msg = "Serialized startup manifest is missing runtime_paths"
+        raise TypeError(msg)
+    if not isinstance(raw_tool_validation_snapshot, Mapping):
+        msg = "Serialized startup manifest is missing tool_validation_snapshot"
+        raise TypeError(msg)
+    runtime_paths_payload: dict[str, object] = {
+        key: value for key, value in raw_runtime_paths.items() if isinstance(key, str)
+    }
+    tool_validation_snapshot = {
+        key: value for key, value in raw_tool_validation_snapshot.items() if isinstance(key, str)
+    }
+    return deserialize_runtime_paths(runtime_paths_payload), tool_validation_snapshot
 
 
 def _expand_runtime_path_vars(value: str, paths: RuntimePaths) -> str:

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import MappingProxyType
-from typing import cast
+from typing import TypeGuard, cast
 
 from dotenv import dotenv_values
 
@@ -25,6 +25,7 @@ ROUTER_AGENT_NAME = "router"
 _CONFIG_SEARCH_PATHS = [Path("config.yaml"), Path.home() / ".mindroom" / "config.yaml"]
 _RUNTIME_PATH_ENV_KEYS = frozenset({"MINDROOM_CONFIG_PATH", "MINDROOM_STORAGE_PATH"})
 SANDBOX_STARTUP_MANIFEST_PATH_ENV = "MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH"
+SANDBOX_STARTUP_MANIFEST_RELATIVE_PATH = Path(".runtime") / "startup_manifest.json"
 _CONFIG_PATH_PLACEHOLDER_PATTERN = re.compile(r"\$(?:\{(?P<braced>[A-Z0-9_]+)\}|(?P<bare>[A-Z0-9_]+))")
 _RUNTIME_STARTUP_ENV_PREFIXES = ("MINDROOM_", "MATRIX_", "BROWSER_")
 _RUNTIME_STARTUP_ENV_EXTRA_KEYS = frozenset(
@@ -309,8 +310,20 @@ def serialize_startup_manifest(
     }
 
 
-def deserialize_runtime_paths(payload: Mapping[str, object]) -> RuntimePaths:
+def sandbox_startup_manifest_path(storage_root: Path) -> Path:
+    """Return the canonical startup manifest path under one runtime root."""
+    return storage_root / SANDBOX_STARTUP_MANIFEST_RELATIVE_PATH
+
+
+def _is_json_object(value: object) -> TypeGuard[dict[str, object]]:
+    return isinstance(value, dict)
+
+
+def deserialize_runtime_paths(payload: object) -> RuntimePaths:
     """Build one RuntimePaths object from an explicit serialized payload."""
+    if not _is_json_object(payload):
+        msg = "Serialized runtime payload must be a JSON object"
+        raise TypeError(msg)
     raw_config_path = payload.get("config_path")
     raw_storage_root = payload.get("storage_root")
     raw_process_env = payload.get("process_env")
@@ -345,23 +358,16 @@ def deserialize_runtime_paths(payload: Mapping[str, object]) -> RuntimePaths:
     )
 
 
-def deserialize_startup_manifest(payload: Mapping[str, object]) -> tuple[RuntimePaths, dict[str, object]]:
+def deserialize_startup_manifest(payload: object) -> tuple[RuntimePaths, object]:
     """Build one startup manifest from explicit serialized payload."""
+    if not _is_json_object(payload):
+        msg = "Serialized startup manifest must be a JSON object"
+        raise TypeError(msg)
     raw_runtime_paths = payload.get("runtime_paths")
-    raw_tool_validation_snapshot = payload.get("tool_validation_snapshot", {})
-    if not isinstance(raw_runtime_paths, Mapping):
+    if raw_runtime_paths is None:
         msg = "Serialized startup manifest is missing runtime_paths"
         raise TypeError(msg)
-    if not isinstance(raw_tool_validation_snapshot, Mapping):
-        msg = "Serialized startup manifest is missing tool_validation_snapshot"
-        raise TypeError(msg)
-    runtime_paths_payload: dict[str, object] = {
-        key: value for key, value in raw_runtime_paths.items() if isinstance(key, str)
-    }
-    tool_validation_snapshot = {
-        key: value for key, value in raw_tool_validation_snapshot.items() if isinstance(key, str)
-    }
-    return deserialize_runtime_paths(runtime_paths_payload), tool_validation_snapshot
+    return deserialize_runtime_paths(raw_runtime_paths), payload.get("tool_validation_snapshot", {})
 
 
 def _expand_runtime_path_vars(value: str, paths: RuntimePaths) -> str:

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -6,6 +6,7 @@ codebase.
 """
 
 import fnmatch
+import json
 import os
 import re
 import shutil
@@ -313,6 +314,31 @@ def serialize_startup_manifest(
 def sandbox_startup_manifest_path(storage_root: Path) -> Path:
     """Return the canonical startup manifest path under one runtime root."""
     return storage_root / SANDBOX_STARTUP_MANIFEST_RELATIVE_PATH
+
+
+def write_startup_manifest(
+    storage_root: Path,
+    runtime_paths: RuntimePaths,
+    *,
+    tool_validation_snapshot: Mapping[str, object] | None = None,
+    public_runtime: bool = False,
+) -> Path:
+    """Write one sandbox-runner startup manifest and return its path."""
+    manifest_path = sandbox_startup_manifest_path(storage_root)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(
+            serialize_startup_manifest(
+                runtime_paths,
+                tool_validation_snapshot=tool_validation_snapshot,
+                public_runtime=public_runtime,
+            ),
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return manifest_path
 
 
 def _is_json_object(value: object) -> TypeGuard[dict[str, object]]:

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -642,9 +642,8 @@ class KubernetesResourceManager:
         dedicated_root: Path,
         local_dedicated_root: Path,
     ) -> str:
-        runtime_dir = local_dedicated_root / ".runtime"
-        runtime_dir.mkdir(parents=True, exist_ok=True)
-        target_path = runtime_dir / "startup_manifest.json"
+        target_path = constants.sandbox_startup_manifest_path(local_dedicated_root)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
         startup_runtime_paths = self._worker_runtime_paths(
             worker_key=worker_key,
             dedicated_root=dedicated_root,
@@ -660,7 +659,7 @@ class KubernetesResourceManager:
             ),
             encoding="utf-8",
         )
-        return str(dedicated_root / ".runtime" / target_path.name)
+        return str(constants.sandbox_startup_manifest_path(dedicated_root))
 
     def _worker_runtime_paths(
         self,

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -642,22 +642,14 @@ class KubernetesResourceManager:
         dedicated_root: Path,
         local_dedicated_root: Path,
     ) -> str:
-        target_path = constants.sandbox_startup_manifest_path(local_dedicated_root)
-        target_path.parent.mkdir(parents=True, exist_ok=True)
         startup_runtime_paths = self._worker_runtime_paths(
             worker_key=worker_key,
             dedicated_root=dedicated_root,
         )
-        target_path.write_text(
-            json.dumps(
-                constants.serialize_startup_manifest(
-                    startup_runtime_paths,
-                    tool_validation_snapshot=self.tool_validation_snapshot,
-                ),
-                separators=(",", ":"),
-                sort_keys=True,
-            ),
-            encoding="utf-8",
+        constants.write_startup_manifest(
+            local_dedicated_root,
+            startup_runtime_paths,
+            tool_validation_snapshot=self.tool_validation_snapshot,
         )
         return str(constants.sandbox_startup_manifest_path(dedicated_root))
 

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -56,8 +56,6 @@ _RUNNER_PORT_ENV_NAME = "MINDROOM_SANDBOX_RUNNER_PORT"
 _DEDICATED_WORKER_KEY_ENV = "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY"
 _DEDICATED_WORKER_ROOT_ENV = "MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT"
 _SHARED_STORAGE_ROOT_ENV = "MINDROOM_SANDBOX_SHARED_STORAGE_ROOT"
-_STARTUP_RUNTIME_PATHS_ENV = "MINDROOM_RUNTIME_PATHS_JSON"
-_TOOL_VALIDATION_SNAPSHOT_ENV = "MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON"
 _DEFAULT_CONTAINER_PATH = "/app/.venv/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 
@@ -587,30 +585,20 @@ class KubernetesResourceManager:
 
     def _worker_env(self, worker_key: str, state_subpath: str) -> list[dict[str, object]]:
         dedicated_root = f"{self.config.storage_mount_path}/{state_subpath}".rstrip("/")
+        local_dedicated_root = (self.storage_root / state_subpath).resolve()
         venv_path = f"{dedicated_root}/venv"
-        startup_runtime_paths = self._worker_runtime_paths(
+        startup_manifest_path = self._write_startup_manifest(
             worker_key=worker_key,
             dedicated_root=Path(dedicated_root),
+            local_dedicated_root=local_dedicated_root,
         )
         env: list[dict[str, object]] = [
             {"name": "MINDROOM_SANDBOX_RUNNER_MODE", "value": "true"},
             {"name": "MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE", "value": "subprocess"},
             {"name": _RUNNER_PORT_ENV_NAME, "value": str(self.config.worker_port)},
             {
-                "name": _STARTUP_RUNTIME_PATHS_ENV,
-                "value": json.dumps(
-                    constants.serialize_runtime_paths(startup_runtime_paths),
-                    separators=(",", ":"),
-                    sort_keys=True,
-                ),
-            },
-            {
-                "name": _TOOL_VALIDATION_SNAPSHOT_ENV,
-                "value": json.dumps(
-                    self.tool_validation_snapshot,
-                    separators=(",", ":"),
-                    sort_keys=True,
-                ),
+                "name": constants.SANDBOX_STARTUP_MANIFEST_PATH_ENV,
+                "value": startup_manifest_path,
             },
             {"name": "MINDROOM_CONFIG_PATH", "value": self.config.config_path},
             {"name": "MINDROOM_STORAGE_PATH", "value": dedicated_root},
@@ -646,6 +634,33 @@ class KubernetesResourceManager:
         for name, value in sorted(self.config.extra_env.items()):
             env.append({"name": name, "value": value})
         return env
+
+    def _write_startup_manifest(
+        self,
+        *,
+        worker_key: str,
+        dedicated_root: Path,
+        local_dedicated_root: Path,
+    ) -> str:
+        runtime_dir = local_dedicated_root / ".runtime"
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        target_path = runtime_dir / "startup_manifest.json"
+        startup_runtime_paths = self._worker_runtime_paths(
+            worker_key=worker_key,
+            dedicated_root=dedicated_root,
+        )
+        target_path.write_text(
+            json.dumps(
+                constants.serialize_startup_manifest(
+                    startup_runtime_paths,
+                    tool_validation_snapshot=self.tool_validation_snapshot,
+                ),
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        return str(dedicated_root / ".runtime" / target_path.name)
 
     def _worker_runtime_paths(
         self,

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -108,7 +108,7 @@ def _set_sandbox_token(monkeypatch: pytest.MonkeyPatch) -> None:
     _refresh_runner_app_from_env()
 
 
-def _set_worker_tool_validation_snapshot(monkeypatch: pytest.MonkeyPatch, *tool_names: str) -> None:
+def _set_worker_tool_validation_snapshot(*tool_names: str) -> None:
     """Set the upstream-authored validation snapshot visible to one worker runtime."""
     runtime_paths = resolve_primary_runtime_paths(process_env=dict(os.environ))
     config = Config.validate_with_runtime({}, runtime_paths)
@@ -121,10 +121,66 @@ def _set_worker_tool_validation_snapshot(monkeypatch: pytest.MonkeyPatch, *tool_
             "agent_override_fields": [],
             "authored_override_validator": "default",
         }
-    monkeypatch.setenv(
-        "MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON",
-        json.dumps(snapshot, separators=(",", ":"), sort_keys=True),
+    _write_startup_manifest(
+        runtime_paths=runtime_paths,
+        tool_validation_snapshot=snapshot,
     )
+
+
+def _write_startup_manifest(
+    *,
+    runtime_paths: RuntimePaths,
+    public_runtime: bool = False,
+    tool_validation_snapshot: dict[str, object] | None = None,
+) -> Path:
+    manifest_path = runtime_paths.storage_root / ".runtime" / "startup_manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_payload = {
+        "runtime_paths": (
+            serialize_public_runtime_paths(runtime_paths) if public_runtime else serialize_runtime_paths(runtime_paths)
+        ),
+        "tool_validation_snapshot": tool_validation_snapshot or {},
+    }
+    manifest_path.write_text(
+        json.dumps(manifest_payload, separators=(",", ":"), sort_keys=True),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _set_startup_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    manifest_path: Path,
+) -> None:
+    monkeypatch.setenv("MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH", str(manifest_path))
+    monkeypatch.delenv("MINDROOM_RUNTIME_PATHS_JSON", raising=False)
+    monkeypatch.delenv("MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_PATH", raising=False)
+    monkeypatch.delenv("MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON", raising=False)
+
+
+def test_worker_tool_validation_snapshot_reads_from_startup_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dedicated workers should load tool validation snapshots from the startup manifest."""
+    runtime_paths = resolve_primary_runtime_paths(process_env=dict(os.environ))
+    config = Config.validate_with_runtime({}, runtime_paths)
+    snapshot = serialize_tool_validation_snapshot(
+        resolved_tool_validation_snapshot_for_runtime(runtime_paths, config),
+    )
+    snapshot["agentspace_slack_search"] = {
+        "config_fields": [],
+        "agent_override_fields": [],
+        "authored_override_validator": "default",
+        "runtime_loadable": True,
+    }
+    manifest_path = _write_startup_manifest(runtime_paths=runtime_paths, tool_validation_snapshot=snapshot)
+    _set_startup_manifest(monkeypatch, manifest_path=manifest_path)
+
+    loaded_snapshot = sandbox_runner_module._upstream_tool_validation_snapshot(runtime_paths)
+
+    assert "agentspace_slack_search" in loaded_snapshot
+    assert loaded_snapshot["agentspace_slack_search"].runtime_loadable is True
+    assert loaded_snapshot["agentspace_slack_search"].config_fields == ()
+    assert loaded_snapshot["agentspace_slack_search"].agent_override_fields == ()
 
 
 def _refresh_runner_app_from_env() -> tuple[RuntimePaths, Config]:
@@ -264,7 +320,8 @@ def test_startup_runtime_keeps_runner_token_outside_runtime_paths(
         storage_path=tmp_path / "storage",
         process_env={"MINDROOM_NAMESPACE": "alpha1234"},
     )
-    monkeypatch.setenv("MINDROOM_RUNTIME_PATHS_JSON", json.dumps(serialize_runtime_paths(payload_runtime)))
+    manifest_path = _write_startup_manifest(runtime_paths=payload_runtime)
+    _set_startup_manifest(monkeypatch, manifest_path=manifest_path)
     monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", "from-env")
 
     startup_runtime = sandbox_runner_module._startup_runtime_paths_from_env()
@@ -328,7 +385,8 @@ def test_startup_runtime_rehydrates_runtime_env_from_process_env_and_dotenv(
         storage_path=tmp_path / "storage",
         process_env={"MINDROOM_NAMESPACE": "alpha1234"},
     )
-    monkeypatch.setenv("MINDROOM_RUNTIME_PATHS_JSON", json.dumps(serialize_public_runtime_paths(payload_runtime)))
+    manifest_path = _write_startup_manifest(runtime_paths=payload_runtime, public_runtime=True)
+    _set_startup_manifest(monkeypatch, manifest_path=manifest_path)
     monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", "from-env")
     monkeypatch.setenv("TEST_EXECUTION_ENV", "worker-visible")
 
@@ -365,7 +423,10 @@ def test_dedicated_worker_startup_runtime_does_not_rehydrate_dotenv_credentials(
     )
     payload = serialize_runtime_paths(payload_runtime)
     payload["env_file_values"] = {"MINDROOM_NAMESPACE": "alpha1234"}
-    monkeypatch.setenv("MINDROOM_RUNTIME_PATHS_JSON", json.dumps(payload))
+    manifest_path = _write_startup_manifest(
+        runtime_paths=sandbox_runner_module.constants.deserialize_runtime_paths(payload),
+    )
+    _set_startup_manifest(monkeypatch, manifest_path=manifest_path)
     monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", "from-env")
     monkeypatch.setenv("OPENAI_BASE_URL", "http://runner-env.example/v1")
     monkeypatch.setenv("TEST_EXECUTION_ENV", "worker-visible")
@@ -409,7 +470,10 @@ async def test_dedicated_worker_inprocess_shell_does_not_see_runner_local_env(
     )
     payload = serialize_runtime_paths(payload_runtime)
     payload["env_file_values"] = {"MINDROOM_NAMESPACE": "alpha1234"}
-    monkeypatch.setenv("MINDROOM_RUNTIME_PATHS_JSON", json.dumps(payload))
+    manifest_path = _write_startup_manifest(
+        runtime_paths=sandbox_runner_module.constants.deserialize_runtime_paths(payload),
+    )
+    _set_startup_manifest(monkeypatch, manifest_path=manifest_path)
     monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", SANDBOX_TOKEN)
     monkeypatch.setenv("OPENAI_BASE_URL", "http://runner-env.example/v1")
     monkeypatch.setenv("TEST_EXECUTION_ENV", "worker-visible")
@@ -885,7 +949,7 @@ def test_sandbox_runner_skips_unavailable_plugins_for_worker_runtime(
     monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
     monkeypatch.setenv("MINDROOM_SANDBOX_DEDICATED_WORKER_KEY", "worker-a")
-    _set_worker_tool_validation_snapshot(monkeypatch, "agentspace_slack_search")
+    _set_worker_tool_validation_snapshot("agentspace_slack_search")
     _set_sandbox_token(monkeypatch)
 
     runtime_paths, config = _refresh_runner_app_from_env()
@@ -921,7 +985,7 @@ def test_sandbox_runner_shared_startup_still_rejects_missing_plugins(
     config_path = _missing_plugin_path_config_path(tmp_path)
     monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
-    _set_worker_tool_validation_snapshot(monkeypatch, "agentspace_slack_search")
+    _set_worker_tool_validation_snapshot("agentspace_slack_search")
     monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", SANDBOX_TOKEN)
 
     with pytest.raises(ConfigRuntimeValidationError, match="Configured plugin path does not exist"):
@@ -937,7 +1001,7 @@ def test_sandbox_runner_still_rejects_invalid_tools_after_skipping_worker_plugin
     monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
     monkeypatch.setenv("MINDROOM_SANDBOX_DEDICATED_WORKER_KEY", "worker-a")
-    _set_worker_tool_validation_snapshot(monkeypatch, "agentspace_slack_search")
+    _set_worker_tool_validation_snapshot("agentspace_slack_search")
     monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", SANDBOX_TOKEN)
 
     with pytest.raises(ConfigRuntimeValidationError) as exc_info:

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -27,7 +27,6 @@ from mindroom.config.main import Config, ConfigRuntimeValidationError
 from mindroom.constants import (
     resolve_primary_runtime_paths,
     resolve_runtime_paths,
-    sandbox_startup_manifest_path,
     serialize_public_runtime_paths,
     serialize_runtime_paths,
 )
@@ -134,21 +133,12 @@ def _write_startup_manifest(
     public_runtime: bool = False,
     tool_validation_snapshot: dict[str, object] | None = None,
 ) -> Path:
-    manifest_path = sandbox_startup_manifest_path(runtime_paths.storage_root)
-    manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_path.write_text(
-        json.dumps(
-            sandbox_runner_module.constants.serialize_startup_manifest(
-                runtime_paths,
-                tool_validation_snapshot=tool_validation_snapshot,
-                public_runtime=public_runtime,
-            ),
-            separators=(",", ":"),
-            sort_keys=True,
-        ),
-        encoding="utf-8",
+    return sandbox_runner_module.constants.write_startup_manifest(
+        runtime_paths.storage_root,
+        runtime_paths,
+        tool_validation_snapshot=tool_validation_snapshot,
+        public_runtime=public_runtime,
     )
-    return manifest_path
 
 
 def _set_startup_manifest(

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -27,6 +27,7 @@ from mindroom.config.main import Config, ConfigRuntimeValidationError
 from mindroom.constants import (
     resolve_primary_runtime_paths,
     resolve_runtime_paths,
+    sandbox_startup_manifest_path,
     serialize_public_runtime_paths,
     serialize_runtime_paths,
 )
@@ -133,16 +134,18 @@ def _write_startup_manifest(
     public_runtime: bool = False,
     tool_validation_snapshot: dict[str, object] | None = None,
 ) -> Path:
-    manifest_path = runtime_paths.storage_root / ".runtime" / "startup_manifest.json"
+    manifest_path = sandbox_startup_manifest_path(runtime_paths.storage_root)
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_payload = {
-        "runtime_paths": (
-            serialize_public_runtime_paths(runtime_paths) if public_runtime else serialize_runtime_paths(runtime_paths)
-        ),
-        "tool_validation_snapshot": tool_validation_snapshot or {},
-    }
     manifest_path.write_text(
-        json.dumps(manifest_payload, separators=(",", ":"), sort_keys=True),
+        json.dumps(
+            sandbox_runner_module.constants.serialize_startup_manifest(
+                runtime_paths,
+                tool_validation_snapshot=tool_validation_snapshot,
+                public_runtime=public_runtime,
+            ),
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
         encoding="utf-8",
     )
     return manifest_path
@@ -154,9 +157,6 @@ def _set_startup_manifest(
     manifest_path: Path,
 ) -> None:
     monkeypatch.setenv("MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH", str(manifest_path))
-    monkeypatch.delenv("MINDROOM_RUNTIME_PATHS_JSON", raising=False)
-    monkeypatch.delenv("MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_PATH", raising=False)
-    monkeypatch.delenv("MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON", raising=False)
 
 
 def test_worker_tool_validation_snapshot_reads_from_startup_manifest(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -14,6 +14,7 @@ from mindroom.constants import (
     DEFAULT_WORKER_GRANTABLE_CREDENTIALS,
     deserialize_runtime_paths,
     resolve_primary_runtime_paths,
+    sandbox_startup_manifest_path,
 )
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
@@ -50,8 +51,8 @@ def _load_startup_manifest(
     *,
     worker_key: str,
 ) -> dict[str, object]:
-    manifest_path = (
-        backend.storage_root / f"workers/{worker_dir_name(worker_key)}" / ".runtime" / "startup_manifest.json"
+    manifest_path = sandbox_startup_manifest_path(
+        backend.storage_root / f"workers/{worker_dir_name(worker_key)}",
     )
     return json.loads(manifest_path.read_text(encoding="utf-8"))
 

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -45,6 +45,17 @@ _TEST_TOOL_VALIDATION_SNAPSHOT = {
 }
 
 
+def _load_startup_manifest(
+    backend: KubernetesWorkerBackend,
+    *,
+    worker_key: str,
+) -> dict[str, object]:
+    manifest_path = (
+        backend.storage_root / f"workers/{worker_dir_name(worker_key)}" / ".runtime" / "startup_manifest.json"
+    )
+    return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
 class _FakeApiError(Exception):
     def __init__(self, status: int) -> None:
         super().__init__(status)
@@ -275,8 +286,7 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:  # 
     assert "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY" in env_names
     assert "MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT" in env_names
     assert "MINDROOM_STORAGE_PATH" in env_names
-    assert "MINDROOM_RUNTIME_PATHS_JSON" in env_names
-    assert "MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON" in env_names
+    assert "MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH" in env_names
     assert "MINDROOM_SANDBOX_ALLOWED_TOOL_NAMES_JSON" not in env_names
     assert "MINDROOM_SANDBOX_SHARED_STORAGE_ROOT" in env_names
     assert "VIRTUAL_ENV" in env_names
@@ -285,10 +295,14 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:  # 
     assert "MINDROOM_SANDBOX_PROXY_TOKEN" in env_names
     assert env_values["MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE"] == "subprocess"
     assert env_values["MINDROOM_SANDBOX_RUNNER_PORT"] == "8766"
-    validation_snapshot = json.loads(env_values["MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON"])
+    manifest_path = env_values["MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH"]
+    assert manifest_path is not None
+    startup_manifest = _load_startup_manifest(backend, worker_key=worker_key)
+    validation_snapshot = startup_manifest["tool_validation_snapshot"]
     assert validation_snapshot == _TEST_TOOL_VALIDATION_SNAPSHOT
     expected_dedicated_root = f"/app/worker/workers/{worker_dir_name(worker_key)}"
-    committed_runtime = deserialize_runtime_paths(json.loads(env_values["MINDROOM_RUNTIME_PATHS_JSON"]))
+    assert manifest_path == f"{expected_dedicated_root}/.runtime/startup_manifest.json"
+    committed_runtime = deserialize_runtime_paths(startup_manifest["runtime_paths"])
     assert env_values["MINDROOM_STORAGE_PATH"] == expected_dedicated_root
     assert env_values["MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT"] == expected_dedicated_root
     assert env_values["MINDROOM_SANDBOX_SHARED_STORAGE_ROOT"] == "/app/worker"
@@ -388,10 +402,9 @@ def test_kubernetes_backend_commits_parent_runtime_env_into_worker_payload(tmp_p
 
     backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
 
-    deployment = apps_api.created_bodies[0]
-    container = deployment["spec"]["template"]["spec"]["containers"][0]
-    env_values = {env["name"]: env.get("value") for env in container["env"]}
-    committed_runtime = deserialize_runtime_paths(json.loads(env_values["MINDROOM_RUNTIME_PATHS_JSON"]))
+    committed_runtime = deserialize_runtime_paths(
+        _load_startup_manifest(backend, worker_key=_TEST_SCOPED_WORKER_KEY_A)["runtime_paths"],
+    )
     state_subpath = Path("workers") / worker_dir_name(_TEST_SCOPED_WORKER_KEY_A)
     local_credentials_path = runtime_paths.storage_root / state_subpath / ".runtime" / credentials_path.name
 
@@ -432,7 +445,11 @@ def test_kubernetes_backend_uses_provided_validation_snapshot() -> None:
     container = deployment["spec"]["template"]["spec"]["containers"][0]
     env_values = {env["name"]: env.get("value") for env in container["env"]}
 
-    assert json.loads(env_values["MINDROOM_SANDBOX_TOOL_VALIDATION_SNAPSHOT_JSON"]) == custom_snapshot
+    assert env_values["MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH"] is not None
+    assert (
+        _load_startup_manifest(backend, worker_key=_TEST_SCOPED_WORKER_KEY_A)["tool_validation_snapshot"]
+        == custom_snapshot
+    )
 
 
 def test_kubernetes_backend_drops_host_local_adc_path_when_not_mounted(tmp_path: Path) -> None:
@@ -455,10 +472,9 @@ def test_kubernetes_backend_drops_host_local_adc_path_when_not_mounted(tmp_path:
 
     backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
 
-    deployment = apps_api.created_bodies[0]
-    container = deployment["spec"]["template"]["spec"]["containers"][0]
-    env_values = {env["name"]: env.get("value") for env in container["env"]}
-    committed_runtime = deserialize_runtime_paths(json.loads(env_values["MINDROOM_RUNTIME_PATHS_JSON"]))
+    committed_runtime = deserialize_runtime_paths(
+        _load_startup_manifest(backend, worker_key=_TEST_SCOPED_WORKER_KEY_A)["runtime_paths"],
+    )
 
     assert committed_runtime.env_value("GOOGLE_APPLICATION_CREDENTIALS") is None
 
@@ -501,10 +517,9 @@ def test_kubernetes_backend_preserves_primary_config_path_without_configmap(tmp_
 
     backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
 
-    deployment = apps_api.created_bodies[0]
-    container = deployment["spec"]["template"]["spec"]["containers"][0]
-    env_values = {env["name"]: env.get("value") for env in container["env"]}
-    committed_runtime = deserialize_runtime_paths(json.loads(env_values["MINDROOM_RUNTIME_PATHS_JSON"]))
+    committed_runtime = deserialize_runtime_paths(
+        _load_startup_manifest(backend, worker_key=_TEST_SCOPED_WORKER_KEY_A)["runtime_paths"],
+    )
 
     assert committed_runtime.config_path == config_path.resolve()
 


### PR DESCRIPTION
## Summary
- move dedicated worker startup state out of pod env and into one shared startup manifest file
- keep runtime paths and tool validation snapshot in the same file-backed transport
- centralize the manifest path/serializer helpers and update worker + runner tests

## Why
Fresh Kubernetes worker pods can fail to start with `exec /app/run-sandbox-runner.sh: argument list too long` once the tool validation snapshot grows too large for env transport. This keeps the same startup contract while moving the payload off env.

## Verification
- `uv run pre-commit run --files src/mindroom/constants.py src/mindroom/api/sandbox_runner.py src/mindroom/workers/backends/kubernetes_resources.py tests/api/test_sandbox_runner_api.py tests/test_kubernetes_worker_backend.py`
- `uv run pytest tests/api/test_sandbox_runner_api.py tests/test_kubernetes_worker_backend.py -x --no-cov -q -n auto`
- `uv run pytest`
