### PR TITLE
fix(config): set Codex starter context window to 258K

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -350,7 +350,7 @@ mindroom config init --profile public-vertexai-anthropic
 mindroom config init --force
 ```
 
-The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5`.
+The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5` and `context_window: 258000`.
 They set `extra_kwargs.reasoning_effort: medium`.
 Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key.
 Run `codex login` first so MindRoom can read `~/.codex/auth.json`.

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -118,6 +118,7 @@ models:
   default:
     provider: codex
     id: gpt-5.5
+    context_window: 258000
     # Prompt caching is enabled automatically per active agent session.
     extra_kwargs:
       reasoning_effort: medium

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1858,6 +1858,7 @@ models:
   default:
     provider: codex
     id: gpt-5.5
+    context_window: 258000
     # Prompt caching is enabled automatically per active agent session.
     extra_kwargs:
       reasoning_effort: medium
@@ -12595,7 +12596,7 @@ mindroom config init --profile public-vertexai-anthropic
 mindroom config init --force
 ```
 
-The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5`. They set `extra_kwargs.reasoning_effort: medium`. Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key. Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
+The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5` and `context_window: 258000`. They set `extra_kwargs.reasoning_effort: medium`. Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key. Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
 
 ### config show
 

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -211,7 +211,7 @@ mindroom config init --profile public-vertexai-anthropic
 mindroom config init --force
 ```
 
-The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5`. They set `extra_kwargs.reasoning_effort: medium`. Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key. Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
+The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5` and `context_window: 258000`. They set `extra_kwargs.reasoning_effort: medium`. Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key. Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
 
 ### config show
 

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -109,6 +109,7 @@ models:
   default:
     provider: codex
     id: gpt-5.5
+    context_window: 258000
     # Prompt caching is enabled automatically per active agent session.
     extra_kwargs:
       reasoning_effort: medium

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -663,6 +663,7 @@ def _model_template_block(provider_preset: _ProviderPreset) -> str:
     if provider_preset == "codex":
         lines.extend(
             [
+                "context_window: 258000",
                 "# Prompt caching is enabled automatically per active agent session.",
                 "extra_kwargs:",
                 "  reasoning_effort: medium",

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -357,6 +357,7 @@ class TestConfigInit:
         assert "mindroom_user" not in config
         assert config["models"]["default"]["provider"] == "codex"
         assert config["models"]["default"]["id"] == "gpt-5.5"
+        assert config["models"]["default"]["context_window"] == 258_000
         assert config["models"]["default"]["extra_kwargs"]["reasoning_effort"] == "medium"
         assert "prompt_cache_key" not in config["models"]["default"]["extra_kwargs"]
         assert "Prompt caching is enabled automatically per active agent session." in target.read_text()
@@ -386,6 +387,7 @@ class TestConfigInit:
         assert "mindroom_user" not in config
         assert config["models"]["default"]["provider"] == "codex"
         assert config["models"]["default"]["id"] == "gpt-5.5"
+        assert config["models"]["default"]["context_window"] == 258_000
         assert config["models"]["default"]["extra_kwargs"]["reasoning_effort"] == "medium"
 
     @pytest.mark.parametrize("profile", ["openai-codex", "public-openai-codex"])
@@ -585,6 +587,7 @@ class TestConfigInit:
         config = yaml.safe_load(target.read_text())
         assert config["models"]["default"]["provider"] == "codex"
         assert config["models"]["default"]["id"] == "gpt-5.5"
+        assert config["models"]["default"]["context_window"] == 258_000
         assert config["models"]["default"]["extra_kwargs"]["reasoning_effort"] == "medium"
         assert "prompt_cache_key" not in config["models"]["default"]["extra_kwargs"]
 


### PR DESCRIPTION
## Summary
- cherry-picks source commit bfcde0537 from gitea/main
- adds a 258K context window to Codex starter config output
- updates generated CLI/model docs and config-init tests

## Validation
- uv run pytest tests/test_cli_config.py -n auto --no-cov -q
- uv run pre-commit run --files docs/cli.md docs/configuration/models.md skills/mindroom-docs/references/llms-full.txt skills/mindroom-docs/references/page__cli__index.md skills/mindroom-docs/references/page__configuration__models__index.md src/mindroom/cli/config.py tests/test_cli_config.py