### PR TITLE
Enable Codex prompt caching and auth hardening

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -351,6 +351,8 @@ mindroom config init --force
 ```
 
 The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5`.
+They set `extra_kwargs.reasoning_effort: medium`.
+Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key.
 Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
 
 ### config show

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -118,7 +118,21 @@ models:
   default:
     provider: codex
     id: gpt-5.5
+    # Prompt caching is enabled automatically per active agent session.
+    extra_kwargs:
+      reasoning_effort: medium
 ```
+
+Set Codex reasoning effort through `extra_kwargs.reasoning_effort`.
+Agno maps this to the Responses API `reasoning.effort` field.
+Supported effort values are `minimal`, `low`, `medium`, and `high`.
+The starter Codex profile uses `medium`.
+MindRoom sends a Codex prompt-cache key plus the Codex CLI session headers for each active agent session.
+By default, that key is derived from the current execution identity, so separate Matrix threads can run concurrently without sharing one global cache key.
+You can set `extra_kwargs.prompt_cache_key` to override that derived key for a model, but avoid a single low-cardinality value for many busy threads unless you intentionally want those requests routed together.
+Live testing against the Codex subscription endpoint reported `cached_tokens` only when the request included Codex CLI-style session headers tied to the prompt-cache key.
+Repeated long requests then reported cache hits, while requests without those headers stayed at `cached_tokens: 0`, and `prompt_cache_retention` was rejected.
+Treat Codex prompt caching as best-effort rather than guaranteed.
 
 ## Context Window
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1858,7 +1858,12 @@ models:
   default:
     provider: codex
     id: gpt-5.5
+    # Prompt caching is enabled automatically per active agent session.
+    extra_kwargs:
+      reasoning_effort: medium
 ```
+
+Set Codex reasoning effort through `extra_kwargs.reasoning_effort`. Agno maps this to the Responses API `reasoning.effort` field. Supported effort values are `minimal`, `low`, `medium`, and `high`. The starter Codex profile uses `medium`. MindRoom sends a Codex prompt-cache key plus the Codex CLI session headers for each active agent session. By default, that key is derived from the current execution identity, so separate Matrix threads can run concurrently without sharing one global cache key. You can set `extra_kwargs.prompt_cache_key` to override that derived key for a model, but avoid a single low-cardinality value for many busy threads unless you intentionally want those requests routed together. Live testing against the Codex subscription endpoint reported `cached_tokens` only when the request included Codex CLI-style session headers tied to the prompt-cache key. Repeated long requests then reported cache hits, while requests without those headers stayed at `cached_tokens: 0`, and `prompt_cache_retention` was rejected. Treat Codex prompt caching as best-effort rather than guaranteed.
 
 ## Context Window
 
@@ -12590,7 +12595,7 @@ mindroom config init --profile public-vertexai-anthropic
 mindroom config init --force
 ```
 
-The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5`. Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
+The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5`. They set `extra_kwargs.reasoning_effort: medium`. Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key. Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
 
 ### config show
 

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -211,7 +211,7 @@ mindroom config init --profile public-vertexai-anthropic
 mindroom config init --force
 ```
 
-The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5`. Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
+The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5`. They set `extra_kwargs.reasoning_effort: medium`. Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key. Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
 
 ### config show
 

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -109,7 +109,12 @@ models:
   default:
     provider: codex
     id: gpt-5.5
+    # Prompt caching is enabled automatically per active agent session.
+    extra_kwargs:
+      reasoning_effort: medium
 ```
+
+Set Codex reasoning effort through `extra_kwargs.reasoning_effort`. Agno maps this to the Responses API `reasoning.effort` field. Supported effort values are `minimal`, `low`, `medium`, and `high`. The starter Codex profile uses `medium`. MindRoom sends a Codex prompt-cache key plus the Codex CLI session headers for each active agent session. By default, that key is derived from the current execution identity, so separate Matrix threads can run concurrently without sharing one global cache key. You can set `extra_kwargs.prompt_cache_key` to override that derived key for a model, but avoid a single low-cardinality value for many busy threads unless you intentionally want those requests routed together. Live testing against the Codex subscription endpoint reported `cached_tokens` only when the request included Codex CLI-style session headers tied to the prompt-cache key. Repeated long requests then reported cache hits, while requests without those headers stayed at `cached_tokens: 0`, and `prompt_cache_retention` was rejected. Treat Codex prompt caching as best-effort rather than guaranteed.
 
 ## Context Window
 

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -402,9 +402,15 @@ def _load_agent_model_instance(
     config: Config,
     runtime_paths: constants.RuntimePaths,
     model_name: str,
+    execution_identity: ToolExecutionIdentity | None = None,
 ) -> Model:
     """Load one agent model while preserving prompt-assembly timing attribution."""
-    return model_loading.get_model_instance(config, runtime_paths, model_name)
+    return model_loading.get_model_instance(
+        config,
+        runtime_paths,
+        model_name,
+        execution_identity=execution_identity,
+    )
 
 
 @timed("system_prompt_assembly.agent_create.toolkit_build")
@@ -1097,7 +1103,7 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         instructions = list(agent_config.instructions)
 
     # Create agent with defaults applied
-    model = _load_agent_model_instance(config, runtime_paths, model_name)
+    model = _load_agent_model_instance(config, runtime_paths, model_name, execution_identity)
     logger.info(
         "create_agent",
         agent=agent_name,

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -660,6 +660,14 @@ def _model_template_block(provider_preset: _ProviderPreset) -> str:
     """Render the provider-specific YAML fragment for models.default."""
     provider, model_id = _DEFAULT_MODEL_PRESETS[provider_preset]
     lines = [f"provider: {provider}", f"id: {model_id}"]
+    if provider_preset == "codex":
+        lines.extend(
+            [
+                "# Prompt caching is enabled automatically per active agent session.",
+                "extra_kwargs:",
+                "  reasoning_effort: medium",
+            ],
+        )
     return textwrap.indent("\n".join(lines), "    ")
 
 

--- a/src/mindroom/codex_model.py
+++ b/src/mindroom/codex_model.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import base64
+import fcntl
+import hashlib
 import json
 import os
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -17,9 +20,13 @@ from agno.utils.http import get_default_async_client, get_default_sync_client
 from openai import AsyncOpenAI, OpenAI
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from agno.models.message import Message
     from agno.run.agent import RunOutput
     from pydantic import BaseModel
+
+    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 CODEX_REFRESH_URL = "https://auth.openai.com/oauth/token"
@@ -28,6 +35,7 @@ CODEX_REFRESH_SKEW_SECONDS = 30
 CODEX_MODEL_PREFIX = "openai-codex/"
 CODEX_DEFAULT_INSTRUCTIONS = "You are a helpful assistant."
 CODEX_UNSUPPORTED_REQUEST_PARAMS = {"max_output_tokens"}
+CODEX_PROMPT_CACHE_KEY_PREFIX = "mindroom"
 
 
 class CodexAuthError(ValueError):
@@ -51,27 +59,37 @@ def borrow_codex_key(*, codex_home: str | Path | None = None) -> tuple[str, str 
         msg = "No ChatGPT access token found in Codex auth.json. Run `codex login` first."
         raise CodexAuthError(msg)
 
-    access_token = str(tokens["access_token"])
-    account_id = str(tokens["account_id"]) if tokens.get("account_id") else None
-    expires_at = _jwt_exp(access_token)
-    if expires_at is not None and time.time() < expires_at - CODEX_REFRESH_SKEW_SECONDS:
-        return access_token, account_id
+    usable_token = _usable_access_token(tokens)
+    if usable_token is not None:
+        return usable_token
 
-    refresh_token = tokens.get("refresh_token")
-    if not refresh_token:
-        msg = "No Codex refresh token found. Run `codex login` to re-authenticate."
-        raise CodexAuthError(msg)
+    with _codex_auth_refresh_lock(auth_path):
+        auth = _read_codex_auth(auth_path)
+        tokens = auth.get("tokens")
+        if not isinstance(tokens, dict) or not tokens.get("access_token"):
+            msg = "No ChatGPT access token found in Codex auth.json. Run `codex login` first."
+            raise CodexAuthError(msg)
 
-    refreshed = _refresh_codex_tokens(str(refresh_token))
-    if not refreshed.get("access_token"):
-        msg = "Codex token refresh response did not include an access token."
-        raise CodexAuthError(msg)
+        usable_token = _usable_access_token(tokens)
+        if usable_token is not None:
+            return usable_token
 
-    _update_tokens(tokens, refreshed)
-    auth["tokens"] = tokens
-    auth["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime())
-    _write_codex_auth(auth_path, auth)
-    return str(tokens["access_token"]), account_id
+        refresh_token = tokens.get("refresh_token")
+        if not refresh_token:
+            msg = "No Codex refresh token found. Run `codex login` to re-authenticate."
+            raise CodexAuthError(msg)
+
+        account_id = str(tokens["account_id"]) if tokens.get("account_id") else None
+        refreshed = _refresh_codex_tokens(str(refresh_token))
+        if not refreshed.get("access_token"):
+            msg = "Codex token refresh response did not include an access token."
+            raise CodexAuthError(msg)
+
+        _update_tokens(tokens, refreshed)
+        auth["tokens"] = tokens
+        auth["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime())
+        _write_codex_auth(auth_path, auth)
+        return str(tokens["access_token"]), account_id
 
 
 def _codex_auth_path(*, codex_home: str | Path | None) -> Path:
@@ -92,9 +110,32 @@ def _read_codex_auth(auth_path: Path) -> dict[str, Any]:
     return auth
 
 
+@contextmanager
+def _codex_auth_refresh_lock(auth_path: Path) -> Iterator[None]:
+    lock_path = auth_path.with_name(f"{auth_path.name}.lock")
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _usable_access_token(tokens: dict[str, Any]) -> tuple[str, str | None] | None:
+    access_token = str(tokens["access_token"])
+    expires_at = _jwt_exp(access_token)
+    if expires_at is None or time.time() >= expires_at - CODEX_REFRESH_SKEW_SECONDS:
+        return None
+    account_id = str(tokens["account_id"]) if tokens.get("account_id") else None
+    return access_token, account_id
+
+
 def _write_codex_auth(auth_path: Path, auth: dict[str, Any]) -> None:
     temp_path = auth_path.with_name(f"{auth_path.name}.tmp")
-    temp_path.write_text(json.dumps(auth, indent=2), encoding="utf-8")
+    temp_path.unlink(missing_ok=True)
+    fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
+        temp_file.write(json.dumps(auth, indent=2))
     temp_path.replace(auth_path)
     auth_path.chmod(0o600)
 
@@ -153,6 +194,32 @@ def _update_tokens(tokens: dict[str, Any], refreshed: dict[str, Any]) -> None:
             tokens[key] = refreshed[key]
 
 
+def derive_codex_prompt_cache_key(identity: ToolExecutionIdentity) -> str | None:
+    """Derive a stable Codex prompt-cache routing key for one active execution."""
+    if identity.session_id is None:
+        return None
+    source = ":".join(
+        (
+            identity.channel,
+            identity.agent_name,
+            identity.requester_id or "",
+            identity.room_id or "",
+            identity.resolved_thread_id or identity.thread_id or "",
+            identity.session_id,
+        ),
+    )
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:32]
+    return f"{CODEX_PROMPT_CACHE_KEY_PREFIX}-{digest}"
+
+
+def _codex_prompt_cache_headers(prompt_cache_key: str) -> dict[str, str]:
+    return {
+        "session_id": prompt_cache_key,
+        "x-client-request-id": prompt_cache_key,
+        "x-codex-window-id": f"{prompt_cache_key}:1",
+    }
+
+
 @dataclass
 class CodexResponses(OpenAIResponses):
     """Agno Responses model backed by the local Codex CLI ChatGPT OAuth credentials."""
@@ -163,6 +230,7 @@ class CodexResponses(OpenAIResponses):
     base_url: str = CODEX_BASE_URL
     store: bool = False
     codex_home: str | None = None
+    prompt_cache_key: str | None = None
 
     def __post_init__(self) -> None:
         """Normalize LLM-plugin-style model IDs before Agno uses the model id."""
@@ -193,6 +261,9 @@ class CodexResponses(OpenAIResponses):
         instructions = [self.system_prompt, *(self.instructions or [])]
         return "\n\n".join(instruction for instruction in instructions if instruction) or CODEX_DEFAULT_INSTRUCTIONS
 
+    def _prompt_cache_key(self) -> str | None:
+        return self.prompt_cache_key
+
     def get_request_params(
         self,
         messages: list[Message] | None = None,
@@ -208,6 +279,13 @@ class CodexResponses(OpenAIResponses):
             tool_choice=tool_choice,
         )
         request_params.setdefault("instructions", self._instructions_text())
+        prompt_cache_key = self._prompt_cache_key()
+        if prompt_cache_key:
+            request_params.setdefault("prompt_cache_key", prompt_cache_key)
+            extra_headers = dict(request_params.get("extra_headers") or {})
+            for header_name, header_value in _codex_prompt_cache_headers(prompt_cache_key).items():
+                extra_headers.setdefault(header_name, header_value)
+            request_params["extra_headers"] = extra_headers
         for param_name in CODEX_UNSUPPORTED_REQUEST_PARAMS:
             request_params.pop(param_name, None)
         return request_params

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -15,7 +15,7 @@ from agno.models.openai import OpenAIChat
 from agno.models.openrouter import OpenRouter
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 
-from mindroom.codex_model import CodexResponses, normalize_codex_model_id
+from mindroom.codex_model import CodexResponses, derive_codex_prompt_cache_key, normalize_codex_model_id
 from mindroom.constants import RuntimePaths, runtime_env_path
 from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 
     from mindroom.config.main import Config
     from mindroom.config.models import ModelConfig
+    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 logger = get_logger(__name__)
 
@@ -45,6 +46,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0912
     model_config: ModelConfig,
     extra_kwargs: dict[str, Any],
     runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None,
 ) -> Model:
     """Create a model instance for one provider."""
     canonical_provider = _canonical_provider(provider)
@@ -103,6 +105,10 @@ def _create_model_for_provider(  # noqa: C901, PLR0912
 
     if canonical_provider in {"codex", "openai_codex"}:
         extra_kwargs.pop("api_key", None)
+        if "prompt_cache_key" not in extra_kwargs and execution_identity is not None:
+            prompt_cache_key = derive_codex_prompt_cache_key(execution_identity)
+            if prompt_cache_key is not None:
+                extra_kwargs["prompt_cache_key"] = prompt_cache_key
         return CodexResponses(id=normalize_codex_model_id(model_id), **extra_kwargs)
 
     provider_map: dict[str, type[Any]] = {
@@ -128,6 +134,7 @@ def get_model_instance(
     config: Config,
     runtime_paths: RuntimePaths,
     model_name: str = "default",
+    execution_identity: ToolExecutionIdentity | None = None,
 ) -> Model:
     """Get a model instance from config.yaml."""
     if model_name not in config.models:
@@ -156,6 +163,7 @@ def get_model_instance(
         model_config,
         extra_kwargs,
         runtime_paths,
+        execution_identity,
     )
     if config.debug.log_llm_requests:
         install_llm_request_logging(

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -357,6 +357,9 @@ class TestConfigInit:
         assert "mindroom_user" not in config
         assert config["models"]["default"]["provider"] == "codex"
         assert config["models"]["default"]["id"] == "gpt-5.5"
+        assert config["models"]["default"]["extra_kwargs"]["reasoning_effort"] == "medium"
+        assert "prompt_cache_key" not in config["models"]["default"]["extra_kwargs"]
+        assert "Prompt caching is enabled automatically per active agent session." in target.read_text()
 
         env_content = (tmp_path / ".env").read_text()
         assert "MATRIX_HOMESERVER=https://mindroom.chat" in env_content
@@ -383,6 +386,7 @@ class TestConfigInit:
         assert "mindroom_user" not in config
         assert config["models"]["default"]["provider"] == "codex"
         assert config["models"]["default"]["id"] == "gpt-5.5"
+        assert config["models"]["default"]["extra_kwargs"]["reasoning_effort"] == "medium"
 
     @pytest.mark.parametrize("profile", ["openai-codex", "public-openai-codex"])
     def test_init_rejects_openai_codex_profile_aliases(self, tmp_path: Path, profile: str) -> None:
@@ -581,6 +585,8 @@ class TestConfigInit:
         config = yaml.safe_load(target.read_text())
         assert config["models"]["default"]["provider"] == "codex"
         assert config["models"]["default"]["id"] == "gpt-5.5"
+        assert config["models"]["default"]["extra_kwargs"]["reasoning_effort"] == "medium"
+        assert "prompt_cache_key" not in config["models"]["default"]["extra_kwargs"]
 
         env_content = (tmp_path / ".env").read_text()
         assert "Run `codex login` before starting MindRoom." in env_content

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import base64
 import json
+import os
+import stat
+import threading
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -12,15 +16,16 @@ from agno.metrics import MessageMetrics
 from agno.models.message import Message
 from agno.models.response import ModelResponse
 
+from mindroom import codex_model
 from mindroom.codex_model import CODEX_BASE_URL, CodexResponses, borrow_codex_key
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import resolve_runtime_paths
 from mindroom.model_loading import get_model_instance
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
 
     import pytest
 
@@ -83,6 +88,82 @@ def test_borrow_codex_key_refreshes_expired_access_token(tmp_path: Path) -> None
     assert "last_refresh" in auth
 
 
+def test_write_codex_auth_creates_private_temp_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refreshed Codex OAuth tokens should never be written through a world-readable temp file."""
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    auth_path = codex_home / "auth.json"
+    observed_temp_modes: list[int] = []
+    original_replace = Path.replace
+
+    def spy_replace(self: Path, target: str | Path) -> Path:
+        if self.name == "auth.json.tmp":
+            observed_temp_modes.append(stat.S_IMODE(self.stat().st_mode))
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", spy_replace)
+    old_umask = os.umask(0o022)
+    try:
+        codex_model._write_codex_auth(auth_path, {"auth_mode": "chatgpt", "tokens": {"access_token": "token"}})
+    finally:
+        os.umask(old_umask)
+
+    assert observed_temp_modes == [0o600]
+    assert stat.S_IMODE(auth_path.stat().st_mode) == 0o600
+
+
+def test_borrow_codex_key_serializes_concurrent_refreshes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent expired-token readers should share one refreshed token instead of racing refresh-token rotation."""
+    codex_home = tmp_path / ".codex"
+    _write_codex_auth(codex_home, _jwt_with_exp(int(time.time()) - 60), "refresh-value")
+    refreshed_token = _jwt_with_exp(int(time.time()) + 7200)
+    refresh_started = threading.Event()
+    release_refresh = threading.Event()
+    refresh_call_count = 0
+    refresh_call_count_lock = threading.Lock()
+    results: list[tuple[str, str | None]] = []
+    errors: list[BaseException] = []
+
+    def fake_refresh(received_refresh: str) -> dict[str, str]:
+        nonlocal refresh_call_count
+        assert received_refresh == "refresh-value"
+        with refresh_call_count_lock:
+            refresh_call_count += 1
+        refresh_started.set()
+        assert release_refresh.wait(timeout=2)
+        return {
+            "access_token": refreshed_token,
+            "refresh_token": "new-refresh-value",
+        }
+
+    def borrow_key() -> None:
+        try:
+            results.append(borrow_codex_key(codex_home=codex_home))
+        except BaseException as exc:
+            errors.append(exc)
+
+    monkeypatch.setattr(codex_model, "_refresh_codex_tokens", fake_refresh)
+
+    first_thread = threading.Thread(target=borrow_key)
+    first_thread.start()
+    assert refresh_started.wait(timeout=2)
+
+    second_thread = threading.Thread(target=borrow_key)
+    second_thread.start()
+    release_refresh.set()
+    first_thread.join(timeout=2)
+    second_thread.join(timeout=2)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert errors == []
+    assert refresh_call_count == 1
+    assert results == [(refreshed_token, "acct_123"), (refreshed_token, "acct_123")]
+
+
 def test_codex_responses_client_params_use_codex_endpoint_and_account_header(tmp_path: Path) -> None:
     """CodexResponses should translate Codex CLI auth into OpenAI client params."""
     codex_home = tmp_path / ".codex"
@@ -115,6 +196,74 @@ def test_codex_responses_request_params_drop_unsupported_limits() -> None:
     model = CodexResponses(id="gpt-5.5", max_output_tokens=40)
 
     assert "max_output_tokens" not in model.get_request_params()
+
+
+def test_codex_responses_request_params_include_prompt_cache_key() -> None:
+    """Codex should expose OpenAI's cache-routing key when configured."""
+    model = CodexResponses(id="gpt-5.5", prompt_cache_key="mindroom-code-agent")
+
+    params = model.get_request_params()
+
+    assert params["prompt_cache_key"] == "mindroom-code-agent"
+    assert params["extra_headers"] == {
+        "session_id": "mindroom-code-agent",
+        "x-client-request-id": "mindroom-code-agent",
+        "x-codex-window-id": "mindroom-code-agent:1",
+    }
+
+
+def test_codex_responses_request_params_preserve_existing_extra_headers() -> None:
+    """Codex prompt-cache headers should not clobber caller-supplied headers."""
+    model = CodexResponses(
+        id="gpt-5.5",
+        prompt_cache_key="mindroom-code-agent",
+        extra_headers={"X-Test": "1", "x-codex-window-id": "custom-window"},
+    )
+
+    assert model.get_request_params()["extra_headers"] == {
+        "X-Test": "1",
+        "session_id": "mindroom-code-agent",
+        "x-client-request-id": "mindroom-code-agent",
+        "x-codex-window-id": "custom-window",
+    }
+
+
+def test_codex_model_loader_derives_prompt_cache_key_from_execution_identity(tmp_path: Path) -> None:
+    """MindRoom should use a stable per-agent/session Codex cache key by default."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={},
+    )
+    config = Config(
+        models={
+            "default": ModelConfig(
+                provider="codex",
+                id="gpt-5.5",
+            ),
+        },
+        agents={},
+    )
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="code",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id="$thread:example.org",
+        resolved_thread_id="$thread:example.org",
+        session_id="!room:example.org:$thread:example.org",
+    )
+
+    model = get_model_instance(config, runtime_paths, execution_identity=identity)
+    params = model.get_request_params()
+
+    assert isinstance(model, CodexResponses)
+    assert params["prompt_cache_key"] == "mindroom-7ac97f304c4001bd9939c88ddba8b0e2"
+    assert params["extra_headers"] == {
+        "session_id": "mindroom-7ac97f304c4001bd9939c88ddba8b0e2",
+        "x-client-request-id": "mindroom-7ac97f304c4001bd9939c88ddba8b0e2",
+        "x-codex-window-id": "mindroom-7ac97f304c4001bd9939c88ddba8b0e2:1",
+    }
 
 
 def test_codex_responses_invoke_aggregates_streaming_deltas(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Serialize Codex auth refresh with a file lock and re-check token freshness inside the lock.
- Write refreshed `auth.json` through a private temp file, then replace the final auth file with `0600` permissions.
- Make Codex prompt caching work by sending `prompt_cache_key` with the Codex CLI session headers and deriving a per-agent/session key from explicit execution identity.
- Make `mindroom config init --profile codex`, `--profile public-codex`, and `--provider codex` generate `extra_kwargs.reasoning_effort: medium`; prompt caching is automatic, so the generated config deliberately leaves `prompt_cache_key` unset to avoid one shared key across concurrent threads.

## Live Codex checks
- `gpt-5.5` through Codex returned marker `mindroom-codex-followup-ok` with `reasoning_effort: high` mapped to `reasoning.effort`.
- `CodexResponses(prompt_cache_key="mindroom-codex-wrapper-smoke")` returned marker `mindroom-codex-cache-key-wrapper-ok`.
- Raw repeated Codex requests without `session_id` / `x-client-request-id` / `x-codex-window-id` stayed at `cached_tokens: 0`.
- Repeated Codex requests with Codex CLI-style session headers reported cache hits: `cached_tokens: 53504` on a roughly 54k-token request.
- The patched `CodexResponses` wrapper, without manual headers, reported `cached_tokens: 17664` on the second identical request through both direct wrapper construction and `get_model_instance(..., execution_identity=...)`.
- `prompt_cache_retention` is still rejected by the Codex subscription endpoint.

## Test Plan
- [x] `uv run pytest tests/test_codex_model.py tests/test_config_discovery.py::TestRuntimeGuardrails::test_production_code_does_not_read_ambient_execution_identity -q`
- [x] `uv run pytest tests/test_cli_config.py::TestConfigInit::test_init_profile_public_codex_writes_hosted_codex_defaults tests/test_cli_config.py::TestConfigInit::test_init_profile_codex_alias_writes_hosted_codex_defaults tests/test_cli_config.py::TestConfigInit::test_init_codex_preset_uses_codex_models tests/test_timing.py::test_load_agent_model_instance_preserves_prompt_assembly_subspan -q`
- [x] `uv run pytest tests/api/test_sandbox_runner_api.py::test_sandbox_runner_worker_python_supports_matrix_scoped_worker_keys -q`
- [x] `uv run pytest` (`5132 passed, 28 skipped`)
- [x] `uv run pre-commit run --all-files`
- [x] Final focused rerun after pre-commit-generated changes: `uv run pytest tests/test_codex_model.py tests/test_cli_config.py::TestConfigInit::test_init_profile_public_codex_writes_hosted_codex_defaults tests/test_cli_config.py::TestConfigInit::test_init_profile_codex_alias_writes_hosted_codex_defaults tests/test_cli_config.py::TestConfigInit::test_init_codex_preset_uses_codex_models tests/test_timing.py::test_load_agent_model_instance_preserves_prompt_assembly_subspan tests/test_config_discovery.py::TestRuntimeGuardrails::test_production_code_does_not_read_ambient_execution_identity -q` (`17 passed`)
