### PR TITLE
fix(matrix): trust synced thread caches across restarts

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -624,7 +624,7 @@ class AgentBot:
 
     @property
     def runtime_started_at(self) -> float:
-        """Return the current runtime freshness boundary for this bot."""
+        """Return when this bot runtime started."""
         return self._runtime_view.runtime_started_at
 
     @property
@@ -962,20 +962,15 @@ class AgentBot:
         self.logger.info(
             "matrix_sync_token_restored",
             certified=token_record.certified,
-            thread_cache_valid_after=token_record.thread_cache_valid_after,
         )
         return token_record.checkpoint if token_record.checkpoint is not None else token_record.token
 
     def _restore_saved_sync_token(self) -> None:
         """Restore Matrix sync continuity and initialize cache certification state."""
         assert self.client is not None
-        startup = start_from_loaded_token(
-            self._loaded_sync_token_for_certification(),
-            runtime_started_at=self._runtime_view.runtime_started_at,
-        )
+        startup = start_from_loaded_token(self._loaded_sync_token_for_certification())
         self._sync_trust_state = startup.state
-        self._sync_checkpoint = startup.checkpoint
-        self._runtime_view.thread_cache_read_boundary = startup.thread_cache_read_boundary
+        self._sync_checkpoint = None
         self.client.next_batch = startup.sync_token
         if startup.legacy_token:
             self.logger.warning("matrix_sync_token_uncertified_legacy")
@@ -989,7 +984,6 @@ class AgentBot:
                 self.storage_path,
                 self.agent_name,
                 checkpoint.token,
-                thread_cache_valid_after=checkpoint.thread_cache_valid_after,
             )
         except (OSError, ValueError) as exc:
             self.logger.warning("matrix_sync_token_save_failed", error=str(exc))
@@ -1004,7 +998,6 @@ class AgentBot:
     def _apply_sync_certification_decision(self, decision: SyncCertificationDecision) -> None:
         """Apply a certifier decision to runtime state and token storage."""
         self._sync_trust_state = decision.state
-        self._runtime_view.thread_cache_read_boundary = decision.thread_cache_read_boundary
         self._sync_checkpoint = decision.checkpoint_to_save
         if decision.reset_client_token and self.client is not None:
             self.client.next_batch = None
@@ -1028,17 +1021,13 @@ class AgentBot:
         *,
         cache_result: SyncCacheWriteResult,
         first_sync_response: bool,
-        now: float,
     ) -> SyncCertificationDecision:
         """Return the certifier decision for one sync response."""
         return certify_sync_response(
             self._sync_trust_state,
-            previous_checkpoint=self._sync_checkpoint,
             next_batch=response.next_batch,
             cache_result=cache_result,
             first_sync=first_sync_response,
-            now=now,
-            current_read_boundary=self._runtime_view.thread_cache_read_boundary,
         )
 
     def seconds_since_last_sync_activity(self) -> float | None:
@@ -1064,7 +1053,6 @@ class AgentBot:
                     _response,
                     cache_result=SyncCacheWriteResult(complete=False, errors=(exc,)),
                     first_sync_response=first_sync_response,
-                    now=time.time(),
                 )
                 self._apply_sync_certification_decision(decision)
                 raise
@@ -1072,7 +1060,6 @@ class AgentBot:
                 _response,
                 cache_result=cache_result,
                 first_sync_response=first_sync_response,
-                now=time.time(),
             )
             self._apply_sync_certification_decision(decision)
         self._first_sync_done = True
@@ -1089,7 +1076,7 @@ class AgentBot:
         logger.debug("SyncError received", agent_name=self.agent_name, error=str(_response))
         self._last_sync_monotonic = time.monotonic()
         if _response.status_code == "M_UNKNOWN_POS":
-            self._apply_sync_certification_decision(handle_unknown_pos(now=time.time()))
+            self._apply_sync_certification_decision(handle_unknown_pos())
             self.logger.warning(
                 "matrix_sync_token_rejected",
                 status_code=_response.status_code,

--- a/src/mindroom/bot_runtime_view.py
+++ b/src/mindroom/bot_runtime_view.py
@@ -46,9 +46,6 @@ class BotRuntimeView(Protocol):
     @property
     def runtime_started_at(self) -> float: ...  # noqa: D102
 
-    @property
-    def thread_cache_read_boundary(self) -> float: ...  # noqa: D102
-
 
 @dataclass
 class BotRuntimeState:
@@ -63,14 +60,7 @@ class BotRuntimeState:
     event_cache_write_coordinator: EventCacheWriteCoordinator | None
     startup_thread_prewarm_registry: StartupThreadPrewarmRegistry | None = None
     runtime_started_at: float = field(default_factory=time.time)
-    thread_cache_read_boundary: float = 0.0
-
-    def __post_init__(self) -> None:
-        """Default the thread-cache read boundary to this runtime start."""
-        if self.thread_cache_read_boundary == 0.0:
-            self.thread_cache_read_boundary = self.runtime_started_at
 
     def mark_runtime_started(self) -> None:
-        """Advance runtime and thread-cache freshness boundaries for one bot start."""
+        """Record the runtime start time for this bot start."""
         self.runtime_started_at = time.time()
-        self.thread_cache_read_boundary = self.runtime_started_at

--- a/src/mindroom/matrix/cache/agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/agent_message_snapshot.py
@@ -77,7 +77,6 @@ async def _thread_scope_has_no_snapshot(
     *,
     room_id: str,
     thread_id: str | None,
-    runtime_started_at: float | None,
 ) -> bool:
     if thread_id is None:
         return False
@@ -88,7 +87,6 @@ async def _thread_scope_has_no_snapshot(
             room_id=room_id,
             thread_id=thread_id,
         ),
-        runtime_started_at=runtime_started_at,
     )
     if rejection_reason in _THREAD_CACHE_REJECTION_NONE_REASONS:
         return True
@@ -219,7 +217,6 @@ async def load_agent_message_snapshot(
             db,
             room_id=room_id,
             thread_id=thread_id,
-            runtime_started_at=runtime_started_at,
         ):
             return None
         return await _load_scope_snapshot(

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -451,8 +451,6 @@ class ConversationEventCache(Protocol):
         self,
         room_id: str,
         thread_id: str,
-        *,
-        runtime_started_at: float | None,
     ) -> bool:
         """Refresh thread validation after a safe incremental update."""
 
@@ -800,8 +798,6 @@ class _EventCache:
         self,
         room_id: str,
         thread_id: str,
-        *,
-        runtime_started_at: float | None,
     ) -> bool:
         """Refresh one thread's validated timestamp after a safe incremental update."""
         return bool(
@@ -813,7 +809,6 @@ class _EventCache:
                     db,
                     room_id=room_id,
                     thread_id=thread_id,
-                    runtime_started_at=runtime_started_at,
                 ),
             ),
         )

--- a/src/mindroom/matrix/cache/event_cache_threads.py
+++ b/src/mindroom/matrix/cache/event_cache_threads.py
@@ -421,7 +421,6 @@ async def revalidate_thread_after_incremental_update_locked(
     *,
     room_id: str,
     thread_id: str,
-    runtime_started_at: float | None,
 ) -> bool:
     """Mark one thread cache fresh after a safe incremental update."""
     row = await load_thread_cache_state_row(
@@ -434,10 +433,8 @@ async def revalidate_thread_after_incremental_update_locked(
     validated_at, invalidated_at, invalidation_reason, room_invalidated_at, _room_invalidation_reason = row
     can_revalidate = (
         validated_at is not None
-        and (runtime_started_at is None or validated_at >= runtime_started_at)
         and invalidated_at is not None
         and invalidation_reason in _INCREMENTAL_THREAD_REVALIDATION_REASONS
-        and (runtime_started_at is None or invalidated_at >= runtime_started_at)
         and not (room_invalidated_at is not None and room_invalidated_at >= validated_at)
     )
     if not can_revalidate:

--- a/src/mindroom/matrix/cache/thread_cache_helpers.py
+++ b/src/mindroom/matrix/cache/thread_cache_helpers.py
@@ -29,8 +29,6 @@ def latest_visible_thread_event_id(history: Sequence[ResolvedVisibleMessage]) ->
 
 def thread_cache_rejection_reason(
     cache_state: ThreadCacheStateLike | None,
-    *,
-    runtime_started_at: float | None,
 ) -> str | None:
     """Return why one durable thread snapshot must be rejected, if at all."""
     rejection_reason: str | None = None
@@ -38,8 +36,6 @@ def thread_cache_rejection_reason(
         rejection_reason = "no_cache_state"
     elif cache_state.validated_at is None:
         rejection_reason = "cache_never_validated"
-    elif runtime_started_at is not None and cache_state.validated_at < runtime_started_at:
-        rejection_reason = "validated_before_runtime_start"
     elif cache_state.invalidated_at is not None and cache_state.invalidated_at >= cache_state.validated_at:
         rejection_reason = "thread_invalidated_after_validation"
     elif cache_state.room_invalidated_at is not None and cache_state.room_invalidated_at >= cache_state.validated_at:
@@ -49,14 +45,6 @@ def thread_cache_rejection_reason(
 
 def thread_cache_state_is_usable(
     cache_state: ThreadCacheStateLike | None,
-    *,
-    runtime_started_at: float | None,
 ) -> bool:
     """Return whether one durable thread snapshot is safe to reuse."""
-    return (
-        thread_cache_rejection_reason(
-            cache_state,
-            runtime_started_at=runtime_started_at,
-        )
-        is None
-    )
+    return thread_cache_rejection_reason(cache_state) is None

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -40,10 +40,6 @@ class ThreadMutationCacheOps:
             and self.runtime.event_cache.durable_writes_available
         )
 
-    def _effective_thread_cache_runtime_started_at(self) -> float | None:
-        """Return the restart freshness boundary for incremental thread revalidation."""
-        return self.runtime.thread_cache_read_boundary
-
     def queue_room_cache_update(
         self,
         room_id: str,
@@ -238,7 +234,6 @@ class ThreadMutationCacheOps:
             await self.runtime.event_cache.revalidate_thread_after_incremental_update(
                 room_id,
                 thread_id,
-                runtime_started_at=self._effective_thread_cache_runtime_started_at(),
             )
         except Exception as exc:
             self.logger.warning(

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -400,14 +400,11 @@ def _cache_reject_diagnostics(
     *,
     cache_state: object,
     rejection_reason: str,
-    runtime_started_at: float | None,
 ) -> dict[str, str | int | float | bool]:
     diagnostics: dict[str, str | int | float | bool] = {
         THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: rejection_reason,
     }
     if not isinstance(cache_state, ThreadCacheState):
-        if runtime_started_at is not None:
-            diagnostics["cache_runtime_started_at"] = runtime_started_at
         return diagnostics
     if cache_state.validated_at is not None:
         diagnostics["cache_validated_at"] = cache_state.validated_at
@@ -420,8 +417,6 @@ def _cache_reject_diagnostics(
         diagnostics["room_cache_invalidated_at"] = cache_state.room_invalidated_at
     if cache_state.room_invalidation_reason is not None:
         diagnostics["room_cache_invalidation_reason"] = cache_state.room_invalidation_reason
-    if runtime_started_at is not None:
-        diagnostics["cache_runtime_started_at"] = runtime_started_at
     return diagnostics
 
 
@@ -432,20 +427,15 @@ async def _load_cached_thread_history_if_usable(
     thread_id: str,
     event_cache: ConversationEventCache,
     hydrate_sidecars: bool,
-    runtime_started_at: float | None,
     trusted_sender_ids: Collection[str] = (),
 ) -> tuple[ThreadHistoryResult | None, dict[str, str | int | float | bool] | None]:
     """Return a durable thread snapshot when the current runtime may safely trust it."""
     cache_state = await event_cache.get_thread_cache_state(room_id, thread_id)
-    rejection_reason = thread_cache_rejection_reason(
-        cache_state,
-        runtime_started_at=runtime_started_at,
-    )
+    rejection_reason = thread_cache_rejection_reason(cache_state)
     if rejection_reason is not None:
         cache_reject_diagnostics = _cache_reject_diagnostics(
             cache_state=cache_state,
             rejection_reason=rejection_reason,
-            runtime_started_at=runtime_started_at,
         )
         logger.info(
             "Thread cache rejected for read",
@@ -681,7 +671,6 @@ async def fetch_thread_history(
     thread_id: str,
     event_cache: ConversationEventCache,
     *,
-    runtime_started_at: float | None = None,
     cache_write_guard_started_at: float | None = None,
     trusted_sender_ids: Collection[str] = (),
 ) -> ThreadHistoryResult:
@@ -694,7 +683,6 @@ async def fetch_thread_history(
             thread_id=thread_id,
             event_cache=event_cache,
             hydrate_sidecars=True,
-            runtime_started_at=runtime_started_at,
             trusted_sender_ids=trusted_sender_ids,
         )
     except Exception as exc:
@@ -725,7 +713,6 @@ async def fetch_thread_snapshot(
     thread_id: str,
     event_cache: ConversationEventCache,
     *,
-    runtime_started_at: float | None = None,
     cache_write_guard_started_at: float | None = None,
     trusted_sender_ids: Collection[str] = (),
 ) -> ThreadHistoryResult:
@@ -738,7 +725,6 @@ async def fetch_thread_snapshot(
             thread_id=thread_id,
             event_cache=event_cache,
             hydrate_sidecars=False,
-            runtime_started_at=runtime_started_at,
             trusted_sender_ids=trusted_sender_ids,
         )
     except Exception as exc:
@@ -770,7 +756,6 @@ async def fetch_dispatch_thread_history(
     thread_id: str,
     event_cache: ConversationEventCache,
     *,
-    runtime_started_at: float | None = None,
     cache_write_guard_started_at: float | None = None,
     trusted_sender_ids: Collection[str] = (),
 ) -> ThreadHistoryResult:
@@ -783,7 +768,6 @@ async def fetch_dispatch_thread_history(
             thread_id=thread_id,
             event_cache=event_cache,
             hydrate_sidecars=True,
-            runtime_started_at=runtime_started_at,
             trusted_sender_ids=trusted_sender_ids,
         )
     except Exception as exc:
@@ -815,7 +799,6 @@ async def fetch_dispatch_thread_snapshot(
     thread_id: str,
     event_cache: ConversationEventCache,
     *,
-    runtime_started_at: float | None = None,
     cache_write_guard_started_at: float | None = None,
     trusted_sender_ids: Collection[str] = (),
 ) -> ThreadHistoryResult:
@@ -828,7 +811,6 @@ async def fetch_dispatch_thread_snapshot(
             thread_id=thread_id,
             event_cache=event_cache,
             hydrate_sidecars=False,
-            runtime_started_at=runtime_started_at,
             trusted_sender_ids=trusted_sender_ids,
         )
     except Exception as exc:

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -409,10 +409,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
             self.runtime.runtime_paths,
         )
 
-    def _effective_thread_cache_runtime_started_at(self) -> float | None:
-        """Return the active restart freshness boundary for durable thread-cache reads."""
-        return self.runtime.thread_cache_read_boundary
-
     @asynccontextmanager
     async def turn_scope(self) -> AsyncIterator[None]:
         """Memoize event lookups and thread reads for the lifetime of one inbound turn."""
@@ -569,7 +565,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
             room_id,
             thread_id,
             event_cache=self.runtime.event_cache,
-            runtime_started_at=self._effective_thread_cache_runtime_started_at(),
             cache_write_guard_started_at=fetch_started_at,
             trusted_sender_ids=self._trusted_sender_ids(),
         )
@@ -585,7 +580,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
             room_id,
             thread_id,
             event_cache=self.runtime.event_cache,
-            runtime_started_at=self._effective_thread_cache_runtime_started_at(),
             cache_write_guard_started_at=fetch_started_at,
             trusted_sender_ids=self._trusted_sender_ids(),
         )
@@ -601,7 +595,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
             room_id,
             thread_id,
             event_cache=self.runtime.event_cache,
-            runtime_started_at=self._effective_thread_cache_runtime_started_at(),
             cache_write_guard_started_at=fetch_started_at,
             trusted_sender_ids=self._trusted_sender_ids(),
         )
@@ -617,7 +610,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
             room_id,
             thread_id,
             event_cache=self.runtime.event_cache,
-            runtime_started_at=self._effective_thread_cache_runtime_started_at(),
             cache_write_guard_started_at=fetch_started_at,
             trusted_sender_ids=self._trusted_sender_ids(),
         )
@@ -634,7 +626,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
             room_id,
             thread_id,
             event_cache=self.runtime.event_cache,
-            runtime_started_at=self._effective_thread_cache_runtime_started_at(),
             cache_write_guard_started_at=fetch_started_at,
             trusted_sender_ids=self._trusted_sender_ids(),
         )

--- a/src/mindroom/matrix/sync_certification.py
+++ b/src/mindroom/matrix/sync_certification.py
@@ -17,10 +17,9 @@ class SyncTrustState(Enum):
 
 @dataclass(frozen=True)
 class SyncCheckpoint:
-    """A sync token certified against a durable thread-cache boundary."""
+    """A sync token saved after its sync response was durably cached."""
 
     token: str
-    thread_cache_valid_after: float
 
 
 @dataclass(frozen=True)
@@ -42,7 +41,6 @@ class SyncCertificationDecision:
     """Action returned by the certification state machine."""
 
     state: SyncTrustState
-    thread_cache_read_boundary: float
     checkpoint_to_save: SyncCheckpoint | None = None
     clear_saved_token: bool = False
     reset_client_token: bool = False
@@ -55,8 +53,6 @@ class SyncCertificationStart:
 
     state: SyncTrustState
     sync_token: str | None
-    thread_cache_read_boundary: float
-    checkpoint: SyncCheckpoint | None = None
     legacy_token: bool = False
 
 
@@ -68,11 +64,7 @@ def _non_empty_token(token: str | None) -> str | None:
     return normalized or None
 
 
-def start_from_loaded_token(
-    loaded: SyncCheckpoint | str | None,
-    *,
-    runtime_started_at: float,
-) -> SyncCertificationStart:
+def start_from_loaded_token(loaded: SyncCheckpoint | str | None) -> SyncCertificationStart:
     """Build initial certifier state from a loaded token or checkpoint."""
     if isinstance(loaded, SyncCheckpoint):
         token = _non_empty_token(loaded.token)
@@ -80,38 +72,28 @@ def start_from_loaded_token(
             return SyncCertificationStart(
                 state=SyncTrustState.COLD,
                 sync_token=None,
-                thread_cache_read_boundary=runtime_started_at,
             )
-        checkpoint = SyncCheckpoint(
-            token=token,
-            thread_cache_valid_after=loaded.thread_cache_valid_after,
-        )
         return SyncCertificationStart(
             state=SyncTrustState.PENDING,
             sync_token=token,
-            thread_cache_read_boundary=runtime_started_at,
-            checkpoint=checkpoint,
         )
 
     token = _non_empty_token(loaded) if isinstance(loaded, str) else None
     return SyncCertificationStart(
         state=SyncTrustState.COLD,
         sync_token=token,
-        thread_cache_read_boundary=runtime_started_at,
         legacy_token=token is not None,
     )
 
 
 def _uncertain_decision(
     *,
-    now: float,
     reason: str,
     reset_client_token: bool = False,
 ) -> SyncCertificationDecision:
     """Return a fail-closed uncertainty decision."""
     return SyncCertificationDecision(
         state=SyncTrustState.UNCERTAIN,
-        thread_cache_read_boundary=now,
         clear_saved_token=True,
         reset_client_token=reset_client_token,
         reason=reason,
@@ -131,60 +113,35 @@ def _uncertain_reason(cache_result: SyncCacheWriteResult, *, next_batch: str | N
     return None
 
 
-def _checkpoint_boundary(
-    state: SyncTrustState,
-    *,
-    previous_checkpoint: SyncCheckpoint | None,
-    current_read_boundary: float,
-) -> float:
-    """Return the boundary to carry into a newly certified checkpoint."""
-    if state is SyncTrustState.PENDING and previous_checkpoint is not None:
-        return previous_checkpoint.thread_cache_valid_after
-    if state is SyncTrustState.CERTIFIED and previous_checkpoint is not None:
-        return previous_checkpoint.thread_cache_valid_after
-    return current_read_boundary
-
-
 def certify_sync_response(
     state: SyncTrustState,
     *,
-    previous_checkpoint: SyncCheckpoint | None,
     next_batch: str | None,
     cache_result: SyncCacheWriteResult,
     first_sync: bool,
-    now: float,
-    current_read_boundary: float,
 ) -> SyncCertificationDecision:
     """Return the certifier decision for one sync response."""
     reason = _uncertain_reason(cache_result, next_batch=next_batch)
     if reason is not None:
         return _uncertain_decision(
-            now=now,
             reason=reason,
             reset_client_token=state is SyncTrustState.PENDING and first_sync,
         )
 
     token = _non_empty_token(next_batch)
     if token is None:
-        return _uncertain_decision(now=now, reason="missing_next_batch")
+        return _uncertain_decision(reason="missing_next_batch")
 
-    boundary = _checkpoint_boundary(
-        state,
-        previous_checkpoint=previous_checkpoint,
-        current_read_boundary=current_read_boundary,
-    )
-    checkpoint = SyncCheckpoint(token=token, thread_cache_valid_after=boundary)
+    checkpoint = SyncCheckpoint(token=token)
     return SyncCertificationDecision(
         state=SyncTrustState.CERTIFIED,
-        thread_cache_read_boundary=boundary,
         checkpoint_to_save=checkpoint,
     )
 
 
-def handle_unknown_pos(*, now: float) -> SyncCertificationDecision:
+def handle_unknown_pos() -> SyncCertificationDecision:
     """Return the fail-closed decision for Matrix ``M_UNKNOWN_POS``."""
     return _uncertain_decision(
-        now=now,
         reason="unknown_pos",
         reset_client_token=True,
     )

--- a/src/mindroom/matrix/sync_tokens.py
+++ b/src/mindroom/matrix/sync_tokens.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -27,13 +26,6 @@ class SyncTokenRecord:
         """Return whether this token carries cache-trust certification."""
         return self.checkpoint is not None
 
-    @property
-    def thread_cache_valid_after(self) -> float | None:
-        """Return the certified thread-cache boundary when present."""
-        if self.checkpoint is None:
-            return None
-        return self.checkpoint.thread_cache_valid_after
-
 
 def _sync_token_path(storage_path: Path, agent_name: str) -> Path:
     """Return the on-disk path for one agent's sync token."""
@@ -43,16 +35,6 @@ def _sync_token_path(storage_path: Path, agent_name: str) -> Path:
 def _sync_token_certification_path(storage_path: Path, agent_name: str) -> Path:
     """Return the legacy marker path removed during cleanup."""
     return storage_path / "sync_tokens" / f"{agent_name}.token.certified"
-
-
-def _normalized_thread_cache_valid_after(value: object) -> float | None:
-    """Return a safe cache-validity boundary parsed from checkpoint metadata."""
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return None
-    boundary = float(value)
-    if not math.isfinite(boundary):
-        return None
-    return boundary
 
 
 def _normalized_token(value: object) -> str | None:
@@ -72,17 +54,15 @@ def _record_from_json(text: str) -> SyncTokenRecord | None:
     if not isinstance(payload, dict) or payload.get("version") != _SYNC_TOKEN_RECORD_VERSION:
         return None
     token = _normalized_token(payload.get("token"))
-    valid_after = _normalized_thread_cache_valid_after(payload.get("thread_cache_valid_after"))
-    if token is None or valid_after is None:
+    if token is None:
         return None
-    checkpoint = SyncCheckpoint(token=token, thread_cache_valid_after=valid_after)
+    checkpoint = SyncCheckpoint(token=token)
     return SyncTokenRecord(token=token, checkpoint=checkpoint)
 
 
 def _record_json(checkpoint: SyncCheckpoint) -> str:
     """Return the durable JSON token record for one certified checkpoint."""
     payload = {
-        "thread_cache_valid_after": checkpoint.thread_cache_valid_after,
         "token": checkpoint.token,
         "version": _SYNC_TOKEN_RECORD_VERSION,
     }
@@ -93,8 +73,6 @@ def save_sync_token(
     storage_path: Path,
     agent_name: str,
     token: str,
-    *,
-    thread_cache_valid_after: float,
 ) -> None:
     """Persist one cache-certified sync token checkpoint."""
     token_path = _sync_token_path(storage_path, agent_name)
@@ -102,11 +80,7 @@ def save_sync_token(
     if token_value is None:
         msg = "Certified sync tokens require a non-empty token"
         raise ValueError(msg)
-    valid_after = _normalized_thread_cache_valid_after(thread_cache_valid_after)
-    if valid_after is None:
-        msg = "Certified sync tokens require a finite thread-cache valid-after boundary"
-        raise ValueError(msg)
-    checkpoint = SyncCheckpoint(token=token_value, thread_cache_valid_after=valid_after)
+    checkpoint = SyncCheckpoint(token=token_value)
     token_path.parent.mkdir(parents=True, exist_ok=True)
     token_path.write_text(_record_json(checkpoint), encoding="utf-8")
     _sync_token_certification_path(storage_path, agent_name).unlink(missing_ok=True)

--- a/tests/test_matrix_cache_agent_message_snapshot.py
+++ b/tests/test_matrix_cache_agent_message_snapshot.py
@@ -440,10 +440,10 @@ async def test_room_scope_does_not_fall_back_to_older_fresh_message_when_latest_
 
 
 @pytest.mark.asyncio
-async def test_accessor_accepts_old_thread_cache_inside_trusted_boundary(
+async def test_accessor_accepts_old_thread_cache_without_stale_marker(
     tmp_path: Path,
 ) -> None:
-    """Threaded reads should trust old snapshots after certified sync catch-up."""
+    """Threaded reads should trust old snapshots unless a stale marker exists."""
     db_path = tmp_path / "event_cache.db"
     cache = _EventCache(db_path)
     await cache.initialize()
@@ -490,10 +490,10 @@ async def test_accessor_accepts_old_thread_cache_inside_trusted_boundary(
 
 
 @pytest.mark.asyncio
-async def test_accessor_rejects_thread_cache_from_prior_bot_run(
+async def test_accessor_reuses_thread_cache_from_prior_bot_run(
     tmp_path: Path,
 ) -> None:
-    """Threaded reads should reject snapshots validated before the current runtime."""
+    """Threaded reads should trust snapshots unless an explicit stale marker exists."""
     db_path = tmp_path / "event_cache.db"
     cache = _EventCache(db_path)
     await cache.initialize()
@@ -521,14 +521,22 @@ async def test_accessor_rejects_thread_cache_from_prior_bot_run(
     finally:
         await cache.close()
 
-    with pytest.raises(AgentMessageSnapshotUnavailable, match="validated_before_runtime_start"):
-        await _read_snapshot(
-            db_path,
-            room_id="!room:localhost",
-            thread_id="$thread-root",
-            sender="@agent:localhost",
-            runtime_started_at=1001.0,
-        )
+    snapshot = await _read_snapshot(
+        db_path,
+        room_id="!room:localhost",
+        thread_id="$thread-root",
+        sender="@agent:localhost",
+        runtime_started_at=1001.0,
+    )
+
+    assert snapshot == AgentMessageSnapshot(
+        content={
+            "body": "Working...",
+            "msgtype": "m.text",
+            "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread-root"},
+        },
+        origin_server_ts=2000,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -29,8 +29,6 @@ from tests.conftest import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-_THREAD_CACHE_VALID_AFTER = 1234.5
-
 
 def _config(tmp_path: Path) -> Config:
     runtime_paths = test_runtime_paths(tmp_path)
@@ -85,16 +83,10 @@ def test_load_sync_token_returns_none_for_whitespace_only_file(tmp_path: Path) -
 
 def test_save_sync_token_round_trip(tmp_path: Path) -> None:
     """Saving and loading should round-trip the token value."""
-    save_sync_token(
-        tmp_path,
-        "code",
-        "s12345",
-        thread_cache_valid_after=_THREAD_CACHE_VALID_AFTER,
-    )
+    save_sync_token(tmp_path, "code", "s12345")
 
     token_path = _token_path(tmp_path)
     assert json.loads(token_path.read_text(encoding="utf-8")) == {
-        "thread_cache_valid_after": _THREAD_CACHE_VALID_AFTER,
         "token": "s12345",
         "version": "mindroom-sync-token-v1",
     }
@@ -103,11 +95,11 @@ def test_save_sync_token_round_trip(tmp_path: Path) -> None:
     token_record = load_sync_token_record(tmp_path, "code")
     assert token_record is not None
     assert token_record.certified is True
-    assert token_record.thread_cache_valid_after == _THREAD_CACHE_VALID_AFTER
+    assert token_record.checkpoint == SyncCheckpoint("s12345")
 
 
-def test_marker_without_thread_cache_boundary_is_not_certified(tmp_path: Path) -> None:
-    """Older marker-only tokens restore for sync continuity but cannot trust durable cache rows."""
+def test_legacy_marker_file_does_not_certify_plaintext_token(tmp_path: Path) -> None:
+    """Older marker-only tokens restore for sync continuity but are not certified checkpoints."""
     saved_batch = "s_marker_only"
     token_path = _token_path(tmp_path)
     certification_path = _certification_path(tmp_path)
@@ -120,17 +112,11 @@ def test_marker_without_thread_cache_boundary_is_not_certified(tmp_path: Path) -
     assert token_record is not None
     assert token_record.token == saved_batch
     assert token_record.certified is False
-    assert token_record.thread_cache_valid_after is None
 
 
 def test_clear_sync_token_removes_saved_token(tmp_path: Path) -> None:
     """Clearing should remove an existing persisted token."""
-    save_sync_token(
-        tmp_path,
-        "code",
-        "s12345",
-        thread_cache_valid_after=_THREAD_CACHE_VALID_AFTER,
-    )
+    save_sync_token(tmp_path, "code", "s12345")
 
     clear_sync_token(tmp_path, "code")
 
@@ -150,12 +136,7 @@ def test_clear_sync_token_is_idempotent(tmp_path: Path) -> None:
 async def test_bot_start_restores_saved_sync_token(tmp_path: Path) -> None:
     """Startup should hydrate the nio client from the previously saved token."""
     bot = _agent_bot(tmp_path)
-    save_sync_token(
-        tmp_path,
-        bot.agent_name,
-        "s_saved",
-        thread_cache_valid_after=_THREAD_CACHE_VALID_AFTER,
-    )
+    save_sync_token(tmp_path, bot.agent_name, "s_saved")
 
     client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     client.next_batch = None
@@ -194,7 +175,6 @@ async def test_legacy_plaintext_sync_token_restores_without_cache_trust(tmp_path
 
     assert client.next_batch == "s_legacy"
     assert bot._sync_trust_state is SyncTrustState.COLD
-    assert bot._runtime_view.thread_cache_read_boundary == bot._runtime_view.runtime_started_at
 
     response = MagicMock(spec=nio.SyncResponse)
     response.next_batch = "s_after_legacy"
@@ -206,7 +186,7 @@ async def test_legacy_plaintext_sync_token_restores_without_cache_trust(tmp_path
     assert token_record is not None
     assert token_record.token == "s_after_legacy"  # noqa: S105
     assert token_record.certified is True
-    assert token_record.thread_cache_valid_after == bot._runtime_view.runtime_started_at
+    assert token_record.checkpoint == SyncCheckpoint("s_after_legacy")
 
 
 def test_restore_saved_sync_token_ignores_invalid_utf8(tmp_path: Path) -> None:
@@ -231,13 +211,7 @@ async def test_unknown_pos_first_sync_clears_client_and_saved_token(tmp_path: Pa
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     bot.client.next_batch = "s_rejected"
     bot._runtime_view.mark_runtime_started()
-    original_boundary = bot._runtime_view.thread_cache_read_boundary
-    save_sync_token(
-        tmp_path,
-        bot.agent_name,
-        "s_rejected",
-        thread_cache_valid_after=_THREAD_CACHE_VALID_AFTER,
-    )
+    save_sync_token(tmp_path, bot.agent_name, "s_rejected")
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
 
@@ -246,22 +220,16 @@ async def test_unknown_pos_first_sync_clears_client_and_saved_token(tmp_path: Pa
     assert bot.client.next_batch is None
     assert load_sync_token(tmp_path, bot.agent_name) is None
     assert bot._sync_trust_state is SyncTrustState.UNCERTAIN
-    assert bot._runtime_view.thread_cache_read_boundary >= original_boundary
 
 
 @pytest.mark.asyncio
-async def test_unknown_pos_restored_first_sync_advances_boundary_before_later_checkpoint(tmp_path: Path) -> None:
-    """After M_UNKNOWN_POS, later tokens may save only with the advanced safe boundary."""
+async def test_unknown_pos_restored_first_sync_saves_later_checkpoint(tmp_path: Path) -> None:
+    """After M_UNKNOWN_POS, later successful sync responses can save a fresh checkpoint."""
     bot = _agent_bot(tmp_path)
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     bot.client.next_batch = "s_rejected"
     bot._runtime_view.mark_runtime_started()
-    save_sync_token(
-        tmp_path,
-        bot.agent_name,
-        "s_rejected",
-        thread_cache_valid_after=_THREAD_CACHE_VALID_AFTER,
-    )
+    save_sync_token(tmp_path, bot.agent_name, "s_rejected")
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
 
@@ -276,7 +244,7 @@ async def test_unknown_pos_restored_first_sync_advances_boundary_before_later_ch
     token_record = load_sync_token_record(tmp_path, bot.agent_name)
     assert token_record is not None
     assert token_record.token == "s_later"  # noqa: S105
-    assert token_record.thread_cache_valid_after == bot._runtime_view.thread_cache_read_boundary
+    assert token_record.checkpoint == SyncCheckpoint("s_later")
 
 
 @pytest.mark.asyncio
@@ -287,12 +255,7 @@ async def test_unknown_pos_after_first_sync_clears_client_and_saved_token(tmp_pa
     bot.client.next_batch = "s_rejected_after_start"
     bot._first_sync_done = True
     bot._runtime_view.mark_runtime_started()
-    save_sync_token(
-        tmp_path,
-        bot.agent_name,
-        "s_rejected_after_start",
-        thread_cache_valid_after=_THREAD_CACHE_VALID_AFTER,
-    )
+    save_sync_token(tmp_path, bot.agent_name, "s_rejected_after_start")
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
 
@@ -304,8 +267,8 @@ async def test_unknown_pos_after_first_sync_clears_client_and_saved_token(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_unknown_pos_non_restored_runtime_advances_later_checkpoint_boundary(tmp_path: Path) -> None:
-    """M_UNKNOWN_POS should fail closed, then allow later certified tokens with the new boundary."""
+async def test_unknown_pos_non_restored_runtime_allows_later_checkpoint(tmp_path: Path) -> None:
+    """M_UNKNOWN_POS should fail closed, then allow later certified tokens."""
     bot = _agent_bot(tmp_path)
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     bot.client.next_batch = "s_rejected_cold"
@@ -325,7 +288,7 @@ async def test_unknown_pos_non_restored_runtime_advances_later_checkpoint_bounda
     token_record = load_sync_token_record(tmp_path, bot.agent_name)
     assert token_record is not None
     assert token_record.token == "s_later_after_unknown_pos"  # noqa: S105
-    assert token_record.thread_cache_valid_after == bot._runtime_view.thread_cache_read_boundary
+    assert token_record.checkpoint == SyncCheckpoint("s_later_after_unknown_pos")
 
 
 @pytest.mark.asyncio
@@ -344,7 +307,7 @@ async def test_on_sync_response_persists_latest_sync_token(tmp_path: Path) -> No
     assert load_sync_token(tmp_path, bot.agent_name) == "s_latest"
     token_record = load_sync_token_record(tmp_path, bot.agent_name)
     assert token_record is not None
-    assert token_record.thread_cache_valid_after == bot._runtime_view.thread_cache_read_boundary
+    assert token_record.checkpoint == SyncCheckpoint("s_latest")
 
 
 @pytest.mark.asyncio
@@ -354,7 +317,7 @@ async def test_prepare_for_sync_shutdown_flushes_latest_sync_token(tmp_path: Pat
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     bot.client.next_batch = "s_shutdown"
     bot._sync_trust_state = SyncTrustState.CERTIFIED
-    bot._sync_checkpoint = SyncCheckpoint("s_shutdown", bot._runtime_view.thread_cache_read_boundary)
+    bot._sync_checkpoint = SyncCheckpoint("s_shutdown")
     bot._coalescing_gate.drain_all = AsyncMock()
 
     await bot.prepare_for_sync_shutdown()
@@ -362,7 +325,7 @@ async def test_prepare_for_sync_shutdown_flushes_latest_sync_token(tmp_path: Pat
     assert load_sync_token(tmp_path, bot.agent_name) == "s_shutdown"
     token_record = load_sync_token_record(tmp_path, bot.agent_name)
     assert token_record is not None
-    assert token_record.thread_cache_valid_after == bot._runtime_view.thread_cache_read_boundary
+    assert token_record.checkpoint == SyncCheckpoint("s_shutdown")
 
 
 @pytest.mark.asyncio
@@ -371,12 +334,7 @@ async def test_prepare_for_sync_shutdown_skips_precallback_uncertified_token(tmp
     bot = _agent_bot(tmp_path)
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     bot._coalescing_gate.drain_all = AsyncMock()
-    save_sync_token(
-        tmp_path,
-        bot.agent_name,
-        "s_before_precallback",
-        thread_cache_valid_after=_THREAD_CACHE_VALID_AFTER,
-    )
+    save_sync_token(tmp_path, bot.agent_name, "s_before_precallback")
     bot._runtime_view.mark_runtime_started()
     bot._restore_saved_sync_token()
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -7924,7 +7924,6 @@ class TestAgentBot:
             room.room_id,
             "$thread_root",
             event_cache=bot.event_cache,
-            runtime_started_at=bot._runtime_view.runtime_started_at,
             cache_write_guard_started_at=ANY,
             trusted_sender_ids=trusted_sender_ids,
         )

--- a/tests/test_sync_certification.py
+++ b/tests/test_sync_certification.py
@@ -17,67 +17,54 @@ from mindroom.matrix.sync_certification import (
 
 
 def test_start_without_token_is_cold() -> None:
-    """Missing saved token should keep reads behind the runtime boundary."""
-    startup = start_from_loaded_token(None, runtime_started_at=10.0)
+    """Missing saved token should start from cold sync state."""
+    startup = start_from_loaded_token(None)
 
     assert startup.state is SyncTrustState.COLD
     assert startup.sync_token is None
-    assert startup.thread_cache_read_boundary == 10.0
-    assert startup.checkpoint is None
 
 
 def test_start_with_legacy_token_restores_sync_only() -> None:
-    """Plaintext tokens restore nio continuity without trusting old cache rows."""
-    startup = start_from_loaded_token("s_legacy", runtime_started_at=10.0)
+    """Plaintext tokens restore nio continuity without checkpoint certification."""
+    startup = start_from_loaded_token("s_legacy")
 
     assert startup.state is SyncTrustState.COLD
     assert startup.sync_token == "s_legacy"  # noqa: S105
-    assert startup.thread_cache_read_boundary == 10.0
-    assert startup.checkpoint is None
     assert startup.legacy_token is True
 
 
 def test_start_with_checkpoint_waits_for_first_sync() -> None:
     """Certified checkpoints become pending until catch-up writes are durable."""
-    checkpoint = SyncCheckpoint(token="s_saved", thread_cache_valid_after=3.0)  # noqa: S106
+    checkpoint = SyncCheckpoint(token="s_saved")  # noqa: S106
 
-    startup = start_from_loaded_token(checkpoint, runtime_started_at=10.0)
+    startup = start_from_loaded_token(checkpoint)
 
     assert startup.state is SyncTrustState.PENDING
     assert startup.sync_token == "s_saved"  # noqa: S105
-    assert startup.thread_cache_read_boundary == 10.0
-    assert startup.checkpoint == checkpoint
 
 
 @pytest.mark.parametrize(
-    ("state", "checkpoint", "current_boundary", "expected_boundary"),
+    "state",
     [
-        (SyncTrustState.COLD, None, 10.0, 10.0),
-        (SyncTrustState.PENDING, SyncCheckpoint("s_saved", 3.0), 10.0, 3.0),
-        (SyncTrustState.CERTIFIED, SyncCheckpoint("s_saved", 3.0), 3.0, 3.0),
-        (SyncTrustState.UNCERTAIN, None, 12.0, 12.0),
+        SyncTrustState.COLD,
+        SyncTrustState.PENDING,
+        SyncTrustState.CERTIFIED,
+        SyncTrustState.UNCERTAIN,
     ],
 )
 def test_successful_sync_certifies_checkpoint(
     state: SyncTrustState,
-    checkpoint: SyncCheckpoint | None,
-    current_boundary: float,
-    expected_boundary: float,
 ) -> None:
-    """Durable sync writes should save the next batch with the active safe boundary."""
+    """Durable sync writes should save the next batch as certified."""
     decision = certify_sync_response(
         state,
-        previous_checkpoint=checkpoint,
         next_batch="s_next",
         cache_result=SyncCacheWriteResult(complete=True),
         first_sync=state is SyncTrustState.PENDING,
-        now=20.0,
-        current_read_boundary=current_boundary,
     )
 
     assert decision.state is SyncTrustState.CERTIFIED
-    assert decision.thread_cache_read_boundary == expected_boundary
-    assert decision.checkpoint_to_save == SyncCheckpoint("s_next", expected_boundary)
+    assert decision.checkpoint_to_save == SyncCheckpoint("s_next")
     assert decision.clear_saved_token is False
     assert decision.reset_client_token is False
 
@@ -95,16 +82,12 @@ def test_uncertain_sync_fails_closed(cache_result: SyncCacheWriteResult, reason:
     """Limited, failed, incomplete, or cancelled cache writes must not save a token."""
     decision = certify_sync_response(
         SyncTrustState.CERTIFIED,
-        previous_checkpoint=SyncCheckpoint("s_saved", 3.0),
         next_batch="s_next",
         cache_result=cache_result,
         first_sync=False,
-        now=20.0,
-        current_read_boundary=3.0,
     )
 
     assert decision.state is SyncTrustState.UNCERTAIN
-    assert decision.thread_cache_read_boundary == 20.0
     assert decision.checkpoint_to_save is None
     assert decision.clear_saved_token is True
     assert decision.reset_client_token is False
@@ -115,30 +98,23 @@ def test_pending_first_sync_uncertainty_resets_client_token() -> None:
     """A failed restored-token catch-up should force nio off the ambiguous token."""
     decision = certify_sync_response(
         SyncTrustState.PENDING,
-        previous_checkpoint=SyncCheckpoint("s_saved", 3.0),
         next_batch="s_next",
         cache_result=SyncCacheWriteResult(complete=False),
         first_sync=True,
-        now=20.0,
-        current_read_boundary=10.0,
     )
 
     assert decision.state is SyncTrustState.UNCERTAIN
     assert decision.clear_saved_token is True
     assert decision.reset_client_token is True
-    assert decision.thread_cache_read_boundary == 20.0
 
 
 def test_missing_next_batch_fails_closed() -> None:
     """A sync response without a next batch cannot become a checkpoint."""
     decision = certify_sync_response(
         SyncTrustState.COLD,
-        previous_checkpoint=None,
         next_batch=None,
         cache_result=SyncCacheWriteResult(complete=True),
         first_sync=True,
-        now=20.0,
-        current_read_boundary=10.0,
     )
 
     assert decision.state is SyncTrustState.UNCERTAIN
@@ -148,10 +124,9 @@ def test_missing_next_batch_fails_closed() -> None:
 
 def test_unknown_pos_clears_saved_and_client_token() -> None:
     """M_UNKNOWN_POS must fail closed regardless of current state."""
-    decision = handle_unknown_pos(now=20.0)
+    decision = handle_unknown_pos()
 
     assert decision.state is SyncTrustState.UNCERTAIN
-    assert decision.thread_cache_read_boundary == 20.0
     assert decision.checkpoint_to_save is None
     assert decision.clear_saved_token is True
     assert decision.reset_client_token is True

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -2173,7 +2173,6 @@ class TestThreadHistoryCache:
         client: nio.AsyncClient,
         event_cache: _EventCache,
         runtime_started_at: float,
-        thread_cache_valid_after: float | None = None,
     ) -> tuple[MatrixConversationCache, _EventCacheWriteCoordinator]:
         runtime_paths = test_runtime_paths(tmp_path)
         config = bind_runtime_paths(
@@ -2191,9 +2190,6 @@ class TestThreadHistoryCache:
             event_cache_write_coordinator=coordinator,
         )
         runtime.runtime_started_at = runtime_started_at
-        runtime.thread_cache_read_boundary = (
-            runtime_started_at if thread_cache_valid_after is None else thread_cache_valid_after
-        )
         return MatrixConversationCache(logger=MagicMock(), runtime=runtime), coordinator
 
     @staticmethod
@@ -2578,12 +2574,11 @@ class TestThreadHistoryCache:
         assert history.diagnostics["homeserver_scan_pages"] == 1
 
     @pytest.mark.asyncio
-    async def test_restored_token_post_sync_reuses_pre_runtime_thread_cache(self, tmp_path: Path) -> None:
-        """Restored-token catch-up may reuse pre-runtime snapshots inside the token cache window."""
+    async def test_reuses_pre_runtime_thread_cache_after_restart(self, tmp_path: Path) -> None:
+        """Restarted runtimes may reuse pre-runtime snapshots unless a stale marker exists."""
         cache = _EventCache(tmp_path / "event_cache.db")
         await cache.initialize()
         runtime_started_at = time.time()
-        thread_cache_valid_after = runtime_started_at - 20.0
 
         root_event = self._make_text_event(
             event_id="$thread_root",
@@ -2616,7 +2611,6 @@ class TestThreadHistoryCache:
             client=client,
             event_cache=cache,
             runtime_started_at=runtime_started_at,
-            thread_cache_valid_after=thread_cache_valid_after,
         )
 
         try:
@@ -2634,15 +2628,14 @@ class TestThreadHistoryCache:
         client.room_messages.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_restored_token_post_sync_reuses_old_thread_cache_inside_trusted_boundary(
+    async def test_reuses_older_pre_runtime_thread_cache_after_restart(
         self,
         tmp_path: Path,
     ) -> None:
-        """Certified sync catch-up should make cache age irrelevant inside the token cache window."""
+        """Thread cache reads should not reject old snapshots by process age."""
         cache = _EventCache(tmp_path / "event_cache.db")
         await cache.initialize()
         runtime_started_at = time.time()
-        thread_cache_valid_after = runtime_started_at - 1000.0
 
         root_event = self._make_text_event(
             event_id="$thread_root",
@@ -2675,7 +2668,6 @@ class TestThreadHistoryCache:
             client=client,
             event_cache=cache,
             runtime_started_at=runtime_started_at,
-            thread_cache_valid_after=thread_cache_valid_after,
         )
 
         try:
@@ -2693,11 +2685,11 @@ class TestThreadHistoryCache:
         client.room_messages.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_untrusted_restart_rejects_pre_runtime_thread_cache(
+    async def test_thread_cache_reuse_ignores_runtime_age_without_invalidation(
         self,
         tmp_path: Path,
     ) -> None:
-        """Cold starts and pre-catch-up restarts must reject pre-runtime thread snapshots."""
+        """Thread cache trust should depend on explicit stale markers, not process age."""
         cache = _EventCache(tmp_path / "event_cache.db")
         await cache.initialize()
         runtime_started_at = time.time()
@@ -2727,10 +2719,7 @@ class TestThreadHistoryCache:
         )
 
         client = MagicMock()
-        page = MagicMock(spec=nio.RoomMessagesResponse)
-        page.chunk = [reply_event, root_event]
-        page.end = None
-        client.room_messages = AsyncMock(return_value=page)
+        client.room_messages = AsyncMock(side_effect=AssertionError("should reuse cache by default"))
         conversation_cache, coordinator = self._conversation_cache_for_runtime(
             tmp_path=tmp_path,
             client=client,
@@ -2748,10 +2737,9 @@ class TestThreadHistoryCache:
             await cache.close()
 
         assert [message.event_id for message in history] == ["$thread_root", "$reply"]
-        assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_HOMESERVER
-        assert history.diagnostics[THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC] == ("validated_before_runtime_start")
-        assert history.diagnostics["cache_runtime_started_at"] == runtime_started_at
-        client.room_messages.assert_awaited_once()
+        assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_CACHE
+        assert THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC not in history.diagnostics
+        client.room_messages.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_fetch_thread_history_cache_miss_persists_reference_descendant_in_causal_order(
@@ -3041,11 +3029,11 @@ class TestThreadHistoryCache:
         broken_cache.replace_thread_if_not_newer.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_incremental_thread_revalidation_does_not_bypass_runtime_or_room_staleness(
+    async def test_incremental_thread_revalidation_ignores_runtime_age_but_not_room_staleness(
         self,
         tmp_path: Path,
     ) -> None:
-        """Incremental append refresh must not bless pre-runtime or room-invalidated cache."""
+        """Incremental append refresh should trust old caches unless room state is stale."""
         cache = _EventCache(tmp_path / "event_cache.db")
         await cache.initialize()
 
@@ -3093,7 +3081,6 @@ class TestThreadHistoryCache:
         pre_runtime_revalidated = await cache.revalidate_thread_after_incremental_update(
             "!room:localhost",
             "$thread_root",
-            runtime_started_at=runtime_started_at,
         )
 
         await cache.replace_thread(
@@ -3112,7 +3099,6 @@ class TestThreadHistoryCache:
         room_stale_revalidated = await cache.revalidate_thread_after_incremental_update(
             "!room:localhost",
             "$thread_root",
-            runtime_started_at=runtime_started_at,
         )
 
         client = MagicMock()
@@ -3127,13 +3113,12 @@ class TestThreadHistoryCache:
                 "!room:localhost",
                 "$thread_root",
                 event_cache=cache,
-                runtime_started_at=runtime_started_at,
             )
         finally:
             await cache.close()
 
         assert pre_runtime_appended is True
-        assert pre_runtime_revalidated is False
+        assert pre_runtime_revalidated is True
         assert room_stale_appended is True
         assert room_stale_revalidated is False
         assert [message.event_id for message in history] == ["$thread_root", "$reply1", "$reply2"]

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -1429,7 +1429,7 @@ class TestExtractedModuleLoggerRebinding:
             "$threadroot",
         )
         assert call_args.kwargs["event_cache"] is bot.event_cache
-        assert call_args.kwargs["runtime_started_at"] == bot._runtime_view.runtime_started_at
+        assert "runtime_started_at" not in call_args.kwargs
 
     @pytest.mark.asyncio
     async def test_conversation_cache_reuses_fresh_durable_snapshot_before_full_history_hydration(

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -60,7 +60,7 @@ from mindroom.matrix.client import (
 from mindroom.matrix.conversation_cache import MatrixConversationCache
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.message_content import _clear_mxc_cache
-from mindroom.matrix.sync_certification import SyncCacheWriteResult
+from mindroom.matrix.sync_certification import SyncCacheWriteResult, SyncCheckpoint
 from mindroom.matrix.sync_tokens import load_sync_token, load_sync_token_record, save_sync_token
 from mindroom.matrix.thread_bookkeeping import MutationThreadImpact
 from mindroom.matrix.thread_membership import (
@@ -472,13 +472,7 @@ async def _assert_thread_read_guard_rejects_cache_when_unknown_live_mutation_rac
     assert thread_state.validated_at is not None
     assert thread_state.room_invalidated_at is not None
     assert thread_state.room_invalidated_at > thread_state.validated_at
-    assert (
-        matrix_cache.thread_cache_rejection_reason(
-            thread_state,
-            runtime_started_at=access.runtime.runtime_started_at,
-        )
-        is not None
-    )
+    assert matrix_cache.thread_cache_rejection_reason(thread_state) is not None
     client.room_messages.assert_awaited_once()
 
 
@@ -521,15 +515,12 @@ async def _close_bound_runtime_support(bot: AgentBot, support: OwnedRuntimeSuppo
 def _save_certified_sync_token(
     bot: AgentBot,
     token: str,
-    *,
-    thread_cache_valid_after: float = 1.0,
 ) -> None:
     """Persist one cache-bound certified sync token for bot lifecycle tests."""
     save_sync_token(
         bot.storage_path,
         bot.agent_name,
         token,
-        thread_cache_valid_after=thread_cache_valid_after,
     )
 
 
@@ -1956,11 +1947,10 @@ class TestThreadingBehavior:
         assert load_sync_token(bot.storage_path, bot.agent_name) == "s_after_delayed_cache"
 
     @pytest.mark.asyncio
-    async def test_restored_first_sync_success_uses_checkpoint_boundary(self, bot: AgentBot) -> None:
-        """Successful restored-token catch-up should carry forward the loaded cache boundary."""
-        _save_certified_sync_token(bot, "s_before_complete", thread_cache_valid_after=1.0)
+    async def test_restored_first_sync_success_updates_checkpoint(self, bot: AgentBot) -> None:
+        """Successful restored-token catch-up should save the new checkpoint token."""
+        _save_certified_sync_token(bot, "s_before_complete")
         bot._runtime_view.mark_runtime_started()
-        runtime_started_at = bot._runtime_view.runtime_started_at
         bot._restore_saved_sync_token()
         bot.client.next_batch = "s_after_complete"
 
@@ -1969,16 +1959,13 @@ class TestThreadingBehavior:
         token_record = load_sync_token_record(bot.storage_path, bot.agent_name)
         assert token_record is not None
         assert token_record.token == "s_after_complete"  # noqa: S105
-        assert token_record.thread_cache_valid_after == 1.0
-        assert bot._runtime_view.thread_cache_read_boundary == 1.0
-        assert bot._runtime_view.thread_cache_read_boundary < runtime_started_at
+        assert token_record.checkpoint == SyncCheckpoint("s_after_complete")
 
     @pytest.mark.asyncio
-    async def test_limited_restored_first_sync_clears_token_and_advances_boundary(self, bot: AgentBot) -> None:
+    async def test_limited_restored_first_sync_clears_token(self, bot: AgentBot) -> None:
         """Limited restored-token catch-up must fail closed and force a cold retry token."""
-        _save_certified_sync_token(bot, "s_before_limited", thread_cache_valid_after=1.0)
+        _save_certified_sync_token(bot, "s_before_limited")
         bot._runtime_view.mark_runtime_started()
-        runtime_started_at = bot._runtime_view.runtime_started_at
         bot._restore_saved_sync_token()
         bot.client.next_batch = "s_after_limited"
         sync_response = self._sync_response(
@@ -1989,15 +1976,14 @@ class TestThreadingBehavior:
 
         assert bot.client.next_batch is None
         assert load_sync_token(bot.storage_path, bot.agent_name) is None
-        assert bot._runtime_view.thread_cache_read_boundary >= runtime_started_at
 
     @pytest.mark.asyncio
-    async def test_cache_failure_clears_token_then_later_success_saves_advanced_boundary(
+    async def test_cache_failure_clears_token_then_later_success_saves_checkpoint(
         self,
         bot: AgentBot,
     ) -> None:
-        """After cache uncertainty, later checkpoints are allowed only with the new boundary."""
-        _save_certified_sync_token(bot, "s_before_failure", thread_cache_valid_after=1.0)
+        """After cache uncertainty, later successful sync responses can save a checkpoint."""
+        _save_certified_sync_token(bot, "s_before_failure")
         bot._runtime_view.mark_runtime_started()
         bot._restore_saved_sync_token()
         bot._first_sync_done = True
@@ -2011,7 +1997,6 @@ class TestThreadingBehavior:
         ):
             await self._run_sync_response_without_startup_side_effects(bot, self._sync_response({}))
 
-        failed_boundary = bot._runtime_view.thread_cache_read_boundary
         assert load_sync_token(bot.storage_path, bot.agent_name) is None
 
         bot.client.next_batch = "s_after_recovery"
@@ -2025,12 +2010,12 @@ class TestThreadingBehavior:
         token_record = load_sync_token_record(bot.storage_path, bot.agent_name)
         assert token_record is not None
         assert token_record.token == "s_after_recovery"  # noqa: S105
-        assert token_record.thread_cache_valid_after == failed_boundary
+        assert token_record.checkpoint == SyncCheckpoint("s_after_recovery")
 
     @pytest.mark.asyncio
     async def test_empty_joined_rooms_first_sync_certifies_checkpoint(self, bot: AgentBot) -> None:
         """A non-limited empty sync response can certify that there were no room deltas."""
-        _save_certified_sync_token(bot, "s_before_empty", thread_cache_valid_after=1.0)
+        _save_certified_sync_token(bot, "s_before_empty")
         bot._runtime_view.mark_runtime_started()
         bot._restore_saved_sync_token()
         bot.client.next_batch = "s_after_empty"
@@ -2040,7 +2025,7 @@ class TestThreadingBehavior:
         token_record = load_sync_token_record(bot.storage_path, bot.agent_name)
         assert token_record is not None
         assert token_record.token == "s_after_empty"  # noqa: S105
-        assert token_record.thread_cache_valid_after == 1.0
+        assert token_record.checkpoint == SyncCheckpoint("s_after_empty")
 
     @pytest.mark.asyncio
     async def test_sync_error_keeps_watchdog_clock_on_latest_activity(self, bot: AgentBot) -> None:
@@ -5321,11 +5306,11 @@ class TestThreadingBehavior:
         assert [event["event_id"] for event in cached_history] == [thread_id, "$reply_new:localhost"]
 
     @pytest.mark.asyncio
-    async def test_prewarm_started_before_trust_revocation_does_not_seed_fresh_cache(
+    async def test_prewarm_result_remains_reusable_after_restart(
         self,
         bot: AgentBot,
     ) -> None:
-        """A prewarm fetch that began before trust revocation must not look fresh afterward."""
+        """A prewarm fetch should stay usable unless an explicit stale marker exists."""
         support = await _bind_owned_runtime_support(bot)
         room_id = "!test:localhost"
         thread_id = "$thread_root:localhost"
@@ -5388,7 +5373,6 @@ class TestThreadingBehavior:
             )
             await asyncio.wait_for(prewarm_fetch_started.wait(), timeout=1.0)
 
-            bot._runtime_view.thread_cache_read_boundary = time.time()
             allow_prewarm_fetch_finish.set()
             prewarm_history = await asyncio.wait_for(prewarm_task, timeout=1.0)
 
@@ -5398,17 +5382,17 @@ class TestThreadingBehavior:
             await _close_bound_runtime_support(bot, support)
 
         assert [message.body for message in prewarm_history] == ["Old root", "Old reply"]
-        assert [message.body for message in history] == ["Fresh root", "Fresh reply"]
-        assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_HOMESERVER
-        assert history.diagnostics[THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC] == "validated_before_runtime_start"
-        assert bot.client.room_messages.await_count == 2
+        assert [message.body for message in history] == ["Old root", "Old reply"]
+        assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_CACHE
+        assert THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC not in history.diagnostics
+        bot.client.room_messages.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_dispatch_refill_started_before_trust_revocation_does_not_seed_fresh_cache(
+    async def test_dispatch_refill_result_remains_reusable_after_restart(
         self,
         bot: AgentBot,
     ) -> None:
-        """A normal dispatch refill that began before revocation must not seed a fresh row."""
+        """A normal dispatch refill should stay usable unless an explicit stale marker exists."""
         support = await _bind_owned_runtime_support(bot)
         room_id = "!test:localhost"
         thread_id = "$thread_root:localhost"
@@ -5468,7 +5452,6 @@ class TestThreadingBehavior:
             )
             await asyncio.wait_for(dispatch_fetch_started.wait(), timeout=1.0)
 
-            bot._runtime_view.thread_cache_read_boundary = time.time()
             allow_dispatch_fetch_finish.set()
             dispatch_history = await asyncio.wait_for(dispatch_task, timeout=1.0)
 
@@ -5478,17 +5461,17 @@ class TestThreadingBehavior:
             await _close_bound_runtime_support(bot, support)
 
         assert [message.body for message in dispatch_history] == ["Old root", "Old reply"]
-        assert [message.body for message in history] == ["Fresh root", "Fresh reply"]
-        assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_HOMESERVER
-        assert history.diagnostics[THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC] == "validated_before_runtime_start"
-        assert bot.client.room_messages.await_count == 2
+        assert [message.body for message in history] == ["Old root", "Old reply"]
+        assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_CACHE
+        assert THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC not in history.diagnostics
+        bot.client.room_messages.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_guarded_refill_commit_after_trust_revocation_does_not_look_fresh(
+    async def test_guarded_refill_commit_remains_reusable_after_restart(
         self,
         bot: AgentBot,
     ) -> None:
-        """A guarded replacement that commits after revocation must still be rejected by strict reads."""
+        """A guarded replacement should stay usable unless an explicit stale marker exists."""
         support = await _bind_owned_runtime_support(bot)
         room_id = "!test:localhost"
         thread_id = "$thread_root:localhost"
@@ -5543,7 +5526,6 @@ class TestThreadingBehavior:
                 )
                 await asyncio.wait_for(write_entered.wait(), timeout=1.0)
 
-                bot._runtime_view.thread_cache_read_boundary = time.time()
                 allow_write_commit.set()
                 replaced = await asyncio.wait_for(write_task, timeout=1.0)
 
@@ -5558,10 +5540,10 @@ class TestThreadingBehavior:
             await _close_bound_runtime_support(bot, support)
 
         assert replaced is True
-        assert [message.body for message in history] == ["Fresh root", "Fresh reply"]
-        assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_HOMESERVER
-        assert history.diagnostics[THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC] == "validated_before_runtime_start"
-        bot.client.room_messages.assert_awaited_once()
+        assert [message.body for message in history] == ["Old root", "Old reply"]
+        assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_CACHE
+        assert THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC not in history.diagnostics
+        bot.client.room_messages.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_lookup_miss_sync_plain_edit_invalidates_room_cache_state(
@@ -6128,13 +6110,7 @@ class TestThreadingBehavior:
         assert thread_state.validated_at is not None
         assert thread_state.room_invalidated_at is not None
         assert thread_state.room_invalidated_at > thread_state.validated_at
-        assert (
-            matrix_cache.thread_cache_rejection_reason(
-                thread_state,
-                runtime_started_at=access.runtime.runtime_started_at,
-            )
-            is not None
-        )
+        assert matrix_cache.thread_cache_rejection_reason(thread_state) is not None
         client.room_messages.assert_awaited_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Cherry-picks bb4482ecb onto GitHub main as a single-commit PR.
- Trusts synchronized Matrix thread caches across process restarts instead of rejecting them by runtime age alone.
- Updates Matrix thread cache and sync certification tests for restart cache reuse behavior.

## Test Plan
- [x] uv sync --all-extras
- [x] git --no-pager diff --check origin/main
- [x] uv run pytest tests/test_matrix_cache_agent_message_snapshot.py tests/test_matrix_sync_tokens.py tests/test_multi_agent_bot.py tests/test_sync_certification.py tests/test_thread_history.py tests/test_thread_mode.py tests/test_threading_error.py -n 0 --no-cov -v
- [x] uv run pytest --no-cov
- [x] uv run pre-commit run --all-files