### PR TITLE
fix: align team prompt preparation across matrix and ad hoc runs

### DIFF
--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -98,6 +98,15 @@ class PreparedExecutionContext:
         return self.messages[:-1]
 
 
+@dataclass(frozen=True)
+class ThreadHistoryRenderLimits:
+    """Optional limits for rendering visible thread history back into prompt messages."""
+
+    max_messages: int | None = None
+    max_message_length: int | None = None
+    missing_sender_label: str | None = None
+
+
 def _wrap_msg_body(sender: str, body: str) -> str:
     """Render one Matrix message as a <msg from="..."><![CDATA[...]]></msg> tag."""
     safe_body = body.replace("]]>", "]]]]><![CDATA[>")
@@ -492,9 +501,7 @@ async def _prepare_execution_context_common(
     config: Config,
     prepare_scope_history_fn: Callable[[str, str | None], Awaitable[PreparedScopeHistory]],
     estimate_static_tokens_fn: Callable[[str, str | None], int],
-    fallback_max_messages: int | None = None,
-    fallback_max_message_length: int | None = None,
-    fallback_missing_sender_label: str | None = None,
+    thread_history_render_limits: ThreadHistoryRenderLimits | None = None,
     timing_scope: str | None = None,
 ) -> PreparedExecutionContext:
     """Prepare one request-scoped prompt/replay plan after unseen-thread handling."""
@@ -508,9 +515,13 @@ async def _prepare_execution_context_common(
             thread_history,
             response_sender_id=response_sender_id,
             current_sender_id=current_sender_id,
-            max_messages=fallback_max_messages,
-            max_message_length=fallback_max_message_length,
-            missing_sender_label=fallback_missing_sender_label,
+            max_messages=thread_history_render_limits.max_messages if thread_history_render_limits else None,
+            max_message_length=(
+                thread_history_render_limits.max_message_length if thread_history_render_limits else None
+            ),
+            missing_sender_label=(
+                thread_history_render_limits.missing_sender_label if thread_history_render_limits else None
+            ),
         )
     )
 
@@ -628,9 +639,7 @@ async def prepare_agent_execution_context(
             full_prompt=prepared_prompt,
             fallback_full_prompt=replay_fallback_prompt,
         ),
-        fallback_max_messages=None,
-        fallback_max_message_length=None,
-        fallback_missing_sender_label=None,
+        thread_history_render_limits=None,
         timing_scope=timing_scope,
     )
 
@@ -652,9 +661,7 @@ async def prepare_bound_team_execution_context(
     response_sender_id: str | None = None,
     current_sender_id: str | None = None,
     compaction_outcomes_collector: list[CompactionOutcome] | None = None,
-    fallback_max_messages: int | None = None,
-    fallback_max_message_length: int | None = None,
-    fallback_missing_sender_label: str | None = None,
+    thread_history_render_limits: ThreadHistoryRenderLimits | None = None,
 ) -> PreparedExecutionContext:
     """Prepare one bound team scope for the current call."""
 
@@ -692,7 +699,5 @@ async def prepare_bound_team_execution_context(
             full_prompt=prepared_prompt,
             fallback_full_prompt=replay_fallback_prompt,
         ),
-        fallback_max_messages=fallback_max_messages,
-        fallback_max_message_length=fallback_max_message_length,
-        fallback_missing_sender_label=fallback_missing_sender_label,
+        thread_history_render_limits=thread_history_render_limits,
     )

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -340,6 +340,17 @@ def render_prepared_messages_text(messages: Sequence[Message]) -> str:
     return "\n\n".join(str(message.content) for message in messages if message.content)
 
 
+def render_prepared_team_messages_text(messages: Sequence[Message]) -> str:
+    """Render prepared team messages into the exact string form passed to Agno teams."""
+    rendered_chunks: list[str] = []
+    for message in messages:
+        if not message.content:
+            continue
+        content = str(message.content)
+        rendered_chunks.append(f"assistant: {content}" if message.role == "assistant" else content)
+    return "\n\n".join(rendered_chunks)
+
+
 def _build_unseen_context_messages(
     prompt: str,
     thread_history: Sequence[ResolvedVisibleMessage],
@@ -501,6 +512,7 @@ async def _prepare_execution_context_common(
     config: Config,
     prepare_scope_history_fn: Callable[[str, str | None], Awaitable[PreparedScopeHistory]],
     estimate_static_tokens_fn: Callable[[str, str | None], int],
+    render_messages_text_fn: Callable[[Sequence[Message]], str],
     thread_history_render_limits: ThreadHistoryRenderLimits | None = None,
     timing_scope: str | None = None,
 ) -> PreparedExecutionContext:
@@ -538,8 +550,8 @@ async def _prepare_execution_context_common(
         )
 
     prepared_scope_history = await prepare_scope_history_fn(
-        render_prepared_messages_text(provisional_messages),
-        render_prepared_messages_text(replay_fallback_messages) if replay_fallback_messages is not None else None,
+        render_messages_text_fn(provisional_messages),
+        render_messages_text_fn(replay_fallback_messages) if replay_fallback_messages is not None else None,
     )
 
     final_messages = _messages_with_current_prompt(prompt, current_sender_id=current_sender_id)
@@ -560,8 +572,8 @@ async def _prepare_execution_context_common(
         prepared_scope_history=prepared_scope_history,
         config=config,
         static_prompt_tokens=estimate_static_tokens_fn(
-            render_prepared_messages_text(final_messages),
-            render_prepared_messages_text(replay_fallback_messages) if replay_fallback_messages is not None else None,
+            render_messages_text_fn(final_messages),
+            render_messages_text_fn(replay_fallback_messages) if replay_fallback_messages is not None else None,
         ),
     )
     if replay_fallback_messages is not None and not prepared_history.replays_persisted_history and thread_history:
@@ -639,6 +651,7 @@ async def prepare_agent_execution_context(
             full_prompt=prepared_prompt,
             fallback_full_prompt=replay_fallback_prompt,
         ),
+        render_messages_text_fn=render_prepared_messages_text,
         thread_history_render_limits=None,
         timing_scope=timing_scope,
     )
@@ -699,5 +712,6 @@ async def prepare_bound_team_execution_context(
             full_prompt=prepared_prompt,
             fallback_full_prompt=replay_fallback_prompt,
         ),
+        render_messages_text_fn=render_prepared_team_messages_text,
         thread_history_render_limits=thread_history_render_limits,
     )

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -269,11 +269,14 @@ def _context_message_from_visible_message(
     message: ResolvedVisibleMessage,
     *,
     response_sender_id: str | None,
+    missing_sender_label: str | None = None,
 ) -> Message:
     """Convert one visible Matrix message into a structured Agno message."""
     if response_sender_id is not None and message.sender == response_sender_id:
         return Message(role="assistant", content=message.body)
     speaker_label = _message_speaker_label(message)
+    if not speaker_label:
+        speaker_label = missing_sender_label
     if speaker_label:
         return Message(role="user", content=f"{speaker_label}: {message.body}")
     return Message(role="user", content=message.body)
@@ -283,12 +286,20 @@ def _context_messages_from_visible_messages(
     messages: Sequence[ResolvedVisibleMessage],
     *,
     response_sender_id: str | None,
+    max_messages: int | None = None,
+    max_message_length: int | None = None,
+    missing_sender_label: str | None = None,
 ) -> tuple[Message, ...]:
     """Convert visible Matrix context into provider-native message objects."""
+    visible_messages = messages[-max_messages:] if max_messages is not None else messages
     return tuple(
-        _context_message_from_visible_message(message, response_sender_id=response_sender_id)
-        for message in messages
-        if message.body
+        _context_message_from_visible_message(
+            message,
+            response_sender_id=response_sender_id,
+            missing_sender_label=missing_sender_label,
+        )
+        for message in visible_messages
+        if message.body and (max_message_length is None or len(message.body) < max_message_length)
     )
 
 
@@ -366,6 +377,9 @@ def _build_thread_history_messages(
     *,
     response_sender_id: str | None,
     current_sender_id: str | None = None,
+    max_messages: int | None = None,
+    max_message_length: int | None = None,
+    missing_sender_label: str | None = None,
 ) -> tuple[Message, ...]:
     """Return canonical request messages for fallback full-thread replay."""
     if not thread_history:
@@ -375,6 +389,9 @@ def _build_thread_history_messages(
         context_messages=_context_messages_from_visible_messages(
             thread_history,
             response_sender_id=response_sender_id,
+            max_messages=max_messages,
+            max_message_length=max_message_length,
+            missing_sender_label=missing_sender_label,
         ),
         current_sender_id=current_sender_id,
     )
@@ -475,6 +492,9 @@ async def _prepare_execution_context_common(
     config: Config,
     prepare_scope_history_fn: Callable[[str, str | None], Awaitable[PreparedScopeHistory]],
     estimate_static_tokens_fn: Callable[[str, str | None], int],
+    fallback_max_messages: int | None = None,
+    fallback_max_message_length: int | None = None,
+    fallback_missing_sender_label: str | None = None,
     timing_scope: str | None = None,
 ) -> PreparedExecutionContext:
     """Prepare one request-scoped prompt/replay plan after unseen-thread handling."""
@@ -488,6 +508,9 @@ async def _prepare_execution_context_common(
             thread_history,
             response_sender_id=response_sender_id,
             current_sender_id=current_sender_id,
+            max_messages=fallback_max_messages,
+            max_message_length=fallback_max_message_length,
+            missing_sender_label=fallback_missing_sender_label,
         )
     )
 
@@ -605,6 +628,9 @@ async def prepare_agent_execution_context(
             full_prompt=prepared_prompt,
             fallback_full_prompt=replay_fallback_prompt,
         ),
+        fallback_max_messages=None,
+        fallback_max_message_length=None,
+        fallback_missing_sender_label=None,
         timing_scope=timing_scope,
     )
 
@@ -626,6 +652,9 @@ async def prepare_bound_team_execution_context(
     response_sender_id: str | None = None,
     current_sender_id: str | None = None,
     compaction_outcomes_collector: list[CompactionOutcome] | None = None,
+    fallback_max_messages: int | None = None,
+    fallback_max_message_length: int | None = None,
+    fallback_missing_sender_label: str | None = None,
 ) -> PreparedExecutionContext:
     """Prepare one bound team scope for the current call."""
 
@@ -663,4 +692,7 @@ async def prepare_bound_team_execution_context(
             full_prompt=prepared_prompt,
             fallback_full_prompt=replay_fallback_prompt,
         ),
+        fallback_max_messages=fallback_max_messages,
+        fallback_max_message_length=fallback_max_message_length,
+        fallback_missing_sender_label=fallback_missing_sender_label,
     )

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -207,6 +207,8 @@ def build_llm_request_log_context(
             context["source_event_prompts"] = source_event_prompts
 
     return context
+
+
 @contextmanager
 def bind_llm_request_log_context(**context: object) -> Iterator[None]:
     """Bind per-run request metadata so log entries can be attributed later."""

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -216,7 +216,15 @@ def prepare_memory_and_model_context(
     """Return raw memory inputs alongside timestamped model-facing context."""
     model_prompt_content = model_prompt or prompt
     if model_prompt is not None and prompt:
-        if model_prompt == prompt or model_prompt.startswith(f"{prompt}\n\n"):
+        normalized_model_prompt = model_prompt.strip()
+        normalized_prompt = prompt.strip()
+        normalized_model_prompt_without_time = strip_user_turn_time_prefix(normalized_model_prompt)
+        if (
+            normalized_model_prompt == normalized_prompt
+            or normalized_model_prompt.startswith(f"{normalized_prompt}\n\n")
+            or normalized_model_prompt_without_time == normalized_prompt
+            or normalized_model_prompt_without_time.startswith(f"{normalized_prompt}\n\n")
+        ):
             model_prompt_content = model_prompt
         else:
             model_prompt_content = f"{prompt}\n\n{model_prompt}"
@@ -908,14 +916,14 @@ class ResponseRunner:
             request.pipeline_timing.mark("thread_refresh_ready")
         team_request = replace(team_request, request=request)
         requester_user_id = request.user_id or ""
-        prepared_prompt = _prefix_user_turn_time(
-            request.model_prompt or request.prompt,
-            timezone=self.deps.runtime.config.timezone,
-        )
-        model_thread_history = _timestamp_thread_history_user_turns(
-            request.thread_history,
-            config=self.deps.runtime.config,
-            runtime_paths=self.deps.runtime_paths,
+        _memory_prompt, _memory_thread_history, prepared_prompt, model_thread_history = (
+            prepare_memory_and_model_context(
+                request.prompt,
+                request.thread_history,
+                config=self.deps.runtime.config,
+                runtime_paths=self.deps.runtime_paths,
+                model_prompt=request.model_prompt,
+            )
         )
         model_name = select_model_for_team(
             self.deps.agent_name,

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -40,6 +40,7 @@ from mindroom.authorization import get_available_agents_in_room
 from mindroom.constants import MATRIX_SEEN_EVENT_IDS_METADATA_KEY, ROUTER_AGENT_NAME
 from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.execution_preparation import (
+    ThreadHistoryRenderLimits,
     prepare_bound_team_execution_context,
 )
 from mindroom.history.runtime import (
@@ -92,6 +93,11 @@ _MAX_CONTEXT_MESSAGE_LENGTH = 200  # Maximum length for messages to include in t
 _MAX_LOG_MESSAGE_LENGTH = 500  # Maximum length for messages in team response logs
 _TeamStreamChunk = str | StructuredStreamChunk
 _NO_AGENTS_RESPONSE = "Sorry, no agents available for team collaboration."
+_MATRIX_TEAM_THREAD_HISTORY_RENDER_LIMITS = ThreadHistoryRenderLimits(
+    max_messages=30,
+    max_message_length=_MAX_CONTEXT_MESSAGE_LENGTH,
+    missing_sender_label="Unknown",
+)
 
 
 class TeamMode(str, Enum):
@@ -1316,6 +1322,7 @@ async def prepare_materialized_team_execution(
     matrix_run_metadata: dict[str, Any] | None = None,
     system_enrichment_items: Sequence[EnrichmentItem] = (),
     current_sender_id: str | None = None,
+    thread_history_render_limits: ThreadHistoryRenderLimits | None = None,
 ) -> _PreparedMaterializedTeamExecution:
     """Prepare one materialized team for execution."""
     scrub_queued_notice_session_context(
@@ -1346,9 +1353,7 @@ async def prepare_materialized_team_execution(
         response_sender_id=response_sender_id,
         current_sender_id=current_sender_id,
         compaction_outcomes_collector=compaction_outcomes_collector,
-        fallback_max_messages=30,
-        fallback_max_message_length=_MAX_CONTEXT_MESSAGE_LENGTH,
-        fallback_missing_sender_label="Unknown",
+        thread_history_render_limits=thread_history_render_limits,
     )
     if prepared_execution.replay_plan is not None:
         apply_replay_plan(target=team, replay_plan=prepared_execution.replay_plan)
@@ -1456,6 +1461,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                 matrix_run_metadata=matrix_run_metadata,
                 system_enrichment_items=system_enrichment_items,
                 current_sender_id=user_id,
+                thread_history_render_limits=_MATRIX_TEAM_THREAD_HISTORY_RENDER_LIMITS,
             )
             prepared_prompt = prepared_execution.prepared_prompt
             run_metadata = prepared_execution.run_metadata
@@ -1756,6 +1762,7 @@ async def team_response_stream(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 matrix_run_metadata=matrix_run_metadata,
                 system_enrichment_items=system_enrichment_items,
                 current_sender_id=user_id,
+                thread_history_render_limits=_MATRIX_TEAM_THREAD_HISTORY_RENDER_LIMITS,
             )
             prepared_run_input = prepared_execution.prepared_prompt
             unseen_event_ids = prepared_execution.unseen_event_ids

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -42,6 +42,7 @@ from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.execution_preparation import (
     ThreadHistoryRenderLimits,
     prepare_bound_team_execution_context,
+    render_prepared_team_messages_text,
 )
 from mindroom.history.runtime import (
     ScopeSessionContext,
@@ -114,17 +115,6 @@ class _PreparedMaterializedTeamExecution:
     prepared_prompt: str
     run_metadata: dict[str, Any] | None
     unseen_event_ids: list[str]
-
-
-def _render_team_run_input(messages: Sequence[Message]) -> str:
-    """Render prepared messages into the string form Agno teams actually consume."""
-    rendered_chunks: list[str] = []
-    for message in messages:
-        if not message.content:
-            continue
-        content = str(message.content)
-        rendered_chunks.append(f"assistant: {content}" if message.role == "assistant" else content)
-    return "\n\n".join(rendered_chunks)
 
 
 def _next_retry_run_id(run_id: str | None) -> str | None:
@@ -1363,7 +1353,7 @@ async def prepare_materialized_team_execution(
         extra_metadata=matrix_run_metadata,
     )
     return _PreparedMaterializedTeamExecution(
-        prepared_prompt=_render_team_run_input(prepared_execution.messages),
+        prepared_prompt=render_prepared_team_messages_text(prepared_execution.messages),
         run_metadata=run_metadata,
         unseen_event_ids=prepared_execution.unseen_event_ids,
     )

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -110,6 +110,17 @@ class _PreparedMaterializedTeamExecution:
     unseen_event_ids: list[str]
 
 
+def _render_team_run_input(messages: Sequence[Message]) -> str:
+    """Render prepared messages into the string form Agno teams actually consume."""
+    rendered_chunks: list[str] = []
+    for message in messages:
+        if not message.content:
+            continue
+        content = str(message.content)
+        rendered_chunks.append(f"assistant: {content}" if message.role == "assistant" else content)
+    return "\n\n".join(rendered_chunks)
+
+
 def _next_retry_run_id(run_id: str | None) -> str | None:
     """Return a fresh Agno run identifier for a retry attempt."""
     if run_id is None:
@@ -1335,6 +1346,9 @@ async def prepare_materialized_team_execution(
         response_sender_id=response_sender_id,
         current_sender_id=current_sender_id,
         compaction_outcomes_collector=compaction_outcomes_collector,
+        fallback_max_messages=30,
+        fallback_max_message_length=_MAX_CONTEXT_MESSAGE_LENGTH,
+        fallback_missing_sender_label="Unknown",
     )
     if prepared_execution.replay_plan is not None:
         apply_replay_plan(target=team, replay_plan=prepared_execution.replay_plan)
@@ -1344,7 +1358,7 @@ async def prepare_materialized_team_execution(
         extra_metadata=matrix_run_metadata,
     )
     return _PreparedMaterializedTeamExecution(
-        prepared_prompt=prepared_execution.final_prompt,
+        prepared_prompt=_render_team_run_input(prepared_execution.messages),
         run_metadata=run_metadata,
         unseen_event_ids=prepared_execution.unseen_event_ids,
     )

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -1862,6 +1862,48 @@ async def test_generate_team_response_helper_uses_persisted_team_scope_for_sessi
 
 
 @pytest.mark.asyncio
+async def test_generate_team_response_helper_merges_raw_prompt_into_model_prompt(
+    tmp_path: Path,
+) -> None:
+    """Ad hoc team responses should keep the user request when model_prompt only adds metadata."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = bind_runtime_paths(_config(), runtime_paths)
+    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name=ROUTER_AGENT_NAME)
+
+    with (
+        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
+        patch("mindroom.response_runner.team_response", new_callable=AsyncMock) as mock_team_response,
+    ):
+        mock_team_response.return_value = "Team hello"
+        coordinator = _build_response_runner(
+            bot,
+            config=config,
+            runtime_paths=runtime_paths,
+            storage_path=tmp_path,
+            requester_id="@alice:localhost",
+            message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
+            orchestrator=_team_orchestrator(config, runtime_paths),
+        )
+
+        event_id = await coordinator.generate_team_response_helper(
+            _response_request(
+                prompt="What is in the image?",
+                model_prompt="Available attachment IDs: att_img. Use tool calls to inspect or process them.",
+                user_id="@alice:localhost",
+                thread_id="$thread-root",
+            ),
+            team_agents=[MatrixID.from_agent("general", "localhost", runtime_paths)],
+            team_mode="coordinate",
+        )
+
+    assert event_id == "$response_id"
+    assert mock_team_response.await_args is not None
+    message = mock_team_response.await_args.kwargs["message"]
+    assert "What is in the image?" in message
+    assert "Available attachment IDs: att_img. Use tool calls to inspect or process them." in message
+
+
+@pytest.mark.asyncio
 async def test_generate_team_response_helper_uses_delivery_result_failure_reason_for_cancelled_stream(
     tmp_path: Path,
 ) -> None:
@@ -2036,6 +2078,26 @@ class TestUserIdPassthrough:
         assert model_prompt.endswith(
             "report\n\nAvailable attachment IDs: att_report. Use tool calls to inspect or process them.",
         )
+
+    def test_prepare_memory_and_model_context_keeps_existing_timestamped_merged_model_prompt(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Pre-merged timestamped model prompts should not duplicate the raw prompt on reuse."""
+        config = _config()
+        runtime_paths = _runtime_paths(tmp_path)
+
+        existing_model_prompt = "[2026-03-20 08:15 PDT] report\n\nAvailable attachment IDs: att_report."
+
+        _memory_prompt, _memory_thread_history, model_prompt, _model_thread_history = prepare_memory_and_model_context(
+            "report",
+            [],
+            config=config,
+            runtime_paths=runtime_paths,
+            model_prompt=existing_model_prompt,
+        )
+
+        assert model_prompt == existing_model_prompt
 
     @pytest.mark.asyncio
     async def test_non_streaming_passes_user_id(self, tmp_path: Path) -> None:

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -3317,6 +3317,50 @@ class TestTeamCompletion:
         run_input = mock_team.arun.call_args.args[0]
         assert run_input == "user: Start\n\nassistant: Ack\n\nFollow-up"
 
+    def test_team_non_streaming_preserves_full_request_history_for_ad_hoc_team_runs(
+        self,
+        team_app_client: TestClient,
+    ) -> None:
+        """Ad hoc team runs must not apply Matrix-specific truncation to request history."""
+        from agno.run.team import TeamRunOutput  # noqa: PLC0415
+
+        from mindroom.teams import TeamMode  # noqa: PLC0415
+
+        long_body = "L" * 250
+        request_messages: list[dict[str, str]] = [
+            {"role": "user", "content": "msg 0"},
+            {"role": "assistant", "content": long_body},
+        ]
+        request_messages.extend(
+            {
+                "role": "user" if idx % 2 == 0 else "assistant",
+                "content": "Final prompt" if idx == 34 else f"msg {idx}",
+            }
+            for idx in range(2, 35)
+        )
+
+        mock_team = _make_test_team()
+        mock_team.arun = AsyncMock(return_value=TeamRunOutput(content="ok"))
+        mock_team.add_history_to_context = True
+        mock_team.num_history_runs = 3
+        mock_team.num_history_messages = None
+        mock_agents = [_make_test_agent("GeneralAgent"), _make_test_agent("CodeAgent")]
+
+        with patch(
+            "mindroom.api.openai_compat._build_team",
+            return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
+        ):
+            response = team_app_client.post(
+                "/v1/chat/completions",
+                json={"model": "team/super_team", "messages": request_messages},
+            )
+
+        assert response.status_code == 200
+        run_input = mock_team.arun.call_args.args[0]
+        assert "user: msg 0" in run_input
+        assert f"assistant: {long_body}" in run_input
+        assert run_input.endswith("Final prompt")
+
     def test_team_non_streaming_prefers_persisted_history_over_thread_history(
         self,
         team_app_client: TestClient,

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -41,6 +41,7 @@ from mindroom.teams import (
     TeamMode,
     _materialize_team_members,
     _team_response_stream_raw,
+    prepare_materialized_team_execution,
     team_response,
     team_response_stream,
 )
@@ -1399,7 +1400,48 @@ async def test_team_response_stream_preserves_assistant_context_in_team_prompt()
 
     assert len(chunks) == 1
     assert "Streamed team response" in str(chunks[0])
-    assert mock_raw.await_args.kwargs["prompt"] == "Previous team reply\n\nAnalyze this."
+    assert mock_raw.await_args.kwargs["prompt"] == "assistant: Previous team reply\n\nAnalyze this."
+
+
+@pytest.mark.asyncio
+async def test_prepare_materialized_team_execution_caps_matrix_fallback_thread_context() -> None:
+    """Matrix fallback replay must stay bounded to the recent short thread context."""
+    config = _build_test_config()
+    runtime_paths = runtime_paths_for(config)
+    agents = [_make_test_agent("GeneralAgent")]
+    team = _make_test_team()
+    long_body = "x" * 250
+    thread_history = [
+        make_visible_message(event_id=f"old-{idx}", sender=f"user{idx}", body=f"old message {idx}") for idx in range(5)
+    ]
+    thread_history.extend(
+        make_visible_message(event_id=f"keep-{idx}", sender=f"user{idx}", body=f"recent message {idx}")
+        for idx in range(30)
+    )
+    thread_history.append(make_visible_message(event_id="long", sender="user-long", body=long_body))
+
+    prepared = await prepare_materialized_team_execution(
+        scope_context=None,
+        agents=agents,
+        team=team,
+        message="Analyze this.",
+        thread_history=thread_history,
+        config=config,
+        runtime_paths=runtime_paths,
+        active_model_name="default",
+        reply_to_event_id=None,
+        active_event_ids=frozenset(),
+        response_sender_id=None,
+        compaction_outcomes_collector=None,
+        configured_team_name=None,
+    )
+
+    assert "old message 0" not in prepared.prepared_prompt
+    assert "old message 4" not in prepared.prepared_prompt
+    assert "recent message 5" in prepared.prepared_prompt
+    assert "recent message 29" in prepared.prepared_prompt
+    assert long_body not in prepared.prepared_prompt
+    assert prepared.prepared_prompt.endswith("Analyze this.")
 
 
 def test_agno_team_message_normalization_drops_assistant_context() -> None:

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -27,7 +27,7 @@ from mindroom.config.agent import AgentConfig, AgentPrivateConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import ROUTER_AGENT_NAME
-from mindroom.execution_preparation import PreparedExecutionContext
+from mindroom.execution_preparation import PreparedExecutionContext, ThreadHistoryRenderLimits
 from mindroom.history.runtime import open_bound_scope_session_context
 from mindroom.history.storage import read_scope_seen_event_ids, update_scope_seen_event_ids
 from mindroom.matrix.identity import MatrixID
@@ -38,6 +38,7 @@ from mindroom.team_runtime_resolution import (
     resolve_live_shared_agent_names,
 )
 from mindroom.teams import (
+    _MATRIX_TEAM_THREAD_HISTORY_RENDER_LIMITS,
     TeamMode,
     _materialize_team_members,
     _team_response_stream_raw,
@@ -336,6 +337,7 @@ async def test_team_response_uses_compaction_aware_member_execution() -> None:
     assert scope_context is not None
     assert scope_context.scope.kind == "team"
     assert mock_prepare.await_args.kwargs["compaction_outcomes_collector"] is collector
+    assert mock_prepare.await_args.kwargs["thread_history_render_limits"] == _MATRIX_TEAM_THREAD_HISTORY_RENDER_LIMITS
 
 
 @pytest.mark.asyncio
@@ -1400,12 +1402,13 @@ async def test_team_response_stream_preserves_assistant_context_in_team_prompt()
 
     assert len(chunks) == 1
     assert "Streamed team response" in str(chunks[0])
+    assert mock_prepare.await_args.kwargs["thread_history_render_limits"] == _MATRIX_TEAM_THREAD_HISTORY_RENDER_LIMITS
     assert mock_raw.await_args.kwargs["prompt"] == "assistant: Previous team reply\n\nAnalyze this."
 
 
 @pytest.mark.asyncio
-async def test_prepare_materialized_team_execution_caps_matrix_fallback_thread_context() -> None:
-    """Matrix fallback replay must stay bounded to the recent short thread context."""
+async def test_prepare_materialized_team_execution_applies_explicit_thread_history_render_limits() -> None:
+    """Explicit thread-history render limits should bound prompt stuffing for Matrix fallback replay."""
     config = _build_test_config()
     runtime_paths = runtime_paths_for(config)
     agents = [_make_test_agent("GeneralAgent")]
@@ -1434,6 +1437,11 @@ async def test_prepare_materialized_team_execution_caps_matrix_fallback_thread_c
         response_sender_id=None,
         compaction_outcomes_collector=None,
         configured_team_name=None,
+        thread_history_render_limits=ThreadHistoryRenderLimits(
+            max_messages=30,
+            max_message_length=200,
+            missing_sender_label="Unknown",
+        ),
     )
 
     assert "old message 0" not in prepared.prepared_prompt

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -27,9 +27,15 @@ from mindroom.config.agent import AgentConfig, AgentPrivateConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import ROUTER_AGENT_NAME
-from mindroom.execution_preparation import PreparedExecutionContext, ThreadHistoryRenderLimits
+from mindroom.execution_preparation import (
+    PreparedExecutionContext,
+    ThreadHistoryRenderLimits,
+    prepare_bound_team_execution_context,
+    render_prepared_team_messages_text,
+)
 from mindroom.history.runtime import open_bound_scope_session_context
 from mindroom.history.storage import read_scope_seen_event_ids, update_scope_seen_event_ids
+from mindroom.history.types import PreparedHistoryState
 from mindroom.matrix.identity import MatrixID
 from mindroom.media_inputs import MediaInputs
 from mindroom.team_runtime_resolution import (
@@ -1450,6 +1456,72 @@ async def test_prepare_materialized_team_execution_applies_explicit_thread_histo
     assert "recent message 29" in prepared.prepared_prompt
     assert long_body not in prepared.prepared_prompt
     assert prepared.prepared_prompt.endswith("Analyze this.")
+
+
+@pytest.mark.asyncio
+async def test_prepare_bound_team_execution_context_uses_team_renderer_for_history_planning() -> None:
+    """Team history planning and token estimation must use the same renderer as team execution."""
+    config = _build_test_config()
+    runtime_paths = runtime_paths_for(config)
+    team = _make_test_team()
+    agents = [_make_test_agent("GeneralAgent")]
+    planner_fallback_full_prompt: str | None = None
+    estimator_fallback_full_prompt: str | None = None
+
+    async def fake_prepare_bound_scope_history(**kwargs: object) -> object:
+        nonlocal planner_fallback_full_prompt
+        planner_fallback_full_prompt = kwargs["fallback_full_prompt"]
+        return object()
+
+    def fake_estimate_preparation_static_tokens_for_team(
+        _team: object,
+        *,
+        full_prompt: str,
+        fallback_full_prompt: str | None = None,
+    ) -> int:
+        nonlocal estimator_fallback_full_prompt
+        assert full_prompt == "Analyze this."
+        estimator_fallback_full_prompt = fallback_full_prompt
+        return 0
+
+    with (
+        patch(
+            "mindroom.execution_preparation.prepare_bound_scope_history",
+            new=AsyncMock(side_effect=fake_prepare_bound_scope_history),
+        ),
+        patch(
+            "mindroom.execution_preparation.estimate_preparation_static_tokens_for_team",
+            new=fake_estimate_preparation_static_tokens_for_team,
+        ),
+        patch(
+            "mindroom.execution_preparation._finalize_prepared_history",
+            return_value=PreparedHistoryState(replay_plan=None, replays_persisted_history=False),
+        ),
+    ):
+        prepared = await prepare_bound_team_execution_context(
+            scope_context=None,
+            agents=agents,
+            team=team,
+            prompt="Analyze this.",
+            thread_history=[
+                make_visible_message(
+                    event_id="event-1",
+                    sender="@mindroom_team:example.org",
+                    body="Previous team reply",
+                ),
+            ],
+            runtime_paths=runtime_paths,
+            config=config,
+            team_name=None,
+            active_model_name="default",
+            active_context_window=8192,
+            response_sender_id="@mindroom_team:example.org",
+        )
+
+    expected = "assistant: Previous team reply\n\nAnalyze this."
+    assert planner_fallback_full_prompt == expected
+    assert estimator_fallback_full_prompt == expected
+    assert render_prepared_team_messages_text(prepared.messages) == expected
 
 
 def test_agno_team_message_normalization_drops_assistant_context() -> None:


### PR DESCRIPTION
## Summary
- preserve the raw user prompt in ad hoc team responses when `model_prompt` only appends metadata such as attachment IDs
- keep bounded thread-history replay limits scoped to Matrix team runs instead of leaking them into ad hoc and OpenAI-compatible team execution
- use the same team prompt renderer for history planning, token estimation, and final `team.arun()` input so assistant-context budgeting matches the actual request shape
- add regression coverage for raw prompt merging, Matrix fallback bounds, OpenAI-compatible full-history preservation, and renderer alignment

## Why
This PR fixes three concrete team-prompt regressions:
1. ad hoc team responses could drop the user’s raw prompt
2. Matrix-specific fallback bounds were being applied to shared/ad hoc team execution
3. team history planning and execution were using different prompt renderers, so budgeting could drift from the real `team.arun()` input

## Verification
- `uv run pytest tests/test_ai_user_id.py tests/test_openai_compat.py tests/test_team_media_fallback.py tests/test_system_enrich.py -x -n 0 --no-cov -v` (`276 passed`)
