### PR TITLE
fix: preserve LaTeX escapes in Matrix formatted_body

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "markdown-it-py>=4",
   "matrix-nio>=0.25",
   "mcp[cli]>=1.12.4",
+  "mdit-py-plugins>=0.5",
   "mem0ai>=0.1.115",
   "openai",
   "pydantic>=2",

--- a/src/mindroom/matrix/message_builder.py
+++ b/src/mindroom/matrix/message_builder.py
@@ -8,6 +8,8 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from markdown_it import MarkdownIt
+from markdown_it.token import Token
+from mdit_py_plugins.dollarmath import dollarmath_plugin
 from pygments import highlight as _pygments_highlight
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexers import get_lexer_by_name
@@ -131,7 +133,6 @@ _SUPPORTED_BLOCK_END_TAG_PATTERN = re.compile(
 )
 _HR_BLOCK_TAG_PATTERN = re.compile(r"^[ ]{0,3}<hr\b[^<>]*/?>\s*$", re.IGNORECASE)
 _FENCE_OPEN_PATTERN = re.compile(r"^[ ]{0,3}(`{3,}|~{3,})")
-_MATH_PLACEHOLDER_TEMPLATE = "MINDROOMMATHPLACEHOLDER{index}TOKEN"
 
 
 def _count_repeated_characters(text: str, start_index: int, character: str) -> int:
@@ -139,15 +140,6 @@ def _count_repeated_characters(text: str, start_index: int, character: str) -> i
     while end_index < len(text) and text[end_index] == character:
         end_index += 1
     return end_index - start_index
-
-
-def _is_escaped_character(text: str, index: int) -> bool:
-    backslash_count = 0
-    cursor = index - 1
-    while cursor >= 0 and text[cursor] == "\\":
-        backslash_count += 1
-        cursor -= 1
-    return backslash_count % 2 == 1
 
 
 def _is_fence_closing_line(line: str, fence_character: str, opening_length: int) -> bool:
@@ -305,121 +297,6 @@ def _escape_unterminated_html_fragments(html_text: str) -> str:
     return _UNTERMINATED_HTML_FRAGMENT_PATTERN.sub(lambda match: escape(match.group(0)), html_text)
 
 
-def _find_inline_code_span_end(text: str, search_start: int, delimiter_length: int) -> int | None:
-    index = search_start
-    while index < len(text):
-        if text[index] != "`":
-            index += 1
-            continue
-        run_length = _count_repeated_characters(text, index, "`")
-        if run_length == delimiter_length:
-            return index
-        index += run_length
-    return None
-
-
-def _can_open_inline_math(text: str, index: int) -> bool:
-    if index > 0 and text[index - 1].isdigit():
-        return False
-    next_index = index + 1
-    return next_index < len(text) and not text[next_index].isspace() and text[next_index] != "$"
-
-
-def _find_display_math_end(text: str, start_index: int) -> int | None:
-    index = start_index + 2
-    while index < len(text):
-        match_index = text.find("$$", index)
-        if match_index == -1:
-            return None
-        if not _is_escaped_character(text, match_index):
-            return match_index + 2
-        index = match_index + 2
-    return None
-
-
-def _find_inline_math_end(text: str, start_index: int) -> int | None:
-    index = start_index + 1
-    while index < len(text):
-        current_character = text[index]
-        if current_character == "\n":
-            return None
-        if current_character != "$":
-            index += 1
-            continue
-        if text.startswith("$$", index):
-            index += 2
-            continue
-        if _is_escaped_character(text, index):
-            index += 1
-            continue
-        if text[index - 1].isspace():
-            index += 1
-            continue
-        if index + 1 < len(text) and text[index + 1].isdigit():
-            index += 1
-            continue
-        return index + 1
-    return None
-
-
-def _find_math_span_end(text: str, start_index: int) -> int | None:
-    if text[start_index] != "$" or _is_escaped_character(text, start_index):
-        return None
-    if text.startswith("$$", start_index):
-        return _find_display_math_end(text, start_index)
-    if not _can_open_inline_math(text, start_index):
-        return None
-    return _find_inline_math_end(text, start_index)
-
-
-def _protect_math_spans_in_text(
-    text: str,
-    protected_spans: list[tuple[str, str]],
-) -> str:
-    protected_parts: list[str] = []
-    index = 0
-    while index < len(text):
-        if text[index] == "`":
-            delimiter_length = _count_repeated_characters(text, index, "`")
-            closing_index = _find_inline_code_span_end(text, index + delimiter_length, delimiter_length)
-            if closing_index is not None:
-                protected_parts.append(text[index : closing_index + delimiter_length])
-                index = closing_index + delimiter_length
-                continue
-            protected_parts.append(text[index : index + delimiter_length])
-            index += delimiter_length
-            continue
-
-        math_end_index = _find_math_span_end(text, index)
-        if math_end_index is None:
-            protected_parts.append(text[index])
-            index += 1
-            continue
-
-        placeholder = _MATH_PLACEHOLDER_TEMPLATE.format(index=len(protected_spans))
-        protected_spans.append((placeholder, text[index:math_end_index]))
-        protected_parts.append(placeholder)
-        index = math_end_index
-
-    return "".join(protected_parts)
-
-
-def _protect_math_spans(text: str) -> tuple[str, list[tuple[str, str]]]:
-    protected_spans: list[tuple[str, str]] = []
-    protected_text = _transform_markdown_outside_fenced_code(
-        text,
-        lambda prose_text: _protect_math_spans_in_text(prose_text, protected_spans),
-    )
-    return protected_text, protected_spans
-
-
-def _restore_protected_math_spans(html_text: str, protected_spans: list[tuple[str, str]]) -> str:
-    restored_html = html_text
-    for placeholder, original_math in protected_spans:
-        restored_html = restored_html.replace(placeholder, escape(original_math))
-    return restored_html
-
-
 def _format_sanitized_attributes(tag_name: str, attrs: list[tuple[str, str | None]]) -> str:
     allowed_attributes = _ALLOWED_FORMATTED_BODY_ATTRIBUTES.get(tag_name, frozenset())
     sanitized_attributes: list[str] = []
@@ -529,10 +406,39 @@ def _highlight(code: str, lang: str, _attrs: str) -> str:
     return _pygments_highlight(code, lexer, _HIGHLIGHT_FORMATTER)
 
 
+def _render_preserved_math_inline(
+    _self: object,
+    tokens: list[Token],
+    idx: int,
+    _options: object,
+    _env: object,
+) -> str:
+    return escape(f"${tokens[idx].content}$")
+
+
+def _render_preserved_math_block(
+    _self: object,
+    tokens: list[Token],
+    idx: int,
+    _options: object,
+    _env: object,
+) -> str:
+    content = f"$$\n{tokens[idx].content.strip()}\n$$"
+    return f"<div>{escape(content)}</div>\n"
+
+
 def _build_markdown_renderer() -> MarkdownIt:
     renderer = MarkdownIt("commonmark", {"breaks": True, "highlight": _highlight})
     renderer.enable("table")
     renderer.enable("strikethrough")
+    renderer.use(
+        dollarmath_plugin,
+        allow_labels=False,
+        allow_space=False,
+        allow_digits=False,
+    )
+    renderer.add_render_rule("math_inline", _render_preserved_math_inline)
+    renderer.add_render_rule("math_block", _render_preserved_math_block)
     return renderer
 
 
@@ -548,12 +454,10 @@ def markdown_to_html(text: str) -> str:
     blank line before them.
     """
     normalized_input = _normalize_input_line_endings(text)
-    protected_text, protected_spans = _protect_math_spans(normalized_input)
-    escaped_text = _escape_html_block_openers(protected_text)
+    escaped_text = _escape_html_block_openers(normalized_input)
     normalized_text = _normalize_supported_block_html_boundaries(escaped_text)
     html_text: str = _MARKDOWN_RENDERER.render(normalized_text)
-    sanitized_html = _sanitize_formatted_body_html(html_text)
-    return _restore_protected_math_spans(sanitized_html, protected_spans)
+    return _sanitize_formatted_body_html(html_text)
 
 
 def _build_thread_relation(

--- a/src/mindroom/matrix/message_builder.py
+++ b/src/mindroom/matrix/message_builder.py
@@ -131,6 +131,7 @@ _SUPPORTED_BLOCK_END_TAG_PATTERN = re.compile(
 )
 _HR_BLOCK_TAG_PATTERN = re.compile(r"^[ ]{0,3}<hr\b[^<>]*/?>\s*$", re.IGNORECASE)
 _FENCE_OPEN_PATTERN = re.compile(r"^[ ]{0,3}(`{3,}|~{3,})")
+_MATH_PLACEHOLDER_TEMPLATE = "MINDROOMMATHPLACEHOLDER{index}TOKEN"
 
 
 def _count_repeated_characters(text: str, start_index: int, character: str) -> int:
@@ -138,6 +139,15 @@ def _count_repeated_characters(text: str, start_index: int, character: str) -> i
     while end_index < len(text) and text[end_index] == character:
         end_index += 1
     return end_index - start_index
+
+
+def _is_escaped_character(text: str, index: int) -> bool:
+    backslash_count = 0
+    cursor = index - 1
+    while cursor >= 0 and text[cursor] == "\\":
+        backslash_count += 1
+        cursor -= 1
+    return backslash_count % 2 == 1
 
 
 def _is_fence_closing_line(line: str, fence_character: str, opening_length: int) -> bool:
@@ -295,6 +305,121 @@ def _escape_unterminated_html_fragments(html_text: str) -> str:
     return _UNTERMINATED_HTML_FRAGMENT_PATTERN.sub(lambda match: escape(match.group(0)), html_text)
 
 
+def _find_inline_code_span_end(text: str, search_start: int, delimiter_length: int) -> int | None:
+    index = search_start
+    while index < len(text):
+        if text[index] != "`":
+            index += 1
+            continue
+        run_length = _count_repeated_characters(text, index, "`")
+        if run_length == delimiter_length:
+            return index
+        index += run_length
+    return None
+
+
+def _can_open_inline_math(text: str, index: int) -> bool:
+    if index > 0 and text[index - 1].isdigit():
+        return False
+    next_index = index + 1
+    return next_index < len(text) and not text[next_index].isspace() and text[next_index] != "$"
+
+
+def _find_display_math_end(text: str, start_index: int) -> int | None:
+    index = start_index + 2
+    while index < len(text):
+        match_index = text.find("$$", index)
+        if match_index == -1:
+            return None
+        if not _is_escaped_character(text, match_index):
+            return match_index + 2
+        index = match_index + 2
+    return None
+
+
+def _find_inline_math_end(text: str, start_index: int) -> int | None:
+    index = start_index + 1
+    while index < len(text):
+        current_character = text[index]
+        if current_character == "\n":
+            return None
+        if current_character != "$":
+            index += 1
+            continue
+        if text.startswith("$$", index):
+            index += 2
+            continue
+        if _is_escaped_character(text, index):
+            index += 1
+            continue
+        if text[index - 1].isspace():
+            index += 1
+            continue
+        if index + 1 < len(text) and text[index + 1].isdigit():
+            index += 1
+            continue
+        return index + 1
+    return None
+
+
+def _find_math_span_end(text: str, start_index: int) -> int | None:
+    if text[start_index] != "$" or _is_escaped_character(text, start_index):
+        return None
+    if text.startswith("$$", start_index):
+        return _find_display_math_end(text, start_index)
+    if not _can_open_inline_math(text, start_index):
+        return None
+    return _find_inline_math_end(text, start_index)
+
+
+def _protect_math_spans_in_text(
+    text: str,
+    protected_spans: list[tuple[str, str]],
+) -> str:
+    protected_parts: list[str] = []
+    index = 0
+    while index < len(text):
+        if text[index] == "`":
+            delimiter_length = _count_repeated_characters(text, index, "`")
+            closing_index = _find_inline_code_span_end(text, index + delimiter_length, delimiter_length)
+            if closing_index is not None:
+                protected_parts.append(text[index : closing_index + delimiter_length])
+                index = closing_index + delimiter_length
+                continue
+            protected_parts.append(text[index : index + delimiter_length])
+            index += delimiter_length
+            continue
+
+        math_end_index = _find_math_span_end(text, index)
+        if math_end_index is None:
+            protected_parts.append(text[index])
+            index += 1
+            continue
+
+        placeholder = _MATH_PLACEHOLDER_TEMPLATE.format(index=len(protected_spans))
+        protected_spans.append((placeholder, text[index:math_end_index]))
+        protected_parts.append(placeholder)
+        index = math_end_index
+
+    return "".join(protected_parts)
+
+
+def _protect_math_spans(text: str) -> tuple[str, list[tuple[str, str]]]:
+    protected_spans: list[tuple[str, str]] = []
+    protected_text = _transform_markdown_outside_fenced_code(
+        text,
+        lambda prose_text: _protect_math_spans_in_text(prose_text, protected_spans),
+    )
+    return protected_text, protected_spans
+
+
+def _restore_protected_math_spans(html_text: str, protected_spans: list[tuple[str, str]]) -> str:
+    restored_html = html_text
+    for placeholder, original_math in protected_spans:
+        restored_html = restored_html.replace(placeholder, escape(original_math))
+    return restored_html
+
+
 def _format_sanitized_attributes(tag_name: str, attrs: list[tuple[str, str | None]]) -> str:
     allowed_attributes = _ALLOWED_FORMATTED_BODY_ATTRIBUTES.get(tag_name, frozenset())
     sanitized_attributes: list[str] = []
@@ -423,10 +548,12 @@ def markdown_to_html(text: str) -> str:
     blank line before them.
     """
     normalized_input = _normalize_input_line_endings(text)
-    escaped_text = _escape_html_block_openers(normalized_input)
+    protected_text, protected_spans = _protect_math_spans(normalized_input)
+    escaped_text = _escape_html_block_openers(protected_text)
     normalized_text = _normalize_supported_block_html_boundaries(escaped_text)
     html_text: str = _MARKDOWN_RENDERER.render(normalized_text)
-    return _sanitize_formatted_body_html(html_text)
+    sanitized_html = _sanitize_formatted_body_html(html_text)
+    return _restore_protected_math_spans(sanitized_html, protected_spans)
 
 
 def _build_thread_relation(

--- a/tests/test_markdown_to_html.py
+++ b/tests/test_markdown_to_html.py
@@ -130,6 +130,46 @@ def test_inline_code_escapes_html_without_double_escaping() -> None:
     assert "&amp;lt;tool&amp;gt;" not in html
 
 
+def test_inline_math_preserves_latex_escapes() -> None:
+    """Inline math content should survive markdown parsing verbatim."""
+    html = markdown_to_html(r"$\text{previous\_speaker}$")
+    assert r"$\text{previous\_speaker}$" in html
+    assert r"$\text{previous_speaker}$" not in html
+
+
+def test_display_math_preserves_latex_escapes() -> None:
+    """Display math blocks should preserve escaped underscores."""
+    html = markdown_to_html("$$\n\\text{previous\\_speaker} = \\text{Latone}\n$$")
+    assert "$$\n\\text{previous\\_speaker} = \\text{Latone}\n$$" in html
+    assert r"\text{previous_speaker}" not in html
+
+
+def test_mixed_markdown_around_math_preserves_formatting() -> None:
+    """Normal markdown should still render around protected math spans."""
+    html = markdown_to_html(
+        "Paragraph text with **bold text**, `inline_code`, and "
+        r"$\text{previous\_speaker}$"
+        "\n- bullet item",
+    )
+    assert "<strong>bold text</strong>" in html
+    assert "<code>inline_code</code>" in html
+    assert r"$\text{previous\_speaker}$" in html
+    assert "<ul>" in html
+    assert "<li>bullet item</li>" in html
+
+
+def test_code_spans_containing_dollar_delimiters_remain_untouched() -> None:
+    """Math protection must not rewrite code spans."""
+    html = markdown_to_html(r"`$\text{previous\_speaker}$`")
+    assert r"<code>$\text{previous\_speaker}$</code>" in html
+
+
+def test_non_math_markdown_escaping_behavior_is_unchanged() -> None:
+    """Escapes outside math should keep current markdown semantics."""
+    html = markdown_to_html(r"outside \_ math")
+    assert "<p>outside _ math</p>" in html
+
+
 # --- Links, images, lists, blockquotes ---
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3185,6 +3185,18 @@ cli = [
 ]
 
 [[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3234,6 +3246,7 @@ dependencies = [
     { name = "markdown-it-py" },
     { name = "matrix-nio" },
     { name = "mcp", extra = ["cli"] },
+    { name = "mdit-py-plugins" },
     { name = "mem0ai" },
     { name = "openai" },
     { name = "pydantic" },
@@ -3667,6 +3680,7 @@ requires-dist = [
     { name = "matrix-nio", specifier = ">=0.25" },
     { name = "matrix-nio", extras = ["e2e"], marker = "extra == 'matrix-e2ee'", specifier = ">=0.25" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.4" },
+    { name = "mdit-py-plugins", specifier = ">=0.5.0" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
     { name = "moviepy", marker = "extra == 'moviepy-video-tools'" },


### PR DESCRIPTION
## Summary
- add `mdit-py-plugins` and use `dollarmath_plugin` in MindRoom's markdown renderer
- preserve raw `$...$` and `$$...$$` content in `formatted_body` instead of letting core CommonMark consume LaTeX escapes
- keep code spans, fenced code, links, lists, and surrounding markdown behavior covered by regression tests

## Root cause
`markdown-it-py` in `commonmark` mode has no built-in math parser in this repo, so `$...$` content was treated as ordinary text. During inline parsing, escapes like `\_` were normalized to `_`, which broke downstream KaTeX rendering in Cinny.

## Implementation
The fix now uses `mdit_py_plugins.dollarmath.dollarmath_plugin` to parse math spans and blocks, with custom render rules that preserve the original math delimiters in the emitted HTML fragment. That keeps math content intact for downstream rendering while avoiding the previous bespoke span-protection logic.

## Testing
- `uv run pytest tests/test_markdown_to_html.py -n auto --no-cov -q`
- `uv run pre-commit run --all-files`
- `uv run pytest -n auto --no-cov`
