### PR TITLE
Defer dedicated worker tool validation to execution

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -24,14 +24,13 @@ from pydantic import BaseModel, Field, ValidationError
 
 from mindroom import constants
 from mindroom.api import sandbox_exec, sandbox_protocol, sandbox_worker_prep
-from mindroom.config.main import Config, ConfigRuntimeValidationError, _normalized_config_data, load_config
+from mindroom.config.main import Config, _normalized_config_data, load_config
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.catalog import (
     TOOL_METADATA,
     ToolConfigOverrideError,
     ToolInitOverrideError,
-    ToolMetadataValidationError,
     ToolValidationInfo,
     deserialize_tool_validation_snapshot,
     ensure_tool_registry_loaded,
@@ -39,7 +38,6 @@ from mindroom.tool_system.catalog import (
     sanitize_tool_init_overrides,
     validate_authored_tool_entry_overrides,
 )
-from mindroom.tool_system.plugins import PluginValidationError
 from mindroom.tool_system.sandbox_proxy import (
     sandbox_proxy_config,
     to_json_compatible,
@@ -152,27 +150,14 @@ def _dedicated_worker_runtime_config_or_empty(runtime_paths: RuntimePaths) -> Co
         return load_config(runtime_paths)
 
     # Dedicated workers only need the authored config shape plus the subset of
-    # plugin entries that actually exist in that runtime filesystem. Upstream
-    # validation remains authoritative for the full configured tool surface.
+    # plugin entries that actually exist in that runtime filesystem. The primary
+    # runtime is authoritative for full authored tool validation; workers
+    # validate the requested tool at execution time with their local registry.
     config = Config.model_validate(
         _normalized_config_data(data),
         context={"runtime_paths": runtime_paths},
     )
-    config = _config_with_available_plugins(config, runtime_paths)
-
-    try:
-        config._validate_authored_tool_entries_with_snapshot(
-            tool_validation_snapshot=tool_validation_snapshot,
-        )
-    except (
-        PluginValidationError,
-        ToolConfigOverrideError,
-        ToolMetadataValidationError,
-        TypeError,
-        ValueError,
-    ) as exc:
-        raise ConfigRuntimeValidationError(str(exc)) from exc
-    return config
+    return _config_with_available_plugins(config, runtime_paths)
 
 
 def _config_with_available_plugins(config: Config, runtime_paths: RuntimePaths) -> Config:

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -1068,24 +1068,42 @@ def test_sandbox_runner_shared_startup_still_rejects_missing_plugins(
         _refresh_runner_app_from_env()
 
 
-def test_sandbox_runner_still_rejects_invalid_tools_after_skipping_worker_plugins(
+def test_sandbox_runner_defers_unavailable_authored_tools_for_worker_runtime(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Worker plugin filtering must not weaken authored tool validation."""
+    """Dedicated workers should trust primary-runtime config validation and reject only executed tools."""
     config_path = _missing_plugin_path_with_invalid_tool_config_path(tmp_path)
     monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(tmp_path / ".mindroom"))
     monkeypatch.setenv("MINDROOM_SANDBOX_DEDICATED_WORKER_KEY", "worker-a")
     _set_worker_tool_validation_snapshot("agentspace_slack_search")
-    monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", SANDBOX_TOKEN)
+    _set_sandbox_token(monkeypatch)
 
-    with pytest.raises(ConfigRuntimeValidationError) as exc_info:
-        _refresh_runner_app_from_env()
+    runtime_paths, config = _refresh_runner_app_from_env()
 
-    assert str(exc_info.value) == (
-        "agents.invalid.tools[0].definitely_not_a_tool: Unknown tool 'definitely_not_a_tool'."
-    )
+    assert runtime_paths.config_path.exists()
+    assert config.plugins == []
+
+    with (
+        patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=_fake_local_worker_venv_create),
+        TestClient(sandbox_runner_app) as client,
+    ):
+        response = client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "definitely_not_a_tool",
+                "function_name": "run",
+                "args": [],
+                "kwargs": {},
+            },
+        )
+
+    assert response.status_code == 200
+    response_payload = response.json()
+    assert response_payload["ok"] is False
+    assert "Unknown tool: definitely_not_a_tool" in response_payload["error"]
 
 
 def test_sandbox_runner_execute_rejects_invalid_mcp_tool_overrides(


### PR DESCRIPTION
## Summary
- let dedicated workers load config even when unrelated plugin paths are unavailable in the worker runtime
- keep shared runner startup validation strict
- reject unavailable tools when an execution request actually targets them

## Tests
- `uv run pytest tests/api/test_sandbox_runner_api.py -k "skips_unavailable_plugins_for_worker_runtime or shared_startup_still_rejects_missing_plugins or defers_unavailable_authored_tools_for_worker_runtime"`
- `uv run ruff check src/mindroom/api/sandbox_runner.py tests/api/test_sandbox_runner_api.py`