### PR TITLE
fix: surface error when streaming model emits only extended-thinking blocks (ISSUE-181)

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -226,6 +226,7 @@ class _StreamingAttemptState:
     full_response: str = ""
     tool_count: int = 0
     observed_tool_calls: int = 0
+    observed_reasoning_content: bool = False
     pending_tools: list[_PendingStreamingTool] = field(default_factory=list)
     completed_tools: list[ToolTraceEntry] = field(default_factory=list)
     latest_model_id: str | None = None
@@ -1210,7 +1211,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
 
 
 @timed("model_request_to_completion")
-async def _process_stream_events(  # noqa: C901, PLR0912
+async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
     stream_generator: AsyncIterator[object],
     *,
     state: _StreamingAttemptState,
@@ -1226,7 +1227,13 @@ async def _process_stream_events(  # noqa: C901, PLR0912
     del timing_scope
     try:
         async for event in stream_generator:
-            if isinstance(event, RunContentEvent) and event.content:
+            if isinstance(event, RunContentEvent):
+                if event.reasoning_content:
+                    state.observed_reasoning_content = True
+                if not event.content:
+                    if event.reasoning_content:
+                        yield event
+                    continue
                 if not state.first_token_logged:
                     state.first_token_logged = True
                     if pipeline_timing is not None:
@@ -1268,6 +1275,9 @@ async def _process_stream_events(  # noqa: C901, PLR0912
 
             if isinstance(event, RunCompletedEvent):
                 state.completed_run_event = event
+                if event.reasoning_content:
+                    state.observed_reasoning_content = True
+                    yield event
                 continue
 
             if isinstance(event, RunCancelledEvent):

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 from dataclasses import dataclass
 from html import escape as html_escape
 from typing import TYPE_CHECKING, Any, Literal
@@ -644,6 +645,14 @@ class DeliveryGateway:
         request: FinalizeStreamedResponseRequest,
     ) -> DeliveryResult:
         """Apply hooks and any final edit needed after streamed delivery completes."""
+        terminal_stream_status_snapshot = (
+            request.extra_content.get(constants.STREAM_STATUS_KEY) if request.extra_content is not None else None
+        )
+        terminal_ai_run_snapshot = (
+            copy.deepcopy(request.extra_content.get(constants.AI_RUN_METADATA_KEY))
+            if request.extra_content is not None
+            else None
+        )
         draft = await self.deps.response_hooks.apply_before_response(
             correlation_id=request.correlation_id,
             envelope=request.response_envelope,
@@ -686,6 +695,14 @@ class DeliveryGateway:
             or draft.extra_content != request.extra_content
         )
         if needs_final_edit:
+            terminal_extra_content = dict(draft.extra_content or {})
+            terminal_extra_content[constants.STREAM_STATUS_KEY] = (
+                terminal_stream_status_snapshot
+                if terminal_stream_status_snapshot is not None
+                else constants.STREAM_STATUS_COMPLETED
+            )
+            if terminal_ai_run_snapshot is not None:
+                terminal_extra_content[constants.AI_RUN_METADATA_KEY] = terminal_ai_run_snapshot
             return await self.deliver_final(
                 FinalDeliveryRequest(
                     target=request.target,
@@ -695,7 +712,7 @@ class DeliveryGateway:
                     response_envelope=request.response_envelope,
                     correlation_id=request.correlation_id,
                     tool_trace=draft.tool_trace,
-                    extra_content=draft.extra_content,
+                    extra_content=terminal_extra_content,
                     apply_before_hooks=False,
                 ),
             )

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn
 
 from mindroom import interactive
 from mindroom.constants import (
+    AI_RUN_METADATA_KEY,
     STREAM_STATUS_CANCELLED,
     STREAM_STATUS_COMPLETED,
     STREAM_STATUS_ERROR,
@@ -60,6 +61,7 @@ CANCELLED_RESPONSE_NOTE = _CANCELLED_RESPONSE_NOTE
 _INTERRUPTED_RESPONSE_NOTE = "**[Response interrupted]**"
 INTERRUPTED_RESPONSE_NOTE = _INTERRUPTED_RESPONSE_NOTE
 _RESTART_INTERRUPTED_RESPONSE_NOTE = "**[Response interrupted by service restart]**"
+_NO_VISIBLE_TEXT_AFTER_THINKING_NOTE = "**[Model emitted no visible text content after thinking. Please retry.]**"
 _STREAM_ERROR_RESPONSE_NOTE = "**[Response interrupted by an error"
 _StreamInputChunk = StreamInputChunk
 _TerminalStreamStatus = Literal["completed", "cancelled", "error", "interrupted"]
@@ -250,6 +252,8 @@ class StreamingResponse:
     pipeline_timing: DispatchPipelineTiming | None = None
     conversation_cache: ConversationCacheProtocol | None = None
     visible_event_id_callback: Callable[[str], None] | None = None
+    observed_reasoning_content: bool = False
+    observed_tool_calls: int = 0
     _warmup_state: WorkerWarmupState = field(default_factory=WorkerWarmupState, init=False, repr=False)
     _last_delivered_text: str = field(default="", init=False, repr=False)
     _last_delivered_tool_trace: list[ToolTraceEntry] = field(default_factory=list, init=False, repr=False)
@@ -339,6 +343,44 @@ class StreamingResponse:
         self._update(new_chunk)
         await self._throttled_send(client)
 
+    def _prepare_terminal_text_and_status(
+        self,
+        *,
+        error: Exception | None,
+        resolved_cancel_source: CancelSource | None,
+    ) -> _TerminalStreamStatus:
+        """Apply terminal text adjustments and return the terminal stream status."""
+        ai_run_payload = self.extra_content.get(AI_RUN_METADATA_KEY) if self.extra_content is not None else None
+        no_visible_text_error = (
+            error is None
+            and resolved_cancel_source is None
+            and not self.accumulated_text.strip()
+            and self.observed_reasoning_content
+            and self.observed_tool_calls == 0
+        )
+        if no_visible_text_error:
+            self.accumulated_text = _NO_VISIBLE_TEXT_AFTER_THINKING_NOTE
+            if self.extra_content is not None:
+                self.extra_content[STREAM_STATUS_KEY] = STREAM_STATUS_ERROR
+                if isinstance(ai_run_payload, dict):
+                    ai_run_payload["status"] = STREAM_STATUS_ERROR
+            return STREAM_STATUS_ERROR
+
+        if error is not None:
+            stripped_text = self.accumulated_text.rstrip()
+            error_note = _format_stream_error_note(error)
+            self.accumulated_text = f"{stripped_text}\n\n{error_note}" if stripped_text else error_note
+            return STREAM_STATUS_ERROR
+
+        if resolved_cancel_source is not None:
+            self.accumulated_text, stream_status = build_cancelled_response_update(
+                self.accumulated_text,
+                cancel_source=resolved_cancel_source,
+            )
+            return stream_status
+
+        return STREAM_STATUS_COMPLETED
+
     async def finalize(
         self,
         client: nio.AsyncClient,
@@ -350,24 +392,16 @@ class StreamingResponse:
     ) -> None:
         """Send final message update."""
         self._warmup_state.clear_for_terminal_transition()
-        if error is not None:
-            stripped_text = self.accumulated_text.rstrip()
-            error_note = _format_stream_error_note(error)
-            self.accumulated_text = f"{stripped_text}\n\n{error_note}" if stripped_text else error_note
-            final_stream_status = STREAM_STATUS_ERROR
-        else:
-            resolved_cancel_source = cancel_source
-            if resolved_cancel_source is None:
-                if restart_interrupted:
-                    resolved_cancel_source = "sync_restart"
-                elif cancelled:
-                    resolved_cancel_source = "user_stop"
-            final_stream_status = STREAM_STATUS_COMPLETED
-            if resolved_cancel_source is not None:
-                self.accumulated_text, final_stream_status = build_cancelled_response_update(
-                    self.accumulated_text,
-                    cancel_source=resolved_cancel_source,
-                )
+        resolved_cancel_source = cancel_source
+        if resolved_cancel_source is None:
+            if restart_interrupted:
+                resolved_cancel_source = "sync_restart"
+            elif cancelled:
+                resolved_cancel_source = "user_stop"
+        final_stream_status = self._prepare_terminal_text_and_status(
+            error=error,
+            resolved_cancel_source=resolved_cancel_source,
+        )
 
         # When a placeholder message exists but no real text arrived,
         # still edit the message to finalize the stream status.

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, NoReturn
 
-from agno.run.agent import RunContentEvent, ToolCallCompletedEvent, ToolCallStartedEvent
+from agno.run.agent import RunCompletedEvent, RunContentEvent, ToolCallCompletedEvent, ToolCallStartedEvent
 
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.events import (
@@ -30,7 +30,9 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-StreamInputChunk = str | StructuredStreamChunk | RunContentEvent | ToolCallStartedEvent | ToolCallCompletedEvent
+StreamInputChunk = (
+    str | StructuredStreamChunk | RunContentEvent | RunCompletedEvent | ToolCallStartedEvent | ToolCallCompletedEvent
+)
 _STREAM_DELIVERY_DRAIN_TIMEOUT_SECONDS = 5.0
 _STREAM_DELIVERY_CANCEL_TIMEOUT_SECONDS = 5.0
 
@@ -119,9 +121,21 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
             text_chunk = chunk.content
             if chunk.tool_trace is not None:
                 streaming.tool_trace = _merge_tool_trace(streaming.tool_trace, chunk.tool_trace)
-        elif isinstance(chunk, RunContentEvent) and chunk.content:
-            text_chunk = str(chunk.content)
+        elif isinstance(chunk, RunContentEvent):
+            if chunk.reasoning_content:
+                streaming.observed_reasoning_content = True
+            if chunk.content:
+                text_chunk = str(chunk.content)
+            else:
+                _queue_delivery_request(delivery_queue, progress_hint=True)
+                continue
+        elif isinstance(chunk, RunCompletedEvent):
+            if chunk.reasoning_content:
+                streaming.observed_reasoning_content = True
+            continue
         elif isinstance(chunk, ToolCallStartedEvent):
+            if chunk.tool is not None:
+                streaming.observed_tool_calls += 1
             if not streaming.show_tool_calls:
                 if chunk.tool is not None:
                     streaming._ensure_hidden_tool_gap()

--- a/tests/test_streaming_finalize.py
+++ b/tests/test_streaming_finalize.py
@@ -1,0 +1,228 @@
+"""Regression tests for streamed-response finalization."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from agno.metrics import RunMetrics
+from agno.run.agent import ModelRequestCompletedEvent, RunCompletedEvent, RunContentEvent
+
+from mindroom.constants import AI_RUN_METADATA_KEY, STREAM_STATUS_ERROR, STREAM_STATUS_KEY
+from mindroom.delivery_gateway import DeliveryGateway, DeliveryGatewayDeps
+from mindroom.hooks import ResponseDraft
+from mindroom.matrix.client import DeliveredMatrixEvent
+from mindroom.matrix.message_builder import markdown_to_html
+from tests.conftest import bind_runtime_paths
+from tests.test_ai_user_id import (
+    _build_response_runner,
+    _config,
+    _make_bot,
+    _prepared_prompt_result,
+    _response_request,
+    _runtime_paths,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+_NO_VISIBLE_TEXT_AFTER_THINKING_NOTE = "**[Model emitted no visible text content after thinking. Please retry.]**"
+
+
+@asynccontextmanager
+async def _noop_typing(*_args: object, **_kwargs: object) -> AsyncIterator[None]:
+    yield
+
+
+def _make_streaming_agent(*events: object) -> MagicMock:
+    agent = MagicMock()
+    agent.model = MagicMock()
+    agent.model.__class__.__name__ = "OpenAIChat"
+    agent.model.id = "test-model"
+    agent.name = "GeneralAgent"
+    agent.add_history_to_context = False
+
+    def fake_arun(*_args: object, **kwargs: object) -> AsyncIterator[object]:
+        assert kwargs["stream"] is True
+        assert kwargs["stream_events"] is True
+
+        async def stream() -> AsyncIterator[object]:
+            for event in events:
+                yield event
+
+        return stream()
+
+    agent.arun = MagicMock(side_effect=fake_arun)
+    return agent
+
+
+async def _run_streaming_finalize_scenario(
+    tmp_path: Path,
+    *events: object,
+    before_response_hook: object | None = None,
+) -> tuple[object, list[dict[str, object]]]:
+    runtime_paths = _runtime_paths(tmp_path)
+    config = bind_runtime_paths(_config(), runtime_paths)
+    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
+    coordinator = _build_response_runner(
+        bot,
+        config=config,
+        runtime_paths=runtime_paths,
+        storage_path=tmp_path,
+        requester_id="@alice:localhost",
+    )
+    conversation_cache = SimpleNamespace(
+        get_latest_thread_event_id_if_needed=AsyncMock(return_value=None),
+        notify_outbound_message=MagicMock(),
+    )
+    bot._conversation_resolver.deps = SimpleNamespace(conversation_cache=conversation_cache)
+    captured_edits: list[dict[str, object]] = []
+
+    async def record_edit(
+        _client: object,
+        _room_id: str,
+        _event_id: str,
+        new_content: dict[str, object],
+        _new_text: str,
+    ) -> DeliveredMatrixEvent:
+        captured_edits.append(new_content)
+        return DeliveredMatrixEvent(event_id="$edit", content_sent=new_content)
+
+    async def apply_before_response(
+        *,
+        correlation_id: str,
+        envelope: object,
+        response_text: str,
+        response_kind: str,
+        tool_trace: object,
+        extra_content: dict[str, object] | None,
+    ) -> ResponseDraft:
+        if before_response_hook is not None:
+            return await before_response_hook(
+                correlation_id=correlation_id,
+                envelope=envelope,
+                response_text=response_text,
+                response_kind=response_kind,
+                tool_trace=tool_trace,
+                extra_content=extra_content,
+            )
+        return ResponseDraft(
+            response_text=response_text,
+            response_kind=response_kind,
+            tool_trace=tool_trace,
+            extra_content=extra_content,
+            envelope=envelope,
+        )
+
+    agent = _make_streaming_agent(*events)
+    delivery_gateway = DeliveryGateway(
+        DeliveryGatewayDeps(
+            runtime=coordinator.deps.runtime,
+            runtime_paths=runtime_paths,
+            agent_name=coordinator.deps.agent_name,
+            logger=coordinator.deps.logger,
+            redact_message_event=AsyncMock(return_value=True),
+            sender_domain="localhost",
+            resolver=coordinator.deps.resolver,
+            response_hooks=SimpleNamespace(
+                apply_before_response=AsyncMock(side_effect=apply_before_response),
+                emit_after_response=AsyncMock(),
+                emit_cancelled_response=AsyncMock(),
+            ),
+        ),
+    )
+    coordinator.deps = replace(coordinator.deps, delivery_gateway=delivery_gateway)
+    request = replace(
+        _response_request(prompt="Hello", user_id="@alice:localhost"),
+        existing_event_id="$thinking",
+        existing_event_is_placeholder=True,
+    )
+    request = replace(
+        request,
+        response_envelope=coordinator._response_envelope_for_request(
+            request,
+            resolved_target=coordinator.deps.resolver.build_message_target.return_value,
+        ),
+        correlation_id=coordinator._correlation_id_for_request(request),
+    )
+
+    with (
+        patch("mindroom.ai._prepare_agent_and_prompt", new=AsyncMock(return_value=_prepared_prompt_result(agent))),
+        patch("mindroom.response_runner.ensure_request_knowledge_managers", new=AsyncMock(return_value={})),
+        patch("mindroom.response_runner.typing_indicator", new=_noop_typing),
+        patch("mindroom.delivery_gateway.edit_message_result", new=AsyncMock(side_effect=record_edit)),
+        patch("mindroom.streaming.edit_message_result", new=AsyncMock(side_effect=record_edit)),
+    ):
+        delivery = await coordinator.process_and_respond_streaming(request)
+
+    return delivery, captured_edits
+
+
+@pytest.mark.asyncio
+async def test_streaming_finalize_surfaces_reasoning_only_run_as_error(tmp_path: Path) -> None:
+    """A run that only emits thinking blocks should finalize as a visible error."""
+    delivery, captured_edits = await _run_streaming_finalize_scenario(
+        tmp_path,
+        RunContentEvent(reasoning_content="pondering"),
+        ModelRequestCompletedEvent(input_tokens=6, output_tokens=0, cache_read_tokens=46449),
+        RunCompletedEvent(
+            content=None,
+            reasoning_content="pondering",
+            metrics=RunMetrics(input_tokens=6, output_tokens=0, cache_read_tokens=46449),
+        ),
+    )
+
+    final_content = captured_edits[-1]
+    ai_run = final_content[AI_RUN_METADATA_KEY]
+
+    assert delivery.response_text == _NO_VISIBLE_TEXT_AFTER_THINKING_NOTE
+    assert final_content["body"] == _NO_VISIBLE_TEXT_AFTER_THINKING_NOTE
+    assert final_content[STREAM_STATUS_KEY] == STREAM_STATUS_ERROR
+    assert ai_run["status"] == "error"
+    assert final_content["formatted_body"] == markdown_to_html(_NO_VISIBLE_TEXT_AFTER_THINKING_NOTE)
+
+
+@pytest.mark.asyncio
+async def test_streaming_finalize_keeps_error_status_after_hook_reedit(tmp_path: Path) -> None:
+    """A hook-driven final re-edit must preserve the error stream status."""
+
+    async def mutate_before_response(
+        *,
+        correlation_id: str,
+        envelope: object,
+        response_text: str,
+        response_kind: str,
+        tool_trace: object,
+        extra_content: dict[str, object] | None,
+    ) -> ResponseDraft:
+        del correlation_id
+        mutated_extra_content = dict(extra_content or {})
+        mutated_extra_content.pop(STREAM_STATUS_KEY, None)
+        return ResponseDraft(
+            response_text=f"{response_text}\n\nHook footer.",
+            response_kind=response_kind,
+            tool_trace=tool_trace,
+            extra_content=mutated_extra_content,
+            envelope=envelope,
+        )
+
+    delivery, captured_edits = await _run_streaming_finalize_scenario(
+        tmp_path,
+        RunContentEvent(reasoning_content="pondering"),
+        ModelRequestCompletedEvent(input_tokens=6, output_tokens=0, cache_read_tokens=46449),
+        RunCompletedEvent(content=None, reasoning_content="pondering"),
+        before_response_hook=mutate_before_response,
+    )
+
+    final_content = captured_edits[-1]
+    ai_run = final_content[AI_RUN_METADATA_KEY]
+
+    assert delivery.response_text.endswith("Hook footer.")
+    assert final_content["body"].endswith("Hook footer.")
+    assert final_content[STREAM_STATUS_KEY] == STREAM_STATUS_ERROR
+    assert ai_run["status"] == "error"


### PR DESCRIPTION
## Summary
- port the ISSUE-181 reasoning-only streaming fix from `gitea/main` onto current `origin/main`
- surface an explicit visible error when a streamed run emits only thinking/reasoning blocks and no visible text or tool calls
- preserve the terminal `stream_status` and `ai_run.status` when `before_response` hooks trigger a final re-edit
- add regression coverage for the primary reasoning-only case and the hook re-edit follow-up

## Verification
- `uv run pytest -n 0 --no-cov`
- `uv run pre-commit run --all-files`
- `uv run pytest tests/test_streaming_finalize.py tests/test_streaming_behavior.py::TestStreamingBehavior::test_send_streaming_response_finalizes_adopted_placeholder_without_chunks tests/test_streaming_behavior.py::TestStreamingBehavior::test_stream_error_replaces_placeholder_when_no_text_arrives -x -n 0 --no-cov -q`