### PR TITLE
feat: instruct agents to mention users with full Matrix ID

### DIFF
--- a/src/mindroom/agent_prompts.py
+++ b/src/mindroom/agent_prompts.py
@@ -6,6 +6,9 @@ You are {display_name} (username: @mindroom_{agent_name}), a specialized agent i
 You are powered by the {model_provider} model: {model_id}.
 When working in teams with other agents, you should identify yourself as {display_name} and leverage your specific expertise.
 
+Conversation messages are prefixed with the sender's full Matrix ID (e.g. `@alice:example.org: hello`).
+When mentioning a user, always write the complete Matrix ID including the homeserver (e.g. `@alice:example.org`), never just the localpart before the colon. The chat client renders the full ID as a clickable mention pill.
+
 """
 
 INTERACTIVE_QUESTION_PROMPT = """When you need the user to choose between options, create an interactive question by including this JSON in your response with the following format:

--- a/src/mindroom/agent_prompts.py
+++ b/src/mindroom/agent_prompts.py
@@ -2,7 +2,7 @@
 
 # Universal identity context template for all agents
 AGENT_IDENTITY_CONTEXT = """## Your Identity
-You are {display_name} (username: @mindroom_{agent_name}), a specialized agent in the Mindroom multi-agent system in a Matrix chatroom (with Markdown support).
+You are {display_name} (Matrix ID: {matrix_id}), a specialized agent in the Mindroom multi-agent system in a Matrix chatroom (with Markdown support).
 You are powered by the {model_provider} model: {model_id}.
 When working in teams with other agents, you should identify yourself as {display_name} and leverage your specific expertise.
 

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -25,6 +25,7 @@ from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.hooks import HookRegistry
 from mindroom.logging_config import get_logger
+from mindroom.matrix.identity import MatrixID
 from mindroom.runtime_resolution import (
     ResolvedAgentRuntime,
     resolve_agent_runtime,
@@ -1097,9 +1098,14 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         model_id = model_name
 
     # Add identity context to all agents using the unified template
+    matrix_id = MatrixID.from_agent(
+        agent_name,
+        config.get_domain(runtime_paths),
+        runtime_paths,
+    ).full_id
     identity_context = agent_prompts.AGENT_IDENTITY_CONTEXT.format(
         display_name=agent_config.display_name,
-        agent_name=agent_name,
+        matrix_id=matrix_id,
         model_provider=model_provider,
         model_id=model_id,
     )


### PR DESCRIPTION
## Summary
- Agents see thread history as flat `@user:server: body` lines (built in `execution_preparation.py`), but they were replying with just the localpart (`@alice`), which doesn't render as a Matrix mention pill.
- The identity block also hardcoded `@mindroom_{agent_name}` with no homeserver — and was actually incorrect for multi-instance setups where `agent_username_localpart()` appends a namespace suffix.
- Resolve the real Matrix ID via `MatrixID.from_agent(...)` and inject it as `{matrix_id}` in `AGENT_IDENTITY_CONTEXT`, plus add two sentences instructing the agent to mirror the same full-ID format when mentioning users.

## Test plan
- [ ] Send a message in a multi-person room and verify the agent replies with `@user:homeserver` and the mention renders as a pill in the client.
- [ ] In a multi-instance / namespaced deployment, confirm the agent reports its own ID with the namespace suffix and homeserver (e.g. `@mindroom_code_acme:example.org`).
- [ ] Confirm single-user / DM behavior is unchanged.