### PR TITLE
Fix Tach enforcement for split Matrix client imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,6 +437,7 @@ helm upgrade --install platform ./cluster/k8s/platform -f cluster/k8s/platform/v
 
 - **Test Before Committing**: **NEVER** claim a task is complete without running `pytest` to ensure all tests pass.
 - **Run Pre-commit Hooks**: After `uv sync --all-extras`, run `uv run pre-commit run --all-files` before committing to enforce code style and quality.
+- **Update Tach Boundaries in the Same PR**: If your PR changes a Tach-governed boundary, update `tach.toml` in the same PR, follow the guidance in the comment at the top of that file, and run `uv run tach check --dependencies --interfaces`.
 - **Handle Linter Issues**:
   - **False Positives**: The linter may incorrectly flag issues in `pyproject.toml`; these can be ignored.
   - **Test-Related Errors**: If a pre-commit fix breaks a test (e.g., by removing an unused but necessary fixture), suppress the warning with a `# noqa: <error_code>` comment.

--- a/src/mindroom/cli/templates/mind_data/AGENTS.md
+++ b/src/mindroom/cli/templates/mind_data/AGENTS.md
@@ -131,6 +131,10 @@ Skills provide your tools. When you need one, check its `SKILL.md`. Keep local n
 - Use clear Markdown and keep formatting readable in Matrix rooms.
 - Prefer bullet lists over large tables in chat contexts.
 
+**🧱 MindRoom Tach Boundaries:**
+
+- If your work changes a Tach-governed boundary, update `tach.toml` in the same PR, follow the guidance in the comment at the top of that file, and run `uv run tach check --dependencies --interfaces`.
+
 ## 💓 Heartbeats - Be Proactive!
 
 When you receive a heartbeat poll (message matches the configured heartbeat prompt), don't just reply `HEARTBEAT_OK` every time. Use heartbeats productively!

--- a/tach.toml
+++ b/tach.toml
@@ -1,15 +1,110 @@
+# Tach is the source of truth for enforced module boundaries in this repo.
+# If a PR changes runtime module dependencies or public import surfaces in a
+# Tach-governed area, update this file in the same PR.
+#
+# Boundary rules:
+# - Use explicit `[[modules]] path = "..."` entries plus `depends_on` for
+#   importer-specific enforcement.
+# - Use module `visibility` to restrict which modules may import a module.
+# - Use `[[interfaces]]` only for symbol-level public APIs.
+# - Do not rely on interface `visibility` as a substitute for module
+#   dependency rules.
+# - Use grouped `paths = [...]` only when every grouped module intentionally
+#   shares the exact same policy.
+#
+# Docs:
+# - https://docs.gauge.sh/usage/configuration/
+# - https://docs.gauge.sh/usage/interfaces/
 exclude = ["**/*__pycache__", "**/*egg-info", "**/docs", "**/tests", "**/venv"]
 source_roots = ["src"]
 
-# Keep the current memory facade consumers visible to Tach so the public
-# interface is enforced without widening dependency enforcement repo-wide.
+# Keep memory consumers explicit so imports are enforced rather than merely
+# interface-checked.
 [[modules]]
-paths = [
-    "mindroom.ai",
-    "mindroom.custom_tools.memory",
-    "mindroom.orchestrator",
-    "mindroom.response_runner",
+path = "mindroom.ai"
+depends_on = [
+    "mindroom.constants",
+    "mindroom.execution_preparation",
+    "mindroom.memory",
 ]
+
+[[modules]]
+path = "mindroom.custom_tools.memory"
+depends_on = ["mindroom.memory"]
+
+# Keep split Matrix client consumers on explicit per-module rules so Tach can
+# enforce both dependency edges and module visibility for each importer.
+[[modules]]
+path = "mindroom.api.matrix_operations"
+depends_on = ["mindroom.constants", "mindroom.matrix.client_room_admin", "mindroom.matrix.rooms", "mindroom.matrix.users"]
+
+[[modules]]
+path = "mindroom.api.openai_compat"
+depends_on = ["mindroom.knowledge", "mindroom.execution_preparation", "mindroom.constants", "mindroom.routing", "mindroom.matrix.client_visible_messages", "mindroom.ai"]
+
+[[modules]]
+path = "mindroom.bot_room_lifecycle"
+depends_on = ["mindroom.matrix.client_room_admin", "mindroom.constants", "mindroom.matrix.rooms", "mindroom.commands.handler"]
+
+[[modules]]
+path = "mindroom.custom_tools.attachments"
+depends_on = ["mindroom.tool_system.runtime_context", "mindroom.matrix.client_delivery"]
+
+[[modules]]
+path = "mindroom.custom_tools.matrix_message"
+depends_on = ["mindroom.matrix.message_content", "mindroom.custom_tools.attachments", "mindroom.tool_system.runtime_context", "mindroom.matrix.client_thread_history", "mindroom.matrix.client_delivery", "mindroom.constants"]
+
+[[modules]]
+path = "mindroom.custom_tools.matrix_room"
+depends_on = ["mindroom.matrix.client_thread_history", "mindroom.tool_system.runtime_context"]
+
+[[modules]]
+path = "mindroom.custom_tools.subagents"
+depends_on = ["mindroom.constants", "mindroom.matrix.client_delivery", "mindroom.tool_system.runtime_context", "mindroom.thread_summary"]
+
+[[modules]]
+path = "mindroom.delivery_gateway"
+depends_on = ["mindroom.streaming", "mindroom.constants", "mindroom.matrix.client_delivery"]
+
+[[modules]]
+path = "mindroom.execution_preparation"
+depends_on = ["mindroom.matrix.client_visible_messages", "mindroom.streaming", "mindroom.constants"]
+
+[[modules]]
+path = "mindroom.hooks.matrix_admin"
+depends_on = ["mindroom.matrix.client_room_admin"]
+
+[[modules]]
+path = "mindroom.matrix.provisioning"
+depends_on = ["mindroom.matrix.client_session", "mindroom.constants"]
+
+[[modules]]
+path = "mindroom.matrix.room_cleanup"
+depends_on = ["mindroom.matrix.rooms", "mindroom.matrix.client_room_admin", "mindroom.matrix.users"]
+
+[[modules]]
+path = "mindroom.matrix.rooms"
+depends_on = ["mindroom.constants", "mindroom.matrix.client_room_admin", "mindroom.matrix.client_session", "mindroom.matrix.users"]
+
+[[modules]]
+path = "mindroom.matrix.users"
+depends_on = ["mindroom.matrix.client_session", "mindroom.matrix.provisioning", "mindroom.constants"]
+
+[[modules]]
+path = "mindroom.orchestration.runtime"
+depends_on = ["mindroom.matrix.client_session", "mindroom.constants", "mindroom.matrix.users"]
+
+[[modules]]
+path = "mindroom.orchestrator"
+depends_on = ["mindroom.matrix.users", "mindroom.orchestration.runtime", "mindroom.knowledge", "mindroom.memory", "mindroom.matrix.client_room_admin", "mindroom.scheduling", "mindroom.matrix.rooms", "mindroom.matrix.stale_stream_cleanup", "mindroom.constants", "mindroom.bot", "mindroom.matrix.client_session", "mindroom.runtime_support"]
+
+[[modules]]
+path = "mindroom.response_runner"
+depends_on = ["mindroom.ai", "mindroom.post_response_effects", "mindroom.constants", "mindroom.delivery_gateway", "mindroom.orchestration.runtime", "mindroom.thread_summary", "mindroom.matrix.client_visible_messages", "mindroom.tool_system.runtime_context", "mindroom.knowledge", "mindroom.memory", "mindroom.streaming"]
+
+[[modules]]
+path = "mindroom.routing"
+depends_on = ["mindroom.matrix.client_visible_messages", "mindroom.ai"]
 
 # ARCH-B memory enforcement slice: keep public memory config types owned by config.
 [[modules]]
@@ -127,14 +222,47 @@ depends_on = [
 [[modules]]
 path = "mindroom.matrix.client_delivery"
 depends_on = ["mindroom.matrix.conversation_cache"]
+visibility = [
+    "mindroom.conversation_resolver",
+    "mindroom.custom_tools.attachments",
+    "mindroom.custom_tools.matrix_message",
+    "mindroom.custom_tools.subagents",
+    "mindroom.delivery_gateway",
+    "mindroom.hooks.sender",
+    "mindroom.matrix.client",
+    "mindroom.matrix.stale_stream_cleanup",
+    "mindroom.scheduling",
+    "mindroom.streaming",
+    "mindroom.thread_summary",
+]
 
 [[modules]]
 path = "mindroom.matrix.client_room_admin"
 depends_on = []
+visibility = [
+    "mindroom.api.matrix_operations",
+    "mindroom.bot",
+    "mindroom.bot_room_lifecycle",
+    "mindroom.hooks.matrix_admin",
+    "mindroom.matrix.client",
+    "mindroom.matrix.room_cleanup",
+    "mindroom.matrix.rooms",
+    "mindroom.matrix.stale_stream_cleanup",
+    "mindroom.orchestrator",
+]
 
 [[modules]]
 path = "mindroom.matrix.client_session"
 depends_on = ["mindroom.constants"]
+visibility = [
+    "mindroom.bot",
+    "mindroom.matrix.client",
+    "mindroom.matrix.provisioning",
+    "mindroom.matrix.rooms",
+    "mindroom.matrix.users",
+    "mindroom.orchestration.runtime",
+    "mindroom.orchestrator",
+]
 
 [[modules]]
 path = "mindroom.matrix.client_visible_messages"
@@ -142,6 +270,15 @@ depends_on = [
     "mindroom.constants",
     "mindroom.matrix.event_info",
     "mindroom.matrix.message_content",
+]
+visibility = [
+    "mindroom.api.openai_compat",
+    "mindroom.execution_preparation",
+    "mindroom.matrix.client",
+    "mindroom.matrix.client_thread_history",
+    "mindroom.matrix.stale_stream_cleanup",
+    "mindroom.response_runner",
+    "mindroom.routing",
 ]
 
 [[modules]]
@@ -162,6 +299,13 @@ depends_on = [
     "mindroom.matrix.message_content",
     "mindroom.matrix.thread_membership",
     "mindroom.matrix.thread_projection",
+]
+visibility = [
+    "mindroom.custom_tools.matrix_message",
+    "mindroom.custom_tools.matrix_room",
+    "mindroom.matrix.client",
+    "mindroom.matrix.conversation_cache",
+    "mindroom.matrix.thread_room_scan",
 ]
 
 [[modules]]
@@ -218,8 +362,10 @@ depends_on = [
 path = "mindroom.bot"
 depends_on = [
     "mindroom.bot_runtime_view",
+    "mindroom.bot_room_lifecycle",
     "mindroom.constants",
     "mindroom.conversation_resolver",
+    "mindroom.delivery_gateway",
     "mindroom.hooks.sender",
     "mindroom.knowledge",
     "mindroom.memory",
@@ -228,6 +374,9 @@ depends_on = [
     "mindroom.matrix.client_session",
     "mindroom.matrix.conversation_cache",
     "mindroom.matrix.event_info",
+    "mindroom.matrix.room_cleanup",
+    "mindroom.matrix.rooms",
+    "mindroom.matrix.users",
     "mindroom.post_response_effects",
     "mindroom.response_runner",
     "mindroom.runtime_support",
@@ -270,11 +419,11 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.streaming"
-depends_on = ["mindroom.constants", "mindroom.matrix.client_delivery", "mindroom.matrix.conversation_cache"]
+depends_on = ["mindroom.constants", "mindroom.matrix.client_delivery", "mindroom.matrix.conversation_cache", "mindroom.orchestration.runtime"]
 
 [[modules]]
 path = "mindroom.post_response_effects"
-depends_on = ["mindroom.matrix.conversation_cache", "mindroom.thread_summary"]
+depends_on = ["mindroom.matrix.conversation_cache", "mindroom.thread_summary", "mindroom.delivery_gateway"]
 
 [[modules]]
 path = "mindroom.hooks.sender"
@@ -287,9 +436,12 @@ depends_on = [
     "mindroom.constants",
     "mindroom.matrix.cache",
     "mindroom.matrix.conversation_cache",
-    "mindroom.response_runner",
     "mindroom.matrix.event_info",
     "mindroom.matrix.message_content",
+    "mindroom.matrix.rooms",
+    "mindroom.response_runner",
+    "mindroom.routing",
+    "mindroom.delivery_gateway",
 ]
 
 [[modules]]
@@ -514,8 +666,6 @@ expose = [
     "leave_room",
 ]
 from = ["mindroom.matrix.client_room_admin"]
-visibility = ["mindroom.matrix.client", "mindroom.matrix.rooms"]
-exclusive = true
 
 [[interfaces]]
 expose = [
@@ -526,12 +676,6 @@ expose = [
     "restore_login",
 ]
 from = ["mindroom.matrix.client_session"]
-visibility = [
-    "mindroom.matrix.client",
-    "mindroom.matrix.provisioning",
-    "mindroom.matrix.users",
-]
-exclusive = true
 
 [[interfaces]]
 expose = [
@@ -545,8 +689,6 @@ expose = [
     "send_message_result",
 ]
 from = ["mindroom.matrix.client_delivery"]
-visibility = ["mindroom.matrix.client"]
-exclusive = true
 
 [[interfaces]]
 expose = [
@@ -557,12 +699,6 @@ expose = [
     "resolve_latest_visible_messages",
 ]
 from = ["mindroom.matrix.client_visible_messages"]
-visibility = [
-    "mindroom.matrix.client",
-    "mindroom.matrix.client_thread_history",
-    "mindroom.matrix.stale_stream_cleanup",
-]
-exclusive = true
 
 [[interfaces]]
 expose = [
@@ -577,12 +713,6 @@ expose = [
     "refresh_thread_history_from_source",
 ]
 from = ["mindroom.matrix.client_thread_history"]
-visibility = [
-    "mindroom.matrix.client",
-    "mindroom.matrix.conversation_cache",
-    "mindroom.matrix.thread_room_scan",
-]
-exclusive = true
 
 [[interfaces]]
 expose = [

--- a/tests/test_tach_split_matrix_client_boundaries.py
+++ b/tests/test_tach_split_matrix_client_boundaries.py
@@ -1,0 +1,178 @@
+"""Regression tests for split Matrix client Tach boundaries."""
+
+from __future__ import annotations
+
+import ast
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = REPO_ROOT / "src" / "mindroom"
+TACH_CONFIG = REPO_ROOT / "tach.toml"
+SPLIT_MATRIX_CLIENT_MODULES = {
+    "mindroom.matrix.client_delivery",
+    "mindroom.matrix.client_room_admin",
+    "mindroom.matrix.client_session",
+    "mindroom.matrix.client_thread_history",
+    "mindroom.matrix.client_visible_messages",
+}
+
+
+def _load_tach_config() -> dict[str, object]:
+    with TACH_CONFIG.open("rb") as f:
+        return tomllib.load(f)
+
+
+def _module_entries_by_path() -> dict[str, dict[str, object]]:
+    config = _load_tach_config()
+    module_entries: dict[str, dict[str, object]] = {}
+    for module in config["modules"]:
+        module_entry = dict(module)
+        path = module_entry.get("path")
+        if isinstance(path, str):
+            module_entries[path] = module_entry
+    return module_entries
+
+
+def _resolve_import_from_module(importer_module: str, node: ast.ImportFrom) -> str | None:
+    if node.level == 0:
+        return node.module
+
+    package_parts = importer_module.split(".")[:-1]
+    if node.level > len(package_parts):
+        return None
+
+    base_parts = package_parts[: len(package_parts) - node.level + 1]
+    if node.module:
+        base_parts.extend(node.module.split("."))
+    return ".".join(base_parts)
+
+
+def _is_type_checking_test(test: ast.expr) -> bool:
+    if isinstance(test, ast.Name):
+        return test.id == "TYPE_CHECKING"
+    return (
+        isinstance(test, ast.Attribute)
+        and isinstance(test.value, ast.Name)
+        and test.value.id == "typing"
+        and test.attr == "TYPE_CHECKING"
+    )
+
+
+def _record_runtime_split_import(node: ast.AST, importer_module: str, imports: set[str]) -> None:
+    if isinstance(node, ast.ImportFrom):
+        resolved_module = _resolve_import_from_module(importer_module, node)
+        if resolved_module in SPLIT_MATRIX_CLIENT_MODULES:
+            imports.add(resolved_module)
+        return
+
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            if alias.name in SPLIT_MATRIX_CLIENT_MODULES:
+                imports.add(alias.name)
+
+
+def _walk_runtime_nodes(
+    node: ast.AST,
+    importer_module: str,
+    imports: set[str],
+    *,
+    in_type_checking: bool = False,
+) -> None:
+    if isinstance(node, ast.If) and _is_type_checking_test(node.test):
+        for child in node.body:
+            _walk_runtime_nodes(child, importer_module, imports, in_type_checking=True)
+        for child in node.orelse:
+            _walk_runtime_nodes(child, importer_module, imports, in_type_checking=in_type_checking)
+        return
+
+    if not in_type_checking:
+        _record_runtime_split_import(node, importer_module, imports)
+
+    for child in ast.iter_child_nodes(node):
+        _walk_runtime_nodes(child, importer_module, imports, in_type_checking=in_type_checking)
+
+
+def _runtime_direct_split_imports(py_path: Path, importer_module: str) -> set[str]:
+    tree = ast.parse(py_path.read_text())
+    imports: set[str] = set()
+    _walk_runtime_nodes(tree, importer_module, imports)
+    return imports
+
+
+def _split_matrix_client_importers() -> dict[str, set[str]]:
+    importers: dict[str, set[str]] = {}
+    for py_path in SOURCE_ROOT.rglob("*.py"):
+        importer_module = f"mindroom.{py_path.relative_to(SOURCE_ROOT).with_suffix('').as_posix().replace('/', '.')}"
+        if importer_module in SPLIT_MATRIX_CLIENT_MODULES or importer_module == "mindroom.matrix.client":
+            continue
+        runtime_imports = _runtime_direct_split_imports(py_path, importer_module)
+        if runtime_imports:
+            importers[importer_module] = runtime_imports
+    return importers
+
+
+def test_split_matrix_client_importers_have_explicit_tach_modules() -> None:
+    """Every runtime direct importer must own an explicit Tach module entry."""
+    module_entries = _module_entries_by_path()
+    importers = _split_matrix_client_importers()
+
+    missing_module_entries: list[str] = []
+    missing_dependencies: list[str] = []
+    missing_visibility: list[str] = []
+
+    for importer_module, imported_targets in sorted(importers.items()):
+        importer_entry = module_entries.get(importer_module)
+        if importer_entry is None:
+            missing_module_entries.append(importer_module)
+            continue
+
+        depends_on = importer_entry.get("depends_on")
+        if not isinstance(depends_on, list):
+            missing_dependencies.extend(f"{importer_module} -> {target}" for target in sorted(imported_targets))
+            continue
+
+        for target in sorted(imported_targets):
+            if target not in depends_on:
+                missing_dependencies.append(f"{importer_module} -> {target}")
+            target_entry = module_entries.get(target)
+            visibility = target_entry.get("visibility") if target_entry is not None else None
+            if not isinstance(visibility, list) or importer_module not in visibility:
+                missing_visibility.append(f"{target} !<- {importer_module}")
+
+    assert not missing_module_entries, f"Missing explicit Tach modules: {missing_module_entries}"
+    assert not missing_dependencies, f"Missing split-client dependencies: {missing_dependencies}"
+    assert not missing_visibility, f"Missing split-client module visibility: {missing_visibility}"
+
+
+def test_tach_rejects_forbidden_split_matrix_client_import(tmp_path: Path) -> None:
+    """A new direct split-client import must fail Tach until tach.toml is updated."""
+    project_root = tmp_path / "project"
+    shutil.copytree(REPO_ROOT / "src", project_root / "src")
+    shutil.copy2(TACH_CONFIG, project_root / "tach.toml")
+
+    attachments_path = project_root / "src" / "mindroom" / "custom_tools" / "attachments.py"
+    original_text = attachments_path.read_text()
+    probe_import = (
+        "from mindroom.matrix.client_session import _create_matrix_client as _tach_probe_private_client_session\n"
+    )
+    attachments_path.write_text(
+        original_text.replace(
+            "from mindroom.matrix.client_delivery import send_file_message\n",
+            f"{probe_import}from mindroom.matrix.client_delivery import send_file_message\n",
+        ),
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tach", "check", "--dependencies", "--interfaces"],
+        cwd=project_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "mindroom.matrix.client_session" in (result.stdout + result.stderr)


### PR DESCRIPTION
## Summary
- replace the permissive grouped Tach consumer block with explicit per-importer module entries for split Matrix client imports
- enforce importer allowlists at the split client module level and add regression tests that prove forbidden imports fail `tach check`
- document the rule in `CLAUDE.md` and the generated workspace `AGENTS.md` template so future PRs update Tach in the same change

## Verification
- env -u VIRTUAL_ENV uv run tach check --dependencies --interfaces
- env -u VIRTUAL_ENV uv run pytest tests/test_tach_split_matrix_client_boundaries.py -x -n 0 --no-cov -q
- env -u VIRTUAL_ENV uv run pre-commit run --all-files
- env -u VIRTUAL_ENV uv run pytest -n auto -q