### PR TITLE
Align agent storage Tach interface

### DIFF
--- a/tach.toml
+++ b/tach.toml
@@ -1674,13 +1674,20 @@ expose = [
     "show_tool_calls_for_agent",
     "build_agent_toolkit",
     "get_agent_toolkit_names",
-    "create_session_storage",
-    "get_agent_session",
-    "get_team_session",
     "remove_run_by_event_id",
     "get_agent_ids_for_room",
 ]
 from = ["mindroom.agents"]
+
+[[interfaces]]
+expose = [
+    "create_session_storage",
+    "create_state_storage_db",
+    "get_agent_runtime_sqlite_dbs",
+    "get_agent_session",
+    "get_team_session",
+]
+from = ["mindroom.agent_storage"]
 
 [[interfaces]]
 expose = [

--- a/tests/test_config_discovery.py
+++ b/tests/test_config_discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import importlib
 import os
+import tomllib
 from functools import cache
 from pathlib import Path
 
@@ -110,6 +111,17 @@ def _runtime_source_contexts() -> tuple[tuple[str, ast.AST, set[str]], ...]:
         tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
         contexts.append((relative_path, tree, _runtime_constant_aliases(tree)))
     return tuple(contexts)
+
+
+@cache
+def _tach_public_interfaces() -> dict[str, set[str]]:
+    tach_data = tomllib.loads((_repo_root() / "tach.toml").read_text(encoding="utf-8"))
+    interfaces: dict[str, set[str]] = {}
+    for entry in tach_data["interfaces"]:
+        exposed = set(entry["expose"])
+        for source in entry["from"]:
+            interfaces.setdefault(source, set()).update(exposed)
+    return interfaces
 
 
 def _runtime_constant_aliases(tree: ast.AST) -> set[str]:
@@ -1092,6 +1104,16 @@ class TestRuntimeGuardrails:
         """Keep storage-only helpers off the heavy agents facade in production code."""
         violations = _collect_agent_storage_helper_facade_import_violations()
         assert not violations, "\n".join(violations)
+
+    def test_agent_storage_helpers_are_owned_by_agent_storage_interface(self) -> None:
+        """Keep Tach's public interface metadata aligned with storage helper ownership."""
+        interfaces = _tach_public_interfaces()
+
+        agents_exports = interfaces.get("mindroom.agents", set())
+        agent_storage_exports = interfaces.get("mindroom.agent_storage", set())
+
+        assert not (_AGENT_STORAGE_HELPERS & agents_exports)
+        assert agent_storage_exports >= _AGENT_STORAGE_HELPERS
 
     def test_plain_config_remains_runtime_free(self) -> None:
         """Plain Config() should not silently acquire runtime bindings in tests."""


### PR DESCRIPTION
## Summary
- remove stale storage-helper exports from the `mindroom.agents` Tach interface
- add `mindroom.agent_storage` as the explicit owner of storage helper interface symbols
- add a guardrail test so Tach interface metadata cannot drift back to the heavy agents facade

## Verification
- `uv sync --all-extras`
- `uv run pytest tests/test_config_discovery.py::TestRuntimeGuardrails::test_agent_storage_helpers_are_owned_by_agent_storage_interface -q -n 0 --no-cov`
- `uv run pytest tests/test_config_discovery.py -q -n 0 --no-cov`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --all-files`

Full-suite note: `uv run pytest -x -n 0 --no-cov -v` reached the passing summary `5319 passed, 28 skipped, 53 warnings in 617.21s`, but the pytest process did not return after printing the summary and was terminated, so I am not treating that as a clean full-suite exit.