### PR TITLE
refactor: centralize matrix visible-message resolution

### DIFF
--- a/src/mindroom/custom_tools/matrix_helpers.py
+++ b/src/mindroom/custom_tools/matrix_helpers.py
@@ -3,16 +3,10 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, cast
-
-import nio
-
-from mindroom.matrix.message_content import resolve_event_source_content
-from mindroom.matrix.visible_body import bundled_visible_body_preview, visible_body_from_event_source
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections import deque
-    from collections.abc import Collection
     from threading import Lock
 
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
@@ -26,87 +20,6 @@ def message_preview(body: object, max_length: int = 120) -> str:
     if len(compact) <= max_length:
         return compact
     return f"{compact[: max_length - 3].rstrip()}..."
-
-
-def _bundled_replacement_candidates(event_source: object) -> list[dict[str, object]]:
-    """Return bundled replacement event-source candidates in preference order."""
-    candidates: list[dict[str, object]] = []
-    unsigned = None
-    if isinstance(event_source, dict):
-        event_source_dict = cast("dict[str, object]", event_source)
-        unsigned = event_source_dict.get("unsigned")
-    for container in (unsigned, event_source):
-        if not isinstance(container, dict):
-            continue
-        container_dict = cast("dict[str, object]", container)
-        relations = container_dict.get("m.relations")
-        if not isinstance(relations, dict):
-            continue
-        relations_dict = cast("dict[str, object]", relations)
-        replacement = relations_dict.get("m.replace")
-        if not isinstance(replacement, dict):
-            continue
-        replacement_dict = cast("dict[str, object]", replacement)
-        for candidate in (
-            replacement_dict.get("latest_event"),
-            replacement_dict.get("event"),
-            replacement_dict,
-        ):
-            candidates.extend(
-                [cast("dict[str, object]", candidate)] if isinstance(candidate, dict) else [],
-            )
-    return candidates
-
-
-async def bundled_replacement_body(
-    event_source: object,
-    *,
-    client: nio.AsyncClient,
-    trusted_sender_ids: Collection[str] = (),
-) -> str | None:
-    """Return one trusted preview body from bundled replacement metadata."""
-    for candidate in _bundled_replacement_candidates(event_source):
-        resolved_candidate = await resolve_event_source_content(candidate, client)
-        body = bundled_visible_body_preview(
-            resolved_candidate,
-            trusted_sender_ids=trusted_sender_ids,
-        )
-        if body is not None:
-            return body
-    return None
-
-
-async def thread_root_body_preview(
-    event: nio.Event,
-    *,
-    client: nio.AsyncClient,
-    trusted_sender_ids: Collection[str] = (),
-) -> str:
-    """Return the canonical preview body for one thread root event."""
-    if isinstance(event, nio.MegolmEvent):
-        return "[encrypted]"
-    replacement_body = await bundled_replacement_body(
-        event.source,
-        client=client,
-        trusted_sender_ids=trusted_sender_ids,
-    )
-    if replacement_body is not None:
-        return message_preview(replacement_body)
-    event_source = event.source if isinstance(event.source, dict) else {}
-    resolved_event_source = await resolve_event_source_content(event_source, client)
-    content = resolved_event_source.get("content")
-    fallback_body = ""
-    if isinstance(content, dict):
-        body = content.get("body")
-        if isinstance(body, str):
-            fallback_body = body
-    return message_preview(
-        visible_body_from_event_source(
-            resolved_event_source,
-            fallback_body,
-            trusted_sender_ids=trusted_sender_ids,
-        ),
-    )
 
 
 def check_rate_limit(

--- a/src/mindroom/custom_tools/matrix_helpers.py
+++ b/src/mindroom/custom_tools/matrix_helpers.py
@@ -1,4 +1,4 @@
-"""Shared helpers for Matrix tool modules."""
+"""Shared non-rendering helpers for Matrix tool modules."""
 
 from __future__ import annotations
 
@@ -10,16 +10,6 @@ if TYPE_CHECKING:
     from threading import Lock
 
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
-
-
-def message_preview(body: object, max_length: int = 120) -> str:
-    """Return a compact preview of a message body, truncated to max_length."""
-    if not isinstance(body, str):
-        return ""
-    compact = " ".join(body.split())
-    if len(compact) <= max_length:
-        return compact
-    return f"{compact[: max_length - 3].rstrip()}..."
 
 
 def check_rate_limit(

--- a/src/mindroom/custom_tools/matrix_message.py
+++ b/src/mindroom/custom_tools/matrix_message.py
@@ -23,10 +23,7 @@ from mindroom.custom_tools.attachments import (
     _send_attachment_paths,
     send_context_attachments,
 )
-from mindroom.custom_tools.matrix_helpers import (
-    check_rate_limit,
-    message_preview,
-)
+from mindroom.custom_tools.matrix_helpers import check_rate_limit
 from mindroom.interactive import (
     add_reaction_buttons,
     clear_interactive_question,
@@ -45,7 +42,9 @@ from mindroom.matrix.client_visible_messages import (
     extract_visible_message as extract_and_resolve_message,
 )
 from mindroom.matrix.client_visible_messages import (
+    message_preview,
     thread_root_body_preview,
+    trusted_visible_sender_ids,
 )
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.tool_system.runtime_context import (
@@ -499,12 +498,14 @@ class MatrixMessageTools(Toolkit):
                 response=str(response),
             )
 
+        trusted_sender_ids = trusted_visible_sender_ids(context.config, context.runtime_paths)
         resolved = [
             await extract_and_resolve_message(
                 event,
                 context.client,
                 config=context.config,
                 runtime_paths=context.runtime_paths,
+                trusted_sender_ids=trusted_sender_ids,
             )
             for event in reversed(response.chunk)
             if isinstance(event, self._VISIBLE_ROOM_MESSAGE_EVENT_TYPES)
@@ -578,6 +579,7 @@ class MatrixMessageTools(Toolkit):
         context: ToolRuntimeContext,
         *,
         event: nio.Event,
+        trusted_sender_ids: frozenset[str],
     ) -> dict[str, object] | None:
         event_id = event.event_id
         sender = event.sender
@@ -601,6 +603,7 @@ class MatrixMessageTools(Toolkit):
             client=context.client,
             config=context.config,
             runtime_paths=context.runtime_paths,
+            trusted_sender_ids=trusted_sender_ids,
         )
 
         payload = {
@@ -643,8 +646,13 @@ class MatrixMessageTools(Toolkit):
             return self._payload("error", **error_payload)
 
         threads: list[dict[str, object]] = []
+        trusted_sender_ids = trusted_visible_sender_ids(context.config, context.runtime_paths)
         for event in thread_roots:
-            thread = await self._serialize_thread_root(context, event=event)
+            thread = await self._serialize_thread_root(
+                context,
+                event=event,
+                trusted_sender_ids=trusted_sender_ids,
+            )
             if thread is not None:
                 threads.append(thread)
         return self._payload(

--- a/src/mindroom/custom_tools/matrix_message.py
+++ b/src/mindroom/custom_tools/matrix_message.py
@@ -26,7 +26,6 @@ from mindroom.custom_tools.attachments import (
 from mindroom.custom_tools.matrix_helpers import (
     check_rate_limit,
     message_preview,
-    thread_root_body_preview,
 )
 from mindroom.interactive import (
     add_reaction_buttons,
@@ -42,9 +41,13 @@ from mindroom.matrix.client_delivery import (
     send_message_result,
 )
 from mindroom.matrix.client_thread_history import RoomThreadsPageError, get_room_threads_page
-from mindroom.matrix.identity import active_internal_sender_ids
+from mindroom.matrix.client_visible_messages import (
+    extract_visible_message as extract_and_resolve_message,
+)
+from mindroom.matrix.client_visible_messages import (
+    thread_root_body_preview,
+)
 from mindroom.matrix.mentions import format_message_with_mentions
-from mindroom.matrix.message_content import extract_and_resolve_message
 from mindroom.tool_system.runtime_context import (
     ToolRuntimeContext,
     get_tool_runtime_context,
@@ -496,12 +499,12 @@ class MatrixMessageTools(Toolkit):
                 response=str(response),
             )
 
-        trusted_sender_ids = active_internal_sender_ids(context.config, context.runtime_paths)
         resolved = [
             await extract_and_resolve_message(
                 event,
                 context.client,
-                trusted_sender_ids=trusted_sender_ids,
+                config=context.config,
+                runtime_paths=context.runtime_paths,
             )
             for event in reversed(response.chunk)
             if isinstance(event, self._VISIBLE_ROOM_MESSAGE_EVENT_TYPES)
@@ -593,11 +596,11 @@ class MatrixMessageTools(Toolkit):
                 event_type=type(event).__name__,
             )
             return None
-        trusted_sender_ids = active_internal_sender_ids(context.config, context.runtime_paths)
         body_preview = await thread_root_body_preview(
             event,
             client=context.client,
-            trusted_sender_ids=trusted_sender_ids,
+            config=context.config,
+            runtime_paths=context.runtime_paths,
         )
 
         payload = {

--- a/src/mindroom/custom_tools/matrix_room.py
+++ b/src/mindroom/custom_tools/matrix_room.py
@@ -16,10 +16,9 @@ from mindroom.custom_tools.attachment_helpers import room_access_allowed
 from mindroom.custom_tools.matrix_helpers import (
     check_rate_limit,
     message_preview,
-    thread_root_body_preview,
 )
 from mindroom.matrix.client_thread_history import RoomThreadsPageError, get_room_threads_page
-from mindroom.matrix.identity import active_internal_sender_ids
+from mindroom.matrix.client_visible_messages import thread_root_body_preview
 from mindroom.tool_system.runtime_context import (
     ToolRuntimeContext,
     get_tool_runtime_context,
@@ -342,7 +341,6 @@ class MatrixRoomTools(Toolkit):
             )
 
         threads_list: list[dict[str, Any]] = []
-        trusted_sender_ids = active_internal_sender_ids(context.config, context.runtime_paths)
         for event in thread_roots:
             thread_info: dict[str, Any] = {
                 "thread_id": event.event_id,
@@ -352,7 +350,8 @@ class MatrixRoomTools(Toolkit):
             thread_info["body_preview"] = await thread_root_body_preview(
                 event,
                 client=context.client,
-                trusted_sender_ids=trusted_sender_ids,
+                config=context.config,
+                runtime_paths=context.runtime_paths,
             )
             thread_info["reply_count"] = self._thread_reply_count(event)
 

--- a/src/mindroom/custom_tools/matrix_room.py
+++ b/src/mindroom/custom_tools/matrix_room.py
@@ -13,12 +13,13 @@ from agno.tools import Toolkit
 from aiohttp import ClientError
 
 from mindroom.custom_tools.attachment_helpers import room_access_allowed
-from mindroom.custom_tools.matrix_helpers import (
-    check_rate_limit,
-    message_preview,
-)
+from mindroom.custom_tools.matrix_helpers import check_rate_limit
 from mindroom.matrix.client_thread_history import RoomThreadsPageError, get_room_threads_page
-from mindroom.matrix.client_visible_messages import thread_root_body_preview
+from mindroom.matrix.client_visible_messages import (
+    message_preview,
+    thread_root_body_preview,
+    trusted_visible_sender_ids,
+)
 from mindroom.tool_system.runtime_context import (
     ToolRuntimeContext,
     get_tool_runtime_context,
@@ -341,6 +342,7 @@ class MatrixRoomTools(Toolkit):
             )
 
         threads_list: list[dict[str, Any]] = []
+        trusted_sender_ids = trusted_visible_sender_ids(context.config, context.runtime_paths)
         for event in thread_roots:
             thread_info: dict[str, Any] = {
                 "thread_id": event.event_id,
@@ -352,6 +354,7 @@ class MatrixRoomTools(Toolkit):
                 client=context.client,
                 config=context.config,
                 runtime_paths=context.runtime_paths,
+                trusted_sender_ids=trusted_sender_ids,
             )
             thread_info["reply_count"] = self._thread_reply_count(event)
 

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -9,8 +9,8 @@ from mindroom.coalescing import coalesced_prompt
 from mindroom.conversation_resolver import MessageContext
 from mindroom.handled_turns import HandledTurnRecord, HandledTurnState
 from mindroom.hooks.ingress import hook_ingress_policy
-from mindroom.matrix.identity import active_internal_sender_ids, extract_agent_name
-from mindroom.matrix.message_content import extract_edit_body
+from mindroom.matrix.client_visible_messages import extract_visible_edit_body
+from mindroom.matrix.identity import extract_agent_name
 from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 
 if TYPE_CHECKING:
@@ -185,13 +185,11 @@ class EditRegenerator:
             response_event_id=response_event_id,
         )
 
-        edited_content, _ = await extract_edit_body(
+        edited_content, _ = await extract_visible_edit_body(
             event.source,
             self._client(),
-            trusted_sender_ids=active_internal_sender_ids(
-                self.deps.runtime.config,
-                self.deps.runtime_paths,
-            ),
+            config=self.deps.runtime.config,
+            runtime_paths=self.deps.runtime_paths,
         )
         if edited_content is None:
             self._logger().debug("Edited message missing resolved body", event_id=event.event_id)

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -18,14 +18,12 @@ from mindroom.attachments import (
 )
 from mindroom.coalescing import PreparedTextEvent
 from mindroom.logging_config import bound_log_context
+from mindroom.matrix.client_visible_messages import resolve_visible_event_source
 from mindroom.matrix.event_info import EventInfo
-from mindroom.matrix.identity import active_internal_sender_ids
 from mindroom.matrix.image_handler import download_image
 from mindroom.matrix.message_content import (
     is_v2_sidecar_text_preview,
-    resolve_event_source_content,
 )
-from mindroom.matrix.visible_body import visible_body_from_event_source
 from mindroom.media_inputs import MediaInputs
 from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 from mindroom.voice_handler import prepare_voice_message
@@ -144,19 +142,17 @@ class InboundTurnNormalizer:
         if isinstance(event, PreparedTextEvent):
             return event
 
-        resolved_source = await resolve_event_source_content(event.source, self._client())
-        trusted_sender_ids = active_internal_sender_ids(
-            self.deps.runtime.config,
-            self.deps.runtime_paths,
+        resolved_source, body = await resolve_visible_event_source(
+            event.source,
+            self._client(),
+            fallback_body=event.body,
+            config=self.deps.runtime.config,
+            runtime_paths=self.deps.runtime_paths,
         )
         return PreparedTextEvent(
             sender=event.sender,
             event_id=event.event_id,
-            body=visible_body_from_event_source(
-                resolved_source,
-                event.body,
-                trusted_sender_ids=trusted_sender_ids,
-            ),
+            body=body,
             source=resolved_source,
             server_timestamp=event.server_timestamp if isinstance(event.server_timestamp, int) else None,
         )
@@ -217,19 +213,17 @@ class InboundTurnNormalizer:
         if not is_v2_sidecar_text_preview(event.source):
             return None
 
-        resolved_source = await resolve_event_source_content(event.source, self._client())
-        trusted_sender_ids = active_internal_sender_ids(
-            self.deps.runtime.config,
-            self.deps.runtime_paths,
+        resolved_source, body = await resolve_visible_event_source(
+            event.source,
+            self._client(),
+            fallback_body=event.body,
+            config=self.deps.runtime.config,
+            runtime_paths=self.deps.runtime_paths,
         )
         return PreparedTextEvent(
             sender=event.sender,
             event_id=event.event_id,
-            body=visible_body_from_event_source(
-                resolved_source,
-                event.body,
-                trusted_sender_ids=trusted_sender_ids,
-            ),
+            body=body,
             source=resolved_source,
             server_timestamp=event.server_timestamp if isinstance(event.server_timestamp, int) else None,
         )

--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -10,9 +10,17 @@ import nio
 
 from mindroom.constants import STREAM_STATUS_KEY
 from mindroom.matrix.event_info import EventInfo
-from mindroom.matrix.message_content import extract_and_resolve_message, extract_edit_body
+from mindroom.matrix.identity import active_internal_sender_ids
+from mindroom.matrix.message_content import (
+    extract_and_resolve_message,
+    extract_edit_body,
+    resolve_event_source_content,
+)
+from mindroom.matrix.visible_body import bundled_visible_body_preview, visible_body_from_event_source
 
 if TYPE_CHECKING:
+    from mindroom.config.main import Config
+    from mindroom.constants import RuntimePaths
     from mindroom.matrix.cache import ConversationEventCache
 
 _VISIBLE_ROOM_MESSAGE_EVENT_TYPES = (nio.RoomMessageText, nio.RoomMessageNotice)
@@ -126,6 +134,187 @@ class ResolvedVisibleMessage:
         if self.stream_status is not None:
             message_data["stream_status"] = self.stream_status
         return message_data
+
+
+def _trusted_sender_ids(
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> frozenset[str]:
+    """Return the trusted internal senders for high-level Matrix read helpers."""
+    return active_internal_sender_ids(config, runtime_paths)
+
+
+async def extract_visible_message(
+    event: nio.RoomMessageText | nio.RoomMessageNotice,
+    client: nio.AsyncClient | None = None,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    event_cache: ConversationEventCache | None = None,
+    room_id: str | None = None,
+) -> dict[str, Any]:
+    """Extract one visible message using runtime-derived sender trust."""
+    return await extract_and_resolve_message(
+        event,
+        client,
+        event_cache=event_cache,
+        room_id=room_id,
+        trusted_sender_ids=_trusted_sender_ids(config, runtime_paths),
+    )
+
+
+async def extract_visible_edit_body(
+    event_source: dict[str, Any],
+    client: nio.AsyncClient | None = None,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    event_cache: ConversationEventCache | None = None,
+    room_id: str | None = None,
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Extract one visible edit body using runtime-derived sender trust."""
+    return await extract_edit_body(
+        event_source,
+        client,
+        event_cache=event_cache,
+        room_id=room_id,
+        trusted_sender_ids=_trusted_sender_ids(config, runtime_paths),
+    )
+
+
+async def resolve_visible_event_source(
+    event_source: Mapping[str, Any],
+    client: nio.AsyncClient | None = None,
+    *,
+    fallback_body: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    event_cache: ConversationEventCache | None = None,
+    room_id: str | None = None,
+) -> tuple[dict[str, Any], str]:
+    """Resolve one event source plus its canonical visible body from runtime config."""
+    normalized_event_source = {key: value for key, value in event_source.items() if isinstance(key, str)}
+    resolved_event_source = await resolve_event_source_content(
+        normalized_event_source,
+        client,
+        event_cache=event_cache,
+        room_id=room_id,
+    )
+    return resolved_event_source, visible_body_from_event_source(
+        resolved_event_source,
+        fallback_body,
+        trusted_sender_ids=_trusted_sender_ids(config, runtime_paths),
+    )
+
+
+def _message_preview(body: object, max_length: int = 120) -> str:
+    """Return one compact visible-body preview."""
+    if not isinstance(body, str):
+        return ""
+    compact = " ".join(body.split())
+    if len(compact) <= max_length:
+        return compact
+    return f"{compact[: max_length - 3].rstrip()}..."
+
+
+def _bundled_replacement_candidates(event_source: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return bundled replacement candidates in preference order."""
+    candidates: list[dict[str, Any]] = []
+    unsigned = event_source.get("unsigned")
+    for container in (unsigned, event_source):
+        if not isinstance(container, Mapping):
+            continue
+        relations = container.get("m.relations")
+        if not isinstance(relations, Mapping):
+            continue
+        replacement = relations.get("m.replace")
+        if not isinstance(replacement, Mapping):
+            continue
+        for candidate in (
+            replacement.get("latest_event"),
+            replacement.get("event"),
+            replacement,
+        ):
+            if isinstance(candidate, Mapping):
+                candidates.extend(
+                    [{key: value for key, value in candidate.items() if isinstance(key, str)}],
+                )
+    return candidates
+
+
+async def bundled_replacement_body(
+    event_source: Mapping[str, Any],
+    *,
+    client: nio.AsyncClient,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    event_cache: ConversationEventCache | None = None,
+    room_id: str | None = None,
+) -> str | None:
+    """Return one canonical bundled replacement body using runtime-derived sender trust."""
+    trusted_sender_ids = _trusted_sender_ids(config, runtime_paths)
+    for candidate in _bundled_replacement_candidates(event_source):
+        resolved_candidate = await resolve_event_source_content(
+            candidate,
+            client,
+            event_cache=event_cache,
+            room_id=room_id,
+        )
+        body = bundled_visible_body_preview(
+            resolved_candidate,
+            trusted_sender_ids=trusted_sender_ids,
+        )
+        if body is not None:
+            return body
+    return None
+
+
+def _event_fallback_body(event: nio.Event) -> str:
+    """Return one best-effort Matrix body for preview fallback."""
+    if isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES):
+        return event.body
+    event_source = event.source if isinstance(event.source, dict) else {}
+    content = event_source.get("content")
+    if isinstance(content, dict):
+        body = content.get("body")
+        if isinstance(body, str):
+            return body
+    return ""
+
+
+async def thread_root_body_preview(
+    event: nio.Event,
+    *,
+    client: nio.AsyncClient,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    event_cache: ConversationEventCache | None = None,
+    room_id: str | None = None,
+) -> str:
+    """Return the canonical preview body for one thread root event."""
+    if isinstance(event, nio.MegolmEvent):
+        return "[encrypted]"
+    event_source = event.source if isinstance(event.source, dict) else {}
+    replacement_body = await bundled_replacement_body(
+        event_source,
+        client=client,
+        config=config,
+        runtime_paths=runtime_paths,
+        event_cache=event_cache,
+        room_id=room_id,
+    )
+    if replacement_body is not None:
+        return _message_preview(replacement_body)
+    _resolved_event_source, visible_body = await resolve_visible_event_source(
+        event_source,
+        client,
+        fallback_body=_event_fallback_body(event),
+        config=config,
+        runtime_paths=runtime_paths,
+        event_cache=event_cache,
+        room_id=room_id,
+    )
+    return _message_preview(visible_body)
 
 
 def _reply_to_event_id_from_content(content: Mapping[str, Any] | None) -> str | None:
@@ -294,6 +483,11 @@ async def resolve_latest_visible_messages(
 
 __all__ = [
     "ResolvedVisibleMessage",
+    "bundled_replacement_body",
+    "extract_visible_edit_body",
+    "extract_visible_message",
     "replace_visible_message",
     "resolve_latest_visible_messages",
+    "resolve_visible_event_source",
+    "thread_root_body_preview",
 ]

--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -136,12 +136,23 @@ class ResolvedVisibleMessage:
         return message_data
 
 
-def _trusted_sender_ids(
+def trusted_visible_sender_ids(
     config: Config,
     runtime_paths: RuntimePaths,
 ) -> frozenset[str]:
     """Return the trusted internal senders for high-level Matrix read helpers."""
     return active_internal_sender_ids(config, runtime_paths)
+
+
+def _resolved_trusted_sender_ids(
+    config: Config,
+    runtime_paths: RuntimePaths,
+    trusted_sender_ids: Collection[str] | None,
+) -> Collection[str]:
+    """Reuse one caller-provided trust set or derive it from the current runtime."""
+    if trusted_sender_ids is not None:
+        return trusted_sender_ids
+    return trusted_visible_sender_ids(config, runtime_paths)
 
 
 async def extract_visible_message(
@@ -152,6 +163,7 @@ async def extract_visible_message(
     runtime_paths: RuntimePaths,
     event_cache: ConversationEventCache | None = None,
     room_id: str | None = None,
+    trusted_sender_ids: Collection[str] | None = None,
 ) -> dict[str, Any]:
     """Extract one visible message using runtime-derived sender trust."""
     return await extract_and_resolve_message(
@@ -159,7 +171,7 @@ async def extract_visible_message(
         client,
         event_cache=event_cache,
         room_id=room_id,
-        trusted_sender_ids=_trusted_sender_ids(config, runtime_paths),
+        trusted_sender_ids=_resolved_trusted_sender_ids(config, runtime_paths, trusted_sender_ids),
     )
 
 
@@ -171,6 +183,7 @@ async def extract_visible_edit_body(
     runtime_paths: RuntimePaths,
     event_cache: ConversationEventCache | None = None,
     room_id: str | None = None,
+    trusted_sender_ids: Collection[str] | None = None,
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Extract one visible edit body using runtime-derived sender trust."""
     return await extract_edit_body(
@@ -178,7 +191,7 @@ async def extract_visible_edit_body(
         client,
         event_cache=event_cache,
         room_id=room_id,
-        trusted_sender_ids=_trusted_sender_ids(config, runtime_paths),
+        trusted_sender_ids=_resolved_trusted_sender_ids(config, runtime_paths, trusted_sender_ids),
     )
 
 
@@ -191,6 +204,7 @@ async def resolve_visible_event_source(
     runtime_paths: RuntimePaths,
     event_cache: ConversationEventCache | None = None,
     room_id: str | None = None,
+    trusted_sender_ids: Collection[str] | None = None,
 ) -> tuple[dict[str, Any], str]:
     """Resolve one event source plus its canonical visible body from runtime config."""
     normalized_event_source = {key: value for key, value in event_source.items() if isinstance(key, str)}
@@ -203,11 +217,11 @@ async def resolve_visible_event_source(
     return resolved_event_source, visible_body_from_event_source(
         resolved_event_source,
         fallback_body,
-        trusted_sender_ids=_trusted_sender_ids(config, runtime_paths),
+        trusted_sender_ids=_resolved_trusted_sender_ids(config, runtime_paths, trusted_sender_ids),
     )
 
 
-def _message_preview(body: object, max_length: int = 120) -> str:
+def message_preview(body: object, max_length: int = 120) -> str:
     """Return one compact visible-body preview."""
     if not isinstance(body, str):
         return ""
@@ -250,9 +264,10 @@ async def bundled_replacement_body(
     runtime_paths: RuntimePaths,
     event_cache: ConversationEventCache | None = None,
     room_id: str | None = None,
+    trusted_sender_ids: Collection[str] | None = None,
 ) -> str | None:
     """Return one canonical bundled replacement body using runtime-derived sender trust."""
-    trusted_sender_ids = _trusted_sender_ids(config, runtime_paths)
+    trusted_sender_ids = _resolved_trusted_sender_ids(config, runtime_paths, trusted_sender_ids)
     for candidate in _bundled_replacement_candidates(event_source):
         resolved_candidate = await resolve_event_source_content(
             candidate,
@@ -290,11 +305,13 @@ async def thread_root_body_preview(
     runtime_paths: RuntimePaths,
     event_cache: ConversationEventCache | None = None,
     room_id: str | None = None,
+    trusted_sender_ids: Collection[str] | None = None,
 ) -> str:
     """Return the canonical preview body for one thread root event."""
     if isinstance(event, nio.MegolmEvent):
         return "[encrypted]"
     event_source = event.source if isinstance(event.source, dict) else {}
+    trusted_sender_ids = _resolved_trusted_sender_ids(config, runtime_paths, trusted_sender_ids)
     replacement_body = await bundled_replacement_body(
         event_source,
         client=client,
@@ -302,9 +319,10 @@ async def thread_root_body_preview(
         runtime_paths=runtime_paths,
         event_cache=event_cache,
         room_id=room_id,
+        trusted_sender_ids=trusted_sender_ids,
     )
     if replacement_body is not None:
-        return _message_preview(replacement_body)
+        return message_preview(replacement_body)
     _resolved_event_source, visible_body = await resolve_visible_event_source(
         event_source,
         client,
@@ -313,8 +331,9 @@ async def thread_root_body_preview(
         runtime_paths=runtime_paths,
         event_cache=event_cache,
         room_id=room_id,
+        trusted_sender_ids=trusted_sender_ids,
     )
-    return _message_preview(visible_body)
+    return message_preview(visible_body)
 
 
 def _reply_to_event_id_from_content(content: Mapping[str, Any] | None) -> str | None:
@@ -486,8 +505,10 @@ __all__ = [
     "bundled_replacement_body",
     "extract_visible_edit_body",
     "extract_visible_message",
+    "message_preview",
     "replace_visible_message",
     "resolve_latest_visible_messages",
     "resolve_visible_event_source",
     "thread_root_body_preview",
+    "trusted_visible_sender_ids",
 ]

--- a/tach.toml
+++ b/tach.toml
@@ -270,8 +270,6 @@ depends_on = [
     "mindroom.matrix.client_delivery",
     "mindroom.matrix.client_thread_history",
     "mindroom.matrix.client_visible_messages",
-    "mindroom.matrix.message_content",
-    "mindroom.matrix.visible_body",
     "mindroom.tool_system.runtime_context",
 ]
 
@@ -281,7 +279,6 @@ depends_on = [
     "mindroom.custom_tools.matrix_helpers",
     "mindroom.matrix.client_thread_history",
     "mindroom.matrix.client_visible_messages",
-    "mindroom.matrix.visible_body",
     "mindroom.tool_system.runtime_context",
 ]
 
@@ -312,8 +309,6 @@ depends_on = [
     "mindroom.hooks.ingress",
     "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.identity",
-    "mindroom.matrix.message_content",
-    "mindroom.matrix.visible_body",
     "mindroom.runtime_protocols",
 ]
 
@@ -833,11 +828,6 @@ depends_on = [
     "mindroom.matrix.identity",
 ]
 visibility = [
-    "mindroom.custom_tools.matrix_helpers",
-    "mindroom.custom_tools.matrix_message",
-    "mindroom.custom_tools.matrix_room",
-    "mindroom.edit_regenerator",
-    "mindroom.inbound_turn_normalizer",
     "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.client_thread_history",
     "mindroom.matrix.conversation_cache",
@@ -1198,7 +1188,6 @@ depends_on = [
     "mindroom.matrix.event_info",
     "mindroom.matrix.image_handler",
     "mindroom.matrix.message_content",
-    "mindroom.matrix.visible_body",
     "mindroom.media_inputs",
     "mindroom.runtime_protocols",
     "mindroom.voice_handler",
@@ -1570,10 +1559,12 @@ expose = [
     "_record_latest_thread_edit",
     "extract_visible_edit_body",
     "extract_visible_message",
+    "message_preview",
     "replace_visible_message",
     "resolve_visible_event_source",
     "resolve_latest_visible_messages",
     "thread_root_body_preview",
+    "trusted_visible_sender_ids",
 ]
 from = ["mindroom.matrix.client_visible_messages"]
 

--- a/tach.toml
+++ b/tach.toml
@@ -255,10 +255,7 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.custom_tools.matrix_helpers"
-depends_on = [
-    "mindroom.matrix.message_content",
-    "mindroom.matrix.visible_body",
-]
+depends_on = []
 visibility = [
     "mindroom.custom_tools.matrix_message",
     "mindroom.custom_tools.matrix_room",
@@ -272,6 +269,7 @@ depends_on = [
     "mindroom.custom_tools.matrix_helpers",
     "mindroom.matrix.client_delivery",
     "mindroom.matrix.client_thread_history",
+    "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.message_content",
     "mindroom.matrix.visible_body",
     "mindroom.tool_system.runtime_context",
@@ -282,6 +280,7 @@ path = "mindroom.custom_tools.matrix_room"
 depends_on = [
     "mindroom.custom_tools.matrix_helpers",
     "mindroom.matrix.client_thread_history",
+    "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.visible_body",
     "mindroom.tool_system.runtime_context",
 ]
@@ -311,6 +310,7 @@ depends_on = [
     "mindroom.conversation_resolver",
     "mindroom.handled_turns",
     "mindroom.hooks.ingress",
+    "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.identity",
     "mindroom.matrix.message_content",
     "mindroom.matrix.visible_body",
@@ -804,11 +804,17 @@ path = "mindroom.matrix.client_visible_messages"
 depends_on = [
     "mindroom.constants",
     "mindroom.matrix.event_info",
+    "mindroom.matrix.identity",
     "mindroom.matrix.message_content",
+    "mindroom.matrix.visible_body",
 ]
 visibility = [
     "mindroom.api.openai_compat",
+    "mindroom.custom_tools.matrix_message",
+    "mindroom.custom_tools.matrix_room",
+    "mindroom.edit_regenerator",
     "mindroom.execution_preparation",
+    "mindroom.inbound_turn_normalizer",
     "mindroom.matrix.client",
     "mindroom.matrix.client_thread_history",
     "mindroom.matrix.stale_stream_cleanup",
@@ -832,6 +838,7 @@ visibility = [
     "mindroom.custom_tools.matrix_room",
     "mindroom.edit_regenerator",
     "mindroom.inbound_turn_normalizer",
+    "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.client_thread_history",
     "mindroom.matrix.conversation_cache",
     "mindroom.matrix.message_content",
@@ -1187,6 +1194,7 @@ depends_on = [
     "mindroom.attachments",
     "mindroom.coalescing",
     "mindroom.logging_config",
+    "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.event_info",
     "mindroom.matrix.image_handler",
     "mindroom.matrix.message_content",
@@ -1560,8 +1568,12 @@ expose = [
     "ResolvedVisibleMessage",
     "_apply_latest_edits_to_messages",
     "_record_latest_thread_edit",
+    "extract_visible_edit_body",
+    "extract_visible_message",
     "replace_visible_message",
+    "resolve_visible_event_source",
     "resolve_latest_visible_messages",
+    "thread_root_body_preview",
 ]
 from = ["mindroom.matrix.client_visible_messages"]
 

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -1683,9 +1683,8 @@ async def test_matrix_message_room_threads_resolves_notice_root_without_replacem
     mock_preview.assert_awaited_once_with(
         thread_root,
         client=ctx.client,
-        trusted_sender_ids=frozenset(
-            {"@mindroom_general:localhost", "@mindroom_router:localhost"},
-        ),
+        config=ctx.config,
+        runtime_paths=ctx.runtime_paths,
     )
 
 
@@ -1843,9 +1842,8 @@ async def test_matrix_message_room_threads_skips_malformed_roots() -> None:
     mock_preview.assert_awaited_once_with(
         thread_root,
         client=ctx.client,
-        trusted_sender_ids=frozenset(
-            {"@mindroom_general:localhost", "@mindroom_router:localhost"},
-        ),
+        config=ctx.config,
+        runtime_paths=ctx.runtime_paths,
     )
     mock_warning.assert_called_once()
 
@@ -2143,11 +2141,11 @@ async def test_matrix_message_read_room_includes_notice_events() -> None:
         event: nio.Event,
         _client: nio.AsyncClient,
         *,
-        trusted_sender_ids: frozenset[str],
+        config: Config,
+        runtime_paths: object,
     ) -> dict[str, object]:
-        assert trusted_sender_ids == frozenset(
-            {"@mindroom_general:localhost", "@mindroom_router:localhost"},
-        )
+        assert config is ctx.config
+        assert runtime_paths == ctx.runtime_paths
         return extracted_messages[event.event_id]
 
     with (

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -7,7 +7,7 @@ import json
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 import nio
 import pytest
@@ -1685,6 +1685,7 @@ async def test_matrix_message_room_threads_resolves_notice_root_without_replacem
         client=ctx.client,
         config=ctx.config,
         runtime_paths=ctx.runtime_paths,
+        trusted_sender_ids=ANY,
     )
 
 
@@ -1844,6 +1845,7 @@ async def test_matrix_message_room_threads_skips_malformed_roots() -> None:
         client=ctx.client,
         config=ctx.config,
         runtime_paths=ctx.runtime_paths,
+        trusted_sender_ids=ANY,
     )
     mock_warning.assert_called_once()
 
@@ -2143,9 +2145,11 @@ async def test_matrix_message_read_room_includes_notice_events() -> None:
         *,
         config: Config,
         runtime_paths: object,
+        trusted_sender_ids: frozenset[str],
     ) -> dict[str, object]:
         assert config is ctx.config
         assert runtime_paths == ctx.runtime_paths
+        assert trusted_sender_ids
         return extracted_messages[event.event_id]
 
     with (
@@ -2162,6 +2166,74 @@ async def test_matrix_message_read_room_includes_notice_events() -> None:
         {"event_id": "$text", "body": "hello"},
         {"event_id": "$notice", "body": "Compacted 12 messages", "msgtype": "m.notice"},
     ]
+    assert mock_extract.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_matrix_message_read_room_precomputes_trusted_sender_ids_once() -> None:
+    """Room reads should resolve the trust set once and pass it through every extraction."""
+    tool = MatrixMessageTools()
+    ctx = _make_context(thread_id=None)
+    response = nio.RoomMessagesResponse.from_dict(
+        {
+            "chunk": [
+                {
+                    "type": "m.room.message",
+                    "event_id": "$notice",
+                    "sender": "@mindroom:localhost",
+                    "origin_server_ts": 2,
+                    "content": {"msgtype": "m.notice", "body": "Compacted 12 messages"},
+                },
+                {
+                    "type": "m.room.message",
+                    "event_id": "$text",
+                    "sender": "@alice:localhost",
+                    "origin_server_ts": 1,
+                    "content": {"msgtype": "m.text", "body": "hello"},
+                },
+            ],
+            "start": "s",
+            "end": "e",
+        },
+        ctx.room_id,
+    )
+    ctx.client.room_messages.return_value = response
+    trusted_sender_ids = frozenset({"@mindroom_general:localhost"})
+
+    async def _extract(
+        event: nio.Event,
+        _client: nio.AsyncClient,
+        *,
+        config: Config,
+        runtime_paths: object,
+        trusted_sender_ids: frozenset[str],
+    ) -> dict[str, object]:
+        assert config is ctx.config
+        assert runtime_paths == ctx.runtime_paths
+        assert trusted_sender_ids is trusted_sender_ids_for_assertion
+        return {"event_id": event.event_id, "body": event.source["content"]["body"]}
+
+    trusted_sender_ids_for_assertion = trusted_sender_ids
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_message.trusted_visible_sender_ids",
+            return_value=trusted_sender_ids,
+        ) as mock_trusted_sender_ids,
+        patch(
+            "mindroom.custom_tools.matrix_message.extract_and_resolve_message",
+            new=AsyncMock(side_effect=_extract),
+        ) as mock_extract,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(await tool.matrix_message(action="read", limit=5))
+
+    assert payload["status"] == "ok"
+    assert payload["messages"] == [
+        {"event_id": "$text", "body": "hello"},
+        {"event_id": "$notice", "body": "Compacted 12 messages"},
+    ]
+    mock_trusted_sender_ids.assert_called_once_with(ctx.config, ctx.runtime_paths)
     assert mock_extract.await_count == 2
 
 

--- a/tests/test_matrix_room_tool.py
+++ b/tests/test_matrix_room_tool.py
@@ -480,6 +480,56 @@ async def test_threads_happy_path() -> None:
 
 
 @pytest.mark.asyncio
+async def test_threads_precompute_trusted_sender_ids_once_for_previews() -> None:
+    """Thread listings should resolve the trust set once and pass it through every preview."""
+    tool = MatrixRoomTools()
+    ctx = _make_context()
+    trusted_sender_ids = frozenset({"@mindroom_general:localhost"})
+    events = [
+        _thread_event("$thread1", body="Thread root message", reply_count=5),
+        _thread_event("$thread2", body="Another thread", reply_count=2),
+    ]
+
+    async def _preview(
+        event: nio.Event,
+        *,
+        client: nio.AsyncClient,
+        config: Config,
+        runtime_paths: object,
+        trusted_sender_ids: frozenset[str],
+    ) -> str:
+        assert client is ctx.client
+        assert config is ctx.config
+        assert runtime_paths == ctx.runtime_paths
+        assert trusted_sender_ids is trusted_sender_ids_for_assertion
+        return event.body
+
+    trusted_sender_ids_for_assertion = trusted_sender_ids
+
+    with (
+        tool_runtime_context(ctx),
+        patch(_MOCK_TARGET, return_value=(events, None)),
+        patch(
+            "mindroom.custom_tools.matrix_room.trusted_visible_sender_ids",
+            return_value=trusted_sender_ids,
+        ) as mock_trusted_sender_ids,
+        patch(
+            "mindroom.custom_tools.matrix_room.thread_root_body_preview",
+            new=AsyncMock(side_effect=_preview),
+        ) as mock_preview,
+    ):
+        payload = json.loads(await tool.matrix_room(action="threads"))
+
+    assert payload["status"] == "ok"
+    assert [thread["body_preview"] for thread in payload["threads"]] == [
+        "Thread root message",
+        "Another thread",
+    ]
+    mock_trusted_sender_ids.assert_called_once_with(ctx.config, ctx.runtime_paths)
+    assert mock_preview.await_count == 2
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("bundle_key", [None, "event", "latest_event"])
 async def test_threads_preview_prefers_bundled_replacement_body(
     bundle_key: str | None,

--- a/tests/test_message_content.py
+++ b/tests/test_message_content.py
@@ -3,7 +3,7 @@
 import json
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
 import pytest
@@ -14,6 +14,7 @@ from mindroom.config.main import Config
 from mindroom.constants import STREAM_STATUS_KEY, STREAM_WARMUP_SUFFIX_KEY
 from mindroom.matrix.client_visible_messages import (
     extract_visible_edit_body,
+    message_preview,
     resolve_visible_event_source,
     thread_root_body_preview,
 )
@@ -605,6 +606,69 @@ class TestResolvedMessageExtraction:
         )
 
         assert preview == "Edited body"
+
+    @pytest.mark.asyncio
+    async def test_thread_root_body_preview_passes_precomputed_trusted_sender_ids_to_nested_helpers(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Thread previews should reuse one caller-provided trust set through nested helpers."""
+        config = bind_runtime_paths(
+            Config(agents={"general": AgentConfig(display_name="General Agent")}),
+            test_runtime_paths(tmp_path),
+        )
+        runtime_paths = runtime_paths_for(config)
+        event = _make_message_event(
+            body="Original root",
+            content={"msgtype": "m.text", "body": "Original root"},
+            event_id="$thread-root",
+            sender="@user:example.com",
+        )
+        client = _make_client()
+        trusted_sender_ids = frozenset({"@mindroom_general:localhost"})
+
+        with (
+            patch(
+                "mindroom.matrix.client_visible_messages.bundled_replacement_body",
+                new=AsyncMock(return_value=None),
+            ) as mock_bundled,
+            patch(
+                "mindroom.matrix.client_visible_messages.resolve_visible_event_source",
+                new=AsyncMock(return_value=(event.source, "Resolved root")),
+            ) as mock_resolve,
+        ):
+            preview = await thread_root_body_preview(
+                event,
+                client=client,
+                config=config,
+                runtime_paths=runtime_paths,
+                trusted_sender_ids=trusted_sender_ids,
+            )
+
+        assert preview == "Resolved root"
+        mock_bundled.assert_awaited_once_with(
+            event.source,
+            client=client,
+            config=config,
+            runtime_paths=runtime_paths,
+            event_cache=None,
+            room_id=None,
+            trusted_sender_ids=trusted_sender_ids,
+        )
+        mock_resolve.assert_awaited_once_with(
+            event.source,
+            client,
+            fallback_body="Original root",
+            config=config,
+            runtime_paths=runtime_paths,
+            event_cache=None,
+            room_id=None,
+            trusted_sender_ids=trusted_sender_ids,
+        )
+
+    def test_message_preview_compacts_whitespace_and_truncates(self) -> None:
+        """Shared preview compaction should live in the Matrix visible-message layer."""
+        assert message_preview("  alpha   beta  \n gamma  ", max_length=12) == "alpha bet..."
 
 
 class TestDownloadMxcText:

--- a/tests/test_message_content.py
+++ b/tests/test_message_content.py
@@ -12,6 +12,11 @@ import mindroom.matrix.message_content as message_content_module
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.constants import STREAM_STATUS_KEY, STREAM_WARMUP_SUFFIX_KEY
+from mindroom.matrix.client_visible_messages import (
+    extract_visible_edit_body,
+    resolve_visible_event_source,
+    thread_root_body_preview,
+)
 from mindroom.matrix.identity import active_internal_sender_ids
 from mindroom.matrix.message_content import (
     _clear_mxc_cache,
@@ -487,6 +492,119 @@ class TestResolvedMessageExtraction:
             )
             == "hello\n\n⏳ Preparing isolated worker..."
         )
+
+    @pytest.mark.asyncio
+    async def test_resolve_visible_event_source_trusts_runtime_sender_ids(self, tmp_path: Path) -> None:
+        """High-level visible-source resolution should derive trust from runtime config."""
+        config = bind_runtime_paths(
+            Config(agents={"general": AgentConfig(display_name="General Agent")}),
+            test_runtime_paths(tmp_path),
+        )
+        runtime_paths = runtime_paths_for(config)
+        current_domain = config.get_domain(runtime_paths)
+        event_source = {
+            "sender": f"@mindroom_general:{current_domain}",
+            "content": {
+                "msgtype": "m.text",
+                "body": "hello\n\n⏳ Preparing isolated worker...",
+                "io.mindroom.visible_body": "hello",
+            },
+        }
+
+        resolved_source, visible_body = await resolve_visible_event_source(
+            event_source,
+            None,
+            fallback_body="hello",
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+
+        assert resolved_source == event_source
+        assert visible_body == "hello"
+
+    @pytest.mark.asyncio
+    async def test_extract_visible_edit_body_trusts_runtime_sender_ids(self, tmp_path: Path) -> None:
+        """High-level edit extraction should derive trusted visible-body rules from runtime config."""
+        config = bind_runtime_paths(
+            Config(agents={"general": AgentConfig(display_name="General Agent")}),
+            test_runtime_paths(tmp_path),
+        )
+        runtime_paths = runtime_paths_for(config)
+        current_domain = config.get_domain(runtime_paths)
+
+        body, content = await extract_visible_edit_body(
+            {
+                "sender": f"@mindroom_general:{current_domain}",
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "* Preview edit",
+                    "m.new_content": {
+                        "msgtype": "m.text",
+                        "body": "hello\n\n⏳ Preparing isolated worker...",
+                        "io.mindroom.visible_body": "hello",
+                    },
+                    "m.relates_to": {"rel_type": "m.replace", "event_id": "$original"},
+                },
+            },
+            None,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+
+        assert body == "hello"
+        assert content == {
+            "msgtype": "m.text",
+            "body": "hello",
+            "io.mindroom.visible_body": "hello",
+        }
+
+    @pytest.mark.asyncio
+    async def test_thread_root_body_preview_uses_runtime_sender_ids_for_bundled_edits(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Thread previews should resolve trusted bundled edits without raw trusted-sender plumbing."""
+        config = bind_runtime_paths(
+            Config(agents={"general": AgentConfig(display_name="General Agent")}),
+            test_runtime_paths(tmp_path),
+        )
+        runtime_paths = runtime_paths_for(config)
+        current_domain = config.get_domain(runtime_paths)
+        event = _make_message_event(
+            body="Original root",
+            content={"msgtype": "m.text", "body": "Original root"},
+            event_id="$thread-root",
+            sender="@user:example.com",
+        )
+        event.source["unsigned"] = {
+            "m.relations": {
+                "m.replace": {
+                    "event_id": "$thread-root-edit",
+                    "sender": f"@mindroom_general:{current_domain}",
+                    "origin_server_ts": 2000,
+                    "type": "m.room.message",
+                    "content": {
+                        "body": "* Edited body\n\n⏳ Preparing isolated worker...",
+                        "msgtype": "m.text",
+                        "m.new_content": {
+                            "body": "Edited body\n\n⏳ Preparing isolated worker...",
+                            "msgtype": "m.text",
+                            "io.mindroom.visible_body": "Edited body",
+                        },
+                        "m.relates_to": {"rel_type": "m.replace", "event_id": "$thread-root"},
+                    },
+                },
+            },
+        }
+
+        preview = await thread_root_body_preview(
+            event,
+            client=_make_client(),
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+
+        assert preview == "Edited body"
 
 
 class TestDownloadMxcText:


### PR DESCRIPTION
## Summary
- centralize Matrix visible-message reads in `mindroom.matrix.client_visible_messages`, including trusted sender resolution, sidecar hydration, bundled replacements, visible edit extraction, and thread-root previews
- migrate Matrix tools, inbound normalization, and edit regeneration to the shared Matrix read helper layer so callers stop plumbing `trusted_sender_ids` or interpreting bundled `m.replace` themselves
- update Tach boundaries/interfaces and add regression coverage for runtime-derived visible-message resolution

## Invariant
Every Matrix read surface gets canonical visible text and previews from one Matrix-layer resolver instead of recomposing trust, hydration, and preview logic locally.

## Test Plan
- [x] `uv run pytest -x -nauto --no-cov`
- [x] `uv run pre-commit run --all-files`
- [x] `uv run tach check --dependencies --interfaces`
