### PR TITLE
feat(matrix.cache): add latest agent snapshot accessor with freshness checks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -513,15 +513,15 @@ Deeper synthetic hook hops still arrive as messages, but they do not re-enter `m
 Queries Matrix room state events.
 When `state_key` is provided, returns the content `dict` for that single state event, or `None` on Matrix error response/not-found.
 When `state_key` is `None`, returns a `{state_key: content}` dict of all state events matching `event_type`, or `None` on Matrix error response.
+Returns `None` when no room state querier is available (e.g. no Matrix client bound).
+When both the current bot and the router can query room state, MindRoom tries the current bot first and falls back to the router on Matrix error responses.
+Transport exceptions from the underlying Matrix client propagate to the hook.
 
 **`await ctx.get_latest_agent_message_snapshot(room_id, sender, *, thread_id=None)`**
 Returns the latest visible cached `m.room.message` from `sender` in the given room or thread scope.
 The helper automatically applies `ctx.runtime_started_at` so room-level reads ignore visible cache rows from before the current bot runtime.
 It returns `None` when no reader is bound, when the advisory cache is disabled or missing usable rows, or when the sender has no cached message in that scope.
 It raises `CacheUnavailable` when a thread snapshot exists but fails the cache freshness contract, such as a stale or invalidated thread cache row.
-Returns `None` when no room state querier is available (e.g. no Matrix client bound).
-When both the current bot and the router can query room state, MindRoom tries the current bot first and falls back to the router on Matrix error responses.
-Transport exceptions from the underlying Matrix client propagate to the hook.
 
 **`await ctx.put_room_state(room_id, event_type, state_key, content)`**
 Writes a single Matrix room state event and returns `True` on success, `False` on Matrix error response.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -521,7 +521,7 @@ Transport exceptions from the underlying Matrix client propagate to the hook.
 Returns the latest visible cached `m.room.message` from `sender` in the given room or thread scope.
 The helper automatically applies `ctx.runtime_started_at` so room-level reads ignore visible cache rows from before the current bot runtime.
 It returns `None` when no reader is bound, when the advisory cache is disabled or missing usable rows, or when the sender has no cached message in that scope.
-It raises `CacheUnavailable` when a thread snapshot exists but fails the cache freshness contract, such as a stale or invalidated thread cache row.
+It raises `AgentMessageSnapshotUnavailable` when a thread snapshot exists but fails the cache freshness contract, such as a stale or invalidated thread cache row.
 
 **`await ctx.put_room_state(room_id, event_type, state_key, content)`**
 Writes a single Matrix room state event and returns `True` on success, `False` on Matrix error response.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -513,6 +513,12 @@ Deeper synthetic hook hops still arrive as messages, but they do not re-enter `m
 Queries Matrix room state events.
 When `state_key` is provided, returns the content `dict` for that single state event, or `None` on Matrix error response/not-found.
 When `state_key` is `None`, returns a `{state_key: content}` dict of all state events matching `event_type`, or `None` on Matrix error response.
+
+**`await ctx.get_latest_agent_message_snapshot(room_id, sender, *, thread_id=None)`**
+Returns the latest visible cached `m.room.message` from `sender` in the given room or thread scope.
+The helper automatically applies `ctx.runtime_started_at` so room-level reads ignore visible cache rows from before the current bot runtime.
+It returns `None` when no reader is bound, when the advisory cache is disabled or missing usable rows, or when the sender has no cached message in that scope.
+It raises `CacheUnavailable` when a thread snapshot exists but fails the cache freshness contract, such as a stale or invalidated thread cache row.
 Returns `None` when no room state querier is available (e.g. no Matrix client bound).
 When both the current bot and the router can query room state, MindRoom tries the current bot first and falls back to the router on Matrix error responses.
 Transport exceptions from the underlying Matrix client propagate to the hook.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -491,6 +491,7 @@ Every hook context includes these fields:
 | `runtime_paths` | `RuntimePaths` | Storage paths and environment values |
 | `logger` | `BoundLogger` | Plugin-scoped structured logger |
 | `correlation_id` | `str` | Unique ID per inbound event |
+| `runtime_started_at` | `float \| None` | Unix timestamp for the current runtime freshness boundary, useful when plugin state must ignore cache rows from before the latest bot start |
 | `state_root` | `Path` | Plugin state directory (property) |
 
 Every hook context also exposes the following helpers:

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -383,6 +383,7 @@ class AgentBot:
             agent_name=self.agent_name,
             hook_registry_state=self._hook_registry_state,
             hook_send_message=self._hook_send_message,
+            latest_agent_message_snapshot_reader=self._hook_latest_agent_message_snapshot,
         )
         self._knowledge_access_support = KnowledgeAccessSupport(
             runtime=self._runtime_view,
@@ -1565,6 +1566,31 @@ class AgentBot:
             return event_id
         self.logger.error("Failed to send hook message", room_id=room_id, source_hook=source_hook)
         return None
+
+    async def _hook_latest_agent_message_snapshot(
+        self,
+        room_id: str,
+        thread_id: str | None,
+        sender: str,
+        *,
+        runtime_started_at: float | None,
+    ) -> object | None:
+        """Read the latest visible cached sender message for hook helpers."""
+        event_cache = self._runtime_view.event_cache
+        if event_cache is None:
+            self.logger.warning(
+                "Latest-agent-message snapshot requested before event cache is ready",
+                room_id=room_id,
+                thread_id=thread_id,
+                sender=sender,
+            )
+            return None
+        return await event_cache.get_latest_agent_message_snapshot(
+            room_id,
+            thread_id,
+            sender,
+            runtime_started_at=runtime_started_at,
+        )
 
     async def _edit_message(
         self,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -383,7 +383,7 @@ class AgentBot:
             agent_name=self.agent_name,
             hook_registry_state=self._hook_registry_state,
             hook_send_message=self._hook_send_message,
-            latest_agent_message_snapshot_reader=self._hook_latest_agent_message_snapshot,
+            agent_message_snapshot_reader=self._hook_agent_message_snapshot,
         )
         self._knowledge_access_support = KnowledgeAccessSupport(
             runtime=self._runtime_view,
@@ -1567,7 +1567,7 @@ class AgentBot:
         self.logger.error("Failed to send hook message", room_id=room_id, source_hook=source_hook)
         return None
 
-    async def _hook_latest_agent_message_snapshot(
+    async def _hook_agent_message_snapshot(
         self,
         room_id: str,
         thread_id: str | None,
@@ -1579,7 +1579,7 @@ class AgentBot:
         event_cache = self._runtime_view.event_cache
         if event_cache is None:
             self.logger.warning(
-                "Latest-agent-message snapshot requested before event cache is ready",
+                "Agent-message snapshot requested before event cache is ready",
                 room_id=room_id,
                 thread_id=thread_id,
                 sender=sender,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -606,6 +606,11 @@ class AgentBot:
         self._runtime_view.startup_thread_prewarm_registry = value
 
     @property
+    def runtime_started_at(self) -> float:
+        """Return the current runtime freshness boundary for this bot."""
+        return self._runtime_view.runtime_started_at
+
+    @property
     def hook_registry(self) -> HookRegistry:
         """Return the currently active hook registry."""
         return self._hook_registry_state.registry

--- a/src/mindroom/hooks/context.py
+++ b/src/mindroom/hooks/context.py
@@ -192,6 +192,7 @@ class HookContextSupport:
             "runtime_paths": self.runtime_paths,
             "logger": self.logger.bind(event_name=event_name),
             "correlation_id": correlation_id,
+            "runtime_started_at": getattr(self.runtime, "runtime_started_at", None),
             "message_sender": self.message_sender(),
             "matrix_admin": self.matrix_admin(),
             "room_state_querier": self.room_state_querier(),
@@ -251,6 +252,7 @@ class HookContext:
     runtime_paths: RuntimePaths
     logger: structlog.stdlib.BoundLogger
     correlation_id: str
+    runtime_started_at: float | None = field(default=None, kw_only=True)
     message_sender: HookMessageSender | None = field(default=None, kw_only=True)
     matrix_admin: HookMatrixAdmin | None = field(default=None, kw_only=True)
     room_state_querier: HookRoomStateQuerier | None = field(default=None, kw_only=True)

--- a/src/mindroom/hooks/context.py
+++ b/src/mindroom/hooks/context.py
@@ -192,7 +192,7 @@ class HookContextSupport:
             "runtime_paths": self.runtime_paths,
             "logger": self.logger.bind(event_name=event_name),
             "correlation_id": correlation_id,
-            "runtime_started_at": getattr(self.runtime, "runtime_started_at", None),
+            "runtime_started_at": self.runtime.runtime_started_at,
             "message_sender": self.message_sender(),
             "matrix_admin": self.matrix_admin(),
             "room_state_querier": self.room_state_querier(),

--- a/src/mindroom/hooks/context.py
+++ b/src/mindroom/hooks/context.py
@@ -31,7 +31,9 @@ class _UnsetType:
 _UNSET = _UnsetType()
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
     from pathlib import Path
+    from typing import Protocol
 
     import structlog
     from agno.models.message import Message
@@ -39,6 +41,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.history.types import HistoryScope
+    from mindroom.matrix.cache import AgentMessageSnapshot
     from mindroom.message_target import MessageTarget
     from mindroom.scheduling import ScheduledWorkflow
     from mindroom.tool_system.events import ToolTraceEntry
@@ -46,6 +49,19 @@ if TYPE_CHECKING:
     from .registry import HookRegistry, HookRegistryState
     from .sender import HookMessageSender
     from .types import HookMatrixAdmin, HookRoomStatePutter, HookRoomStateQuerier
+
+    class HookLatestAgentMessageSnapshotReader(Protocol):
+        """Callable contract for hook-facing latest-agent-message snapshot reads."""
+
+        def __call__(
+            self,
+            room_id: str,
+            thread_id: str | None,
+            sender: str,
+            *,
+            runtime_started_at: float | None,
+        ) -> Awaitable[AgentMessageSnapshot | None]:
+            """Read the latest visible cached sender message for one room or thread scope."""
 
 
 def _resolve_plugin_state_root(
@@ -134,6 +150,7 @@ class HookContextSupport:
     agent_name: str
     hook_registry_state: HookRegistryState
     hook_send_message: HookMessageSender
+    latest_agent_message_snapshot_reader: HookLatestAgentMessageSnapshotReader | None = None
 
     @property
     def registry(self) -> HookRegistry:
@@ -194,6 +211,7 @@ class HookContextSupport:
             "correlation_id": correlation_id,
             "runtime_started_at": self.runtime.runtime_started_at,
             "message_sender": self.message_sender(),
+            "latest_agent_message_snapshot_reader": self.latest_agent_message_snapshot_reader,
             "matrix_admin": self.matrix_admin(),
             "room_state_querier": self.room_state_querier(),
             "room_state_putter": self.room_state_putter(),
@@ -254,6 +272,10 @@ class HookContext:
     correlation_id: str
     runtime_started_at: float | None = field(default=None, kw_only=True)
     message_sender: HookMessageSender | None = field(default=None, kw_only=True)
+    latest_agent_message_snapshot_reader: HookLatestAgentMessageSnapshotReader | None = field(
+        default=None,
+        kw_only=True,
+    )
     matrix_admin: HookMatrixAdmin | None = field(default=None, kw_only=True)
     room_state_querier: HookRoomStateQuerier | None = field(default=None, kw_only=True)
     room_state_putter: HookRoomStatePutter | None = field(default=None, kw_only=True)
@@ -312,6 +334,24 @@ class HookContext:
             room_id,
             event_type,
             state_key,
+        )
+
+    async def get_latest_agent_message_snapshot(
+        self,
+        room_id: str,
+        sender: str,
+        *,
+        thread_id: str | None = None,
+    ) -> AgentMessageSnapshot | None:
+        """Return the latest visible cached sender message when a reader is available."""
+        if self.latest_agent_message_snapshot_reader is None:
+            self.logger.warning("No latest-agent-message snapshot reader available")
+            return None
+        return await self.latest_agent_message_snapshot_reader(
+            room_id=room_id,
+            thread_id=thread_id,
+            sender=sender,
+            runtime_started_at=self.runtime_started_at,
         )
 
     async def put_room_state(

--- a/src/mindroom/hooks/context.py
+++ b/src/mindroom/hooks/context.py
@@ -50,8 +50,8 @@ if TYPE_CHECKING:
     from .sender import HookMessageSender
     from .types import HookMatrixAdmin, HookRoomStatePutter, HookRoomStateQuerier
 
-    class HookLatestAgentMessageSnapshotReader(Protocol):
-        """Callable contract for hook-facing latest-agent-message snapshot reads."""
+    class HookAgentMessageSnapshotReader(Protocol):
+        """Callable contract for hook-facing agent-message snapshot reads."""
 
         def __call__(
             self,
@@ -150,7 +150,7 @@ class HookContextSupport:
     agent_name: str
     hook_registry_state: HookRegistryState
     hook_send_message: HookMessageSender
-    latest_agent_message_snapshot_reader: HookLatestAgentMessageSnapshotReader | None = None
+    agent_message_snapshot_reader: HookAgentMessageSnapshotReader | None = None
 
     @property
     def registry(self) -> HookRegistry:
@@ -211,7 +211,7 @@ class HookContextSupport:
             "correlation_id": correlation_id,
             "runtime_started_at": self.runtime.runtime_started_at,
             "message_sender": self.message_sender(),
-            "latest_agent_message_snapshot_reader": self.latest_agent_message_snapshot_reader,
+            "agent_message_snapshot_reader": self.agent_message_snapshot_reader,
             "matrix_admin": self.matrix_admin(),
             "room_state_querier": self.room_state_querier(),
             "room_state_putter": self.room_state_putter(),
@@ -272,7 +272,7 @@ class HookContext:
     correlation_id: str
     runtime_started_at: float | None = field(default=None, kw_only=True)
     message_sender: HookMessageSender | None = field(default=None, kw_only=True)
-    latest_agent_message_snapshot_reader: HookLatestAgentMessageSnapshotReader | None = field(
+    agent_message_snapshot_reader: HookAgentMessageSnapshotReader | None = field(
         default=None,
         kw_only=True,
     )
@@ -344,10 +344,10 @@ class HookContext:
         thread_id: str | None = None,
     ) -> AgentMessageSnapshot | None:
         """Return the latest visible cached sender message when a reader is available."""
-        if self.latest_agent_message_snapshot_reader is None:
-            self.logger.warning("No latest-agent-message snapshot reader available")
+        if self.agent_message_snapshot_reader is None:
+            self.logger.warning("No agent-message snapshot reader available")
             return None
-        return await self.latest_agent_message_snapshot_reader(
+        return await self.agent_message_snapshot_reader(
             room_id=room_id,
             thread_id=thread_id,
             sender=sender,

--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -19,7 +19,7 @@ Main invariants:
 
 from .agent_message_snapshot import (
     AgentMessageSnapshot,
-    CacheUnavailable,
+    AgentMessageSnapshotUnavailable,
 )
 from .event_cache import ConversationEventCache, ThreadCacheState
 from .event_cache_events import normalize_nio_event_for_cache
@@ -46,7 +46,7 @@ __all__ = [
     "THREAD_HISTORY_SOURCE_HOMESERVER",
     "THREAD_HISTORY_SOURCE_STALE_CACHE",
     "AgentMessageSnapshot",
-    "CacheUnavailable",
+    "AgentMessageSnapshotUnavailable",
     "ConversationEventCache",
     "EventCacheWriteCoordinator",
     "ThreadCacheState",

--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -20,7 +20,6 @@ Main invariants:
 from .agent_message_snapshot import (
     AgentMessageSnapshot,
     CacheUnavailable,
-    get_latest_agent_message_snapshot,
 )
 from .event_cache import ConversationEventCache, ThreadCacheState
 from .event_cache_events import normalize_nio_event_for_cache
@@ -52,7 +51,6 @@ __all__ = [
     "EventCacheWriteCoordinator",
     "ThreadCacheState",
     "ThreadHistoryResult",
-    "get_latest_agent_message_snapshot",
     "normalize_nio_event_for_cache",
     "thread_cache_rejection_reason",
     "thread_cache_state_is_usable",

--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -17,6 +17,11 @@ Main invariants:
 - Thread invalidation is durable state first, with fail-closed deletion only when stale markers cannot be written.
 """
 
+from .agent_message_snapshot import (
+    AgentMessageSnapshot,
+    CacheUnavailable,
+    get_latest_agent_message_snapshot,
+)
 from .event_cache import ConversationEventCache, ThreadCacheState
 from .event_cache_events import normalize_nio_event_for_cache
 from .thread_cache_helpers import thread_cache_rejection_reason, thread_cache_state_is_usable
@@ -41,10 +46,13 @@ __all__ = [
     "THREAD_HISTORY_SOURCE_DIAGNOSTIC",
     "THREAD_HISTORY_SOURCE_HOMESERVER",
     "THREAD_HISTORY_SOURCE_STALE_CACHE",
+    "AgentMessageSnapshot",
+    "CacheUnavailable",
     "ConversationEventCache",
     "EventCacheWriteCoordinator",
     "ThreadCacheState",
     "ThreadHistoryResult",
+    "get_latest_agent_message_snapshot",
     "normalize_nio_event_for_cache",
     "thread_cache_rejection_reason",
     "thread_cache_state_is_usable",

--- a/src/mindroom/matrix/cache/agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/agent_message_snapshot.py
@@ -1,4 +1,4 @@
-"""Public snapshot reads for the latest visible agent message in one scope."""
+"""Snapshot reads for the latest visible agent message in one cached scope."""
 
 from __future__ import annotations
 
@@ -7,10 +7,11 @@ import sqlite3
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from . import event_cache_events, event_cache_threads
 from .thread_cache_helpers import thread_cache_rejection_reason
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    import aiosqlite
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,30 +27,20 @@ class CacheUnavailable(RuntimeError):  # noqa: N818
 
 
 @dataclass(frozen=True, slots=True)
-class _ThreadCacheStateSnapshot:
-    """Freshness metadata read directly from the SQLite cache."""
-
-    validated_at: float | None
-    invalidated_at: float | None
-    invalidation_reason: str | None
-    room_invalidated_at: float | None
-    room_invalidation_reason: str | None
-
-
-@dataclass(frozen=True, slots=True)
-class _CachedEventRow:
-    """One cached event payload plus the write timestamp for its visible version."""
-
-    event: dict[str, Any]
-    cached_at: float | None
-
-
-@dataclass(frozen=True, slots=True)
 class _SnapshotLookupResult:
     """Outcome for one matching scope event during latest-message lookup."""
 
     snapshot: AgentMessageSnapshot | None
     stop_scanning: bool = False
+
+
+_THREAD_CACHE_REJECTION_NONE_REASONS = frozenset({"no_cache_state", "cache_never_validated"})
+
+
+def _content_dict(content: object) -> dict[str, Any]:
+    if not isinstance(content, dict):
+        return {}
+    return {key: value for key, value in content.items() if isinstance(key, str)}
 
 
 def _relation_type(event: dict[str, Any]) -> str | None:
@@ -61,124 +52,10 @@ def _relation_type(event: dict[str, Any]) -> str | None:
     return relation_type if isinstance(relation_type, str) else None
 
 
-def _content_dict(content: object) -> dict[str, Any]:
-    if not isinstance(content, dict):
-        return {}
-    return {key: value for key, value in content.items() if isinstance(key, str)}
-
-
 def _visible_content(event: dict[str, Any]) -> dict[str, Any]:
     content = _content_dict(event.get("content"))
     new_content = _content_dict(content.get("m.new_content"))
     return new_content or content
-
-
-def _load_latest_edit(
-    conn: sqlite3.Connection,
-    *,
-    room_id: str,
-    original_event_id: str,
-) -> _CachedEventRow | None:
-    row = conn.execute(
-        """
-        SELECT events.event_json, events.cached_at
-        FROM event_edits
-        JOIN events ON events.event_id = event_edits.edit_event_id
-        WHERE event_edits.room_id = ? AND event_edits.original_event_id = ?
-        ORDER BY event_edits.origin_server_ts DESC, event_edits.edit_event_id DESC
-        LIMIT 1
-        """,
-        (room_id, original_event_id),
-    ).fetchone()
-    if row is None:
-        return None
-    return _CachedEventRow(
-        event=json.loads(row[0]),
-        cached_at=None if row[1] is None else float(row[1]),
-    )
-
-
-def _load_thread_cache_state(
-    conn: sqlite3.Connection,
-    *,
-    room_id: str,
-    thread_id: str,
-) -> _ThreadCacheStateSnapshot | None:
-    row = conn.execute(
-        """
-        SELECT
-            thread_cache_state.validated_at,
-            thread_cache_state.invalidated_at,
-            thread_cache_state.invalidation_reason,
-            room_cache_state.invalidated_at,
-            room_cache_state.invalidation_reason
-        FROM (SELECT ? AS requested_room_id, ? AS requested_thread_id) AS requested
-        LEFT JOIN thread_cache_state
-            ON thread_cache_state.room_id = requested.requested_room_id
-            AND thread_cache_state.thread_id = requested.requested_thread_id
-        LEFT JOIN room_cache_state
-            ON room_cache_state.room_id = requested.requested_room_id
-        """,
-        (room_id, thread_id),
-    ).fetchone()
-    if row is None or all(value is None for value in row):
-        return None
-    return _ThreadCacheStateSnapshot(
-        validated_at=None if row[0] is None else float(row[0]),
-        invalidated_at=None if row[1] is None else float(row[1]),
-        invalidation_reason=row[2] if isinstance(row[2], str) else None,
-        room_invalidated_at=None if row[3] is None else float(row[3]),
-        room_invalidation_reason=row[4] if isinstance(row[4], str) else None,
-    )
-
-
-_THREAD_CACHE_REJECTION_NONE_REASONS = frozenset({"no_cache_state", "cache_never_validated"})
-
-
-def _thread_scope_rejection_reason(
-    conn: sqlite3.Connection,
-    *,
-    room_id: str,
-    thread_id: str,
-    runtime_started_at: float | None,
-    now: float | None,
-) -> str | None:
-    return thread_cache_rejection_reason(
-        _load_thread_cache_state(
-            conn,
-            room_id=room_id,
-            thread_id=thread_id,
-        ),
-        runtime_started_at=runtime_started_at,
-        now=now,
-    )
-
-
-def _iter_scope_events(
-    conn: sqlite3.Connection,
-    *,
-    room_id: str,
-    thread_id: str | None,
-) -> sqlite3.Cursor:
-    if thread_id is None:
-        return conn.execute(
-            """
-            SELECT event_json, cached_at
-            FROM events
-            WHERE room_id = ?
-            ORDER BY origin_server_ts DESC, event_id DESC
-            """,
-            (room_id,),
-        )
-    return conn.execute(
-        """
-        SELECT event_json, NULL AS cached_at
-        FROM thread_events
-        WHERE room_id = ? AND thread_id = ?
-        ORDER BY origin_server_ts DESC, rowid DESC
-        """,
-        (room_id, thread_id),
-    )
 
 
 def _event_matches_scope(
@@ -195,52 +72,8 @@ def _event_matches_scope(
     return not (thread_id is None and relation_type == "m.thread")
 
 
-def _snapshot_from_event(
-    conn: sqlite3.Connection,
-    *,
-    room_id: str,
-    thread_id: str | None,
-    event: dict[str, Any],
-    cached_at: float | None,
-    runtime_started_at: float | None,
-) -> _SnapshotLookupResult:
-    event_id = event.get("event_id")
-    if not isinstance(event_id, str) or not event_id:
-        return _SnapshotLookupResult(snapshot=None)
-    latest_edit = _load_latest_edit(
-        conn,
-        room_id=room_id,
-        original_event_id=event_id,
-    )
-    latest_event = latest_edit.event if latest_edit is not None else event
-    visible_cached_at = latest_edit.cached_at if latest_edit is not None else cached_at
-    if (
-        thread_id is None
-        and runtime_started_at is not None
-        and (visible_cached_at is None or visible_cached_at < runtime_started_at)
-    ):
-        return _SnapshotLookupResult(snapshot=None, stop_scanning=True)
-    timestamp = latest_event.get("origin_server_ts")
-    if not isinstance(timestamp, int) or isinstance(timestamp, bool):
-        return _SnapshotLookupResult(snapshot=None)
-    return _SnapshotLookupResult(
-        snapshot=AgentMessageSnapshot(
-            content=_visible_content(latest_event),
-            origin_server_ts=timestamp,
-        ),
-    )
-
-
-def _open_readonly_cache(db_path: Path) -> sqlite3.Connection:
-    try:
-        return sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    except sqlite3.Error as exc:
-        msg = f"Failed to open Matrix event cache at {db_path}"
-        raise CacheUnavailable(msg) from exc
-
-
-def _thread_scope_has_no_snapshot(
-    conn: sqlite3.Connection,
+async def _thread_scope_has_no_snapshot(
+    db: aiosqlite.Connection,
     *,
     room_id: str,
     thread_id: str | None,
@@ -250,10 +83,12 @@ def _thread_scope_has_no_snapshot(
     if thread_id is None:
         return False
 
-    rejection_reason = _thread_scope_rejection_reason(
-        conn,
-        room_id=room_id,
-        thread_id=thread_id,
+    rejection_reason = thread_cache_rejection_reason(
+        await event_cache_threads.load_thread_cache_state(
+            db,
+            room_id=room_id,
+            thread_id=thread_id,
+        ),
         runtime_started_at=runtime_started_at,
         now=now,
     )
@@ -265,85 +100,142 @@ def _thread_scope_has_no_snapshot(
     return False
 
 
-def _load_scope_snapshot(
-    conn: sqlite3.Connection,
+async def _snapshot_from_event(
+    db: aiosqlite.Connection,
+    *,
+    room_id: str,
+    thread_id: str | None,
+    event: dict[str, Any],
+    cached_at: float | None,
+    runtime_started_at: float | None,
+) -> _SnapshotLookupResult:
+    event_id = event.get("event_id")
+    if not isinstance(event_id, str) or not event_id:
+        return _SnapshotLookupResult(snapshot=None)
+
+    latest_edit = await event_cache_events.load_latest_edit_row(
+        db,
+        room_id=room_id,
+        original_event_id=event_id,
+    )
+    latest_event = latest_edit.event if latest_edit is not None else event
+    visible_cached_at = latest_edit.cached_at if latest_edit is not None else cached_at
+    if (
+        thread_id is None
+        and runtime_started_at is not None
+        and (visible_cached_at is None or visible_cached_at < runtime_started_at)
+    ):
+        return _SnapshotLookupResult(snapshot=None, stop_scanning=True)
+
+    timestamp = latest_event.get("origin_server_ts")
+    if not isinstance(timestamp, int) or isinstance(timestamp, bool):
+        return _SnapshotLookupResult(snapshot=None)
+
+    return _SnapshotLookupResult(
+        snapshot=AgentMessageSnapshot(
+            content=_visible_content(latest_event),
+            origin_server_ts=timestamp,
+        ),
+    )
+
+
+async def _iter_scope_events(
+    db: aiosqlite.Connection,
+    *,
+    room_id: str,
+    thread_id: str | None,
+) -> aiosqlite.Cursor:
+    if thread_id is None:
+        return await db.execute(
+            """
+            SELECT event_json, cached_at
+            FROM events
+            WHERE room_id = ?
+            ORDER BY origin_server_ts DESC, event_id DESC
+            """,
+            (room_id,),
+        )
+    return await db.execute(
+        """
+        SELECT event_json, NULL AS cached_at
+        FROM thread_events
+        WHERE room_id = ? AND thread_id = ?
+        ORDER BY origin_server_ts DESC, rowid DESC
+        """,
+        (room_id, thread_id),
+    )
+
+
+async def _load_scope_snapshot(
+    db: aiosqlite.Connection,
     *,
     room_id: str,
     thread_id: str | None,
     sender: str,
     runtime_started_at: float | None,
 ) -> AgentMessageSnapshot | None:
-    rows = _iter_scope_events(
-        conn,
+    cursor = await _iter_scope_events(
+        db,
         room_id=room_id,
         thread_id=thread_id,
     )
-    for event_json, cached_at in rows:
-        event = json.loads(event_json)
-        if not _event_matches_scope(
-            event,
-            thread_id=thread_id,
-            sender=sender,
-        ):
-            continue
-        result = _snapshot_from_event(
-            conn,
-            room_id=room_id,
-            thread_id=thread_id,
-            event=event,
-            cached_at=None if cached_at is None else float(cached_at),
-            runtime_started_at=runtime_started_at,
-        )
-        if result.stop_scanning:
-            return None
-        if result.snapshot is not None:
-            return result.snapshot
-    return None
+    try:
+        while True:
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+            event = json.loads(row[0])
+            if not _event_matches_scope(
+                event,
+                thread_id=thread_id,
+                sender=sender,
+            ):
+                continue
+            result = await _snapshot_from_event(
+                db,
+                room_id=room_id,
+                thread_id=thread_id,
+                event=event,
+                cached_at=None if row[1] is None else float(row[1]),
+                runtime_started_at=runtime_started_at,
+            )
+            if result.stop_scanning:
+                return None
+            if result.snapshot is not None:
+                return result.snapshot
+    finally:
+        await cursor.close()
 
 
-def get_latest_agent_message_snapshot(
+async def load_latest_agent_message_snapshot(
+    db: aiosqlite.Connection,
     *,
-    db_path: Path,
     room_id: str,
     thread_id: str | None,
     sender: str,
     runtime_started_at: float | None,
     now: float | None = None,
 ) -> AgentMessageSnapshot | None:
-    """Return the latest visible message from ``sender`` in the given scope.
-
-    Used by the workloop plugin to gate auto-poke on stream status. Returns ``None``
-    when the cache file is missing or the sender has no cached message in the
-    requested scope. Raises ``CacheUnavailable`` when an existing cache file cannot
-    be safely read or a cached thread snapshot is present but rejected by the cache
-    freshness contract.
-    """
-    if not db_path.exists():
-        return None
-
-    conn = _open_readonly_cache(db_path)
-
+    """Return the latest visible message from ``sender`` in the given scope."""
     try:
-        if _thread_scope_has_no_snapshot(
-            conn,
+        if await _thread_scope_has_no_snapshot(
+            db,
             room_id=room_id,
             thread_id=thread_id,
             runtime_started_at=runtime_started_at,
             now=now,
         ):
             return None
-        return _load_scope_snapshot(
-            conn,
+        return await _load_scope_snapshot(
+            db,
             room_id=room_id,
             thread_id=thread_id,
             sender=sender,
             runtime_started_at=runtime_started_at,
         )
     except json.JSONDecodeError as exc:
-        msg = f"Cached Matrix event JSON is corrupt in {db_path}"
+        msg = "Cached Matrix event JSON is corrupt"
         raise CacheUnavailable(msg) from exc
     except sqlite3.Error as exc:
-        msg = f"Failed to read Matrix event cache at {db_path}"
+        msg = "Failed to read Matrix event cache snapshot"
         raise CacheUnavailable(msg) from exc
-    finally:
-        conn.close()

--- a/src/mindroom/matrix/cache/agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/agent_message_snapshot.py
@@ -36,6 +36,14 @@ class _ThreadCacheStateSnapshot:
     room_invalidation_reason: str | None
 
 
+@dataclass(frozen=True, slots=True)
+class _CachedEventRow:
+    """One cached event payload plus the write timestamp for its visible version."""
+
+    event: dict[str, Any]
+    cached_at: float | None
+
+
 def _relation_type(event: dict[str, Any]) -> str | None:
     content = _content_dict(event.get("content"))
     relates_to = content.get("m.relates_to")
@@ -62,10 +70,10 @@ def _load_latest_edit(
     *,
     room_id: str,
     original_event_id: str,
-) -> dict[str, Any] | None:
+) -> _CachedEventRow | None:
     row = conn.execute(
         """
-        SELECT events.event_json
+        SELECT events.event_json, events.cached_at
         FROM event_edits
         JOIN events ON events.event_id = event_edits.edit_event_id
         WHERE event_edits.room_id = ? AND event_edits.original_event_id = ?
@@ -74,7 +82,12 @@ def _load_latest_edit(
         """,
         (room_id, original_event_id),
     ).fetchone()
-    return None if row is None else json.loads(row[0])
+    if row is None:
+        return None
+    return _CachedEventRow(
+        event=json.loads(row[0]),
+        cached_at=None if row[1] is None else float(row[1]),
+    )
 
 
 def _load_thread_cache_state(
@@ -142,7 +155,7 @@ def _iter_scope_events(
     if thread_id is None:
         return conn.execute(
             """
-            SELECT event_json
+            SELECT event_json, cached_at
             FROM events
             WHERE room_id = ?
             ORDER BY origin_server_ts DESC, event_id DESC
@@ -151,7 +164,7 @@ def _iter_scope_events(
         )
     return conn.execute(
         """
-        SELECT event_json
+        SELECT event_json, NULL AS cached_at
         FROM thread_events
         WHERE room_id = ? AND thread_id = ?
         ORDER BY origin_server_ts DESC, rowid DESC
@@ -178,19 +191,27 @@ def _snapshot_from_event(
     conn: sqlite3.Connection,
     *,
     room_id: str,
+    thread_id: str | None,
     event: dict[str, Any],
+    cached_at: float | None,
+    runtime_started_at: float | None,
 ) -> AgentMessageSnapshot | None:
     event_id = event.get("event_id")
     if not isinstance(event_id, str) or not event_id:
         return None
-    latest_event = (
-        _load_latest_edit(
-            conn,
-            room_id=room_id,
-            original_event_id=event_id,
-        )
-        or event
+    latest_edit = _load_latest_edit(
+        conn,
+        room_id=room_id,
+        original_event_id=event_id,
     )
+    latest_event = latest_edit.event if latest_edit is not None else event
+    visible_cached_at = latest_edit.cached_at if latest_edit is not None else cached_at
+    if (
+        thread_id is None
+        and runtime_started_at is not None
+        and (visible_cached_at is None or visible_cached_at < runtime_started_at)
+    ):
+        return None
     timestamp = latest_event.get("origin_server_ts")
     if not isinstance(timestamp, int) or isinstance(timestamp, bool):
         return None
@@ -240,13 +261,14 @@ def _load_scope_snapshot(
     room_id: str,
     thread_id: str | None,
     sender: str,
+    runtime_started_at: float | None,
 ) -> AgentMessageSnapshot | None:
     rows = _iter_scope_events(
         conn,
         room_id=room_id,
         thread_id=thread_id,
     )
-    for (event_json,) in rows:
+    for event_json, cached_at in rows:
         event = json.loads(event_json)
         if not _event_matches_scope(
             event,
@@ -257,7 +279,10 @@ def _load_scope_snapshot(
         snapshot = _snapshot_from_event(
             conn,
             room_id=room_id,
+            thread_id=thread_id,
             event=event,
+            cached_at=None if cached_at is None else float(cached_at),
+            runtime_started_at=runtime_started_at,
         )
         if snapshot is not None:
             return snapshot
@@ -300,6 +325,7 @@ def get_latest_agent_message_snapshot(
             room_id=room_id,
             thread_id=thread_id,
             sender=sender,
+            runtime_started_at=runtime_started_at,
         )
     except json.JSONDecodeError as exc:
         msg = f"Cached Matrix event JSON is corrupt in {db_path}"

--- a/src/mindroom/matrix/cache/agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/agent_message_snapshot.py
@@ -22,7 +22,7 @@ class AgentMessageSnapshot:
     origin_server_ts: int
 
 
-class CacheUnavailable(RuntimeError):  # noqa: N818
+class AgentMessageSnapshotUnavailable(RuntimeError):  # noqa: N818
     """Raised when an existing Matrix event cache cannot be safely read."""
 
 
@@ -96,7 +96,7 @@ async def _thread_scope_has_no_snapshot(
         return True
     if rejection_reason is not None:
         msg = f"Thread cache snapshot is not usable: {rejection_reason}"
-        raise CacheUnavailable(msg)
+        raise AgentMessageSnapshotUnavailable(msg)
     return False
 
 
@@ -207,7 +207,7 @@ async def _load_scope_snapshot(
         await cursor.close()
 
 
-async def load_latest_agent_message_snapshot(
+async def load_agent_message_snapshot(
     db: aiosqlite.Connection,
     *,
     room_id: str,
@@ -235,7 +235,7 @@ async def load_latest_agent_message_snapshot(
         )
     except json.JSONDecodeError as exc:
         msg = "Cached Matrix event JSON is corrupt"
-        raise CacheUnavailable(msg) from exc
+        raise AgentMessageSnapshotUnavailable(msg) from exc
     except sqlite3.Error as exc:
         msg = "Failed to read Matrix event cache snapshot"
-        raise CacheUnavailable(msg) from exc
+        raise AgentMessageSnapshotUnavailable(msg) from exc

--- a/src/mindroom/matrix/cache/agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/agent_message_snapshot.py
@@ -1,0 +1,311 @@
+"""Public snapshot reads for the latest visible agent message in one scope."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from .thread_cache_helpers import thread_cache_rejection_reason
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class AgentMessageSnapshot:
+    """Latest visible message content and timestamp for one sender."""
+
+    content: dict[str, Any]
+    origin_server_ts: int
+
+
+class CacheUnavailable(RuntimeError):  # noqa: N818
+    """Raised when an existing Matrix event cache cannot be safely read."""
+
+
+@dataclass(frozen=True, slots=True)
+class _ThreadCacheStateSnapshot:
+    """Freshness metadata read directly from the SQLite cache."""
+
+    validated_at: float | None
+    invalidated_at: float | None
+    invalidation_reason: str | None
+    room_invalidated_at: float | None
+    room_invalidation_reason: str | None
+
+
+def _relation_type(event: dict[str, Any]) -> str | None:
+    content = _content_dict(event.get("content"))
+    relates_to = content.get("m.relates_to")
+    if not isinstance(relates_to, dict):
+        return None
+    relation_type = relates_to.get("rel_type")
+    return relation_type if isinstance(relation_type, str) else None
+
+
+def _content_dict(content: object) -> dict[str, Any]:
+    if not isinstance(content, dict):
+        return {}
+    return {key: value for key, value in content.items() if isinstance(key, str)}
+
+
+def _visible_content(event: dict[str, Any]) -> dict[str, Any]:
+    content = _content_dict(event.get("content"))
+    new_content = _content_dict(content.get("m.new_content"))
+    return new_content or content
+
+
+def _load_latest_edit(
+    conn: sqlite3.Connection,
+    *,
+    room_id: str,
+    original_event_id: str,
+) -> dict[str, Any] | None:
+    row = conn.execute(
+        """
+        SELECT events.event_json
+        FROM event_edits
+        JOIN events ON events.event_id = event_edits.edit_event_id
+        WHERE event_edits.room_id = ? AND event_edits.original_event_id = ?
+        ORDER BY event_edits.origin_server_ts DESC, event_edits.edit_event_id DESC
+        LIMIT 1
+        """,
+        (room_id, original_event_id),
+    ).fetchone()
+    return None if row is None else json.loads(row[0])
+
+
+def _load_thread_cache_state(
+    conn: sqlite3.Connection,
+    *,
+    room_id: str,
+    thread_id: str,
+) -> _ThreadCacheStateSnapshot | None:
+    row = conn.execute(
+        """
+        SELECT
+            thread_cache_state.validated_at,
+            thread_cache_state.invalidated_at,
+            thread_cache_state.invalidation_reason,
+            room_cache_state.invalidated_at,
+            room_cache_state.invalidation_reason
+        FROM (SELECT ? AS requested_room_id, ? AS requested_thread_id) AS requested
+        LEFT JOIN thread_cache_state
+            ON thread_cache_state.room_id = requested.requested_room_id
+            AND thread_cache_state.thread_id = requested.requested_thread_id
+        LEFT JOIN room_cache_state
+            ON room_cache_state.room_id = requested.requested_room_id
+        """,
+        (room_id, thread_id),
+    ).fetchone()
+    if row is None or all(value is None for value in row):
+        return None
+    return _ThreadCacheStateSnapshot(
+        validated_at=None if row[0] is None else float(row[0]),
+        invalidated_at=None if row[1] is None else float(row[1]),
+        invalidation_reason=row[2] if isinstance(row[2], str) else None,
+        room_invalidated_at=None if row[3] is None else float(row[3]),
+        room_invalidation_reason=row[4] if isinstance(row[4], str) else None,
+    )
+
+
+_THREAD_CACHE_REJECTION_NONE_REASONS = frozenset({"no_cache_state", "cache_never_validated"})
+
+
+def _thread_scope_rejection_reason(
+    conn: sqlite3.Connection,
+    *,
+    room_id: str,
+    thread_id: str,
+    runtime_started_at: float | None,
+    now: float | None,
+) -> str | None:
+    return thread_cache_rejection_reason(
+        _load_thread_cache_state(
+            conn,
+            room_id=room_id,
+            thread_id=thread_id,
+        ),
+        runtime_started_at=runtime_started_at,
+        now=now,
+    )
+
+
+def _iter_scope_events(
+    conn: sqlite3.Connection,
+    *,
+    room_id: str,
+    thread_id: str | None,
+) -> sqlite3.Cursor:
+    if thread_id is None:
+        return conn.execute(
+            """
+            SELECT event_json
+            FROM events
+            WHERE room_id = ?
+            ORDER BY origin_server_ts DESC, event_id DESC
+            """,
+            (room_id,),
+        )
+    return conn.execute(
+        """
+        SELECT event_json
+        FROM thread_events
+        WHERE room_id = ? AND thread_id = ?
+        ORDER BY origin_server_ts DESC, rowid DESC
+        """,
+        (room_id, thread_id),
+    )
+
+
+def _event_matches_scope(
+    event: dict[str, Any],
+    *,
+    thread_id: str | None,
+    sender: str,
+) -> bool:
+    if event.get("type") != "m.room.message" or event.get("sender") != sender:
+        return False
+    relation_type = _relation_type(event)
+    if relation_type == "m.replace":
+        return False
+    return not (thread_id is None and relation_type == "m.thread")
+
+
+def _snapshot_from_event(
+    conn: sqlite3.Connection,
+    *,
+    room_id: str,
+    event: dict[str, Any],
+) -> AgentMessageSnapshot | None:
+    event_id = event.get("event_id")
+    if not isinstance(event_id, str) or not event_id:
+        return None
+    latest_event = (
+        _load_latest_edit(
+            conn,
+            room_id=room_id,
+            original_event_id=event_id,
+        )
+        or event
+    )
+    timestamp = latest_event.get("origin_server_ts")
+    if not isinstance(timestamp, int) or isinstance(timestamp, bool):
+        return None
+    return AgentMessageSnapshot(
+        content=_visible_content(latest_event),
+        origin_server_ts=timestamp,
+    )
+
+
+def _open_readonly_cache(db_path: Path) -> sqlite3.Connection:
+    try:
+        return sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.Error as exc:
+        msg = f"Failed to open Matrix event cache at {db_path}"
+        raise CacheUnavailable(msg) from exc
+
+
+def _thread_scope_has_no_snapshot(
+    conn: sqlite3.Connection,
+    *,
+    room_id: str,
+    thread_id: str | None,
+    runtime_started_at: float | None,
+    now: float | None,
+) -> bool:
+    if thread_id is None:
+        return False
+
+    rejection_reason = _thread_scope_rejection_reason(
+        conn,
+        room_id=room_id,
+        thread_id=thread_id,
+        runtime_started_at=runtime_started_at,
+        now=now,
+    )
+    if rejection_reason in _THREAD_CACHE_REJECTION_NONE_REASONS:
+        return True
+    if rejection_reason is not None:
+        msg = f"Thread cache snapshot is not usable: {rejection_reason}"
+        raise CacheUnavailable(msg)
+    return False
+
+
+def _load_scope_snapshot(
+    conn: sqlite3.Connection,
+    *,
+    room_id: str,
+    thread_id: str | None,
+    sender: str,
+) -> AgentMessageSnapshot | None:
+    rows = _iter_scope_events(
+        conn,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    for (event_json,) in rows:
+        event = json.loads(event_json)
+        if not _event_matches_scope(
+            event,
+            thread_id=thread_id,
+            sender=sender,
+        ):
+            continue
+        snapshot = _snapshot_from_event(
+            conn,
+            room_id=room_id,
+            event=event,
+        )
+        if snapshot is not None:
+            return snapshot
+    return None
+
+
+def get_latest_agent_message_snapshot(
+    *,
+    db_path: Path,
+    room_id: str,
+    thread_id: str | None,
+    sender: str,
+    runtime_started_at: float | None,
+    now: float | None = None,
+) -> AgentMessageSnapshot | None:
+    """Return the latest visible message from ``sender`` in the given scope.
+
+    Used by the workloop plugin to gate auto-poke on stream status. Returns ``None``
+    when the cache file is missing or the sender has no cached message in the
+    requested scope. Raises ``CacheUnavailable`` when an existing cache file cannot
+    be safely read or a cached thread snapshot is present but rejected by the cache
+    freshness contract.
+    """
+    if not db_path.exists():
+        return None
+
+    conn = _open_readonly_cache(db_path)
+
+    try:
+        if _thread_scope_has_no_snapshot(
+            conn,
+            room_id=room_id,
+            thread_id=thread_id,
+            runtime_started_at=runtime_started_at,
+            now=now,
+        ):
+            return None
+        return _load_scope_snapshot(
+            conn,
+            room_id=room_id,
+            thread_id=thread_id,
+            sender=sender,
+        )
+    except json.JSONDecodeError as exc:
+        msg = f"Cached Matrix event JSON is corrupt in {db_path}"
+        raise CacheUnavailable(msg) from exc
+    except sqlite3.Error as exc:
+        msg = f"Failed to read Matrix event cache at {db_path}"
+        raise CacheUnavailable(msg) from exc
+    finally:
+        conn.close()

--- a/src/mindroom/matrix/cache/agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/agent_message_snapshot.py
@@ -151,7 +151,7 @@ async def _iter_scope_events(
             SELECT event_json, cached_at
             FROM events
             WHERE room_id = ?
-            ORDER BY origin_server_ts DESC, event_id DESC
+            ORDER BY origin_server_ts DESC, rowid DESC
             """,
             (room_id,),
         )

--- a/src/mindroom/matrix/cache/agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/agent_message_snapshot.py
@@ -44,6 +44,14 @@ class _CachedEventRow:
     cached_at: float | None
 
 
+@dataclass(frozen=True, slots=True)
+class _SnapshotLookupResult:
+    """Outcome for one matching scope event during latest-message lookup."""
+
+    snapshot: AgentMessageSnapshot | None
+    stop_scanning: bool = False
+
+
 def _relation_type(event: dict[str, Any]) -> str | None:
     content = _content_dict(event.get("content"))
     relates_to = content.get("m.relates_to")
@@ -195,10 +203,10 @@ def _snapshot_from_event(
     event: dict[str, Any],
     cached_at: float | None,
     runtime_started_at: float | None,
-) -> AgentMessageSnapshot | None:
+) -> _SnapshotLookupResult:
     event_id = event.get("event_id")
     if not isinstance(event_id, str) or not event_id:
-        return None
+        return _SnapshotLookupResult(snapshot=None)
     latest_edit = _load_latest_edit(
         conn,
         room_id=room_id,
@@ -211,13 +219,15 @@ def _snapshot_from_event(
         and runtime_started_at is not None
         and (visible_cached_at is None or visible_cached_at < runtime_started_at)
     ):
-        return None
+        return _SnapshotLookupResult(snapshot=None, stop_scanning=True)
     timestamp = latest_event.get("origin_server_ts")
     if not isinstance(timestamp, int) or isinstance(timestamp, bool):
-        return None
-    return AgentMessageSnapshot(
-        content=_visible_content(latest_event),
-        origin_server_ts=timestamp,
+        return _SnapshotLookupResult(snapshot=None)
+    return _SnapshotLookupResult(
+        snapshot=AgentMessageSnapshot(
+            content=_visible_content(latest_event),
+            origin_server_ts=timestamp,
+        ),
     )
 
 
@@ -276,7 +286,7 @@ def _load_scope_snapshot(
             sender=sender,
         ):
             continue
-        snapshot = _snapshot_from_event(
+        result = _snapshot_from_event(
             conn,
             room_id=room_id,
             thread_id=thread_id,
@@ -284,8 +294,10 @@ def _load_scope_snapshot(
             cached_at=None if cached_at is None else float(cached_at),
             runtime_started_at=runtime_started_at,
         )
-        if snapshot is not None:
-            return snapshot
+        if result.stop_scanning:
+            return None
+        if result.snapshot is not None:
+            return result.snapshot
     return None
 
 

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -14,7 +14,7 @@ import aiosqlite
 from mindroom.logging_config import get_logger
 
 from . import event_cache_events, event_cache_threads
-from .agent_message_snapshot import AgentMessageSnapshot, load_latest_agent_message_snapshot
+from .agent_message_snapshot import AgentMessageSnapshot, load_agent_message_snapshot
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
@@ -602,7 +602,7 @@ class _EventCache:
             room_id,
             operation="get_latest_agent_message_snapshot",
             disabled_result=None,
-            reader=lambda db: load_latest_agent_message_snapshot(
+            reader=lambda db: load_agent_message_snapshot(
                 db,
                 room_id=room_id,
                 thread_id=thread_id,

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
     from pathlib import Path
 
-EVENT_CACHE_SCHEMA_VERSION = 9
+EVENT_CACHE_SCHEMA_VERSION = 10
 _EVENT_CACHE_TABLES = (
     "thread_events",
     "events",
@@ -90,7 +90,7 @@ async def create_event_cache_schema(db: aiosqlite.Connection) -> None:
     await db.execute(
         """
         CREATE INDEX IF NOT EXISTS idx_events_room_origin_ts
-        ON events(room_id, origin_server_ts DESC, event_id DESC)
+        ON events(room_id, origin_server_ts DESC)
         """,
     )
     await db.execute(

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -14,6 +14,7 @@ import aiosqlite
 from mindroom.logging_config import get_logger
 
 from . import event_cache_events, event_cache_threads
+from .agent_message_snapshot import AgentMessageSnapshot, load_latest_agent_message_snapshot
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
@@ -384,6 +385,17 @@ class ConversationEventCache(Protocol):
     async def get_latest_edit(self, room_id: str, original_event_id: str) -> dict[str, Any] | None:
         """Return the latest cached edit event for one original event."""
 
+    async def get_latest_agent_message_snapshot(
+        self,
+        room_id: str,
+        thread_id: str | None,
+        sender: str,
+        *,
+        runtime_started_at: float | None,
+        now: float | None = None,
+    ) -> AgentMessageSnapshot | None:
+        """Return the latest visible cached message from one sender in the given scope."""
+
     async def get_mxc_text(self, room_id: str, mxc_url: str) -> str | None:
         """Return one durably cached MXC text payload when present."""
 
@@ -573,6 +585,30 @@ class _EventCache:
                 db,
                 room_id=room_id,
                 original_event_id=original_event_id,
+            ),
+        )
+
+    async def get_latest_agent_message_snapshot(
+        self,
+        room_id: str,
+        thread_id: str | None,
+        sender: str,
+        *,
+        runtime_started_at: float | None,
+        now: float | None = None,
+    ) -> AgentMessageSnapshot | None:
+        """Return the latest visible cached message from one sender in the given scope."""
+        return await self._read_operation(
+            room_id,
+            operation="get_latest_agent_message_snapshot",
+            disabled_result=None,
+            reader=lambda db: load_latest_agent_message_snapshot(
+                db,
+                room_id=room_id,
+                thread_id=thread_id,
+                sender=sender,
+                runtime_started_at=runtime_started_at,
+                now=now,
             ),
         )
 

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
     from pathlib import Path
 
-EVENT_CACHE_SCHEMA_VERSION = 8
+EVENT_CACHE_SCHEMA_VERSION = 9
 _EVENT_CACHE_TABLES = (
     "thread_events",
     "events",
@@ -80,9 +80,16 @@ async def create_event_cache_schema(db: aiosqlite.Connection) -> None:
         CREATE TABLE IF NOT EXISTS events (
             event_id TEXT PRIMARY KEY,
             room_id TEXT NOT NULL,
+            origin_server_ts INTEGER NOT NULL,
             event_json TEXT NOT NULL,
             cached_at REAL NOT NULL
         )
+        """,
+    )
+    await db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_events_room_origin_ts
+        ON events(room_id, origin_server_ts DESC, event_id DESC)
         """,
     )
     await db.execute(

--- a/src/mindroom/matrix/cache/event_cache_events.py
+++ b/src/mindroom/matrix/cache/event_cache_events.py
@@ -29,7 +29,7 @@ class SerializedCachedEvent:
 
 
 @dataclass(frozen=True, slots=True)
-class LoadedCachedEvent:
+class CachedEventRow:
     """One cached event payload plus the time its visible row was written."""
 
     event: dict[str, Any]
@@ -158,7 +158,7 @@ async def load_latest_edit_row(
     *,
     room_id: str,
     original_event_id: str,
-) -> LoadedCachedEvent | None:
+) -> CachedEventRow | None:
     """Return the latest cached edit event plus its lookup-row write time."""
     cursor = await db.execute(
         """
@@ -175,7 +175,7 @@ async def load_latest_edit_row(
     await cursor.close()
     if row is None:
         return None
-    return LoadedCachedEvent(
+    return CachedEventRow(
         event=json.loads(row[0]),
         cached_at=None if row[1] is None else float(row[1]),
     )

--- a/src/mindroom/matrix/cache/event_cache_events.py
+++ b/src/mindroom/matrix/cache/event_cache_events.py
@@ -316,13 +316,14 @@ async def write_lookup_index_rows(
         return
     await db.executemany(
         """
-        INSERT OR REPLACE INTO events(event_id, room_id, event_json, cached_at)
-        VALUES (?, ?, ?, ?)
+        INSERT OR REPLACE INTO events(event_id, room_id, origin_server_ts, event_json, cached_at)
+        VALUES (?, ?, ?, ?, ?)
         """,
         [
             (
                 event.event_id,
                 room_id,
+                event.origin_server_ts,
                 event.event_json,
                 cached_at,
             )

--- a/src/mindroom/matrix/cache/event_cache_events.py
+++ b/src/mindroom/matrix/cache/event_cache_events.py
@@ -143,7 +143,7 @@ async def load_latest_edit(
         FROM event_edits
         JOIN events ON events.event_id = event_edits.edit_event_id
         WHERE event_edits.room_id = ? AND event_edits.original_event_id = ?
-        ORDER BY event_edits.origin_server_ts DESC, event_edits.edit_event_id DESC
+        ORDER BY event_edits.origin_server_ts DESC, events.rowid DESC
         LIMIT 1
         """,
         (room_id, original_event_id),
@@ -166,7 +166,7 @@ async def load_latest_edit_row(
         FROM event_edits
         JOIN events ON events.event_id = event_edits.edit_event_id
         WHERE event_edits.room_id = ? AND event_edits.original_event_id = ?
-        ORDER BY event_edits.origin_server_ts DESC, event_edits.edit_event_id DESC
+        ORDER BY event_edits.origin_server_ts DESC, events.rowid DESC
         LIMIT 1
         """,
         (room_id, original_event_id),
@@ -352,8 +352,13 @@ async def write_lookup_index_rows(
         return
     await db.executemany(
         """
-        INSERT OR REPLACE INTO events(event_id, room_id, origin_server_ts, event_json, cached_at)
+        INSERT INTO events(event_id, room_id, origin_server_ts, event_json, cached_at)
         VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(event_id) DO UPDATE SET
+            room_id = excluded.room_id,
+            origin_server_ts = excluded.origin_server_ts,
+            event_json = excluded.event_json,
+            cached_at = excluded.cached_at
         """,
         [
             (

--- a/src/mindroom/matrix/cache/event_cache_events.py
+++ b/src/mindroom/matrix/cache/event_cache_events.py
@@ -28,6 +28,14 @@ class SerializedCachedEvent:
     event: dict[str, Any]
 
 
+@dataclass(frozen=True, slots=True)
+class LoadedCachedEvent:
+    """One cached event payload plus the time its visible row was written."""
+
+    event: dict[str, Any]
+    cached_at: float | None
+
+
 def event_id_for_cache(event: dict[str, Any]) -> str:
     """Return the required event ID from one normalized cached event."""
     event_id = event.get("event_id")
@@ -143,6 +151,34 @@ async def load_latest_edit(
     row = await cursor.fetchone()
     await cursor.close()
     return None if row is None else json.loads(row[0])
+
+
+async def load_latest_edit_row(
+    db: aiosqlite.Connection,
+    *,
+    room_id: str,
+    original_event_id: str,
+) -> LoadedCachedEvent | None:
+    """Return the latest cached edit event plus its lookup-row write time."""
+    cursor = await db.execute(
+        """
+        SELECT events.event_json, events.cached_at
+        FROM event_edits
+        JOIN events ON events.event_id = event_edits.edit_event_id
+        WHERE event_edits.room_id = ? AND event_edits.original_event_id = ?
+        ORDER BY event_edits.origin_server_ts DESC, event_edits.edit_event_id DESC
+        LIMIT 1
+        """,
+        (room_id, original_event_id),
+    )
+    row = await cursor.fetchone()
+    await cursor.close()
+    if row is None:
+        return None
+    return LoadedCachedEvent(
+        event=json.loads(row[0]),
+        cached_at=None if row[1] is None else float(row[1]),
+    )
 
 
 async def load_mxc_text(

--- a/src/mindroom/matrix/cache/thread_cache_helpers.py
+++ b/src/mindroom/matrix/cache/thread_cache_helpers.py
@@ -3,16 +3,25 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from mindroom.matrix.cache.event_cache import ThreadCacheState
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 
 
 THREAD_CACHE_MAX_AGE_SECONDS = 300.0
+
+
+class ThreadCacheStateLike(Protocol):
+    """Structural contract for durable thread cache freshness state."""
+
+    validated_at: float | None
+    invalidated_at: float | None
+    invalidation_reason: str | None
+    room_invalidated_at: float | None
+    room_invalidation_reason: str | None
 
 
 def latest_visible_thread_event_id(history: Sequence[ResolvedVisibleMessage]) -> str | None:
@@ -23,7 +32,7 @@ def latest_visible_thread_event_id(history: Sequence[ResolvedVisibleMessage]) ->
 
 
 def thread_cache_rejection_reason(
-    cache_state: ThreadCacheState | None,
+    cache_state: ThreadCacheStateLike | None,
     *,
     runtime_started_at: float | None,
     now: float | None = None,
@@ -48,7 +57,7 @@ def thread_cache_rejection_reason(
 
 
 def thread_cache_state_is_usable(
-    cache_state: ThreadCacheState | None,
+    cache_state: ThreadCacheStateLike | None,
     *,
     runtime_started_at: float | None,
     now: float | None = None,

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1160,8 +1160,8 @@ class MultiAgentOrchestrator:
             correlation_id=f"config-reload:{uuid4().hex}",
             runtime_started_at=(router_bot.runtime_started_at if isinstance(router_bot, AgentBot) else time.time()),
             message_sender=self._hook_message_sender(),
-            latest_agent_message_snapshot_reader=(
-                router_bot._hook_latest_agent_message_snapshot if isinstance(router_bot, AgentBot) else None
+            agent_message_snapshot_reader=(
+                router_bot._hook_agent_message_snapshot if isinstance(router_bot, AgentBot) else None
             ),
             matrix_admin=self._hook_matrix_admin(),
             room_state_querier=self._hook_room_state_querier(),

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1160,6 +1160,9 @@ class MultiAgentOrchestrator:
             correlation_id=f"config-reload:{uuid4().hex}",
             runtime_started_at=(router_bot.runtime_started_at if isinstance(router_bot, AgentBot) else time.time()),
             message_sender=self._hook_message_sender(),
+            latest_agent_message_snapshot_reader=(
+                router_bot._hook_latest_agent_message_snapshot if isinstance(router_bot, AgentBot) else None
+            ),
             matrix_admin=self._hook_matrix_admin(),
             room_state_querier=self._hook_room_state_querier(),
             room_state_putter=self._hook_room_state_putter(),

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1149,6 +1149,7 @@ class MultiAgentOrchestrator:
         if not self.hook_registry.has_hooks(EVENT_CONFIG_RELOADED):
             return
 
+        router_bot = self.agent_bots.get(ROUTER_AGENT_NAME)
         context = ConfigReloadedContext(
             event_name=EVENT_CONFIG_RELOADED,
             plugin_name="",
@@ -1157,6 +1158,7 @@ class MultiAgentOrchestrator:
             runtime_paths=self.runtime_paths,
             logger=logger.bind(event_name=EVENT_CONFIG_RELOADED),
             correlation_id=f"config-reload:{uuid4().hex}",
+            runtime_started_at=(router_bot.runtime_started_at if isinstance(router_bot, AgentBot) else time.time()),
             message_sender=self._hook_message_sender(),
             matrix_admin=self._hook_matrix_admin(),
             room_state_querier=self._hook_room_state_querier(),

--- a/src/mindroom/runtime_protocols.py
+++ b/src/mindroom/runtime_protocols.py
@@ -43,10 +43,13 @@ class SupportsConfigOrchestrator(SupportsConfig, Protocol):
 
 
 class SupportsClientConfigOrchestrator(SupportsClientConfig, Protocol):
-    """Expose client/config access plus the orchestrator."""
+    """Expose client/config access, orchestrator access, and runtime freshness."""
 
     @property
     def orchestrator(self) -> MultiAgentOrchestrator | None: ...  # noqa: D102
+
+    @property
+    def runtime_started_at(self) -> float: ...  # noqa: D102
 
 
 if TYPE_CHECKING:

--- a/tach.toml
+++ b/tach.toml
@@ -1400,7 +1400,7 @@ from = ["mindroom.runtime_protocols"]
 [[interfaces]]
 expose = [
     "AgentMessageSnapshot",
-    "CacheUnavailable",
+    "AgentMessageSnapshotUnavailable",
     "ConversationEventCache",
     "EventCacheWriteCoordinator",
     "THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC",

--- a/tach.toml
+++ b/tach.toml
@@ -627,11 +627,20 @@ depends_on = [
 [[modules]]
 path = "mindroom.matrix.cache"
 depends_on = [
+    "mindroom.matrix.cache.agent_message_snapshot",
     "mindroom.matrix.cache.event_cache",
     "mindroom.matrix.cache.event_cache_events",
     "mindroom.matrix.cache.write_coordinator",
     "mindroom.matrix.cache.thread_cache_helpers",
     "mindroom.matrix.cache.thread_history_result",
+]
+
+[[modules]]
+path = "mindroom.matrix.cache.agent_message_snapshot"
+depends_on = [
+    "mindroom.matrix.cache.event_cache_events",
+    "mindroom.matrix.cache.event_cache_threads",
+    "mindroom.matrix.cache.thread_cache_helpers",
 ]
 
 [[modules]]
@@ -641,6 +650,7 @@ depends_on = ["mindroom.matrix.cache.event_cache_events"]
 [[modules]]
 path = "mindroom.matrix.cache.event_cache"
 depends_on = [
+    "mindroom.matrix.cache.agent_message_snapshot",
     "mindroom.matrix.cache.event_cache_events",
     "mindroom.matrix.cache.event_cache_threads",
 ]
@@ -968,6 +978,7 @@ depends_on = [
     "mindroom.hooks.state",
     "mindroom.hooks.types",
     "mindroom.logging_config",
+    "mindroom.matrix.cache",
     "mindroom.runtime_protocols",
     "mindroom.tool_system.plugin_identity",
 ]
@@ -1388,6 +1399,8 @@ from = ["mindroom.runtime_protocols"]
 
 [[interfaces]]
 expose = [
+    "AgentMessageSnapshot",
+    "CacheUnavailable",
     "ConversationEventCache",
     "EventCacheWriteCoordinator",
     "THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,6 +211,7 @@ def make_event_cache_mock() -> AsyncMock:
     event_cache.get_thread_events.return_value = None
     event_cache.get_thread_cache_state.return_value = None
     event_cache.get_thread_id_for_event.return_value = None
+    event_cache.get_latest_agent_message_snapshot.return_value = None
     event_cache.append_event.return_value = True
     event_cache.redact_event.return_value = False
     return event_cache

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -341,6 +341,7 @@ def _build_response_runner(
         enable_streaming=bot.enable_streaming,
         orchestrator=bot.orchestrator,
         event_cache=make_event_cache_mock(),
+        runtime_started_at=0.0,
     )
     hook_context = HookContextSupport(
         runtime=runtime,

--- a/tests/test_cancelled_response_hook.py
+++ b/tests/test_cancelled_response_hook.py
@@ -85,7 +85,7 @@ def _response_hook_service(tmp_path: Path, registry: HookRegistry) -> tuple[Conf
     config = _config(tmp_path)
     rp = runtime_paths_for(config)
     hook_context = HookContextSupport(
-        runtime=type("RT", (), {"client": None, "orchestrator": None, "config": config})(),
+        runtime=type("RT", (), {"client": None, "orchestrator": None, "config": config, "runtime_started_at": 0.0})(),
         logger=get_logger("tests"),
         runtime_paths=rp,
         agent_name="code",
@@ -259,7 +259,7 @@ async def test_response_hook_service_emit_cancelled(tmp_path: Path) -> None:
     rp = runtime_paths_for(config)
 
     hook_context = HookContextSupport(
-        runtime=type("RT", (), {"client": None, "orchestrator": None, "config": config})(),
+        runtime=type("RT", (), {"client": None, "orchestrator": None, "config": config, "runtime_started_at": 0.0})(),
         logger=get_logger("tests"),
         runtime_paths=rp,
         agent_name="code",
@@ -287,7 +287,7 @@ async def test_response_hook_service_skips_when_no_hooks(tmp_path: Path) -> None
     rp = runtime_paths_for(config)
 
     hook_context = HookContextSupport(
-        runtime=type("RT", (), {"client": None, "orchestrator": None, "config": config})(),
+        runtime=type("RT", (), {"client": None, "orchestrator": None, "config": config, "runtime_started_at": 0.0})(),
         logger=get_logger("tests"),
         runtime_paths=rp,
         agent_name="code",

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -1347,6 +1347,41 @@ async def test_initialize_resets_stale_old_cache_schema(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_disabled_event_cache_skips_latest_agent_message_snapshot_reads(tmp_path: Path) -> None:
+    """Disabled caches should fail open for latest-agent-message snapshot reads."""
+    cache = _EventCache(tmp_path / "event_cache.db")
+    await cache.initialize()
+    try:
+        await cache.store_events_batch(
+            [
+                (
+                    "$reply",
+                    "!room:localhost",
+                    {
+                        "event_id": "$reply",
+                        "sender": "@agent:localhost",
+                        "origin_server_ts": 2000,
+                        "type": "m.room.message",
+                        "content": {"body": "Working...", "msgtype": "m.text"},
+                    },
+                ),
+            ],
+        )
+        cache.disable("test_disabled")
+
+        snapshot = await cache.get_latest_agent_message_snapshot(
+            "!room:localhost",
+            None,
+            "@agent:localhost",
+            runtime_started_at=0.0,
+        )
+    finally:
+        await cache.close()
+
+    assert snapshot is None
+
+
+@pytest.mark.asyncio
 async def test_fetch_thread_history_cache_hit_avoids_full_fetch_calls(tmp_path: Path) -> None:
     """Cache hits should bypass the full root-plus-relations fetch path."""
     cache = _EventCache(tmp_path / "event_cache.db")

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -141,6 +141,7 @@ def test_hook_context_support_prefers_orchestrator_router_matrix_admin(tmp_path:
         client=AsyncMock(spec=nio.AsyncClient),
         orchestrator=orchestrator,
         config=config,
+        runtime_started_at=0.0,
     )
     support = HookContextSupport(
         runtime=runtime,
@@ -167,6 +168,7 @@ def test_hook_context_support_builds_router_matrix_admin_without_orchestrator(tm
         client=AsyncMock(spec=nio.AsyncClient),
         orchestrator=None,
         config=config,
+        runtime_started_at=0.0,
     )
     support = HookContextSupport(
         runtime=runtime,
@@ -196,6 +198,7 @@ def test_hook_context_support_falls_back_to_orchestrator_router_matrix_admin(tmp
         client=AsyncMock(spec=nio.AsyncClient),
         orchestrator=orchestrator,
         config=config,
+        runtime_started_at=0.0,
     )
     support = HookContextSupport(
         runtime=runtime,
@@ -220,6 +223,7 @@ def test_hook_context_support_returns_none_without_router_matrix_admin(tmp_path:
         client=None,
         orchestrator=None,
         config=config,
+        runtime_started_at=0.0,
     )
     support = HookContextSupport(
         runtime=runtime,

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -16,6 +16,7 @@ from mindroom.config.models import ModelConfig
 from mindroom.hooks import HookContext, HookContextSupport
 from mindroom.hooks.registry import HookRegistry, HookRegistryState
 from mindroom.logging_config import get_logger
+from mindroom.matrix.cache import AgentMessageSnapshot
 from mindroom.orchestrator import MultiAgentOrchestrator
 from tests.conftest import (
     bind_runtime_paths,
@@ -53,6 +54,51 @@ def test_hooks_package_reexports_hook_matrix_admin_api() -> None:
 def test_hook_context_declares_matrix_admin_field() -> None:
     """HookContext should expose a bound matrix admin helper."""
     assert "matrix_admin" in HookContext.__dataclass_fields__
+
+
+def test_hook_context_declares_latest_agent_message_snapshot_reader_field() -> None:
+    """HookContext should expose a bound latest-agent-message snapshot reader."""
+    assert "latest_agent_message_snapshot_reader" in HookContext.__dataclass_fields__
+
+
+@pytest.mark.asyncio
+async def test_hook_context_delegates_latest_agent_message_snapshot_reads(tmp_path: Path) -> None:
+    """HookContext should route latest-agent-message snapshot reads through the bound helper."""
+    config = _config(tmp_path)
+    reader = AsyncMock(
+        return_value=AgentMessageSnapshot(
+            content={"body": "Working...", "msgtype": "m.text"},
+            origin_server_ts=2000,
+        ),
+    )
+    context = HookContext(
+        event_name="message:enrich",
+        plugin_name="workloop",
+        settings={},
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        logger=get_logger("tests.hook_matrix_admin"),
+        correlation_id="corr-snapshot",
+        runtime_started_at=1234.0,
+        latest_agent_message_snapshot_reader=reader,
+    )
+
+    snapshot = await context.get_latest_agent_message_snapshot(
+        "!room:localhost",
+        "@agent:localhost",
+        thread_id="$thread_root",
+    )
+
+    assert snapshot == AgentMessageSnapshot(
+        content={"body": "Working...", "msgtype": "m.text"},
+        origin_server_ts=2000,
+    )
+    reader.assert_awaited_once_with(
+        room_id="!room:localhost",
+        thread_id="$thread_root",
+        sender="@agent:localhost",
+        runtime_started_at=1234.0,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -56,9 +56,9 @@ def test_hook_context_declares_matrix_admin_field() -> None:
     assert "matrix_admin" in HookContext.__dataclass_fields__
 
 
-def test_hook_context_declares_latest_agent_message_snapshot_reader_field() -> None:
-    """HookContext should expose a bound latest-agent-message snapshot reader."""
-    assert "latest_agent_message_snapshot_reader" in HookContext.__dataclass_fields__
+def test_hook_context_declares_agent_message_snapshot_reader_field() -> None:
+    """HookContext should expose a bound agent-message snapshot reader."""
+    assert "agent_message_snapshot_reader" in HookContext.__dataclass_fields__
 
 
 @pytest.mark.asyncio
@@ -80,7 +80,7 @@ async def test_hook_context_delegates_latest_agent_message_snapshot_reads(tmp_pa
         logger=get_logger("tests.hook_matrix_admin"),
         correlation_id="corr-snapshot",
         runtime_started_at=1234.0,
-        latest_agent_message_snapshot_reader=reader,
+        agent_message_snapshot_reader=reader,
     )
 
     snapshot = await context.get_latest_agent_message_snapshot(

--- a/tests/test_matrix_cache_agent_message_snapshot.py
+++ b/tests/test_matrix_cache_agent_message_snapshot.py
@@ -633,3 +633,57 @@ async def test_room_scope_returns_latest_by_origin_server_ts_not_cached_at(
         content={"body": "Newest room message", "msgtype": "m.text"},
         origin_server_ts=3000,
     )
+
+
+@pytest.mark.asyncio
+async def test_room_scope_preserves_cache_insert_order_for_same_timestamp_messages(
+    tmp_path: Path,
+) -> None:
+    """Room-scope reads should keep the later cached sender message when timestamps tie."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.store_events_batch(
+            [
+                (
+                    "$zzz-first",
+                    "!room:localhost",
+                    _message_event(
+                        event_id="$zzz-first",
+                        sender="@agent:localhost",
+                        body="First cached message",
+                        origin_server_ts=3000,
+                    ),
+                ),
+            ],
+        )
+        await cache.store_events_batch(
+            [
+                (
+                    "$aaa-second",
+                    "!room:localhost",
+                    _message_event(
+                        event_id="$aaa-second",
+                        sender="@agent:localhost",
+                        body="Second cached message",
+                        origin_server_ts=3000,
+                    ),
+                ),
+            ],
+        )
+    finally:
+        await cache.close()
+
+    snapshot = await _read_snapshot(
+        db_path,
+        room_id="!room:localhost",
+        thread_id=None,
+        sender="@agent:localhost",
+        runtime_started_at=0.0,
+    )
+
+    assert snapshot == AgentMessageSnapshot(
+        content={"body": "Second cached message", "msgtype": "m.text"},
+        origin_server_ts=3000,
+    )

--- a/tests/test_matrix_cache_agent_message_snapshot.py
+++ b/tests/test_matrix_cache_agent_message_snapshot.py
@@ -1,0 +1,506 @@
+"""Tests for the public latest-agent-message cache accessor."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from mindroom.matrix.cache import (
+    AgentMessageSnapshot,
+    CacheUnavailable,
+    get_latest_agent_message_snapshot,
+)
+from mindroom.matrix.cache.event_cache import _EventCache
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _message_event(
+    *,
+    event_id: str,
+    sender: str,
+    body: str,
+    origin_server_ts: int,
+    relates_to: dict[str, object] | None = None,
+    new_content: dict[str, object] | None = None,
+) -> dict[str, Any]:
+    content: dict[str, Any] = {
+        "body": body,
+        "msgtype": "m.text",
+    }
+    if relates_to is not None:
+        content["m.relates_to"] = relates_to
+    if new_content is not None:
+        content["m.new_content"] = {
+            "msgtype": "m.text",
+            **new_content,
+        }
+    return {
+        "event_id": event_id,
+        "sender": sender,
+        "origin_server_ts": origin_server_ts,
+        "type": "m.room.message",
+        "content": content,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_latest_agent_message_snapshot_returns_unedited_thread_message(
+    tmp_path: Path,
+) -> None:
+    """Thread-scope reads should return the latest unedited agent message."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.replace_thread(
+            "!room:localhost",
+            "$thread-root",
+            [
+                _message_event(
+                    event_id="$thread-root",
+                    sender="@user:localhost",
+                    body="Question",
+                    origin_server_ts=1000,
+                ),
+                _message_event(
+                    event_id="$reply",
+                    sender="@agent:localhost",
+                    body="Answer",
+                    origin_server_ts=2000,
+                    relates_to={"rel_type": "m.thread", "event_id": "$thread-root"},
+                ),
+            ],
+        )
+    finally:
+        await cache.close()
+
+    snapshot = get_latest_agent_message_snapshot(
+        db_path=db_path,
+        room_id="!room:localhost",
+        thread_id="$thread-root",
+        sender="@agent:localhost",
+        runtime_started_at=0.0,
+    )
+
+    assert snapshot == AgentMessageSnapshot(
+        content={
+            "body": "Answer",
+            "msgtype": "m.text",
+            "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread-root"},
+        },
+        origin_server_ts=2000,
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_sqlite_reader_returns_streaming_status_for_threaded_message(
+    tmp_path: Path,
+) -> None:
+    """Edited threaded messages should surface the latest visible stream status."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.replace_thread(
+            "!room:localhost",
+            "$thread-root",
+            [
+                _message_event(
+                    event_id="$thread-root",
+                    sender="@user:localhost",
+                    body="Question",
+                    origin_server_ts=1000,
+                ),
+                _message_event(
+                    event_id="$reply",
+                    sender="@agent:localhost",
+                    body="Working...",
+                    origin_server_ts=2000,
+                    relates_to={"rel_type": "m.thread", "event_id": "$thread-root"},
+                ),
+                _message_event(
+                    event_id="$reply-edit",
+                    sender="@agent:localhost",
+                    body="* Working...",
+                    origin_server_ts=3000,
+                    relates_to={"rel_type": "m.replace", "event_id": "$reply"},
+                    new_content={
+                        "body": "Still working",
+                        "io.mindroom.stream_status": "streaming",
+                    },
+                ),
+            ],
+        )
+    finally:
+        await cache.close()
+
+    snapshot = get_latest_agent_message_snapshot(
+        db_path=db_path,
+        room_id="!room:localhost",
+        thread_id="$thread-root",
+        sender="@agent:localhost",
+        runtime_started_at=0.0,
+    )
+
+    assert snapshot == AgentMessageSnapshot(
+        content={
+            "body": "Still working",
+            "msgtype": "m.text",
+            "io.mindroom.stream_status": "streaming",
+        },
+        origin_server_ts=3000,
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_sqlite_reader_returns_room_level_message_when_thread_id_none(
+    tmp_path: Path,
+) -> None:
+    """Room-scope reads should skip threaded replies and stay on the room timeline."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.store_events_batch(
+            [
+                (
+                    "$room-message",
+                    "!room:localhost",
+                    _message_event(
+                        event_id="$room-message",
+                        sender="@agent:localhost",
+                        body="Room timeline reply",
+                        origin_server_ts=2000,
+                    ),
+                ),
+            ],
+        )
+        await cache.store_events_batch(
+            [
+                (
+                    "$thread-reply",
+                    "!room:localhost",
+                    _message_event(
+                        event_id="$thread-reply",
+                        sender="@agent:localhost",
+                        body="Thread reply",
+                        origin_server_ts=3000,
+                        relates_to={"rel_type": "m.thread", "event_id": "$thread-root"},
+                    ),
+                ),
+            ],
+        )
+    finally:
+        await cache.close()
+
+    snapshot = get_latest_agent_message_snapshot(
+        db_path=db_path,
+        room_id="!room:localhost",
+        thread_id=None,
+        sender="@agent:localhost",
+        runtime_started_at=0.0,
+    )
+
+    assert snapshot == AgentMessageSnapshot(
+        content={"body": "Room timeline reply", "msgtype": "m.text"},
+        origin_server_ts=2000,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_latest_agent_message_snapshot_returns_none_when_sender_has_no_message(
+    tmp_path: Path,
+) -> None:
+    """Missing sender matches should return None instead of raising."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.store_events_batch(
+            [
+                (
+                    "$room-message",
+                    "!room:localhost",
+                    _message_event(
+                        event_id="$room-message",
+                        sender="@other:localhost",
+                        body="Not the agent",
+                        origin_server_ts=2000,
+                    ),
+                ),
+            ],
+        )
+    finally:
+        await cache.close()
+
+    snapshot = get_latest_agent_message_snapshot(
+        db_path=db_path,
+        room_id="!room:localhost",
+        thread_id=None,
+        sender="@agent:localhost",
+        runtime_started_at=0.0,
+    )
+
+    assert snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_get_latest_agent_message_snapshot_returns_none_when_cache_has_no_rows(
+    tmp_path: Path,
+) -> None:
+    """Empty cache files should return None for any scope lookup."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    await cache.close()
+
+    snapshot = get_latest_agent_message_snapshot(
+        db_path=db_path,
+        room_id="!room:localhost",
+        thread_id="$thread-root",
+        sender="@agent:localhost",
+        runtime_started_at=0.0,
+    )
+
+    assert snapshot is None
+
+
+def test_real_sqlite_reader_handles_missing_db_returns_none(tmp_path: Path) -> None:
+    """Missing cache files should return None instead of raising."""
+    snapshot = get_latest_agent_message_snapshot(
+        db_path=tmp_path / "missing.db",
+        room_id="!room:localhost",
+        thread_id="$thread-root",
+        sender="@agent:localhost",
+        runtime_started_at=0.0,
+    )
+
+    assert snapshot is None
+
+
+def test_accessor_raises_on_corrupt_db(tmp_path: Path) -> None:
+    """Existing non-SQLite cache files should raise CacheUnavailable."""
+    db_path = tmp_path / "event_cache.db"
+    db_path.write_text("not a sqlite database", encoding="utf-8")
+
+    with pytest.raises(CacheUnavailable):
+        get_latest_agent_message_snapshot(
+            db_path=db_path,
+            room_id="!room:localhost",
+            thread_id=None,
+            sender="@agent:localhost",
+            runtime_started_at=0.0,
+        )
+
+
+def test_accessor_raises_when_required_tables_missing(tmp_path: Path) -> None:
+    """Existing SQLite files without the cache schema should raise CacheUnavailable."""
+    db_path = tmp_path / "event_cache.db"
+    sqlite3.connect(db_path).close()
+
+    with pytest.raises(CacheUnavailable):
+        get_latest_agent_message_snapshot(
+            db_path=db_path,
+            room_id="!room:localhost",
+            thread_id=None,
+            sender="@agent:localhost",
+            runtime_started_at=0.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_accessor_rejects_stale_thread_cache_validated_too_long_ago(
+    tmp_path: Path,
+) -> None:
+    """Threaded reads should reject snapshots older than the shared cache max age."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.replace_thread(
+            "!room:localhost",
+            "$thread-root",
+            [
+                _message_event(
+                    event_id="$thread-root",
+                    sender="@user:localhost",
+                    body="Question",
+                    origin_server_ts=1000,
+                ),
+                _message_event(
+                    event_id="$reply",
+                    sender="@agent:localhost",
+                    body="Working...",
+                    origin_server_ts=2000,
+                    relates_to={"rel_type": "m.thread", "event_id": "$thread-root"},
+                ),
+            ],
+            validated_at=400.0,
+        )
+    finally:
+        await cache.close()
+
+    with pytest.raises(CacheUnavailable, match="cache_too_old"):
+        get_latest_agent_message_snapshot(
+            db_path=db_path,
+            room_id="!room:localhost",
+            thread_id="$thread-root",
+            sender="@agent:localhost",
+            runtime_started_at=0.0,
+            now=1000.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_accessor_rejects_thread_cache_from_prior_bot_run(
+    tmp_path: Path,
+) -> None:
+    """Threaded reads should reject snapshots validated before the current runtime."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.replace_thread(
+            "!room:localhost",
+            "$thread-root",
+            [
+                _message_event(
+                    event_id="$thread-root",
+                    sender="@user:localhost",
+                    body="Question",
+                    origin_server_ts=1000,
+                ),
+                _message_event(
+                    event_id="$reply",
+                    sender="@agent:localhost",
+                    body="Working...",
+                    origin_server_ts=2000,
+                    relates_to={"rel_type": "m.thread", "event_id": "$thread-root"},
+                ),
+            ],
+            validated_at=1000.0,
+        )
+    finally:
+        await cache.close()
+
+    with pytest.raises(CacheUnavailable, match="validated_before_runtime_start"):
+        get_latest_agent_message_snapshot(
+            db_path=db_path,
+            room_id="!room:localhost",
+            thread_id="$thread-root",
+            sender="@agent:localhost",
+            runtime_started_at=1001.0,
+            now=1001.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_accessor_rejects_invalidated_thread_cache(
+    tmp_path: Path,
+) -> None:
+    """Threaded reads should fail closed after durable invalidation."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.replace_thread(
+            "!room:localhost",
+            "$thread-root",
+            [
+                _message_event(
+                    event_id="$thread-root",
+                    sender="@user:localhost",
+                    body="Question",
+                    origin_server_ts=1000,
+                ),
+                _message_event(
+                    event_id="$reply",
+                    sender="@agent:localhost",
+                    body="Working...",
+                    origin_server_ts=2000,
+                    relates_to={"rel_type": "m.thread", "event_id": "$thread-root"},
+                ),
+            ],
+            validated_at=1000.0,
+        )
+        await cache.mark_thread_stale(
+            "!room:localhost",
+            "$thread-root",
+            reason="test_invalidated",
+        )
+    finally:
+        await cache.close()
+
+    with pytest.raises(CacheUnavailable, match="thread_invalidated_after_validation"):
+        get_latest_agent_message_snapshot(
+            db_path=db_path,
+            room_id="!room:localhost",
+            thread_id="$thread-root",
+            sender="@agent:localhost",
+            runtime_started_at=0.0,
+            now=1000.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_room_scope_returns_latest_by_origin_server_ts_not_cached_at(
+    tmp_path: Path,
+) -> None:
+    """Room-scope reads should follow Matrix timeline order, not cache write time."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.store_events_batch(
+            [
+                (
+                    "$room-message",
+                    "!room:localhost",
+                    _message_event(
+                        event_id="$room-message",
+                        sender="@agent:localhost",
+                        body="Newest room message",
+                        origin_server_ts=3000,
+                    ),
+                ),
+            ],
+        )
+        await cache.replace_thread(
+            "!room:localhost",
+            "$thread-root",
+            [
+                _message_event(
+                    event_id="$thread-root",
+                    sender="@agent:localhost",
+                    body="Older thread root",
+                    origin_server_ts=1000,
+                ),
+                _message_event(
+                    event_id="$thread-reply",
+                    sender="@user:localhost",
+                    body="Question",
+                    origin_server_ts=2000,
+                    relates_to={"rel_type": "m.thread", "event_id": "$thread-root"},
+                ),
+            ],
+            validated_at=5000.0,
+        )
+    finally:
+        await cache.close()
+
+    snapshot = get_latest_agent_message_snapshot(
+        db_path=db_path,
+        room_id="!room:localhost",
+        thread_id=None,
+        sender="@agent:localhost",
+        runtime_started_at=0.0,
+    )
+
+    assert snapshot == AgentMessageSnapshot(
+        content={"body": "Newest room message", "msgtype": "m.text"},
+        origin_server_ts=3000,
+    )

--- a/tests/test_matrix_cache_agent_message_snapshot.py
+++ b/tests/test_matrix_cache_agent_message_snapshot.py
@@ -371,6 +371,58 @@ async def test_room_scope_keeps_visible_edit_cached_in_current_runtime(
     )
 
 
+@pytest.mark.asyncio
+async def test_room_scope_does_not_fall_back_to_older_fresh_message_when_latest_is_stale(
+    tmp_path: Path,
+) -> None:
+    """Room-scope reads should fail closed when the latest sender message is stale."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.store_events_batch(
+            [
+                (
+                    "$newer-message",
+                    "!room:localhost",
+                    _message_event(
+                        event_id="$newer-message",
+                        sender="@agent:localhost",
+                        body="Newest stale message",
+                        origin_server_ts=2000,
+                    ),
+                ),
+            ],
+        )
+        runtime_started_at = time.time()
+        await cache.store_events_batch(
+            [
+                (
+                    "$older-message",
+                    "!room:localhost",
+                    _message_event(
+                        event_id="$older-message",
+                        sender="@agent:localhost",
+                        body="Older fresh message",
+                        origin_server_ts=1000,
+                    ),
+                ),
+            ],
+        )
+    finally:
+        await cache.close()
+
+    snapshot = get_latest_agent_message_snapshot(
+        db_path=db_path,
+        room_id="!room:localhost",
+        thread_id=None,
+        sender="@agent:localhost",
+        runtime_started_at=runtime_started_at,
+    )
+
+    assert snapshot is None
+
+
 def test_real_sqlite_reader_handles_missing_db_returns_none(tmp_path: Path) -> None:
     """Missing cache files should return None instead of raising."""
     snapshot = get_latest_agent_message_snapshot(

--- a/tests/test_matrix_cache_agent_message_snapshot.py
+++ b/tests/test_matrix_cache_agent_message_snapshot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import time
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -267,6 +268,107 @@ async def test_get_latest_agent_message_snapshot_returns_none_when_cache_has_no_
     )
 
     assert snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_room_scope_ignores_messages_cached_before_current_runtime(
+    tmp_path: Path,
+) -> None:
+    """Room-scope reads should ignore stale message rows from a prior runtime."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.store_events_batch(
+            [
+                (
+                    "$room-message",
+                    "!room:localhost",
+                    _message_event(
+                        event_id="$room-message",
+                        sender="@agent:localhost",
+                        body="Working...",
+                        origin_server_ts=2000,
+                    ),
+                ),
+            ],
+        )
+    finally:
+        await cache.close()
+
+    snapshot = get_latest_agent_message_snapshot(
+        db_path=db_path,
+        room_id="!room:localhost",
+        thread_id=None,
+        sender="@agent:localhost",
+        runtime_started_at=time.time() + 1.0,
+    )
+
+    assert snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_room_scope_keeps_visible_edit_cached_in_current_runtime(
+    tmp_path: Path,
+) -> None:
+    """Room-scope reads should keep a message whose visible edit was cached after restart."""
+    db_path = tmp_path / "event_cache.db"
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        await cache.store_events_batch(
+            [
+                (
+                    "$room-message",
+                    "!room:localhost",
+                    _message_event(
+                        event_id="$room-message",
+                        sender="@agent:localhost",
+                        body="Working...",
+                        origin_server_ts=2000,
+                    ),
+                ),
+            ],
+        )
+        runtime_started_at = time.time()
+        await cache.store_events_batch(
+            [
+                (
+                    "$room-message-edit",
+                    "!room:localhost",
+                    _message_event(
+                        event_id="$room-message-edit",
+                        sender="@agent:localhost",
+                        body="* Working...",
+                        origin_server_ts=3000,
+                        relates_to={"rel_type": "m.replace", "event_id": "$room-message"},
+                        new_content={
+                            "body": "Still working",
+                            "io.mindroom.stream_status": "streaming",
+                        },
+                    ),
+                ),
+            ],
+        )
+    finally:
+        await cache.close()
+
+    snapshot = get_latest_agent_message_snapshot(
+        db_path=db_path,
+        room_id="!room:localhost",
+        thread_id=None,
+        sender="@agent:localhost",
+        runtime_started_at=runtime_started_at,
+    )
+
+    assert snapshot == AgentMessageSnapshot(
+        content={
+            "body": "Still working",
+            "msgtype": "m.text",
+            "io.mindroom.stream_status": "streaming",
+        },
+        origin_server_ts=3000,
+    )
 
 
 def test_real_sqlite_reader_handles_missing_db_returns_none(tmp_path: Path) -> None:

--- a/tests/test_matrix_cache_agent_message_snapshot.py
+++ b/tests/test_matrix_cache_agent_message_snapshot.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from mindroom.matrix.cache import AgentMessageSnapshot, CacheUnavailable
+from mindroom.matrix.cache import AgentMessageSnapshot, AgentMessageSnapshotUnavailable
 from mindroom.matrix.cache.event_cache import _EventCache
 
 if TYPE_CHECKING:
@@ -473,7 +473,7 @@ async def test_accessor_rejects_stale_thread_cache_validated_too_long_ago(
     finally:
         await cache.close()
 
-    with pytest.raises(CacheUnavailable, match="cache_too_old"):
+    with pytest.raises(AgentMessageSnapshotUnavailable, match="cache_too_old"):
         await _read_snapshot(
             db_path,
             room_id="!room:localhost",
@@ -516,7 +516,7 @@ async def test_accessor_rejects_thread_cache_from_prior_bot_run(
     finally:
         await cache.close()
 
-    with pytest.raises(CacheUnavailable, match="validated_before_runtime_start"):
+    with pytest.raises(AgentMessageSnapshotUnavailable, match="validated_before_runtime_start"):
         await _read_snapshot(
             db_path,
             room_id="!room:localhost",
@@ -564,7 +564,7 @@ async def test_accessor_rejects_invalidated_thread_cache(
     finally:
         await cache.close()
 
-    with pytest.raises(CacheUnavailable, match="thread_invalidated_after_validation"):
+    with pytest.raises(AgentMessageSnapshotUnavailable, match="thread_invalidated_after_validation"):
         await _read_snapshot(
             db_path,
             room_id="!room:localhost",

--- a/tests/test_matrix_cache_agent_message_snapshot.py
+++ b/tests/test_matrix_cache_agent_message_snapshot.py
@@ -1,18 +1,13 @@
-"""Tests for the public latest-agent-message cache accessor."""
+"""Tests for latest-agent-message snapshot reads via the event cache API."""
 
 from __future__ import annotations
 
-import sqlite3
 import time
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from mindroom.matrix.cache import (
-    AgentMessageSnapshot,
-    CacheUnavailable,
-    get_latest_agent_message_snapshot,
-)
+from mindroom.matrix.cache import AgentMessageSnapshot, CacheUnavailable
 from mindroom.matrix.cache.event_cache import _EventCache
 
 if TYPE_CHECKING:
@@ -48,6 +43,29 @@ def _message_event(
     }
 
 
+async def _read_snapshot(
+    db_path: Path,
+    *,
+    room_id: str,
+    thread_id: str | None,
+    sender: str,
+    runtime_started_at: float | None,
+    now: float | None = None,
+) -> AgentMessageSnapshot | None:
+    cache = _EventCache(db_path)
+    await cache.initialize()
+    try:
+        return await cache.get_latest_agent_message_snapshot(
+            room_id,
+            thread_id,
+            sender,
+            runtime_started_at=runtime_started_at,
+            now=now,
+        )
+    finally:
+        await cache.close()
+
+
 @pytest.mark.asyncio
 async def test_get_latest_agent_message_snapshot_returns_unedited_thread_message(
     tmp_path: Path,
@@ -79,8 +97,8 @@ async def test_get_latest_agent_message_snapshot_returns_unedited_thread_message
     finally:
         await cache.close()
 
-    snapshot = get_latest_agent_message_snapshot(
-        db_path=db_path,
+    snapshot = await _read_snapshot(
+        db_path,
         room_id="!room:localhost",
         thread_id="$thread-root",
         sender="@agent:localhost",
@@ -98,7 +116,7 @@ async def test_get_latest_agent_message_snapshot_returns_unedited_thread_message
 
 
 @pytest.mark.asyncio
-async def test_real_sqlite_reader_returns_streaming_status_for_threaded_message(
+async def test_get_latest_agent_message_snapshot_returns_streaming_status_for_threaded_message(
     tmp_path: Path,
 ) -> None:
     """Edited threaded messages should surface the latest visible stream status."""
@@ -139,8 +157,8 @@ async def test_real_sqlite_reader_returns_streaming_status_for_threaded_message(
     finally:
         await cache.close()
 
-    snapshot = get_latest_agent_message_snapshot(
-        db_path=db_path,
+    snapshot = await _read_snapshot(
+        db_path,
         room_id="!room:localhost",
         thread_id="$thread-root",
         sender="@agent:localhost",
@@ -158,7 +176,7 @@ async def test_real_sqlite_reader_returns_streaming_status_for_threaded_message(
 
 
 @pytest.mark.asyncio
-async def test_real_sqlite_reader_returns_room_level_message_when_thread_id_none(
+async def test_get_latest_agent_message_snapshot_returns_room_level_message_when_thread_id_none(
     tmp_path: Path,
 ) -> None:
     """Room-scope reads should skip threaded replies and stay on the room timeline."""
@@ -198,8 +216,8 @@ async def test_real_sqlite_reader_returns_room_level_message_when_thread_id_none
     finally:
         await cache.close()
 
-    snapshot = get_latest_agent_message_snapshot(
-        db_path=db_path,
+    snapshot = await _read_snapshot(
+        db_path,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",
@@ -238,8 +256,8 @@ async def test_get_latest_agent_message_snapshot_returns_none_when_sender_has_no
     finally:
         await cache.close()
 
-    snapshot = get_latest_agent_message_snapshot(
-        db_path=db_path,
+    snapshot = await _read_snapshot(
+        db_path,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",
@@ -259,8 +277,8 @@ async def test_get_latest_agent_message_snapshot_returns_none_when_cache_has_no_
     await cache.initialize()
     await cache.close()
 
-    snapshot = get_latest_agent_message_snapshot(
-        db_path=db_path,
+    snapshot = await _read_snapshot(
+        db_path,
         room_id="!room:localhost",
         thread_id="$thread-root",
         sender="@agent:localhost",
@@ -296,8 +314,8 @@ async def test_room_scope_ignores_messages_cached_before_current_runtime(
     finally:
         await cache.close()
 
-    snapshot = get_latest_agent_message_snapshot(
-        db_path=db_path,
+    snapshot = await _read_snapshot(
+        db_path,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",
@@ -353,8 +371,8 @@ async def test_room_scope_keeps_visible_edit_cached_in_current_runtime(
     finally:
         await cache.close()
 
-    snapshot = get_latest_agent_message_snapshot(
-        db_path=db_path,
+    snapshot = await _read_snapshot(
+        db_path,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",
@@ -412,8 +430,8 @@ async def test_room_scope_does_not_fall_back_to_older_fresh_message_when_latest_
     finally:
         await cache.close()
 
-    snapshot = get_latest_agent_message_snapshot(
-        db_path=db_path,
+    snapshot = await _read_snapshot(
+        db_path,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",
@@ -421,49 +439,6 @@ async def test_room_scope_does_not_fall_back_to_older_fresh_message_when_latest_
     )
 
     assert snapshot is None
-
-
-def test_real_sqlite_reader_handles_missing_db_returns_none(tmp_path: Path) -> None:
-    """Missing cache files should return None instead of raising."""
-    snapshot = get_latest_agent_message_snapshot(
-        db_path=tmp_path / "missing.db",
-        room_id="!room:localhost",
-        thread_id="$thread-root",
-        sender="@agent:localhost",
-        runtime_started_at=0.0,
-    )
-
-    assert snapshot is None
-
-
-def test_accessor_raises_on_corrupt_db(tmp_path: Path) -> None:
-    """Existing non-SQLite cache files should raise CacheUnavailable."""
-    db_path = tmp_path / "event_cache.db"
-    db_path.write_text("not a sqlite database", encoding="utf-8")
-
-    with pytest.raises(CacheUnavailable):
-        get_latest_agent_message_snapshot(
-            db_path=db_path,
-            room_id="!room:localhost",
-            thread_id=None,
-            sender="@agent:localhost",
-            runtime_started_at=0.0,
-        )
-
-
-def test_accessor_raises_when_required_tables_missing(tmp_path: Path) -> None:
-    """Existing SQLite files without the cache schema should raise CacheUnavailable."""
-    db_path = tmp_path / "event_cache.db"
-    sqlite3.connect(db_path).close()
-
-    with pytest.raises(CacheUnavailable):
-        get_latest_agent_message_snapshot(
-            db_path=db_path,
-            room_id="!room:localhost",
-            thread_id=None,
-            sender="@agent:localhost",
-            runtime_started_at=0.0,
-        )
 
 
 @pytest.mark.asyncio
@@ -499,8 +474,8 @@ async def test_accessor_rejects_stale_thread_cache_validated_too_long_ago(
         await cache.close()
 
     with pytest.raises(CacheUnavailable, match="cache_too_old"):
-        get_latest_agent_message_snapshot(
-            db_path=db_path,
+        await _read_snapshot(
+            db_path,
             room_id="!room:localhost",
             thread_id="$thread-root",
             sender="@agent:localhost",
@@ -542,8 +517,8 @@ async def test_accessor_rejects_thread_cache_from_prior_bot_run(
         await cache.close()
 
     with pytest.raises(CacheUnavailable, match="validated_before_runtime_start"):
-        get_latest_agent_message_snapshot(
-            db_path=db_path,
+        await _read_snapshot(
+            db_path,
             room_id="!room:localhost",
             thread_id="$thread-root",
             sender="@agent:localhost",
@@ -590,8 +565,8 @@ async def test_accessor_rejects_invalidated_thread_cache(
         await cache.close()
 
     with pytest.raises(CacheUnavailable, match="thread_invalidated_after_validation"):
-        get_latest_agent_message_snapshot(
-            db_path=db_path,
+        await _read_snapshot(
+            db_path,
             room_id="!room:localhost",
             thread_id="$thread-root",
             sender="@agent:localhost",
@@ -646,8 +621,8 @@ async def test_room_scope_returns_latest_by_origin_server_ts_not_cached_at(
     finally:
         await cache.close()
 
-    snapshot = get_latest_agent_message_snapshot(
-        db_path=db_path,
+    snapshot = await _read_snapshot(
+        db_path,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",

--- a/tests/test_workloop_thread_scope.py
+++ b/tests/test_workloop_thread_scope.py
@@ -726,7 +726,11 @@ async def test_late_after_response_cancellation_still_runs_workloop_cleanup(
         ],
     )
     hook_context = HookContextSupport(
-        runtime=type("RT", (), {"client": None, "orchestrator": None, "config": loaded_workloop.config})(),
+        runtime=type(
+            "RT",
+            (),
+            {"client": None, "orchestrator": None, "config": loaded_workloop.config, "runtime_started_at": 0.0},
+        )(),
         logger=get_logger("tests.workloop.delivery"),
         runtime_paths=loaded_workloop.runtime_paths,
         agent_name="code",


### PR DESCRIPTION
## Summary
- add a public Matrix cache accessor for the latest visible agent message in room and thread scope
- project cached edits into returned snapshots and reject stale or invalidated cache reads
- cover thread, room-scope, and freshness edge cases in tests

## Test Plan
- `.venv/bin/pytest tests/test_matrix_cache_agent_message_snapshot.py -x -n 0 --no-cov -v`