### PR TITLE
test: retarget stale room lifecycle patch points

### DIFF
--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -574,7 +574,7 @@ async def test_agent_joins_new_rooms_on_config_reload(  # noqa: C901
         left_rooms[user_id].append(room_id)
         return True
 
-    monkeypatch.setattr("mindroom.bot.join_room", mock_join_room)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", mock_join_room)
     monkeypatch.setattr("mindroom.matrix.rooms.leave_room", mock_leave_room)
 
     # Mock restore_scheduled_tasks
@@ -609,7 +609,7 @@ async def test_agent_joins_new_rooms_on_config_reload(  # noqa: C901
             return ["room1", "room2", "room3"]  # router is in all initial rooms
         return []
 
-    monkeypatch.setattr("mindroom.bot.get_joined_rooms", mock_get_joined_rooms)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.get_joined_rooms", mock_get_joined_rooms)
 
     # Create agent1 bot with initial config
     config = _runtime_bound_config(Config(router=RouterConfig(model="default")), tmp_path)
@@ -658,7 +658,7 @@ async def test_router_updates_rooms_on_config_reload(
         left_rooms.append(room_id)
         return True
 
-    monkeypatch.setattr("mindroom.bot.join_room", mock_join_room)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", mock_join_room)
     monkeypatch.setattr("mindroom.matrix.rooms.leave_room", mock_leave_room)
 
     # Mock restore_scheduled_tasks
@@ -685,7 +685,7 @@ async def test_router_updates_rooms_on_config_reload(
         # Router is currently in initial config rooms
         return ["room1", "room2", "room3"]
 
-    monkeypatch.setattr("mindroom.bot.get_joined_rooms", mock_get_joined_rooms)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.get_joined_rooms", mock_get_joined_rooms)
 
     # Get initial router rooms
     initial_router_rooms = initial_config.get_all_configured_rooms()
@@ -745,7 +745,7 @@ async def test_new_agent_joins_rooms_on_config_reload(
         joined_rooms[user_id].append(room_id)
         return True
 
-    monkeypatch.setattr("mindroom.bot.join_room", mock_join_room)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", mock_join_room)
 
     # Mock restore_scheduled_tasks
     async def mock_restore_scheduled_tasks(
@@ -770,7 +770,7 @@ async def test_new_agent_joins_rooms_on_config_reload(
     async def mock_get_joined_rooms(_client: AsyncMock) -> list[str]:
         return []  # New agent has no rooms initially
 
-    monkeypatch.setattr("mindroom.bot.get_joined_rooms", mock_get_joined_rooms)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.get_joined_rooms", mock_get_joined_rooms)
 
     # Create agent3 bot (new agent in updated config)
     config = _runtime_bound_config(Config(router=RouterConfig(model="default")), tmp_path)
@@ -819,7 +819,7 @@ async def test_team_room_changes_on_config_reload(
         left_rooms[user_id].append(room_id)
         return True
 
-    monkeypatch.setattr("mindroom.bot.join_room", mock_join_room)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", mock_join_room)
     monkeypatch.setattr("mindroom.matrix.rooms.leave_room", mock_leave_room)
 
     # Mock restore_scheduled_tasks
@@ -848,7 +848,7 @@ async def test_team_room_changes_on_config_reload(
             return ["room3"]  # team1 is currently only in room3
         return []
 
-    monkeypatch.setattr("mindroom.bot.get_joined_rooms", mock_get_joined_rooms)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.get_joined_rooms", mock_get_joined_rooms)
 
     # Create team1 bot with updated config
     config = _runtime_bound_config(Config(router=RouterConfig(model="default")), tmp_path)
@@ -1029,7 +1029,7 @@ async def test_room_membership_state_after_config_update(  # noqa: C901, PLR0915
         update_room_membership(client.user_id, room_id, "leave")
         return True
 
-    monkeypatch.setattr("mindroom.bot.join_room", mock_join_room)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", mock_join_room)
     monkeypatch.setattr("mindroom.matrix.rooms.leave_room", mock_leave_room)
 
     # Mock restore_scheduled_tasks
@@ -1060,7 +1060,7 @@ async def test_room_membership_state_after_config_update(  # noqa: C901, PLR0915
                 rooms.append(room_id)
         return rooms
 
-    monkeypatch.setattr("mindroom.bot.get_joined_rooms", mock_get_joined_rooms)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.get_joined_rooms", mock_get_joined_rooms)
 
     # Apply config updates for each bot
     bots_config = {

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -5439,8 +5439,8 @@ class TestAgentBot:
 
         bot._send_response = AsyncMock(side_effect=fake_send_response)
         with (
-            patch("mindroom.bot._generate_welcome_message", return_value="Welcome"),
-            patch("mindroom.bot.get_joined_rooms", new=AsyncMock(return_value=[])),
+            patch("mindroom.bot_room_lifecycle._generate_welcome_message", return_value="Welcome"),
+            patch("mindroom.bot_room_lifecycle.get_joined_rooms", new=AsyncMock(return_value=[])),
             patch("mindroom.bot.restore_scheduled_tasks", new=AsyncMock(return_value=0)),
             patch("mindroom.bot.config_confirmation.restore_pending_changes", new=AsyncMock(return_value=0)),
         ):

--- a/tests/test_router_rooms.py
+++ b/tests/test_router_rooms.py
@@ -162,7 +162,7 @@ async def test_router_joins_rooms_on_start(
         joined_rooms.append(room_id)
         return True
 
-    monkeypatch.setattr("mindroom.bot.join_room", mock_join_room)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", mock_join_room)
 
     # Mock restore_scheduled_tasks
     async def mock_restore_scheduled_tasks(

--- a/tests/test_scheduled_task_restoration.py
+++ b/tests/test_scheduled_task_restoration.py
@@ -85,8 +85,8 @@ class TestScheduledTaskRestoration:
         self._install_runtime_support(router_bot)
 
         with (
-            patch("mindroom.bot.get_joined_rooms", new_callable=AsyncMock, return_value=[]),
-            patch("mindroom.bot.join_room", new_callable=AsyncMock, return_value=True) as mock_join,
+            patch("mindroom.bot_room_lifecycle.get_joined_rooms", new_callable=AsyncMock, return_value=[]),
+            patch("mindroom.bot_room_lifecycle.join_room", new_callable=AsyncMock, return_value=True) as mock_join,
             patch("mindroom.bot.restore_scheduled_tasks", new_callable=AsyncMock, return_value=2) as mock_restore,
             patch(
                 "mindroom.bot.config_confirmation.restore_pending_changes",
@@ -147,8 +147,8 @@ class TestScheduledTaskRestoration:
         self._install_runtime_support(regular_bot)
 
         with (
-            patch("mindroom.bot.get_joined_rooms", new_callable=AsyncMock, return_value=[]),
-            patch("mindroom.bot.join_room", new_callable=AsyncMock, return_value=True) as mock_join,
+            patch("mindroom.bot_room_lifecycle.get_joined_rooms", new_callable=AsyncMock, return_value=[]),
+            patch("mindroom.bot_room_lifecycle.join_room", new_callable=AsyncMock, return_value=True) as mock_join,
             patch("mindroom.bot.restore_scheduled_tasks", new_callable=AsyncMock, return_value=2) as mock_restore,
         ):
             await regular_bot.join_configured_rooms()
@@ -180,8 +180,8 @@ class TestScheduledTaskRestoration:
         self._install_runtime_support(router_bot)
 
         with (
-            patch("mindroom.bot.get_joined_rooms", new_callable=AsyncMock, return_value=["lobby"]),
-            patch("mindroom.bot.join_room", new_callable=AsyncMock) as mock_join,
+            patch("mindroom.bot_room_lifecycle.get_joined_rooms", new_callable=AsyncMock, return_value=["lobby"]),
+            patch("mindroom.bot_room_lifecycle.join_room", new_callable=AsyncMock) as mock_join,
             patch("mindroom.bot.restore_scheduled_tasks", new_callable=AsyncMock, return_value=2) as mock_restore,
             patch(
                 "mindroom.bot.config_confirmation.restore_pending_changes",
@@ -440,8 +440,8 @@ class TestScheduledTaskRestoration:
             self._install_runtime_support(bot)
 
             with (
-                patch("mindroom.bot.get_joined_rooms", new_callable=AsyncMock, return_value=[]),
-                patch("mindroom.bot.join_room", new_callable=AsyncMock, return_value=True),
+                patch("mindroom.bot_room_lifecycle.get_joined_rooms", new_callable=AsyncMock, return_value=[]),
+                patch("mindroom.bot_room_lifecycle.join_room", new_callable=AsyncMock, return_value=True),
                 patch("mindroom.bot.restore_scheduled_tasks", new_callable=AsyncMock, return_value=2) as mock_restore,
                 patch(
                     "mindroom.bot.config_confirmation.restore_pending_changes",


### PR DESCRIPTION
## Summary
- retarget stale test monkeypatches from `mindroom.bot` to `mindroom.bot_room_lifecycle`
- keep the follow-up strictly test-only after #638 moved those symbols out of `bot.py`
- cover the config reload, router startup, welcome-message, and scheduled-task restoration tests that broke after the merge

## Root cause
#638 extracted room join and welcome behavior into `mindroom.bot_room_lifecycle`, but a small set of tests still patched old import locations on `mindroom.bot`.

## Verification
- `uv run pytest tests/test_config_reload.py tests/test_multi_agent_bot.py tests/test_router_rooms.py tests/test_scheduled_task_restoration.py -k "join_room or welcome_after_join or joins_new_rooms_on_config_reload or updates_rooms_on_config_reload or new_agent_joins_rooms_on_config_reload or team_room_changes_on_config_reload or room_membership_state_after_config_update or only_router_restores_tasks or non_router_agents_dont_restore_tasks or router_restores_tasks_without_rejoining_existing_room or multiple_agents_only_router_restores or router_joins_rooms_on_start" -x -n 0 --no-cov -v`
- `uv sync --all-extras`
- `uv run pytest -n 0 --no-cov`