### PR TITLE
Make thread summary temperature configurable and omit it for Vertex Claude

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -256,6 +256,7 @@ defaults:
   worker_scope: null               # Default: null (no runtime reuse; set shared/user/user_agent to enable)
   worker_grantable_credentials: null  # Default: null (deny by default; list credential service names to make available inside isolated workers, e.g. [openai, github_private])
   allow_self_config: false         # Default: false (allow agents to modify their own config via a tool)
+  thread_summary_temperature: 0.2  # Default: 0.2 (set null to omit temperature and use provider defaults)
   thread_summary_first_threshold: 1  # Default: 1 (first automatic thread summary after first message)
   thread_summary_subsequent_interval: 10  # Default: 10 (messages between later automatic thread summaries)
 
@@ -263,6 +264,10 @@ defaults:
 # Set agents.<name>.include_default_tools: false to opt out a specific agent.
 # defaults.streaming is also global-only and controls streamed message edit cadence.
 # Tools can be plain strings or single-key dicts with per-agent config overrides.
+
+MindRoom uses `defaults.thread_summary_temperature` for automatic thread summaries on providers that support runtime temperature overrides.
+Set it to `null` to omit the field and use provider defaults.
+MindRoom always omits temperature for Vertex Claude thread summaries because the provider rejects that field on this path.
 
 `defaults.worker_grantable_credentials` is a list of credential service names.
 Use built-in names like `openai`, `anthropic`, `google`, `openrouter`, `deepseek`, `cerebras`, `groq`, `ollama`, `google_oauth_client`, and `github_private`, or custom shared credential service names you saved through the dashboard or API.

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -356,6 +356,7 @@ defaults:
   show_tool_calls: true
   allow_self_config: false
   max_preload_chars: 50000  # Hard cap for context_files preload
+  thread_summary_temperature: 0.2  # Set null to omit temperature and use provider defaults
   thread_summary_first_threshold: 1  # First automatic thread summary after 1 message
   thread_summary_subsequent_interval: 10  # Re-summarize after each additional 10 messages
   # num_history_runs: null  # Default: all
@@ -364,6 +365,9 @@ defaults:
   # worker_tools: null  # Default: use built-in routing policy
   # worker_scope: null  # Default: no worker scoping
 ```
+
+Automatic thread summaries use `defaults.thread_summary_temperature` when the selected provider supports runtime temperature overrides.
+MindRoom always omits temperature for Vertex Claude thread summaries because the provider rejects that field on this path.
 
 ## Room Configuration
 

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -257,6 +257,7 @@ matrix_message(action="reply", message="Sharing the plan here.", attachment_ids=
 
 Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior.
 The summarizer posts one `m.notice` summary after a thread reaches five messages, and then again every ten additional messages, using `defaults.thread_summary_model` or `default`.
+MindRoom uses `defaults.thread_summary_temperature` for automatic summaries when the provider supports runtime temperature overrides, and always omits temperature for Vertex Claude summaries.
 The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
 
 ## Related Docs

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -256,7 +256,7 @@ matrix_message(action="reply", message="Sharing the plan here.", attachment_ids=
 ## Related Matrix Runtime Features
 
 Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior.
-The summarizer posts one `m.notice` summary after a thread reaches five messages, and then again every ten additional messages, using `defaults.thread_summary_model` or `default`.
+The summarizer posts one `m.notice` summary after a thread reaches the configured first threshold (one message by default), and then again every ten additional messages by default, using `defaults.thread_summary_model` or `default`.
 MindRoom uses `defaults.thread_summary_temperature` for automatic summaries when the provider supports runtime temperature overrides, and always omits temperature for Vertex Claude summaries.
 The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -5627,7 +5627,7 @@ matrix_message(action="reply", message="Sharing the plan here.", attachment_ids=
 
 ## Related Matrix Runtime Features
 
-Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior. The summarizer posts one `m.notice` summary after a thread reaches five messages, and then again every ten additional messages, using `defaults.thread_summary_model` or `default`. MindRoom uses `defaults.thread_summary_temperature` for automatic summaries when the provider supports runtime temperature overrides, and always omits temperature for Vertex Claude summaries. The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
+Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior. The summarizer posts one `m.notice` summary after a thread reaches the configured first threshold (one message by default), and then again every ten additional messages by default, using `defaults.thread_summary_model` or `default`. MindRoom uses `defaults.thread_summary_temperature` for automatic summaries when the provider supports runtime temperature overrides, and always omits temperature for Vertex Claude summaries. The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
 
 ## Related Docs
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -987,6 +987,7 @@ defaults:
   worker_scope: null               # Default: null (no runtime reuse; set shared/user/user_agent to enable)
   worker_grantable_credentials: null  # Default: null (deny by default; list credential service names to make available inside isolated workers, e.g. [openai, github_private])
   allow_self_config: false         # Default: false (allow agents to modify their own config via a tool)
+  thread_summary_temperature: 0.2  # Default: 0.2 (set null to omit temperature and use provider defaults)
   thread_summary_first_threshold: 1  # Default: 1 (first automatic thread summary after first message)
   thread_summary_subsequent_interval: 10  # Default: 10 (messages between later automatic thread summaries)
 
@@ -994,6 +995,10 @@ defaults:
 # Set agents.<name>.include_default_tools: false to opt out a specific agent.
 # defaults.streaming is also global-only and controls streamed message edit cadence.
 # Tools can be plain strings or single-key dicts with per-agent config overrides.
+
+MindRoom uses `defaults.thread_summary_temperature` for automatic thread summaries on providers that support runtime temperature overrides.
+Set it to `null` to omit the field and use provider defaults.
+MindRoom always omits temperature for Vertex Claude thread summaries because the provider rejects that field on this path.
 
 `defaults.worker_grantable_credentials` is a list of credential service names.
 Use built-in names like `openai`, `anthropic`, `google`, `openrouter`, `deepseek`, `cerebras`, `groq`, `ollama`, `google_oauth_client`, and `github_private`, or custom shared credential service names you saved through the dashboard or API.
@@ -5622,7 +5627,7 @@ matrix_message(action="reply", message="Sharing the plan here.", attachment_ids=
 
 ## Related Matrix Runtime Features
 
-Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior. The summarizer posts one `m.notice` summary after a thread reaches five messages, and then again every ten additional messages, using `defaults.thread_summary_model` or `default`. The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
+Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior. The summarizer posts one `m.notice` summary after a thread reaches five messages, and then again every ten additional messages, using `defaults.thread_summary_model` or `default`. MindRoom uses `defaults.thread_summary_temperature` for automatic summaries when the provider supports runtime temperature overrides, and always omits temperature for Vertex Claude summaries. The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
 
 ## Related Docs
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -250,6 +250,7 @@ defaults:
   worker_scope: null               # Default: null (no runtime reuse; set shared/user/user_agent to enable)
   worker_grantable_credentials: null  # Default: null (deny by default; list credential service names to make available inside isolated workers, e.g. [openai, github_private])
   allow_self_config: false         # Default: false (allow agents to modify their own config via a tool)
+  thread_summary_temperature: 0.2  # Default: 0.2 (set null to omit temperature and use provider defaults)
   thread_summary_first_threshold: 1  # Default: 1 (first automatic thread summary after first message)
   thread_summary_subsequent_interval: 10  # Default: 10 (messages between later automatic thread summaries)
 
@@ -257,6 +258,10 @@ defaults:
 # Set agents.<name>.include_default_tools: false to opt out a specific agent.
 # defaults.streaming is also global-only and controls streamed message edit cadence.
 # Tools can be plain strings or single-key dicts with per-agent config overrides.
+
+MindRoom uses `defaults.thread_summary_temperature` for automatic thread summaries on providers that support runtime temperature overrides.
+Set it to `null` to omit the field and use provider defaults.
+MindRoom always omits temperature for Vertex Claude thread summaries because the provider rejects that field on this path.
 
 `defaults.worker_grantable_credentials` is a list of credential service names.
 Use built-in names like `openai`, `anthropic`, `google`, `openrouter`, `deepseek`, `cerebras`, `groq`, `ollama`, `google_oauth_client`, and `github_private`, or custom shared credential service names you saved through the dashboard or API.

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -209,7 +209,7 @@ matrix_message(action="reply", message="Sharing the plan here.", attachment_ids=
 
 ## Related Matrix Runtime Features
 
-Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior. The summarizer posts one `m.notice` summary after a thread reaches five messages, and then again every ten additional messages, using `defaults.thread_summary_model` or `default`. The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
+Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior. The summarizer posts one `m.notice` summary after a thread reaches five messages, and then again every ten additional messages, using `defaults.thread_summary_model` or `default`. MindRoom uses `defaults.thread_summary_temperature` for automatic summaries when the provider supports runtime temperature overrides, and always omits temperature for Vertex Claude summaries. The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
 
 ## Related Docs
 

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -209,7 +209,7 @@ matrix_message(action="reply", message="Sharing the plan here.", attachment_ids=
 
 ## Related Matrix Runtime Features
 
-Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior. The summarizer posts one `m.notice` summary after a thread reaches five messages, and then again every ten additional messages, using `defaults.thread_summary_model` or `default`. MindRoom uses `defaults.thread_summary_temperature` for automatic summaries when the provider supports runtime temperature overrides, and always omits temperature for Vertex Claude summaries. The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
+Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior. The summarizer posts one `m.notice` summary after a thread reaches the configured first threshold (one message by default), and then again every ten additional messages by default, using `defaults.thread_summary_model` or `default`. MindRoom uses `defaults.thread_summary_temperature` for automatic summaries when the provider supports runtime temperature overrides, and always omits temperature for Vertex Claude summaries. The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
 
 ## Related Docs
 

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -376,6 +376,14 @@ class DefaultsConfig(BaseModel):
         default=None,
         description="Model config name for generating thread summaries (e.g., 'haiku'). Uses 'default' if not set.",
     )
+    thread_summary_temperature: float | None = Field(
+        default=0.2,
+        description=(
+            "Temperature override for automatic thread summaries. "
+            "Set to null to omit temperature and use provider defaults. "
+            "MindRoom always omits temperature for Vertex Claude thread summaries."
+        ),
+    )
     thread_summary_first_threshold: int = Field(
         default=1,
         ge=1,

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -78,6 +78,18 @@ class _SupportsTemperature(Protocol):
     temperature: float | None
 
 
+def _supports_summary_temperature_override(model: object) -> bool:
+    """Return whether the summary path should override ``model.temperature``.
+
+    Vertex Claude models currently reject a ``temperature`` parameter on the
+    rawPredict helper path even though the Python object exposes the attribute.
+    """
+    model_module = type(model).__module__
+    if model_module.startswith("agno.models.vertexai.claude"):
+        return False
+    return isinstance(model, _SupportsTemperature)
+
+
 def normalize_thread_summary_text(raw_text: str) -> str:
     """Strip common markdown formatting and collapse the result to one plain-text line."""
     normalized = raw_text.strip()
@@ -296,7 +308,7 @@ async def _generate_summary(
     """Generate a one-line summary of a thread conversation via LLM."""
     model_name = config.defaults.thread_summary_model or "default"
     model = model_loading.get_model_instance(config, runtime_paths, model_name)
-    if isinstance(model, _SupportsTemperature):
+    if _supports_summary_temperature_override(model):
         model.temperature = _SUMMARY_TEMPERATURE
     else:
         model_class = type(model).__name__

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import nio
 from agno.agent import Agent
+from agno.models.vertexai.claude import Claude as VertexAIClaude
 from pydantic import BaseModel, Field
 
 from mindroom import model_loading
@@ -41,7 +42,6 @@ _MARKDOWN_HEADING_RE = re.compile(r"(?m)^\s{0,3}#{1,6}\s+")
 _MARKDOWN_BLOCKQUOTE_RE = re.compile(r"(?m)^\s{0,3}>\s?")
 _MARKDOWN_LIST_ITEM_RE = re.compile(r"(?m)^\s*(?:[-+*]|\d+\.)\s+")
 _PREQUEUE_CONCURRENCY_MARGIN = 2
-_SUMMARY_TEMPERATURE = 0.2
 
 # In-memory tracking of last summarized message count per thread.
 # Key: "{room_id}:{thread_id}", value: message count at last summary.
@@ -78,16 +78,29 @@ class _SupportsTemperature(Protocol):
     temperature: float | None
 
 
-def _supports_summary_temperature_override(model: object) -> bool:
-    """Return whether the summary path should override ``model.temperature``.
+def _configure_summary_model_temperature(
+    model: object,
+    *,
+    summary_temperature: float | None,
+    model_name: str,
+) -> None:
+    """Prepare the summary model's temperature setting for one request."""
+    if isinstance(model, VertexAIClaude):
+        # Vertex Claude's rawPredict helper rejects a temperature field entirely.
+        model.temperature = None
+        return
+    if isinstance(model, _SupportsTemperature):
+        model.temperature = summary_temperature
+        return
+    if summary_temperature is None:
+        return
 
-    Vertex Claude models currently reject a ``temperature`` parameter on the
-    rawPredict helper path even though the Python object exposes the attribute.
-    """
-    model_module = type(model).__module__
-    if model_module.startswith("agno.models.vertexai.claude"):
-        return False
-    return isinstance(model, _SupportsTemperature)
+    model_class = type(model).__name__
+    logger.warning(
+        f"Thread summary model class {model_class} does not support a runtime temperature override; continuing with provider defaults",
+        model_class=model_class,
+        model_name=model_name,
+    )
 
 
 def normalize_thread_summary_text(raw_text: str) -> str:
@@ -308,15 +321,11 @@ async def _generate_summary(
     """Generate a one-line summary of a thread conversation via LLM."""
     model_name = config.defaults.thread_summary_model or "default"
     model = model_loading.get_model_instance(config, runtime_paths, model_name)
-    if _supports_summary_temperature_override(model):
-        model.temperature = _SUMMARY_TEMPERATURE
-    else:
-        model_class = type(model).__name__
-        logger.warning(
-            f"Thread summary model class {model_class} does not support a runtime temperature override; continuing with provider defaults",
-            model_class=model_class,
-            model_name=model_name,
-        )
+    _configure_summary_model_temperature(
+        model,
+        summary_temperature=config.defaults.thread_summary_temperature,
+        model_name=model_name,
+    )
 
     conversation = _build_conversation_text(thread_history)
     session_hash = hashlib.sha256(conversation.encode()).hexdigest()[:8]

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -185,6 +185,8 @@ def emit_elapsed_timing(label: str, start: float, **event_data: object) -> None:
         duration_ms=round((time.monotonic() - start) * 1000, 1),
         **event_data,
     )
+
+
 def timed(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator that logs elapsed time for sync/async functions.
 

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -365,6 +365,15 @@ class _TemperatureAwareModel:
         self.temperature = temperature
 
 
+class _VertexClaudeLikeTemperatureModel:
+    """Tiny stub mimicking Vertex Claude temperature behavior."""
+
+    __module__ = "agno.models.vertexai.claude"
+
+    def __init__(self, temperature: float | None = None) -> None:
+        self.temperature = temperature
+
+
 class _ModelWithoutTemperature:
     """Tiny real model stub for providers that do not expose temperature."""
 
@@ -1442,6 +1451,46 @@ class TestGenerateSummary:
         assert len(warning_messages) == 1
         assert "_ModelWithoutTemperature" in warning_messages[0]
         assert "does not support a runtime temperature override" in warning_messages[0]
+
+    async def test_generate_summary_skips_temperature_override_for_vertex_claude(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Vertex Claude should keep provider defaults for summary generation."""
+        history = _make_thread_history(3)
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+        mock_model = _VertexClaudeLikeTemperatureModel(temperature=0.9)
+        mock_response = MagicMock()
+        mock_response.content = _ThreadSummary(summary="🧵 ISSUE-200 vertex claude summary")
+        monkeypatch.delenv("MINDROOM_LOG_FORMAT", raising=False)
+        setup_logging(level="WARNING", runtime_paths=_logging_runtime_paths(tmp_path))
+        caplog.clear()
+        root_logger = logging.getLogger()
+        root_logger.addHandler(caplog.handler)
+
+        try:
+            with (
+                caplog.at_level("WARNING", logger="mindroom.thread_summary"),
+                patch("mindroom.model_loading.get_model_instance", return_value=mock_model),
+                patch("mindroom.thread_summary.Agent"),
+                patch("mindroom.thread_summary.cached_agent_run", new=AsyncMock(return_value=mock_response)),
+            ):
+                result = await _generate_summary(history, config, rp)
+        finally:
+            root_logger.removeHandler(caplog.handler)
+
+        assert result == "🧵 ISSUE-200 vertex claude summary"
+        assert mock_model.temperature == 0.9
+        warning_messages = [
+            record.getMessage()
+            for record in caplog.records
+            if "does not support a runtime temperature override" in record.getMessage()
+        ]
+        assert len(warning_messages) == 1
+        assert "_VertexClaudeLikeTemperatureModel" in warning_messages[0]
 
     async def test_prompt_good_examples_are_stable_and_within_hard_limit(self) -> None:
         """Prompt GOOD examples should be short and avoid transient-status wording."""

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import nio
 import pytest
+from agno.models.vertexai.claude import Claude as VertexAIClaude
 from pydantic import ValidationError
 
 from mindroom.constants import RuntimePaths
@@ -17,7 +18,6 @@ from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.thread_summary import (
     _MAX_MESSAGES_BEFORE_TRUNCATION,
     _SUMMARY_INSTRUCTIONS,
-    _SUMMARY_TEMPERATURE,
     _TRUNCATION_SAMPLE_SIZE,
     THREAD_SUMMARY_MAX_LENGTH,
     ThreadSummaryWriteError,
@@ -332,11 +332,13 @@ def _mock_config(
     *,
     first_threshold: int = 5,
     subsequent_interval: int = 10,
+    summary_temperature: float | None = 0.2,
 ) -> MagicMock:
     config = MagicMock()
     config.defaults.thread_summary_model = model_name
     config.defaults.thread_summary_first_threshold = first_threshold
     config.defaults.thread_summary_subsequent_interval = subsequent_interval
+    config.defaults.thread_summary_temperature = summary_temperature
     return config
 
 
@@ -360,15 +362,6 @@ def _logging_runtime_paths(tmp_path: Path) -> RuntimePaths:
 
 class _TemperatureAwareModel:
     """Tiny real model stub that advertises a temperature attribute."""
-
-    def __init__(self, temperature: float | None = None) -> None:
-        self.temperature = temperature
-
-
-class _VertexClaudeLikeTemperatureModel:
-    """Tiny stub mimicking Vertex Claude temperature behavior."""
-
-    __module__ = "agno.models.vertexai.claude"
 
     def __init__(self, temperature: float | None = None) -> None:
         self.temperature = temperature
@@ -1393,10 +1386,10 @@ class TestGenerateSummary:
         prompt = mock_run.await_args.kwargs["run_input"]
         assert prompt == f"<thread_messages>\n{conversation}\n</thread_messages>\n\nSummarize the above thread."
 
-    async def test_generate_summary_forces_low_temperature(self) -> None:
-        """Summary generation should override model temperature with the fixed summary value."""
+    async def test_generate_summary_uses_configured_summary_temperature(self) -> None:
+        """Summary generation should use the configured summary temperature override."""
         history = _make_thread_history(3)
-        config = _mock_config()
+        config = _mock_config(summary_temperature=0.1)
         rp = _mock_runtime_paths()
         mock_model = _TemperatureAwareModel(temperature=0.9)
         mock_response = MagicMock()
@@ -1410,7 +1403,26 @@ class TestGenerateSummary:
             result = await _generate_summary(history, config, rp)
 
         assert result == "🧪 ISSUE-148 matrix cache invalidate-and-refetch live test"
-        assert mock_model.temperature == _SUMMARY_TEMPERATURE
+        assert mock_model.temperature == 0.1
+
+    async def test_generate_summary_can_disable_temperature_override(self) -> None:
+        """A null summary temperature should clear any inherited model temperature."""
+        history = _make_thread_history(3)
+        config = _mock_config(summary_temperature=None)
+        rp = _mock_runtime_paths()
+        mock_model = _TemperatureAwareModel(temperature=0.9)
+        mock_response = MagicMock()
+        mock_response.content = _ThreadSummary(summary="🧪 ISSUE-149 provider default summary")
+
+        with (
+            patch("mindroom.model_loading.get_model_instance", return_value=mock_model),
+            patch("mindroom.thread_summary.Agent"),
+            patch("mindroom.thread_summary.cached_agent_run", new=AsyncMock(return_value=mock_response)),
+        ):
+            result = await _generate_summary(history, config, rp)
+
+        assert result == "🧪 ISSUE-149 provider default summary"
+        assert mock_model.temperature is None
 
     async def test_generate_summary_warns_when_model_lacks_temperature(
         self,
@@ -1452,17 +1464,17 @@ class TestGenerateSummary:
         assert "_ModelWithoutTemperature" in warning_messages[0]
         assert "does not support a runtime temperature override" in warning_messages[0]
 
-    async def test_generate_summary_skips_temperature_override_for_vertex_claude(
+    async def test_generate_summary_omits_temperature_for_vertex_claude(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Vertex Claude should keep provider defaults for summary generation."""
+        """Vertex Claude summary requests must omit the temperature field entirely."""
         history = _make_thread_history(3)
-        config = _mock_config()
+        config = _mock_config(summary_temperature=0.4)
         rp = _mock_runtime_paths()
-        mock_model = _VertexClaudeLikeTemperatureModel(temperature=0.9)
+        mock_model = VertexAIClaude(id="claude-sonnet-4@20250514", temperature=0.9)
         mock_response = MagicMock()
         mock_response.content = _ThreadSummary(summary="🧵 ISSUE-200 vertex claude summary")
         monkeypatch.delenv("MINDROOM_LOG_FORMAT", raising=False)
@@ -1483,14 +1495,14 @@ class TestGenerateSummary:
             root_logger.removeHandler(caplog.handler)
 
         assert result == "🧵 ISSUE-200 vertex claude summary"
-        assert mock_model.temperature == 0.9
+        assert mock_model.temperature is None
+        assert "temperature" not in mock_model.get_request_params()
         warning_messages = [
             record.getMessage()
             for record in caplog.records
             if "does not support a runtime temperature override" in record.getMessage()
         ]
-        assert len(warning_messages) == 1
-        assert "_VertexClaudeLikeTemperatureModel" in warning_messages[0]
+        assert warning_messages == []
 
     async def test_prompt_good_examples_are_stable_and_within_hard_limit(self) -> None:
         """Prompt GOOD examples should be short and avoid transient-status wording."""


### PR DESCRIPTION
## Summary
- add `defaults.thread_summary_temperature` for automatic thread summaries with a default of `0.2`
- allow `thread_summary_temperature: null` to omit the runtime override and use provider defaults
- always omit `temperature` for Vertex Claude thread summaries because that provider path rejects the field
- replace the Vertex Claude regression test with a real `VertexAIClaude` assertion and update docs/skill references

## Testing
- `uv run pytest tests/test_thread_summary.py -k temperature -x -n 0 --no-cov -v`
- `uv run pytest tests/test_thread_summary.py -x -n 0 --no-cov -v`
- `uv run pytest tests/test_dynamic_config_update.py -k thread_summary -x -n 0 --no-cov -v`
- `uv run ruff check src/mindroom/thread_summary.py src/mindroom/config/models.py tests/test_thread_summary.py`
- `uv run pre-commit run --all-files`
- `uv run pytest -x -n 0 --no-cov -v`
