### PR TITLE
chore: format worker warmup tool labels as code

### DIFF
--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -6,7 +6,6 @@ import asyncio
 import time
 from copy import deepcopy
 from dataclasses import dataclass, field
-from html import escape
 from typing import TYPE_CHECKING, Any, NoReturn
 
 from mindroom import interactive
@@ -424,11 +423,11 @@ class StreamingResponse:
         canonical_visible_body = content["body"]
         if warmup_suffix_lines:
             content[STREAM_VISIBLE_BODY_KEY] = canonical_visible_body
-            warmup_suffix = "\n".join(warmup_suffix_lines)
+            warmup_suffix = "\n".join(line.text for line in warmup_suffix_lines)
             content[STREAM_WARMUP_SUFFIX_KEY] = warmup_suffix
             display_text = f"{display_text}\n\n{warmup_suffix}" if display_text else warmup_suffix
             content["body"] = f"{content['body']}\n\n{warmup_suffix}"
-            suffix_html = "".join(f"<p>{escape(line)}</p>" for line in warmup_suffix_lines)
+            suffix_html = "".join(f"<p>{line.html}</p>" for line in warmup_suffix_lines)
             content["formatted_body"] = f"{content['formatted_body']}{suffix_html}"
 
         return _PreparedStreamingDelivery(

--- a/src/mindroom/streaming_warmup.py
+++ b/src/mindroom/streaming_warmup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from html import escape
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -28,26 +29,52 @@ class _ActiveWarmup:
     last_event: WorkerReadyProgress
 
 
-def _render_worker_status_line(warmup: _ActiveWarmup, *, show_tool_calls: bool) -> str:
+@dataclass(frozen=True)
+class RenderedWarmupLine:
+    """One warmup line rendered for plain-text and HTML Matrix bodies."""
+
+    text: str
+    html: str
+
+
+def _render_tool_labels(tool_labels: list[str]) -> tuple[str, str]:
+    """Render tool labels for plain-text and HTML output."""
+    plain = ", ".join(f"`{label}`" for label in tool_labels)
+    html = ", ".join(f"<code>{escape(label)}</code>" for label in tool_labels)
+    return plain, html
+
+
+def _render_worker_status_line(warmup: _ActiveWarmup, *, show_tool_calls: bool) -> RenderedWarmupLine:
     """Render one worker warmup line without leaking hidden tool metadata."""
-    labels = ", ".join(warmup.tool_labels)
-    if show_tool_calls and labels:
-        waiting_copy = f"Preparing isolated worker for {labels}..."
-        failure_copy = f"Worker startup failed for {labels}"
+    if show_tool_calls and warmup.tool_labels:
+        labels_text, labels_html = _render_tool_labels(warmup.tool_labels)
+        waiting_copy_text = f"Preparing isolated worker for {labels_text}..."
+        waiting_copy_html = f"Preparing isolated worker for {labels_html}..."
+        failure_copy_text = f"Worker startup failed for {labels_text}"
+        failure_copy_html = f"Worker startup failed for {labels_html}"
     else:
-        waiting_copy = "Preparing isolated worker..."
-        failure_copy = "Worker startup failed"
+        waiting_copy_text = waiting_copy_html = "Preparing isolated worker..."
+        failure_copy_text = failure_copy_html = "Worker startup failed"
 
     phase = warmup.last_event.phase
     if phase == "failed":
         error = _shorten_warmup_error(warmup.last_event.error)
         suffix = "" if error.endswith((".", "!", "?")) else "."
-        return f"⚠️ {failure_copy}: {error}{suffix}"
+        return RenderedWarmupLine(
+            text=f"⚠️ {failure_copy_text}: {error}{suffix}",
+            html=f"⚠️ {failure_copy_html}: {escape(error)}{suffix}",
+        )
     if phase == "cold_start":
-        return f"⏳ {waiting_copy}"
+        return RenderedWarmupLine(
+            text=f"⏳ {waiting_copy_text}",
+            html=f"⏳ {waiting_copy_html}",
+        )
 
     elapsed_seconds = max(1, int(warmup.last_event.elapsed_seconds))
-    return f"⏳ {waiting_copy} {elapsed_seconds}s elapsed."
+    return RenderedWarmupLine(
+        text=f"⏳ {waiting_copy_text} {elapsed_seconds}s elapsed.",
+        html=f"⏳ {waiting_copy_html} {elapsed_seconds}s elapsed.",
+    )
 
 
 @dataclass
@@ -94,7 +121,7 @@ class WorkerWarmupState:
         for stale_worker_key in stale_failed_worker_keys:
             self.active_warmups.pop(stale_worker_key, None)
 
-    def render_lines(self, *, show_tool_calls: bool) -> list[str]:
+    def render_lines(self, *, show_tool_calls: bool) -> list[RenderedWarmupLine]:
         """Render all active worker warmup notices as side-band suffix lines."""
         if not self.active_warmups:
             return []

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -2156,11 +2156,12 @@ class TestStreamingBehavior:
         await streaming._send_or_edit_message(mock_client)
 
         content = mock_client.room_send.call_args.kwargs["content"]
-        warmup_text = "⏳ Preparing isolated worker for shell.run..."
+        warmup_text = "⏳ Preparing isolated worker for `shell.run`..."
         assert content["body"].endswith(f"\n\n{warmup_text}")
         assert "<pre><code" in content["formatted_body"]
-        assert content["formatted_body"].endswith(f"<p>{warmup_text}</p>")
-        assert content["formatted_body"].rfind(f"<p>{warmup_text}</p>") > content["formatted_body"].rfind("</pre>")
+        expected_html = "<p>⏳ Preparing isolated worker for <code>shell.run</code>...</p>"
+        assert content["formatted_body"].endswith(expected_html)
+        assert content["formatted_body"].rfind(expected_html) > content["formatted_body"].rfind("</pre>")
 
     @pytest.mark.asyncio
     async def test_worker_warmup_visible_body_uses_canonical_matrix_body(self) -> None:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -2001,9 +2001,13 @@ class TestStreamingBehavior:
 
         await streaming._send_or_edit_message(mock_client, allow_empty_progress=True)
 
-        first_body = mock_client.room_send.call_args.kwargs["content"]["body"]
-        assert "Preparing isolated worker" in first_body
-        assert "shell.run" in first_body
+        content = mock_client.room_send.call_args.kwargs["content"]
+        first_body = content["body"]
+        assert first_body == "Thinking...\n\n⏳ Preparing isolated worker for `shell.run`..."
+        assert (
+            content["formatted_body"]
+            == "<p>Thinking...</p>\n<p>⏳ Preparing isolated worker for <code>shell.run</code>...</p>"
+        )
         assert streaming.accumulated_text == ""
 
         streaming.accumulated_text = "hello"
@@ -2447,10 +2451,13 @@ class TestStreamingBehavior:
 
         await streaming._send_or_edit_message(mock_client, allow_empty_progress=True)
 
-        body = mock_client.room_send.call_args.kwargs["content"]["body"]
-        assert body.count("Preparing isolated worker") == 1
-        assert "shell.run" in body
-        assert "python.execute" in body
+        content = mock_client.room_send.call_args.kwargs["content"]
+        body = content["body"]
+        assert body == "Thinking...\n\n⏳ Preparing isolated worker for `shell.run`, `python.execute`... 10s elapsed."
+        assert (
+            content["formatted_body"]
+            == "<p>Thinking...</p>\n<p>⏳ Preparing isolated worker for <code>shell.run</code>, <code>python.execute</code>... 10s elapsed.</p>"
+        )
 
     @pytest.mark.asyncio
     async def test_worker_warmup_renders_multiple_lines_for_distinct_workers(self) -> None:
@@ -2536,6 +2543,46 @@ class TestStreamingBehavior:
         body = mock_client.room_send.call_args.kwargs["content"]["body"]
         assert "Preparing isolated worker" in body
         assert "Worker startup failed" not in body
+
+    @pytest.mark.asyncio
+    async def test_worker_warmup_failed_status_renders_exact_visible_copy(self) -> None:
+        """Visible failed warmups should pin exact plain-text and HTML formatting."""
+        mock_client = _make_matrix_client_mock()
+        mock_response = MagicMock()
+        mock_response.__class__ = nio.RoomSendResponse
+        mock_response.event_id = "$warmup_failed_visible"
+        mock_client.room_send.return_value = mock_response
+
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id=None,
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+        )
+        streaming.apply_worker_progress_event(
+            WorkerProgressEvent(
+                tool_name="shell",
+                function_name="run",
+                progress=WorkerReadyProgress(
+                    phase="failed",
+                    worker_key="worker-a",
+                    backend_name="kubernetes",
+                    elapsed_seconds=1.0,
+                    error="intentional example",
+                ),
+            ),
+        )
+
+        await streaming._send_or_edit_message(mock_client, allow_empty_progress=True)
+
+        content = mock_client.room_send.call_args.kwargs["content"]
+        assert content["body"] == "Thinking...\n\n⚠️ Worker startup failed for `shell.run`: intentional example."
+        assert (
+            content["formatted_body"]
+            == "<p>Thinking...</p>\n<p>⚠️ Worker startup failed for <code>shell.run</code>: intentional example.</p>"
+        )
 
 
 class TestStreamingConfig:


### PR DESCRIPTION
## Summary
- render worker warmup tool labels as inline code in streamed warmup copy
- split warmup rendering into text and HTML variants so Matrix formatted bodies use `<code>` tags
- add regression coverage for warmup suffix formatting outside partial markdown blocks

## Testing
- uv run pytest
- uv run pre-commit run --all-files