### PR TITLE
docs: document accept_invites in config templates

### DIFF
--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -140,6 +140,7 @@ agents:
     rooms:
       - lobby
       - dev
+    accept_invites: true  # Optional: accept direct room invites and auto-join invited rooms
     learning: true  # Optional: enable Agno Learning (defaults to true)
     learning_mode: "always"  # Optional: "always" or "agentic"
     memory_backend: "file"  # Optional: per-agent override ("mem0" or "file")
@@ -164,6 +165,7 @@ agents:
 - **skills**: Skill names the agent can use
 - **instructions**: Specific guidelines for the agent's behavior
 - **rooms**: List of room aliases where this agent should be active
+- **accept_invites**: Whether this agent accepts direct Matrix room invites and auto-joins invited rooms (default: `true`)
 - **markdown**: Per-agent override for markdown formatting (default: inherits from `defaults.markdown`; `null` means inherit)
 - **learning**: Enable Agno Learning for this agent (default: inherits from `defaults.learning`, which defaults to `true`)
 - **learning_mode**: Learning mode (`always` or `agentic`, default: `always`)

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -696,6 +696,7 @@ agents:
     model: default
     rooms:
       - lobby
+    accept_invites: true
     tools: []
     instructions:
       - Be helpful and conversational
@@ -708,6 +709,7 @@ agents:
     memory_backend: file
     rooms:
       - personal
+    accept_invites: true
     context_files:
       - SOUL.md
       - AGENTS.md
@@ -857,6 +859,7 @@ agents:
     model: default
     rooms:
       - lobby
+    accept_invites: true
 
 router:
   model: default

--- a/src/mindroom/config_template.yaml
+++ b/src/mindroom/config_template.yaml
@@ -16,6 +16,7 @@ agents:
     model: default
     rooms:
       - lobby
+    accept_invites: true  # Accept direct room invites and auto-join invited rooms
     tools: []
     # Tools can be plain strings or single-key dicts with per-agent config overrides:
     # tools:


### PR DESCRIPTION
Cherry-picks `gitea/main` commit `2506047b2` onto current `origin/main`.

This documents `accept_invites` in the shipped config templates.

Verification:
- `uv run pre-commit run --all-files`
- `uv run pytest -x -n auto --no-cov`
