### PR TITLE
feat(streaming): idle-time flush trigger for Matrix message streaming

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -575,7 +575,7 @@ defaults:
     update_interval: 5.0                # Steady-state seconds between streamed edits
     min_update_interval: 0.5            # Fast-start seconds between early edits
     interval_ramp_seconds: 15.0         # Set 0 to disable interval ramping
-    max_idle: 0.25                      # Event-driven idle ceiling before the next edit
+    max_idle: 2.0                       # Event-driven idle ceiling before the next edit
   compress_tool_results: false          # Safer default; enabling can invalidate Anthropic/Vertex Claude prompt caches
   # Auto-compaction is disabled until you author this block.
   # compaction:

--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -575,6 +575,7 @@ defaults:
     update_interval: 5.0                # Steady-state seconds between streamed edits
     min_update_interval: 0.5            # Fast-start seconds between early edits
     interval_ramp_seconds: 15.0         # Set 0 to disable interval ramping
+    max_idle: 0.25                      # Event-driven idle ceiling before the next edit
   compress_tool_results: false          # Safer default; enabling can invalidate Anthropic/Vertex Claude prompt caches
   # Auto-compaction is disabled until you author this block.
   # compaction:

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -235,7 +235,7 @@ defaults:
     update_interval: 5.0           # Default: 5.0 (steady-state seconds between streamed edits)
     min_update_interval: 0.5       # Default: 0.5 (fast-start seconds between early edits)
     interval_ramp_seconds: 15.0    # Default: 15.0 (set 0 to disable interval ramping)
-    max_idle: 0.25                 # Default: 0.25 (event-driven idle ceiling before the next edit)
+    max_idle: 2.0                  # Default: 2.0 (event-driven idle ceiling before the next edit)
   learning: true                   # Default: true
   learning_mode: always            # Default: always (or agentic)
   max_preload_chars: 50000         # Hard cap for preloaded context from context_files

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -235,6 +235,7 @@ defaults:
     update_interval: 5.0           # Default: 5.0 (steady-state seconds between streamed edits)
     min_update_interval: 0.5       # Default: 0.5 (fast-start seconds between early edits)
     interval_ramp_seconds: 15.0    # Default: 15.0 (set 0 to disable interval ramping)
+    max_idle: 0.25                 # Default: 0.25 (event-driven idle ceiling before the next edit)
   learning: true                   # Default: true
   learning_mode: always            # Default: always (or agentic)
   max_preload_chars: 50000         # Hard cap for preloaded context from context_files

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -54,7 +54,7 @@ defaults:
     update_interval: 5.0         # Default: 5.0 steady-state seconds between edits
     min_update_interval: 0.5     # Default: 0.5 fast-start seconds between early edits
     interval_ramp_seconds: 15.0  # Default: 15.0; set 0 to disable ramping
-    max_idle: 0.25               # Default: 0.25 event-driven idle ceiling before the next edit
+    max_idle: 2.0                # Default: 2.0 event-driven idle ceiling before the next edit
 ```
 
 These timing settings are global-only. Agents inherit them from `defaults` and cannot override them individually.
@@ -99,7 +99,7 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
 - **Minimum interval**: A hard floor (0.35s) applies to character-triggered and idle-triggered throttled edits.
   Time-triggered edits still follow the current ramped interval.
-- **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed.
+- **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 2.0s without a new delta, but only once `min_char_update_interval` has also elapsed.
   This is event-driven and does not run on a background timer.
 - **Tool-start boundary refresh**: Visible tool-start markers request an immediate refresh so the marker can surface without waiting for later text.
   Rapid back-to-back tool starts are coalesced by the single delivery owner instead of forcing one Matrix edit per tool.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -97,9 +97,11 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
   The character threshold ramps from 48 characters (fast start) to 240 characters (steady-state) over the ramp-up period.
 - **Ramp-up**: `defaults.streaming.min_update_interval` and `defaults.streaming.interval_ramp_seconds` control how quickly the time-based interval ramps from a fast start to the steady-state value. By default it ramps from 0.5s to 5s over 15 seconds. Setting `interval_ramp_seconds: 0` disables the ramp and uses the steady-state interval immediately.
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
-- **Minimum interval**: A hard floor (0.35s) prevents edit spam even when character thresholds are met.
+- **Minimum interval**: A hard floor (0.35s) applies to the normal time, character, and idle-triggered throttled edits.
 - **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed.
   This is event-driven and does not run on a background timer.
+- **Tool-start boundary refresh**: Visible tool-start markers request an immediate refresh so the marker can surface without waiting for later text.
+  Rapid back-to-back tool starts are coalesced by the single delivery owner instead of forcing one Matrix edit per tool.
 
 ## Tool Calls During Streaming
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -54,6 +54,7 @@ defaults:
     update_interval: 5.0         # Default: 5.0 steady-state seconds between edits
     min_update_interval: 0.5     # Default: 0.5 fast-start seconds between early edits
     interval_ramp_seconds: 15.0  # Default: 15.0; set 0 to disable ramping
+    max_idle: 0.25               # Default: 0.25 event-driven idle ceiling before the next edit
 ```
 
 These timing settings are global-only. Agents inherit them from `defaults` and cannot override them individually.
@@ -97,6 +98,8 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
 - **Ramp-up**: `defaults.streaming.min_update_interval` and `defaults.streaming.interval_ramp_seconds` control how quickly the time-based interval ramps from a fast start to the steady-state value. By default it ramps from 0.5s to 5s over 15 seconds. Setting `interval_ramp_seconds: 0` disables the ramp and uses the steady-state interval immediately.
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
 - **Minimum interval**: A hard floor (0.35s) prevents edit spam even when character thresholds are met.
+- **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed.
+  This is event-driven and does not run on a background timer.
 
 ## Tool Calls During Streaming
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -97,7 +97,8 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
   The character threshold ramps from 48 characters (fast start) to 240 characters (steady-state) over the ramp-up period.
 - **Ramp-up**: `defaults.streaming.min_update_interval` and `defaults.streaming.interval_ramp_seconds` control how quickly the time-based interval ramps from a fast start to the steady-state value. By default it ramps from 0.5s to 5s over 15 seconds. Setting `interval_ramp_seconds: 0` disables the ramp and uses the steady-state interval immediately.
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
-- **Minimum interval**: A hard floor (0.35s) applies to the normal time, character, and idle-triggered throttled edits.
+- **Minimum interval**: A hard floor (0.35s) applies to character-triggered and idle-triggered throttled edits.
+  Time-triggered edits still follow the current ramped interval.
 - **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed.
   This is event-driven and does not run on a background timer.
 - **Tool-start boundary refresh**: Visible tool-start markers request an immediate refresh so the marker can surface without waiting for later text.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -9892,7 +9892,7 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
 - **Character-based**: An edit is also triggered when enough new characters have accumulated. The character threshold ramps from 48 characters (fast start) to 240 characters (steady-state) over the ramp-up period.
 - **Ramp-up**: `defaults.streaming.min_update_interval` and `defaults.streaming.interval_ramp_seconds` control how quickly the time-based interval ramps from a fast start to the steady-state value. By default it ramps from 0.5s to 5s over 15 seconds. Setting `interval_ramp_seconds: 0` disables the ramp and uses the steady-state interval immediately.
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
-- **Minimum interval**: A hard floor (0.35s) applies to the normal time, character, and idle-triggered throttled edits.
+- **Minimum interval**: A hard floor (0.35s) applies to character-triggered and idle-triggered throttled edits. Time-triggered edits still follow the current ramped interval.
 - **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed. This is event-driven and does not run on a background timer.
 - **Tool-start boundary refresh**: Visible tool-start markers request an immediate refresh so the marker can surface without waiting for later text. Rapid back-to-back tool starts are coalesced by the single delivery owner instead of forcing one Matrix edit per tool.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -966,6 +966,7 @@ defaults:
     update_interval: 5.0           # Default: 5.0 (steady-state seconds between streamed edits)
     min_update_interval: 0.5       # Default: 0.5 (fast-start seconds between early edits)
     interval_ramp_seconds: 15.0    # Default: 15.0 (set 0 to disable interval ramping)
+    max_idle: 0.25                 # Default: 0.25 (event-driven idle ceiling before the next edit)
   learning: true                   # Default: true
   learning_mode: always            # Default: always (or agentic)
   max_preload_chars: 50000         # Hard cap for preloaded context from context_files
@@ -1708,6 +1709,7 @@ defaults:
     update_interval: 5.0                # Steady-state seconds between streamed edits
     min_update_interval: 0.5            # Fast-start seconds between early edits
     interval_ramp_seconds: 15.0         # Set 0 to disable interval ramping
+    max_idle: 0.25                      # Event-driven idle ceiling before the next edit
   compress_tool_results: false          # Safer default; enabling can invalidate Anthropic/Vertex Claude prompt caches
   # Auto-compaction is disabled until you author this block.
   # compaction:
@@ -9852,6 +9854,7 @@ defaults:
     update_interval: 5.0         # Default: 5.0 steady-state seconds between edits
     min_update_interval: 0.5     # Default: 0.5 fast-start seconds between early edits
     interval_ramp_seconds: 15.0  # Default: 15.0; set 0 to disable ramping
+    max_idle: 0.25               # Default: 0.25 event-driven idle ceiling before the next edit
 ```
 
 These timing settings are global-only. Agents inherit them from `defaults` and cannot override them individually.
@@ -9890,6 +9893,7 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
 - **Ramp-up**: `defaults.streaming.min_update_interval` and `defaults.streaming.interval_ramp_seconds` control how quickly the time-based interval ramps from a fast start to the steady-state value. By default it ramps from 0.5s to 5s over 15 seconds. Setting `interval_ramp_seconds: 0` disables the ramp and uses the steady-state interval immediately.
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
 - **Minimum interval**: A hard floor (0.35s) prevents edit spam even when character thresholds are met.
+- **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed. This is event-driven and does not run on a background timer.
 
 ## Tool Calls During Streaming
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -966,7 +966,7 @@ defaults:
     update_interval: 5.0           # Default: 5.0 (steady-state seconds between streamed edits)
     min_update_interval: 0.5       # Default: 0.5 (fast-start seconds between early edits)
     interval_ramp_seconds: 15.0    # Default: 15.0 (set 0 to disable interval ramping)
-    max_idle: 0.25                 # Default: 0.25 (event-driven idle ceiling before the next edit)
+    max_idle: 2.0                  # Default: 2.0 (event-driven idle ceiling before the next edit)
   learning: true                   # Default: true
   learning_mode: always            # Default: always (or agentic)
   max_preload_chars: 50000         # Hard cap for preloaded context from context_files
@@ -1709,7 +1709,7 @@ defaults:
     update_interval: 5.0                # Steady-state seconds between streamed edits
     min_update_interval: 0.5            # Fast-start seconds between early edits
     interval_ramp_seconds: 15.0         # Set 0 to disable interval ramping
-    max_idle: 0.25                      # Event-driven idle ceiling before the next edit
+    max_idle: 2.0                       # Event-driven idle ceiling before the next edit
   compress_tool_results: false          # Safer default; enabling can invalidate Anthropic/Vertex Claude prompt caches
   # Auto-compaction is disabled until you author this block.
   # compaction:
@@ -9854,7 +9854,7 @@ defaults:
     update_interval: 5.0         # Default: 5.0 steady-state seconds between edits
     min_update_interval: 0.5     # Default: 0.5 fast-start seconds between early edits
     interval_ramp_seconds: 15.0  # Default: 15.0; set 0 to disable ramping
-    max_idle: 0.25               # Default: 0.25 event-driven idle ceiling before the next edit
+    max_idle: 2.0                # Default: 2.0 event-driven idle ceiling before the next edit
 ```
 
 These timing settings are global-only. Agents inherit them from `defaults` and cannot override them individually.
@@ -9893,7 +9893,7 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
 - **Ramp-up**: `defaults.streaming.min_update_interval` and `defaults.streaming.interval_ramp_seconds` control how quickly the time-based interval ramps from a fast start to the steady-state value. By default it ramps from 0.5s to 5s over 15 seconds. Setting `interval_ramp_seconds: 0` disables the ramp and uses the steady-state interval immediately.
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
 - **Minimum interval**: A hard floor (0.35s) applies to character-triggered and idle-triggered throttled edits. Time-triggered edits still follow the current ramped interval.
-- **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed. This is event-driven and does not run on a background timer.
+- **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 2.0s without a new delta, but only once `min_char_update_interval` has also elapsed. This is event-driven and does not run on a background timer.
 - **Tool-start boundary refresh**: Visible tool-start markers request an immediate refresh so the marker can surface without waiting for later text. Rapid back-to-back tool starts are coalesced by the single delivery owner instead of forcing one Matrix edit per tool.
 
 ## Tool Calls During Streaming

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -9892,8 +9892,9 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
 - **Character-based**: An edit is also triggered when enough new characters have accumulated. The character threshold ramps from 48 characters (fast start) to 240 characters (steady-state) over the ramp-up period.
 - **Ramp-up**: `defaults.streaming.min_update_interval` and `defaults.streaming.interval_ramp_seconds` control how quickly the time-based interval ramps from a fast start to the steady-state value. By default it ramps from 0.5s to 5s over 15 seconds. Setting `interval_ramp_seconds: 0` disables the ramp and uses the steady-state interval immediately.
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
-- **Minimum interval**: A hard floor (0.35s) prevents edit spam even when character thresholds are met.
+- **Minimum interval**: A hard floor (0.35s) applies to the normal time, character, and idle-triggered throttled edits.
 - **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed. This is event-driven and does not run on a background timer.
+- **Tool-start boundary refresh**: Visible tool-start markers request an immediate refresh so the marker can surface without waiting for later text. Rapid back-to-back tool starts are coalesced by the single delivery owner instead of forcing one Matrix edit per tool.
 
 ## Tool Calls During Streaming
 

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -508,6 +508,7 @@ defaults:
     update_interval: 5.0                # Steady-state seconds between streamed edits
     min_update_interval: 0.5            # Fast-start seconds between early edits
     interval_ramp_seconds: 15.0         # Set 0 to disable interval ramping
+    max_idle: 0.25                      # Event-driven idle ceiling before the next edit
   compress_tool_results: false          # Safer default; enabling can invalidate Anthropic/Vertex Claude prompt caches
   # Auto-compaction is disabled until you author this block.
   # compaction:

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -508,7 +508,7 @@ defaults:
     update_interval: 5.0                # Steady-state seconds between streamed edits
     min_update_interval: 0.5            # Fast-start seconds between early edits
     interval_ramp_seconds: 15.0         # Set 0 to disable interval ramping
-    max_idle: 0.25                      # Event-driven idle ceiling before the next edit
+    max_idle: 2.0                       # Event-driven idle ceiling before the next edit
   compress_tool_results: false          # Safer default; enabling can invalidate Anthropic/Vertex Claude prompt caches
   # Auto-compaction is disabled until you author this block.
   # compaction:

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -229,6 +229,7 @@ defaults:
     update_interval: 5.0           # Default: 5.0 (steady-state seconds between streamed edits)
     min_update_interval: 0.5       # Default: 0.5 (fast-start seconds between early edits)
     interval_ramp_seconds: 15.0    # Default: 15.0 (set 0 to disable interval ramping)
+    max_idle: 0.25                 # Default: 0.25 (event-driven idle ceiling before the next edit)
   learning: true                   # Default: true
   learning_mode: always            # Default: always (or agentic)
   max_preload_chars: 50000         # Hard cap for preloaded context from context_files

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -229,7 +229,7 @@ defaults:
     update_interval: 5.0           # Default: 5.0 (steady-state seconds between streamed edits)
     min_update_interval: 0.5       # Default: 0.5 (fast-start seconds between early edits)
     interval_ramp_seconds: 15.0    # Default: 15.0 (set 0 to disable interval ramping)
-    max_idle: 0.25                 # Default: 0.25 (event-driven idle ceiling before the next edit)
+    max_idle: 2.0                  # Default: 2.0 (event-driven idle ceiling before the next edit)
   learning: true                   # Default: true
   learning_mode: always            # Default: always (or agentic)
   max_preload_chars: 50000         # Hard cap for preloaded context from context_files

--- a/skills/mindroom-docs/references/page__streaming__index.md
+++ b/skills/mindroom-docs/references/page__streaming__index.md
@@ -86,8 +86,9 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
 - **Character-based**: An edit is also triggered when enough new characters have accumulated. The character threshold ramps from 48 characters (fast start) to 240 characters (steady-state) over the ramp-up period.
 - **Ramp-up**: `defaults.streaming.min_update_interval` and `defaults.streaming.interval_ramp_seconds` control how quickly the time-based interval ramps from a fast start to the steady-state value. By default it ramps from 0.5s to 5s over 15 seconds. Setting `interval_ramp_seconds: 0` disables the ramp and uses the steady-state interval immediately.
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
-- **Minimum interval**: A hard floor (0.35s) prevents edit spam even when character thresholds are met.
+- **Minimum interval**: A hard floor (0.35s) applies to the normal time, character, and idle-triggered throttled edits.
 - **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed. This is event-driven and does not run on a background timer.
+- **Tool-start boundary refresh**: Visible tool-start markers request an immediate refresh so the marker can surface without waiting for later text. Rapid back-to-back tool starts are coalesced by the single delivery owner instead of forcing one Matrix edit per tool.
 
 ## Tool Calls During Streaming
 

--- a/skills/mindroom-docs/references/page__streaming__index.md
+++ b/skills/mindroom-docs/references/page__streaming__index.md
@@ -48,6 +48,7 @@ defaults:
     update_interval: 5.0         # Default: 5.0 steady-state seconds between edits
     min_update_interval: 0.5     # Default: 0.5 fast-start seconds between early edits
     interval_ramp_seconds: 15.0  # Default: 15.0; set 0 to disable ramping
+    max_idle: 0.25               # Default: 0.25 event-driven idle ceiling before the next edit
 ```
 
 These timing settings are global-only. Agents inherit them from `defaults` and cannot override them individually.
@@ -86,6 +87,7 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
 - **Ramp-up**: `defaults.streaming.min_update_interval` and `defaults.streaming.interval_ramp_seconds` control how quickly the time-based interval ramps from a fast start to the steady-state value. By default it ramps from 0.5s to 5s over 15 seconds. Setting `interval_ramp_seconds: 0` disables the ramp and uses the steady-state interval immediately.
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
 - **Minimum interval**: A hard floor (0.35s) prevents edit spam even when character thresholds are met.
+- **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed. This is event-driven and does not run on a background timer.
 
 ## Tool Calls During Streaming
 

--- a/skills/mindroom-docs/references/page__streaming__index.md
+++ b/skills/mindroom-docs/references/page__streaming__index.md
@@ -48,7 +48,7 @@ defaults:
     update_interval: 5.0         # Default: 5.0 steady-state seconds between edits
     min_update_interval: 0.5     # Default: 0.5 fast-start seconds between early edits
     interval_ramp_seconds: 15.0  # Default: 15.0; set 0 to disable ramping
-    max_idle: 0.25               # Default: 0.25 event-driven idle ceiling before the next edit
+    max_idle: 2.0                # Default: 2.0 event-driven idle ceiling before the next edit
 ```
 
 These timing settings are global-only. Agents inherit them from `defaults` and cannot override them individually.
@@ -87,7 +87,7 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
 - **Ramp-up**: `defaults.streaming.min_update_interval` and `defaults.streaming.interval_ramp_seconds` control how quickly the time-based interval ramps from a fast start to the steady-state value. By default it ramps from 0.5s to 5s over 15 seconds. Setting `interval_ramp_seconds: 0` disables the ramp and uses the steady-state interval immediately.
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
 - **Minimum interval**: A hard floor (0.35s) applies to character-triggered and idle-triggered throttled edits. Time-triggered edits still follow the current ramped interval.
-- **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed. This is event-driven and does not run on a background timer.
+- **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 2.0s without a new delta, but only once `min_char_update_interval` has also elapsed. This is event-driven and does not run on a background timer.
 - **Tool-start boundary refresh**: Visible tool-start markers request an immediate refresh so the marker can surface without waiting for later text. Rapid back-to-back tool starts are coalesced by the single delivery owner instead of forcing one Matrix edit per tool.
 
 ## Tool Calls During Streaming

--- a/skills/mindroom-docs/references/page__streaming__index.md
+++ b/skills/mindroom-docs/references/page__streaming__index.md
@@ -86,7 +86,7 @@ MindRoom throttles edits to avoid overwhelming the Matrix homeserver:
 - **Character-based**: An edit is also triggered when enough new characters have accumulated. The character threshold ramps from 48 characters (fast start) to 240 characters (steady-state) over the ramp-up period.
 - **Ramp-up**: `defaults.streaming.min_update_interval` and `defaults.streaming.interval_ramp_seconds` control how quickly the time-based interval ramps from a fast start to the steady-state value. By default it ramps from 0.5s to 5s over 15 seconds. Setting `interval_ramp_seconds: 0` disables the ramp and uses the steady-state interval immediately.
 - **Shared ramp window**: The same ramp window also controls the built-in character threshold ramp from 48 characters (fast start) to 240 characters (steady-state).
-- **Minimum interval**: A hard floor (0.35s) applies to the normal time, character, and idle-triggered throttled edits.
+- **Minimum interval**: A hard floor (0.35s) applies to character-triggered and idle-triggered throttled edits. Time-triggered edits still follow the current ramped interval.
 - **Idle flush**: `defaults.streaming.max_idle` triggers an edit on the next streaming event after 0.25s without a new delta, but only once `min_char_update_interval` has also elapsed. This is event-driven and does not run on a background timer.
 - **Tool-start boundary refresh**: Visible tool-start markers request an immediate refresh so the marker can surface without waiting for later text. Rapid back-to-back tool starts are coalesced by the single delivery owner instead of forcing one Matrix edit per tool.
 

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -38,6 +38,15 @@ class StreamingConfig(BaseModel):
         ge=0,
         description="Seconds to ramp from min to steady-state interval (0 disables ramp)",
     )
+    max_idle: float = Field(
+        default=0.25,
+        gt=0,
+        description=(
+            "Flush buffered streaming text on the next streaming event when no new "
+            "deltas have arrived for at least this many seconds (event-driven, not "
+            "a background timer)."
+        ),
+    )
 
 
 class CoalescingConfig(BaseModel):

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -39,7 +39,7 @@ class StreamingConfig(BaseModel):
         description="Seconds to ramp from min to steady-state interval (0 disables ramp)",
     )
     max_idle: float = Field(
-        default=0.25,
+        default=2.0,
         gt=0,
         description=(
             "Flush buffered streaming text on the next streaming event when no new "

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -281,6 +281,11 @@ class StreamingResponse:
         self.chars_since_last_update += len(new_chunk)
         self.last_delta_at = time.time()
 
+    def _mark_nonadditive_text_mutation(self) -> None:
+        """Record a visible in-place text change that did not append characters."""
+        self.chars_since_last_update = max(1, self.chars_since_last_update)
+        self.last_delta_at = time.time()
+
     def _ensure_hidden_tool_gap(self) -> None:
         """Insert a single placeholder gap for hidden tool calls."""
         if not self.accumulated_text.endswith("\n\n"):

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -248,6 +248,7 @@ class StreamingResponse:
     stream_started_at: float | None = None
     chars_since_last_update: int = 0
     last_delta_at: float | None = None
+    last_boundary_refresh_at: float | None = None
     placeholder_progress_sent: bool = False
     pipeline_timing: DispatchPipelineTiming | None = None
     conversation_cache: ConversationCacheProtocol | None = None
@@ -335,11 +336,13 @@ class StreamingResponse:
         if sent:
             self._mark_nonterminal_delivery()
 
-    def _mark_nonterminal_delivery(self) -> None:
+    def _mark_nonterminal_delivery(self, *, boundary_refresh: bool = False) -> None:
         """Reset throttle state after a non-terminal send or edit reached Matrix."""
         now = time.time()
         self.last_update = now
         self.last_delta_at = now
+        if boundary_refresh:
+            self.last_boundary_refresh_at = now
         self.chars_since_last_update = 0
 
     async def _throttled_send(

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -340,11 +340,11 @@ class StreamingResponse:
         now = time.time()
         if self.stream_started_at is None:
             self.stream_started_at = now
-        self.last_update = now
         delivery_matches_live_state = (
             self.accumulated_text == committed_state.accumulated_text and self.tool_trace == committed_state.tool_trace
         )
         if delivery_matches_live_state:
+            self.last_update = now
             self.last_delta_at = now
             self.last_boundary_refresh_at = now if boundary_refresh else None
             self.chars_since_last_update = 0

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -244,7 +244,7 @@ class StreamingResponse:
     min_update_char_threshold: int = 48
     min_char_update_interval: float = 0.35
     progress_update_interval: float = 1.0
-    max_idle: float = 0.25
+    max_idle: float = 2.0
     latest_thread_event_id: str | None = None  # For MSC3440 compliance
     room_mode: bool = False  # When True, skip all thread relations (for bridges/mobile)
     show_tool_calls: bool = True  # When False, omit inline tool call text and tool-trace metadata

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -257,6 +257,8 @@ class StreamingResponse:
     _last_delivered_text: str = field(default="", init=False, repr=False)
     _last_delivered_tool_trace: list[ToolTraceEntry] = field(default_factory=list, init=False, repr=False)
     _last_placeholder_progress_sent: bool = field(default=False, init=False, repr=False)
+    _inflight_nonterminal_capture: asyncio.Future[None] | None = field(default=None, init=False, repr=False)
+    _inflight_nonterminal_capture_state: _CommittedDeliveryState | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Normalize transitional target fields onto one canonical target."""
@@ -275,6 +277,10 @@ class StreamingResponse:
     def _update(self, new_chunk: str) -> None:
         """Append new chunk to accumulated text."""
         self._append_incremental_text(new_chunk)
+
+    def uses_replacement_updates(self) -> bool:
+        """Return whether text chunks replace the current visible body."""
+        return False
 
     def _append_incremental_text(self, new_chunk: str) -> None:
         """Append additive streaming text regardless of snapshot replacement mode."""
@@ -350,12 +356,24 @@ class StreamingResponse:
         self.last_boundary_refresh_at = None
         self.chars_since_last_update = max(1, self.chars_since_last_update)
 
+    def matching_inflight_nonterminal_capture(self) -> asyncio.Future[None] | None:
+        """Return the current in-flight capture when it already froze the live state."""
+        if self._inflight_nonterminal_capture is None or self._inflight_nonterminal_capture_state is None:
+            return None
+        if (
+            self.accumulated_text == self._inflight_nonterminal_capture_state.accumulated_text
+            and self.tool_trace == self._inflight_nonterminal_capture_state.tool_trace
+        ):
+            return self._inflight_nonterminal_capture
+        return None
+
     async def _throttled_send(
         self,
         client: nio.AsyncClient,
         *,
         progress_hint: bool = False,
         prior_delta_at: float | None = None,
+        capture_completions: tuple[asyncio.Future[None], ...] = (),
     ) -> None:
         """Send/edit when either time or character thresholds are met."""
         current_time = time.time()
@@ -381,7 +399,11 @@ class StreamingResponse:
         should_send = time_triggered or char_triggered or idle_triggered
         allow_empty_progress = progress_hint and not self.accumulated_text.strip()
         if should_send and (self.accumulated_text.strip() or allow_empty_progress):
-            await self._send_or_edit_message(client, allow_empty_progress=allow_empty_progress)
+            await self._send_or_edit_message(
+                client,
+                allow_empty_progress=allow_empty_progress,
+                capture_completions=capture_completions,
+            )
 
     async def update_content(self, new_chunk: str, client: nio.AsyncClient) -> None:
         """Add new content and potentially update the message."""
@@ -447,6 +469,7 @@ class StreamingResponse:
         allow_empty_progress: bool = False,
         stream_status: str | None = None,
         boundary_refresh: bool = False,
+        capture_completions: tuple[asyncio.Future[None], ...] = (),
     ) -> bool:
         """Send new message or edit existing one."""
         prepared_delivery = self._prepare_delivery(
@@ -462,6 +485,7 @@ class StreamingResponse:
             prepared_delivery=prepared_delivery,
             is_final=is_final,
             boundary_refresh=boundary_refresh,
+            capture_completions=capture_completions,
         )
 
     async def _send_prepared_delivery(
@@ -471,15 +495,30 @@ class StreamingResponse:
         prepared_delivery: _PreparedStreamingDelivery,
         is_final: bool,
         boundary_refresh: bool = False,
+        capture_completions: tuple[asyncio.Future[None], ...] = (),
     ) -> bool:
         """Send one already-prepared non-terminal or terminal payload."""
         is_initial_send = self.event_id is None
-        send_succeeded = await self._send_content(
-            client,
-            content=prepared_delivery.content,
-            display_text=prepared_delivery.display_text,
-            retry_on_failure=is_final,
-        )
+        capture = None
+        if not is_final:
+            capture = asyncio.get_running_loop().create_future()
+            self._inflight_nonterminal_capture = capture
+            self._inflight_nonterminal_capture_state = prepared_delivery.committed_state
+            capture.set_result(None)
+            for capture_completion in capture_completions:
+                if not capture_completion.done():
+                    capture_completion.set_result(None)
+        try:
+            send_succeeded = await self._send_content(
+                client,
+                content=prepared_delivery.content,
+                display_text=prepared_delivery.display_text,
+                retry_on_failure=is_final,
+            )
+        finally:
+            if self._inflight_nonterminal_capture is capture:
+                self._inflight_nonterminal_capture = None
+                self._inflight_nonterminal_capture_state = None
         if not send_succeeded:
             if not is_final:
                 action = "send initial" if is_initial_send else "edit"
@@ -687,6 +726,10 @@ class ReplacementStreamingResponse(StreamingResponse):
     on each tick and we want the message to reflect the latest full view,
     not incremental concatenation.
     """
+
+    def uses_replacement_updates(self) -> bool:
+        """Return whether each visible chunk replaces the current body."""
+        return True
 
     def _update(self, new_chunk: str) -> None:
         """Replace accumulated text with new chunk."""

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -170,6 +170,11 @@ class _CommittedDeliveryState:
     placeholder_progress_sent: bool
 
 
+def _normalize_stream_accumulated_text(text: str) -> str:
+    """Normalize whitespace-only placeholder buffers to the committed empty state."""
+    return text if text.strip() else ""
+
+
 def build_cancelled_response_update(
     text: str,
     *,
@@ -341,7 +346,8 @@ class StreamingResponse:
         if self.stream_started_at is None:
             self.stream_started_at = now
         delivery_matches_live_state = (
-            self.accumulated_text == committed_state.accumulated_text and self.tool_trace == committed_state.tool_trace
+            _normalize_stream_accumulated_text(self.accumulated_text) == committed_state.accumulated_text
+            and self.tool_trace == committed_state.tool_trace
         )
         if delivery_matches_live_state:
             self.last_update = now
@@ -361,7 +367,8 @@ class StreamingResponse:
         if self._inflight_nonterminal_capture is None or self._inflight_nonterminal_capture_state is None:
             return None
         if (
-            self.accumulated_text == self._inflight_nonterminal_capture_state.accumulated_text
+            _normalize_stream_accumulated_text(self.accumulated_text)
+            == self._inflight_nonterminal_capture_state.accumulated_text
             and self.tool_trace == self._inflight_nonterminal_capture_state.tool_trace
         ):
             return self._inflight_nonterminal_capture
@@ -591,7 +598,7 @@ class StreamingResponse:
             content=content,
             display_text=display_text,
             committed_state=_CommittedDeliveryState(
-                accumulated_text=self.accumulated_text if self.accumulated_text.strip() else "",
+                accumulated_text=_normalize_stream_accumulated_text(self.accumulated_text),
                 tool_trace=deepcopy(self.tool_trace),
                 placeholder_progress_sent=not self.accumulated_text.strip(),
             ),

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -324,27 +324,6 @@ class StreamingResponse:
         threshold = fast_threshold + (self.update_char_threshold - fast_threshold) * progress
         return max(1, round(threshold))
 
-    async def force_flush(self, client: nio.AsyncClient) -> None:
-        """Unconditionally send buffered text and reset all throttle state.
-
-        Bypasses _throttled_send's OR but maintains the same post-send invariants.
-        Use at explicit phase boundaries where throttling is semantically wrong.
-        """
-        if self.chars_since_last_update == 0 or not self.accumulated_text.strip():
-            return
-        prepared_delivery = self._prepare_delivery(
-            is_final=False,
-            allow_empty_progress=False,
-            stream_status=None,
-        )
-        if prepared_delivery is None:
-            return
-        await self._send_prepared_delivery(
-            client,
-            prepared_delivery=prepared_delivery,
-            is_final=False,
-        )
-
     def _mark_nonterminal_delivery(
         self,
         committed_state: _CommittedDeliveryState,

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -36,9 +36,6 @@ from mindroom.streaming_delivery import (
     _shutdown_worker_progress_drain,
     _StreamDeliveryShutdownTimeoutError,
 )
-from mindroom.streaming_delivery import (
-    _consume_streaming_chunks as _consume_streaming_chunks_impl,
-)
 from mindroom.streaming_warmup import WorkerWarmupState
 from mindroom.tool_system.runtime_context import worker_progress_pump_scope
 
@@ -664,30 +661,6 @@ class ReplacementStreamingResponse(StreamingResponse):
         self.accumulated_text = new_chunk
         self.chars_since_last_update += len(new_chunk)
         self.last_delta_at = time.time()
-
-
-async def _consume_streaming_chunks(
-    client: nio.AsyncClient,
-    response_stream: AsyncIterator[_StreamInputChunk],
-    streaming: StreamingResponse,
-) -> None:
-    """Compatibility helper for tests that exercise chunk consumption directly."""
-    delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-    delivery_task = asyncio.create_task(_drive_stream_delivery(client, streaming, delivery_queue))
-    try:
-        await _consume_streaming_chunks_impl(response_stream, streaming, delivery_queue)
-        delivery_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
-        delivery_task = None
-        if delivery_error is not None:
-            raise delivery_error
-    finally:
-        if delivery_task is not None:
-            cleanup_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
-            if cleanup_error is not None:
-                logger.warning(
-                    "Stream delivery controller raised during compatibility cleanup",
-                    error=str(cleanup_error),
-                )
 
 
 async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -26,6 +26,7 @@ from mindroom.message_target import MessageTarget
 from mindroom.orchestration.runtime import CancelSource, classify_cancel_source
 from mindroom.streaming_delivery import (
     StreamInputChunk,
+    _consume_streaming_chunks as _consume_streaming_chunks_impl,
     _consume_stream_with_progress_supervision,
     _DeliveryRequest,
     _drain_worker_progress_events,
@@ -239,6 +240,7 @@ class StreamingResponse:
     min_update_char_threshold: int = 48
     min_char_update_interval: float = 0.35
     progress_update_interval: float = 1.0
+    max_idle: float = 0.25
     latest_thread_event_id: str | None = None  # For MSC3440 compliance
     room_mode: bool = False  # When True, skip all thread relations (for bridges/mobile)
     show_tool_calls: bool = True  # When False, omit inline tool call text and tool-trace metadata
@@ -246,6 +248,7 @@ class StreamingResponse:
     extra_content: dict[str, Any] | None = None
     stream_started_at: float | None = None
     chars_since_last_update: int = 0
+    last_delta_at: float | None = None
     placeholder_progress_sent: bool = False
     pipeline_timing: DispatchPipelineTiming | None = None
     conversation_cache: ConversationCacheProtocol | None = None
@@ -271,13 +274,18 @@ class StreamingResponse:
 
     def _update(self, new_chunk: str) -> None:
         """Append new chunk to accumulated text."""
+        self._append_incremental_text(new_chunk)
+
+    def _append_incremental_text(self, new_chunk: str) -> None:
+        """Append additive streaming text regardless of snapshot replacement mode."""
         self.accumulated_text += new_chunk
         self.chars_since_last_update += len(new_chunk)
+        self.last_delta_at = time.time()
 
     def _ensure_hidden_tool_gap(self) -> None:
         """Insert a single placeholder gap for hidden tool calls."""
         if not self.accumulated_text.endswith("\n\n"):
-            self._update("\n\n")
+            self._append_incremental_text("\n\n")
 
     def _current_update_interval(self, current_time: float) -> float:
         """Return the current throttling interval.
@@ -311,7 +319,32 @@ class StreamingResponse:
         threshold = fast_threshold + (self.update_char_threshold - fast_threshold) * progress
         return max(1, round(threshold))
 
-    async def _throttled_send(self, client: nio.AsyncClient, *, progress_hint: bool = False) -> None:
+    async def force_flush(self, client: nio.AsyncClient) -> None:
+        """Unconditionally send buffered text and reset all throttle state.
+
+        Bypasses _throttled_send's OR but maintains the same post-send invariants.
+        Use at explicit phase boundaries where throttling is semantically wrong.
+        """
+        if self.chars_since_last_update == 0 or not self.accumulated_text.strip():
+            return
+        sent = await self._send_or_edit_message(client)
+        if sent:
+            self._mark_nonterminal_delivery()
+
+    def _mark_nonterminal_delivery(self) -> None:
+        """Reset throttle state after a non-terminal send or edit reached Matrix."""
+        now = time.time()
+        self.last_update = now
+        self.last_delta_at = now
+        self.chars_since_last_update = 0
+
+    async def _throttled_send(
+        self,
+        client: nio.AsyncClient,
+        *,
+        progress_hint: bool = False,
+        prior_delta_at: float | None = None,
+    ) -> None:
         """Send/edit when either time or character thresholds are met."""
         current_time = time.time()
         if self.stream_started_at is None:
@@ -326,18 +359,26 @@ class StreamingResponse:
             self.chars_since_last_update >= self._current_char_threshold(current_time)
             and elapsed_since_last_update >= self.min_char_update_interval
         )
-        should_send = time_triggered or char_triggered
+        idle_reference_delta_at = prior_delta_at if prior_delta_at is not None else self.last_delta_at
+        idle_triggered = (
+            self.chars_since_last_update > 0
+            and idle_reference_delta_at is not None
+            and (current_time - idle_reference_delta_at) >= self.max_idle
+            and elapsed_since_last_update >= self.min_char_update_interval
+        )
+        should_send = time_triggered or char_triggered or idle_triggered
         allow_empty_progress = progress_hint and not self.accumulated_text.strip()
         if should_send and (self.accumulated_text.strip() or allow_empty_progress):
-            await self._send_or_edit_message(client, allow_empty_progress=allow_empty_progress)
-            self.last_update = current_time
-            self.chars_since_last_update = 0
+            sent = await self._send_or_edit_message(client, allow_empty_progress=allow_empty_progress)
+            if sent:
+                self._mark_nonterminal_delivery()
 
     async def update_content(self, new_chunk: str, client: nio.AsyncClient) -> None:
         """Add new content and potentially update the message."""
         self._warmup_state.clear_terminal_failures()
+        previous_last_delta_at = self.last_delta_at
         self._update(new_chunk)
-        await self._throttled_send(client)
+        await self._throttled_send(client, prior_delta_at=previous_last_delta_at)
 
     async def finalize(
         self,
@@ -620,6 +661,31 @@ class ReplacementStreamingResponse(StreamingResponse):
         """Replace accumulated text with new chunk."""
         self.accumulated_text = new_chunk
         self.chars_since_last_update += len(new_chunk)
+        self.last_delta_at = time.time()
+
+
+async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
+    client: nio.AsyncClient,
+    response_stream: AsyncIterator[_StreamInputChunk],
+    streaming: StreamingResponse,
+) -> None:
+    """Compatibility helper for tests that exercise chunk consumption directly."""
+    delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+    delivery_task = asyncio.create_task(_drive_stream_delivery(client, streaming, delivery_queue))
+    try:
+        await _consume_streaming_chunks_impl(response_stream, streaming, delivery_queue)
+        delivery_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        delivery_task = None
+        if delivery_error is not None:
+            raise delivery_error
+    finally:
+        if delivery_task is not None:
+            cleanup_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            if cleanup_error is not None:
+                logger.warning(
+                    "Stream delivery controller raised during compatibility cleanup",
+                    error=str(cleanup_error),
+                )
 
 
 async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
@@ -670,6 +736,7 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
         update_interval=sc.update_interval,
         min_update_interval=sc.min_update_interval,
         interval_ramp_seconds=sc.interval_ramp_seconds,
+        max_idle=sc.max_idle,
         pipeline_timing=pipeline_timing,
         conversation_cache=conversation_cache,
         visible_event_id_callback=visible_event_id_callback,

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -332,17 +332,29 @@ class StreamingResponse:
         """
         if self.chars_since_last_update == 0 or not self.accumulated_text.strip():
             return
-        sent = await self._send_or_edit_message(client)
+        prepared_delivery = self._prepare_delivery(
+            is_final=False,
+            allow_empty_progress=False,
+            stream_status=None,
+        )
+        if prepared_delivery is None:
+            return
+        sent = await self._send_prepared_delivery(
+            client,
+            prepared_delivery=prepared_delivery,
+            is_final=False,
+        )
         if sent:
             self._mark_nonterminal_delivery()
 
     def _mark_nonterminal_delivery(self, *, boundary_refresh: bool = False) -> None:
         """Reset throttle state after a non-terminal send or edit reached Matrix."""
         now = time.time()
+        if self.stream_started_at is None:
+            self.stream_started_at = now
         self.last_update = now
         self.last_delta_at = now
-        if boundary_refresh:
-            self.last_boundary_refresh_at = now
+        self.last_boundary_refresh_at = now if boundary_refresh else None
         self.chars_since_last_update = 0
 
     async def _throttled_send(
@@ -453,6 +465,20 @@ class StreamingResponse:
         if prepared_delivery is None:
             return True
 
+        return await self._send_prepared_delivery(
+            client,
+            prepared_delivery=prepared_delivery,
+            is_final=is_final,
+        )
+
+    async def _send_prepared_delivery(
+        self,
+        client: nio.AsyncClient,
+        *,
+        prepared_delivery: _PreparedStreamingDelivery,
+        is_final: bool,
+    ) -> bool:
+        """Send one already-prepared non-terminal or terminal payload."""
         is_initial_send = self.event_id is None
         send_succeeded = await self._send_content(
             client,

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -339,23 +339,37 @@ class StreamingResponse:
         )
         if prepared_delivery is None:
             return
-        sent = await self._send_prepared_delivery(
+        await self._send_prepared_delivery(
             client,
             prepared_delivery=prepared_delivery,
             is_final=False,
         )
-        if sent:
-            self._mark_nonterminal_delivery()
 
-    def _mark_nonterminal_delivery(self, *, boundary_refresh: bool = False) -> None:
-        """Reset throttle state after a non-terminal send or edit reached Matrix."""
+    def _mark_nonterminal_delivery(
+        self,
+        committed_state: _CommittedDeliveryState,
+        *,
+        boundary_refresh: bool = False,
+    ) -> None:
+        """Advance throttle state after one non-terminal send or edit reached Matrix."""
         now = time.time()
         if self.stream_started_at is None:
             self.stream_started_at = now
         self.last_update = now
-        self.last_delta_at = now
-        self.last_boundary_refresh_at = now if boundary_refresh else None
-        self.chars_since_last_update = 0
+        delivery_matches_live_state = (
+            self.accumulated_text == committed_state.accumulated_text and self.tool_trace == committed_state.tool_trace
+        )
+        if delivery_matches_live_state:
+            self.last_delta_at = now
+            self.last_boundary_refresh_at = now if boundary_refresh else None
+            self.chars_since_last_update = 0
+            return
+
+        # The outbound payload was captured before newer live state arrived.
+        # Keep pending-delta bookkeeping and boundary-refresh eligibility intact
+        # so the next request can surface the newer content immediately.
+        self.last_boundary_refresh_at = None
+        self.chars_since_last_update = max(1, self.chars_since_last_update)
 
     async def _throttled_send(
         self,
@@ -388,9 +402,7 @@ class StreamingResponse:
         should_send = time_triggered or char_triggered or idle_triggered
         allow_empty_progress = progress_hint and not self.accumulated_text.strip()
         if should_send and (self.accumulated_text.strip() or allow_empty_progress):
-            sent = await self._send_or_edit_message(client, allow_empty_progress=allow_empty_progress)
-            if sent:
-                self._mark_nonterminal_delivery()
+            await self._send_or_edit_message(client, allow_empty_progress=allow_empty_progress)
 
     async def update_content(self, new_chunk: str, client: nio.AsyncClient) -> None:
         """Add new content and potentially update the message."""
@@ -455,6 +467,7 @@ class StreamingResponse:
         *,
         allow_empty_progress: bool = False,
         stream_status: str | None = None,
+        boundary_refresh: bool = False,
     ) -> bool:
         """Send new message or edit existing one."""
         prepared_delivery = self._prepare_delivery(
@@ -469,6 +482,7 @@ class StreamingResponse:
             client,
             prepared_delivery=prepared_delivery,
             is_final=is_final,
+            boundary_refresh=boundary_refresh,
         )
 
     async def _send_prepared_delivery(
@@ -477,6 +491,7 @@ class StreamingResponse:
         *,
         prepared_delivery: _PreparedStreamingDelivery,
         is_final: bool,
+        boundary_refresh: bool = False,
     ) -> bool:
         """Send one already-prepared non-terminal or terminal payload."""
         is_initial_send = self.event_id is None
@@ -498,6 +513,10 @@ class StreamingResponse:
                 had_warmup_suffix=prepared_delivery.had_warmup_suffix,
             )
             self._mark_delivery_committed(prepared_delivery.committed_state)
+            self._mark_nonterminal_delivery(
+                prepared_delivery.committed_state,
+                boundary_refresh=boundary_refresh,
+            )
         else:
             self.placeholder_progress_sent = False
         return True

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -26,7 +26,6 @@ from mindroom.message_target import MessageTarget
 from mindroom.orchestration.runtime import CancelSource, classify_cancel_source
 from mindroom.streaming_delivery import (
     StreamInputChunk,
-    _consume_streaming_chunks as _consume_streaming_chunks_impl,
     _consume_stream_with_progress_supervision,
     _DeliveryRequest,
     _drain_worker_progress_events,
@@ -36,6 +35,9 @@ from mindroom.streaming_delivery import (
     _shutdown_stream_delivery,
     _shutdown_worker_progress_drain,
     _StreamDeliveryShutdownTimeoutError,
+)
+from mindroom.streaming_delivery import (
+    _consume_streaming_chunks as _consume_streaming_chunks_impl,
 )
 from mindroom.streaming_warmup import WorkerWarmupState
 from mindroom.tool_system.runtime_context import worker_progress_pump_scope
@@ -664,7 +666,7 @@ class ReplacementStreamingResponse(StreamingResponse):
         self.last_delta_at = time.time()
 
 
-async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
+async def _consume_streaming_chunks(
     client: nio.AsyncClient,
     response_stream: AsyncIterator[_StreamInputChunk],
     streaming: StreamingResponse,

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -19,7 +19,7 @@ from mindroom.tool_system.events import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Callable
 
     import nio
 
@@ -130,6 +130,32 @@ async def _flush_phase_boundary_if_needed(
     await completion
 
 
+async def _apply_visible_text_chunk(
+    streaming: StreamingResponse,
+    delivery_queue: asyncio.Queue[_DeliveryRequest | None],
+    text_chunk: str,
+    *,
+    apply_chunk: Callable[[str], None],
+    force_refresh: bool = False,
+    wait_for_delivery: bool = False,
+) -> None:
+    """Apply one visible text-like chunk and queue the matching delivery request."""
+    if not text_chunk:
+        return
+
+    streaming._warmup_state.clear_terminal_failures()
+    prior_delta_at = streaming.last_delta_at
+    apply_chunk(text_chunk)
+    completion = _queue_delivery_request(
+        delivery_queue,
+        force_refresh=force_refresh,
+        prior_delta_at=None if force_refresh else prior_delta_at,
+        wait_for_delivery=wait_for_delivery,
+    )
+    if completion is not None:
+        await completion
+
+
 async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
     response_stream: AsyncIterator[StreamInputChunk],
     streaming: StreamingResponse,
@@ -164,15 +190,14 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
             if trace_entry is not None:
                 streaming.tool_trace.append(trace_entry)
                 pending_tools.append((trace_entry.tool_name, tool_index))
-            if text_chunk:
-                streaming._append_incremental_text(text_chunk)
-                completion = _queue_delivery_request(
-                    delivery_queue,
-                    force_refresh=True,
-                    wait_for_delivery=True,
-                )
-                assert completion is not None
-                await completion
+            await _apply_visible_text_chunk(
+                streaming,
+                delivery_queue,
+                text_chunk,
+                apply_chunk=streaming._append_incremental_text,
+                force_refresh=True,
+                wait_for_delivery=True,
+            )
             continue
         elif isinstance(chunk, ToolCallCompletedEvent):
             info = extract_tool_completed_info(chunk.tool)
@@ -219,11 +244,12 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
             logger.debug("unhandled_streaming_event_type", event_type=type(chunk).__name__)
             continue
 
-        if text_chunk:
-            streaming._warmup_state.clear_terminal_failures()
-            prior_delta_at = streaming.last_delta_at
-            streaming._update(text_chunk)
-            _queue_delivery_request(delivery_queue, prior_delta_at=prior_delta_at)
+        await _apply_visible_text_chunk(
+            streaming,
+            delivery_queue,
+            text_chunk,
+            apply_chunk=streaming._update,
+        )
 
 
 async def _drain_worker_progress_events(

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -92,6 +92,7 @@ class _DeliveryRequest:
     phase_boundary_flush: bool = False
     allow_empty_progress: bool = False
     prior_delta_at: float | None = None
+    boundary_refresh_prior_delta_at: float | None = None
     capture_completion: asyncio.Future[None] | None = None
 
 
@@ -121,6 +122,7 @@ def _queue_delivery_request(
             phase_boundary_flush=phase_boundary_flush,
             allow_empty_progress=allow_empty_progress,
             prior_delta_at=prior_delta_at,
+            boundary_refresh_prior_delta_at=prior_delta_at if boundary_refresh else None,
             capture_completion=capture_completion,
         ),
     )
@@ -133,6 +135,10 @@ async def _flush_phase_boundary_if_needed(
 ) -> None:
     """Flush any buffered visible text before mutating the next phase."""
     if streaming.chars_since_last_update == 0:
+        return
+    inflight_capture = streaming.matching_inflight_nonterminal_capture()
+    if inflight_capture is not None:
+        await inflight_capture
         return
     completion = _queue_delivery_request(
         delivery_queue,
@@ -149,8 +155,10 @@ async def _apply_visible_text_chunk(
     text_chunk: str,
     *,
     apply_chunk: Callable[[str], None],
+    replacement_suffixes: tuple[str, ...] = (),
     force_refresh: bool = False,
     boundary_refresh: bool = False,
+    wait_for_capture: bool = False,
 ) -> None:
     """Apply one visible text-like chunk and queue the matching delivery request."""
     if not text_chunk:
@@ -159,12 +167,19 @@ async def _apply_visible_text_chunk(
     streaming._warmup_state.clear_terminal_failures()
     prior_delta_at = streaming.last_delta_at
     apply_chunk(text_chunk)
-    _queue_delivery_request(
+    if replacement_suffixes and streaming.uses_replacement_updates():
+        for suffix in replacement_suffixes:
+            if suffix not in streaming.accumulated_text:
+                streaming._append_incremental_text(suffix)
+    completion = _queue_delivery_request(
         delivery_queue,
         force_refresh=force_refresh,
         boundary_refresh=boundary_refresh,
         prior_delta_at=None if force_refresh else prior_delta_at,
+        wait_for_capture=wait_for_capture,
     )
+    if completion is not None:
+        await completion
 
 
 async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
@@ -173,7 +188,7 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
     delivery_queue: asyncio.Queue[_DeliveryRequest | None],
 ) -> None:
     """Consume stream chunks and apply incremental message updates."""
-    pending_tools: list[tuple[str, int]] = []
+    pending_tools: list[tuple[str, int, str]] = []
 
     async for chunk in response_stream:
         if isinstance(chunk, str):
@@ -201,13 +216,16 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
             text_chunk, trace_entry = format_tool_started_event(chunk.tool, tool_index=tool_index)
             if trace_entry is not None:
                 streaming.tool_trace.append(trace_entry)
-                pending_tools.append((trace_entry.tool_name, tool_index))
+                pending_tools.append((trace_entry.tool_name, tool_index, text_chunk))
             await _apply_visible_text_chunk(
                 streaming,
                 delivery_queue,
                 text_chunk,
                 apply_chunk=streaming._append_incremental_text,
                 boundary_refresh=True,
+                wait_for_capture=(
+                    streaming.uses_replacement_updates() and streaming.matching_inflight_nonterminal_capture() is None
+                ),
             )
             continue
         elif isinstance(chunk, ToolCallCompletedEvent):
@@ -226,7 +244,7 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
                         )
                         _queue_delivery_request(delivery_queue, progress_hint=True)
                         continue
-                    _, tool_index = pending_tools.pop(match_pos)
+                    _, tool_index, _ = pending_tools.pop(match_pos)
                     prior_delta_at = streaming.last_delta_at
                     previous_text = streaming.accumulated_text
                     streaming.accumulated_text, trace_entry = complete_pending_tool_block(
@@ -268,6 +286,7 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
             delivery_queue,
             text_chunk,
             apply_chunk=streaming._update,
+            replacement_suffixes=tuple(marker_text for _, _, marker_text in pending_tools),
         )
 
 
@@ -337,7 +356,14 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
             return
 
         merged_request = request
-        capture_completions = [request.capture_completion] if request.capture_completion is not None else []
+        phase_boundary_capture_completions = (
+            [request.capture_completion]
+            if request.phase_boundary_flush and request.capture_completion is not None
+            else []
+        )
+        boundary_refresh_capture_completions = (
+            [request.capture_completion] if request.boundary_refresh and request.capture_completion is not None else []
+        )
         while True:
             try:
                 next_request = delivery_queue.get_nowait()
@@ -346,8 +372,10 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
             if next_request is None:
                 stop_after_current = True
                 break
-            if next_request.capture_completion is not None:
-                capture_completions.append(next_request.capture_completion)
+            if next_request.phase_boundary_flush and next_request.capture_completion is not None:
+                phase_boundary_capture_completions.append(next_request.capture_completion)
+            if next_request.boundary_refresh and next_request.capture_completion is not None:
+                boundary_refresh_capture_completions.append(next_request.capture_completion)
             merged_request = _DeliveryRequest(
                 progress_hint=merged_request.progress_hint or next_request.progress_hint,
                 force_refresh=merged_request.force_refresh or next_request.force_refresh,
@@ -357,6 +385,11 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                 prior_delta_at=_merge_prior_delta_at(
                     merged_request.prior_delta_at,
                     next_request.prior_delta_at,
+                ),
+                boundary_refresh_prior_delta_at=(
+                    next_request.boundary_refresh_prior_delta_at
+                    if next_request.boundary_refresh_prior_delta_at is not None
+                    else merged_request.boundary_refresh_prior_delta_at
                 ),
             )
 
@@ -370,14 +403,16 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                     allow_empty_progress=False,
                     stream_status=None,
                 )
-            for capture_completion in capture_completions:
-                if not capture_completion.done():
-                    capture_completion.set_result(None)
+            if prepared_phase_boundary_flush is None:
+                for capture_completion in phase_boundary_capture_completions:
+                    if not capture_completion.done():
+                        capture_completion.set_result(None)
             if prepared_phase_boundary_flush is not None:
                 await streaming._send_prepared_delivery(
                     client,
                     prepared_delivery=prepared_phase_boundary_flush,
                     is_final=False,
+                    capture_completions=tuple(phase_boundary_capture_completions),
                 )
             if merged_request.force_refresh:
                 await streaming._send_or_edit_message(
@@ -386,9 +421,16 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                 )
             elif merged_request.boundary_refresh:
                 current_time = time.time()
+                visible_delta_since_last_boundary_refresh = (
+                    merged_request.boundary_refresh_prior_delta_at is not None
+                    and streaming.last_boundary_refresh_at is not None
+                    and merged_request.boundary_refresh_prior_delta_at > streaming.last_boundary_refresh_at
+                )
                 should_send_boundary_refresh = (
                     streaming.event_id is None
                     or streaming.last_boundary_refresh_at is None
+                    or bool(boundary_refresh_capture_completions)
+                    or visible_delta_since_last_boundary_refresh
                     or (current_time - streaming.last_boundary_refresh_at) >= streaming.progress_update_interval
                 )
                 if should_send_boundary_refresh:
@@ -396,6 +438,7 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                         client,
                         allow_empty_progress=merged_request.allow_empty_progress,
                         boundary_refresh=True,
+                        capture_completions=tuple(boundary_refresh_capture_completions),
                     )
                 else:
                     await streaming._throttled_send(
@@ -410,7 +453,10 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                     prior_delta_at=merged_request.prior_delta_at,
                 )
         except Exception as exc:
-            for capture_completion in capture_completions:
+            for capture_completion in [
+                *phase_boundary_capture_completions,
+                *boundary_refresh_capture_completions,
+            ]:
                 if not capture_completion.done():
                     capture_completion.set_exception(exc)
             raise

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -334,7 +334,7 @@ async def _shutdown_worker_progress_drain(
     return None
 
 
-async def _drive_stream_delivery(  # noqa: C901, PLR0912, PLR0915
+async def _drive_stream_delivery(  # noqa: C901, PLR0912
     client: nio.AsyncClient,
     streaming: StreamingResponse,
     delivery_queue: asyncio.Queue[_DeliveryRequest | None],
@@ -388,20 +388,16 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912, PLR0915
                 if not capture_completion.done():
                     capture_completion.set_result(None)
             if prepared_phase_boundary_flush is not None:
-                sent = await streaming._send_prepared_delivery(
+                await streaming._send_prepared_delivery(
                     client,
                     prepared_delivery=prepared_phase_boundary_flush,
                     is_final=False,
                 )
-                if sent:
-                    streaming._mark_nonterminal_delivery()
             if merged_request.force_refresh:
-                sent = await streaming._send_or_edit_message(
+                await streaming._send_or_edit_message(
                     client,
                     allow_empty_progress=merged_request.allow_empty_progress,
                 )
-                if sent:
-                    streaming._mark_nonterminal_delivery()
             elif merged_request.boundary_refresh:
                 current_time = time.time()
                 should_send_boundary_refresh = (
@@ -410,12 +406,11 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912, PLR0915
                     or (current_time - streaming.last_boundary_refresh_at) >= streaming.progress_update_interval
                 )
                 if should_send_boundary_refresh:
-                    sent = await streaming._send_or_edit_message(
+                    await streaming._send_or_edit_message(
                         client,
                         allow_empty_progress=merged_request.allow_empty_progress,
+                        boundary_refresh=True,
                     )
-                    if sent:
-                        streaming._mark_nonterminal_delivery(boundary_refresh=True)
                 else:
                     await streaming._throttled_send(
                         client,

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -93,6 +93,7 @@ class _DeliveryRequest:
     allow_empty_progress: bool = False
     prior_delta_at: float | None = None
     completion: asyncio.Future[None] | None = None
+    capture_completion: asyncio.Future[None] | None = None
 
 
 def _raise_progress_delivery_error(error: Exception) -> NoReturn:
@@ -110,9 +111,14 @@ def _queue_delivery_request(
     allow_empty_progress: bool = False,
     prior_delta_at: float | None = None,
     wait_for_delivery: bool = False,
+    wait_for_capture: bool = False,
 ) -> asyncio.Future[None] | None:
     """Queue one non-terminal delivery request for the single delivery owner."""
+    if wait_for_delivery and wait_for_capture:
+        msg = "delivery requests can wait for capture or delivery, not both"
+        raise ValueError(msg)
     completion = asyncio.get_running_loop().create_future() if wait_for_delivery else None
+    capture_completion = asyncio.get_running_loop().create_future() if wait_for_capture else None
     delivery_queue.put_nowait(
         _DeliveryRequest(
             progress_hint=progress_hint,
@@ -122,9 +128,10 @@ def _queue_delivery_request(
             allow_empty_progress=allow_empty_progress,
             prior_delta_at=prior_delta_at,
             completion=completion,
+            capture_completion=capture_completion,
         ),
     )
-    return completion
+    return completion or capture_completion
 
 
 async def _flush_phase_boundary_if_needed(
@@ -137,7 +144,7 @@ async def _flush_phase_boundary_if_needed(
     completion = _queue_delivery_request(
         delivery_queue,
         phase_boundary_flush=True,
-        wait_for_delivery=True,
+        wait_for_capture=True,
     )
     assert completion is not None
     await completion
@@ -327,7 +334,7 @@ async def _shutdown_worker_progress_drain(
     return None
 
 
-async def _drive_stream_delivery(  # noqa: C901, PLR0912
+async def _drive_stream_delivery(  # noqa: C901, PLR0912, PLR0915
     client: nio.AsyncClient,
     streaming: StreamingResponse,
     delivery_queue: asyncio.Queue[_DeliveryRequest | None],
@@ -342,6 +349,7 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
 
         merged_request = request
         completions = [request.completion] if request.completion is not None else []
+        capture_completions = [request.capture_completion] if request.capture_completion is not None else []
         while True:
             try:
                 next_request = delivery_queue.get_nowait()
@@ -352,6 +360,8 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                 break
             if next_request.completion is not None:
                 completions.append(next_request.completion)
+            if next_request.capture_completion is not None:
+                capture_completions.append(next_request.capture_completion)
             merged_request = _DeliveryRequest(
                 progress_hint=merged_request.progress_hint or next_request.progress_hint,
                 force_refresh=merged_request.force_refresh or next_request.force_refresh,
@@ -365,8 +375,26 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
             )
 
         try:
-            if merged_request.phase_boundary_flush:
-                await streaming.force_flush(client)
+            prepared_phase_boundary_flush = None
+            if merged_request.phase_boundary_flush and (
+                streaming.chars_since_last_update > 0 and streaming.accumulated_text.strip()
+            ):
+                prepared_phase_boundary_flush = streaming._prepare_delivery(
+                    is_final=False,
+                    allow_empty_progress=False,
+                    stream_status=None,
+                )
+            for capture_completion in capture_completions:
+                if not capture_completion.done():
+                    capture_completion.set_result(None)
+            if prepared_phase_boundary_flush is not None:
+                sent = await streaming._send_prepared_delivery(
+                    client,
+                    prepared_delivery=prepared_phase_boundary_flush,
+                    is_final=False,
+                )
+                if sent:
+                    streaming._mark_nonterminal_delivery()
             if merged_request.force_refresh:
                 sent = await streaming._send_or_edit_message(
                     client,
@@ -404,6 +432,9 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
             for completion in completions:
                 if not completion.done():
                     completion.set_exception(exc)
+            for capture_completion in capture_completions:
+                if not capture_completion.done():
+                    capture_completion.set_exception(exc)
             raise
         else:
             for completion in completions:

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -216,12 +216,17 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
                         _queue_delivery_request(delivery_queue, progress_hint=True)
                         continue
                     _, tool_index = pending_tools.pop(match_pos)
+                    prior_delta_at = streaming.last_delta_at
+                    previous_text = streaming.accumulated_text
                     streaming.accumulated_text, trace_entry = complete_pending_tool_block(
                         streaming.accumulated_text,
                         tool_name,
                         result,
                         tool_index=tool_index,
                     )
+                    text_changed = streaming.accumulated_text != previous_text
+                    if text_changed:
+                        streaming._mark_nonadditive_text_mutation()
                     if 0 < tool_index <= len(streaming.tool_trace):
                         existing_entry = streaming.tool_trace[tool_index - 1]
                         existing_entry.type = "tool_call_completed"
@@ -237,7 +242,10 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
                 else:
                     _queue_delivery_request(delivery_queue, progress_hint=True)
                     continue
-                _queue_delivery_request(delivery_queue)
+                _queue_delivery_request(
+                    delivery_queue,
+                    prior_delta_at=prior_delta_at if text_changed else None,
+                )
                 continue
             text_chunk = ""
         else:

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -72,6 +72,15 @@ def _merge_tool_trace(existing: list[ToolTraceEntry], incoming: list[ToolTraceEn
     return existing.copy()
 
 
+def _merge_prior_delta_at(existing: float | None, incoming: float | None) -> float | None:
+    """Keep the oldest unsent delta timestamp across merged delivery requests."""
+    if existing is None:
+        return incoming
+    if incoming is None:
+        return existing
+    return min(existing, incoming)
+
+
 @dataclass(frozen=True, slots=True)
 class _DeliveryRequest:
     """One non-terminal stream delivery request for the single delivery owner."""
@@ -342,10 +351,9 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                 force_refresh=merged_request.force_refresh or next_request.force_refresh,
                 phase_boundary_flush=merged_request.phase_boundary_flush or next_request.phase_boundary_flush,
                 allow_empty_progress=merged_request.allow_empty_progress or next_request.allow_empty_progress,
-                prior_delta_at=(
-                    next_request.prior_delta_at
-                    if next_request.prior_delta_at is not None
-                    else merged_request.prior_delta_at
+                prior_delta_at=_merge_prior_delta_at(
+                    merged_request.prior_delta_at,
+                    next_request.prior_delta_at,
                 ),
             )
 

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -443,7 +443,7 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                 visible_delta_since_last_boundary_refresh = (
                     merged_request.boundary_refresh_prior_delta_at is not None
                     and streaming.last_boundary_refresh_at is not None
-                    and merged_request.boundary_refresh_prior_delta_at > streaming.last_boundary_refresh_at
+                    and merged_request.boundary_refresh_prior_delta_at >= streaming.last_boundary_refresh_at
                 )
                 should_send_boundary_refresh = (
                     streaming.event_id is None

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, NoReturn
@@ -79,7 +78,10 @@ class _DeliveryRequest:
 
     progress_hint: bool = False
     force_refresh: bool = False
+    phase_boundary_flush: bool = False
     allow_empty_progress: bool = False
+    prior_delta_at: float | None = None
+    completion: asyncio.Future[None] | None = None
 
 
 def _raise_progress_delivery_error(error: Exception) -> NoReturn:
@@ -92,16 +94,40 @@ def _queue_delivery_request(
     *,
     progress_hint: bool = False,
     force_refresh: bool = False,
+    phase_boundary_flush: bool = False,
     allow_empty_progress: bool = False,
-) -> None:
+    prior_delta_at: float | None = None,
+    wait_for_delivery: bool = False,
+) -> asyncio.Future[None] | None:
     """Queue one non-terminal delivery request for the single delivery owner."""
+    completion = asyncio.get_running_loop().create_future() if wait_for_delivery else None
     delivery_queue.put_nowait(
         _DeliveryRequest(
             progress_hint=progress_hint,
             force_refresh=force_refresh,
+            phase_boundary_flush=phase_boundary_flush,
             allow_empty_progress=allow_empty_progress,
+            prior_delta_at=prior_delta_at,
+            completion=completion,
         ),
     )
+    return completion
+
+
+async def _flush_phase_boundary_if_needed(
+    streaming: StreamingResponse,
+    delivery_queue: asyncio.Queue[_DeliveryRequest | None],
+) -> None:
+    """Flush any buffered visible text before mutating the next phase."""
+    if streaming.chars_since_last_update == 0:
+        return
+    completion = _queue_delivery_request(
+        delivery_queue,
+        phase_boundary_flush=True,
+        wait_for_delivery=True,
+    )
+    assert completion is not None
+    await completion
 
 
 async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
@@ -123,9 +149,14 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
             text_chunk = str(chunk.content)
         elif isinstance(chunk, ToolCallStartedEvent):
             if not streaming.show_tool_calls:
+                await _flush_phase_boundary_if_needed(streaming, delivery_queue)
                 if chunk.tool is not None:
                     streaming._ensure_hidden_tool_gap()
                 _queue_delivery_request(delivery_queue, progress_hint=True)
+                continue
+
+            if chunk.tool is None:
+                await _flush_phase_boundary_if_needed(streaming, delivery_queue)
                 continue
 
             tool_index = len(streaming.tool_trace) + 1
@@ -133,6 +164,16 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
             if trace_entry is not None:
                 streaming.tool_trace.append(trace_entry)
                 pending_tools.append((trace_entry.tool_name, tool_index))
+            if text_chunk:
+                streaming._append_incremental_text(text_chunk)
+                completion = _queue_delivery_request(
+                    delivery_queue,
+                    force_refresh=True,
+                    wait_for_delivery=True,
+                )
+                assert completion is not None
+                await completion
+            continue
         elif isinstance(chunk, ToolCallCompletedEvent):
             info = extract_tool_completed_info(chunk.tool)
             if info:
@@ -180,8 +221,9 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
 
         if text_chunk:
             streaming._warmup_state.clear_terminal_failures()
+            prior_delta_at = streaming.last_delta_at
             streaming._update(text_chunk)
-            _queue_delivery_request(delivery_queue)
+            _queue_delivery_request(delivery_queue, prior_delta_at=prior_delta_at)
 
 
 async def _drain_worker_progress_events(
@@ -250,6 +292,7 @@ async def _drive_stream_delivery(
             return
 
         merged_request = request
+        completions = [request.completion] if request.completion is not None else []
         while True:
             try:
                 next_request = delivery_queue.get_nowait()
@@ -258,22 +301,45 @@ async def _drive_stream_delivery(
             if next_request is None:
                 stop_after_current = True
                 break
+            if next_request.completion is not None:
+                completions.append(next_request.completion)
             merged_request = _DeliveryRequest(
                 progress_hint=merged_request.progress_hint or next_request.progress_hint,
                 force_refresh=merged_request.force_refresh or next_request.force_refresh,
+                phase_boundary_flush=merged_request.phase_boundary_flush or next_request.phase_boundary_flush,
                 allow_empty_progress=merged_request.allow_empty_progress or next_request.allow_empty_progress,
+                prior_delta_at=(
+                    merged_request.prior_delta_at
+                    if merged_request.prior_delta_at is not None
+                    else next_request.prior_delta_at
+                ),
             )
 
-        if merged_request.force_refresh:
-            sent = await streaming._send_or_edit_message(
-                client,
-                allow_empty_progress=merged_request.allow_empty_progress,
-            )
-            if sent:
-                streaming.last_update = time.time()
-                streaming.chars_since_last_update = 0
+        try:
+            if merged_request.phase_boundary_flush:
+                await streaming.force_flush(client)
+            if merged_request.force_refresh:
+                sent = await streaming._send_or_edit_message(
+                    client,
+                    allow_empty_progress=merged_request.allow_empty_progress,
+                )
+                if sent:
+                    streaming._mark_nonterminal_delivery()
+            elif not merged_request.phase_boundary_flush:
+                await streaming._throttled_send(
+                    client,
+                    progress_hint=merged_request.progress_hint,
+                    prior_delta_at=merged_request.prior_delta_at,
+                )
+        except Exception as exc:
+            for completion in completions:
+                if not completion.done():
+                    completion.set_exception(exc)
+            raise
         else:
-            await streaming._throttled_send(client, progress_hint=merged_request.progress_hint)
+            for completion in completions:
+                if not completion.done():
+                    completion.set_result(None)
 
         if stop_after_current:
             return

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -92,7 +92,6 @@ class _DeliveryRequest:
     phase_boundary_flush: bool = False
     allow_empty_progress: bool = False
     prior_delta_at: float | None = None
-    completion: asyncio.Future[None] | None = None
     capture_completion: asyncio.Future[None] | None = None
 
 
@@ -110,14 +109,9 @@ def _queue_delivery_request(
     phase_boundary_flush: bool = False,
     allow_empty_progress: bool = False,
     prior_delta_at: float | None = None,
-    wait_for_delivery: bool = False,
     wait_for_capture: bool = False,
 ) -> asyncio.Future[None] | None:
     """Queue one non-terminal delivery request for the single delivery owner."""
-    if wait_for_delivery and wait_for_capture:
-        msg = "delivery requests can wait for capture or delivery, not both"
-        raise ValueError(msg)
-    completion = asyncio.get_running_loop().create_future() if wait_for_delivery else None
     capture_completion = asyncio.get_running_loop().create_future() if wait_for_capture else None
     delivery_queue.put_nowait(
         _DeliveryRequest(
@@ -127,11 +121,10 @@ def _queue_delivery_request(
             phase_boundary_flush=phase_boundary_flush,
             allow_empty_progress=allow_empty_progress,
             prior_delta_at=prior_delta_at,
-            completion=completion,
             capture_completion=capture_completion,
         ),
     )
-    return completion or capture_completion
+    return capture_completion
 
 
 async def _flush_phase_boundary_if_needed(
@@ -158,7 +151,6 @@ async def _apply_visible_text_chunk(
     apply_chunk: Callable[[str], None],
     force_refresh: bool = False,
     boundary_refresh: bool = False,
-    wait_for_delivery: bool = False,
 ) -> None:
     """Apply one visible text-like chunk and queue the matching delivery request."""
     if not text_chunk:
@@ -167,15 +159,12 @@ async def _apply_visible_text_chunk(
     streaming._warmup_state.clear_terminal_failures()
     prior_delta_at = streaming.last_delta_at
     apply_chunk(text_chunk)
-    completion = _queue_delivery_request(
+    _queue_delivery_request(
         delivery_queue,
         force_refresh=force_refresh,
         boundary_refresh=boundary_refresh,
         prior_delta_at=None if force_refresh else prior_delta_at,
-        wait_for_delivery=wait_for_delivery,
     )
-    if completion is not None:
-        await completion
 
 
 async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
@@ -348,7 +337,6 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
             return
 
         merged_request = request
-        completions = [request.completion] if request.completion is not None else []
         capture_completions = [request.capture_completion] if request.capture_completion is not None else []
         while True:
             try:
@@ -358,8 +346,6 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
             if next_request is None:
                 stop_after_current = True
                 break
-            if next_request.completion is not None:
-                completions.append(next_request.completion)
             if next_request.capture_completion is not None:
                 capture_completions.append(next_request.capture_completion)
             merged_request = _DeliveryRequest(
@@ -424,17 +410,10 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                     prior_delta_at=merged_request.prior_delta_at,
                 )
         except Exception as exc:
-            for completion in completions:
-                if not completion.done():
-                    completion.set_exception(exc)
             for capture_completion in capture_completions:
                 if not capture_completion.done():
                     capture_completion.set_exception(exc)
             raise
-        else:
-            for completion in completions:
-                if not completion.done():
-                    completion.set_result(None)
 
         if stop_after_current:
             return

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -110,6 +110,7 @@ def _queue_delivery_request(
     phase_boundary_flush: bool = False,
     allow_empty_progress: bool = False,
     prior_delta_at: float | None = None,
+    boundary_refresh_prior_delta_at: float | None = None,
     wait_for_capture: bool = False,
 ) -> asyncio.Future[None] | None:
     """Queue one non-terminal delivery request for the single delivery owner."""
@@ -122,7 +123,11 @@ def _queue_delivery_request(
             phase_boundary_flush=phase_boundary_flush,
             allow_empty_progress=allow_empty_progress,
             prior_delta_at=prior_delta_at,
-            boundary_refresh_prior_delta_at=prior_delta_at if boundary_refresh else None,
+            boundary_refresh_prior_delta_at=(
+                (prior_delta_at if boundary_refresh_prior_delta_at is None else boundary_refresh_prior_delta_at)
+                if boundary_refresh
+                else None
+            ),
             capture_completion=capture_completion,
         ),
     )
@@ -176,6 +181,7 @@ async def _apply_visible_text_chunk(
         force_refresh=force_refresh,
         boundary_refresh=boundary_refresh,
         prior_delta_at=None if force_refresh else prior_delta_at,
+        boundary_refresh_prior_delta_at=streaming.last_delta_at if boundary_refresh else None,
         wait_for_capture=wait_for_capture,
     )
     if completion is not None:
@@ -203,8 +209,19 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
             if not streaming.show_tool_calls:
                 await _flush_phase_boundary_if_needed(streaming, delivery_queue)
                 if chunk.tool is not None:
+                    cleared_terminal_failures = any(
+                        warmup.last_event.phase == "failed"
+                        for warmup in streaming._warmup_state.active_warmups.values()
+                    )
                     streaming._warmup_state.clear_terminal_failures()
                     streaming._ensure_hidden_tool_gap()
+                    _queue_delivery_request(
+                        delivery_queue,
+                        force_refresh=cleared_terminal_failures,
+                        progress_hint=not cleared_terminal_failures,
+                        allow_empty_progress=cleared_terminal_failures and not streaming.accumulated_text.strip(),
+                    )
+                    continue
                 _queue_delivery_request(delivery_queue, progress_hint=True)
                 continue
 
@@ -418,6 +435,8 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                 await streaming._send_or_edit_message(
                     client,
                     allow_empty_progress=merged_request.allow_empty_progress,
+                    boundary_refresh=merged_request.boundary_refresh,
+                    capture_completions=tuple(boundary_refresh_capture_completions),
                 )
             elif merged_request.boundary_refresh:
                 current_time = time.time()

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -278,7 +278,7 @@ async def _shutdown_worker_progress_drain(
     return None
 
 
-async def _drive_stream_delivery(
+async def _drive_stream_delivery(  # noqa: C901, PLR0912
     client: nio.AsyncClient,
     streaming: StreamingResponse,
     delivery_queue: asyncio.Queue[_DeliveryRequest | None],
@@ -309,9 +309,9 @@ async def _drive_stream_delivery(
                 phase_boundary_flush=merged_request.phase_boundary_flush or next_request.phase_boundary_flush,
                 allow_empty_progress=merged_request.allow_empty_progress or next_request.allow_empty_progress,
                 prior_delta_at=(
-                    merged_request.prior_delta_at
-                    if merged_request.prior_delta_at is not None
-                    else next_request.prior_delta_at
+                    next_request.prior_delta_at
+                    if next_request.prior_delta_at is not None
+                    else merged_request.prior_delta_at
                 ),
             )
 

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, NoReturn
@@ -87,6 +88,7 @@ class _DeliveryRequest:
 
     progress_hint: bool = False
     force_refresh: bool = False
+    boundary_refresh: bool = False
     phase_boundary_flush: bool = False
     allow_empty_progress: bool = False
     prior_delta_at: float | None = None
@@ -103,6 +105,7 @@ def _queue_delivery_request(
     *,
     progress_hint: bool = False,
     force_refresh: bool = False,
+    boundary_refresh: bool = False,
     phase_boundary_flush: bool = False,
     allow_empty_progress: bool = False,
     prior_delta_at: float | None = None,
@@ -114,6 +117,7 @@ def _queue_delivery_request(
         _DeliveryRequest(
             progress_hint=progress_hint,
             force_refresh=force_refresh,
+            boundary_refresh=boundary_refresh,
             phase_boundary_flush=phase_boundary_flush,
             allow_empty_progress=allow_empty_progress,
             prior_delta_at=prior_delta_at,
@@ -146,6 +150,7 @@ async def _apply_visible_text_chunk(
     *,
     apply_chunk: Callable[[str], None],
     force_refresh: bool = False,
+    boundary_refresh: bool = False,
     wait_for_delivery: bool = False,
 ) -> None:
     """Apply one visible text-like chunk and queue the matching delivery request."""
@@ -158,6 +163,7 @@ async def _apply_visible_text_chunk(
     completion = _queue_delivery_request(
         delivery_queue,
         force_refresh=force_refresh,
+        boundary_refresh=boundary_refresh,
         prior_delta_at=None if force_refresh else prior_delta_at,
         wait_for_delivery=wait_for_delivery,
     )
@@ -186,6 +192,7 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
             if not streaming.show_tool_calls:
                 await _flush_phase_boundary_if_needed(streaming, delivery_queue)
                 if chunk.tool is not None:
+                    streaming._warmup_state.clear_terminal_failures()
                     streaming._ensure_hidden_tool_gap()
                 _queue_delivery_request(delivery_queue, progress_hint=True)
                 continue
@@ -204,8 +211,7 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
                 delivery_queue,
                 text_chunk,
                 apply_chunk=streaming._append_incremental_text,
-                force_refresh=True,
-                wait_for_delivery=True,
+                boundary_refresh=True,
             )
             continue
         elif isinstance(chunk, ToolCallCompletedEvent):
@@ -349,6 +355,7 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
             merged_request = _DeliveryRequest(
                 progress_hint=merged_request.progress_hint or next_request.progress_hint,
                 force_refresh=merged_request.force_refresh or next_request.force_refresh,
+                boundary_refresh=merged_request.boundary_refresh or next_request.boundary_refresh,
                 phase_boundary_flush=merged_request.phase_boundary_flush or next_request.phase_boundary_flush,
                 allow_empty_progress=merged_request.allow_empty_progress or next_request.allow_empty_progress,
                 prior_delta_at=_merge_prior_delta_at(
@@ -367,6 +374,26 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                 )
                 if sent:
                     streaming._mark_nonterminal_delivery()
+            elif merged_request.boundary_refresh:
+                current_time = time.time()
+                should_send_boundary_refresh = (
+                    streaming.event_id is None
+                    or streaming.last_boundary_refresh_at is None
+                    or (current_time - streaming.last_boundary_refresh_at) >= streaming.progress_update_interval
+                )
+                if should_send_boundary_refresh:
+                    sent = await streaming._send_or_edit_message(
+                        client,
+                        allow_empty_progress=merged_request.allow_empty_progress,
+                    )
+                    if sent:
+                        streaming._mark_nonterminal_delivery(boundary_refresh=True)
+                else:
+                    await streaming._throttled_send(
+                        client,
+                        progress_hint=True,
+                        prior_delta_at=merged_request.prior_delta_at,
+                    )
             elif not merged_request.phase_boundary_flush:
                 await streaming._throttled_send(
                     client,

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -1,5 +1,6 @@
 """Integration tests for large message handling with streaming and regular messages."""
 
+import asyncio
 import json
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -818,7 +819,9 @@ async def test_hidden_tool_calls_coalesce_placeholder_spacing() -> None:
 
     async def stream() -> AsyncIterator[_StreamInputChunk]:
         yield ToolCallStartedEvent(tool=ToolExecution(tool_name="first_tool", tool_args={}))
+        await asyncio.sleep(0)
         yield ToolCallStartedEvent(tool=ToolExecution(tool_name="second_tool", tool_args={}))
+        await asyncio.sleep(0)
         yield "Done"
 
     event_id, accumulated = await send_streaming_response(
@@ -835,3 +838,5 @@ async def test_hidden_tool_calls_coalesce_placeholder_spacing() -> None:
 
     assert event_id is not None
     assert accumulated == "\n\nDone"
+    bodies = [content.get("m.new_content", content)["body"] for _, _, content in client.messages_sent]
+    assert bodies == ["Thinking...", "\n\nDone"]

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -774,6 +774,43 @@ async def test_replacement_streaming_tool_start_preserves_prior_visible_text() -
 
 
 @pytest.mark.asyncio
+async def test_replacement_streaming_preserves_visible_tool_marker_across_snapshots() -> None:
+    """Replacement snapshots should not wipe a pending visible tool marker before completion."""
+    client = MockClient()
+    config = MockConfig()
+
+    tool = ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}, result="ok")
+
+    async def stream() -> AsyncIterator[_StreamInputChunk]:
+        yield "hello"
+        yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
+        yield "hello world"
+        yield ToolCallCompletedEvent(tool=tool, content="ok")
+
+    event_id, accumulated = await send_streaming_response(
+        client=client,
+        room_id="!test:room",
+        reply_to_event_id=None,
+        thread_id=None,
+        sender_domain="example.com",
+        config=config,
+        runtime_paths=_runtime_paths(),
+        response_stream=stream(),
+        streaming_cls=ReplacementStreamingResponse,
+    )
+
+    assert event_id is not None
+    assert accumulated.startswith("hello world")
+    assert "save_file" in accumulated
+    assert "⏳" not in accumulated
+
+    target_content = client.messages_sent[-1][2].get("m.new_content", client.messages_sent[-1][2])
+    assert target_content["body"].startswith("hello world")
+    assert "save_file" in target_content["body"]
+    assert "⏳" not in target_content["body"]
+
+
+@pytest.mark.asyncio
 async def test_hidden_tool_calls_coalesce_placeholder_spacing() -> None:
     """Hidden tool calls should not stack repeated blank-line placeholders."""
     client = MockClient()

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -743,6 +743,37 @@ async def test_replacement_streaming_preserves_text_on_tool_completion() -> None
 
 
 @pytest.mark.asyncio
+async def test_replacement_streaming_tool_start_preserves_prior_visible_text() -> None:
+    """Visible tool-start markers must append to the current replacement snapshot, not replace it."""
+    client = MockClient()
+    config = MockConfig()
+
+    async def stream() -> AsyncIterator[_StreamInputChunk]:
+        yield "hello"
+        yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
+
+    event_id, accumulated = await send_streaming_response(
+        client=client,
+        room_id="!test:room",
+        reply_to_event_id=None,
+        thread_id=None,
+        sender_domain="example.com",
+        config=config,
+        runtime_paths=_runtime_paths(),
+        response_stream=stream(),
+        streaming_cls=ReplacementStreamingResponse,
+    )
+
+    assert event_id is not None
+    assert accumulated.startswith("hello")
+    assert "save_file" in accumulated
+
+    target_content = client.messages_sent[-1][2].get("m.new_content", client.messages_sent[-1][2])
+    assert target_content["body"].startswith("hello")
+    assert "save_file" in target_content["body"]
+
+
+@pytest.mark.asyncio
 async def test_hidden_tool_calls_coalesce_placeholder_spacing() -> None:
     """Hidden tool calls should not stack repeated blank-line placeholders."""
     client = MockClient()

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -4048,7 +4048,7 @@ class TestStreamingConfig:
         assert sc.update_interval == 2.0
         assert sc.min_update_interval == 0.5
         assert sc.interval_ramp_seconds == 15.0
-        assert sc.max_idle == 0.25
+        assert sc.max_idle == 2.0
 
     def test_streaming_config_validation(self) -> None:
         """Reject invalid values: update_interval <= 0, min_update_interval <= 0, interval_ramp_seconds < 0."""

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -863,6 +863,72 @@ class TestStreamingBehavior:
         assert "save_file" in streaming.accumulated_text
 
     @pytest.mark.asyncio
+    async def test_visible_tool_start_arriving_during_inflight_refresh_gets_sent_before_finalize(self) -> None:
+        """A later visible tool start must not wait for finalization when the earlier refresh is still in flight."""
+        mock_client = _make_matrix_client_mock()
+        first_send_started = asyncio.Event()
+        allow_first_send_to_finish = asyncio.Event()
+        send_count = 0
+
+        async def slow_room_send(*args: object, **kwargs: object) -> nio.RoomSendResponse:
+            nonlocal send_count
+            _ = (args, kwargs)
+            send_count += 1
+            if send_count == 1:
+                first_send_started.set()
+                await allow_first_send_to_finish.wait()
+            mock_response = MagicMock()
+            mock_response.__class__ = nio.RoomSendResponse
+            mock_response.event_id = f"$tool_start_inflight_{send_count}"
+            return mock_response
+
+        mock_client.room_send.side_effect = slow_room_send
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=10_000,
+            min_update_char_threshold=10_000,
+            min_char_update_interval=10.0,
+            progress_update_interval=10.0,
+            max_idle=0.25,
+            show_tool_calls=True,
+        )
+        streaming.last_update = 100.0
+        streaming.stream_started_at = 100.0
+
+        async def response_stream() -> AsyncIterator[object]:
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
+            await first_send_started.wait()
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
+
+        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        consume_task = asyncio.create_task(_consume_streaming_chunks_impl(response_stream(), streaming, delivery_queue))
+
+        await first_send_started.wait()
+        await asyncio.sleep(0)
+        allow_first_send_to_finish.set()
+        await consume_task
+        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        assert shutdown_error is None
+
+        assert mock_client.room_send.call_count == 2
+        bodies = [
+            call.kwargs["content"].get("m.new_content", call.kwargs["content"])["body"]
+            for call in mock_client.room_send.call_args_list
+        ]
+        assert "search_web" in bodies[0]
+        assert "save_file" in bodies[1]
+
+    @pytest.mark.asyncio
     async def test_visible_tool_start_after_intervening_edit_refreshes_immediately(self) -> None:
         """A later visible tool start should refresh immediately once another edit has already landed."""
         mock_client = _make_matrix_client_mock()
@@ -1040,17 +1106,17 @@ class TestStreamingBehavior:
         streaming.event_id = "$existing_event"
         streaming.stream_started_at = 100.0
         streaming.last_update = 100.0
-        streaming._send_or_edit_message = AsyncMock(return_value=True)
+        streaming._send_content = AsyncMock(return_value=True)
 
         with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0]):
             await streaming.update_content("first", mock_client)
 
-        assert streaming._send_or_edit_message.await_count == 0
+        assert streaming._send_content.await_count == 0
 
         with patch("mindroom.streaming.time.time", side_effect=[105.0, 105.0, 105.0]):
             await streaming.update_content(" second", mock_client)
 
-        assert streaming._send_or_edit_message.await_count == 1
+        assert streaming._send_content.await_count == 1
         assert streaming.last_delta_at == 105.0
         assert streaming.chars_since_last_update == 0
 
@@ -1119,6 +1185,10 @@ class TestStreamingBehavior:
     async def test_boundary_refresh_initializes_stream_started_at(self) -> None:
         """Boundary-refresh sends should anchor the ramp window before later throttled edits."""
         mock_client = _make_matrix_client_mock()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$boundary_refresh_start"
+        mock_client.room_send.return_value = mock_response
         streaming = StreamingResponse(
             room_id="!test:localhost",
             reply_to_event_id="$original_123",
@@ -1129,7 +1199,6 @@ class TestStreamingBehavior:
         )
         streaming.accumulated_text = "hello"
         streaming.chars_since_last_update = len(streaming.accumulated_text)
-        streaming._send_or_edit_message = AsyncMock(return_value=True)
 
         delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
         delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
@@ -1169,7 +1238,7 @@ class TestStreamingBehavior:
         streaming.event_id = "$existing_event"
         streaming.stream_started_at = 100.0
         streaming.last_update = 100.0
-        streaming._send_or_edit_message = AsyncMock(return_value=True)
+        streaming._send_content = AsyncMock(return_value=True)
 
         with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0]):
             await streaming.update_content("partial", mock_client)
@@ -1177,12 +1246,12 @@ class TestStreamingBehavior:
         with patch("mindroom.streaming.time.time", return_value=100.3):
             await streaming._throttled_send(mock_client)
 
-        assert streaming._send_or_edit_message.await_count == 1
+        assert streaming._send_content.await_count == 1
 
         with patch("mindroom.streaming.time.time", side_effect=[100.35, 100.35, 100.35]):
             await streaming.update_content("!", mock_client)
 
-        assert streaming._send_or_edit_message.await_count == 1
+        assert streaming._send_content.await_count == 1
 
     @pytest.mark.asyncio
     async def test_idle_flush_does_not_fire_during_steady_streaming(self) -> None:
@@ -1206,14 +1275,14 @@ class TestStreamingBehavior:
         streaming.event_id = "$existing_event"
         streaming.stream_started_at = 100.0
         streaming.last_update = 100.0
-        streaming._send_or_edit_message = AsyncMock(return_value=True)
+        streaming._send_content = AsyncMock(return_value=True)
 
         clock = iter(100.0 + 0.03 * step for step in range(1, 80))
         with patch("mindroom.streaming.time.time", side_effect=lambda: next(clock)):
             for _ in range(20):
                 await streaming.update_content("a", mock_client)
 
-        assert streaming._send_or_edit_message.await_count == 2
+        assert streaming._send_content.await_count == 2
 
     @pytest.mark.asyncio
     async def test_idle_flush_triggers_after_delta_gap(self) -> None:
@@ -1237,18 +1306,18 @@ class TestStreamingBehavior:
         streaming.event_id = "$existing_event"
         streaming.stream_started_at = 100.0
         streaming.last_update = 100.0
-        streaming._send_or_edit_message = AsyncMock(return_value=True)
+        streaming._send_content = AsyncMock(return_value=True)
 
         with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.05]):
             await streaming.update_content("partial", mock_client)
 
-        assert streaming._send_or_edit_message.await_count == 0
+        assert streaming._send_content.await_count == 0
         assert streaming.last_delta_at == 100.0
 
         with patch("mindroom.streaming.time.time", return_value=100.3):
             await streaming._throttled_send(mock_client)
 
-        assert streaming._send_or_edit_message.await_count == 1
+        assert streaming._send_content.await_count == 1
         assert streaming.chars_since_last_update == 0
 
     @pytest.mark.asyncio
@@ -1320,7 +1389,7 @@ class TestStreamingBehavior:
         streaming.event_id = "$existing_event"
         streaming.stream_started_at = 100.0
         streaming.last_update = 100.0
-        streaming._send_or_edit_message = AsyncMock(return_value=True)
+        streaming._send_content = AsyncMock(return_value=True)
 
         with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0]):
             await streaming.update_content("first", mock_client)
@@ -1328,7 +1397,7 @@ class TestStreamingBehavior:
         with patch("mindroom.streaming.time.time", side_effect=[100.3, 100.3, 100.3]):
             await streaming.update_content(" second", mock_client)
 
-        assert streaming._send_or_edit_message.await_count == 0
+        assert streaming._send_content.await_count == 0
 
     @pytest.mark.asyncio
     async def test_progress_hint_uses_shorter_interval(self) -> None:
@@ -2706,7 +2775,7 @@ class TestStreamingBehavior:
         streaming.last_delta_at = 105.0
         streaming.accumulated_text = "first second"
         streaming.chars_since_last_update = len(streaming.accumulated_text)
-        streaming._send_or_edit_message = AsyncMock(return_value=True)
+        streaming._send_content = AsyncMock(return_value=True)
 
         delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
         delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
@@ -2717,7 +2786,7 @@ class TestStreamingBehavior:
             shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
 
         assert shutdown_error is None
-        assert streaming._send_or_edit_message.await_count == 1
+        assert streaming._send_content.await_count == 1
         assert streaming.chars_since_last_update == 0
 
     @pytest.mark.asyncio

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -1112,7 +1112,7 @@ class TestStreamingBehavior:
 
     @pytest.mark.asyncio
     async def test_visible_tool_start_after_unsent_text_refreshes_immediately(self) -> None:
-        """A second visible tool start should bypass the refresh gate after an unsent text delta."""
+        """A same-tick visible tool start should still bypass the boundary refresh gate."""
         mock_client = _make_matrix_client_mock()
         mock_response = MagicMock()
         mock_response.__class__ = nio.RoomSendResponse
@@ -1149,13 +1149,13 @@ class TestStreamingBehavior:
             _DeliveryRequest(
                 boundary_refresh=True,
                 prior_delta_at=100.0,
-                boundary_refresh_prior_delta_at=100.1,
+                boundary_refresh_prior_delta_at=100.0,
             ),
         )
 
         with (
-            patch("mindroom.streaming.time.time", return_value=100.2),
-            patch("mindroom.streaming_delivery.time.time", return_value=100.2),
+            patch("mindroom.streaming.time.time", return_value=100.0),
+            patch("mindroom.streaming_delivery.time.time", return_value=100.0),
         ):
             shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
 
@@ -1692,6 +1692,37 @@ class TestStreamingBehavior:
         sent_content = mock_client.room_send.call_args[1]["content"]
         assert sent_content["body"].startswith(PROGRESS_PLACEHOLDER)
         assert IN_PROGRESS_MARKER not in sent_content["body"]
+
+    @pytest.mark.asyncio
+    async def test_placeholder_progress_hint_does_not_resend_after_commit(self) -> None:
+        """Whitespace-only placeholder sends should advance throttle state after committing."""
+        mock_client = _make_matrix_client_mock()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$placeholder_progress_1"
+        mock_client.room_send.return_value = mock_response
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=5.0,
+            progress_update_interval=0.2,
+            show_tool_calls=False,
+        )
+        streaming.accumulated_text = "\n\n"
+        streaming.stream_started_at = 100.0
+        streaming.last_update = 100.0
+
+        with patch("mindroom.streaming.time.time", return_value=100.25):
+            await streaming._throttled_send(mock_client, progress_hint=True)
+        with patch("mindroom.streaming.time.time", return_value=100.26):
+            await streaming._throttled_send(mock_client, progress_hint=True)
+
+        assert mock_client.room_send.call_count == 1
 
     @pytest.mark.asyncio
     async def test_finalize_strips_marker_from_placeholder_only_stream(self) -> None:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -3154,6 +3154,49 @@ class TestStreamingBehavior:
             == "<p>Thinking...</p>\n<p>⚠️ Worker startup failed for <code>shell.run</code>: intentional example.</p>"
         )
 
+    @pytest.mark.asyncio
+    async def test_worker_warmup_failure_notice_clears_before_visible_tool_start(self) -> None:
+        """A visible tool-start marker should clear stale worker failure suffixes before sending."""
+        mock_client = _make_matrix_client_mock()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$warmup_tool_start"
+        mock_client.room_send.return_value = mock_response
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            show_tool_calls=True,
+        )
+        streaming.apply_worker_progress_event(
+            WorkerProgressEvent(
+                tool_name="shell",
+                function_name="run",
+                progress=WorkerReadyProgress(
+                    phase="failed",
+                    worker_key="worker-a",
+                    backend_name="kubernetes",
+                    elapsed_seconds=4.0,
+                    error="boom",
+                ),
+            ),
+        )
+
+        async def response_stream() -> AsyncIterator[object]:
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
+
+        await _consume_streaming_chunks_for_test(mock_client, response_stream(), streaming)
+        await streaming.finalize(mock_client)
+
+        assert mock_client.room_send.call_count == 2
+        first_body = mock_client.room_send.call_args_list[0].kwargs["content"]["body"]
+        assert "save_file" in first_body
+        assert "Worker startup failed" not in first_body
+
 
 class TestStreamingConfig:
     """Tests for StreamingConfig and its wiring into send_streaming_response."""

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -863,6 +863,109 @@ class TestStreamingBehavior:
         assert "save_file" in streaming.accumulated_text
 
     @pytest.mark.asyncio
+    async def test_visible_tool_start_after_intervening_edit_refreshes_immediately(self) -> None:
+        """A later visible tool start should refresh immediately once another edit has already landed."""
+        mock_client = _make_matrix_client_mock()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$tool_start_after_text"
+        mock_client.room_send.return_value = mock_response
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=1,
+            min_update_char_threshold=1,
+            min_char_update_interval=0.0,
+            progress_update_interval=10.0,
+            max_idle=0.25,
+            show_tool_calls=True,
+        )
+        streaming.last_update = float("-inf")
+
+        async def response_stream() -> AsyncIterator[object]:
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            yield "x"
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
+
+        await _consume_streaming_chunks_for_test(mock_client, response_stream(), streaming)
+
+        assert mock_client.room_send.call_count == 3
+        bodies = [
+            call.kwargs["content"].get("m.new_content", call.kwargs["content"])["body"]
+            for call in mock_client.room_send.call_args_list
+        ]
+        assert "search_web" in bodies[0]
+        assert "save_file" not in bodies[1]
+        assert "save_file" in bodies[2]
+
+    @pytest.mark.asyncio
+    async def test_hidden_tool_start_does_not_block_subsequent_stream_events_on_matrix_send(self) -> None:
+        """Hidden tool-start preflush should not wait for Matrix I/O before pulling later events."""
+        mock_client = _make_matrix_client_mock()
+        first_send_started = asyncio.Event()
+        allow_send_to_finish = asyncio.Event()
+        second_yield_started = asyncio.Event()
+
+        async def slow_room_send(*args: object, **kwargs: object) -> nio.RoomSendResponse:
+            _ = (args, kwargs)
+            first_send_started.set()
+            await allow_send_to_finish.wait()
+            mock_response = MagicMock()
+            mock_response.__class__ = nio.RoomSendResponse
+            mock_response.event_id = "$hidden_tool_start_backpressure"
+            return mock_response
+
+        mock_client.room_send.side_effect = slow_room_send
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            max_idle=0.25,
+            show_tool_calls=False,
+        )
+        streaming.last_update = 100.0
+        streaming.stream_started_at = 100.0
+
+        async def response_stream() -> AsyncIterator[object]:
+            yield "partial text"
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
+            second_yield_started.set()
+            yield "after"
+
+        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        consume_task = asyncio.create_task(_consume_streaming_chunks_impl(response_stream(), streaming, delivery_queue))
+
+        await first_send_started.wait()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert second_yield_started.is_set()
+
+        allow_send_to_finish.set()
+        await consume_task
+        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        assert shutdown_error is None
+
+    @pytest.mark.asyncio
     async def test_idle_flush_fires_on_tool_completion_after_pause(self) -> None:
         """A paused tool completion should emit before finalization via the idle trigger."""
         mock_client = _make_matrix_client_mock()
@@ -991,6 +1094,58 @@ class TestStreamingBehavior:
             await streaming.update_content("Hi", mock_client)
 
         assert mock_client.room_send.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_force_flush_initializes_stream_started_at(self) -> None:
+        """Direct force-flush sends should anchor the ramp window from that first visible send."""
+        mock_client = _make_matrix_client_mock()
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+        )
+        streaming._send_content = AsyncMock(return_value=True)
+
+        with patch("mindroom.streaming.time.time", side_effect=[100.0, 101.0]):
+            streaming._update("hello")
+            await streaming.force_flush(mock_client)
+
+        assert streaming.stream_started_at == 101.0
+
+    @pytest.mark.asyncio
+    async def test_boundary_refresh_initializes_stream_started_at(self) -> None:
+        """Boundary-refresh sends should anchor the ramp window before later throttled edits."""
+        mock_client = _make_matrix_client_mock()
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+        )
+        streaming.accumulated_text = "hello"
+        streaming.chars_since_last_update = len(streaming.accumulated_text)
+        streaming._send_or_edit_message = AsyncMock(return_value=True)
+
+        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue.put_nowait(_DeliveryRequest(boundary_refresh=True))
+
+        with (
+            patch("mindroom.streaming.time.time", return_value=101.0),
+            patch(
+                "mindroom.streaming_delivery.time.time",
+                return_value=101.0,
+            ),
+        ):
+            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+
+        assert shutdown_error is None
+        assert streaming.stream_started_at == 101.0
 
     @pytest.mark.asyncio
     async def test_idle_flush_followed_by_small_chunk_does_not_double_emit(self) -> None:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -978,8 +978,20 @@ class TestStreamingBehavior:
         assert "save_file" in bodies[2]
 
     @pytest.mark.asyncio
-    async def test_hidden_tool_start_does_not_block_subsequent_stream_events_on_matrix_send(self) -> None:
-        """Hidden tool-start preflush should not wait for Matrix I/O before pulling later events."""
+    @pytest.mark.parametrize(
+        ("show_tool_calls", "streaming_cls", "event_id"),
+        [
+            pytest.param(False, StreamingResponse, "$hidden_tool_start_backpressure", id="hidden"),
+            pytest.param(True, ReplacementStreamingResponse, "$visible_tool_start_backpressure", id="visible"),
+        ],
+    )
+    async def test_tool_start_does_not_block_subsequent_stream_events_on_matrix_send(
+        self,
+        show_tool_calls: bool,
+        streaming_cls: type[StreamingResponse],
+        event_id: str,
+    ) -> None:
+        """Tool-start capture waits should not block later stream events while Matrix I/O is in flight."""
         mock_client = _make_matrix_client_mock()
         first_send_started = asyncio.Event()
         allow_send_to_finish = asyncio.Event()
@@ -991,12 +1003,12 @@ class TestStreamingBehavior:
             await allow_send_to_finish.wait()
             mock_response = MagicMock()
             mock_response.__class__ = nio.RoomSendResponse
-            mock_response.event_id = "$hidden_tool_start_backpressure"
+            mock_response.event_id = event_id
             return mock_response
 
         mock_client.room_send.side_effect = slow_room_send
 
-        streaming = StreamingResponse(
+        streaming = streaming_cls(
             room_id="!test:localhost",
             reply_to_event_id="$original_123",
             thread_id=None,
@@ -1006,14 +1018,17 @@ class TestStreamingBehavior:
             update_interval=10.0,
             min_update_interval=10.0,
             interval_ramp_seconds=0.0,
-            max_idle=0.25,
-            show_tool_calls=False,
+            update_char_threshold=1,
+            min_update_char_threshold=1,
+            min_char_update_interval=0.0,
+            max_idle=10.0,
+            show_tool_calls=show_tool_calls,
         )
         streaming.last_update = 100.0
         streaming.stream_started_at = 100.0
 
         async def response_stream() -> AsyncIterator[object]:
-            yield "partial text"
+            yield "x"
             yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
             second_yield_started.set()
             yield "after"
@@ -1031,6 +1046,64 @@ class TestStreamingBehavior:
         await consume_task
         shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
         assert shutdown_error is None
+
+    @pytest.mark.asyncio
+    async def test_visible_tool_start_after_unsent_text_refreshes_immediately(self) -> None:
+        """A second visible tool start should bypass the refresh gate after an unsent text delta."""
+        mock_client = _make_matrix_client_mock()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$tool_start_after_unsent_text"
+        mock_client.room_send.return_value = mock_response
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=10_000,
+            min_update_char_threshold=10_000,
+            min_char_update_interval=10.0,
+            progress_update_interval=10.0,
+            max_idle=10.0,
+            show_tool_calls=True,
+        )
+        streaming.event_id = "$existing_event"
+        streaming.last_update = 100.0
+        streaming.stream_started_at = 100.0
+        streaming.last_boundary_refresh_at = 100.0
+        streaming.accumulated_text = "\n\n🔧 `search_web` [1] ⏳\nx\n\n🔧 `save_file` [2] ⏳\n"
+        streaming.chars_since_last_update = len(streaming.accumulated_text)
+
+        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue.put_nowait(
+            _DeliveryRequest(
+                boundary_refresh=True,
+                prior_delta_at=100.0,
+                boundary_refresh_prior_delta_at=100.1,
+            ),
+        )
+
+        with (
+            patch("mindroom.streaming.time.time", return_value=100.2),
+            patch("mindroom.streaming_delivery.time.time", return_value=100.2),
+        ):
+            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+
+        assert shutdown_error is None
+        assert mock_client.room_send.call_count == 1
+        bodies = [
+            call.kwargs["content"].get("m.new_content", call.kwargs["content"])["body"]
+            for call in mock_client.room_send.call_args_list
+        ]
+        assert "search_web" in bodies[-1]
+        assert "save_file" in bodies[-1]
 
     @pytest.mark.asyncio
     async def test_idle_flush_fires_on_tool_completion_after_pause(self) -> None:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -60,6 +60,7 @@ from mindroom.streaming_delivery import (
 from mindroom.streaming_delivery import (
     _DeliveryRequest,
     _drive_stream_delivery,
+    _flush_phase_boundary_if_needed,
     _shutdown_stream_delivery,
     _StreamDeliveryShutdownTimeoutError,
 )
@@ -1121,8 +1122,8 @@ class TestStreamingBehavior:
         assert streaming.chars_since_last_update == 0
 
     @pytest.mark.asyncio
-    async def test_force_flush_ignores_whitespace_only_buffer(self) -> None:
-        """Whitespace-only buffered text should not consume the first visible send window."""
+    async def test_phase_boundary_flush_ignores_whitespace_only_buffer(self) -> None:
+        """Whitespace-only pre-tool flushes should not consume the first visible send window."""
         mock_client = _make_matrix_client_mock()
         mock_response = MagicMock()
         mock_response.__class__ = nio.RoomSendResponse
@@ -1149,9 +1150,17 @@ class TestStreamingBehavior:
         with patch("mindroom.streaming.time.time", return_value=100.0):
             streaming._update("\n")
 
-        with patch("mindroom.streaming.time.time", side_effect=[101.0, 101.0, 101.0]):
-            await streaming.force_flush(mock_client)
+        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        await _flush_phase_boundary_if_needed(streaming, delivery_queue)
 
+        with (
+            patch("mindroom.streaming.time.time", return_value=101.0),
+            patch("mindroom.streaming_delivery.time.time", return_value=101.0),
+        ):
+            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+
+        assert shutdown_error is None
         assert mock_client.room_send.call_count == 0
         assert streaming.last_update == float("-inf")
         assert streaming.chars_since_last_update == 1
@@ -1160,26 +1169,6 @@ class TestStreamingBehavior:
             await streaming.update_content("Hi", mock_client)
 
         assert mock_client.room_send.call_count == 1
-
-    @pytest.mark.asyncio
-    async def test_force_flush_initializes_stream_started_at(self) -> None:
-        """Direct force-flush sends should anchor the ramp window from that first visible send."""
-        mock_client = _make_matrix_client_mock()
-        streaming = StreamingResponse(
-            room_id="!test:localhost",
-            reply_to_event_id="$original_123",
-            thread_id=None,
-            sender_domain="localhost",
-            config=self.config,
-            runtime_paths=runtime_paths_for(self.config),
-        )
-        streaming._send_content = AsyncMock(return_value=True)
-
-        with patch("mindroom.streaming.time.time", side_effect=[100.0, 101.0]):
-            streaming._update("hello")
-            await streaming.force_flush(mock_client)
-
-        assert streaming.stream_started_at == 101.0
 
     @pytest.mark.asyncio
     async def test_boundary_refresh_initializes_stream_started_at(self) -> None:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -754,13 +754,129 @@ class TestStreamingBehavior:
         assert "search_web" in bodies[1]
 
     @pytest.mark.asyncio
+    async def test_visible_tool_start_does_not_block_subsequent_stream_events_on_matrix_send(self) -> None:
+        """Visible tool-start refreshes must not backpressure later stream events on Matrix I/O."""
+        mock_client = _make_matrix_client_mock()
+        first_send_started = asyncio.Event()
+        allow_send_to_finish = asyncio.Event()
+        second_yield_started = asyncio.Event()
+
+        async def slow_room_send(*args: object, **kwargs: object) -> nio.RoomSendResponse:
+            _ = (args, kwargs)
+            first_send_started.set()
+            await allow_send_to_finish.wait()
+            mock_response = MagicMock()
+            mock_response.__class__ = nio.RoomSendResponse
+            mock_response.event_id = "$tool_start_backpressure"
+            return mock_response
+
+        mock_client.room_send.side_effect = slow_room_send
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            max_idle=0.25,
+            show_tool_calls=True,
+        )
+        streaming.last_update = 100.0
+        streaming.stream_started_at = 100.0
+
+        async def response_stream() -> AsyncIterator[object]:
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
+            second_yield_started.set()
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
+
+        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        consume_task = asyncio.create_task(_consume_streaming_chunks_impl(response_stream(), streaming, delivery_queue))
+
+        await first_send_started.wait()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert second_yield_started.is_set()
+
+        allow_send_to_finish.set()
+        await consume_task
+        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        assert shutdown_error is None
+
+    @pytest.mark.asyncio
+    async def test_visible_tool_start_burst_coalesces_to_one_nonterminal_send(self) -> None:
+        """Rapid visible tool-start bursts should not emit one Matrix edit per tool."""
+        mock_client = _make_matrix_client_mock()
+        first_send_started = asyncio.Event()
+        allow_send_to_finish = asyncio.Event()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$tool_start_burst"
+
+        async def slow_room_send(*args: object, **kwargs: object) -> nio.RoomSendResponse:
+            _ = (args, kwargs)
+            first_send_started.set()
+            await allow_send_to_finish.wait()
+            return mock_response
+
+        mock_client.room_send.side_effect = slow_room_send
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            min_char_update_interval=10.0,
+            max_idle=0.25,
+            show_tool_calls=True,
+        )
+        streaming.last_update = 100.0
+        streaming.stream_started_at = 100.0
+
+        async def response_stream() -> AsyncIterator[object]:
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
+
+        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        consume_task = asyncio.create_task(_consume_streaming_chunks_impl(response_stream(), streaming, delivery_queue))
+
+        await first_send_started.wait()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        allow_send_to_finish.set()
+        await consume_task
+        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        assert shutdown_error is None
+
+        assert mock_client.room_send.call_count == 1
+        assert "search_web" in streaming.accumulated_text
+        assert "save_file" in streaming.accumulated_text
+
+    @pytest.mark.asyncio
     async def test_idle_flush_fires_on_tool_completion_after_pause(self) -> None:
         """A paused tool completion should emit before finalization via the idle trigger."""
         mock_client = _make_matrix_client_mock()
         mock_response = MagicMock()
         mock_response.__class__ = nio.RoomSendResponse
         mock_response.event_id = "$stream_tool_complete_1"
-        mock_client.room_send.return_value = mock_response
+        first_send_seen = asyncio.Event()
+
+        async def room_send(*args: object, **kwargs: object) -> nio.RoomSendResponse:
+            _ = (args, kwargs)
+            first_send_seen.set()
+            return mock_response
+
+        mock_client.room_send.side_effect = room_send
 
         streaming = StreamingResponse(
             room_id="!test:localhost",
@@ -785,9 +901,10 @@ class TestStreamingBehavior:
 
         async def response_stream() -> AsyncIterator[object]:
             yield ToolCallStartedEvent(tool=tool)
+            await first_send_seen.wait()
             yield ToolCallCompletedEvent(tool=tool, content="ok")
 
-        with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0, 100.5, 100.5, 100.5]):
+        with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0, 100.0, 100.5, 100.5, 100.5]):
             await _consume_streaming_chunks_for_test(mock_client, response_stream(), streaming)
 
         assert mock_client.room_send.call_count == 2
@@ -3243,6 +3360,52 @@ class TestStreamingBehavior:
         first_body = mock_client.room_send.call_args_list[0].kwargs["content"]["body"]
         assert "save_file" in first_body
         assert "Worker startup failed" not in first_body
+
+    @pytest.mark.asyncio
+    async def test_worker_warmup_failure_notice_clears_before_hidden_tool_start(self) -> None:
+        """A hidden tool-start keepalive should drop stale worker failure suffixes before sending."""
+        mock_client = _make_matrix_client_mock()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$warmup_hidden_tool_start"
+        mock_client.room_send.return_value = mock_response
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            show_tool_calls=False,
+            progress_update_interval=0.0,
+        )
+        streaming.last_update = 100.0
+        streaming.stream_started_at = 100.0
+        streaming.apply_worker_progress_event(
+            WorkerProgressEvent(
+                tool_name="shell",
+                function_name="run",
+                progress=WorkerReadyProgress(
+                    phase="failed",
+                    worker_key="worker-a",
+                    backend_name="kubernetes",
+                    elapsed_seconds=4.0,
+                    error="boom",
+                ),
+            ),
+        )
+
+        async def response_stream() -> AsyncIterator[object]:
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
+
+        with patch("mindroom.streaming.time.time", return_value=100.25):
+            await _consume_streaming_chunks_for_test(mock_client, response_stream(), streaming)
+        await streaming.finalize(mock_client)
+
+        assert mock_client.room_send.call_count == 2
+        first_body = mock_client.room_send.call_args_list[0].kwargs["content"]["body"]
+        assert first_body == "Thinking..."
 
 
 class TestStreamingConfig:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -55,7 +55,12 @@ from mindroom.streaming import (
     is_interrupted_partial_reply,
     send_streaming_response,
 )
-from mindroom.streaming_delivery import _shutdown_stream_delivery, _StreamDeliveryShutdownTimeoutError
+from mindroom.streaming_delivery import (
+    _DeliveryRequest,
+    _drive_stream_delivery,
+    _shutdown_stream_delivery,
+    _StreamDeliveryShutdownTimeoutError,
+)
 from mindroom.tool_system.runtime_context import WorkerProgressEvent, get_worker_progress_pump
 from mindroom.workers.models import WorkerReadyProgress
 from tests.conftest import (
@@ -2336,6 +2341,43 @@ class TestStreamingBehavior:
 
         assert shutdown_error is None
         await delivery_task
+
+    @pytest.mark.asyncio
+    async def test_drive_stream_delivery_uses_latest_prior_delta_at_when_merging_requests(self) -> None:
+        """Merged requests must keep the newest prior_delta_at for idle-flush decisions."""
+        mock_client = _make_matrix_client_mock()
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+        )
+        seen_prior_delta_at: list[float | None] = []
+
+        async def record_throttled_send(
+            _client: object,
+            *,
+            progress_hint: bool = False,
+            prior_delta_at: float | None = None,
+        ) -> None:
+            assert progress_hint is False
+            seen_prior_delta_at.append(prior_delta_at)
+
+        streaming._throttled_send = AsyncMock(side_effect=record_throttled_send)
+
+        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue.put_nowait(_DeliveryRequest(prior_delta_at=None))
+        delivery_queue.put_nowait(_DeliveryRequest(prior_delta_at=100.0))
+        delivery_queue.put_nowait(_DeliveryRequest(prior_delta_at=100.1))
+
+        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+
+        assert shutdown_error is None
+        assert streaming._throttled_send.await_count == 1
+        assert seen_prior_delta_at == [100.1]
 
     @pytest.mark.asyncio
     async def test_send_streaming_response_skips_terminal_finalize_when_delivery_shutdown_times_out(self) -> None:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -2410,8 +2410,8 @@ class TestStreamingBehavior:
         await delivery_task
 
     @pytest.mark.asyncio
-    async def test_drive_stream_delivery_uses_latest_prior_delta_at_when_merging_requests(self) -> None:
-        """Merged requests must keep the newest prior_delta_at for idle-flush decisions."""
+    async def test_drive_stream_delivery_preserves_oldest_prior_delta_at_for_idle_flush(self) -> None:
+        """Merged requests must retain the oldest unsent delta so idle flush still fires."""
         mock_client = _make_matrix_client_mock()
         streaming = StreamingResponse(
             room_id="!test:localhost",
@@ -2420,31 +2420,33 @@ class TestStreamingBehavior:
             sender_domain="localhost",
             config=self.config,
             runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=10_000,
+            min_update_char_threshold=10_000,
+            min_char_update_interval=0.0,
+            max_idle=0.25,
         )
-        seen_prior_delta_at: list[float | None] = []
-
-        async def record_throttled_send(
-            _client: object,
-            *,
-            progress_hint: bool = False,
-            prior_delta_at: float | None = None,
-        ) -> None:
-            assert progress_hint is False
-            seen_prior_delta_at.append(prior_delta_at)
-
-        streaming._throttled_send = AsyncMock(side_effect=record_throttled_send)
+        streaming.event_id = "$existing_event"
+        streaming.stream_started_at = 100.0
+        streaming.last_update = 100.0
+        streaming.last_delta_at = 105.0
+        streaming.accumulated_text = "first second"
+        streaming.chars_since_last_update = len(streaming.accumulated_text)
+        streaming._send_or_edit_message = AsyncMock(return_value=True)
 
         delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
         delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
-        delivery_queue.put_nowait(_DeliveryRequest(prior_delta_at=None))
         delivery_queue.put_nowait(_DeliveryRequest(prior_delta_at=100.0))
-        delivery_queue.put_nowait(_DeliveryRequest(prior_delta_at=100.1))
+        delivery_queue.put_nowait(_DeliveryRequest(prior_delta_at=105.0))
 
-        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        with patch("mindroom.streaming.time.time", return_value=105.02):
+            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
 
         assert shutdown_error is None
-        assert streaming._throttled_send.await_count == 1
-        assert seen_prior_delta_at == [100.1]
+        assert streaming._send_or_edit_message.await_count == 1
+        assert streaming.chars_since_last_update == 0
 
     @pytest.mark.asyncio
     async def test_send_streaming_response_skips_terminal_finalize_when_delivery_shutdown_times_out(self) -> None:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import nio
 import pytest
 from agno.models.response import ToolExecution
-from agno.run.agent import ToolCallStartedEvent
+from agno.run.agent import ToolCallCompletedEvent, ToolCallStartedEvent
 from pydantic import ValidationError
 
 from mindroom.bot import AgentBot
@@ -752,6 +752,51 @@ class TestStreamingBehavior:
         assert bodies[0].startswith("x" * 40)
         assert "search_web" in bodies[0]
         assert "search_web" in bodies[1]
+
+    @pytest.mark.asyncio
+    async def test_idle_flush_fires_on_tool_completion_after_pause(self) -> None:
+        """A paused tool completion should emit before finalization via the idle trigger."""
+        mock_client = _make_matrix_client_mock()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$stream_tool_complete_1"
+        mock_client.room_send.return_value = mock_response
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=10_000,
+            min_update_char_threshold=10_000,
+            min_char_update_interval=0.0,
+            max_idle=0.25,
+            show_tool_calls=True,
+        )
+        streaming.last_update = 100.0
+        streaming.stream_started_at = 100.0
+
+        tool = ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}, result="ok")
+
+        async def response_stream() -> AsyncIterator[object]:
+            yield ToolCallStartedEvent(tool=tool)
+            yield ToolCallCompletedEvent(tool=tool, content="ok")
+
+        with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0, 100.5, 100.5, 100.5]):
+            await _consume_streaming_chunks_for_test(mock_client, response_stream(), streaming)
+
+        assert mock_client.room_send.call_count == 2
+        bodies = [
+            call.kwargs["content"].get("m.new_content", call.kwargs["content"])["body"]
+            for call in mock_client.room_send.call_args_list
+        ]
+        assert "⏳" in bodies[0]
+        assert "⏳" not in bodies[1]
 
     @pytest.mark.asyncio
     async def test_idle_flush_fires_on_text_after_pause(self) -> None:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -930,6 +930,69 @@ class TestStreamingBehavior:
         assert "save_file" in bodies[1]
 
     @pytest.mark.asyncio
+    async def test_back_to_back_visible_tool_starts_refresh_immediately_without_intervening_text(self) -> None:
+        """Back-to-back visible tool starts should both surface before finalization."""
+        mock_client = _make_matrix_client_mock()
+        send_count = 0
+
+        async def room_send(*args: object, **kwargs: object) -> nio.RoomSendResponse:
+            nonlocal send_count
+            _ = (args, kwargs)
+            send_count += 1
+            mock_response = MagicMock()
+            mock_response.__class__ = nio.RoomSendResponse
+            mock_response.event_id = f"$tool_start_post_delta_{send_count}"
+            return mock_response
+
+        mock_client.room_send.side_effect = room_send
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=10_000,
+            min_update_char_threshold=10_000,
+            min_char_update_interval=10.0,
+            progress_update_interval=10.0,
+            max_idle=0.25,
+            show_tool_calls=True,
+        )
+        streaming.last_update = 100.0
+        streaming.stream_started_at = 100.0
+
+        async def first_response_stream() -> AsyncIterator[object]:
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
+
+        with (
+            patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0]),
+            patch("mindroom.streaming_delivery.time.time", return_value=100.0),
+        ):
+            await _consume_streaming_chunks_for_test(mock_client, first_response_stream(), streaming)
+
+        async def second_response_stream() -> AsyncIterator[object]:
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
+
+        with (
+            patch("mindroom.streaming.time.time", side_effect=[100.1, 100.1]),
+            patch("mindroom.streaming_delivery.time.time", return_value=100.1),
+        ):
+            await _consume_streaming_chunks_for_test(mock_client, second_response_stream(), streaming)
+
+        assert mock_client.room_send.call_count == 2
+        bodies = [
+            call.kwargs["content"].get("m.new_content", call.kwargs["content"])["body"]
+            for call in mock_client.room_send.call_args_list
+        ]
+        assert "search_web" in bodies[0]
+        assert "save_file" in bodies[1]
+
+    @pytest.mark.asyncio
     async def test_visible_tool_start_after_intervening_edit_refreshes_immediately(self) -> None:
         """A later visible tool start should refresh immediately once another edit has already landed."""
         mock_client = _make_matrix_client_mock()
@@ -1242,6 +1305,73 @@ class TestStreamingBehavior:
             await streaming.update_content("Hi", mock_client)
 
         assert mock_client.room_send.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_stale_nonterminal_send_does_not_strand_newer_text(self) -> None:
+        """A stale send must not reset throttling state for a newer buffered chunk."""
+        mock_client = _make_matrix_client_mock()
+        first_send_started = asyncio.Event()
+        allow_first_send_to_finish = asyncio.Event()
+        second_yield_started = asyncio.Event()
+        send_count = 0
+
+        async def room_send(*args: object, **kwargs: object) -> nio.RoomSendResponse:
+            nonlocal send_count
+            _ = (args, kwargs)
+            send_count += 1
+            if send_count == 1:
+                first_send_started.set()
+                await allow_first_send_to_finish.wait()
+            mock_response = MagicMock()
+            mock_response.__class__ = nio.RoomSendResponse
+            mock_response.event_id = f"$stale_send_{send_count}"
+            return mock_response
+
+        mock_client.room_send.side_effect = room_send
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_char_threshold=1,
+            min_char_update_interval=0.35,
+            max_idle=0.25,
+        )
+        streaming.last_update = float("-inf")
+
+        async def response_stream() -> AsyncIterator[object]:
+            yield "A"
+            await first_send_started.wait()
+            second_yield_started.set()
+            yield "B"
+
+        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        streaming_times = iter([100.0, 100.0, 100.1, 100.2, 100.2, 100.2])
+
+        with patch("mindroom.streaming.time.time", side_effect=lambda: next(streaming_times, 100.2)):
+            consume_task = asyncio.create_task(
+                _consume_streaming_chunks_impl(response_stream(), streaming, delivery_queue),
+            )
+            await first_send_started.wait()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert second_yield_started.is_set()
+            allow_first_send_to_finish.set()
+            await consume_task
+            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+
+        assert shutdown_error is None
+        assert mock_client.room_send.call_count == 2
+        bodies = [
+            call.kwargs["content"].get("m.new_content", call.kwargs["content"])["body"]
+            for call in mock_client.room_send.call_args_list
+        ]
+        assert bodies[0] == "A"
+        assert bodies[1] == "AB"
 
     @pytest.mark.asyncio
     async def test_boundary_refresh_initializes_stream_started_at(self) -> None:
@@ -2852,6 +2982,42 @@ class TestStreamingBehavior:
         assert streaming.chars_since_last_update == 0
 
     @pytest.mark.asyncio
+    async def test_force_refresh_merge_preserves_boundary_refresh_capture_completion(self) -> None:
+        """Merged force-refresh sends must still resolve boundary-refresh capture waiters."""
+        mock_client = _make_matrix_client_mock()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$merged_force_refresh"
+        mock_client.room_send.return_value = mock_response
+
+        streaming = ReplacementStreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+        )
+        streaming.accumulated_text = "latest body"
+        streaming.chars_since_last_update = len(streaming.accumulated_text)
+
+        capture_completion = asyncio.get_running_loop().create_future()
+        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue.put_nowait(_DeliveryRequest(force_refresh=True))
+        delivery_queue.put_nowait(
+            _DeliveryRequest(boundary_refresh=True, capture_completion=capture_completion),
+        )
+
+        with patch("mindroom.streaming.time.time", return_value=101.0):
+            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+
+        assert shutdown_error is None
+        assert capture_completion.done()
+        assert capture_completion.result() is None
+        assert streaming.last_boundary_refresh_at == 101.0
+
+    @pytest.mark.asyncio
     async def test_send_streaming_response_skips_terminal_finalize_when_delivery_shutdown_times_out(self) -> None:
         """Terminal finalization must not run when the delivery owner refuses to stop."""
         mock_client = _make_matrix_client_mock()
@@ -3692,6 +3858,87 @@ class TestStreamingBehavior:
         assert mock_client.room_send.call_count == 2
         first_body = mock_client.room_send.call_args_list[0].kwargs["content"]["body"]
         assert first_body == "Thinking..."
+
+    @pytest.mark.asyncio
+    async def test_hidden_tool_start_force_refresh_clears_inflight_warmup_failure(self) -> None:
+        """A hidden tool start should correct an in-flight failed warmup notice immediately."""
+        mock_client = _make_matrix_client_mock()
+        first_send_started = asyncio.Event()
+        allow_first_send_to_finish = asyncio.Event()
+        send_count = 0
+
+        async def room_send(*args: object, **kwargs: object) -> nio.RoomSendResponse:
+            nonlocal send_count
+            _ = (args, kwargs)
+            send_count += 1
+            if send_count == 1:
+                first_send_started.set()
+                await allow_first_send_to_finish.wait()
+            mock_response = MagicMock()
+            mock_response.__class__ = nio.RoomSendResponse
+            mock_response.event_id = f"$warmup_hidden_refresh_{send_count}"
+            return mock_response
+
+        mock_client.room_send.side_effect = room_send
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            show_tool_calls=False,
+            update_interval=10.0,
+            min_update_interval=10.0,
+            progress_update_interval=10.0,
+            min_char_update_interval=0.35,
+            max_idle=0.25,
+        )
+        streaming.last_update = 100.0
+        streaming.stream_started_at = 100.0
+        streaming.apply_worker_progress_event(
+            WorkerProgressEvent(
+                tool_name="shell",
+                function_name="run",
+                progress=WorkerReadyProgress(
+                    phase="failed",
+                    worker_key="worker-a",
+                    backend_name="kubernetes",
+                    elapsed_seconds=4.0,
+                    error="boom",
+                ),
+            ),
+        )
+
+        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue.put_nowait(_DeliveryRequest(force_refresh=True, allow_empty_progress=True))
+
+        async def response_stream() -> AsyncIterator[object]:
+            await first_send_started.wait()
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
+
+        streaming_times = iter([100.1, 100.2, 100.3])
+        with patch("mindroom.streaming.time.time", side_effect=lambda: next(streaming_times, 100.3)):
+            consume_task = asyncio.create_task(
+                _consume_streaming_chunks_impl(response_stream(), streaming, delivery_queue),
+            )
+            await first_send_started.wait()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            allow_first_send_to_finish.set()
+            await consume_task
+            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+
+        assert shutdown_error is None
+        assert mock_client.room_send.call_count == 2
+        bodies = [
+            call.kwargs["content"].get("m.new_content", call.kwargs["content"])["body"]
+            for call in mock_client.room_send.call_args_list
+        ]
+        assert "Worker startup failed" in bodies[0]
+        assert bodies[1] == "Thinking..."
 
 
 class TestStreamingConfig:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -49,11 +49,13 @@ from mindroom.streaming import (
     ReplacementStreamingResponse,
     StreamingDeliveryError,
     StreamingResponse,
-    _consume_streaming_chunks,
     build_restart_interrupted_body,
     clean_partial_reply_text,
     is_interrupted_partial_reply,
     send_streaming_response,
+)
+from mindroom.streaming_delivery import (
+    _consume_streaming_chunks as _consume_streaming_chunks_impl,
 )
 from mindroom.streaming_delivery import (
     _DeliveryRequest,
@@ -105,6 +107,26 @@ def _make_matrix_client_mock() -> AsyncMock:
     client = make_matrix_client_mock(user_id="@mindroom_streaming:localhost")
     client.room_get_event_relations = MagicMock(return_value=_aiter())
     return client
+
+
+async def _consume_streaming_chunks_for_test(
+    client: nio.AsyncClient,
+    response_stream: AsyncIterator[object],
+    streaming: StreamingResponse,
+) -> None:
+    delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+    delivery_task = asyncio.create_task(_drive_stream_delivery(client, streaming, delivery_queue))
+    try:
+        await _consume_streaming_chunks_impl(response_stream, streaming, delivery_queue)
+        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        delivery_task = None
+        if shutdown_error is not None:
+            raise shutdown_error
+    finally:
+        if delivery_task is not None:
+            cleanup_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            if cleanup_error is not None:
+                raise cleanup_error
 
 
 @pytest.fixture
@@ -667,7 +689,7 @@ class TestStreamingBehavior:
                 yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
 
             with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0, 100.0, 100.0, 100.0]):
-                await _consume_streaming_chunks(mock_client, response_stream(), streaming)
+                await _consume_streaming_chunks_for_test(mock_client, response_stream(), streaming)
             await streaming.finalize(mock_client)
 
             assert mock_client.room_send.call_count == 2
@@ -719,7 +741,7 @@ class TestStreamingBehavior:
             yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
 
         with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0, 105.0, 105.0, 105.0]):
-            await _consume_streaming_chunks(mock_client, response_stream(), streaming)
+            await _consume_streaming_chunks_for_test(mock_client, response_stream(), streaming)
         await streaming.finalize(mock_client)
 
         assert mock_client.room_send.call_count == 2
@@ -950,7 +972,7 @@ class TestStreamingBehavior:
             yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
 
         with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0, 100.1, 100.1, 100.1]):
-            await _consume_streaming_chunks(mock_client, response_stream(), streaming)
+            await _consume_streaming_chunks_for_test(mock_client, response_stream(), streaming)
         await streaming.finalize(mock_client)
 
         assert streaming._send_or_edit_message.await_count == 2

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -13,6 +13,9 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import nio
 import pytest
+from agno.models.response import ToolExecution
+from agno.run.agent import ToolCallStartedEvent
+from pydantic import ValidationError
 
 from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig
@@ -46,6 +49,7 @@ from mindroom.streaming import (
     ReplacementStreamingResponse,
     StreamingDeliveryError,
     StreamingResponse,
+    _consume_streaming_chunks,
     build_restart_interrupted_body,
     clean_partial_reply_text,
     is_interrupted_partial_reply,
@@ -625,6 +629,362 @@ class TestStreamingBehavior:
 
         assert mock_client.room_send.call_count == 1
         assert streaming.event_id == "$stream_char_1"
+
+    @pytest.mark.asyncio
+    async def test_pre_tool_flush_fires_on_immediate_tool_start(self) -> None:
+        """Tool-start phase boundaries should flush buffered text immediately in both visible and hidden modes."""
+
+        async def run_case(*, show_tool_calls: bool) -> list[str]:
+            mock_client = _make_matrix_client_mock()
+            mock_response = MagicMock()
+            mock_response.__class__ = nio.RoomSendResponse
+            mock_response.event_id = "$stream_tool_1"
+            mock_client.room_send.return_value = mock_response
+
+            streaming = StreamingResponse(
+                room_id="!test:localhost",
+                reply_to_event_id="$original_123",
+                thread_id=None,
+                sender_domain="localhost",
+                config=self.config,
+                runtime_paths=runtime_paths_for(self.config),
+                update_interval=10.0,
+                min_update_interval=10.0,
+                interval_ramp_seconds=0.0,
+                max_idle=0.25,
+                show_tool_calls=show_tool_calls,
+            )
+            streaming.last_update = 100.0
+            streaming.stream_started_at = 100.0
+
+            async def response_stream() -> AsyncIterator[object]:
+                yield "Hello, this is a partial wo"
+                yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
+
+            with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0, 100.0, 100.0, 100.0]):
+                await _consume_streaming_chunks(mock_client, response_stream(), streaming)
+            await streaming.finalize(mock_client)
+
+            assert mock_client.room_send.call_count == 2
+            return [
+                call.kwargs["content"].get("m.new_content", call.kwargs["content"])["body"]
+                for call in mock_client.room_send.call_args_list
+            ]
+
+        visible_bodies = await run_case(show_tool_calls=True)
+        assert visible_bodies[0].startswith("Hello, this is a partial wo")
+        assert "search_web" in visible_bodies[0]
+        assert visible_bodies[1].startswith("Hello, this is a partial wo")
+        assert "search_web" in visible_bodies[1]
+
+        hidden_bodies = await run_case(show_tool_calls=False)
+        assert hidden_bodies[0] == "Hello, this is a partial wo"
+        assert hidden_bodies[1] == "Hello, this is a partial wo\n\n"
+
+    @pytest.mark.asyncio
+    async def test_pre_tool_flush_does_not_double_emit_after_idle_gap(self) -> None:
+        """Tool-start after an idle gap should not emit an extra edit before finalization."""
+        mock_client = _make_matrix_client_mock()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$stream_tool_gap_1"
+        mock_client.room_send.return_value = mock_response
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=48,
+            min_update_char_threshold=48,
+            min_char_update_interval=0.0,
+            max_idle=0.25,
+            show_tool_calls=True,
+        )
+        streaming.last_update = 100.0
+        streaming.stream_started_at = 100.0
+
+        async def response_stream() -> AsyncIterator[object]:
+            yield "x" * 40
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
+
+        with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0, 105.0, 105.0, 105.0]):
+            await _consume_streaming_chunks(mock_client, response_stream(), streaming)
+        await streaming.finalize(mock_client)
+
+        assert mock_client.room_send.call_count == 2
+        bodies = [
+            call.kwargs["content"].get("m.new_content", call.kwargs["content"])["body"]
+            for call in mock_client.room_send.call_args_list
+        ]
+        assert bodies[0].startswith("x" * 40)
+        assert "search_web" in bodies[0]
+        assert "search_web" in bodies[1]
+
+    @pytest.mark.asyncio
+    async def test_idle_flush_fires_on_text_after_pause(self) -> None:
+        """A long gap before the next text chunk should trigger an idle flush on that text event."""
+        mock_client = _make_matrix_client_mock()
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=10_000,
+            min_update_char_threshold=10_000,
+            min_char_update_interval=0.0,
+            max_idle=0.25,
+        )
+        streaming.event_id = "$existing_event"
+        streaming.stream_started_at = 100.0
+        streaming.last_update = 100.0
+        streaming._send_or_edit_message = AsyncMock(return_value=True)
+
+        with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0]):
+            await streaming.update_content("first", mock_client)
+
+        assert streaming._send_or_edit_message.await_count == 0
+
+        with patch("mindroom.streaming.time.time", side_effect=[105.0, 105.0, 105.0]):
+            await streaming.update_content(" second", mock_client)
+
+        assert streaming._send_or_edit_message.await_count == 1
+        assert streaming.last_delta_at == 105.0
+        assert streaming.chars_since_last_update == 0
+
+    @pytest.mark.asyncio
+    async def test_force_flush_ignores_whitespace_only_buffer(self) -> None:
+        """Whitespace-only buffered text should not consume the first visible send window."""
+        mock_client = _make_matrix_client_mock()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$stream_whitespace_1"
+        mock_client.room_send.return_value = mock_response
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=10_000,
+            min_update_char_threshold=10_000,
+            min_char_update_interval=10.0,
+            max_idle=0.25,
+        )
+        streaming.last_update = float("-inf")
+
+        with patch("mindroom.streaming.time.time", return_value=100.0):
+            streaming._update("\n")
+
+        with patch("mindroom.streaming.time.time", side_effect=[101.0, 101.0, 101.0]):
+            await streaming.force_flush(mock_client)
+
+        assert mock_client.room_send.call_count == 0
+        assert streaming.last_update == float("-inf")
+        assert streaming.chars_since_last_update == 1
+
+        with patch("mindroom.streaming.time.time", side_effect=[102.0, 102.0, 102.0]):
+            await streaming.update_content("Hi", mock_client)
+
+        assert mock_client.room_send.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_idle_flush_followed_by_small_chunk_does_not_double_emit(self) -> None:
+        """An idle flush should reset the idle baseline before the next small chunk arrives."""
+        mock_client = _make_matrix_client_mock()
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=10_000,
+            min_update_char_threshold=10_000,
+            min_char_update_interval=0.0,
+            max_idle=0.25,
+        )
+        streaming.event_id = "$existing_event"
+        streaming.stream_started_at = 100.0
+        streaming.last_update = 100.0
+        streaming._send_or_edit_message = AsyncMock(return_value=True)
+
+        with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0]):
+            await streaming.update_content("partial", mock_client)
+
+        with patch("mindroom.streaming.time.time", return_value=100.3):
+            await streaming._throttled_send(mock_client)
+
+        assert streaming._send_or_edit_message.await_count == 1
+
+        with patch("mindroom.streaming.time.time", side_effect=[100.35, 100.35, 100.35]):
+            await streaming.update_content("!", mock_client)
+
+        assert streaming._send_or_edit_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_idle_flush_does_not_fire_during_steady_streaming(self) -> None:
+        """Small inter-delta gaps should not inflate edit cadence via the idle trigger."""
+        mock_client = _make_matrix_client_mock()
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=0.5,
+            min_update_interval=0.5,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=10_000,
+            min_update_char_threshold=10_000,
+            min_char_update_interval=0.0,
+            max_idle=0.25,
+        )
+        streaming.event_id = "$existing_event"
+        streaming.stream_started_at = 100.0
+        streaming.last_update = 100.0
+        streaming._send_or_edit_message = AsyncMock(return_value=True)
+
+        clock = iter(100.0 + 0.03 * step for step in range(1, 80))
+        with patch("mindroom.streaming.time.time", side_effect=lambda: next(clock)):
+            for _ in range(20):
+                await streaming.update_content("a", mock_client)
+
+        assert streaming._send_or_edit_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_idle_flush_triggers_after_delta_gap(self) -> None:
+        """A single buffered chunk should flush once the idle gap exceeds max_idle."""
+        mock_client = _make_matrix_client_mock()
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=10_000,
+            min_update_char_threshold=10_000,
+            min_char_update_interval=0.0,
+            max_idle=0.25,
+        )
+        streaming.event_id = "$existing_event"
+        streaming.stream_started_at = 100.0
+        streaming.last_update = 100.0
+        streaming._send_or_edit_message = AsyncMock(return_value=True)
+
+        with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.05]):
+            await streaming.update_content("partial", mock_client)
+
+        assert streaming._send_or_edit_message.await_count == 0
+        assert streaming.last_delta_at == 100.0
+
+        with patch("mindroom.streaming.time.time", return_value=100.3):
+            await streaming._throttled_send(mock_client)
+
+        assert streaming._send_or_edit_message.await_count == 1
+        assert streaming.chars_since_last_update == 0
+
+    @pytest.mark.asyncio
+    async def test_pre_tool_flush_does_not_hide_tool_marker_below_threshold(self) -> None:
+        """A failed phase-boundary flush should preserve buffered chars so the marker can still surface."""
+        mock_client = _make_matrix_client_mock()
+        sent_bodies: list[str] = []
+        send_results = iter((False, True))
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=48,
+            min_update_char_threshold=48,
+            min_char_update_interval=0.0,
+            max_idle=10.0,
+            show_tool_calls=True,
+        )
+        streaming.last_update = 100.0
+        streaming.stream_started_at = 100.0
+
+        async def record_send(*args: object, **kwargs: object) -> bool:
+            _ = (args, kwargs)
+            sent_bodies.append(streaming.accumulated_text)
+            return next(send_results)
+
+        streaming._send_or_edit_message = AsyncMock(side_effect=record_send)
+
+        async def response_stream() -> AsyncIterator[object]:
+            yield "x" * 40
+            yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
+
+        with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0, 100.1, 100.1, 100.1]):
+            await _consume_streaming_chunks(mock_client, response_stream(), streaming)
+        await streaming.finalize(mock_client)
+
+        assert streaming._send_or_edit_message.await_count == 2
+        assert sent_bodies[0].startswith("x" * 40)
+        assert "search_web" in sent_bodies[0]
+        assert sent_bodies[1].startswith("x" * 40)
+        assert "search_web" in sent_bodies[1]
+
+    @pytest.mark.asyncio
+    async def test_idle_does_not_fire_below_min_char_interval(self) -> None:
+        """Idle-triggered edits should still respect the anti-spam minimum interval floor."""
+        mock_client = _make_matrix_client_mock()
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+            update_interval=10.0,
+            min_update_interval=10.0,
+            interval_ramp_seconds=0.0,
+            update_char_threshold=10_000,
+            min_update_char_threshold=10_000,
+            min_char_update_interval=0.35,
+            max_idle=0.25,
+        )
+        streaming.event_id = "$existing_event"
+        streaming.stream_started_at = 100.0
+        streaming.last_update = 100.0
+        streaming._send_or_edit_message = AsyncMock(return_value=True)
+
+        with patch("mindroom.streaming.time.time", side_effect=[100.0, 100.0]):
+            await streaming.update_content("first", mock_client)
+
+        with patch("mindroom.streaming.time.time", side_effect=[100.3, 100.3, 100.3]):
+            await streaming.update_content(" second", mock_client)
+
+        assert streaming._send_or_edit_message.await_count == 0
 
     @pytest.mark.asyncio
     async def test_progress_hint_uses_shorter_interval(self) -> None:
@@ -2741,11 +3101,12 @@ class TestStreamingConfig:
         assert sc.update_interval == sr["update_interval"].default
         assert sc.min_update_interval == sr["min_update_interval"].default
         assert sc.interval_ramp_seconds == sr["interval_ramp_seconds"].default
+        assert sc.max_idle == sr["max_idle"].default
 
     @pytest.mark.asyncio
     async def test_streaming_config_applied(self) -> None:
         """Custom StreamingConfig values should propagate to the StreamingResponse instance."""
-        sc = StreamingConfig(update_interval=2.0, min_update_interval=0.3, interval_ramp_seconds=10.0)
+        sc = StreamingConfig(update_interval=2.0, min_update_interval=0.3, interval_ramp_seconds=10.0, max_idle=0.7)
         config = Config(
             agents={"a": AgentConfig(display_name="A", rooms=["!r:localhost"])},
             models={"default": ModelConfig(provider="openai", id="gpt-5.4")},
@@ -2792,6 +3153,7 @@ class TestStreamingConfig:
         assert sr.update_interval == 2.0
         assert sr.min_update_interval == 0.3
         assert sr.interval_ramp_seconds == 10.0
+        assert sr.max_idle == 0.7
 
     def test_streaming_config_partial_override(self) -> None:
         """Setting only update_interval via Config should keep other fields at defaults."""
@@ -2805,6 +3167,7 @@ class TestStreamingConfig:
         assert sc.update_interval == 2.0
         assert sc.min_update_interval == 0.5
         assert sc.interval_ramp_seconds == 15.0
+        assert sc.max_idle == 0.25
 
     def test_streaming_config_validation(self) -> None:
         """Reject invalid values: update_interval <= 0, min_update_interval <= 0, interval_ramp_seconds < 0."""
@@ -2818,6 +3181,10 @@ class TestStreamingConfig:
             StreamingConfig(min_update_interval=-0.5)
         with pytest.raises(ValueError, match="greater than or equal to 0"):
             StreamingConfig(interval_ramp_seconds=-1)
+        with pytest.raises(ValidationError, match="greater than 0"):
+            StreamingConfig(max_idle=0)
+        with pytest.raises(ValidationError, match="greater than 0"):
+            StreamingConfig(max_idle=-0.25)
         # interval_ramp_seconds=0 should be valid (disables ramp)
         sc = StreamingConfig(interval_ramp_seconds=0)
         assert sc.interval_ramp_seconds == 0


### PR DESCRIPTION
## Summary
- add idle-time as a second flush trigger for buffered Matrix streaming text
- expose `max_idle` on streaming config and thread it through the runtime
- cover idle-gap and no-double-emit behavior in streaming tests

## Test Plan
- `.venv/bin/pytest tests/test_streaming_behavior.py -x -n 0 --no-cov -v`