### PR TITLE
refactor(runtime): narrow BotRuntimeView consumers to per-consumer Protocols

### DIFF
--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -19,6 +19,7 @@ from mindroom.matrix.invited_rooms_store import (
 )
 from mindroom.matrix.rooms import leave_non_dm_rooms
 from mindroom.matrix.state import MatrixState
+from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
@@ -26,7 +27,6 @@ if TYPE_CHECKING:
 
     import structlog
 
-    from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.matrix.users import AgentMatrixUser
@@ -38,7 +38,7 @@ class BotRoomLifecycleDeps:
 
     agent_name: str
     agent_user: AgentMatrixUser
-    runtime: BotRuntimeView
+    runtime: SupportsClientConfig
     runtime_paths: RuntimePaths
     get_logger: Callable[[], structlog.stdlib.BoundLogger]
     get_configured_rooms: Callable[[], Sequence[str]]

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -25,12 +25,12 @@ from mindroom.matrix.thread_membership import (
     thread_messages_thread_membership_access,
 )
 from mindroom.message_target import MessageTarget
+from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 from mindroom.thread_utils import check_agent_mentioned
 
 if TYPE_CHECKING:
     import structlog
 
-    from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.constants import RuntimePaths
     from mindroom.hooks import MessageEnvelope
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
@@ -78,7 +78,7 @@ class MessageContext:
 class ConversationResolverDeps:
     """Explicit collaborators for conversation resolution."""
 
-    runtime: BotRuntimeView
+    runtime: SupportsClientConfig
     logger: structlog.stdlib.BoundLogger
     runtime_paths: RuntimePaths
     agent_name: str

--- a/src/mindroom/conversation_state_writer.py
+++ b/src/mindroom/conversation_state_writer.py
@@ -16,12 +16,12 @@ from mindroom.agents import (
 )
 from mindroom.history.runtime import create_scope_session_storage
 from mindroom.history.types import HistoryScope
+from mindroom.runtime_protocols import SupportsConfig  # noqa: TC001
 
 if TYPE_CHECKING:
     import structlog
     from agno.db.sqlite import SqliteDb
 
-    from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.constants import RuntimePaths
     from mindroom.matrix.identity import MatrixID
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 class ConversationStateWriterDeps:
     """Static collaborators for conversation-state persistence and cache writes."""
 
-    runtime: BotRuntimeView
+    runtime: SupportsConfig
     logger: structlog.stdlib.BoundLogger
     runtime_paths: RuntimePaths
     agent_name: str

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -27,6 +27,7 @@ from mindroom.hooks.types import (
 from mindroom.matrix.client_delivery import build_threaded_edit_content, edit_message_result, send_message_result
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_message_content
+from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 from mindroom.streaming import StreamingResponse, send_streaming_response
 
 if TYPE_CHECKING:
@@ -35,7 +36,6 @@ if TYPE_CHECKING:
     import nio
     import structlog
 
-    from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.constants import RuntimePaths
     from mindroom.conversation_resolver import ConversationResolver
     from mindroom.history.types import CompactionOutcome
@@ -220,7 +220,7 @@ class StreamingDeliveryRequest:
 class DeliveryGatewayDeps:
     """Explicit dependencies needed for Matrix delivery."""
 
-    runtime: BotRuntimeView
+    runtime: SupportsClientConfig
     runtime_paths: RuntimePaths
     agent_name: str
     logger: structlog.stdlib.BoundLogger

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -11,6 +11,7 @@ from mindroom.handled_turns import HandledTurnRecord, HandledTurnState
 from mindroom.hooks.ingress import hook_ingress_policy
 from mindroom.matrix.identity import extract_agent_name
 from mindroom.matrix.message_content import extract_edit_body
+from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -18,7 +19,6 @@ if TYPE_CHECKING:
     import nio
     import structlog
 
-    from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.constants import RuntimePaths
     from mindroom.conversation_resolver import ConversationResolver
     from mindroom.hooks import MessageEnvelope
@@ -56,7 +56,7 @@ class _GenerateResponse(Protocol):
 class EditRegeneratorDeps:
     """Collaborators needed for edit-triggered regeneration."""
 
-    runtime: BotRuntimeView
+    runtime: SupportsClientConfig
     get_logger: Callable[[], structlog.stdlib.BoundLogger]
     runtime_paths: RuntimePaths
     agent_name: str

--- a/src/mindroom/hooks/context.py
+++ b/src/mindroom/hooks/context.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from mindroom.constants import HOOK_MESSAGE_RECEIVED_DEPTH_KEY, ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME
 from mindroom.logging_config import get_logger
+from mindroom.runtime_protocols import SupportsClientConfigOrchestrator  # noqa: TC001
 from mindroom.tool_system.plugin_identity import validate_plugin_name
 
 from .state import (
@@ -35,7 +36,6 @@ if TYPE_CHECKING:
     import structlog
     from agno.models.message import Message
 
-    from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.history.types import HistoryScope
@@ -128,7 +128,7 @@ async def _put_bound_room_state(
 class HookContextSupport:
     """Own live hook bindings and shared hook-context base fields."""
 
-    runtime: BotRuntimeView
+    runtime: SupportsClientConfigOrchestrator
     logger: structlog.stdlib.BoundLogger
     runtime_paths: RuntimePaths
     agent_name: str

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -27,6 +27,7 @@ from mindroom.matrix.message_content import (
     visible_body_from_event_source,
 )
 from mindroom.media_inputs import MediaInputs
+from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 from mindroom.voice_handler import prepare_voice_message
 
 if TYPE_CHECKING:
@@ -35,7 +36,6 @@ if TYPE_CHECKING:
     import structlog
     from agno.media import Image
 
-    from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.constants import RuntimePaths
     from mindroom.conversation_resolver import ConversationResolver
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
@@ -117,7 +117,7 @@ class DispatchPayloadWithAttachmentsRequest:
 class InboundTurnNormalizerDeps:
     """Explicit collaborators for inbound normalization."""
 
-    runtime: BotRuntimeView
+    runtime: SupportsClientConfig
     logger: structlog.stdlib.BoundLogger
     storage_path: Path
     runtime_paths: RuntimePaths

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -13,6 +13,7 @@ from mindroom.knowledge.shared_managers import (
     get_shared_knowledge_manager_for_config,
 )
 from mindroom.logging_config import get_logger
+from mindroom.runtime_protocols import SupportsConfigOrchestrator  # noqa: TC001
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -20,7 +21,6 @@ if TYPE_CHECKING:
     from agno.knowledge.document import Document
     from structlog.stdlib import BoundLogger
 
-    from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.knowledge.manager import KnowledgeManager
@@ -126,7 +126,7 @@ def get_agent_knowledge(
 class KnowledgeAccessSupport:
     """Resolve live knowledge access for one runtime without routing through AgentBot."""
 
-    runtime: BotRuntimeView
+    runtime: SupportsConfigOrchestrator
     logger: BoundLogger
     runtime_paths: RuntimePaths
 

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -9,6 +9,7 @@ from mindroom import interactive
 from mindroom.background_tasks import create_background_task
 from mindroom.delivery_gateway import CompactionNoticeRequest
 from mindroom.message_target import MessageTarget
+from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 from mindroom.thread_summary import maybe_generate_thread_summary
 from mindroom.thread_summary import (
     should_queue_thread_summary as should_queue_thread_summary_check,
@@ -22,7 +23,6 @@ if TYPE_CHECKING:
     import structlog
     from agno.db.base import SessionType
 
-    from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.constants import RuntimePaths
     from mindroom.delivery_gateway import DeliveryGateway, DeliveryResult
     from mindroom.history.types import CompactionOutcome
@@ -83,7 +83,7 @@ class PostResponseEffectsDeps:
 class PostResponseEffectsSupport:
     """Shared support used to build per-response post-effect deps."""
 
-    runtime: BotRuntimeView
+    runtime: SupportsClientConfig
     logger: structlog.stdlib.BoundLogger
     runtime_paths: RuntimePaths
     delivery_gateway: DeliveryGateway

--- a/src/mindroom/runtime_protocols.py
+++ b/src/mindroom/runtime_protocols.py
@@ -1,0 +1,67 @@
+"""Small runtime Protocols for extracted bot collaborators."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    import nio
+
+    from mindroom.config.main import Config
+    from mindroom.orchestrator import MultiAgentOrchestrator
+
+__all__ = [
+    "SupportsClientConfig",
+    "SupportsClientConfigOrchestrator",
+    "SupportsConfig",
+    "SupportsConfigOrchestrator",
+]
+
+
+class SupportsConfig(Protocol):
+    """Expose the runtime config snapshot."""
+
+    @property
+    def config(self) -> Config: ...  # noqa: D102
+
+
+class SupportsClientConfig(Protocol):
+    """Expose the Matrix client plus runtime config."""
+
+    @property
+    def client(self) -> nio.AsyncClient | None: ...  # noqa: D102
+
+    @property
+    def config(self) -> Config: ...  # noqa: D102
+
+
+class SupportsConfigOrchestrator(SupportsConfig, Protocol):
+    """Expose the config plus optional orchestrator handle."""
+
+    @property
+    def orchestrator(self) -> MultiAgentOrchestrator | None: ...  # noqa: D102
+
+
+class SupportsClientConfigOrchestrator(SupportsClientConfig, Protocol):
+    """Expose client/config access plus the orchestrator."""
+
+    @property
+    def orchestrator(self) -> MultiAgentOrchestrator | None: ...  # noqa: D102
+
+
+if TYPE_CHECKING:
+    from mindroom.bot_runtime_view import BotRuntimeView
+
+    def _check_narrow_protocols_are_subsets_of_bot_runtime_view(
+        view: BotRuntimeView,
+    ) -> None:
+        """Type-only proof that BotRuntimeView satisfies every narrow protocol.
+
+        This function is never called at runtime. The assignments below
+        will fail static type-check if any narrow protocol drifts out of
+        the BotRuntimeView surface.
+        """
+        _a: SupportsConfig = view
+        _b: SupportsClientConfig = view
+        _c: SupportsConfigOrchestrator = view
+        _d: SupportsClientConfigOrchestrator = view

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -27,6 +27,7 @@ from mindroom.hooks import (
 from mindroom.hooks.ingress import HookIngressPolicy, is_automation_source_kind
 from mindroom.inbound_turn_normalizer import DispatchPayload
 from mindroom.matrix.identity import MatrixID, is_agent_id
+from mindroom.runtime_protocols import SupportsConfigOrchestrator  # noqa: TC001
 from mindroom.team_runtime_resolution import resolve_live_shared_agent_names
 from mindroom.teams import (
     TeamIntent,
@@ -51,7 +52,6 @@ if TYPE_CHECKING:
     import nio
     import structlog
 
-    from mindroom.bot_runtime_view import BotRuntimeView
     from mindroom.conversation_resolver import (
         DispatchEvent,
         MediaDispatchEvent,
@@ -210,7 +210,7 @@ class IngressHookRunner:
 class TurnPolicyDeps:
     """Explicit collaborators needed by pure turn policy decisions."""
 
-    runtime: BotRuntimeView
+    runtime: SupportsConfigOrchestrator
     logger: structlog.stdlib.BoundLogger
     runtime_paths: RuntimePaths
     agent_name: str

--- a/tach.toml
+++ b/tach.toml
@@ -51,7 +51,13 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.bot_room_lifecycle"
-depends_on = ["mindroom.matrix.client_room_admin", "mindroom.constants", "mindroom.matrix.rooms", "mindroom.commands.handler"]
+depends_on = [
+    "mindroom.commands.handler",
+    "mindroom.constants",
+    "mindroom.matrix.client_room_admin",
+    "mindroom.matrix.rooms",
+    "mindroom.runtime_protocols",
+]
 
 [[modules]]
 path = "mindroom.custom_tools.attachments"
@@ -89,7 +95,24 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.delivery_gateway"
-depends_on = ["mindroom.streaming", "mindroom.constants", "mindroom.matrix.client_delivery"]
+depends_on = [
+    "mindroom.constants",
+    "mindroom.matrix.client_delivery",
+    "mindroom.runtime_protocols",
+    "mindroom.streaming",
+]
+
+[[modules]]
+path = "mindroom.edit_regenerator"
+depends_on = [
+    "mindroom.coalescing",
+    "mindroom.conversation_resolver",
+    "mindroom.handled_turns",
+    "mindroom.hooks.ingress",
+    "mindroom.matrix.identity",
+    "mindroom.matrix.message_content",
+    "mindroom.runtime_protocols",
+]
 
 [[modules]]
 path = "mindroom.execution_preparation"
@@ -266,7 +289,34 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.bot_runtime_view"
-depends_on = []
+depends_on = ["mindroom.matrix.cache"]
+visibility = [
+    "mindroom.bot",
+    "mindroom.matrix.cache.thread_reads",
+    "mindroom.matrix.cache.thread_write_cache_ops",
+    "mindroom.matrix.conversation_cache",
+    "mindroom.matrix.thread_bookkeeping",
+    "mindroom.response_runner",
+    "mindroom.runtime_protocols",
+    "mindroom.tool_system.runtime_context",
+    "mindroom.turn_controller",
+]
+
+[[modules]]
+path = "mindroom.runtime_protocols"
+depends_on = ["mindroom.bot_runtime_view"]
+visibility = [
+    "mindroom.bot_room_lifecycle",
+    "mindroom.conversation_resolver",
+    "mindroom.conversation_state_writer",
+    "mindroom.delivery_gateway",
+    "mindroom.edit_regenerator",
+    "mindroom.hooks.context",
+    "mindroom.inbound_turn_normalizer",
+    "mindroom.knowledge.utils",
+    "mindroom.post_response_effects",
+    "mindroom.turn_policy",
+]
 
 [[modules]]
 path = "mindroom.constants"
@@ -417,6 +467,16 @@ depends_on = [
     "mindroom.matrix.event_info",
     "mindroom.matrix.message_content",
     "mindroom.matrix.thread_membership",
+    "mindroom.runtime_protocols",
+]
+
+[[modules]]
+path = "mindroom.conversation_state_writer"
+depends_on = [
+    "mindroom.agents",
+    "mindroom.history.runtime",
+    "mindroom.history.types",
+    "mindroom.runtime_protocols",
 ]
 
 [[modules]]
@@ -426,8 +486,11 @@ depends_on = [
     "mindroom.bot_room_lifecycle",
     "mindroom.constants",
     "mindroom.conversation_resolver",
+    "mindroom.conversation_state_writer",
     "mindroom.delivery_gateway",
+    "mindroom.edit_regenerator",
     "mindroom.hooks.sender",
+    "mindroom.inbound_turn_normalizer",
     "mindroom.knowledge",
     "mindroom.memory",
     "mindroom.matrix.client_room_admin",
@@ -439,7 +502,10 @@ depends_on = [
     "mindroom.post_response_effects",
     "mindroom.response_runner",
     "mindroom.scheduling",
-    "mindroom.turn_controller", "mindroom.tool_system.runtime_context", "mindroom.tool_system.worker_routing",
+    "mindroom.tool_system.runtime_context",
+    "mindroom.tool_system.worker_routing",
+    "mindroom.turn_controller",
+    "mindroom.turn_policy",
 ]
 
 [[modules]]
@@ -448,6 +514,18 @@ depends_on = [
     "mindroom.constants",
     "mindroom.matrix.event_info",
     "mindroom.scheduling", "mindroom.tool_system.skills", "mindroom.tool_system.worker_routing", "mindroom.tool_system.runtime_context",
+]
+
+[[modules]]
+path = "mindroom.hooks.context"
+depends_on = [
+    "mindroom.constants",
+    "mindroom.hooks.matrix_admin",
+    "mindroom.hooks.state",
+    "mindroom.hooks.types",
+    "mindroom.logging_config",
+    "mindroom.runtime_protocols",
+    "mindroom.tool_system.plugin_identity",
 ]
 
 [[modules]]
@@ -582,7 +660,12 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.post_response_effects"
-depends_on = [ "mindroom.thread_summary", "mindroom.delivery_gateway"]
+depends_on = [
+    "mindroom.delivery_gateway",
+    "mindroom.matrix.conversation_cache",
+    "mindroom.runtime_protocols",
+    "mindroom.thread_summary",
+]
 
 [[modules]]
 path = "mindroom.hooks.sender"
@@ -593,13 +676,46 @@ path = "mindroom.turn_controller"
 depends_on = [
     "mindroom.commands.handler",
     "mindroom.constants",
+    "mindroom.delivery_gateway",
+    "mindroom.inbound_turn_normalizer",
     "mindroom.matrix.cache",
     "mindroom.matrix.event_info",
     "mindroom.matrix.message_content",
     "mindroom.matrix.rooms",
     "mindroom.response_runner",
     "mindroom.routing",
-    "mindroom.delivery_gateway",
+    "mindroom.turn_policy",
+]
+
+[[modules]]
+path = "mindroom.inbound_turn_normalizer"
+depends_on = [
+    "mindroom.attachment_media",
+    "mindroom.attachments",
+    "mindroom.coalescing",
+    "mindroom.logging_config",
+    "mindroom.matrix.event_info",
+    "mindroom.matrix.image_handler",
+    "mindroom.matrix.message_content",
+    "mindroom.media_inputs",
+    "mindroom.runtime_protocols",
+    "mindroom.voice_handler",
+]
+
+[[modules]]
+path = "mindroom.turn_policy"
+depends_on = [
+    "mindroom.authorization",
+    "mindroom.constants",
+    "mindroom.hooks",
+    "mindroom.hooks.ingress",
+    "mindroom.inbound_turn_normalizer",
+    "mindroom.matrix.identity",
+    "mindroom.runtime_protocols",
+    "mindroom.team_runtime_resolution",
+    "mindroom.teams",
+    "mindroom.thread_utils",
+    "mindroom.timing",
 ]
 
 [[modules]]
@@ -636,6 +752,7 @@ depends_on = [
 path = "mindroom.knowledge.utils"
 depends_on = [
     "mindroom.knowledge.shared_managers",
+    "mindroom.runtime_protocols",
 ]
 
 [[interfaces]]
@@ -680,6 +797,15 @@ expose = [
     "update_agent_memory",
 ]
 from = ["mindroom.memory"]
+
+[[interfaces]]
+expose = [
+    "SupportsClientConfig",
+    "SupportsClientConfigOrchestrator",
+    "SupportsConfig",
+    "SupportsConfigOrchestrator",
+]
+from = ["mindroom.runtime_protocols"]
 
 [[interfaces]]
 expose = [

--- a/tests/test_tach_split_matrix_client_boundaries.py
+++ b/tests/test_tach_split_matrix_client_boundaries.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import ast
+import importlib
 import shutil
 import subprocess
 import sys
+import textwrap
 import tomllib
 from pathlib import Path
 
@@ -18,6 +20,39 @@ SPLIT_MATRIX_CLIENT_MODULES = {
     "mindroom.matrix.client_session",
     "mindroom.matrix.client_thread_history",
     "mindroom.matrix.client_visible_messages",
+}
+RUNTIME_PROTOCOL_MODULE = "mindroom.runtime_protocols"
+BOT_RUNTIME_VIEW_MODULE = "mindroom.bot_runtime_view"
+RUNTIME_VIEW_STRUCTURAL_MEMBER = "orchestrator"
+RUNTIME_PROTOCOL_PRIVATE_SYMBOL = "_check_narrow_protocols_are_subsets_of_bot_runtime_view"
+RUNTIME_PROTOCOL_PUBLIC_SYMBOLS = [
+    "SupportsClientConfig",
+    "SupportsClientConfigOrchestrator",
+    "SupportsConfig",
+    "SupportsConfigOrchestrator",
+]
+RUNTIME_PROTOCOL_IMPORTERS = {
+    "mindroom.bot_room_lifecycle",
+    "mindroom.conversation_resolver",
+    "mindroom.conversation_state_writer",
+    "mindroom.delivery_gateway",
+    "mindroom.edit_regenerator",
+    "mindroom.hooks.context",
+    "mindroom.inbound_turn_normalizer",
+    "mindroom.knowledge.utils",
+    "mindroom.post_response_effects",
+    "mindroom.turn_policy",
+}
+BOT_RUNTIME_VIEW_ALLOWED_IMPORTERS = {
+    "mindroom.bot",
+    RUNTIME_PROTOCOL_MODULE,
+    "mindroom.matrix.cache.thread_reads",
+    "mindroom.matrix.cache.thread_write_cache_ops",
+    "mindroom.matrix.conversation_cache",
+    "mindroom.matrix.thread_bookkeeping",
+    "mindroom.response_runner",
+    "mindroom.tool_system.runtime_context",
+    "mindroom.turn_controller",
 }
 
 
@@ -62,45 +97,61 @@ def _is_type_checking_test(test: ast.expr) -> bool:
     )
 
 
-def _record_runtime_split_import(node: ast.AST, importer_module: str, imports: set[str]) -> None:
+def _record_runtime_module_import(
+    node: ast.AST,
+    importer_module: str,
+    target_modules: set[str],
+    imports: set[str],
+) -> None:
     if isinstance(node, ast.ImportFrom):
         resolved_module = _resolve_import_from_module(importer_module, node)
-        if resolved_module in SPLIT_MATRIX_CLIENT_MODULES:
+        if resolved_module in target_modules:
             imports.add(resolved_module)
         return
 
     if isinstance(node, ast.Import):
         for alias in node.names:
-            if alias.name in SPLIT_MATRIX_CLIENT_MODULES:
+            if alias.name in target_modules:
                 imports.add(alias.name)
 
 
 def _walk_runtime_nodes(
     node: ast.AST,
     importer_module: str,
+    target_modules: set[str],
     imports: set[str],
     *,
     in_type_checking: bool = False,
 ) -> None:
     if isinstance(node, ast.If) and _is_type_checking_test(node.test):
         for child in node.body:
-            _walk_runtime_nodes(child, importer_module, imports, in_type_checking=True)
+            _walk_runtime_nodes(child, importer_module, target_modules, imports, in_type_checking=True)
         for child in node.orelse:
-            _walk_runtime_nodes(child, importer_module, imports, in_type_checking=in_type_checking)
+            _walk_runtime_nodes(
+                child,
+                importer_module,
+                target_modules,
+                imports,
+                in_type_checking=in_type_checking,
+            )
         return
 
     if not in_type_checking:
-        _record_runtime_split_import(node, importer_module, imports)
+        _record_runtime_module_import(node, importer_module, target_modules, imports)
 
     for child in ast.iter_child_nodes(node):
-        _walk_runtime_nodes(child, importer_module, imports, in_type_checking=in_type_checking)
+        _walk_runtime_nodes(child, importer_module, target_modules, imports, in_type_checking=in_type_checking)
+
+
+def _runtime_direct_imports(py_path: Path, importer_module: str, target_modules: set[str]) -> set[str]:
+    tree = ast.parse(py_path.read_text())
+    imports: set[str] = set()
+    _walk_runtime_nodes(tree, importer_module, target_modules, imports)
+    return imports
 
 
 def _runtime_direct_split_imports(py_path: Path, importer_module: str) -> set[str]:
-    tree = ast.parse(py_path.read_text())
-    imports: set[str] = set()
-    _walk_runtime_nodes(tree, importer_module, imports)
-    return imports
+    return _runtime_direct_imports(py_path, importer_module, SPLIT_MATRIX_CLIENT_MODULES)
 
 
 def _split_matrix_client_importers() -> dict[str, set[str]]:
@@ -112,6 +163,18 @@ def _split_matrix_client_importers() -> dict[str, set[str]]:
         runtime_imports = _runtime_direct_split_imports(py_path, importer_module)
         if runtime_imports:
             importers[importer_module] = runtime_imports
+    return importers
+
+
+def _runtime_protocol_importers() -> set[str]:
+    importers: set[str] = set()
+    for py_path in SOURCE_ROOT.rglob("*.py"):
+        importer_module = f"mindroom.{py_path.relative_to(SOURCE_ROOT).with_suffix('').as_posix().replace('/', '.')}"
+        if importer_module == RUNTIME_PROTOCOL_MODULE:
+            continue
+        runtime_imports = _runtime_direct_imports(py_path, importer_module, {RUNTIME_PROTOCOL_MODULE})
+        if runtime_imports:
+            importers.add(importer_module)
     return importers
 
 
@@ -148,6 +211,71 @@ def test_split_matrix_client_importers_have_explicit_tach_modules() -> None:
     assert not missing_visibility, f"Missing split-client module visibility: {missing_visibility}"
 
 
+def test_runtime_protocol_importers_have_explicit_tach_modules() -> None:
+    """Every runtime-protocol consumer must be explicit and Tach-governed."""
+    module_entries = _module_entries_by_path()
+    actual_importers = _runtime_protocol_importers()
+
+    assert actual_importers == RUNTIME_PROTOCOL_IMPORTERS
+    assert RUNTIME_PROTOCOL_MODULE in module_entries
+
+    missing_module_entries: list[str] = []
+    missing_dependencies: list[str] = []
+    missing_visibility: list[str] = []
+
+    runtime_protocol_entry = module_entries[RUNTIME_PROTOCOL_MODULE]
+    visibility = runtime_protocol_entry.get("visibility")
+    assert isinstance(visibility, list)
+    assert set(visibility) == RUNTIME_PROTOCOL_IMPORTERS
+
+    for importer_module in sorted(actual_importers):
+        importer_entry = module_entries.get(importer_module)
+        if importer_entry is None:
+            missing_module_entries.append(importer_module)
+            continue
+
+        depends_on = importer_entry.get("depends_on")
+        if not isinstance(depends_on, list) or RUNTIME_PROTOCOL_MODULE not in depends_on:
+            missing_dependencies.append(f"{importer_module} -> {RUNTIME_PROTOCOL_MODULE}")
+
+        if importer_module not in visibility:
+            missing_visibility.append(f"{RUNTIME_PROTOCOL_MODULE} !<- {importer_module}")
+
+    assert not missing_module_entries, f"Missing explicit runtime-protocol modules: {missing_module_entries}"
+    assert not missing_dependencies, f"Missing runtime-protocol dependencies: {missing_dependencies}"
+    assert not missing_visibility, f"Missing runtime-protocol module visibility: {missing_visibility}"
+
+
+def test_runtime_protocol_interface_matches_public_symbols() -> None:
+    """The runtime protocol facade must expose only the declared public protocols."""
+    module_entries = _module_entries_by_path()
+    runtime_protocols = importlib.import_module(RUNTIME_PROTOCOL_MODULE)
+
+    assert runtime_protocols.__all__ == RUNTIME_PROTOCOL_PUBLIC_SYMBOLS
+
+    interface_entries = [
+        entry for entry in _load_tach_config()["interfaces"] if entry["from"] == [RUNTIME_PROTOCOL_MODULE]
+    ]
+    assert len(interface_entries) == 1
+    assert interface_entries[0]["expose"] == RUNTIME_PROTOCOL_PUBLIC_SYMBOLS
+    assert RUNTIME_PROTOCOL_MODULE in module_entries
+
+
+def test_bot_runtime_view_visibility_is_limited_to_owner_and_protocol_facade() -> None:
+    """Only the bot shell, the protocol facade, and core runtime-heavy modules may import the full runtime view."""
+    module_entries = _module_entries_by_path()
+    entry = module_entries[BOT_RUNTIME_VIEW_MODULE]
+    visibility = entry.get("visibility")
+
+    assert isinstance(visibility, list)
+    assert set(visibility) == BOT_RUNTIME_VIEW_ALLOWED_IMPORTERS
+
+    runtime_protocol_entry = module_entries[RUNTIME_PROTOCOL_MODULE]
+    depends_on = runtime_protocol_entry.get("depends_on")
+    assert isinstance(depends_on, list)
+    assert BOT_RUNTIME_VIEW_MODULE in depends_on
+
+
 def test_tach_rejects_forbidden_split_matrix_client_import(tmp_path: Path) -> None:
     """A new direct split-client import must fail Tach until tach.toml is updated."""
     project_root = tmp_path / "project"
@@ -176,3 +304,145 @@ def test_tach_rejects_forbidden_split_matrix_client_import(tmp_path: Path) -> No
 
     assert result.returncode == 1, result.stdout + result.stderr
     assert "mindroom.matrix.client_session" in (result.stdout + result.stderr)
+
+
+def test_tach_rejects_forbidden_runtime_protocol_import(tmp_path: Path) -> None:
+    """A new runtime-protocol consumer must fail Tach until allowed explicitly."""
+    project_root = tmp_path / "project"
+    shutil.copytree(REPO_ROOT / "src", project_root / "src")
+    shutil.copy2(TACH_CONFIG, project_root / "tach.toml")
+
+    attachments_path = project_root / "src" / "mindroom" / "custom_tools" / "attachments.py"
+    original_text = attachments_path.read_text()
+    probe_import = "from mindroom.runtime_protocols import SupportsConfig as _tach_probe_runtime_protocol\n"
+    attachments_path.write_text(
+        original_text.replace(
+            "from __future__ import annotations\n\n",
+            f"from __future__ import annotations\n\n{probe_import}",
+        ),
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tach", "check", "--dependencies", "--interfaces"],
+        cwd=project_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert RUNTIME_PROTOCOL_MODULE in (result.stdout + result.stderr)
+
+
+def test_tach_rejects_private_runtime_protocol_import(tmp_path: Path) -> None:
+    """An allowed consumer still may not import a private runtime-protocol helper."""
+    project_root = tmp_path / "project"
+    shutil.copytree(REPO_ROOT / "src", project_root / "src")
+    shutil.copy2(TACH_CONFIG, project_root / "tach.toml")
+
+    effects_path = project_root / "src" / "mindroom" / "post_response_effects.py"
+    original_text = effects_path.read_text()
+    probe_import = (
+        "from mindroom.runtime_protocols import "
+        "_check_narrow_protocols_are_subsets_of_bot_runtime_view as _tach_probe_private_runtime_protocol\n"
+    )
+    effects_path.write_text(
+        original_text.replace(
+            "from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001\n",
+            f"from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001\n{probe_import}",
+        ),
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tach", "check", "--dependencies", "--interfaces"],
+        cwd=project_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    assert RUNTIME_PROTOCOL_MODULE in output
+    assert RUNTIME_PROTOCOL_PRIVATE_SYMBOL in output
+
+
+def test_tach_rejects_forbidden_bot_runtime_view_import(tmp_path: Path) -> None:
+    """A direct full-runtime import must fail Tach outside the owning bot shell."""
+    project_root = tmp_path / "project"
+    shutil.copytree(REPO_ROOT / "src", project_root / "src")
+    shutil.copy2(TACH_CONFIG, project_root / "tach.toml")
+
+    effects_path = project_root / "src" / "mindroom" / "post_response_effects.py"
+    original_text = effects_path.read_text()
+    probe_import = "from mindroom.bot_runtime_view import BotRuntimeView as _tach_probe_runtime_view\n"
+    effects_path.write_text(
+        original_text.replace(
+            "from __future__ import annotations\n\n",
+            f"from __future__ import annotations\n\n{probe_import}",
+        ),
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "tach", "check", "--dependencies", "--interfaces"],
+        cwd=project_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert BOT_RUNTIME_VIEW_MODULE in (result.stdout + result.stderr)
+
+
+def test_ty_rejects_runtime_view_missing_structural_member(tmp_path: Path) -> None:
+    """The runtime view must keep members required by the narrow protocol proof."""
+    project_root = tmp_path / "project"
+    shutil.copytree(REPO_ROOT / "src", project_root / "src")
+
+    runtime_protocols_path = project_root / "src" / "mindroom" / "runtime_protocols.py"
+    bot_runtime_view_path = project_root / "src" / "mindroom" / "bot_runtime_view.py"
+    original_text = bot_runtime_view_path.read_text()
+    missing_member_block = (
+        "\n    @property\n"
+        f"    def {RUNTIME_VIEW_STRUCTURAL_MEMBER}(self) -> MultiAgentOrchestrator | None: ...  # noqa: D102\n"
+    )
+    assert missing_member_block in original_text
+    bot_runtime_view_path.write_text(original_text.replace(missing_member_block, "\n"))
+
+    helper_path = project_root / "check_runtime_view.py"
+    helper_path.write_text(
+        textwrap.dedent(
+            f"""
+            from mindroom.bot_runtime_view import BotRuntimeView
+            from mindroom.orchestrator import MultiAgentOrchestrator
+
+
+            def require_orchestrator(view: BotRuntimeView) -> MultiAgentOrchestrator | None:
+                return view.{RUNTIME_VIEW_STRUCTURAL_MEMBER}
+            """,
+        ).lstrip(),
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ty",
+            "check",
+            "--project",
+            str(project_root),
+            str(runtime_protocols_path),
+            str(bot_runtime_view_path),
+            str(helper_path),
+        ],
+        cwd=project_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    assert RUNTIME_VIEW_STRUCTURAL_MEMBER in output
+    assert "SupportsConfigOrchestrator" in output


### PR DESCRIPTION
## Summary
- make `mindroom.runtime_protocols` a real Tach-governed facade for the narrow bot runtime surfaces used by extracted collaborators
- restrict `mindroom.bot_runtime_view` visibility to `mindroom.bot` and `mindroom.runtime_protocols`, and add regression tests that fail when new modules bypass those boundaries
- add CI `ty` enforcement so the `BotRuntimeView` compatibility proof runs on GitHub instead of only through local pre-commit

## Testing
- `uv run pytest`
- `uv run pre-commit run --all-files`
- `uv run tach check --dependencies --interfaces`
- `uv run ty check src tests`