### PR TITLE
feat: render thread history as structured XML

### DIFF
--- a/src/mindroom/agent_prompts.py
+++ b/src/mindroom/agent_prompts.py
@@ -6,7 +6,7 @@ You are {display_name} (Matrix ID: {matrix_id}), a specialized agent in the Mind
 You are powered by the {model_provider} model: {model_id}.
 When working in teams with other agents, you should identify yourself as {display_name} and leverage your specific expertise.
 
-Conversation history is provided inside a `<conversation>` block, with each prior message wrapped as `<msg from="@user:server">body</msg>`. The `from` attribute is the sender's full Matrix ID; bodies are passed through verbatim (so code snippets, markdown, and special characters appear exactly as the sender wrote them).
+Conversation history is provided inside a `<conversation>` block, with each prior message wrapped as `<msg from="@user:server">body</msg>`. The `from` attribute is the sender's full Matrix ID; bodies are passed through verbatim (so code snippets, markdown, and special characters appear exactly as the sender wrote them). The current message you are responding to may also be wrapped in the same `<msg from="...">` tag — use it to attribute the latest turn, especially in multi-user threads where the sender may differ from prior messages.
 When mentioning a user in your reply, always write the complete Matrix ID including the homeserver (e.g. `@alice:example.org`), never just the localpart before the colon. The chat client renders the full ID as a clickable mention pill.
 
 """

--- a/src/mindroom/agent_prompts.py
+++ b/src/mindroom/agent_prompts.py
@@ -6,7 +6,7 @@ You are {display_name} (Matrix ID: {matrix_id}), a specialized agent in the Mind
 You are powered by the {model_provider} model: {model_id}.
 When working in teams with other agents, you should identify yourself as {display_name} and leverage your specific expertise.
 
-Conversation history is provided as XML inside a `<conversation>` block, with each prior message wrapped as `<msg from="@user:server">body</msg>`. The `from` attribute is the sender's full Matrix ID; bodies are XML-escaped (`&lt;`, `&gt;`, `&amp;`).
+Conversation history is provided inside a `<conversation>` block, with each prior message wrapped as `<msg from="@user:server">body</msg>`. The `from` attribute is the sender's full Matrix ID; bodies are passed through verbatim (so code snippets, markdown, and special characters appear exactly as the sender wrote them).
 When mentioning a user in your reply, always write the complete Matrix ID including the homeserver (e.g. `@alice:example.org`), never just the localpart before the colon. The chat client renders the full ID as a clickable mention pill.
 
 """

--- a/src/mindroom/agent_prompts.py
+++ b/src/mindroom/agent_prompts.py
@@ -1,16 +1,39 @@
 """Rich prompts for agents - like prompts.py but for agents instead of tools."""
 
 # Universal identity context template for all agents
-AGENT_IDENTITY_CONTEXT = """## Your Identity
+AGENT_IDENTITY_CONTEXT_TEMPLATE = """## Your Identity
 You are {display_name} (Matrix ID: {matrix_id}), a specialized agent in the Mindroom multi-agent system in a Matrix chatroom (with Markdown support).
 You are powered by the {model_provider} model: {model_id}.
 When working in teams with other agents, you should identify yourself as {display_name} and leverage your specific expertise.
 
 In Matrix chat contexts, conversation history may be provided inside a `<conversation>` block, with each prior message wrapped as `<msg from="@user:server"><![CDATA[body]]></msg>`. The `from` attribute is the sender's full Matrix ID, and the CDATA body preserves code snippets, markdown, and other special characters exactly as written. The current message you are responding to may also be wrapped in the same `<msg from="...">` tag.
-In OpenAI-compatible API contexts, prior turns may instead appear as plain `role: body` lines. Always use the sender or role labels exactly as provided in the prompt.
-When mentioning a user in your reply, always write the complete Matrix ID including the homeserver (e.g. `@alice:example.org`), never just the localpart before the colon. The chat client renders the full ID as a clickable mention pill.
+{openai_compat_history_guidance}When mentioning a user in your reply, always write the complete Matrix ID including the homeserver (e.g. `@alice:example.org`), never just the localpart before the colon. The chat client renders the full ID as a clickable mention pill.
 
 """
+
+OPENAI_COMPAT_HISTORY_GUIDANCE = (
+    "In OpenAI-compatible API contexts, prior turns may instead appear as plain `role: body` lines. "
+    "Always use the sender or role labels exactly as provided in the prompt.\n"
+)
+
+
+def build_agent_identity_context(
+    *,
+    display_name: str,
+    matrix_id: str,
+    model_provider: str,
+    model_id: str,
+    include_openai_compat_guidance: bool = False,
+) -> str:
+    """Render the shared identity prompt with optional OpenAI-compatible guidance."""
+    return AGENT_IDENTITY_CONTEXT_TEMPLATE.format(
+        display_name=display_name,
+        matrix_id=matrix_id,
+        model_provider=model_provider,
+        model_id=model_id,
+        openai_compat_history_guidance=(OPENAI_COMPAT_HISTORY_GUIDANCE if include_openai_compat_guidance else ""),
+    )
+
 
 INTERACTIVE_QUESTION_PROMPT = """When you need the user to choose between options, create an interactive question by including this JSON in your response with the following format:
 

--- a/src/mindroom/agent_prompts.py
+++ b/src/mindroom/agent_prompts.py
@@ -6,7 +6,8 @@ You are {display_name} (Matrix ID: {matrix_id}), a specialized agent in the Mind
 You are powered by the {model_provider} model: {model_id}.
 When working in teams with other agents, you should identify yourself as {display_name} and leverage your specific expertise.
 
-Conversation history is provided inside a `<conversation>` block, with each prior message wrapped as `<msg from="@user:server">body</msg>`. The `from` attribute is the sender's full Matrix ID; bodies are passed through verbatim (so code snippets, markdown, and special characters appear exactly as the sender wrote them). The current message you are responding to may also be wrapped in the same `<msg from="...">` tag — use it to attribute the latest turn, especially in multi-user threads where the sender may differ from prior messages.
+In Matrix chat contexts, conversation history may be provided inside a `<conversation>` block, with each prior message wrapped as `<msg from="@user:server"><![CDATA[body]]></msg>`. The `from` attribute is the sender's full Matrix ID, and the CDATA body preserves code snippets, markdown, and other special characters exactly as written. The current message you are responding to may also be wrapped in the same `<msg from="...">` tag.
+In OpenAI-compatible API contexts, prior turns may instead appear as plain `role: body` lines. Always use the sender or role labels exactly as provided in the prompt.
 When mentioning a user in your reply, always write the complete Matrix ID including the homeserver (e.g. `@alice:example.org`), never just the localpart before the colon. The chat client renders the full ID as a clickable mention pill.
 
 """

--- a/src/mindroom/agent_prompts.py
+++ b/src/mindroom/agent_prompts.py
@@ -6,8 +6,8 @@ You are {display_name} (Matrix ID: {matrix_id}), a specialized agent in the Mind
 You are powered by the {model_provider} model: {model_id}.
 When working in teams with other agents, you should identify yourself as {display_name} and leverage your specific expertise.
 
-Conversation messages are prefixed with the sender's full Matrix ID (e.g. `@alice:example.org: hello`).
-When mentioning a user, always write the complete Matrix ID including the homeserver (e.g. `@alice:example.org`), never just the localpart before the colon. The chat client renders the full ID as a clickable mention pill.
+Conversation history is provided as XML inside a `<conversation>` block, with each prior message wrapped as `<msg from="@user:server">body</msg>`. The `from` attribute is the sender's full Matrix ID; bodies are XML-escaped (`&lt;`, `&gt;`, `&amp;`).
+When mentioning a user in your reply, always write the complete Matrix ID including the homeserver (e.g. `@alice:example.org`), never just the localpart before the colon. The chat client renders the full ID as a clickable mention pill.
 
 """
 

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -962,6 +962,7 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
     history_storage: SqliteDb | None = None,
     active_model_name: str | None = None,
     include_interactive_questions: bool = True,
+    include_openai_compat_guidance: bool = False,
     delegation_depth: int = 0,
     timing_scope: str | None = None,
 ) -> Agent:
@@ -983,6 +984,8 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         include_interactive_questions: Whether to include the interactive
             question authoring prompt. Set to False for channels that do not
             support Matrix reaction-based question flows.
+        include_openai_compat_guidance: Whether to include OpenAI-compatible
+            history-format guidance in the shared identity prompt.
         delegation_depth: Current delegation nesting depth. Used to prevent
             infinite recursion when agents delegate to each other.
         timing_scope: Optional correlated timing scope id for nested
@@ -1103,11 +1106,12 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         config.get_domain(runtime_paths),
         runtime_paths,
     ).full_id
-    identity_context = agent_prompts.AGENT_IDENTITY_CONTEXT.format(
+    identity_context = agent_prompts.build_agent_identity_context(
         display_name=agent_config.display_name,
         matrix_id=matrix_id,
         model_provider=model_provider,
         model_id=model_id,
+        include_openai_compat_guidance=include_openai_compat_guidance,
     )
 
     # Add current date context with the user's configured timezone

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -989,6 +989,7 @@ async def _prepare_agent_and_prompt(
     delegation_depth: int = 0,
     system_enrichment_items: Sequence[EnrichmentItem] = (),
     current_sender_id: str | None = None,
+    include_openai_compat_guidance: bool = False,
     timing_scope: str | None = None,
 ) -> tuple[Agent, str, list[str], PreparedHistoryState]:
     """Prepare agent and full prompt for AI processing.
@@ -1029,6 +1030,7 @@ async def _prepare_agent_and_prompt(
         active_model_name=runtime_model.model_name,
         knowledge=knowledge,
         include_interactive_questions=include_interactive_questions,
+        include_openai_compat_guidance=include_openai_compat_guidance,
         execution_identity=execution_identity,
         delegation_depth=delegation_depth,
         timing_scope=timing_scope,
@@ -1097,6 +1099,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
     run_id: str | None = None,
     run_id_callback: Callable[[str], None] | None = None,
     include_interactive_questions: bool = True,
+    include_openai_compat_guidance: bool = False,
     media: MediaInputs | None = None,
     reply_to_event_id: str | None = None,
     active_event_ids: Collection[str] = frozenset(),
@@ -1128,6 +1131,8 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
         include_interactive_questions: Whether to include the interactive
             question authoring prompt. Set to False for channels that do not
             support Matrix reaction-based question flows.
+        include_openai_compat_guidance: Whether to include OpenAI-compatible
+            history-format guidance in the shared identity prompt.
         media: Optional multimodal inputs (audio/images/files/videos)
         reply_to_event_id: Matrix event ID of the triggering message, stored
             in run metadata for unseen message tracking and edit cleanup.
@@ -1202,6 +1207,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                     delegation_depth=delegation_depth,
                     system_enrichment_items=system_enrichment_items,
                     current_sender_id=user_id,
+                    include_openai_compat_guidance=include_openai_compat_guidance,
                     timing_scope=timing_scope,
                 )
                 if pipeline_timing is not None:
@@ -1424,6 +1430,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
     run_id: str | None = None,
     run_id_callback: Callable[[str], None] | None = None,
     include_interactive_questions: bool = True,
+    include_openai_compat_guidance: bool = False,
     media: MediaInputs | None = None,
     reply_to_event_id: str | None = None,
     active_event_ids: Collection[str] = frozenset(),
@@ -1454,6 +1461,8 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
         include_interactive_questions: Whether to include the interactive
             question authoring prompt. Set to False for channels that do not
             support Matrix reaction-based question flows.
+        include_openai_compat_guidance: Whether to include OpenAI-compatible
+            history-format guidance in the shared identity prompt.
         media: Optional multimodal inputs (audio/images/files/videos)
         reply_to_event_id: Matrix event ID of the triggering message, stored
             in run metadata for unseen message tracking and edit cleanup.
@@ -1528,6 +1537,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     delegation_depth=delegation_depth,
                     system_enrichment_items=system_enrichment_items,
                     current_sender_id=user_id,
+                    include_openai_compat_guidance=include_openai_compat_guidance,
                     timing_scope=timing_scope,
                 )
                 if pipeline_timing is not None:

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -988,6 +988,7 @@ async def _prepare_agent_and_prompt(
     compaction_outcomes_collector: list[CompactionOutcome] | None = None,
     delegation_depth: int = 0,
     system_enrichment_items: Sequence[EnrichmentItem] = (),
+    current_sender_id: str | None = None,
     timing_scope: str | None = None,
 ) -> tuple[Agent, str, list[str], PreparedHistoryState]:
     """Prepare agent and full prompt for AI processing.
@@ -1050,6 +1051,7 @@ async def _prepare_agent_and_prompt(
         reply_to_event_id=reply_to_event_id,
         active_event_ids=active_event_ids,
         compaction_outcomes_collector=compaction_outcomes_collector,
+        current_sender_id=current_sender_id,
         timing_scope=timing_scope,
     )
     prepared_history = PreparedHistoryState(
@@ -1199,6 +1201,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                     compaction_outcomes_collector=compaction_outcomes_collector,
                     delegation_depth=delegation_depth,
                     system_enrichment_items=system_enrichment_items,
+                    current_sender_id=user_id,
                     timing_scope=timing_scope,
                 )
                 if pipeline_timing is not None:
@@ -1524,6 +1527,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     compaction_outcomes_collector=compaction_outcomes_collector,
                     delegation_depth=delegation_depth,
                     system_enrichment_items=system_enrichment_items,
+                    current_sender_id=user_id,
                     timing_scope=timing_scope,
                 )
                 if pipeline_timing is not None:

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -878,6 +878,7 @@ async def _non_stream_completion(
         knowledge=knowledge,
         user_id=user,
         include_interactive_questions=False,
+        include_openai_compat_guidance=True,
         active_event_ids=set(),
         execution_identity=execution_identity,
     )
@@ -1062,6 +1063,7 @@ async def _stream_completion(
                 knowledge=knowledge,
                 user_id=user,
                 include_interactive_questions=False,
+                include_openai_compat_guidance=True,
                 active_event_ids=set(),
                 execution_identity=execution_identity,
             ),
@@ -1142,6 +1144,7 @@ def _build_team(
         runtime_paths=runtime_paths,
         execution_identity=execution_identity,
         session_id=session_id,
+        include_openai_compat_guidance=True,
         reason_prefix=f"Team '{team_name}'",
     )
 

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
+from xml.sax.saxutils import escape as xml_escape
+from xml.sax.saxutils import quoteattr as xml_quoteattr
 
 from mindroom.constants import (
     COMPACTION_NOTICE_CONTENT_KEY,
@@ -96,7 +98,12 @@ def build_prompt_with_thread_history(
     max_message_length: int | None = None,
     missing_sender_label: str | None = None,
 ) -> str:
-    """Build a prompt with thread history context when available."""
+    """Build a prompt with thread history context when available.
+
+    History is rendered as XML so the model can unambiguously attribute each
+    message to its sender even when bodies contain colons, newlines, or
+    quoted log lines that would otherwise look like a new sender prefix.
+    """
     if not thread_history:
         return prompt
     messages = thread_history[-max_messages:] if max_messages is not None else thread_history
@@ -112,10 +119,10 @@ def build_prompt_with_thread_history(
             if missing_sender_label is None:
                 continue
             sender = missing_sender_label
-        context_lines.append(f"{sender}: {body}")
+        context_lines.append(f"<msg from={xml_quoteattr(sender)}>{xml_escape(body)}</msg>")
     if not context_lines:
         return prompt
-    context = "\n".join(context_lines)
+    context = "<conversation>\n" + "\n".join(context_lines) + "\n</conversation>"
     return f"{header}\n{context}\n\n{prompt_intro}{prompt}"
 
 

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -93,6 +93,40 @@ def _wrap_msg_body(sender: str, body: str) -> str:
     return f"<msg from={xml_quoteattr(sender)}>{safe_body}</msg>"
 
 
+def _format_history_line(sender: str, body: str, *, wrap: bool) -> str:
+    return _wrap_msg_body(sender, body) if wrap else f"{sender}: {body}"
+
+
+def _format_history_block(context_lines: list[str], *, wrap: bool) -> str:
+    joined = "\n".join(context_lines)
+    return f"<conversation>\n{joined}\n</conversation>" if wrap else joined
+
+
+def _collect_history_lines(
+    thread_history: Sequence[ResolvedVisibleMessage],
+    *,
+    max_messages: int | None,
+    max_message_length: int | None,
+    missing_sender_label: str | None,
+    wrap: bool,
+) -> list[str]:
+    messages = thread_history[-max_messages:] if max_messages is not None else thread_history
+    lines: list[str] = []
+    for msg in messages:
+        body = msg.body
+        if not body:
+            continue
+        if max_message_length is not None and len(body) >= max_message_length:
+            continue
+        sender = msg.sender
+        if not sender:
+            if missing_sender_label is None:
+                continue
+            sender = missing_sender_label
+        lines.append(_format_history_line(sender, body, wrap=wrap))
+    return lines
+
+
 def build_prompt_with_thread_history(
     prompt: str,
     thread_history: Sequence[ResolvedVisibleMessage] | None = None,
@@ -106,42 +140,34 @@ def build_prompt_with_thread_history(
 ) -> str:
     """Build a prompt with thread history context when available.
 
-    History is rendered inside a <conversation> block as <msg from="..."> tags
-    so the model can unambiguously attribute each message even when bodies
-    contain colons, newlines, or quoted log lines. Bodies are passed through
-    verbatim (preserving code, markdown, and special characters); the only
-    transformation is neutralizing a literal "</msg>" sequence so it cannot
-    prematurely close the wrapper.
+    When ``current_sender`` is provided, history is rendered as
+    ``<msg from="...">body</msg>`` tags inside a ``<conversation>`` block and
+    the current prompt receives the same wrapping so the model can attribute
+    every turn — used for Matrix multi-sender threads where unseen messages
+    from other participants may be prepended. Bodies are passed through
+    verbatim; a literal ``</msg>`` is neutralized so it cannot prematurely
+    close the wrapper.
 
-    When ``current_sender`` is provided, the current ``prompt`` is wrapped in
-    the same <msg from="..."> tag so the model can also attribute the latest
-    message — useful in multi-user threads where the sender of the current
-    turn may differ from the senders of prior unseen messages.
+    When ``current_sender`` is ``None`` (e.g., the OpenAI-compatible API),
+    callers have already organized prior turns by role, so we render history
+    as plain ``sender: body`` lines and pass the current prompt through
+    unwrapped.
     """
-    if not thread_history:
-        if current_sender:
-            return f"{prompt_intro}{_wrap_msg_body(current_sender, prompt)}"
-        return prompt
-    messages = thread_history[-max_messages:] if max_messages is not None else thread_history
-    context_lines: list[str] = []
-    for msg in messages:
-        body = msg.body
-        if not body:
-            continue
-        if max_message_length is not None and len(body) >= max_message_length:
-            continue
-        sender = msg.sender
-        if not sender:
-            if missing_sender_label is None:
-                continue
-            sender = missing_sender_label
-        context_lines.append(_wrap_msg_body(sender, body))
-    if not context_lines:
-        if current_sender:
-            return f"{prompt_intro}{_wrap_msg_body(current_sender, prompt)}"
-        return prompt
-    context = "<conversation>\n" + "\n".join(context_lines) + "\n</conversation>"
+    wrap = current_sender is not None
     current_block = _wrap_msg_body(current_sender, prompt) if current_sender else prompt
+    standalone_prompt = f"{prompt_intro}{current_block}" if current_sender else prompt
+    if not thread_history:
+        return standalone_prompt
+    context_lines = _collect_history_lines(
+        thread_history,
+        max_messages=max_messages,
+        max_message_length=max_message_length,
+        missing_sender_label=missing_sender_label,
+        wrap=wrap,
+    )
+    if not context_lines:
+        return standalone_prompt
+    context = _format_history_block(context_lines, wrap=wrap)
     return f"{header}\n{context}\n\n{prompt_intro}{current_block}"
 
 

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -88,30 +88,20 @@ class PreparedExecutionContext:
 
 
 def _wrap_msg_body(sender: str, body: str) -> str:
-    """Render one message as a <msg from="..."> tag with verbatim body."""
-    safe_body = body.replace("</msg>", "<\\/msg>")
-    return f"<msg from={xml_quoteattr(sender)}>{safe_body}</msg>"
+    """Render one Matrix message as a <msg from="..."><![CDATA[...]]></msg> tag."""
+    safe_body = body.replace("]]>", "]]]]><![CDATA[>")
+    return f"<msg from={xml_quoteattr(sender)}><![CDATA[{safe_body}]]></msg>"
 
 
-def _format_history_line(sender: str, body: str, *, wrap: bool) -> str:
-    return _wrap_msg_body(sender, body) if wrap else f"{sender}: {body}"
-
-
-def _format_history_block(context_lines: list[str], *, wrap: bool) -> str:
-    joined = "\n".join(context_lines)
-    return f"<conversation>\n{joined}\n</conversation>" if wrap else joined
-
-
-def _collect_history_lines(
+def _collect_history_messages(
     thread_history: Sequence[ResolvedVisibleMessage],
     *,
     max_messages: int | None,
     max_message_length: int | None,
     missing_sender_label: str | None,
-    wrap: bool,
-) -> list[str]:
+) -> list[tuple[str, str]]:
     messages = thread_history[-max_messages:] if max_messages is not None else thread_history
-    lines: list[str] = []
+    collected: list[tuple[str, str]] = []
     for msg in messages:
         body = msg.body
         if not body:
@@ -123,8 +113,37 @@ def _collect_history_lines(
             if missing_sender_label is None:
                 continue
             sender = missing_sender_label
-        lines.append(_format_history_line(sender, body, wrap=wrap))
-    return lines
+        collected.append((sender, body))
+    return collected
+
+
+def _build_plain_prompt_with_history(
+    prompt: str,
+    history_messages: list[tuple[str, str]],
+    *,
+    header: str,
+    prompt_intro: str,
+) -> str:
+    if not history_messages:
+        return prompt
+    context = "\n".join(f"{sender}: {body}" for sender, body in history_messages)
+    return f"{header}\n{context}\n\n{prompt_intro}{prompt}"
+
+
+def _build_matrix_prompt_with_history(
+    prompt: str,
+    history_messages: list[tuple[str, str]],
+    *,
+    header: str,
+    prompt_intro: str,
+    current_sender: str | None,
+) -> str:
+    current_block = _wrap_msg_body(current_sender, prompt) if current_sender is not None else prompt
+    standalone_prompt = f"{prompt_intro}{current_block}" if current_sender is not None else prompt
+    if not history_messages:
+        return standalone_prompt
+    rendered_history = "\n".join(_wrap_msg_body(sender, body) for sender, body in history_messages)
+    return f"{header}\n<conversation>\n{rendered_history}\n</conversation>\n\n{prompt_intro}{current_block}"
 
 
 def build_prompt_with_thread_history(
@@ -136,39 +155,53 @@ def build_prompt_with_thread_history(
     max_messages: int | None = None,
     max_message_length: int | None = None,
     missing_sender_label: str | None = None,
-    current_sender: str | None = None,
 ) -> str:
-    """Build a prompt with thread history context when available.
-
-    When ``current_sender`` is provided, history is rendered as
-    ``<msg from="...">body</msg>`` tags inside a ``<conversation>`` block and
-    the current prompt receives the same wrapping so the model can attribute
-    every turn — used for Matrix multi-sender threads where unseen messages
-    from other participants may be prepended. Bodies are passed through
-    verbatim; a literal ``</msg>`` is neutralized so it cannot prematurely
-    close the wrapper.
-
-    When ``current_sender`` is ``None`` (e.g., the OpenAI-compatible API),
-    callers have already organized prior turns by role, so we render history
-    as plain ``sender: body`` lines and pass the current prompt through
-    unwrapped.
-    """
-    wrap = current_sender is not None
-    current_block = _wrap_msg_body(current_sender, prompt) if current_sender else prompt
-    standalone_prompt = f"{prompt_intro}{current_block}" if current_sender else prompt
+    """Build a plain-text prompt with ``sender: body`` history lines."""
     if not thread_history:
-        return standalone_prompt
-    context_lines = _collect_history_lines(
+        return prompt
+    history_messages = _collect_history_messages(
         thread_history,
         max_messages=max_messages,
         max_message_length=max_message_length,
         missing_sender_label=missing_sender_label,
-        wrap=wrap,
     )
-    if not context_lines:
-        return standalone_prompt
-    context = _format_history_block(context_lines, wrap=wrap)
-    return f"{header}\n{context}\n\n{prompt_intro}{current_block}"
+    return _build_plain_prompt_with_history(
+        prompt,
+        history_messages,
+        header=header,
+        prompt_intro=prompt_intro,
+    )
+
+
+def build_matrix_prompt_with_thread_history(
+    prompt: str,
+    thread_history: Sequence[ResolvedVisibleMessage] | None = None,
+    *,
+    header: str = "Previous conversation in this thread:",
+    prompt_intro: str = "Current message:\n",
+    max_messages: int | None = None,
+    max_message_length: int | None = None,
+    missing_sender_label: str | None = None,
+    current_sender: str | None = None,
+) -> str:
+    """Build a Matrix prompt with structured XML-like message wrappers."""
+    history_messages = (
+        _collect_history_messages(
+            thread_history,
+            max_messages=max_messages,
+            max_message_length=max_message_length,
+            missing_sender_label=missing_sender_label,
+        )
+        if thread_history
+        else []
+    )
+    return _build_matrix_prompt_with_history(
+        prompt,
+        history_messages,
+        header=header,
+        prompt_intro=prompt_intro,
+        current_sender=current_sender,
+    )
 
 
 def _classify_partial_reply(
@@ -318,17 +351,23 @@ def _build_prompt_with_unseen(
     """Prepend unseen messages from other participants to the prompt."""
     if not unseen_messages:
         if current_sender_id:
-            return build_prompt_with_thread_history(
+            return build_matrix_prompt_with_thread_history(
                 prompt,
                 None,
                 current_sender=current_sender_id,
             )
         return prompt
+    if current_sender_id:
+        return build_matrix_prompt_with_thread_history(
+            prompt,
+            unseen_messages,
+            header=_build_unseen_messages_header(partial_reply_kinds or set()),
+            current_sender=current_sender_id,
+        )
     return build_prompt_with_thread_history(
         prompt,
         unseen_messages,
         header=_build_unseen_messages_header(partial_reply_kinds or set()),
-        current_sender=current_sender_id,
     )
 
 
@@ -401,6 +440,7 @@ async def _prepare_execution_context_common(
     *,
     scope_context: ScopeSessionContext | None,
     prompt: str,
+    standalone_prompt: str,
     fallback_prompt: str | None,
     thread_history: Sequence[ResolvedVisibleMessage] | None,
     reply_to_event_id: str | None,
@@ -445,7 +485,7 @@ async def _prepare_execution_context_common(
             current_sender_id=current_sender_id,
         )
     else:
-        final_prompt = prompt
+        final_prompt = standalone_prompt
         unseen_event_ids = []
 
     prepared_history = _finalize_prepared_history(
@@ -457,7 +497,7 @@ async def _prepare_execution_context_common(
         ),
     )
     if replay_fallback_prompt is not None:
-        final_prompt = prompt if prepared_history.replays_persisted_history else replay_fallback_prompt
+        final_prompt = standalone_prompt if prepared_history.replays_persisted_history else replay_fallback_prompt
 
     return PreparedExecutionContext(
         final_prompt=final_prompt,
@@ -488,13 +528,29 @@ async def prepare_agent_execution_context(
     """Prepare one agent's final prompt and replay plan for the current call."""
     response_sender_id = config.get_ids(runtime_paths).get(agent_name)
     response_sender = response_sender_id.full_id if response_sender_id is not None else None
+    standalone_prompt = (
+        build_matrix_prompt_with_thread_history(
+            prompt,
+            None,
+            current_sender=current_sender_id,
+        )
+        if current_sender_id is not None
+        else prompt
+    )
     fallback_prompt = (
         None
         if reply_to_event_id and thread_history
-        else build_prompt_with_thread_history(
-            prompt,
-            thread_history,
-            current_sender=current_sender_id,
+        else (
+            build_matrix_prompt_with_thread_history(
+                prompt,
+                thread_history,
+                current_sender=current_sender_id,
+            )
+            if current_sender_id is not None
+            else build_prompt_with_thread_history(
+                prompt,
+                thread_history,
+            )
         )
     )
     runtime_model = config.resolve_runtime_model(
@@ -528,6 +584,7 @@ async def prepare_agent_execution_context(
     return await _prepare_execution_context_common(
         scope_context=scope_context,
         prompt=prompt,
+        standalone_prompt=standalone_prompt,
         fallback_prompt=fallback_prompt,
         thread_history=thread_history,
         reply_to_event_id=reply_to_event_id,
@@ -565,6 +622,15 @@ async def prepare_bound_team_execution_context(
     compaction_outcomes_collector: list[CompactionOutcome] | None = None,
 ) -> PreparedExecutionContext:
     """Prepare one bound team scope for the current call."""
+    standalone_prompt = (
+        build_matrix_prompt_with_thread_history(
+            prompt,
+            None,
+            current_sender=current_sender_id,
+        )
+        if current_sender_id is not None
+        else prompt
+    )
 
     async def _prepare_team_scope_history(
         prepared_prompt: str,
@@ -587,6 +653,7 @@ async def prepare_bound_team_execution_context(
     return await _prepare_execution_context_common(
         scope_context=scope_context,
         prompt=prompt,
+        standalone_prompt=standalone_prompt,
         fallback_prompt=fallback_prompt,
         thread_history=thread_history,
         reply_to_event_id=reply_to_event_id,

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -87,6 +87,12 @@ class PreparedExecutionContext:
     compaction_outcomes: list[CompactionOutcome]
 
 
+def _wrap_msg_body(sender: str, body: str) -> str:
+    """Render one message as a <msg from="..."> tag with verbatim body."""
+    safe_body = body.replace("</msg>", "<\\/msg>")
+    return f"<msg from={xml_quoteattr(sender)}>{safe_body}</msg>"
+
+
 def build_prompt_with_thread_history(
     prompt: str,
     thread_history: Sequence[ResolvedVisibleMessage] | None = None,
@@ -96,6 +102,7 @@ def build_prompt_with_thread_history(
     max_messages: int | None = None,
     max_message_length: int | None = None,
     missing_sender_label: str | None = None,
+    current_sender: str | None = None,
 ) -> str:
     """Build a prompt with thread history context when available.
 
@@ -105,8 +112,15 @@ def build_prompt_with_thread_history(
     verbatim (preserving code, markdown, and special characters); the only
     transformation is neutralizing a literal "</msg>" sequence so it cannot
     prematurely close the wrapper.
+
+    When ``current_sender`` is provided, the current ``prompt`` is wrapped in
+    the same <msg from="..."> tag so the model can also attribute the latest
+    message — useful in multi-user threads where the sender of the current
+    turn may differ from the senders of prior unseen messages.
     """
     if not thread_history:
+        if current_sender:
+            return f"{prompt_intro}{_wrap_msg_body(current_sender, prompt)}"
         return prompt
     messages = thread_history[-max_messages:] if max_messages is not None else thread_history
     context_lines: list[str] = []
@@ -121,12 +135,14 @@ def build_prompt_with_thread_history(
             if missing_sender_label is None:
                 continue
             sender = missing_sender_label
-        safe_body = body.replace("</msg>", "<\\/msg>")
-        context_lines.append(f"<msg from={xml_quoteattr(sender)}>{safe_body}</msg>")
+        context_lines.append(_wrap_msg_body(sender, body))
     if not context_lines:
+        if current_sender:
+            return f"{prompt_intro}{_wrap_msg_body(current_sender, prompt)}"
         return prompt
     context = "<conversation>\n" + "\n".join(context_lines) + "\n</conversation>"
-    return f"{header}\n{context}\n\n{prompt_intro}{prompt}"
+    current_block = _wrap_msg_body(current_sender, prompt) if current_sender else prompt
+    return f"{header}\n{context}\n\n{prompt_intro}{current_block}"
 
 
 def _classify_partial_reply(
@@ -241,6 +257,7 @@ def build_prompt_with_unseen_thread_context(
     current_event_id: str | None,
     active_event_ids: Collection[str],
     response_sender_id: str | None,
+    current_sender_id: str | None = None,
 ) -> tuple[str, list[str]]:
     """Prepend unseen thread messages and return their persisted event ids."""
     if not current_event_id or not thread_history:
@@ -257,6 +274,7 @@ def build_prompt_with_unseen_thread_context(
         prompt,
         unseen_messages,
         partial_reply_kinds=partial_reply_kinds,
+        current_sender_id=current_sender_id,
     )
     return prompt_with_unseen, _get_unseen_event_ids_for_metadata(
         unseen_messages,
@@ -269,14 +287,22 @@ def _build_prompt_with_unseen(
     unseen_messages: list[ResolvedVisibleMessage],
     *,
     partial_reply_kinds: set[_PartialReplyKind] | None,
+    current_sender_id: str | None = None,
 ) -> str:
     """Prepend unseen messages from other participants to the prompt."""
     if not unseen_messages:
+        if current_sender_id:
+            return build_prompt_with_thread_history(
+                prompt,
+                None,
+                current_sender=current_sender_id,
+            )
         return prompt
     return build_prompt_with_thread_history(
         prompt,
         unseen_messages,
         header=_build_unseen_messages_header(partial_reply_kinds or set()),
+        current_sender=current_sender_id,
     )
 
 
@@ -296,6 +322,7 @@ def _build_initial_unseen_context(
     current_event_id: str,
     active_event_ids: Collection[str],
     response_sender_id: str | None,
+    current_sender_id: str | None,
 ) -> tuple[str, list[str]]:
     return build_prompt_with_unseen_thread_context(
         prompt,
@@ -304,6 +331,7 @@ def _build_initial_unseen_context(
         current_event_id=current_event_id,
         active_event_ids=active_event_ids,
         response_sender_id=response_sender_id,
+        current_sender_id=current_sender_id,
     )
 
 
@@ -316,6 +344,7 @@ def _build_final_unseen_context(
     current_event_id: str,
     active_event_ids: Collection[str],
     response_sender_id: str | None,
+    current_sender_id: str | None,
 ) -> tuple[str, list[str]]:
     return build_prompt_with_unseen_thread_context(
         prompt,
@@ -324,6 +353,7 @@ def _build_final_unseen_context(
         current_event_id=current_event_id,
         active_event_ids=active_event_ids,
         response_sender_id=response_sender_id,
+        current_sender_id=current_sender_id,
     )
 
 
@@ -350,6 +380,7 @@ async def _prepare_execution_context_common(
     reply_to_event_id: str | None,
     active_event_ids: Collection[str],
     response_sender_id: str | None,
+    current_sender_id: str | None,
     config: Config,
     prepare_scope_history_fn: Callable[[str, str | None], Awaitable[PreparedScopeHistory]],
     estimate_static_tokens_fn: Callable[[str, str | None], int],
@@ -369,6 +400,7 @@ async def _prepare_execution_context_common(
             current_event_id=reply_to_event_id,
             active_event_ids=active_event_ids,
             response_sender_id=response_sender_id,
+            current_sender_id=current_sender_id,
         )
 
     prepared_scope_history = await prepare_scope_history_fn(
@@ -384,6 +416,7 @@ async def _prepare_execution_context_common(
             current_event_id=reply_to_event_id,
             active_event_ids=active_event_ids,
             response_sender_id=response_sender_id,
+            current_sender_id=current_sender_id,
         )
     else:
         final_prompt = prompt
@@ -423,6 +456,7 @@ async def prepare_agent_execution_context(
     reply_to_event_id: str | None,
     active_event_ids: Collection[str],
     compaction_outcomes_collector: list[CompactionOutcome] | None,
+    current_sender_id: str | None = None,
     timing_scope: str | None = None,
 ) -> PreparedExecutionContext:
     """Prepare one agent's final prompt and replay plan for the current call."""
@@ -434,6 +468,7 @@ async def prepare_agent_execution_context(
         else build_prompt_with_thread_history(
             prompt,
             thread_history,
+            current_sender=current_sender_id,
         )
     )
     runtime_model = config.resolve_runtime_model(
@@ -472,6 +507,7 @@ async def prepare_agent_execution_context(
         reply_to_event_id=reply_to_event_id,
         active_event_ids=active_event_ids,
         response_sender_id=response_sender,
+        current_sender_id=current_sender_id,
         config=config,
         prepare_scope_history_fn=_prepare_agent_scope_history,
         estimate_static_tokens_fn=lambda prepared_prompt, replay_fallback_prompt: estimate_preparation_static_tokens(
@@ -499,6 +535,7 @@ async def prepare_bound_team_execution_context(
     reply_to_event_id: str | None = None,
     active_event_ids: Collection[str] = frozenset(),
     response_sender_id: str | None = None,
+    current_sender_id: str | None = None,
     compaction_outcomes_collector: list[CompactionOutcome] | None = None,
 ) -> PreparedExecutionContext:
     """Prepare one bound team scope for the current call."""
@@ -529,6 +566,7 @@ async def prepare_bound_team_execution_context(
         reply_to_event_id=reply_to_event_id,
         active_event_ids=active_event_ids,
         response_sender_id=response_sender_id,
+        current_sender_id=current_sender_id,
         config=config,
         prepare_scope_history_fn=_prepare_team_scope_history,
         estimate_static_tokens_fn=lambda prepared_prompt,

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
-from xml.sax.saxutils import escape as xml_escape
 from xml.sax.saxutils import quoteattr as xml_quoteattr
 
 from mindroom.constants import (
@@ -100,9 +99,12 @@ def build_prompt_with_thread_history(
 ) -> str:
     """Build a prompt with thread history context when available.
 
-    History is rendered as XML so the model can unambiguously attribute each
-    message to its sender even when bodies contain colons, newlines, or
-    quoted log lines that would otherwise look like a new sender prefix.
+    History is rendered inside a <conversation> block as <msg from="..."> tags
+    so the model can unambiguously attribute each message even when bodies
+    contain colons, newlines, or quoted log lines. Bodies are passed through
+    verbatim (preserving code, markdown, and special characters); the only
+    transformation is neutralizing a literal "</msg>" sequence so it cannot
+    prematurely close the wrapper.
     """
     if not thread_history:
         return prompt
@@ -119,7 +121,8 @@ def build_prompt_with_thread_history(
             if missing_sender_label is None:
                 continue
             sender = missing_sender_label
-        context_lines.append(f"<msg from={xml_quoteattr(sender)}>{xml_escape(body)}</msg>")
+        safe_body = body.replace("</msg>", "<\\/msg>")
+        context_lines.append(f"<msg from={xml_quoteattr(sender)}>{safe_body}</msg>")
     if not context_lines:
         return prompt
     context = "<conversation>\n" + "\n".join(context_lines) + "\n</conversation>"

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1999,6 +1999,7 @@ class ResponseRunner:
                     thread_history=thread_history,
                     room_id=room_id,
                     knowledge=knowledge,
+                    user_id=user_id,
                     reply_to_event_id=reply_to_event_id,
                     active_event_ids=active_event_ids,
                     show_tool_calls=show_tool_calls,

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -39,7 +39,7 @@ from mindroom.authorization import get_available_agents_in_room
 from mindroom.constants import MATRIX_SEEN_EVENT_IDS_METADATA_KEY, ROUTER_AGENT_NAME
 from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.execution_preparation import (
-    build_prompt_with_thread_history,
+    build_matrix_prompt_with_thread_history,
     prepare_bound_team_execution_context,
 )
 from mindroom.history.runtime import (
@@ -1400,7 +1400,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                 scope_context=scope_context,
                 entity_name=configured_team_name or team_name,
             )
-            fallback_prompt = build_prompt_with_thread_history(
+            fallback_prompt = build_matrix_prompt_with_thread_history(
                 message,
                 thread_history,
                 header="Thread Context:",
@@ -1701,7 +1701,7 @@ async def team_response_stream(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 scope_context=scope_context,
                 entity_name=configured_team_name or team_label,
             )
-            fallback_prompt = build_prompt_with_thread_history(
+            fallback_prompt = build_matrix_prompt_with_thread_history(
                 message,
                 thread_history,
                 header="Thread Context:",

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1023,6 +1023,7 @@ def materialize_exact_team_members(
     runtime_paths: RuntimePaths,
     execution_identity: ToolExecutionIdentity | None,
     session_id: str | None = None,
+    include_openai_compat_guidance: bool = False,
     materializable_agent_names: set[str] | None = None,
     request_knowledge_managers: Mapping[str, KnowledgeManager] | None = None,
     shared_manager_lookup: Callable[[str], KnowledgeManager | None] | None = None,
@@ -1060,6 +1061,7 @@ def materialize_exact_team_members(
             else None,
             knowledge=knowledge,
             include_interactive_questions=False,
+            include_openai_compat_guidance=include_openai_compat_guidance,
         )
 
     team_members = materialize_exact_requested_team_members(

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1292,6 +1292,7 @@ async def prepare_materialized_team_execution(
     configured_team_name: str | None,
     matrix_run_metadata: dict[str, Any] | None = None,
     system_enrichment_items: Sequence[EnrichmentItem] = (),
+    current_sender_id: str | None = None,
 ) -> _PreparedMaterializedTeamExecution:
     """Prepare one materialized team for execution."""
     if system_enrichment_items:
@@ -1317,6 +1318,7 @@ async def prepare_materialized_team_execution(
         reply_to_event_id=reply_to_event_id,
         active_event_ids=active_event_ids,
         response_sender_id=response_sender_id,
+        current_sender_id=current_sender_id,
         compaction_outcomes_collector=compaction_outcomes_collector,
     )
     if prepared_execution.replay_plan is not None:
@@ -1406,6 +1408,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                 max_messages=30,
                 max_message_length=_MAX_CONTEXT_MESSAGE_LENGTH,
                 missing_sender_label="Unknown",
+                current_sender=user_id,
             )
             team = build_materialized_team_instance(
                 requested_agent_names=team_members.requested_agent_names,
@@ -1434,6 +1437,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                 configured_team_name=configured_team_name,
                 matrix_run_metadata=matrix_run_metadata,
                 system_enrichment_items=system_enrichment_items,
+                current_sender_id=user_id,
             )
             prompt = prepared_execution.prepared_prompt
             run_metadata = prepared_execution.run_metadata
@@ -1705,6 +1709,7 @@ async def team_response_stream(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 max_messages=30,
                 max_message_length=_MAX_CONTEXT_MESSAGE_LENGTH,
                 missing_sender_label="Unknown",
+                current_sender=user_id,
             )
             team = build_materialized_team_instance(
                 requested_agent_names=team_members.requested_agent_names,
@@ -1733,6 +1738,7 @@ async def team_response_stream(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 configured_team_name=configured_team_name,
                 matrix_run_metadata=matrix_run_metadata,
                 system_enrichment_items=system_enrichment_items,
+                current_sender_id=user_id,
             )
             prepared_prompt = prepared_execution.prepared_prompt
             unseen_event_ids = prepared_execution.unseen_event_ids

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -135,6 +135,21 @@ def _create_agent_for_test(agent_name: str, config: Config, **kwargs: object) ->
     )
 
 
+def test_create_agent_includes_openai_compat_guidance_only_when_requested() -> None:
+    """OpenAI-compatible prompt guidance should be opt-in at agent construction time."""
+    config = _test_config()
+
+    matrix_agent = _create_agent_for_test("general", config)
+    openai_compat_agent = _create_agent_for_test(
+        "general",
+        config,
+        include_openai_compat_guidance=True,
+    )
+
+    assert agent_prompts.OPENAI_COMPAT_HISTORY_GUIDANCE not in matrix_agent.role
+    assert agent_prompts.OPENAI_COMPAT_HISTORY_GUIDANCE in openai_compat_agent.role
+
+
 def test_config_round_trips_structured_agent_tool_entries() -> None:
     """Structured tool entries should stay authored while runtime access stays name-based."""
     runtime_paths = _runtime_paths(Path(tempfile.mkdtemp()))

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -29,6 +29,7 @@ from agno.team import Team
 from agno.team._tools import _determine_tools_for_model as determine_team_tools_for_model
 from agno.tools import Toolkit
 from agno.tools.function import Function
+from defusedxml.ElementTree import fromstring
 
 from mindroom.agents import create_agent, create_session_storage, get_agent_session
 from mindroom.ai import _prepare_agent_and_prompt, build_prompt_with_thread_history
@@ -37,7 +38,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import CompactionConfig, CompactionOverrideConfig, DefaultsConfig, ModelConfig
 from mindroom.config.plugin import PluginEntryConfig
 from mindroom.constants import MINDROOM_COMPACTION_METADATA_KEY, RuntimePaths, resolve_runtime_paths
-from mindroom.execution_preparation import PreparedExecutionContext
+from mindroom.execution_preparation import PreparedExecutionContext, build_matrix_prompt_with_thread_history
 from mindroom.history import PreparedHistoryState, prepare_history_for_run
 from mindroom.history.compaction import (
     _build_summary_input,
@@ -2830,6 +2831,32 @@ def test_plan_replay_that_fits_reduces_replay_for_non_authored_scope(tmp_path: P
     assert replay_plan.history_limit == 1
 
 
+def test_build_matrix_prompt_with_thread_history_preserves_verbatim_bodies_in_cdata() -> None:
+    thread_history = [
+        make_visible_message(
+            sender="@alice:localhost",
+            body='Try <msg from="@mallory:localhost">code</msg > and <button>Click & go</button>',
+        ),
+    ]
+
+    prompt = build_matrix_prompt_with_thread_history(
+        "Follow-up",
+        thread_history,
+        current_sender="@bob:localhost",
+    )
+
+    conversation_xml = prompt.split("Previous conversation in this thread:\n", 1)[1].split("\n\nCurrent message:\n", 1)[
+        0
+    ]
+    conversation = fromstring(conversation_xml)
+    message = conversation.find("msg")
+
+    assert conversation.tag == "conversation"
+    assert message is not None
+    assert message.attrib["from"] == "@alice:localhost"
+    assert message.text == thread_history[0].body
+
+
 @pytest.mark.asyncio
 async def test_prepare_agent_and_prompt_budgets_against_thread_history_fallback(tmp_path: Path) -> None:
     config, runtime_paths = _make_config(tmp_path)
@@ -2949,6 +2976,38 @@ async def test_prepare_agent_and_prompt_uses_thread_history_when_persisted_repla
     assert prepared_agent is live_agent
     assert prepared.replays_persisted_history is False
     assert full_prompt == build_prompt_with_thread_history("Current prompt", thread_history)
+
+
+@pytest.mark.asyncio
+async def test_prepare_agent_and_prompt_keeps_matrix_current_sender_when_persisted_replay_is_enabled(
+    tmp_path: Path,
+) -> None:
+    config, runtime_paths = _make_config(tmp_path)
+    live_agent = _agent()
+
+    with (
+        patch("mindroom.ai.create_agent", return_value=live_agent),
+        patch("mindroom.ai.build_memory_enhanced_prompt", new=AsyncMock(return_value="Current prompt")),
+        patch(
+            "mindroom.execution_preparation.prepare_scope_history",
+            new=AsyncMock(return_value=MagicMock()),
+        ),
+        patch(
+            "mindroom.execution_preparation.finalize_history_preparation",
+            return_value=PreparedHistoryState(replays_persisted_history=True),
+        ),
+    ):
+        prepared_agent, full_prompt, _unseen_event_ids, prepared = await _prepare_agent_and_prompt(
+            "test_agent",
+            "Current prompt",
+            runtime_paths,
+            config,
+            current_sender_id="@alice:localhost",
+        )
+
+    assert prepared_agent is live_agent
+    assert prepared.replays_persisted_history is True
+    assert full_prompt == 'Current message:\n<msg from="@alice:localhost"><![CDATA[Current prompt]]></msg>'
 
 
 def _make_test_compaction_outcome() -> CompactionOutcome:

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -2147,9 +2147,11 @@ class TestUserIdPassthrough:
                 session_id="session1",
                 runtime_paths=_runtime_paths(tmp_path, config_path=config_path),
                 config=_config(),
+                include_openai_compat_guidance=True,
             )
 
         assert mock_prepare.call_args.args[2].config_path == config_path
+        assert mock_prepare.await_args.kwargs["include_openai_compat_guidance"] is True
 
     @pytest.mark.asyncio
     async def test_stream_agent_response_passes_config_path_to_prepare_agent(self, tmp_path: Path) -> None:
@@ -2176,10 +2178,12 @@ class TestUserIdPassthrough:
                     session_id="session1",
                     runtime_paths=_runtime_paths(tmp_path, config_path=config_path),
                     config=_config(),
+                    include_openai_compat_guidance=True,
                 )
             ]
 
         assert mock_prepare.call_args.args[2].config_path == config_path
+        assert mock_prepare.await_args.kwargs["include_openai_compat_guidance"] is True
 
     @pytest.mark.asyncio
     async def test_stream_agent_response_passes_user_id_to_agent_arun(self, tmp_path: Path) -> None:

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -799,6 +799,43 @@ async def test_send_skill_command_response_returns_event_id_after_post_effect_fa
 
 
 @pytest.mark.asyncio
+async def test_send_skill_command_response_passes_user_id_to_ai_response(tmp_path: Path) -> None:
+    """Skill-command replies should preserve the Matrix sender on the ai_response path."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = bind_runtime_paths(_config(), runtime_paths)
+    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
+
+    with (
+        patch("mindroom.response_runner.ai_response", new=AsyncMock(return_value="Skill response")) as mock_ai,
+        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock()),
+    ):
+        coordinator = _build_response_runner(
+            bot,
+            config=config,
+            runtime_paths=runtime_paths,
+            storage_path=tmp_path,
+            requester_id="@alice:localhost",
+            hook_registry=HookRegistry.empty(),
+            message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
+        )
+        coordinator.deps.delivery_gateway.send_text = AsyncMock(return_value="$skill-reply")
+
+        event_id = await coordinator.send_skill_command_response(
+            room_id="!test:localhost",
+            reply_to_event_id="$user_msg",
+            thread_id="$thread-root",
+            thread_history=(),
+            prompt="Use demo skill",
+            agent_name="general",
+            user_id="@alice:localhost",
+        )
+
+    assert event_id == "$skill-reply"
+    assert mock_ai.await_args is not None
+    assert mock_ai.await_args.kwargs["user_id"] == "@alice:localhost"
+
+
+@pytest.mark.asyncio
 async def test_should_watch_session_started_returns_false_when_storage_probe_fails(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -1046,6 +1046,7 @@ def test_team_builder_passes_team_session_id_to_create_agent(tmp_path: Path) -> 
 
     assert result is mock_create_agent.return_value
     assert mock_create_agent.call_args.kwargs["session_id"] == "team-session"
+    assert mock_create_agent.call_args.kwargs["include_openai_compat_guidance"] is False
 
 
 def test_openai_team_builder_passes_session_id_to_member_agents(tmp_path: Path) -> None:
@@ -1090,6 +1091,7 @@ def test_openai_team_builder_passes_session_id_to_member_agents(tmp_path: Path) 
         )
 
     assert mock_create.call_args.kwargs["session_id"] == "openai-team-session"
+    assert mock_create.call_args.kwargs["include_openai_compat_guidance"] is True
 
 
 def test_openai_derived_stable_session_id_preserves_dynamic_toolkit_state(tmp_path: Path) -> None:

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -711,6 +711,7 @@ class TestChatCompletions:
 
             assert "include_default_tools" not in mock_ai.call_args.kwargs
             assert mock_ai.call_args.kwargs["include_interactive_questions"] is False
+            assert mock_ai.call_args.kwargs["include_openai_compat_guidance"] is True
             assert mock_ai.call_args.kwargs["active_event_ids"] == set()
 
     def test_passes_knowledge_none(self, app_client: TestClient) -> None:
@@ -1213,6 +1214,7 @@ class TestStreamingCompletion:
         assert response.status_code == 200
         assert "include_default_tools" not in mock_stream_fn.call_args.kwargs
         assert mock_stream_fn.call_args.kwargs["include_interactive_questions"] is False
+        assert mock_stream_fn.call_args.kwargs["include_openai_compat_guidance"] is True
         assert mock_stream_fn.call_args.kwargs["active_event_ids"] == set()
 
     def test_streaming_consistent_id(self, app_client: TestClient) -> None:

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -3034,8 +3034,9 @@ class TestTeamCompletion:
         assert response.status_code == 200
         prompt = mock_team.arun.call_args.args[0]
         assert "Previous conversation in this thread:" in prompt
-        assert '<msg from="user">Start</msg>' in prompt
-        assert '<msg from="assistant">Ack</msg>' in prompt
+        assert "user: Start" in prompt
+        assert "assistant: Ack" in prompt
+        assert "<msg from=" not in prompt
         assert "Current message:\nFollow-up" in prompt
 
     def test_team_non_streaming_prefers_persisted_history_over_thread_history(
@@ -3094,8 +3095,8 @@ class TestTeamCompletion:
         prompt = mock_team.arun.call_args.args[0]
         assert prompt == "Follow-up"
         assert "Previous conversation in this thread:" not in prompt
-        assert '<msg from="user">Start</msg>' not in prompt
-        assert '<msg from="assistant">Ack</msg>' not in prompt
+        assert "user: Start" not in prompt
+        assert "assistant: Ack" not in prompt
 
     def test_team_streaming_prefers_persisted_history_over_thread_history(self, team_app_client: TestClient) -> None:
         """Persisted team history should suppress request-history stuffing in the streaming path too."""

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -3034,8 +3034,8 @@ class TestTeamCompletion:
         assert response.status_code == 200
         prompt = mock_team.arun.call_args.args[0]
         assert "Previous conversation in this thread:" in prompt
-        assert "user: Start" in prompt
-        assert "assistant: Ack" in prompt
+        assert '<msg from="user">Start</msg>' in prompt
+        assert '<msg from="assistant">Ack</msg>' in prompt
         assert "Current message:\nFollow-up" in prompt
 
     def test_team_non_streaming_prefers_persisted_history_over_thread_history(
@@ -3094,8 +3094,8 @@ class TestTeamCompletion:
         prompt = mock_team.arun.call_args.args[0]
         assert prompt == "Follow-up"
         assert "Previous conversation in this thread:" not in prompt
-        assert "user: Start" not in prompt
-        assert "assistant: Ack" not in prompt
+        assert '<msg from="user">Start</msg>' not in prompt
+        assert '<msg from="assistant">Ack</msg>' not in prompt
 
     def test_team_streaming_prefers_persisted_history_over_thread_history(self, team_app_client: TestClient) -> None:
         """Persisted team history should suppress request-history stuffing in the streaming path too."""


### PR DESCRIPTION
## Summary
Follow-up to #644.
Matrix thread prompts now use a structured `<conversation><msg from=...><![CDATA[...]]></msg></conversation>` format so prior turns and the current turn keep exact sender attribution without mangling code snippets, markdown, or multiline bodies.

The OpenAI-compatible `/v1` path stays on plain `role: body` history.
That split is now explicit:
- Matrix paths render structured `<msg from="...">` history and current-message wrappers when the sender is known.
- OpenAI-compatible paths keep the existing plain-text history shape.
- Agent prompt guidance is composed per path, so Matrix agents are not told about `/v1`-only `role: body` lines.

This moves the behavior to the correct boundary.
History selection and replay stay shared, but prompt serialization is chosen by the caller.
That fixes the earlier correctness/caching issue where prompt shape changed inside mixed replay/fallback logic.

Example Matrix prompt shape:

```
Previous conversation in this thread:
<conversation>
<msg from="@alice:example.org"><![CDATA[Hello there]]></msg>
<msg from="@bob:example.org"><![CDATA[Try <button onClick={fn}>Click & go</button>
Multi-line works too]]></msg>
</conversation>

Current message:
<msg from="@bob:example.org"><![CDATA[What is next?]]></msg>
```

Bodies are preserved verbatim inside CDATA.
If a body contains `]]>`, it is split safely across CDATA boundaries so the wrapper remains valid without XML-escaping the content.

## Changes
- `execution_preparation.py`
  - Add Matrix-specific prompt rendering via `build_matrix_prompt_with_thread_history(...)`.
  - Render Matrix history/current turns as `<msg from="..."><![CDATA[...]]></msg>`.
  - Keep the plain `build_prompt_with_thread_history(...)` renderer for OpenAI-compatible `role: body` prompts.
  - Preserve current-sender attribution even when persisted history replay is active.
- `ai.py`
  - Thread `current_sender_id=user_id` through agent execution prep for Matrix paths.
  - Add explicit `include_openai_compat_guidance` plumbing so only `/v1` requests opt into the extra prompt guidance.
- `teams.py`
  - Use the Matrix renderer for Matrix team fallback prompts.
  - Thread `current_sender_id=user_id` through both team execution paths.
  - Let OpenAI-compatible team member materialization opt into `/v1` guidance explicitly.
- `response_runner.py`
  - Pass `user_id` through the remaining Matrix skill-command `ai_response(...)` path.
- `agent_prompts.py` / `agents.py`
  - Split the shared identity prompt from the OpenAI-compatible guidance line.
  - Build the final identity context explicitly instead of using one global mixed-format prompt block.
- `api/openai_compat.py`
  - Keep `/v1` history rendering unchanged.
  - Explicitly opt agent and team requests into the OpenAI-compatible identity guidance so the prompt contract matches what those callers actually send.
- Tests
  - Cover Matrix current-sender attribution with persisted replay.
  - Cover explicit `/v1` guidance opt-in and default Matrix opt-out.
  - Cover the remaining Matrix skill-command path and OpenAI-compatible team member construction.

## Scope
- This PR does not attempt display-name resolution.
  That still requires async room-state lookups and should stay in a separate follow-up if we want it.

## Test plan
- [x] `uv run pytest tests/test_openai_compat.py tests/test_agno_history.py tests/test_ai_user_id.py tests/test_system_enrich.py tests/test_agents.py tests/test_dynamic_toolkits.py -x -n 0 --no-cov -q`
  - `468 passed`
- [x] `uv run pre-commit run --files src/mindroom/agent_prompts.py src/mindroom/agents.py src/mindroom/ai.py src/mindroom/teams.py src/mindroom/api/openai_compat.py tests/test_agents.py tests/test_ai_user_id.py tests/test_dynamic_toolkits.py tests/test_openai_compat.py`
  - all hooks passed
- [ ] Live Matrix/Matty smoke test in a multi-person room to confirm sender attribution end-to-end.
