### PR TITLE
refactor(knowledge): enforce mindroom.knowledge module boundary via 8-symbol facade

### DIFF
--- a/src/mindroom/api/knowledge.py
+++ b/src/mindroom/api/knowledge.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, File, HTTPException, Request, UploadFile
 
 from mindroom import constants
 from mindroom.api import config_lifecycle
-from mindroom.knowledge.manager import (
+from mindroom.knowledge import (
     KnowledgeManager,
     ensure_shared_knowledge_manager,
     get_shared_knowledge_manager_for_config,

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -35,8 +35,7 @@ from mindroom.history.runtime import (
     close_team_runtime_sqlite_dbs,
     open_bound_scope_session_context,
 )
-from mindroom.knowledge.manager import initialize_shared_knowledge_managers
-from mindroom.knowledge.utils import get_agent_knowledge
+from mindroom.knowledge import get_agent_knowledge, initialize_shared_knowledge_managers
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.routing import suggest_agent

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -99,7 +99,7 @@ from .inbound_turn_normalizer import (
     InboundTurnNormalizer,
     InboundTurnNormalizerDeps,
 )
-from .knowledge.utils import KnowledgeAccessSupport, MultiKnowledgeVectorDb
+from .knowledge import KnowledgeAccessSupport
 from .logging_config import get_logger
 from .matrix.avatar import check_and_set_avatar
 from .matrix.client import (
@@ -146,7 +146,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-__all__ = ["AgentBot", "MultiKnowledgeVectorDb"]
+__all__ = ["AgentBot"]
 
 
 # Constants

--- a/src/mindroom/custom_tools/delegate.py
+++ b/src/mindroom/custom_tools/delegate.py
@@ -15,7 +15,7 @@ from agno.tools import Toolkit
 
 from mindroom.agents import describe_agent
 from mindroom.ai import ai_response
-from mindroom.knowledge.utils import ensure_request_knowledge_managers, get_agent_knowledge
+from mindroom.knowledge import KnowledgeManager, ensure_request_knowledge_managers, get_agent_knowledge
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.runtime_context import (
     ToolRuntimeContext,
@@ -26,7 +26,6 @@ from mindroom.tool_system.runtime_context import (
 if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
-    from mindroom.knowledge.manager import KnowledgeManager
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 logger = get_logger(__name__)

--- a/src/mindroom/knowledge/__init__.py
+++ b/src/mindroom/knowledge/__init__.py
@@ -1,1 +1,27 @@
-"""Knowledge base management for file-backed RAG."""
+"""Public knowledge package interface."""
+
+# ruff: noqa: RUF022
+
+from mindroom.knowledge.manager import KnowledgeManager
+from mindroom.knowledge.shared_managers import (
+    ensure_shared_knowledge_manager,
+    get_shared_knowledge_manager_for_config,
+    initialize_shared_knowledge_managers,
+    shutdown_shared_knowledge_managers,
+)
+from mindroom.knowledge.utils import (
+    KnowledgeAccessSupport,
+    ensure_request_knowledge_managers,
+    get_agent_knowledge,
+)
+
+__all__ = [
+    "KnowledgeManager",
+    "initialize_shared_knowledge_managers",
+    "shutdown_shared_knowledge_managers",
+    "ensure_shared_knowledge_manager",
+    "get_shared_knowledge_manager_for_config",
+    "ensure_request_knowledge_managers",
+    "get_agent_knowledge",
+    "KnowledgeAccessSupport",
+]

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -781,6 +781,8 @@ class KnowledgeManager:
                 return set(), set(), False
 
             await self._run_git(["checkout", git_config.branch])
+            # Reviewed with Bas (2026-04-17): program-owned checkout, hard reset is the
+            # intentional way to realign it with the configured remote state.
             await self._run_git(["reset", "--hard", remote_ref])
             await self._hydrate_git_lfs_worktree(git_config, current_head=remote_head)
             after_files = await self._git_list_tracked_files()
@@ -788,7 +790,8 @@ class KnowledgeManager:
             return changed_files, set(), True
 
         await self._run_git(["checkout", git_config.branch])
-        # Force-align the local checkout with remote to tolerate local dirty state.
+        # Reviewed with Bas (2026-04-17): program-owned checkout, hard reset is the
+        # intentional way to realign it with the configured remote state.
         await self._run_git(["reset", "--hard", remote_ref])
         await self._hydrate_git_lfs_worktree(git_config, current_head=remote_head)
 
@@ -1417,14 +1420,3 @@ class KnowledgeManager:
                 await self.index_file(resolved_path, upsert=True)
         elif change == Change.deleted:
             await self.remove_file(resolved_path)
-
-
-from mindroom.knowledge import shared_managers as _shared_manager_api  # noqa: E402
-
-_get_shared_knowledge_manager = _shared_manager_api._get_shared_knowledge_manager
-_shared_knowledge_managers = _shared_manager_api._shared_knowledge_managers
-ensure_agent_knowledge_managers = _shared_manager_api.ensure_agent_knowledge_managers
-ensure_shared_knowledge_manager = _shared_manager_api.ensure_shared_knowledge_manager
-get_shared_knowledge_manager_for_config = _shared_manager_api.get_shared_knowledge_manager_for_config
-initialize_shared_knowledge_managers = _shared_manager_api.initialize_shared_knowledge_managers
-shutdown_shared_knowledge_managers = _shared_manager_api.shutdown_shared_knowledge_managers

--- a/src/mindroom/knowledge/shared_managers.py
+++ b/src/mindroom/knowledge/shared_managers.py
@@ -42,6 +42,8 @@ class _ResolvedKnowledgeManagerTarget:
 
 
 _shared_knowledge_managers: dict[str, KnowledgeManager] = {}
+# Two registries: shared managers serialize by base_id, request-scoped managers
+# serialize by resolved storage/path key. Weakref-backed so transient request keys don't leak.
 _shared_knowledge_manager_init_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
 _request_knowledge_manager_init_locks: weakref.WeakValueDictionary[_KnowledgeManagerKey, asyncio.Lock] = (
     weakref.WeakValueDictionary()

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 from agno.knowledge.knowledge import Knowledge
 
-from mindroom.knowledge.manager import (
+from mindroom.knowledge.shared_managers import (
     ensure_agent_knowledge_managers,
     get_shared_knowledge_manager_for_config,
 )
@@ -33,6 +33,19 @@ class _KnowledgeVectorDb(Protocol):
     """Subset of vector DB interface this module requires."""
 
     def search(
+        self,
+        *,
+        query: str,
+        limit: int,
+        filters: dict[str, Any] | list[Any] | None = None,
+    ) -> list[Document]: ...
+
+
+@runtime_checkable
+class _AsyncKnowledgeVectorDb(_KnowledgeVectorDb, Protocol):
+    """Vector DBs that support the async search path directly."""
+
+    async def async_search(
         self,
         *,
         query: str,
@@ -155,6 +168,8 @@ class MultiKnowledgeVectorDb:
     If agno changes the ``__post_init__`` protocol, this adapter will need updating.
     """
 
+    # Agno Knowledge.__post_init__ calls exists()/create(); this adapter intentionally
+    # lies because KnowledgeManager already owns the underlying DB lifecycle.
     vector_dbs: list[_KnowledgeVectorDb]
 
     def exists(self) -> bool:
@@ -199,9 +214,12 @@ class MultiKnowledgeVectorDb:
         async def _search_one(vdb: _KnowledgeVectorDb) -> list[Document]:
             results: list[Document]
             try:
-                try:
-                    results = await cast("Any", vdb).async_search(query=query, limit=limit, filters=filters)
-                except (NotImplementedError, AttributeError):
+                if isinstance(vdb, _AsyncKnowledgeVectorDb):
+                    try:
+                        results = await vdb.async_search(query=query, limit=limit, filters=filters)
+                    except (NotImplementedError, AttributeError):
+                        results = vdb.search(query=query, limit=limit, filters=filters)
+                else:
                     results = vdb.search(query=query, limit=limit, filters=filters)
             except Exception:
                 logger.warning(

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -26,7 +26,8 @@ from mindroom.hooks import (
 )
 from mindroom.hooks.execution import reset_hook_execution_state
 from mindroom.hooks.types import EVENT_CONFIG_RELOADED
-from mindroom.knowledge.manager import (
+from mindroom.knowledge import (
+    KnowledgeManager,
     initialize_shared_knowledge_managers,
     shutdown_shared_knowledge_managers,
 )
@@ -115,8 +116,6 @@ if TYPE_CHECKING:
     from mindroom.hooks.sender import HookMessageSender
 
     from .constants import RuntimePaths
-    from .knowledge.manager import KnowledgeManager
-
 logger = get_logger(__name__)
 
 _AUXILIARY_TASK_RESTART_INITIAL_DELAY_SECONDS = 1.0

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -34,7 +34,7 @@ from mindroom.hooks import (
 )
 from mindroom.hooks.ingress import is_automation_source_kind
 from mindroom.hooks.types import EVENT_SESSION_STARTED
-from mindroom.knowledge.utils import KnowledgeAccessSupport, ensure_request_knowledge_managers
+from mindroom.knowledge import KnowledgeAccessSupport, ensure_request_knowledge_managers
 from mindroom.logging_config import bound_log_context
 from mindroom.matrix.client import replace_visible_message
 from mindroom.matrix.identity import is_agent_id

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -51,7 +51,7 @@ from mindroom.history.runtime import (
 )
 from mindroom.history.storage import update_scope_seen_event_ids
 from mindroom.hooks import EnrichmentItem, render_system_enrichment_block
-from mindroom.knowledge.utils import ensure_request_knowledge_managers, get_agent_knowledge
+from mindroom.knowledge import KnowledgeManager, ensure_request_knowledge_managers, get_agent_knowledge
 from mindroom.logging_config import get_logger
 from mindroom.matrix.rooms import get_room_alias_from_id
 from mindroom.media_fallback import append_inline_media_fallback_prompt, should_retry_without_inline_media
@@ -79,7 +79,6 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.history import CompactionOutcome
-    from mindroom.knowledge.manager import KnowledgeManager
     from mindroom.matrix.client import ResolvedVisibleMessage
     from mindroom.matrix.identity import MatrixID
     from mindroom.orchestrator import MultiAgentOrchestrator

--- a/tach.toml
+++ b/tach.toml
@@ -114,6 +114,55 @@ depends_on = [
     "mindroom.matrix.conversation_cache",
 ]
 
+[[modules]]
+path = "mindroom.knowledge"
+depends_on = [
+    "mindroom.knowledge.manager",
+    "mindroom.knowledge.shared_managers",
+    "mindroom.knowledge.utils",
+]
+
+[[modules]]
+path = "mindroom.knowledge.chunking"
+depends_on = []
+
+[[modules]]
+path = "mindroom.knowledge.startup"
+depends_on = []
+
+[[modules]]
+path = "mindroom.knowledge.shared_managers"
+depends_on = [
+    "mindroom.knowledge.manager",
+    "mindroom.knowledge.startup",
+]
+
+[[modules]]
+path = "mindroom.knowledge.manager"
+depends_on = [
+    "mindroom.knowledge.chunking",
+]
+
+[[modules]]
+path = "mindroom.knowledge.utils"
+depends_on = [
+    "mindroom.knowledge.manager",
+    "mindroom.knowledge.shared_managers",
+]
+
+[[interfaces]]
+expose = [
+    "KnowledgeAccessSupport",
+    "KnowledgeManager",
+    "ensure_request_knowledge_managers",
+    "ensure_shared_knowledge_manager",
+    "get_agent_knowledge",
+    "get_shared_knowledge_manager_for_config",
+    "initialize_shared_knowledge_managers",
+    "shutdown_shared_knowledge_managers",
+]
+from = ["mindroom.knowledge"]
+
 [[interfaces]]
 expose = [
     "ConversationEventCache",

--- a/tests/api/test_knowledge_api.py
+++ b/tests/api/test_knowledge_api.py
@@ -16,7 +16,7 @@ from mindroom.config.knowledge import KnowledgeBaseConfig, KnowledgeGitConfig
 from mindroom.config.main import Config
 from mindroom.config.plugin import PluginEntryConfig
 from mindroom.constants import resolve_runtime_paths
-from mindroom.knowledge.manager import initialize_shared_knowledge_managers, shutdown_shared_knowledge_managers
+from mindroom.knowledge import initialize_shared_knowledge_managers, shutdown_shared_knowledge_managers
 
 
 def _knowledge_config(

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -23,6 +23,8 @@ from mindroom.knowledge.manager import (
     _MAX_CONCURRENT_KNOWLEDGE_FILE_INDEXES,
     KnowledgeManager,
     _create_embedder,
+)
+from mindroom.knowledge.shared_managers import (
     _get_shared_knowledge_manager,
     _shared_knowledge_managers,
     ensure_agent_knowledge_managers,

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -31,7 +31,6 @@ from mindroom.attachments import _attachment_id_for_event, register_local_attach
 from mindroom.authorization import is_authorized_sender as is_authorized_sender_for_test
 from mindroom.bot import (
     AgentBot,
-    MultiKnowledgeVectorDb,
     TeamBot,
 )
 from mindroom.coalescing import PreparedTextEvent
@@ -69,7 +68,8 @@ from mindroom.hooks import (
     hook,
 )
 from mindroom.inbound_turn_normalizer import DispatchPayload, DispatchPayloadWithAttachmentsRequest
-from mindroom.knowledge.manager import KnowledgeManager
+from mindroom.knowledge import KnowledgeManager
+from mindroom.knowledge.utils import MultiKnowledgeVectorDb
 from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.matrix.client import (
     DeliveredMatrixEvent,
@@ -865,6 +865,27 @@ class TestAgentBot:
 
         docs = await vector_db.async_search(query="knowledge query", limit=3)
         assert [doc.content for doc in docs] == ["research 1", "research 2"]
+
+    @pytest.mark.asyncio
+    async def test_multi_knowledge_vector_db_async_falls_back_on_attribute_error(self) -> None:
+        """Async search should fall back to sync search when async_search errors mid-call."""
+
+        class _AttributeErrorAsyncStubVectorDb(_SyncStubVectorDb):
+            async def async_search(
+                self,
+                *,
+                query: str,
+                limit: int,
+                filters: dict[str, Any] | list[Any] | None = None,
+            ) -> list[Document]:
+                _ = (query, limit, filters)
+                error_message = "simulated mid-execution"
+                raise AttributeError(error_message)
+
+        docs = await MultiKnowledgeVectorDb(
+            vector_dbs=[_AttributeErrorAsyncStubVectorDb(documents=[Document(content="fallback doc")])],
+        ).async_search(query="knowledge query", limit=1)
+        assert [doc.content for doc in docs] == ["fallback doc"]
 
     @pytest.mark.asyncio
     @patch("mindroom.config.main.Config.from_yaml")


### PR DESCRIPTION
## Summary
- enforce a narrow `mindroom.knowledge` facade and codify it with a `tach.toml` interface boundary
- migrate cross-domain callers to the facade and drop the accidental `MultiKnowledgeVectorDb` re-export from `bot.py`
- tighten `async_search` dispatch with a runtime-checkable protocol and add regression coverage around the sync fallback path

## Test Plan
- `uv run pytest`
