### PR TITLE
test: fix router helper patch targets

### DIFF
--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -5367,7 +5367,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.extract_agent_name", return_value=None),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
-            patch("mindroom.turn_policy.has_multiple_non_agent_users_in_thread", return_value=False),
+            patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
             patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.coalescing.extract_media_caption", return_value="[Attached image]"),
@@ -5508,7 +5508,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.extract_agent_name", return_value=None),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
-            patch("mindroom.turn_policy.has_multiple_non_agent_users_in_thread", return_value=False),
+            patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
             patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch(
@@ -5889,7 +5889,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.extract_agent_name", return_value=None),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
-            patch("mindroom.turn_policy.has_multiple_non_agent_users_in_thread", return_value=False),
+            patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
             patch(
                 "mindroom.turn_policy.get_available_agents_for_sender",
                 return_value=[
@@ -5967,7 +5967,7 @@ class TestAgentBot:
         with (
             patch("mindroom.bot.extract_agent_name", return_value=None),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
-            patch("mindroom.turn_policy.has_multiple_non_agent_users_in_thread", return_value=False),
+            patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
             patch(
                 "mindroom.turn_policy.get_available_agents_for_sender",
                 return_value=[config.get_ids(runtime_paths_for(config))["calculator"]],


### PR DESCRIPTION
## Summary
- update stale `turn_policy` patch targets in multi-agent bot tests after the router thread-targeting helper refactor
- keep the fix scoped to the four CI failures from the merged router ingress optimization

## Verification
- `uv run pytest tests/test_multi_agent_bot.py -x --no-cov -q -n auto -k 'router_routes_image_messages_in_multi_agent_rooms or router_routes_file_messages_with_sender_metadata or router_dispatch_parity_text_and_image_route_under_same_conditions or router_dispatch_parity_text_and_image_skip_under_same_conditions'`
- `uv sync --all-extras`
- `uv run pre-commit run --files tests/test_multi_agent_bot.py`
