### PR TITLE
fix: auto-link full Matrix user IDs in mentions

### DIFF
--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -205,7 +205,9 @@ def _resolve_explicit_matrix_id_token(
         msg = "Explicit MXID token is missing explicit_user_id"
         raise ValueError(msg)
 
-    if agent_name := _find_matching_agent_name_for_explicit_localpart(token.localpart, config, runtime_paths):
+    if token.localpart.lower().startswith(MatrixID.AGENT_PREFIX) and (
+        agent_name := _find_matching_agent_name_for_localpart(token.localpart, config, runtime_paths)
+    ):
         return _agent_mention_resolution(
             agent_name,
             sender_domain=sender_domain,
@@ -226,7 +228,7 @@ def _resolve_agent_alias_token(
     """Resolve one alias-style token to a local configured agent, if any."""
     if has_server_name and not localpart.lower().startswith(MatrixID.AGENT_PREFIX):
         return None
-    if agent_name := _find_matching_agent_name_for_alias_localpart(localpart, config, runtime_paths):
+    if agent_name := _find_matching_agent_name_for_localpart(localpart, config, runtime_paths):
         return _agent_mention_resolution(
             agent_name,
             sender_domain=sender_domain,
@@ -338,26 +340,6 @@ def _is_valid_dns_name(host: str) -> bool:
     """Return whether one host string is a valid DNS name."""
     labels = host.split(".")
     return bool(host) and all(label and _DNS_LABEL_PATTERN.fullmatch(label) for label in labels)
-
-
-def _find_matching_agent_name_for_alias_localpart(
-    localpart: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-) -> str | None:
-    """Return the configured agent name for one alias-style localpart."""
-    return _find_matching_agent_name_for_localpart(localpart, config, runtime_paths)
-
-
-def _find_matching_agent_name_for_explicit_localpart(
-    localpart: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-) -> str | None:
-    """Return the configured agent name for one explicit MXID localpart when it is agent-shaped."""
-    if not localpart.lower().startswith(MatrixID.AGENT_PREFIX):
-        return None
-    return _find_matching_agent_name_for_localpart(localpart, config, runtime_paths)
 
 
 def _find_matching_agent_name_for_localpart(

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -1,12 +1,13 @@
 """Matrix mention utilities."""
 
+import ipaddress
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths
-from mindroom.matrix.identity import MatrixID, mindroom_namespace
+from mindroom.matrix.identity import MatrixID, agent_username_localpart, mindroom_namespace
 from mindroom.matrix.message_builder import build_message_content, markdown_to_html
 from mindroom.tool_system.events import build_tool_trace_content
 
@@ -14,9 +15,9 @@ if TYPE_CHECKING:
     from mindroom.tool_system.events import ToolTraceEntry
 
 _AGENT_MENTION_PATTERN = re.compile(r"@(mindroom_)?(\w+)(?::[^\s]+)?", flags=re.IGNORECASE)
-_FULL_MATRIX_ID_PATTERN = re.compile(
-    r"(?<![A-Za-z0-9._=/-])@([A-Za-z0-9._=/-]+):((?:[A-Za-z0-9-]+\.)*[A-Za-z0-9-]+(?::\d+)?)",
-)
+_FULL_MATRIX_ID_CANDIDATE_PATTERN = re.compile(r"(?<![-A-Za-z0-9._=/+])@\S+")
+_DNS_LABEL_PATTERN = re.compile(r"[A-Za-z0-9-]+")
+_MATRIX_USER_ID_LOCALPART_CHARACTERS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._=/-+")
 
 
 @dataclass(frozen=True)
@@ -46,15 +47,18 @@ def parse_mentions_in_text(
         Tuple of (plain_text, list_of_mentioned_user_ids, markdown_text_with_links)
 
     """
-    replacements = _collect_agent_mention_replacements(
+    replacements = _collect_full_matrix_id_replacements(
         text,
         sender_domain=sender_domain,
         config=config,
         runtime_paths=runtime_paths,
     )
     replacements.extend(
-        _collect_full_matrix_id_replacements(
+        _collect_agent_mention_replacements(
             text,
+            sender_domain=sender_domain,
+            config=config,
+            runtime_paths=runtime_paths,
             occupied_ranges=[(replacement.start, replacement.end) for replacement in replacements],
         ),
     )
@@ -78,10 +82,13 @@ def _collect_agent_mention_replacements(
     sender_domain: str,
     config: Config,
     runtime_paths: RuntimePaths,
+    occupied_ranges: list[tuple[int, int]],
 ) -> list[_MentionReplacement]:
     """Return replacement data for configured agent mentions in text."""
     replacements: list[_MentionReplacement] = []
     for match in _AGENT_MENTION_PATTERN.finditer(text):
+        if _range_overlaps_existing(match.start(), match.end(), occupied_ranges):
+            continue
         mention_info = _process_mention(match, config, sender_domain, runtime_paths)
         if mention_info is None:
             continue
@@ -101,24 +108,152 @@ def _collect_agent_mention_replacements(
 def _collect_full_matrix_id_replacements(
     text: str,
     *,
-    occupied_ranges: list[tuple[int, int]],
+    sender_domain: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
 ) -> list[_MentionReplacement]:
     """Return replacement data for explicit full Matrix user IDs in text."""
     replacements: list[_MentionReplacement] = []
-    for match in _FULL_MATRIX_ID_PATTERN.finditer(text):
-        if _range_overlaps_existing(match.start(), match.end(), occupied_ranges):
+    for match in _FULL_MATRIX_ID_CANDIDATE_PATTERN.finditer(text):
+        user_id = _extract_longest_valid_matrix_user_id(match.group(0))
+        if user_id is None:
             continue
-        user_id = match.group(0)
+        matrix_id = MatrixID.parse(user_id)
+        replacement = _replacement_for_explicit_matrix_id(
+            matrix_id,
+            sender_domain=sender_domain,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
         replacements.append(
             _MentionReplacement(
                 start=match.start(),
-                end=match.end(),
-                plain_text=user_id,
-                markdown_text=f"[{user_id}](https://matrix.to/#/{user_id})",
-                user_id=user_id,
+                end=match.start() + len(user_id),
+                plain_text=replacement.plain_text,
+                markdown_text=replacement.markdown_text,
+                user_id=replacement.user_id,
             ),
         )
     return replacements
+
+
+def _extract_longest_valid_matrix_user_id(token: str) -> str | None:
+    """Return the longest valid Matrix user ID prefix from one non-whitespace token."""
+    for end in range(len(token), 0, -1):
+        candidate = token[:end]
+        if _is_valid_explicit_matrix_user_id(candidate):
+            return candidate
+    return None
+
+
+def _is_valid_explicit_matrix_user_id(candidate: str) -> bool:
+    """Return whether one candidate string is a valid explicit Matrix user ID."""
+    try:
+        matrix_id = MatrixID.parse(candidate)
+    except ValueError:
+        return False
+
+    if not matrix_id.username or len(candidate.encode("utf-8")) > 255:
+        return False
+    if any(character not in _MATRIX_USER_ID_LOCALPART_CHARACTERS for character in matrix_id.username):
+        return False
+    return _is_valid_matrix_server_name(matrix_id.domain)
+
+
+def _is_valid_matrix_server_name(server_name: str) -> bool:
+    """Return whether one Matrix server name matches hostname/IP plus optional port."""
+    split = _split_server_name_and_port(server_name)
+    if split is None:
+        return False
+    host, port = split
+    if port is not None and (not port.isdigit() or len(port) > 5):
+        return False
+    if host.startswith("["):
+        is_valid_ipv6_host = host.endswith("]")
+        if is_valid_ipv6_host:
+            try:
+                ipaddress.IPv6Address(host[1:-1])
+            except ValueError:
+                is_valid_ipv6_host = False
+        return is_valid_ipv6_host
+    try:
+        ipaddress.IPv4Address(host)
+    except ValueError:
+        is_valid_host = _is_valid_dns_name(host)
+    else:
+        is_valid_host = True
+    return is_valid_host
+
+
+def _split_server_name_and_port(server_name: str) -> tuple[str, str | None] | None:
+    """Split a Matrix server name into host and optional port."""
+    if not server_name:
+        return None
+
+    if server_name.startswith("["):
+        closing_index = server_name.find("]")
+        if closing_index == -1:
+            return None
+        host = server_name[: closing_index + 1]
+        remainder = server_name[closing_index + 1 :]
+        port = remainder[1:] if remainder.startswith(":") else None
+        if remainder and port is None:
+            return None
+    elif ":" in server_name:
+        host, port = server_name.rsplit(":", 1)
+    else:
+        host, port = server_name, None
+
+    if not host or port == "":
+        return None
+    return host, port
+
+
+def _is_valid_dns_name(host: str) -> bool:
+    """Return whether one host string is a valid DNS name."""
+    labels = host.split(".")
+    return bool(host) and all(label and _DNS_LABEL_PATTERN.fullmatch(label) for label in labels)
+
+
+def _replacement_for_explicit_matrix_id(
+    matrix_id: MatrixID,
+    *,
+    sender_domain: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> _MentionReplacement:
+    """Return replacement data for one explicit Matrix user ID."""
+    user_id = matrix_id.full_id
+    if agent_name := _agent_name_for_explicit_matrix_id(matrix_id, config, runtime_paths):
+        agent_config = config.agents[agent_name]
+        resolved_user_id = MatrixID.from_agent(agent_name, sender_domain, runtime_paths).full_id
+        return _MentionReplacement(
+            start=0,
+            end=0,
+            plain_text=resolved_user_id,
+            markdown_text=f"[@{agent_config.display_name}](https://matrix.to/#/{resolved_user_id})",
+            user_id=resolved_user_id,
+        )
+    return _MentionReplacement(
+        start=0,
+        end=0,
+        plain_text=user_id,
+        markdown_text=f"[{user_id}](https://matrix.to/#/{user_id})",
+        user_id=user_id,
+    )
+
+
+def _agent_name_for_explicit_matrix_id(
+    matrix_id: MatrixID,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> str | None:
+    """Return the agent name for an explicit MXID only when the localpart is the full agent localpart."""
+    matrix_username = matrix_id.username.lower()
+    for agent_name in config.agents:
+        if agent_username_localpart(agent_name, runtime_paths).lower() == matrix_username:
+            return agent_name
+    return None
 
 
 def _range_overlaps_existing(start: int, end: int, ranges: list[tuple[int, int]]) -> bool:

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 _AGENT_MENTION_PATTERN = re.compile(r"@(mindroom_)?(\w+)(?::[^\s]+)?", flags=re.IGNORECASE)
 _FULL_MATRIX_ID_CANDIDATE_PATTERN = re.compile(r"(?<![-A-Za-z0-9._=/+])@\S+")
 _DNS_LABEL_PATTERN = re.compile(r"[A-Za-z0-9-]+")
-_MATRIX_USER_ID_LOCALPART_CHARACTERS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._=/-+")
+_MATRIX_USER_ID_LOCALPART_CHARACTERS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._=/-+")
 
 
 @dataclass(frozen=True)
@@ -25,6 +25,7 @@ class _MentionToken:
     start: int
     end: int
     localpart: str
+    has_server_name: bool = False
     explicit_user_id: str | None = None
 
 
@@ -104,6 +105,7 @@ def _scan_explicit_matrix_id_tokens(text: str) -> list[_MentionToken]:
                 start=match.start(),
                 end=match.start() + len(user_id),
                 localpart=matrix_id.username,
+                has_server_name=True,
                 explicit_user_id=matrix_id.full_id,
             ),
         )
@@ -125,6 +127,7 @@ def _scan_agent_alias_tokens(
                 start=match.start(),
                 end=match.end(),
                 localpart=_mention_localpart(match.group(0)),
+                has_server_name=":" in match.group(0),
             ),
         )
     return tokens
@@ -182,6 +185,7 @@ def _resolve_mention_token(
         )
     return _resolve_agent_alias_token(
         token.localpart,
+        has_server_name=token.has_server_name,
         sender_domain=sender_domain,
         config=config,
         runtime_paths=runtime_paths,
@@ -214,11 +218,14 @@ def _resolve_explicit_matrix_id_token(
 def _resolve_agent_alias_token(
     localpart: str,
     *,
+    has_server_name: bool,
     sender_domain: str,
     config: Config,
     runtime_paths: RuntimePaths,
 ) -> _MentionResolution | None:
     """Resolve one alias-style token to a local configured agent, if any."""
+    if has_server_name and not localpart.lower().startswith(MatrixID.AGENT_PREFIX):
+        return None
     if agent_name := _find_matching_agent_name_for_alias_localpart(localpart, config, runtime_paths):
         return _agent_mention_resolution(
             agent_name,

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -1,6 +1,7 @@
 """Matrix mention utilities."""
 
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from mindroom.config.main import Config
@@ -11,6 +12,20 @@ from mindroom.tool_system.events import build_tool_trace_content
 
 if TYPE_CHECKING:
     from mindroom.tool_system.events import ToolTraceEntry
+
+_AGENT_MENTION_PATTERN = re.compile(r"@(mindroom_)?(\w+)(?::[^\s]+)?", flags=re.IGNORECASE)
+_FULL_MATRIX_ID_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9._=/-])@([A-Za-z0-9._=/-]+):((?:[A-Za-z0-9-]+\.)*[A-Za-z0-9-]+(?::\d+)?)",
+)
+
+
+@dataclass(frozen=True)
+class _MentionReplacement:
+    start: int
+    end: int
+    plain_text: str
+    markdown_text: str
+    user_id: str
 
 
 def parse_mentions_in_text(
@@ -31,36 +46,104 @@ def parse_mentions_in_text(
         Tuple of (plain_text, list_of_mentioned_user_ids, markdown_text_with_links)
 
     """
-    # Pattern to match @agent_name (with optional case-insensitive @mindroom_ prefix or domain)
-    # Matches: @calculator, @mindroom_calculator, @mindroom_calculator:localhost
-    pattern = r"@(mindroom_)?(\w+)(?::[^\s]+)?"
+    replacements = _collect_agent_mention_replacements(
+        text,
+        sender_domain=sender_domain,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    replacements.extend(
+        _collect_full_matrix_id_replacements(
+            text,
+            occupied_ranges=[(replacement.start, replacement.end) for replacement in replacements],
+        ),
+    )
+    ordered_replacements = sorted(replacements, key=lambda replacement: replacement.start)
 
-    # Find all mentions and process them
-    mentions_data = []
-    for match in re.finditer(pattern, text, flags=re.IGNORECASE):
-        mention_info = _process_mention(match, config, sender_domain, runtime_paths)
-        if mention_info:
-            mentions_data.append(mention_info)
-
-    # Build outputs from collected data
-    plain_text = text
-    markdown_text = text
     mentioned_user_ids: list[str] = []
+    for replacement in ordered_replacements:
+        if replacement.user_id not in mentioned_user_ids:
+            mentioned_user_ids.append(replacement.user_id)
 
-    # Apply replacements (reverse order to preserve positions)
-    for original, user_id, display_name in reversed(mentions_data):
-        # Plain text: replace with full Matrix ID
-        plain_text = plain_text.replace(original, user_id, 1)
+    return (
+        _apply_replacements(text, ordered_replacements, use_markdown=False),
+        mentioned_user_ids,
+        _apply_replacements(text, ordered_replacements, use_markdown=True),
+    )
 
-        # Markdown: replace with clickable link
-        link = f"[@{display_name}](https://matrix.to/#/{user_id})"
-        markdown_text = markdown_text.replace(original, link, 1)
 
-        # Collect unique user IDs
-        if user_id not in mentioned_user_ids:
-            mentioned_user_ids.insert(0, user_id)  # Insert at start to maintain order
+def _collect_agent_mention_replacements(
+    text: str,
+    *,
+    sender_domain: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> list[_MentionReplacement]:
+    """Return replacement data for configured agent mentions in text."""
+    replacements: list[_MentionReplacement] = []
+    for match in _AGENT_MENTION_PATTERN.finditer(text):
+        mention_info = _process_mention(match, config, sender_domain, runtime_paths)
+        if mention_info is None:
+            continue
+        _original, user_id, display_name = mention_info
+        replacements.append(
+            _MentionReplacement(
+                start=match.start(),
+                end=match.end(),
+                plain_text=user_id,
+                markdown_text=f"[@{display_name}](https://matrix.to/#/{user_id})",
+                user_id=user_id,
+            ),
+        )
+    return replacements
 
-    return plain_text, mentioned_user_ids, markdown_text
+
+def _collect_full_matrix_id_replacements(
+    text: str,
+    *,
+    occupied_ranges: list[tuple[int, int]],
+) -> list[_MentionReplacement]:
+    """Return replacement data for explicit full Matrix user IDs in text."""
+    replacements: list[_MentionReplacement] = []
+    for match in _FULL_MATRIX_ID_PATTERN.finditer(text):
+        if _range_overlaps_existing(match.start(), match.end(), occupied_ranges):
+            continue
+        user_id = match.group(0)
+        replacements.append(
+            _MentionReplacement(
+                start=match.start(),
+                end=match.end(),
+                plain_text=user_id,
+                markdown_text=f"[{user_id}](https://matrix.to/#/{user_id})",
+                user_id=user_id,
+            ),
+        )
+    return replacements
+
+
+def _range_overlaps_existing(start: int, end: int, ranges: list[tuple[int, int]]) -> bool:
+    """Return whether one text span overlaps any existing replacement span."""
+    return any(start < existing_end and end > existing_start for existing_start, existing_end in ranges)
+
+
+def _apply_replacements(
+    text: str,
+    replacements: list[_MentionReplacement],
+    *,
+    use_markdown: bool,
+) -> str:
+    """Apply collected mention replacements to text."""
+    if not replacements:
+        return text
+
+    parts: list[str] = []
+    last_end = 0
+    for replacement in replacements:
+        parts.append(text[last_end : replacement.start])
+        parts.append(replacement.markdown_text if use_markdown else replacement.plain_text)
+        last_end = replacement.end
+    parts.append(text[last_end:])
+    return "".join(parts)
 
 
 def _process_mention(

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths
-from mindroom.matrix.identity import MatrixID, agent_username_localpart, mindroom_namespace
+from mindroom.matrix.identity import MatrixID, mindroom_namespace
 from mindroom.matrix.message_builder import build_message_content, markdown_to_html
 from mindroom.tool_system.events import build_tool_trace_content
 
@@ -21,12 +21,24 @@ _MATRIX_USER_ID_LOCALPART_CHARACTERS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcd
 
 
 @dataclass(frozen=True)
-class _MentionReplacement:
+class _MentionToken:
     start: int
     end: int
+    localpart: str
+    explicit_user_id: str | None = None
+
+
+@dataclass(frozen=True)
+class _MentionResolution:
     plain_text: str
     markdown_text: str
     user_id: str
+
+
+@dataclass(frozen=True)
+class _MentionReplacement(_MentionResolution):
+    start: int
+    end: int
 
 
 def parse_mentions_in_text(
@@ -47,94 +59,200 @@ def parse_mentions_in_text(
         Tuple of (plain_text, list_of_mentioned_user_ids, markdown_text_with_links)
 
     """
-    replacements = _collect_full_matrix_id_replacements(
-        text,
+    tokens = _scan_mention_tokens(text)
+    replacements = _resolve_mention_tokens(
+        tokens,
         sender_domain=sender_domain,
         config=config,
         runtime_paths=runtime_paths,
     )
-    replacements.extend(
-        _collect_agent_mention_replacements(
-            text,
-            sender_domain=sender_domain,
-            config=config,
-            runtime_paths=runtime_paths,
-            occupied_ranges=[(replacement.start, replacement.end) for replacement in replacements],
-        ),
-    )
-    ordered_replacements = sorted(replacements, key=lambda replacement: replacement.start)
 
     mentioned_user_ids: list[str] = []
-    for replacement in ordered_replacements:
+    for replacement in replacements:
         if replacement.user_id not in mentioned_user_ids:
             mentioned_user_ids.append(replacement.user_id)
 
     return (
-        _apply_replacements(text, ordered_replacements, use_markdown=False),
+        _apply_replacements(text, replacements, use_markdown=False),
         mentioned_user_ids,
-        _apply_replacements(text, ordered_replacements, use_markdown=True),
+        _apply_replacements(text, replacements, use_markdown=True),
     )
 
 
-def _collect_agent_mention_replacements(
-    text: str,
-    *,
-    sender_domain: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    occupied_ranges: list[tuple[int, int]],
-) -> list[_MentionReplacement]:
-    """Return replacement data for configured agent mentions in text."""
-    replacements: list[_MentionReplacement] = []
-    for match in _AGENT_MENTION_PATTERN.finditer(text):
-        if _range_overlaps_existing(match.start(), match.end(), occupied_ranges):
-            continue
-        mention_info = _process_mention(match, config, sender_domain, runtime_paths)
-        if mention_info is None:
-            continue
-        _original, user_id, display_name = mention_info
-        replacements.append(
-            _MentionReplacement(
-                start=match.start(),
-                end=match.end(),
-                plain_text=user_id,
-                markdown_text=f"[@{display_name}](https://matrix.to/#/{user_id})",
-                user_id=user_id,
-            ),
-        )
-    return replacements
+def _scan_mention_tokens(text: str) -> list[_MentionToken]:
+    """Return ordered mention tokens from one message body."""
+    tokens = _scan_explicit_matrix_id_tokens(text)
+    tokens.extend(
+        _scan_agent_alias_tokens(
+            text,
+            occupied_ranges=[(token.start, token.end) for token in tokens],
+        ),
+    )
+    return sorted(tokens, key=lambda token: token.start)
 
 
-def _collect_full_matrix_id_replacements(
-    text: str,
-    *,
-    sender_domain: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-) -> list[_MentionReplacement]:
-    """Return replacement data for explicit full Matrix user IDs in text."""
-    replacements: list[_MentionReplacement] = []
+def _scan_explicit_matrix_id_tokens(text: str) -> list[_MentionToken]:
+    """Return explicit full-MXID tokens from text."""
+    tokens: list[_MentionToken] = []
     for match in _FULL_MATRIX_ID_CANDIDATE_PATTERN.finditer(text):
         user_id = _extract_longest_valid_matrix_user_id(match.group(0))
         if user_id is None:
             continue
         matrix_id = MatrixID.parse(user_id)
-        replacement = _replacement_for_explicit_matrix_id(
-            matrix_id,
+        tokens.append(
+            _MentionToken(
+                start=match.start(),
+                end=match.start() + len(user_id),
+                localpart=matrix_id.username,
+                explicit_user_id=matrix_id.full_id,
+            ),
+        )
+    return tokens
+
+
+def _scan_agent_alias_tokens(
+    text: str,
+    *,
+    occupied_ranges: list[tuple[int, int]],
+) -> list[_MentionToken]:
+    """Return non-overlapping alias-style mention tokens from text."""
+    tokens: list[_MentionToken] = []
+    for match in _AGENT_MENTION_PATTERN.finditer(text):
+        if _range_overlaps_existing(match.start(), match.end(), occupied_ranges):
+            continue
+        tokens.append(
+            _MentionToken(
+                start=match.start(),
+                end=match.end(),
+                localpart=_mention_localpart(match.group(0)),
+            ),
+        )
+    return tokens
+
+
+def _mention_localpart(mention_text: str) -> str:
+    """Return the localpart-like segment from one raw mention token."""
+    return mention_text[1:].split(":", 1)[0]
+
+
+def _resolve_mention_tokens(
+    tokens: list[_MentionToken],
+    *,
+    sender_domain: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> list[_MentionReplacement]:
+    """Resolve scanned tokens into render-ready replacements."""
+    replacements: list[_MentionReplacement] = []
+    for token in tokens:
+        resolution = _resolve_mention_token(
+            token,
             sender_domain=sender_domain,
             config=config,
             runtime_paths=runtime_paths,
         )
+        if resolution is None:
+            continue
         replacements.append(
             _MentionReplacement(
-                start=match.start(),
-                end=match.start() + len(user_id),
-                plain_text=replacement.plain_text,
-                markdown_text=replacement.markdown_text,
-                user_id=replacement.user_id,
+                start=token.start,
+                end=token.end,
+                plain_text=resolution.plain_text,
+                markdown_text=resolution.markdown_text,
+                user_id=resolution.user_id,
             ),
         )
     return replacements
+
+
+def _resolve_mention_token(
+    token: _MentionToken,
+    *,
+    sender_domain: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> _MentionResolution | None:
+    """Resolve one scanned mention token into an agent or literal-user target."""
+    if token.explicit_user_id is not None:
+        return _resolve_explicit_matrix_id_token(
+            token,
+            sender_domain=sender_domain,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+    return _resolve_agent_alias_token(
+        token.localpart,
+        sender_domain=sender_domain,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+
+
+def _resolve_explicit_matrix_id_token(
+    token: _MentionToken,
+    *,
+    sender_domain: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> _MentionResolution:
+    """Resolve one explicit full MXID token."""
+    explicit_user_id = token.explicit_user_id
+    if explicit_user_id is None:
+        msg = "Explicit MXID token is missing explicit_user_id"
+        raise ValueError(msg)
+
+    if agent_name := _find_matching_agent_name_for_explicit_localpart(token.localpart, config, runtime_paths):
+        return _agent_mention_resolution(
+            agent_name,
+            sender_domain=sender_domain,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+    return _literal_user_resolution(explicit_user_id)
+
+
+def _resolve_agent_alias_token(
+    localpart: str,
+    *,
+    sender_domain: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> _MentionResolution | None:
+    """Resolve one alias-style token to a local configured agent, if any."""
+    if agent_name := _find_matching_agent_name_for_alias_localpart(localpart, config, runtime_paths):
+        return _agent_mention_resolution(
+            agent_name,
+            sender_domain=sender_domain,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+    return None
+
+
+def _agent_mention_resolution(
+    agent_name: str,
+    *,
+    sender_domain: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> _MentionResolution:
+    """Return rendering data for one resolved local agent mention."""
+    agent_config = config.agents[agent_name]
+    resolved_user_id = MatrixID.from_agent(agent_name, sender_domain, runtime_paths).full_id
+    return _MentionResolution(
+        plain_text=resolved_user_id,
+        markdown_text=f"[@{agent_config.display_name}](https://matrix.to/#/{resolved_user_id})",
+        user_id=resolved_user_id,
+    )
+
+
+def _literal_user_resolution(user_id: str) -> _MentionResolution:
+    """Return rendering data for one literal Matrix user mention."""
+    return _MentionResolution(
+        plain_text=user_id,
+        markdown_text=f"[{user_id}](https://matrix.to/#/{user_id})",
+        user_id=user_id,
+    )
 
 
 def _extract_longest_valid_matrix_user_id(token: str) -> str | None:
@@ -215,45 +333,70 @@ def _is_valid_dns_name(host: str) -> bool:
     return bool(host) and all(label and _DNS_LABEL_PATTERN.fullmatch(label) for label in labels)
 
 
-def _replacement_for_explicit_matrix_id(
-    matrix_id: MatrixID,
-    *,
-    sender_domain: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-) -> _MentionReplacement:
-    """Return replacement data for one explicit Matrix user ID."""
-    user_id = matrix_id.full_id
-    if agent_name := _agent_name_for_explicit_matrix_id(matrix_id, config, runtime_paths):
-        agent_config = config.agents[agent_name]
-        resolved_user_id = MatrixID.from_agent(agent_name, sender_domain, runtime_paths).full_id
-        return _MentionReplacement(
-            start=0,
-            end=0,
-            plain_text=resolved_user_id,
-            markdown_text=f"[@{agent_config.display_name}](https://matrix.to/#/{resolved_user_id})",
-            user_id=resolved_user_id,
-        )
-    return _MentionReplacement(
-        start=0,
-        end=0,
-        plain_text=user_id,
-        markdown_text=f"[{user_id}](https://matrix.to/#/{user_id})",
-        user_id=user_id,
-    )
-
-
-def _agent_name_for_explicit_matrix_id(
-    matrix_id: MatrixID,
+def _find_matching_agent_name_for_alias_localpart(
+    localpart: str,
     config: Config,
     runtime_paths: RuntimePaths,
 ) -> str | None:
-    """Return the agent name for an explicit MXID only when the localpart is the full agent localpart."""
-    matrix_username = matrix_id.username.lower()
-    for agent_name in config.agents:
-        if agent_username_localpart(agent_name, runtime_paths).lower() == matrix_username:
-            return agent_name
+    """Return the configured agent name for one alias-style localpart."""
+    return _find_matching_agent_name_for_localpart(localpart, config, runtime_paths)
+
+
+def _find_matching_agent_name_for_explicit_localpart(
+    localpart: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> str | None:
+    """Return the configured agent name for one explicit MXID localpart when it is agent-shaped."""
+    if not localpart.lower().startswith(MatrixID.AGENT_PREFIX):
+        return None
+    return _find_matching_agent_name_for_localpart(localpart, config, runtime_paths)
+
+
+def _find_matching_agent_name_for_localpart(
+    localpart: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> str | None:
+    """Return the configured agent name matched by one localpart string, if any."""
+    for candidate_name in _localpart_candidate_names(localpart, runtime_paths):
+        candidate_lower = candidate_name.lower()
+        for config_agent_name in config.agents:
+            if config_agent_name.lower() == candidate_lower:
+                return config_agent_name
     return None
+
+
+def _localpart_candidate_names(localpart: str, runtime_paths: RuntimePaths) -> list[str]:
+    """Build ordered candidate agent names from one mention localpart."""
+    name = localpart
+    prefix: str | None = None
+
+    if localpart.lower().startswith(MatrixID.AGENT_PREFIX):
+        prefix = MatrixID.AGENT_PREFIX
+        name = localpart[len(prefix) :]
+
+    if name.lower().startswith("user_"):
+        return []
+
+    candidate_names = [name]
+    stripped_name: str | None = None
+
+    namespace = mindroom_namespace(runtime_paths)
+    if namespace:
+        suffix = f"_{namespace}"
+        if name.lower().endswith(suffix):
+            stripped_name = name[: -len(suffix)]
+            if stripped_name:
+                candidate_names.append(stripped_name)
+            else:
+                stripped_name = None
+
+    if prefix:
+        candidate_names.append(f"{prefix}{name}")
+        if stripped_name:
+            candidate_names.append(f"{prefix}{stripped_name}")
+    return candidate_names
 
 
 def _range_overlaps_existing(start: int, end: int, ranges: list[tuple[int, int]]) -> bool:
@@ -279,85 +422,6 @@ def _apply_replacements(
         last_end = replacement.end
     parts.append(text[last_end:])
     return "".join(parts)
-
-
-def _process_mention(
-    match: re.Match,
-    config: Config,
-    sender_domain: str,
-    runtime_paths: RuntimePaths,
-) -> tuple[str, str, str] | None:
-    """Process a single mention match and return replacement data.
-
-    Args:
-        match: The regex match object
-        config: The loaded config
-        sender_domain: Domain for constructing Matrix IDs
-        runtime_paths: Explicit runtime context for namespace-aware agent lookup
-
-    Returns:
-        Tuple of (original_text, matrix_user_id, display_name) or None if not a valid agent
-
-    """
-    original = match.group(0)
-    name = match.group(2)
-
-    # Skip user-like mentions (e.g. mindroom_user_*)
-    if name.lower().startswith("user_"):
-        return None
-
-    agent_name = _find_matching_agent_name(match, config, runtime_paths)
-    if agent_name is None:
-        return None
-
-    agent_config = config.agents[agent_name]
-    user_id = MatrixID.from_agent(agent_name, sender_domain, runtime_paths).full_id
-    return (original, user_id, agent_config.display_name)
-
-
-def _find_matching_agent_name(
-    match: re.Match,
-    config: Config,
-    runtime_paths: RuntimePaths,
-) -> str | None:
-    """Return the configured agent name matched by one mention, if any."""
-    for candidate_name in _mention_candidate_names(match, runtime_paths):
-        candidate_lower = candidate_name.lower()
-        for config_agent_name in config.agents:
-            if config_agent_name.lower() == candidate_lower:
-                return config_agent_name
-    return None
-
-
-def _mention_candidate_names(match: re.Match, runtime_paths: RuntimePaths) -> list[str]:
-    """Build ordered candidate agent names for one mention match."""
-    name = match.group(2)
-    prefix = match.group(1)
-
-    # Prefer exact/base forms first, then prefix-reconstructed variants.
-    candidate_names = [name]
-    stripped_name: str | None = None
-
-    namespace = mindroom_namespace(runtime_paths)
-    if namespace:
-        suffix = f"_{namespace}"
-        if name.lower().endswith(suffix):
-            stripped_name = name[: -len(suffix)]
-            if stripped_name:
-                candidate_names.append(stripped_name)
-            else:
-                stripped_name = None
-
-    # When the regex captured a "mindroom_" prefix (group 1), the original mention
-    # was e.g. "@mindroom_dev" but group(2) is just "dev". The config key might
-    # be "mindroom_dev", so we must also try the un-stripped form. For namespaced
-    # mentions like "@mindroom_dev_ns123", we also need the combined
-    # prefix-plus-namespace-stripped candidate "mindroom_dev".
-    if prefix:
-        candidate_names.append(f"{prefix}{name}")
-        if stripped_name:
-            candidate_names.append(f"{prefix}{stripped_name}")
-    return candidate_names
 
 
 def format_message_with_mentions(

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -303,6 +303,57 @@ class TestMentionParsing:
             "@bas.nijholt:chat-mindroom.example.com</a></p>\n"
         )
 
+    def test_format_message_with_full_matrix_id_matching_agent_name_keeps_explicit_user(self) -> None:
+        """A fully qualified MXID should not be reinterpreted as an agent shorthand."""
+        config = _make_config(_default_runtime_paths())
+
+        content = _format_message_with_mentions(
+            config,
+            "Please ask @code:matrix.org to review this.",
+            sender_domain="localhost",
+        )
+
+        assert content["body"] == "Please ask @code:matrix.org to review this."
+        assert content["m.mentions"]["user_ids"] == ["@code:matrix.org"]
+        assert (
+            content["formatted_body"]
+            == '<p>Please ask <a href="https://matrix.to/#/@code:matrix.org">@code:matrix.org</a> to review this.</p>\n'
+        )
+
+    def test_format_message_with_plus_in_matrix_user_id_creates_clickable_mention(self) -> None:
+        """Matrix user IDs with a plus in the localpart should be linked."""
+        config = _make_config(_default_runtime_paths())
+
+        content = _format_message_with_mentions(
+            config,
+            "Ping @alice+ops:matrix.org please.",
+            sender_domain="localhost",
+        )
+
+        assert content["body"] == "Ping @alice+ops:matrix.org please."
+        assert content["m.mentions"]["user_ids"] == ["@alice+ops:matrix.org"]
+        assert (
+            content["formatted_body"]
+            == '<p>Ping <a href="https://matrix.to/#/@alice+ops:matrix.org">@alice+ops:matrix.org</a> please.</p>\n'
+        )
+
+    def test_format_message_with_ipv6_matrix_user_id_creates_clickable_mention(self) -> None:
+        """Matrix user IDs with bracketed IPv6 server names should be linked."""
+        config = _make_config(_default_runtime_paths())
+
+        content = _format_message_with_mentions(
+            config,
+            "Ping @alice:[2001:db8::1] please.",
+            sender_domain="localhost",
+        )
+
+        assert content["body"] == "Ping @alice:[2001:db8::1] please."
+        assert content["m.mentions"]["user_ids"] == ["@alice:[2001:db8::1]"]
+        assert (
+            content["formatted_body"]
+            == '<p>Ping <a href="https://matrix.to/#/@alice:%5B2001:db8::1%5D">@alice:[2001:db8::1]</a> please.</p>\n'
+        )
+
     def test_no_mentions_in_text(self) -> None:
         """Test text with no mentions."""
         config = _make_config(_default_runtime_paths())

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -134,6 +134,22 @@ class TestMentionParsing:
         assert processed == "Ask @mindroom_calculator_a1b2c3d4:localhost for help"
         assert mentions == ["@mindroom_calculator_a1b2c3d4:localhost"]
 
+    def test_parse_with_unnamespaced_agent_full_mxid_in_namespaced_install(self, tmp_path: Path) -> None:
+        """Explicit agent-shaped MXIDs should still map to local namespaced agents."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("agents: {}\nmodels: {}\nrouter:\n  model: default\n", encoding="utf-8")
+        runtime_paths = constants_mod.resolve_runtime_paths(
+            config_path=config_path,
+            process_env={"MINDROOM_NAMESPACE": "a1b2c3d4"},
+        )
+        config = _make_config(runtime_paths)
+
+        text = "Ask @mindroom_calculator:matrix.org for help"
+        processed, mentions, _markdown = _parse_mentions_in_text(text, "localhost", config)
+
+        assert processed == "Ask @mindroom_calculator_a1b2c3d4:localhost for help"
+        assert mentions == ["@mindroom_calculator_a1b2c3d4:localhost"]
+
     def test_custom_domain(self) -> None:
         """Test with custom sender domain."""
         config = _make_config(_default_runtime_paths())

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -336,6 +336,20 @@ class TestMentionParsing:
             == '<p>Please ask <a href="https://matrix.to/#/@code:matrix.org">@code:matrix.org</a> to review this.</p>\n'
         )
 
+    def test_format_message_with_uppercase_matrix_user_id_does_not_create_mention(self) -> None:
+        """Non-compliant uppercase MXIDs should remain plain text."""
+        config = _make_config(_default_runtime_paths())
+
+        content = _format_message_with_mentions(
+            config,
+            "Please ask @Code:matrix.org to review this.",
+            sender_domain="localhost",
+        )
+
+        assert content["body"] == "Please ask @Code:matrix.org to review this."
+        assert "m.mentions" not in content
+        assert content["formatted_body"] == "<p>Please ask @Code:matrix.org to review this.</p>\n"
+
     def test_format_message_with_plus_in_matrix_user_id_creates_clickable_mention(self) -> None:
         """Matrix user IDs with a plus in the localpart should be linked."""
         config = _make_config(_default_runtime_paths())

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -241,6 +241,68 @@ class TestMentionParsing:
 
         assert content["m.mentions"]["user_ids"] == ["@mindroom_research:matrix.org"]
 
+    def test_format_message_with_full_matrix_user_id_creates_clickable_mention(self) -> None:
+        """Non-agent full Matrix IDs should be rendered as clickable mentions."""
+        config = _make_config(_default_runtime_paths())
+
+        content = _format_message_with_mentions(
+            config,
+            "Yes, @bas.nijholt:chat-mindroom.example.com -- noted.",
+            sender_domain="matrix.org",
+        )
+
+        assert content["body"] == "Yes, @bas.nijholt:chat-mindroom.example.com -- noted."
+        assert content["m.mentions"]["user_ids"] == ["@bas.nijholt:chat-mindroom.example.com"]
+        assert (
+            content["formatted_body"] == '<p>Yes, <a href="https://matrix.to/#/@bas.nijholt:chat-mindroom.example.com">'
+            "@bas.nijholt:chat-mindroom.example.com</a> -- noted.</p>\n"
+        )
+
+    def test_format_message_with_agent_and_full_matrix_user_id_preserves_both_mentions(self) -> None:
+        """Agent mentions and explicit full Matrix user IDs should coexist cleanly."""
+        config = _make_config(_default_runtime_paths())
+
+        content = _format_message_with_mentions(
+            config,
+            "@calculator please follow up with @bas.nijholt:chat-mindroom.example.com",
+            sender_domain="matrix.org",
+        )
+
+        assert content["body"] == (
+            "@mindroom_calculator:matrix.org please follow up with @bas.nijholt:chat-mindroom.example.com"
+        )
+        assert content["m.mentions"]["user_ids"] == [
+            "@mindroom_calculator:matrix.org",
+            "@bas.nijholt:chat-mindroom.example.com",
+        ]
+        assert (
+            content["formatted_body"]
+            == '<p><a href="https://matrix.to/#/@mindroom_calculator:matrix.org">@Calculator</a> '
+            'please follow up with <a href="https://matrix.to/#/@bas.nijholt:chat-mindroom.example.com">'
+            "@bas.nijholt:chat-mindroom.example.com</a></p>\n"
+        )
+
+    def test_format_message_with_duplicate_full_matrix_user_ids_deduplicates_mentions(self) -> None:
+        """Repeated full Matrix user IDs should appear once in m.mentions."""
+        config = _make_config(_default_runtime_paths())
+
+        content = _format_message_with_mentions(
+            config,
+            "@bas.nijholt:chat-mindroom.example.com and again @bas.nijholt:chat-mindroom.example.com",
+            sender_domain="matrix.org",
+        )
+
+        assert content["body"] == (
+            "@bas.nijholt:chat-mindroom.example.com and again @bas.nijholt:chat-mindroom.example.com"
+        )
+        assert content["m.mentions"]["user_ids"] == ["@bas.nijholt:chat-mindroom.example.com"]
+        assert (
+            content["formatted_body"] == '<p><a href="https://matrix.to/#/@bas.nijholt:chat-mindroom.example.com">'
+            "@bas.nijholt:chat-mindroom.example.com</a> and again "
+            '<a href="https://matrix.to/#/@bas.nijholt:chat-mindroom.example.com">'
+            "@bas.nijholt:chat-mindroom.example.com</a></p>\n"
+        )
+
     def test_no_mentions_in_text(self) -> None:
         """Test text with no mentions."""
         config = _make_config(_default_runtime_paths())


### PR DESCRIPTION
## Summary
- detect full Matrix user IDs like `@alice:example.org` in `format_message_with_mentions()` and convert them into Matrix mention pills
- preserve existing configured-agent mention behavior while deduplicating `m.mentions.user_ids`
- add regression tests for human MXIDs, mixed agent-plus-human mentions, and duplicate full MXIDs

## Root Cause
The recent prompt update told agents to mention users using full Matrix IDs, but the outbound mention formatter still only upgraded configured agent mentions. That left human MXIDs as plain text with no `m.mentions` entry and no clickable pill.

## Test Plan
- `uv run pytest tests/test_mentions.py -q -n 0 --no-cov`
- `uv run pytest -n 0 --no-cov`
- `uv run pre-commit run --all-files`