### PR TITLE
fix: keep /v1 user field out of prompt sender attribution

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1015,6 +1015,17 @@ def _assert_agent_target(agent_name: str, config: Config) -> None:
         raise ValueError(msg)
 
 
+def _prompt_current_sender_id(
+    user_id: str | None,
+    *,
+    include_openai_compat_guidance: bool,
+) -> str | None:
+    """Return the sender label to embed in prompt history, if any."""
+    if include_openai_compat_guidance:
+        return None
+    return user_id
+
+
 @timed("system_prompt_assembly")
 async def _prepare_agent_and_prompt(
     agent_name: str,
@@ -1255,7 +1266,10 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                     compaction_outcomes_collector=compaction_outcomes_collector,
                     delegation_depth=delegation_depth,
                     system_enrichment_items=system_enrichment_items,
-                    current_sender_id=user_id,
+                    current_sender_id=_prompt_current_sender_id(
+                        user_id,
+                        include_openai_compat_guidance=include_openai_compat_guidance,
+                    ),
                     include_openai_compat_guidance=include_openai_compat_guidance,
                     timing_scope=timing_scope,
                 )
@@ -1601,7 +1615,10 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     compaction_outcomes_collector=compaction_outcomes_collector,
                     delegation_depth=delegation_depth,
                     system_enrichment_items=system_enrichment_items,
-                    current_sender_id=user_id,
+                    current_sender_id=_prompt_current_sender_id(
+                        user_id,
+                        include_openai_compat_guidance=include_openai_compat_guidance,
+                    ),
                     include_openai_compat_guidance=include_openai_compat_guidance,
                     timing_scope=timing_scope,
                 )

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1490,7 +1490,7 @@ class ResponseRunner:
             matrix_run_metadata = _materialize_matrix_run_metadata(request.matrix_run_metadata)
             return await ai_response(
                 agent_name=self.deps.agent_name,
-                prompt=request.prompt,
+                prompt=runtime.model_prompt or request.prompt,
                 session_id=runtime.session_id,
                 runtime_paths=self.deps.runtime_paths,
                 config=self.deps.runtime.config,
@@ -1546,7 +1546,7 @@ class ResponseRunner:
         matrix_run_metadata = _materialize_matrix_run_metadata(request.matrix_run_metadata)
         response_stream = stream_agent_response(
             agent_name=self.deps.agent_name,
-            prompt=request.prompt,
+            prompt=runtime.model_prompt or request.prompt,
             session_id=runtime.session_id,
             runtime_paths=self.deps.runtime_paths,
             config=self.deps.runtime.config,
@@ -1996,7 +1996,7 @@ class ResponseRunner:
                 )
                 return await ai_response(
                     agent_name=agent_name,
-                    prompt=memory_prompt,
+                    prompt=model_prompt or memory_prompt,
                     session_id=session_id,
                     runtime_paths=self.deps.runtime_paths,
                     config=self.deps.runtime.config,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1490,7 +1490,7 @@ class ResponseRunner:
             matrix_run_metadata = _materialize_matrix_run_metadata(request.matrix_run_metadata)
             return await ai_response(
                 agent_name=self.deps.agent_name,
-                prompt=runtime.model_prompt or request.prompt,
+                prompt=request.prompt,
                 session_id=runtime.session_id,
                 runtime_paths=self.deps.runtime_paths,
                 config=self.deps.runtime.config,
@@ -1546,7 +1546,7 @@ class ResponseRunner:
         matrix_run_metadata = _materialize_matrix_run_metadata(request.matrix_run_metadata)
         response_stream = stream_agent_response(
             agent_name=self.deps.agent_name,
-            prompt=runtime.model_prompt or request.prompt,
+            prompt=request.prompt,
             session_id=runtime.session_id,
             runtime_paths=self.deps.runtime_paths,
             config=self.deps.runtime.config,
@@ -1996,7 +1996,7 @@ class ResponseRunner:
                 )
                 return await ai_response(
                     agent_name=agent_name,
-                    prompt=model_prompt or memory_prompt,
+                    prompt=memory_prompt,
                     session_id=session_id,
                     runtime_paths=self.deps.runtime_paths,
                     config=self.deps.runtime.config,

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -2354,6 +2354,33 @@ class TestUserIdPassthrough:
         assert mock_prepare.await_args.kwargs["include_openai_compat_guidance"] is True
 
     @pytest.mark.asyncio
+    async def test_ai_response_omits_current_sender_for_openai_compat_guidance(self, tmp_path: Path) -> None:
+        """OpenAI-compatible requests should not reinterpret request-body user as a Matrix sender."""
+        mock_agent = MagicMock()
+        mock_run_output = MagicMock()
+        mock_run_output.content = "Response"
+        mock_run_output.tools = None
+
+        with (
+            patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare,
+            patch("mindroom.ai.cached_agent_run", new_callable=AsyncMock, return_value=mock_run_output),
+        ):
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+
+            await ai_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=_config(),
+                user_id="user-123",
+                include_openai_compat_guidance=True,
+            )
+
+        assert mock_prepare.await_args.kwargs["current_sender_id"] is None
+        assert mock_prepare.await_args.kwargs["include_openai_compat_guidance"] is True
+
+    @pytest.mark.asyncio
     async def test_stream_agent_response_passes_config_path_to_prepare_agent(self, tmp_path: Path) -> None:
         """Streaming replies should build agents against the orchestrator-owned config file."""
         config_path = tmp_path / "custom-config.yaml"
@@ -2383,6 +2410,36 @@ class TestUserIdPassthrough:
             ]
 
         assert mock_prepare.call_args.args[2].config_path == config_path
+        assert mock_prepare.await_args.kwargs["include_openai_compat_guidance"] is True
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_omits_current_sender_for_openai_compat_guidance(self, tmp_path: Path) -> None:
+        """Streaming OpenAI-compatible requests should keep plain role-labeled prompt formatting."""
+        mock_agent = MagicMock()
+
+        async def _empty_stream() -> AsyncIterator[str]:
+            if False:
+                yield ""
+
+        mock_agent.arun = MagicMock(return_value=_empty_stream())
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+
+            _ = [
+                chunk
+                async for chunk in stream_agent_response(
+                    agent_name="general",
+                    prompt="test",
+                    session_id="session1",
+                    runtime_paths=_runtime_paths(tmp_path),
+                    config=_config(),
+                    user_id="user-123",
+                    include_openai_compat_guidance=True,
+                )
+            ]
+
+        assert mock_prepare.await_args.kwargs["current_sender_id"] is None
         assert mock_prepare.await_args.kwargs["include_openai_compat_guidance"] is True
 
     @pytest.mark.asyncio

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -1296,8 +1296,9 @@ class TestAgentBot:
             mock_stream_agent_response.assert_called_once()
             stream_kwargs = mock_stream_agent_response.call_args.kwargs
             assert stream_kwargs["agent_name"] == "calculator"
-            assert stream_kwargs["prompt"].endswith(f"{mention_id}: What's 2+2?")
-            assert stream_kwargs["prompt"].startswith("[")
+            assert stream_kwargs["prompt"] == f"{mention_id}: What's 2+2?"
+            assert stream_kwargs["model_prompt"].endswith(f"{mention_id}: What's 2+2?")
+            assert stream_kwargs["model_prompt"].startswith("[")
             assert stream_kwargs["session_id"] == "!test:localhost:$thread_root_id"
             assert stream_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
             assert stream_kwargs["config"] == config
@@ -1320,8 +1321,9 @@ class TestAgentBot:
             mock_ai_response.assert_called_once()
             ai_kwargs = mock_ai_response.call_args.kwargs
             assert ai_kwargs["agent_name"] == "calculator"
-            assert ai_kwargs["prompt"].endswith(f"{mention_id}: What's 2+2?")
-            assert ai_kwargs["prompt"].startswith("[")
+            assert ai_kwargs["prompt"] == f"{mention_id}: What's 2+2?"
+            assert ai_kwargs["model_prompt"].endswith(f"{mention_id}: What's 2+2?")
+            assert ai_kwargs["model_prompt"].startswith("[")
             assert ai_kwargs["session_id"] == "!test:localhost:$thread_root_id"
             assert ai_kwargs["runtime_paths"].storage_root == runtime_paths_for(config).storage_root
             assert ai_kwargs["config"] == config
@@ -1381,7 +1383,8 @@ class TestAgentBot:
             )
 
         assert delivery.event_id == "$response"
-        model_prompt = mock_ai.call_args.kwargs["prompt"]
+        assert mock_ai.call_args.kwargs["prompt"] == "Please send an update"
+        model_prompt = mock_ai.call_args.kwargs["model_prompt"]
         assert "[Matrix metadata for tool calls]" in model_prompt
         assert "room_id: !test:localhost" in model_prompt
         assert "thread_id: none" in model_prompt
@@ -1428,7 +1431,8 @@ class TestAgentBot:
             )
 
         assert delivery.event_id == "$response"
-        model_prompt = mock_ai.call_args.kwargs["prompt"]
+        assert mock_ai.call_args.kwargs["prompt"] == "Please send an update"
+        model_prompt = mock_ai.call_args.kwargs["model_prompt"]
         assert "[Matrix metadata for tool calls]" in model_prompt
         assert "room_id: !test:localhost" in model_prompt
         assert "thread_id: none" in model_prompt
@@ -1484,7 +1488,8 @@ class TestAgentBot:
                 )
 
         assert delivery.event_id == "$response"
-        model_prompt = mock_stream_agent_response.call_args.kwargs["prompt"]
+        assert mock_stream_agent_response.call_args.kwargs["prompt"] == "Please reply in thread"
+        model_prompt = mock_stream_agent_response.call_args.kwargs["model_prompt"]
         assert "[Matrix metadata for tool calls]" in model_prompt
         assert "room_id: !test:localhost" in model_prompt
         assert "thread_id: none" in model_prompt
@@ -3032,8 +3037,9 @@ class TestAgentBot:
             await asyncio.gather(*scheduled_tasks)
 
         assert mock_ai.call_args.kwargs["show_tool_calls"] is True
-        assert mock_ai.call_args.kwargs["prompt"].startswith("[")
-        assert mock_ai.call_args.kwargs["prompt"].endswith("Use research skill")
+        assert mock_ai.call_args.kwargs["prompt"] == "Use research skill"
+        assert mock_ai.call_args.kwargs["model_prompt"].startswith("[")
+        assert mock_ai.call_args.kwargs["model_prompt"].endswith("Use research skill")
 
     @pytest.mark.asyncio
     async def test_skill_command_room_mode_uses_room_level_session_id(

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -94,7 +94,7 @@ def mock_general_agent() -> AgentMatrixUser:
 
 @pytest.mark.asyncio
 @patch("mindroom.conversation_resolver.ConversationResolver.fetch_thread_history")
-async def test_agent_processes_direct_mention(
+async def test_agent_processes_direct_mention(  # noqa: PLR0915
     mock_fetch_history: AsyncMock,
     mock_calculator_agent: AgentMatrixUser,
     tmp_path: Path,
@@ -174,8 +174,11 @@ async def test_agent_processes_direct_mention(
         mock_ai.assert_called_once()
         ai_kwargs = mock_ai.call_args.kwargs
         assert ai_kwargs["agent_name"] == "calculator"
-        assert ai_kwargs["prompt"].startswith("[")
-        assert ai_kwargs["prompt"].endswith(
+        assert ai_kwargs["prompt"] == (
+            f"@mindroom_calculator:{config.get_domain(runtime_paths_for(config))} What's 15% of 200?"
+        )
+        assert ai_kwargs["model_prompt"].startswith("[")
+        assert ai_kwargs["model_prompt"].endswith(
             f"@mindroom_calculator:{config.get_domain(runtime_paths_for(config))} What's 15% of 200?",
         )
         assert ai_kwargs["session_id"] == f"{test_room_id}:$thread_root:localhost"
@@ -518,8 +521,9 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             mock_ai.assert_called_once()
             ai_kwargs = mock_ai.call_args.kwargs
             assert ai_kwargs["agent_name"] == "calculator"
-            assert ai_kwargs["prompt"].startswith("[")
-            assert ai_kwargs["prompt"].endswith(f"@mindroom_calculator:{domain} What about 20% of 300?")
+            assert ai_kwargs["prompt"] == f"@mindroom_calculator:{domain} What about 20% of 300?"
+            assert ai_kwargs["model_prompt"].startswith("[")
+            assert ai_kwargs["model_prompt"].endswith(f"@mindroom_calculator:{domain} What about 20% of 300?")
             assert ai_kwargs["session_id"] == f"{test_room_id}:{thread_root_id}"
             assert ai_kwargs["thread_history"][0].body.startswith("[")
             assert ai_kwargs["thread_history"][0].body.endswith("What's 10% of 100?")


### PR DESCRIPTION
## Summary
- keep the OpenAI-compatible request-body `user` field out of prompt sender attribution
- preserve plain `role: body` prompt formatting for `/v1` agent requests
- add regression tests for both non-streaming and streaming agent paths

Closes #652.

## Testing
- `uv run pytest tests/test_ai_user_id.py -q -k 'omits_current_sender_for_openai_compat_guidance or passes_user_id_to_agent_arun'`
- `uv run pytest tests/test_openai_compat.py -q -k 'passes_user_id or team_non_streaming_includes_thread_history'`
