### PR TITLE
Add Codex model backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Coding model training data often lags recent releases, so never trust memorized 
 | Anthropic | Max intelligence | Claude Opus 4.7 | `claude-opus-4-7` |
 | Anthropic | Fast / cheap | Claude Haiku 4.5 | `claude-haiku-4-5` |
 | OpenAI | Frontier default | GPT-5.4 | `gpt-5.4` |
+| OpenAI Codex subscription | Frontier via Codex CLI | GPT-5.5 | `gpt-5.5` |
 | Google (Gemini API) | Fast / cheap text | Gemini 3.1 Flash-Lite Preview | `gemini-3.1-flash-lite-preview` |
 | Google (Gemini API) | Strongest text / coding | Gemini 3.1 Pro Preview | `gemini-3.1-pro-preview` |
 | Google (Gemini API) | Image generation / editing | Nano Banana 2 Preview | `gemini-3.1-flash-image-preview` |

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -10,6 +10,7 @@ Models define the AI providers and model IDs used by agents.
 
 - `anthropic` - Claude models (Anthropic)
 - `openai` - GPT models and OpenAI-compatible endpoints
+- `codex` or `openai_codex` - OpenAI models available through a local Codex CLI ChatGPT subscription login
 - `google` or `gemini` - Google Gemini models
 - `vertexai_claude` - Anthropic Claude models on Google Vertex AI
 - `ollama` - Local models via Ollama
@@ -50,6 +51,11 @@ models:
   gpt:
     provider: openai
     id: gpt-5.4
+
+  # OpenAI via Codex CLI subscription
+  codex:
+    provider: codex
+    id: gpt-5.5
 
   # Google Gemini (both 'google' and 'gemini' work as provider names)
   gemini:
@@ -96,6 +102,21 @@ models:
     id: my-model
     extra_kwargs:
       base_url: http://localhost:8080/v1
+```
+
+## Codex Subscription Models
+
+Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API.
+Run `codex login` first so `~/.codex/auth.json` contains ChatGPT OAuth tokens.
+MindRoom refreshes the access token when needed and sends requests to the Codex Responses endpoint.
+The model ID may be either the bare Codex slug, such as `gpt-5.5`, or the LLM-plugin-style form `openai-codex/gpt-5.5`.
+If you keep Codex state outside `~/.codex`, pass `extra_kwargs.codex_home`.
+
+```yaml
+models:
+  default:
+    provider: codex
+    id: gpt-5.5
 ```
 
 ## Context Window

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1745,6 +1745,7 @@ Models define the AI providers and model IDs used by agents.
 
 - `anthropic` - Claude models (Anthropic)
 - `openai` - GPT models and OpenAI-compatible endpoints
+- `codex` or `openai_codex` - OpenAI models available through a local Codex CLI ChatGPT subscription login
 - `google` or `gemini` - Google Gemini models
 - `vertexai_claude` - Anthropic Claude models on Google Vertex AI
 - `ollama` - Local models via Ollama
@@ -1785,6 +1786,11 @@ models:
   gpt:
     provider: openai
     id: gpt-5.4
+
+  # OpenAI via Codex CLI subscription
+  codex:
+    provider: codex
+    id: gpt-5.5
 
   # Google Gemini (both 'google' and 'gemini' work as provider names)
   gemini:
@@ -1831,6 +1837,17 @@ models:
     id: my-model
     extra_kwargs:
       base_url: http://localhost:8080/v1
+```
+
+## Codex Subscription Models
+
+Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API. Run `codex login` first so `~/.codex/auth.json` contains ChatGPT OAuth tokens. MindRoom refreshes the access token when needed and sends requests to the Codex Responses endpoint. The model ID may be either the bare Codex slug, such as `gpt-5.5`, or the LLM-plugin-style form `openai-codex/gpt-5.5`. If you keep Codex state outside `~/.codex`, pass `extra_kwargs.codex_home`.
+
+```
+models:
+  default:
+    provider: codex
+    id: gpt-5.5
 ```
 
 ## Context Window

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -6,6 +6,7 @@ Models define the AI providers and model IDs used by agents.
 
 - `anthropic` - Claude models (Anthropic)
 - `openai` - GPT models and OpenAI-compatible endpoints
+- `codex` or `openai_codex` - OpenAI models available through a local Codex CLI ChatGPT subscription login
 - `google` or `gemini` - Google Gemini models
 - `vertexai_claude` - Anthropic Claude models on Google Vertex AI
 - `ollama` - Local models via Ollama
@@ -46,6 +47,11 @@ models:
   gpt:
     provider: openai
     id: gpt-5.4
+
+  # OpenAI via Codex CLI subscription
+  codex:
+    provider: codex
+    id: gpt-5.5
 
   # Google Gemini (both 'google' and 'gemini' work as provider names)
   gemini:
@@ -92,6 +98,17 @@ models:
     id: my-model
     extra_kwargs:
       base_url: http://localhost:8080/v1
+```
+
+## Codex Subscription Models
+
+Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API. Run `codex login` first so `~/.codex/auth.json` contains ChatGPT OAuth tokens. MindRoom refreshes the access token when needed and sends requests to the Codex Responses endpoint. The model ID may be either the bare Codex slug, such as `gpt-5.5`, or the LLM-plugin-style form `openai-codex/gpt-5.5`. If you keep Codex state outside `~/.codex`, pass `extra_kwargs.codex_home`.
+
+```
+models:
+  default:
+    provider: codex
+    id: gpt-5.5
 ```
 
 ## Context Window

--- a/src/mindroom/codex_model.py
+++ b/src/mindroom/codex_model.py
@@ -1,0 +1,399 @@
+"""OpenAI Codex subscription model support via the Codex CLI OAuth state."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from agno.models.openai import OpenAIResponses
+from agno.models.response import ModelResponse
+from agno.utils.http import get_default_async_client, get_default_sync_client
+from openai import AsyncOpenAI, OpenAI
+
+if TYPE_CHECKING:
+    from agno.models.message import Message
+    from agno.run.agent import RunOutput
+    from pydantic import BaseModel
+
+CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+CODEX_REFRESH_URL = "https://auth.openai.com/oauth/token"
+CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CODEX_REFRESH_SKEW_SECONDS = 30
+CODEX_MODEL_PREFIX = "openai-codex/"
+CODEX_DEFAULT_INSTRUCTIONS = "You are a helpful assistant."
+CODEX_UNSUPPORTED_REQUEST_PARAMS = {"max_output_tokens"}
+
+
+class CodexAuthError(ValueError):
+    """Raised when the local Codex CLI OAuth state cannot provide a usable token."""
+
+
+def normalize_codex_model_id(model_id: str) -> str:
+    """Return the Codex endpoint model slug from either bare or LLM-plugin-style IDs."""
+    normalized = model_id.strip()
+    if normalized.startswith(CODEX_MODEL_PREFIX):
+        return normalized.removeprefix(CODEX_MODEL_PREFIX)
+    return normalized
+
+
+def borrow_codex_key(*, codex_home: str | Path | None = None) -> tuple[str, str | None]:
+    """Return a valid Codex CLI ChatGPT access token and optional account id."""
+    auth_path = _codex_auth_path(codex_home=codex_home)
+    auth = _read_codex_auth(auth_path)
+    tokens = auth.get("tokens")
+    if not isinstance(tokens, dict) or not tokens.get("access_token"):
+        msg = "No ChatGPT access token found in Codex auth.json. Run `codex login` first."
+        raise CodexAuthError(msg)
+
+    access_token = str(tokens["access_token"])
+    account_id = str(tokens["account_id"]) if tokens.get("account_id") else None
+    expires_at = _jwt_exp(access_token)
+    if expires_at is not None and time.time() < expires_at - CODEX_REFRESH_SKEW_SECONDS:
+        return access_token, account_id
+
+    refresh_token = tokens.get("refresh_token")
+    if not refresh_token:
+        msg = "No Codex refresh token found. Run `codex login` to re-authenticate."
+        raise CodexAuthError(msg)
+
+    refreshed = _refresh_codex_tokens(str(refresh_token))
+    if not refreshed.get("access_token"):
+        msg = "Codex token refresh response did not include an access token."
+        raise CodexAuthError(msg)
+
+    _update_tokens(tokens, refreshed)
+    auth["tokens"] = tokens
+    auth["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime())
+    _write_codex_auth(auth_path, auth)
+    return str(tokens["access_token"]), account_id
+
+
+def _codex_auth_path(*, codex_home: str | Path | None) -> Path:
+    home = Path(codex_home) if codex_home is not None else Path(os.environ.get("CODEX_HOME", "~/.codex")).expanduser()
+    auth_path = home / "auth.json"
+    if not auth_path.exists():
+        msg = f"Codex auth file not found at {auth_path}. Run `codex login` first."
+        raise CodexAuthError(msg)
+    return auth_path
+
+
+def _read_codex_auth(auth_path: Path) -> dict[str, Any]:
+    with auth_path.open(encoding="utf-8") as auth_file:
+        auth = json.load(auth_file)
+    if auth.get("auth_mode") != "chatgpt":
+        msg = "Codex auth.json must use ChatGPT OAuth auth_mode. Run `codex login` first."
+        raise CodexAuthError(msg)
+    return auth
+
+
+def _write_codex_auth(auth_path: Path, auth: dict[str, Any]) -> None:
+    temp_path = auth_path.with_name(f"{auth_path.name}.tmp")
+    temp_path.write_text(json.dumps(auth, indent=2), encoding="utf-8")
+    temp_path.replace(auth_path)
+    auth_path.chmod(0o600)
+
+
+def _jwt_exp(token: str) -> int | None:
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        decoded = base64.urlsafe_b64decode(payload)
+        exp = json.loads(decoded).get("exp")
+    except (IndexError, ValueError, json.JSONDecodeError):
+        return None
+    return int(exp) if isinstance(exp, int) else None
+
+
+def _refresh_codex_tokens(refresh_token: str) -> dict[str, Any]:
+    payload = {
+        "client_id": CODEX_CLIENT_ID,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    }
+    try:
+        response = httpx.post(CODEX_REFRESH_URL, json=payload, timeout=10)
+    except httpx.HTTPError as exc:
+        msg = f"Codex token refresh failed: {exc}"
+        raise CodexAuthError(msg) from exc
+
+    if not response.is_success:
+        error_body = response.text
+        error_code = _refresh_error_code(error_body)
+        if error_code in {"refresh_token_expired", "refresh_token_reused", "refresh_token_invalidated"}:
+            msg = f"Codex refresh token is no longer valid ({error_code}). Run `codex login` again."
+            raise CodexAuthError(msg) from None
+        msg = f"Codex token refresh failed (HTTP {response.status_code}): {error_body}"
+        raise CodexAuthError(msg) from None
+
+    try:
+        return response.json()
+    except json.JSONDecodeError as exc:
+        msg = "Codex token refresh returned invalid JSON."
+        raise CodexAuthError(msg) from exc
+
+
+def _refresh_error_code(error_body: str) -> str | None:
+    try:
+        error = json.loads(error_body)
+    except json.JSONDecodeError:
+        return None
+    code = error.get("error")
+    return code if isinstance(code, str) else None
+
+
+def _update_tokens(tokens: dict[str, Any], refreshed: dict[str, Any]) -> None:
+    for key in ("access_token", "id_token", "refresh_token"):
+        if refreshed.get(key):
+            tokens[key] = refreshed[key]
+
+
+@dataclass
+class CodexResponses(OpenAIResponses):
+    """Agno Responses model backed by the local Codex CLI ChatGPT OAuth credentials."""
+
+    id: str = "gpt-5.5"
+    name: str = "CodexResponses"
+    provider: str = "OpenAI Codex"
+    base_url: str = CODEX_BASE_URL
+    store: bool = False
+    codex_home: str | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize LLM-plugin-style model IDs before Agno uses the model id."""
+        self.id = normalize_codex_model_id(self.id)
+        super().__post_init__()
+
+    def _get_client_params(self) -> dict[str, Any]:
+        token, account_id = borrow_codex_key(codex_home=self.codex_home)
+        headers = dict(self.default_headers or {})
+        if account_id:
+            headers["ChatGPT-Account-ID"] = account_id
+
+        base_params = {
+            "api_key": token,
+            "organization": self.organization,
+            "base_url": self.base_url,
+            "timeout": self.timeout,
+            "max_retries": self.max_retries,
+            "default_headers": headers or None,
+            "default_query": self.default_query,
+        }
+        client_params = {key: value for key, value in base_params.items() if value is not None}
+        if self.client_params:
+            client_params.update(self.client_params)
+        return client_params
+
+    def _instructions_text(self) -> str:
+        instructions = [self.system_prompt, *(self.instructions or [])]
+        return "\n\n".join(instruction for instruction in instructions if instruction) or CODEX_DEFAULT_INSTRUCTIONS
+
+    def get_request_params(
+        self,
+        messages: list[Message] | None = None,
+        response_format: dict[Any, Any] | type[BaseModel] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Add the top-level instructions field required by the Codex endpoint."""
+        request_params = super().get_request_params(
+            messages=messages,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        request_params.setdefault("instructions", self._instructions_text())
+        for param_name in CODEX_UNSUPPORTED_REQUEST_PARAMS:
+            request_params.pop(param_name, None)
+        return request_params
+
+    def invoke(
+        self,
+        messages: list[Message],
+        assistant_message: Message,
+        response_format: dict[Any, Any] | type[BaseModel] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        run_response: RunOutput | None = None,
+        compress_tool_results: bool = False,
+    ) -> ModelResponse:
+        """Return a normal response by consuming the Codex endpoint's required stream."""
+        self._ensure_message_metrics_initialized(assistant_message)
+        model_response = ModelResponse(role=self.assistant_message_role)
+
+        for response_delta in self.invoke_stream(
+            messages=messages,
+            assistant_message=assistant_message,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+            run_response=run_response,
+            compress_tool_results=compress_tool_results,
+        ):
+            _merge_response_delta(model_response, response_delta)
+
+        self._populate_assistant_message(assistant_message, model_response)
+        return model_response
+
+    async def ainvoke(
+        self,
+        messages: list[Message],
+        assistant_message: Message,
+        response_format: dict[Any, Any] | type[BaseModel] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        run_response: RunOutput | None = None,
+        compress_tool_results: bool = False,
+    ) -> ModelResponse:
+        """Return a normal async response by consuming the required Codex stream."""
+        self._ensure_message_metrics_initialized(assistant_message)
+        model_response = ModelResponse(role=self.assistant_message_role)
+
+        async for response_delta in self.ainvoke_stream(
+            messages=messages,
+            assistant_message=assistant_message,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+            run_response=run_response,
+            compress_tool_results=compress_tool_results,
+        ):
+            _merge_response_delta(model_response, response_delta)
+
+        self._populate_assistant_message(assistant_message, model_response)
+        return model_response
+
+    def get_client(self) -> OpenAI:
+        """Return a fresh sync client so expired Codex tokens are refreshed between requests."""
+        client_params = self._get_client_params()
+        client_params["http_client"] = (
+            self.http_client if isinstance(self.http_client, httpx.Client) else get_default_sync_client()
+        )
+        return OpenAI(**client_params)
+
+    def get_async_client(self) -> AsyncOpenAI:
+        """Return a fresh async client so expired Codex tokens are refreshed between requests."""
+        client_params = self._get_client_params()
+        client_params["http_client"] = (
+            self.http_client if isinstance(self.http_client, httpx.AsyncClient) else get_default_async_client()
+        )
+        return AsyncOpenAI(**client_params)
+
+
+def _append_response_string(existing: str | None, value: str) -> str:
+    return value if existing is None else existing + value
+
+
+def _merge_dict_data(target_data: dict[str, Any] | None, delta_data: dict[str, Any] | None) -> dict[str, Any] | None:
+    if delta_data is None:
+        return target_data
+    if target_data is None:
+        target_data = {}
+    for key, value in delta_data.items():
+        existing = target_data.get(key)
+        if isinstance(existing, list) and isinstance(value, list):
+            existing.extend(value)
+        else:
+            target_data[key] = value
+    return target_data
+
+
+def _extend_response_list(existing: list[Any] | None, value: list[Any] | None) -> list[Any] | None:
+    if value is None:
+        return existing
+    if existing is None:
+        existing = []
+    existing.extend(value)
+    return existing
+
+
+def _merge_response_delta(model_response: ModelResponse, response_delta: ModelResponse) -> None:
+    _merge_response_content(model_response, response_delta)
+    _merge_response_media(model_response, response_delta)
+    _merge_response_tools(model_response, response_delta)
+    _merge_response_metadata(model_response, response_delta)
+    _merge_response_metrics(model_response, response_delta)
+
+
+def _merge_response_content(model_response: ModelResponse, response_delta: ModelResponse) -> None:
+    if response_delta.role is not None:
+        model_response.role = response_delta.role
+    if response_delta.content is not None:
+        if isinstance(model_response.content, str) and isinstance(response_delta.content, str):
+            model_response.content += response_delta.content
+        else:
+            model_response.content = response_delta.content
+    if response_delta.parsed is not None:
+        model_response.parsed = response_delta.parsed
+    if response_delta.redacted_reasoning_content is not None:
+        model_response.redacted_reasoning_content = _append_response_string(
+            model_response.redacted_reasoning_content,
+            response_delta.redacted_reasoning_content,
+        )
+    if response_delta.reasoning_content is not None:
+        model_response.reasoning_content = _append_response_string(
+            model_response.reasoning_content,
+            response_delta.reasoning_content,
+        )
+    if response_delta.citations is not None:
+        model_response.citations = response_delta.citations
+
+
+def _merge_response_media(model_response: ModelResponse, response_delta: ModelResponse) -> None:
+    if response_delta.audio is not None:
+        model_response.audio = response_delta.audio
+    if response_delta.images is not None:
+        model_response.images = _extend_response_list(model_response.images, response_delta.images)
+    if response_delta.videos is not None:
+        model_response.videos = _extend_response_list(model_response.videos, response_delta.videos)
+    if response_delta.audios is not None:
+        model_response.audios = _extend_response_list(model_response.audios, response_delta.audios)
+    if response_delta.files is not None:
+        model_response.files = _extend_response_list(model_response.files, response_delta.files)
+
+
+def _merge_response_tools(model_response: ModelResponse, response_delta: ModelResponse) -> None:
+    if response_delta.tool_calls:
+        model_response.tool_calls.extend(response_delta.tool_calls)
+    if response_delta.tool_executions:
+        if model_response.tool_executions is None:
+            model_response.tool_executions = []
+        model_response.tool_executions.extend(response_delta.tool_executions)
+
+
+def _merge_response_metadata(model_response: ModelResponse, response_delta: ModelResponse) -> None:
+    if response_delta.provider_data is not None:
+        model_response.provider_data = _merge_dict_data(model_response.provider_data, response_delta.provider_data)
+    if response_delta.extra is not None:
+        model_response.extra = _merge_dict_data(model_response.extra, response_delta.extra)
+    if response_delta.updated_session_state is not None:
+        model_response.updated_session_state = _merge_dict_data(
+            model_response.updated_session_state,
+            response_delta.updated_session_state,
+        )
+    if response_delta.compression_stats is not None:
+        model_response.compression_stats = response_delta.compression_stats
+
+
+def _merge_response_metrics(model_response: ModelResponse, response_delta: ModelResponse) -> None:
+    if response_delta.response_usage is not None:
+        model_response.response_usage = response_delta.response_usage
+    if response_delta.input_tokens is not None:
+        model_response.input_tokens = response_delta.input_tokens
+    if response_delta.output_tokens is not None:
+        model_response.output_tokens = response_delta.output_tokens
+    if response_delta.total_tokens is not None:
+        model_response.total_tokens = response_delta.total_tokens
+    if response_delta.time_to_first_token is not None:
+        model_response.time_to_first_token = response_delta.time_to_first_token
+    if response_delta.reasoning_tokens is not None:
+        model_response.reasoning_tokens = response_delta.reasoning_tokens
+    if response_delta.cache_read_tokens is not None:
+        model_response.cache_read_tokens = response_delta.cache_read_tokens
+    if response_delta.cache_write_tokens is not None:
+        model_response.cache_write_tokens = response_delta.cache_write_tokens

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -15,6 +15,7 @@ from agno.models.openai import OpenAIChat
 from agno.models.openrouter import OpenRouter
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 
+from mindroom.codex_model import CodexResponses, normalize_codex_model_id
 from mindroom.constants import RuntimePaths, runtime_env_path
 from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host
@@ -48,7 +49,10 @@ def _create_model_for_provider(  # noqa: C901, PLR0912
     """Create a model instance for one provider."""
     canonical_provider = _canonical_provider(provider)
 
-    if canonical_provider not in {"ollama", "vertexai_claude"} and "api_key" not in extra_kwargs:
+    if (
+        canonical_provider not in {"ollama", "vertexai_claude", "codex", "openai_codex"}
+        and "api_key" not in extra_kwargs
+    ):
         api_key = get_api_key_for_provider(canonical_provider, runtime_paths=runtime_paths)
         if api_key:
             extra_kwargs["api_key"] = api_key
@@ -96,6 +100,10 @@ def _create_model_for_provider(  # noqa: C901, PLR0912
         if not api_key:
             logger.warning("No OpenRouter API key found in environment or CredentialsManager")
         return OpenRouter(id=model_id, api_key=api_key, **extra_kwargs)
+
+    if canonical_provider in {"codex", "openai_codex"}:
+        extra_kwargs.pop("api_key", None)
+        return CodexResponses(id=normalize_codex_model_id(model_id), **extra_kwargs)
 
     provider_map: dict[str, type[Any]] = {
         "openai": OpenAIChat,

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -1,0 +1,177 @@
+"""Tests for the Codex-backed OpenAI Responses model provider."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from agno.metrics import MessageMetrics
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+
+from mindroom.codex_model import CODEX_BASE_URL, CodexResponses, borrow_codex_key
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
+from mindroom.constants import resolve_runtime_paths
+from mindroom.model_loading import get_model_instance
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    import pytest
+
+
+def _jwt_with_exp(exp: int) -> str:
+    payload = json.dumps({"exp": exp}).encode()
+    encoded_payload = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    return f"header.{encoded_payload}.signature"
+
+
+def _write_codex_auth(codex_home: Path, access_token: str, refresh_value: str) -> None:
+    codex_home.mkdir()
+    auth = {
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_value,
+            "account_id": "acct_123",
+        },
+    }
+    (codex_home / "auth.json").write_text(json.dumps(auth), encoding="utf-8")
+
+
+def test_borrow_codex_key_uses_unexpired_chatgpt_access_token(tmp_path: Path) -> None:
+    """A valid Codex CLI ChatGPT token should be reused directly."""
+    access_token = _jwt_with_exp(int(time.time()) + 3600)
+    codex_home = tmp_path / ".codex"
+    _write_codex_auth(codex_home, access_token, "refresh-value")
+
+    token, account_id = borrow_codex_key(codex_home=codex_home)
+
+    assert token == access_token
+    assert account_id == "acct_123"
+
+
+def test_borrow_codex_key_refreshes_expired_access_token(tmp_path: Path) -> None:
+    """Expired Codex CLI ChatGPT tokens should be refreshed and persisted."""
+    codex_home = tmp_path / ".codex"
+    _write_codex_auth(codex_home, _jwt_with_exp(int(time.time()) - 60), "refresh-value")
+    refreshed_token = _jwt_with_exp(int(time.time()) + 7200)
+    new_id_value = "new-id-value"
+    new_refresh_value = "new-refresh-value"
+
+    with patch(
+        "mindroom.codex_model._refresh_codex_tokens",
+        return_value={
+            "access_token": refreshed_token,
+            "id_token": new_id_value,
+            "refresh_token": new_refresh_value,
+        },
+    ):
+        token, account_id = borrow_codex_key(codex_home=codex_home)
+
+    auth = json.loads((codex_home / "auth.json").read_text(encoding="utf-8"))
+    assert token == refreshed_token
+    assert account_id == "acct_123"
+    assert auth["tokens"]["access_token"] == refreshed_token
+    assert auth["tokens"]["id_token"] == new_id_value
+    assert auth["tokens"]["refresh_token"] == new_refresh_value
+    assert "last_refresh" in auth
+
+
+def test_codex_responses_client_params_use_codex_endpoint_and_account_header(tmp_path: Path) -> None:
+    """CodexResponses should translate Codex CLI auth into OpenAI client params."""
+    codex_home = tmp_path / ".codex"
+    access_token = _jwt_with_exp(int(time.time()) + 3600)
+    _write_codex_auth(codex_home, access_token, "refresh-value")
+
+    model = CodexResponses(id="gpt-5.5", codex_home=str(codex_home), default_headers={"X-Test": "1"})
+
+    params = model._get_client_params()
+
+    assert params["api_key"] == access_token
+    assert params["base_url"] == CODEX_BASE_URL
+    assert params["default_headers"] == {
+        "X-Test": "1",
+        "ChatGPT-Account-ID": "acct_123",
+    }
+
+
+def test_codex_responses_request_params_include_required_instructions() -> None:
+    """Codex Responses requests should always include top-level instructions."""
+    default_model = CodexResponses(id="gpt-5.5")
+    configured_model = CodexResponses(id="gpt-5.5", instructions=["Be brief.", "Return plain text."])
+
+    assert default_model.get_request_params()["instructions"] == "You are a helpful assistant."
+    assert configured_model.get_request_params()["instructions"] == "Be brief.\n\nReturn plain text."
+
+
+def test_codex_responses_request_params_drop_unsupported_limits() -> None:
+    """Unsupported OpenAI Responses parameters should not be sent to Codex."""
+    model = CodexResponses(id="gpt-5.5", max_output_tokens=40)
+
+    assert "max_output_tokens" not in model.get_request_params()
+
+
+def test_codex_responses_invoke_aggregates_streaming_deltas(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-streaming callers should still work with Codex's stream-only endpoint."""
+    model = CodexResponses(id="gpt-5.5")
+    usage = MessageMetrics(input_tokens=7, output_tokens=3, total_tokens=10)
+
+    def fake_invoke_stream(
+        *,
+        messages: list[Message],
+        assistant_message: Message,
+        response_format: object | None = None,
+        tools: list[dict[str, object]] | None = None,
+        tool_choice: str | dict[str, object] | None = None,
+        run_response: object | None = None,
+        compress_tool_results: bool = False,
+    ) -> Iterator[ModelResponse]:
+        del messages, response_format, tools, tool_choice, run_response, compress_tool_results
+        model._ensure_message_metrics_initialized(assistant_message)
+        yield ModelResponse(provider_data={"response_id": "resp_123"})
+        yield ModelResponse(content="mindroom")
+        yield ModelResponse(content="-codex-live-ok")
+        yield ModelResponse(response_usage=usage)
+
+    monkeypatch.setattr(model, "invoke_stream", fake_invoke_stream)
+    assistant_message = Message(role="assistant")
+
+    response = model.invoke([Message(role="user", content="hello")], assistant_message)
+
+    assert response.content == "mindroom-codex-live-ok"
+    assert response.provider_data == {"response_id": "resp_123"}
+    assert response.response_usage == usage
+    assert assistant_message.content == "mindroom-codex-live-ok"
+    assert assistant_message.provider_data == {"response_id": "resp_123"}
+    assert assistant_message.metrics.input_tokens == 7
+
+
+def test_get_model_instance_supports_codex_provider(tmp_path: Path) -> None:
+    """The model loader should expose Codex as a first-class model provider."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={},
+    )
+    config = Config(
+        models={
+            "default": ModelConfig(
+                provider="codex",
+                id="openai-codex/gpt-5.5",
+            ),
+        },
+        agents={},
+    )
+
+    model = get_model_instance(config, runtime_paths)
+
+    assert isinstance(model, CodexResponses)
+    assert model.id == "gpt-5.5"
+    assert model.store is False
+    assert str(model.base_url) == CODEX_BASE_URL


### PR DESCRIPTION
## Summary
- Add a `codex` / `openai_codex` model backend that uses the local Codex CLI ChatGPT OAuth state and refreshes tokens when needed.
- Bridge Codex's stream-only Responses endpoint into Agno's normal `invoke()` / `ainvoke()` contract, including tool calls and response metadata.
- Document `provider: codex` configuration for `gpt-5.5` and update generated MindRoom docs references.

## Test Plan
- [x] `uv run pytest tests/test_codex_model.py -q`
- [x] `uv run pre-commit run --all-files`
- [x] `uv run pytest`
- [x] Real Codex call with `CodexResponses(id="gpt-5.5")` returned `mindroom-codex-live-ok`.
- [x] Real MindRoom model loader config with `provider: codex`, `id: openai-codex/gpt-5.5` returned `mindroom-loader-codex-ok`.
- [x] Real forced tool-call probe returned a valid `lookup_code` tool call.
