### PR TITLE
Refine shared knowledge refresh scheduling

### DIFF
--- a/src/mindroom/knowledge/__init__.py
+++ b/src/mindroom/knowledge/__init__.py
@@ -11,6 +11,7 @@ from mindroom.knowledge.shared_managers import (
     ensure_shared_knowledge_manager,
     get_shared_knowledge_manager_for_config,
     initialize_shared_knowledge_managers,
+    referenced_shared_knowledge_base_ids,
     shutdown_shared_knowledge_managers,
 )
 from mindroom.knowledge.utils import (
@@ -27,6 +28,7 @@ __all__ = [
     "shutdown_shared_knowledge_managers",
     "ensure_shared_knowledge_manager",
     "get_shared_knowledge_manager_for_config",
+    "referenced_shared_knowledge_base_ids",
     "ensure_request_knowledge_managers",
     "get_agent_knowledge",
     "KnowledgeAccessSupport",

--- a/src/mindroom/knowledge/refresh_owner.py
+++ b/src/mindroom/knowledge/refresh_owner.py
@@ -140,19 +140,15 @@ class OrchestratorKnowledgeRefreshOwner:
 
     def is_refreshing(self, base_id: str) -> bool:
         """Return whether one shared knowledge base is already refreshing."""
-        _ = base_id
-        task = self.orchestrator._knowledge_refresh_task
+        task = self.orchestrator._knowledge_base_refresh_tasks.get(base_id)
         return task is not None and not task.done()
 
     def _schedule(self, base_id: str) -> None:
         config = self.orchestrator.config
         if config is None or base_id not in config.knowledge_bases or self.is_refreshing(base_id):
             return
-        _create_logged_task(
-            self.orchestrator._schedule_knowledge_refresh(
-                config,
-                start_watcher=self.orchestrator.running,
-            ),
-            name=f"schedule_knowledge_refresh:{base_id}",
-            failure_message="Background knowledge refresh scheduling failed",
+        self.orchestrator._schedule_knowledge_base_refresh(
+            base_id,
+            config,
+            start_watcher=self.orchestrator.running,
         )

--- a/src/mindroom/knowledge/shared_managers.py
+++ b/src/mindroom/knowledge/shared_managers.py
@@ -17,6 +17,8 @@ from mindroom.logging_config import get_logger
 from mindroom.runtime_resolution import ResolvedKnowledgeBinding, resolve_knowledge_binding
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
@@ -104,6 +106,23 @@ async def _stop_and_remove_shared_manager(base_id: str) -> None:
     if manager is None:
         return
     await manager.stop_watcher()
+
+
+def _publish_allowed(publish_guard: Callable[[], bool] | None) -> bool:
+    return publish_guard is None or publish_guard()
+
+
+async def _publish_shared_manager_if_current(
+    base_id: str,
+    manager: KnowledgeManager,
+    *,
+    publish_guard: Callable[[], bool] | None,
+) -> KnowledgeManager | None:
+    if not _publish_allowed(publish_guard):
+        await manager.stop_watcher()
+        return None
+    _shared_knowledge_managers[base_id] = manager
+    return manager
 
 
 def _shared_knowledge_manager_init_lock(base_id: str) -> asyncio.Lock:
@@ -271,12 +290,15 @@ async def _ensure_shared_knowledge_manager_for_target(
     reindex_on_create: bool,
     reconcile_existing_runtime: bool,
     initialize_on_create: bool = True,
-) -> KnowledgeManager:
+    publish_guard: Callable[[], bool] | None = None,
+) -> KnowledgeManager | None:
     if target.binding.request_scoped:
         msg = f"Shared knowledge manager target '{target.key.base_id}' must not be request-scoped"
         raise ValueError(msg)
 
     async with _shared_knowledge_manager_init_lock(target.key.base_id):
+        if not _publish_allowed(publish_guard):
+            return None
         existing = _shared_knowledge_managers.get(target.key.base_id)
         if existing is not None:
             persisted_state = existing._load_persisted_indexing_state()
@@ -285,24 +307,15 @@ async def _ensure_shared_knowledge_manager_for_target(
                 target.binding.storage_root,
                 target.binding.knowledge_path,
             ) or (persisted_state is not None and persisted_state.availability == "refresh_failed"):
-                preserved_runtime_mode = (
-                    _shared_manager_background_runtime_mode(existing) if not reconcile_existing_runtime else None
-                )
-                await existing.stop_watcher()
-                manager = await _create_knowledge_manager_for_target(
+                return await _replace_shared_manager_after_full_reindex(
+                    existing=existing,
                     target=target,
                     config=config,
                     runtime_paths=runtime_paths,
-                    reindex_on_create=True,
+                    reconcile_existing_runtime=reconcile_existing_runtime,
                     initialize_on_create=initialize_on_create,
-                    start_runtime=reconcile_existing_runtime and initialize_on_create,
+                    publish_guard=publish_guard,
                 )
-                if initialize_on_create:
-                    await _start_shared_manager_runtime_mode(manager, preserved_runtime_mode)
-                else:
-                    manager.defer_shared_runtime_restore(preserved_runtime_mode)
-                _shared_knowledge_managers[target.key.base_id] = manager
-                return manager
 
             existing._refresh_settings(
                 config,
@@ -327,8 +340,11 @@ async def _ensure_shared_knowledge_manager_for_target(
             initialize_on_create=initialize_on_create,
             start_runtime=initialize_on_create,
         )
-        _shared_knowledge_managers[target.key.base_id] = manager
-        return manager
+        return await _publish_shared_manager_if_current(
+            target.key.base_id,
+            manager,
+            publish_guard=publish_guard,
+        )
 
 
 async def _create_request_knowledge_manager_for_target(
@@ -349,6 +365,45 @@ async def _create_request_knowledge_manager_for_target(
             runtime_paths=runtime_paths,
             reindex_on_create=reindex_on_create,
         )
+
+
+async def _replace_shared_manager_after_full_reindex(
+    *,
+    existing: KnowledgeManager,
+    target: _ResolvedKnowledgeManagerTarget,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    reconcile_existing_runtime: bool,
+    initialize_on_create: bool,
+    publish_guard: Callable[[], bool] | None,
+) -> KnowledgeManager | None:
+    stopped_runtime_mode = _shared_manager_background_runtime_mode(existing)
+    preserved_runtime_mode = stopped_runtime_mode if not reconcile_existing_runtime else None
+    await existing.stop_watcher()
+    published = False
+    try:
+        manager = await _create_knowledge_manager_for_target(
+            target=target,
+            config=config,
+            runtime_paths=runtime_paths,
+            reindex_on_create=True,
+            initialize_on_create=initialize_on_create,
+            start_runtime=reconcile_existing_runtime and initialize_on_create,
+        )
+        if initialize_on_create:
+            await _start_shared_manager_runtime_mode(manager, preserved_runtime_mode)
+        else:
+            manager.defer_shared_runtime_restore(preserved_runtime_mode)
+        published_manager = await _publish_shared_manager_if_current(
+            target.key.base_id,
+            manager,
+            publish_guard=publish_guard,
+        )
+        published = published_manager is not None
+        return published_manager
+    finally:
+        if not published and _shared_knowledge_managers.get(target.key.base_id) is existing:
+            await _start_shared_manager_runtime_mode(existing, stopped_runtime_mode)
 
 
 async def ensure_agent_knowledge_managers(
@@ -393,9 +448,11 @@ async def initialize_shared_knowledge_managers(
     start_watchers: bool = False,
     reindex_on_create: bool = True,
     reconcile_existing_runtime: bool = False,
+    base_ids: Iterable[str] | None = None,
+    publish_guard: Callable[[], bool] | None = None,
 ) -> dict[str, KnowledgeManager]:
     """Initialize process-global shared knowledge managers for configured shared bases only."""
-    configured_base_ids = set(config.knowledge_bases)
+    configured_base_ids = set(config.knowledge_bases) if base_ids is None else set(base_ids)
     managers: dict[str, KnowledgeManager] = {}
 
     for base_id in sorted(configured_base_ids):
@@ -406,15 +463,27 @@ async def initialize_shared_knowledge_managers(
             start_watchers=start_watchers,
             reindex_on_create=reindex_on_create,
             reconcile_existing_runtime=reconcile_existing_runtime,
+            publish_guard=publish_guard,
         )
         if manager is None:
             continue
         managers[base_id] = manager
 
-    for base_id in [candidate for candidate in list(_shared_knowledge_managers) if candidate not in managers]:
-        await _stop_and_remove_shared_manager(base_id)
+    if _publish_allowed(publish_guard):
+        for base_id in [candidate for candidate in list(_shared_knowledge_managers) if candidate not in managers]:
+            await _stop_and_remove_shared_manager(base_id)
 
     return managers
+
+
+def referenced_shared_knowledge_base_ids(config: Config) -> set[str]:
+    """Return configured shared knowledge bases referenced by active agents."""
+    referenced_base_ids: set[str] = set()
+    for agent_name in config.agents:
+        for base_id in config.get_agent_knowledge_base_ids(agent_name):
+            if base_id in config.knowledge_bases and config.get_private_knowledge_base_agent(base_id) is None:
+                referenced_base_ids.add(base_id)
+    return referenced_base_ids
 
 
 async def ensure_shared_knowledge_manager(
@@ -426,6 +495,7 @@ async def ensure_shared_knowledge_manager(
     reindex_on_create: bool = True,
     reconcile_existing_runtime: bool = False,
     initialize_on_create: bool = True,
+    publish_guard: Callable[[], bool] | None = None,
 ) -> KnowledgeManager | None:
     """Ensure one process-global shared knowledge manager exists for the given base."""
     target = _resolve_knowledge_manager_target(
@@ -444,6 +514,7 @@ async def ensure_shared_knowledge_manager(
         reindex_on_create=reindex_on_create,
         reconcile_existing_runtime=reconcile_existing_runtime,
         initialize_on_create=initialize_on_create,
+        publish_guard=publish_guard,
     )
 
 

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -28,7 +28,9 @@ from mindroom.hooks.types import EVENT_CONFIG_RELOADED
 from mindroom.knowledge import (
     KnowledgeManager,
     OrchestratorKnowledgeRefreshOwner,
+    ensure_shared_knowledge_manager,
     initialize_shared_knowledge_managers,
+    referenced_shared_knowledge_base_ids,
     shutdown_shared_knowledge_managers,
 )
 from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_members, invite_to_room
@@ -223,6 +225,8 @@ class MultiAgentOrchestrator:
     _memory_auto_flush_worker: MemoryAutoFlushWorker | None = field(default=None, init=False)
     _memory_auto_flush_task: asyncio.Task | None = field(default=None, init=False)
     _knowledge_refresh_task: asyncio.Task | None = field(default=None, init=False)
+    _knowledge_base_refresh_tasks: dict[str, asyncio.Task] = field(default_factory=dict, init=False)
+    _knowledge_refresh_generation: int = field(default=0, init=False)
     _config_reload_task: asyncio.Task | None = field(default=None, init=False)
     _config_reload_requested_at: float | None = field(default=None, init=False)
     _mcp_manager: MCPServerManager | None = field(default=None, init=False)
@@ -355,21 +359,54 @@ class MultiAgentOrchestrator:
             update_runtime_state=update_runtime_state,
         )
 
-    async def _configure_knowledge(self, config: Config, *, start_watcher: bool) -> None:
+    def _advance_knowledge_refresh_generation(self) -> int:
+        """Advance and return the current knowledge refresh generation."""
+        self._knowledge_refresh_generation += 1
+        return self._knowledge_refresh_generation
+
+    def _knowledge_refresh_is_current(self, generation: int) -> bool:
+        """Return whether one scheduled knowledge refresh can still publish."""
+        return generation == self._knowledge_refresh_generation
+
+    async def _configure_knowledge(
+        self,
+        config: Config,
+        *,
+        start_watcher: bool,
+        generation: int | None = None,
+    ) -> None:
         """Initialize or reconfigure knowledge managers for the current config."""
-        self.knowledge_managers = await initialize_shared_knowledge_managers(
+        base_ids = referenced_shared_knowledge_base_ids(config)
+        publish_guard = None if generation is None else partial(self._knowledge_refresh_is_current, generation)
+        managers = await initialize_shared_knowledge_managers(
             config=config,
             runtime_paths=self.runtime_paths,
             start_watchers=start_watcher,
             reindex_on_create=False,
             reconcile_existing_runtime=True,
+            base_ids=base_ids,
+            publish_guard=publish_guard,
         )
+        if generation is None or self._knowledge_refresh_is_current(generation):
+            self.knowledge_managers = managers
 
     async def _cancel_knowledge_refresh_task(self) -> None:
-        """Cancel any in-flight background knowledge refresh task."""
+        """Cancel the in-flight global background knowledge refresh task."""
         task = self._knowledge_refresh_task
         self._knowledge_refresh_task = None
         await cancel_logged_task(task)
+
+    async def _cancel_knowledge_base_refresh_tasks(self) -> None:
+        """Cancel any in-flight per-base background knowledge refresh tasks."""
+        tasks = list(self._knowledge_base_refresh_tasks.values())
+        self._knowledge_base_refresh_tasks.clear()
+        for task in tasks:
+            await cancel_logged_task(task)
+
+    async def _cancel_knowledge_refresh_tasks(self) -> None:
+        """Cancel all in-flight background knowledge refresh tasks."""
+        await self._cancel_knowledge_refresh_task()
+        await self._cancel_knowledge_base_refresh_tasks()
 
     async def _cancel_config_reload_task(self) -> None:
         """Cancel any queued config reload task."""
@@ -484,18 +521,66 @@ class MultiAgentOrchestrator:
         config: Config,
         *,
         start_watcher: bool,
+        generation: int,
     ) -> None:
         """Run background knowledge refresh until it succeeds or is cancelled."""
         current_task = asyncio.current_task()
         try:
             await run_with_retry(
                 "Background knowledge refresh",
-                lambda: self._configure_knowledge(config, start_watcher=start_watcher),
+                lambda: self._configure_knowledge(config, start_watcher=start_watcher, generation=generation),
                 update_runtime_state=False,
             )
         finally:
             if self._knowledge_refresh_task is current_task:
                 self._knowledge_refresh_task = None
+
+    async def _run_knowledge_base_refresh(
+        self,
+        base_id: str,
+        config: Config,
+        *,
+        start_watcher: bool,
+        generation: int,
+    ) -> None:
+        """Run one background knowledge base refresh until it succeeds or is cancelled."""
+        current_task = asyncio.current_task()
+        started_at = time.perf_counter()
+        refreshed_manager: KnowledgeManager | None = None
+        logger.info(
+            "Background knowledge base refresh started",
+            base_id=base_id,
+            start_watcher=start_watcher,
+        )
+        try:
+
+            async def refresh_one() -> None:
+                nonlocal refreshed_manager
+                refreshed_manager = await ensure_shared_knowledge_manager(
+                    base_id,
+                    config=config,
+                    runtime_paths=self.runtime_paths,
+                    start_watchers=start_watcher,
+                    reindex_on_create=False,
+                    reconcile_existing_runtime=True,
+                    publish_guard=partial(self._knowledge_refresh_is_current, generation),
+                )
+
+            await run_with_retry(
+                f"Background knowledge refresh for {base_id}",
+                refresh_one,
+                update_runtime_state=False,
+            )
+            if refreshed_manager is not None and self._knowledge_refresh_is_current(generation):
+                self.knowledge_managers[base_id] = refreshed_manager
+                logger.info(
+                    "Background knowledge base refresh finished",
+                    base_id=base_id,
+                    elapsed_ms=round((time.perf_counter() - started_at) * 1000, 1),
+                )
+        finally:
+            if self._knowledge_base_refresh_tasks.get(base_id) is current_task:
+                self._knowledge_base_refresh_tasks.pop(base_id, None)
 
     async def _schedule_knowledge_refresh(
         self,
@@ -504,11 +589,36 @@ class MultiAgentOrchestrator:
         start_watcher: bool,
     ) -> None:
         """Schedule knowledge refresh in the background, replacing any in-flight run."""
+        generation = self._advance_knowledge_refresh_generation()
         await self._cancel_knowledge_refresh_task()
+        await self._cancel_knowledge_base_refresh_tasks()
         self._knowledge_refresh_task = create_logged_task(
-            self._run_knowledge_refresh(config, start_watcher=start_watcher),
+            self._run_knowledge_refresh(config, start_watcher=start_watcher, generation=generation),
             name="knowledge_refresh",
             failure_message="Background knowledge refresh failed",
+        )
+
+    def _schedule_knowledge_base_refresh(
+        self,
+        base_id: str,
+        config: Config,
+        *,
+        start_watcher: bool,
+    ) -> None:
+        """Schedule refresh for one shared knowledge base without replacing other bases."""
+        task = self._knowledge_base_refresh_tasks.get(base_id)
+        if task is not None and not task.done():
+            return
+        generation = self._knowledge_refresh_generation
+        self._knowledge_base_refresh_tasks[base_id] = create_logged_task(
+            self._run_knowledge_base_refresh(
+                base_id,
+                config,
+                start_watcher=start_watcher,
+                generation=generation,
+            ),
+            name=f"knowledge_refresh:{base_id}",
+            failure_message="Background knowledge base refresh failed",
         )
 
     def in_flight_response_count(self) -> int:
@@ -1627,7 +1737,7 @@ class MultiAgentOrchestrator:
         self.running = False
         await self._cancel_config_reload_task()
         await self._stop_memory_auto_flush_worker()
-        await self._cancel_knowledge_refresh_task()
+        await self._cancel_knowledge_refresh_tasks()
         await self._cancel_bot_start_tasks()
         await self._stop_mcp_manager()
         await shutdown_shared_knowledge_managers()

--- a/tach.toml
+++ b/tach.toml
@@ -1643,6 +1643,7 @@ expose = [
     "initialize_shared_knowledge_managers",
     "KnowledgeAvailability",
     "OrchestratorKnowledgeRefreshOwner",
+    "referenced_shared_knowledge_base_ids",
     "StandaloneKnowledgeRefreshOwner",
     "shutdown_shared_knowledge_managers",
 ]

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -1516,6 +1516,96 @@ async def test_initialize_shared_knowledge_managers_maintains_registry(
 
 
 @pytest.mark.asyncio
+async def test_ensure_shared_knowledge_manager_skips_publish_when_guard_is_stale(tmp_path: Path) -> None:
+    """A stale refresh candidate must not replace the published shared manager."""
+    config = bind_runtime_paths(
+        Config(
+            agents={},
+            models={},
+            knowledge_bases={"docs": KnowledgeBaseConfig(path=str(tmp_path / "docs"), watch=False)},
+        ),
+        _runtime_paths(tmp_path / "config.yaml", tmp_path / "storage"),
+    )
+    manager = MagicMock(spec=KnowledgeManager)
+    manager.stop_watcher = AsyncMock()
+    publish_allowed = True
+
+    async def create_stale_candidate(*_: object, **__: object) -> KnowledgeManager:
+        nonlocal publish_allowed
+        publish_allowed = False
+        return manager
+
+    try:
+        with patch(
+            "mindroom.knowledge.shared_managers._create_knowledge_manager_for_target",
+            new=AsyncMock(side_effect=create_stale_candidate),
+        ):
+            result = await ensure_shared_knowledge_manager(
+                "docs",
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                publish_guard=lambda: publish_allowed,
+            )
+
+        assert result is None
+        assert _get_shared_knowledge_manager("docs") is None
+        manager.stop_watcher.assert_awaited_once()
+    finally:
+        await shutdown_shared_knowledge_managers()
+
+
+@pytest.mark.asyncio
+async def test_ensure_shared_knowledge_manager_restores_existing_runtime_when_stale(tmp_path: Path) -> None:
+    """A stale replacement refresh must not leave the published manager stopped."""
+    config = bind_runtime_paths(
+        Config(
+            agents={},
+            models={},
+            knowledge_bases={"docs": KnowledgeBaseConfig(path=str(tmp_path / "docs"), watch=True)},
+        ),
+        _runtime_paths(tmp_path / "config.yaml", tmp_path / "storage"),
+    )
+    existing = MagicMock(spec=KnowledgeManager)
+    watch_task = asyncio.create_task(asyncio.sleep(60))
+    existing._watch_task = watch_task
+    existing._git_sync_task = None
+    existing._load_persisted_indexing_state.return_value = None
+    existing.needs_full_reindex.return_value = True
+    existing.stop_watcher = AsyncMock(side_effect=lambda: setattr(existing, "_watch_task", None))
+    existing.start_watcher = AsyncMock()
+    candidate = MagicMock(spec=KnowledgeManager)
+    candidate.stop_watcher = AsyncMock()
+    publish_allowed = True
+    _shared_knowledge_managers["docs"] = existing
+
+    async def create_stale_candidate(*_: object, **__: object) -> KnowledgeManager:
+        nonlocal publish_allowed
+        publish_allowed = False
+        return candidate
+
+    try:
+        with patch(
+            "mindroom.knowledge.shared_managers._create_knowledge_manager_for_target",
+            new=AsyncMock(side_effect=create_stale_candidate),
+        ):
+            result = await ensure_shared_knowledge_manager(
+                "docs",
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                publish_guard=lambda: publish_allowed,
+            )
+
+        assert result is None
+        assert _get_shared_knowledge_manager("docs") is existing
+        existing.stop_watcher.assert_awaited_once()
+        existing.start_watcher.assert_awaited_once()
+        candidate.stop_watcher.assert_awaited_once()
+    finally:
+        watch_task.cancel()
+        await shutdown_shared_knowledge_managers()
+
+
+@pytest.mark.asyncio
 async def test_initialize_shared_knowledge_managers_full_reindex_on_settings_change(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -3169,8 +3169,7 @@ class TestAgentBot:
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
             )
         tracker.record_handled_turn.assert_called_once_with(
-            HandledTurnState.from_source_event_id(event.event_id)
-            .with_response_event_id("$cancelled"),
+            HandledTurnState.from_source_event_id(event.event_id).with_response_event_id("$cancelled"),
         )
 
     @pytest.mark.asyncio
@@ -10568,6 +10567,7 @@ class TestMultiAgentOrchestrator:
         """Background knowledge refresh should keep retrying until it succeeds."""
         orchestrator = MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
         config = MagicMock()
+        orchestrator.config = config
         attempts = 0
 
         async def _configure(*_: object, **__: object) -> None:
@@ -10589,6 +10589,149 @@ class TestMultiAgentOrchestrator:
 
         assert orchestrator._knowledge_refresh_task is None
         assert attempts == 2
+
+    @pytest.mark.asyncio
+    async def test_knowledge_refresh_owner_schedules_one_base_without_global_refresh(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A knowledge refresh request should not replace all shared-base refreshes."""
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": AgentConfig(
+                        display_name="GeneralAgent",
+                        rooms=["!room1:localhost"],
+                        knowledge_bases=["research"],
+                    ),
+                },
+                knowledge_bases={
+                    "research": KnowledgeBaseConfig(path=str(tmp_path / "research"), watch=False),
+                    "unused": KnowledgeBaseConfig(path=str(tmp_path / "unused"), watch=False),
+                },
+            ),
+            tmp_path,
+        )
+        orchestrator = MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        orchestrator.config = config
+        orchestrator.running = True
+        started = asyncio.Event()
+        unblock = asyncio.Event()
+        manager = MagicMock(spec=KnowledgeManager)
+
+        async def slow_refresh(base_id: str, **_kwargs: object) -> KnowledgeManager:
+            assert base_id == "research"
+            started.set()
+            await unblock.wait()
+            return manager
+
+        with (
+            patch(
+                "mindroom.orchestrator.ensure_shared_knowledge_manager",
+                new=AsyncMock(side_effect=slow_refresh),
+            ) as mock_ensure,
+            patch.object(orchestrator, "_schedule_knowledge_refresh", new=AsyncMock()) as mock_global_refresh,
+        ):
+            orchestrator.knowledge_refresh_owner.schedule_refresh("research")
+            task = orchestrator._knowledge_base_refresh_tasks["research"]
+            await asyncio.wait_for(started.wait(), timeout=1.0)
+
+            assert orchestrator.knowledge_refresh_owner.is_refreshing("research")
+            assert not orchestrator.knowledge_refresh_owner.is_refreshing("unused")
+            assert "unused" not in orchestrator._knowledge_base_refresh_tasks
+
+            orchestrator.knowledge_refresh_owner.schedule_refresh("research")
+            assert mock_ensure.await_count == 1
+
+            unblock.set()
+            await asyncio.wait_for(task, timeout=1.0)
+
+        mock_global_refresh.assert_not_called()
+        mock_ensure.assert_awaited_once()
+        assert orchestrator.knowledge_managers == {"research": manager}
+        assert "research" not in orchestrator._knowledge_base_refresh_tasks
+
+    @pytest.mark.asyncio
+    async def test_stale_knowledge_base_refresh_does_not_publish_after_generation_advances(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A stale per-base refresh result should not replace the current manager."""
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": AgentConfig(
+                        display_name="GeneralAgent",
+                        rooms=["!room1:localhost"],
+                        knowledge_bases=["research"],
+                    ),
+                },
+                knowledge_bases={"research": KnowledgeBaseConfig(path=str(tmp_path / "research"), watch=False)},
+            ),
+            tmp_path,
+        )
+        orchestrator = MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        orchestrator.config = config
+        stale_generation = orchestrator._knowledge_refresh_generation
+        started = asyncio.Event()
+        unblock = asyncio.Event()
+        stale_manager = MagicMock(spec=KnowledgeManager)
+
+        async def stale_refresh(base_id: str, **kwargs: object) -> KnowledgeManager | None:
+            assert base_id == "research"
+            publish_guard = cast("Callable[[], bool]", kwargs["publish_guard"])
+            started.set()
+            await unblock.wait()
+            return stale_manager if publish_guard() else None
+
+        with patch("mindroom.orchestrator.ensure_shared_knowledge_manager", new=AsyncMock(side_effect=stale_refresh)):
+            task = asyncio.create_task(
+                orchestrator._run_knowledge_base_refresh(
+                    "research",
+                    config,
+                    start_watcher=True,
+                    generation=stale_generation,
+                ),
+            )
+            await asyncio.wait_for(started.wait(), timeout=1.0)
+
+            orchestrator._advance_knowledge_refresh_generation()
+            unblock.set()
+            await asyncio.wait_for(task, timeout=1.0)
+
+        assert orchestrator.knowledge_managers == {}
+
+    @pytest.mark.asyncio
+    async def test_configure_knowledge_initializes_only_referenced_shared_bases(self, tmp_path: Path) -> None:
+        """Runtime startup should not initialize unused top-level shared knowledge bases."""
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": AgentConfig(
+                        display_name="GeneralAgent",
+                        rooms=["!room1:localhost"],
+                        knowledge_bases=["research"],
+                    ),
+                },
+                knowledge_bases={
+                    "research": KnowledgeBaseConfig(path=str(tmp_path / "research"), watch=False),
+                    "unused": KnowledgeBaseConfig(path=str(tmp_path / "unused"), watch=False),
+                },
+            ),
+            tmp_path,
+        )
+        orchestrator = MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        manager = MagicMock(spec=KnowledgeManager)
+
+        with patch(
+            "mindroom.orchestrator.initialize_shared_knowledge_managers",
+            new=AsyncMock(return_value={"research": manager}),
+        ) as mock_initialize:
+            await orchestrator._configure_knowledge(config, start_watcher=True)
+
+        mock_initialize.assert_awaited_once()
+        assert mock_initialize.await_args.kwargs["base_ids"] == {"research"}
+        assert orchestrator.knowledge_managers == {"research": manager}
 
     @pytest.mark.asyncio
     async def test_orchestrator_start_schedules_retry_for_failed_agents(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- initialize only shared knowledge bases referenced by configured agents during orchestrator refresh
- schedule on-access shared knowledge refresh per base instead of replacing all shared refresh work
- guard refresh publication by generation so stale work cannot replace or leave the current published manager stopped

## Tests
- uv run pytest --no-cov
- uv run pytest -n0 --no-cov tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_schedule_knowledge_refresh_retries_until_success tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_knowledge_refresh_owner_schedules_one_base_without_global_refresh tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_stale_knowledge_base_refresh_does_not_publish_after_generation_advances tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_configure_knowledge_initializes_only_referenced_shared_bases tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_update_config_schedules_knowledge_refresh_when_running tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_orchestrator_start_schedules_retry_for_failed_agents tests/test_openai_compat.py::TestKnowledgeIntegration::test_chat_completions_does_not_await_initialize_shared_knowledge_managers tests/test_knowledge_manager.py::test_ensure_shared_knowledge_manager_skips_publish_when_guard_is_stale tests/test_knowledge_manager.py::test_ensure_shared_knowledge_manager_restores_existing_runtime_when_stale -q
- uv run pre-commit run --files src/mindroom/knowledge/__init__.py src/mindroom/knowledge/refresh_owner.py src/mindroom/knowledge/shared_managers.py src/mindroom/orchestrator.py tach.toml tests/test_knowledge_manager.py tests/test_multi_agent_bot.py
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --all-files (fails on unrelated existing lint in tests/test_final_delivery.py and tests/test_preformed_team_routing.py)