### PR TITLE
fix: normalize run_shell_command string args to list (ISSUE-124)

### DIFF
--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import os
 import re
 import signal
@@ -12,8 +13,10 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Annotated, cast
 
 from agno.tools.toolkit import Toolkit
+from pydantic import BeforeValidator
 
 from mindroom.constants import RuntimePaths, shell_execution_runtime_env_values
 from mindroom.logging_config import get_logger
@@ -59,11 +62,29 @@ _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS = frozenset(
 _STALE_RECORD_SECONDS = 600  # 10 minutes
 _MAX_BACKGROUNDED = 16
 _MAX_OUTPUT_LINES = 10_000
+_SHELL_ARGS_ERROR = '\'args\' must be a flat list of strings. Send args like ["bash", "-lc", "ls"].'
 
 # Module-level process registry shared across all MindRoomShellTools instances.
 # This ensures handles survive toolkit re-creation (e.g. in sandbox runner mode
 # where _resolve_entrypoint builds a fresh toolkit per request).
 _process_registry: dict[str, _ProcessRecord] = {}
+
+
+def _normalize_shell_args(args: object) -> list[str]:
+    """Normalize stringified shell args while keeping the public schema as list[str]."""
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except json.JSONDecodeError as exc:
+            raise ValueError(_SHELL_ARGS_ERROR) from exc
+
+    if not isinstance(args, list):
+        raise ValueError(_SHELL_ARGS_ERROR)  # noqa: TRY004
+
+    if any(not isinstance(item, str) for item in args):
+        raise ValueError(_SHELL_ARGS_ERROR)
+
+    return cast("list[str]", args)
 
 
 def _shell_path_prepend_entries(shell_path_prepend: str | None) -> tuple[str, ...]:
@@ -251,6 +272,12 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                 tools.extend([self.run_shell_command, self.check_shell_command, self.kill_shell_command])
 
             super().__init__(name="shell_tools", tools=tools, **kwargs)  # ty: ignore[invalid-argument-type]
+            run_shell_command_function = self.async_functions.get("run_shell_command")
+            if run_shell_command_function is not None:
+                effective_strict = (
+                    False if run_shell_command_function.strict is None else run_shell_command_function.strict
+                )
+                run_shell_command_function.process_entrypoint(strict=effective_strict)
 
             self._runtime_env = dict(
                 shell_execution_runtime_env_values(
@@ -264,7 +291,12 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
             self._handle_namespace = _handle_namespace(runtime_paths=runtime_paths, base_dir=self.base_dir)
             self._shell_path_prepend = shell_path_prepend
 
-        async def run_shell_command(self, args: list[str], tail: int = 100, timeout: int = 120) -> str:  # noqa: ASYNC109
+        async def run_shell_command(
+            self,
+            args: Annotated[list[str], BeforeValidator(_normalize_shell_args)],
+            tail: int = 100,
+            timeout: int = 120,  # noqa: ASYNC109
+        ) -> str:
             """Runs a shell command and returns the output or error.
 
             If the command completes within ``timeout`` seconds the last ``tail``

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
+from agno.tools.function import Function, FunctionCall, FunctionExecutionResult
 
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.tool_system.metadata import get_tool_by_name
@@ -40,6 +41,14 @@ def _get_toolkit(tmp_path: Path) -> Toolkit:
     return get_tool_by_name("shell", runtime_paths, disable_sandbox_proxy=True, worker_target=None)
 
 
+def _get_run_shell_command_function(tool: Toolkit) -> Function:
+    return tool.async_functions["run_shell_command"]
+
+
+async def _aexecute_run_shell_command(tool: Toolkit, args: object) -> FunctionExecutionResult:
+    return await FunctionCall(function=_get_run_shell_command_function(tool), arguments={"args": args}).aexecute()
+
+
 # ---------------------------------------------------------------------------
 # run_shell_command
 # ---------------------------------------------------------------------------
@@ -54,6 +63,73 @@ async def test_run_shell_command_returns_output(tmp_path: Path) -> None:
 
     result = await entrypoint(["echo", "hello world"])
     assert result == "hello world"
+
+
+def test_run_shell_command_schema_keeps_args_as_string_array(tmp_path: Path) -> None:
+    """The tool schema should expose args as array<string>, not anyOf."""
+    tool = _get_toolkit(tmp_path)
+    args_schema = _get_run_shell_command_function(tool).parameters["properties"]["args"]
+
+    assert args_schema["type"] == "array"
+    assert args_schema["items"] == {"type": "string"}
+    assert "anyOf" not in args_schema
+
+
+@pytest.mark.asyncio
+async def test_run_shell_command_parses_json_string_args(tmp_path: Path) -> None:
+    """JSON-stringified args should be parsed into a shell argv list."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    result = await entrypoint('["echo", "hello world"]')
+    assert result == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_run_shell_command_parses_single_item_json_args(tmp_path: Path) -> None:
+    """A single command item in JSON string form should execute normally."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    result = await entrypoint('["ls"]')
+    assert result
+    assert not result.startswith("Error:")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "args",
+    [
+        '["echo",',
+        '{"cmd": "ls"}',
+        '"echo"',
+        "",
+        '["echo", 42]',
+        '["bash", ["-c", "ls"]]',
+        '["echo", {"x": 1}]',
+    ],
+)
+async def test_run_shell_command_rejects_invalid_stringified_args(tmp_path: Path, args: str) -> None:
+    """Malformed or non-flat stringified args should fail validation."""
+    tool = _get_toolkit(tmp_path)
+    result = await _aexecute_run_shell_command(tool, args)
+
+    assert result.status == "failure"
+    assert result.error is not None
+    assert "'args' must be a flat list of strings" in result.error
+
+
+@pytest.mark.asyncio
+async def test_run_shell_command_empty_json_list_uses_existing_empty_behavior(tmp_path: Path) -> None:
+    """An empty JSON list should fall through to the existing subprocess error path."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    result = await entrypoint("[]")
+    assert result.startswith("Error:")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Cherry-picked from `gitea/main` onto `origin/main`.

Verification:
- `uv run --active pytest -x -n 0 --no-cov --timeout=120 tests/test_shell_async.py`
