### PR TITLE
Add workspace knowledge links for bound sources

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -328,6 +328,7 @@ memory:
 # MindRoom auto-installs that optional extra on first use.
 
 # Knowledge base configuration (optional)
+# Keys must be non-empty single path components, so do not use "", ., .., /, or \ in a knowledge base ID.
 knowledge_bases:
   docs:
     path: ./knowledge_docs          # Folder containing documents for this base (Pydantic default)

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -53,6 +53,8 @@ agents:
 
 Place files in `./knowledge_docs/` and they'll be indexed automatically on startup.
 When `watch: true`, new or modified files are re-indexed in real time.
+Knowledge base IDs are the keys under `knowledge_bases`.
+Use a non-empty single path component such as `docs` or `company_docs`, not `""`, `.`, `..`, or names containing `/` or `\`.
 
 ## Configuration
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1059,6 +1059,7 @@ memory:
 # MindRoom auto-installs that optional extra on first use.
 
 # Knowledge base configuration (optional)
+# Keys must be non-empty single path components, so do not use "", ., .., /, or \ in a knowledge base ID.
 knowledge_bases:
   docs:
     path: ./knowledge_docs          # Folder containing documents for this base (Pydantic default)
@@ -8654,7 +8655,7 @@ agents:
     knowledge_bases: [docs]
 ```
 
-Place files in `./knowledge_docs/` and they'll be indexed automatically on startup. When `watch: true`, new or modified files are re-indexed in real time.
+Place files in `./knowledge_docs/` and they'll be indexed automatically on startup. When `watch: true`, new or modified files are re-indexed in real time. Knowledge base IDs are the keys under `knowledge_bases`. Use a non-empty single path component such as `docs` or `company_docs`, not `""`, `.`, `..`, or names containing `/` or `\`.
 
 ## Configuration
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -322,6 +322,7 @@ memory:
 # MindRoom auto-installs that optional extra on first use.
 
 # Knowledge base configuration (optional)
+# Keys must be non-empty single path components, so do not use "", ., .., /, or \ in a knowledge base ID.
 knowledge_bases:
   docs:
     path: ./knowledge_docs          # Folder containing documents for this base (Pydantic default)

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -46,7 +46,7 @@ agents:
     knowledge_bases: [docs]
 ```
 
-Place files in `./knowledge_docs/` and they'll be indexed automatically on startup. When `watch: true`, new or modified files are re-indexed in real time.
+Place files in `./knowledge_docs/` and they'll be indexed automatically on startup. When `watch: true`, new or modified files are re-indexed in real time. Knowledge base IDs are the keys under `knowledge_bases`. Use a non-empty single path component such as `docs` or `company_docs`, not `""`, `.`, `..`, or names containing `/` or `\`.
 
 ## Configuration
 

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -683,10 +683,17 @@ class Config(BaseModel):
     @model_validator(mode="after")
     def validate_knowledge_base_ids_are_path_safe(self) -> Config:
         """Reject knowledge base IDs that would create nested or overlapping alias paths."""
-        invalid_ids = sorted(base_id for base_id in self.knowledge_bases if "/" in base_id or "\\" in base_id)
+        invalid_ids = sorted(
+            base_id
+            for base_id in self.knowledge_bases
+            if not base_id or base_id in {".", ".."} or "/" in base_id or "\\" in base_id
+        )
         if invalid_ids:
             formatted = ", ".join(invalid_ids)
-            msg = f"knowledge_bases keys must not contain path separators; invalid keys: {formatted}"
+            msg = (
+                "knowledge_bases keys must be non-empty single path components without path separators "
+                f"or dot segments; invalid keys: {formatted}"
+            )
             raise ValueError(msg)
         return self
 

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -681,6 +681,16 @@ class Config(BaseModel):
         return self
 
     @model_validator(mode="after")
+    def validate_knowledge_base_ids_are_path_safe(self) -> Config:
+        """Reject knowledge base IDs that would create nested or overlapping alias paths."""
+        invalid_ids = sorted(base_id for base_id in self.knowledge_bases if "/" in base_id or "\\" in base_id)
+        if invalid_ids:
+            formatted = ", ".join(invalid_ids)
+            msg = f"knowledge_bases keys must not contain path separators; invalid keys: {formatted}"
+            raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
     def validate_private_knowledge(self) -> Config:
         """Ensure enabled private knowledge declares an explicit path."""
         invalid_private_knowledge = [

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -702,6 +702,17 @@ def resolve_config_relative_path(
     return (runtime_paths.config_dir / unresolved).resolve()
 
 
+def resolve_config_relative_path_preserving_leaf(
+    raw_path: str | Path,
+    runtime_paths: RuntimePaths,
+) -> Path:
+    """Resolve a configured path lexically without following the final component."""
+    unresolved = Path(_expand_runtime_path_vars(os.fspath(raw_path), runtime_paths)).expanduser()
+    if unresolved.is_absolute():
+        return unresolved
+    return runtime_paths.config_dir / unresolved
+
+
 def _docker_container_enabled(runtime_paths: RuntimePaths) -> bool:
     """Return whether MindRoom is running from the packaged container image."""
     return runtime_paths.env_flag("DOCKER_CONTAINER")

--- a/src/mindroom/runtime_resolution.py
+++ b/src/mindroom/runtime_resolution.py
@@ -20,6 +20,7 @@ from mindroom.tool_system.worker_routing import (
 )
 from mindroom.workspaces import (
     ResolvedAgentWorkspace,
+    ensure_workspace_knowledge_links,
     resolve_agent_workspace_from_state_path,
     resolve_relative_path_within_root,
     resolve_workspace_relative_path,
@@ -215,6 +216,22 @@ def resolve_agent_runtime(
         use_state_storage_path=resolved_execution.policy.request_scoped_workspace_enabled,
         create=create,
     )
+    if workspace is not None and (create or workspace.root.exists()):
+        knowledge_paths: dict[str, Path] = {}
+        for base_id in config.get_agent_knowledge_base_ids(agent_name):
+            base_config = config.get_knowledge_base_config(base_id)
+            if config.get_private_knowledge_base_agent(base_id) is None:
+                knowledge_paths[base_id] = resolve_config_relative_path(base_config.path, runtime_paths).resolve()
+            else:
+                knowledge_paths[base_id] = resolve_workspace_relative_path(
+                    workspace.root,
+                    base_config.path,
+                    field_name="private.knowledge.path",
+                )
+        ensure_workspace_knowledge_links(
+            workspace.root,
+            knowledge_paths=knowledge_paths,
+        )
     tool_base_dir = workspace.root if workspace is not None else None
     file_memory_root = workspace.file_memory_path if workspace is not None else None
     return ResolvedAgentRuntime(

--- a/src/mindroom/runtime_resolution.py
+++ b/src/mindroom/runtime_resolution.py
@@ -11,7 +11,11 @@ from mindroom.agent_policy import (
     resolve_agent_policy_from_data,
     resolve_private_knowledge_base_agent,
 )
-from mindroom.constants import RuntimePaths, resolve_config_relative_path
+from mindroom.constants import (
+    RuntimePaths,
+    resolve_config_relative_path,
+    resolve_config_relative_path_preserving_leaf,
+)
 from mindroom.tool_system.worker_routing import (
     private_instance_scope_root_path,
     resolve_agent_state_storage_path,
@@ -217,6 +221,18 @@ def resolve_agent_runtime(
         create=create,
     )
     if workspace is not None and (create or workspace.root.exists()):
+        workspace_knowledge_root = resolve_workspace_relative_path(
+            workspace.root,
+            "knowledge",
+            field_name="workspace knowledge root",
+        )
+        protected_knowledge_paths = {
+            configured_path
+            for base_config in config.knowledge_bases.values()
+            if (
+                configured_path := resolve_config_relative_path_preserving_leaf(base_config.path, runtime_paths)
+            ).is_relative_to(workspace_knowledge_root)
+        }
         knowledge_paths: dict[str, Path] = {}
         for base_id in config.get_agent_knowledge_base_ids(agent_name):
             base_config = config.get_knowledge_base_config(base_id)
@@ -231,6 +247,7 @@ def resolve_agent_runtime(
         ensure_workspace_knowledge_links(
             workspace.root,
             knowledge_paths=knowledge_paths,
+            protected_paths=protected_knowledge_paths,
         )
     tool_base_dir = workspace.root if workspace is not None else None
     file_memory_root = workspace.file_memory_path if workspace is not None else None

--- a/src/mindroom/workspaces.py
+++ b/src/mindroom/workspaces.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import shutil
-from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -11,6 +10,8 @@ from typing import TYPE_CHECKING
 from mindroom.constants import RuntimePaths, resolve_config_relative_path
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from mindroom.config.main import Config
 
 _MIND_TEMPLATE_DIR = Path(__file__).resolve().parent / "cli" / "templates" / "mind_data"
@@ -55,6 +56,41 @@ def resolve_relative_path_within_root(
         msg = f"{field_name} must stay within the {root_label}: {resolved_root}"
         raise ValueError(msg)
     return candidate
+
+
+def resolve_relative_path_within_root_preserving_leaf(
+    root: Path,
+    relative_path: str | Path,
+    *,
+    field_name: str,
+    root_label: str = "canonical root",
+) -> Path:
+    """Resolve one relative path under a canonical root without following the final component."""
+    lexical_root = root.expanduser()
+    resolved_root = lexical_root.resolve()
+    candidate_path = lexical_root / relative_path
+    relative = Path(relative_path)
+    if relative.is_absolute():
+        msg = f"{field_name} must stay within the {root_label}: {resolved_root}"
+        raise ValueError(msg)
+    if relative == Path():
+        return resolved_root
+
+    current = lexical_root
+    for index, part in enumerate(relative.parts):
+        if part == "..":
+            msg = f"{field_name} must stay within the {root_label}: {resolved_root}"
+            raise ValueError(msg)
+        current = current / part
+        if index < len(relative.parts) - 1 and current.is_symlink():
+            msg = f"{field_name} must stay within the {root_label}: {resolved_root}"
+            raise ValueError(msg)
+
+    candidate_parent = candidate_path.parent.resolve()
+    if not candidate_parent.is_relative_to(resolved_root):
+        msg = f"{field_name} must stay within the {root_label}: {resolved_root}"
+        raise ValueError(msg)
+    return candidate_path
 
 
 def resolve_workspace_relative_path(
@@ -140,44 +176,86 @@ def ensure_workspace_template(
     (workspace_path / "memory").mkdir(parents=True, exist_ok=True)
 
 
-def ensure_workspace_knowledge_links(
-    workspace_path: Path,
+def _build_workspace_knowledge_links(
     *,
+    workspace_root: Path,
+    knowledge_root: Path,
     knowledge_paths: Mapping[str, Path],
-) -> None:
-    """Expose canonical workspace-local paths for bound knowledge bases.
-
-    Each knowledge base becomes visible under ``<workspace>/knowledge/<base_id>``.
-    The symlink targets may live outside the workspace root; the point of this
-    namespace is to give file-aware tools one stable in-workspace entrypoint for
-    direct inspection of bound knowledge sources.
-    """
-    if not knowledge_paths:
-        return
-
-    workspace_path.mkdir(parents=True, exist_ok=True)
-    knowledge_root = resolve_workspace_relative_path(
-        workspace_path,
-        "knowledge",
-        field_name="workspace knowledge root",
-    )
-    knowledge_root.mkdir(parents=True, exist_ok=True)
-
+) -> dict[Path, Path]:
+    desired_links: dict[Path, Path] = {}
     for base_id, target_path in knowledge_paths.items():
-        link_path = resolve_workspace_relative_path(
+        link_path = resolve_relative_path_within_root_preserving_leaf(
             knowledge_root,
             base_id,
             field_name="workspace knowledge link",
         )
         resolved_target = target_path.expanduser().resolve()
+        if not resolved_target.is_relative_to(workspace_root):
+            continue
+        if resolved_target in link_path.parents and resolved_target != link_path:
+            continue
+        desired_links[link_path] = resolved_target
+    return desired_links
+
+
+def _remove_stale_workspace_knowledge_links(
+    knowledge_root: Path,
+    *,
+    desired_links: Mapping[Path, Path],
+) -> None:
+    for existing_path in knowledge_root.iterdir():
+        if existing_path.is_symlink() and existing_path not in desired_links:
+            existing_path.unlink()
+
+
+def _apply_workspace_knowledge_links(desired_links: Mapping[Path, Path]) -> None:
+    for link_path, resolved_target in desired_links.items():
         if link_path.is_symlink():
             if link_path.resolve() == resolved_target:
                 continue
             link_path.unlink()
         elif link_path.exists():
+            if link_path.resolve() == resolved_target:
+                continue
             msg = f"Workspace knowledge link path already exists and is not a symlink: {link_path}"
             raise ValueError(msg)
+        if resolved_target == link_path:
+            continue
+        link_path.parent.mkdir(parents=True, exist_ok=True)
         link_path.symlink_to(resolved_target, target_is_directory=True)
+
+
+def ensure_workspace_knowledge_links(
+    workspace_path: Path,
+    *,
+    knowledge_paths: Mapping[str, Path],
+) -> None:
+    """Expose canonical workspace-local paths for bound knowledge rooted inside the workspace.
+
+    Each knowledge base becomes visible under ``<workspace>/knowledge/<base_id>``.
+    Targets outside the workspace are intentionally excluded because the default
+    file-aware tools enforce workspace containment after resolving symlinks.
+    """
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    workspace_root = workspace_path.resolve()
+    knowledge_root = resolve_workspace_relative_path(
+        workspace_path,
+        "knowledge",
+        field_name="workspace knowledge root",
+    )
+    if not knowledge_paths and not knowledge_root.exists():
+        return
+    knowledge_root.mkdir(parents=True, exist_ok=True)
+    desired_links = _build_workspace_knowledge_links(
+        workspace_root=workspace_root,
+        knowledge_root=knowledge_root,
+        knowledge_paths=knowledge_paths,
+    )
+    _remove_stale_workspace_knowledge_links(
+        knowledge_root,
+        desired_links=desired_links,
+    )
+    _apply_workspace_knowledge_links(desired_links)
 
 
 def _private_root_name(agent_name: str, config: Config) -> str:

--- a/src/mindroom/workspaces.py
+++ b/src/mindroom/workspaces.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -137,6 +138,46 @@ def ensure_workspace_template(
         raise ValueError(msg)
     _copy_workspace_template(workspace_path, template_dir=_MIND_TEMPLATE_DIR, force=force)
     (workspace_path / "memory").mkdir(parents=True, exist_ok=True)
+
+
+def ensure_workspace_knowledge_links(
+    workspace_path: Path,
+    *,
+    knowledge_paths: Mapping[str, Path],
+) -> None:
+    """Expose canonical workspace-local paths for bound knowledge bases.
+
+    Each knowledge base becomes visible under ``<workspace>/knowledge/<base_id>``.
+    The symlink targets may live outside the workspace root; the point of this
+    namespace is to give file-aware tools one stable in-workspace entrypoint for
+    direct inspection of bound knowledge sources.
+    """
+    if not knowledge_paths:
+        return
+
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    knowledge_root = resolve_workspace_relative_path(
+        workspace_path,
+        "knowledge",
+        field_name="workspace knowledge root",
+    )
+    knowledge_root.mkdir(parents=True, exist_ok=True)
+
+    for base_id, target_path in knowledge_paths.items():
+        link_path = resolve_workspace_relative_path(
+            knowledge_root,
+            base_id,
+            field_name="workspace knowledge link",
+        )
+        resolved_target = target_path.expanduser().resolve()
+        if link_path.is_symlink():
+            if link_path.resolve() == resolved_target:
+                continue
+            link_path.unlink()
+        elif link_path.exists():
+            msg = f"Workspace knowledge link path already exists and is not a symlink: {link_path}"
+            raise ValueError(msg)
+        link_path.symlink_to(resolved_target, target_is_directory=True)
 
 
 def _private_root_name(agent_name: str, config: Config) -> str:

--- a/src/mindroom/workspaces.py
+++ b/src/mindroom/workspaces.py
@@ -201,10 +201,15 @@ def _build_workspace_knowledge_links(
 def _remove_stale_workspace_knowledge_links(
     knowledge_root: Path,
     *,
+    workspace_root: Path,
     desired_links: Mapping[Path, Path],
 ) -> None:
     for existing_path in knowledge_root.iterdir():
-        if existing_path.is_symlink() and existing_path not in desired_links:
+        if (
+            existing_path.is_symlink()
+            and existing_path not in desired_links
+            and existing_path.resolve().is_relative_to(workspace_root)
+        ):
             existing_path.unlink()
 
 
@@ -253,6 +258,7 @@ def ensure_workspace_knowledge_links(
     )
     _remove_stale_workspace_knowledge_links(
         knowledge_root,
+        workspace_root=workspace_root,
         desired_links=desired_links,
     )
     _apply_workspace_knowledge_links(desired_links)

--- a/src/mindroom/workspaces.py
+++ b/src/mindroom/workspaces.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from mindroom.constants import RuntimePaths, resolve_config_relative_path
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Collection, Mapping
 
     from mindroom.config.main import Config
 
@@ -192,7 +192,9 @@ def _build_workspace_knowledge_links(
         resolved_target = target_path.expanduser().resolve()
         if not resolved_target.is_relative_to(workspace_root):
             continue
-        if resolved_target in link_path.parents and resolved_target != link_path:
+        if resolved_target == link_path or resolved_target.is_relative_to(link_path):
+            continue
+        if link_path.is_relative_to(resolved_target):
             continue
         desired_links[link_path] = resolved_target
     return desired_links
@@ -201,6 +203,7 @@ def _build_workspace_knowledge_links(
 def _remove_stale_workspace_knowledge_links(
     knowledge_root: Path,
     *,
+    protected_paths: Collection[Path],
     workspace_root: Path,
     desired_links: Mapping[Path, Path],
 ) -> None:
@@ -208,6 +211,7 @@ def _remove_stale_workspace_knowledge_links(
         if (
             existing_path.is_symlink()
             and existing_path not in desired_links
+            and existing_path not in protected_paths
             and existing_path.resolve().is_relative_to(workspace_root)
         ):
             existing_path.unlink()
@@ -234,6 +238,7 @@ def ensure_workspace_knowledge_links(
     workspace_path: Path,
     *,
     knowledge_paths: Mapping[str, Path],
+    protected_paths: Collection[Path] = (),
 ) -> None:
     """Expose canonical workspace-local paths for bound knowledge rooted inside the workspace.
 
@@ -258,6 +263,7 @@ def ensure_workspace_knowledge_links(
     )
     _remove_stale_workspace_knowledge_links(
         knowledge_root,
+        protected_paths=protected_paths,
         workspace_root=workspace_root,
         desired_links=desired_links,
     )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1039,6 +1039,28 @@ def test_resolve_agent_runtime_reuses_existing_workspace_local_knowledge_directo
     assert not knowledge_link.is_symlink()
 
 
+def test_resolve_agent_runtime_skips_workspace_knowledge_links_for_targets_below_canonical_alias_path(
+    tmp_path: Path,
+) -> None:
+    """A knowledge base already nested under the canonical alias path should be reused without a new alias."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = _bind_runtime_paths(_test_config(), runtime_paths)
+    knowledge_root = tmp_path / "agents" / "general" / "workspace" / "knowledge" / "research" / "docs"
+    knowledge_root.mkdir(parents=True, exist_ok=True)
+    config.agents["general"].memory_backend = "file"
+    config.agents["general"].knowledge_bases = ["research"]
+    config.knowledge_bases["research"] = KnowledgeBaseConfig(path=str(knowledge_root))
+
+    runtime = resolve_agent_runtime("general", config, runtime_paths, execution_identity=None, create=True)
+
+    assert runtime.workspace is not None
+    knowledge_link = runtime.workspace.root / "knowledge" / "research"
+    assert knowledge_link.exists()
+    assert knowledge_link.is_dir()
+    assert not knowledge_link.is_symlink()
+    assert (knowledge_link / "docs").resolve() == knowledge_root.resolve()
+
+
 def test_resolve_agent_runtime_preserves_configured_external_workspace_knowledge_symlink(tmp_path: Path) -> None:
     """A configured canonical knowledge symlink should not be deleted just because it points outside the workspace."""
     runtime_paths = _runtime_paths(tmp_path)
@@ -1058,6 +1080,37 @@ def test_resolve_agent_runtime_preserves_configured_external_workspace_knowledge
     knowledge_link = runtime.workspace.root / "knowledge" / "research"
     assert knowledge_link.is_symlink()
     assert knowledge_link.resolve() == external_root.resolve()
+
+
+def test_resolve_agent_runtime_preserves_configured_workspace_local_knowledge_symlink_when_unbound(
+    tmp_path: Path,
+) -> None:
+    """A configured canonical knowledge symlink should survive agent unbinding when it is the real knowledge root."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = _bind_runtime_paths(_test_config(), runtime_paths)
+    workspace_root = tmp_path / "agents" / "general" / "workspace"
+    target_root = workspace_root / "docs" / "research"
+    target_root.mkdir(parents=True, exist_ok=True)
+    knowledge_root = workspace_root / "knowledge" / "research"
+    knowledge_root.parent.mkdir(parents=True, exist_ok=True)
+    knowledge_root.symlink_to(target_root, target_is_directory=True)
+    config.agents["general"].memory_backend = "file"
+    config.agents["general"].knowledge_bases = ["research"]
+    config.knowledge_bases["research"] = KnowledgeBaseConfig(path=str(knowledge_root))
+
+    runtime = resolve_agent_runtime("general", config, runtime_paths, execution_identity=None, create=True)
+
+    assert runtime.workspace is not None
+    assert knowledge_root.is_symlink()
+    assert knowledge_root.resolve() == target_root.resolve()
+
+    config.agents["general"].knowledge_bases = []
+
+    runtime = resolve_agent_runtime("general", config, runtime_paths, execution_identity=None, create=True)
+
+    assert runtime.workspace is not None
+    assert knowledge_root.is_symlink()
+    assert knowledge_root.resolve() == target_root.resolve()
 
 
 def test_resolve_agent_runtime_skips_workspace_knowledge_links_for_private_root_dot_path(tmp_path: Path) -> None:
@@ -2526,21 +2579,25 @@ def test_config_accepts_valid_agent_knowledge_base_assignment() -> None:
     assert config.agents["calculator"].knowledge_bases == ["research"]
 
 
-def test_config_rejects_knowledge_base_ids_with_path_separators() -> None:
-    """Knowledge base IDs must stay single-component so workspace aliases remain well-defined."""
+@pytest.mark.parametrize("base_id", ["", ".", "..", "group/research"])
+def test_config_rejects_knowledge_base_ids_that_are_not_normal_single_path_components(base_id: str) -> None:
+    """Knowledge base IDs must stay single-component and avoid dot-segment aliases."""
     with pytest.raises(
         ValidationError,
-        match=re.escape("knowledge_bases keys must not contain path separators; invalid keys: group/research"),
+        match=re.escape(
+            "knowledge_bases keys must be non-empty single path components without path separators or dot segments; "
+            f"invalid keys: {base_id}",
+        ),
     ):
         Config(
             agents={
                 "calculator": AgentConfig(
                     display_name="CalculatorAgent",
-                    knowledge_bases=["group/research"],
+                    knowledge_bases=[base_id],
                 ),
             },
             knowledge_bases={
-                "group/research": KnowledgeBaseConfig(
+                base_id: KnowledgeBaseConfig(
                     path="./knowledge_docs/research",
                     watch=False,
                 ),

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1039,6 +1039,27 @@ def test_resolve_agent_runtime_reuses_existing_workspace_local_knowledge_directo
     assert not knowledge_link.is_symlink()
 
 
+def test_resolve_agent_runtime_preserves_configured_external_workspace_knowledge_symlink(tmp_path: Path) -> None:
+    """A configured canonical knowledge symlink should not be deleted just because it points outside the workspace."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = _bind_runtime_paths(_test_config(), runtime_paths)
+    external_root = tmp_path / "external_repo"
+    external_root.mkdir(parents=True, exist_ok=True)
+    knowledge_root = tmp_path / "agents" / "general" / "workspace" / "knowledge" / "research"
+    knowledge_root.parent.mkdir(parents=True, exist_ok=True)
+    knowledge_root.symlink_to(external_root, target_is_directory=True)
+    config.agents["general"].memory_backend = "file"
+    config.agents["general"].knowledge_bases = ["research"]
+    config.knowledge_bases["research"] = KnowledgeBaseConfig(path=str(knowledge_root))
+
+    runtime = resolve_agent_runtime("general", config, runtime_paths, execution_identity=None, create=True)
+
+    assert runtime.workspace is not None
+    knowledge_link = runtime.workspace.root / "knowledge" / "research"
+    assert knowledge_link.is_symlink()
+    assert knowledge_link.resolve() == external_root.resolve()
+
+
 def test_resolve_agent_runtime_skips_workspace_knowledge_links_for_private_root_dot_path(tmp_path: Path) -> None:
     """A private knowledge path of '.' should not mirror the whole workspace inside itself."""
     runtime_paths = _runtime_paths(tmp_path)
@@ -2503,6 +2524,28 @@ def test_config_accepts_valid_agent_knowledge_base_assignment() -> None:
     )
 
     assert config.agents["calculator"].knowledge_bases == ["research"]
+
+
+def test_config_rejects_knowledge_base_ids_with_path_separators() -> None:
+    """Knowledge base IDs must stay single-component so workspace aliases remain well-defined."""
+    with pytest.raises(
+        ValidationError,
+        match=re.escape("knowledge_bases keys must not contain path separators; invalid keys: group/research"),
+    ):
+        Config(
+            agents={
+                "calculator": AgentConfig(
+                    display_name="CalculatorAgent",
+                    knowledge_bases=["group/research"],
+                ),
+            },
+            knowledge_bases={
+                "group/research": KnowledgeBaseConfig(
+                    path="./knowledge_docs/research",
+                    watch=False,
+                ),
+            },
+        )
 
 
 def test_config_rejects_reserved_private_knowledge_base_prefix() -> None:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -913,6 +913,60 @@ def test_resolve_agent_runtime_uses_private_instance_roots_for_private_agents(
     assert runtime.file_memory_root == runtime.workspace.root
 
 
+def test_resolve_agent_runtime_creates_workspace_knowledge_links_for_shared_bases(tmp_path: Path) -> None:
+    """Shared agents with a workspace should expose canonical knowledge symlinks inside it."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = _bind_runtime_paths(_test_config(), runtime_paths)
+    knowledge_root = tmp_path / "research"
+    knowledge_root.mkdir(parents=True, exist_ok=True)
+    config.agents["general"].memory_backend = "file"
+    config.agents["general"].knowledge_bases = ["research"]
+    config.knowledge_bases["research"] = KnowledgeBaseConfig(path=str(knowledge_root))
+
+    runtime = resolve_agent_runtime("general", config, runtime_paths, execution_identity=None, create=True)
+
+    assert runtime.workspace is not None
+    knowledge_link = runtime.workspace.root / "knowledge" / "research"
+    assert knowledge_link.is_symlink()
+    assert knowledge_link.resolve() == knowledge_root.resolve()
+
+
+def test_resolve_agent_runtime_creates_workspace_knowledge_links_for_private_bases(tmp_path: Path) -> None:
+    """Private requester-local knowledge should also surface through workspace-local symlinks."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = _bind_runtime_paths(_test_config(), runtime_paths)
+    config.agents["general"].memory_backend = "file"
+    config.agents["general"].private = AgentPrivateConfig(
+        per="user",
+        root="mind_data",
+        knowledge=AgentPrivateKnowledgeConfig(path="kb_repo"),
+    )
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id="$thread",
+        resolved_thread_id="$thread",
+        session_id="s1",
+    )
+
+    runtime = resolve_agent_runtime(
+        "general",
+        config,
+        runtime_paths,
+        execution_identity=identity,
+        create=True,
+    )
+
+    assert runtime.workspace is not None
+    private_base_id = config.get_agent_private_knowledge_base_id("general")
+    assert private_base_id is not None
+    knowledge_link = runtime.workspace.root / "knowledge" / private_base_id
+    assert knowledge_link.is_symlink()
+    assert knowledge_link.resolve() == (runtime.workspace.root / "kb_repo").resolve()
+
+
 def test_private_workspace_template_preserves_metadata_and_backfills_missing_files(tmp_path: Path) -> None:
     """Private templates should preserve file metadata and backfill new files without overwriting edits."""
     template_dir = tmp_path / "template"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -913,8 +913,29 @@ def test_resolve_agent_runtime_uses_private_instance_roots_for_private_agents(
     assert runtime.file_memory_root == runtime.workspace.root
 
 
-def test_resolve_agent_runtime_creates_workspace_knowledge_links_for_shared_bases(tmp_path: Path) -> None:
-    """Shared agents with a workspace should expose canonical knowledge symlinks inside it."""
+def test_resolve_agent_runtime_creates_workspace_knowledge_links_for_workspace_local_shared_bases(
+    tmp_path: Path,
+) -> None:
+    """Workspace-local shared knowledge should be exposed through a canonical workspace symlink."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = _bind_runtime_paths(_test_config(), runtime_paths)
+    knowledge_root = tmp_path / "agents" / "general" / "workspace" / "research"
+    knowledge_root.mkdir(parents=True, exist_ok=True)
+    config.agents["general"].memory_backend = "file"
+    config.agents["general"].knowledge_bases = ["research"]
+    config.knowledge_bases["research"] = KnowledgeBaseConfig(path=str(knowledge_root))
+
+    runtime = resolve_agent_runtime("general", config, runtime_paths, execution_identity=None, create=True)
+    runtime = resolve_agent_runtime("general", config, runtime_paths, execution_identity=None, create=True)
+
+    assert runtime.workspace is not None
+    knowledge_link = runtime.workspace.root / "knowledge" / "research"
+    assert knowledge_link.is_symlink()
+    assert knowledge_link.resolve() == knowledge_root.resolve()
+
+
+def test_resolve_agent_runtime_skips_workspace_knowledge_links_for_external_shared_bases(tmp_path: Path) -> None:
+    """Shared knowledge outside the workspace should not get a misleading in-workspace alias."""
     runtime_paths = _runtime_paths(tmp_path)
     config = _bind_runtime_paths(_test_config(), runtime_paths)
     knowledge_root = tmp_path / "research"
@@ -927,8 +948,8 @@ def test_resolve_agent_runtime_creates_workspace_knowledge_links_for_shared_base
 
     assert runtime.workspace is not None
     knowledge_link = runtime.workspace.root / "knowledge" / "research"
-    assert knowledge_link.is_symlink()
-    assert knowledge_link.resolve() == knowledge_root.resolve()
+    assert not knowledge_link.exists()
+    assert not knowledge_link.is_symlink()
 
 
 def test_resolve_agent_runtime_creates_workspace_knowledge_links_for_private_bases(tmp_path: Path) -> None:
@@ -958,6 +979,13 @@ def test_resolve_agent_runtime_creates_workspace_knowledge_links_for_private_bas
         execution_identity=identity,
         create=True,
     )
+    runtime = resolve_agent_runtime(
+        "general",
+        config,
+        runtime_paths,
+        execution_identity=identity,
+        create=True,
+    )
 
     assert runtime.workspace is not None
     private_base_id = config.get_agent_private_knowledge_base_id("general")
@@ -965,6 +993,86 @@ def test_resolve_agent_runtime_creates_workspace_knowledge_links_for_private_bas
     knowledge_link = runtime.workspace.root / "knowledge" / private_base_id
     assert knowledge_link.is_symlink()
     assert knowledge_link.resolve() == (runtime.workspace.root / "kb_repo").resolve()
+
+
+def test_resolve_agent_runtime_removes_stale_workspace_knowledge_links(tmp_path: Path) -> None:
+    """Removing a bound knowledge base should remove its canonical workspace alias."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = _bind_runtime_paths(_test_config(), runtime_paths)
+    knowledge_root = tmp_path / "agents" / "general" / "workspace" / "research"
+    knowledge_root.mkdir(parents=True, exist_ok=True)
+    config.agents["general"].memory_backend = "file"
+    config.agents["general"].knowledge_bases = ["research"]
+    config.knowledge_bases["research"] = KnowledgeBaseConfig(path=str(knowledge_root))
+
+    runtime = resolve_agent_runtime("general", config, runtime_paths, execution_identity=None, create=True)
+
+    assert runtime.workspace is not None
+    knowledge_link = runtime.workspace.root / "knowledge" / "research"
+    assert knowledge_link.is_symlink()
+
+    config.agents["general"].knowledge_bases = []
+
+    runtime = resolve_agent_runtime("general", config, runtime_paths, execution_identity=None, create=True)
+
+    assert runtime.workspace is not None
+    knowledge_link = runtime.workspace.root / "knowledge" / "research"
+    assert not knowledge_link.exists()
+    assert not knowledge_link.is_symlink()
+
+
+def test_resolve_agent_runtime_reuses_existing_workspace_local_knowledge_directory(tmp_path: Path) -> None:
+    """A knowledge base already rooted at the canonical path should be reused as-is."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = _bind_runtime_paths(_test_config(), runtime_paths)
+    knowledge_root = tmp_path / "agents" / "general" / "workspace" / "knowledge" / "research"
+    knowledge_root.mkdir(parents=True, exist_ok=True)
+    config.agents["general"].memory_backend = "file"
+    config.agents["general"].knowledge_bases = ["research"]
+    config.knowledge_bases["research"] = KnowledgeBaseConfig(path=str(knowledge_root))
+
+    runtime = resolve_agent_runtime("general", config, runtime_paths, execution_identity=None, create=True)
+
+    assert runtime.workspace is not None
+    knowledge_link = runtime.workspace.root / "knowledge" / "research"
+    assert knowledge_link.exists()
+    assert not knowledge_link.is_symlink()
+
+
+def test_resolve_agent_runtime_skips_workspace_knowledge_links_for_private_root_dot_path(tmp_path: Path) -> None:
+    """A private knowledge path of '.' should not mirror the whole workspace inside itself."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = _bind_runtime_paths(_test_config(), runtime_paths)
+    config.agents["general"].memory_backend = "file"
+    config.agents["general"].private = AgentPrivateConfig(
+        per="user",
+        root="mind_data",
+        knowledge=AgentPrivateKnowledgeConfig(path="."),
+    )
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id="$thread",
+        resolved_thread_id="$thread",
+        session_id="s1",
+    )
+
+    runtime = resolve_agent_runtime(
+        "general",
+        config,
+        runtime_paths,
+        execution_identity=identity,
+        create=True,
+    )
+
+    assert runtime.workspace is not None
+    private_base_id = config.get_agent_private_knowledge_base_id("general")
+    assert private_base_id is not None
+    knowledge_link = runtime.workspace.root / "knowledge" / private_base_id
+    assert not knowledge_link.exists()
+    assert not knowledge_link.is_symlink()
 
 
 def test_private_workspace_template_preserves_metadata_and_backfills_missing_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- create canonical workspace-local `knowledge/<base_id>` symlinks for bound knowledge bases
- materialize those links during agent runtime setup for both shared and private knowledge bases
- add regression coverage for shared and private knowledge-link creation

## Testing
- `/Users/bas.nijholt/Work/dev/mindroom/.venv/bin/python -m pytest -q tests/test_agents.py -k "workspace_knowledge_links or resolve_agent_runtime_uses_private_instance_roots_for_private_agents or uses_shared_agent_roots_for_shared_agents"`