### PR TITLE
Rejoin persisted invited rooms on startup

### DIFF
--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -102,13 +102,16 @@ class BotRoomLifecycle:
         save_invited_rooms(self.invited_rooms_file_path(), self.invited_rooms)
 
     async def join_configured_rooms(self) -> None:
-        """Join all rooms this bot is configured for."""
+        """Join all rooms this bot should preserve across restarts."""
         client = self._client()
         joined_rooms = await get_joined_rooms(client)
         current_rooms = set(joined_rooms or [])
         current_rooms.update(client.rooms)
+        desired_rooms = set(self.deps.get_configured_rooms())
+        if self.should_persist_invited_rooms():
+            desired_rooms.update(self.invited_rooms)
 
-        for room_id in self.deps.get_configured_rooms():
+        for room_id in desired_rooms:
             if room_id in current_rooms:
                 self._logger().debug("Already joined room", room_id=room_id)
                 await self.deps.on_configured_room_joined(room_id)

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -151,6 +151,55 @@ async def test_agent_skips_rejoining_rooms_it_already_has(monkeypatch: pytest.Mo
 
 
 @pytest.mark.asyncio
+async def test_agent_rejoins_persisted_invited_rooms_on_startup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Persisted ad-hoc invited rooms should be reconciled during startup joins."""
+    agent_user = AgentMatrixUser(
+        agent_name="agent1",
+        user_id="@mindroom_agent1:localhost",
+        display_name="Agent 1",
+        password=TEST_PASSWORD,
+    )
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "agent1": AgentConfig(
+                    display_name="Agent 1",
+                    role="Test agent",
+                    accept_invites=True,
+                ),
+            },
+            router=RouterConfig(model="default"),
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    invited_path = _invited_rooms_path(config, "agent1")
+    invited_path.parent.mkdir(parents=True, exist_ok=True)
+    invited_path.write_text('[\n  "!invited-room:localhost"\n]\n', encoding="utf-8")
+
+    bot = AgentBot(
+        agent_user=agent_user,
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+
+    mock_client = AsyncMock()
+    bot.client = mock_client
+
+    join_room = AsyncMock(return_value=True)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", join_room)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.get_joined_rooms", AsyncMock(return_value=[]))
+    monkeypatch.setattr("mindroom.bot.restore_scheduled_tasks", AsyncMock(return_value=0))
+
+    await bot.join_configured_rooms()
+
+    join_room.assert_awaited_once_with(mock_client, "!invited-room:localhost")
+
+
+@pytest.mark.asyncio
 async def test_agent_leaves_unconfigured_rooms(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:  # noqa: ARG001
     """Test that agents leave rooms they're no longer configured for."""
     # Create a mock agent user


### PR DESCRIPTION
## Summary
- include persisted invited rooms in startup join reconciliation
- add a regression test covering ad-hoc invited rooms restored from disk
- keep existing invite-preservation and cleanup behavior unchanged

## Testing
- uv run pytest -q tests/test_room_invites.py
- uv run pytest -q tests/test_dm_room_preservation.py -k "persisted_ad_hoc_invited_rooms or invited_room"
- uv run pytest -q tests/test_multi_agent_bot.py -k "ignores_persisted_ad_hoc_invited_rooms"