### PR TITLE
perf: skip redundant router ingress work

### DIFF
--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -15,6 +15,7 @@ from .commands.parsing import command_parser
 from .constants import ATTACHMENT_IDS_KEY, ORIGINAL_SENDER_KEY, VOICE_RAW_AUDIO_FALLBACK_KEY
 from .hooks.ingress import is_voice_event
 from .matrix.media import extract_media_caption
+from .timing import emit_elapsed_timing
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -408,9 +409,16 @@ class CoalescingGate:
 
     async def enqueue(self, key: CoalescingKey, pending_event: PendingEvent) -> None:
         """Queue one pending event and schedule its eventual flush."""
+        enqueue_start = time.monotonic()
         # Path 1: bypass — explicitly exempt automation
         if is_coalescing_exempt_source_kind(pending_event.event, pending_event.source_kind):
             await self._dispatch_batch(build_coalesced_batch(key, [pending_event]))
+            emit_elapsed_timing(
+                "coalescing_gate.enqueue",
+                enqueue_start,
+                path="bypass",
+                source_kind=pending_event.source_kind,
+            )
             return
 
         # Path 2: command interrupt — flush pending, dispatch command solo
@@ -420,6 +428,12 @@ class CoalescingGate:
                 self._cancel_timer(gate)
             await self._flush(key, bypass_grace=True)
             await self._dispatch_batch(build_coalesced_batch(key, [pending_event]))
+            emit_elapsed_timing(
+                "coalescing_gate.enqueue",
+                enqueue_start,
+                path="command_interrupt",
+                source_kind=pending_event.source_kind,
+            )
             return
 
         gate = self._gates.get(key)
@@ -432,6 +446,13 @@ class CoalescingGate:
             if _is_media_event(pending_event.event):
                 gate.pending.append(pending_event)
                 self._schedule_grace(key)
+                emit_elapsed_timing(
+                    "coalescing_gate.enqueue",
+                    enqueue_start,
+                    path="grace_media_extend",
+                    source_kind=pending_event.source_kind,
+                    pending_count=len(gate.pending),
+                )
                 return
             # Text during grace → flush existing batch, start new turn
             self._cancel_timer(gate)
@@ -444,11 +465,32 @@ class CoalescingGate:
         # Path 4: normal append + schedule
         gate.pending.append(pending_event)
         if gate.phase is GatePhase.IN_FLIGHT:
+            emit_elapsed_timing(
+                "coalescing_gate.enqueue",
+                enqueue_start,
+                path="in_flight_buffer",
+                source_kind=pending_event.source_kind,
+                pending_count=len(gate.pending),
+            )
             return
         if self._debounce_seconds() <= 0:
             await self._flush(key)
+            emit_elapsed_timing(
+                "coalescing_gate.enqueue",
+                enqueue_start,
+                path="immediate_flush",
+                source_kind=pending_event.source_kind,
+                pending_count=len(gate.pending),
+            )
             return
         self._reset_timer(key, delay=self._debounce_seconds(), phase=GatePhase.DEBOUNCE)
+        emit_elapsed_timing(
+            "coalescing_gate.enqueue",
+            enqueue_start,
+            path="debounce_schedule",
+            source_kind=pending_event.source_kind,
+            pending_count=len(gate.pending),
+        )
 
     async def drain_all(self) -> None:
         """Flush every active gate, canceling timers and awaiting dispatch.
@@ -539,6 +581,7 @@ class CoalescingGate:
 
     async def _flush(self, key: CoalescingKey, *, bypass_grace: bool = False) -> None:
         """Execute one gate flush cycle."""
+        flush_start = time.monotonic()
         gate = self._gates.get(key)
         if gate is None or not gate.pending or gate.phase is GatePhase.IN_FLIGHT:
             return
@@ -550,6 +593,12 @@ class CoalescingGate:
             and _pending_has_only_text(gate.pending)
         ):
             self._schedule_grace(key)
+            emit_elapsed_timing(
+                "coalescing_gate.flush",
+                flush_start,
+                outcome="scheduled_grace",
+                pending_count=len(gate.pending),
+            )
             return
         # Set IN_FLIGHT before _cancel_timer so the running timer task
         # (which may be the current task) is not self-cancelled.
@@ -558,8 +607,22 @@ class CoalescingGate:
         pending_events = list(gate.pending)
         gate.pending.clear()
         try:
+            dispatch_batch_start = time.monotonic()
             await self._dispatch_batch(build_coalesced_batch(key, pending_events))
+            emit_elapsed_timing(
+                "coalescing_gate.flush.dispatch_batch",
+                dispatch_batch_start,
+                pending_count=len(pending_events),
+                bypass_grace=bypass_grace,
+            )
         finally:
+            emit_elapsed_timing(
+                "coalescing_gate.flush",
+                flush_start,
+                outcome="dispatched",
+                pending_count=len(pending_events),
+                bypass_grace=bypass_grace,
+            )
             current_key, gate = self._resolve_gate_entry(key, gate)
             if gate is not None and current_key is not None:
                 gate.phase = GatePhase.DEBOUNCE

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -152,6 +152,31 @@ def get_dispatch_pipeline_timing(source: object) -> DispatchPipelineTiming | Non
     return None
 
 
+def emit_timing_event(event_name: str, **event_data: object) -> None:
+    """Emit one structured timing event when timing instrumentation is enabled."""
+    if not _is_enabled():
+        return
+    scope = event_data.pop("timing_scope", None)
+    if not isinstance(scope, str) or not scope:
+        scope = timing_scope.get()
+    filtered_event_data = {key: value for key, value in event_data.items() if value is not None}
+    if scope:
+        filtered_event_data["timing_scope"] = scope
+    logger.info(event_name, **filtered_event_data)
+
+
+def emit_elapsed_timing(label: str, start: float, **event_data: object) -> None:
+    """Emit one elapsed timing event relative to a previously recorded start time."""
+    if not _is_enabled():
+        return
+    emit_timing_event(
+        "timing_elapsed",
+        label=label,
+        duration_ms=round((time.monotonic() - start) * 1000, 1),
+        **event_data,
+    )
+
+
 def timed(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:  # noqa: C901
     """Decorator that logs elapsed time for sync/async functions.
 

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -68,11 +68,17 @@ from mindroom.matrix.message_content import is_v2_sidecar_text_preview
 from mindroom.matrix.rooms import is_dm_room
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest
 from mindroom.routing import suggest_agent_for_message
-from mindroom.thread_utils import get_configured_agents_for_room
+from mindroom.thread_utils import (
+    check_agent_mentioned,
+    get_agents_in_thread,
+    get_configured_agents_for_room,
+    has_multiple_non_agent_users_in_thread,
+)
 from mindroom.timing import (
     DispatchPipelineTiming,
     attach_dispatch_pipeline_timing,
     create_dispatch_pipeline_timing,
+    emit_elapsed_timing,
     get_dispatch_pipeline_timing,
 )
 from mindroom.timing import timing_scope as timing_scope_context
@@ -360,6 +366,53 @@ class TurnController:
             return False
         return self.deps.response_runner.has_active_response_for_target(target)
 
+    async def _should_skip_router_before_shared_ingress_work(
+        self,
+        room: nio.MatrixRoom,
+        event: nio.RoomMessageText,
+        *,
+        requester_user_id: str,
+        thread_id: str | None,
+    ) -> bool:
+        """Return whether the router can safely skip shared ingress work for one text event."""
+        if self.deps.agent_name != ROUTER_AGENT_NAME:
+            return False
+        if command_parser.parse(event.body.strip()) is not None:
+            return False
+
+        mentioned_agents, _am_i_mentioned, has_non_agent_mentions = check_agent_mentioned(
+            event.source,
+            self.deps.matrix_id,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
+        if mentioned_agents or has_non_agent_mentions:
+            return True
+        if thread_id is None:
+            return False
+
+        thread_history = await self.deps.conversation_cache.get_dispatch_thread_snapshot(
+            room.room_id,
+            thread_id,
+        )
+        sender_visible_agents = filter_agents_by_sender_permissions(
+            get_agents_in_thread(
+                thread_history,
+                self.deps.runtime.config,
+                self.deps.runtime_paths,
+            ),
+            requester_user_id,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
+        if sender_visible_agents:
+            return True
+        return has_multiple_non_agent_users_in_thread(
+            thread_history,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
+
     async def _coalescing_key_for_event(
         self,
         room: nio.MatrixRoom,
@@ -418,6 +471,7 @@ class TurnController:
         dispatch_timing = get_dispatch_pipeline_timing(event.source)
         if dispatch_timing is not None:
             dispatch_timing.mark("gate_enter")
+        enqueue_start = time.monotonic()
         effective_requester_user_id = requester_user_id or self._requester_user_id(
             sender=event.sender,
             source=event.source,
@@ -432,14 +486,37 @@ class TurnController:
                 trusted_relay_event,
                 effective_requester_user_id,
             )
+            emit_elapsed_timing(
+                "ingress_handoff.enqueue_for_dispatch",
+                enqueue_start,
+                path="trusted_internal_relay",
+            )
             return
+        coalescing_key_start = time.monotonic()
+        resolved_key = coalescing_key or await self._coalescing_key_for_event(room, event, effective_requester_user_id)
+        emit_elapsed_timing(
+            "ingress_handoff.enqueue_for_dispatch.coalescing_key",
+            coalescing_key_start,
+            thread_id=resolved_key[1],
+        )
+        gate_enqueue_start = time.monotonic()
         await self.deps.coalescing_gate.enqueue(
-            coalescing_key or await self._coalescing_key_for_event(room, event, effective_requester_user_id),
+            resolved_key,
             PendingEvent(
                 event=event,
                 room=room,
                 source_kind=source_kind,
             ),
+        )
+        emit_elapsed_timing(
+            "ingress_handoff.enqueue_for_dispatch.coalescing_gate",
+            gate_enqueue_start,
+            source_kind=source_kind,
+        )
+        emit_elapsed_timing(
+            "ingress_handoff.enqueue_for_dispatch",
+            enqueue_start,
+            source_kind=source_kind,
         )
 
     async def _maybe_send_visible_voice_echo(
@@ -485,17 +562,35 @@ class TurnController:
         handled_turn: HandledTurnState,
     ) -> PreparedDispatch | None:
         """Build the shared dispatch context for one prepared inbound turn."""
+        extract_context_start = time.monotonic()
         if self._is_trusted_router_relay_event(event):
             context = await self.deps.resolver.extract_trusted_router_relay_context(room, event)
+            emit_elapsed_timing(
+                "dispatch_handoff.prepare_dispatch.extract_context",
+                extract_context_start,
+                path="trusted_router_relay",
+            )
         else:
             context = await self.deps.resolver.extract_dispatch_context(room, event)
+            emit_elapsed_timing(
+                "dispatch_handoff.prepare_dispatch.extract_context",
+                extract_context_start,
+                path="normal",
+            )
+        target_start = time.monotonic()
         target = self.deps.resolver.build_message_target(
             room_id=room.room_id,
             thread_id=context.thread_id,
             reply_to_event_id=event.event_id,
             event_source=event.source,
         )
+        emit_elapsed_timing(
+            "dispatch_handoff.prepare_dispatch.build_message_target",
+            target_start,
+            resolved_thread_id=target.resolved_thread_id,
+        )
         correlation_id = event.event_id
+        envelope_start = time.monotonic()
         envelope = self.deps.resolver.build_message_envelope(
             room_id=room.room_id,
             event=event,
@@ -503,11 +598,22 @@ class TurnController:
             context=context,
             target=target,
         )
+        emit_elapsed_timing(
+            "dispatch_handoff.prepare_dispatch.build_message_envelope",
+            envelope_start,
+            source_kind=envelope.source_kind,
+        )
         ingress_policy = hook_ingress_policy(envelope)
+        hooks_start = time.monotonic()
         suppressed = await self.deps.ingress_hook_runner.emit_message_received_hooks(
             envelope=envelope,
             correlation_id=correlation_id,
             policy=ingress_policy,
+        )
+        emit_elapsed_timing(
+            "dispatch_handoff.prepare_dispatch.emit_message_received_hooks",
+            hooks_start,
+            suppressed=suppressed,
         )
         if suppressed:
             self._mark_source_events_responded(handled_turn)
@@ -1136,6 +1242,7 @@ class TurnController:
         dispatch_timing = get_dispatch_pipeline_timing(dispatch_event.source)
         if dispatch_timing is not None:
             dispatch_timing.mark("gate_exit")
+        retarget_start = time.monotonic()
         batch_coalescing_key = await self._coalescing_key_for_event(
             batch.room,
             batch.primary_event,
@@ -1152,7 +1259,14 @@ class TurnController:
             batch.requester_user_id,
         )
         self.deps.coalescing_gate.retarget(batch_coalescing_key, canonical_key)
+        emit_elapsed_timing(
+            "coalescing.handle_batch.retarget",
+            retarget_start,
+            original_thread_id=batch_coalescing_key[1],
+            resolved_thread_id=canonical_key[1],
+        )
         async with self.deps.resolver.turn_thread_cache_scope():
+            dispatch_start = time.monotonic()
             await self._dispatch_text_message(
                 batch.room,
                 dispatch_event,
@@ -1163,34 +1277,25 @@ class TurnController:
                     source_event_prompts=batch.source_event_prompts,
                 ),
             )
+            emit_elapsed_timing(
+                "coalescing.handle_batch.dispatch_text_message",
+                dispatch_start,
+                source_event_count=len(batch.source_event_ids),
+            )
 
     async def handle_text_event(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
         """Handle one inbound text event."""
         async with self.deps.resolver.turn_thread_cache_scope():
             await self._handle_message_inner(room, event)
 
-    async def _handle_message_inner(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
+    async def _handle_message_inner(  # noqa: C901, PLR0911
+        self,
+        room: nio.MatrixRoom,
+        event: nio.RoomMessageText,
+    ) -> None:
         """Handle one text message inside the per-turn conversation lookup scope."""
         ingress_thread_id = await self.deps.resolver.coalescing_thread_id(room, event)
-        self.deps.logger.info(
-            "Received message",
-            event_id=event.event_id,
-            room_id=room.room_id,
-            sender=event.sender,
-            thread_id=ingress_thread_id,
-        )
-        dispatch_timing = create_dispatch_pipeline_timing(
-            event_id=event.event_id,
-            room_id=room.room_id,
-        )
-        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
         event_info = EventInfo.from_event(event.source)
-        await self._append_live_event_with_timing(
-            room.room_id,
-            event,
-            event_info=event_info,
-            dispatch_timing=dispatch_timing,
-        )
         if not isinstance(event.body, str):
             return
         event_content = event.source.get("content") if isinstance(event.source, dict) else None
@@ -1203,6 +1308,38 @@ class TurnController:
         prechecked_event = self._precheck_dispatch_event(room, event, is_edit=event_info.is_edit)
         if prechecked_event is None:
             return
+        if await self._should_skip_router_before_shared_ingress_work(
+            room,
+            prechecked_event.event,
+            requester_user_id=prechecked_event.requester_user_id,
+            thread_id=ingress_thread_id,
+        ):
+            self.deps.logger.debug(
+                "skip_router_shared_ingress_work",
+                event_id=event.event_id,
+                room_id=room.room_id,
+                thread_id=ingress_thread_id,
+            )
+            return
+
+        self.deps.logger.info(
+            "Received message",
+            event_id=event.event_id,
+            room_id=room.room_id,
+            sender=event.sender,
+            thread_id=ingress_thread_id,
+        )
+        dispatch_timing = create_dispatch_pipeline_timing(
+            event_id=event.event_id,
+            room_id=room.room_id,
+        )
+        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
+        await self._append_live_event_with_timing(
+            room.room_id,
+            event,
+            event_info=event_info,
+            dispatch_timing=dispatch_timing,
+        )
 
         if event_info.is_edit:
             await self.deps.edit_regenerator.handle_message_edit(

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -1366,6 +1366,147 @@ class TestRouterSkipsSingleAgent:
     """Test router's behavior when there's only one agent in the room."""
 
     @pytest.mark.asyncio
+    async def test_router_skips_shared_ingress_work_for_explicit_agent_mentions(self) -> None:
+        """Router should bail out before shared ingress work when another agent is explicitly mentioned."""
+        agent_user = AgentMatrixUser(
+            agent_name=ROUTER_AGENT_NAME,
+            user_id="@mindroom_router:localhost",
+            display_name="Router Agent",
+            password=TEST_PASSWORD,
+            access_token=TEST_ACCESS_TOKEN,
+        )
+
+        config = _runtime_bound_config(
+            Config(
+                router=RouterConfig(model="default"),
+                agents={
+                    "general": AgentConfig(display_name="General Agent", role="General assistant"),
+                    "calculator": AgentConfig(display_name="Calculator Agent", role="Math calculations"),
+                },
+            ),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bot = AgentBot(
+                agent_user=agent_user,
+                storage_path=Path(tmpdir),
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                rooms=["!test:server"],
+            )
+        bot.client = AsyncMock()
+        bot.client.user_id = bot.agent_user.user_id
+        bot.logger = MagicMock()
+        wrap_extracted_collaborators(bot, "_turn_policy")
+        _sync_turn_policy_runtime(bot)
+        bot._turn_controller._append_live_event_with_timing = AsyncMock()
+        bot._turn_controller._enqueue_for_dispatch = AsyncMock()
+        bot._conversation_cache.get_dispatch_thread_snapshot = AsyncMock(
+            return_value=thread_history_result([], is_full_history=False),
+        )
+
+        room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
+        room.users = {
+            "@mindroom_router:localhost": None,
+            "@mindroom_general:localhost": None,
+            "@mindroom_calculator:localhost": None,
+            "@user:localhost": None,
+        }
+
+        event = nio.RoomMessageText.from_dict(
+            {
+                "event_id": "$event_explicit_mention",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "Hey @mindroom_general:localhost can you help?",
+                    "m.mentions": {"user_ids": ["@mindroom_general:localhost"]},
+                },
+            },
+        )
+
+        await bot._on_message(room, event)
+
+        bot._turn_controller._append_live_event_with_timing.assert_not_awaited()
+        bot._turn_controller._enqueue_for_dispatch.assert_not_awaited()
+        bot._conversation_cache.get_dispatch_thread_snapshot.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_router_skips_shared_ingress_work_for_agent_owned_thread_follow_up(self) -> None:
+        """Router should bail out before shared ingress work when the thread already has a visible agent."""
+        agent_user = AgentMatrixUser(
+            agent_name=ROUTER_AGENT_NAME,
+            user_id="@mindroom_router:localhost",
+            display_name="Router Agent",
+            password=TEST_PASSWORD,
+            access_token=TEST_ACCESS_TOKEN,
+        )
+
+        config = _runtime_bound_config(
+            Config(
+                router=RouterConfig(model="default"),
+                agents={
+                    "general": AgentConfig(display_name="General Agent", role="General assistant"),
+                    "calculator": AgentConfig(display_name="Calculator Agent", role="Math calculations"),
+                },
+            ),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bot = AgentBot(
+                agent_user=agent_user,
+                storage_path=Path(tmpdir),
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                rooms=["!test:server"],
+            )
+        bot.client = AsyncMock()
+        bot.client.user_id = bot.agent_user.user_id
+        bot.logger = MagicMock()
+        wrap_extracted_collaborators(bot, "_turn_policy")
+        _sync_turn_policy_runtime(bot)
+        bot._turn_controller._append_live_event_with_timing = AsyncMock()
+        bot._turn_controller._enqueue_for_dispatch = AsyncMock()
+        bot._conversation_cache.get_dispatch_thread_snapshot = AsyncMock(
+            return_value=thread_history_result(
+                [
+                    _message(sender="@mindroom_general:localhost", body="I can help with that."),
+                    _message(sender="@user:localhost", body="Can you continue?"),
+                ],
+                is_full_history=False,
+            ),
+        )
+
+        room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
+        room.users = {
+            "@mindroom_router:localhost": None,
+            "@mindroom_general:localhost": None,
+            "@mindroom_calculator:localhost": None,
+            "@user:localhost": None,
+        }
+
+        event = nio.RoomMessageText.from_dict(
+            {
+                "event_id": "$event_thread_follow_up",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "Following up on that",
+                    "m.relates_to": {"event_id": "$thread_root", "rel_type": "m.thread"},
+                },
+            },
+        )
+
+        await bot._on_message(room, event)
+
+        bot._conversation_cache.get_dispatch_thread_snapshot.assert_awaited_once_with(
+            "!test:server",
+            "$thread_root",
+        )
+        bot._turn_controller._append_live_event_with_timing.assert_not_awaited()
+        bot._turn_controller._enqueue_for_dispatch.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_router_skips_routing_with_single_agent(self) -> None:
         """Test that router doesn't route when there's only one agent available."""
         # Create router agent


### PR DESCRIPTION
## Summary
- cherry-pick `19c081012` from `gitea/main` onto the current `origin/main`
- skip redundant router ingress work when the router can already determine the turn should not go through shared ingress setup
- add focused scheduling coverage for the router early-bail paths

## Verification
- uv run pytest tests/test_bot_scheduling.py -x --no-cov -q -n auto
- uv run pytest -n auto
- uv run pre-commit run --all-files
