### PR TITLE
fix: preserve invited members during membership refresh

### DIFF
--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -255,7 +255,8 @@ def _apply_authoritative_joined_members(
     members_by_user_id = {member.user_id: member for member in members}
 
     for user_id in tuple(room.users):
-        if user_id not in members_by_user_id:
+        cached_user = room.users[user_id]
+        if not cached_user.invited and user_id not in members_by_user_id:
             room.remove_member(user_id)
 
     for member in members:

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -434,6 +434,45 @@ async def test_get_available_agents_for_sender_authoritative_updates_room_cache_
     client.joined_members.assert_awaited_once_with("!test:server")
 
 
+@pytest.mark.asyncio
+async def test_get_available_agents_for_sender_authoritative_preserves_invited_members() -> None:
+    """Authoritative refresh should not delete invited users from the cached room."""
+    config = _config(
+        agents={
+            "assistant": {
+                "display_name": "Assistant",
+                "role": "Test assistant",
+                "rooms": ["test_room"],
+            },
+        },
+    )
+    client = AsyncMock()
+    room = nio.MatrixRoom("!test:server", "@mindroom_test:example.com")
+    room.add_member("@mindroom_router:example.com", "Router", None)
+    room.add_member("@guest:example.com", "Guest", None, invited=True)
+    room.members_synced = False
+    client.joined_members.return_value = nio.JoinedMembersResponse.from_dict(
+        {
+            "joined": {
+                "@mindroom_router:example.com": {"display_name": "Router"},
+                "@mindroom_assistant:example.com": {"display_name": "Assistant"},
+            },
+        },
+        room_id="!test:server",
+    )
+
+    available = await get_available_agents_for_sender_authoritative(
+        client,
+        room,
+        "@alice:example.com",
+        config,
+    )
+
+    assert [agent.agent_name(config, _runtime_paths_for(config)) for agent in available] == ["assistant"]
+    assert "@guest:example.com" in room.users
+    assert "@guest:example.com" in room.invited_users
+
+
 def test_router_always_allowed(mock_config_with_restrictions: Config) -> None:
     """Test that the router agent is always allowed."""
     # Router should always be allowed


### PR DESCRIPTION
## Summary
- preserve invited Matrix members when authoritative joined-members refresh updates a room cache
- add a regression test covering invited users surviving `get_available_agents_for_sender_authoritative()`
- keep the fix minimal and aligned with `nio` semantics for joined-member refreshes

## Context
Follow-up to the merged room-membership refresh change from #668.
The previous implementation could drop `room.invited_users` entries while rebuilding cached membership from `/joined_members`.

## Verification
- `uv run --active pytest -x -n 0 --no-cov tests/test_authorization.py -k invited_members`
- `uv run --active pytest -x -n 0 --no-cov --timeout=120 tests/test_authorization.py tests/test_bot_scheduling.py tests/test_hook_sender.py tests/test_multi_agent_bot.py tests/test_scheduling.py tests/test_voice_command_processing.py -k 'authorization or scheduling or voice or membership or sender or thread or invited'`
- `uv run --active pytest -x -n 0 --no-cov`
- `uv run pre-commit run --all-files`
