### PR TITLE
debug: add cache and thread timing diagnostics

### DIFF
--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -585,11 +585,13 @@ class ThreadLiveWritePolicy:
 
         outcome = "ok"
         try:
-            await self._cache_ops.queue_room_cache_update(
+            appended = await self._cache_ops.queue_room_cache_update(
                 room_id,
                 append_and_invalidate,
                 name="matrix_cache_append_live_event",
             )
+            if appended is False:
+                outcome = "append_failed"
         except asyncio.CancelledError:
             outcome = "cancelled"
             raise

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -22,6 +22,7 @@ from mindroom.matrix.thread_bookkeeping import (
     ThreadMutationResolver,
     is_thread_affecting_relation,
 )
+from mindroom.timing import emit_timing_event
 
 if TYPE_CHECKING:
     from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
@@ -486,47 +487,111 @@ class ThreadLiveWritePolicy:
         if not self._cache_ops.cache_runtime_available():
             return
 
+        started = time.perf_counter()
+        impact_started = time.perf_counter()
         impact = await self._resolver.resolve_thread_impact_for_mutation(
             room_id,
             event_info=event_info,
             event_id=event.event_id,
             context="live",
         )
-        room_level_skip_message = "Skipping live thread cache bookkeeping for known non-threaded message mutation"
-        if impact.state is not MutationThreadImpactState.THREADED:
-            await _apply_thread_message_mutation(
-                cache_ops=self._cache_ops,
+        impact_resolution_ms = round((time.perf_counter() - impact_started) * 1000, 1)
+        if impact.state is MutationThreadImpactState.ROOM_LEVEL:
+            self._cache_ops.logger.debug(
+                "Skipping live thread cache bookkeeping for known non-threaded message mutation",
                 room_id=room_id,
-                event_info=event_info,
-                impact=impact,
-                event_source=None,
                 event_id=event.event_id,
-                context="live",
-                room_level_skip_message=room_level_skip_message,
-                invalidate_on_append_failure=True,
+                original_event_id=event_info.original_event_id,
+            )
+            emit_timing_event(
+                "Live event cache append timing",
+                room_id=room_id,
+                event_id=event.event_id,
+                impact_state="room_level",
+                impact_resolution_ms=impact_resolution_ms,
+                total_ms=round((time.perf_counter() - started) * 1000, 1),
+                outcome="non_threaded_skip",
             )
             return
-
+        if impact.state is MutationThreadImpactState.UNKNOWN:
+            invalidate_started = time.perf_counter()
+            await self._cache_ops.invalidate_room_threads(
+                room_id,
+                reason="live_thread_lookup_unavailable",
+            )
+            emit_timing_event(
+                "Live event cache append timing",
+                room_id=room_id,
+                event_id=event.event_id,
+                impact_state="unknown",
+                impact_resolution_ms=impact_resolution_ms,
+                invalidate_ms=round((time.perf_counter() - invalidate_started) * 1000, 1),
+                total_ms=round((time.perf_counter() - started) * 1000, 1),
+                outcome="room_invalidated",
+            )
+            return
+        assert impact.thread_id is not None
+        thread_id = impact.thread_id
         event_source = normalize_nio_event_for_cache(event)
+        queue_started = time.perf_counter()
+        append_metrics: dict[str, str | int | float | bool] = {}
 
         async def append_and_invalidate() -> bool:
-            return await _apply_thread_message_mutation(
-                cache_ops=self._cache_ops,
-                room_id=room_id,
-                event_info=event_info,
-                impact=impact,
-                event_source=event_source,
-                event_id=event.event_id,
-                context="live",
-                room_level_skip_message=room_level_skip_message,
-                invalidate_on_append_failure=True,
+            invalidate_started = time.perf_counter()
+            await self._cache_ops.invalidate_known_thread(
+                room_id,
+                thread_id,
+                reason="live_thread_mutation",
             )
+            append_metrics["invalidate_ms"] = round((time.perf_counter() - invalidate_started) * 1000, 1)
+            append_started = time.perf_counter()
+            appended = await self._cache_ops.append_event_to_cache(
+                room_id,
+                thread_id,
+                event_source,
+                context="live",
+            )
+            append_metrics["append_ms"] = round((time.perf_counter() - append_started) * 1000, 1)
+            append_metrics["appended"] = appended
+            if not appended:
+                fallback_invalidate_started = time.perf_counter()
+                await self._cache_ops.invalidate_known_thread(
+                    room_id,
+                    thread_id,
+                    reason="live_append_failed",
+                )
+                append_metrics["append_failure_invalidate_ms"] = round(
+                    (time.perf_counter() - fallback_invalidate_started) * 1000,
+                    1,
+                )
+            return appended
 
-        await self._cache_ops.queue_room_cache_update(
-            room_id,
-            append_and_invalidate,
-            name="matrix_cache_append_live_event",
-        )
+        outcome = "ok"
+        try:
+            await self._cache_ops.queue_room_cache_update(
+                room_id,
+                append_and_invalidate,
+                name="matrix_cache_append_live_event",
+            )
+        except asyncio.CancelledError:
+            outcome = "cancelled"
+            raise
+        except Exception:
+            outcome = "error"
+            raise
+        finally:
+            emit_timing_event(
+                "Live event cache append timing",
+                room_id=room_id,
+                thread_id=thread_id,
+                event_id=event.event_id,
+                impact_state="threaded",
+                impact_resolution_ms=impact_resolution_ms,
+                queue_and_update_ms=round((time.perf_counter() - queue_started) * 1000, 1),
+                total_ms=round((time.perf_counter() - started) * 1000, 1),
+                outcome=outcome,
+                **append_metrics,
+            )
 
     async def apply_redaction(self, room_id: str, event: nio.RedactionEvent) -> None:
         """Apply one redaction to the advisory cache when the affected thread is known."""

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -22,7 +22,7 @@ from mindroom.matrix.thread_bookkeeping import (
     ThreadMutationResolver,
     is_thread_affecting_relation,
 )
-from mindroom.timing import emit_timing_event
+from mindroom.timing import emit_timing_event, timing_enabled
 
 if TYPE_CHECKING:
     from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
@@ -476,60 +476,77 @@ class ThreadLiveWritePolicy:
         self._resolver = resolver
         self._cache_ops = cache_ops
 
-    async def append_live_event(
+    async def _resolve_live_event_impact(
+        self,
+        room_id: str,
+        *,
+        event_id: str,
+        event_info: EventInfo,
+    ) -> MutationThreadImpact:
+        return await self._resolver.resolve_thread_impact_for_mutation(
+            room_id,
+            event_info=event_info,
+            event_id=event_id,
+            context="live",
+        )
+
+    async def _append_live_event_without_timing(
         self,
         room_id: str,
         event: nio.RoomMessage,
         *,
         event_info: EventInfo,
     ) -> None:
-        """Append one live threaded event into the advisory cache when the thread is known."""
-        if not self._cache_ops.cache_runtime_available():
+        impact = await self._resolve_live_event_impact(
+            room_id,
+            event_id=event.event_id,
+            event_info=event_info,
+        )
+        room_level_skip_message = "Skipping live thread cache bookkeeping for known non-threaded message mutation"
+        if impact.state is not MutationThreadImpactState.THREADED:
+            await _apply_thread_message_mutation(
+                cache_ops=self._cache_ops,
+                room_id=room_id,
+                event_info=event_info,
+                impact=impact,
+                event_source=None,
+                event_id=event.event_id,
+                context="live",
+                room_level_skip_message=room_level_skip_message,
+                invalidate_on_append_failure=True,
+            )
             return
 
-        started = time.perf_counter()
-        impact_started = time.perf_counter()
-        impact = await self._resolver.resolve_thread_impact_for_mutation(
+        event_source = normalize_nio_event_for_cache(event)
+
+        async def append_and_invalidate() -> bool:
+            return await _apply_thread_message_mutation(
+                cache_ops=self._cache_ops,
+                room_id=room_id,
+                event_info=event_info,
+                impact=impact,
+                event_source=event_source,
+                event_id=event.event_id,
+                context="live",
+                room_level_skip_message=room_level_skip_message,
+                invalidate_on_append_failure=True,
+            )
+
+        await self._cache_ops.queue_room_cache_update(
             room_id,
-            event_info=event_info,
-            event_id=event.event_id,
-            context="live",
+            append_and_invalidate,
+            name="matrix_cache_append_live_event",
         )
-        impact_resolution_ms = round((time.perf_counter() - impact_started) * 1000, 1)
-        if impact.state is MutationThreadImpactState.ROOM_LEVEL:
-            self._cache_ops.logger.debug(
-                "Skipping live thread cache bookkeeping for known non-threaded message mutation",
-                room_id=room_id,
-                event_id=event.event_id,
-                original_event_id=event_info.original_event_id,
-            )
-            emit_timing_event(
-                "Live event cache append timing",
-                room_id=room_id,
-                event_id=event.event_id,
-                impact_state="room_level",
-                impact_resolution_ms=impact_resolution_ms,
-                total_ms=round((time.perf_counter() - started) * 1000, 1),
-                outcome="non_threaded_skip",
-            )
-            return
-        if impact.state is MutationThreadImpactState.UNKNOWN:
-            invalidate_started = time.perf_counter()
-            await self._cache_ops.invalidate_room_threads(
-                room_id,
-                reason="live_thread_lookup_unavailable",
-            )
-            emit_timing_event(
-                "Live event cache append timing",
-                room_id=room_id,
-                event_id=event.event_id,
-                impact_state="unknown",
-                impact_resolution_ms=impact_resolution_ms,
-                invalidate_ms=round((time.perf_counter() - invalidate_started) * 1000, 1),
-                total_ms=round((time.perf_counter() - started) * 1000, 1),
-                outcome="room_invalidated",
-            )
-            return
+
+    async def _append_live_threaded_event_with_timing(
+        self,
+        room_id: str,
+        event: nio.RoomMessage,
+        *,
+        impact: MutationThreadImpact,
+        impact_resolution_ms: float,
+        started: float,
+    ) -> None:
         assert impact.thread_id is not None
         thread_id = impact.thread_id
         event_source = normalize_nio_event_for_cache(event)
@@ -592,6 +609,88 @@ class ThreadLiveWritePolicy:
                 outcome=outcome,
                 **append_metrics,
             )
+
+    async def _append_live_event_with_timing(
+        self,
+        room_id: str,
+        event: nio.RoomMessage,
+        *,
+        event_info: EventInfo,
+    ) -> None:
+        started = time.perf_counter()
+        impact_started = time.perf_counter()
+        impact = await self._resolve_live_event_impact(
+            room_id,
+            event_id=event.event_id,
+            event_info=event_info,
+        )
+        impact_resolution_ms = round((time.perf_counter() - impact_started) * 1000, 1)
+        if impact.state is MutationThreadImpactState.ROOM_LEVEL:
+            self._cache_ops.logger.debug(
+                "Skipping live thread cache bookkeeping for known non-threaded message mutation",
+                room_id=room_id,
+                event_id=event.event_id,
+                original_event_id=event_info.original_event_id,
+            )
+            emit_timing_event(
+                "Live event cache append timing",
+                room_id=room_id,
+                event_id=event.event_id,
+                impact_state="room_level",
+                impact_resolution_ms=impact_resolution_ms,
+                total_ms=round((time.perf_counter() - started) * 1000, 1),
+                outcome="non_threaded_skip",
+            )
+            return
+        if impact.state is MutationThreadImpactState.UNKNOWN:
+            invalidate_started = time.perf_counter()
+            await self._cache_ops.invalidate_room_threads(
+                room_id,
+                reason="live_thread_lookup_unavailable",
+            )
+            emit_timing_event(
+                "Live event cache append timing",
+                room_id=room_id,
+                event_id=event.event_id,
+                impact_state="unknown",
+                impact_resolution_ms=impact_resolution_ms,
+                invalidate_ms=round((time.perf_counter() - invalidate_started) * 1000, 1),
+                total_ms=round((time.perf_counter() - started) * 1000, 1),
+                outcome="room_invalidated",
+            )
+            return
+        await self._append_live_threaded_event_with_timing(
+            room_id,
+            event,
+            impact=impact,
+            impact_resolution_ms=impact_resolution_ms,
+            started=started,
+        )
+
+    async def append_live_event(
+        self,
+        room_id: str,
+        event: nio.RoomMessage,
+        *,
+        event_info: EventInfo,
+    ) -> None:
+        """Append one live threaded event into the advisory cache when the thread is known."""
+        if not self._cache_ops.cache_runtime_available():
+            return
+
+        if not timing_enabled():
+            await self._append_live_event_without_timing(
+                room_id,
+                event,
+                event_info=event_info,
+            )
+            return
+
+        await self._append_live_event_with_timing(
+            room_id,
+            event,
+            event_info=event_info,
+        )
 
     async def apply_redaction(self, room_id: str, event: nio.RedactionEvent) -> None:
         """Apply one redaction to the advisory cache when the affected thread is known."""

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
 from mindroom.background_tasks import create_background_task, wait_for_background_tasks
-from mindroom.timing import emit_timing_event
+from mindroom.timing import emit_timing_event, timing_enabled
 
 if TYPE_CHECKING:
     import structlog
@@ -57,9 +57,16 @@ class _EventCacheWriteCoordinator:
         asyncio.Task[Any] | None,
     ] = field(default_factory=weakref.WeakKeyDictionary, init=False)
 
-    @staticmethod
-    def _active_predecessor_count(previous_tasks: tuple[asyncio.Task[Any], ...]) -> int:
-        return sum(1 for task in previous_tasks if not task.done())
+    def _pending_chain_length(self, task: asyncio.Task[Any] | None) -> int:
+        count = 0
+        seen: set[asyncio.Task[Any]] = set()
+        current = task
+        while current is not None and current not in seen:
+            seen.add(current)
+            if not current.done():
+                count += 1
+            current = self._pending_predecessor(current)
+        return count
 
     def _emit_idle_wait_timing(
         self,
@@ -79,6 +86,23 @@ class _EventCacheWriteCoordinator:
             wait_iterations=wait_iterations,
             pending_task_count=pending_task_count,
         )
+
+    async def _await_room_tail(self, room_id: str, tail_task: asyncio.Task[Any]) -> None:
+        try:
+            await tail_task
+        except asyncio.CancelledError:
+            current_task = asyncio.current_task()
+            if current_task is not None and current_task.cancelling():
+                raise
+        except Exception as exc:
+            self.logger.debug(
+                "Room cache update failed before room became idle",
+                room_id=room_id,
+                error=str(exc),
+            )
+        finally:
+            if self._room_update_tasks.get(room_id) is tail_task and tail_task.done():
+                self._clear_room_tail(room_id, tail_task)
 
     def _pending_predecessor(self, task: asyncio.Task[Any]) -> asyncio.Task[Any] | None:
         predecessor = self._room_update_predecessors.get(task)
@@ -133,39 +157,52 @@ class _EventCacheWriteCoordinator:
     ) -> asyncio.Task[object]:
         """Schedule one room-scoped cache update behind any active predecessor."""
         previous_task = self._room_update_tasks.get(room_id)
-        predecessor_count = self._active_predecessor_count((previous_task,)) if previous_task is not None else 0
+        instrument_timing = timing_enabled()
 
-        async def run_after_previous() -> object:
-            started = time.perf_counter()
-            outcome = "ok"
-            update_started: float | None = None
-            try:
+        if not instrument_timing:
+
+            async def run_after_previous() -> object:
                 await self._await_predecessor(room_id, name, previous_task)
-                update_started = time.perf_counter()
                 return await update_coro_factory()
-            except asyncio.CancelledError:
-                outcome = "cancelled"
-                raise
-            except Exception:
-                outcome = "error"
-                raise
-            finally:
-                update_run_ms = (
-                    round((time.perf_counter() - update_started) * 1000, 1) if update_started is not None else 0.0
-                )
-                total_ms = round((time.perf_counter() - started) * 1000, 1)
-                emit_timing_event(
-                    "Event cache update timing",
-                    barrier_kind="room",
-                    room_id=room_id,
-                    operation=name,
-                    predecessor_count=predecessor_count,
-                    queued_behind_predecessor=predecessor_count > 0,
-                    predecessor_wait_ms=round(total_ms - update_run_ms, 1),
-                    update_run_ms=update_run_ms,
-                    total_ms=total_ms,
-                    outcome=outcome,
-                )
+
+        else:
+            predecessor_count = self._pending_chain_length(previous_task)
+
+            async def run_after_previous() -> object:
+                started = time.perf_counter()
+                outcome = "ok"
+                update_started: float | None = None
+                try:
+                    await self._await_predecessor(room_id, name, previous_task)
+                    update_started = time.perf_counter()
+                    return await update_coro_factory()
+                except asyncio.CancelledError:
+                    outcome = "cancelled"
+                    raise
+                except Exception:
+                    outcome = "error"
+                    raise
+                finally:
+                    finished = time.perf_counter()
+                    total_ms = round((finished - started) * 1000, 1)
+                    if update_started is None:
+                        predecessor_wait_ms = total_ms
+                        update_run_ms = 0.0
+                    else:
+                        predecessor_wait_ms = round((update_started - started) * 1000, 1)
+                        update_run_ms = round((finished - update_started) * 1000, 1)
+                    emit_timing_event(
+                        "Event cache update timing",
+                        barrier_kind="room",
+                        room_id=room_id,
+                        operation=name,
+                        predecessor_count=predecessor_count,
+                        queued_behind_predecessor=predecessor_count > 0,
+                        predecessor_wait_ms=predecessor_wait_ms,
+                        update_run_ms=update_run_ms,
+                        total_ms=total_ms,
+                        outcome=outcome,
+                    )
 
         task = create_background_task(
             run_after_previous(),
@@ -193,8 +230,14 @@ class _EventCacheWriteCoordinator:
             log_exceptions=False,
         )
 
-    async def wait_for_room_idle(self, room_id: str) -> None:
-        """Wait for the currently queued same-room update chain to drain."""
+    async def _wait_for_room_idle_without_timing(self, room_id: str) -> None:
+        while True:
+            tail_task = self._room_update_tasks.get(room_id)
+            if tail_task is None:
+                return
+            await self._await_room_tail(room_id, tail_task)
+
+    async def _wait_for_room_idle_with_timing(self, room_id: str) -> None:
         wait_started: float | None = None
         wait_iterations = 0
         pending_task_count = 0
@@ -210,23 +253,16 @@ class _EventCacheWriteCoordinator:
                 return
             if wait_started is None:
                 wait_started = time.perf_counter()
-                pending_task_count = self._active_predecessor_count((tail_task,))
+                pending_task_count = self._pending_chain_length(tail_task)
             wait_iterations += 1
-            try:
-                await tail_task
-            except asyncio.CancelledError:
-                current_task = asyncio.current_task()
-                if current_task is not None and current_task.cancelling():
-                    raise
-            except Exception as exc:
-                self.logger.debug(
-                    "Room cache update failed before room became idle",
-                    room_id=room_id,
-                    error=str(exc),
-                )
-            finally:
-                if self._room_update_tasks.get(room_id) is tail_task and tail_task.done():
-                    self._clear_room_tail(room_id, tail_task)
+            await self._await_room_tail(room_id, tail_task)
+
+    async def wait_for_room_idle(self, room_id: str) -> None:
+        """Wait for the currently queued same-room update chain to drain."""
+        if timing_enabled():
+            await self._wait_for_room_idle_with_timing(room_id)
+            return
+        await self._wait_for_room_idle_without_timing(room_id)
 
     async def close(self) -> None:
         """Drain any queued cache writes for this coordinator."""

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -253,9 +253,12 @@ class _EventCacheWriteCoordinator:
                 return
             if wait_started is None:
                 wait_started = time.perf_counter()
-                pending_task_count = self._pending_chain_length(tail_task)
-            wait_iterations += 1
+            pending_task_count = max(
+                pending_task_count,
+                wait_iterations + self._pending_chain_length(tail_task),
+            )
             await self._await_room_tail(room_id, tail_task)
+            wait_iterations += 1
 
     async def wait_for_room_idle(self, room_id: str) -> None:
         """Wait for the currently queued same-room update chain to drain."""

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -58,15 +58,18 @@ class _EventCacheWriteCoordinator:
     ] = field(default_factory=weakref.WeakKeyDictionary, init=False)
 
     def _pending_chain_length(self, task: asyncio.Task[Any] | None) -> int:
-        count = 0
+        return len(self._pending_chain_tasks(task))
+
+    def _pending_chain_tasks(self, task: asyncio.Task[Any] | None) -> set[asyncio.Task[Any]]:
+        pending_tasks: set[asyncio.Task[Any]] = set()
         seen: set[asyncio.Task[Any]] = set()
         current = task
         while current is not None and current not in seen:
             seen.add(current)
             if not current.done():
-                count += 1
+                pending_tasks.add(current)
             current = self._pending_predecessor(current)
-        return count
+        return pending_tasks
 
     def _emit_idle_wait_timing(
         self,
@@ -240,7 +243,7 @@ class _EventCacheWriteCoordinator:
     async def _wait_for_room_idle_with_timing(self, room_id: str) -> None:
         wait_started: float | None = None
         wait_iterations = 0
-        pending_task_count = 0
+        pending_tasks: set[asyncio.Task[Any]] = set()
         while True:
             tail_task = self._room_update_tasks.get(room_id)
             if tail_task is None:
@@ -248,15 +251,12 @@ class _EventCacheWriteCoordinator:
                     room_id=room_id,
                     wait_started=wait_started,
                     wait_iterations=wait_iterations,
-                    pending_task_count=pending_task_count,
+                    pending_task_count=len(pending_tasks),
                 )
                 return
             if wait_started is None:
                 wait_started = time.perf_counter()
-            pending_task_count = max(
-                pending_task_count,
-                wait_iterations + self._pending_chain_length(tail_task),
-            )
+            pending_tasks.update(self._pending_chain_tasks(tail_task))
             await self._await_room_tail(room_id, tail_task)
             wait_iterations += 1
 

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import time
 import typing
 import weakref
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
 from mindroom.background_tasks import create_background_task, wait_for_background_tasks
+from mindroom.timing import emit_timing_event
 
 if TYPE_CHECKING:
     import structlog
@@ -54,6 +56,29 @@ class _EventCacheWriteCoordinator:
         asyncio.Task[Any],
         asyncio.Task[Any] | None,
     ] = field(default_factory=weakref.WeakKeyDictionary, init=False)
+
+    @staticmethod
+    def _active_predecessor_count(previous_tasks: tuple[asyncio.Task[Any], ...]) -> int:
+        return sum(1 for task in previous_tasks if not task.done())
+
+    def _emit_idle_wait_timing(
+        self,
+        *,
+        room_id: str,
+        wait_started: float | None,
+        wait_iterations: int,
+        pending_task_count: int,
+    ) -> None:
+        if wait_started is None:
+            return
+        emit_timing_event(
+            "Event cache idle wait timing",
+            barrier_kind="room",
+            room_id=room_id,
+            wait_ms=round((time.perf_counter() - wait_started) * 1000, 1),
+            wait_iterations=wait_iterations,
+            pending_task_count=pending_task_count,
+        )
 
     def _pending_predecessor(self, task: asyncio.Task[Any]) -> asyncio.Task[Any] | None:
         predecessor = self._room_update_predecessors.get(task)
@@ -108,10 +133,39 @@ class _EventCacheWriteCoordinator:
     ) -> asyncio.Task[object]:
         """Schedule one room-scoped cache update behind any active predecessor."""
         previous_task = self._room_update_tasks.get(room_id)
+        predecessor_count = self._active_predecessor_count((previous_task,)) if previous_task is not None else 0
 
         async def run_after_previous() -> object:
-            await self._await_predecessor(room_id, name, previous_task)
-            return await update_coro_factory()
+            started = time.perf_counter()
+            outcome = "ok"
+            update_started: float | None = None
+            try:
+                await self._await_predecessor(room_id, name, previous_task)
+                update_started = time.perf_counter()
+                return await update_coro_factory()
+            except asyncio.CancelledError:
+                outcome = "cancelled"
+                raise
+            except Exception:
+                outcome = "error"
+                raise
+            finally:
+                update_run_ms = (
+                    round((time.perf_counter() - update_started) * 1000, 1) if update_started is not None else 0.0
+                )
+                total_ms = round((time.perf_counter() - started) * 1000, 1)
+                emit_timing_event(
+                    "Event cache update timing",
+                    barrier_kind="room",
+                    room_id=room_id,
+                    operation=name,
+                    predecessor_count=predecessor_count,
+                    queued_behind_predecessor=predecessor_count > 0,
+                    predecessor_wait_ms=round(total_ms - update_run_ms, 1),
+                    update_run_ms=update_run_ms,
+                    total_ms=total_ms,
+                    outcome=outcome,
+                )
 
         task = create_background_task(
             run_after_previous(),
@@ -141,10 +195,23 @@ class _EventCacheWriteCoordinator:
 
     async def wait_for_room_idle(self, room_id: str) -> None:
         """Wait for the currently queued same-room update chain to drain."""
+        wait_started: float | None = None
+        wait_iterations = 0
+        pending_task_count = 0
         while True:
             tail_task = self._room_update_tasks.get(room_id)
             if tail_task is None:
+                self._emit_idle_wait_timing(
+                    room_id=room_id,
+                    wait_started=wait_started,
+                    wait_iterations=wait_iterations,
+                    pending_task_count=pending_task_count,
+                )
                 return
+            if wait_started is None:
+                wait_started = time.perf_counter()
+                pending_task_count = self._active_predecessor_count((tail_task,))
+            wait_iterations += 1
             try:
                 await tail_task
             except asyncio.CancelledError:

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -32,6 +32,11 @@ def _is_enabled() -> bool:
     return os.environ.get("MINDROOM_TIMING", "") == "1"
 
 
+def timing_enabled() -> bool:
+    """Return whether structured timing diagnostics should be emitted."""
+    return _is_enabled()
+
+
 type TimingMetadataValue = str | int | float | bool
 
 PRIMARY_SEGMENTS: tuple[tuple[str, str, str], ...] = (
@@ -150,6 +155,19 @@ def get_dispatch_pipeline_timing(source: object) -> DispatchPipelineTiming | Non
     if isinstance(raw_timing, DispatchPipelineTiming):
         return raw_timing
     return None
+
+
+def emit_timing_event(event_name: str, **event_data: object) -> None:
+    """Emit one structured timing event when timing instrumentation is enabled."""
+    if not _is_enabled():
+        return
+    scope = event_data.pop("timing_scope", None)
+    if not isinstance(scope, str) or not scope:
+        scope = timing_scope.get()
+    filtered_event_data = {key: value for key, value in event_data.items() if value is not None}
+    if scope:
+        filtered_event_data["timing_scope"] = scope
+    logger.info(event_name, **filtered_event_data)
 
 
 def timed(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:  # noqa: C901

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -4237,6 +4237,89 @@ class TestThreadingBehavior:
         assert timing_call.kwargs["pending_task_count"] == 2
 
     @pytest.mark.asyncio
+    async def test_wait_for_room_idle_counts_full_backlog_when_queue_grows_mid_wait(  # noqa: PLR0915
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Room-idle waits should count both the initial backlog and tasks queued later."""
+        monkeypatch.setenv("MINDROOM_TIMING", "1")
+        timing_logger = MagicMock()
+        monkeypatch.setattr(timing_module, "logger", timing_logger)
+        coordinator = _EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+        first_started = asyncio.Event()
+        allow_first_finish = asyncio.Event()
+        second_started = asyncio.Event()
+        allow_second_finish = asyncio.Event()
+        third_started = asyncio.Event()
+        allow_third_finish = asyncio.Event()
+        fourth_started = asyncio.Event()
+        allow_fourth_finish = asyncio.Event()
+
+        async def first_update() -> None:
+            first_started.set()
+            await allow_first_finish.wait()
+
+        async def second_update() -> None:
+            second_started.set()
+            await allow_second_finish.wait()
+
+        async def third_update() -> None:
+            third_started.set()
+            await allow_third_finish.wait()
+
+        async def fourth_update() -> None:
+            fourth_started.set()
+            await allow_fourth_finish.wait()
+
+        try:
+            first_task = coordinator.queue_room_update(
+                "!room:localhost",
+                first_update,
+                name="matrix_cache_first_update",
+            )
+            await asyncio.wait_for(first_started.wait(), timeout=1.0)
+            second_task = coordinator.queue_room_update(
+                "!room:localhost",
+                second_update,
+                name="matrix_cache_second_update",
+            )
+            third_task = coordinator.queue_room_update(
+                "!room:localhost",
+                third_update,
+                name="matrix_cache_third_update",
+            )
+            waiter = asyncio.create_task(coordinator.wait_for_room_idle("!room:localhost"))
+            await asyncio.sleep(0)
+            fourth_task = coordinator.queue_room_update(
+                "!room:localhost",
+                fourth_update,
+                name="matrix_cache_fourth_update",
+            )
+            await asyncio.sleep(0)
+            allow_first_finish.set()
+            await asyncio.wait_for(second_started.wait(), timeout=1.0)
+            allow_second_finish.set()
+            await asyncio.wait_for(third_started.wait(), timeout=1.0)
+            allow_third_finish.set()
+            await asyncio.wait_for(fourth_started.wait(), timeout=1.0)
+            allow_fourth_finish.set()
+            await first_task
+            await second_task
+            await third_task
+            await fourth_task
+            await waiter
+        finally:
+            await coordinator.close()
+
+        timing_call = next(
+            call for call in timing_logger.info.call_args_list if call.args == ("Event cache idle wait timing",)
+        )
+        assert timing_call.kwargs["pending_task_count"] == 4
+
+    @pytest.mark.asyncio
     async def test_queue_room_update_skips_timing_overhead_when_disabled(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -4318,6 +4401,52 @@ class TestThreadingBehavior:
             and call.kwargs["outcome"] == "ok"
             for call in append_calls
         )
+
+    @pytest.mark.asyncio
+    async def test_append_live_event_logs_append_failure_outcome_when_enabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Live ingress timing should classify append misses as append failures."""
+        monkeypatch.setenv("MINDROOM_TIMING", "1")
+        timing_logger = MagicMock()
+        monkeypatch.setattr(timing_module, "logger", timing_logger)
+        event_cache = _runtime_event_cache()
+        event_cache.append_event = AsyncMock(return_value=False)
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(event_cache=event_cache),
+        )
+        access._live._resolver.resolve_thread_impact_for_mutation = AsyncMock(
+            return_value=MutationThreadImpact.threaded("$thread:localhost"),
+        )
+        event = nio.RoomMessageText.from_dict(
+            {
+                "type": "m.room.message",
+                "room_id": "!room:localhost",
+                "event_id": "$reply:localhost",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234,
+                "content": {
+                    "body": "hello",
+                    "msgtype": "m.text",
+                    "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread:localhost"},
+                },
+            },
+        )
+
+        await access.append_live_event(
+            "!room:localhost",
+            event,
+            event_info=EventInfo.from_event(event.source),
+        )
+
+        timing_call = next(
+            call for call in timing_logger.info.call_args_list if call.args == ("Live event cache append timing",)
+        )
+        assert timing_call.kwargs["thread_id"] == "$thread:localhost"
+        assert timing_call.kwargs["appended"] is False
+        assert timing_call.kwargs["outcome"] == "append_failed"
 
     @pytest.mark.asyncio
     async def test_append_live_event_skips_timing_overhead_when_disabled(

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -4182,6 +4182,61 @@ class TestThreadingBehavior:
         assert timing_call.kwargs["pending_task_count"] == 2
 
     @pytest.mark.asyncio
+    async def test_wait_for_room_idle_counts_tasks_queued_after_wait_starts(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Room-idle waits should include same-room tasks queued after the wait begins."""
+        monkeypatch.setenv("MINDROOM_TIMING", "1")
+        timing_logger = MagicMock()
+        monkeypatch.setattr(timing_module, "logger", timing_logger)
+        coordinator = _EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+        first_started = asyncio.Event()
+        allow_first_finish = asyncio.Event()
+        second_started = asyncio.Event()
+        allow_second_finish = asyncio.Event()
+
+        async def first_update() -> None:
+            first_started.set()
+            await allow_first_finish.wait()
+
+        async def second_update() -> None:
+            second_started.set()
+            await allow_second_finish.wait()
+
+        try:
+            first_task = coordinator.queue_room_update(
+                "!room:localhost",
+                first_update,
+                name="matrix_cache_first_update",
+            )
+            await asyncio.wait_for(first_started.wait(), timeout=1.0)
+            waiter = asyncio.create_task(coordinator.wait_for_room_idle("!room:localhost"))
+            await asyncio.sleep(0)
+            second_task = coordinator.queue_room_update(
+                "!room:localhost",
+                second_update,
+                name="matrix_cache_second_update",
+            )
+            await asyncio.sleep(0)
+            allow_first_finish.set()
+            await asyncio.wait_for(second_started.wait(), timeout=1.0)
+            allow_second_finish.set()
+            await first_task
+            await second_task
+            await waiter
+        finally:
+            await coordinator.close()
+
+        timing_call = next(
+            call for call in timing_logger.info.call_args_list if call.args == ("Event cache idle wait timing",)
+        )
+        assert timing_call.kwargs["pending_task_count"] == 2
+
+    @pytest.mark.asyncio
     async def test_queue_room_update_skips_timing_overhead_when_disabled(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -12,7 +12,7 @@ import asyncio
 import json
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 import nio
@@ -87,7 +87,7 @@ from tests.conftest import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Sequence
+    from collections.abc import AsyncGenerator, Callable, Coroutine, Sequence
     from pathlib import Path
 
 
@@ -3976,6 +3976,113 @@ class TestThreadingBehavior:
         )
 
     @pytest.mark.asyncio
+    async def test_queue_room_update_logs_wait_from_raw_interval_when_enabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Predecessor wait should come from the raw pre-update interval, not rounded subtraction."""
+        monkeypatch.setenv("MINDROOM_TIMING", "1")
+        timing_logger = MagicMock()
+        monkeypatch.setattr(timing_module, "logger", timing_logger)
+        perf_counter_values = iter([0.0, 0.00002, 0.00016, 0.00016])
+        monkeypatch.setattr(
+            "mindroom.matrix.cache.write_coordinator.time.perf_counter",
+            lambda: next(perf_counter_values),
+        )
+        coordinator = _EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+
+        async def update() -> str:
+            return "ok"
+
+        try:
+            task = coordinator.queue_room_update(
+                "!room:localhost",
+                update,
+                name="matrix_cache_single_update",
+            )
+            assert await task == "ok"
+        finally:
+            await coordinator.close()
+
+        timing_call = next(
+            call
+            for call in timing_logger.info.call_args_list
+            if call.args == ("Event cache update timing",) and call.kwargs["operation"] == "matrix_cache_single_update"
+        )
+        assert timing_call.kwargs["predecessor_wait_ms"] == 0.0
+        assert timing_call.kwargs["update_run_ms"] == 0.1
+        assert timing_call.kwargs["total_ms"] == 0.2
+
+    @pytest.mark.asyncio
+    async def test_queue_room_update_logs_full_predecessor_chain_when_enabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Room-scoped cache updates should report the full queued predecessor chain length."""
+        monkeypatch.setenv("MINDROOM_TIMING", "1")
+        timing_logger = MagicMock()
+        monkeypatch.setattr(timing_module, "logger", timing_logger)
+        coordinator = _EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+        first_started = asyncio.Event()
+        allow_first_finish = asyncio.Event()
+        second_started = asyncio.Event()
+        allow_second_finish = asyncio.Event()
+
+        async def first_update() -> str:
+            first_started.set()
+            await allow_first_finish.wait()
+            return "first"
+
+        async def second_update() -> str:
+            second_started.set()
+            await allow_second_finish.wait()
+            return "second"
+
+        async def third_update() -> str:
+            return "third"
+
+        try:
+            first_task = coordinator.queue_room_update(
+                "!room:localhost",
+                first_update,
+                name="matrix_cache_first_update",
+            )
+            await asyncio.wait_for(first_started.wait(), timeout=1.0)
+            second_task = coordinator.queue_room_update(
+                "!room:localhost",
+                second_update,
+                name="matrix_cache_second_update",
+            )
+            third_task = coordinator.queue_room_update(
+                "!room:localhost",
+                third_update,
+                name="matrix_cache_third_update",
+            )
+            await asyncio.sleep(0)
+            allow_first_finish.set()
+            await asyncio.wait_for(second_started.wait(), timeout=1.0)
+            allow_second_finish.set()
+            assert await first_task == "first"
+            assert await second_task == "second"
+            assert await third_task == "third"
+        finally:
+            await coordinator.close()
+
+        timing_call = next(
+            call
+            for call in timing_logger.info.call_args_list
+            if call.args == ("Event cache update timing",) and call.kwargs["operation"] == "matrix_cache_third_update"
+        )
+        assert timing_call.kwargs["predecessor_count"] == 2
+        assert timing_call.kwargs["queued_behind_predecessor"] is True
+
+    @pytest.mark.asyncio
     async def test_wait_for_room_idle_logs_timing_when_enabled(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -4019,6 +4126,89 @@ class TestThreadingBehavior:
             and call.kwargs["wait_ms"] >= 0.0
             for call in idle_wait_calls
         )
+
+    @pytest.mark.asyncio
+    async def test_wait_for_room_idle_logs_full_pending_chain_when_enabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Room-idle waits should report the full pending same-room backlog."""
+        monkeypatch.setenv("MINDROOM_TIMING", "1")
+        timing_logger = MagicMock()
+        monkeypatch.setattr(timing_module, "logger", timing_logger)
+        coordinator = _EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+        first_started = asyncio.Event()
+        allow_first_finish = asyncio.Event()
+        second_started = asyncio.Event()
+        allow_second_finish = asyncio.Event()
+
+        async def first_update() -> None:
+            first_started.set()
+            await allow_first_finish.wait()
+
+        async def second_update() -> None:
+            second_started.set()
+            await allow_second_finish.wait()
+
+        try:
+            first_task = coordinator.queue_room_update(
+                "!room:localhost",
+                first_update,
+                name="matrix_cache_first_update",
+            )
+            await asyncio.wait_for(first_started.wait(), timeout=1.0)
+            second_task = coordinator.queue_room_update(
+                "!room:localhost",
+                second_update,
+                name="matrix_cache_second_update",
+            )
+            waiter = asyncio.create_task(coordinator.wait_for_room_idle("!room:localhost"))
+            await asyncio.sleep(0)
+            allow_first_finish.set()
+            await asyncio.wait_for(second_started.wait(), timeout=1.0)
+            allow_second_finish.set()
+            await first_task
+            await second_task
+            await waiter
+        finally:
+            await coordinator.close()
+
+        timing_call = next(
+            call for call in timing_logger.info.call_args_list if call.args == ("Event cache idle wait timing",)
+        )
+        assert timing_call.kwargs["pending_task_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_queue_room_update_skips_timing_overhead_when_disabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Disabled timing should not touch the perf_counter instrumentation path."""
+        monkeypatch.delenv("MINDROOM_TIMING", raising=False)
+        monkeypatch.setattr(
+            "mindroom.matrix.cache.write_coordinator.time.perf_counter",
+            Mock(side_effect=AssertionError("perf_counter should stay unused when timing is disabled")),
+        )
+        coordinator = _EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+
+        async def update() -> str:
+            return "ok"
+
+        try:
+            task = coordinator.queue_room_update(
+                "!room:localhost",
+                update,
+                name="matrix_cache_single_update",
+            )
+            assert await task == "ok"
+        finally:
+            await coordinator.close()
 
     @pytest.mark.asyncio
     async def test_append_live_event_logs_phase_breakdown_when_enabled(
@@ -4073,6 +4263,68 @@ class TestThreadingBehavior:
             and call.kwargs["outcome"] == "ok"
             for call in append_calls
         )
+
+    @pytest.mark.asyncio
+    async def test_append_live_event_skips_timing_overhead_when_disabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Disabled timing should not touch the live-append perf_counter instrumentation path."""
+        monkeypatch.delenv("MINDROOM_TIMING", raising=False)
+        monkeypatch.setattr(
+            "mindroom.matrix.cache.thread_writes.time.perf_counter",
+            Mock(side_effect=AssertionError("perf_counter should stay unused when timing is disabled")),
+        )
+        cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
+
+        class _InlineCoordinator:
+            def queue_room_update(
+                self,
+                room_id: str,
+                update_coro_factory: Callable[[], Coroutine[Any, Any, object]],
+                *,
+                name: str,
+                log_exceptions: bool = True,
+            ) -> asyncio.Task[object]:
+                del room_id, name, log_exceptions
+                return asyncio.create_task(update_coro_factory())
+
+        cache_ops.runtime.event_cache_write_coordinator = _InlineCoordinator()
+        resolver = MagicMock()
+        resolver.resolve_thread_impact_for_mutation = AsyncMock(
+            return_value=MutationThreadImpact.threaded("$thread:localhost"),
+        )
+        policy = thread_writes.ThreadLiveWritePolicy(
+            resolver=resolver,
+            cache_ops=cache_ops,
+        )
+        event = nio.RoomMessageText.from_dict(
+            {
+                "type": "m.room.message",
+                "room_id": "!room:localhost",
+                "event_id": "$reply:localhost",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234,
+                "content": {
+                    "body": "hello",
+                    "msgtype": "m.text",
+                    "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread:localhost"},
+                },
+            },
+        )
+
+        await policy.append_live_event(
+            "!room:localhost",
+            event,
+            event_info=EventInfo.from_event(event.source),
+        )
+
+        event_cache.mark_thread_stale.assert_awaited_once_with(
+            "!room:localhost",
+            "$thread:localhost",
+            reason="live_thread_mutation",
+        )
+        event_cache.append_event.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_sync_edit_marks_cached_thread_stale_and_next_read_refetches(

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -21,6 +21,7 @@ import pytest_asyncio
 from nio.api import RelationshipType
 
 import mindroom.matrix.cache as matrix_cache
+import mindroom.timing as timing_module
 from mindroom.background_tasks import create_background_task, wait_for_background_tasks
 from mindroom.bot import AgentBot
 from mindroom.bot_runtime_view import BotRuntimeState
@@ -3916,6 +3917,162 @@ class TestThreadingBehavior:
             assert coordinator._room_update_tasks.get("!room:localhost") is None
         finally:
             await coordinator.close()
+
+    @pytest.mark.asyncio
+    async def test_queue_room_update_logs_timing_breakdown_when_enabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Room-scoped cache updates should log predecessor wait versus update time."""
+        monkeypatch.setenv("MINDROOM_TIMING", "1")
+        timing_logger = MagicMock()
+        monkeypatch.setattr(timing_module, "logger", timing_logger)
+        coordinator = _EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+        first_started = asyncio.Event()
+        allow_first_finish = asyncio.Event()
+
+        async def first_update() -> str:
+            first_started.set()
+            await allow_first_finish.wait()
+            return "first"
+
+        async def second_update() -> str:
+            return "second"
+
+        try:
+            first_task = coordinator.queue_room_update(
+                "!room:localhost",
+                first_update,
+                name="matrix_cache_first_update",
+            )
+            await asyncio.wait_for(first_started.wait(), timeout=1.0)
+            second_task = coordinator.queue_room_update(
+                "!room:localhost",
+                second_update,
+                name="matrix_cache_second_update",
+            )
+            await asyncio.sleep(0)
+            allow_first_finish.set()
+            assert await first_task == "first"
+            assert await second_task == "second"
+        finally:
+            await coordinator.close()
+
+        timing_calls = [
+            call for call in timing_logger.info.call_args_list if call.args == ("Event cache update timing",)
+        ]
+        assert any(
+            call.kwargs["barrier_kind"] == "room"
+            and call.kwargs["operation"] == "matrix_cache_second_update"
+            and call.kwargs["queued_behind_predecessor"] is True
+            and call.kwargs["predecessor_count"] >= 1
+            and call.kwargs["predecessor_wait_ms"] >= 0.0
+            and call.kwargs["update_run_ms"] >= 0.0
+            and call.kwargs["total_ms"] >= call.kwargs["update_run_ms"]
+            for call in timing_calls
+        )
+
+    @pytest.mark.asyncio
+    async def test_wait_for_room_idle_logs_timing_when_enabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Room-idle waits should log how long the caller sat behind queued room work."""
+        monkeypatch.setenv("MINDROOM_TIMING", "1")
+        timing_logger = MagicMock()
+        monkeypatch.setattr(timing_module, "logger", timing_logger)
+        coordinator = _EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+        update_started = asyncio.Event()
+        allow_update_finish = asyncio.Event()
+
+        async def slow_update() -> None:
+            update_started.set()
+            await allow_update_finish.wait()
+
+        try:
+            queued_task = coordinator.queue_room_update(
+                "!room:localhost",
+                slow_update,
+                name="matrix_cache_slow_update",
+            )
+            await asyncio.wait_for(update_started.wait(), timeout=1.0)
+            waiter = asyncio.create_task(coordinator.wait_for_room_idle("!room:localhost"))
+            await asyncio.sleep(0)
+            allow_update_finish.set()
+            await queued_task
+            await waiter
+        finally:
+            await coordinator.close()
+
+        idle_wait_calls = [
+            call for call in timing_logger.info.call_args_list if call.args == ("Event cache idle wait timing",)
+        ]
+        assert any(
+            call.kwargs["barrier_kind"] == "room"
+            and call.kwargs["pending_task_count"] >= 1
+            and call.kwargs["wait_ms"] >= 0.0
+            for call in idle_wait_calls
+        )
+
+    @pytest.mark.asyncio
+    async def test_append_live_event_logs_phase_breakdown_when_enabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Live ingress appends should expose resolver, queue, and cache-write timings."""
+        monkeypatch.setenv("MINDROOM_TIMING", "1")
+        timing_logger = MagicMock()
+        monkeypatch.setattr(timing_module, "logger", timing_logger)
+        event_cache = _runtime_event_cache()
+        event_cache.append_event = AsyncMock(return_value=True)
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(event_cache=event_cache),
+        )
+        access._live._resolver.resolve_thread_impact_for_mutation = AsyncMock(
+            return_value=MutationThreadImpact.threaded("$thread:localhost"),
+        )
+        event = nio.RoomMessageText.from_dict(
+            {
+                "type": "m.room.message",
+                "room_id": "!room:localhost",
+                "event_id": "$reply:localhost",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234,
+                "content": {
+                    "body": "hello",
+                    "msgtype": "m.text",
+                    "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread:localhost"},
+                },
+            },
+        )
+
+        await access.append_live_event(
+            "!room:localhost",
+            event,
+            event_info=EventInfo.from_event(event.source),
+        )
+
+        append_calls = [
+            call for call in timing_logger.info.call_args_list if call.args == ("Live event cache append timing",)
+        ]
+        assert any(
+            call.kwargs["thread_id"] == "$thread:localhost"
+            and call.kwargs["event_id"] == "$reply:localhost"
+            and call.kwargs["impact_state"] == "threaded"
+            and call.kwargs["impact_resolution_ms"] >= 0.0
+            and call.kwargs["queue_and_update_ms"] >= 0.0
+            and call.kwargs["invalidate_ms"] >= 0.0
+            and call.kwargs["append_ms"] >= 0.0
+            and call.kwargs["outcome"] == "ok"
+            for call in append_calls
+        )
 
     @pytest.mark.asyncio
     async def test_sync_edit_marks_cached_thread_stale_and_next_read_refetches(

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -14,7 +14,7 @@ from unittest.mock import Mock
 import pytest
 
 import mindroom.timing as timing_module
-from mindroom.timing import DispatchPipelineTiming, timed, timing_scope
+from mindroom.timing import DispatchPipelineTiming, emit_timing_event, timed, timing_enabled, timing_scope
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -229,6 +229,34 @@ def test_timed_logs_omit_scope_when_unset(monkeypatch: pytest.MonkeyPatch) -> No
     run()
 
     _assert_timing_logged(logger, "plain_label")
+
+
+def test_emit_timing_event_logs_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Structured timing events should inherit the current timing scope."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+
+    token = timing_scope.set("scope-123")
+    try:
+        emit_timing_event("custom_timing_event", value=42, ok=True)
+    finally:
+        timing_scope.reset(token)
+
+    logger.info.assert_called_once_with(
+        "custom_timing_event",
+        value=42,
+        ok=True,
+        timing_scope="scope-123",
+    )
+
+
+def test_timing_enabled_reflects_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The public timing-enabled helper should mirror the environment switch."""
+    monkeypatch.delenv("MINDROOM_TIMING", raising=False)
+    assert timing_enabled() is False
+
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    assert timing_enabled() is True
 
 
 def _timing_probe_labels(

--- a/tests/test_workloop_thread_scope.py
+++ b/tests/test_workloop_thread_scope.py
@@ -118,20 +118,23 @@ def _copy_plugin_root(tmp_path: Path) -> Path:
         )
         module_text = module_text.replace("from .formatting import ", f"from {package_prefix}.formatting import ")
         module_text = module_text.replace("from .poke import ", f"from {package_prefix}.poke import ")
+        module_text = module_text.replace("from .runtime import ", f"from {package_prefix}.runtime import ")
         module_text = module_text.replace("from .state import ", f"from {package_prefix}.state import ")
         module_text = module_text.replace("from .todos import ", f"from {package_prefix}.todos import ")
         module_text = module_text.replace("from .types import ", f"from {package_prefix}.types import ")
         module_path.write_text(module_text, encoding="utf-8")
-    types_path = copied_root / "types.py"
-    types_text = types_path.read_text(encoding="utf-8")
-    if "ROUTER_AGENT_NAME" not in types_text:
-        types_text = types_text.replace(
+    shared_types_path = copied_root / "runtime.py"
+    if not shared_types_path.exists():
+        shared_types_path = copied_root / "types.py"
+    shared_types_text = shared_types_path.read_text(encoding="utf-8")
+    if "ROUTER_AGENT_NAME" not in shared_types_text:
+        shared_types_text = shared_types_text.replace(
             "    from mindroom.hooks import HookMessageSender, HookRoomStateQuerier\n",
             "    from mindroom.constants import ROUTER_AGENT_NAME\n"
             "    from mindroom.hooks import HookMessageSender, HookRoomStateQuerier\n",
             1,
         )
-        types_path.write_text(types_text, encoding="utf-8")
+        shared_types_path.write_text(shared_types_text, encoding="utf-8")
     hooks_path = copied_root / "hooks.py"
     hooks_text = hooks_path.read_text(encoding="utf-8")
     if 'name="workloop-command"' not in hooks_text:


### PR DESCRIPTION
## Summary
- add timing diagnostics around Matrix thread cache writes and write coordination
- add shared elapsed timing helpers in `src/mindroom/timing.py`
- extend threading and timing tests to cover the new diagnostics

## Test Plan
- `uv run --active pytest -x -n 0 --no-cov --timeout=180 tests/test_threading_error.py tests/test_timing.py`
