### PR TITLE
perf: skip redundant router ingress work

### DIFF
--- a/src/mindroom/thread_utils.py
+++ b/src/mindroom/thread_utils.py
@@ -183,6 +183,25 @@ def has_multiple_non_agent_users_in_thread(
     return False
 
 
+def thread_requires_explicit_agent_targeting(
+    thread_history: Sequence[ResolvedVisibleMessage],
+    *,
+    sender_id: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> bool:
+    """Return whether a thread already has visible ownership or multiple human participants."""
+    sender_visible_agents = authorization.filter_agents_by_sender_permissions(
+        get_agents_in_thread(thread_history, config, runtime_paths),
+        sender_id,
+        config,
+        runtime_paths,
+    )
+    if sender_visible_agents:
+        return True
+    return has_multiple_non_agent_users_in_thread(thread_history, config, runtime_paths)
+
+
 def get_configured_agents_for_room(
     room_id: str,
     config: Config,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -70,9 +70,8 @@ from mindroom.response_runner import PostLockRequestPreparationError, ResponseRe
 from mindroom.routing import suggest_agent_for_message
 from mindroom.thread_utils import (
     check_agent_mentioned,
-    get_agents_in_thread,
     get_configured_agents_for_room,
-    has_multiple_non_agent_users_in_thread,
+    thread_requires_explicit_agent_targeting,
 )
 from mindroom.timing import (
     DispatchPipelineTiming,
@@ -394,22 +393,11 @@ class TurnController:
             room.room_id,
             thread_id,
         )
-        sender_visible_agents = filter_agents_by_sender_permissions(
-            get_agents_in_thread(
-                thread_history,
-                self.deps.runtime.config,
-                self.deps.runtime_paths,
-            ),
-            requester_user_id,
-            self.deps.runtime.config,
-            self.deps.runtime_paths,
-        )
-        if sender_visible_agents:
-            return True
-        return has_multiple_non_agent_users_in_thread(
+        return thread_requires_explicit_agent_targeting(
             thread_history,
-            self.deps.runtime.config,
-            self.deps.runtime_paths,
+            sender_id=requester_user_id,
+            config=self.deps.runtime.config,
+            runtime_paths=self.deps.runtime_paths,
         )
 
     async def _coalescing_key_for_event(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -68,7 +68,12 @@ from mindroom.matrix.message_content import is_v2_sidecar_text_preview
 from mindroom.matrix.rooms import is_dm_room
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest
 from mindroom.routing import suggest_agent_for_message
-from mindroom.thread_utils import get_configured_agents_for_room
+from mindroom.thread_utils import (
+    check_agent_mentioned,
+    get_agents_in_thread,
+    get_configured_agents_for_room,
+    has_multiple_non_agent_users_in_thread,
+)
 from mindroom.timing import (
     DispatchPipelineTiming,
     attach_dispatch_pipeline_timing,
@@ -359,6 +364,53 @@ class TurnController:
         if is_agent_id(sender_id, self.deps.runtime.config, self.deps.runtime_paths):
             return False
         return self.deps.response_runner.has_active_response_for_target(target)
+
+    async def _should_skip_router_before_shared_ingress_work(
+        self,
+        room: nio.MatrixRoom,
+        event: nio.RoomMessageText,
+        *,
+        requester_user_id: str,
+        thread_id: str | None,
+    ) -> bool:
+        """Return whether the router can safely skip shared ingress work for one text event."""
+        if self.deps.agent_name != ROUTER_AGENT_NAME:
+            return False
+        if command_parser.parse(event.body.strip()) is not None:
+            return False
+
+        mentioned_agents, _am_i_mentioned, has_non_agent_mentions = check_agent_mentioned(
+            event.source,
+            self.deps.matrix_id,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
+        if mentioned_agents or has_non_agent_mentions:
+            return True
+        if thread_id is None:
+            return False
+
+        thread_history = await self.deps.conversation_cache.get_dispatch_thread_snapshot(
+            room.room_id,
+            thread_id,
+        )
+        sender_visible_agents = filter_agents_by_sender_permissions(
+            get_agents_in_thread(
+                thread_history,
+                self.deps.runtime.config,
+                self.deps.runtime_paths,
+            ),
+            requester_user_id,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
+        if sender_visible_agents:
+            return True
+        return has_multiple_non_agent_users_in_thread(
+            thread_history,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
 
     async def _coalescing_key_for_event(
         self,
@@ -1169,28 +1221,14 @@ class TurnController:
         async with self.deps.resolver.turn_thread_cache_scope():
             await self._handle_message_inner(room, event)
 
-    async def _handle_message_inner(self, room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
+    async def _handle_message_inner(  # noqa: C901, PLR0911
+        self,
+        room: nio.MatrixRoom,
+        event: nio.RoomMessageText,
+    ) -> None:
         """Handle one text message inside the per-turn conversation lookup scope."""
         ingress_thread_id = await self.deps.resolver.coalescing_thread_id(room, event)
-        self.deps.logger.info(
-            "Received message",
-            event_id=event.event_id,
-            room_id=room.room_id,
-            sender=event.sender,
-            thread_id=ingress_thread_id,
-        )
-        dispatch_timing = create_dispatch_pipeline_timing(
-            event_id=event.event_id,
-            room_id=room.room_id,
-        )
-        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
         event_info = EventInfo.from_event(event.source)
-        await self._append_live_event_with_timing(
-            room.room_id,
-            event,
-            event_info=event_info,
-            dispatch_timing=dispatch_timing,
-        )
         if not isinstance(event.body, str):
             return
         event_content = event.source.get("content") if isinstance(event.source, dict) else None
@@ -1203,6 +1241,38 @@ class TurnController:
         prechecked_event = self._precheck_dispatch_event(room, event, is_edit=event_info.is_edit)
         if prechecked_event is None:
             return
+        if await self._should_skip_router_before_shared_ingress_work(
+            room,
+            prechecked_event.event,
+            requester_user_id=prechecked_event.requester_user_id,
+            thread_id=ingress_thread_id,
+        ):
+            self.deps.logger.debug(
+                "skip_router_shared_ingress_work",
+                event_id=event.event_id,
+                room_id=room.room_id,
+                thread_id=ingress_thread_id,
+            )
+            return
+
+        self.deps.logger.info(
+            "Received message",
+            event_id=event.event_id,
+            room_id=room.room_id,
+            sender=event.sender,
+            thread_id=ingress_thread_id,
+        )
+        dispatch_timing = create_dispatch_pipeline_timing(
+            event_id=event.event_id,
+            room_id=room.room_id,
+        )
+        attach_dispatch_pipeline_timing(event.source, dispatch_timing)
+        await self._append_live_event_with_timing(
+            room.room_id,
+            event,
+            event_info=event_info,
+            dispatch_timing=dispatch_timing,
+        )
 
         if event_info.is_edit:
             await self.deps.edit_regenerator.handle_message_edit(

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from mindroom.authorization import (
-    filter_agents_by_sender_permissions,
     get_available_agents_for_sender,
     is_sender_allowed_for_agent_reply,
 )
@@ -40,8 +39,8 @@ from mindroom.teams import (
 from mindroom.thread_utils import (
     get_agents_in_thread,
     get_all_mentioned_agents_in_thread,
-    has_multiple_non_agent_users_in_thread,
     should_agent_respond,
+    thread_requires_explicit_agent_targeting,
 )
 from mindroom.timing import timed
 
@@ -393,25 +392,14 @@ class TurnPolicy:
 
         context = dispatch.context
         requester_user_id = dispatch.requester_user_id
-        agents_in_thread = get_agents_in_thread(
-            context.thread_history,
-            self.deps.runtime.config,
-            self.deps.runtime_paths,
-        )
-        sender_visible = filter_agents_by_sender_permissions(
-            agents_in_thread,
-            requester_user_id,
-            self.deps.runtime.config,
-            self.deps.runtime_paths,
-        )
-
-        if not context.mentioned_agents and not context.has_non_agent_mentions and not sender_visible:
-            if context.is_thread and has_multiple_non_agent_users_in_thread(
+        if not context.mentioned_agents and not context.has_non_agent_mentions:
+            if context.is_thread and thread_requires_explicit_agent_targeting(
                 context.thread_history,
-                self.deps.runtime.config,
-                self.deps.runtime_paths,
+                sender_id=requester_user_id,
+                config=self.deps.runtime.config,
+                runtime_paths=self.deps.runtime_paths,
             ):
-                self.deps.logger.info("Skipping routing: multiple non-agent users in thread (mention required)")
+                self.deps.logger.info("Skipping routing: thread already requires explicit agent targeting")
                 return DispatchPlan(kind="ignore", ignore_reason="router")
             available_agents = get_available_agents_for_sender(
                 room,

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -1366,6 +1366,147 @@ class TestRouterSkipsSingleAgent:
     """Test router's behavior when there's only one agent in the room."""
 
     @pytest.mark.asyncio
+    async def test_router_skips_shared_ingress_work_for_explicit_agent_mentions(self) -> None:
+        """Router should bail out before shared ingress work when another agent is explicitly mentioned."""
+        agent_user = AgentMatrixUser(
+            agent_name=ROUTER_AGENT_NAME,
+            user_id="@mindroom_router:localhost",
+            display_name="Router Agent",
+            password=TEST_PASSWORD,
+            access_token=TEST_ACCESS_TOKEN,
+        )
+
+        config = _runtime_bound_config(
+            Config(
+                router=RouterConfig(model="default"),
+                agents={
+                    "general": AgentConfig(display_name="General Agent", role="General assistant"),
+                    "calculator": AgentConfig(display_name="Calculator Agent", role="Math calculations"),
+                },
+            ),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bot = AgentBot(
+                agent_user=agent_user,
+                storage_path=Path(tmpdir),
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                rooms=["!test:server"],
+            )
+        bot.client = AsyncMock()
+        bot.client.user_id = bot.agent_user.user_id
+        bot.logger = MagicMock()
+        wrap_extracted_collaborators(bot, "_turn_policy")
+        _sync_turn_policy_runtime(bot)
+        bot._turn_controller._append_live_event_with_timing = AsyncMock()
+        bot._turn_controller._enqueue_for_dispatch = AsyncMock()
+        bot._conversation_cache.get_dispatch_thread_snapshot = AsyncMock(
+            return_value=thread_history_result([], is_full_history=False),
+        )
+
+        room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
+        room.users = {
+            "@mindroom_router:localhost": None,
+            "@mindroom_general:localhost": None,
+            "@mindroom_calculator:localhost": None,
+            "@user:localhost": None,
+        }
+
+        event = nio.RoomMessageText.from_dict(
+            {
+                "event_id": "$event_explicit_mention",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "Hey @mindroom_general:localhost can you help?",
+                    "m.mentions": {"user_ids": ["@mindroom_general:localhost"]},
+                },
+            },
+        )
+
+        await bot._on_message(room, event)
+
+        bot._turn_controller._append_live_event_with_timing.assert_not_awaited()
+        bot._turn_controller._enqueue_for_dispatch.assert_not_awaited()
+        bot._conversation_cache.get_dispatch_thread_snapshot.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_router_skips_shared_ingress_work_for_agent_owned_thread_follow_up(self) -> None:
+        """Router should bail out before shared ingress work when the thread already has a visible agent."""
+        agent_user = AgentMatrixUser(
+            agent_name=ROUTER_AGENT_NAME,
+            user_id="@mindroom_router:localhost",
+            display_name="Router Agent",
+            password=TEST_PASSWORD,
+            access_token=TEST_ACCESS_TOKEN,
+        )
+
+        config = _runtime_bound_config(
+            Config(
+                router=RouterConfig(model="default"),
+                agents={
+                    "general": AgentConfig(display_name="General Agent", role="General assistant"),
+                    "calculator": AgentConfig(display_name="Calculator Agent", role="Math calculations"),
+                },
+            ),
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bot = AgentBot(
+                agent_user=agent_user,
+                storage_path=Path(tmpdir),
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                rooms=["!test:server"],
+            )
+        bot.client = AsyncMock()
+        bot.client.user_id = bot.agent_user.user_id
+        bot.logger = MagicMock()
+        wrap_extracted_collaborators(bot, "_turn_policy")
+        _sync_turn_policy_runtime(bot)
+        bot._turn_controller._append_live_event_with_timing = AsyncMock()
+        bot._turn_controller._enqueue_for_dispatch = AsyncMock()
+        bot._conversation_cache.get_dispatch_thread_snapshot = AsyncMock(
+            return_value=thread_history_result(
+                [
+                    _message(sender="@mindroom_general:localhost", body="I can help with that."),
+                    _message(sender="@user:localhost", body="Can you continue?"),
+                ],
+                is_full_history=False,
+            ),
+        )
+
+        room = nio.MatrixRoom(room_id="!test:server", own_user_id="@mindroom_router:localhost")
+        room.users = {
+            "@mindroom_router:localhost": None,
+            "@mindroom_general:localhost": None,
+            "@mindroom_calculator:localhost": None,
+            "@user:localhost": None,
+        }
+
+        event = nio.RoomMessageText.from_dict(
+            {
+                "event_id": "$event_thread_follow_up",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "Following up on that",
+                    "m.relates_to": {"event_id": "$thread_root", "rel_type": "m.thread"},
+                },
+            },
+        )
+
+        await bot._on_message(room, event)
+
+        bot._conversation_cache.get_dispatch_thread_snapshot.assert_awaited_once_with(
+            "!test:server",
+            "$thread_root",
+        )
+        bot._turn_controller._append_live_event_with_timing.assert_not_awaited()
+        bot._turn_controller._enqueue_for_dispatch.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_router_skips_routing_with_single_agent(self) -> None:
         """Test that router doesn't route when there's only one agent available."""
         # Create router agent

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -1775,7 +1775,7 @@ class TestRouterSkipsSingleAgent:
 
         bot._turn_controller._execute_router_relay.assert_not_called()
         info_calls = [call[0][0] for call in bot.logger.info.call_args_list]
-        assert "Skipping routing: multiple non-agent users in thread (mention required)" in info_calls
+        assert "Skipping routing: thread already requires explicit agent targeting" in info_calls
 
     @pytest.mark.asyncio
     async def test_router_handles_command_even_with_single_agent(self) -> None:


### PR DESCRIPTION
## Summary
- skip router shared ingress work before cache append and dispatch queueing when another agent is explicitly targeted
- skip the same redundant router work for follow-ups in threads that already require explicit agent targeting
- share the thread targeting predicate between turn controller and turn policy

## Notes
- this replaces the earlier stacked PR path from #636, which was merged into the timing branch instead of `main`

## Verification
- `uv run pytest tests/test_bot_scheduling.py -x --no-cov -q -n auto`
- `uv sync --all-extras`
- `uv run pre-commit run --files src/mindroom/thread_utils.py src/mindroom/turn_controller.py src/mindroom/turn_policy.py tests/test_bot_scheduling.py`
