### PR TITLE
fix(history): raise compaction timeout to 5 minutes

### DIFF
--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -22,7 +22,7 @@ from dotenv import dotenv_values
 
 # Agent names
 ROUTER_AGENT_NAME = "router"
-MINDROOM_COMPACTION_CALL_TIMEOUT_SECONDS = 60.0
+MINDROOM_COMPACTION_CALL_TIMEOUT_SECONDS = 300.0
 
 # Search order for existing files: env var > ./config.yaml > ~/.mindroom/config.yaml
 _CONFIG_SEARCH_PATHS = [Path("config.yaml"), Path.home() / ".mindroom" / "config.yaml"]


### PR DESCRIPTION
## Summary
- raise the history compaction timeout from the previous default to 5 minutes in `src/mindroom/constants.py`
- publish the updated `gitea/fix/compaction-timeout-5m` branch on GitHub

## Test Plan
- [x] `uv run pytest -n auto --no-cov`
