### PR TITLE
Require explicit mentions in multi-user team threads

### DIFF
--- a/docs/configuration/teams.md
+++ b/docs/configuration/teams.md
@@ -114,10 +114,12 @@ Startup thread prewarm is a background, best-effort cache warmup for rooms alrea
 ## Dynamic Team Formation
 
 When multiple agents are mentioned in a message (e.g., `@code @research analyze this`), MindRoom automatically forms an ad-hoc team. Dynamic teams form in these scenarios:
+In threads with multiple human participants, stale thread context does not auto-form a team.
+A fresh explicit `@mention` in the current message is required before agents respond.
 
 1. **Multiple agents explicitly tagged** - e.g., `@code @research analyze this`
-2. **Thread with previously mentioned agents** - Follow-up messages in a thread where multiple agents were mentioned earlier
-3. **Thread with multiple agent participants** - Continuing a conversation where multiple agents have responded
+2. **Thread with previously mentioned agents** - Follow-up messages in a thread where multiple agents were mentioned earlier, as long as the thread has not become a multi-human conversation that now requires a fresh explicit mention
+3. **Thread with multiple agent participants** - Continuing a conversation where multiple agents have responded, as long as the thread has not become a multi-human conversation that now requires a fresh explicit mention
 4. **DM room with multiple agents** - Messages in a DM room containing multiple agents (main timeline only)
 
 ### Mode Selection

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -543,9 +543,10 @@ To interact with an agent:
 1. **Mention the agent by its Matrix display name or ID**: `@mindroom_agentname:<server>`
    - Example: `@mindroom_code what is 25 * 4?`
 
-2. **In threads**: Agents automatically respond to all messages without needing mentions
+2. **In threads**: Agents continue responding based on thread context, but multi-human threads require an explicit current `@mention`
    - Start a thread by replying to any message
-   - The agent will see and respond to all subsequent messages in that thread
+   - In single-human threads, the agent can continue the conversation without repeated mentions
+   - Once two or more humans are participating, mention the agent again before expecting a reply
 
 3. **Multiple agents**: You can mention multiple agents in one message
    - Example: `@mindroom_research @mindroom_code Compare renewable energy trends`

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1997,11 +1997,11 @@ Startup thread prewarm is a background, best-effort cache warmup for rooms alrea
 
 ## Dynamic Team Formation
 
-When multiple agents are mentioned in a message (e.g., `@code @research analyze this`), MindRoom automatically forms an ad-hoc team. Dynamic teams form in these scenarios:
+When multiple agents are mentioned in a message (e.g., `@code @research analyze this`), MindRoom automatically forms an ad-hoc team. Dynamic teams form in these scenarios: In threads with multiple human participants, stale thread context does not auto-form a team. A fresh explicit `@mention` in the current message is required before agents respond.
 
 1. **Multiple agents explicitly tagged** - e.g., `@code @research analyze this`
-1. **Thread with previously mentioned agents** - Follow-up messages in a thread where multiple agents were mentioned earlier
-1. **Thread with multiple agent participants** - Continuing a conversation where multiple agents have responded
+1. **Thread with previously mentioned agents** - Follow-up messages in a thread where multiple agents were mentioned earlier, as long as the thread has not become a multi-human conversation that now requires a fresh explicit mention
+1. **Thread with multiple agent participants** - Continuing a conversation where multiple agents have responded, as long as the thread has not become a multi-human conversation that now requires a fresh explicit mention
 1. **DM room with multiple agents** - Messages in a DM room containing multiple agents (main timeline only)
 
 ### Mode Selection

--- a/skills/mindroom-docs/references/page__configuration__teams__index.md
+++ b/skills/mindroom-docs/references/page__configuration__teams__index.md
@@ -108,11 +108,11 @@ Startup thread prewarm is a background, best-effort cache warmup for rooms alrea
 
 ## Dynamic Team Formation
 
-When multiple agents are mentioned in a message (e.g., `@code @research analyze this`), MindRoom automatically forms an ad-hoc team. Dynamic teams form in these scenarios:
+When multiple agents are mentioned in a message (e.g., `@code @research analyze this`), MindRoom automatically forms an ad-hoc team. Dynamic teams form in these scenarios: In threads with multiple human participants, stale thread context does not auto-form a team. A fresh explicit `@mention` in the current message is required before agents respond.
 
 1. **Multiple agents explicitly tagged** - e.g., `@code @research analyze this`
-1. **Thread with previously mentioned agents** - Follow-up messages in a thread where multiple agents were mentioned earlier
-1. **Thread with multiple agent participants** - Continuing a conversation where multiple agents have responded
+1. **Thread with previously mentioned agents** - Follow-up messages in a thread where multiple agents were mentioned earlier, as long as the thread has not become a multi-human conversation that now requires a fresh explicit mention
+1. **Thread with multiple agent participants** - Continuing a conversation where multiple agents have responded, as long as the thread has not become a multi-human conversation that now requires a fresh explicit mention
 1. **DM room with multiple agents** - Messages in a DM room containing multiple agents (main timeline only)
 
 ### Mode Selection

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -39,6 +39,7 @@ from mindroom.teams import (
 from mindroom.thread_utils import (
     get_agents_in_thread,
     get_all_mentioned_agents_in_thread,
+    has_multiple_non_agent_users_in_thread,
     should_agent_respond,
     thread_requires_explicit_agent_targeting,
 )
@@ -346,6 +347,17 @@ class TurnPolicy:
         materializable_agent_names: set[str] | None = None,
     ) -> TeamResolution:
         """Decide team formation using sender-visible candidates without losing explicit intent."""
+        if (
+            context.is_thread
+            and not context.mentioned_agents
+            and has_multiple_non_agent_users_in_thread(
+                context.thread_history,
+                self.deps.runtime.config,
+                self.deps.runtime_paths,
+            )
+        ):
+            return TeamResolution.none()
+
         all_mentioned_in_thread = get_all_mentioned_agents_in_thread(
             context.thread_history,
             self.deps.runtime.config,

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -6797,6 +6797,105 @@ class TestAgentBot:
         mock_has_active_response.assert_called_once_with(target)
 
     @pytest.mark.asyncio
+    async def test_resolve_response_action_requires_explicit_mention_in_multi_human_thread_even_after_prior_team_mentions(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Untargeted follow-ups in a multi-human thread must not reuse stale thread mentions to form a team."""
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "synth": AgentConfig(
+                        display_name="Synthesis",
+                        rooms=["!room:localhost"],
+                    ),
+                    "reasoner": AgentConfig(
+                        display_name="Reasoner",
+                        rooms=["!room:localhost"],
+                    ),
+                    "critic": AgentConfig(
+                        display_name="Critic",
+                        rooms=["!room:localhost"],
+                    ),
+                },
+            ),
+            tmp_path,
+        )
+        runtime_paths = runtime_paths_for(config)
+        ids = config.get_ids(runtime_paths)
+        bot_user = AgentMatrixUser(
+            agent_name="synth",
+            user_id=ids["synth"].full_id,
+            display_name="Synthesis",
+            password=TEST_PASSWORD,
+        )
+        bot = AgentBot(bot_user, tmp_path, config=config, runtime_paths=runtime_paths)
+        room = MagicMock(spec=nio.MatrixRoom)
+        room.room_id = "!room:localhost"
+        room.users = {
+            ids["synth"].full_id: MagicMock(),
+            ids["reasoner"].full_id: MagicMock(),
+            ids["critic"].full_id: MagicMock(),
+            "@bas:localhost": MagicMock(),
+            "@maciej:localhost": MagicMock(),
+        }
+        context = MessageContext(
+            am_i_mentioned=False,
+            is_thread=True,
+            thread_id="$thread",
+            thread_history=[
+                ResolvedVisibleMessage(
+                    sender="@bas:localhost",
+                    body="Team, please assess this",
+                    timestamp=1,
+                    event_id="$m1",
+                    content={
+                        "body": "Team, please assess this",
+                        "m.mentions": {
+                            "user_ids": [
+                                ids["synth"].full_id,
+                                ids["reasoner"].full_id,
+                                ids["critic"].full_id,
+                            ],
+                        },
+                    },
+                    thread_id="$thread",
+                    latest_event_id="$m1",
+                ),
+                ResolvedVisibleMessage(
+                    sender="@maciej:localhost",
+                    body="I fixed two issues",
+                    timestamp=2,
+                    event_id="$m2",
+                    content={"body": "I fixed two issues"},
+                    thread_id="$thread",
+                    latest_event_id="$m2",
+                ),
+            ],
+            mentioned_agents=[],
+            has_non_agent_mentions=False,
+        )
+
+        with (
+            patch(
+                "mindroom.turn_policy.decide_team_formation",
+                new=AsyncMock(side_effect=AssertionError("team formation should be skipped")),
+            ) as mock_decide_team_formation,
+            patch("mindroom.turn_policy.should_agent_respond", return_value=False) as mock_should_respond,
+        ):
+            action = await bot._turn_policy.resolve_response_action(
+                context,
+                room,
+                "@bas:localhost",
+                "I fixed two issues",
+                False,
+            )
+
+        assert action.kind == "skip"
+        mock_decide_team_formation.assert_not_awaited()
+        mock_should_respond.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_execute_dispatch_action_sends_visible_rejection_for_unsupported_team_request(
         self,
         mock_agent_user: AgentMatrixUser,


### PR DESCRIPTION
## Summary
- stop reusing stale thread mentions to reform implicit teams in multi-user threads
- require explicit current-message agent targeting before team formation in that case
- add a regression test covering untagged follow-ups after prior team mentions

## Testing
- `uv run --project . pytest tests/test_multi_agent_bot.py -k 'requires_explicit_mention_in_multi_human_thread_even_after_prior_team_mentions or keeps_human_follow_up_in_active_thread'`
