### PR TITLE
perf: add elapsed timing event helpers

### DIFF
--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -15,6 +15,7 @@ from .commands.parsing import command_parser
 from .constants import ATTACHMENT_IDS_KEY, ORIGINAL_SENDER_KEY, VOICE_RAW_AUDIO_FALLBACK_KEY
 from .hooks.ingress import is_voice_event
 from .matrix.media import extract_media_caption
+from .timing import emit_elapsed_timing
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -408,9 +409,16 @@ class CoalescingGate:
 
     async def enqueue(self, key: CoalescingKey, pending_event: PendingEvent) -> None:
         """Queue one pending event and schedule its eventual flush."""
+        enqueue_start = time.monotonic()
         # Path 1: bypass — explicitly exempt automation
         if is_coalescing_exempt_source_kind(pending_event.event, pending_event.source_kind):
             await self._dispatch_batch(build_coalesced_batch(key, [pending_event]))
+            emit_elapsed_timing(
+                "coalescing_gate.enqueue",
+                enqueue_start,
+                path="bypass",
+                source_kind=pending_event.source_kind,
+            )
             return
 
         # Path 2: command interrupt — flush pending, dispatch command solo
@@ -420,6 +428,12 @@ class CoalescingGate:
                 self._cancel_timer(gate)
             await self._flush(key, bypass_grace=True)
             await self._dispatch_batch(build_coalesced_batch(key, [pending_event]))
+            emit_elapsed_timing(
+                "coalescing_gate.enqueue",
+                enqueue_start,
+                path="command_interrupt",
+                source_kind=pending_event.source_kind,
+            )
             return
 
         gate = self._gates.get(key)
@@ -432,6 +446,13 @@ class CoalescingGate:
             if _is_media_event(pending_event.event):
                 gate.pending.append(pending_event)
                 self._schedule_grace(key)
+                emit_elapsed_timing(
+                    "coalescing_gate.enqueue",
+                    enqueue_start,
+                    path="grace_media_extend",
+                    source_kind=pending_event.source_kind,
+                    pending_count=len(gate.pending),
+                )
                 return
             # Text during grace → flush existing batch, start new turn
             self._cancel_timer(gate)
@@ -444,11 +465,32 @@ class CoalescingGate:
         # Path 4: normal append + schedule
         gate.pending.append(pending_event)
         if gate.phase is GatePhase.IN_FLIGHT:
+            emit_elapsed_timing(
+                "coalescing_gate.enqueue",
+                enqueue_start,
+                path="in_flight_buffer",
+                source_kind=pending_event.source_kind,
+                pending_count=len(gate.pending),
+            )
             return
         if self._debounce_seconds() <= 0:
             await self._flush(key)
+            emit_elapsed_timing(
+                "coalescing_gate.enqueue",
+                enqueue_start,
+                path="immediate_flush",
+                source_kind=pending_event.source_kind,
+                pending_count=len(gate.pending),
+            )
             return
         self._reset_timer(key, delay=self._debounce_seconds(), phase=GatePhase.DEBOUNCE)
+        emit_elapsed_timing(
+            "coalescing_gate.enqueue",
+            enqueue_start,
+            path="debounce_schedule",
+            source_kind=pending_event.source_kind,
+            pending_count=len(gate.pending),
+        )
 
     async def drain_all(self) -> None:
         """Flush every active gate, canceling timers and awaiting dispatch.
@@ -539,6 +581,7 @@ class CoalescingGate:
 
     async def _flush(self, key: CoalescingKey, *, bypass_grace: bool = False) -> None:
         """Execute one gate flush cycle."""
+        flush_start = time.monotonic()
         gate = self._gates.get(key)
         if gate is None or not gate.pending or gate.phase is GatePhase.IN_FLIGHT:
             return
@@ -550,6 +593,12 @@ class CoalescingGate:
             and _pending_has_only_text(gate.pending)
         ):
             self._schedule_grace(key)
+            emit_elapsed_timing(
+                "coalescing_gate.flush",
+                flush_start,
+                outcome="scheduled_grace",
+                pending_count=len(gate.pending),
+            )
             return
         # Set IN_FLIGHT before _cancel_timer so the running timer task
         # (which may be the current task) is not self-cancelled.
@@ -558,8 +607,22 @@ class CoalescingGate:
         pending_events = list(gate.pending)
         gate.pending.clear()
         try:
+            dispatch_batch_start = time.monotonic()
             await self._dispatch_batch(build_coalesced_batch(key, pending_events))
+            emit_elapsed_timing(
+                "coalescing_gate.flush.dispatch_batch",
+                dispatch_batch_start,
+                pending_count=len(pending_events),
+                bypass_grace=bypass_grace,
+            )
         finally:
+            emit_elapsed_timing(
+                "coalescing_gate.flush",
+                flush_start,
+                outcome="dispatched",
+                pending_count=len(pending_events),
+                bypass_grace=bypass_grace,
+            )
             current_key, gate = self._resolve_gate_entry(key, gate)
             if gate is not None and current_key is not None:
                 gate.phase = GatePhase.DEBOUNCE

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -474,13 +474,14 @@ class CoalescingGate:
             )
             return
         if self._debounce_seconds() <= 0:
+            pending_count = len(gate.pending)
             await self._flush(key)
             emit_elapsed_timing(
                 "coalescing_gate.enqueue",
                 enqueue_start,
                 path="immediate_flush",
                 source_kind=pending_event.source_kind,
-                pending_count=len(gate.pending),
+                pending_count=pending_count,
             )
             return
         self._reset_timer(key, delay=self._debounce_seconds(), phase=GatePhase.DEBOUNCE)
@@ -605,22 +606,25 @@ class CoalescingGate:
         gate.phase = GatePhase.IN_FLIGHT
         self._cancel_timer(gate)
         pending_events = list(gate.pending)
+        pending_count = len(pending_events)
         gate.pending.clear()
+        dispatched = False
         try:
             dispatch_batch_start = time.monotonic()
             await self._dispatch_batch(build_coalesced_batch(key, pending_events))
+            dispatched = True
             emit_elapsed_timing(
                 "coalescing_gate.flush.dispatch_batch",
                 dispatch_batch_start,
-                pending_count=len(pending_events),
+                pending_count=pending_count,
                 bypass_grace=bypass_grace,
             )
         finally:
             emit_elapsed_timing(
                 "coalescing_gate.flush",
                 flush_start,
-                outcome="dispatched",
-                pending_count=len(pending_events),
+                outcome="dispatched" if dispatched else "failed",
+                pending_count=pending_count,
                 bypass_grace=bypass_grace,
             )
             current_key, gate = self._resolve_gate_entry(key, gate)

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -15,7 +15,7 @@ from .commands.parsing import command_parser
 from .constants import ATTACHMENT_IDS_KEY, ORIGINAL_SENDER_KEY, VOICE_RAW_AUDIO_FALLBACK_KEY
 from .hooks.ingress import is_voice_event
 from .matrix.media import extract_media_caption
-from .timing import emit_elapsed_timing
+from .timing import emit_elapsed_timing, event_timing_scope
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -418,6 +418,7 @@ class CoalescingGate:
                 enqueue_start,
                 path="bypass",
                 source_kind=pending_event.source_kind,
+                timing_scope=event_timing_scope(pending_event.event.event_id),
             )
             return
 
@@ -433,6 +434,7 @@ class CoalescingGate:
                 enqueue_start,
                 path="command_interrupt",
                 source_kind=pending_event.source_kind,
+                timing_scope=event_timing_scope(pending_event.event.event_id),
             )
             return
 
@@ -452,6 +454,7 @@ class CoalescingGate:
                     path="grace_media_extend",
                     source_kind=pending_event.source_kind,
                     pending_count=len(gate.pending),
+                    timing_scope=event_timing_scope(pending_event.event.event_id),
                 )
                 return
             # Text during grace → flush existing batch, start new turn
@@ -471,17 +474,20 @@ class CoalescingGate:
                 path="in_flight_buffer",
                 source_kind=pending_event.source_kind,
                 pending_count=len(gate.pending),
+                timing_scope=event_timing_scope(pending_event.event.event_id),
             )
             return
         if self._debounce_seconds() <= 0:
             pending_count = len(gate.pending)
-            await self._flush(key)
+            flush_outcome = await self._flush(key)
             emit_elapsed_timing(
                 "coalescing_gate.enqueue",
                 enqueue_start,
-                path="immediate_flush",
+                path="zero_debounce",
                 source_kind=pending_event.source_kind,
                 pending_count=pending_count,
+                flush_outcome=flush_outcome,
+                timing_scope=event_timing_scope(pending_event.event.event_id),
             )
             return
         self._reset_timer(key, delay=self._debounce_seconds(), phase=GatePhase.DEBOUNCE)
@@ -491,6 +497,7 @@ class CoalescingGate:
             path="debounce_schedule",
             source_kind=pending_event.source_kind,
             pending_count=len(gate.pending),
+            timing_scope=event_timing_scope(pending_event.event.event_id),
         )
 
     async def drain_all(self) -> None:
@@ -580,12 +587,12 @@ class CoalescingGate:
         self._reset_timer(key, delay=min(grace_seconds, remaining_seconds), phase=GatePhase.GRACE)
         self._gates[key].grace_deadline = saved_deadline
 
-    async def _flush(self, key: CoalescingKey, *, bypass_grace: bool = False) -> None:
+    async def _flush(self, key: CoalescingKey, *, bypass_grace: bool = False) -> str | None:
         """Execute one gate flush cycle."""
         flush_start = time.monotonic()
         gate = self._gates.get(key)
         if gate is None or not gate.pending or gate.phase is GatePhase.IN_FLIGHT:
-            return
+            return None
         if (
             not bypass_grace
             and gate.phase is not GatePhase.GRACE
@@ -599,8 +606,9 @@ class CoalescingGate:
                 flush_start,
                 outcome="scheduled_grace",
                 pending_count=len(gate.pending),
+                timing_scope=event_timing_scope(build_coalesced_batch(key, gate.pending).primary_event.event_id),
             )
-            return
+            return "scheduled_grace"
         # Set IN_FLIGHT before _cancel_timer so the running timer task
         # (which may be the current task) is not self-cancelled.
         gate.phase = GatePhase.IN_FLIGHT
@@ -608,17 +616,21 @@ class CoalescingGate:
         pending_events = list(gate.pending)
         pending_count = len(pending_events)
         gate.pending.clear()
+        batch = build_coalesced_batch(key, pending_events)
+        timing_scope = event_timing_scope(batch.primary_event.event_id)
         dispatched = False
         try:
             dispatch_batch_start = time.monotonic()
-            await self._dispatch_batch(build_coalesced_batch(key, pending_events))
+            await self._dispatch_batch(batch)
             dispatched = True
             emit_elapsed_timing(
                 "coalescing_gate.flush.dispatch_batch",
                 dispatch_batch_start,
                 pending_count=pending_count,
                 bypass_grace=bypass_grace,
+                timing_scope=timing_scope,
             )
+            return "dispatched"
         finally:
             emit_elapsed_timing(
                 "coalescing_gate.flush",
@@ -626,6 +638,7 @@ class CoalescingGate:
                 outcome="dispatched" if dispatched else "failed",
                 pending_count=pending_count,
                 bypass_grace=bypass_grace,
+                timing_scope=timing_scope,
             )
             current_key, gate = self._resolve_gate_entry(key, gate)
             if gate is not None and current_key is not None:

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -180,29 +180,19 @@ def emit_elapsed_timing(label: str, start: float, **event_data: object) -> None:
         duration_ms=round((time.monotonic() - start) * 1000, 1),
         **event_data,
     )
-def timed(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:  # noqa: C901
+def timed(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator that logs elapsed time for sync/async functions.
 
     When MINDROOM_TIMING != "1", returns the original function unchanged (zero overhead).
     Log format: TIMING [<scope>] <label>: <elapsed>s  (scope omitted if not set)
     """
 
-    def decorator(fn: Callable[P, R]) -> Callable[P, R]:  # noqa: C901
+    def decorator(fn: Callable[P, R]) -> Callable[P, R]:
         if not _is_enabled():
             return fn
 
         def emit_timing(start: float, kwargs: P.kwargs) -> None:
-            scope = kwargs.get("timing_scope")
-            if not isinstance(scope, str) or not scope:
-                scope = timing_scope.get()
-            duration_ms = round((time.monotonic() - start) * 1000, 1)
-            event_data: dict[str, object] = {
-                "label": label,
-                "duration_ms": duration_ms,
-            }
-            if scope:
-                event_data["timing_scope"] = scope
-            logger.info("timing_elapsed", **event_data)
+            emit_elapsed_timing(label, start, timing_scope=kwargs.get("timing_scope"))
 
         if inspect.isasyncgenfunction(fn):
 

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -170,6 +170,16 @@ def emit_timing_event(event_name: str, **event_data: object) -> None:
     logger.info(event_name, **filtered_event_data)
 
 
+def emit_elapsed_timing(label: str, start: float, **event_data: object) -> None:
+    """Emit one elapsed timing event relative to a previously recorded start time."""
+    if not _is_enabled():
+        return
+    emit_timing_event(
+        "timing_elapsed",
+        label=label,
+        duration_ms=round((time.monotonic() - start) * 1000, 1),
+        **event_data,
+    )
 def timed(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:  # noqa: C901
     """Decorator that logs elapsed time for sync/async functions.
 

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -152,6 +152,31 @@ def get_dispatch_pipeline_timing(source: object) -> DispatchPipelineTiming | Non
     return None
 
 
+def emit_timing_event(event_name: str, **event_data: object) -> None:
+    """Emit one structured timing event when timing instrumentation is enabled."""
+    if not _is_enabled():
+        return
+    scope = event_data.pop("timing_scope", None)
+    if not isinstance(scope, str) or not scope:
+        scope = timing_scope.get()
+    filtered_event_data = {key: value for key, value in event_data.items() if value is not None}
+    if scope:
+        filtered_event_data["timing_scope"] = scope
+    logger.info(event_name, **filtered_event_data)
+
+
+def emit_elapsed_timing(label: str, start: float, **event_data: object) -> None:
+    """Emit one elapsed timing event relative to a previously recorded start time."""
+    if not _is_enabled():
+        return
+    emit_timing_event(
+        "timing_elapsed",
+        label=label,
+        duration_ms=round((time.monotonic() - start) * 1000, 1),
+        **event_data,
+    )
+
+
 def timed(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:  # noqa: C901
     """Decorator that logs elapsed time for sync/async functions.
 

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -157,6 +157,11 @@ def get_dispatch_pipeline_timing(source: object) -> DispatchPipelineTiming | Non
     return None
 
 
+def event_timing_scope(event_id: str | None) -> str:
+    """Return the stable timing scope identifier for one event."""
+    return event_id[:20] if event_id else "unknown"
+
+
 def emit_timing_event(event_name: str, **event_data: object) -> None:
     """Emit one structured timing event when timing instrumentation is enabled."""
     if not _is_enabled():

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -73,6 +73,7 @@ from mindroom.timing import (
     DispatchPipelineTiming,
     attach_dispatch_pipeline_timing,
     create_dispatch_pipeline_timing,
+    emit_elapsed_timing,
     get_dispatch_pipeline_timing,
 )
 from mindroom.timing import timing_scope as timing_scope_context
@@ -418,6 +419,7 @@ class TurnController:
         dispatch_timing = get_dispatch_pipeline_timing(event.source)
         if dispatch_timing is not None:
             dispatch_timing.mark("gate_enter")
+        enqueue_start = time.monotonic()
         effective_requester_user_id = requester_user_id or self._requester_user_id(
             sender=event.sender,
             source=event.source,
@@ -432,14 +434,37 @@ class TurnController:
                 trusted_relay_event,
                 effective_requester_user_id,
             )
+            emit_elapsed_timing(
+                "ingress_handoff.enqueue_for_dispatch",
+                enqueue_start,
+                path="trusted_internal_relay",
+            )
             return
+        coalescing_key_start = time.monotonic()
+        resolved_key = coalescing_key or await self._coalescing_key_for_event(room, event, effective_requester_user_id)
+        emit_elapsed_timing(
+            "ingress_handoff.enqueue_for_dispatch.coalescing_key",
+            coalescing_key_start,
+            thread_id=resolved_key[1],
+        )
+        gate_enqueue_start = time.monotonic()
         await self.deps.coalescing_gate.enqueue(
-            coalescing_key or await self._coalescing_key_for_event(room, event, effective_requester_user_id),
+            resolved_key,
             PendingEvent(
                 event=event,
                 room=room,
                 source_kind=source_kind,
             ),
+        )
+        emit_elapsed_timing(
+            "ingress_handoff.enqueue_for_dispatch.coalescing_gate",
+            gate_enqueue_start,
+            source_kind=source_kind,
+        )
+        emit_elapsed_timing(
+            "ingress_handoff.enqueue_for_dispatch",
+            enqueue_start,
+            source_kind=source_kind,
         )
 
     async def _maybe_send_visible_voice_echo(
@@ -485,17 +510,35 @@ class TurnController:
         handled_turn: HandledTurnState,
     ) -> PreparedDispatch | None:
         """Build the shared dispatch context for one prepared inbound turn."""
+        extract_context_start = time.monotonic()
         if self._is_trusted_router_relay_event(event):
             context = await self.deps.resolver.extract_trusted_router_relay_context(room, event)
+            emit_elapsed_timing(
+                "dispatch_handoff.prepare_dispatch.extract_context",
+                extract_context_start,
+                path="trusted_router_relay",
+            )
         else:
             context = await self.deps.resolver.extract_dispatch_context(room, event)
+            emit_elapsed_timing(
+                "dispatch_handoff.prepare_dispatch.extract_context",
+                extract_context_start,
+                path="normal",
+            )
+        target_start = time.monotonic()
         target = self.deps.resolver.build_message_target(
             room_id=room.room_id,
             thread_id=context.thread_id,
             reply_to_event_id=event.event_id,
             event_source=event.source,
         )
+        emit_elapsed_timing(
+            "dispatch_handoff.prepare_dispatch.build_message_target",
+            target_start,
+            resolved_thread_id=target.resolved_thread_id,
+        )
         correlation_id = event.event_id
+        envelope_start = time.monotonic()
         envelope = self.deps.resolver.build_message_envelope(
             room_id=room.room_id,
             event=event,
@@ -503,11 +546,22 @@ class TurnController:
             context=context,
             target=target,
         )
+        emit_elapsed_timing(
+            "dispatch_handoff.prepare_dispatch.build_message_envelope",
+            envelope_start,
+            source_kind=envelope.source_kind,
+        )
         ingress_policy = hook_ingress_policy(envelope)
+        hooks_start = time.monotonic()
         suppressed = await self.deps.ingress_hook_runner.emit_message_received_hooks(
             envelope=envelope,
             correlation_id=correlation_id,
             policy=ingress_policy,
+        )
+        emit_elapsed_timing(
+            "dispatch_handoff.prepare_dispatch.emit_message_received_hooks",
+            hooks_start,
+            suppressed=suppressed,
         )
         if suppressed:
             self._mark_source_events_responded(handled_turn)
@@ -1136,6 +1190,7 @@ class TurnController:
         dispatch_timing = get_dispatch_pipeline_timing(dispatch_event.source)
         if dispatch_timing is not None:
             dispatch_timing.mark("gate_exit")
+        retarget_start = time.monotonic()
         batch_coalescing_key = await self._coalescing_key_for_event(
             batch.room,
             batch.primary_event,
@@ -1152,7 +1207,14 @@ class TurnController:
             batch.requester_user_id,
         )
         self.deps.coalescing_gate.retarget(batch_coalescing_key, canonical_key)
+        emit_elapsed_timing(
+            "coalescing.handle_batch.retarget",
+            retarget_start,
+            original_thread_id=batch_coalescing_key[1],
+            resolved_thread_id=canonical_key[1],
+        )
         async with self.deps.resolver.turn_thread_cache_scope():
+            dispatch_start = time.monotonic()
             await self._dispatch_text_message(
                 batch.room,
                 dispatch_event,
@@ -1162,6 +1224,11 @@ class TurnController:
                     batch.source_event_ids,
                     source_event_prompts=batch.source_event_prompts,
                 ),
+            )
+            emit_elapsed_timing(
+                "coalescing.handle_batch.dispatch_text_message",
+                dispatch_start,
+                source_event_count=len(batch.source_event_ids),
             )
 
     async def handle_text_event(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -77,6 +77,7 @@ from mindroom.timing import (
     DispatchPipelineTiming,
     attach_dispatch_pipeline_timing,
     create_dispatch_pipeline_timing,
+    emit_elapsed_timing,
     get_dispatch_pipeline_timing,
 )
 from mindroom.timing import timing_scope as timing_scope_context
@@ -458,6 +459,7 @@ class TurnController:
         dispatch_timing = get_dispatch_pipeline_timing(event.source)
         if dispatch_timing is not None:
             dispatch_timing.mark("gate_enter")
+        enqueue_start = time.monotonic()
         effective_requester_user_id = requester_user_id or self._requester_user_id(
             sender=event.sender,
             source=event.source,
@@ -472,14 +474,37 @@ class TurnController:
                 trusted_relay_event,
                 effective_requester_user_id,
             )
+            emit_elapsed_timing(
+                "ingress_handoff.enqueue_for_dispatch",
+                enqueue_start,
+                path="trusted_internal_relay",
+            )
             return
+        coalescing_key_start = time.monotonic()
+        resolved_key = coalescing_key or await self._coalescing_key_for_event(room, event, effective_requester_user_id)
+        emit_elapsed_timing(
+            "ingress_handoff.enqueue_for_dispatch.coalescing_key",
+            coalescing_key_start,
+            thread_id=resolved_key[1],
+        )
+        gate_enqueue_start = time.monotonic()
         await self.deps.coalescing_gate.enqueue(
-            coalescing_key or await self._coalescing_key_for_event(room, event, effective_requester_user_id),
+            resolved_key,
             PendingEvent(
                 event=event,
                 room=room,
                 source_kind=source_kind,
             ),
+        )
+        emit_elapsed_timing(
+            "ingress_handoff.enqueue_for_dispatch.coalescing_gate",
+            gate_enqueue_start,
+            source_kind=source_kind,
+        )
+        emit_elapsed_timing(
+            "ingress_handoff.enqueue_for_dispatch",
+            enqueue_start,
+            source_kind=source_kind,
         )
 
     async def _maybe_send_visible_voice_echo(
@@ -525,17 +550,35 @@ class TurnController:
         handled_turn: HandledTurnState,
     ) -> PreparedDispatch | None:
         """Build the shared dispatch context for one prepared inbound turn."""
+        extract_context_start = time.monotonic()
         if self._is_trusted_router_relay_event(event):
             context = await self.deps.resolver.extract_trusted_router_relay_context(room, event)
+            emit_elapsed_timing(
+                "dispatch_handoff.prepare_dispatch.extract_context",
+                extract_context_start,
+                path="trusted_router_relay",
+            )
         else:
             context = await self.deps.resolver.extract_dispatch_context(room, event)
+            emit_elapsed_timing(
+                "dispatch_handoff.prepare_dispatch.extract_context",
+                extract_context_start,
+                path="normal",
+            )
+        target_start = time.monotonic()
         target = self.deps.resolver.build_message_target(
             room_id=room.room_id,
             thread_id=context.thread_id,
             reply_to_event_id=event.event_id,
             event_source=event.source,
         )
+        emit_elapsed_timing(
+            "dispatch_handoff.prepare_dispatch.build_message_target",
+            target_start,
+            resolved_thread_id=target.resolved_thread_id,
+        )
         correlation_id = event.event_id
+        envelope_start = time.monotonic()
         envelope = self.deps.resolver.build_message_envelope(
             room_id=room.room_id,
             event=event,
@@ -543,11 +586,22 @@ class TurnController:
             context=context,
             target=target,
         )
+        emit_elapsed_timing(
+            "dispatch_handoff.prepare_dispatch.build_message_envelope",
+            envelope_start,
+            source_kind=envelope.source_kind,
+        )
         ingress_policy = hook_ingress_policy(envelope)
+        hooks_start = time.monotonic()
         suppressed = await self.deps.ingress_hook_runner.emit_message_received_hooks(
             envelope=envelope,
             correlation_id=correlation_id,
             policy=ingress_policy,
+        )
+        emit_elapsed_timing(
+            "dispatch_handoff.prepare_dispatch.emit_message_received_hooks",
+            hooks_start,
+            suppressed=suppressed,
         )
         if suppressed:
             self._mark_source_events_responded(handled_turn)
@@ -1178,6 +1232,7 @@ class TurnController:
         dispatch_timing = get_dispatch_pipeline_timing(dispatch_event.source)
         if dispatch_timing is not None:
             dispatch_timing.mark("gate_exit")
+        retarget_start = time.monotonic()
         batch_coalescing_key = await self._coalescing_key_for_event(
             batch.room,
             batch.primary_event,
@@ -1194,7 +1249,14 @@ class TurnController:
             batch.requester_user_id,
         )
         self.deps.coalescing_gate.retarget(batch_coalescing_key, canonical_key)
+        emit_elapsed_timing(
+            "coalescing.handle_batch.retarget",
+            retarget_start,
+            original_thread_id=batch_coalescing_key[1],
+            resolved_thread_id=canonical_key[1],
+        )
         async with self.deps.resolver.turn_thread_cache_scope():
+            dispatch_start = time.monotonic()
             await self._dispatch_text_message(
                 batch.room,
                 dispatch_event,
@@ -1204,6 +1266,11 @@ class TurnController:
                     batch.source_event_ids,
                     source_event_prompts=batch.source_event_prompts,
                 ),
+            )
+            emit_elapsed_timing(
+                "coalescing.handle_batch.dispatch_text_message",
+                dispatch_start,
+                source_event_count=len(batch.source_event_ids),
             )
 
     async def handle_text_event(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -78,6 +78,7 @@ from mindroom.timing import (
     attach_dispatch_pipeline_timing,
     create_dispatch_pipeline_timing,
     emit_elapsed_timing,
+    event_timing_scope,
     get_dispatch_pipeline_timing,
 )
 from mindroom.timing import timing_scope as timing_scope_context
@@ -460,6 +461,7 @@ class TurnController:
         if dispatch_timing is not None:
             dispatch_timing.mark("gate_enter")
         enqueue_start = time.monotonic()
+        timing_scope = event_timing_scope(event.event_id)
         effective_requester_user_id = requester_user_id or self._requester_user_id(
             sender=event.sender,
             source=event.source,
@@ -478,6 +480,7 @@ class TurnController:
                 "ingress_handoff.enqueue_for_dispatch",
                 enqueue_start,
                 path="trusted_internal_relay",
+                timing_scope=timing_scope,
             )
             return
         coalescing_key_start = time.monotonic()
@@ -486,6 +489,7 @@ class TurnController:
             "ingress_handoff.enqueue_for_dispatch.coalescing_key",
             coalescing_key_start,
             thread_id=resolved_key[1],
+            timing_scope=timing_scope,
         )
         gate_enqueue_start = time.monotonic()
         await self.deps.coalescing_gate.enqueue(
@@ -500,11 +504,13 @@ class TurnController:
             "ingress_handoff.enqueue_for_dispatch.coalescing_gate",
             gate_enqueue_start,
             source_kind=source_kind,
+            timing_scope=timing_scope,
         )
         emit_elapsed_timing(
             "ingress_handoff.enqueue_for_dispatch",
             enqueue_start,
             source_kind=source_kind,
+            timing_scope=timing_scope,
         )
 
     async def _maybe_send_visible_voice_echo(
@@ -1229,6 +1235,7 @@ class TurnController:
     async def handle_coalesced_batch(self, batch: CoalescedBatch) -> None:
         """Dispatch one flushed batch through the normal text pipeline."""
         dispatch_event = build_batch_dispatch_event(batch)
+        timing_scope = event_timing_scope(dispatch_event.event_id)
         dispatch_timing = get_dispatch_pipeline_timing(dispatch_event.source)
         if dispatch_timing is not None:
             dispatch_timing.mark("gate_exit")
@@ -1254,6 +1261,7 @@ class TurnController:
             retarget_start,
             original_thread_id=batch_coalescing_key[1],
             resolved_thread_id=canonical_key[1],
+            timing_scope=timing_scope,
         )
         async with self.deps.resolver.turn_thread_cache_scope():
             dispatch_start = time.monotonic()
@@ -1271,6 +1279,7 @@ class TurnController:
                 "coalescing.handle_batch.dispatch_text_message",
                 dispatch_start,
                 source_event_count=len(batch.source_event_ids),
+                timing_scope=timing_scope,
             )
 
     async def handle_text_event(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
@@ -1428,7 +1437,7 @@ class TurnController:
         )
         dispatch_timing = get_dispatch_pipeline_timing(raw_event.source)
         attach_dispatch_pipeline_timing(event.source, dispatch_timing)
-        timing_scope_token = timing_scope_context.set(event.event_id[:20] if event.event_id else "unknown")
+        timing_scope_token = timing_scope_context.set(event_timing_scope(event.event_id))
         try:
             if dispatch_timing is not None:
                 dispatch_timing.mark("dispatch_start")

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -1430,6 +1430,70 @@ async def test_retargeted_sleeping_timer_flushes_under_current_key() -> None:
 
 
 @pytest.mark.asyncio
+async def test_zero_debounce_immediate_flush_logs_pending_count_before_clearing() -> None:
+    """Immediate-flush telemetry should report the batch size before _flush clears pending."""
+    room = _make_room()
+    gate = CoalescingGate(
+        dispatch_batch=AsyncMock(),
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+
+    with patch("mindroom.coalescing.emit_elapsed_timing") as mock_emit:
+        await gate.enqueue(
+            ("!room:localhost", None, "@user:localhost"),
+            PendingEvent(
+                event=_text_event(event_id="$m1", body="first"),
+                room=room,
+                source_kind="message",
+            ),
+        )
+
+    immediate_flush_calls = [
+        call
+        for call in mock_emit.call_args_list
+        if call.args and call.args[0] == "coalescing_gate.enqueue" and call.kwargs.get("path") == "immediate_flush"
+    ]
+    assert len(immediate_flush_calls) == 1
+    assert immediate_flush_calls[0].kwargs["pending_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_flush_logs_failed_outcome_when_dispatch_batch_raises() -> None:
+    """Flush telemetry should not report success when dispatch_batch raises."""
+    room = _make_room()
+
+    async def failing_dispatch_batch(_batch: object) -> None:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    gate = CoalescingGate(
+        dispatch_batch=failing_dispatch_batch,
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+
+    with (
+        patch("mindroom.coalescing.emit_elapsed_timing") as mock_emit,
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        await gate.enqueue(
+            ("!room:localhost", None, "@user:localhost"),
+            PendingEvent(
+                event=_text_event(event_id="$m1", body="first"),
+                room=room,
+                source_kind="message",
+            ),
+        )
+
+    flush_calls = [call for call in mock_emit.call_args_list if call.args and call.args[0] == "coalescing_gate.flush"]
+    assert len(flush_calls) == 1
+    assert flush_calls[0].kwargs["outcome"] == "failed"
+
+
+@pytest.mark.asyncio
 async def test_cleanup_drains_pending_debounce_tasks(tmp_path: Path) -> None:
     """Drain pending debounce tasks when a bot is cleaned up."""
     bot = _make_bot(tmp_path, debounce_ms=1000)

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -1453,10 +1453,102 @@ async def test_zero_debounce_immediate_flush_logs_pending_count_before_clearing(
     immediate_flush_calls = [
         call
         for call in mock_emit.call_args_list
-        if call.args and call.args[0] == "coalescing_gate.enqueue" and call.kwargs.get("path") == "immediate_flush"
+        if call.args and call.args[0] == "coalescing_gate.enqueue" and call.kwargs.get("path") == "zero_debounce"
     ]
     assert len(immediate_flush_calls) == 1
     assert immediate_flush_calls[0].kwargs["pending_count"] == 1
+    assert immediate_flush_calls[0].kwargs["flush_outcome"] == "dispatched"
+
+
+@pytest.mark.asyncio
+async def test_zero_debounce_with_upload_grace_logs_scheduled_grace_outcome() -> None:
+    """Zero debounce should not claim an immediate flush when upload grace delays dispatch."""
+    room = _make_room()
+    gate = CoalescingGate(
+        dispatch_batch=AsyncMock(),
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.1,
+        is_shutting_down=lambda: False,
+    )
+
+    with patch("mindroom.coalescing.emit_elapsed_timing") as mock_emit:
+        await gate.enqueue(
+            ("!room:localhost", None, "@user:localhost"),
+            PendingEvent(
+                event=_text_event(event_id="$m1", body="first"),
+                room=room,
+                source_kind="message",
+            ),
+        )
+
+    zero_debounce_calls = [
+        call
+        for call in mock_emit.call_args_list
+        if call.args and call.args[0] == "coalescing_gate.enqueue" and call.kwargs.get("path") == "zero_debounce"
+    ]
+    assert len(zero_debounce_calls) == 1
+    assert zero_debounce_calls[0].kwargs["flush_outcome"] == "scheduled_grace"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_for_dispatch_timing_events_include_explicit_scope(tmp_path: Path) -> None:
+    """Pre-dispatch handoff telemetry should carry the source-event timing scope explicitly."""
+    bot = _make_bot(tmp_path)
+    room = _make_room()
+    event = _text_event(event_id="$m1", body="hello")
+
+    with (
+        patch.object(bot._coalescing_gate, "enqueue", new=AsyncMock()),
+        patch("mindroom.turn_controller.emit_elapsed_timing") as mock_emit,
+    ):
+        await bot._turn_controller._enqueue_for_dispatch(
+            event,
+            room,
+            source_kind="message",
+            requester_user_id="@user:localhost",
+            coalescing_key=(room.room_id, None, "@user:localhost"),
+        )
+
+    handoff_calls = [
+        call
+        for call in mock_emit.call_args_list
+        if call.args
+        and isinstance(call.args[0], str)
+        and call.args[0].startswith("ingress_handoff.enqueue_for_dispatch")
+    ]
+    assert handoff_calls
+    assert all(call.kwargs["timing_scope"] == "$m1" for call in handoff_calls)
+
+
+@pytest.mark.asyncio
+async def test_handle_coalesced_batch_timing_events_include_dispatch_scope(tmp_path: Path) -> None:
+    """Coalesced-batch telemetry emitted before dispatch should carry the batch event scope."""
+    bot = _make_bot(tmp_path)
+    room = _make_room()
+    batch = build_coalesced_batch(
+        (room.room_id, None, "@user:localhost"),
+        [
+            PendingEvent(
+                event=_text_event(event_id="$m1", body="hello"),
+                room=room,
+                source_kind="message",
+            ),
+        ],
+    )
+
+    with (
+        patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock()),
+        patch("mindroom.turn_controller.emit_elapsed_timing") as mock_emit,
+    ):
+        await bot._turn_controller.handle_coalesced_batch(batch)
+
+    batch_calls = [
+        call
+        for call in mock_emit.call_args_list
+        if call.args and isinstance(call.args[0], str) and call.args[0].startswith("coalescing.handle_batch.")
+    ]
+    assert batch_calls
+    assert all(call.kwargs["timing_scope"] == "$m1" for call in batch_calls)
 
 
 @pytest.mark.asyncio

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -259,6 +259,26 @@ def test_timing_enabled_reflects_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert timing_enabled() is True
 
 
+def test_timed_routes_elapsed_logging_through_shared_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    """timed() should delegate timing_elapsed event shaping to emit_elapsed_timing()."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+    emit_elapsed_timing = Mock()
+    monkeypatch.setattr(timing_module, "emit_elapsed_timing", emit_elapsed_timing)
+
+    @timed("delegated_label")
+    def run(*, timing_scope: str | None = None) -> None:
+        del timing_scope
+
+    run(timing_scope="scope-123")
+
+    emit_elapsed_timing.assert_called_once()
+    assert emit_elapsed_timing.call_args.args[0] == "delegated_label"
+    assert isinstance(emit_elapsed_timing.call_args.args[1], float)
+    assert emit_elapsed_timing.call_args.kwargs["timing_scope"] == "scope-123"
+    logger.info.assert_not_called()
+
+
 def _timing_probe_labels(
     *,
     module_name: str,


### PR DESCRIPTION
## Summary
- add `emit_timing_event()` for structured one-off timing events
- add `emit_elapsed_timing()` to log elapsed timing from a recorded monotonic start
- instrument coalescing and dispatch handoff paths so timing coverage lands separately from the router behavior change

## Testing
- `uv run pytest -n auto`
- `uv run pre-commit run --all-files`
