### PR TITLE
Remove internal matrix.client facade imports

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -95,7 +95,7 @@ if TYPE_CHECKING:
 
     from mindroom.config.main import Config
     from mindroom.config.models import ModelConfig
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.tool_system.events import ToolTraceEntry
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 

--- a/src/mindroom/api/matrix_operations.py
+++ b/src/mindroom/api/matrix_operations.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from mindroom import constants
 from mindroom.api.config_lifecycle import read_committed_config_and_runtime
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client import get_joined_rooms, get_room_name, leave_room
+from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_name, leave_room
 from mindroom.matrix.rooms import resolve_room_aliases
 from mindroom.matrix.users import create_agent_user, login_agent_user
 

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -37,7 +37,7 @@ from mindroom.history.runtime import (
 )
 from mindroom.knowledge import get_agent_knowledge, initialize_shared_knowledge_managers
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client import ResolvedVisibleMessage
+from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 from mindroom.routing import suggest_agent
 from mindroom.teams import (
     TeamMode,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -101,11 +101,8 @@ from .inbound_turn_normalizer import (
 from .knowledge import KnowledgeAccessSupport
 from .logging_config import get_logger
 from .matrix.avatar import check_and_set_avatar
-from .matrix.client import (
-    PermanentMatrixStartupError,
-    ResolvedVisibleMessage,
-    get_joined_rooms,
-)
+from .matrix.client_room_admin import get_joined_rooms
+from .matrix.client_session import PermanentMatrixStartupError
 from .media_inputs import MediaInputs
 from .response_runner import (
     ResponseRequest,
@@ -138,7 +135,7 @@ if TYPE_CHECKING:
 
     from mindroom.config.main import Config
     from mindroom.matrix.cache import ConversationEventCache, EventCacheWriteCoordinator
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.orchestrator import MultiAgentOrchestrator
     from mindroom.runtime_support import StartupThreadPrewarmRegistry
     from mindroom.tool_system.events import ToolTraceEntry

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -10,7 +10,7 @@ import nio
 from mindroom.authorization import is_authorized_sender
 from mindroom.commands.handler import _generate_welcome_message
 from mindroom.constants import ROUTER_AGENT_NAME
-from mindroom.matrix.client import get_joined_rooms, join_room
+from mindroom.matrix.client_room_admin import get_joined_rooms, join_room
 from mindroom.matrix.invited_rooms_store import (
     invited_rooms_path,
     load_invited_rooms,

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
     from mindroom.config.main import Config
     from mindroom.hooks.types import HookMatrixAdmin
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol, ConversationEventCache
     from mindroom.matrix.identity import MatrixID
     from mindroom.message_target import MessageTarget

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -13,7 +13,7 @@ from nio.responses import RoomGetEventError
 from mindroom.attachments import parse_attachment_ids_from_event_source
 from mindroom.coalescing import PreparedTextEvent
 from mindroom.constants import HOOK_MESSAGE_RECEIVED_DEPTH_KEY
-from mindroom.matrix.client import cached_room as matrix_cached_room
+from mindroom.matrix.client_delivery import cached_room as matrix_cached_room
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.identity import MatrixID, extract_agent_name
 from mindroom.matrix.message_content import resolve_event_source_content
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.constants import RuntimePaths
     from mindroom.hooks import MessageEnvelope
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.conversation_cache import MatrixConversationCache, ThreadReadResult
 
 type TextDispatchEvent = nio.RoomMessageText | PreparedTextEvent

--- a/src/mindroom/custom_tools/attachments.py
+++ b/src/mindroom/custom_tools/attachments.py
@@ -19,7 +19,7 @@ from mindroom.attachments import (
 from mindroom.custom_tools.attachment_helpers import (
     room_access_allowed,
 )
-from mindroom.matrix.client import send_file_message
+from mindroom.matrix.client_delivery import send_file_message
 from mindroom.tool_system.runtime_context import (
     append_tool_runtime_attachment_id,
     attachment_id_available_in_tool_runtime_context,

--- a/src/mindroom/custom_tools/matrix_message.py
+++ b/src/mindroom/custom_tools/matrix_message.py
@@ -32,20 +32,20 @@ from mindroom.interactive import (
     should_create_interactive_question,
 )
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client import (
-    ResolvedVisibleMessage,
-    RoomThreadsPageError,
+from mindroom.matrix.client_delivery import (
     edit_message_result,
-    get_room_threads_page,
     send_file_message,
     send_message_result,
 )
+from mindroom.matrix.client_thread_history import RoomThreadsPageError, get_room_threads_page
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_content import extract_and_resolve_message
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 
 logger = get_logger(__name__)
 

--- a/src/mindroom/custom_tools/matrix_room.py
+++ b/src/mindroom/custom_tools/matrix_room.py
@@ -14,7 +14,7 @@ from aiohttp import ClientError
 
 from mindroom.custom_tools.attachment_helpers import room_access_allowed
 from mindroom.custom_tools.matrix_helpers import check_rate_limit, message_preview
-from mindroom.matrix.client import RoomThreadsPageError, get_room_threads_page
+from mindroom.matrix.client_thread_history import RoomThreadsPageError, get_room_threads_page
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
 
 

--- a/src/mindroom/custom_tools/subagents.py
+++ b/src/mindroom/custom_tools/subagents.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, cast
 from agno.tools import Toolkit
 
 from mindroom.constants import ORIGINAL_SENDER_KEY
-from mindroom.matrix.client import send_message_result
+from mindroom.matrix.client_delivery import send_message_result
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.message_target import MessageTarget
 from mindroom.thread_summary import (

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.conversation_resolver import ConversationResolver
     from mindroom.hooks import MessageEnvelope
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.event_info import EventInfo
     from mindroom.message_target import MessageTarget
     from mindroom.turn_policy import IngressHookRunner

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -26,10 +26,7 @@ from mindroom.history.runtime import (
 )
 from mindroom.history.storage import read_scope_seen_event_ids
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client import (
-    ResolvedVisibleMessage,
-    replace_visible_message,
-)
+from mindroom.matrix.client_visible_messages import replace_visible_message
 from mindroom.streaming import clean_partial_reply_text, is_interrupted_partial_reply
 from mindroom.timing import timed
 
@@ -43,6 +40,7 @@ if TYPE_CHECKING:
     from mindroom.history import CompactionOutcome
     from mindroom.history.runtime import PreparedScopeHistory
     from mindroom.history.types import PreparedHistoryState, ResolvedReplayPlan
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 
 logger = get_logger(__name__)
 

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import nio
 
-from mindroom.matrix.client import add_room_to_space, create_room, get_room_members, invite_to_room
+from mindroom.matrix.client_room_admin import add_room_to_space, create_room, get_room_members, invite_to_room
 from mindroom.matrix.identity import extract_server_name_from_homeserver
 
 if TYPE_CHECKING:

--- a/src/mindroom/hooks/sender.py
+++ b/src/mindroom/hooks/sender.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from mindroom.hooks.types import HookMessageSender  # noqa: TC001
-from mindroom.matrix.client import send_message_result
+from mindroom.matrix.client_delivery import send_message_result
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.mentions import format_message_with_mentions
 

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.constants import RuntimePaths
     from mindroom.conversation_resolver import ConversationResolver
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 
 type MediaDispatchEvent = (
     nio.RoomMessageImage

--- a/src/mindroom/matrix/room_cleanup.py
+++ b/src/mindroom/matrix/room_cleanup.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 import nio
 
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client import get_joined_rooms, get_room_members
+from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_members
 from mindroom.matrix.identity import MatrixID, agent_username_localpart
 from mindroom.matrix.invited_rooms_store import invited_rooms_path, load_invited_rooms, should_persist_invited_rooms
 from mindroom.matrix.rooms import is_dm_room

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -21,13 +21,9 @@ from mindroom.constants import (
     STREAM_STATUS_STREAMING,
 )
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client import (
-    ResolvedVisibleMessage,
-    edit_message_result,
-    get_joined_rooms,
-    send_message_result,
-)
-from mindroom.matrix.client_visible_messages import resolve_latest_visible_messages
+from mindroom.matrix.client_delivery import edit_message_result, send_message_result
+from mindroom.matrix.client_room_admin import get_joined_rooms
+from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage, resolve_latest_visible_messages
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.identity import MatrixID, extract_agent_name
 from mindroom.matrix.mentions import format_message_with_mentions

--- a/src/mindroom/memory/_prompting.py
+++ b/src/mindroom/memory/_prompting.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 
     from ._shared import MemoryResult
 

--- a/src/mindroom/memory/functions.py
+++ b/src/mindroom/memory/functions.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
     from ._shared import ScopedMemoryCrud

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -14,7 +14,7 @@ import httpx
 from mindroom import constants
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths, runtime_matrix_ssl_verify
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client import PermanentMatrixStartupError
+from mindroom.matrix.client_session import PermanentMatrixStartupError
 from mindroom.matrix.health import (
     MATRIX_SYNC_STARTUP_GRACE_SECONDS,
     MATRIX_SYNC_WATCHDOG_TIMEOUT_SECONDS,

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -31,12 +31,8 @@ from mindroom.knowledge import (
     initialize_shared_knowledge_managers,
     shutdown_shared_knowledge_managers,
 )
-from mindroom.matrix.client import (
-    PermanentMatrixStartupError,
-    get_joined_rooms,
-    get_room_members,
-    invite_to_room,
-)
+from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_members, invite_to_room
+from mindroom.matrix.client_session import PermanentMatrixStartupError
 from mindroom.matrix.health import reset_matrix_sync_health
 from mindroom.matrix.identity import MatrixID, extract_server_name_from_homeserver
 from mindroom.matrix.rooms import (

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.delivery_gateway import DeliveryGateway, DeliveryResult
     from mindroom.history.types import CompactionOutcome
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -36,7 +36,7 @@ from mindroom.hooks.ingress import is_automation_source_kind
 from mindroom.hooks.types import EVENT_SESSION_STARTED
 from mindroom.knowledge import KnowledgeAccessSupport, ensure_request_knowledge_managers
 from mindroom.logging_config import bound_log_context
-from mindroom.matrix.client import replace_visible_message
+from mindroom.matrix.client_visible_messages import replace_visible_message
 from mindroom.matrix.identity import is_agent_id
 from mindroom.matrix.presence import is_user_online, should_use_streaming
 from mindroom.matrix.typing import typing_indicator
@@ -96,7 +96,7 @@ if TYPE_CHECKING:
     from mindroom.conversation_resolver import ConversationResolver
     from mindroom.conversation_state_writer import ConversationStateWriter
     from mindroom.history.types import CompactionOutcome
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.identity import MatrixID
     from mindroom.message_target import MessageTarget
     from mindroom.stop import StopManager

--- a/src/mindroom/routing.py
+++ b/src/mindroom/routing.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 from mindroom.agents import describe_agent
 from mindroom.ai import get_model_instance
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client import ResolvedVisibleMessage, replace_visible_message
+from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage, replace_visible_message
 from mindroom.matrix.identity import MatrixID
 
 if TYPE_CHECKING:

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -33,7 +33,7 @@ from mindroom.hooks import (
 from mindroom.hooks.sender import build_hook_message_sender
 from mindroom.hooks.types import EVENT_SCHEDULE_FIRED
 from mindroom.logging_config import bound_log_context, get_logger
-from mindroom.matrix.client import send_message_result
+from mindroom.matrix.client_delivery import send_message_result
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.mentions import format_message_with_mentions, parse_mentions_in_text
 from mindroom.matrix.message_builder import build_message_content

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -19,7 +19,7 @@ from mindroom.constants import (
     STREAM_STATUS_STREAMING,
 )
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client import edit_message_result, send_message_result
+from mindroom.matrix.client_delivery import edit_message_result, send_message_result
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.message_target import MessageTarget
 from mindroom.orchestration.runtime import is_sync_restart_cancel

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -79,7 +79,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.history import CompactionOutcome
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.identity import MatrixID
     from mindroom.orchestrator import MultiAgentOrchestrator
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field
 
 from mindroom.ai import cached_agent_run, get_model_instance
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client import send_message_result
+from mindroom.matrix.client_delivery import send_message_result
 from mindroom.matrix.message_builder import build_message_content
 from mindroom.timing import timed
 
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol
 
 logger = get_logger(__name__)

--- a/src/mindroom/thread_utils.py
+++ b/src/mindroom/thread_utils.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 # Matches <a href="https://matrix.to/#/@user:domain">...</a> pills used by bridges.
 # Accepts both single and double quotes (mautrix bridges use single quotes).
 # Requires @localpart:domain format to avoid feeding malformed IDs to MatrixID.parse.

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -94,7 +94,7 @@ if TYPE_CHECKING:
     from mindroom.conversation_resolver import ConversationResolver, MessageContext
     from mindroom.delivery_gateway import DeliveryGateway
     from mindroom.hooks import MessageEnvelope
-    from mindroom.matrix.client import ResolvedVisibleMessage
+    from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.conversation_cache import MatrixConversationCache
     from mindroom.matrix.identity import MatrixID
     from mindroom.message_target import MessageTarget

--- a/tach.toml
+++ b/tach.toml
@@ -193,7 +193,8 @@ depends_on = [
 path = "mindroom.matrix.stale_stream_cleanup"
 depends_on = [
     "mindroom.constants",
-    "mindroom.matrix.client",
+    "mindroom.matrix.client_delivery",
+    "mindroom.matrix.client_room_admin",
     "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.conversation_cache",
     "mindroom.matrix.event_info",
@@ -206,7 +207,7 @@ depends_on = [
 path = "mindroom.conversation_resolver"
 depends_on = [
     "mindroom.constants",
-    "mindroom.matrix.client",
+    "mindroom.matrix.client_delivery",
     "mindroom.matrix.conversation_cache",
     "mindroom.matrix.event_info",
     "mindroom.matrix.message_content",
@@ -223,7 +224,8 @@ depends_on = [
     "mindroom.knowledge",
     "mindroom.memory",
     "mindroom.matrix.cache",
-    "mindroom.matrix.client",
+    "mindroom.matrix.client_room_admin",
+    "mindroom.matrix.client_session",
     "mindroom.matrix.conversation_cache",
     "mindroom.matrix.event_info",
     "mindroom.post_response_effects",
@@ -250,7 +252,7 @@ depends_on = [
     "mindroom.ai",
     "mindroom.hooks.sender",
     "mindroom.constants",
-    "mindroom.matrix.client",
+    "mindroom.matrix.client_delivery",
     "mindroom.matrix.conversation_cache",
 ]
 
@@ -262,13 +264,13 @@ depends_on = ["mindroom.matrix.conversation_cache", "mindroom.scheduling"]
 path = "mindroom.thread_summary"
 depends_on = [
     "mindroom.ai",
-    "mindroom.matrix.client",
+    "mindroom.matrix.client_delivery",
     "mindroom.matrix.conversation_cache",
 ]
 
 [[modules]]
 path = "mindroom.streaming"
-depends_on = ["mindroom.constants", "mindroom.matrix.client", "mindroom.matrix.conversation_cache"]
+depends_on = ["mindroom.constants", "mindroom.matrix.client_delivery", "mindroom.matrix.conversation_cache"]
 
 [[modules]]
 path = "mindroom.post_response_effects"
@@ -276,7 +278,7 @@ depends_on = ["mindroom.matrix.conversation_cache", "mindroom.thread_summary"]
 
 [[modules]]
 path = "mindroom.hooks.sender"
-depends_on = ["mindroom.matrix.client", "mindroom.matrix.conversation_cache"]
+depends_on = ["mindroom.matrix.client_delivery", "mindroom.matrix.conversation_cache"]
 
 [[modules]]
 path = "mindroom.turn_controller"


### PR DESCRIPTION
## Summary
- remove internal `mindroom.matrix.client` imports from `src/mindroom` and point callers at the split Matrix modules directly
- update the governed Tach slice so the cleaned-up dependencies stay enforced for bot, scheduling, streaming, thread summary, hooks, and stale stream cleanup
- keep `mindroom.matrix.client` as the thin public compatibility seam instead of the default internal import path

## Test Plan
- env -u VIRTUAL_ENV uv sync --all-extras
- env -u VIRTUAL_ENV uv run tach check --dependencies --interfaces
- env -u VIRTUAL_ENV uv run pytest -n auto -q
- env -u VIRTUAL_ENV uv run pre-commit run --all-files
