### PR TITLE
fix: roll workers on startup manifest changes

### DIFF
--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -6,6 +6,7 @@ codebase.
 """
 
 import fnmatch
+import hashlib
 import json
 import os
 import re
@@ -311,6 +312,39 @@ def serialize_startup_manifest(
     }
 
 
+def startup_manifest_json(
+    runtime_paths: RuntimePaths,
+    *,
+    tool_validation_snapshot: Mapping[str, object] | None = None,
+    public_runtime: bool = False,
+) -> str:
+    """Return one deterministic JSON string for sandbox-runner startup state."""
+    return json.dumps(
+        serialize_startup_manifest(
+            runtime_paths,
+            tool_validation_snapshot=tool_validation_snapshot,
+            public_runtime=public_runtime,
+        ),
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def startup_manifest_sha256(
+    runtime_paths: RuntimePaths,
+    *,
+    tool_validation_snapshot: Mapping[str, object] | None = None,
+    public_runtime: bool = False,
+) -> str:
+    """Return one stable content hash for sandbox-runner startup state."""
+    payload = startup_manifest_json(
+        runtime_paths,
+        tool_validation_snapshot=tool_validation_snapshot,
+        public_runtime=public_runtime,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def sandbox_startup_manifest_path(storage_root: Path) -> Path:
     """Return the canonical startup manifest path under one runtime root."""
     return storage_root / SANDBOX_STARTUP_MANIFEST_RELATIVE_PATH
@@ -327,14 +361,10 @@ def write_startup_manifest(
     manifest_path = sandbox_startup_manifest_path(storage_root)
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_path.write_text(
-        json.dumps(
-            serialize_startup_manifest(
-                runtime_paths,
-                tool_validation_snapshot=tool_validation_snapshot,
-                public_runtime=public_runtime,
-            ),
-            separators=(",", ":"),
-            sort_keys=True,
+        startup_manifest_json(
+            runtime_paths,
+            tool_validation_snapshot=tool_validation_snapshot,
+            public_runtime=public_runtime,
         ),
         encoding="utf-8",
     )

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -40,6 +40,7 @@ ANNOTATION_FAILURE_REASON = "mindroom.ai/failure-reason"
 ANNOTATION_WORKER_KEY = "mindroom.ai/worker-key"
 ANNOTATION_WORKER_STATUS = "mindroom.ai/worker-status"
 ANNOTATION_STATE_SUBPATH = "mindroom.ai/state-subpath"
+ANNOTATION_STARTUP_MANIFEST_HASH = "mindroom.ai/startup-manifest-hash"
 ANNOTATION_TEMPLATE_HASH = "mindroom.ai/template-hash"
 
 _LABEL_COMPONENT = "mindroom.ai/component"
@@ -506,7 +507,15 @@ class KubernetesResourceManager:
         private_agent_names: frozenset[str] | None = None,
     ) -> dict[str, object]:
         worker_labels = _labels(extra_labels=self.config.extra_labels, worker_id=worker_id)
-        template_metadata = {"labels": worker_labels}
+        startup_manifest_path, startup_manifest_hash = self._write_startup_manifest(
+            worker_key=worker_key,
+            dedicated_root=Path(f"{self.config.storage_mount_path}/{state_subpath}".rstrip("/")),
+            local_dedicated_root=(self.storage_root / state_subpath).resolve(),
+        )
+        template_metadata = {
+            "labels": worker_labels,
+            "annotations": {ANNOTATION_STARTUP_MANIFEST_HASH: startup_manifest_hash},
+        }
         template_spec: dict[str, object] = {
             "serviceAccountName": self.config.service_account_name,
             "securityContext": {
@@ -524,7 +533,7 @@ class KubernetesResourceManager:
                     "imagePullPolicy": self.config.image_pull_policy,
                     "command": ["/app/run-sandbox-runner.sh"],
                     "ports": [{"containerPort": self.config.worker_port, "name": "api"}],
-                    "env": self._worker_env(worker_key, state_subpath),
+                    "env": self._worker_env(worker_key, state_subpath, startup_manifest_path=startup_manifest_path),
                     "volumeMounts": self._volume_mounts(worker_key, state_subpath, private_agent_names),
                     "readinessProbe": {
                         "httpGet": {"path": "/healthz", "port": "api"},
@@ -583,15 +592,15 @@ class KubernetesResourceManager:
             },
         }
 
-    def _worker_env(self, worker_key: str, state_subpath: str) -> list[dict[str, object]]:
+    def _worker_env(
+        self,
+        worker_key: str,
+        state_subpath: str,
+        *,
+        startup_manifest_path: str,
+    ) -> list[dict[str, object]]:
         dedicated_root = f"{self.config.storage_mount_path}/{state_subpath}".rstrip("/")
-        local_dedicated_root = (self.storage_root / state_subpath).resolve()
         venv_path = f"{dedicated_root}/venv"
-        startup_manifest_path = self._write_startup_manifest(
-            worker_key=worker_key,
-            dedicated_root=Path(dedicated_root),
-            local_dedicated_root=local_dedicated_root,
-        )
         env: list[dict[str, object]] = [
             {"name": "MINDROOM_SANDBOX_RUNNER_MODE", "value": "true"},
             {"name": "MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE", "value": "subprocess"},
@@ -641,7 +650,7 @@ class KubernetesResourceManager:
         worker_key: str,
         dedicated_root: Path,
         local_dedicated_root: Path,
-    ) -> str:
+    ) -> tuple[str, str]:
         startup_runtime_paths = self._worker_runtime_paths(
             worker_key=worker_key,
             dedicated_root=dedicated_root,
@@ -651,7 +660,13 @@ class KubernetesResourceManager:
             startup_runtime_paths,
             tool_validation_snapshot=self.tool_validation_snapshot,
         )
-        return str(constants.sandbox_startup_manifest_path(dedicated_root))
+        return (
+            str(constants.sandbox_startup_manifest_path(dedicated_root)),
+            constants.startup_manifest_sha256(
+                startup_runtime_paths,
+                tool_validation_snapshot=self.tool_validation_snapshot,
+            ),
+        )
 
     def _worker_runtime_paths(
         self,

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -15,6 +15,7 @@ from mindroom.constants import (
     deserialize_runtime_paths,
     resolve_primary_runtime_paths,
     sandbox_startup_manifest_path,
+    startup_manifest_sha256,
 )
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
@@ -25,6 +26,7 @@ from mindroom.tool_system.worker_routing import (
 )
 from mindroom.workers.backend import WorkerBackendError
 from mindroom.workers.backends.kubernetes import KubernetesWorkerBackend, _KubernetesWorkerBackendConfig
+from mindroom.workers.backends.kubernetes_resources import ANNOTATION_STARTUP_MANIFEST_HASH
 from mindroom.workers.models import WorkerSpec
 from mindroom.workers.runtime import primary_worker_backend_available, primary_worker_backend_name
 
@@ -338,7 +340,12 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:  # 
             "blockOwnerDeletion": False,
         },
     ]
-    assert "annotations" not in deployment["spec"]["template"]["metadata"]
+    assert deployment["spec"]["template"]["metadata"]["annotations"] == {
+        ANNOTATION_STARTUP_MANIFEST_HASH: startup_manifest_sha256(
+            committed_runtime,
+            tool_validation_snapshot=_TEST_TOOL_VALIDATION_SNAPSHOT,
+        ),
+    }
     assert deployment["spec"]["template"]["spec"]["securityContext"] == {
         "runAsUser": 1000,
         "runAsGroup": 1000,
@@ -358,6 +365,54 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment() -> None:  # 
         "periodSeconds": 5,
         "failureThreshold": 60,
     }
+
+
+def test_kubernetes_backend_recreates_worker_when_startup_manifest_changes(tmp_path: Path) -> None:
+    """Changing startup state should force a worker Deployment recreate."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    initial_snapshot = deepcopy(_TEST_TOOL_VALIDATION_SNAPSHOT)
+    updated_snapshot = deepcopy(_TEST_TOOL_VALIDATION_SNAPSHOT)
+    updated_snapshot["search"] = {
+        "config_fields": ["engine"],
+        "agent_override_fields": [],
+        "authored_override_validator": "default",
+        "runtime_loadable": True,
+    }
+    backend, apps_api, core_api = _backend(
+        runtime_paths=runtime_paths,
+        owner_deployment_name="mindroom-demo",
+        tool_validation_snapshot=initial_snapshot,
+    )
+    worker_key = _TEST_SCOPED_WORKER_KEY_A
+
+    handle = backend.ensure_worker(WorkerSpec(worker_key), now=10.0)
+
+    initial_deployment = apps_api.created_bodies[0]
+    initial_manifest_hash = initial_deployment["spec"]["template"]["metadata"]["annotations"][
+        ANNOTATION_STARTUP_MANIFEST_HASH
+    ]
+
+    updated_backend, _, _ = _backend(
+        runtime_paths=runtime_paths,
+        owner_deployment_name="mindroom-demo",
+        tool_validation_snapshot=updated_snapshot,
+    )
+    updated_backend._resources.apps_api = apps_api
+    updated_backend._resources.core_api = core_api
+    updated_backend._resources.api_exception_cls = _FakeApiError
+
+    updated_backend.ensure_worker(WorkerSpec(worker_key), now=20.0)
+
+    assert apps_api.deleted_names == [handle.worker_id]
+    assert len(apps_api.created_bodies) == 2
+    updated_deployment = apps_api.created_bodies[1]
+    updated_manifest_hash = updated_deployment["spec"]["template"]["metadata"]["annotations"][
+        ANNOTATION_STARTUP_MANIFEST_HASH
+    ]
+    assert updated_manifest_hash != initial_manifest_hash
 
 
 def test_kubernetes_backend_commits_parent_runtime_env_into_worker_payload(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a stable startup-manifest content hash helper alongside the existing manifest writer
- put that hash on the worker pod template so Kubernetes rolls dedicated workers when startup inputs change
- cover the new rollout trigger in the Kubernetes worker backend tests

## Verification
- uv run pytest tests/test_kubernetes_worker_backend.py -x --no-cov -q -n auto
- uv run pytest tests/api/test_sandbox_runner_api.py tests/test_kubernetes_worker_backend.py -x --no-cov -q -n auto
- uv run pre-commit run --files src/mindroom/constants.py src/mindroom/workers/backends/kubernetes_resources.py tests/test_kubernetes_worker_backend.py
- uv run pytest -n auto