### PR TITLE
config: thread_summary_first_threshold default 5→1 (ISSUE-155)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ defaults:
   #   notify: false
   max_tool_calls_from_history: null  # Limit tool call messages replayed from history (null = no limit)
   num_history_runs: null             # Number of prior runs to include (null = all)
-  thread_summary_first_threshold: 5  # First automatic summary after 5 thread messages
+  thread_summary_first_threshold: 1  # First automatic summary after 1 thread message
   thread_summary_subsequent_interval: 10  # Re-summarize after each additional 10 messages
 ```
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -256,7 +256,7 @@ defaults:
   worker_scope: null               # Default: null (no runtime reuse; set shared/user/user_agent to enable)
   worker_grantable_credentials: null  # Default: null (deny by default; list credential service names to make available inside isolated workers, e.g. [openai, github_private])
   allow_self_config: false         # Default: false (allow agents to modify their own config via a tool)
-  thread_summary_first_threshold: 5  # Default: 5 (first automatic thread summary)
+  thread_summary_first_threshold: 1  # Default: 1 (first automatic thread summary after first message)
   thread_summary_subsequent_interval: 10  # Default: 10 (messages between later automatic thread summaries)
 
 # defaults.tools are appended to each agent's tools list with duplicates removed.

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -356,7 +356,7 @@ defaults:
   show_tool_calls: true
   allow_self_config: false
   max_preload_chars: 50000  # Hard cap for context_files preload
-  thread_summary_first_threshold: 5  # First automatic thread summary after 5 messages
+  thread_summary_first_threshold: 1  # First automatic thread summary after 1 message
   thread_summary_subsequent_interval: 10  # Re-summarize after each additional 10 messages
   # num_history_runs: null  # Default: all
   # num_history_messages: null  # Mutually exclusive with num_history_runs
@@ -625,7 +625,7 @@ defaults:
   tools: [scheduler]
   markdown: true
   enable_streaming: true
-  thread_summary_first_threshold: 5
+  thread_summary_first_threshold: 1
   thread_summary_subsequent_interval: 10
 
 # Router

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -377,7 +377,7 @@ class DefaultsConfig(BaseModel):
         description="Model config name for generating thread summaries (e.g., 'haiku'). Uses 'default' if not set.",
     )
     thread_summary_first_threshold: int = Field(
-        default=5,
+        default=1,
         ge=1,
         description="Message count required before the first automatic thread summary is generated.",
     )


### PR DESCRIPTION
Cherry-picked from `gitea/main` onto `origin/main`.

Verification:
- `uv run --active pytest -x -n 0 --no-cov --timeout=120 tests/test_dynamic_config_update.py tests/test_thread_summary.py tests/test_multi_agent_bot.py -k 'thread_summary_first_threshold or summary'`
