### PR TITLE
docs: expand plugin documentation with security warning, accurate dependency docs, and community catalog

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4,8 +4,14 @@ icon: lucide/plug-2
 
 # Plugins
 
-MindRoom plugins add tools and can optionally ship skills and [hooks](hooks.md).
-Plugins are loaded from paths listed in `config.yaml`.
+> [!WARNING]
+> **Plugins execute arbitrary Python code in the same process as MindRoom.**
+> A malicious plugin has full access to your credentials, Matrix sessions, file system, and network.
+> Only install plugins you trust and have reviewed.
+
+MindRoom plugins extend agents with custom tools, [hooks](hooks.md), and skills.
+A plugin is a directory with a `mindroom.plugin.json` manifest, one or more Python modules, and optionally skill directories.
+Plugins are loaded from paths listed under `plugins:` in `config.yaml`.
 
 ## Plugin structure
 
@@ -13,15 +19,22 @@ A plugin is a directory containing `mindroom.plugin.json`:
 
 ```
 my-plugin/
-├── mindroom.plugin.json
-├── tools.py
-├── hooks.py
-└── skills/
+├── mindroom.plugin.json   # Required manifest
+├── tools.py               # Tool factories (optional)
+├── hooks.py               # Event hooks (optional)
+└── skills/                # Skill directories (optional)
     └── my-skill/
         └── SKILL.md
 ```
 
+A plugin must have at least one of `tools_module`, `hooks_module`, or `skills`.
+A tools-only plugin exposes callable functions to agents.
+A hooks-only plugin observes or transforms events without adding agent-facing tools.
+Many plugins combine both.
+
 ## Manifest format
+
+The manifest is a JSON file named `mindroom.plugin.json` at the plugin root:
 
 ```json
 {
@@ -32,30 +45,33 @@ my-plugin/
 }
 ```
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `name` | string | Plugin identifier (required, must use only lowercase ASCII letters, digits, `-`, and `_`, and must be unique across configured plugins; invalid or duplicate names abort plugin loading) |
-| `tools_module` | string | Path to the tools module (optional) |
-| `hooks_module` | string | Path to the hooks module relative to the plugin root (optional) |
-| `skills` | list of strings | Relative directories containing skills (optional) |
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | **yes** | Plugin identifier. Must be lowercase ASCII letters, digits, `-`, and `_` only (pattern: `^[a-z0-9_-]+$`). Must be unique across all configured plugins. Invalid or duplicate names abort plugin loading entirely. |
+| `tools_module` | string | no | Relative path to the Python module containing `@register_tool_with_metadata` factories. Must exist on disk if declared. |
+| `hooks_module` | string | no | Relative path to the Python module containing `@hook`-decorated functions. Must exist on disk if declared. |
+| `skills` | list of strings | no | Relative directories containing skill subdirectories (each with a `SKILL.md`). Each directory must exist on disk. |
 
-Unknown fields are ignored.
-Invalid, duplicate, or malformed configured plugin manifests are configuration errors and stop plugin loading.
-Configured plugin paths, declared module files, and declared skill directories must exist.
+Unknown fields are silently ignored.
+Invalid, duplicate, or malformed manifests are configuration errors and stop all plugin loading.
+All declared module files and skill directories must exist on disk.
+
 If `hooks_module` is omitted, MindRoom auto-scans `tools_module` for `@hook`-decorated functions.
 If both fields point at the same file, MindRoom imports it once and reuses it for both tool registration and hook discovery.
 
 ## Configure plugins
 
-Add plugin paths to `config.yaml`:
+Add plugin paths under `plugins:` in `config.yaml`:
 
 ```yaml
 plugins:
   - ./plugins/my-plugin
   - python:my_skill_pack
   - path: ./plugins/personal-context
+    enabled: true
     settings:
       dawarich_url: http://dawarich.local
+      api_key: secret
     hooks:
       enrich_with_location:
         priority: 20
@@ -63,14 +79,53 @@ plugins:
         enabled: false
 ```
 
-Plugin entries can be strings (path only) or objects (with `settings` and per-hook overrides).
+### Entry formats
+
+Plugin entries can be **strings** (path only) or **objects** (with options).
 Both forms can be mixed in the same list.
 
-Paths may be:
+**String entry** — just the path:
 
-- Absolute paths
-- Paths relative to `config.yaml`
-- Python package specs (see below)
+```yaml
+plugins:
+  - ./plugins/my-plugin
+```
+
+**Object entry** — path plus options:
+
+```yaml
+plugins:
+  - path: ./plugins/my-plugin
+    enabled: true
+    settings:
+      api_key: secret
+    hooks:
+      my_hook:
+        enabled: false
+```
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `path` | string | *required* | Plugin path (see resolution rules below) |
+| `enabled` | bool | `true` | Set to `false` to disable the plugin without removing it from the list |
+| `settings` | dict | `{}` | Free-form key-value config passed to the plugin at load time |
+| `hooks` | dict | `{}` | Per-hook overrides keyed by hook function name |
+
+Each hook override supports:
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `enabled` | bool | `true` | Disable a specific hook without removing it from the plugin |
+| `priority` | int | `null` | Override the hook's default execution priority |
+| `timeout_ms` | int | `null` | Override the hook's default timeout |
+
+### Path resolution
+
+Paths are resolved in this order:
+
+1. **Absolute paths** — used as-is
+2. **Relative paths** — resolved relative to the directory containing `config.yaml`
+3. **Python package specs** — see below
 
 ## Python package plugins
 
@@ -86,17 +141,211 @@ plugins:
 
 Rules:
 
-- A bare package name is allowed if it contains no slashes.
-- `python:`, `pkg:`, and `module:` are explicit prefixes.
-- `:sub/path` points to a subdirectory inside the package.
+- A bare package name (no slashes, no `.` or `..` prefix) is tried as a Python package first.
+- `python:`, `pkg:`, and `module:` are explicit prefixes that force package resolution.
+- `:sub/path` after the package name points to a subdirectory inside the package.
 
-MindRoom resolves the package location and looks for `mindroom.plugin.json` in that directory.
+MindRoom resolves the package location via `importlib` and looks for `mindroom.plugin.json` in that directory.
+
+## Tools module
+
+A tools module is a Python file that registers one or more tool factories using the `@register_tool_with_metadata` decorator.
+Each factory function returns a **Toolkit class** (not an instance).
+MindRoom instantiates the class when building agents.
+
+### Minimal example
+
+```python
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.tool_system.metadata import (
+    SetupType,
+    ToolCategory,
+    ToolStatus,
+    register_tool_with_metadata,
+)
+
+if TYPE_CHECKING:
+    from agno.tools import Toolkit
+
+
+@register_tool_with_metadata(
+    name="greeter",
+    display_name="Greeter",
+    description="A simple greeting tool",
+    category=ToolCategory.DEVELOPMENT,
+    status=ToolStatus.AVAILABLE,
+    setup_type=SetupType.NONE,
+)
+def greeter_tools() -> type[Toolkit]:
+    from agno.tools import Toolkit
+
+    class GreeterTools(Toolkit):
+        def __init__(self) -> None:
+            super().__init__(name="greeter", tools=[self.greet])
+
+        def greet(self, name: str) -> str:
+            """Greet someone by name."""
+            return f"Hello, {name}!"
+
+    return GreeterTools
+```
+
+After registering the plugin, assign the tool to agents in `config.yaml`:
+
+```yaml
+plugins:
+  - ./plugins/my-greeter
+
+agents:
+  assistant:
+    tools:
+      - greeter
+```
+
+### Decorator fields
+
+All `@register_tool_with_metadata` arguments are keyword-only.
+
+**Required fields:**
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | string | Tool identifier — used to reference the tool in `config.yaml` agent `tools:` lists |
+| `display_name` | string | Human-readable name shown in the dashboard |
+| `description` | string | Brief description of what the tool does |
+| `category` | `ToolCategory` | Category for dashboard grouping (see values below) |
+
+`ToolCategory` values: `COMMUNICATION`, `DEVELOPMENT`, `EMAIL`, `ENTERTAINMENT`, `INFORMATION`, `INTEGRATIONS`, `PRODUCTIVITY`, `RESEARCH`, `SHOPPING`, `SMART_HOME`, `SOCIAL`.
+
+**Optional fields:**
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `status` | `ToolStatus` | `AVAILABLE` | `AVAILABLE` or `REQUIRES_CONFIG` — controls whether the tool appears as ready or needs setup in the dashboard |
+| `setup_type` | `SetupType` | `NONE` | `NONE`, `API_KEY`, `OAUTH`, or `SPECIAL` — tells the dashboard what kind of setup flow to show |
+| `config_fields` | list of `ConfigField` | `None` | Describes constructor parameters configurable through the dashboard (see [ConfigField](#configfield)) |
+| `dependencies` | list of strings | `None` | Python packages the tool requires (see [Dependencies](#dependencies)) |
+| `docs_url` | string | `None` | Link to external documentation |
+| `icon` | string | `None` | Icon name for the dashboard (e.g., `"FaGoogle"`, `"Home"`) |
+| `icon_color` | string | `None` | Tailwind color class for the icon (e.g., `"text-blue-500"`) |
+| `helper_text` | string | `None` | Markdown help text shown in the dashboard setup panel |
+| `auth_provider` | string | `None` | OAuth provider identifier when using OAuth-based setup |
+| `managed_init_args` | tuple of `ToolManagedInitArg` | `()` | Declares which MindRoom-managed values the toolkit constructor expects (see [Managed init args](#managed-init-args)) |
+| `default_execution_target` | `ToolExecutionTarget` | `PRIMARY` | `PRIMARY` or `WORKER` — controls whether the tool runs on the primary agent or a sandbox worker |
+
+### Dependencies
+
+The `dependencies` field lists Python packages that the tool requires at runtime.
+MindRoom checks whether each package is importable before the tool is instantiated.
+
+**For built-in tools** (those shipped inside `src/mindroom/tools/`), missing dependencies trigger automatic installation via `uv sync` or `pip install` using the matching optional extra from MindRoom's `pyproject.toml`.
+
+**For plugin tools**, automatic installation does **not** apply — there is no matching optional extra in MindRoom's package metadata.
+If the listed dependencies are not already installed in the environment, MindRoom raises an `ImportError` with a message listing the missing packages.
+Plugin authors should document their dependencies in their README so users can install them manually:
+
+```bash
+pip install openviking-client aiohttp
+```
+
+Even though plugin dependencies are not auto-installed, listing them in the decorator is still useful: MindRoom surfaces a clear error at tool load time rather than failing with an obscure traceback when an agent tries to call the tool mid-conversation.
+
+You can disable automatic dependency installation entirely (for built-in tools too) by setting the environment variable `MINDROOM_NO_AUTO_INSTALL_TOOLS=1`.
+
+### ConfigField
+
+Each `ConfigField` describes one constructor parameter that can be configured through the dashboard or credentials store.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `name` | string | *required* | Constructor kwarg name (e.g., `"api_key"`) |
+| `label` | string | *required* | Display label shown in the dashboard |
+| `type` | string | `"text"` | Input type: `text`, `password`, `url`, `number`, `boolean`, or `select` |
+| `required` | bool | `True` | Whether the field must be set before the tool can be used |
+| `default` | any | `None` | Default value when not configured |
+| `placeholder` | string | `None` | Placeholder text shown in the input |
+| `description` | string | `None` | Help text for the field |
+| `options` | list | `None` | For `select` type: list of `{"label": "...", "value": "..."}` dicts |
+| `validation` | dict | `None` | Optional validation rules (min, max, pattern, etc.) |
+
+Example — a tool that requires an API key:
+
+```python
+from mindroom.tool_system.metadata import (
+    ConfigField,
+    SetupType,
+    ToolCategory,
+    ToolStatus,
+    register_tool_with_metadata,
+)
+
+@register_tool_with_metadata(
+    name="weather",
+    display_name="Weather",
+    description="Get current weather data",
+    category=ToolCategory.INFORMATION,
+    status=ToolStatus.REQUIRES_CONFIG,
+    setup_type=SetupType.API_KEY,
+    config_fields=[
+        ConfigField(name="api_key", label="API Key", type="password"),
+        ConfigField(
+            name="units",
+            label="Units",
+            type="select",
+            required=False,
+            default="metric",
+            options=[
+                {"label": "Metric (°C)", "value": "metric"},
+                {"label": "Imperial (°F)", "value": "imperial"},
+            ],
+        ),
+    ],
+)
+def weather_tools() -> type[Toolkit]:
+    ...
+```
+
+### Managed init args
+
+If your toolkit constructor needs MindRoom-managed runtime values, declare them with `managed_init_args`.
+MindRoom does **not** auto-detect constructor parameter names — undeclared managed args are not passed through.
+
+| Value | Constructor kwarg | Description |
+| --- | --- | --- |
+| `RUNTIME_PATHS` | `runtime_paths` | Storage paths, environment values, and data directory access |
+| `CREDENTIALS_MANAGER` | `credentials_manager` | Read and write the per-tool credentials store |
+| `WORKER_TARGET` | `worker_target` | Resolved worker routing context (scope, execution identity, worker key) |
+
+Example:
+
+```python
+from agno.tools import Toolkit
+from mindroom.tool_system.metadata import ToolCategory, ToolManagedInitArg, register_tool_with_metadata
+
+
+@register_tool_with_metadata(
+    name="needs_runtime",
+    display_name="Needs Runtime",
+    description="Example tool that needs runtime paths",
+    category=ToolCategory.DEVELOPMENT,
+    managed_init_args=(ToolManagedInitArg.RUNTIME_PATHS,),
+)
+def needs_runtime_tools() -> type[Toolkit]:
+    class NeedsRuntimeTools(Toolkit):
+        def __init__(self, *, runtime_paths):
+            self.runtime_paths = runtime_paths
+            super().__init__(name="needs_runtime", tools=[])
+
+    return NeedsRuntimeTools
+```
 
 ## MCP via plugins (advanced)
 
-MindRoom now supports native MCP servers in `config.yaml`.
-See [MCP](mcp.md) for the normal setup path.
-This plugin pattern is still useful when you want a custom wrapper around Agno `MCPTools` instead of MindRoom's native MCP registry:
+MindRoom supports native MCP servers in `config.yaml` — see [MCP](mcp.md) for the normal setup path.
+This plugin pattern is still useful when you want a custom wrapper around Agno `MCPTools`:
 
 ```python
 from agno.tools.mcp import MCPTools
@@ -140,132 +389,18 @@ agents:
       - mcp_filesystem
 ```
 
-The factory function must return the toolkit class, not an instance. MCP toolkits are async; Agno's async agent runs (`arun`, `aprint_response`) handle MCP connect and disconnect automatically.
-
-## Tools module example
-
-```python
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-from mindroom.tool_system.metadata import (
-    SetupType,
-    ToolCategory,
-    ToolStatus,
-    register_tool_with_metadata,
-)
-
-if TYPE_CHECKING:
-    from agno.tools import Toolkit
-
-
-@register_tool_with_metadata(
-    name="greeter",
-    display_name="Greeter",
-    description="A simple greeting tool",
-    category=ToolCategory.DEVELOPMENT,
-    status=ToolStatus.AVAILABLE,
-    setup_type=SetupType.NONE,
-)
-def greeter_tools() -> type[Toolkit]:
-    from agno.tools import Toolkit
-
-    class GreeterTools(Toolkit):
-        """A simple greeting toolkit."""
-
-        def __init__(self) -> None:
-            super().__init__(name="greeter", tools=[self.greet])
-
-        def greet(self, name: str) -> str:
-            """Greet someone by name."""
-            return f"Hello, {name}!"
-
-    return GreeterTools
-```
-
-The factory function (decorated with `@register_tool_with_metadata`) must return the **class**, not an instance. MindRoom instantiates the class when building agents.
-
-All decorator arguments are keyword-only. Required fields:
-
-- `name`: Tool identifier
-- `display_name`: Human-readable name
-- `description`: Brief description
-- `category`: A `ToolCategory` enum value (`COMMUNICATION`, `DEVELOPMENT`, `EMAIL`, `ENTERTAINMENT`, `INFORMATION`, `INTEGRATIONS`, `PRODUCTIVITY`, `RESEARCH`, `SHOPPING`, `SMART_HOME`, `SOCIAL`)
-
-Common optional fields:
-
-- `status`: `ToolStatus.AVAILABLE` (default) or `REQUIRES_CONFIG`
-- `setup_type`: `SetupType.NONE` (default), `API_KEY`, `OAUTH`, or `SPECIAL`
-- `config_fields`: List of `ConfigField` objects (see below)
-- `dependencies`: List of required pip packages
-- `docs_url`: Link to documentation
-- `managed_init_args`: Explicit MindRoom-managed constructor kwargs such as `runtime_paths` or `credentials_manager`
-- `icon`: Icon name for the dashboard (e.g., `"FaGoogle"`, `"Home"`)
-- `icon_color`: Tailwind color class for the icon (e.g., `"text-blue-500"`)
-- `helper_text`: Markdown help text shown in the dashboard
-- `auth_provider`: OAuth provider identifier when using OAuth-based setup
-- `default_execution_target`: `ToolExecutionTarget.PRIMARY` (default) or `WORKER` — controls whether the tool runs on the primary agent or a sandbox worker
-
-### ConfigField
-
-Each `ConfigField` describes one constructor parameter that can be configured through the dashboard or credentials store.
-
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| `name` | string | *required* | Constructor kwarg name (e.g., `"api_key"`) |
-| `label` | string | *required* | Display label shown in the dashboard |
-| `type` | string | `"text"` | Input type: `text`, `password`, `url`, `number`, `boolean`, or `select` |
-| `required` | bool | `True` | Whether the field must be set before the tool can be used |
-| `default` | any | `None` | Default value when not configured |
-| `placeholder` | string | `None` | Placeholder text shown in the input |
-| `description` | string | `None` | Help text for the field |
-| `options` | list | `None` | For `select` type: list of `{"label": "...", "value": "..."}` dicts |
-| `validation` | dict | `None` | Optional validation rules (min, max, pattern, etc.) |
-
-If your toolkit constructor expects MindRoom-managed values, declare them with `managed_init_args`.
-This applies to built-in tools under `src/mindroom/tools/` just as much as external plugins.
-MindRoom no longer inspects constructor parameter names and injects those values automatically.
-Undeclared managed constructor inputs will not be passed through.
-
-Available `ToolManagedInitArg` values:
-
-| Value | Constructor kwarg | Description |
-| --- | --- | --- |
-| `RUNTIME_PATHS` | `runtime_paths` | Access to storage paths and environment values |
-| `CREDENTIALS_MANAGER` | `credentials_manager` | Read and write the per-tool credentials store |
-| `WORKER_TARGET` | `worker_target` | Resolved worker routing context (scope, execution identity, worker key) |
-
-For example, a toolkit that expects `runtime_paths` must opt in explicitly:
-
-```python
-from agno.tools import Toolkit
-from mindroom.tool_system.metadata import ToolCategory, ToolManagedInitArg, register_tool_with_metadata
-
-
-@register_tool_with_metadata(
-    name="needs_runtime",
-    display_name="Needs Runtime",
-    description="Example tool that needs runtime paths",
-    category=ToolCategory.DEVELOPMENT,
-    managed_init_args=(ToolManagedInitArg.RUNTIME_PATHS,),
-)
-def needs_runtime_tools() -> type[Toolkit]:
-    class NeedsRuntimeTools(Toolkit):
-        def __init__(self, *, runtime_paths):
-            self.runtime_paths = runtime_paths
-            super().__init__(name="needs_runtime", tools=[])
-
-    return NeedsRuntimeTools
-```
+The factory function must return the toolkit class, not an instance.
+MCP toolkits are async; Agno's async agent runs (`arun`, `aprint_response`) handle MCP connect and disconnect automatically.
 
 ## Plugin skills
 
-List skill directories in the manifest `skills` array. Those directories are added to the skill search roots.
+List skill directories in the manifest `skills` array.
+Each listed directory is added to MindRoom's skill search roots.
+Skill subdirectories must contain a `SKILL.md` file with YAML frontmatter (name, description, requirements).
 
 ## Hooks
 
-Plugins can ship typed event hooks for message enrichment, response transformation, lifecycle observation, tool call gating and observation, reactions, schedules, and custom events.
+Plugins can ship typed event hooks for message enrichment, response transformation, lifecycle observation, tool call gating, reactions, schedules, and custom events.
 See the [Hooks](hooks.md) page for full documentation including:
 
 - The `@hook` decorator and all parameters
@@ -275,10 +410,64 @@ See the [Hooks](hooks.md) page for full documentation including:
 - Error handling and circuit breaker behavior
 - Testing patterns
 
-## Reloading plugins
+## Live development (hot reload)
 
-Plugin manifests and tools modules are cached by mtime. Changes are picked up the next time MindRoom reloads the tool registry (for example, on startup or config reload).
+Plugins hot-reload automatically.
+When you edit any file inside a configured plugin directory, MindRoom detects the change within ~1 second, re-imports the plugin's modules in place, swaps the new hooks and tools into the live registry, and the next event invokes your new code.
+No service restart, no agent session disruption.
 
-## Security notes
+### How it works
 
-Plugins execute code in-process. Only install plugins you trust.
+- A background watcher polls each configured plugin root every ~1s and debounces saves over a ~1s window.
+- On change: the synthetic plugin package subtree is evicted from `sys.modules`, `load_plugins()` re-runs, a fresh `HookRegistry` is built, and the live registry is swapped atomically.
+- Module-level `asyncio.Task` objects on the old module are best-effort cancelled before the swap.
+- The watcher ignores `__pycache__/`, `*.pyc`, `*.pyo`, editor swap files (`*.swp`, `*~`, `.#*`, `*.tmp`), and tool caches (`.ruff_cache/`, `.mypy_cache/`, `.pytest_cache/`).
+
+### Manual reload
+
+An admin user can force a reload by sending the chat command:
+
+```
+!reload-plugins
+```
+
+The bot replies with the active plugin set and the count of cancelled background tasks.
+
+### Caveats
+
+- **In-flight turns keep their old code.** A reload swaps the registry for new events; any callback already running on the old module finishes there.
+- **No partial-write detection.** If your editor saves in two writes, the watcher may briefly load a half-written state, log an import error, and reload again on the second write.
+- **New plugins added to disk are not auto-enabled.** You still have to add them under `plugins:` in `config.yaml`. The watcher only reloads plugins that are already configured. (Editing `config.yaml` triggers its own separate hot-reload path.)
+
+## Community plugins
+
+The [mindroom-ai](https://github.com/mindroom-ai) organization maintains a collection of open-source plugins.
+Clone any of them into your plugins directory and add the path to `config.yaml`:
+
+```bash
+git clone https://github.com/mindroom-ai/ping-hook-plugin.git ~/.mindroom-chat/plugins/ping-hook
+```
+
+```yaml
+plugins:
+  - ~/.mindroom-chat/plugins/ping-hook
+```
+
+### Hooks-only plugins
+
+| Plugin | Description |
+| --- | --- |
+| [ping-hook-plugin](https://github.com/mindroom-ai/ping-hook-plugin) | Minimal example — responds to `!ping-hook` with a pong message. Good starting point for learning the hook system. |
+| [shell-guard-plugin](https://github.com/mindroom-ai/shell-guard-plugin) | Blocks dangerous shell commands (e.g., `systemctl restart mindroom-chat`) via `tool:before_call` gating. |
+| [voice-enrich-plugin](https://github.com/mindroom-ai/voice-enrich-plugin) | Injects AI-only metadata when a voice-transcribed message arrives, warning the model about possible transcription errors. |
+| [location-enrich-plugin](https://github.com/mindroom-ai/location-enrich-plugin) | Enriches prompts with real-time GPS location from [Dawarich](https://dawarich.app/), including place matching and movement classification. |
+| [restart-resume-plugin](https://github.com/mindroom-ai/restart-resume-plugin) | Re-activates threads tagged `pending-restart` after a bot restart. |
+
+### Hooks + tools plugins
+
+| Plugin | Description |
+| --- | --- |
+| [thread-snooze-plugin](https://github.com/mindroom-ai/thread-snooze-plugin) | Snooze and unsnooze threads — temporarily resolves a thread and wakes it at a specified time. |
+| [thread-goal-plugin](https://github.com/mindroom-ai/thread-goal-plugin) | Persistent per-thread goals stored in Matrix room state that survive context compaction and restarts. |
+| [workloop-plugin](https://github.com/mindroom-ai/workloop-plugin) | Autonomous work plans with dependencies, priorities, auto-poke, and template-driven task creation. |
+| [openviking-plugin](https://github.com/mindroom-ai/openviking-plugin) | Long-term memory via [OpenViking](https://github.com/volcengine/OpenViking) — automatic memory extraction, recall, and compaction archiving. |

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -8144,7 +8144,9 @@ MindRoom polls skill directories every second. When a `SKILL.md` file is added, 
 
 # Plugins
 
-MindRoom plugins add tools and can optionally ship skills and [hooks](https://docs.mindroom.chat/hooks/index.md). Plugins are loaded from paths listed in `config.yaml`.
+> [!WARNING] **Plugins execute arbitrary Python code in the same process as MindRoom.** A malicious plugin has full access to your credentials, Matrix sessions, file system, and network. Only install plugins you trust and have reviewed.
+
+MindRoom plugins extend agents with custom tools, [hooks](https://docs.mindroom.chat/hooks/index.md), and skills. A plugin is a directory with a `mindroom.plugin.json` manifest, one or more Python modules, and optionally skill directories. Plugins are loaded from paths listed under `plugins:` in `config.yaml`.
 
 ## Plugin structure
 
@@ -8152,15 +8154,19 @@ A plugin is a directory containing `mindroom.plugin.json`:
 
 ```
 my-plugin/
-├── mindroom.plugin.json
-├── tools.py
-├── hooks.py
-└── skills/
+├── mindroom.plugin.json   # Required manifest
+├── tools.py               # Tool factories (optional)
+├── hooks.py               # Event hooks (optional)
+└── skills/                # Skill directories (optional)
     └── my-skill/
         └── SKILL.md
 ```
 
+A plugin must have at least one of `tools_module`, `hooks_module`, or `skills`. A tools-only plugin exposes callable functions to agents. A hooks-only plugin observes or transforms events without adding agent-facing tools. Many plugins combine both.
+
 ## Manifest format
+
+The manifest is a JSON file named `mindroom.plugin.json` at the plugin root:
 
 ```
 {
@@ -8171,26 +8177,30 @@ my-plugin/
 }
 ```
 
-| Field          | Type            | Description                                                                                                                                                                              |
-| -------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`         | string          | Plugin identifier (required, must use only lowercase ASCII letters, digits, `-`, and `_`, and must be unique across configured plugins; invalid or duplicate names abort plugin loading) |
-| `tools_module` | string          | Path to the tools module (optional)                                                                                                                                                      |
-| `hooks_module` | string          | Path to the hooks module relative to the plugin root (optional)                                                                                                                          |
-| `skills`       | list of strings | Relative directories containing skills (optional)                                                                                                                                        |
+| Field          | Type            | Required | Description                                                                                                                                                                                                       |
+| -------------- | --------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`         | string          | **yes**  | Plugin identifier. Must be lowercase ASCII letters, digits, `-`, and `_` only (pattern: `^[a-z0-9_-]+$`). Must be unique across all configured plugins. Invalid or duplicate names abort plugin loading entirely. |
+| `tools_module` | string          | no       | Relative path to the Python module containing `@register_tool_with_metadata` factories. Must exist on disk if declared.                                                                                           |
+| `hooks_module` | string          | no       | Relative path to the Python module containing `@hook`-decorated functions. Must exist on disk if declared.                                                                                                        |
+| `skills`       | list of strings | no       | Relative directories containing skill subdirectories (each with a `SKILL.md`). Each directory must exist on disk.                                                                                                 |
 
-Unknown fields are ignored. Invalid, duplicate, or malformed configured plugin manifests are configuration errors and stop plugin loading. Configured plugin paths, declared module files, and declared skill directories must exist. If `hooks_module` is omitted, MindRoom auto-scans `tools_module` for `@hook`-decorated functions. If both fields point at the same file, MindRoom imports it once and reuses it for both tool registration and hook discovery.
+Unknown fields are silently ignored. Invalid, duplicate, or malformed manifests are configuration errors and stop all plugin loading. All declared module files and skill directories must exist on disk.
+
+If `hooks_module` is omitted, MindRoom auto-scans `tools_module` for `@hook`-decorated functions. If both fields point at the same file, MindRoom imports it once and reuses it for both tool registration and hook discovery.
 
 ## Configure plugins
 
-Add plugin paths to `config.yaml`:
+Add plugin paths under `plugins:` in `config.yaml`:
 
 ```
 plugins:
   - ./plugins/my-plugin
   - python:my_skill_pack
   - path: ./plugins/personal-context
+    enabled: true
     settings:
       dawarich_url: http://dawarich.local
+      api_key: secret
     hooks:
       enrich_with_location:
         priority: 20
@@ -8198,13 +8208,52 @@ plugins:
         enabled: false
 ```
 
-Plugin entries can be strings (path only) or objects (with `settings` and per-hook overrides). Both forms can be mixed in the same list.
+### Entry formats
 
-Paths may be:
+Plugin entries can be **strings** (path only) or **objects** (with options). Both forms can be mixed in the same list.
 
-- Absolute paths
-- Paths relative to `config.yaml`
-- Python package specs (see below)
+**String entry** — just the path:
+
+```
+plugins:
+  - ./plugins/my-plugin
+```
+
+**Object entry** — path plus options:
+
+```
+plugins:
+  - path: ./plugins/my-plugin
+    enabled: true
+    settings:
+      api_key: secret
+    hooks:
+      my_hook:
+        enabled: false
+```
+
+| Field      | Type   | Default    | Description                                                            |
+| ---------- | ------ | ---------- | ---------------------------------------------------------------------- |
+| `path`     | string | *required* | Plugin path (see resolution rules below)                               |
+| `enabled`  | bool   | `true`     | Set to `false` to disable the plugin without removing it from the list |
+| `settings` | dict   | `{}`       | Free-form key-value config passed to the plugin at load time           |
+| `hooks`    | dict   | `{}`       | Per-hook overrides keyed by hook function name                         |
+
+Each hook override supports:
+
+| Field        | Type | Default | Description                                                 |
+| ------------ | ---- | ------- | ----------------------------------------------------------- |
+| `enabled`    | bool | `true`  | Disable a specific hook without removing it from the plugin |
+| `priority`   | int  | `null`  | Override the hook's default execution priority              |
+| `timeout_ms` | int  | `null`  | Override the hook's default timeout                         |
+
+### Path resolution
+
+Paths are resolved in this order:
+
+1. **Absolute paths** — used as-is
+1. **Relative paths** — resolved relative to the directory containing `config.yaml`
+1. **Python package specs** — see below
 
 ## Python package plugins
 
@@ -8220,15 +8269,204 @@ plugins:
 
 Rules:
 
-- A bare package name is allowed if it contains no slashes.
-- `python:`, `pkg:`, and `module:` are explicit prefixes.
-- `:sub/path` points to a subdirectory inside the package.
+- A bare package name (no slashes, no `.` or `..` prefix) is tried as a Python package first.
+- `python:`, `pkg:`, and `module:` are explicit prefixes that force package resolution.
+- `:sub/path` after the package name points to a subdirectory inside the package.
 
-MindRoom resolves the package location and looks for `mindroom.plugin.json` in that directory.
+MindRoom resolves the package location via `importlib` and looks for `mindroom.plugin.json` in that directory.
+
+## Tools module
+
+A tools module is a Python file that registers one or more tool factories using the `@register_tool_with_metadata` decorator. Each factory function returns a **Toolkit class** (not an instance). MindRoom instantiates the class when building agents.
+
+### Minimal example
+
+```
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.tool_system.metadata import (
+    SetupType,
+    ToolCategory,
+    ToolStatus,
+    register_tool_with_metadata,
+)
+
+if TYPE_CHECKING:
+    from agno.tools import Toolkit
+
+
+@register_tool_with_metadata(
+    name="greeter",
+    display_name="Greeter",
+    description="A simple greeting tool",
+    category=ToolCategory.DEVELOPMENT,
+    status=ToolStatus.AVAILABLE,
+    setup_type=SetupType.NONE,
+)
+def greeter_tools() -> type[Toolkit]:
+    from agno.tools import Toolkit
+
+    class GreeterTools(Toolkit):
+        def __init__(self) -> None:
+            super().__init__(name="greeter", tools=[self.greet])
+
+        def greet(self, name: str) -> str:
+            """Greet someone by name."""
+            return f"Hello, {name}!"
+
+    return GreeterTools
+```
+
+After registering the plugin, assign the tool to agents in `config.yaml`:
+
+```
+plugins:
+  - ./plugins/my-greeter
+
+agents:
+  assistant:
+    tools:
+      - greeter
+```
+
+### Decorator fields
+
+All `@register_tool_with_metadata` arguments are keyword-only.
+
+**Required fields:**
+
+| Field          | Type           | Description                                                                        |
+| -------------- | -------------- | ---------------------------------------------------------------------------------- |
+| `name`         | string         | Tool identifier — used to reference the tool in `config.yaml` agent `tools:` lists |
+| `display_name` | string         | Human-readable name shown in the dashboard                                         |
+| `description`  | string         | Brief description of what the tool does                                            |
+| `category`     | `ToolCategory` | Category for dashboard grouping (see values below)                                 |
+
+`ToolCategory` values: `COMMUNICATION`, `DEVELOPMENT`, `EMAIL`, `ENTERTAINMENT`, `INFORMATION`, `INTEGRATIONS`, `PRODUCTIVITY`, `RESEARCH`, `SHOPPING`, `SMART_HOME`, `SOCIAL`.
+
+**Optional fields:**
+
+| Field                      | Type                          | Default     | Description                                                                                                          |
+| -------------------------- | ----------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------- |
+| `status`                   | `ToolStatus`                  | `AVAILABLE` | `AVAILABLE` or `REQUIRES_CONFIG` — controls whether the tool appears as ready or needs setup in the dashboard        |
+| `setup_type`               | `SetupType`                   | `NONE`      | `NONE`, `API_KEY`, `OAUTH`, or `SPECIAL` — tells the dashboard what kind of setup flow to show                       |
+| `config_fields`            | list of `ConfigField`         | `None`      | Describes constructor parameters configurable through the dashboard (see [ConfigField](#configfield))                |
+| `dependencies`             | list of strings               | `None`      | Python packages the tool requires (see [Dependencies](#dependencies))                                                |
+| `docs_url`                 | string                        | `None`      | Link to external documentation                                                                                       |
+| `icon`                     | string                        | `None`      | Icon name for the dashboard (e.g., `"FaGoogle"`, `"Home"`)                                                           |
+| `icon_color`               | string                        | `None`      | Tailwind color class for the icon (e.g., `"text-blue-500"`)                                                          |
+| `helper_text`              | string                        | `None`      | Markdown help text shown in the dashboard setup panel                                                                |
+| `auth_provider`            | string                        | `None`      | OAuth provider identifier when using OAuth-based setup                                                               |
+| `managed_init_args`        | tuple of `ToolManagedInitArg` | `()`        | Declares which MindRoom-managed values the toolkit constructor expects (see [Managed init args](#managed-init-args)) |
+| `default_execution_target` | `ToolExecutionTarget`         | `PRIMARY`   | `PRIMARY` or `WORKER` — controls whether the tool runs on the primary agent or a sandbox worker                      |
+
+### Dependencies
+
+The `dependencies` field lists Python packages that the tool requires at runtime. MindRoom checks whether each package is importable before the tool is instantiated.
+
+**For built-in tools** (those shipped inside `src/mindroom/tools/`), missing dependencies trigger automatic installation via `uv sync` or `pip install` using the matching optional extra from MindRoom's `pyproject.toml`.
+
+**For plugin tools**, automatic installation does **not** apply — there is no matching optional extra in MindRoom's package metadata. If the listed dependencies are not already installed in the environment, MindRoom raises an `ImportError` with a message listing the missing packages. Plugin authors should document their dependencies in their README so users can install them manually:
+
+```
+pip install openviking-client aiohttp
+```
+
+Even though plugin dependencies are not auto-installed, listing them in the decorator is still useful: MindRoom surfaces a clear error at tool load time rather than failing with an obscure traceback when an agent tries to call the tool mid-conversation.
+
+You can disable automatic dependency installation entirely (for built-in tools too) by setting the environment variable `MINDROOM_NO_AUTO_INSTALL_TOOLS=1`.
+
+### ConfigField
+
+Each `ConfigField` describes one constructor parameter that can be configured through the dashboard or credentials store.
+
+| Field         | Type   | Default    | Description                                                             |
+| ------------- | ------ | ---------- | ----------------------------------------------------------------------- |
+| `name`        | string | *required* | Constructor kwarg name (e.g., `"api_key"`)                              |
+| `label`       | string | *required* | Display label shown in the dashboard                                    |
+| `type`        | string | `"text"`   | Input type: `text`, `password`, `url`, `number`, `boolean`, or `select` |
+| `required`    | bool   | `True`     | Whether the field must be set before the tool can be used               |
+| `default`     | any    | `None`     | Default value when not configured                                       |
+| `placeholder` | string | `None`     | Placeholder text shown in the input                                     |
+| `description` | string | `None`     | Help text for the field                                                 |
+| `options`     | list   | `None`     | For `select` type: list of `{"label": "...", "value": "..."}` dicts     |
+| `validation`  | dict   | `None`     | Optional validation rules (min, max, pattern, etc.)                     |
+
+Example — a tool that requires an API key:
+
+```
+from mindroom.tool_system.metadata import (
+    ConfigField,
+    SetupType,
+    ToolCategory,
+    ToolStatus,
+    register_tool_with_metadata,
+)
+
+@register_tool_with_metadata(
+    name="weather",
+    display_name="Weather",
+    description="Get current weather data",
+    category=ToolCategory.INFORMATION,
+    status=ToolStatus.REQUIRES_CONFIG,
+    setup_type=SetupType.API_KEY,
+    config_fields=[
+        ConfigField(name="api_key", label="API Key", type="password"),
+        ConfigField(
+            name="units",
+            label="Units",
+            type="select",
+            required=False,
+            default="metric",
+            options=[
+                {"label": "Metric (°C)", "value": "metric"},
+                {"label": "Imperial (°F)", "value": "imperial"},
+            ],
+        ),
+    ],
+)
+def weather_tools() -> type[Toolkit]:
+    ...
+```
+
+### Managed init args
+
+If your toolkit constructor needs MindRoom-managed runtime values, declare them with `managed_init_args`. MindRoom does **not** auto-detect constructor parameter names — undeclared managed args are not passed through.
+
+| Value                 | Constructor kwarg     | Description                                                             |
+| --------------------- | --------------------- | ----------------------------------------------------------------------- |
+| `RUNTIME_PATHS`       | `runtime_paths`       | Storage paths, environment values, and data directory access            |
+| `CREDENTIALS_MANAGER` | `credentials_manager` | Read and write the per-tool credentials store                           |
+| `WORKER_TARGET`       | `worker_target`       | Resolved worker routing context (scope, execution identity, worker key) |
+
+Example:
+
+```
+from agno.tools import Toolkit
+from mindroom.tool_system.metadata import ToolCategory, ToolManagedInitArg, register_tool_with_metadata
+
+
+@register_tool_with_metadata(
+    name="needs_runtime",
+    display_name="Needs Runtime",
+    description="Example tool that needs runtime paths",
+    category=ToolCategory.DEVELOPMENT,
+    managed_init_args=(ToolManagedInitArg.RUNTIME_PATHS,),
+)
+def needs_runtime_tools() -> type[Toolkit]:
+    class NeedsRuntimeTools(Toolkit):
+        def __init__(self, *, runtime_paths):
+            self.runtime_paths = runtime_paths
+            super().__init__(name="needs_runtime", tools=[])
+
+    return NeedsRuntimeTools
+```
 
 ## MCP via plugins (advanced)
 
-MindRoom now supports native MCP servers in `config.yaml`. See [MCP](https://docs.mindroom.chat/mcp/index.md) for the normal setup path. This plugin pattern is still useful when you want a custom wrapper around Agno `MCPTools` instead of MindRoom's native MCP registry:
+MindRoom supports native MCP servers in `config.yaml` — see [MCP](https://docs.mindroom.chat/mcp/index.md) for the normal setup path. This plugin pattern is still useful when you want a custom wrapper around Agno `MCPTools`:
 
 ```
 from agno.tools.mcp import MCPTools
@@ -8274,127 +8512,13 @@ agents:
 
 The factory function must return the toolkit class, not an instance. MCP toolkits are async; Agno's async agent runs (`arun`, `aprint_response`) handle MCP connect and disconnect automatically.
 
-## Tools module example
-
-```
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-from mindroom.tool_system.metadata import (
-    SetupType,
-    ToolCategory,
-    ToolStatus,
-    register_tool_with_metadata,
-)
-
-if TYPE_CHECKING:
-    from agno.tools import Toolkit
-
-
-@register_tool_with_metadata(
-    name="greeter",
-    display_name="Greeter",
-    description="A simple greeting tool",
-    category=ToolCategory.DEVELOPMENT,
-    status=ToolStatus.AVAILABLE,
-    setup_type=SetupType.NONE,
-)
-def greeter_tools() -> type[Toolkit]:
-    from agno.tools import Toolkit
-
-    class GreeterTools(Toolkit):
-        """A simple greeting toolkit."""
-
-        def __init__(self) -> None:
-            super().__init__(name="greeter", tools=[self.greet])
-
-        def greet(self, name: str) -> str:
-            """Greet someone by name."""
-            return f"Hello, {name}!"
-
-    return GreeterTools
-```
-
-The factory function (decorated with `@register_tool_with_metadata`) must return the **class**, not an instance. MindRoom instantiates the class when building agents.
-
-All decorator arguments are keyword-only. Required fields:
-
-- `name`: Tool identifier
-- `display_name`: Human-readable name
-- `description`: Brief description
-- `category`: A `ToolCategory` enum value (`COMMUNICATION`, `DEVELOPMENT`, `EMAIL`, `ENTERTAINMENT`, `INFORMATION`, `INTEGRATIONS`, `PRODUCTIVITY`, `RESEARCH`, `SHOPPING`, `SMART_HOME`, `SOCIAL`)
-
-Common optional fields:
-
-- `status`: `ToolStatus.AVAILABLE` (default) or `REQUIRES_CONFIG`
-- `setup_type`: `SetupType.NONE` (default), `API_KEY`, `OAUTH`, or `SPECIAL`
-- `config_fields`: List of `ConfigField` objects (see below)
-- `dependencies`: List of required pip packages
-- `docs_url`: Link to documentation
-- `managed_init_args`: Explicit MindRoom-managed constructor kwargs such as `runtime_paths` or `credentials_manager`
-- `icon`: Icon name for the dashboard (e.g., `"FaGoogle"`, `"Home"`)
-- `icon_color`: Tailwind color class for the icon (e.g., `"text-blue-500"`)
-- `helper_text`: Markdown help text shown in the dashboard
-- `auth_provider`: OAuth provider identifier when using OAuth-based setup
-- `default_execution_target`: `ToolExecutionTarget.PRIMARY` (default) or `WORKER` — controls whether the tool runs on the primary agent or a sandbox worker
-
-### ConfigField
-
-Each `ConfigField` describes one constructor parameter that can be configured through the dashboard or credentials store.
-
-| Field         | Type   | Default    | Description                                                             |
-| ------------- | ------ | ---------- | ----------------------------------------------------------------------- |
-| `name`        | string | *required* | Constructor kwarg name (e.g., `"api_key"`)                              |
-| `label`       | string | *required* | Display label shown in the dashboard                                    |
-| `type`        | string | `"text"`   | Input type: `text`, `password`, `url`, `number`, `boolean`, or `select` |
-| `required`    | bool   | `True`     | Whether the field must be set before the tool can be used               |
-| `default`     | any    | `None`     | Default value when not configured                                       |
-| `placeholder` | string | `None`     | Placeholder text shown in the input                                     |
-| `description` | string | `None`     | Help text for the field                                                 |
-| `options`     | list   | `None`     | For `select` type: list of `{"label": "...", "value": "..."}` dicts     |
-| `validation`  | dict   | `None`     | Optional validation rules (min, max, pattern, etc.)                     |
-
-If your toolkit constructor expects MindRoom-managed values, declare them with `managed_init_args`. This applies to built-in tools under `src/mindroom/tools/` just as much as external plugins. MindRoom no longer inspects constructor parameter names and injects those values automatically. Undeclared managed constructor inputs will not be passed through.
-
-Available `ToolManagedInitArg` values:
-
-| Value                 | Constructor kwarg     | Description                                                             |
-| --------------------- | --------------------- | ----------------------------------------------------------------------- |
-| `RUNTIME_PATHS`       | `runtime_paths`       | Access to storage paths and environment values                          |
-| `CREDENTIALS_MANAGER` | `credentials_manager` | Read and write the per-tool credentials store                           |
-| `WORKER_TARGET`       | `worker_target`       | Resolved worker routing context (scope, execution identity, worker key) |
-
-For example, a toolkit that expects `runtime_paths` must opt in explicitly:
-
-```
-from agno.tools import Toolkit
-from mindroom.tool_system.metadata import ToolCategory, ToolManagedInitArg, register_tool_with_metadata
-
-
-@register_tool_with_metadata(
-    name="needs_runtime",
-    display_name="Needs Runtime",
-    description="Example tool that needs runtime paths",
-    category=ToolCategory.DEVELOPMENT,
-    managed_init_args=(ToolManagedInitArg.RUNTIME_PATHS,),
-)
-def needs_runtime_tools() -> type[Toolkit]:
-    class NeedsRuntimeTools(Toolkit):
-        def __init__(self, *, runtime_paths):
-            self.runtime_paths = runtime_paths
-            super().__init__(name="needs_runtime", tools=[])
-
-    return NeedsRuntimeTools
-```
-
 ## Plugin skills
 
-List skill directories in the manifest `skills` array. Those directories are added to the skill search roots.
+List skill directories in the manifest `skills` array. Each listed directory is added to MindRoom's skill search roots. Skill subdirectories must contain a `SKILL.md` file with YAML frontmatter (name, description, requirements).
 
 ## Hooks
 
-Plugins can ship typed event hooks for message enrichment, response transformation, lifecycle observation, tool call gating and observation, reactions, schedules, and custom events. See the [Hooks](https://docs.mindroom.chat/hooks/index.md) page for full documentation including:
+Plugins can ship typed event hooks for message enrichment, response transformation, lifecycle observation, tool call gating, reactions, schedules, and custom events. See the [Hooks](https://docs.mindroom.chat/hooks/index.md) page for full documentation including:
 
 - The `@hook` decorator and all parameters
 - The built-in events and their execution modes
@@ -8403,13 +8527,64 @@ Plugins can ship typed event hooks for message enrichment, response transformati
 - Error handling and circuit breaker behavior
 - Testing patterns
 
-## Reloading plugins
+## Live development (hot reload)
 
-Plugin manifests and tools modules are cached by mtime. Changes are picked up the next time MindRoom reloads the tool registry (for example, on startup or config reload).
+Plugins hot-reload automatically. When you edit any file inside a configured plugin directory, MindRoom detects the change within ~1 second, re-imports the plugin's modules in place, swaps the new hooks and tools into the live registry, and the next event invokes your new code. No service restart, no agent session disruption.
 
-## Security notes
+### How it works
 
-Plugins execute code in-process. Only install plugins you trust.
+- A background watcher polls each configured plugin root every ~1s and debounces saves over a ~1s window.
+- On change: the synthetic plugin package subtree is evicted from `sys.modules`, `load_plugins()` re-runs, a fresh `HookRegistry` is built, and the live registry is swapped atomically.
+- Module-level `asyncio.Task` objects on the old module are best-effort cancelled before the swap.
+- The watcher ignores `__pycache__/`, `*.pyc`, `*.pyo`, editor swap files (`*.swp`, `*~`, `.#*`, `*.tmp`), and tool caches (`.ruff_cache/`, `.mypy_cache/`, `.pytest_cache/`).
+
+### Manual reload
+
+An admin user can force a reload by sending the chat command:
+
+```
+!reload-plugins
+```
+
+The bot replies with the active plugin set and the count of cancelled background tasks.
+
+### Caveats
+
+- **In-flight turns keep their old code.** A reload swaps the registry for new events; any callback already running on the old module finishes there.
+- **No partial-write detection.** If your editor saves in two writes, the watcher may briefly load a half-written state, log an import error, and reload again on the second write.
+- **New plugins added to disk are not auto-enabled.** You still have to add them under `plugins:` in `config.yaml`. The watcher only reloads plugins that are already configured. (Editing `config.yaml` triggers its own separate hot-reload path.)
+
+## Community plugins
+
+The [mindroom-ai](https://github.com/mindroom-ai) organization maintains a collection of open-source plugins. Clone any of them into your plugins directory and add the path to `config.yaml`:
+
+```
+git clone https://github.com/mindroom-ai/ping-hook-plugin.git ~/.mindroom-chat/plugins/ping-hook
+```
+
+```
+plugins:
+  - ~/.mindroom-chat/plugins/ping-hook
+```
+
+### Hooks-only plugins
+
+| Plugin                                                                          | Description                                                                                                                                |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [ping-hook-plugin](https://github.com/mindroom-ai/ping-hook-plugin)             | Minimal example — responds to `!ping-hook` with a pong message. Good starting point for learning the hook system.                          |
+| [shell-guard-plugin](https://github.com/mindroom-ai/shell-guard-plugin)         | Blocks dangerous shell commands (e.g., `systemctl restart mindroom-chat`) via `tool:before_call` gating.                                   |
+| [voice-enrich-plugin](https://github.com/mindroom-ai/voice-enrich-plugin)       | Injects AI-only metadata when a voice-transcribed message arrives, warning the model about possible transcription errors.                  |
+| [location-enrich-plugin](https://github.com/mindroom-ai/location-enrich-plugin) | Enriches prompts with real-time GPS location from [Dawarich](https://dawarich.app/), including place matching and movement classification. |
+| [restart-resume-plugin](https://github.com/mindroom-ai/restart-resume-plugin)   | Re-activates threads tagged `pending-restart` after a bot restart.                                                                         |
+
+### Hooks + tools plugins
+
+| Plugin                                                                      | Description                                                                                                                                  |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| [thread-snooze-plugin](https://github.com/mindroom-ai/thread-snooze-plugin) | Snooze and unsnooze threads — temporarily resolves a thread and wakes it at a specified time.                                                |
+| [thread-goal-plugin](https://github.com/mindroom-ai/thread-goal-plugin)     | Persistent per-thread goals stored in Matrix room state that survive context compaction and restarts.                                        |
+| [workloop-plugin](https://github.com/mindroom-ai/workloop-plugin)           | Autonomous work plans with dependencies, priorities, auto-poke, and template-driven task creation.                                           |
+| [openviking-plugin](https://github.com/mindroom-ai/openviking-plugin)       | Long-term memory via [OpenViking](https://github.com/volcengine/OpenViking) — automatic memory extraction, recall, and compaction archiving. |
 
 # Knowledge Bases
 

--- a/skills/mindroom-docs/references/page__plugins__index.md
+++ b/skills/mindroom-docs/references/page__plugins__index.md
@@ -1,6 +1,8 @@
 # Plugins
 
-MindRoom plugins add tools and can optionally ship skills and [hooks](https://docs.mindroom.chat/hooks/index.md). Plugins are loaded from paths listed in `config.yaml`.
+> [!WARNING] **Plugins execute arbitrary Python code in the same process as MindRoom.** A malicious plugin has full access to your credentials, Matrix sessions, file system, and network. Only install plugins you trust and have reviewed.
+
+MindRoom plugins extend agents with custom tools, [hooks](https://docs.mindroom.chat/hooks/index.md), and skills. A plugin is a directory with a `mindroom.plugin.json` manifest, one or more Python modules, and optionally skill directories. Plugins are loaded from paths listed under `plugins:` in `config.yaml`.
 
 ## Plugin structure
 
@@ -8,15 +10,19 @@ A plugin is a directory containing `mindroom.plugin.json`:
 
 ```
 my-plugin/
-├── mindroom.plugin.json
-├── tools.py
-├── hooks.py
-└── skills/
+├── mindroom.plugin.json   # Required manifest
+├── tools.py               # Tool factories (optional)
+├── hooks.py               # Event hooks (optional)
+└── skills/                # Skill directories (optional)
     └── my-skill/
         └── SKILL.md
 ```
 
+A plugin must have at least one of `tools_module`, `hooks_module`, or `skills`. A tools-only plugin exposes callable functions to agents. A hooks-only plugin observes or transforms events without adding agent-facing tools. Many plugins combine both.
+
 ## Manifest format
+
+The manifest is a JSON file named `mindroom.plugin.json` at the plugin root:
 
 ```
 {
@@ -27,26 +33,30 @@ my-plugin/
 }
 ```
 
-| Field          | Type            | Description                                                                                                                                                                              |
-| -------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`         | string          | Plugin identifier (required, must use only lowercase ASCII letters, digits, `-`, and `_`, and must be unique across configured plugins; invalid or duplicate names abort plugin loading) |
-| `tools_module` | string          | Path to the tools module (optional)                                                                                                                                                      |
-| `hooks_module` | string          | Path to the hooks module relative to the plugin root (optional)                                                                                                                          |
-| `skills`       | list of strings | Relative directories containing skills (optional)                                                                                                                                        |
+| Field          | Type            | Required | Description                                                                                                                                                                                                       |
+| -------------- | --------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`         | string          | **yes**  | Plugin identifier. Must be lowercase ASCII letters, digits, `-`, and `_` only (pattern: `^[a-z0-9_-]+$`). Must be unique across all configured plugins. Invalid or duplicate names abort plugin loading entirely. |
+| `tools_module` | string          | no       | Relative path to the Python module containing `@register_tool_with_metadata` factories. Must exist on disk if declared.                                                                                           |
+| `hooks_module` | string          | no       | Relative path to the Python module containing `@hook`-decorated functions. Must exist on disk if declared.                                                                                                        |
+| `skills`       | list of strings | no       | Relative directories containing skill subdirectories (each with a `SKILL.md`). Each directory must exist on disk.                                                                                                 |
 
-Unknown fields are ignored. Invalid, duplicate, or malformed configured plugin manifests are configuration errors and stop plugin loading. Configured plugin paths, declared module files, and declared skill directories must exist. If `hooks_module` is omitted, MindRoom auto-scans `tools_module` for `@hook`-decorated functions. If both fields point at the same file, MindRoom imports it once and reuses it for both tool registration and hook discovery.
+Unknown fields are silently ignored. Invalid, duplicate, or malformed manifests are configuration errors and stop all plugin loading. All declared module files and skill directories must exist on disk.
+
+If `hooks_module` is omitted, MindRoom auto-scans `tools_module` for `@hook`-decorated functions. If both fields point at the same file, MindRoom imports it once and reuses it for both tool registration and hook discovery.
 
 ## Configure plugins
 
-Add plugin paths to `config.yaml`:
+Add plugin paths under `plugins:` in `config.yaml`:
 
 ```
 plugins:
   - ./plugins/my-plugin
   - python:my_skill_pack
   - path: ./plugins/personal-context
+    enabled: true
     settings:
       dawarich_url: http://dawarich.local
+      api_key: secret
     hooks:
       enrich_with_location:
         priority: 20
@@ -54,13 +64,52 @@ plugins:
         enabled: false
 ```
 
-Plugin entries can be strings (path only) or objects (with `settings` and per-hook overrides). Both forms can be mixed in the same list.
+### Entry formats
 
-Paths may be:
+Plugin entries can be **strings** (path only) or **objects** (with options). Both forms can be mixed in the same list.
 
-- Absolute paths
-- Paths relative to `config.yaml`
-- Python package specs (see below)
+**String entry** — just the path:
+
+```
+plugins:
+  - ./plugins/my-plugin
+```
+
+**Object entry** — path plus options:
+
+```
+plugins:
+  - path: ./plugins/my-plugin
+    enabled: true
+    settings:
+      api_key: secret
+    hooks:
+      my_hook:
+        enabled: false
+```
+
+| Field      | Type   | Default    | Description                                                            |
+| ---------- | ------ | ---------- | ---------------------------------------------------------------------- |
+| `path`     | string | *required* | Plugin path (see resolution rules below)                               |
+| `enabled`  | bool   | `true`     | Set to `false` to disable the plugin without removing it from the list |
+| `settings` | dict   | `{}`       | Free-form key-value config passed to the plugin at load time           |
+| `hooks`    | dict   | `{}`       | Per-hook overrides keyed by hook function name                         |
+
+Each hook override supports:
+
+| Field        | Type | Default | Description                                                 |
+| ------------ | ---- | ------- | ----------------------------------------------------------- |
+| `enabled`    | bool | `true`  | Disable a specific hook without removing it from the plugin |
+| `priority`   | int  | `null`  | Override the hook's default execution priority              |
+| `timeout_ms` | int  | `null`  | Override the hook's default timeout                         |
+
+### Path resolution
+
+Paths are resolved in this order:
+
+1. **Absolute paths** — used as-is
+1. **Relative paths** — resolved relative to the directory containing `config.yaml`
+1. **Python package specs** — see below
 
 ## Python package plugins
 
@@ -76,15 +125,204 @@ plugins:
 
 Rules:
 
-- A bare package name is allowed if it contains no slashes.
-- `python:`, `pkg:`, and `module:` are explicit prefixes.
-- `:sub/path` points to a subdirectory inside the package.
+- A bare package name (no slashes, no `.` or `..` prefix) is tried as a Python package first.
+- `python:`, `pkg:`, and `module:` are explicit prefixes that force package resolution.
+- `:sub/path` after the package name points to a subdirectory inside the package.
 
-MindRoom resolves the package location and looks for `mindroom.plugin.json` in that directory.
+MindRoom resolves the package location via `importlib` and looks for `mindroom.plugin.json` in that directory.
+
+## Tools module
+
+A tools module is a Python file that registers one or more tool factories using the `@register_tool_with_metadata` decorator. Each factory function returns a **Toolkit class** (not an instance). MindRoom instantiates the class when building agents.
+
+### Minimal example
+
+```
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.tool_system.metadata import (
+    SetupType,
+    ToolCategory,
+    ToolStatus,
+    register_tool_with_metadata,
+)
+
+if TYPE_CHECKING:
+    from agno.tools import Toolkit
+
+
+@register_tool_with_metadata(
+    name="greeter",
+    display_name="Greeter",
+    description="A simple greeting tool",
+    category=ToolCategory.DEVELOPMENT,
+    status=ToolStatus.AVAILABLE,
+    setup_type=SetupType.NONE,
+)
+def greeter_tools() -> type[Toolkit]:
+    from agno.tools import Toolkit
+
+    class GreeterTools(Toolkit):
+        def __init__(self) -> None:
+            super().__init__(name="greeter", tools=[self.greet])
+
+        def greet(self, name: str) -> str:
+            """Greet someone by name."""
+            return f"Hello, {name}!"
+
+    return GreeterTools
+```
+
+After registering the plugin, assign the tool to agents in `config.yaml`:
+
+```
+plugins:
+  - ./plugins/my-greeter
+
+agents:
+  assistant:
+    tools:
+      - greeter
+```
+
+### Decorator fields
+
+All `@register_tool_with_metadata` arguments are keyword-only.
+
+**Required fields:**
+
+| Field          | Type           | Description                                                                        |
+| -------------- | -------------- | ---------------------------------------------------------------------------------- |
+| `name`         | string         | Tool identifier — used to reference the tool in `config.yaml` agent `tools:` lists |
+| `display_name` | string         | Human-readable name shown in the dashboard                                         |
+| `description`  | string         | Brief description of what the tool does                                            |
+| `category`     | `ToolCategory` | Category for dashboard grouping (see values below)                                 |
+
+`ToolCategory` values: `COMMUNICATION`, `DEVELOPMENT`, `EMAIL`, `ENTERTAINMENT`, `INFORMATION`, `INTEGRATIONS`, `PRODUCTIVITY`, `RESEARCH`, `SHOPPING`, `SMART_HOME`, `SOCIAL`.
+
+**Optional fields:**
+
+| Field                      | Type                          | Default     | Description                                                                                                          |
+| -------------------------- | ----------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------- |
+| `status`                   | `ToolStatus`                  | `AVAILABLE` | `AVAILABLE` or `REQUIRES_CONFIG` — controls whether the tool appears as ready or needs setup in the dashboard        |
+| `setup_type`               | `SetupType`                   | `NONE`      | `NONE`, `API_KEY`, `OAUTH`, or `SPECIAL` — tells the dashboard what kind of setup flow to show                       |
+| `config_fields`            | list of `ConfigField`         | `None`      | Describes constructor parameters configurable through the dashboard (see [ConfigField](#configfield))                |
+| `dependencies`             | list of strings               | `None`      | Python packages the tool requires (see [Dependencies](#dependencies))                                                |
+| `docs_url`                 | string                        | `None`      | Link to external documentation                                                                                       |
+| `icon`                     | string                        | `None`      | Icon name for the dashboard (e.g., `"FaGoogle"`, `"Home"`)                                                           |
+| `icon_color`               | string                        | `None`      | Tailwind color class for the icon (e.g., `"text-blue-500"`)                                                          |
+| `helper_text`              | string                        | `None`      | Markdown help text shown in the dashboard setup panel                                                                |
+| `auth_provider`            | string                        | `None`      | OAuth provider identifier when using OAuth-based setup                                                               |
+| `managed_init_args`        | tuple of `ToolManagedInitArg` | `()`        | Declares which MindRoom-managed values the toolkit constructor expects (see [Managed init args](#managed-init-args)) |
+| `default_execution_target` | `ToolExecutionTarget`         | `PRIMARY`   | `PRIMARY` or `WORKER` — controls whether the tool runs on the primary agent or a sandbox worker                      |
+
+### Dependencies
+
+The `dependencies` field lists Python packages that the tool requires at runtime. MindRoom checks whether each package is importable before the tool is instantiated.
+
+**For built-in tools** (those shipped inside `src/mindroom/tools/`), missing dependencies trigger automatic installation via `uv sync` or `pip install` using the matching optional extra from MindRoom's `pyproject.toml`.
+
+**For plugin tools**, automatic installation does **not** apply — there is no matching optional extra in MindRoom's package metadata. If the listed dependencies are not already installed in the environment, MindRoom raises an `ImportError` with a message listing the missing packages. Plugin authors should document their dependencies in their README so users can install them manually:
+
+```
+pip install openviking-client aiohttp
+```
+
+Even though plugin dependencies are not auto-installed, listing them in the decorator is still useful: MindRoom surfaces a clear error at tool load time rather than failing with an obscure traceback when an agent tries to call the tool mid-conversation.
+
+You can disable automatic dependency installation entirely (for built-in tools too) by setting the environment variable `MINDROOM_NO_AUTO_INSTALL_TOOLS=1`.
+
+### ConfigField
+
+Each `ConfigField` describes one constructor parameter that can be configured through the dashboard or credentials store.
+
+| Field         | Type   | Default    | Description                                                             |
+| ------------- | ------ | ---------- | ----------------------------------------------------------------------- |
+| `name`        | string | *required* | Constructor kwarg name (e.g., `"api_key"`)                              |
+| `label`       | string | *required* | Display label shown in the dashboard                                    |
+| `type`        | string | `"text"`   | Input type: `text`, `password`, `url`, `number`, `boolean`, or `select` |
+| `required`    | bool   | `True`     | Whether the field must be set before the tool can be used               |
+| `default`     | any    | `None`     | Default value when not configured                                       |
+| `placeholder` | string | `None`     | Placeholder text shown in the input                                     |
+| `description` | string | `None`     | Help text for the field                                                 |
+| `options`     | list   | `None`     | For `select` type: list of `{"label": "...", "value": "..."}` dicts     |
+| `validation`  | dict   | `None`     | Optional validation rules (min, max, pattern, etc.)                     |
+
+Example — a tool that requires an API key:
+
+```
+from mindroom.tool_system.metadata import (
+    ConfigField,
+    SetupType,
+    ToolCategory,
+    ToolStatus,
+    register_tool_with_metadata,
+)
+
+@register_tool_with_metadata(
+    name="weather",
+    display_name="Weather",
+    description="Get current weather data",
+    category=ToolCategory.INFORMATION,
+    status=ToolStatus.REQUIRES_CONFIG,
+    setup_type=SetupType.API_KEY,
+    config_fields=[
+        ConfigField(name="api_key", label="API Key", type="password"),
+        ConfigField(
+            name="units",
+            label="Units",
+            type="select",
+            required=False,
+            default="metric",
+            options=[
+                {"label": "Metric (°C)", "value": "metric"},
+                {"label": "Imperial (°F)", "value": "imperial"},
+            ],
+        ),
+    ],
+)
+def weather_tools() -> type[Toolkit]:
+    ...
+```
+
+### Managed init args
+
+If your toolkit constructor needs MindRoom-managed runtime values, declare them with `managed_init_args`. MindRoom does **not** auto-detect constructor parameter names — undeclared managed args are not passed through.
+
+| Value                 | Constructor kwarg     | Description                                                             |
+| --------------------- | --------------------- | ----------------------------------------------------------------------- |
+| `RUNTIME_PATHS`       | `runtime_paths`       | Storage paths, environment values, and data directory access            |
+| `CREDENTIALS_MANAGER` | `credentials_manager` | Read and write the per-tool credentials store                           |
+| `WORKER_TARGET`       | `worker_target`       | Resolved worker routing context (scope, execution identity, worker key) |
+
+Example:
+
+```
+from agno.tools import Toolkit
+from mindroom.tool_system.metadata import ToolCategory, ToolManagedInitArg, register_tool_with_metadata
+
+
+@register_tool_with_metadata(
+    name="needs_runtime",
+    display_name="Needs Runtime",
+    description="Example tool that needs runtime paths",
+    category=ToolCategory.DEVELOPMENT,
+    managed_init_args=(ToolManagedInitArg.RUNTIME_PATHS,),
+)
+def needs_runtime_tools() -> type[Toolkit]:
+    class NeedsRuntimeTools(Toolkit):
+        def __init__(self, *, runtime_paths):
+            self.runtime_paths = runtime_paths
+            super().__init__(name="needs_runtime", tools=[])
+
+    return NeedsRuntimeTools
+```
 
 ## MCP via plugins (advanced)
 
-MindRoom now supports native MCP servers in `config.yaml`. See [MCP](https://docs.mindroom.chat/mcp/index.md) for the normal setup path. This plugin pattern is still useful when you want a custom wrapper around Agno `MCPTools` instead of MindRoom's native MCP registry:
+MindRoom supports native MCP servers in `config.yaml` — see [MCP](https://docs.mindroom.chat/mcp/index.md) for the normal setup path. This plugin pattern is still useful when you want a custom wrapper around Agno `MCPTools`:
 
 ```
 from agno.tools.mcp import MCPTools
@@ -130,127 +368,13 @@ agents:
 
 The factory function must return the toolkit class, not an instance. MCP toolkits are async; Agno's async agent runs (`arun`, `aprint_response`) handle MCP connect and disconnect automatically.
 
-## Tools module example
-
-```
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-from mindroom.tool_system.metadata import (
-    SetupType,
-    ToolCategory,
-    ToolStatus,
-    register_tool_with_metadata,
-)
-
-if TYPE_CHECKING:
-    from agno.tools import Toolkit
-
-
-@register_tool_with_metadata(
-    name="greeter",
-    display_name="Greeter",
-    description="A simple greeting tool",
-    category=ToolCategory.DEVELOPMENT,
-    status=ToolStatus.AVAILABLE,
-    setup_type=SetupType.NONE,
-)
-def greeter_tools() -> type[Toolkit]:
-    from agno.tools import Toolkit
-
-    class GreeterTools(Toolkit):
-        """A simple greeting toolkit."""
-
-        def __init__(self) -> None:
-            super().__init__(name="greeter", tools=[self.greet])
-
-        def greet(self, name: str) -> str:
-            """Greet someone by name."""
-            return f"Hello, {name}!"
-
-    return GreeterTools
-```
-
-The factory function (decorated with `@register_tool_with_metadata`) must return the **class**, not an instance. MindRoom instantiates the class when building agents.
-
-All decorator arguments are keyword-only. Required fields:
-
-- `name`: Tool identifier
-- `display_name`: Human-readable name
-- `description`: Brief description
-- `category`: A `ToolCategory` enum value (`COMMUNICATION`, `DEVELOPMENT`, `EMAIL`, `ENTERTAINMENT`, `INFORMATION`, `INTEGRATIONS`, `PRODUCTIVITY`, `RESEARCH`, `SHOPPING`, `SMART_HOME`, `SOCIAL`)
-
-Common optional fields:
-
-- `status`: `ToolStatus.AVAILABLE` (default) or `REQUIRES_CONFIG`
-- `setup_type`: `SetupType.NONE` (default), `API_KEY`, `OAUTH`, or `SPECIAL`
-- `config_fields`: List of `ConfigField` objects (see below)
-- `dependencies`: List of required pip packages
-- `docs_url`: Link to documentation
-- `managed_init_args`: Explicit MindRoom-managed constructor kwargs such as `runtime_paths` or `credentials_manager`
-- `icon`: Icon name for the dashboard (e.g., `"FaGoogle"`, `"Home"`)
-- `icon_color`: Tailwind color class for the icon (e.g., `"text-blue-500"`)
-- `helper_text`: Markdown help text shown in the dashboard
-- `auth_provider`: OAuth provider identifier when using OAuth-based setup
-- `default_execution_target`: `ToolExecutionTarget.PRIMARY` (default) or `WORKER` — controls whether the tool runs on the primary agent or a sandbox worker
-
-### ConfigField
-
-Each `ConfigField` describes one constructor parameter that can be configured through the dashboard or credentials store.
-
-| Field         | Type   | Default    | Description                                                             |
-| ------------- | ------ | ---------- | ----------------------------------------------------------------------- |
-| `name`        | string | *required* | Constructor kwarg name (e.g., `"api_key"`)                              |
-| `label`       | string | *required* | Display label shown in the dashboard                                    |
-| `type`        | string | `"text"`   | Input type: `text`, `password`, `url`, `number`, `boolean`, or `select` |
-| `required`    | bool   | `True`     | Whether the field must be set before the tool can be used               |
-| `default`     | any    | `None`     | Default value when not configured                                       |
-| `placeholder` | string | `None`     | Placeholder text shown in the input                                     |
-| `description` | string | `None`     | Help text for the field                                                 |
-| `options`     | list   | `None`     | For `select` type: list of `{"label": "...", "value": "..."}` dicts     |
-| `validation`  | dict   | `None`     | Optional validation rules (min, max, pattern, etc.)                     |
-
-If your toolkit constructor expects MindRoom-managed values, declare them with `managed_init_args`. This applies to built-in tools under `src/mindroom/tools/` just as much as external plugins. MindRoom no longer inspects constructor parameter names and injects those values automatically. Undeclared managed constructor inputs will not be passed through.
-
-Available `ToolManagedInitArg` values:
-
-| Value                 | Constructor kwarg     | Description                                                             |
-| --------------------- | --------------------- | ----------------------------------------------------------------------- |
-| `RUNTIME_PATHS`       | `runtime_paths`       | Access to storage paths and environment values                          |
-| `CREDENTIALS_MANAGER` | `credentials_manager` | Read and write the per-tool credentials store                           |
-| `WORKER_TARGET`       | `worker_target`       | Resolved worker routing context (scope, execution identity, worker key) |
-
-For example, a toolkit that expects `runtime_paths` must opt in explicitly:
-
-```
-from agno.tools import Toolkit
-from mindroom.tool_system.metadata import ToolCategory, ToolManagedInitArg, register_tool_with_metadata
-
-
-@register_tool_with_metadata(
-    name="needs_runtime",
-    display_name="Needs Runtime",
-    description="Example tool that needs runtime paths",
-    category=ToolCategory.DEVELOPMENT,
-    managed_init_args=(ToolManagedInitArg.RUNTIME_PATHS,),
-)
-def needs_runtime_tools() -> type[Toolkit]:
-    class NeedsRuntimeTools(Toolkit):
-        def __init__(self, *, runtime_paths):
-            self.runtime_paths = runtime_paths
-            super().__init__(name="needs_runtime", tools=[])
-
-    return NeedsRuntimeTools
-```
-
 ## Plugin skills
 
-List skill directories in the manifest `skills` array. Those directories are added to the skill search roots.
+List skill directories in the manifest `skills` array. Each listed directory is added to MindRoom's skill search roots. Skill subdirectories must contain a `SKILL.md` file with YAML frontmatter (name, description, requirements).
 
 ## Hooks
 
-Plugins can ship typed event hooks for message enrichment, response transformation, lifecycle observation, tool call gating and observation, reactions, schedules, and custom events. See the [Hooks](https://docs.mindroom.chat/hooks/index.md) page for full documentation including:
+Plugins can ship typed event hooks for message enrichment, response transformation, lifecycle observation, tool call gating, reactions, schedules, and custom events. See the [Hooks](https://docs.mindroom.chat/hooks/index.md) page for full documentation including:
 
 - The `@hook` decorator and all parameters
 - The built-in events and their execution modes
@@ -259,10 +383,61 @@ Plugins can ship typed event hooks for message enrichment, response transformati
 - Error handling and circuit breaker behavior
 - Testing patterns
 
-## Reloading plugins
+## Live development (hot reload)
 
-Plugin manifests and tools modules are cached by mtime. Changes are picked up the next time MindRoom reloads the tool registry (for example, on startup or config reload).
+Plugins hot-reload automatically. When you edit any file inside a configured plugin directory, MindRoom detects the change within ~1 second, re-imports the plugin's modules in place, swaps the new hooks and tools into the live registry, and the next event invokes your new code. No service restart, no agent session disruption.
 
-## Security notes
+### How it works
 
-Plugins execute code in-process. Only install plugins you trust.
+- A background watcher polls each configured plugin root every ~1s and debounces saves over a ~1s window.
+- On change: the synthetic plugin package subtree is evicted from `sys.modules`, `load_plugins()` re-runs, a fresh `HookRegistry` is built, and the live registry is swapped atomically.
+- Module-level `asyncio.Task` objects on the old module are best-effort cancelled before the swap.
+- The watcher ignores `__pycache__/`, `*.pyc`, `*.pyo`, editor swap files (`*.swp`, `*~`, `.#*`, `*.tmp`), and tool caches (`.ruff_cache/`, `.mypy_cache/`, `.pytest_cache/`).
+
+### Manual reload
+
+An admin user can force a reload by sending the chat command:
+
+```
+!reload-plugins
+```
+
+The bot replies with the active plugin set and the count of cancelled background tasks.
+
+### Caveats
+
+- **In-flight turns keep their old code.** A reload swaps the registry for new events; any callback already running on the old module finishes there.
+- **No partial-write detection.** If your editor saves in two writes, the watcher may briefly load a half-written state, log an import error, and reload again on the second write.
+- **New plugins added to disk are not auto-enabled.** You still have to add them under `plugins:` in `config.yaml`. The watcher only reloads plugins that are already configured. (Editing `config.yaml` triggers its own separate hot-reload path.)
+
+## Community plugins
+
+The [mindroom-ai](https://github.com/mindroom-ai) organization maintains a collection of open-source plugins. Clone any of them into your plugins directory and add the path to `config.yaml`:
+
+```
+git clone https://github.com/mindroom-ai/ping-hook-plugin.git ~/.mindroom-chat/plugins/ping-hook
+```
+
+```
+plugins:
+  - ~/.mindroom-chat/plugins/ping-hook
+```
+
+### Hooks-only plugins
+
+| Plugin                                                                          | Description                                                                                                                                |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [ping-hook-plugin](https://github.com/mindroom-ai/ping-hook-plugin)             | Minimal example — responds to `!ping-hook` with a pong message. Good starting point for learning the hook system.                          |
+| [shell-guard-plugin](https://github.com/mindroom-ai/shell-guard-plugin)         | Blocks dangerous shell commands (e.g., `systemctl restart mindroom-chat`) via `tool:before_call` gating.                                   |
+| [voice-enrich-plugin](https://github.com/mindroom-ai/voice-enrich-plugin)       | Injects AI-only metadata when a voice-transcribed message arrives, warning the model about possible transcription errors.                  |
+| [location-enrich-plugin](https://github.com/mindroom-ai/location-enrich-plugin) | Enriches prompts with real-time GPS location from [Dawarich](https://dawarich.app/), including place matching and movement classification. |
+| [restart-resume-plugin](https://github.com/mindroom-ai/restart-resume-plugin)   | Re-activates threads tagged `pending-restart` after a bot restart.                                                                         |
+
+### Hooks + tools plugins
+
+| Plugin                                                                      | Description                                                                                                                                  |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| [thread-snooze-plugin](https://github.com/mindroom-ai/thread-snooze-plugin) | Snooze and unsnooze threads — temporarily resolves a thread and wakes it at a specified time.                                                |
+| [thread-goal-plugin](https://github.com/mindroom-ai/thread-goal-plugin)     | Persistent per-thread goals stored in Matrix room state that survive context compaction and restarts.                                        |
+| [workloop-plugin](https://github.com/mindroom-ai/workloop-plugin)           | Autonomous work plans with dependencies, priorities, auto-poke, and template-driven task creation.                                           |
+| [openviking-plugin](https://github.com/mindroom-ai/openviking-plugin)       | Long-term memory via [OpenViking](https://github.com/volcengine/OpenViking) — automatic memory extraction, recall, and compaction archiving. |


### PR DESCRIPTION
## Summary
- add a prominent security warning explaining that plugins execute arbitrary Python in-process
- document the normalized plugin entry shape, manifest constraints, dependency behavior, hot-reload details, and a fuller `ConfigField` example
- refresh generated `mindroom-docs` plugin references and add a community plugin catalog

## Testing
- `uv run pytest`
- `uv run pre-commit run --all-files`