### PR TITLE
refactor: extract shared thread-mutation helpers

### DIFF
--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -562,15 +562,6 @@ class ThreadLiveWritePolicy:
             event_id=event.event_id,
             context="live",
         )
-        if impact.state is not MutationThreadImpactState.THREADED:
-            await _apply_thread_redaction_mutation(
-                cache_ops=self._cache_ops,
-                room_id=room_id,
-                redacted_event_id=event.redacts,
-                impact=impact,
-                context="live",
-            )
-            return
 
         async def redact_and_invalidate() -> bool:
             return await _apply_thread_redaction_mutation(

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -82,6 +82,124 @@ def _threaded_sync_event_cache_update(
     return room_id, normalize_nio_event_for_cache(event)
 
 
+async def _apply_thread_message_mutation(
+    *,
+    cache_ops: ThreadMutationCacheOps,
+    resolver: ThreadMutationResolver,
+    room_id: str,
+    event_info: EventInfo,
+    event_source: dict[str, Any],
+    event_id: str | None,
+    context: str,
+    reason_prefix: str,
+    invalidate_on_append_failure: bool,
+    resolution_context: MutationResolutionContext | None = None,
+    allow_room_invalidation: bool = True,
+) -> bool:
+    impact = await resolver.resolve_thread_impact_for_mutation(
+        room_id,
+        event_info=event_info,
+        event_id=event_id,
+        context=context,
+        resolution_context=resolution_context,
+    )
+    if impact.state is MutationThreadImpactState.ROOM_LEVEL:
+        cache_ops.logger.debug(
+            (
+                "Skipping outbound thread cache bookkeeping for non-threaded event mutation"
+                if context == "outbound"
+                else f"Skipping {context} thread cache bookkeeping for known non-threaded message mutation"
+            ),
+            room_id=room_id,
+            event_id=event_id,
+            original_event_id=event_info.original_event_id,
+        )
+        return False
+    if impact.state is MutationThreadImpactState.UNKNOWN:
+        if not allow_room_invalidation:
+            return False
+        await cache_ops.invalidate_room_threads(
+            room_id,
+            reason=f"{reason_prefix}_thread_lookup_unavailable",
+        )
+        return True
+    assert impact.thread_id is not None
+    await cache_ops.invalidate_known_thread(
+        room_id,
+        impact.thread_id,
+        reason=f"{reason_prefix}_thread_mutation",
+    )
+    appended = await cache_ops.append_event_to_cache(
+        room_id,
+        impact.thread_id,
+        event_source,
+        context=context,
+    )
+    if invalidate_on_append_failure and not appended:
+        await cache_ops.invalidate_known_thread(
+            room_id,
+            impact.thread_id,
+            reason=f"{reason_prefix}_append_failed",
+        )
+    return False
+
+
+async def _apply_thread_redaction_mutation(
+    *,
+    cache_ops: ThreadMutationCacheOps,
+    resolver: ThreadMutationResolver,
+    room_id: str,
+    redacted_event_id: str,
+    context: str,
+    reason_prefix: str,
+    event_id: str | None = None,
+    resolution_context: MutationResolutionContext | None = None,
+    allow_room_invalidation: bool = True,
+    redact_room_level_event: bool = True,
+) -> bool:
+    lookup_failure_message = {
+        "outbound": "Ignoring outbound Matrix redaction cache lookup failure after successful redact",
+        "live": "Failed to resolve cached thread for redaction",
+        "sync": "Failed to resolve cached thread for sync redaction",
+    }[context]
+    redact_failure_message = {
+        "outbound": "Ignoring outbound Matrix redaction cache bookkeeping failure after successful redact",
+        "live": "Failed to apply live redaction to cache",
+        "sync": "Failed to apply sync redaction to cache",
+    }[context]
+    impact = await resolver.resolve_redaction_thread_impact(
+        room_id,
+        redacted_event_id,
+        failure_message=lookup_failure_message,
+        event_id=event_id,
+        resolution_context=resolution_context,
+    )
+    if impact.state is MutationThreadImpactState.ROOM_LEVEL and not redact_room_level_event:
+        cache_ops.logger.debug(
+            "Skipping outbound thread cache bookkeeping for non-threaded redaction",
+            room_id=room_id,
+            redacted_event_id=redacted_event_id,
+        )
+        return False
+    redacted = await cache_ops.redact_cached_event(
+        room_id,
+        redacted_event_id,
+        thread_id=impact.thread_id,
+        failure_message=redact_failure_message,
+    )
+    if impact.state is MutationThreadImpactState.UNKNOWN and redacted and not allow_room_invalidation:
+        return False
+    await cache_ops.invalidate_after_redaction(
+        room_id,
+        impact=impact,
+        redacted=redacted,
+        success_reason=f"{reason_prefix}_redaction",
+        failure_reason=f"{reason_prefix}_redaction_failed",
+        lookup_unavailable_reason=f"{reason_prefix}_redaction_lookup_unavailable",
+    )
+    return impact.state is MutationThreadImpactState.UNKNOWN and redacted
+
+
 class ThreadOutboundWritePolicy:
     """Own advisory bookkeeping for locally sent thread mutations."""
 
@@ -103,44 +221,16 @@ class ThreadOutboundWritePolicy:
         event_source: dict[str, Any],
         event_info: EventInfo,
     ) -> None:
-        impact = await self._resolver.resolve_thread_impact_for_mutation(
-            room_id,
+        await _apply_thread_message_mutation(
+            cache_ops=self._cache_ops,
+            resolver=self._resolver,
+            room_id=room_id,
             event_info=event_info,
+            event_source=event_source,
             event_id=event_id,
             context="outbound",
-        )
-        if impact.state is MutationThreadImpactState.ROOM_LEVEL:
-            if event_info.is_reaction:
-                await self._cache_ops.store_events_batch(
-                    room_id,
-                    [(event_id, room_id, event_source)],
-                    failure_message="Failed to persist outbound reaction lookup to cache",
-                )
-                return
-            self._cache_ops.logger.debug(
-                "Skipping outbound thread cache bookkeeping for non-threaded event mutation",
-                room_id=room_id,
-                event_id=event_id,
-                original_event_id=event_info.original_event_id,
-            )
-            return
-        if impact.state is MutationThreadImpactState.UNKNOWN:
-            await self._cache_ops.invalidate_room_threads(
-                room_id,
-                reason="outbound_thread_lookup_unavailable",
-            )
-            return
-        assert impact.thread_id is not None
-        await self._cache_ops.invalidate_known_thread(
-            room_id,
-            impact.thread_id,
-            reason="outbound_thread_mutation",
-        )
-        await self._cache_ops.append_event_to_cache(
-            room_id,
-            impact.thread_id,
-            event_source,
-            context="outbound",
+            reason_prefix="outbound",
+            invalidate_on_append_failure=False,
         )
 
     def notify_outbound_event(
@@ -261,32 +351,14 @@ class ThreadOutboundWritePolicy:
         room_id: str,
         redacted_event_id: str,
     ) -> None:
-        impact = await self._resolver.resolve_redaction_thread_impact(
-            room_id,
-            redacted_event_id,
-            failure_message="Ignoring outbound Matrix redaction cache lookup failure after successful redact",
-        )
-        if impact.state is MutationThreadImpactState.ROOM_LEVEL:
-            self._cache_ops.logger.debug(
-                "Skipping outbound thread cache bookkeeping for non-threaded redaction",
-                room_id=room_id,
-                redacted_event_id=redacted_event_id,
-            )
-            return
-        thread_id = impact.thread_id
-        redacted = await self._cache_ops.redact_cached_event(
-            room_id,
-            redacted_event_id,
-            thread_id=thread_id,
-            failure_message="Ignoring outbound Matrix redaction cache bookkeeping failure after successful redact",
-        )
-        await self._cache_ops.invalidate_after_redaction(
-            room_id,
-            impact=impact,
-            redacted=redacted,
-            success_reason="outbound_redaction",
-            failure_reason="outbound_redaction_failed",
-            lookup_unavailable_reason="outbound_redaction_lookup_unavailable",
+        await _apply_thread_redaction_mutation(
+            cache_ops=self._cache_ops,
+            resolver=self._resolver,
+            room_id=room_id,
+            redacted_event_id=redacted_event_id,
+            context="outbound",
+            reason_prefix="outbound",
+            redact_room_level_event=False,
         )
 
     def notify_outbound_redaction(
@@ -397,49 +469,20 @@ class ThreadLiveWritePolicy:
         if not self._cache_ops.cache_runtime_available():
             return
 
-        impact = await self._resolver.resolve_thread_impact_for_mutation(
-            room_id,
-            event_info=event_info,
-            event_id=event.event_id,
-            context="live",
-        )
-        if impact.state is MutationThreadImpactState.ROOM_LEVEL:
-            self._cache_ops.logger.debug(
-                "Skipping live thread cache bookkeeping for known non-threaded message mutation",
-                room_id=room_id,
-                event_id=event.event_id,
-                original_event_id=event_info.original_event_id,
-            )
-            return
-        if impact.state is MutationThreadImpactState.UNKNOWN:
-            await self._cache_ops.invalidate_room_threads(
-                room_id,
-                reason="live_thread_lookup_unavailable",
-            )
-            return
-        assert impact.thread_id is not None
-        thread_id = impact.thread_id
         event_source = normalize_nio_event_for_cache(event)
 
         async def append_and_invalidate() -> bool:
-            await self._cache_ops.invalidate_known_thread(
-                room_id,
-                thread_id,
-                reason="live_thread_mutation",
-            )
-            appended = await self._cache_ops.append_event_to_cache(
-                room_id,
-                thread_id,
-                event_source,
+            return await _apply_thread_message_mutation(
+                cache_ops=self._cache_ops,
+                resolver=self._resolver,
+                room_id=room_id,
+                event_info=event_info,
+                event_source=event_source,
+                event_id=event.event_id,
                 context="live",
+                reason_prefix="live",
+                invalidate_on_append_failure=True,
             )
-            if not appended:
-                await self._cache_ops.invalidate_known_thread(
-                    room_id,
-                    thread_id,
-                    reason="live_append_failed",
-                )
-            return appended
 
         await self._cache_ops.queue_room_cache_update(
             room_id,
@@ -451,30 +494,17 @@ class ThreadLiveWritePolicy:
         """Apply one redaction to the advisory cache when the affected thread is known."""
         if not self._cache_ops.cache_runtime_available():
             return
-        impact = await self._resolver.resolve_redaction_thread_impact(
-            room_id,
-            event.redacts,
-            failure_message="Failed to resolve cached thread for redaction",
-            event_id=event.event_id,
-        )
-        thread_id = impact.thread_id
 
         async def redact_and_invalidate() -> bool:
-            redacted = await self._cache_ops.redact_cached_event(
-                room_id,
-                event.redacts,
-                thread_id=thread_id,
-                failure_message="Failed to apply live redaction to cache",
+            return await _apply_thread_redaction_mutation(
+                cache_ops=self._cache_ops,
+                resolver=self._resolver,
+                room_id=room_id,
+                redacted_event_id=event.redacts,
+                event_id=event.event_id,
+                context="live",
+                reason_prefix="live",
             )
-            await self._cache_ops.invalidate_after_redaction(
-                room_id,
-                impact=impact,
-                redacted=redacted,
-                success_reason="live_redaction",
-                failure_reason="live_redaction_failed",
-                lookup_unavailable_reason="live_redaction_lookup_unavailable",
-            )
-            return redacted
 
         await self._cache_ops.queue_room_cache_update(
             room_id,
@@ -506,47 +536,22 @@ class ThreadSyncWritePolicy:
         for event_source in threaded_events:
             event_info = EventInfo.from_event(event_source)
             event_id = event_source.get("event_id")
-            impact = await self._resolver.resolve_thread_impact_for_mutation(
-                room_id,
-                event_info=event_info,
-                event_id=event_id if isinstance(event_id, str) else None,
-                context="sync",
-                resolution_context=resolution_context,
-            )
-            if impact.state is MutationThreadImpactState.ROOM_LEVEL:
-                self._cache_ops.logger.debug(
-                    "Skipping sync thread cache bookkeeping for known non-threaded message mutation",
+            room_threads_invalidated = (
+                await _apply_thread_message_mutation(
+                    cache_ops=self._cache_ops,
+                    resolver=self._resolver,
                     room_id=room_id,
-                    event_id=event_id,
-                    original_event_id=event_info.original_event_id,
+                    event_info=event_info,
+                    event_source=event_source,
+                    event_id=event_id if isinstance(event_id, str) else None,
+                    context="sync",
+                    reason_prefix="sync",
+                    invalidate_on_append_failure=True,
+                    resolution_context=resolution_context,
+                    allow_room_invalidation=not room_threads_invalidated,
                 )
-                continue
-            if impact.state is MutationThreadImpactState.UNKNOWN:
-                if not room_threads_invalidated:
-                    await self._cache_ops.invalidate_room_threads(
-                        room_id,
-                        reason="sync_thread_lookup_unavailable",
-                    )
-                    room_threads_invalidated = True
-                continue
-            assert impact.thread_id is not None
-            await self._cache_ops.invalidate_known_thread(
-                room_id,
-                impact.thread_id,
-                reason="sync_thread_mutation",
+                or room_threads_invalidated
             )
-            appended = await self._cache_ops.append_event_to_cache(
-                room_id,
-                impact.thread_id,
-                event_source,
-                context="sync",
-            )
-            if not appended:
-                await self._cache_ops.invalidate_known_thread(
-                    room_id,
-                    impact.thread_id,
-                    reason="sync_append_failed",
-                )
 
     async def _apply_sync_redactions(
         self,
@@ -557,34 +562,18 @@ class ThreadSyncWritePolicy:
     ) -> None:
         room_threads_invalidated = False
         for redacted_event_id in redacted_event_ids:
-            impact = await self._resolver.resolve_redaction_thread_impact(
-                room_id,
-                redacted_event_id,
-                failure_message="Failed to resolve cached thread for sync redaction",
-                resolution_context=resolution_context,
-            )
-            thread_id = impact.thread_id
-            redacted = await self._cache_ops.redact_cached_event(
-                room_id,
-                redacted_event_id,
-                thread_id=thread_id,
-                failure_message="Failed to apply sync redaction to cache",
-            )
-            if impact.state is MutationThreadImpactState.UNKNOWN:
-                if redacted and not room_threads_invalidated:
-                    await self._cache_ops.invalidate_room_threads(
-                        room_id,
-                        reason="sync_redaction_lookup_unavailable",
-                    )
-                    room_threads_invalidated = True
-                continue
-            await self._cache_ops.invalidate_after_redaction(
-                room_id,
-                impact=impact,
-                redacted=redacted,
-                success_reason="sync_redaction",
-                failure_reason="sync_redaction_failed",
-                lookup_unavailable_reason="sync_redaction_lookup_unavailable",
+            room_threads_invalidated = (
+                await _apply_thread_redaction_mutation(
+                    cache_ops=self._cache_ops,
+                    resolver=self._resolver,
+                    room_id=room_id,
+                    redacted_event_id=redacted_event_id,
+                    context="sync",
+                    reason_prefix="sync",
+                    resolution_context=resolution_context,
+                    allow_room_invalidation=not room_threads_invalidated,
+                )
+                or room_threads_invalidated
             )
 
     async def _persist_room_sync_timeline_updates(

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 import typing
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import nio
 
@@ -16,6 +16,7 @@ from mindroom.matrix.cache.event_cache_events import (
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.thread_bookkeeping import (
     MutationResolutionContext,
+    MutationThreadImpact,
     MutationThreadImpactState,
     ThreadMutationResolver,
     is_thread_affecting_relation,
@@ -25,6 +26,9 @@ if TYPE_CHECKING:
     from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
 
 __all__ = ["_collect_sync_timeline_cache_updates"]
+
+
+MutationWriteContext = Literal["outbound", "live", "sync"]
 
 
 def _collect_sync_timeline_cache_updates(
@@ -82,34 +86,47 @@ def _threaded_sync_event_cache_update(
     return room_id, normalize_nio_event_for_cache(event)
 
 
-async def _apply_thread_message_mutation(
+def _mutation_reason(
+    context: MutationWriteContext,
+    suffix: str,
+) -> str:
+    return f"{context}_{suffix}"
+
+
+async def _resolve_thread_message_mutation_impact(
     *,
-    cache_ops: ThreadMutationCacheOps,
     resolver: ThreadMutationResolver,
     room_id: str,
     event_info: EventInfo,
-    event_source: dict[str, Any],
     event_id: str | None,
-    context: str,
-    reason_prefix: str,
-    invalidate_on_append_failure: bool,
+    context: MutationWriteContext,
     resolution_context: MutationResolutionContext | None = None,
-    allow_room_invalidation: bool = True,
-) -> bool:
-    impact = await resolver.resolve_thread_impact_for_mutation(
+) -> MutationThreadImpact:
+    return await resolver.resolve_thread_impact_for_mutation(
         room_id,
         event_info=event_info,
         event_id=event_id,
         context=context,
         resolution_context=resolution_context,
     )
+
+
+async def _apply_thread_message_mutation(
+    *,
+    cache_ops: ThreadMutationCacheOps,
+    room_id: str,
+    event_info: EventInfo,
+    impact: MutationThreadImpact,
+    event_source: dict[str, Any] | None,
+    event_id: str | None,
+    context: MutationWriteContext,
+    room_level_skip_message: str,
+    invalidate_on_append_failure: bool,
+    allow_room_invalidation: bool = True,
+) -> bool:
     if impact.state is MutationThreadImpactState.ROOM_LEVEL:
         cache_ops.logger.debug(
-            (
-                "Skipping outbound thread cache bookkeeping for non-threaded event mutation"
-                if context == "outbound"
-                else f"Skipping {context} thread cache bookkeeping for known non-threaded message mutation"
-            ),
+            room_level_skip_message,
             room_id=room_id,
             event_id=event_id,
             original_event_id=event_info.original_event_id,
@@ -120,14 +137,15 @@ async def _apply_thread_message_mutation(
             return False
         await cache_ops.invalidate_room_threads(
             room_id,
-            reason=f"{reason_prefix}_thread_lookup_unavailable",
+            reason=_mutation_reason(context, "thread_lookup_unavailable"),
         )
         return True
     assert impact.thread_id is not None
+    assert event_source is not None
     await cache_ops.invalidate_known_thread(
         room_id,
         impact.thread_id,
-        reason=f"{reason_prefix}_thread_mutation",
+        reason=_mutation_reason(context, "thread_mutation"),
     )
     appended = await cache_ops.append_event_to_cache(
         room_id,
@@ -139,41 +157,49 @@ async def _apply_thread_message_mutation(
         await cache_ops.invalidate_known_thread(
             room_id,
             impact.thread_id,
-            reason=f"{reason_prefix}_append_failed",
+            reason=_mutation_reason(context, "append_failed"),
         )
     return False
 
 
-async def _apply_thread_redaction_mutation(
+async def _resolve_thread_redaction_mutation_impact(
     *,
-    cache_ops: ThreadMutationCacheOps,
     resolver: ThreadMutationResolver,
     room_id: str,
     redacted_event_id: str,
-    context: str,
-    reason_prefix: str,
+    context: MutationWriteContext,
     event_id: str | None = None,
     resolution_context: MutationResolutionContext | None = None,
-    allow_room_invalidation: bool = True,
-    redact_room_level_event: bool = True,
-) -> bool:
+) -> MutationThreadImpact:
     lookup_failure_message = {
         "outbound": "Ignoring outbound Matrix redaction cache lookup failure after successful redact",
         "live": "Failed to resolve cached thread for redaction",
         "sync": "Failed to resolve cached thread for sync redaction",
     }[context]
-    redact_failure_message = {
-        "outbound": "Ignoring outbound Matrix redaction cache bookkeeping failure after successful redact",
-        "live": "Failed to apply live redaction to cache",
-        "sync": "Failed to apply sync redaction to cache",
-    }[context]
-    impact = await resolver.resolve_redaction_thread_impact(
+    return await resolver.resolve_redaction_thread_impact(
         room_id,
         redacted_event_id,
         failure_message=lookup_failure_message,
         event_id=event_id,
         resolution_context=resolution_context,
     )
+
+
+async def _apply_thread_redaction_mutation(
+    *,
+    cache_ops: ThreadMutationCacheOps,
+    room_id: str,
+    redacted_event_id: str,
+    impact: MutationThreadImpact,
+    context: MutationWriteContext,
+    allow_room_invalidation: bool = True,
+    redact_room_level_event: bool = True,
+) -> bool:
+    redact_failure_message = {
+        "outbound": "Ignoring outbound Matrix redaction cache bookkeeping failure after successful redact",
+        "live": "Failed to apply live redaction to cache",
+        "sync": "Failed to apply sync redaction to cache",
+    }[context]
     if impact.state is MutationThreadImpactState.ROOM_LEVEL and not redact_room_level_event:
         cache_ops.logger.debug(
             "Skipping outbound thread cache bookkeeping for non-threaded redaction",
@@ -193,9 +219,9 @@ async def _apply_thread_redaction_mutation(
         room_id,
         impact=impact,
         redacted=redacted,
-        success_reason=f"{reason_prefix}_redaction",
-        failure_reason=f"{reason_prefix}_redaction_failed",
-        lookup_unavailable_reason=f"{reason_prefix}_redaction_lookup_unavailable",
+        success_reason=_mutation_reason(context, "redaction"),
+        failure_reason=_mutation_reason(context, "redaction_failed"),
+        lookup_unavailable_reason=_mutation_reason(context, "redaction_lookup_unavailable"),
     )
     return impact.state is MutationThreadImpactState.UNKNOWN and redacted
 
@@ -221,15 +247,22 @@ class ThreadOutboundWritePolicy:
         event_source: dict[str, Any],
         event_info: EventInfo,
     ) -> None:
-        await _apply_thread_message_mutation(
-            cache_ops=self._cache_ops,
+        impact = await _resolve_thread_message_mutation_impact(
             resolver=self._resolver,
             room_id=room_id,
             event_info=event_info,
+            event_id=event_id,
+            context="outbound",
+        )
+        await _apply_thread_message_mutation(
+            cache_ops=self._cache_ops,
+            room_id=room_id,
+            event_info=event_info,
+            impact=impact,
             event_source=event_source,
             event_id=event_id,
             context="outbound",
-            reason_prefix="outbound",
+            room_level_skip_message="Skipping outbound thread cache bookkeeping for non-threaded event mutation",
             invalidate_on_append_failure=False,
         )
 
@@ -351,13 +384,18 @@ class ThreadOutboundWritePolicy:
         room_id: str,
         redacted_event_id: str,
     ) -> None:
-        await _apply_thread_redaction_mutation(
-            cache_ops=self._cache_ops,
+        impact = await _resolve_thread_redaction_mutation_impact(
             resolver=self._resolver,
             room_id=room_id,
             redacted_event_id=redacted_event_id,
             context="outbound",
-            reason_prefix="outbound",
+        )
+        await _apply_thread_redaction_mutation(
+            cache_ops=self._cache_ops,
+            room_id=room_id,
+            redacted_event_id=redacted_event_id,
+            impact=impact,
+            context="outbound",
             redact_room_level_event=False,
         )
 
@@ -469,18 +507,40 @@ class ThreadLiveWritePolicy:
         if not self._cache_ops.cache_runtime_available():
             return
 
+        impact = await _resolve_thread_message_mutation_impact(
+            resolver=self._resolver,
+            room_id=room_id,
+            event_info=event_info,
+            event_id=event.event_id,
+            context="live",
+        )
+        room_level_skip_message = "Skipping live thread cache bookkeeping for known non-threaded message mutation"
+        if impact.state is not MutationThreadImpactState.THREADED:
+            await _apply_thread_message_mutation(
+                cache_ops=self._cache_ops,
+                room_id=room_id,
+                event_info=event_info,
+                impact=impact,
+                event_source=None,
+                event_id=event.event_id,
+                context="live",
+                room_level_skip_message=room_level_skip_message,
+                invalidate_on_append_failure=True,
+            )
+            return
+
         event_source = normalize_nio_event_for_cache(event)
 
         async def append_and_invalidate() -> bool:
             return await _apply_thread_message_mutation(
                 cache_ops=self._cache_ops,
-                resolver=self._resolver,
                 room_id=room_id,
                 event_info=event_info,
+                impact=impact,
                 event_source=event_source,
                 event_id=event.event_id,
                 context="live",
-                reason_prefix="live",
+                room_level_skip_message=room_level_skip_message,
                 invalidate_on_append_failure=True,
             )
 
@@ -495,15 +555,30 @@ class ThreadLiveWritePolicy:
         if not self._cache_ops.cache_runtime_available():
             return
 
+        impact = await _resolve_thread_redaction_mutation_impact(
+            resolver=self._resolver,
+            room_id=room_id,
+            redacted_event_id=event.redacts,
+            event_id=event.event_id,
+            context="live",
+        )
+        if impact.state is not MutationThreadImpactState.THREADED:
+            await _apply_thread_redaction_mutation(
+                cache_ops=self._cache_ops,
+                room_id=room_id,
+                redacted_event_id=event.redacts,
+                impact=impact,
+                context="live",
+            )
+            return
+
         async def redact_and_invalidate() -> bool:
             return await _apply_thread_redaction_mutation(
                 cache_ops=self._cache_ops,
-                resolver=self._resolver,
                 room_id=room_id,
                 redacted_event_id=event.redacts,
-                event_id=event.event_id,
+                impact=impact,
                 context="live",
-                reason_prefix="live",
             )
 
         await self._cache_ops.queue_room_cache_update(
@@ -536,18 +611,25 @@ class ThreadSyncWritePolicy:
         for event_source in threaded_events:
             event_info = EventInfo.from_event(event_source)
             event_id = event_source.get("event_id")
+            impact = await _resolve_thread_message_mutation_impact(
+                resolver=self._resolver,
+                room_id=room_id,
+                event_info=event_info,
+                event_id=event_id if isinstance(event_id, str) else None,
+                context="sync",
+                resolution_context=resolution_context,
+            )
             room_threads_invalidated = (
                 await _apply_thread_message_mutation(
                     cache_ops=self._cache_ops,
-                    resolver=self._resolver,
                     room_id=room_id,
                     event_info=event_info,
+                    impact=impact,
                     event_source=event_source,
                     event_id=event_id if isinstance(event_id, str) else None,
                     context="sync",
-                    reason_prefix="sync",
+                    room_level_skip_message="Skipping sync thread cache bookkeeping for known non-threaded message mutation",
                     invalidate_on_append_failure=True,
-                    resolution_context=resolution_context,
                     allow_room_invalidation=not room_threads_invalidated,
                 )
                 or room_threads_invalidated
@@ -562,15 +644,20 @@ class ThreadSyncWritePolicy:
     ) -> None:
         room_threads_invalidated = False
         for redacted_event_id in redacted_event_ids:
+            impact = await _resolve_thread_redaction_mutation_impact(
+                resolver=self._resolver,
+                room_id=room_id,
+                redacted_event_id=redacted_event_id,
+                context="sync",
+                resolution_context=resolution_context,
+            )
             room_threads_invalidated = (
                 await _apply_thread_redaction_mutation(
                     cache_ops=self._cache_ops,
-                    resolver=self._resolver,
                     room_id=room_id,
                     redacted_event_id=redacted_event_id,
+                    impact=impact,
                     context="sync",
-                    reason_prefix="sync",
-                    resolution_context=resolution_context,
                     allow_room_invalidation=not room_threads_invalidated,
                 )
                 or room_threads_invalidated

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 import typing
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 import nio
 
@@ -18,6 +18,7 @@ from mindroom.matrix.thread_bookkeeping import (
     MutationResolutionContext,
     MutationThreadImpact,
     MutationThreadImpactState,
+    MutationWriteContext,
     ThreadMutationResolver,
     is_thread_affecting_relation,
 )
@@ -26,9 +27,6 @@ if TYPE_CHECKING:
     from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
 
 __all__ = ["_collect_sync_timeline_cache_updates"]
-
-
-MutationWriteContext = Literal["outbound", "live", "sync"]
 
 
 def _collect_sync_timeline_cache_updates(
@@ -91,24 +89,6 @@ def _mutation_reason(
     suffix: str,
 ) -> str:
     return f"{context}_{suffix}"
-
-
-async def _resolve_thread_message_mutation_impact(
-    *,
-    resolver: ThreadMutationResolver,
-    room_id: str,
-    event_info: EventInfo,
-    event_id: str | None,
-    context: MutationWriteContext,
-    resolution_context: MutationResolutionContext | None = None,
-) -> MutationThreadImpact:
-    return await resolver.resolve_thread_impact_for_mutation(
-        room_id,
-        event_info=event_info,
-        event_id=event_id,
-        context=context,
-        resolution_context=resolution_context,
-    )
 
 
 async def _apply_thread_message_mutation(
@@ -247,9 +227,8 @@ class ThreadOutboundWritePolicy:
         event_source: dict[str, Any],
         event_info: EventInfo,
     ) -> None:
-        impact = await _resolve_thread_message_mutation_impact(
-            resolver=self._resolver,
-            room_id=room_id,
+        impact = await self._resolver.resolve_thread_impact_for_mutation(
+            room_id,
             event_info=event_info,
             event_id=event_id,
             context="outbound",
@@ -507,9 +486,8 @@ class ThreadLiveWritePolicy:
         if not self._cache_ops.cache_runtime_available():
             return
 
-        impact = await _resolve_thread_message_mutation_impact(
-            resolver=self._resolver,
-            room_id=room_id,
+        impact = await self._resolver.resolve_thread_impact_for_mutation(
+            room_id,
             event_info=event_info,
             event_id=event.event_id,
             context="live",
@@ -602,9 +580,8 @@ class ThreadSyncWritePolicy:
         for event_source in threaded_events:
             event_info = EventInfo.from_event(event_source)
             event_id = event_source.get("event_id")
-            impact = await _resolve_thread_message_mutation_impact(
-                resolver=self._resolver,
-                room_id=room_id,
+            impact = await self._resolver.resolve_thread_impact_for_mutation(
+                room_id,
                 event_info=event_info,
                 event_id=event_id if isinstance(event_id, str) else None,
                 context="sync",

--- a/src/mindroom/matrix/thread_bookkeeping.py
+++ b/src/mindroom/matrix/thread_bookkeeping.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.thread_membership import (
@@ -254,7 +254,7 @@ class ThreadMutationResolver:
         *,
         event_info: EventInfo,
         event_id: str | None,
-        context: str,
+        context: Literal["outbound", "live", "sync"],
         resolution_context: MutationResolutionContext | None = None,
     ) -> MutationThreadImpact:
         """Resolve how one message mutation should affect thread cache state."""

--- a/src/mindroom/matrix/thread_bookkeeping.py
+++ b/src/mindroom/matrix/thread_bookkeeping.py
@@ -39,6 +39,9 @@ if TYPE_CHECKING:
     from mindroom.bot_runtime_view import BotRuntimeView
 
 
+MutationWriteContext = Literal["outbound", "live", "sync"]
+
+
 def is_thread_affecting_relation(event_info: EventInfo) -> bool:
     """Return whether one room message relation can affect thread-scoped cache state."""
     return (
@@ -254,7 +257,7 @@ class ThreadMutationResolver:
         *,
         event_info: EventInfo,
         event_id: str | None,
-        context: Literal["outbound", "live", "sync"],
+        context: MutationWriteContext,
         resolution_context: MutationResolutionContext | None = None,
     ) -> MutationThreadImpact:
         """Resolve how one message mutation should affect thread cache state."""

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -2116,6 +2116,68 @@ class TestThreadingBehavior:
         bot.client.room_messages.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_cache_sync_timeline_unknown_redactions_invalidate_room_threads_once(self, bot: AgentBot) -> None:
+        """Sync redaction fallback should stale-mark the room once even when multiple lookups miss in one batch."""
+        event_cache = _runtime_event_cache()
+        event_cache.store_events_batch = AsyncMock()
+        event_cache.redact_event = AsyncMock(return_value=True)
+        event_cache.get_thread_id_for_event = AsyncMock(return_value=None)
+        event_cache.get_event = AsyncMock(return_value=None)
+        bot.event_cache = event_cache
+        bot.client = _make_client_mock()
+        bot.client.room_get_event = AsyncMock(return_value=MagicMock())
+        _install_runtime_write_coordinator(bot)
+
+        first_redaction_event = MagicMock(spec=nio.RedactionEvent)
+        first_redaction_event.event_id = "$redaction-1:localhost"
+        first_redaction_event.redacts = "$missing-room-msg-1:localhost"
+        first_redaction_event.sender = "@user:localhost"
+        first_redaction_event.server_timestamp = 1234567891
+        first_redaction_event.source = {
+            "content": {},
+            "event_id": "$redaction-1:localhost",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1234567891,
+            "redacts": "$missing-room-msg-1:localhost",
+            "room_id": "!test:localhost",
+            "type": "m.room.redaction",
+        }
+        second_redaction_event = MagicMock(spec=nio.RedactionEvent)
+        second_redaction_event.event_id = "$redaction-2:localhost"
+        second_redaction_event.redacts = "$missing-room-msg-2:localhost"
+        second_redaction_event.sender = "@user:localhost"
+        second_redaction_event.server_timestamp = 1234567892
+        second_redaction_event.source = {
+            "content": {},
+            "event_id": "$redaction-2:localhost",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1234567892,
+            "redacts": "$missing-room-msg-2:localhost",
+            "room_id": "!test:localhost",
+            "type": "m.room.redaction",
+        }
+        sync_response = MagicMock()
+        sync_response.__class__ = nio.SyncResponse
+        sync_response.rooms = MagicMock()
+        sync_response.rooms.join = {
+            "!test:localhost": MagicMock(
+                timeline=MagicMock(events=[first_redaction_event, second_redaction_event]),
+            ),
+        }
+
+        bot._conversation_cache.cache_sync_timeline(sync_response)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+        assert event_cache.redact_event.await_args_list == [
+            call("!test:localhost", "$missing-room-msg-1:localhost"),
+            call("!test:localhost", "$missing-room-msg-2:localhost"),
+        ]
+        event_cache.mark_room_threads_stale.assert_awaited_once_with(
+            "!test:localhost",
+            reason="sync_redaction_lookup_unavailable",
+        )
+
+    @pytest.mark.asyncio
     async def test_cache_sync_timeline_serializes_same_room_updates_in_order(self, bot: AgentBot) -> None:
         """Later sync updates for one room should wait for earlier queued cache writes."""
         store_started = asyncio.Event()
@@ -2758,6 +2820,120 @@ class TestThreadingBehavior:
         allow_resolve.set()
         await live_task
         await coordinator.wait_for_room_idle("!test:localhost")
+
+    @pytest.mark.asyncio
+    async def test_live_redaction_resolution_does_not_block_same_room_read(self) -> None:
+        """A same-room read must not wait on live redaction resolution before the queued cache write starts."""
+        coordinator = _runtime_write_coordinator()
+        event_cache = _runtime_event_cache()
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(
+                client=_make_client_mock(),
+                event_cache=event_cache,
+                coordinator=coordinator,
+            ),
+        )
+        resolve_started = asyncio.Event()
+        allow_resolve = asyncio.Event()
+        read_finished = asyncio.Event()
+
+        async def slow_resolve(*_args: object, **_kwargs: object) -> MutationThreadImpact:
+            resolve_started.set()
+            await allow_resolve.wait()
+            return MutationThreadImpact.room_level()
+
+        async def quick_snapshot(_room_id: str, _thread_id: str) -> ThreadHistoryResult:
+            read_finished.set()
+            return thread_history_result(
+                [_message(event_id="$other-thread:localhost", body="Root")],
+                is_full_history=True,
+            )
+
+        access._live._resolver.resolve_redaction_thread_impact = AsyncMock(side_effect=slow_resolve)
+        access._reads.fetch_thread_snapshot_from_client = AsyncMock(side_effect=quick_snapshot)
+        event_cache.redact_event = AsyncMock(return_value=True)
+
+        redaction_event = MagicMock(spec=nio.RedactionEvent)
+        redaction_event.event_id = "$redaction:localhost"
+        redaction_event.redacts = "$room-message:localhost"
+        redaction_event.source = {
+            "content": {},
+            "event_id": "$redaction:localhost",
+            "origin_server_ts": 1234567891,
+            "redacts": "$room-message:localhost",
+            "room_id": "!test:localhost",
+            "sender": "@user:localhost",
+            "type": "m.room.redaction",
+        }
+
+        live_task = asyncio.create_task(access.apply_redaction("!test:localhost", redaction_event))
+        await asyncio.wait_for(resolve_started.wait(), timeout=1.0)
+
+        read_task = asyncio.create_task(access.get_thread_snapshot("!test:localhost", "$other-thread:localhost"))
+        await asyncio.wait_for(read_finished.wait(), timeout=1.0)
+        await asyncio.wait_for(asyncio.shield(read_task), timeout=0.1)
+
+        allow_resolve.set()
+        await live_task
+        await coordinator.wait_for_room_idle("!test:localhost")
+
+        event_cache.redact_event.assert_awaited_once_with("!test:localhost", "$room-message:localhost")
+
+    @pytest.mark.asyncio
+    async def test_live_room_level_redaction_waits_for_same_room_write_barrier(self) -> None:
+        """Live room-level redactions should still run under the room write barrier."""
+        coordinator = _runtime_write_coordinator()
+        event_cache = _runtime_event_cache()
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(
+                client=_make_client_mock(),
+                event_cache=event_cache,
+                coordinator=coordinator,
+            ),
+        )
+        prior_write_started = asyncio.Event()
+        allow_prior_write_finish = asyncio.Event()
+
+        async def slow_prior_room_update() -> None:
+            prior_write_started.set()
+            await allow_prior_write_finish.wait()
+
+        access._live._resolver.resolve_redaction_thread_impact = AsyncMock(
+            return_value=MutationThreadImpact.room_level(),
+        )
+        event_cache.redact_event = AsyncMock(return_value=True)
+
+        coordinator.queue_room_update(
+            "!test:localhost",
+            slow_prior_room_update,
+            name="matrix_cache_prior_update",
+        )
+        await asyncio.wait_for(prior_write_started.wait(), timeout=1.0)
+
+        redaction_event = MagicMock(spec=nio.RedactionEvent)
+        redaction_event.event_id = "$redaction:localhost"
+        redaction_event.redacts = "$room-message:localhost"
+        redaction_event.source = {
+            "content": {},
+            "event_id": "$redaction:localhost",
+            "origin_server_ts": 1234567891,
+            "redacts": "$room-message:localhost",
+            "room_id": "!test:localhost",
+            "sender": "@user:localhost",
+            "type": "m.room.redaction",
+        }
+
+        live_task = asyncio.create_task(access.apply_redaction("!test:localhost", redaction_event))
+        await asyncio.sleep(0)
+        event_cache.redact_event.assert_not_awaited()
+
+        allow_prior_write_finish.set()
+        await live_task
+        await coordinator.wait_for_room_idle("!test:localhost")
+
+        event_cache.redact_event.assert_awaited_once_with("!test:localhost", "$room-message:localhost")
 
     @pytest.mark.asyncio
     async def test_live_plain_reply_to_threaded_event_persists_event_thread_membership(

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -39,7 +39,12 @@ from mindroom.matrix.cache.thread_history_result import (
 from mindroom.matrix.cache.thread_history_result import (
     thread_history_result as _thread_history_result_impl,
 )
-from mindroom.matrix.cache.thread_writes import _collect_sync_timeline_cache_updates
+from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
+from mindroom.matrix.cache.thread_writes import (
+    _apply_thread_message_mutation,
+    _apply_thread_redaction_mutation,
+    _collect_sync_timeline_cache_updates,
+)
 from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
 from mindroom.matrix.client import (
     DeliveredMatrixEvent,
@@ -49,6 +54,7 @@ from mindroom.matrix.client import (
 from mindroom.matrix.conversation_cache import MatrixConversationCache
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.message_content import _clear_mxc_cache
+from mindroom.matrix.thread_bookkeeping import MutationThreadImpact
 from mindroom.matrix.thread_membership import (
     ThreadMembershipAccess,
     ThreadRootProof,
@@ -262,6 +268,40 @@ def _runtime_write_coordinator() -> _EventCacheWriteCoordinator:
     )
 
 
+def _thread_mutation_cache_ops() -> tuple[ThreadMutationCacheOps, MagicMock, MagicMock]:
+    """Return concrete thread cache ops backed by one async-mock event cache."""
+    logger = MagicMock()
+    event_cache = MagicMock()
+    event_cache.append_event = AsyncMock(return_value=True)
+    event_cache.disable = Mock()
+    event_cache.invalidate_room_threads = AsyncMock()
+    event_cache.invalidate_thread = AsyncMock()
+    event_cache.mark_room_threads_stale = AsyncMock()
+    event_cache.mark_thread_stale = AsyncMock()
+    event_cache.redact_event = AsyncMock(return_value=True)
+    event_cache.revalidate_thread_after_incremental_update = AsyncMock()
+    runtime = MagicMock()
+    runtime.event_cache = event_cache
+    runtime.event_cache_write_coordinator = _runtime_write_coordinator()
+    runtime.runtime_started_at = 1234567890.0
+    return ThreadMutationCacheOps(logger_getter=lambda: logger, runtime=runtime), logger, event_cache
+
+
+def _message_mutation_event_info(*, original_event_id: str = "$target:localhost") -> EventInfo:
+    """Return one thread-affecting event info for direct mutation-helper tests."""
+    return EventInfo.from_event(
+        {
+            "type": "m.room.message",
+            "content": {
+                "body": "* updated",
+                "msgtype": "m.text",
+                "m.new_content": {"body": "updated", "msgtype": "m.text"},
+                "m.relates_to": {"rel_type": "m.replace", "event_id": original_event_id},
+            },
+        },
+    )
+
+
 async def _reopen_event_cache(event_cache: _EventCache) -> _EventCache:
     """Close and reopen one SQLite cache against the same database file."""
     db_path = event_cache.db_path
@@ -335,6 +375,276 @@ def test_matrix_cache_package_does_not_export_thread_policy_wrappers() -> None:
     assert not hasattr(matrix_cache, "_ThreadOutboundWritePolicy")
     assert not hasattr(matrix_cache, "_ThreadLiveWritePolicy")
     assert not hasattr(matrix_cache, "_ThreadSyncWritePolicy")
+
+
+class TestThreadMutationHelpers:
+    """Direct mutation-helper coverage for outbound/live/sync message and redaction paths."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("context", "invalidate_on_append_failure"),
+        [
+            ("outbound", False),
+            ("live", True),
+            ("sync", True),
+        ],
+    )
+    async def test_thread_message_mutation_room_level_skips_invalidation(
+        self,
+        context: str,
+        invalidate_on_append_failure: bool,
+    ) -> None:
+        """Room-level message mutations should only log and leave thread state untouched."""
+        cache_ops, logger, event_cache = _thread_mutation_cache_ops()
+
+        result = await _apply_thread_message_mutation(
+            cache_ops=cache_ops,
+            room_id="!room:localhost",
+            event_info=_message_mutation_event_info(),
+            impact=MutationThreadImpact.room_level(),
+            event_source=None,
+            event_id="$event:localhost",
+            context=context,
+            room_level_skip_message=f"skip-{context}",
+            invalidate_on_append_failure=invalidate_on_append_failure,
+        )
+
+        assert result is False
+        logger.debug.assert_called_once_with(
+            f"skip-{context}",
+            room_id="!room:localhost",
+            event_id="$event:localhost",
+            original_event_id="$target:localhost",
+        )
+        event_cache.append_event.assert_not_awaited()
+        event_cache.mark_room_threads_stale.assert_not_awaited()
+        event_cache.mark_thread_stale.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("context", "invalidate_on_append_failure"),
+        [
+            ("outbound", False),
+            ("live", True),
+            ("sync", True),
+        ],
+    )
+    async def test_thread_message_mutation_unknown_invalidates_room_once(
+        self,
+        context: str,
+        invalidate_on_append_failure: bool,
+    ) -> None:
+        """Unknown message mutations should fail closed with one room-thread invalidation."""
+        cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
+
+        result = await _apply_thread_message_mutation(
+            cache_ops=cache_ops,
+            room_id="!room:localhost",
+            event_info=_message_mutation_event_info(),
+            impact=MutationThreadImpact.unknown(),
+            event_source=None,
+            event_id="$event:localhost",
+            context=context,
+            room_level_skip_message=f"skip-{context}",
+            invalidate_on_append_failure=invalidate_on_append_failure,
+        )
+
+        assert result is True
+        event_cache.append_event.assert_not_awaited()
+        event_cache.mark_room_threads_stale.assert_awaited_once_with(
+            "!room:localhost",
+            reason=f"{context}_thread_lookup_unavailable",
+        )
+        event_cache.mark_thread_stale.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("context", "invalidate_on_append_failure"),
+        [
+            ("outbound", False),
+            ("live", True),
+            ("sync", True),
+        ],
+    )
+    async def test_thread_message_mutation_threaded_success_uses_context_reasons(
+        self,
+        context: str,
+        invalidate_on_append_failure: bool,
+    ) -> None:
+        """Threaded message mutations should stale-mark once, append, and avoid room invalidation."""
+        cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
+        event_source = {"event_id": "$event:localhost"}
+
+        result = await _apply_thread_message_mutation(
+            cache_ops=cache_ops,
+            room_id="!room:localhost",
+            event_info=_message_mutation_event_info(),
+            impact=MutationThreadImpact.threaded("$thread:localhost"),
+            event_source=event_source,
+            event_id="$event:localhost",
+            context=context,
+            room_level_skip_message=f"skip-{context}",
+            invalidate_on_append_failure=invalidate_on_append_failure,
+        )
+
+        assert result is False
+        event_cache.append_event.assert_awaited_once_with(
+            "!room:localhost",
+            "$thread:localhost",
+            event_source,
+        )
+        event_cache.mark_room_threads_stale.assert_not_awaited()
+        event_cache.mark_thread_stale.assert_awaited_once_with(
+            "!room:localhost",
+            "$thread:localhost",
+            reason=f"{context}_thread_mutation",
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("context", "invalidate_on_append_failure", "expected_reasons"),
+        [
+            ("outbound", False, ["outbound_thread_mutation"]),
+            ("live", True, ["live_thread_mutation", "live_append_failed"]),
+            ("sync", True, ["sync_thread_mutation", "sync_append_failed"]),
+        ],
+    )
+    async def test_thread_message_mutation_threaded_append_failure_uses_path_policy(
+        self,
+        context: str,
+        invalidate_on_append_failure: bool,
+        expected_reasons: list[str],
+    ) -> None:
+        """Append failures should only add the extra stale mark on the live and sync paths."""
+        cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
+        event_cache.append_event = AsyncMock(return_value=False)
+
+        result = await _apply_thread_message_mutation(
+            cache_ops=cache_ops,
+            room_id="!room:localhost",
+            event_info=_message_mutation_event_info(),
+            impact=MutationThreadImpact.threaded("$thread:localhost"),
+            event_source={"event_id": "$event:localhost"},
+            event_id="$event:localhost",
+            context=context,
+            room_level_skip_message=f"skip-{context}",
+            invalidate_on_append_failure=invalidate_on_append_failure,
+        )
+
+        assert result is False
+        assert event_cache.mark_thread_stale.await_args_list == [
+            call("!room:localhost", "$thread:localhost", reason=reason) for reason in expected_reasons
+        ]
+        event_cache.mark_room_threads_stale.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("context", "redact_room_level_event"),
+        [
+            ("outbound", False),
+            ("live", True),
+            ("sync", True),
+        ],
+    )
+    async def test_thread_redaction_mutation_room_level_skips_thread_invalidations(
+        self,
+        context: str,
+        redact_room_level_event: bool,
+    ) -> None:
+        """Room-level redactions should never stale-mark thread state."""
+        cache_ops, logger, event_cache = _thread_mutation_cache_ops()
+
+        result = await _apply_thread_redaction_mutation(
+            cache_ops=cache_ops,
+            room_id="!room:localhost",
+            redacted_event_id="$target:localhost",
+            impact=MutationThreadImpact.room_level(),
+            context=context,
+            redact_room_level_event=redact_room_level_event,
+        )
+
+        assert result is False
+        event_cache.mark_room_threads_stale.assert_not_awaited()
+        event_cache.mark_thread_stale.assert_not_awaited()
+        if redact_room_level_event:
+            event_cache.redact_event.assert_awaited_once_with("!room:localhost", "$target:localhost")
+            logger.debug.assert_not_called()
+        else:
+            event_cache.redact_event.assert_not_awaited()
+            logger.debug.assert_called_once_with(
+                "Skipping outbound thread cache bookkeeping for non-threaded redaction",
+                room_id="!room:localhost",
+                redacted_event_id="$target:localhost",
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("context", ["outbound", "live", "sync"])
+    async def test_thread_redaction_mutation_unknown_invalidates_room_once(self, context: str) -> None:
+        """Unknown redactions should fail closed with one room-thread invalidation."""
+        cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
+
+        result = await _apply_thread_redaction_mutation(
+            cache_ops=cache_ops,
+            room_id="!room:localhost",
+            redacted_event_id="$target:localhost",
+            impact=MutationThreadImpact.unknown(),
+            context=context,
+        )
+
+        assert result is True
+        event_cache.mark_room_threads_stale.assert_awaited_once_with(
+            "!room:localhost",
+            reason=f"{context}_redaction_lookup_unavailable",
+        )
+        event_cache.mark_thread_stale.assert_not_awaited()
+        event_cache.redact_event.assert_awaited_once_with("!room:localhost", "$target:localhost")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("context", ["outbound", "live", "sync"])
+    async def test_thread_redaction_mutation_threaded_success_uses_context_reason(self, context: str) -> None:
+        """Threaded redactions should stale-mark the owning thread once on success."""
+        cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
+
+        result = await _apply_thread_redaction_mutation(
+            cache_ops=cache_ops,
+            room_id="!room:localhost",
+            redacted_event_id="$target:localhost",
+            impact=MutationThreadImpact.threaded("$thread:localhost"),
+            context=context,
+        )
+
+        assert result is False
+        event_cache.mark_room_threads_stale.assert_not_awaited()
+        event_cache.mark_thread_stale.assert_awaited_once_with(
+            "!room:localhost",
+            "$thread:localhost",
+            reason=f"{context}_redaction",
+        )
+        event_cache.redact_event.assert_awaited_once_with("!room:localhost", "$target:localhost")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("context", ["outbound", "live", "sync"])
+    async def test_thread_redaction_mutation_threaded_failure_uses_failure_reason(self, context: str) -> None:
+        """Threaded redaction failures should stale-mark once with the failure reason."""
+        cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
+        event_cache.redact_event = AsyncMock(return_value=False)
+
+        result = await _apply_thread_redaction_mutation(
+            cache_ops=cache_ops,
+            room_id="!room:localhost",
+            redacted_event_id="$target:localhost",
+            impact=MutationThreadImpact.threaded("$thread:localhost"),
+            context=context,
+        )
+
+        assert result is False
+        event_cache.mark_room_threads_stale.assert_not_awaited()
+        event_cache.mark_thread_stale.assert_awaited_once_with(
+            "!room:localhost",
+            "$thread:localhost",
+            reason=f"{context}_redaction_failed",
+        )
+        event_cache.redact_event.assert_awaited_once_with("!room:localhost", "$target:localhost")
 
 
 class TestMatrixConversationCacheThreadReads:
@@ -2384,6 +2694,70 @@ class TestThreadingBehavior:
             reason="live_thread_lookup_unavailable",
         )
         event_cache.append_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_live_message_resolution_does_not_block_same_room_read(self) -> None:
+        """A same-room read must not wait on live mutation resolution before the write is queued."""
+        coordinator = _runtime_write_coordinator()
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(
+                client=_make_client_mock(),
+                event_cache=_runtime_event_cache(),
+                coordinator=coordinator,
+            ),
+        )
+        resolve_started = asyncio.Event()
+        allow_resolve = asyncio.Event()
+        read_finished = asyncio.Event()
+
+        async def slow_resolve(*_args: object, **_kwargs: object) -> MutationThreadImpact:
+            resolve_started.set()
+            await allow_resolve.wait()
+            return MutationThreadImpact.threaded("$mutated-thread:localhost")
+
+        async def quick_snapshot(_room_id: str, _thread_id: str) -> ThreadHistoryResult:
+            read_finished.set()
+            return thread_history_result(
+                [_message(event_id="$other-thread:localhost", body="Root")],
+                is_full_history=True,
+            )
+
+        access._live._resolver.resolve_thread_impact_for_mutation = AsyncMock(side_effect=slow_resolve)
+        access._reads.fetch_thread_snapshot_from_client = AsyncMock(side_effect=quick_snapshot)
+
+        edit_event = nio.RoomMessageText.from_dict(
+            {
+                "content": {
+                    "body": "* updated",
+                    "msgtype": "m.text",
+                    "m.new_content": {"body": "updated", "msgtype": "m.text"},
+                    "m.relates_to": {"rel_type": "m.replace", "event_id": "$thread-msg:localhost"},
+                },
+                "event_id": "$edit-event:localhost",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "room_id": "!test:localhost",
+                "type": "m.room.message",
+            },
+        )
+
+        live_task = asyncio.create_task(
+            access.append_live_event(
+                "!test:localhost",
+                edit_event,
+                event_info=EventInfo.from_event(edit_event.source),
+            ),
+        )
+        await asyncio.wait_for(resolve_started.wait(), timeout=1.0)
+
+        read_task = asyncio.create_task(access.get_thread_snapshot("!test:localhost", "$other-thread:localhost"))
+        await asyncio.wait_for(read_finished.wait(), timeout=1.0)
+        await asyncio.wait_for(asyncio.shield(read_task), timeout=0.1)
+
+        allow_resolve.set()
+        await live_task
+        await coordinator.wait_for_room_idle("!test:localhost")
 
     @pytest.mark.asyncio
     async def test_live_plain_reply_to_threaded_event_persists_event_thread_membership(

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -28,7 +28,8 @@ from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.hooks import EVENT_AGENT_STARTED
-from mindroom.matrix.cache import ThreadHistoryResult
+from mindroom.matrix import thread_bookkeeping
+from mindroom.matrix.cache import ThreadHistoryResult, thread_writes
 from mindroom.matrix.cache.event_cache import ThreadCacheState, _EventCache
 from mindroom.matrix.cache.thread_history_result import (
     THREAD_HISTORY_SOURCE_CACHE,
@@ -375,6 +376,16 @@ def test_matrix_cache_package_does_not_export_thread_policy_wrappers() -> None:
     assert not hasattr(matrix_cache, "_ThreadOutboundWritePolicy")
     assert not hasattr(matrix_cache, "_ThreadLiveWritePolicy")
     assert not hasattr(matrix_cache, "_ThreadSyncWritePolicy")
+
+
+def test_thread_writes_uses_shared_mutation_write_context_alias() -> None:
+    """Thread writes should reuse the shared mutation-write context alias."""
+    assert thread_writes.MutationWriteContext is thread_bookkeeping.MutationWriteContext
+
+
+def test_thread_writes_does_not_keep_message_impact_wrapper() -> None:
+    """Message-impact resolution should call the resolver directly instead of wrapping it."""
+    assert not hasattr(thread_writes, "_resolve_thread_message_mutation_impact")
 
 
 class TestThreadMutationHelpers:


### PR DESCRIPTION
## Summary
- extract shared helpers for thread message and redaction cache mutations across outbound, live, and sync write paths
- centralize mutation reason naming and impact handling so thread invalidation behavior stays consistent
- extend threading regression coverage for the shared helper paths and review follow-up cases

## Test Plan
- [x] `uv sync --all-extras`
- [x] `uv run pytest`