### PR TITLE
fix: refresh unsynced room membership authoritatively

### DIFF
--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from fnmatch import fnmatchcase
 from typing import TYPE_CHECKING, Any
 
+import nio
+
 from mindroom.constants import ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME
+from mindroom.logging_config import get_logger
 from mindroom.matrix.identity import (
     MatrixID,
     extract_agent_name,
@@ -18,10 +21,11 @@ from mindroom.matrix.state import MatrixState
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    import nio
-
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
+
+
+logger = get_logger(__name__)
 
 
 def _room_permission_lookup_keys(
@@ -201,6 +205,21 @@ def filter_agents_by_sender_permissions(
     return result
 
 
+def _available_agents_from_member_ids(
+    member_ids: Iterable[str],
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> list[MatrixID]:
+    """Return non-router agent IDs present in one membership snapshot."""
+    agents: list[MatrixID] = []
+    for member_id in member_ids:
+        mid = MatrixID.parse(member_id)
+        agent_name = mid.agent_name(config, runtime_paths)
+        if agent_name and agent_name != ROUTER_AGENT_NAME:
+            agents.append(mid)
+    return sorted(agents, key=lambda x: x.full_id)
+
+
 def get_available_agents_in_room(
     room: nio.MatrixRoom,
     config: Config,
@@ -210,16 +229,7 @@ def get_available_agents_in_room(
 
     Note: Router agent is excluded as it's not a regular conversation participant.
     """
-    agents: list[MatrixID] = []
-
-    for member_id in room.users:
-        mid = MatrixID.parse(member_id)
-        agent_name = mid.agent_name(config, runtime_paths)
-        # Exclude router agent
-        if agent_name and agent_name != ROUTER_AGENT_NAME:
-            agents.append(mid)
-
-    return sorted(agents, key=lambda x: x.full_id)
+    return _available_agents_from_member_ids(room.users, config, runtime_paths)
 
 
 def get_available_agents_for_sender(
@@ -235,3 +245,41 @@ def get_available_agents_for_sender(
         config,
         runtime_paths,
     )
+
+
+async def get_available_agents_for_sender_authoritative(
+    client: nio.AsyncClient,
+    room: nio.MatrixRoom,
+    sender_id: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> list[MatrixID]:
+    """Return sender-visible room agents, refreshing membership once when cache is empty."""
+    cached_agents = get_available_agents_for_sender(room, sender_id, config, runtime_paths)
+    if cached_agents:
+        return cached_agents
+
+    response = await client.joined_members(room.room_id)
+    if not isinstance(response, nio.JoinedMembersResponse):
+        logger.warning(
+            "authoritative_room_membership_fetch_failed",
+            room_id=room.room_id,
+            sender_id=sender_id,
+            error=str(response),
+        )
+        return []
+
+    refreshed_agents = filter_agents_by_sender_permissions(
+        _available_agents_from_member_ids((member.user_id for member in response.members), config, runtime_paths),
+        sender_id,
+        config,
+        runtime_paths,
+    )
+    logger.info(
+        "authoritative_room_membership_refreshed",
+        room_id=room.room_id,
+        sender_id=sender_id,
+        cached_agent_count=len(cached_agents),
+        refreshed_agent_count=len(refreshed_agents),
+    )
+    return refreshed_agents

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -247,6 +247,32 @@ def get_available_agents_for_sender(
     )
 
 
+def _apply_authoritative_joined_members(
+    room: nio.MatrixRoom,
+    members: Sequence[nio.RoomMember],
+) -> None:
+    """Replace one room's cached joined-member snapshot with authoritative data."""
+    members_by_user_id = {member.user_id: member for member in members}
+
+    for user_id in tuple(room.users):
+        if user_id not in members_by_user_id:
+            room.remove_member(user_id)
+
+    for member in members:
+        cached_user = room.users.get(member.user_id)
+        if (
+            cached_user is not None
+            and cached_user.display_name == member.display_name
+            and cached_user.avatar_url == member.avatar_url
+        ):
+            continue
+        if cached_user is not None:
+            room.remove_member(member.user_id)
+        room.add_member(member.user_id, member.display_name, member.avatar_url)
+
+    room.members_synced = True
+
+
 async def get_available_agents_for_sender_authoritative(
     client: nio.AsyncClient,
     room: nio.MatrixRoom,
@@ -255,9 +281,15 @@ async def get_available_agents_for_sender_authoritative(
     runtime_paths: RuntimePaths,
 ) -> list[MatrixID]:
     """Return sender-visible room agents, refreshing membership once when cache is empty."""
-    cached_agents = get_available_agents_for_sender(room, sender_id, config, runtime_paths)
-    if cached_agents:
-        return cached_agents
+    cached_room_agents = get_available_agents_in_room(room, config, runtime_paths)
+    cached_visible_agents = filter_agents_by_sender_permissions(
+        cached_room_agents,
+        sender_id,
+        config,
+        runtime_paths,
+    )
+    if cached_room_agents or room.members_synced:
+        return cached_visible_agents
 
     response = await client.joined_members(room.room_id)
     if not isinstance(response, nio.JoinedMembersResponse):
@@ -269,8 +301,14 @@ async def get_available_agents_for_sender_authoritative(
         )
         return []
 
+    _apply_authoritative_joined_members(room, response.members)
+    refreshed_room_agents = _available_agents_from_member_ids(
+        (member.user_id for member in response.members),
+        config,
+        runtime_paths,
+    )
     refreshed_agents = filter_agents_by_sender_permissions(
-        _available_agents_from_member_ids((member.user_id for member in response.members), config, runtime_paths),
+        refreshed_room_agents,
         sender_id,
         config,
         runtime_paths,
@@ -279,7 +317,7 @@ async def get_available_agents_for_sender_authoritative(
         "authoritative_room_membership_refreshed",
         room_id=room.room_id,
         sender_id=sender_id,
-        cached_agent_count=len(cached_agents),
+        cached_agent_count=len(cached_room_agents),
         refreshed_agent_count=len(refreshed_agents),
     )
     return refreshed_agents

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -299,7 +299,7 @@ async def get_available_agents_for_sender_authoritative(
             sender_id=sender_id,
             error=str(response),
         )
-        return []
+        return cached_visible_agents
 
     _apply_authoritative_joined_members(room, response.members)
     refreshed_room_agents = _available_agents_from_member_ids(

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -280,7 +280,7 @@ async def get_available_agents_for_sender_authoritative(
     config: Config,
     runtime_paths: RuntimePaths,
 ) -> list[MatrixID]:
-    """Return sender-visible room agents, refreshing membership once when cache is empty."""
+    """Return sender-visible room agents, refreshing membership while the cache is unsynced."""
     cached_room_agents = get_available_agents_in_room(room, config, runtime_paths)
     cached_visible_agents = filter_agents_by_sender_permissions(
         cached_room_agents,
@@ -288,7 +288,7 @@ async def get_available_agents_for_sender_authoritative(
         config,
         runtime_paths,
     )
-    if cached_room_agents or room.members_synced:
+    if room.members_synced:
         return cached_visible_agents
 
     response = await client.joined_members(room.room_id)

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Protocol
 
 from mindroom.agents import build_agent_tool_init_context, build_agent_toolkit, get_agent_toolkit_names
-from mindroom.authorization import get_available_agents_for_sender
+from mindroom.authorization import get_available_agents_for_sender_authoritative
 from mindroom.commands import config_confirmation
 from mindroom.commands.config_commands import handle_config_command
 from mindroom.commands.parsing import Command, CommandType, get_command_help
@@ -217,9 +217,10 @@ def _format_plugin_reload_summary(result: PluginReloadResult) -> str:
     return f"✅ Reloaded {plugin_count} {plugin_label}; cancelled {result.cancelled_task_count} {task_label}; active: {active_plugins}"
 
 
-def _resolve_skill_command_agent(  # noqa: C901
+async def _resolve_skill_command_agent(  # noqa: C901
     skill_name: str,
     *,
+    client: nio.AsyncClient,
     config: Config,
     room: nio.MatrixRoom,
     mentioned_agents: list[MatrixID],
@@ -237,7 +238,13 @@ def _resolve_skill_command_agent(  # noqa: C901
     if len(unique_mentions) > 1:
         return None, f"❌ Multiple agents mentioned: {', '.join(unique_mentions)}. Mention only one."
 
-    agents_in_room = get_available_agents_for_sender(room, requester_user_id, config, runtime_paths)
+    agents_in_room = await get_available_agents_for_sender_authoritative(
+        client,
+        room,
+        requester_user_id,
+        config,
+        runtime_paths,
+    )
     candidate_names: list[str] = []
     for mid in agents_in_room:
         name = mid.agent_name(config, runtime_paths)
@@ -665,8 +672,9 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
                 context.config,
                 context.runtime_paths,
             )
-            target_agent, error = _resolve_skill_command_agent(
+            target_agent, error = await _resolve_skill_command_agent(
                 skill_name,
+                client=context.client,
                 config=context.config,
                 room=room,
                 mentioned_agents=mentioned_agents,

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -20,7 +20,7 @@ from croniter import croniter
 from pydantic import BaseModel, Field
 
 from mindroom.ai import get_model_instance
-from mindroom.authorization import get_available_agents_for_sender
+from mindroom.authorization import get_available_agents_for_sender_authoritative
 from mindroom.constants import ORIGINAL_SENDER_KEY
 from mindroom.hooks import (
     HookRegistry,
@@ -1260,7 +1260,13 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
     if mentioned_agents is None:
         mentioned_agents = _extract_mentioned_agents_from_text(full_text, config, runtime_paths)
 
-    sender_visible_room_agents = get_available_agents_for_sender(room, scheduled_by, config, runtime_paths)
+    sender_visible_room_agents = await get_available_agents_for_sender_authoritative(
+        client,
+        room,
+        scheduled_by,
+        config,
+        runtime_paths,
+    )
 
     available_agents: list[MatrixID] = []
     if new_thread:

--- a/src/mindroom/thread_utils.py
+++ b/src/mindroom/thread_utils.py
@@ -278,6 +278,7 @@ def should_agent_respond(  # noqa: PLR0911
     has_non_agent_mentions: bool = False,
     *,
     sender_id: str,
+    available_agents_in_room: list[MatrixID] | None = None,
 ) -> bool:
     """Determine if an agent should respond to a message individually.
 
@@ -294,6 +295,7 @@ def should_agent_respond(  # noqa: PLR0911
         mentioned_agents: List of all agent MatrixIDs mentioned in the message
         has_non_agent_mentions: True when the message explicitly tags a non-agent user
         sender_id: Sender Matrix ID used for per-agent reply permissions
+        available_agents_in_room: Optional precomputed sender-visible agents for the room
 
     """
     if not authorization.is_sender_allowed_for_agent_reply(sender_id, agent_name, config, runtime_paths):
@@ -307,7 +309,9 @@ def should_agent_respond(  # noqa: PLR0911
     if mentioned_agents or has_non_agent_mentions:
         return False
 
-    available_agents = authorization.get_available_agents_for_sender(room, sender_id, config, runtime_paths)
+    available_agents = available_agents_in_room
+    if available_agents is None:
+        available_agents = authorization.get_available_agents_for_sender(room, sender_id, config, runtime_paths)
     agent_matrix_id = config.get_ids(runtime_paths)[agent_name]
 
     # Non-thread messages: auto-respond if we're the only visible agent in the room.

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -28,7 +28,7 @@ from mindroom.hooks import (
 from mindroom.hooks.ingress import HookIngressPolicy, is_automation_source_kind
 from mindroom.inbound_turn_normalizer import DispatchPayload
 from mindroom.matrix.identity import MatrixID, is_agent_id
-from mindroom.runtime_protocols import SupportsConfigOrchestrator  # noqa: TC001
+from mindroom.runtime_protocols import SupportsClientConfigOrchestrator  # noqa: TC001
 from mindroom.team_runtime_resolution import resolve_live_shared_agent_names
 from mindroom.teams import (
     TeamIntent,
@@ -210,7 +210,7 @@ class IngressHookRunner:
 class TurnPolicyDeps:
     """Explicit collaborators needed by pure turn policy decisions."""
 
-    runtime: SupportsConfigOrchestrator
+    runtime: SupportsClientConfigOrchestrator
     logger: structlog.stdlib.BoundLogger
     runtime_paths: RuntimePaths
     agent_name: str

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from mindroom.authorization import (
     get_available_agents_for_sender,
+    get_available_agents_for_sender_authoritative,
     is_sender_allowed_for_agent_reply,
 )
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths
@@ -253,6 +254,28 @@ class TurnPolicy:
             in materializable_agent_names
         ]
 
+    async def available_agents_for_sender(
+        self,
+        room: nio.MatrixRoom,
+        requester_user_id: str,
+    ) -> list[MatrixID]:
+        """Return sender-visible room agents, refreshing membership when a client is available."""
+        client = self.deps.runtime.client
+        if client is None:
+            return get_available_agents_for_sender(
+                room,
+                requester_user_id,
+                self.deps.runtime.config,
+                self.deps.runtime_paths,
+            )
+        return await get_available_agents_for_sender_authoritative(
+            client,
+            room,
+            requester_user_id,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
+
     def response_owner_for_team_resolution(
         self,
         form_team: TeamResolution,
@@ -363,12 +386,7 @@ class TurnPolicy:
             self.deps.runtime_paths,
         )
         if available_agents_in_room is None:
-            available_agents_in_room = get_available_agents_for_sender(
-                room,
-                requester_user_id,
-                self.deps.runtime.config,
-                self.deps.runtime_paths,
-            )
+            available_agents_in_room = await self.available_agents_for_sender(room, requester_user_id)
         if materializable_agent_names is None:
             materializable_agent_names = self.materializable_agent_names()
         return await decide_team_formation(
@@ -412,12 +430,7 @@ class TurnPolicy:
             ):
                 self.deps.logger.info("Skipping routing: thread already requires explicit agent targeting")
                 return DispatchPlan(kind="ignore", ignore_reason="router")
-            available_agents = get_available_agents_for_sender(
-                room,
-                requester_user_id,
-                self.deps.runtime.config,
-                self.deps.runtime_paths,
-            )
+            available_agents = await self.available_agents_for_sender(room, requester_user_id)
             if len(available_agents) == 1:
                 self.deps.logger.info("Skipping routing: only one agent present")
                 return DispatchPlan(kind="ignore", ignore_reason="router")
@@ -489,12 +502,7 @@ class TurnPolicy:
             self.deps.runtime.config,
             self.deps.runtime_paths,
         )
-        available_agents_in_room = get_available_agents_for_sender(
-            room,
-            requester_user_id,
-            self.deps.runtime.config,
-            self.deps.runtime_paths,
-        )
+        available_agents_in_room = await self.available_agents_for_sender(room, requester_user_id)
         materializable_agent_names = self.materializable_agent_names()
         responder_pool = self.filter_materializable_agents(
             available_agents_in_room,
@@ -525,6 +533,7 @@ class TurnPolicy:
             mentioned_agents=context.mentioned_agents,
             has_non_agent_mentions=context.has_non_agent_mentions,
             sender_id=requester_user_id,
+            available_agents_in_room=available_agents_in_room,
         ):
             if self._should_queue_follow_up_in_active_response_thread(
                 context=context,

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -15,7 +15,7 @@ from agno.media import Audio
 
 from mindroom.ai import get_model_instance
 from mindroom.attachments import register_audio_attachment
-from mindroom.authorization import get_available_agents_for_sender
+from mindroom.authorization import get_available_agents_for_sender_authoritative
 from mindroom.constants import (
     ATTACHMENT_IDS_KEY,
     ORIGINAL_SENDER_KEY,
@@ -294,7 +294,8 @@ async def _handle_voice_message(
 
         logger.info("voice_transcription_received", transcription=transcription)
 
-        available_agent_names, available_team_names = _get_available_entities_for_sender(
+        available_agent_names, available_team_names = await _get_available_entities_for_sender(
+            client,
             room,
             event.sender,
             config,
@@ -488,7 +489,8 @@ Output the formatted message only, no explanation:"""
         return transcription
 
 
-def _get_available_entities_for_sender(
+async def _get_available_entities_for_sender(
+    client: nio.AsyncClient,
     room: nio.MatrixRoom,
     sender_id: str,
     config: Config,
@@ -498,7 +500,13 @@ def _get_available_entities_for_sender(
     available_agent_names: list[str] = []
     available_team_names: list[str] = []
 
-    for matrix_id in get_available_agents_for_sender(room, sender_id, config, runtime_paths):
+    for matrix_id in await get_available_agents_for_sender_authoritative(
+        client,
+        room,
+        sender_id,
+        config,
+        runtime_paths,
+    ):
         name = matrix_id.agent_name(config, runtime_paths)
         if name is None:
             continue

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -244,6 +244,7 @@ async def test_get_available_agents_for_sender_authoritative_refreshes_empty_cac
     room = MagicMock(spec=nio.MatrixRoom)
     room.room_id = "!test:server"
     room.users = {"@mindroom_router:example.com": MagicMock()}
+    room.members_synced = False
     client.joined_members.return_value = nio.JoinedMembersResponse.from_dict(
         {
             "joined": {
@@ -262,6 +263,89 @@ async def test_get_available_agents_for_sender_authoritative_refreshes_empty_cac
     )
 
     assert [agent.agent_name(config, _runtime_paths_for(config)) for agent in available] == ["assistant"]
+    client.joined_members.assert_awaited_once_with("!test:server")
+
+
+@pytest.mark.asyncio
+async def test_get_available_agents_for_sender_authoritative_skips_refresh_when_cache_has_hidden_agents() -> None:
+    """Authoritative lookup should not refetch when room membership is present but sender visibility is empty."""
+    config = _config(
+        agents={
+            "assistant": {
+                "display_name": "Assistant",
+                "role": "Test assistant",
+                "rooms": ["test_room"],
+            },
+            "general": {
+                "display_name": "General",
+                "role": "Test generalist",
+                "rooms": ["test_room"],
+            },
+        },
+        authorization={
+            "agent_reply_permissions": {
+                "assistant": ["@alice:example.com"],
+                "general": ["@alice:example.com"],
+            },
+        },
+    )
+    client = AsyncMock()
+    room = nio.MatrixRoom("!test:server", "@mindroom_test:example.com")
+    room.add_member("@mindroom_assistant:example.com", "Assistant", None)
+    room.add_member("@mindroom_general:example.com", "General", None)
+
+    available = await get_available_agents_for_sender_authoritative(
+        client,
+        room,
+        "@bob:example.com",
+        config,
+    )
+
+    assert available == []
+    client.joined_members.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_available_agents_for_sender_authoritative_updates_room_cache_after_refresh() -> None:
+    """Authoritative refresh should hydrate room membership so repeated calls stay local."""
+    config = _config(
+        agents={
+            "assistant": {
+                "display_name": "Assistant",
+                "role": "Test assistant",
+                "rooms": ["test_room"],
+            },
+        },
+    )
+    client = AsyncMock()
+    room = nio.MatrixRoom("!test:server", "@mindroom_test:example.com")
+    room.add_member("@mindroom_router:example.com", "Router", None)
+    client.joined_members.return_value = nio.JoinedMembersResponse.from_dict(
+        {
+            "joined": {
+                "@mindroom_router:example.com": {"display_name": "Router"},
+                "@mindroom_assistant:example.com": {"display_name": "Assistant"},
+            },
+        },
+        room_id="!test:server",
+    )
+
+    first = await get_available_agents_for_sender_authoritative(
+        client,
+        room,
+        "@alice:example.com",
+        config,
+    )
+    second = await get_available_agents_for_sender_authoritative(
+        client,
+        room,
+        "@alice:example.com",
+        config,
+    )
+
+    assert [agent.agent_name(config, _runtime_paths_for(config)) for agent in first] == ["assistant"]
+    assert [agent.agent_name(config, _runtime_paths_for(config)) for agent in second] == ["assistant"]
+    assert "@mindroom_assistant:example.com" in room.users
     client.joined_members.assert_awaited_once_with("!test:server")
 
 

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -354,6 +354,43 @@ async def test_get_available_agents_for_sender_authoritative_refreshes_partial_u
 
 
 @pytest.mark.asyncio
+async def test_get_available_agents_for_sender_authoritative_falls_back_to_cached_visible_agents_on_refresh_error() -> (
+    None
+):
+    """Authoritative lookup should keep usable cached agents when joined_members fails."""
+    config = _config(
+        agents={
+            "assistant": {
+                "display_name": "Assistant",
+                "role": "Test assistant",
+                "rooms": ["test_room"],
+            },
+        },
+    )
+    client = AsyncMock()
+    room = nio.MatrixRoom("!test:server", "@mindroom_test:example.com")
+    room.add_member("@mindroom_router:example.com", "Router", None)
+    room.add_member("@mindroom_assistant:example.com", "Assistant", None)
+    room.members_synced = False
+    client.joined_members.return_value = nio.JoinedMembersError(
+        "M_FORBIDDEN",
+        "forbidden",
+        room_id="!test:server",
+    )
+
+    available = await get_available_agents_for_sender_authoritative(
+        client,
+        room,
+        "@alice:example.com",
+        config,
+    )
+
+    assert [agent.agent_name(config, _runtime_paths_for(config)) for agent in available] == ["assistant"]
+    assert room.members_synced is False
+    client.joined_members.assert_awaited_once_with("!test:server")
+
+
+@pytest.mark.asyncio
 async def test_get_available_agents_for_sender_authoritative_updates_room_cache_after_refresh() -> None:
     """Authoritative refresh should hydrate room membership so repeated calls stay local."""
     config = _config(

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -293,6 +293,7 @@ async def test_get_available_agents_for_sender_authoritative_skips_refresh_when_
     room = nio.MatrixRoom("!test:server", "@mindroom_test:example.com")
     room.add_member("@mindroom_assistant:example.com", "Assistant", None)
     room.add_member("@mindroom_general:example.com", "General", None)
+    room.members_synced = True
 
     available = await get_available_agents_for_sender_authoritative(
         client,
@@ -303,6 +304,53 @@ async def test_get_available_agents_for_sender_authoritative_skips_refresh_when_
 
     assert available == []
     client.joined_members.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_available_agents_for_sender_authoritative_refreshes_partial_unsynced_cache() -> None:
+    """Authoritative lookup should refresh when cached membership is present but unsynced."""
+    config = _config(
+        agents={
+            "assistant": {
+                "display_name": "Assistant",
+                "role": "Test assistant",
+                "rooms": ["test_room"],
+            },
+            "general": {
+                "display_name": "General",
+                "role": "Test generalist",
+                "rooms": ["test_room"],
+            },
+        },
+    )
+    client = AsyncMock()
+    room = nio.MatrixRoom("!test:server", "@mindroom_test:example.com")
+    room.add_member("@mindroom_router:example.com", "Router", None)
+    room.add_member("@mindroom_general:example.com", "General", None)
+    room.members_synced = False
+    client.joined_members.return_value = nio.JoinedMembersResponse.from_dict(
+        {
+            "joined": {
+                "@mindroom_router:example.com": {"display_name": "Router"},
+                "@mindroom_general:example.com": {"display_name": "General"},
+                "@mindroom_assistant:example.com": {"display_name": "Assistant"},
+            },
+        },
+        room_id="!test:server",
+    )
+
+    available = await get_available_agents_for_sender_authoritative(
+        client,
+        room,
+        "@alice:example.com",
+        config,
+    )
+
+    assert [agent.agent_name(config, _runtime_paths_for(config)) for agent in available] == [
+        "assistant",
+        "general",
+    ]
+    client.joined_members.assert_awaited_once_with("!test:server")
 
 
 @pytest.mark.asyncio

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
+import nio
 import pytest
 
 import mindroom.authorization
@@ -81,6 +83,22 @@ def get_effective_sender_id_for_reply_permissions(
 
 def _config(**kwargs: object) -> Config:
     return _bind_runtime_paths(Config(**kwargs))
+
+
+async def get_available_agents_for_sender_authoritative(
+    client: nio.AsyncClient,
+    room: nio.MatrixRoom,
+    sender_id: str,
+    config: Config,
+) -> list[mindroom.authorization.MatrixID]:
+    """Run authoritative room-agent resolution with the test config's bound runtime context."""
+    return await mindroom.authorization.get_available_agents_for_sender_authoritative(
+        client,
+        room,
+        sender_id,
+        config,
+        _runtime_paths_for(config),
+    )
 
 
 @pytest.fixture
@@ -208,6 +226,43 @@ def test_teams_always_allowed(mock_config_with_restrictions: Config) -> None:
 
     # Non-configured team should be blocked
     assert not is_authorized_sender("@mindroom_unknown_team:example.com", mock_config_with_restrictions, "!test:server")
+
+
+@pytest.mark.asyncio
+async def test_get_available_agents_for_sender_authoritative_refreshes_empty_cached_room() -> None:
+    """Authoritative agent lookup should recover from empty cached room membership."""
+    config = _config(
+        agents={
+            "assistant": {
+                "display_name": "Assistant",
+                "role": "Test assistant",
+                "rooms": ["test_room"],
+            },
+        },
+    )
+    client = AsyncMock()
+    room = MagicMock(spec=nio.MatrixRoom)
+    room.room_id = "!test:server"
+    room.users = {"@mindroom_router:example.com": MagicMock()}
+    client.joined_members.return_value = nio.JoinedMembersResponse.from_dict(
+        {
+            "joined": {
+                "@mindroom_router:example.com": {"display_name": "Router"},
+                "@mindroom_assistant:example.com": {"display_name": "Assistant"},
+            },
+        },
+        room_id="!test:server",
+    )
+
+    available = await get_available_agents_for_sender_authoritative(
+        client,
+        room,
+        "@alice:example.com",
+        config,
+    )
+
+    assert [agent.agent_name(config, _runtime_paths_for(config)) for agent in available] == ["assistant"]
+    client.joined_members.assert_awaited_once_with("!test:server")
 
 
 def test_router_always_allowed(mock_config_with_restrictions: Config) -> None:

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -1575,7 +1575,10 @@ class TestRouterSkipsSingleAgent:
             patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_controller.extract_agent_name", return_value=None),  # User message
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
-            patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
+            patch(
+                "mindroom.turn_policy.get_available_agents_for_sender_authoritative",
+                new_callable=AsyncMock,
+            ) as mock_get_available,
         ):
             # Return only one agent (general)
             mock_get_available.return_value = [config.get_ids(runtime_paths_for(config))["general"]]
@@ -1661,7 +1664,10 @@ class TestRouterSkipsSingleAgent:
             patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_controller.extract_agent_name", return_value=None),  # User message
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
-            patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
+            patch(
+                "mindroom.turn_policy.get_available_agents_for_sender_authoritative",
+                new_callable=AsyncMock,
+            ) as mock_get_available,
         ):
             # Return multiple agents
             mock_get_available.return_value = [
@@ -1762,7 +1768,10 @@ class TestRouterSkipsSingleAgent:
             patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
             patch("mindroom.turn_controller.extract_agent_name", return_value=None),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
-            patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
+            patch(
+                "mindroom.turn_policy.get_available_agents_for_sender_authoritative",
+                new_callable=AsyncMock,
+            ) as mock_get_available,
         ):
             mock_get_available.return_value = [
                 config.get_ids(runtime_paths_for(config))["general"],
@@ -1834,7 +1843,10 @@ class TestRouterSkipsSingleAgent:
 
         with (
             patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
-            patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
+            patch(
+                "mindroom.turn_policy.get_available_agents_for_sender_authoritative",
+                new_callable=AsyncMock,
+            ) as mock_get_available,
         ):
             mock_get_available.return_value = [config.get_ids(runtime_paths_for(config))["general"]]
             await bot._on_message(room, event)
@@ -1902,7 +1914,10 @@ class TestRouterSkipsSingleAgent:
 
         with (
             patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
-            patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
+            patch(
+                "mindroom.turn_policy.get_available_agents_for_sender_authoritative",
+                new_callable=AsyncMock,
+            ) as mock_get_available,
         ):
             mock_get_available.return_value = [config.get_ids(runtime_paths_for(config))["general"]]
             await bot._on_message(room, event)
@@ -1983,7 +1998,10 @@ class TestRouterSkipsSingleAgent:
 
         with (
             patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
-            patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
+            patch(
+                "mindroom.turn_policy.get_available_agents_for_sender_authoritative",
+                new_callable=AsyncMock,
+            ) as mock_get_available,
             patch("mindroom.turn_policy.get_agents_in_thread") as mock_agents_in_thread,
         ):
             mock_get_available.return_value = [config.get_ids(runtime_paths_for(config))["general"]]
@@ -2057,7 +2075,10 @@ class TestRouterSkipsSingleAgent:
 
         with (
             patch("mindroom.turn_controller.interactive.handle_text_response", return_value=None),
-            patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
+            patch(
+                "mindroom.turn_policy.get_available_agents_for_sender_authoritative",
+                new_callable=AsyncMock,
+            ) as mock_get_available,
         ):
             mock_get_available.return_value = [
                 config.get_ids(runtime_paths_for(config))["general"],

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -3903,6 +3903,7 @@ async def test_on_media_message_tracks_relay_event_id(tmp_path: Path) -> None:
         "@mindroom_test_agent:example.com": None,
         "@user:example.com": None,
     }
+    room.members_synced = True
 
     # Create a voice message event
     voice_event = nio.RoomMessageAudio.from_dict(
@@ -4016,6 +4017,7 @@ async def test_on_media_message_no_transcription_still_marks_relayed(tmp_path: P
         "@mindroom_test_agent:example.com": None,
         "@user:example.com": None,
     }
+    room.members_synced = True
 
     # Create a voice message event
     voice_event = nio.RoomMessageAudio.from_dict(

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -1826,7 +1826,7 @@ async def test_hook_dispatch_skill_tool_command_builds_full_tool_runtime_context
     )
 
     with (
-        patch("mindroom.commands.handler._resolve_skill_command_agent", return_value=("code", None)),
+        patch("mindroom.commands.handler._resolve_skill_command_agent", new=AsyncMock(return_value=("code", None))),
         patch("mindroom.commands.handler.resolve_skill_command_spec", return_value=spec),
         patch(
             "mindroom.turn_controller._run_skill_command_tool",

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -5779,7 +5779,7 @@ class TestAgentBot:
             patch("mindroom.bot.extract_agent_name", return_value=None),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
-            patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
+            patch("mindroom.turn_policy.get_available_agents_for_sender_authoritative") as mock_get_available,
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch("mindroom.coalescing.extract_media_caption", return_value="[Attached image]"),
         ):
@@ -5920,7 +5920,7 @@ class TestAgentBot:
             patch("mindroom.bot.extract_agent_name", return_value=None),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
-            patch("mindroom.turn_policy.get_available_agents_for_sender") as mock_get_available,
+            patch("mindroom.turn_policy.get_available_agents_for_sender_authoritative") as mock_get_available,
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch(
                 "mindroom.inbound_turn_normalizer.register_file_or_video_attachment",
@@ -6302,7 +6302,7 @@ class TestAgentBot:
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
             patch(
-                "mindroom.turn_policy.get_available_agents_for_sender",
+                "mindroom.turn_policy.get_available_agents_for_sender_authoritative",
                 return_value=[
                     config.get_ids(runtime_paths_for(config))["calculator"],
                     config.get_ids(runtime_paths_for(config))["general"],
@@ -6380,7 +6380,7 @@ class TestAgentBot:
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
             patch(
-                "mindroom.turn_policy.get_available_agents_for_sender",
+                "mindroom.turn_policy.get_available_agents_for_sender_authoritative",
                 return_value=[config.get_ids(runtime_paths_for(config))["calculator"]],
             ),
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
@@ -6455,7 +6455,7 @@ class TestAgentBot:
             ),
             patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
-            patch("mindroom.turn_policy.get_available_agents_for_sender", return_value=[]),
+            patch("mindroom.turn_policy.get_available_agents_for_sender_authoritative", return_value=[]),
             patch(
                 "mindroom.inbound_turn_normalizer.resolve_thread_attachment_ids",
                 new_callable=AsyncMock,

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -339,6 +339,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
             mock_calculator_agent.user_id: MagicMock(),
             f"@mindroom_general:{domain}": MagicMock(),
         }
+        room.members_synced = True
 
         with (
             patch.object(bot._conversation_cache, "get_thread_snapshot") as mock_fetch_snapshot,

--- a/tests/test_schedule_agent_validation.py
+++ b/tests/test_schedule_agent_validation.py
@@ -32,6 +32,7 @@ def create_mock_room(room_id: str, user_ids: list[str] | None = None) -> nio.Mat
                 display_name=user_id,
                 avatar_url=None,
             )
+    room.members_synced = True
     return room
 
 

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -1465,6 +1465,7 @@ async def test_schedule_task_refreshes_room_membership_when_cached_room_has_no_a
     client = AsyncMock()
     room = MagicMock(spec=nio.MatrixRoom)
     room.room_id = "!test:server"
+    room.members_synced = False
     config = bind_runtime_paths(
         Config(
             agents={

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -11,6 +11,9 @@ import nio
 import pytest
 
 from mindroom import scheduling
+from mindroom.config.agent import AgentConfig
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
 from mindroom.constants import resolve_runtime_paths
 from mindroom.scheduling import (
     _SCHEDULED_TASK_EVENT_TYPE,
@@ -30,7 +33,7 @@ from mindroom.scheduling import (
     save_edited_scheduled_task,
     schedule_task,
 )
-from tests.conftest import make_event_cache_mock
+from tests.conftest import bind_runtime_paths, make_event_cache_mock
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -1406,7 +1409,7 @@ async def test_schedule_task_returns_error_when_sender_blocked_from_all_agents()
 
     with (
         patch(
-            "mindroom.scheduling.get_available_agents_for_sender",
+            "mindroom.scheduling.get_available_agents_for_sender_authoritative",
             return_value=[],
         ),
         patch(
@@ -1435,7 +1438,7 @@ async def test_schedule_task_blocked_sender_new_thread_returns_error() -> None:
 
     with (
         patch(
-            "mindroom.scheduling.get_available_agents_for_sender",
+            "mindroom.scheduling.get_available_agents_for_sender_authoritative",
             return_value=[],
         ),
         patch(
@@ -1454,3 +1457,63 @@ async def test_schedule_task_blocked_sender_new_thread_returns_error() -> None:
 
     assert task_id is None
     assert "No agents" in message
+
+
+@pytest.mark.asyncio
+async def test_schedule_task_refreshes_room_membership_when_cached_room_has_no_agents() -> None:
+    """Scheduling should recover from empty cached room membership via joined_members."""
+    client = AsyncMock()
+    room = MagicMock(spec=nio.MatrixRoom)
+    room.room_id = "!test:server"
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "assistant": AgentConfig(
+                    display_name="Assistant",
+                    role="Test assistant",
+                    rooms=["!test:server"],
+                ),
+            },
+            models={"default": ModelConfig(provider="test", id="test-model")},
+        ),
+        _runtime_paths(),
+    )
+    room.users = {f"@mindroom_router:{config.get_domain(_runtime_paths())}": MagicMock()}
+    runtime = _scheduling_runtime(client=client, config=config, room=room)
+    parse_result = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime.now(UTC) + timedelta(minutes=5),
+        message="check logs",
+        description="check logs",
+        room_id="!test:server",
+        thread_id=None,
+    )
+    client.joined_members.return_value = nio.JoinedMembersResponse.from_dict(
+        {
+            "joined": {
+                f"@mindroom_router:{config.get_domain(_runtime_paths())}": {"display_name": "Router"},
+                f"@mindroom_assistant:{config.get_domain(_runtime_paths())}": {"display_name": "Assistant"},
+            },
+        },
+        room_id="!test:server",
+    )
+
+    with (
+        patch("mindroom.scheduling._extract_mentioned_agents_from_text", return_value=[]),
+        patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=parse_result)),
+        patch("mindroom.scheduling._validate_agent_mentions") as mock_validate,
+        patch("mindroom.scheduling._save_pending_scheduled_task", new=AsyncMock(return_value=None)),
+        patch("mindroom.scheduling.uuid.uuid4", return_value="task12345"),
+    ):
+        mock_validate.return_value = scheduling._AgentValidationResult(True, [], [])
+        task_id, message = await schedule_task(
+            runtime=runtime,
+            room_id="!test:server",
+            thread_id=None,
+            scheduled_by=f"@alice:{config.get_domain(_runtime_paths())}",
+            full_text="in 5 minutes check logs",
+        )
+
+    assert task_id == "task1234"
+    assert "Scheduled" in message
+    client.joined_members.assert_awaited_once_with("!test:server")

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -110,6 +110,7 @@ async def test_voice_message_in_main_room_creates_thread(mock_home_bot: AgentBot
         "@mindroom_home:localhost": MagicMock(),
         "@user:example.com": MagicMock(),
     }
+    room.members_synced = True
 
     voice_event = _make_voice_event(event_id="$voice123", source={"content": {}})
 
@@ -153,6 +154,7 @@ async def test_voice_message_in_thread_continues_thread(mock_home_bot: AgentBot)
         "@mindroom_home:localhost": MagicMock(),
         "@user:example.com": MagicMock(),
     }
+    room.members_synced = True
 
     voice_event = _make_voice_event(
         event_id="$voice456",
@@ -195,6 +197,7 @@ async def test_voice_plain_reply_to_thread_message_stays_threaded_transitively(
         "@mindroom_home:localhost": MagicMock(),
         "@user:example.com": MagicMock(),
     }
+    room.members_synced = True
 
     voice_event = _make_voice_event(
         event_id="$voice789",

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -109,6 +109,7 @@ def _make_room(*user_ids: str) -> nio.MatrixRoom:
     room.room_id = "!test:example.com"
     room.canonical_alias = None
     room.users = {user_id: MagicMock() for user_id in user_ids}
+    room.members_synced = True
     return room
 
 

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -165,6 +165,7 @@ class TestVoiceHandler:
             f"@mindroom_router:{config.get_domain(runtime_paths_for(config))}": MagicMock(),
             "@alice:example.com": MagicMock(),
         }
+        room.members_synced = True
         event = MagicMock(spec=nio.RoomMessageAudio)
         event.sender = "@alice:example.com"
 
@@ -238,6 +239,7 @@ class TestVoiceHandler:
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:server"
         room.users = {"@alice:example.com": MagicMock()}
+        room.members_synced = True
         event = MagicMock(spec=nio.RoomMessageAudio)
         event.event_id = "$voice123"
         event.sender = "@alice:example.com"
@@ -274,6 +276,7 @@ class TestVoiceHandler:
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:server"
         room.users = {"@alice:example.com": MagicMock()}
+        room.members_synced = True
         event = MagicMock(spec=nio.RoomMessageAudio)
         event.event_id = "$voice123"
         event.sender = "@alice:example.com"

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -731,6 +731,7 @@ class TestIntegrationWithScheduling:
             display_name="Research",
             avatar_url=None,
         )
+        room.members_synced = True
 
         with patch("mindroom.scheduling._run_cron_task", new=AsyncMock()):
             task_id, message = await schedule_task(


### PR DESCRIPTION
## Summary
- refresh sender-visible room agents from Matrix authoritative membership when a room's membership cache is unsynced
- hydrate the in-memory room membership cache after a successful refresh so repeated lookups stay local
- fall back to cached sender-visible agents when `joined_members` fails instead of treating the room as empty
- apply the authoritative helper to router turn policy, `!skill`, scheduling, and voice entity resolution
- add regressions for empty-cache refresh, partial unsynced cache refresh, cache hydration, and refresh-error fallback

## Verification
- `uv run pytest tests/test_authorization.py tests/test_scheduling.py tests/test_bot_scheduling.py tests/test_multi_agent_bot.py tests/test_hook_sender.py -x -n 0 --no-cov -q`
- `uv run pre-commit run --all-files`
- `uv run pytest`