### PR TITLE
Add Codex config init profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Use this path if you want to run MindRoom locally while using hosted chat + Matr
 # Create ~/.mindroom/config.yaml and ~/.mindroom/.env with hosted defaults
 uvx mindroom config init --profile public
 
-# Add at least one model API key
+# Add model auth, or use `--profile public-codex` and run `codex login`
 $EDITOR ~/.mindroom/.env
 
 # Generate pair code in https://chat.mindroom.chat:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -328,9 +328,10 @@ Profiles control the template style:
 - `--profile full` (default) — rich example config with interactive provider selection
 - `--profile minimal` — bare-minimum config
 - `--profile public` — hosted Matrix (`mindroom.chat`) with prefilled homeserver settings
+- `--profile public-codex` — hosted Matrix with Codex CLI subscription defaults
 - `--profile public-vertexai-anthropic` — hosted Matrix with Vertex AI Claude defaults
 
-Provider presets (`--provider`) set the default model: `anthropic`, `openai`, `openrouter`, or `vertexai_claude`.
+Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `openai`, `openrouter`, or `vertexai_claude`.
 
 ```bash
 # Hosted Matrix quickstart (creates ~/.mindroom/config.yaml)
@@ -339,12 +340,18 @@ mindroom config init --profile public
 # Minimal config with Anthropic
 mindroom config init --minimal --provider anthropic
 
-# Full config with Vertex AI Claude on hosted Matrix
+# Hosted Matrix with Codex CLI ChatGPT subscription auth
+mindroom config init --profile public-codex
+
+# Hosted Matrix with Vertex AI Claude
 mindroom config init --profile public-vertexai-anthropic
 
 # Force overwrite existing config
 mindroom config init --force
 ```
+
+The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5`.
+Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
 
 ### config show
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -65,6 +65,12 @@ Set the API key for each provider you use in `config.yaml`:
 All API key variables also support a `_FILE` suffix for file-based secrets (e.g., `ANTHROPIC_API_KEY_FILE=/run/secrets/anthropic-api-key`).
 See [Model Configuration — File-based Secrets](models.md#file-based-secrets) for details.
 
+### Codex CLI Subscription Auth
+
+The `codex` provider does not use an API key environment variable.
+Run `codex login` so `~/.codex/auth.json` contains ChatGPT OAuth tokens.
+Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
+
 ### Operational
 
 | Variable | Description | Default |

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -111,6 +111,7 @@ Run `codex login` first so `~/.codex/auth.json` contains ChatGPT OAuth tokens.
 MindRoom refreshes the access token when needed and sends requests to the Codex Responses endpoint.
 The model ID may be either the bare Codex slug, such as `gpt-5.5`, or the LLM-plugin-style form `openai-codex/gpt-5.5`.
 If you keep Codex state outside `~/.codex`, pass `extra_kwargs.codex_home`.
+For starter config generation, use `mindroom config init --profile public-codex` or `mindroom config init --provider codex`.
 
 ```yaml
 models:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -77,7 +77,7 @@ Configure AI model providers:
 - **Test connection** to verify model accessibility
 - **Provider API keys** section for configuring credentials
 
-**Runtime-supported providers:** OpenAI, Anthropic, Google Gemini (`google`/`gemini`), Vertex AI Claude (`vertexai_claude`), Ollama, OpenRouter, Groq, DeepSeek, Cerebras
+**Runtime-supported providers:** OpenAI, Codex CLI subscription auth (`codex`), Anthropic, Google Gemini (`google`/`gemini`), Vertex AI Claude (`vertexai_claude`), Ollama, OpenRouter, Groq, DeepSeek, Cerebras
 
 ### Memory
 

--- a/docs/deployment/hosted-matrix.md
+++ b/docs/deployment/hosted-matrix.md
@@ -23,7 +23,7 @@ This guide covers the simplest production-like setup:
 - Python 3.12+
 - `uv` installed
 - A Matrix account that can sign in to `chat.mindroom.chat`
-- At least one AI provider API key
+- At least one AI provider API key, or a local Codex CLI ChatGPT subscription login
 
 ## 1. Initialize Local Config
 
@@ -32,6 +32,7 @@ uvx mindroom config init --profile public
 ```
 
 This creates `~/.mindroom/config.yaml` and `~/.mindroom/.env` with hosted defaults.
+Use `uvx mindroom config init --profile public-codex` if you want the starter config to use `provider: codex`.
 
 ## 2. Add AI Provider Key
 
@@ -41,6 +42,9 @@ Edit `~/.mindroom/.env` and set at least one provider key:
 OPENAI_API_KEY=...
 # or OPENROUTER_API_KEY=...
 ```
+
+For Codex CLI subscription auth, run `codex login` instead of adding an API key.
+MindRoom reads `~/.codex/auth.json` by default.
 
 ## 3. Pair This Install
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,9 +31,16 @@ Use `--provider` to select a different provider preset:
 # Use Anthropic Claude
 uvx mindroom config init --profile public --provider anthropic
 
+# Use Codex CLI ChatGPT subscription auth
+uvx mindroom config init --profile public-codex
+
 # Use Vertex AI Claude (Google Cloud)
 uvx mindroom config init --profile public-vertexai-anthropic
 ```
+
+`public-codex` is the canonical profile name for hosted Matrix with Codex CLI subscription auth.
+The shorter `codex` profile alias is also accepted.
+Run `codex login` before starting MindRoom when using this profile.
 
 `public-vertexai-anthropic` is the canonical profile name for Vertex AI Claude on hosted Matrix.
 Aliases `public-vertexai-claude`, `vertexai-anthropic`, and `vertexai-claude` are also accepted.
@@ -54,6 +61,7 @@ Set at least one key:
 - `ANTHROPIC_API_KEY=...`, or
 - `OPENAI_API_KEY=...`, or
 - `OPENROUTER_API_KEY=...`, or
+- For Codex CLI subscription auth: run `codex login`.
 - For Vertex AI Claude: set `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION` and authenticate with `gcloud auth application-default login`.
 
 ### 3. Pair your local install from chat UI

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -211,9 +211,14 @@ The `--profile public` template defaults to the `openai` provider. Use `--provid
 # Use Anthropic Claude
 uvx mindroom config init --profile public --provider anthropic
 
+# Use Codex CLI ChatGPT subscription auth
+uvx mindroom config init --profile public-codex
+
 # Use Vertex AI Claude (Google Cloud)
 uvx mindroom config init --profile public-vertexai-anthropic
 ```
+
+`public-codex` is the canonical profile name for hosted Matrix with Codex CLI subscription auth. The shorter `codex` profile alias is also accepted. Run `codex login` before starting MindRoom when using this profile.
 
 `public-vertexai-anthropic` is the canonical profile name for Vertex AI Claude on hosted Matrix. Aliases `public-vertexai-claude`, `vertexai-anthropic`, and `vertexai-claude` are also accepted.
 
@@ -233,6 +238,7 @@ Set at least one key:
 - `ANTHROPIC_API_KEY=...`, or
 - `OPENAI_API_KEY=...`, or
 - `OPENROUTER_API_KEY=...`, or
+- For Codex CLI subscription auth: run `codex login`.
 - For Vertex AI Claude: set `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION` and authenticate with `gcloud auth application-default login`.
 
 ### 3. Pair your local install from chat UI
@@ -521,7 +527,7 @@ Configure AI model providers:
 - **Test connection** to verify model accessibility
 - **Provider API keys** section for configuring credentials
 
-**Runtime-supported providers:** OpenAI, Anthropic, Google Gemini (`google`/`gemini`), Vertex AI Claude (`vertexai_claude`), Ollama, OpenRouter, Groq, DeepSeek, Cerebras
+**Runtime-supported providers:** OpenAI, Codex CLI subscription auth (`codex`), Anthropic, Google Gemini (`google`/`gemini`), Vertex AI Claude (`vertexai_claude`), Ollama, OpenRouter, Groq, DeepSeek, Cerebras
 
 ### Memory
 
@@ -795,6 +801,10 @@ Set the API key for each provider you use in `config.yaml`:
 | `OPENAI_BASE_URL`    | Base URL for OpenAI-compatible APIs (e.g., local inference servers) |
 
 All API key variables also support a `_FILE` suffix for file-based secrets (e.g., `ANTHROPIC_API_KEY_FILE=/run/secrets/anthropic-api-key`). See [Model Configuration — File-based Secrets](https://docs.mindroom.chat/configuration/models/#file-based-secrets) for details.
+
+### Codex CLI Subscription Auth
+
+The `codex` provider does not use an API key environment variable. Run `codex login` so `~/.codex/auth.json` contains ChatGPT OAuth tokens. Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
 
 ### Operational
 
@@ -1841,7 +1851,7 @@ models:
 
 ## Codex Subscription Models
 
-Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API. Run `codex login` first so `~/.codex/auth.json` contains ChatGPT OAuth tokens. MindRoom refreshes the access token when needed and sends requests to the Codex Responses endpoint. The model ID may be either the bare Codex slug, such as `gpt-5.5`, or the LLM-plugin-style form `openai-codex/gpt-5.5`. If you keep Codex state outside `~/.codex`, pass `extra_kwargs.codex_home`.
+Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API. Run `codex login` first so `~/.codex/auth.json` contains ChatGPT OAuth tokens. MindRoom refreshes the access token when needed and sends requests to the Codex Responses endpoint. The model ID may be either the bare Codex slug, such as `gpt-5.5`, or the LLM-plugin-style form `openai-codex/gpt-5.5`. If you keep Codex state outside `~/.codex`, pass `extra_kwargs.codex_home`. For starter config generation, use `mindroom config init --profile public-codex` or `mindroom config init --provider codex`.
 
 ```
 models:
@@ -11016,7 +11026,7 @@ This guide covers the simplest production-like setup:
 - Python 3.12+
 - `uv` installed
 - A Matrix account that can sign in to `chat.mindroom.chat`
-- At least one AI provider API key
+- At least one AI provider API key, or a local Codex CLI ChatGPT subscription login
 
 ## 1. Initialize Local Config
 
@@ -11024,7 +11034,7 @@ This guide covers the simplest production-like setup:
 uvx mindroom config init --profile public
 ```
 
-This creates `~/.mindroom/config.yaml` and `~/.mindroom/.env` with hosted defaults.
+This creates `~/.mindroom/config.yaml` and `~/.mindroom/.env` with hosted defaults. Use `uvx mindroom config init --profile public-codex` if you want the starter config to use `provider: codex`.
 
 ## 2. Add AI Provider Key
 
@@ -11034,6 +11044,8 @@ Edit `~/.mindroom/.env` and set at least one provider key:
 OPENAI_API_KEY=...
 # or OPENROUTER_API_KEY=...
 ```
+
+For Codex CLI subscription auth, run `codex login` instead of adding an API key. MindRoom reads `~/.codex/auth.json` by default.
 
 ## 3. Pair This Install
 
@@ -12556,9 +12568,10 @@ Profiles control the template style:
 - `--profile full` (default) — rich example config with interactive provider selection
 - `--profile minimal` — bare-minimum config
 - `--profile public` — hosted Matrix (`mindroom.chat`) with prefilled homeserver settings
+- `--profile public-codex` — hosted Matrix with Codex CLI subscription defaults
 - `--profile public-vertexai-anthropic` — hosted Matrix with Vertex AI Claude defaults
 
-Provider presets (`--provider`) set the default model: `anthropic`, `openai`, `openrouter`, or `vertexai_claude`.
+Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `openai`, `openrouter`, or `vertexai_claude`.
 
 ```
 # Hosted Matrix quickstart (creates ~/.mindroom/config.yaml)
@@ -12567,12 +12580,17 @@ mindroom config init --profile public
 # Minimal config with Anthropic
 mindroom config init --minimal --provider anthropic
 
-# Full config with Vertex AI Claude on hosted Matrix
+# Hosted Matrix with Codex CLI ChatGPT subscription auth
+mindroom config init --profile public-codex
+
+# Hosted Matrix with Vertex AI Claude
 mindroom config init --profile public-vertexai-anthropic
 
 # Force overwrite existing config
 mindroom config init --force
 ```
+
+The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5`. Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
 
 ### config show
 

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -189,9 +189,10 @@ Profiles control the template style:
 - `--profile full` (default) — rich example config with interactive provider selection
 - `--profile minimal` — bare-minimum config
 - `--profile public` — hosted Matrix (`mindroom.chat`) with prefilled homeserver settings
+- `--profile public-codex` — hosted Matrix with Codex CLI subscription defaults
 - `--profile public-vertexai-anthropic` — hosted Matrix with Vertex AI Claude defaults
 
-Provider presets (`--provider`) set the default model: `anthropic`, `openai`, `openrouter`, or `vertexai_claude`.
+Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `openai`, `openrouter`, or `vertexai_claude`.
 
 ```
 # Hosted Matrix quickstart (creates ~/.mindroom/config.yaml)
@@ -200,12 +201,17 @@ mindroom config init --profile public
 # Minimal config with Anthropic
 mindroom config init --minimal --provider anthropic
 
-# Full config with Vertex AI Claude on hosted Matrix
+# Hosted Matrix with Codex CLI ChatGPT subscription auth
+mindroom config init --profile public-codex
+
+# Hosted Matrix with Vertex AI Claude
 mindroom config init --profile public-vertexai-anthropic
 
 # Force overwrite existing config
 mindroom config init --force
 ```
+
+The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5`. Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
 
 ### config show
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -59,6 +59,10 @@ Set the API key for each provider you use in `config.yaml`:
 
 All API key variables also support a `_FILE` suffix for file-based secrets (e.g., `ANTHROPIC_API_KEY_FILE=/run/secrets/anthropic-api-key`). See [Model Configuration — File-based Secrets](https://docs.mindroom.chat/configuration/models/#file-based-secrets) for details.
 
+### Codex CLI Subscription Auth
+
+The `codex` provider does not use an API key environment variable. Run `codex login` so `~/.codex/auth.json` contains ChatGPT OAuth tokens. Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
+
 ### Operational
 
 | Variable                                             | Description                                                                                                                                                                                                                                      | Default                          |

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -102,7 +102,7 @@ models:
 
 ## Codex Subscription Models
 
-Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API. Run `codex login` first so `~/.codex/auth.json` contains ChatGPT OAuth tokens. MindRoom refreshes the access token when needed and sends requests to the Codex Responses endpoint. The model ID may be either the bare Codex slug, such as `gpt-5.5`, or the LLM-plugin-style form `openai-codex/gpt-5.5`. If you keep Codex state outside `~/.codex`, pass `extra_kwargs.codex_home`.
+Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API. Run `codex login` first so `~/.codex/auth.json` contains ChatGPT OAuth tokens. MindRoom refreshes the access token when needed and sends requests to the Codex Responses endpoint. The model ID may be either the bare Codex slug, such as `gpt-5.5`, or the LLM-plugin-style form `openai-codex/gpt-5.5`. If you keep Codex state outside `~/.codex`, pass `extra_kwargs.codex_home`. For starter config generation, use `mindroom config init --profile public-codex` or `mindroom config init --provider codex`.
 
 ```
 models:

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -72,7 +72,7 @@ Configure AI model providers:
 - **Test connection** to verify model accessibility
 - **Provider API keys** section for configuring credentials
 
-**Runtime-supported providers:** OpenAI, Anthropic, Google Gemini (`google`/`gemini`), Vertex AI Claude (`vertexai_claude`), Ollama, OpenRouter, Groq, DeepSeek, Cerebras
+**Runtime-supported providers:** OpenAI, Codex CLI subscription auth (`codex`), Anthropic, Google Gemini (`google`/`gemini`), Vertex AI Claude (`vertexai_claude`), Ollama, OpenRouter, Groq, DeepSeek, Cerebras
 
 ### Memory
 

--- a/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
+++ b/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
@@ -19,7 +19,7 @@ This guide covers the simplest production-like setup:
 - Python 3.12+
 - `uv` installed
 - A Matrix account that can sign in to `chat.mindroom.chat`
-- At least one AI provider API key
+- At least one AI provider API key, or a local Codex CLI ChatGPT subscription login
 
 ## 1. Initialize Local Config
 
@@ -27,7 +27,7 @@ This guide covers the simplest production-like setup:
 uvx mindroom config init --profile public
 ```
 
-This creates `~/.mindroom/config.yaml` and `~/.mindroom/.env` with hosted defaults.
+This creates `~/.mindroom/config.yaml` and `~/.mindroom/.env` with hosted defaults. Use `uvx mindroom config init --profile public-codex` if you want the starter config to use `provider: codex`.
 
 ## 2. Add AI Provider Key
 
@@ -37,6 +37,8 @@ Edit `~/.mindroom/.env` and set at least one provider key:
 OPENAI_API_KEY=...
 # or OPENROUTER_API_KEY=...
 ```
+
+For Codex CLI subscription auth, run `codex login` instead of adding an API key. MindRoom reads `~/.codex/auth.json` by default.
 
 ## 3. Pair This Install
 

--- a/skills/mindroom-docs/references/page__getting-started__index.md
+++ b/skills/mindroom-docs/references/page__getting-started__index.md
@@ -25,9 +25,14 @@ The `--profile public` template defaults to the `openai` provider. Use `--provid
 # Use Anthropic Claude
 uvx mindroom config init --profile public --provider anthropic
 
+# Use Codex CLI ChatGPT subscription auth
+uvx mindroom config init --profile public-codex
+
 # Use Vertex AI Claude (Google Cloud)
 uvx mindroom config init --profile public-vertexai-anthropic
 ```
+
+`public-codex` is the canonical profile name for hosted Matrix with Codex CLI subscription auth. The shorter `codex` profile alias is also accepted. Run `codex login` before starting MindRoom when using this profile.
 
 `public-vertexai-anthropic` is the canonical profile name for Vertex AI Claude on hosted Matrix. Aliases `public-vertexai-claude`, `vertexai-anthropic`, and `vertexai-claude` are also accepted.
 
@@ -47,6 +52,7 @@ Set at least one key:
 - `ANTHROPIC_API_KEY=...`, or
 - `OPENAI_API_KEY=...`, or
 - `OPENROUTER_API_KEY=...`, or
+- For Codex CLI subscription auth: run `codex login`.
 - For Vertex AI Claude: set `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION` and authenticate with `gcloud auth application-default login`.
 
 ### 3. Pair your local install from chat UI

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -62,10 +62,11 @@ _CONFIG_PATH_OPTION: Path | None = typer.Option(
 )
 
 _ConfigInitProfile = Literal["full", "minimal", "public"]
-_ProviderPreset = Literal["anthropic", "openai", "openrouter", "vertexai_claude"]
+_ProviderPreset = Literal["anthropic", "codex", "openai", "openrouter", "vertexai_claude"]
 
 _DEFAULT_MODEL_PRESETS: dict[_ProviderPreset, tuple[str, str]] = {
     "anthropic": ("anthropic", "claude-sonnet-4-6"),
+    "codex": ("codex", "gpt-5.5"),
     "openai": ("openai", "gpt-5.4"),
     "openrouter": ("openrouter", "anthropic/claude-sonnet-4.6"),
     "vertexai_claude": ("vertexai_claude", "claude-sonnet-4-6"),
@@ -73,11 +74,18 @@ _DEFAULT_MODEL_PRESETS: dict[_ProviderPreset, tuple[str, str]] = {
 
 _REQUIRED_ENV_KEYS: dict[_ProviderPreset, tuple[str, ...]] = {
     "anthropic": ("ANTHROPIC_API_KEY",),
+    "codex": (),
     "openai": ("OPENAI_API_KEY",),
     "openrouter": ("OPENROUTER_API_KEY",),
     "vertexai_claude": (),
 }
-_CANONICAL_INIT_PROFILES: tuple[str, ...] = ("full", "minimal", "public", "public-vertexai-anthropic")
+_CANONICAL_INIT_PROFILES: tuple[str, ...] = (
+    "full",
+    "minimal",
+    "public",
+    "public-codex",
+    "public-vertexai-anthropic",
+)
 
 
 def _config_init_storage_plan(
@@ -158,6 +166,10 @@ def _should_write_env_file(env_path: Path, *, force: bool) -> bool:
 
 def _config_init_env_hint(selected_profile: _ConfigInitProfile, selected_preset: _ProviderPreset) -> str:
     """Return the env setup hint shown after `mindroom config init`."""
+    if selected_preset == "codex":
+        if selected_profile == "public":
+            return "Run `codex login` before starting MindRoom (Matrix homeserver is prefilled)"
+        return "Set your Matrix homeserver and run `codex login` before starting MindRoom"
     if selected_preset == "vertexai_claude":
         if selected_profile == "public":
             return "Set your Vertex AI project/region and Google auth (Matrix homeserver is prefilled)"
@@ -289,14 +301,14 @@ def config_init(
         "full",
         "--profile",
         help=(
-            "Template profile: full, minimal, public, or public-vertexai-anthropic "
-            "(hosted Matrix with Vertex AI Claude defaults)."
+            "Template profile: full, minimal, public, public-codex, or public-vertexai-anthropic "
+            "(hosted Matrix with provider defaults)."
         ),
     ),
     provider: str | None = typer.Option(
         None,
         "--provider",
-        help="Provider preset for generated config: anthropic, openai, openrouter, or vertexai_claude.",
+        help="Provider preset for generated config: anthropic, codex, openai, openrouter, or vertexai_claude.",
     ),
 ) -> None:
     """Create a starter config.yaml with example agents and models.
@@ -567,7 +579,7 @@ def _resolve_config_init_selection(
     provider_preset = _normalize_provider_preset(provider) if provider else None
     if provider and provider_preset is None:
         console.print(
-            "[red]Invalid --provider value.[/red] Use: anthropic, openai, openrouter, or vertexai_claude.",
+            "[red]Invalid --provider value.[/red] Use: anthropic, codex, openai, openrouter, or vertexai_claude.",
         )
         raise typer.Exit(1)
 
@@ -588,6 +600,8 @@ def _normalize_init_profile(profile: str) -> tuple[_ConfigInitProfile, _Provider
         "full": ("full", None),
         "minimal": ("minimal", None),
         "public": ("public", None),
+        "public-codex": ("public", "codex"),
+        "codex": ("public", "codex"),
         "public-vertexai-anthropic": ("public", "vertexai_claude"),
         "public-vertexai-claude": ("public", "vertexai_claude"),
         "vertexai-anthropic": ("public", "vertexai_claude"),
@@ -613,6 +627,7 @@ def _normalize_provider_preset(provider: str) -> _ProviderPreset | None:
         "anthropic": "anthropic",
         "claude": "anthropic",
         "a": "anthropic",
+        "codex": "codex",
         "openai": "openai",
         "o": "openai",
         "openrouter": "openrouter",
@@ -631,14 +646,14 @@ def _prompt_provider_preset() -> _ProviderPreset:
     """Prompt the user for a starter provider preset."""
     while True:
         raw_value = typer.prompt(
-            "Choose provider preset [anthropic/openai/openrouter/vertexai_claude]",
+            "Choose provider preset [anthropic/codex/openai/openrouter/vertexai_claude]",
             default="openai",
             show_default=True,
         )
         provider_preset = _normalize_provider_preset(raw_value)
         if provider_preset is not None:
             return provider_preset
-        console.print("[red]Invalid choice.[/red] Enter anthropic, openai, openrouter, or vertexai_claude.")
+        console.print("[red]Invalid choice.[/red] Enter anthropic, codex, openai, openrouter, or vertexai_claude.")
 
 
 def _model_template_block(provider_preset: _ProviderPreset) -> str:
@@ -893,6 +908,14 @@ defaults:
 
 def _provider_env_template(provider_preset: _ProviderPreset) -> str:
     """Return the provider-specific section of the starter .env file."""
+    if provider_preset == "codex":
+        return textwrap.dedent("""\
+        # Codex CLI subscription authentication
+        # Run `codex login` before starting MindRoom.
+        # MindRoom reads ChatGPT OAuth tokens from ~/.codex/auth.json by default.
+        # CODEX_HOME=~/.codex
+        """).rstrip()
+
     if provider_preset == "vertexai_claude":
         return textwrap.dedent("""\
         # Vertex AI Claude configuration

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -344,6 +344,54 @@ class TestConfigInit:
         assert "Google" in output
         assert "auth" in output
 
+    def test_init_profile_public_codex_writes_hosted_codex_defaults(self, tmp_path: Path) -> None:
+        """Hosted Codex profile should use Codex defaults and hosted Matrix settings."""
+        target = tmp_path / "config.yaml"
+        result = runner.invoke(
+            app,
+            ["config", "init", "--path", str(target), "--profile", "public-codex"],
+        )
+        assert result.exit_code == 0
+
+        config = yaml.safe_load(target.read_text())
+        assert "mindroom_user" not in config
+        assert config["models"]["default"]["provider"] == "codex"
+        assert config["models"]["default"]["id"] == "gpt-5.5"
+
+        env_content = (tmp_path / ".env").read_text()
+        assert "MATRIX_HOMESERVER=https://mindroom.chat" in env_content
+        assert "Run `codex login` before starting MindRoom." in env_content
+        assert "# CODEX_HOME=~/.codex" in env_content
+        assert "\nANTHROPIC_API_KEY=" not in env_content
+        assert "\nOPENAI_API_KEY=" not in env_content
+        assert "\nOPENROUTER_API_KEY=" not in env_content
+
+        output = normalize_console_output(result.output)
+        assert "mindroom connect --pair-code" in output
+        assert "codex login" in output
+
+    def test_init_profile_codex_alias_writes_hosted_codex_defaults(self, tmp_path: Path) -> None:
+        """The concise codex profile alias should use hosted Codex defaults."""
+        target = tmp_path / "config.yaml"
+        result = runner.invoke(
+            app,
+            ["config", "init", "--path", str(target), "--profile", "codex"],
+        )
+        assert result.exit_code == 0
+
+        config = yaml.safe_load(target.read_text())
+        assert "mindroom_user" not in config
+        assert config["models"]["default"]["provider"] == "codex"
+        assert config["models"]["default"]["id"] == "gpt-5.5"
+
+    @pytest.mark.parametrize("profile", ["openai-codex", "public-openai-codex"])
+    def test_init_rejects_openai_codex_profile_aliases(self, tmp_path: Path, profile: str) -> None:
+        """Config init should avoid redundant OpenAI-Codex profile aliases."""
+        target = tmp_path / "config.yaml"
+        result = runner.invoke(app, ["config", "init", "--path", str(target), "--profile", profile])
+        assert result.exit_code == 2
+        assert "Invalid profile" in normalize_console_output(result.output)
+
     def test_init_full_profile_omits_pairing_step(self, tmp_path: Path) -> None:
         """Full profile next steps should NOT mention pairing."""
         target = tmp_path / "config.yaml"
@@ -523,6 +571,29 @@ class TestConfigInit:
         content = target.read_text()
         assert "provider: openrouter" in content
         assert "anthropic/claude-sonnet-4.6" in content
+
+    def test_init_codex_preset_uses_codex_models(self, tmp_path: Path) -> None:
+        """Config init --provider codex uses Codex subscription defaults."""
+        target = tmp_path / "config.yaml"
+        result = runner.invoke(app, ["config", "init", "--path", str(target), "--provider", "codex"])
+        assert result.exit_code == 0
+
+        config = yaml.safe_load(target.read_text())
+        assert config["models"]["default"]["provider"] == "codex"
+        assert config["models"]["default"]["id"] == "gpt-5.5"
+
+        env_content = (tmp_path / ".env").read_text()
+        assert "Run `codex login` before starting MindRoom." in env_content
+        assert "# CODEX_HOME=~/.codex" in env_content
+        assert "OPENAI_API_KEY=your-openai-key-here" not in env_content
+
+    @pytest.mark.parametrize("provider", ["openai-codex", "openai_codex", "c"])
+    def test_init_rejects_openai_codex_provider_aliases(self, tmp_path: Path, provider: str) -> None:
+        """Config init should accept codex as the provider preset without extra aliases."""
+        target = tmp_path / "config.yaml"
+        result = runner.invoke(app, ["config", "init", "--path", str(target), "--provider", provider])
+        assert result.exit_code == 1
+        assert "Invalid --provider value" in normalize_console_output(result.output)
 
     def test_init_anthropic_preset_uses_anthropic_models_and_local_embedder(self, tmp_path: Path) -> None:
         """Config init --provider anthropic should only require the Anthropic API key."""


### PR DESCRIPTION
## Summary
- add a hosted `public-codex` config init profile and `--provider codex` preset
- generate Codex subscription defaults with `provider: codex`, `id: gpt-5.5`, and `codex login` env guidance
- update README, docs, and generated docs skill references

## Tests
- `uv run pytest tests/test_cli_config.py -x -n 0 --no-cov -q`
- `uv run pytest tests/test_kubernetes_worker_backend.py::test_kubernetes_backend_prestartup_failures_are_normalized -n 0 --no-cov -q`
- `uv run pytest -x -n auto --no-cov`
- `uv run pre-commit run --all-files`