### PR TITLE
fix(matrix): stop tool placeholders becoming setext headings

### DIFF
--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -9,7 +9,7 @@ from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths
 from mindroom.matrix.identity import MatrixID, mindroom_namespace
 from mindroom.matrix.message_builder import build_message_content, markdown_to_html
-from mindroom.tool_system.events import build_tool_trace_content
+from mindroom.tool_system.events import build_tool_trace_content, ensure_visible_tool_marker_spacing
 
 if TYPE_CHECKING:
     from mindroom.tool_system.events import ToolTraceEntry
@@ -443,7 +443,13 @@ def format_message_with_mentions(
         Properly formatted content dict for room_send
 
     """
-    plain_text, mentioned_user_ids, markdown_text = parse_mentions_in_text(text, sender_domain, config, runtime_paths)
+    spaced_text = ensure_visible_tool_marker_spacing(text)
+    plain_text, mentioned_user_ids, markdown_text = parse_mentions_in_text(
+        spaced_text,
+        sender_domain,
+        config,
+        runtime_paths,
+    )
 
     # Convert markdown (with links) to HTML
     # The markdown converter will properly handle the [@DisplayName](url) format

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
 _ToolContextResult = TypeVar("_ToolContextResult")
 _ToolStreamChunk = TypeVar("_ToolStreamChunk")
 _VISIBLE_TOOL_MARKER_LINE_PATTERN = re.compile(r"^\s*🔧 `[^`]+` \[\d+\](?: ⏳)?\s*$")
+_VISIBLE_TOOL_MARKER_SEPARATOR_PATTERN = re.compile(r"^\s{0,3}---\s*$")
 
 
 def _merge_response_extra_content(
@@ -146,8 +147,31 @@ def _split_delivery_tool_trace(
 
 
 def _strip_visible_tool_markers(text: str) -> str:
-    """Remove Matrix-visible tool marker lines from streamed text before replay persistence."""
-    filtered_lines = [line for line in text.splitlines() if not _VISIBLE_TOOL_MARKER_LINE_PATTERN.fullmatch(line)]
+    """Remove Matrix-visible tool markers from streamed text before replay persistence."""
+    lines = text.splitlines()
+    filtered_lines: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not _VISIBLE_TOOL_MARKER_LINE_PATTERN.fullmatch(line):
+            filtered_lines.append(line)
+            index += 1
+            continue
+
+        index += 1
+        spacer_lines: list[str] = []
+        while index < len(lines) and not lines[index].strip():
+            spacer_lines.append(lines[index])
+            index += 1
+
+        if index < len(lines) and _VISIBLE_TOOL_MARKER_SEPARATOR_PATTERN.fullmatch(lines[index]):
+            filtered_lines.extend(spacer_lines)
+            index += 1
+            if index < len(lines) and not lines[index].strip():
+                index += 1
+            continue
+
+        filtered_lines.extend(spacer_lines)
     return "\n".join(filtered_lines).rstrip()
 
 

--- a/src/mindroom/tool_system/events.py
+++ b/src/mindroom/tool_system/events.py
@@ -25,6 +25,7 @@ _MAX_TOOL_TRACE_EVENTS = 120
 _TOOL_REF_ICON = "🔧"
 _TOOL_PENDING_MARKER = " ⏳"
 _TOOL_MARKER_PATTERN = re.compile(r"🔧 `([^`]+)` \[(\d+)\]( ⏳)?")
+_VISIBLE_TOOL_MARKER_LINE_PATTERN = re.compile(r"^\s*🔧 `[^`]+` \[\d+\](?: ⏳)?\s*$")
 StructuredResultDict = dict[str, object]
 StructuredResultList = list[object]
 
@@ -300,8 +301,39 @@ def _tool_marker_line(tool_name: str, tool_index: int | None, *, pending: bool) 
     return f"{_TOOL_REF_ICON} `{safe_tool_name}`{suffix}{pending_suffix}"
 
 
+def is_visible_tool_marker_line(line: str) -> bool:
+    """Return whether one plain-text line is a Matrix-visible tool marker."""
+    return _VISIBLE_TOOL_MARKER_LINE_PATTERN.fullmatch(line) is not None
+
+
+def _line_ending(line: str) -> str:
+    if line.endswith("\r\n"):
+        return "\r\n"
+    if line.endswith("\n"):
+        return "\n"
+    return "\n"
+
+
+def ensure_visible_tool_marker_spacing(text: str) -> str:
+    """Ensure visible tool-marker lines cannot become setext headings."""
+    lines = text.splitlines(keepends=True)
+    if not lines:
+        return text
+
+    spaced_lines: list[str] = []
+    for index, line in enumerate(lines):
+        spaced_lines.append(line)
+        line_text = line.rstrip("\r\n")
+        if not is_visible_tool_marker_line(line_text):
+            continue
+        next_line = lines[index + 1] if index + 1 < len(lines) else None
+        if next_line is not None and next_line.strip():
+            spaced_lines.append(_line_ending(line) if line.endswith(("\n", "\r")) else "\n\n")
+    return "".join(spaced_lines)
+
+
 def _format_tool_marker(tool_name: str, tool_index: int | None, *, pending: bool) -> str:
-    return f"\n\n{_tool_marker_line(tool_name, tool_index, pending=pending)}\n"
+    return f"\n\n{_tool_marker_line(tool_name, tool_index, pending=pending)}\n\n"
 
 
 def _format_tool_args(tool_args: dict[str, object]) -> tuple[str, bool]:

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -84,6 +84,7 @@ from mindroom.response_runner import (
     ResponseRequest,
     ResponseRunner,
     ResponseRunnerDeps,
+    _strip_visible_tool_markers,
     prepare_memory_and_model_context,
 )
 from mindroom.streaming import StreamingDeliveryError
@@ -1048,6 +1049,12 @@ async def test_process_and_respond_streaming_persists_interrupted_history_when_d
         ("user", "Hello"),
         ("assistant", "Partial answer\n\n[interrupted]"),
     ]
+
+
+def test_strip_visible_tool_markers_handles_blank_lined_markers() -> None:
+    """The tool-marker stripper should leave bodies intact when markers are followed by blank lines."""
+    text = "Intro\n\n🔧 `run_shell_command` [1]\n\n---\n\nBody"
+    assert _strip_visible_tool_markers(text) == "Intro\n\n\nBody"
 
 
 @pytest.mark.asyncio

--- a/tests/test_markdown_to_html.py
+++ b/tests/test_markdown_to_html.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from mindroom.matrix.message_builder import markdown_to_html
+from mindroom.tool_system.events import ensure_visible_tool_marker_spacing
 
 # --- Core bug fix: tables without blank lines ---
 
@@ -429,6 +430,26 @@ def test_tool_marker_emoji_code_span() -> None:
     html = markdown_to_html("\n\n\U0001f527 `search_web` [1] \u23f3\n")
     assert "<code>search_web</code>" in html
     assert "\U0001f527" in html
+
+
+def test_tool_marker_followed_by_thematic_break_does_not_render_as_setext_heading() -> None:
+    """ISSUE-195: tool placeholder + `---` must render as <p>+<hr>, NOT <h2>."""
+    html = markdown_to_html(ensure_visible_tool_marker_spacing("🔧 `tool` [1]\n---\n"))
+    assert "<p>🔧 <code>tool</code> [1]</p>" in html
+    assert "<hr>" in html
+    assert "<h2>" not in html
+
+
+def test_setext_h1_is_preserved_for_normal_markdown() -> None:
+    """Normal CommonMark setext h1 syntax should keep rendering as a heading."""
+    html = markdown_to_html("Heading\n===\n")
+    assert "<h1>Heading</h1>" in html
+
+
+def test_setext_h2_is_preserved_for_normal_markdown() -> None:
+    """Normal CommonMark setext h2 syntax should keep rendering as a heading."""
+    html = markdown_to_html("Heading\n---\n")
+    assert "<h2>Heading</h2>" in html
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -211,6 +211,23 @@ class TestMentionParsing:
         assert content["m.relates_to"]["event_id"] == "$thread123"
         assert content["m.relates_to"]["rel_type"] == "m.thread"
 
+    def test_tool_marker_followed_by_thematic_break_renders_as_paragraph_hr_heading_via_format_message_with_mentions(
+        self,
+    ) -> None:
+        """Visible tool markers should stay paragraphs through the Matrix message formatter."""
+        config = _make_config(_default_runtime_paths())
+        text = "Some intro text.\n\n🔧 `run_shell_command` [1]\n---\n\n## Heading after"
+
+        content = _format_message_with_mentions(config, text, sender_domain="matrix.org")
+
+        assert "🔧 `run_shell_command` [1]\n\n---" in content["body"]
+        formatted_body = content["formatted_body"]
+        assert "<h2>🔧" not in formatted_body
+        marker_index = formatted_body.index("<p>🔧 <code>run_shell_command</code> [1]</p>")
+        hr_index = formatted_body.index("<hr>")
+        heading_index = formatted_body.index("<h2>Heading after</h2>")
+        assert marker_index < hr_index < heading_index
+
     def test_format_message_with_mentions_includes_tool_trace(self) -> None:
         """Structured tool traces should be attached to message content when provided."""
         config = _make_config(_default_runtime_paths())

--- a/tests/test_tool_events.py
+++ b/tests/test_tool_events.py
@@ -14,6 +14,7 @@ from mindroom.tool_system.events import (
     _format_tool_started,
     build_tool_trace_content,
     complete_pending_tool_block,
+    ensure_visible_tool_marker_spacing,
     extract_tool_completed_info,
     format_tool_combined,
     format_tool_completed_event,
@@ -102,7 +103,7 @@ def test_format_tool_started_uses_plain_marker_and_truncates() -> None:
     )
 
     assert text.startswith("\n\n🔧 `save_file` [1]")
-    assert text.endswith("\n")
+    assert text.endswith("\n\n")
     assert "🔧" in text
     assert "`save_file`" in text
     assert "[1]" in text
@@ -120,7 +121,7 @@ def test_format_tool_combined_with_result() -> None:
     text, trace = format_tool_combined("run_shell_command", {"cmd": "pwd"}, "/app", tool_index=2)
 
     assert text.startswith("\n\n🔧 `run_shell_command` [2]")
-    assert text.endswith("\n")
+    assert text.endswith("\n\n")
     assert "<validation>" not in text
     assert "`run_shell_command`" in text
     assert "[2]" in text
@@ -138,7 +139,7 @@ def test_format_tool_combined_truncates_long_result() -> None:
     text, trace = format_tool_combined("run_shell_command", {}, "done " + ("y" * 5000))
 
     assert text.startswith("\n\n🔧 `run_shell_command`")
-    assert text.endswith("\n")
+    assert text.endswith("\n\n")
     assert trace.type == "tool_call_completed"
     assert trace.result_preview is not None
     assert trace.truncated is True
@@ -243,7 +244,7 @@ def test_format_tool_combined_with_none_result() -> None:
     """Combined formatting should handle missing results."""
     text, trace = format_tool_combined("save_file", {}, None, tool_index=1)
 
-    assert text == "\n\n🔧 `save_file` [1]\n"
+    assert text == "\n\n🔧 `save_file` [1]\n\n"
     assert trace.type == "tool_call_completed"
     assert trace.tool_name == "save_file"
     assert trace.result_preview is None
@@ -254,7 +255,7 @@ def test_format_tool_combined_with_empty_string_result() -> None:
     """Combined formatting should treat empty results as no-result."""
     text, trace = format_tool_combined("save_file", {"file": "a.py"}, "", tool_index=1)
 
-    assert text == "\n\n🔧 `save_file` [1]\n"
+    assert text == "\n\n🔧 `save_file` [1]\n\n"
     assert trace.type == "tool_call_completed"
     assert trace.result_preview is None
     assert trace.truncated is False
@@ -372,7 +373,7 @@ def test_render_tool_trace_for_context_omits_missing_optional_fields() -> None:
 def test_format_tool_started_with_empty_args() -> None:
     """Tool start formatting should handle empty argument maps."""
     text, trace = _format_tool_started("save_file", {}, tool_index=1)
-    assert text == "\n\n🔧 `save_file` [1] ⏳\n"
+    assert text == "\n\n🔧 `save_file` [1] ⏳\n\n"
     assert trace.type == "tool_call_started"
     assert trace.tool_name == "save_file"
     assert trace.args_preview is None
@@ -467,7 +468,7 @@ def test_format_tool_completed_event_formats_combined_block() -> None:
     """Completion event helper should render canonical plain marker."""
     tool = ToolExecution(tool_name="run_shell", tool_args={"cmd": "pwd"}, result="/app")
     text, trace = format_tool_completed_event(tool, tool_index=1)
-    assert text == "\n\n🔧 `run_shell` [1]\n"
+    assert text == "\n\n🔧 `run_shell` [1]\n\n"
     assert trace is not None
     assert trace.type == "tool_call_completed"
     assert trace.tool_name == "run_shell"
@@ -539,3 +540,28 @@ def test_markdown_to_html_plain_tool_marker_renders_code_span() -> None:
     assert "<code>search_web</code>" in html
     assert "🔧" in html
     assert "⏳" in html
+
+
+def test_visible_tool_marker_spacing_inserts_blank_line_before_following_content() -> None:
+    """Visible tool markers should be isolated from immediately following markdown."""
+    body = ensure_visible_tool_marker_spacing("🔧 `tool` [1]\n---\n## Recap\n")
+
+    assert body == "🔧 `tool` [1]\n\n---\n## Recap\n"
+
+
+def test_visible_tool_marker_spacing_preserves_existing_blank_line() -> None:
+    """Already isolated visible tool markers should not gain extra blank lines."""
+    body = ensure_visible_tool_marker_spacing("🔧 `tool` [1]\n\n---\n")
+
+    assert body == "🔧 `tool` [1]\n\n---\n"
+
+
+def test_tool_marker_thematic_break_and_heading_render_in_order() -> None:
+    """A tool marker followed by a rule and ATX heading should render in order."""
+    body = ensure_visible_tool_marker_spacing("🔧 `tool` [1]\n---\n## Recap\n")
+    html = markdown_to_html(body)
+
+    marker_index = html.index("<p>🔧 <code>tool</code> [1]</p>")
+    hr_index = html.index("<hr>")
+    heading_index = html.index("<h2>Recap</h2>")
+    assert marker_index < hr_index < heading_index


### PR DESCRIPTION
Cherry-picks f083d919af6570cbb4c1b8ef4de92712f517f1dc from gitea/main.

Summary:
- Prevent Matrix markdown rendering from treating visible tool placeholders followed by ---/=== as setext headings.
- Normalize spacing around visible tool markers and strip blank-lined markers from interrupted replay persistence.
- Add regression coverage for markdown, mentions, tool event rendering, and interrupted streaming state.

Tests:
- uv run pytest tests/test_markdown_to_html.py tests/test_mentions.py tests/test_tool_events.py tests/test_ai_user_id.py -x -n 0 --no-cov -v
- uv run pre-commit run --all-files
- uv run pytest