### PR TITLE
fix(matrix): avoid sidecar uploads for streaming previews

### DIFF
--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -114,7 +114,11 @@ def _build_nonterminal_streaming_edit_preview(
     """Build an in-progress edit preview without uploading an obsolete sidecar."""
     preview_limit = _NONTERMINAL_STREAM_PREVIEW_BYTES
     while True:
-        preview = _create_preview(preview_text, preview_limit)
+        preview = _create_preview(
+            preview_text,
+            preview_limit,
+            continuation_indicator=_STREAMING_PREVIEW_TRUNCATION_INDICATOR,
+        )
         preview_content: dict[str, Any] = {
             "msgtype": source_content.get("msgtype", "m.text"),
             "body": preview,
@@ -150,14 +154,21 @@ def _prefix_by_bytes(text: str, max_bytes: int) -> str:
 
 
 _CONTINUATION_INDICATOR = "\n\n[Message continues in attached file]"
+_STREAMING_PREVIEW_TRUNCATION_INDICATOR = "\n\n[Streaming preview truncated]"
 
 
-def _create_preview(text: str, max_bytes: int) -> str:
+def _create_preview(
+    text: str,
+    max_bytes: int,
+    *,
+    continuation_indicator: str = _CONTINUATION_INDICATOR,
+) -> str:
     """Create a preview that fits within byte limit.
 
     Args:
         text: The full text to preview
         max_bytes: Maximum size in bytes for the preview
+        continuation_indicator: Marker appended when the preview truncates text
 
     Returns:
         Preview text that fits within the byte limit
@@ -166,12 +177,12 @@ def _create_preview(text: str, max_bytes: int) -> str:
     if len(text.encode("utf-8")) <= max_bytes:
         return text
 
-    indicator_bytes = len(_CONTINUATION_INDICATOR.encode("utf-8"))
+    indicator_bytes = len(continuation_indicator.encode("utf-8"))
     target_bytes = max_bytes - indicator_bytes
     if target_bytes <= 0:
-        return _CONTINUATION_INDICATOR.lstrip()
+        return continuation_indicator.lstrip()
 
-    return _prefix_by_bytes(text, target_bytes) + _CONTINUATION_INDICATOR
+    return _prefix_by_bytes(text, target_bytes) + continuation_indicator
 
 
 async def _upload_text_as_mxc(  # noqa: C901

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -17,6 +17,8 @@ from mindroom.constants import (
     AI_RUN_METADATA_KEY,
     ORIGINAL_SENDER_KEY,
     STREAM_STATUS_KEY,
+    STREAM_STATUS_PENDING,
+    STREAM_STATUS_STREAMING,
     STREAM_VISIBLE_BODY_KEY,
     STREAM_WARMUP_SUFFIX_KEY,
 )
@@ -44,6 +46,9 @@ _SIDECAR_ONLY_MINDROOM_KEYS = frozenset(
         STREAM_VISIBLE_BODY_KEY,
     },
 )
+_NONTERMINAL_STREAM_STATUSES = frozenset({STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING})
+_NONTERMINAL_STREAM_PREVIEW_BYTES = 12000
+_MATRIX_EVENT_HARD_LIMIT = 64000
 
 
 def _is_passthrough_preview_key(key: object) -> bool:
@@ -94,6 +99,39 @@ def _is_edit_message(content: dict[str, Any]) -> bool:
     return "m.new_content" in content or (
         "m.relates_to" in content and content.get("m.relates_to", {}).get("rel_type") == "m.replace"
     )
+
+
+def _is_nonterminal_stream_content(content: dict[str, Any]) -> bool:
+    """Return whether content is an in-progress streaming payload."""
+    return content.get(STREAM_STATUS_KEY) in _NONTERMINAL_STREAM_STATUSES
+
+
+def _build_nonterminal_streaming_edit_preview(
+    content: dict[str, Any],
+    source_content: dict[str, Any],
+    preview_text: str,
+) -> dict[str, Any] | None:
+    """Build an in-progress edit preview without uploading an obsolete sidecar."""
+    preview_limit = _NONTERMINAL_STREAM_PREVIEW_BYTES
+    while True:
+        preview = _create_preview(preview_text, preview_limit)
+        preview_content: dict[str, Any] = {
+            "msgtype": source_content.get("msgtype", "m.text"),
+            "body": preview,
+        }
+        _copy_preview_metadata(source_content, preview_content)
+        modified_content: dict[str, Any] = {
+            "msgtype": "m.text",
+            "body": f"* {preview}",
+            "m.new_content": preview_content,
+            "m.relates_to": content.get("m.relates_to", {}),
+        }
+        _copy_edit_wrapper_metadata(source_content, modified_content)
+        if _calculate_event_size(modified_content) <= _MATRIX_EVENT_HARD_LIMIT:
+            return modified_content
+        if preview_limit == 0:
+            return None
+        preview_limit = max(0, preview_limit // 2)
 
 
 def _prefix_by_bytes(text: str, max_bytes: int) -> str:
@@ -291,6 +329,19 @@ async def prepare_large_message(
 
     source_content = content["m.new_content"] if is_edit and "m.new_content" in content else content
     preview_text = source_content["body"]
+    if is_edit and _is_nonterminal_stream_content(source_content):
+        modified_content = _build_nonterminal_streaming_edit_preview(content, source_content, preview_text)
+        if modified_content is not None:
+            inner: dict[str, Any] = modified_content["m.new_content"]
+            logger.info(
+                "large_streaming_edit_preview_prepared",
+                room_id=room_id,
+                original_size_bytes=current_size,
+                preview_length=len(inner["body"]),
+                final_size_bytes=_calculate_event_size(modified_content),
+            )
+            return modified_content
+
     logger.info(
         "large_message_sidecar_upload_started",
         room_id=room_id,

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -5,7 +5,13 @@ import json
 import nio
 import pytest
 
-from mindroom.constants import AI_RUN_METADATA_KEY, ORIGINAL_SENDER_KEY, STREAM_WARMUP_SUFFIX_KEY
+from mindroom.constants import (
+    AI_RUN_METADATA_KEY,
+    ORIGINAL_SENDER_KEY,
+    STREAM_STATUS_KEY,
+    STREAM_STATUS_STREAMING,
+    STREAM_WARMUP_SUFFIX_KEY,
+)
 from mindroom.matrix.large_messages import (
     _NORMAL_MESSAGE_LIMIT,
     _calculate_event_size,
@@ -204,6 +210,43 @@ async def test_prepare_edit_message() -> None:
     assert result["m.new_content"]["io.mindroom.long_text"]["version"] == 2
     assert client.uploaded_data is not None
     assert json.loads(client.uploaded_data.decode("utf-8")) == edit_content
+
+
+@pytest.mark.asyncio
+async def test_prepare_nonterminal_streaming_edit_uses_preview_without_sidecar() -> None:
+    """In-progress stream edits should not upload obsolete full-content sidecars."""
+
+    class MockClient:
+        rooms: dict = {}  # noqa: RUF012
+
+        async def upload(self, **_kwargs: object) -> tuple:
+            msg = "non-terminal stream edit should not upload a sidecar"
+            raise AssertionError(msg)
+
+    client = MockClient()
+    text = "streaming " * 10000
+    edit_content = {
+        "body": f"* {text}",
+        "m.new_content": {
+            "body": text,
+            "msgtype": "m.text",
+            STREAM_STATUS_KEY: STREAM_STATUS_STREAMING,
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$abc"},
+        "msgtype": "m.text",
+    }
+
+    result = await prepare_large_message(client, "!room:server", edit_content)
+
+    assert result["m.new_content"]["msgtype"] == "m.text"
+    assert result["m.new_content"][STREAM_STATUS_KEY] == STREAM_STATUS_STREAMING
+    assert result[STREAM_STATUS_KEY] == STREAM_STATUS_STREAMING
+    assert "io.mindroom.long_text" not in result["m.new_content"]
+    assert "url" not in result["m.new_content"]
+    assert "file" not in result["m.new_content"]
+    assert len(result["m.new_content"]["body"]) < len(text)
+    assert "[Message continues in attached file]" in result["m.new_content"]["body"]
+    assert _calculate_event_size(result) <= 64000
 
 
 @pytest.mark.asyncio

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -245,7 +245,8 @@ async def test_prepare_nonterminal_streaming_edit_uses_preview_without_sidecar()
     assert "url" not in result["m.new_content"]
     assert "file" not in result["m.new_content"]
     assert len(result["m.new_content"]["body"]) < len(text)
-    assert "[Message continues in attached file]" in result["m.new_content"]["body"]
+    assert "[Streaming preview truncated]" in result["m.new_content"]["body"]
+    assert "[Message continues in attached file]" not in result["m.new_content"]["body"]
     assert _calculate_event_size(result) <= 64000
 
 

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -12,7 +12,13 @@ from agno.models.response import ToolExecution
 from agno.run.agent import ToolCallCompletedEvent, ToolCallStartedEvent
 
 from mindroom.config.models import DefaultsConfig
-from mindroom.constants import AI_RUN_METADATA_KEY, RuntimePaths, resolve_runtime_paths
+from mindroom.constants import (
+    AI_RUN_METADATA_KEY,
+    STREAM_STATUS_KEY,
+    STREAM_STATUS_STREAMING,
+    RuntimePaths,
+    resolve_runtime_paths,
+)
 from mindroom.matrix.client import edit_message_result, send_message_result
 from mindroom.matrix.large_messages import _NORMAL_MESSAGE_LIMIT, prepare_large_message
 from mindroom.streaming import (
@@ -422,18 +428,14 @@ async def test_streaming_multiple_edits_with_growth() -> None:
     # Check final state
     assert len(client.messages_sent) == len(sizes)
 
-    # Last two should have large message handling
-    for i in [-2, -1]:
-        content = client.messages_sent[i][2]
-        # These are edits, so check m.new_content
-        if "m.new_content" in content:
-            assert content["m.new_content"]["msgtype"] == "m.file"
-            assert "io.mindroom.long_text" in content["m.new_content"], (
-                f"Message {i} should have large message handling"
-            )
-        else:
-            assert content["msgtype"] == "m.file"
-            assert "io.mindroom.long_text" in content, f"Message {i} should have large message handling"
+    nonterminal_large_edit = client.messages_sent[-2][2]
+    assert nonterminal_large_edit["m.new_content"]["msgtype"] == "m.text"
+    assert nonterminal_large_edit["m.new_content"][STREAM_STATUS_KEY] == STREAM_STATUS_STREAMING
+    assert "io.mindroom.long_text" not in nonterminal_large_edit["m.new_content"]
+
+    terminal_large_edit = client.messages_sent[-1][2]
+    assert terminal_large_edit["m.new_content"]["msgtype"] == "m.file"
+    assert "io.mindroom.long_text" in terminal_large_edit["m.new_content"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- rebases this streaming-preview fix directly on `origin/main` so the PR only shows the large-message change
- keeps non-terminal streaming previews inline and truncated instead of uploading sidecar payloads for obsolete partial edits
- preserves sidecar behavior for terminal streaming edits and regular oversized messages

## Validation
- `uv run pytest tests/test_large_messages.py tests/test_large_messages_integration.py -n auto --no-cov -q` -> 38 passed, 13 warnings
- `uv run pre-commit run --files src/mindroom/matrix/large_messages.py tests/test_large_messages.py tests/test_large_messages_integration.py` -> passed
- `uv run pytest -n auto --no-cov -q` -> 5321 passed, 28 skipped, 168 warnings
- `uv run pre-commit run --all-files` -> passed