### PR TITLE
chore: fix all-files lint issues

### DIFF
--- a/tests/test_cancelled_response_hook.py
+++ b/tests/test_cancelled_response_hook.py
@@ -353,7 +353,9 @@ async def test_team_bot_empty_prompt_emits_cancelled_hook_once(tmp_path: Path) -
 
     with (
         patch.object(
-            bot._delivery_gateway.deps.response_hooks, "emit_cancelled_response", new=AsyncMock()
+            bot._delivery_gateway.deps.response_hooks,
+            "emit_cancelled_response",
+            new=AsyncMock(),
         ) as mock_emit,
         patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
     ):
@@ -395,7 +397,9 @@ async def test_team_edit_regeneration_empty_prompt_emits_cancelled_hook_once(tmp
 
     with (
         patch.object(
-            bot._delivery_gateway.deps.response_hooks, "emit_cancelled_response", new=AsyncMock()
+            bot._delivery_gateway.deps.response_hooks,
+            "emit_cancelled_response",
+            new=AsyncMock(),
         ) as mock_emit,
         patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
         patch(

--- a/tests/test_final_delivery.py
+++ b/tests/test_final_delivery.py
@@ -93,6 +93,7 @@ def test_final_delivery_outcomes_use_canonical_event_fields(
 
 
 def test_final_delivery_outcome_cancelled_for_empty_prompt_is_not_retryable() -> None:
+    """Empty prompts should cancel without producing a handled response event."""
     outcome = FinalDeliveryOutcome.cancelled_for_empty_prompt()
 
     assert outcome.terminal_status == "cancelled"

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -3169,8 +3169,7 @@ class TestAgentBot:
                 handled_turn=HandledTurnState.from_source_event_id(event.event_id),
             )
         tracker.record_handled_turn.assert_called_once_with(
-            HandledTurnState.from_source_event_id(event.event_id)
-            .with_response_event_id("$cancelled"),
+            HandledTurnState.from_source_event_id(event.event_id).with_response_event_id("$cancelled"),
         )
 
     @pytest.mark.asyncio

--- a/tests/test_preformed_team_routing.py
+++ b/tests/test_preformed_team_routing.py
@@ -20,7 +20,6 @@ from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import RouterConfig
 from mindroom.constants import STREAM_STATUS_KEY
-from mindroom.final_delivery import FinalDeliveryOutcome
 from mindroom.matrix.client import DeliveredMatrixEvent
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.users import AgentMatrixUser
@@ -38,6 +37,8 @@ from tests.conftest import (
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
     from pathlib import Path
+
+    from mindroom.final_delivery import FinalDeliveryOutcome
 
 
 def _bind_runtime_paths(config: Config, tmp_path: Path) -> Config:


### PR DESCRIPTION
## Summary
- resolves source commit 8583d7eef from gitea/main onto current origin/main
- restores the final-delivery test docstring required by D103
- applies all-file ruff formatting and moves a type-only import under TYPE_CHECKING

## Validation
- uv run pre-commit run --all-files
- uv run pytest tests/test_final_delivery.py tests/test_cancelled_response_hook.py tests/test_multi_agent_bot.py tests/test_preformed_team_routing.py -n auto --no-cov -q