### PR TITLE
Fix concurrent module iteration in tool validation

### DIFF
--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -919,6 +919,7 @@ def ensure_tool_registry_loaded(
 
 def _capture_tool_registry_snapshot() -> _ToolRegistrySnapshot:
     """Capture the mutable tool/plugin registry state for transactional restoration."""
+    loaded_modules = sys.modules.copy()
     return _ToolRegistrySnapshot(
         registry=_TOOL_REGISTRY.copy(),
         metadata=TOOL_METADATA.copy(),
@@ -930,7 +931,7 @@ def _capture_tool_registry_snapshot() -> _ToolRegistrySnapshot:
         },
         plugin_modules={
             module_name: module
-            for module_name, module in sys.modules.items()
+            for module_name, module in loaded_modules.items()
             if module_name.startswith(_PLUGIN_MODULE_PREFIX)
         },
     )
@@ -955,7 +956,7 @@ def _restore_tool_registry_snapshot(snapshot: _ToolRegistrySnapshot) -> None:
             for module_name, registrations in snapshot.plugin_tool_metadata_by_module.items()
         },
     )
-    for module_name in tuple(sys.modules):
+    for module_name in tuple(sys.modules.copy()):
         if module_name.startswith(_PLUGIN_MODULE_PREFIX) and module_name not in snapshot.plugin_modules:
             sys.modules.pop(module_name, None)
     sys.modules.update(snapshot.plugin_modules)
@@ -990,9 +991,10 @@ def _execute_validation_plugin_module(
         raise ToolMetadataValidationError(msg)
 
     previous_module = sys.modules.get(validation_module_name)
+    loaded_modules = sys.modules.copy()
     previous_modules_within_root = {
         module_name: loaded_module
-        for module_name, loaded_module in sys.modules.items()
+        for module_name, loaded_module in loaded_modules.items()
         if _module_origin_within_root(loaded_module, plugin_root)
     }
     module = importlib_util.module_from_spec(spec)
@@ -1007,7 +1009,7 @@ def _execute_validation_plugin_module(
         msg = f"Plugin validation module execution failed for {module_path}: {exc}"
         raise ToolMetadataValidationError(msg) from exc
     finally:
-        for loaded_module_name, loaded_module in list(sys.modules.items()):
+        for loaded_module_name, loaded_module in sys.modules.copy().items():
             if loaded_module_name not in previous_modules_within_root and _module_origin_within_root(
                 loaded_module,
                 plugin_root,

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -2,17 +2,22 @@
 
 import inspect
 import json
+import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 from agno.tools import Toolkit
 
 # Import tools to trigger tool registration
 import mindroom.tools  # noqa: F401
+import mindroom.tool_system.metadata as metadata_module
 from mindroom.config.main import Config, load_config
 from mindroom.constants import resolve_runtime_paths
 from mindroom.tool_system.metadata import (
     _TOOL_REGISTRY,
+    _capture_tool_registry_snapshot,
+    _execute_validation_plugin_module,
     AUTHORED_OVERRIDE_INHERIT,
     TOOL_METADATA,
     ConfigField,
@@ -105,6 +110,34 @@ def test_export_tools_metadata_json_resets_leaked_registry_entries() -> None:
         _TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
         _restore_builtin_tool_metadata_state()
+
+
+def test_plugin_validation_uses_sys_modules_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Plugin validation should snapshot sys.modules before iterating over it."""
+
+    class SnapshotOnlyModules(dict[str, ModuleType]):
+        def items(self):  # type: ignore[override]
+            msg = "live sys.modules.items() should not be used"
+            raise RuntimeError(msg)
+
+        def copy(self):  # type: ignore[override]
+            return dict(self)
+
+    plugin_root = tmp_path / "plugins" / "demo"
+    plugin_root.mkdir(parents=True)
+    module_path = plugin_root / "tools.py"
+    module_path.write_text("VALUE = 1\n", encoding="utf-8")
+
+    snapshot_modules = SnapshotOnlyModules(sys.modules.copy())
+    monkeypatch.setattr(metadata_module.sys, "modules", snapshot_modules)
+
+    snapshot = _capture_tool_registry_snapshot()
+    assert isinstance(snapshot.plugin_modules, dict)
+
+    module_name = _execute_validation_plugin_module("demo", plugin_root, module_path, {})
+    assert module_name
+    assert "demo" in module_name
+    assert "__validation__" in module_name
 
 
 def test_tool_metadata_consistency() -> None:

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -5,19 +5,20 @@ import json
 import sys
 from pathlib import Path
 from types import ModuleType
+from typing import Never
 
 import pytest
 from agno.tools import Toolkit
 
+import mindroom.tool_system.metadata as metadata_module
+
 # Import tools to trigger tool registration
 import mindroom.tools  # noqa: F401
-import mindroom.tool_system.metadata as metadata_module
 from mindroom.config.main import Config, load_config
 from mindroom.constants import resolve_runtime_paths
 from mindroom.tool_system.metadata import (
+    _PLUGIN_MODULE_PREFIX,
     _TOOL_REGISTRY,
-    _capture_tool_registry_snapshot,
-    _execute_validation_plugin_module,
     AUTHORED_OVERRIDE_INHERIT,
     TOOL_METADATA,
     ConfigField,
@@ -25,6 +26,9 @@ from mindroom.tool_system.metadata import (
     ToolCategory,
     ToolConfigOverrideError,
     ToolManagedInitArg,
+    _capture_tool_registry_snapshot,
+    _execute_validation_plugin_module,
+    _restore_tool_registry_snapshot,
     deserialize_tool_validation_snapshot,
     ensure_tool_registry_loaded,
     export_tools_metadata,
@@ -116,11 +120,11 @@ def test_plugin_validation_uses_sys_modules_snapshot(tmp_path: Path, monkeypatch
     """Plugin validation should snapshot sys.modules before iterating over it."""
 
     class SnapshotOnlyModules(dict[str, ModuleType]):
-        def items(self):  # type: ignore[override]
+        def items(self) -> Never:
             msg = "live sys.modules.items() should not be used"
             raise RuntimeError(msg)
 
-        def copy(self):  # type: ignore[override]
+        def copy(self) -> dict[str, ModuleType]:
             return dict(self)
 
     plugin_root = tmp_path / "plugins" / "demo"
@@ -138,6 +142,36 @@ def test_plugin_validation_uses_sys_modules_snapshot(tmp_path: Path, monkeypatch
     assert module_name
     assert "demo" in module_name
     assert "__validation__" in module_name
+
+
+def test_restore_tool_registry_snapshot_uses_sys_modules_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restoring registry state should snapshot sys.modules before iterating over it."""
+
+    class SnapshotOnlyModules(dict[str, ModuleType]):
+        def __iter__(self) -> Never:
+            msg = "live sys.modules iteration should not be used"
+            raise RuntimeError(msg)
+
+        def copy(self) -> dict[str, ModuleType]:
+            return dict(self)
+
+    snapshot = _capture_tool_registry_snapshot()
+    leaked_module_name = f"{_PLUGIN_MODULE_PREFIX}leaked"
+    assert leaked_module_name not in snapshot.plugin_modules
+
+    leaked_module = ModuleType(leaked_module_name)
+    leaked_module.__file__ = str(tmp_path / "leaked.py")
+
+    snapshot_modules = SnapshotOnlyModules(sys.modules.copy())
+    snapshot_modules[leaked_module_name] = leaked_module
+    monkeypatch.setattr(metadata_module.sys, "modules", snapshot_modules)
+
+    _restore_tool_registry_snapshot(snapshot)
+
+    assert leaked_module_name not in metadata_module.sys.modules
 
 
 def test_tool_metadata_consistency() -> None:


### PR DESCRIPTION
## Summary
- snapshot `sys.modules` before iterating over it during tool validation
- use the same snapshotting approach when capturing and restoring plugin tool registry state
- add a regression test covering concurrent `sys.modules` mutation during validation

## Testing
- `uv run --project . pytest tests/test_tools_metadata.py -k 'plugin_validation_uses_sys_modules_snapshot or export_tools_metadata_json_resets_leaked_registry_entries'`
