### PR TITLE
fix(history): cap compaction summary input budget

### DIFF
--- a/src/mindroom/token_budget.py
+++ b/src/mindroom/token_budget.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import json
 
+MAX_COMPACTION_SUMMARY_INPUT_TOKENS = 48_000
+
 
 def estimate_text_tokens(value: str | list[str] | None) -> int:
     """Estimate token count using chars / 4."""
@@ -26,14 +28,20 @@ def compute_compaction_input_budget(
     reserve_tokens: int,
     prompt_overhead_tokens: int = 2000,
     safety_margin_ratio: float = 0.10,
+    max_input_tokens: int | None = MAX_COMPACTION_SUMMARY_INPUT_TOKENS,
 ) -> int:
     """Compute the max input tokens available for a compaction summary request.
 
     Subtracts output reserve, prompt overhead (system prompt + response format),
     and a safety margin from the compaction model's context window.
+    Large-window models can theoretically fit much larger requests, but
+    destructive compaction runs inline on the user path behind a fixed timeout,
+    so cap each summary pass to keep latency bounded.
     """
     safety = int(context_window * safety_margin_ratio)
     budget = context_window - reserve_tokens - prompt_overhead_tokens - safety
+    if max_input_tokens is not None:
+        budget = min(budget, max_input_tokens)
     return max(0, budget)
 
 

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -3072,6 +3072,26 @@ def test_resolve_history_execution_plan_marks_non_positive_summary_budget_unavai
     assert execution_plan.unavailable_reason == "non_positive_summary_input_budget"
 
 
+def test_resolve_history_execution_plan_caps_large_summary_input_budget(tmp_path: Path) -> None:
+    config, _runtime_paths_value = _make_config(
+        tmp_path,
+        compaction=CompactionOverrideConfig(enabled=True),
+        context_window=200_000,
+    )
+
+    execution_plan = resolve_history_execution_plan(
+        config=config,
+        compaction_config=config.get_entity_compaction_config("test_agent"),
+        has_authored_compaction_config=config.has_authored_entity_compaction_config("test_agent"),
+        active_model_name="default",
+        active_context_window=200_000,
+        static_prompt_tokens=2_000,
+    )
+
+    assert execution_plan.summary_input_budget_tokens == 48_000
+    assert execution_plan.destructive_compaction_available is True
+
+
 def test_resolve_history_execution_plan_keeps_replay_headroom_when_compaction_disabled(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- cap the compaction summary input budget in `src/mindroom/token_budget.py`
- add regression coverage in `tests/test_agno_history.py`
- cherry-pick only the tip commit from `gitea/fix/compaction-summary-budget-cap`

## Test Plan
- [ ] `uv run pytest -n auto --no-cov`
- [ ] `uv run pre-commit run --all-files`
