### PR TITLE
fix(ISSUE-176): attribute thread-history refresh callers and surface diagnostics

### DIFF
--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -85,6 +85,7 @@ class DeriveConversationContext(Protocol):
         event_info: EventInfo,
         *,
         event_id: str | None = None,
+        caller_label: str = "unknown",
     ) -> tuple[bool, str | None, Sequence[ResolvedVisibleMessage]]:
         """Return whether one event is threaded plus its thread id and history."""
 
@@ -495,6 +496,7 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
         room.room_id,
         event_info,
         event_id=event.event_id,
+        caller_label="command_context",
     )
 
     # Commands/tools that persist conversation context should use the same

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -316,6 +316,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> str | None:
         """Resolve canonical thread membership for one event."""
         return await resolve_event_thread_id(
@@ -325,6 +326,7 @@ class ConversationResolver:
             access=self.thread_membership_access(
                 full_history=full_history,
                 dispatch_safe=dispatch_safe,
+                caller_label=caller_label,
             ),
         )
 
@@ -347,6 +349,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> ThreadMembershipAccess:
         """Return the shared thread-membership accessors for this resolver."""
         return thread_messages_thread_membership_access(
@@ -357,6 +360,7 @@ class ConversationResolver:
                 thread_id,
                 full_history=full_history,
                 dispatch_safe=dispatch_safe,
+                caller_label=caller_label,
             ),
         )
 
@@ -367,6 +371,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve one thread read through the shared cache entrypoint."""
         return await self.deps.conversation_cache.get_thread_messages(
@@ -374,6 +379,7 @@ class ConversationResolver:
             thread_id,
             full_history=full_history,
             dispatch_safe=dispatch_safe,
+            caller_label=caller_label,
         )
 
     async def _event_info_for_event_id(
@@ -400,6 +406,7 @@ class ConversationResolver:
         event_info: EventInfo,
         *,
         event_id: str | None = None,
+        caller_label: str = "unknown",
     ) -> tuple[bool, str | None, Sequence[ResolvedVisibleMessage]]:
         """Derive conversation context from canonical Matrix thread membership."""
         is_thread, thread_id, thread_history, _requires_full_thread_history = await self._resolve_thread_context(
@@ -408,6 +415,7 @@ class ConversationResolver:
             event_info,
             full_history=True,
             dispatch_safe=False,
+            caller_label=caller_label,
         )
         return is_thread, thread_id, thread_history
 
@@ -419,6 +427,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> tuple[bool, str | None, Sequence[ResolvedVisibleMessage], bool]:
         """Resolve one thread context using either snapshot or full history."""
         thread_id = await self._explicit_thread_id_for_event(
@@ -427,6 +436,7 @@ class ConversationResolver:
             event_info,
             full_history=full_history,
             dispatch_safe=dispatch_safe,
+            caller_label=caller_label,
         )
         if thread_id is None:
             return False, None, [], False
@@ -436,6 +446,7 @@ class ConversationResolver:
             thread_id,
             full_history=full_history,
             dispatch_safe=dispatch_safe,
+            caller_label=caller_label,
         )
         if full_history:
             return True, thread_id, thread_messages, False
@@ -524,6 +535,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> MessageContext:
         """Resolve event metadata, mentions, and thread history for one inbound turn."""
         resolved_event_source = await resolve_event_source_content(event.source, self._client())
@@ -569,6 +581,7 @@ class ConversationResolver:
                 event_info,
                 full_history=full_history,
                 dispatch_safe=dispatch_safe,
+                caller_label=caller_label,
             )
 
         return MessageContext(
@@ -597,6 +610,7 @@ class ConversationResolver:
             event,
             full_history=True,
             dispatch_safe=True,
+            caller_label="dispatch_hydration",
         )
         context.thread_history = full_context.thread_history
         context.is_thread = full_context.is_thread
@@ -621,6 +635,8 @@ class ConversationResolver:
         _client: nio.AsyncClient,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Fetch strict post-lock thread history through the shared conversation-cache policy."""
         return await self._read_thread_messages(
@@ -628,4 +644,5 @@ class ConversationResolver:
             thread_id,
             full_history=True,
             dispatch_safe=True,
+            caller_label=caller_label,
         )

--- a/src/mindroom/custom_tools/matrix_message.py
+++ b/src/mindroom/custom_tools/matrix_message.py
@@ -704,7 +704,13 @@ class MatrixMessageTools(Toolkit):
         thread_id: str,
         read_limit: int,
     ) -> str:
-        thread_messages = await context.conversation_cache.get_thread_history(room_id, thread_id)
+        thread_messages = await context.conversation_cache.get_thread_messages(
+            room_id,
+            thread_id,
+            full_history=True,
+            dispatch_safe=False,
+            caller_label="matrix_message_tool",
+        )
         recent_messages = thread_messages[-read_limit:]
         return self._payload(
             "ok",

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -102,6 +102,7 @@ class EditRegenerator:
             self._client(),
             room.room_id,
             conversation_target.resolved_thread_id,
+            caller_label="edit_regeneration_context",
         )
         return MessageContext(
             am_i_mentioned=context.am_i_mentioned,
@@ -132,7 +133,10 @@ class EditRegenerator:
             self._logger().debug("ignoring_edit_from_other_agent", agent=sender_agent_name)
             return
 
-        context = await self.deps.resolver.extract_message_context(room, event)
+        context = await self.deps.resolver.extract_message_context(
+            room,
+            event,
+        )
         loaded_turn = self.deps.turn_store.load_turn(
             room=room,
             thread_id=context.thread_id or event_info.thread_id or event_info.thread_id_from_edit,

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -161,6 +161,7 @@ class InboundTurnNormalizer:
             request.room.room_id,
             event_info,
             event_id=request.event.event_id,
+            caller_label="voice_normalization",
         )
         effective_thread_id = self.deps.conversation_resolver.build_message_target(
             room_id=request.room.room_id,

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import typing
 from typing import TYPE_CHECKING
 
@@ -31,10 +32,10 @@ class ThreadReadPolicy:
         *,
         logger_getter: typing.Callable[[], structlog.stdlib.BoundLogger],
         runtime: BotRuntimeView,
-        fetch_thread_history_from_client: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
-        fetch_thread_snapshot_from_client: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
-        fetch_dispatch_thread_history_from_client: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
-        fetch_dispatch_thread_snapshot_from_client: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
+        fetch_thread_history_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
+        fetch_thread_snapshot_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
+        fetch_dispatch_thread_history_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
+        fetch_dispatch_thread_snapshot_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
     ) -> None:
         self._logger_getter = logger_getter
         self.runtime = runtime
@@ -74,12 +75,19 @@ class ThreadReadPolicy:
         room_id: str,
         thread_id: str,
         *,
-        fetcher: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
+        fetcher: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
         name: str,
         full_history: bool,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
     ) -> ThreadHistoryResult:
         async def load() -> ThreadHistoryResult:
-            thread_history = await fetcher(room_id, thread_id)
+            thread_history = await fetcher(
+                room_id,
+                thread_id,
+                caller_label=caller_label,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+            )
             if full_history:
                 return self._full_history_result(thread_history)
             return thread_history
@@ -103,9 +111,12 @@ class ThreadReadPolicy:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str,
     ) -> ThreadHistoryResult:
         """Resolve one thread read through the shared barrier and fetch selection path."""
+        queue_wait_started = time.perf_counter()
         await self._wait_for_pending_room_cache_updates(room_id)
+        coordinator_queue_wait_ms = round((time.perf_counter() - queue_wait_started) * 1000, 1)
         if full_history and dispatch_safe:
             return await self._run_thread_read(
                 room_id,
@@ -113,6 +124,8 @@ class ThreadReadPolicy:
                 fetcher=self.fetch_dispatch_thread_history_from_client,
                 name="matrix_cache_refresh_dispatch_thread_history",
                 full_history=True,
+                caller_label=caller_label,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
             )
         if full_history:
             return await self._run_thread_read(
@@ -121,6 +134,8 @@ class ThreadReadPolicy:
                 fetcher=self.fetch_thread_history_from_client,
                 name="matrix_cache_refresh_thread_history",
                 full_history=True,
+                caller_label=caller_label,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
             )
         if dispatch_safe:
             return await self._run_thread_read(
@@ -129,6 +144,8 @@ class ThreadReadPolicy:
                 fetcher=self.fetch_dispatch_thread_snapshot_from_client,
                 name="matrix_cache_refresh_dispatch_thread_snapshot",
                 full_history=False,
+                caller_label=caller_label,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
             )
         return await self._run_thread_read(
             room_id,
@@ -136,6 +153,8 @@ class ThreadReadPolicy:
             fetcher=self.fetch_thread_snapshot_from_client,
             name="matrix_cache_refresh_thread_snapshot",
             full_history=False,
+            caller_label=caller_label,
+            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         )
 
     async def get_latest_thread_event_id_if_needed(
@@ -154,6 +173,7 @@ class ThreadReadPolicy:
                 thread_id,
                 full_history=True,
                 dispatch_safe=False,
+                caller_label="unknown",
             )
         except Exception as exc:
             self.logger.warning(

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
 from mindroom.background_tasks import create_background_task, wait_for_background_tasks
+from mindroom.logging_config import bound_log_context
 
 if TYPE_CHECKING:
     import structlog
@@ -68,6 +69,8 @@ class _EventCacheWriteCoordinator:
         room_id: str,
         operation: str,
         previous_task: asyncio.Task[Any] | None,
+        *,
+        logger: structlog.stdlib.BoundLogger,
     ) -> None:
         predecessor = previous_task
         while predecessor is not None:
@@ -79,7 +82,7 @@ class _EventCacheWriteCoordinator:
                     raise
                 predecessor = self._pending_predecessor(predecessor)
             except Exception as exc:
-                self.logger.debug(
+                logger.debug(
                     "Previous room cache update failed before follow-up update",
                     room_id=room_id,
                     operation=operation,
@@ -110,8 +113,16 @@ class _EventCacheWriteCoordinator:
         previous_task = self._room_update_tasks.get(room_id)
 
         async def run_after_previous() -> object:
-            await self._await_predecessor(room_id, name, previous_task)
-            return await update_coro_factory()
+            current_task = asyncio.current_task()
+            task_name = current_task.get_name() if current_task is not None else name
+            with bound_log_context(task_name=task_name):
+                await self._await_predecessor(
+                    room_id,
+                    name,
+                    previous_task,
+                    logger=self.logger,
+                )
+                return await update_coro_factory()
 
         task = create_background_task(
             run_after_previous(),

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -84,6 +84,34 @@ def _thread_history_result(
     return thread_history_result(history, is_full_history=is_full_history, diagnostics=diagnostics)
 
 
+def _log_thread_history_refresh(
+    *,
+    room_id: str,
+    thread_id: str,
+    caller_label: str,
+    mode: str,
+    diagnostics: Mapping[str, str | int | float | bool],
+    coordinator_queue_wait_ms: float,
+) -> None:
+    """Emit one structured INFO line for a completed thread read."""
+    logger.info(
+        "matrix_cache_thread_history_refreshed",
+        room_id=room_id,
+        thread_id=thread_id,
+        caller_label=caller_label,
+        mode=mode,
+        cache_read_ms=diagnostics.get("cache_read_ms", 0.0),
+        homeserver_fetch_ms=diagnostics.get("homeserver_fetch_ms", 0.0),
+        homeserver_scan_pages=diagnostics.get("homeserver_scan_pages", 0),
+        homeserver_scanned_event_count=diagnostics.get("homeserver_scanned_event_count", 0),
+        homeserver_thread_event_count=diagnostics.get("homeserver_thread_event_count", 0),
+        resolution_ms=diagnostics.get("resolution_ms", 0.0),
+        sidecar_hydration_ms=diagnostics.get("sidecar_hydration_ms", 0.0),
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+        cache_reject_reason=diagnostics.get(THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC),
+    )
+
+
 class RoomThreadsPageError(ValueError):
     """Raised when a single /threads page request fails."""
 
@@ -517,6 +545,8 @@ async def refresh_thread_history_from_source(
     allow_stale_fallback: bool = True,
     cache_write_guard_started_at: float | None = None,
     cache_reject_diagnostics: Mapping[str, str | int | float | bool] | None = None,
+    caller_label: str = "unknown",
+    coordinator_queue_wait_ms: float = 0.0,
 ) -> ThreadHistoryResult:
     """Fetch fresh thread history from Matrix and repopulate the advisory cache."""
     try:
@@ -539,6 +569,14 @@ async def refresh_thread_history_from_source(
                 cache_reject_diagnostics=cache_reject_diagnostics,
             )
             if stale_history is not None:
+                _log_thread_history_refresh(
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    caller_label=caller_label,
+                    mode="full_scan",
+                    diagnostics=stale_history.diagnostics,
+                    coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+                )
                 return stale_history
         raise
     if _thread_history_fetch_is_cacheable(fetch_result.event_sources, thread_id=thread_id):
@@ -561,11 +599,20 @@ async def refresh_thread_history_from_source(
     }
     if cache_reject_diagnostics is not None:
         diagnostics.update(cache_reject_diagnostics)
-    return _thread_history_result(
+    result = _thread_history_result(
         fetch_result.history,
         is_full_history=hydrate_sidecars,
         diagnostics=diagnostics,
     )
+    _log_thread_history_refresh(
+        room_id=room_id,
+        thread_id=thread_id,
+        caller_label=caller_label,
+        mode="full_scan",
+        diagnostics=result.diagnostics,
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+    )
+    return result
 
 
 async def _store_thread_history_cache(
@@ -659,6 +706,8 @@ async def fetch_thread_history(
     event_cache: ConversationEventCache,
     *,
     runtime_started_at: float | None = None,
+    caller_label: str = "unknown",
+    coordinator_queue_wait_ms: float = 0.0,
 ) -> ThreadHistoryResult:
     """Fetch all messages in a thread."""
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
@@ -688,6 +737,8 @@ async def fetch_thread_history(
         event_cache,
         allow_stale_fallback=True,
         cache_reject_diagnostics=cache_reject_diagnostics,
+        caller_label=caller_label,
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
     )
 
 
@@ -698,6 +749,8 @@ async def fetch_thread_snapshot(
     event_cache: ConversationEventCache,
     *,
     runtime_started_at: float | None = None,
+    caller_label: str = "unknown",
+    coordinator_queue_wait_ms: float = 0.0,
 ) -> ThreadHistoryResult:
     """Fetch lightweight thread context without hydrating sidecars when a fresh cache hit is unavailable."""
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
@@ -728,6 +781,8 @@ async def fetch_thread_snapshot(
         hydrate_sidecars=False,
         allow_stale_fallback=True,
         cache_reject_diagnostics=cache_reject_diagnostics,
+        caller_label=caller_label,
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
     )
 
 
@@ -738,6 +793,8 @@ async def fetch_dispatch_thread_history(
     event_cache: ConversationEventCache,
     *,
     runtime_started_at: float | None = None,
+    caller_label: str = "unknown",
+    coordinator_queue_wait_ms: float = 0.0,
 ) -> ThreadHistoryResult:
     """Fetch strict full thread history for dispatch using only fresh cache data or a homeserver refill."""
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
@@ -768,6 +825,8 @@ async def fetch_dispatch_thread_history(
         hydrate_sidecars=True,
         allow_stale_fallback=False,
         cache_reject_diagnostics=cache_reject_diagnostics,
+        caller_label=caller_label,
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
     )
 
 
@@ -779,6 +838,8 @@ async def fetch_dispatch_thread_snapshot(
     *,
     runtime_started_at: float | None = None,
     cache_write_guard_started_at: float | None = None,
+    caller_label: str = "unknown",
+    coordinator_queue_wait_ms: float = 0.0,
 ) -> ThreadHistoryResult:
     """Fetch strict lightweight dispatch context using only fresh cache data or a homeserver refill."""
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
@@ -810,6 +871,8 @@ async def fetch_dispatch_thread_snapshot(
         allow_stale_fallback=False,
         cache_write_guard_started_at=cache_write_guard_started_at,
         cache_reject_diagnostics=cache_reject_diagnostics,
+        caller_label=caller_label,
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
     )
 
 

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -140,6 +140,7 @@ class ConversationCacheProtocol(Protocol):
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve thread context using explicit history and dispatch-safety flags."""
 
@@ -154,6 +155,8 @@ class ConversationCacheProtocol(Protocol):
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve advisory full thread history for one conversation root."""
 
@@ -168,6 +171,8 @@ class ConversationCacheProtocol(Protocol):
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve strict full dispatch thread history using only fresh cache data or a homeserver refill."""
 
@@ -423,6 +428,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str,
     ) -> ThreadReadResult:
         """Resolve one thread read through per-turn memoization."""
         cache_key: ThreadReadCacheKey = (room_id, thread_id, full_history, dispatch_safe)
@@ -435,6 +441,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=full_history,
             dispatch_safe=dispatch_safe,
+            caller_label=caller_label,
         )
         if turn_cache is not None:
             turn_cache[cache_key] = self._copy_thread_read_result(result)
@@ -538,6 +545,9 @@ class MatrixConversationCache(ConversationCacheProtocol):
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
     ) -> ThreadHistoryResult:
         return await fetch_thread_history(
             self._require_client(),
@@ -545,12 +555,17 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             event_cache=self.runtime.event_cache,
             runtime_started_at=self.runtime.runtime_started_at,
+            caller_label=caller_label,
+            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         )
 
     async def _fetch_thread_snapshot_from_client(
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
     ) -> ThreadHistoryResult:
         return await fetch_thread_snapshot(
             self._require_client(),
@@ -558,12 +573,17 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             event_cache=self.runtime.event_cache,
             runtime_started_at=self.runtime.runtime_started_at,
+            caller_label=caller_label,
+            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         )
 
     async def _fetch_dispatch_thread_history_from_client(
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
     ) -> ThreadHistoryResult:
         return await fetch_dispatch_thread_history(
             self._require_client(),
@@ -571,12 +591,17 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             event_cache=self.runtime.event_cache,
             runtime_started_at=self.runtime.runtime_started_at,
+            caller_label=caller_label,
+            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         )
 
     async def _fetch_dispatch_thread_snapshot_from_client(
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
     ) -> ThreadHistoryResult:
         return await fetch_dispatch_thread_snapshot(
             self._require_client(),
@@ -584,6 +609,8 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             event_cache=self.runtime.event_cache,
             runtime_started_at=self.runtime.runtime_started_at,
+            caller_label=caller_label,
+            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         )
 
     async def _refresh_dispatch_thread_snapshot_for_startup_prewarm(
@@ -600,6 +627,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             event_cache=self.runtime.event_cache,
             runtime_started_at=self.runtime.runtime_started_at,
             cache_write_guard_started_at=fetch_started_at,
+            caller_label="startup_thread_prewarm",
         )
 
     async def _startup_thread_prewarm_ids(
@@ -713,12 +741,15 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=False,
             dispatch_safe=False,
+            caller_label="unknown",
         )
 
     async def get_thread_history(
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve advisory full thread history for one conversation root."""
         return await self._read_thread_memoized(
@@ -726,6 +757,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=True,
             dispatch_safe=False,
+            caller_label=caller_label,
         )
 
     async def get_thread_messages(
@@ -735,14 +767,23 @@ class MatrixConversationCache(ConversationCacheProtocol):
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve thread context using one explicit read-mode entrypoint."""
         if dispatch_safe:
             if full_history:
-                return await self.get_dispatch_thread_history(room_id, thread_id)
+                return await self.get_dispatch_thread_history(
+                    room_id,
+                    thread_id,
+                    caller_label=caller_label,
+                )
             return await self.get_dispatch_thread_snapshot(room_id, thread_id)
         if full_history:
-            return await self.get_thread_history(room_id, thread_id)
+            return await self.get_thread_history(
+                room_id,
+                thread_id,
+                caller_label=caller_label,
+            )
         return await self.get_thread_snapshot(room_id, thread_id)
 
     async def get_dispatch_thread_snapshot(
@@ -756,12 +797,15 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=False,
             dispatch_safe=True,
+            caller_label="unknown",
         )
 
     async def get_dispatch_thread_history(
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve strict full dispatch thread history using only fresh cache data or a homeserver refill."""
         return await self._read_thread_memoized(
@@ -769,6 +813,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=True,
             dispatch_safe=True,
+            caller_label=caller_label,
         )
 
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -730,6 +730,7 @@ class ResponseRunner:
                 self._client(),
                 request.room_id,
                 request.thread_id,
+                caller_label="dispatch_post_lock_refresh",
             )
         except Exception as exc:
             if request.requires_full_thread_history:

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -1267,7 +1267,15 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
         available_agents = list(sender_visible_room_agents)
     else:
         if thread_id:
-            thread_history = list(await conversation_cache.get_thread_history(room_id, thread_id))
+            thread_history = list(
+                await conversation_cache.get_thread_messages(
+                    room_id,
+                    thread_id,
+                    full_history=True,
+                    dispatch_safe=False,
+                    caller_label="schedule_existing_thread",
+                ),
+            )
             thread_agents = get_agents_in_thread(thread_history, config, runtime_paths)
             available_agents = [agent for agent in thread_agents if agent in sender_visible_room_agents]
 

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -175,7 +175,15 @@ async def _load_thread_history(
     thread_id: str,
 ) -> list[ResolvedVisibleMessage]:
     """Load thread history through the explicit conversation-cache seam."""
-    return list(await conversation_cache.get_thread_history(room_id, thread_id))
+    return list(
+        await conversation_cache.get_thread_messages(
+            room_id,
+            thread_id,
+            full_history=True,
+            dispatch_safe=False,
+            caller_label="thread_summary_background",
+        ),
+    )
 
 
 async def _recover_last_summary_count(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -705,7 +705,12 @@ class TurnController:
     ) -> None:
         """Execute one validated interactive selection through the normal response path."""
         thread_history = (
-            await self.deps.resolver.fetch_thread_history(self._client(), room.room_id, selection.thread_id)
+            await self.deps.resolver.fetch_thread_history(
+                self._client(),
+                room.room_id,
+                selection.thread_id,
+                caller_label="interactive_selection",
+            )
             if selection.thread_id
             else []
         )
@@ -1359,7 +1364,7 @@ class TurnController:
         )
         dispatch_timing = get_dispatch_pipeline_timing(raw_event.source)
         attach_dispatch_pipeline_timing(event.source, dispatch_timing)
-        timing_scope_token = timing_scope_context.set(event.event_id[:20] if event.event_id else "unknown")
+        timing_scope_token = timing_scope_context.set(event.event_id[:20] if event.event_id else "<missing-event-id>")
         try:
             if dispatch_timing is not None:
                 dispatch_timing.mark("dispatch_start")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,7 +238,9 @@ def make_conversation_cache_mock() -> AsyncMock:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> object:
+        _ = caller_label
         if dispatch_safe:
             if full_history:
                 return await conversation_cache.get_dispatch_thread_history(room_id, thread_id)

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -703,7 +703,12 @@ async def test_handle_message_edit_reuses_persisted_target_and_thread_scope(
             requester_user_id="@user:example.com",
         )
 
-    mock_fetch_history.assert_awaited_once_with(bot.client, room.room_id, stored_target.resolved_thread_id)
+    mock_fetch_history.assert_awaited_once_with(
+        bot.client,
+        room.room_id,
+        stored_target.resolved_thread_id,
+        caller_label="edit_regeneration_context",
+    )
     mock_remove_stale_runs.assert_called_once()
     call_kwargs = mock_generate_response.call_args.kwargs
     assert call_kwargs["reply_to_event_id"] == "$original:example.com"

--- a/tests/test_hook_schedule.py
+++ b/tests/test_hook_schedule.py
@@ -306,7 +306,10 @@ async def test_schedule_hook_send_message_inherits_context_thread_id(tmp_path: P
             conversation_cache,
         )
 
-    conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with("!room:localhost", "$thread")
+    conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+        "!room:localhost",
+        "$thread",
+    )
     mock_schedule_send.assert_not_called()
     content = mock_hook_send.await_args.args[2]
     assert content["body"] == "resume"
@@ -346,7 +349,10 @@ async def test_schedule_hook_send_message_allows_explicit_room_level_opt_out(tmp
             conversation_cache,
         )
 
-    conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with("!room:localhost", None)
+    conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+        "!room:localhost",
+        None,
+    )
     mock_schedule_send.assert_not_called()
     content = mock_hook_send.await_args.args[2]
     assert content["body"] == "room-level"

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -786,7 +786,10 @@ async def test_prepare_dispatch_keeps_standard_context_for_non_router_internal_r
 
     assert dispatch is not None
     assert dispatch.context is standard_context
-    bot._conversation_resolver.extract_dispatch_context.assert_awaited_once_with(room, event)
+    bot._conversation_resolver.extract_dispatch_context.assert_awaited_once_with(
+        room,
+        event,
+    )
     bot._conversation_resolver.extract_trusted_router_relay_context.assert_not_called()
 
 

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -1250,7 +1250,13 @@ async def test_matrix_message_read_thread_enforces_max_limit() -> None:
     assert payload["limit"] == MatrixMessageTools._MAX_READ_LIMIT
     assert len(payload["messages"]) == MatrixMessageTools._MAX_READ_LIMIT
     assert "edit_options" in payload
-    ctx.conversation_cache.get_thread_history.assert_awaited_once_with(ctx.room_id, ctx.thread_id)
+    ctx.conversation_cache.get_thread_messages.assert_awaited_once_with(
+        ctx.room_id,
+        ctx.thread_id,
+        full_history=True,
+        dispatch_safe=False,
+        caller_label="matrix_message_tool",
+    )
 
 
 @pytest.mark.asyncio
@@ -1324,7 +1330,13 @@ async def test_matrix_message_thread_list_returns_thread_messages() -> None:
     assert payload["thread_id"] == "$thread-other:localhost"
     assert payload["messages"] == [thread_messages[-1].to_dict()]
     assert payload["edit_options"][0]["event_id"] == "$two"
-    ctx.conversation_cache.get_thread_history.assert_awaited_once_with(ctx.room_id, "$thread-other:localhost")
+    ctx.conversation_cache.get_thread_messages.assert_awaited_once_with(
+        ctx.room_id,
+        "$thread-other:localhost",
+        full_history=True,
+        dispatch_safe=False,
+        caller_label="matrix_message_tool",
+    )
 
 
 @pytest.mark.asyncio
@@ -1356,7 +1368,13 @@ async def test_matrix_message_thread_list_preserves_notice_messages() -> None:
     assert payload["status"] == "ok"
     assert payload["messages"] == [message.to_dict() for message in thread_messages]
     assert payload["messages"][1]["msgtype"] == "m.notice"
-    ctx.conversation_cache.get_thread_history.assert_awaited_once_with(ctx.room_id, "$thread-other:localhost")
+    ctx.conversation_cache.get_thread_messages.assert_awaited_once_with(
+        ctx.room_id,
+        "$thread-other:localhost",
+        full_history=True,
+        dispatch_safe=False,
+        caller_label="matrix_message_tool",
+    )
 
 
 @pytest.mark.asyncio
@@ -2051,7 +2069,13 @@ async def test_matrix_message_read_explicit_thread_id_still_reads_that_thread() 
     assert payload["action"] == "read"
     assert payload["thread_id"] == "$thread-other:localhost"
     assert payload["messages"] == [thread_messages[-1].to_dict()]
-    ctx.conversation_cache.get_thread_history.assert_awaited_once_with(ctx.room_id, "$thread-other:localhost")
+    ctx.conversation_cache.get_thread_messages.assert_awaited_once_with(
+        ctx.room_id,
+        "$thread-other:localhost",
+        full_history=True,
+        dispatch_safe=False,
+        caller_label="matrix_message_tool",
+    )
     ctx.client.room_messages.assert_not_awaited()
 
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -3482,7 +3482,17 @@ class TestAgentBot:
         bot.client = AsyncMock()
         _install_runtime_cache_support(bot)
 
-        async def cached_history_refresh(_room_id: str, _thread_id: str) -> list[ResolvedVisibleMessage]:
+        async def cached_history_refresh(
+            _room_id: str,
+            _thread_id: str,
+            *,
+            full_history: bool,
+            dispatch_safe: bool,
+            caller_label: str,
+        ) -> list[ResolvedVisibleMessage]:
+            assert full_history is True
+            assert dispatch_safe is True
+            assert caller_label == "dispatch_post_lock_refresh"
             return fresh_history
 
         with (
@@ -3504,7 +3514,7 @@ class TestAgentBot:
             ),
             patch.object(
                 bot._conversation_cache,
-                "get_dispatch_thread_history",
+                "get_thread_messages",
                 new=AsyncMock(side_effect=cached_history_refresh),
             ) as mock_get_thread_history,
             patch_response_runner_module(
@@ -3525,7 +3535,13 @@ class TestAgentBot:
                 )
 
         assert event_id == "$response"
-        mock_get_thread_history.assert_awaited_once_with("!test:localhost", "$thread")
+        mock_get_thread_history.assert_awaited_once_with(
+            "!test:localhost",
+            "$thread",
+            full_history=True,
+            dispatch_safe=True,
+            caller_label="dispatch_post_lock_refresh",
+        )
         request = mock_process.await_args.args[0]
         assert list(request.thread_history) == fresh_history
         assert request.thread_history[0].stream_status == STREAM_STATUS_COMPLETED
@@ -7107,12 +7123,11 @@ class TestAgentBot:
         assert context.thread_id == "$thread_root"
         assert context.thread_history == snapshot_history
         assert context.requires_full_thread_history is True
-        mock_snapshot.assert_awaited_once_with(
+        mock_snapshot.assert_awaited_once()
+        assert mock_snapshot.await_args.args == (
             bot.client,
             room.room_id,
             "$thread_root",
-            event_cache=bot.event_cache,
-            runtime_started_at=bot._runtime_view.runtime_started_at,
         )
 
     @pytest.mark.asyncio

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -589,7 +589,12 @@ async def test_refresh_thread_history_after_lock_refreshes_empty_thread_history(
             ),
         )
 
-    mock_fetch_thread_history.assert_awaited_once_with(bot.client, "!room:localhost", "$thread")
+    mock_fetch_thread_history.assert_awaited_once_with(
+        bot.client,
+        "!room:localhost",
+        "$thread",
+        caller_label="dispatch_post_lock_refresh",
+    )
     assert request.thread_history == fresh_history
 
 

--- a/tests/test_schedule_agent_validation.py
+++ b/tests/test_schedule_agent_validation.py
@@ -38,6 +38,7 @@ def create_mock_room(room_id: str, user_ids: list[str] | None = None) -> nio.Mat
 def _conversation_cache(thread_history: list[object] | None = None) -> MagicMock:
     access = MagicMock()
     access.get_thread_history = AsyncMock(return_value=list(thread_history or []))
+    access.get_thread_messages = AsyncMock(return_value=list(thread_history or []))
     return access
 
 
@@ -383,7 +384,7 @@ async def test_schedule_with_no_agent_mentions() -> None:
     assert task_id is not None
     assert "✅ Scheduled" in response
     assert "New room-level thread root" in response
-    conversation_cache.get_thread_history.assert_not_called()
+    conversation_cache.get_thread_messages.assert_not_called()
     available_agents = mock_parse.await_args.args[3]
     expected_agents = [
         config.get_ids(runtime_paths_for(config))["assistant"],

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -51,6 +51,7 @@ def _conversation_cache(
 ) -> AsyncMock:
     access = AsyncMock()
     access.get_thread_history = AsyncMock(return_value=list(thread_history or []))
+    access.get_thread_messages = AsyncMock(return_value=list(thread_history or []))
     access.get_latest_thread_event_id_if_needed = AsyncMock(return_value=latest_thread_event_id)
     access.notify_outbound_message = Mock()
     return access

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -624,6 +624,8 @@ class TestThreadHistory:
             cache_reject_diagnostics={
                 THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "no_cache_state",
             },
+            caller_label="unknown",
+            coordinator_queue_wait_ms=0.0,
         )
 
     @pytest.mark.asyncio
@@ -671,6 +673,8 @@ class TestThreadHistory:
             cache_reject_diagnostics={
                 THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "no_cache_state",
             },
+            caller_label="unknown",
+            coordinator_queue_wait_ms=0.0,
         )
 
     @pytest.mark.asyncio
@@ -2803,3 +2807,76 @@ class TestThreadHistoryCache:
         assert room_stale_revalidated is False
         assert [message.event_id for message in history] == ["$thread_root", "$reply1", "$reply2"]
         assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_HOMESERVER
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_history_logs_refresh_diagnostics_for_cache_miss(self) -> None:
+        """Homeserver refills should emit the phase-1 diagnostics line with miss metadata."""
+        logger = MagicMock()
+        refreshed_history = [
+            ResolvedVisibleMessage.synthetic(
+                sender="@user:localhost",
+                body="refreshed",
+                event_id="$thread_root",
+                content={"body": "refreshed"},
+            ),
+        ]
+
+        with (
+            patch.object(matrix_client_module, "logger", logger),
+            patch(
+                "mindroom.matrix.client_thread_history._load_cached_thread_history_if_usable",
+                new=AsyncMock(
+                    return_value=(
+                        None,
+                        {
+                            THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "no_cache_state",
+                        },
+                    ),
+                ),
+            ),
+            patch(
+                "mindroom.matrix.client_thread_history._fetch_thread_history_with_events",
+                new=AsyncMock(
+                    return_value=MagicMock(
+                        history=refreshed_history,
+                        event_sources=[{"event_id": "$thread_root"}],
+                        fetch_ms=91.2,
+                        room_scan_pages=7,
+                        scanned_event_count=42,
+                        resolution_ms=8.6,
+                        sidecar_hydration_ms=4.4,
+                    ),
+                ),
+            ),
+            patch("mindroom.matrix.client_thread_history._store_thread_history_cache", new=AsyncMock()),
+        ):
+            history = await matrix_client_module.fetch_thread_history(
+                AsyncMock(),
+                "!room:localhost",
+                "$thread_root",
+                event_cache=_event_cache(),
+                caller_label="cache_miss_test",
+                coordinator_queue_wait_ms=45.6,
+            )
+
+        assert [message.event_id for message in history] == ["$thread_root"]
+        refreshed_log = next(
+            call
+            for call in logger.info.call_args_list
+            if call.args and call.args[0] == "matrix_cache_thread_history_refreshed"
+        )
+        assert refreshed_log.kwargs == {
+            "room_id": "!room:localhost",
+            "thread_id": "$thread_root",
+            "caller_label": "cache_miss_test",
+            "mode": "full_scan",
+            "cache_read_ms": 0.0,
+            "homeserver_fetch_ms": 91.2,
+            "homeserver_scan_pages": 7,
+            "homeserver_scanned_event_count": 42,
+            "homeserver_thread_event_count": 1,
+            "resolution_ms": 8.6,
+            "sidecar_hydration_ms": 4.4,
+            "coordinator_queue_wait_ms": 45.6,
+            "cache_reject_reason": "no_cache_state",
+        }

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -1354,7 +1354,11 @@ class TestExtractedModuleLoggerRebinding:
             ),
         )
 
-        bot._conversation_cache.get_dispatch_thread_history.assert_awaited_once_with("!room:localhost", "$threadroot")
+        bot._conversation_cache.get_dispatch_thread_history.assert_awaited_once()
+        assert bot._conversation_cache.get_dispatch_thread_history.await_args.args == (
+            "!room:localhost",
+            "$threadroot",
+        )
 
     @pytest.mark.asyncio
     async def test_conversation_cache_fetch_path_passes_explicit_event_cache(

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -1163,7 +1163,10 @@ class TestSendSummaryEvent:
         assert meta["message_count"] == 15
         assert meta["model"] == "haiku"
         assert "generated_at" in meta
-        conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with("!room:x", "$root1")
+        conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+            "!room:x",
+            "$root1",
+        )
         conversation_cache.notify_outbound_message.assert_called_once_with("!room:x", "$s1", content)
 
     async def test_event_content_truncates_overlong_summary(self) -> None:
@@ -1246,7 +1249,7 @@ class TestSetManualThreadSummary:
         """Manual summary writes should normalize text, count non-summary messages, and update the cache."""
         client = _mock_client()
         conversation_cache = AsyncMock()
-        conversation_cache.get_thread_history.return_value = [
+        conversation_cache.get_thread_messages.return_value = [
             *_make_thread_history(3),
             _make_summary_notice_message("$root1", message_count=2),
         ]
@@ -1265,7 +1268,7 @@ class TestSetManualThreadSummary:
 
         assert result.event_id == "$summary1"
         assert result.summary == "Fix ISSUE-116"
-        assert result.message_count == _count_non_summary_messages(conversation_cache.get_thread_history.return_value)
+        assert result.message_count == _count_non_summary_messages(conversation_cache.get_thread_messages.return_value)
         mock_send.assert_awaited_once_with(
             client,
             "!room:x",
@@ -1281,7 +1284,7 @@ class TestSetManualThreadSummary:
         """A failed manual summary send should not advance the cached threshold baseline."""
         client = _mock_client()
         conversation_cache = AsyncMock()
-        conversation_cache.get_thread_history.return_value = _make_thread_history(5)
+        conversation_cache.get_thread_messages.return_value = _make_thread_history(5)
         update_last_summary_count("!room:x", "$root1", 2)
 
         with (
@@ -1305,7 +1308,7 @@ class TestSetManualThreadSummary:
         """A failed history fetch should raise the shared manual-summary fetch error."""
         client = _mock_client()
         conversation_cache = AsyncMock()
-        conversation_cache.get_thread_history.side_effect = TimeoutError("timed out")
+        conversation_cache.get_thread_messages.side_effect = TimeoutError("timed out")
 
         with pytest.raises(ThreadSummaryWriteError, match=r"Failed to fetch thread history for the target thread\."):
             await set_manual_thread_summary(

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -1101,6 +1101,7 @@ class TestMatrixConversationCacheThreadReads:
             "$thread_root",
             full_history=True,
             dispatch_safe=True,
+            caller_label="unknown",
         )
 
     def test_collect_sync_timeline_cache_updates_treats_reference_as_thread_candidate(self) -> None:
@@ -1163,6 +1164,8 @@ class TestMatrixConversationCacheThreadReads:
         access._reads.fetch_thread_history_from_client.assert_awaited_once_with(
             "!room:localhost",
             "$thread-root:localhost",
+            caller_label="unknown",
+            coordinator_queue_wait_ms=0.0,
         )
 
     @pytest.mark.asyncio
@@ -2789,7 +2792,11 @@ class TestThreadingBehavior:
             await allow_resolve.wait()
             return MutationThreadImpact.threaded("$mutated-thread:localhost")
 
-        async def quick_snapshot(_room_id: str, _thread_id: str) -> ThreadHistoryResult:
+        async def quick_snapshot(
+            _room_id: str,
+            _thread_id: str,
+            **_kwargs: object,
+        ) -> ThreadHistoryResult:
             read_finished.set()
             return thread_history_result(
                 [_message(event_id="$other-thread:localhost", body="Root")],
@@ -2854,7 +2861,11 @@ class TestThreadingBehavior:
             await allow_resolve.wait()
             return MutationThreadImpact.room_level()
 
-        async def quick_snapshot(_room_id: str, _thread_id: str) -> ThreadHistoryResult:
+        async def quick_snapshot(
+            _room_id: str,
+            _thread_id: str,
+            **_kwargs: object,
+        ) -> ThreadHistoryResult:
             read_finished.set()
             return thread_history_result(
                 [_message(event_id="$other-thread:localhost", body="Root")],
@@ -4139,6 +4150,7 @@ class TestThreadingBehavior:
         async def slow_refresh(
             _room_id: str,
             _thread_id: str,
+            **_kwargs: object,
         ) -> ThreadHistoryResult:
             refresh_started.set()
             await allow_refresh.wait()
@@ -4183,6 +4195,7 @@ class TestThreadingBehavior:
         async def slow_refresh(
             _room_id: str,
             _thread_id: str,
+            **_kwargs: object,
         ) -> ThreadHistoryResult:
             refresh_started.set()
             await allow_refresh.wait()
@@ -4263,6 +4276,7 @@ class TestThreadingBehavior:
         async def fetch_fresh_history(
             _room_id: str,
             _thread_id: str,
+            **_kwargs: object,
         ) -> ThreadHistoryResult:
             thread_state["value"] = ThreadCacheState(
                 validated_at=time.time(),
@@ -4317,10 +4331,13 @@ class TestThreadingBehavior:
         await write_task
 
         assert [message.body for message in history] == ["Root", "Old reply", "New reply"]
-        access._reads.fetch_thread_history_from_client.assert_awaited_once_with(
+        access._reads.fetch_thread_history_from_client.assert_awaited_once()
+        assert access._reads.fetch_thread_history_from_client.await_args.args == (
             "!room:localhost",
             "$thread:localhost",
         )
+        assert access._reads.fetch_thread_history_from_client.await_args.kwargs["caller_label"] == "unknown"
+        assert access._reads.fetch_thread_history_from_client.await_args.kwargs["coordinator_queue_wait_ms"] > 0
 
     @pytest.mark.asyncio
     async def test_latest_thread_event_lookup_refetches_invalidated_thread_tail(
@@ -4458,21 +4475,21 @@ class TestThreadingBehavior:
             is_full_history=True,
         )
 
-        access._reads.read_thread = AsyncMock(return_value=expected)
+        access.get_dispatch_thread_history = AsyncMock(return_value=expected)
 
         result = await access.get_thread_messages(
             "!test:localhost",
             "$thread:localhost",
             full_history=True,
             dispatch_safe=True,
+            caller_label="test_label",
         )
 
         assert result == expected
-        access._reads.read_thread.assert_awaited_once_with(
+        access.get_dispatch_thread_history.assert_awaited_once_with(
             "!test:localhost",
             "$thread:localhost",
-            full_history=True,
-            dispatch_safe=True,
+            caller_label="test_label",
         )
 
     @pytest.mark.asyncio
@@ -4817,7 +4834,11 @@ class TestThreadingBehavior:
                 "get_dispatch_thread_snapshot",
                 AsyncMock(return_value=thread_history_result([], is_full_history=False)),
             ),
-            patch.object(bot._conversation_cache, "get_dispatch_thread_history", AsyncMock(return_value=[])),
+            patch.object(
+                bot._conversation_cache,
+                "get_thread_messages",
+                AsyncMock(return_value=thread_history_result([], is_full_history=True)),
+            ),
         ):
             # Process the message
             await bot._on_message(room, event)
@@ -4874,10 +4895,8 @@ class TestThreadingBehavior:
         assert context.is_thread is True
         assert context.thread_id == "$thread_root:localhost"
         assert context.thread_history == expected_history
-        mock_fetch.assert_awaited_once_with(
-            room.room_id,
-            "$thread_root:localhost",
-        )
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_edit_resolves_thread_from_original_event(self, bot: AgentBot) -> None:
@@ -4937,10 +4956,8 @@ class TestThreadingBehavior:
         assert context.thread_id == "$thread_root:localhost"
         assert context.thread_history == expected_history
         bot.client.room_get_event.assert_awaited_once_with(room.room_id, "$thread_msg:localhost")
-        mock_fetch.assert_awaited_once_with(
-            room.room_id,
-            "$thread_root:localhost",
-        )
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_edit_of_plain_root_message_stays_room_level(self, bot: AgentBot) -> None:
@@ -5002,7 +5019,8 @@ class TestThreadingBehavior:
         assert context.thread_id is None
         assert context.thread_history == []
         bot.client.room_get_event.assert_awaited_once_with(room.room_id, "$room_message:localhost")
-        mock_fetch.assert_awaited_once_with(room.room_id, "$room_message:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$room_message:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_plain_reply_to_thread_reply_inherits_existing_thread(
@@ -5051,7 +5069,8 @@ class TestThreadingBehavior:
         assert context.thread_id == "$thread_root:localhost"
         assert context.thread_history == expected_history
         mock_lookup.assert_awaited_once_with(room.room_id, "$thread_msg:localhost")
-        mock_fetch.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_plain_reply_to_thread_root_inherits_existing_thread(
@@ -5217,7 +5236,8 @@ class TestThreadingBehavior:
             call(room.room_id, "$plain_reply_1:localhost"),
             call(room.room_id, "$thread_msg:localhost"),
         ]
-        mock_fetch.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_plain_reply_to_promoted_plain_reply_stays_threaded(
@@ -5279,7 +5299,8 @@ class TestThreadingBehavior:
         assert context.thread_id == "$thread_root:localhost"
         assert context.thread_history == [_message(event_id="$thread_root:localhost", body="root")]
         mock_lookup.assert_awaited_once_with(room.room_id, "$plain_reply_1:localhost")
-        mock_fetch.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
         bot.client.room_get_event.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -5360,7 +5381,8 @@ class TestThreadingBehavior:
             assert context.thread_id == "$thread_root:localhost"
             assert context.thread_history == expected_history
             bot.client.room_get_event.assert_not_awaited()
-            mock_fetch.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+            mock_fetch.assert_awaited_once()
+            assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
         finally:
             await real_event_cache.close()
 
@@ -5519,7 +5541,8 @@ class TestThreadingBehavior:
         assert context.thread_history == expected_history
         assert bot.client.room_get_event.await_args_list[0].args == (room.room_id, "$plain-reply:localhost")
         assert bot.client.room_get_event.await_args_list[1].args == (room.room_id, "$thread-reply:localhost")
-        mock_fetch.assert_awaited_once_with(room.room_id, "$thread-root:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread-root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_edit_of_plain_root_message_stays_room_level_when_snapshot_has_only_root(
@@ -5584,7 +5607,8 @@ class TestThreadingBehavior:
         assert context.thread_history == []
         bot.client.room_get_event.assert_awaited_once_with(room.room_id, "$room_root:localhost")
         bot.event_cache.get_thread_id_for_event.assert_awaited_once_with(room.room_id, "$room_root:localhost")
-        mock_snapshot.assert_awaited_once_with(room.room_id, "$room_root:localhost")
+        mock_snapshot.assert_awaited_once()
+        assert mock_snapshot.await_args.args == (room.room_id, "$room_root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_edit_of_plain_root_message_degrades_when_thread_lookup_fails(
@@ -5654,7 +5678,8 @@ class TestThreadingBehavior:
         assert context.thread_history == []
         bot.client.room_get_event.assert_awaited_once_with(room.room_id, "$room_message:localhost")
         bot.event_cache.get_thread_id_for_event.assert_awaited_once_with(room.room_id, "$room_message:localhost")
-        mock_fetch.assert_awaited_once_with(room.room_id, "$room_message:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$room_message:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_plain_reply_to_threaded_message_stays_threaded_transitively(
@@ -5744,7 +5769,8 @@ class TestThreadingBehavior:
         assert context.is_thread is True
         assert context.thread_id == "$thread_root:localhost"
         assert context.thread_history == expected_history
-        mock_fetch.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
 
     @pytest.mark.asyncio
     async def test_explicit_thread_id_returns_none_for_cyclic_edit_chain(self, bot: AgentBot) -> None:
@@ -5888,7 +5914,8 @@ class TestThreadingBehavior:
             bot.client.download.assert_not_awaited()
             bot.client.room_get_event.assert_not_awaited()
             mock_lookup.assert_awaited_once_with(room.room_id, "$plain1:localhost")
-            mock_snapshot.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+            mock_snapshot.assert_awaited_once()
+            assert mock_snapshot.await_args.args == (room.room_id, "$thread_root:localhost")
             mock_fetch.assert_not_called()
 
     @pytest.mark.asyncio
@@ -5945,6 +5972,7 @@ class TestThreadingBehavior:
             "$thread_root:localhost",
             full_history=False,
             dispatch_safe=True,
+            caller_label="unknown",
         )
 
     @pytest.mark.asyncio
@@ -6127,12 +6155,8 @@ class TestThreadingBehavior:
                     AsyncMock(return_value=thread_history_result([], is_full_history=False)),
                 ),
                 patch(
-                    "mindroom.matrix.conversation_cache.MatrixConversationCache.get_dispatch_thread_history",
-                    AsyncMock(return_value=[]),
-                ),
-                patch(
-                    "mindroom.matrix.conversation_cache.MatrixConversationCache.get_thread_history",
-                    AsyncMock(return_value=[]),
+                    "mindroom.matrix.conversation_cache.MatrixConversationCache.get_thread_messages",
+                    AsyncMock(return_value=thread_history_result([], is_full_history=True)),
                 ),
             ):
                 # Process the command

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -53,6 +53,7 @@ def _conversation_cache(
 ) -> AsyncMock:
     access = AsyncMock()
     access.get_thread_history = AsyncMock(return_value=list(thread_history or []))
+    access.get_thread_messages = AsyncMock(return_value=list(thread_history or []))
     access.get_latest_thread_event_id_if_needed = AsyncMock(return_value=latest_thread_event_id)
     access.notify_outbound_message = Mock()
     return access

--- a/tests/test_workloop_thread_scope.py
+++ b/tests/test_workloop_thread_scope.py
@@ -116,6 +116,10 @@ def _copy_plugin_root(tmp_path: Path) -> Path:
             "from . import commands, formatting, poke, state, todos, types as workloop_types",
             f"from {package_prefix} import commands, formatting, poke, state, todos, types as workloop_types",
         )
+        module_text = module_text.replace(
+            "from . import commands, formatting, poke, runtime as workloop_runtime, state, todos",
+            f"from {package_prefix} import commands, formatting, poke, runtime as workloop_runtime, state, todos",
+        )
         module_text = module_text.replace("from .formatting import ", f"from {package_prefix}.formatting import ")
         module_text = module_text.replace("from .poke import ", f"from {package_prefix}.poke import ")
         module_text = module_text.replace("from .state import ", f"from {package_prefix}.state import ")


### PR DESCRIPTION
## Summary
- cherry-pick `00ab498c6db08e02c94b92d7c26e0ada086d6c41` onto current `main`
- thread `caller_label` through thread-history refresh paths and surface the ISSUE-176 diagnostics on top of current `origin/main`
- include the accompanying tests and conflict resolution needed to apply the commit cleanly after `main` moved

## Test Plan
- `uv sync --all-extras`
- `uv run pytest`
