### PR TITLE
fix: persist compaction progress after each chunk

### DIFF
--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -270,6 +270,8 @@ async def compact_scope_history(
     working_session = deepcopy(session)
     collect_compaction_hook_messages = _should_collect_compaction_hook_messages()
     rewrite_result = await _rewrite_working_session_for_compaction(
+        storage=storage,
+        persisted_session=session,
         working_session=working_session,
         summary_model=summary_model,
         session_id=session.session_id,
@@ -356,6 +358,8 @@ async def compact_scope_history(
 @timed("system_prompt_assembly.history_prepare.compaction.rewrite_working_session")
 async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912
     *,
+    storage: SqliteDb,
+    persisted_session: AgentSession | TeamSession,
     working_session: AgentSession | TeamSession,
     summary_model: Model,
     session_id: str,
@@ -435,6 +439,12 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912
         if pending_selected_run_ids is not None:
             pending_selected_run_ids.difference_update(compacted_run_ids)
 
+        _persist_compaction_progress(
+            storage=storage,
+            persisted_session=persisted_session,
+            working_session=working_session,
+        )
+
         if pending_selected_run_ids:
             continue
 
@@ -456,6 +466,19 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901, PLR0912
         compacted_run_count=total_compacted_run_count,
         compacted_messages=tuple(compacted_messages),
     )
+
+
+def _persist_compaction_progress(
+    *,
+    storage: SqliteDb,
+    persisted_session: AgentSession | TeamSession,
+    working_session: AgentSession | TeamSession,
+) -> None:
+    """Save one successful compaction chunk before attempting the next chunk."""
+    persisted_session.summary = working_session.summary
+    persisted_session.runs = working_session.runs
+    persisted_session.metadata = working_session.metadata
+    storage.upsert_session(persisted_session)
 
 
 def estimate_static_tokens(agent: Agent, full_prompt: str) -> int:

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -1771,6 +1771,136 @@ async def test_prepare_history_for_run_auto_compaction_finishes_selected_runs_ac
 
 
 @pytest.mark.asyncio
+async def test_prepare_history_for_run_persists_successful_compaction_chunks_before_later_failure(
+    tmp_path: Path,
+) -> None:
+    config, runtime_paths = _make_config(
+        tmp_path,
+        compaction=CompactionOverrideConfig(enabled=True),
+        context_window=64_000,
+    )
+    storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    session = _session(
+        "session-1",
+        runs=[
+            _completed_run(
+                "run-1",
+                messages=[
+                    Message(role="user", content="u" * 200),
+                    Message(role="assistant", content="a" * 200),
+                ],
+            ),
+            _completed_run(
+                "run-2",
+                messages=[
+                    Message(role="user", content="u" * 200),
+                    Message(role="assistant", content="a" * 200),
+                ],
+            ),
+            _completed_run(
+                "run-3",
+                messages=[
+                    Message(role="user", content="u" * 200),
+                    Message(role="assistant", content="a" * 200),
+                ],
+            ),
+        ],
+    )
+    storage.upsert_session(session)
+    scope = HistoryScope(kind="agent", scope_id="test_agent")
+    history_settings = ResolvedHistorySettings(
+        policy=HistoryPolicy(mode="all"),
+        max_tool_calls_from_history=None,
+    )
+    visible_runs = list(session.runs or [])
+    first_summary_text = "first pass summary"
+
+    def _included_run_count(
+        previous_summary: str | None,
+        compacted_runs: list[RunOutput | TeamRunOutput],
+        budget: int,
+    ) -> int:
+        return len(
+            _build_summary_input(
+                previous_summary=previous_summary,
+                compacted_runs=compacted_runs,
+                max_input_tokens=budget,
+            )[1],
+        )
+
+    summary_input_budget = next(
+        budget
+        for budget in range(1, 10_000)
+        if _included_run_count(None, visible_runs, budget) == 2
+        and _included_run_count(first_summary_text, visible_runs[2:], budget) == 1
+    )
+    after_first_session = _session(
+        "session-1",
+        runs=visible_runs[2:],
+        summary=SessionSummary(summary=first_summary_text, updated_at=datetime.now(UTC)),
+    )
+    replay_budget = estimate_prompt_visible_history_tokens(
+        session=after_first_session,
+        scope=scope,
+        history_settings=history_settings,
+    )
+
+    execution_plan = ResolvedHistoryExecutionPlan(
+        authored_compaction_config=True,
+        authored_compaction_enabled=True,
+        destructive_compaction_available=True,
+        explicit_compaction_model=True,
+        compaction_model_name="summary-model",
+        compaction_context_window=4_096,
+        replay_window_tokens=64_000,
+        trigger_threshold_tokens=1,
+        reserve_tokens=0,
+        static_prompt_tokens=0,
+        replay_budget_tokens=replay_budget,
+        summary_input_budget_tokens=summary_input_budget,
+    )
+    summary_mock = AsyncMock(
+        side_effect=[
+            SessionSummary(summary=first_summary_text, updated_at=datetime.now(UTC)),
+            RuntimeError("summary failed"),
+        ],
+    )
+
+    with (
+        patch(
+            "mindroom.model_loading.get_model_instance",
+            return_value=FakeModel(id="summary-model", provider="fake"),
+        ),
+        patch(
+            "mindroom.history.compaction._generate_compaction_summary",
+            new=summary_mock,
+        ),
+    ):
+        prepared = await prepare_history_for_run(
+            agent=_agent(db=storage),
+            agent_name="test_agent",
+            full_prompt="Current prompt",
+            session_id="session-1",
+            runtime_paths=runtime_paths,
+            config=config,
+            execution_identity=None,
+            storage=storage,
+            session=session,
+            history_settings=history_settings,
+            execution_plan=execution_plan,
+        )
+
+    persisted = get_agent_session(storage, "session-1")
+    assert persisted is not None
+    assert persisted.summary is not None
+    assert persisted.summary.summary == first_summary_text
+    assert [run.run_id for run in persisted.runs or []] == ["run-3"]
+    assert summary_mock.await_count == 2
+    assert read_scope_state(persisted, scope).force_compact_before_next_run is False
+    assert prepared.compaction_outcomes == []
+
+
+@pytest.mark.asyncio
 async def test_prepare_history_for_run_auto_compaction_compacts_all_runs_when_over_budget(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Cherry-picks 538552f49 from gitea/main.

Summary:
- Persist each successful compaction chunk immediately instead of waiting for the entire multi-chunk compaction pass.
- Preserve completed progress when a later chunk fails, so subsequent runs do not redo already persisted work.
- Add regression coverage for partial compaction success followed by failure.

Tests:
- uv run pytest tests/test_agno_history.py -x -n 0 --no-cov -v
- uv run pre-commit run --all-files
- uv run pytest