### PR TITLE
fix: catch up startup messages without duplicate replies

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -118,7 +118,8 @@ from .scheduling import (
     restore_scheduled_tasks,
 )
 from .startup_catchup import (
-    STARTUP_CATCH_UP_MEDIA_EVENT_TYPES,
+    STARTUP_CATCH_UP_AUDIO_EVENT_TYPES,
+    STARTUP_CATCH_UP_NON_AUDIO_MEDIA_EVENT_TYPES,
     catch_up_missed_user_messages,
 )
 from .turn_controller import TurnController, TurnControllerDeps
@@ -268,6 +269,7 @@ type _MediaDispatchEvent = (
     | nio.RoomMessageVideo
     | nio.RoomEncryptedVideo
 )
+type _AudioDispatchEvent = nio.RoomMessageAudio | nio.RoomEncryptedAudio
 
 type _MessageContext = MessageContext
 
@@ -1054,8 +1056,11 @@ class AgentBot:
         )
 
         media_callback = _create_task_wrapper(self._on_media_message, owner=self._runtime_view)
-        for event_type in STARTUP_CATCH_UP_MEDIA_EVENT_TYPES:
+        for event_type in STARTUP_CATCH_UP_NON_AUDIO_MEDIA_EVENT_TYPES:
             client.add_event_callback(media_callback, event_type)
+        audio_callback = _create_task_wrapper(self._on_audio_message, owner=self._runtime_view)
+        for event_type in STARTUP_CATCH_UP_AUDIO_EVENT_TYPES:
+            client.add_event_callback(audio_callback, event_type)
         client.add_response_callback(self._on_sync_response, nio.SyncResponse)  # ty: ignore[invalid-argument-type]  # matrix-nio callback types are too strict here
         client.add_response_callback(self._on_sync_error, nio.SyncError)  # ty: ignore[invalid-argument-type]
         self._sync_callbacks_registered = True
@@ -1354,6 +1359,14 @@ class AgentBot:
     ) -> None:
         """Delegate one inbound media event to the turn engine."""
         await self._turn_controller.handle_media_event(room, event)
+
+    async def _on_audio_message(
+        self,
+        room: nio.MatrixRoom,
+        event: _AudioDispatchEvent,
+    ) -> None:
+        """Delegate one inbound audio event to the turn engine."""
+        await self._turn_controller.handle_audio_event(room, event)
 
     def _should_queue_follow_up_in_active_response_thread(
         self,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 from uuid import uuid4
 
 import nio
@@ -71,6 +71,7 @@ from .coalescing import (
     CoalescingGate,
 )
 from .commands import config_confirmation
+from .commands.parsing import command_parser
 from .constants import (
     ROUTER_AGENT_NAME,
     RuntimePaths,
@@ -267,6 +268,103 @@ type _MediaDispatchEvent = (
 
 type _MessageContext = MessageContext
 
+type _StartupCatchUpMediaEvent = _MediaDispatchEvent | nio.RoomMessageAudio | nio.RoomEncryptedAudio
+
+
+_STARTUP_CATCH_UP_MEDIA_EVENT_TYPES = (
+    nio.RoomMessageImage,
+    nio.RoomEncryptedImage,
+    nio.RoomMessageFile,
+    nio.RoomEncryptedFile,
+    nio.RoomMessageVideo,
+    nio.RoomEncryptedVideo,
+    nio.RoomMessageAudio,
+    nio.RoomEncryptedAudio,
+)
+
+
+def _should_catch_up_message(bot: AgentBot, event: object) -> bool:
+    if not isinstance(event, (nio.RoomMessageText, *_STARTUP_CATCH_UP_MEDIA_EVENT_TYPES)):
+        return False
+
+    sender = getattr(event, "sender", None)
+    if not isinstance(sender, str) or is_agent_id(sender, bot.config, bot.runtime_paths):
+        return False
+
+    event_id = getattr(event, "event_id", None)
+    if not isinstance(event_id, str) or bot._turn_store.is_handled(event_id):
+        return False
+
+    if not isinstance(event, nio.RoomMessageText):
+        return True
+
+    content = event.source.get("content") if isinstance(event.source, dict) else None
+    relates_to = content.get("m.relates_to") if isinstance(content, dict) else None
+    if isinstance(relates_to, dict) and relates_to.get("rel_type") == "m.replace":
+        return False
+
+    return command_parser.parse(event.body) is None
+
+
+def _require_catch_up_sync_response(bot: AgentBot, response: object) -> nio.SyncResponse:
+    if isinstance(response, nio.SyncResponse):
+        return response
+    if isinstance(response, nio.SyncError):
+        bot.logger.warning("startup_catch_up_sync_failed", status_code=response.status_code)
+        msg = f"Startup catch-up sync failed for {bot.agent_name}"
+        raise RuntimeError(msg)  # noqa: TRY004
+    msg = f"Unexpected startup catch-up response for {bot.agent_name}: {type(response).__name__}"
+    raise TypeError(msg)
+
+
+async def _dispatch_catch_up_event(
+    bot: AgentBot,
+    room: nio.MatrixRoom,
+    room_id: str,
+    event: nio.RoomMessageText | _StartupCatchUpMediaEvent,
+) -> None:
+    try:
+        if isinstance(event, nio.RoomMessageText):
+            await bot._on_message(room, event)
+        else:
+            await bot._on_media_message(room, cast("_MediaDispatchEvent", event))
+    except Exception:
+        bot.logger.exception(
+            "startup_catch_up_dispatch_failed",
+            room_id=room_id,
+            event_id=getattr(event, "event_id", None),
+        )
+
+
+async def catch_up_missed_user_messages(bot: AgentBot) -> None:
+    client = bot.client
+    if client is None:
+        return
+
+    try:
+        token = load_sync_token(bot.storage_path, bot.agent_name)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        bot.logger.warning("matrix_sync_token_load_failed", error=str(exc))
+        return
+
+    if token is None:
+        return
+
+    response = _require_catch_up_sync_response(
+        bot,
+        await client.sync(timeout=0, since=token, full_state=False),
+    )
+
+    for room_id, room_info in response.rooms.join.items():
+        room = client.rooms.get(room_id) or nio.MatrixRoom(room_id, client.user_id or bot.agent_user.user_id or "")
+        for event in room_info.timeline.events:
+            if not _should_catch_up_message(bot, event):
+                continue
+            await _dispatch_catch_up_event(bot, room, room_id, event)
+
+    client.next_batch = response.next_batch
+    save_sync_token(bot.storage_path, bot.agent_name, response.next_batch)
+
 
 class AgentBot:
     """Matrix lifecycle shell for one configured agent or router entity."""
@@ -309,6 +407,7 @@ class AgentBot:
     _turn_controller: TurnController
     _room_lifecycle: BotRoomLifecycle
     _invited_rooms: set[str]
+    _sync_callbacks_registered: bool
 
     def __init__(
         self,
@@ -333,6 +432,7 @@ class AgentBot:
         self._last_sync_monotonic = None
         self._first_sync_done = False
         self._sync_shutting_down = False
+        self._sync_callbacks_registered = False
         self._hook_registry_state = HookRegistryState(HookRegistry.empty())
         self._runtime_view = BotRuntimeState(
             client=None,
@@ -1022,6 +1122,38 @@ class AgentBot:
             return
         raise PermanentMatrixStartupError(self._runtime_support_injection_error())
 
+    def _register_sync_callbacks(self) -> None:
+        """Register nio sync callbacks exactly once per client instance."""
+        if self._sync_callbacks_registered:
+            return
+
+        client = self.client
+        assert client is not None
+
+        client.add_event_callback(
+            _create_task_wrapper(self._on_invite, owner=self._runtime_view),
+            nio.InviteEvent,  # ty: ignore[invalid-argument-type]  # InviteEvent doesn't inherit Event
+        )
+        client.add_event_callback(
+            _create_task_wrapper(self._on_message, owner=self._runtime_view),
+            nio.RoomMessageText,
+        )
+        client.add_event_callback(
+            _create_task_wrapper(self._on_redaction, owner=self._runtime_view),
+            nio.RedactionEvent,
+        )
+        client.add_event_callback(
+            _create_task_wrapper(self._on_reaction, owner=self._runtime_view),
+            nio.ReactionEvent,
+        )
+
+        media_callback = _create_task_wrapper(self._on_media_message, owner=self._runtime_view)
+        for event_type in _STARTUP_CATCH_UP_MEDIA_EVENT_TYPES:
+            client.add_event_callback(media_callback, event_type)
+        client.add_response_callback(self._on_sync_response, nio.SyncResponse)  # ty: ignore[invalid-argument-type]  # matrix-nio callback types are too strict here
+        client.add_response_callback(self._on_sync_error, nio.SyncError)  # ty: ignore[invalid-argument-type]
+        self._sync_callbacks_registered = True
+
     async def start(self) -> None:
         """Start the agent bot with user account setup (but don't join rooms yet)."""
         self._validate_runtime_support_injection_contract_for_startup()
@@ -1039,41 +1171,6 @@ class AgentBot:
             interactive.init_persistence(self.runtime_paths.storage_root)
             client = self.client
             assert client is not None
-
-            # Register event callbacks - wrap them to run as background tasks
-            # This ensures the sync loop is never blocked, allowing stop reactions to work
-            client.add_event_callback(
-                _create_task_wrapper(self._on_invite, owner=self._runtime_view),
-                nio.InviteEvent,  # ty: ignore[invalid-argument-type]  # InviteEvent doesn't inherit Event
-            )
-            client.add_event_callback(
-                _create_task_wrapper(self._on_message, owner=self._runtime_view),
-                nio.RoomMessageText,
-            )
-            client.add_event_callback(
-                _create_task_wrapper(self._on_redaction, owner=self._runtime_view),
-                nio.RedactionEvent,
-            )
-            client.add_event_callback(
-                _create_task_wrapper(self._on_reaction, owner=self._runtime_view),
-                nio.ReactionEvent,
-            )
-
-            # Register media callbacks on all agents (each agent handles its own routing)
-            media_callback = _create_task_wrapper(self._on_media_message, owner=self._runtime_view)
-            for event_type in (
-                nio.RoomMessageImage,
-                nio.RoomEncryptedImage,
-                nio.RoomMessageFile,
-                nio.RoomEncryptedFile,
-                nio.RoomMessageVideo,
-                nio.RoomEncryptedVideo,
-                nio.RoomMessageAudio,
-                nio.RoomEncryptedAudio,
-            ):
-                client.add_event_callback(media_callback, event_type)
-            client.add_response_callback(self._on_sync_response, nio.SyncResponse)  # ty: ignore[invalid-argument-type]  # matrix-nio callback types are too strict here
-            client.add_response_callback(self._on_sync_error, nio.SyncError)  # ty: ignore[invalid-argument-type]
 
             self.running = True
 
@@ -1253,6 +1350,9 @@ class AgentBot:
     async def sync_forever(self) -> None:
         """Run the sync loop for this agent."""
         assert self.client is not None
+        if not self._sync_callbacks_registered:
+            await catch_up_missed_user_messages(self)
+            self._register_sync_callbacks()
         await self.client.sync_forever(timeout=_SYNC_TIMEOUT_MS, full_state=not self._first_sync_done)
 
     async def _on_invite(self, room: nio.MatrixRoom, event: nio.InviteEvent) -> None:

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 import nio
@@ -71,7 +71,6 @@ from .coalescing import (
     CoalescingGate,
 )
 from .commands import config_confirmation
-from .commands.parsing import command_parser
 from .constants import (
     ROUTER_AGENT_NAME,
     RuntimePaths,
@@ -117,6 +116,10 @@ from .scheduling import (
     drain_deferred_overdue_tasks,
     has_deferred_overdue_tasks,
     restore_scheduled_tasks,
+)
+from .startup_catchup import (
+    STARTUP_CATCH_UP_MEDIA_EVENT_TYPES,
+    catch_up_missed_user_messages,
 )
 from .turn_controller import TurnController, TurnControllerDeps
 from .turn_policy import (
@@ -267,103 +270,6 @@ type _MediaDispatchEvent = (
 )
 
 type _MessageContext = MessageContext
-
-type _StartupCatchUpMediaEvent = _MediaDispatchEvent | nio.RoomMessageAudio | nio.RoomEncryptedAudio
-
-
-_STARTUP_CATCH_UP_MEDIA_EVENT_TYPES = (
-    nio.RoomMessageImage,
-    nio.RoomEncryptedImage,
-    nio.RoomMessageFile,
-    nio.RoomEncryptedFile,
-    nio.RoomMessageVideo,
-    nio.RoomEncryptedVideo,
-    nio.RoomMessageAudio,
-    nio.RoomEncryptedAudio,
-)
-
-
-def _should_catch_up_message(bot: AgentBot, event: object) -> bool:
-    if not isinstance(event, (nio.RoomMessageText, *_STARTUP_CATCH_UP_MEDIA_EVENT_TYPES)):
-        return False
-
-    sender = getattr(event, "sender", None)
-    if not isinstance(sender, str) or is_agent_id(sender, bot.config, bot.runtime_paths):
-        return False
-
-    event_id = getattr(event, "event_id", None)
-    if not isinstance(event_id, str) or bot._turn_store.is_handled(event_id):
-        return False
-
-    if not isinstance(event, nio.RoomMessageText):
-        return True
-
-    content = event.source.get("content") if isinstance(event.source, dict) else None
-    relates_to = content.get("m.relates_to") if isinstance(content, dict) else None
-    if isinstance(relates_to, dict) and relates_to.get("rel_type") == "m.replace":
-        return False
-
-    return command_parser.parse(event.body) is None
-
-
-def _require_catch_up_sync_response(bot: AgentBot, response: object) -> nio.SyncResponse:
-    if isinstance(response, nio.SyncResponse):
-        return response
-    if isinstance(response, nio.SyncError):
-        bot.logger.warning("startup_catch_up_sync_failed", status_code=response.status_code)
-        msg = f"Startup catch-up sync failed for {bot.agent_name}"
-        raise RuntimeError(msg)  # noqa: TRY004
-    msg = f"Unexpected startup catch-up response for {bot.agent_name}: {type(response).__name__}"
-    raise TypeError(msg)
-
-
-async def _dispatch_catch_up_event(
-    bot: AgentBot,
-    room: nio.MatrixRoom,
-    room_id: str,
-    event: nio.RoomMessageText | _StartupCatchUpMediaEvent,
-) -> None:
-    try:
-        if isinstance(event, nio.RoomMessageText):
-            await bot._on_message(room, event)
-        else:
-            await bot._on_media_message(room, cast("_MediaDispatchEvent", event))
-    except Exception:
-        bot.logger.exception(
-            "startup_catch_up_dispatch_failed",
-            room_id=room_id,
-            event_id=getattr(event, "event_id", None),
-        )
-
-
-async def catch_up_missed_user_messages(bot: AgentBot) -> None:
-    client = bot.client
-    if client is None:
-        return
-
-    try:
-        token = load_sync_token(bot.storage_path, bot.agent_name)
-    except (OSError, UnicodeDecodeError, ValueError) as exc:
-        bot.logger.warning("matrix_sync_token_load_failed", error=str(exc))
-        return
-
-    if token is None:
-        return
-
-    response = _require_catch_up_sync_response(
-        bot,
-        await client.sync(timeout=0, since=token, full_state=False),
-    )
-
-    for room_id, room_info in response.rooms.join.items():
-        room = client.rooms.get(room_id) or nio.MatrixRoom(room_id, client.user_id or bot.agent_user.user_id or "")
-        for event in room_info.timeline.events:
-            if not _should_catch_up_message(bot, event):
-                continue
-            await _dispatch_catch_up_event(bot, room, room_id, event)
-
-    client.next_batch = response.next_batch
-    save_sync_token(bot.storage_path, bot.agent_name, response.next_batch)
 
 
 class AgentBot:
@@ -1148,7 +1054,7 @@ class AgentBot:
         )
 
         media_callback = _create_task_wrapper(self._on_media_message, owner=self._runtime_view)
-        for event_type in _STARTUP_CATCH_UP_MEDIA_EVENT_TYPES:
+        for event_type in STARTUP_CATCH_UP_MEDIA_EVENT_TYPES:
             client.add_event_callback(media_callback, event_type)
         client.add_response_callback(self._on_sync_response, nio.SyncResponse)  # ty: ignore[invalid-argument-type]  # matrix-nio callback types are too strict here
         client.add_response_callback(self._on_sync_error, nio.SyncError)  # ty: ignore[invalid-argument-type]

--- a/src/mindroom/startup_catchup.py
+++ b/src/mindroom/startup_catchup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeGuard, cast
+from typing import TYPE_CHECKING, TypeGuard
 
 import nio
 
@@ -13,42 +13,51 @@ from mindroom.matrix.sync_tokens import load_sync_token, save_sync_token
 if TYPE_CHECKING:
     from .bot import AgentBot
 
-type StartupCatchUpMediaEvent = (
+type StartupCatchUpNonAudioMediaEvent = (
     nio.RoomMessageImage
     | nio.RoomEncryptedImage
     | nio.RoomMessageFile
     | nio.RoomEncryptedFile
     | nio.RoomMessageVideo
     | nio.RoomEncryptedVideo
-    | nio.RoomMessageAudio
-    | nio.RoomEncryptedAudio
 )
+type StartupCatchUpAudioEvent = nio.RoomMessageAudio | nio.RoomEncryptedAudio
+type StartupCatchUpMediaEvent = StartupCatchUpNonAudioMediaEvent | StartupCatchUpAudioEvent
 
 type StartupCatchUpEvent = nio.RoomMessageText | StartupCatchUpMediaEvent
-type _BotMediaDispatchEvent = (
-    nio.RoomMessageImage
-    | nio.RoomEncryptedImage
-    | nio.RoomMessageFile
-    | nio.RoomEncryptedFile
-    | nio.RoomMessageVideo
-    | nio.RoomEncryptedVideo
-)
+type _BotAudioDispatchEvent = StartupCatchUpAudioEvent
 
 
-STARTUP_CATCH_UP_MEDIA_EVENT_TYPES = (
+STARTUP_CATCH_UP_NON_AUDIO_MEDIA_EVENT_TYPES = (
     nio.RoomMessageImage,
     nio.RoomEncryptedImage,
     nio.RoomMessageFile,
     nio.RoomEncryptedFile,
     nio.RoomMessageVideo,
     nio.RoomEncryptedVideo,
+)
+STARTUP_CATCH_UP_AUDIO_EVENT_TYPES = (
     nio.RoomMessageAudio,
     nio.RoomEncryptedAudio,
+)
+STARTUP_CATCH_UP_MEDIA_EVENT_TYPES = (
+    *STARTUP_CATCH_UP_NON_AUDIO_MEDIA_EVENT_TYPES,
+    *STARTUP_CATCH_UP_AUDIO_EVENT_TYPES,
 )
 
 
 def _is_startup_catch_up_event(event: object) -> TypeGuard[StartupCatchUpEvent]:
     return isinstance(event, (nio.RoomMessageText, *STARTUP_CATCH_UP_MEDIA_EVENT_TYPES))
+
+
+def _is_startup_audio_event(event: StartupCatchUpMediaEvent) -> TypeGuard[_BotAudioDispatchEvent]:
+    return isinstance(event, STARTUP_CATCH_UP_AUDIO_EVENT_TYPES)
+
+
+def _is_startup_non_audio_media_event(
+    event: StartupCatchUpMediaEvent,
+) -> TypeGuard[StartupCatchUpNonAudioMediaEvent]:
+    return isinstance(event, STARTUP_CATCH_UP_NON_AUDIO_MEDIA_EVENT_TYPES)
 
 
 def _should_catch_up_message(bot: AgentBot, event: object) -> bool:
@@ -92,8 +101,10 @@ async def _dispatch_catch_up_event(
     try:
         if isinstance(event, nio.RoomMessageText):
             await bot._on_message(room, event)
-        else:
-            await bot._on_media_message(room, cast("_BotMediaDispatchEvent", event))
+        elif _is_startup_audio_event(event):
+            await bot._on_audio_message(room, event)
+        elif _is_startup_non_audio_media_event(event):
+            await bot._on_media_message(room, event)
     except Exception:
         bot.logger.exception(
             "startup_catch_up_dispatch_failed",

--- a/src/mindroom/startup_catchup.py
+++ b/src/mindroom/startup_catchup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Protocol, TypeGuard, assert_never
 
 import nio
@@ -12,6 +13,8 @@ from mindroom.matrix.sync_tokens import load_sync_token, save_sync_token
 
 if TYPE_CHECKING:
     from .bot import AgentBot
+    from .config.main import Config
+    from .constants import RuntimePaths
 
 type StartupCatchUpNonAudioMediaEvent = (
     nio.RoomMessageImage
@@ -26,10 +29,18 @@ type StartupCatchUpMediaEvent = StartupCatchUpNonAudioMediaEvent | StartupCatchU
 
 type StartupCatchUpEvent = nio.RoomMessageText | StartupCatchUpMediaEvent
 type _BotAudioDispatchEvent = StartupCatchUpAudioEvent
+type _IsHandled = Callable[[str], bool]
+type _TextCatchUpHandler = Callable[[nio.MatrixRoom, nio.RoomMessageText], Awaitable[object]]
+type _AudioCatchUpHandler = Callable[[nio.MatrixRoom, _BotAudioDispatchEvent], Awaitable[object]]
+type _NonAudioMediaCatchUpHandler = Callable[
+    [nio.MatrixRoom, StartupCatchUpNonAudioMediaEvent],
+    Awaitable[object],
+]
 
 
 class _StartupCatchUpLogger(Protocol):
     def warning(self, event: str, /, **kw: object) -> object: ...
+    def exception(self, event: str, /, **kw: object) -> object: ...
 
 
 STARTUP_CATCH_UP_NON_AUDIO_MEDIA_EVENT_TYPES = (
@@ -64,14 +75,20 @@ def _is_startup_non_audio_media_event(
     return isinstance(event, STARTUP_CATCH_UP_NON_AUDIO_MEDIA_EVENT_TYPES)
 
 
-def _should_catch_up_message(bot: AgentBot, event: object) -> bool:
+def _should_catch_up_message(
+    event: object,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    is_handled: _IsHandled,
+) -> bool:
     if not _is_startup_catch_up_event(event):
         return False
 
-    if is_agent_id(event.sender, bot.config, bot.runtime_paths):
+    if is_agent_id(event.sender, config, runtime_paths):
         return False
 
-    if bot._turn_store.is_handled(event.event_id):
+    if is_handled(event.event_id):
         return False
 
     if not isinstance(event, nio.RoomMessageText):
@@ -101,20 +118,24 @@ def _require_catch_up_sync_response(
 
 
 async def _dispatch_catch_up_event(
-    bot: AgentBot,
     room: nio.MatrixRoom,
     room_id: str,
     event: StartupCatchUpEvent,
+    *,
+    on_message: _TextCatchUpHandler,
+    on_audio_message: _AudioCatchUpHandler,
+    on_media_message: _NonAudioMediaCatchUpHandler,
+    logger: _StartupCatchUpLogger,
 ) -> None:
     try:
         if isinstance(event, nio.RoomMessageText):
-            await bot._on_message(room, event)
+            await on_message(room, event)
         elif _is_startup_audio_event(event):
-            await bot._on_audio_message(room, event)
+            await on_audio_message(room, event)
         elif _is_startup_non_audio_media_event(event):
-            await bot._on_media_message(room, event)
+            await on_media_message(room, event)
     except Exception:
-        bot.logger.exception(
+        logger.exception(
             "startup_catch_up_dispatch_failed",
             room_id=room_id,
             event_id=event.event_id,
@@ -127,11 +148,18 @@ async def catch_up_missed_user_messages(bot: AgentBot) -> None:
     client = bot.client
     if client is None:
         return
+    config = bot.config
+    runtime_paths = bot.runtime_paths
+    is_handled = bot._turn_store.is_handled
+    on_message = bot._on_message
+    on_audio_message = bot._on_audio_message
+    on_media_message = bot._on_media_message
+    logger = bot.logger
 
     try:
         token = load_sync_token(bot.storage_path, bot.agent_name)
     except (OSError, UnicodeDecodeError, ValueError) as exc:
-        bot.logger.warning("matrix_sync_token_load_failed", error=str(exc))
+        logger.warning("matrix_sync_token_load_failed", error=str(exc))
         return
 
     if token is None:
@@ -141,15 +169,28 @@ async def catch_up_missed_user_messages(bot: AgentBot) -> None:
         response = _require_catch_up_sync_response(
             await client.sync(timeout=0, since=token, full_state=False),
             agent_name=bot.agent_name,
-            logger=bot.logger,
+            logger=logger,
         )
 
         for room_id, room_info in response.rooms.join.items():
             room = client.rooms.get(room_id) or nio.MatrixRoom(room_id, client.user_id or bot.agent_user.user_id or "")
             for event in room_info.timeline.events:
-                if not _should_catch_up_message(bot, event):
+                if not _should_catch_up_message(
+                    event,
+                    config=config,
+                    runtime_paths=runtime_paths,
+                    is_handled=is_handled,
+                ):
                     continue
-                await _dispatch_catch_up_event(bot, room, room_id, event)
+                await _dispatch_catch_up_event(
+                    room,
+                    room_id,
+                    event,
+                    on_message=on_message,
+                    on_audio_message=on_audio_message,
+                    on_media_message=on_media_message,
+                    logger=logger,
+                )
     except Exception:
         client.next_batch = token
         raise

--- a/src/mindroom/startup_catchup.py
+++ b/src/mindroom/startup_catchup.py
@@ -129,17 +129,21 @@ async def catch_up_missed_user_messages(bot: AgentBot) -> None:
     if token is None:
         return
 
-    response = _require_catch_up_sync_response(
-        bot,
-        await client.sync(timeout=0, since=token, full_state=False),
-    )
+    try:
+        response = _require_catch_up_sync_response(
+            bot,
+            await client.sync(timeout=0, since=token, full_state=False),
+        )
 
-    for room_id, room_info in response.rooms.join.items():
-        room = client.rooms.get(room_id) or nio.MatrixRoom(room_id, client.user_id or bot.agent_user.user_id or "")
-        for event in room_info.timeline.events:
-            if not _should_catch_up_message(bot, event):
-                continue
-            await _dispatch_catch_up_event(bot, room, room_id, event)
+        for room_id, room_info in response.rooms.join.items():
+            room = client.rooms.get(room_id) or nio.MatrixRoom(room_id, client.user_id or bot.agent_user.user_id or "")
+            for event in room_info.timeline.events:
+                if not _should_catch_up_message(bot, event):
+                    continue
+                await _dispatch_catch_up_event(bot, room, room_id, event)
+    except Exception:
+        client.next_batch = token
+        raise
 
     client.next_batch = response.next_batch
     save_sync_token(bot.storage_path, bot.agent_name, response.next_batch)

--- a/src/mindroom/startup_catchup.py
+++ b/src/mindroom/startup_catchup.py
@@ -1,0 +1,133 @@
+"""Replay missed user messages before the long-lived Matrix sync loop starts."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeGuard, cast
+
+import nio
+
+from mindroom.commands.parsing import command_parser
+from mindroom.matrix.identity import is_agent_id
+from mindroom.matrix.sync_tokens import load_sync_token, save_sync_token
+
+if TYPE_CHECKING:
+    from .bot import AgentBot
+
+type StartupCatchUpMediaEvent = (
+    nio.RoomMessageImage
+    | nio.RoomEncryptedImage
+    | nio.RoomMessageFile
+    | nio.RoomEncryptedFile
+    | nio.RoomMessageVideo
+    | nio.RoomEncryptedVideo
+    | nio.RoomMessageAudio
+    | nio.RoomEncryptedAudio
+)
+
+type StartupCatchUpEvent = nio.RoomMessageText | StartupCatchUpMediaEvent
+type _BotMediaDispatchEvent = (
+    nio.RoomMessageImage
+    | nio.RoomEncryptedImage
+    | nio.RoomMessageFile
+    | nio.RoomEncryptedFile
+    | nio.RoomMessageVideo
+    | nio.RoomEncryptedVideo
+)
+
+
+STARTUP_CATCH_UP_MEDIA_EVENT_TYPES = (
+    nio.RoomMessageImage,
+    nio.RoomEncryptedImage,
+    nio.RoomMessageFile,
+    nio.RoomEncryptedFile,
+    nio.RoomMessageVideo,
+    nio.RoomEncryptedVideo,
+    nio.RoomMessageAudio,
+    nio.RoomEncryptedAudio,
+)
+
+
+def _is_startup_catch_up_event(event: object) -> TypeGuard[StartupCatchUpEvent]:
+    return isinstance(event, (nio.RoomMessageText, *STARTUP_CATCH_UP_MEDIA_EVENT_TYPES))
+
+
+def _should_catch_up_message(bot: AgentBot, event: object) -> bool:
+    if not _is_startup_catch_up_event(event):
+        return False
+
+    if is_agent_id(event.sender, bot.config, bot.runtime_paths):
+        return False
+
+    if bot._turn_store.is_handled(event.event_id):
+        return False
+
+    if not isinstance(event, nio.RoomMessageText):
+        return True
+
+    content = event.source.get("content") if isinstance(event.source, dict) else None
+    relates_to = content.get("m.relates_to") if isinstance(content, dict) else None
+    if isinstance(relates_to, dict) and relates_to.get("rel_type") == "m.replace":
+        return False
+
+    return command_parser.parse(event.body) is None
+
+
+def _require_catch_up_sync_response(bot: AgentBot, response: object) -> nio.SyncResponse:
+    if isinstance(response, nio.SyncResponse):
+        return response
+    if isinstance(response, nio.SyncError):
+        bot.logger.warning("startup_catch_up_sync_failed", status_code=response.status_code)
+        msg = f"Startup catch-up sync failed for {bot.agent_name}"
+        raise RuntimeError(msg)  # noqa: TRY004
+    msg = f"Unexpected startup catch-up response for {bot.agent_name}: {type(response).__name__}"
+    raise TypeError(msg)
+
+
+async def _dispatch_catch_up_event(
+    bot: AgentBot,
+    room: nio.MatrixRoom,
+    room_id: str,
+    event: StartupCatchUpEvent,
+) -> None:
+    try:
+        if isinstance(event, nio.RoomMessageText):
+            await bot._on_message(room, event)
+        else:
+            await bot._on_media_message(room, cast("_BotMediaDispatchEvent", event))
+    except Exception:
+        bot.logger.exception(
+            "startup_catch_up_dispatch_failed",
+            room_id=room_id,
+            event_id=event.event_id,
+        )
+
+
+async def catch_up_missed_user_messages(bot: AgentBot) -> None:
+    """Replay missed startup text and media events before live callbacks register."""
+    client = bot.client
+    if client is None:
+        return
+
+    try:
+        token = load_sync_token(bot.storage_path, bot.agent_name)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        bot.logger.warning("matrix_sync_token_load_failed", error=str(exc))
+        return
+
+    if token is None:
+        return
+
+    response = _require_catch_up_sync_response(
+        bot,
+        await client.sync(timeout=0, since=token, full_state=False),
+    )
+
+    for room_id, room_info in response.rooms.join.items():
+        room = client.rooms.get(room_id) or nio.MatrixRoom(room_id, client.user_id or bot.agent_user.user_id or "")
+        for event in room_info.timeline.events:
+            if not _should_catch_up_message(bot, event):
+                continue
+            await _dispatch_catch_up_event(bot, room, room_id, event)
+
+    client.next_batch = response.next_batch
+    save_sync_token(bot.storage_path, bot.agent_name, response.next_batch)

--- a/src/mindroom/startup_catchup.py
+++ b/src/mindroom/startup_catchup.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Protocol, TypeGuard, assert_never
 
 import nio
@@ -13,8 +12,6 @@ from mindroom.matrix.sync_tokens import load_sync_token, save_sync_token
 
 if TYPE_CHECKING:
     from .bot import AgentBot
-    from .config.main import Config
-    from .constants import RuntimePaths
 
 type StartupCatchUpNonAudioMediaEvent = (
     nio.RoomMessageImage
@@ -29,13 +26,6 @@ type StartupCatchUpMediaEvent = StartupCatchUpNonAudioMediaEvent | StartupCatchU
 
 type StartupCatchUpEvent = nio.RoomMessageText | StartupCatchUpMediaEvent
 type _BotAudioDispatchEvent = StartupCatchUpAudioEvent
-type _IsHandled = Callable[[str], bool]
-type _TextCatchUpHandler = Callable[[nio.MatrixRoom, nio.RoomMessageText], Awaitable[object]]
-type _AudioCatchUpHandler = Callable[[nio.MatrixRoom, _BotAudioDispatchEvent], Awaitable[object]]
-type _NonAudioMediaCatchUpHandler = Callable[
-    [nio.MatrixRoom, StartupCatchUpNonAudioMediaEvent],
-    Awaitable[object],
-]
 
 
 class _StartupCatchUpLogger(Protocol):
@@ -76,19 +66,16 @@ def _is_startup_non_audio_media_event(
 
 
 def _should_catch_up_message(
+    bot: AgentBot,
     event: object,
-    *,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    is_handled: _IsHandled,
 ) -> bool:
     if not _is_startup_catch_up_event(event):
         return False
 
-    if is_agent_id(event.sender, config, runtime_paths):
+    if is_agent_id(event.sender, bot.config, bot.runtime_paths):
         return False
 
-    if is_handled(event.event_id):
+    if bot._turn_store.is_handled(event.event_id):
         return False
 
     if not isinstance(event, nio.RoomMessageText):
@@ -118,24 +105,20 @@ def _require_catch_up_sync_response(
 
 
 async def _dispatch_catch_up_event(
+    bot: AgentBot,
     room: nio.MatrixRoom,
     room_id: str,
     event: StartupCatchUpEvent,
-    *,
-    on_message: _TextCatchUpHandler,
-    on_audio_message: _AudioCatchUpHandler,
-    on_media_message: _NonAudioMediaCatchUpHandler,
-    logger: _StartupCatchUpLogger,
 ) -> None:
     try:
         if isinstance(event, nio.RoomMessageText):
-            await on_message(room, event)
+            await bot._on_message(room, event)
         elif _is_startup_audio_event(event):
-            await on_audio_message(room, event)
+            await bot._on_audio_message(room, event)
         elif _is_startup_non_audio_media_event(event):
-            await on_media_message(room, event)
+            await bot._on_media_message(room, event)
     except Exception:
-        logger.exception(
+        bot.logger.exception(
             "startup_catch_up_dispatch_failed",
             room_id=room_id,
             event_id=event.event_id,
@@ -148,18 +131,11 @@ async def catch_up_missed_user_messages(bot: AgentBot) -> None:
     client = bot.client
     if client is None:
         return
-    config = bot.config
-    runtime_paths = bot.runtime_paths
-    is_handled = bot._turn_store.is_handled
-    on_message = bot._on_message
-    on_audio_message = bot._on_audio_message
-    on_media_message = bot._on_media_message
-    logger = bot.logger
 
     try:
         token = load_sync_token(bot.storage_path, bot.agent_name)
     except (OSError, UnicodeDecodeError, ValueError) as exc:
-        logger.warning("matrix_sync_token_load_failed", error=str(exc))
+        bot.logger.warning("matrix_sync_token_load_failed", error=str(exc))
         return
 
     if token is None:
@@ -169,28 +145,15 @@ async def catch_up_missed_user_messages(bot: AgentBot) -> None:
         response = _require_catch_up_sync_response(
             await client.sync(timeout=0, since=token, full_state=False),
             agent_name=bot.agent_name,
-            logger=logger,
+            logger=bot.logger,
         )
 
         for room_id, room_info in response.rooms.join.items():
             room = client.rooms.get(room_id) or nio.MatrixRoom(room_id, client.user_id or bot.agent_user.user_id or "")
             for event in room_info.timeline.events:
-                if not _should_catch_up_message(
-                    event,
-                    config=config,
-                    runtime_paths=runtime_paths,
-                    is_handled=is_handled,
-                ):
+                if not _should_catch_up_message(bot, event):
                     continue
-                await _dispatch_catch_up_event(
-                    room,
-                    room_id,
-                    event,
-                    on_message=on_message,
-                    on_audio_message=on_audio_message,
-                    on_media_message=on_media_message,
-                    logger=logger,
-                )
+                await _dispatch_catch_up_event(bot, room, room_id, event)
     except Exception:
         client.next_batch = token
         raise

--- a/src/mindroom/startup_catchup.py
+++ b/src/mindroom/startup_catchup.py
@@ -111,6 +111,7 @@ async def _dispatch_catch_up_event(
             room_id=room_id,
             event_id=event.event_id,
         )
+        raise
 
 
 async def catch_up_missed_user_messages(bot: AgentBot) -> None:

--- a/src/mindroom/startup_catchup.py
+++ b/src/mindroom/startup_catchup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeGuard
+from typing import TYPE_CHECKING, Protocol, TypeGuard, assert_never
 
 import nio
 
@@ -26,6 +26,10 @@ type StartupCatchUpMediaEvent = StartupCatchUpNonAudioMediaEvent | StartupCatchU
 
 type StartupCatchUpEvent = nio.RoomMessageText | StartupCatchUpMediaEvent
 type _BotAudioDispatchEvent = StartupCatchUpAudioEvent
+
+
+class _StartupCatchUpLogger(Protocol):
+    def warning(self, event: str, /, **kw: object) -> object: ...
 
 
 STARTUP_CATCH_UP_NON_AUDIO_MEDIA_EVENT_TYPES = (
@@ -81,15 +85,19 @@ def _should_catch_up_message(bot: AgentBot, event: object) -> bool:
     return command_parser.parse(event.body) is None
 
 
-def _require_catch_up_sync_response(bot: AgentBot, response: object) -> nio.SyncResponse:
+def _require_catch_up_sync_response(
+    response: nio.SyncResponse | nio.SyncError,
+    *,
+    agent_name: str,
+    logger: _StartupCatchUpLogger,
+) -> nio.SyncResponse:
     if isinstance(response, nio.SyncResponse):
         return response
     if isinstance(response, nio.SyncError):
-        bot.logger.warning("startup_catch_up_sync_failed", status_code=response.status_code)
-        msg = f"Startup catch-up sync failed for {bot.agent_name}"
+        logger.warning("startup_catch_up_sync_failed", status_code=response.status_code)
+        msg = f"Startup catch-up sync failed for {agent_name}"
         raise RuntimeError(msg)  # noqa: TRY004
-    msg = f"Unexpected startup catch-up response for {bot.agent_name}: {type(response).__name__}"
-    raise TypeError(msg)
+    assert_never(response)
 
 
 async def _dispatch_catch_up_event(
@@ -131,8 +139,9 @@ async def catch_up_missed_user_messages(bot: AgentBot) -> None:
 
     try:
         response = _require_catch_up_sync_response(
-            bot,
             await client.sync(timeout=0, since=token, full_state=False),
+            agent_name=bot.agent_name,
+            logger=bot.logger,
         )
 
         for room_id, room_info in response.rooms.join.items():

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, TypeGuard, cast
 
 import nio
 
@@ -142,6 +142,16 @@ type _PrecheckedTextDispatchEvent = _PrecheckedEvent[_TextDispatchEvent]
 type _PrecheckedMediaDispatchEvent = _PrecheckedEvent[_MediaDispatchEvent]
 
 
+def _is_audio_media_event(event: _InboundMediaEvent) -> TypeGuard[nio.RoomMessageAudio | nio.RoomEncryptedAudio]:
+    """Return whether one inbound media event is audio."""
+    return isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio)
+
+
+def _is_non_audio_media_event(event: _InboundMediaEvent) -> TypeGuard[_MediaDispatchEvent]:
+    """Return whether one inbound media event stays on the generic media path."""
+    return not _is_audio_media_event(event)
+
+
 @dataclass(frozen=True)
 class TurnControllerDeps:
     """Collaborators needed for turn control, policy, and execution."""
@@ -270,7 +280,7 @@ class TurnController:
 
         return requester_user_id
 
-    def _precheck_dispatch_event[T: _DispatchEvent](
+    def _precheck_dispatch_event[T: _DispatchEvent | _InboundMediaEvent](
         self,
         room: nio.MatrixRoom,
         event: T,
@@ -1552,12 +1562,21 @@ class TurnController:
     ) -> None:
         """Handle one inbound media event."""
         async with self.deps.resolver.turn_thread_cache_scope():
-            await self._handle_media_message_inner(room, event)
+            await self._handle_inbound_media_message_inner(room, event)
 
-    async def _handle_media_message_inner(
+    async def handle_audio_event(
         self,
         room: nio.MatrixRoom,
-        event: _MediaDispatchEvent,
+        event: nio.RoomMessageAudio | nio.RoomEncryptedAudio,
+    ) -> None:
+        """Handle one inbound audio event."""
+        async with self.deps.resolver.turn_thread_cache_scope():
+            await self._handle_inbound_media_message_inner(room, event)
+
+    async def _handle_inbound_media_message_inner(
+        self,
+        room: nio.MatrixRoom,
+        event: _InboundMediaEvent,
     ) -> None:
         """Handle one media event inside the per-turn conversation lookup scope."""
         prechecked_event = self._precheck_dispatch_event(room, event)
@@ -1568,8 +1587,6 @@ class TurnController:
             room_id=room.room_id,
         )
         attach_dispatch_pipeline_timing(prechecked_event.event.source, dispatch_timing)
-        # Prime transitive ancestor lookups before writing advisory cache membership.
-        await self.deps.resolver.coalescing_thread_id(room, prechecked_event.event)
         event_info = EventInfo.from_event(prechecked_event.event.source)
         await self._append_live_event_with_timing(
             room.room_id,
@@ -1578,9 +1595,31 @@ class TurnController:
             dispatch_timing=dispatch_timing,
         )
 
-        if await self._dispatch_special_media_as_text(room, prechecked_event):
+        if _is_audio_media_event(prechecked_event.event):
+            await self._on_audio_media_message(
+                room,
+                _PrecheckedEvent(
+                    event=prechecked_event.event,
+                    requester_user_id=prechecked_event.requester_user_id,
+                ),
+            )
             return
+
         event = prechecked_event.event
+        if not _is_non_audio_media_event(event):
+            return
+
+        # Prime transitive ancestor lookups before writing advisory cache membership.
+        await self.deps.resolver.coalescing_thread_id(room, event)
+
+        if await self._dispatch_special_media_as_text(
+            room,
+            _PrecheckedEvent(
+                event=event,
+                requester_user_id=prechecked_event.requester_user_id,
+            ),
+        ):
+            return
         await self._enqueue_for_dispatch(
             event,
             room,
@@ -1595,15 +1634,6 @@ class TurnController:
     ) -> bool:
         """Handle media events that normalize into the text dispatch pipeline."""
         event = prechecked_event.event
-        if isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio):
-            await self._on_audio_media_message(
-                room,
-                _PrecheckedEvent(
-                    event=event,
-                    requester_user_id=prechecked_event.requester_user_id,
-                ),
-            )
-            return True
         if isinstance(event, nio.RoomMessageFile | nio.RoomEncryptedFile):
             return await self._dispatch_file_sidecar_text_preview(
                 room,

--- a/tach.toml
+++ b/tach.toml
@@ -359,6 +359,14 @@ depends_on = [
 ]
 
 [[modules]]
+path = "mindroom.startup_catchup"
+depends_on = [
+    "mindroom.commands.parsing",
+    "mindroom.matrix.identity",
+    "mindroom.matrix.sync_tokens",
+]
+
+[[modules]]
 path = "mindroom.bot"
 depends_on = [
     "mindroom.bot_runtime_view",
@@ -381,6 +389,7 @@ depends_on = [
     "mindroom.response_runner",
     "mindroom.runtime_support",
     "mindroom.scheduling",
+    "mindroom.startup_catchup",
     "mindroom.tool_system.runtime_context",
     "mindroom.turn_controller",
 ]

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -581,8 +581,10 @@ class TestAgentBot:
         """Invoke the target handler by name."""
         if handler_name == "message":
             await bot._on_message(room, event)
-        elif handler_name in {"image", "voice", "file"}:
+        elif handler_name in {"image", "file"}:
             await bot._on_media_message(room, event)
+        elif handler_name == "voice":
+            await bot._on_audio_message(room, event)
         elif handler_name == "reaction":
             await bot._on_reaction(room, event)
         else:  # pragma: no cover - defensive guard for test helper misuse
@@ -1040,6 +1042,16 @@ class TestAgentBot:
         assert sync_order == ["catchup", "sync"]
         assert len(mock_client.event_callbacks) == 12
         assert len(mock_client.response_callbacks) == 2
+        callbacks_by_event_type = {event_type: callback for callback, event_type in mock_client.event_callbacks}
+        image_callback = callbacks_by_event_type[nio.RoomMessageImage]
+        assert callbacks_by_event_type[nio.RoomEncryptedImage] is image_callback
+        assert callbacks_by_event_type[nio.RoomMessageFile] is image_callback
+        assert callbacks_by_event_type[nio.RoomEncryptedFile] is image_callback
+        assert callbacks_by_event_type[nio.RoomMessageVideo] is image_callback
+        assert callbacks_by_event_type[nio.RoomEncryptedVideo] is image_callback
+        audio_callback = callbacks_by_event_type[nio.RoomMessageAudio]
+        assert callbacks_by_event_type[nio.RoomEncryptedAudio] is audio_callback
+        assert audio_callback is not image_callback
 
     @pytest.mark.asyncio
     async def test_agent_bot_try_start_reraises_permanent_startup_error(
@@ -4989,7 +5001,7 @@ class TestAgentBot:
         bot._turn_controller._dispatch_special_media_as_text = AsyncMock(return_value=False)
         bot._turn_controller._enqueue_for_dispatch = AsyncMock()
 
-        await bot._turn_controller._handle_media_message_inner(room, event)
+        await bot._turn_controller.handle_media_event(room, event)
 
         bot._conversation_cache.append_live_event.assert_awaited_once()
         append_args = bot._conversation_cache.append_live_event.await_args
@@ -5004,7 +5016,7 @@ class TestAgentBot:
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
     ) -> None:
-        """Audio dispatch should update live cache before special-media short-circuiting."""
+        """Audio dispatch should update live cache before audio normalization runs."""
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         room = MagicMock()
@@ -5012,20 +5024,27 @@ class TestAgentBot:
         event = self._make_handler_event("voice", sender="@user:localhost", event_id="$voice_event")
         prechecked_event = SimpleNamespace(event=event, requester_user_id="@user:localhost")
         bot._conversation_cache.append_live_event = AsyncMock()
-
-        async def record_coalescing(_room: object, _event: object) -> None:
-            assert bot._conversation_cache.append_live_event.await_count == 0
-
-        bot._conversation_resolver.coalescing_thread_id = AsyncMock(side_effect=record_coalescing)
+        bot._conversation_resolver.coalescing_thread_id = AsyncMock()
         bot._turn_controller._precheck_dispatch_event = MagicMock(return_value=prechecked_event)
-        bot._turn_controller._dispatch_special_media_as_text = AsyncMock(return_value=True)
+        bot._turn_controller._dispatch_special_media_as_text = AsyncMock()
         bot._turn_controller._enqueue_for_dispatch = AsyncMock()
+        bot._turn_controller._on_audio_media_message = AsyncMock()
 
-        await bot._turn_controller._handle_media_message_inner(room, event)
+        async def assert_live_cache_appended(
+            _room: object,
+            _prechecked_event: object,
+        ) -> None:
+            assert bot._conversation_cache.append_live_event.await_count == 1
+
+        bot._turn_controller._on_audio_media_message.side_effect = assert_live_cache_appended
+
+        await bot._turn_controller.handle_audio_event(room, event)
 
         bot._conversation_cache.append_live_event.assert_awaited_once()
-        bot._conversation_resolver.coalescing_thread_id.assert_awaited_once_with(room, event)
+        bot._conversation_resolver.coalescing_thread_id.assert_not_awaited()
+        bot._turn_controller._dispatch_special_media_as_text.assert_not_awaited()
         bot._turn_controller._enqueue_for_dispatch.assert_not_awaited()
+        bot._turn_controller._on_audio_media_message.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_media_message_merges_thread_history_attachment_ids(

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -937,6 +937,7 @@ class TestAgentBot:
         # add_event_callback is a sync method, not async
         mock_client.add_event_callback = MagicMock()
         mock_client.add_response_callback = MagicMock()
+        mock_client.sync_forever = AsyncMock()
         mock_login.return_value = mock_client
 
         # Mock ensure_user_account to not change the agent_user
@@ -955,9 +956,17 @@ class TestAgentBot:
         # and then login with whatever user account was ensured
         assert mock_login.called
         mock_init_persistence.assert_called_once_with(runtime_paths_for(config).storage_root)
+        assert mock_client.add_event_callback.call_count == 0
+        assert mock_client.add_response_callback.call_count == 0
+
+        with patch("mindroom.bot.catch_up_missed_user_messages", new=AsyncMock(), create=True) as mock_catchup:
+            await bot.sync_forever()
+
+        mock_catchup.assert_awaited_once_with(bot)
         assert (
             mock_client.add_event_callback.call_count == 12
         )  # invite, message, redaction, reaction, audio, image/file/video callbacks
+        assert mock_client.add_response_callback.call_count == 2
 
     @pytest.mark.asyncio
     @patch("mindroom.constants.runtime_matrix_homeserver", new=lambda *_args, **_kwargs: "http://localhost:8008")
@@ -990,6 +999,47 @@ class TestAgentBot:
         await bot.sync_forever()
 
         assert call_order == ["sync"]
+
+    @pytest.mark.asyncio
+    async def test_agent_bot_sync_registers_callbacks_after_startup_catchup(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """AgentBot should defer callback registration until startup catch-up finishes."""
+        config = self._config_for_storage(tmp_path)
+        mock_client = AsyncMock()
+        mock_client.event_callbacks = []
+        mock_client.response_callbacks = []
+        mock_client.add_event_callback = MagicMock(
+            side_effect=lambda callback, event_type: mock_client.event_callbacks.append((callback, event_type)),
+        )
+        mock_client.add_response_callback = MagicMock(
+            side_effect=lambda callback, event_type: mock_client.response_callbacks.append((callback, event_type)),
+        )
+        sync_order: list[str] = []
+
+        async def _sync_forever(*_args: object, **_kwargs: object) -> None:
+            sync_order.append("sync")
+
+        mock_client.sync_forever = AsyncMock(side_effect=_sync_forever)
+
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        _install_runtime_cache_support(bot)
+        bot.client = mock_client
+        bot.running = True
+
+        async def _fake_catchup(_bot: AgentBot) -> None:
+            assert mock_client.event_callbacks == []
+            assert mock_client.response_callbacks == []
+            sync_order.append("catchup")
+
+        with patch("mindroom.bot.catch_up_missed_user_messages", new=AsyncMock(side_effect=_fake_catchup), create=True):
+            await bot.sync_forever()
+
+        assert sync_order == ["catchup", "sync"]
+        assert len(mock_client.event_callbacks) == 12
+        assert len(mock_client.response_callbacks) == 2
 
     @pytest.mark.asyncio
     async def test_agent_bot_try_start_reraises_permanent_startup_error(

--- a/tests/test_startup_catchup.py
+++ b/tests/test_startup_catchup.py
@@ -178,20 +178,27 @@ async def test_catchup_dispatches_media_messages(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_catchup_continues_after_dispatch_error_and_still_advances_token(tmp_path: Path) -> None:
+async def test_catchup_raises_after_dispatch_error_and_does_not_advance_token(tmp_path: Path) -> None:
     bot = _bot(tmp_path)
+    bot.client.next_batch = "s_prev"
     bot._on_message = AsyncMock(side_effect=[None, RuntimeError("boom"), None])
-    with patch.object(bot.logger, "exception") as log_exception:
-        save_sync_token = await _run_catchup(
-            bot,
-            _text_event("$ok"),
-            _text_event("$boom"),
-            _text_event("$later"),
-            next_batch="s_after",
-        )
-    assert [call.args[1].event_id for call in bot._on_message.await_args_list] == ["$ok", "$boom", "$later"]
-    assert bot.client.next_batch == "s_after"
-    save_sync_token.assert_called_once_with(bot.storage_path, bot.agent_name, "s_after")
+    response = _sync_response(
+        _text_event("$ok"),
+        _text_event("$boom"),
+        _text_event("$later"),
+        next_batch="s_after",
+    )
+    with (
+        patch.object(bot.logger, "exception") as log_exception,
+        patch("mindroom.startup_catchup.load_sync_token", return_value="s_prev"),
+        patch("mindroom.startup_catchup.save_sync_token") as save_sync_token,
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        bot.client.sync = AsyncMock(return_value=response)
+        await catch_up_missed_user_messages(bot)
+    assert [call.args[1].event_id for call in bot._on_message.await_args_list] == ["$ok", "$boom"]
+    assert bot.client.next_batch == "s_prev"
+    save_sync_token.assert_not_called()
     log_exception.assert_called_once()
 
 

--- a/tests/test_startup_catchup.py
+++ b/tests/test_startup_catchup.py
@@ -1,0 +1,239 @@
+# ruff: noqa: ANN001, ANN002, ANN003, ANN202, D103, PT012, TC003
+
+"""Startup catch-up replay tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import nio
+import pytest
+
+from mindroom.bot import catch_up_missed_user_messages
+from tests.conftest import make_matrix_client_mock
+from tests.test_bot_ready_hook import _agent_bot
+
+
+def _bot(tmp_path: Path):
+    bot = _agent_bot(tmp_path)
+    bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id or "@mindroom_code:localhost")
+    bot._on_message = AsyncMock()
+    bot._on_media_message = AsyncMock()
+    return bot
+
+
+def _text_event(event_id: str, *, body: str = "hello", sender: str = "@user:localhost", relates_to=None):
+    content: dict[str, object] = {"body": body, "msgtype": "m.text"}
+    if relates_to is not None:
+        content["m.relates_to"] = relates_to
+    event = nio.RoomMessageText.from_dict(
+        {
+            "content": content,
+            "event_id": event_id,
+            "sender": sender,
+            "origin_server_ts": 1,
+            "room_id": "!room:localhost",
+            "type": "m.room.message",
+        },
+    )
+    assert isinstance(event, nio.RoomMessageText)
+    return event
+
+
+def _media_event(event_class: type, event_id: str, *, body: str, msgtype: str):
+    event = event_class.from_dict(
+        {
+            "content": {"body": body, "msgtype": msgtype, "url": "mxc://localhost/test"},
+            "event_id": event_id,
+            "sender": "@user:localhost",
+            "origin_server_ts": 1,
+            "room_id": "!room:localhost",
+            "type": "m.room.message",
+        },
+    )
+    assert event.event_id == event_id
+    return event
+
+
+def _sync_response(*events: object, next_batch: str = "s_next"):
+    response = MagicMock()
+    response.__class__ = nio.SyncResponse
+    response.next_batch = next_batch
+    response.rooms = MagicMock(join={"!room:localhost": MagicMock(timeline=MagicMock(events=list(events)))})
+    return response
+
+
+async def _run_catchup(bot, *events: object, next_batch: str = "s_next", handled=None):
+    bot._turn_store.is_handled = handled or (lambda _event_id: False)
+    response = _sync_response(*events, next_batch=next_batch)
+    with (
+        patch("mindroom.bot.load_sync_token", return_value="s_prev"),
+        patch("mindroom.bot.save_sync_token") as save_sync_token,
+    ):
+        bot.client.sync = AsyncMock(return_value=response)
+        await catch_up_missed_user_messages(bot)
+    return save_sync_token
+
+
+@pytest.mark.asyncio
+async def test_catchup_dispatches_missed_user_messages(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    await _run_catchup(bot, _text_event("$1"), _text_event("$2"), _text_event("$3"))
+    assert [call.args[1].event_id for call in bot._on_message.await_args_list] == ["$1", "$2", "$3"]
+
+
+@pytest.mark.asyncio
+async def test_catchup_skips_already_responded(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    await _run_catchup(
+        bot,
+        _text_event("$1"),
+        _text_event("$2"),
+        _text_event("$3"),
+        handled=lambda event_id: event_id == "$2",
+    )
+    assert [call.args[1].event_id for call in bot._on_message.await_args_list] == ["$1", "$3"]
+
+
+@pytest.mark.asyncio
+async def test_catchup_skips_bot_own_messages(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    await _run_catchup(bot, _text_event("$1", sender=bot.agent_user.user_id or ""))
+    bot._on_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_catchup_skips_commands(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    await _run_catchup(bot, _text_event("$1", body="!status"))
+    bot._on_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_catchup_skips_edits(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    await _run_catchup(bot, _text_event("$1", body="* updated", relates_to={"rel_type": "m.replace", "event_id": "$0"}))
+    bot._on_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_catchup_no_token_no_op(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    bot.client.sync = AsyncMock()
+    with patch("mindroom.bot.load_sync_token", return_value=None):
+        await catch_up_missed_user_messages(bot)
+    bot.client.sync.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_catchup_sync_error_raises(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    response = MagicMock()
+    response.__class__ = nio.SyncError
+    response.status_code = "M_UNKNOWN"
+    with (
+        patch("mindroom.bot.load_sync_token", return_value="s_prev"),
+        patch("mindroom.bot.save_sync_token") as save_sync_token,
+        pytest.raises(RuntimeError, match="Startup catch-up sync failed"),
+    ):
+        bot.client.sync = AsyncMock(return_value=response)
+        await catch_up_missed_user_messages(bot)
+    save_sync_token.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_catchup_saves_next_batch(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    save_sync_token = await _run_catchup(bot, _text_event("$1"), next_batch="s_after")
+    assert bot.client.next_batch == "s_after"
+    save_sync_token.assert_called_once_with(bot.storage_path, bot.agent_name, "s_after")
+
+
+@pytest.mark.asyncio
+async def test_catchup_preserves_order(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    ordered_event_ids: list[str] = []
+
+    async def capture_message(_room: nio.MatrixRoom, event: nio.RoomMessageText) -> None:
+        ordered_event_ids.append(event.event_id)
+
+    bot._on_message = AsyncMock(side_effect=capture_message)
+    await _run_catchup(bot, _text_event("$older"), _text_event("$middle"), _text_event("$newer"))
+    assert ordered_event_ids == ["$older", "$middle", "$newer"]
+
+
+@pytest.mark.asyncio
+async def test_catchup_dispatches_media_messages(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    await _run_catchup(
+        bot,
+        _media_event(nio.RoomMessageImage, "$image", body="image.png", msgtype="m.image"),
+        _media_event(nio.RoomMessageAudio, "$audio", body="audio.ogg", msgtype="m.audio"),
+    )
+    assert [call.args[1].event_id for call in bot._on_media_message.await_args_list] == ["$image", "$audio"]
+    bot._on_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_catchup_continues_after_dispatch_error_and_still_advances_token(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    bot._on_message = AsyncMock(side_effect=[None, RuntimeError("boom"), None])
+    with patch.object(bot.logger, "exception") as log_exception:
+        save_sync_token = await _run_catchup(
+            bot,
+            _text_event("$ok"),
+            _text_event("$boom"),
+            _text_event("$later"),
+            next_batch="s_after",
+        )
+    assert [call.args[1].event_id for call in bot._on_message.await_args_list] == ["$ok", "$boom", "$later"]
+    assert bot.client.next_batch == "s_after"
+    save_sync_token.assert_called_once_with(bot.storage_path, bot.agent_name, "s_after")
+    log_exception.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_sync_forever_registers_callbacks_after_catchup(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    order: list[str] = []
+    bot.client.add_event_callback.side_effect = lambda *_args, **_kwargs: order.append("register")
+    bot.client.add_response_callback.side_effect = lambda *_args, **_kwargs: order.append("register")
+    bot.client.sync_forever = AsyncMock(side_effect=lambda **_kwargs: order.append("sync_forever"))
+
+    async def fake_catchup(_bot) -> None:
+        assert bot.client.add_event_callback.call_count == 0
+        assert bot.client.add_response_callback.call_count == 0
+        order.append("catchup")
+
+    with patch("mindroom.bot.catch_up_missed_user_messages", new=AsyncMock(side_effect=fake_catchup)):
+        await bot.sync_forever()
+
+    assert order[0] == "catchup"
+    assert order[-1] == "sync_forever"
+
+
+@pytest.mark.asyncio
+async def test_sync_forever_does_not_register_callbacks_before_catchup(tmp_path: Path) -> None:
+    bot = _bot(tmp_path)
+    bot.client.event_callbacks = []
+    bot.client.add_event_callback.side_effect = lambda callback, event_type: bot.client.event_callbacks.append(
+        (callback, event_type),
+    )
+    bot.client.add_response_callback = MagicMock()
+    response = _sync_response(_text_event("$1"))
+
+    async def fake_sync(*_args, **_kwargs):
+        assert bot.client.event_callbacks == []
+        return response
+
+    bot.client.sync = AsyncMock(side_effect=fake_sync)
+    bot.client.sync_forever = AsyncMock()
+
+    with (
+        patch("mindroom.bot.load_sync_token", return_value="s_prev"),
+        patch("mindroom.bot.save_sync_token"),
+    ):
+        await bot.sync_forever()
+
+    assert [call.args[1].event_id for call in bot._on_message.await_args_list] == ["$1"]

--- a/tests/test_startup_catchup.py
+++ b/tests/test_startup_catchup.py
@@ -192,14 +192,22 @@ async def test_catchup_raises_after_dispatch_error_and_does_not_advance_token(tm
         patch.object(bot.logger, "exception") as log_exception,
         patch("mindroom.startup_catchup.load_sync_token", return_value="s_prev"),
         patch("mindroom.startup_catchup.save_sync_token") as save_sync_token,
-        pytest.raises(RuntimeError, match="boom"),
+        patch("mindroom.bot.save_sync_token") as persist_sync_token,
     ):
-        bot.client.sync = AsyncMock(return_value=response)
-        await catch_up_missed_user_messages(bot)
-    assert [call.args[1].event_id for call in bot._on_message.await_args_list] == ["$ok", "$boom"]
-    assert bot.client.next_batch == "s_prev"
-    save_sync_token.assert_not_called()
-    log_exception.assert_called_once()
+
+        async def fake_sync(*_args, **_kwargs):
+            bot.client.next_batch = response.next_batch
+            return response
+
+        bot.client.sync = AsyncMock(side_effect=fake_sync)
+        with pytest.raises(RuntimeError, match="boom"):
+            await catch_up_missed_user_messages(bot)
+        assert [call.args[1].event_id for call in bot._on_message.await_args_list] == ["$ok", "$boom"]
+        assert bot.client.next_batch == "s_prev"
+        save_sync_token.assert_not_called()
+        await bot.prepare_for_sync_shutdown()
+        persist_sync_token.assert_called_once_with(bot.storage_path, bot.agent_name, "s_prev")
+        log_exception.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_startup_catchup.py
+++ b/tests/test_startup_catchup.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 
-from mindroom.bot import catch_up_missed_user_messages
+from mindroom.startup_catchup import catch_up_missed_user_messages
 from tests.conftest import make_matrix_client_mock
 from tests.test_bot_ready_hook import _agent_bot
 
@@ -68,8 +68,8 @@ async def _run_catchup(bot, *events: object, next_batch: str = "s_next", handled
     bot._turn_store.is_handled = handled or (lambda _event_id: False)
     response = _sync_response(*events, next_batch=next_batch)
     with (
-        patch("mindroom.bot.load_sync_token", return_value="s_prev"),
-        patch("mindroom.bot.save_sync_token") as save_sync_token,
+        patch("mindroom.startup_catchup.load_sync_token", return_value="s_prev"),
+        patch("mindroom.startup_catchup.save_sync_token") as save_sync_token,
     ):
         bot.client.sync = AsyncMock(return_value=response)
         await catch_up_missed_user_messages(bot)
@@ -121,7 +121,7 @@ async def test_catchup_skips_edits(tmp_path: Path) -> None:
 async def test_catchup_no_token_no_op(tmp_path: Path) -> None:
     bot = _bot(tmp_path)
     bot.client.sync = AsyncMock()
-    with patch("mindroom.bot.load_sync_token", return_value=None):
+    with patch("mindroom.startup_catchup.load_sync_token", return_value=None):
         await catch_up_missed_user_messages(bot)
     bot.client.sync.assert_not_awaited()
 
@@ -133,8 +133,8 @@ async def test_catchup_sync_error_raises(tmp_path: Path) -> None:
     response.__class__ = nio.SyncError
     response.status_code = "M_UNKNOWN"
     with (
-        patch("mindroom.bot.load_sync_token", return_value="s_prev"),
-        patch("mindroom.bot.save_sync_token") as save_sync_token,
+        patch("mindroom.startup_catchup.load_sync_token", return_value="s_prev"),
+        patch("mindroom.startup_catchup.save_sync_token") as save_sync_token,
         pytest.raises(RuntimeError, match="Startup catch-up sync failed"),
     ):
         bot.client.sync = AsyncMock(return_value=response)
@@ -231,8 +231,8 @@ async def test_sync_forever_does_not_register_callbacks_before_catchup(tmp_path:
     bot.client.sync_forever = AsyncMock()
 
     with (
-        patch("mindroom.bot.load_sync_token", return_value="s_prev"),
-        patch("mindroom.bot.save_sync_token"),
+        patch("mindroom.startup_catchup.load_sync_token", return_value="s_prev"),
+        patch("mindroom.startup_catchup.save_sync_token"),
     ):
         await bot.sync_forever()
 

--- a/tests/test_startup_catchup.py
+++ b/tests/test_startup_catchup.py
@@ -20,6 +20,7 @@ def _bot(tmp_path: Path):
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id or "@mindroom_code:localhost")
     bot._on_message = AsyncMock()
     bot._on_media_message = AsyncMock()
+    bot._on_audio_message = AsyncMock()
     return bot
 
 
@@ -171,7 +172,8 @@ async def test_catchup_dispatches_media_messages(tmp_path: Path) -> None:
         _media_event(nio.RoomMessageImage, "$image", body="image.png", msgtype="m.image"),
         _media_event(nio.RoomMessageAudio, "$audio", body="audio.ogg", msgtype="m.audio"),
     )
-    assert [call.args[1].event_id for call in bot._on_media_message.await_args_list] == ["$image", "$audio"]
+    assert [call.args[1].event_id for call in bot._on_media_message.await_args_list] == ["$image"]
+    assert [call.args[1].event_id for call in bot._on_audio_message.await_args_list] == ["$audio"]
     bot._on_message.assert_not_awaited()
 
 

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -342,6 +342,7 @@ async def test_full_state_stays_enabled_until_first_sync_response() -> None:
 
     bot = MagicMock(spec=AgentBot)
     bot._first_sync_done = False
+    bot._sync_callbacks_registered = True
     bot._sync_shutting_down = False
     bot.client = FakeClient()
 
@@ -381,6 +382,7 @@ async def test_full_state_only_after_successful_first_sync() -> None:
     bot.agent_name = "test_agent"
     bot.last_sync_time = None
     bot._first_sync_done = False
+    bot._sync_callbacks_registered = True
     bot._sync_shutting_down = False
     bot.client = FakeClient()
     bot._runtime_view = BotRuntimeState(

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -2537,7 +2537,7 @@ class TestThreadingBehavior:
         self,
         bot: AgentBot,
     ) -> None:
-        """Cold-start media ingress should persist the same transitive thread membership used at runtime."""
+        """Cold-start audio ingress should persist the same transitive thread membership used at runtime."""
         room_id = "!test:localhost"
         thread_root_id = "$thread_root:localhost"
         thread_reply_id = "$thread_reply:localhost"
@@ -2569,7 +2569,7 @@ class TestThreadingBehavior:
         )
         prechecked_event = MagicMock(event=audio_event, requester_user_id="@user:localhost")
         bot._turn_controller._precheck_dispatch_event = MagicMock(return_value=prechecked_event)
-        bot._turn_controller._dispatch_special_media_as_text = AsyncMock(return_value=True)
+        bot._turn_controller._on_audio_media_message = AsyncMock()
         bot._turn_controller._enqueue_for_dispatch = AsyncMock()
 
         def room_get_event_response(event_id: str, content: dict[str, object]) -> nio.RoomGetEventResponse:
@@ -2611,12 +2611,37 @@ class TestThreadingBehavior:
             raise AssertionError(msg)
 
         bot.client.room_get_event = AsyncMock(side_effect=fetch_related_event)
+        bot.client.room_messages = AsyncMock(
+            return_value=nio.RoomMessagesResponse(
+                room_id=room_id,
+                chunk=[
+                    _text_event(
+                        event_id=thread_reply_id,
+                        body="thread reply",
+                        sender="@user:localhost",
+                        server_timestamp=1234567894,
+                        room_id=room_id,
+                        thread_id=thread_root_id,
+                    ),
+                    _text_event(
+                        event_id=thread_root_id,
+                        body="thread root",
+                        sender="@user:localhost",
+                        server_timestamp=1234567893,
+                        room_id=room_id,
+                    ),
+                ],
+                start="",
+                end=None,
+            ),
+        )
 
         try:
-            await bot._turn_controller.handle_media_event(room, audio_event)
+            await bot._turn_controller.handle_audio_event(room, audio_event)
             await bot.event_cache_write_coordinator.wait_for_room_idle(room_id)
 
             assert await real_event_cache.get_thread_id_for_event(room_id, audio_event_id) == thread_root_id
+            bot._turn_controller._on_audio_media_message.assert_awaited_once()
         finally:
             await real_event_cache.close()
 


### PR DESCRIPTION
Ports the smaller `gitea/main` fix from `aad690b1e` as a simpler replacement for #649.

## Summary
- replay missed user messages exactly once before entering the long-lived sync loop
- defer Matrix event and response callback registration until after startup catch-up completes
- add focused startup catch-up coverage, plus sync-cancellation test updates for the new startup path

This keeps the startup replay logic small and avoids the duplicate-dispatch behavior that #649 was addressing.

## Testing
- `uv run --active pre-commit run --all-files`
- `uv run --active pytest -x -n 0 --no-cov --timeout=120`