### PR TITLE
fix(orchestrator): keep runtime alive across sync restarts

### DIFF
--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -233,6 +233,7 @@ class MultiAgentOrchestrator:
     _plugin_watch_state_revision: int = field(default=0, init=False)
     _knowledge_refresh_owner: OrchestratorKnowledgeRefreshOwner = field(init=False)
     hook_registry: HookRegistry = field(default_factory=HookRegistry.empty, init=False)
+    _runtime_shutdown_event: asyncio.Event | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Store canonical derived paths from the explicit runtime context."""
@@ -284,6 +285,12 @@ class MultiAgentOrchestrator:
         )
         self._memory_auto_flush_worker = worker
         self._memory_auto_flush_task = asyncio.create_task(worker.run(), name="memory_auto_flush_worker")
+
+    def _reset_runtime_shutdown_event(self) -> asyncio.Event:
+        """Create the shutdown event for the current orchestrator run."""
+        shutdown_event = asyncio.Event()
+        self._runtime_shutdown_event = shutdown_event
+        return shutdown_event
 
     def _bind_runtime_support_services(self, bot: AgentBot | TeamBot) -> None:
         """Bind the current runtime support services to one managed bot."""
@@ -1065,6 +1072,7 @@ class MultiAgentOrchestrator:
 
     async def _start_runtime(self) -> None:
         """Run the startup sequence before handing off to the sync loops."""
+        runtime_shutdown_event = self._reset_runtime_shutdown_event()
         await wait_for_matrix_homeserver(runtime_paths=self.runtime_paths)
         if not self.agent_bots:
             await self.initialize()
@@ -1110,8 +1118,10 @@ class MultiAgentOrchestrator:
             await self._schedule_bot_start_retry(entity_name)
 
         set_runtime_ready()
-        # Run all sync tasks until shutdown.
-        await asyncio.gather(*tuple(self._sync_tasks.values()))
+        # Stay alive until explicit shutdown. Hot reload replaces sync tasks in
+        # self._sync_tasks, so awaiting the initial task generation would let a
+        # config-triggered restart look like normal orchestrator completion.
+        await runtime_shutdown_event.wait()
 
     async def _load_initial_config(self, new_config: Config, hook_registry: HookRegistry) -> bool:
         """Handle config loading before the runtime has an active config."""
@@ -1624,6 +1634,8 @@ class MultiAgentOrchestrator:
     async def stop(self) -> None:
         """Stop all agent bots."""
         self.running = False
+        if self._runtime_shutdown_event is not None:
+            self._runtime_shutdown_event.set()
         await self._cancel_config_reload_task()
         await self._stop_memory_auto_flush_worker()
         await self._cancel_knowledge_refresh_task()

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -7,7 +7,7 @@ import itertools
 import os
 import signal
 import sys
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, replace
 from datetime import datetime
 from types import SimpleNamespace
@@ -220,6 +220,26 @@ def _handled_response_event_id(outcome: FinalDeliveryOutcome | str | None) -> st
     if isinstance(outcome, str) or outcome is None:
         return outcome
     return outcome.event_id if outcome.mark_handled and outcome.is_visible_response and not outcome.suppressed else None
+
+
+async def _run_orchestrator_start_until_ready(orchestrator: MultiAgentOrchestrator) -> None:
+    """Run start() until readiness, then explicitly shut the runtime down."""
+    ready = asyncio.Event()
+
+    def mark_ready() -> None:
+        ready.set()
+
+    with patch("mindroom.orchestrator.set_runtime_ready", side_effect=mark_ready):
+        runtime_task = asyncio.create_task(orchestrator.start())
+        try:
+            await asyncio.wait_for(ready.wait(), timeout=1.0)
+            await orchestrator.stop()
+            await asyncio.wait_for(runtime_task, timeout=1.0)
+        finally:
+            if not runtime_task.done():
+                runtime_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await runtime_task
 
 
 def _make_matrix_client_mock() -> AsyncMock:
@@ -10448,6 +10468,7 @@ class TestMultiAgentOrchestrator:
         bot = MagicMock()
         bot.agent_name = "router"
         bot.try_start = AsyncMock(return_value=True)
+        bot.stop = AsyncMock()
         orchestrator.agent_bots = {"router": bot}
 
         call_order: list[str] = []
@@ -10468,7 +10489,7 @@ class TestMultiAgentOrchestrator:
             patch.object(orchestrator, "_sync_memory_auto_flush_worker", new=AsyncMock()),
             patch("mindroom.orchestrator.sync_forever_with_restart", new=AsyncMock()),
         ):
-            await orchestrator.start()
+            await _run_orchestrator_start_until_ready(orchestrator)
 
         assert call_order == ["wait_for_homeserver", "setup_rooms", "schedule_knowledge"]
         bot.try_start.assert_awaited_once()
@@ -10488,6 +10509,7 @@ class TestMultiAgentOrchestrator:
             bot = MagicMock()
             bot.agent_name = "router"
             bot.try_start = AsyncMock(return_value=True)
+            bot.stop = AsyncMock()
             orchestrator.agent_bots = {"router": bot}
 
         with (
@@ -10498,7 +10520,7 @@ class TestMultiAgentOrchestrator:
             patch.object(orchestrator, "_sync_memory_auto_flush_worker", new=AsyncMock()),
             patch("mindroom.orchestrator.sync_forever_with_restart", new=AsyncMock()),
         ):
-            await orchestrator.start()
+            await _run_orchestrator_start_until_ready(orchestrator)
 
         assert call_order[:2] == ["wait_for_homeserver", "initialize"]
 
@@ -10713,10 +10735,12 @@ class TestMultiAgentOrchestrator:
         router_bot = MagicMock()
         router_bot.agent_name = "router"
         router_bot.try_start = AsyncMock(return_value=True)
+        router_bot.stop = AsyncMock()
 
         failing_bot = MagicMock()
         failing_bot.agent_name = "general"
         failing_bot.try_start = AsyncMock(return_value=False)
+        failing_bot.stop = AsyncMock()
 
         orchestrator.agent_bots = {"router": router_bot, "general": failing_bot}
 
@@ -10728,7 +10752,7 @@ class TestMultiAgentOrchestrator:
             patch.object(orchestrator, "_schedule_bot_start_retry", new=AsyncMock()) as mock_schedule_retry,
             patch("mindroom.orchestrator.sync_forever_with_restart", new=AsyncMock()),
         ):
-            await orchestrator.start()
+            await _run_orchestrator_start_until_ready(orchestrator)
 
         assert "general" in orchestrator.agent_bots
         mock_schedule_retry.assert_awaited_once_with("general")
@@ -10742,10 +10766,12 @@ class TestMultiAgentOrchestrator:
         router_bot = MagicMock()
         router_bot.agent_name = "router"
         router_bot.try_start = AsyncMock(return_value=True)
+        router_bot.stop = AsyncMock()
 
         failing_bot = MagicMock()
         failing_bot.agent_name = "general"
         failing_bot.try_start = AsyncMock(side_effect=PermanentMatrixStartupError("boom"))
+        failing_bot.stop = AsyncMock()
 
         orchestrator.agent_bots = {"router": router_bot, "general": failing_bot}
 
@@ -10757,7 +10783,7 @@ class TestMultiAgentOrchestrator:
             patch.object(orchestrator, "_schedule_bot_start_retry", new=AsyncMock()) as mock_schedule_retry,
             patch("mindroom.orchestrator.sync_forever_with_restart", new=AsyncMock()),
         ):
-            await orchestrator.start()
+            await _run_orchestrator_start_until_ready(orchestrator)
 
         assert "general" in orchestrator.agent_bots
         mock_schedule_retry.assert_not_awaited()

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import json
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -2020,6 +2022,7 @@ async def test_orchestrator_runs_cleanup_and_resume_before_sync_loops(tmp_path: 
     router_bot = MagicMock()
     router_bot.agent_name = ROUTER_AGENT_NAME
     router_bot.try_start = AsyncMock(return_value=True)
+    router_bot.stop = AsyncMock()
     router_bot.running = True
     router_bot.client = AsyncMock(spec=nio.AsyncClient)
     router_bot.agent_user = MagicMock(user_id="@mindroom_router:example.com")
@@ -2051,6 +2054,11 @@ async def test_orchestrator_runs_cleanup_and_resume_before_sync_loops(tmp_path: 
     async def _knowledge(*_args: object, **_kwargs: object) -> None:
         call_order.append("knowledge")
 
+    ready = asyncio.Event()
+
+    def _mark_ready() -> None:
+        ready.set()
+
     with (
         patch("mindroom.orchestrator.wait_for_matrix_homeserver", side_effect=_wait_for_homeserver),
         patch.object(orchestrator, "_setup_rooms_and_memberships", side_effect=_setup_rooms),
@@ -2059,8 +2067,18 @@ async def test_orchestrator_runs_cleanup_and_resume_before_sync_loops(tmp_path: 
         patch.object(orchestrator, "_schedule_knowledge_refresh", side_effect=_knowledge),
         patch.object(orchestrator, "_sync_memory_auto_flush_worker", new=AsyncMock()),
         patch("mindroom.orchestrator.sync_forever_with_restart", new=AsyncMock()),
+        patch("mindroom.orchestrator.set_runtime_ready", side_effect=_mark_ready),
     ):
-        await orchestrator.start()
+        runtime_task = asyncio.create_task(orchestrator.start())
+        try:
+            await asyncio.wait_for(ready.wait(), timeout=1.0)
+            await orchestrator.stop()
+            await asyncio.wait_for(runtime_task, timeout=1.0)
+        finally:
+            if not runtime_task.done():
+                runtime_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await runtime_task
 
     assert call_order == ["wait", "setup", "cleanup", "resume", "knowledge"]
 

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -21,6 +21,7 @@ from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths
 from mindroom.orchestration import runtime as runtime_helpers
 from mindroom.orchestration.runtime import (
+    EntityStartResults,
     MatrixSyncStalledError,
     _SyncIteration,
     cancel_sync_task,
@@ -701,6 +702,72 @@ async def test_orchestrator_tracks_sync_tasks(tmp_path: Path) -> None:
         assert len(orchestrator._sync_tasks) == 2
         assert "test_agent" in orchestrator._sync_tasks
         assert "router" in orchestrator._sync_tasks
+
+
+@pytest.mark.asyncio
+async def test_start_runtime_waits_for_shutdown_after_initial_sync_generation_exits(tmp_path: Path) -> None:
+    """A hot-reload restart of the first sync task generation must not end the service."""
+    orchestrator = MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
+
+    config = MagicMock(spec=Config)
+    config.agents = {"general": MagicMock()}
+    config.teams = {}
+    config.mcp_servers = {}
+    config.cache = MagicMock()
+    config.cache.resolve_db_path.return_value = tmp_path / "event_cache.db"
+    orchestrator.config = config
+
+    router_bot = AsyncMock()
+    router_bot.agent_name = "router"
+    router_bot.running = True
+    router_bot.stop = AsyncMock()
+
+    general_bot = AsyncMock()
+    general_bot.agent_name = "general"
+    general_bot.running = True
+    general_bot.stop = AsyncMock()
+
+    orchestrator.agent_bots = {"router": router_bot, "general": general_bot}
+
+    async def completed_sync_supervisor() -> None:
+        return None
+
+    def start_completed_sync_task(entity_name: str, _bot: object) -> None:
+        orchestrator._sync_tasks[entity_name] = asyncio.create_task(completed_sync_supervisor())
+
+    with (
+        patch("mindroom.orchestrator.wait_for_matrix_homeserver", new=AsyncMock()),
+        patch.object(orchestrator, "_start_router_bot", new=AsyncMock(return_value=router_bot)),
+        patch.object(
+            orchestrator,
+            "_start_entities_once",
+            new=AsyncMock(return_value=EntityStartResults(started_bots=[general_bot])),
+        ),
+        patch.object(orchestrator, "_setup_rooms_and_memberships", new=AsyncMock()),
+        patch.object(orchestrator, "_cleanup_stale_streams_after_restart", new=AsyncMock(return_value=[])),
+        patch.object(orchestrator, "_auto_resume_after_restart", new=AsyncMock()),
+        patch.object(orchestrator, "_schedule_knowledge_refresh", new=AsyncMock()),
+        patch.object(orchestrator, "_sync_memory_auto_flush_worker", new=AsyncMock()),
+        patch.object(orchestrator, "_start_sync_task", side_effect=start_completed_sync_task),
+    ):
+        runtime_task = asyncio.create_task(orchestrator._start_runtime())
+        try:
+            for _ in range(50):
+                if set(orchestrator._sync_tasks) == {"router", "general"}:
+                    break
+                await asyncio.sleep(0.01)
+
+            assert set(orchestrator._sync_tasks) == {"router", "general"}
+            await asyncio.sleep(0)
+            assert not runtime_task.done()
+
+            await orchestrator.stop()
+            await asyncio.wait_for(runtime_task, timeout=1.0)
+        finally:
+            if not runtime_task.done():
+                runtime_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await runtime_task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- cherry-picks the runtime-shutdown-event fix from reachable gitea source commit 1a396b6b2 because requested 60f3c85f4 is not reachable from configured remotes
- keeps _start_runtime() alive until explicit stop() instead of awaiting the initial sync-task generation
- updates affected startup tests to stop the runtime explicitly and adds a regression for completed first-generation sync supervisors

## Validation
- uv run pytest tests/test_matrix_sync_tokens.py tests/test_thread_history.py tests/test_threading_error.py tests/test_sync_task_cancellation.py tests/test_config_reload.py tests/test_mcp_orchestrator.py tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_orchestrator_start_sets_up_rooms_before_knowledge tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_orchestrator_waits_for_homeserver_before_initialize tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_orchestrator_start_schedules_retry_for_failed_agents tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_orchestrator_start_skips_retry_for_permanent_failures tests/test_stale_stream_cleanup.py::test_orchestrator_runs_cleanup_and_resume_before_sync_loops -n auto --no-cov -q -> 330 passed, 2 skipped, 13 warnings
- uv run pre-commit run --files src/mindroom/orchestrator.py tests/test_multi_agent_bot.py tests/test_stale_stream_cleanup.py tests/test_sync_task_cancellation.py -> passed
- uv run pytest -n auto --no-cov on stacked top branch fix-streaming-preview-sidecar-uploads -> 5320 passed, 28 skipped, 168 warnings
- uv run pre-commit run --all-files on stacked top branch fix-streaming-preview-sidecar-uploads -> passed