### PR TITLE
feat: agent-editable workspace env hook for worker-routed tools (ISSUE-208)

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -343,6 +343,10 @@ Isolation depends on the worker backend:
 
 Use `user_agent` if you need per-agent filesystem isolation.
 
+For per-workspace env that an agent can edit (PATH, npm/pip cache locations, etc.), drop a `.mindroom/worker-env.sh` script in the agent workspace; MindRoom sources it before each worker-routed `shell`, `python`, `coding`, or `file` request.
+With `worker_scope: user`, the same runtime can move between several agent workspaces, and the hook is discovered from the current request's workspace — different agents get different overlays automatically.
+See [Workspace env hook](../deployment/sandbox-proxy.md#workspace-env-hook-mindroomworker-envsh) for filename, filtering, and failure semantics.
+
 ### Where Agent Data Lives
 
 Agents without `private` store all their data in one canonical directory: `agents/<name>/` (context files, workspace, memory, sessions, learning).

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -116,6 +116,7 @@ Important behavior and constraints:
 - `google_vertex_adc` is intentionally unsupported for dedicated workers because workers do not receive ADC files or `GOOGLE_APPLICATION_CREDENTIALS`; keep Vertex ADC usage in the primary runtime.
 - Dedicated worker runtime env stays deny-by-default for provider and arbitrary `.env` values, while basic runtime plumbing such as `PATH`, `VIRTUAL_ENV`, and linker vars is set separately.
 - This matches the broader sandbox-proxy contract for `python` and `shell`: proxied execution is intentionally stricter than direct local execution and does not inherit ordinary runtime `.env` or provider env by default.
+- For agent-editable per-workspace env (extra PATH entries, npm/pip cache dirs, etc.), use the request-time `.mindroom/worker-env.sh` overlay documented in [Sandbox Proxy Isolation](sandbox-proxy.md#workspace-env-hook-mindroomworker-envsh). The overlay is sourced inside the running worker per request, so it does not change the worker Deployment, the startup manifest, the pod-template hash, or any Helm value, and does not require a worker restart when edited.
 - Worker-local caches may still live under `kubernetesWorkerStorageSubpathPrefix/<worker-dir>/`.
 
 ### Storage Requirements

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -286,7 +286,7 @@ The overlay reuses the same secret rules that protect `extra_env_passthrough`:
 
 **Limits and failure handling:**
 
-- Script ≤ 64 KiB; total overlay ≤ 128 KiB; per-value ≤ 32 KiB.
+- Script ≤ 64 KiB; stdout and stderr capture each ≤ 256 KiB; total overlay ≤ 128 KiB; per-value ≤ 32 KiB.
 - Hook execution times out after 10 seconds.
 - Symlinks that escape the workspace are rejected.
 - Any failure (non-zero exit, timeout, escape, missing `bash`) returns the tool call as `ok: false` with `failure_kind: "tool"` and an error mentioning `.mindroom/worker-env.sh`.

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -266,6 +266,7 @@ The runner sources this script with `bash` before each worker-routed `shell`, `p
 - For shared and unscoped agents that means `agents/<agent>/workspace/.mindroom/worker-env.sh`.
 - For private agents that means `private_instances/<scope>/<agent>/workspace/.mindroom/worker-env.sh`.
 - For `worker_scope: user`, the hook follows the per-request workspace, so one shared user runtime can pick up different hooks as it works in different agent workspaces.
+- For unkeyed static-sidecar proxy calls (no `worker_key`), the hook is discovered from `tool_init_overrides["base_dir"]` only when that value is an absolute path; relative strings are ignored on this path because there is no canonical workspace root to resolve them against.
 
 **Semantics:**
 

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -254,6 +254,47 @@ Use `check_shell_command(handle)` to poll and `kill_shell_command(handle)` to st
 These handles are process-local to the sandbox runner: they survive multiple requests to the same runner process, but not runner restarts.
 To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE=subprocess`.
 
+## Workspace env hook (`.mindroom/worker-env.sh`)
+
+Agents can drop a shell script at `<workspace>/.mindroom/worker-env.sh` to set custom env for worker-routed tool calls without changing config or redeploying.
+
+The runner sources this script with `bash` before each worker-routed `shell`, `python`, `coding`, or `file` request, then merges its exported env into the tool's execution environment.
+
+**Discovery:**
+
+- The hook lives at `<base_dir>/.mindroom/worker-env.sh` where `<base_dir>` is the resolved tool workspace.
+- For shared and unscoped agents that means `agents/<agent>/workspace/.mindroom/worker-env.sh`.
+- For private agents that means `private_instances/<scope>/<agent>/workspace/.mindroom/worker-env.sh`.
+- For `worker_scope: user`, the hook follows the per-request workspace, so one shared user runtime can pick up different hooks as it works in different agent workspaces.
+
+**Semantics:**
+
+- Edits take effect on the next worker-routed tool call. No pod restart, no config reload, no Helm change.
+- The script must `export FOO=bar` for values to overlay; bare `FOO=bar` does not persist (no `set -a`).
+- Filesystem side effects inside the worker sandbox are allowed because the hook is arbitrary agent-editable shell.
+- Shell aliases, functions, and `cd` do not persist — only exported env crosses the boundary.
+
+**Filtering:**
+
+The overlay reuses the same secret rules that protect `extra_env_passthrough`:
+
+- Names ending in `_API_KEY`, `_API_KEYS`, `_PASSWORD`, or `_SECRET` are dropped.
+- Runner control names (`MINDROOM_SANDBOX_*`, `MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) are dropped.
+- `CI_JOB_TOKEN` and bash bookkeeping (`PWD`, `OLDPWD`, `SHLVL`, `_`, `PIPESTATUS`) are dropped.
+- Non-secret service tokens such as `GITEA_TOKEN` are kept.
+
+**Limits and failure handling:**
+
+- Script ≤ 64 KiB; total overlay ≤ 128 KiB; per-value ≤ 32 KiB.
+- Hook execution times out after 10 seconds.
+- Symlinks that escape the workspace are rejected.
+- Any failure (non-zero exit, timeout, escape, missing `bash`) returns the tool call as `ok: false` with `failure_kind: "tool"` and an error mentioning `.mindroom/worker-env.sh`.
+- Hook failures do not poison the worker; only the requesting tool call fails.
+
+This hook works identically for the static sidecar and dedicated Kubernetes worker backends because it runs inside the sandbox runner per request.
+It is not a true container startup hook — it does not change pod templates, recreate Deployments, or alter Helm values.
+For an example, see `docs/tools/execution-and-coding.md`.
+
 ## Credential leases
 
 Some proxied tools need credentials (e.g., a `shell` tool that runs `git push` and needs an SSH key). Rather than giving the runner permanent access to secrets, the primary MindRoom runtime creates a **credential lease** — a short-lived, single-use token that the runner exchanges for credentials during execution.

--- a/docs/tools/execution-and-coding.md
+++ b/docs/tools/execution-and-coding.md
@@ -181,6 +181,16 @@ kill_shell_command("shell:abcd1234")
 - In authored YAML, `extra_env_passthrough` and `shell_path_prepend` can be written as lists, and MindRoom normalizes them to the tool's comma-or-newline form.
 - Background handles survive multiple requests to the same long-lived runner process, but they do not survive runner restarts.
 - `shell_path_prepend` deduplicates PATH entries and only changes subprocess PATH, not the main MindRoom process PATH.
+- For per-workspace env that an agent can edit on the fly (PATH prefixes, `NPM_CONFIG_PREFIX`, `PIP_INDEX_URL`, etc.), drop a `.mindroom/worker-env.sh` script in the workspace and `export` the values you want — see "Workspace env hook" in `docs/deployment/sandbox-proxy.md`. Example:
+
+```bash
+mkdir -p .mindroom .local/bin .cache/npm
+cat > .mindroom/worker-env.sh <<'EOF'
+export NPM_CONFIG_PREFIX="$PWD/.local"
+export NPM_CONFIG_CACHE="$PWD/.cache/npm"
+export PATH="$PWD/.local/bin:$PATH"
+EOF
+```
 
 ## [`python`]
 
@@ -227,6 +237,7 @@ list_files()
 - `restrict_to_base_dir` only constrains the file helper paths, not what arbitrary Python code can do once executed.
 - `safe_globals` and `safe_locals` are exposed directly from the upstream constructor and are mainly useful for advanced programmatic wiring, not typical hand-written YAML.
 - If you need runtime-scoped environment isolation, rely on worker-routed execution instead of assuming in-process Python emulation is a security boundary.
+- Worker-routed `python` execution also receives `.mindroom/worker-env.sh` overlay env via `os.environ` (e.g., `PIP_INDEX_URL`, `UV_CACHE_DIR`). Worker-routed `coding` and `file` subprocesses receive the same overlay as process env, though their documented behavior is file operations rather than env inspection. See "Workspace env hook" in `docs/deployment/sandbox-proxy.md`.
 
 ## [`coding`]
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12064,6 +12064,7 @@ The runner sources this script with `bash` before each worker-routed `shell`, `p
 - For shared and unscoped agents that means `agents/<agent>/workspace/.mindroom/worker-env.sh`.
 - For private agents that means `private_instances/<scope>/<agent>/workspace/.mindroom/worker-env.sh`.
 - For `worker_scope: user`, the hook follows the per-request workspace, so one shared user runtime can pick up different hooks as it works in different agent workspaces.
+- For unkeyed static-sidecar proxy calls (no `worker_key`), the hook is discovered from `tool_init_overrides["base_dir"]` only when that value is an absolute path; relative strings are ignored on this path because there is no canonical workspace root to resolve them against.
 
 **Semantics:**
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12084,7 +12084,7 @@ The overlay reuses the same secret rules that protect `extra_env_passthrough`:
 
 **Limits and failure handling:**
 
-- Script ≤ 64 KiB; total overlay ≤ 128 KiB; per-value ≤ 32 KiB.
+- Script ≤ 64 KiB; stdout and stderr capture each ≤ 256 KiB; total overlay ≤ 128 KiB; per-value ≤ 32 KiB.
 - Hook execution times out after 10 seconds.
 - Symlinks that escape the workspace are rejected.
 - Any failure (non-zero exit, timeout, escape, missing `bash`) returns the tool call as `ok: false` with `failure_kind: "tool"` and an error mentioning `.mindroom/worker-env.sh`.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1518,6 +1518,8 @@ Isolation depends on the worker backend:
 
 Use `user_agent` if you need per-agent filesystem isolation.
 
+For per-workspace env that an agent can edit (PATH, npm/pip cache locations, etc.), drop a `.mindroom/worker-env.sh` script in the agent workspace; MindRoom sources it before each worker-routed `shell`, `python`, `coding`, or `file` request. With `worker_scope: user`, the same runtime can move between several agent workspaces, and the hook is discovered from the current request's workspace — different agents get different overlays automatically. See [Workspace env hook](https://docs.mindroom.chat/deployment/sandbox-proxy/#workspace-env-hook-mindroomworker-envsh) for filename, filtering, and failure semantics.
+
 ### Where Agent Data Lives
 
 Agents without `private` store all their data in one canonical directory: `agents/<name>/` (context files, workspace, memory, sessions, learning). Changing `worker_scope` changes how tool runtimes are isolated. It does **not** change where that non-private agent's data lives. All runtimes for the same non-private agent read and write the same storage directory. If multiple runtimes run concurrently, files and databases in that directory must tolerate concurrent access. Agents that use `private` are different. They materialize one canonical state root per requester-scoped private instance under `private_instances/<scope-key>/<agent>/`. Workers mount those canonical private-instance roots. They do not own them.
@@ -2478,6 +2480,16 @@ kill_shell_command("shell:abcd1234")
 - In authored YAML, `extra_env_passthrough` and `shell_path_prepend` can be written as lists, and MindRoom normalizes them to the tool's comma-or-newline form.
 - Background handles survive multiple requests to the same long-lived runner process, but they do not survive runner restarts.
 - `shell_path_prepend` deduplicates PATH entries and only changes subprocess PATH, not the main MindRoom process PATH.
+- For per-workspace env that an agent can edit on the fly (PATH prefixes, `NPM_CONFIG_PREFIX`, `PIP_INDEX_URL`, etc.), drop a `.mindroom/worker-env.sh` script in the workspace and `export` the values you want — see "Workspace env hook" in `docs/deployment/sandbox-proxy.md`. Example:
+
+```
+mkdir -p .mindroom .local/bin .cache/npm
+cat > .mindroom/worker-env.sh <<'EOF'
+export NPM_CONFIG_PREFIX="$PWD/.local"
+export NPM_CONFIG_CACHE="$PWD/.cache/npm"
+export PATH="$PWD/.local/bin:$PATH"
+EOF
+```
 
 ## \[`python`\]
 
@@ -2520,6 +2532,7 @@ list_files()
 - `restrict_to_base_dir` only constrains the file helper paths, not what arbitrary Python code can do once executed.
 - `safe_globals` and `safe_locals` are exposed directly from the upstream constructor and are mainly useful for advanced programmatic wiring, not typical hand-written YAML.
 - If you need runtime-scoped environment isolation, rely on worker-routed execution instead of assuming in-process Python emulation is a security boundary.
+- Worker-routed `python` execution also receives `.mindroom/worker-env.sh` overlay env via `os.environ` (e.g., `PIP_INDEX_URL`, `UV_CACHE_DIR`). Worker-routed `coding` and `file` subprocesses receive the same overlay as process env, though their documented behavior is file operations rather than env inspection. See "Workspace env hook" in `docs/deployment/sandbox-proxy.md`.
 
 ## \[`coding`\]
 
@@ -12039,6 +12052,45 @@ If proxied shell commands need extra PATH entries such as wrapper directories, c
 
 Shell commands that exceed their timeout return a background handle. Use `check_shell_command(handle)` to poll and `kill_shell_command(handle)` to stop the process. These handles are process-local to the sandbox runner: they survive multiple requests to the same runner process, but not runner restarts. To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE=subprocess`.
 
+## Workspace env hook (`.mindroom/worker-env.sh`)
+
+Agents can drop a shell script at `<workspace>/.mindroom/worker-env.sh` to set custom env for worker-routed tool calls without changing config or redeploying.
+
+The runner sources this script with `bash` before each worker-routed `shell`, `python`, `coding`, or `file` request, then merges its exported env into the tool's execution environment.
+
+**Discovery:**
+
+- The hook lives at `<base_dir>/.mindroom/worker-env.sh` where `<base_dir>` is the resolved tool workspace.
+- For shared and unscoped agents that means `agents/<agent>/workspace/.mindroom/worker-env.sh`.
+- For private agents that means `private_instances/<scope>/<agent>/workspace/.mindroom/worker-env.sh`.
+- For `worker_scope: user`, the hook follows the per-request workspace, so one shared user runtime can pick up different hooks as it works in different agent workspaces.
+
+**Semantics:**
+
+- Edits take effect on the next worker-routed tool call. No pod restart, no config reload, no Helm change.
+- The script must `export FOO=bar` for values to overlay; bare `FOO=bar` does not persist (no `set -a`).
+- Filesystem side effects inside the worker sandbox are allowed because the hook is arbitrary agent-editable shell.
+- Shell aliases, functions, and `cd` do not persist — only exported env crosses the boundary.
+
+**Filtering:**
+
+The overlay reuses the same secret rules that protect `extra_env_passthrough`:
+
+- Names ending in `_API_KEY`, `_API_KEYS`, `_PASSWORD`, or `_SECRET` are dropped.
+- Runner control names (`MINDROOM_SANDBOX_*`, `MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) are dropped.
+- `CI_JOB_TOKEN` and bash bookkeeping (`PWD`, `OLDPWD`, `SHLVL`, `_`, `PIPESTATUS`) are dropped.
+- Non-secret service tokens such as `GITEA_TOKEN` are kept.
+
+**Limits and failure handling:**
+
+- Script ≤ 64 KiB; total overlay ≤ 128 KiB; per-value ≤ 32 KiB.
+- Hook execution times out after 10 seconds.
+- Symlinks that escape the workspace are rejected.
+- Any failure (non-zero exit, timeout, escape, missing `bash`) returns the tool call as `ok: false` with `failure_kind: "tool"` and an error mentioning `.mindroom/worker-env.sh`.
+- Hook failures do not poison the worker; only the requesting tool call fails.
+
+This hook works identically for the static sidecar and dedicated Kubernetes worker backends because it runs inside the sandbox runner per request. It is not a true container startup hook — it does not change pod templates, recreate Deployments, or alter Helm values. For an example, see `docs/tools/execution-and-coding.md`.
+
 ## Credential leases
 
 Some proxied tools need credentials (e.g., a `shell` tool that runs `git push` and needs an SSH key). Rather than giving the runner permanent access to secrets, the primary MindRoom runtime creates a **credential lease** — a short-lived, single-use token that the runner exchanges for credentials during execution.
@@ -12254,6 +12306,7 @@ Important behavior and constraints:
 - `google_vertex_adc` is intentionally unsupported for dedicated workers because workers do not receive ADC files or `GOOGLE_APPLICATION_CREDENTIALS`; keep Vertex ADC usage in the primary runtime.
 - Dedicated worker runtime env stays deny-by-default for provider and arbitrary `.env` values, while basic runtime plumbing such as `PATH`, `VIRTUAL_ENV`, and linker vars is set separately.
 - This matches the broader sandbox-proxy contract for `python` and `shell`: proxied execution is intentionally stricter than direct local execution and does not inherit ordinary runtime `.env` or provider env by default.
+- For agent-editable per-workspace env (extra PATH entries, npm/pip cache dirs, etc.), use the request-time `.mindroom/worker-env.sh` overlay documented in [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/#workspace-env-hook-mindroomworker-envsh). The overlay is sourced inside the running worker per request, so it does not change the worker Deployment, the startup manifest, the pod-template hash, or any Helm value, and does not require a worker restart when edited.
 - Worker-local caches may still live under `kubernetesWorkerStorageSubpathPrefix/<worker-dir>/`.
 
 ### Storage Requirements

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -306,6 +306,8 @@ Isolation depends on the worker backend:
 
 Use `user_agent` if you need per-agent filesystem isolation.
 
+For per-workspace env that an agent can edit (PATH, npm/pip cache locations, etc.), drop a `.mindroom/worker-env.sh` script in the agent workspace; MindRoom sources it before each worker-routed `shell`, `python`, `coding`, or `file` request. With `worker_scope: user`, the same runtime can move between several agent workspaces, and the hook is discovered from the current request's workspace — different agents get different overlays automatically. See [Workspace env hook](https://docs.mindroom.chat/deployment/sandbox-proxy/#workspace-env-hook-mindroomworker-envsh) for filename, filtering, and failure semantics.
+
 ### Where Agent Data Lives
 
 Agents without `private` store all their data in one canonical directory: `agents/<name>/` (context files, workspace, memory, sessions, learning). Changing `worker_scope` changes how tool runtimes are isolated. It does **not** change where that non-private agent's data lives. All runtimes for the same non-private agent read and write the same storage directory. If multiple runtimes run concurrently, files and databases in that directory must tolerate concurrent access. Agents that use `private` are different. They materialize one canonical state root per requester-scoped private instance under `private_instances/<scope-key>/<agent>/`. Workers mount those canonical private-instance roots. They do not own them.

--- a/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
+++ b/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
@@ -99,6 +99,7 @@ Important behavior and constraints:
 - `google_vertex_adc` is intentionally unsupported for dedicated workers because workers do not receive ADC files or `GOOGLE_APPLICATION_CREDENTIALS`; keep Vertex ADC usage in the primary runtime.
 - Dedicated worker runtime env stays deny-by-default for provider and arbitrary `.env` values, while basic runtime plumbing such as `PATH`, `VIRTUAL_ENV`, and linker vars is set separately.
 - This matches the broader sandbox-proxy contract for `python` and `shell`: proxied execution is intentionally stricter than direct local execution and does not inherit ordinary runtime `.env` or provider env by default.
+- For agent-editable per-workspace env (extra PATH entries, npm/pip cache dirs, etc.), use the request-time `.mindroom/worker-env.sh` overlay documented in [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/#workspace-env-hook-mindroomworker-envsh). The overlay is sourced inside the running worker per request, so it does not change the worker Deployment, the startup manifest, the pod-template hash, or any Helm value, and does not require a worker restart when edited.
 - Worker-local caches may still live under `kubernetesWorkerStorageSubpathPrefix/<worker-dir>/`.
 
 ### Storage Requirements

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -234,7 +234,7 @@ The overlay reuses the same secret rules that protect `extra_env_passthrough`:
 
 **Limits and failure handling:**
 
-- Script ≤ 64 KiB; total overlay ≤ 128 KiB; per-value ≤ 32 KiB.
+- Script ≤ 64 KiB; stdout and stderr capture each ≤ 256 KiB; total overlay ≤ 128 KiB; per-value ≤ 32 KiB.
 - Hook execution times out after 10 seconds.
 - Symlinks that escape the workspace are rejected.
 - Any failure (non-zero exit, timeout, escape, missing `bash`) returns the tool call as `ok: false` with `failure_kind: "tool"` and an error mentioning `.mindroom/worker-env.sh`.

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -202,6 +202,45 @@ If proxied shell commands need extra PATH entries such as wrapper directories, c
 
 Shell commands that exceed their timeout return a background handle. Use `check_shell_command(handle)` to poll and `kill_shell_command(handle)` to stop the process. These handles are process-local to the sandbox runner: they survive multiple requests to the same runner process, but not runner restarts. To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE=subprocess`.
 
+## Workspace env hook (`.mindroom/worker-env.sh`)
+
+Agents can drop a shell script at `<workspace>/.mindroom/worker-env.sh` to set custom env for worker-routed tool calls without changing config or redeploying.
+
+The runner sources this script with `bash` before each worker-routed `shell`, `python`, `coding`, or `file` request, then merges its exported env into the tool's execution environment.
+
+**Discovery:**
+
+- The hook lives at `<base_dir>/.mindroom/worker-env.sh` where `<base_dir>` is the resolved tool workspace.
+- For shared and unscoped agents that means `agents/<agent>/workspace/.mindroom/worker-env.sh`.
+- For private agents that means `private_instances/<scope>/<agent>/workspace/.mindroom/worker-env.sh`.
+- For `worker_scope: user`, the hook follows the per-request workspace, so one shared user runtime can pick up different hooks as it works in different agent workspaces.
+
+**Semantics:**
+
+- Edits take effect on the next worker-routed tool call. No pod restart, no config reload, no Helm change.
+- The script must `export FOO=bar` for values to overlay; bare `FOO=bar` does not persist (no `set -a`).
+- Filesystem side effects inside the worker sandbox are allowed because the hook is arbitrary agent-editable shell.
+- Shell aliases, functions, and `cd` do not persist — only exported env crosses the boundary.
+
+**Filtering:**
+
+The overlay reuses the same secret rules that protect `extra_env_passthrough`:
+
+- Names ending in `_API_KEY`, `_API_KEYS`, `_PASSWORD`, or `_SECRET` are dropped.
+- Runner control names (`MINDROOM_SANDBOX_*`, `MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) are dropped.
+- `CI_JOB_TOKEN` and bash bookkeeping (`PWD`, `OLDPWD`, `SHLVL`, `_`, `PIPESTATUS`) are dropped.
+- Non-secret service tokens such as `GITEA_TOKEN` are kept.
+
+**Limits and failure handling:**
+
+- Script ≤ 64 KiB; total overlay ≤ 128 KiB; per-value ≤ 32 KiB.
+- Hook execution times out after 10 seconds.
+- Symlinks that escape the workspace are rejected.
+- Any failure (non-zero exit, timeout, escape, missing `bash`) returns the tool call as `ok: false` with `failure_kind: "tool"` and an error mentioning `.mindroom/worker-env.sh`.
+- Hook failures do not poison the worker; only the requesting tool call fails.
+
+This hook works identically for the static sidecar and dedicated Kubernetes worker backends because it runs inside the sandbox runner per request. It is not a true container startup hook — it does not change pod templates, recreate Deployments, or alter Helm values. For an example, see `docs/tools/execution-and-coding.md`.
+
 ## Credential leases
 
 Some proxied tools need credentials (e.g., a `shell` tool that runs `git push` and needs an SSH key). Rather than giving the runner permanent access to secrets, the primary MindRoom runtime creates a **credential lease** — a short-lived, single-use token that the runner exchanges for credentials during execution.

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -214,6 +214,7 @@ The runner sources this script with `bash` before each worker-routed `shell`, `p
 - For shared and unscoped agents that means `agents/<agent>/workspace/.mindroom/worker-env.sh`.
 - For private agents that means `private_instances/<scope>/<agent>/workspace/.mindroom/worker-env.sh`.
 - For `worker_scope: user`, the hook follows the per-request workspace, so one shared user runtime can pick up different hooks as it works in different agent workspaces.
+- For unkeyed static-sidecar proxy calls (no `worker_key`), the hook is discovered from `tool_init_overrides["base_dir"]` only when that value is an absolute path; relative strings are ignored on this path because there is no canonical workspace root to resolve them against.
 
 **Semantics:**
 

--- a/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
+++ b/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
@@ -150,6 +150,16 @@ kill_shell_command("shell:abcd1234")
 - In authored YAML, `extra_env_passthrough` and `shell_path_prepend` can be written as lists, and MindRoom normalizes them to the tool's comma-or-newline form.
 - Background handles survive multiple requests to the same long-lived runner process, but they do not survive runner restarts.
 - `shell_path_prepend` deduplicates PATH entries and only changes subprocess PATH, not the main MindRoom process PATH.
+- For per-workspace env that an agent can edit on the fly (PATH prefixes, `NPM_CONFIG_PREFIX`, `PIP_INDEX_URL`, etc.), drop a `.mindroom/worker-env.sh` script in the workspace and `export` the values you want — see "Workspace env hook" in `docs/deployment/sandbox-proxy.md`. Example:
+
+```
+mkdir -p .mindroom .local/bin .cache/npm
+cat > .mindroom/worker-env.sh <<'EOF'
+export NPM_CONFIG_PREFIX="$PWD/.local"
+export NPM_CONFIG_CACHE="$PWD/.cache/npm"
+export PATH="$PWD/.local/bin:$PATH"
+EOF
+```
 
 ## \[`python`\]
 
@@ -192,6 +202,7 @@ list_files()
 - `restrict_to_base_dir` only constrains the file helper paths, not what arbitrary Python code can do once executed.
 - `safe_globals` and `safe_locals` are exposed directly from the upstream constructor and are mainly useful for advanced programmatic wiring, not typical hand-written YAML.
 - If you need runtime-scoped environment isolation, rely on worker-routed execution instead of assuming in-process Python emulation is a security boundary.
+- Worker-routed `python` execution also receives `.mindroom/worker-env.sh` overlay env via `os.environ` (e.g., `PIP_INDEX_URL`, `UV_CACHE_DIR`). Worker-routed `coding` and `file` subprocesses receive the same overlay as process env, though their documented behavior is file operations rather than env inspection. See "Workspace env hook" in `docs/deployment/sandbox-proxy.md`.
 
 ## \[`coding`\]
 

--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import os
 import secrets
+import selectors
 import shutil
 import signal
 import site
 import subprocess
 import sys
+import time
 from contextlib import suppress
 from pathlib import Path
 from types import MappingProxyType
@@ -287,6 +289,15 @@ class WorkspaceEnvHookError(RuntimeError):
     """One `.mindroom/worker-env.sh` request failed sourcing or validation."""
 
 
+class _WorkspaceEnvHookOutputLimitError(RuntimeError):
+    """Raised when hook stdout or stderr exceeds the capture cap."""
+
+    def __init__(self, stream_name: str, size: int) -> None:
+        super().__init__(stream_name, size)
+        self.stream_name = stream_name
+        self.size = size
+
+
 def resolve_workspace_env_hook_path(base_dir: Path | str | None) -> Path | None:
     """Resolve the workspace env hook for one effective base_dir, if any.
 
@@ -356,19 +367,28 @@ def source_workspace_env_hook(
     try:
         process = subprocess.Popen(
             [bash_path, "-c", bash_script, "bash", str(hook_path), capture_marker],
-            stdin=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=str(cwd),
             env=dict(base_env),
             start_new_session=True,
         )
-        stdout, stderr = process.communicate(input=b"", timeout=WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS)
+        stdout, stderr = _capture_workspace_env_hook_output(process)
     except subprocess.TimeoutExpired as exc:
         _kill_workspace_env_hook_process_group(process)
         with suppress(OSError, subprocess.TimeoutExpired):
             process.wait(timeout=1.0)
         msg = f".mindroom/worker-env.sh timed out after {WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS} seconds."
+        raise WorkspaceEnvHookError(msg) from exc
+    except _WorkspaceEnvHookOutputLimitError as exc:
+        _kill_workspace_env_hook_process_group(process)
+        with suppress(OSError, subprocess.TimeoutExpired):
+            process.wait(timeout=1.0)
+        msg = (
+            f".mindroom/worker-env.sh produced too much {exc.stream_name} output "
+            f"({exc.size} bytes; limit {_WORKSPACE_ENV_HOOK_MAX_OUTPUT_BYTES})."
+        )
         raise WorkspaceEnvHookError(msg) from exc
     except OSError as exc:
         msg = f"Failed to start bash for .mindroom/worker-env.sh: {exc}"
@@ -377,12 +397,6 @@ def source_workspace_env_hook(
         excerpt = (stderr or stdout or b"").decode(errors="replace")[:512].strip()
         suffix = f" output: {excerpt}" if excerpt else ""
         msg = f".mindroom/worker-env.sh exited with code {process.returncode}.{suffix}"
-        raise WorkspaceEnvHookError(msg)
-    if len(stdout) > _WORKSPACE_ENV_HOOK_MAX_OUTPUT_BYTES:
-        msg = (
-            f".mindroom/worker-env.sh produced {len(stdout)} bytes of "
-            f"capture output (limit {_WORKSPACE_ENV_HOOK_MAX_OUTPUT_BYTES})."
-        )
         raise WorkspaceEnvHookError(msg)
     return _parse_workspace_env_hook_output(
         stdout,
@@ -394,6 +408,58 @@ def source_workspace_env_hook(
 def _kill_workspace_env_hook_process_group(process: subprocess.Popen[bytes]) -> None:
     with suppress(OSError):
         os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+
+
+def _capture_workspace_env_hook_output(process: subprocess.Popen[bytes]) -> tuple[bytes, bytes]:
+    selector = selectors.DefaultSelector()
+    buffers = {
+        "stdout": bytearray(),
+        "stderr": bytearray(),
+    }
+    for stream_name, pipe in (("stdout", process.stdout), ("stderr", process.stderr)):
+        if pipe is None:
+            continue
+        fd = pipe.fileno()
+        os.set_blocking(fd, False)
+        selector.register(fd, selectors.EVENT_READ, stream_name)
+
+    deadline = time.monotonic() + WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS
+    try:
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise subprocess.TimeoutExpired(cmd="bash", timeout=WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS)
+            events = selector.select(remaining)
+            if not events:
+                if process.poll() is not None:
+                    break
+                raise subprocess.TimeoutExpired(cmd="bash", timeout=WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS)
+            for key, _mask in events:
+                _read_workspace_env_hook_event(key, selector, buffers)
+
+        remaining = max(0.0, deadline - time.monotonic())
+        process.wait(timeout=remaining)
+    finally:
+        selector.close()
+    return bytes(buffers["stdout"]), bytes(buffers["stderr"])
+
+
+def _read_workspace_env_hook_event(
+    key: selectors.SelectorKey,
+    selector: selectors.BaseSelector,
+    buffers: dict[str, bytearray],
+) -> None:
+    stream_name = str(key.data)
+    try:
+        chunk = os.read(key.fd, 8192)
+    except BlockingIOError:
+        return
+    if not chunk:
+        selector.unregister(key.fd)
+        return
+    buffers[stream_name].extend(chunk)
+    if len(buffers[stream_name]) > _WORKSPACE_ENV_HOOK_MAX_OUTPUT_BYTES:
+        raise _WorkspaceEnvHookOutputLimitError(stream_name, len(buffers[stream_name]))
 
 
 def _resolve_bash(base_env: Mapping[str, str]) -> str:

--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -337,21 +337,19 @@ def source_workspace_env_hook(
 ) -> dict[str, str]:
     """Source the hook with `base_env` and return new/changed exported values.
 
-    Bash sources the script with `set -a` so plain assignments are also
-    exported, prints a high-entropy capture marker, and emits a NUL-separated
-    `printenv -0` block. The runner ignores anything stdout the script
-    itself printed before the marker, then keeps only entries whose name
-    passes `constants.is_workspace_env_overlay_name_allowed` and whose value
-    differs from `base_env`.
+    Bash sources the script without `set -a`, so agents must write
+    `export FOO=bar` for values to overlay; bare `FOO=bar` does not persist.
+    A high-entropy capture marker separates anything the script printed to
+    stdout from the NUL-separated `printenv -0` block we read afterwards. The
+    runner keeps only entries whose name passes
+    `constants.is_workspace_env_overlay_name_allowed` and whose value differs
+    from `base_env`.
 
     Raises `WorkspaceEnvHookError` on timeout, non-zero exit, missing capture
     marker, missing bash, or oversized output.
     """
     bash_path = _resolve_bash(base_env)
     capture_marker = secrets.token_hex(16)
-    # No `set -a`: agents must write `export FOO=bar` for values to overlay,
-    # so the hook contract stays predictable and aligned with how
-    # `extra_env_passthrough` already documents shell env passthrough.
     bash_script = '. "$1"; printf "%s\\0" "$2"; printenv -0'
     try:
         completed = subprocess.run(
@@ -389,13 +387,10 @@ def source_workspace_env_hook(
 
 
 def _resolve_bash(base_env: Mapping[str, str]) -> str:
-    bash_path = shutil.which("bash", path=base_env.get("PATH"))
+    bash_path = shutil.which("bash", path=base_env.get("PATH")) or shutil.which("bash")
     if bash_path is not None:
         return bash_path
-    bash_path = shutil.which("bash")
-    if bash_path is not None:
-        return bash_path
-    if Path("/bin/bash").exists():
+    if os.access("/bin/bash", os.X_OK):
         return "/bin/bash"
     msg = "bash is required to source .mindroom/worker-env.sh and was not found."
     raise WorkspaceEnvHookError(msg)
@@ -452,4 +447,4 @@ def _accept_overlay_chunk(
 def _is_valid_env_name(name: str) -> bool:
     if not name or name[0].isdigit():
         return False
-    return all(ch == "_" or ch.isalnum() for ch in name)
+    return all(ch == "_" or (ch.isascii() and ch.isalnum()) for ch in name)

--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import os
+import secrets
+import shutil
 import site
+import subprocess
 import sys
 from pathlib import Path
 from types import MappingProxyType
@@ -13,10 +16,18 @@ from mindroom import constants
 from mindroom.tool_system.worker_routing import worker_dir_name
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from mindroom.constants import RuntimePaths
     from mindroom.workers.backends.local import LocalWorkerStatePaths
 
 DEFAULT_SUBPROCESS_TIMEOUT_SECONDS = 120.0
+WORKSPACE_ENV_HOOK_RELATIVE_PATH = Path(".mindroom") / "worker-env.sh"
+WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS = 10.0
+_WORKSPACE_ENV_HOOK_MAX_SCRIPT_BYTES = 64 * 1024
+_WORKSPACE_ENV_HOOK_MAX_OUTPUT_BYTES = 256 * 1024
+_WORKSPACE_ENV_HOOK_MAX_VALUE_BYTES = 32 * 1024
+_WORKSPACE_ENV_HOOK_MAX_OVERLAY_BYTES = 128 * 1024
 RUNNER_EXECUTION_MODE_ENV = "MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE"
 RUNNER_SUBPROCESS_TIMEOUT_ENV = "MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS"
 DEDICATED_WORKER_KEY_ENV = "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY"
@@ -268,3 +279,177 @@ def subprocess_worker_command(
 ) -> list[str]:
     """Build the sandbox subprocess worker command line."""
     return [python_executable or sys.executable, "-m", "mindroom.api.sandbox_runner", subprocess_worker_arg]
+
+
+class WorkspaceEnvHookError(RuntimeError):
+    """One `.mindroom/worker-env.sh` request failed sourcing or validation."""
+
+
+def resolve_workspace_env_hook_path(base_dir: Path | str | None) -> Path | None:
+    """Resolve the workspace env hook for one effective base_dir, if any.
+
+    Returns the resolved file path when a regular file exists at
+    `<base_dir>/.mindroom/worker-env.sh` and stays inside the resolved
+    base_dir. Returns None when the file is absent. Raises
+    `WorkspaceEnvHookError` when the candidate escapes the base_dir
+    (including symlink escape) or exceeds the size cap.
+    """
+    if base_dir is None:
+        return None
+    base_path = Path(base_dir).expanduser()
+    try:
+        base_resolved = base_path.resolve()
+    except OSError as exc:
+        msg = f"Failed to resolve base_dir for .mindroom/worker-env.sh: {exc}"
+        raise WorkspaceEnvHookError(msg) from exc
+    candidate = base_resolved / WORKSPACE_ENV_HOOK_RELATIVE_PATH
+    if not candidate.exists():
+        return None
+    try:
+        candidate_resolved = candidate.resolve()
+    except OSError as exc:
+        msg = f"Failed to resolve .mindroom/worker-env.sh: {exc}"
+        raise WorkspaceEnvHookError(msg) from exc
+    if not candidate_resolved.is_relative_to(base_resolved):
+        msg = (
+            f".mindroom/worker-env.sh resolves outside of {base_resolved}; "
+            "agent-editable workspace hooks must stay inside the resolved tool workspace."
+        )
+        raise WorkspaceEnvHookError(msg)
+    if not candidate_resolved.is_file():
+        return None
+    try:
+        size = candidate_resolved.stat().st_size
+    except OSError as exc:
+        msg = f"Failed to stat .mindroom/worker-env.sh: {exc}"
+        raise WorkspaceEnvHookError(msg) from exc
+    if size > _WORKSPACE_ENV_HOOK_MAX_SCRIPT_BYTES:
+        msg = f".mindroom/worker-env.sh is too large ({size} bytes; limit {_WORKSPACE_ENV_HOOK_MAX_SCRIPT_BYTES})."
+        raise WorkspaceEnvHookError(msg)
+    return candidate_resolved
+
+
+def source_workspace_env_hook(
+    *,
+    hook_path: Path,
+    base_env: Mapping[str, str],
+    cwd: Path,
+) -> dict[str, str]:
+    """Source the hook with `base_env` and return new/changed exported values.
+
+    Bash sources the script with `set -a` so plain assignments are also
+    exported, prints a high-entropy capture marker, and emits a NUL-separated
+    `printenv -0` block. The runner ignores anything stdout the script
+    itself printed before the marker, then keeps only entries whose name
+    passes `constants.is_workspace_env_overlay_name_allowed` and whose value
+    differs from `base_env`.
+
+    Raises `WorkspaceEnvHookError` on timeout, non-zero exit, missing capture
+    marker, missing bash, or oversized output.
+    """
+    bash_path = _resolve_bash(base_env)
+    capture_marker = secrets.token_hex(16)
+    # No `set -a`: agents must write `export FOO=bar` for values to overlay,
+    # so the hook contract stays predictable and aligned with how
+    # `extra_env_passthrough` already documents shell env passthrough.
+    bash_script = '. "$1"; printf "%s\\0" "$2"; printenv -0'
+    try:
+        completed = subprocess.run(
+            [bash_path, "-c", bash_script, "bash", str(hook_path), capture_marker],
+            input=b"",
+            capture_output=True,
+            cwd=str(cwd),
+            env=dict(base_env),
+            timeout=WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS,
+            check=False,
+            start_new_session=True,
+        )
+    except subprocess.TimeoutExpired as exc:
+        msg = f".mindroom/worker-env.sh timed out after {WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS} seconds."
+        raise WorkspaceEnvHookError(msg) from exc
+    except OSError as exc:
+        msg = f"Failed to start bash for .mindroom/worker-env.sh: {exc}"
+        raise WorkspaceEnvHookError(msg) from exc
+    if completed.returncode != 0:
+        excerpt = (completed.stderr or completed.stdout or b"").decode(errors="replace")[:512].strip()
+        suffix = f" output: {excerpt}" if excerpt else ""
+        msg = f".mindroom/worker-env.sh exited with code {completed.returncode}.{suffix}"
+        raise WorkspaceEnvHookError(msg)
+    if len(completed.stdout) > _WORKSPACE_ENV_HOOK_MAX_OUTPUT_BYTES:
+        msg = (
+            f".mindroom/worker-env.sh produced {len(completed.stdout)} bytes of "
+            f"capture output (limit {_WORKSPACE_ENV_HOOK_MAX_OUTPUT_BYTES})."
+        )
+        raise WorkspaceEnvHookError(msg)
+    return _parse_workspace_env_hook_output(
+        completed.stdout,
+        capture_marker,
+        base_env=base_env,
+    )
+
+
+def _resolve_bash(base_env: Mapping[str, str]) -> str:
+    bash_path = shutil.which("bash", path=base_env.get("PATH"))
+    if bash_path is not None:
+        return bash_path
+    bash_path = shutil.which("bash")
+    if bash_path is not None:
+        return bash_path
+    if Path("/bin/bash").exists():
+        return "/bin/bash"
+    msg = "bash is required to source .mindroom/worker-env.sh and was not found."
+    raise WorkspaceEnvHookError(msg)
+
+
+def _parse_workspace_env_hook_output(
+    raw: bytes,
+    capture_marker: str,
+    *,
+    base_env: Mapping[str, str],
+) -> dict[str, str]:
+    text = raw.decode("utf-8", errors="replace")
+    marker_chunk = capture_marker + "\0"
+    marker_index = text.find(marker_chunk)
+    if marker_index < 0:
+        msg = ".mindroom/worker-env.sh output did not include the expected env capture marker."
+        raise WorkspaceEnvHookError(msg)
+    env_block = text[marker_index + len(marker_chunk) :]
+    overlay: dict[str, str] = {}
+    total_bytes = 0
+    for chunk in env_block.split("\0"):
+        kv = _accept_overlay_chunk(chunk, base_env=base_env)
+        if kv is None:
+            continue
+        key, value = kv
+        overlay[key] = value
+        total_bytes += len(key) + 1 + len(value)
+        if total_bytes > _WORKSPACE_ENV_HOOK_MAX_OVERLAY_BYTES:
+            break
+    return overlay
+
+
+def _accept_overlay_chunk(
+    chunk: str,
+    *,
+    base_env: Mapping[str, str],
+) -> tuple[str, str] | None:
+    sep_idx = chunk.find("=") if chunk else -1
+    if sep_idx <= 0:
+        return None
+    key = chunk[:sep_idx]
+    value = chunk[sep_idx + 1 :]
+    if (
+        not _is_valid_env_name(key)
+        or key in constants.WORKSPACE_ENV_OVERLAY_TRANSIENT_NAMES
+        or not constants.is_workspace_env_overlay_name_allowed(key)
+        or base_env.get(key) == value
+        or len(value.encode("utf-8")) > _WORKSPACE_ENV_HOOK_MAX_VALUE_BYTES
+    ):
+        return None
+    return key, value
+
+
+def _is_valid_env_name(name: str) -> bool:
+    if not name or name[0].isdigit():
+        return False
+    return all(ch == "_" or ch.isalnum() for ch in name)

--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import os
 import secrets
 import shutil
+import signal
 import site
 import subprocess
 import sys
+from contextlib import suppress
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -352,38 +354,46 @@ def source_workspace_env_hook(
     capture_marker = secrets.token_hex(16)
     bash_script = '. "$1"; printf "%s\\0" "$2"; printenv -0'
     try:
-        completed = subprocess.run(
+        process = subprocess.Popen(
             [bash_path, "-c", bash_script, "bash", str(hook_path), capture_marker],
-            input=b"",
-            capture_output=True,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             cwd=str(cwd),
             env=dict(base_env),
-            timeout=WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS,
-            check=False,
             start_new_session=True,
         )
+        stdout, stderr = process.communicate(input=b"", timeout=WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS)
     except subprocess.TimeoutExpired as exc:
+        _kill_workspace_env_hook_process_group(process)
+        with suppress(OSError, subprocess.TimeoutExpired):
+            process.wait(timeout=1.0)
         msg = f".mindroom/worker-env.sh timed out after {WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS} seconds."
         raise WorkspaceEnvHookError(msg) from exc
     except OSError as exc:
         msg = f"Failed to start bash for .mindroom/worker-env.sh: {exc}"
         raise WorkspaceEnvHookError(msg) from exc
-    if completed.returncode != 0:
-        excerpt = (completed.stderr or completed.stdout or b"").decode(errors="replace")[:512].strip()
+    if process.returncode != 0:
+        excerpt = (stderr or stdout or b"").decode(errors="replace")[:512].strip()
         suffix = f" output: {excerpt}" if excerpt else ""
-        msg = f".mindroom/worker-env.sh exited with code {completed.returncode}.{suffix}"
+        msg = f".mindroom/worker-env.sh exited with code {process.returncode}.{suffix}"
         raise WorkspaceEnvHookError(msg)
-    if len(completed.stdout) > _WORKSPACE_ENV_HOOK_MAX_OUTPUT_BYTES:
+    if len(stdout) > _WORKSPACE_ENV_HOOK_MAX_OUTPUT_BYTES:
         msg = (
-            f".mindroom/worker-env.sh produced {len(completed.stdout)} bytes of "
+            f".mindroom/worker-env.sh produced {len(stdout)} bytes of "
             f"capture output (limit {_WORKSPACE_ENV_HOOK_MAX_OUTPUT_BYTES})."
         )
         raise WorkspaceEnvHookError(msg)
     return _parse_workspace_env_hook_output(
-        completed.stdout,
+        stdout,
         capture_marker,
         base_env=base_env,
     )
+
+
+def _kill_workspace_env_hook_process_group(process: subprocess.Popen[bytes]) -> None:
+    with suppress(OSError):
+        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
 
 
 def _resolve_bash(base_env: Mapping[str, str]) -> str:
@@ -416,10 +426,13 @@ def _parse_workspace_env_hook_output(
         if kv is None:
             continue
         key, value = kv
+        entry_bytes = len(key.encode("utf-8")) + 1 + len(value.encode("utf-8"))
+        projected_bytes = total_bytes + entry_bytes
+        if projected_bytes > _WORKSPACE_ENV_HOOK_MAX_OVERLAY_BYTES:
+            msg = f".mindroom/worker-env.sh overlay is too large (limit {_WORKSPACE_ENV_HOOK_MAX_OVERLAY_BYTES} bytes)."
+            raise WorkspaceEnvHookError(msg)
         overlay[key] = value
-        total_bytes += len(key) + 1 + len(value)
-        if total_bytes > _WORKSPACE_ENV_HOOK_MAX_OVERLAY_BYTES:
-            break
+        total_bytes = projected_bytes
     return overlay
 
 

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -545,11 +545,48 @@ def _serialize_worker(worker: WorkerHandle) -> SandboxWorkerResponse:
     )
 
 
+def _maybe_read_workspace_env_overlay(
+    request: SandboxRunnerExecuteRequest,
+    prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
+    base_env: dict[str, str],
+    *,
+    apply: bool,
+) -> tuple[dict[str, str], SandboxRunnerExecuteResponse | None]:
+    """Source `.mindroom/worker-env.sh` for one request.
+
+    Returns `(overlay, None)` on success (overlay is empty when no hook
+    exists). Returns `({}, tool_failure_response)` when the hook fails to
+    source — the caller should return that response directly. Skips silently
+    when `apply` is False, used by the in-subprocess re-execution path after
+    the parent already sourced the hook.
+    """
+    if not apply:
+        return {}, None
+    workspace = _workspace_for_env_hook(request, prepared)
+    if workspace is None:
+        return {}, None
+    try:
+        hook_path = sandbox_exec.resolve_workspace_env_hook_path(workspace)
+        if hook_path is None:
+            return {}, None
+        overlay = sandbox_exec.source_workspace_env_hook(
+            hook_path=hook_path,
+            base_env=base_env,
+            cwd=workspace,
+        )
+    except sandbox_exec.WorkspaceEnvHookError as exc:
+        return {}, SandboxRunnerExecuteResponse(
+            ok=False,
+            error=str(exc),
+            failure_kind="tool",
+        )
+    return overlay, None
+
+
 def _workspace_for_env_hook(
     request: SandboxRunnerExecuteRequest,
     prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
 ) -> Path | None:
-    """Return the effective workspace dir used for `.mindroom/worker-env.sh` discovery."""
     if prepared is not None:
         base_dir = prepared.runtime_overrides.get("base_dir")
         if isinstance(base_dir, Path):
@@ -563,62 +600,6 @@ def _workspace_for_env_hook(
         if candidate.is_absolute():
             return candidate
     return None
-
-
-def _maybe_read_workspace_env_overlay(
-    request: SandboxRunnerExecuteRequest,
-    prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
-    execution_env: dict[str, str],
-    *,
-    apply: bool,
-) -> tuple[dict[str, str], SandboxRunnerExecuteResponse | None]:
-    """Source the workspace env hook for one request, returning overlay or a tool failure.
-
-    Skips silently when `apply` is False (used by the in-subprocess re-execution path
-    after the parent already sourced the hook).
-    """
-    if not apply:
-        return {}, None
-    hook_base_env = dict(execution_env)
-    if prepared is None:
-        # Unkeyed proxy: seed with the runner's PATH/HOME defaults so bash
-        # can locate `printenv` and friends when sourcing the hook.
-        for key, value in sandbox_exec.generic_subprocess_env().items():
-            hook_base_env.setdefault(key, value)
-    try:
-        overlay = _read_workspace_env_overlay(request, prepared, hook_base_env)
-    except sandbox_exec.WorkspaceEnvHookError as exc:
-        return {}, SandboxRunnerExecuteResponse(
-            ok=False,
-            error=str(exc),
-            failure_kind="tool",
-        )
-    return overlay, None
-
-
-def _read_workspace_env_overlay(
-    request: SandboxRunnerExecuteRequest,
-    prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
-    base_env: dict[str, str],
-) -> dict[str, str]:
-    """Source `.mindroom/worker-env.sh` for one request, returning the overlay env values.
-
-    Returns an empty dict when no hook is configured. Raises
-    `sandbox_exec.WorkspaceEnvHookError` for the caller to convert into a
-    tool-failure response when the script escapes the workspace, exits
-    non-zero, times out, or otherwise fails to source cleanly.
-    """
-    workspace = _workspace_for_env_hook(request, prepared)
-    if workspace is None:
-        return {}
-    hook_path = sandbox_exec.resolve_workspace_env_hook_path(workspace)
-    if hook_path is None:
-        return {}
-    return sandbox_exec.source_workspace_env_hook(
-        hook_path=hook_path,
-        base_env=base_env,
-        cwd=workspace,
-    )
 
 
 async def _execute_request_inprocess(
@@ -650,10 +631,17 @@ async def _execute_request_inprocess(
         worker_execution_env = sandbox_exec.worker_subprocess_env(prepared.paths)
         worker_execution_env.update(execution_env)
         execution_env = worker_execution_env
+    # Seed PATH/HOME defaults so bash can locate `printenv` when sourcing the
+    # hook for inprocess unkeyed proxy calls (the subprocess path already gets
+    # these via worker_subprocess_env / generic_subprocess_env).
+    hook_base_env = dict(execution_env)
+    if prepared is None:
+        for key, value in sandbox_exec.generic_subprocess_env().items():
+            hook_base_env.setdefault(key, value)
     overlay, overlay_failure = _maybe_read_workspace_env_overlay(
         request,
         prepared,
-        execution_env,
+        hook_base_env,
         apply=apply_workspace_env_hook,
     )
     if overlay_failure is not None:

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -545,61 +545,85 @@ def _serialize_worker(worker: WorkerHandle) -> SandboxWorkerResponse:
     )
 
 
-def _maybe_read_workspace_env_overlay(
+def _workspace_env_overlay_for_request(
     request: SandboxRunnerExecuteRequest,
     prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
-    base_env: dict[str, str],
+    execution_env: dict[str, str],
     *,
+    subprocess_env: dict[str, str] | None = None,
     apply: bool,
-) -> tuple[dict[str, str], SandboxRunnerExecuteResponse | None]:
+) -> tuple[dict[str, str], dict[str, str], SandboxRunnerExecuteResponse | None]:
     """Source `.mindroom/worker-env.sh` for one request.
 
-    Returns `(overlay, None)` on success (overlay is empty when no hook
-    exists). Returns `({}, tool_failure_response)` when the hook fails to
-    source — the caller should return that response directly. Skips silently
-    when `apply` is False, used by the in-subprocess re-execution path after
-    the parent already sourced the hook.
+    Returns `(base_env, overlay, None)` on success (overlay is empty when no
+    hook exists). Returns `(base_env, {}, tool_failure_response)` when the hook
+    fails to source — the caller should return that response directly. Skips
+    silently when `apply` is False, used by the in-subprocess re-execution path
+    after the parent already sourced the hook.
     """
+    base_env = _workspace_env_overlay_base_env(
+        prepared,
+        execution_env,
+        subprocess_env=subprocess_env,
+    )
     if not apply:
-        return {}, None
-    workspace = _workspace_for_env_hook(request, prepared)
+        return base_env, {}, None
+
+    workspace: Path | None = None
+    if prepared is not None:
+        base_dir = prepared.runtime_overrides.get("base_dir")
+        if isinstance(base_dir, Path):
+            workspace = base_dir
+        elif isinstance(base_dir, str):
+            workspace = Path(base_dir)
+    elif isinstance(raw_base_dir := request.tool_init_overrides.get("base_dir"), str):
+        candidate = Path(raw_base_dir).expanduser()
+        if candidate.is_absolute():
+            workspace = candidate
     if workspace is None:
-        return {}, None
+        return base_env, {}, None
+
     try:
         hook_path = sandbox_exec.resolve_workspace_env_hook_path(workspace)
         if hook_path is None:
-            return {}, None
+            return base_env, {}, None
         overlay = sandbox_exec.source_workspace_env_hook(
             hook_path=hook_path,
             base_env=base_env,
             cwd=workspace,
         )
     except sandbox_exec.WorkspaceEnvHookError as exc:
-        return {}, SandboxRunnerExecuteResponse(
-            ok=False,
-            error=str(exc),
-            failure_kind="tool",
+        return (
+            base_env,
+            {},
+            SandboxRunnerExecuteResponse(
+                ok=False,
+                error=str(exc),
+                failure_kind="tool",
+            ),
         )
-    return overlay, None
+    return base_env, overlay, None
 
 
-def _workspace_for_env_hook(
-    request: SandboxRunnerExecuteRequest,
+def _workspace_env_overlay_base_env(
     prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
-) -> Path | None:
-    if prepared is not None:
-        base_dir = prepared.runtime_overrides.get("base_dir")
-        if isinstance(base_dir, Path):
-            return base_dir
-        if isinstance(base_dir, str):
-            return Path(base_dir)
-        return None
-    raw_base_dir = request.tool_init_overrides.get("base_dir")
-    if isinstance(raw_base_dir, str):
-        candidate = Path(raw_base_dir).expanduser()
-        if candidate.is_absolute():
-            return candidate
-    return None
+    execution_env: dict[str, str],
+    *,
+    subprocess_env: dict[str, str] | None,
+) -> dict[str, str]:
+    if subprocess_env is not None:
+        base_env = dict(subprocess_env)
+        base_env.update(execution_env)
+        return base_env
+
+    base_env = dict(execution_env)
+    # Seed PATH/HOME defaults so bash can locate `printenv` when sourcing the
+    # hook for inprocess unkeyed proxy calls (the subprocess path already gets
+    # these via worker_subprocess_env / generic_subprocess_env).
+    if prepared is None:
+        for key, value in sandbox_exec.generic_subprocess_env().items():
+            base_env.setdefault(key, value)
+    return base_env
 
 
 async def _execute_request_inprocess(
@@ -631,17 +655,10 @@ async def _execute_request_inprocess(
         worker_execution_env = sandbox_exec.worker_subprocess_env(prepared.paths)
         worker_execution_env.update(execution_env)
         execution_env = worker_execution_env
-    # Seed PATH/HOME defaults so bash can locate `printenv` when sourcing the
-    # hook for inprocess unkeyed proxy calls (the subprocess path already gets
-    # these via worker_subprocess_env / generic_subprocess_env).
-    hook_base_env = dict(execution_env)
-    if prepared is None:
-        for key, value in sandbox_exec.generic_subprocess_env().items():
-            hook_base_env.setdefault(key, value)
-    overlay, overlay_failure = _maybe_read_workspace_env_overlay(
+    _hook_base_env, overlay, overlay_failure = _workspace_env_overlay_for_request(
         request,
         prepared,
-        hook_base_env,
+        execution_env,
         apply=apply_workspace_env_hook,
     )
     if overlay_failure is not None:
@@ -775,12 +792,11 @@ def _execute_request_subprocess_sync(
     python_executable, subprocess_env, cwd = sandbox_exec.resolve_subprocess_worker_context(
         prepared.paths if prepared is not None else None,
     )
-    overlay_base_env: dict[str, str] = dict(subprocess_env or {})
-    overlay_base_env.update(execution_env)
-    overlay, overlay_failure = _maybe_read_workspace_env_overlay(
+    _hook_base_env, overlay, overlay_failure = _workspace_env_overlay_for_request(
         request,
         prepared,
-        overlay_base_env,
+        execution_env,
+        subprocess_env=subprocess_env,
         apply=apply_workspace_env_hook,
     )
     if overlay_failure is not None:

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -245,26 +245,37 @@ def _request_private_agent_names(request: SandboxRunnerExecuteRequest) -> frozen
 def _request_runtime_overrides(
     request: SandboxRunnerExecuteRequest,
     prepared_worker: sandbox_worker_prep.PreparedWorkerRequest | None,
+    *,
+    workspace_env_overlay: dict[str, str] | None = None,
 ) -> dict[str, object] | None:
     """Return runtime overrides for one runner-side tool rebuild."""
     runtime_overrides = sandbox_worker_prep.ready_runtime_overrides(
         prepared_worker.runtime_overrides if prepared_worker is not None else None,
     )
-    if request.tool_name != "shell" or request.extra_env_passthrough is None:
+    if request.tool_name != "shell":
         return runtime_overrides
 
-    # Pre-resolve passthrough patterns against only the client's env snapshot
-    # to prevent cross-runtime secret leakage via glob patterns that match
-    # runner-only env vars.
-    resolved = constants.shell_extra_env_values(
-        extra_env_passthrough=request.extra_env_passthrough,
-        process_env=request.execution_env,
-    )
-    if not resolved:
+    resolved_keys: list[str] = []
+    if request.extra_env_passthrough is not None:
+        # Pre-resolve passthrough patterns against only the client's env snapshot
+        # to prevent cross-runtime secret leakage via glob patterns that match
+        # runner-only env vars.
+        resolved = constants.shell_extra_env_values(
+            extra_env_passthrough=request.extra_env_passthrough,
+            process_env=request.execution_env,
+        )
+        resolved_keys.extend(resolved.keys())
+    if workspace_env_overlay:
+        # Expose `.mindroom/worker-env.sh` overlay names through the same
+        # extra_env_passthrough channel so the shell tool reads them out of
+        # the effective runtime_paths.process_env snapshot we just built.
+        resolved_keys.extend(name for name in workspace_env_overlay if name not in resolved_keys)
+
+    if not resolved_keys:
         return runtime_overrides
 
     merged_runtime_overrides = dict(runtime_overrides or {})
-    merged_runtime_overrides["extra_env_passthrough"] = ",".join(resolved.keys())
+    merged_runtime_overrides["extra_env_passthrough"] = ",".join(resolved_keys)
     return merged_runtime_overrides
 
 
@@ -534,6 +545,82 @@ def _serialize_worker(worker: WorkerHandle) -> SandboxWorkerResponse:
     )
 
 
+def _workspace_for_env_hook(
+    request: SandboxRunnerExecuteRequest,
+    prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
+) -> Path | None:
+    """Return the effective workspace dir used for `.mindroom/worker-env.sh` discovery."""
+    if prepared is not None:
+        base_dir = prepared.runtime_overrides.get("base_dir")
+        if isinstance(base_dir, Path):
+            return base_dir
+        if isinstance(base_dir, str):
+            return Path(base_dir)
+        return None
+    raw_base_dir = request.tool_init_overrides.get("base_dir")
+    if isinstance(raw_base_dir, str):
+        candidate = Path(raw_base_dir).expanduser()
+        if candidate.is_absolute():
+            return candidate
+    return None
+
+
+def _maybe_read_workspace_env_overlay(
+    request: SandboxRunnerExecuteRequest,
+    prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
+    execution_env: dict[str, str],
+    *,
+    apply: bool,
+) -> tuple[dict[str, str], SandboxRunnerExecuteResponse | None]:
+    """Source the workspace env hook for one request, returning overlay or a tool failure.
+
+    Skips silently when `apply` is False (used by the in-subprocess re-execution path
+    after the parent already sourced the hook).
+    """
+    if not apply:
+        return {}, None
+    hook_base_env = dict(execution_env)
+    if prepared is None:
+        # Unkeyed proxy: seed with the runner's PATH/HOME defaults so bash
+        # can locate `printenv` and friends when sourcing the hook.
+        for key, value in sandbox_exec.generic_subprocess_env().items():
+            hook_base_env.setdefault(key, value)
+    try:
+        overlay = _read_workspace_env_overlay(request, prepared, hook_base_env)
+    except sandbox_exec.WorkspaceEnvHookError as exc:
+        return {}, SandboxRunnerExecuteResponse(
+            ok=False,
+            error=str(exc),
+            failure_kind="tool",
+        )
+    return overlay, None
+
+
+def _read_workspace_env_overlay(
+    request: SandboxRunnerExecuteRequest,
+    prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
+    base_env: dict[str, str],
+) -> dict[str, str]:
+    """Source `.mindroom/worker-env.sh` for one request, returning the overlay env values.
+
+    Returns an empty dict when no hook is configured. Raises
+    `sandbox_exec.WorkspaceEnvHookError` for the caller to convert into a
+    tool-failure response when the script escapes the workspace, exits
+    non-zero, times out, or otherwise fails to source cleanly.
+    """
+    workspace = _workspace_for_env_hook(request, prepared)
+    if workspace is None:
+        return {}
+    hook_path = sandbox_exec.resolve_workspace_env_hook_path(workspace)
+    if hook_path is None:
+        return {}
+    return sandbox_exec.source_workspace_env_hook(
+        hook_path=hook_path,
+        base_env=base_env,
+        cwd=workspace,
+    )
+
+
 async def _execute_request_inprocess(
     request: SandboxRunnerExecuteRequest,
     runtime_paths: RuntimePaths,
@@ -541,6 +628,7 @@ async def _execute_request_inprocess(
     prepared_worker: sandbox_worker_prep.PreparedWorkerRequest | None = None,
     *,
     runner_token: str | None = None,
+    apply_workspace_env_hook: bool = True,
 ) -> SandboxRunnerExecuteResponse:
     execution_env = sandbox_exec.request_execution_env(request.tool_name, request.execution_env, runtime_paths)
     try:
@@ -562,7 +650,17 @@ async def _execute_request_inprocess(
         worker_execution_env = sandbox_exec.worker_subprocess_env(prepared.paths)
         worker_execution_env.update(execution_env)
         execution_env = worker_execution_env
-    runtime_overrides = _request_runtime_overrides(request, prepared)
+    overlay, overlay_failure = _maybe_read_workspace_env_overlay(
+        request,
+        prepared,
+        execution_env,
+        apply=apply_workspace_env_hook,
+    )
+    if overlay_failure is not None:
+        return overlay_failure
+    if overlay:
+        execution_env.update(overlay)
+    runtime_overrides = _request_runtime_overrides(request, prepared, workspace_env_overlay=overlay)
     effective_runtime_paths = sandbox_exec.runtime_paths_with_execution_env(
         runtime_paths,
         execution_env,
@@ -667,6 +765,7 @@ def _execute_request_subprocess_sync(
     prepared_worker: sandbox_worker_prep.PreparedWorkerRequest | None = None,
     *,
     runner_token: str | None = None,
+    apply_workspace_env_hook: bool = True,
 ) -> SandboxRunnerExecuteResponse:
     execution_env = sandbox_exec.request_execution_env(request.tool_name, request.execution_env, runtime_paths)
     try:
@@ -688,6 +787,18 @@ def _execute_request_subprocess_sync(
     python_executable, subprocess_env, cwd = sandbox_exec.resolve_subprocess_worker_context(
         prepared.paths if prepared is not None else None,
     )
+    overlay_base_env: dict[str, str] = dict(subprocess_env or {})
+    overlay_base_env.update(execution_env)
+    overlay, overlay_failure = _maybe_read_workspace_env_overlay(
+        request,
+        prepared,
+        overlay_base_env,
+        apply=apply_workspace_env_hook,
+    )
+    if overlay_failure is not None:
+        return overlay_failure
+    if overlay:
+        execution_env.update(overlay)
     subprocess_env = sandbox_exec.subprocess_env_for_request(subprocess_env, execution_env)
     envelope = sandbox_protocol.serialize_subprocess_envelope(
         request=request.model_dump(mode="json"),
@@ -721,6 +832,7 @@ async def _execute_request_subprocess(
     prepared_worker: sandbox_worker_prep.PreparedWorkerRequest | None = None,
     *,
     runner_token: str | None = None,
+    apply_workspace_env_hook: bool = True,
 ) -> SandboxRunnerExecuteResponse:
     return await asyncio.to_thread(
         _execute_request_subprocess_sync,
@@ -729,6 +841,7 @@ async def _execute_request_subprocess(
         config,
         prepared_worker,
         runner_token=runner_token,
+        apply_workspace_env_hook=apply_workspace_env_hook,
     )
 
 
@@ -776,7 +889,11 @@ def _run_subprocess_worker() -> int:
     captured_out = io.StringIO()
     captured_err = io.StringIO()
     with redirect_stdout(captured_out), redirect_stderr(captured_err):
-        response = asyncio.run(_execute_request_inprocess(request, runtime_paths, config))
+        # The parent runner already sourced .mindroom/worker-env.sh once and
+        # folded the overlay into the subprocess process env.
+        response = asyncio.run(
+            _execute_request_inprocess(request, runtime_paths, config, apply_workspace_env_hook=False),
+        )
 
     # Flush captured tool output to real stdout/stderr (informational only).
     tool_stdout = captured_out.getvalue()

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -552,14 +552,14 @@ def _workspace_env_overlay_for_request(
     *,
     subprocess_env: dict[str, str] | None = None,
     apply: bool,
-) -> tuple[dict[str, str], dict[str, str], SandboxRunnerExecuteResponse | None]:
+) -> tuple[dict[str, str], SandboxRunnerExecuteResponse | None]:
     """Source `.mindroom/worker-env.sh` for one request.
 
-    Returns `(base_env, overlay, None)` on success (overlay is empty when no
-    hook exists). Returns `(base_env, {}, tool_failure_response)` when the hook
-    fails to source — the caller should return that response directly. Skips
-    silently when `apply` is False, used by the in-subprocess re-execution path
-    after the parent already sourced the hook.
+    Returns `(overlay, None)` on success (overlay is empty when no hook exists).
+    Returns `({}, tool_failure_response)` when the hook fails to source — the
+    caller should return that response directly. Skips silently when `apply` is
+    False, used by the in-subprocess re-execution path after the parent already
+    sourced the hook.
     """
     base_env = _workspace_env_overlay_base_env(
         prepared,
@@ -567,7 +567,7 @@ def _workspace_env_overlay_for_request(
         subprocess_env=subprocess_env,
     )
     if not apply:
-        return base_env, {}, None
+        return {}, None
 
     workspace: Path | None = None
     if prepared is not None:
@@ -581,12 +581,12 @@ def _workspace_env_overlay_for_request(
         if candidate.is_absolute():
             workspace = candidate
     if workspace is None:
-        return base_env, {}, None
+        return {}, None
 
     try:
         hook_path = sandbox_exec.resolve_workspace_env_hook_path(workspace)
         if hook_path is None:
-            return base_env, {}, None
+            return {}, None
         overlay = sandbox_exec.source_workspace_env_hook(
             hook_path=hook_path,
             base_env=base_env,
@@ -594,7 +594,6 @@ def _workspace_env_overlay_for_request(
         )
     except sandbox_exec.WorkspaceEnvHookError as exc:
         return (
-            base_env,
             {},
             SandboxRunnerExecuteResponse(
                 ok=False,
@@ -602,7 +601,7 @@ def _workspace_env_overlay_for_request(
                 failure_kind="tool",
             ),
         )
-    return base_env, overlay, None
+    return overlay, None
 
 
 def _workspace_env_overlay_base_env(
@@ -655,7 +654,7 @@ async def _execute_request_inprocess(
         worker_execution_env = sandbox_exec.worker_subprocess_env(prepared.paths)
         worker_execution_env.update(execution_env)
         execution_env = worker_execution_env
-    _hook_base_env, overlay, overlay_failure = _workspace_env_overlay_for_request(
+    overlay, overlay_failure = _workspace_env_overlay_for_request(
         request,
         prepared,
         execution_env,
@@ -792,7 +791,7 @@ def _execute_request_subprocess_sync(
     python_executable, subprocess_env, cwd = sandbox_exec.resolve_subprocess_worker_context(
         prepared.paths if prepared is not None else None,
     )
-    _hook_base_env, overlay, overlay_failure = _workspace_env_overlay_for_request(
+    overlay, overlay_failure = _workspace_env_overlay_for_request(
         request,
         prepared,
         execution_env,

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -76,6 +76,29 @@ _SHELL_EXTRA_ENV_EXCLUDED_NAMES = frozenset({*_EXECUTION_RUNTIME_EXCLUDED_NAMES,
 # provider credentials that should never leak to shell commands.
 _SHELL_EXTRA_ENV_SECRET_SUFFIXES = ("_API_KEY", "_API_KEYS", "_PASSWORD", "_SECRET")
 
+# Bash bookkeeping vars that change every time printenv runs and are never
+# meaningful overlay output from `.mindroom/worker-env.sh`.
+WORKSPACE_ENV_OVERLAY_TRANSIENT_NAMES = frozenset({"PWD", "OLDPWD", "SHLVL", "_", "PIPESTATUS"})
+
+
+def is_workspace_env_overlay_name_allowed(name: str) -> bool:
+    """Return whether one env var name may be returned from `.mindroom/worker-env.sh`.
+
+    Reuses the same secret-suffix and excluded-name rules that protect the
+    `extra_env_passthrough` shell config so the agent-editable overlay can
+    never expose provider credentials, runner control tokens, or sandbox
+    auth state, even if the script intentionally re-exports them.
+    """
+    if not name:
+        return False
+    if name in _SHELL_EXTRA_ENV_EXCLUDED_NAMES:
+        return False
+    if name in _EXECUTION_RUNTIME_EXCLUDED_NAMES:
+        return False
+    if name.endswith(_SHELL_EXTRA_ENV_SECRET_SUFFIXES):
+        return False
+    return not name.startswith("MINDROOM_SANDBOX_")
+
 
 @dataclass(frozen=True)
 class RuntimePaths:

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -93,8 +93,6 @@ def is_workspace_env_overlay_name_allowed(name: str) -> bool:
         return False
     if name in _SHELL_EXTRA_ENV_EXCLUDED_NAMES:
         return False
-    if name in _EXECUTION_RUNTIME_EXCLUDED_NAMES:
-        return False
     if name.endswith(_SHELL_EXTRA_ENV_SECRET_SUFFIXES):
         return False
     return not name.startswith("MINDROOM_SANDBOX_")

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -3307,3 +3307,303 @@ def test_sandbox_runner_records_worker_initialization_failures(
     assert worker["status"] == "failed"
     assert "boom" in worker["failure_reason"]
     assert worker["failure_count"] == 1
+
+
+# ----------------------------------------------------------------------------
+# Workspace env hook (.mindroom/worker-env.sh) integration tests
+# ----------------------------------------------------------------------------
+
+
+def _write_workspace_env_hook(workspace: Path, body: str) -> Path:
+    hook_dir = workspace / ".mindroom"
+    hook_dir.mkdir(parents=True, exist_ok=True)
+    hook_path = hook_dir / "worker-env.sh"
+    hook_path.write_text(body, encoding="utf-8")
+    return hook_path
+
+
+@REQUIRES_LINUX_LOCAL_WORKER
+def test_workspace_env_hook_overlays_shell_execution(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`.mindroom/worker-env.sh` exports should be visible to worker-routed shell calls."""
+    _set_sandbox_token(monkeypatch)
+    storage_root = tmp_path / "storage"
+    workspace = storage_root / "agents" / "general" / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_workspace_env_hook(
+        workspace,
+        'export WORKSPACE_HOOK_TOKEN=hello-from-hook\nexport PATH="$PWD/.local/bin:$PATH"\n',
+    )
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
+    _refresh_runner_app_from_env()
+
+    with patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=_fake_local_worker_venv_create):
+        response = runner_client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "shell",
+                "function_name": "run_shell_command",
+                "args": [["bash", "-c", 'printf "%s|%s" "$WORKSPACE_HOOK_TOKEN" "$PATH"']],
+                "kwargs": {},
+                "worker_key": "v1:tenant-123:shared:general",
+                "tool_init_overrides": {"base_dir": "agents/general/workspace"},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True, payload
+    token, path_value = payload["result"].split("|", 1)
+    assert token == "hello-from-hook"  # noqa: S105
+    assert path_value.startswith(f"{workspace.resolve()}/.local/bin:")
+
+
+@REQUIRES_LINUX_LOCAL_WORKER
+def test_workspace_env_hook_edits_take_effect_on_next_call(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Editing `.mindroom/worker-env.sh` should be reflected in the next shell call."""
+    _set_sandbox_token(monkeypatch)
+    storage_root = tmp_path / "storage"
+    workspace = storage_root / "agents" / "general" / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_workspace_env_hook(workspace, "export WORKSPACE_HOOK_TOKEN=first\n")
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
+    _refresh_runner_app_from_env()
+
+    with patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=_fake_local_worker_venv_create):
+        first = runner_client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "shell",
+                "function_name": "run_shell_command",
+                "args": [["bash", "-c", 'printf "%s" "$WORKSPACE_HOOK_TOKEN"']],
+                "kwargs": {},
+                "worker_key": "v1:tenant-123:shared:general",
+                "tool_init_overrides": {"base_dir": "agents/general/workspace"},
+            },
+        )
+
+        assert first.status_code == 200
+        assert first.json()["ok"] is True
+        assert first.json()["result"] == "first"
+
+        _write_workspace_env_hook(workspace, "export WORKSPACE_HOOK_TOKEN=second\n")
+
+        second = runner_client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "shell",
+                "function_name": "run_shell_command",
+                "args": [["bash", "-c", 'printf "%s" "$WORKSPACE_HOOK_TOKEN"']],
+                "kwargs": {},
+                "worker_key": "v1:tenant-123:shared:general",
+                "tool_init_overrides": {"base_dir": "agents/general/workspace"},
+            },
+        )
+
+    assert second.status_code == 200
+    assert second.json()["ok"] is True
+    assert second.json()["result"] == "second"
+
+
+@REQUIRES_LINUX_LOCAL_WORKER
+def test_workspace_env_hook_filters_secrets(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Secret-suffixed exports must not reach the executed shell environment."""
+    _set_sandbox_token(monkeypatch)
+    storage_root = tmp_path / "storage"
+    workspace = storage_root / "agents" / "general" / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_workspace_env_hook(
+        workspace,
+        "export OPENAI_API_KEY=leaked\nexport GITEA_TOKEN=keep\n",
+    )
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    _refresh_runner_app_from_env()
+
+    with patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=_fake_local_worker_venv_create):
+        response = runner_client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "shell",
+                "function_name": "run_shell_command",
+                "args": [["bash", "-c", 'printf "%s|%s" "${OPENAI_API_KEY:-}" "${GITEA_TOKEN:-}"']],
+                "kwargs": {},
+                "worker_key": "v1:tenant-123:shared:general",
+                "tool_init_overrides": {"base_dir": "agents/general/workspace"},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True, payload
+    api_key, token = payload["result"].split("|", 1)
+    assert api_key == ""
+    assert token == "keep"  # noqa: S105
+
+
+@REQUIRES_LINUX_LOCAL_WORKER
+def test_workspace_env_hook_failure_returns_tool_failure(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A non-zero hook exit should surface as a tool failure mentioning the hook."""
+    _set_sandbox_token(monkeypatch)
+    storage_root = tmp_path / "storage"
+    workspace = storage_root / "agents" / "general" / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_workspace_env_hook(workspace, 'echo "bad hook" >&2\nexit 5\n')
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
+    _refresh_runner_app_from_env()
+
+    with patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=_fake_local_worker_venv_create):
+        response = runner_client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "shell",
+                "function_name": "run_shell_command",
+                "args": [["bash", "-c", "echo should-not-run"]],
+                "kwargs": {},
+                "worker_key": "v1:tenant-123:shared:general",
+                "tool_init_overrides": {"base_dir": "agents/general/workspace"},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is False, payload
+    assert payload["failure_kind"] == "tool"
+    assert ".mindroom/worker-env.sh" in payload["error"]
+    assert "exited with code 5" in payload["error"]
+
+
+@REQUIRES_LINUX_LOCAL_WORKER
+def test_workspace_env_hook_overlays_python_subprocess(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Worker-routed `python` subprocess should observe overlay env via os.environ."""
+    _set_sandbox_token(monkeypatch)
+    monkeypatch.setenv("MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE", "subprocess")
+    storage_root = tmp_path / "storage"
+    workspace = storage_root / "agents" / "general" / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_workspace_env_hook(workspace, "export WORKSPACE_PIP_INDEX=https://wheels.example/simple\n")
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
+    _refresh_runner_app_from_env()
+
+    def _venv_with_real_python(_self: object, venv_dir: Path) -> None:
+        bin_dir = venv_dir / "bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        (bin_dir / "python").symlink_to(Path(sys.executable))
+
+    with patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=_venv_with_real_python):
+        response = runner_client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "python",
+                "function_name": "run_python_code",
+                "args": [
+                    'import os\nresult = os.environ.get("WORKSPACE_PIP_INDEX")',
+                    "result",
+                ],
+                "kwargs": {},
+                "worker_key": "v1:tenant-123:shared:general",
+                "tool_init_overrides": {"base_dir": "agents/general/workspace"},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True, payload
+    assert "https://wheels.example/simple" in str(payload["result"])
+
+
+@REQUIRES_LINUX_LOCAL_WORKER
+def test_workspace_env_hook_unkeyed_proxy_uses_init_override_base_dir(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unkeyed proxy requests should still pick up the workspace hook from the requested base_dir."""
+    _set_sandbox_token(monkeypatch)
+    workspace = tmp_path / "static-workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_workspace_env_hook(workspace, "export STATIC_HOOK_TOKEN=visible\n")
+
+    response = runner_client.post(
+        "/api/sandbox-runner/execute",
+        headers=SANDBOX_HEADERS,
+        json={
+            "tool_name": "shell",
+            "function_name": "run_shell_command",
+            "args": [["bash", "-c", 'printf "%s" "$STATIC_HOOK_TOKEN"']],
+            "kwargs": {},
+            "tool_init_overrides": {"base_dir": str(workspace)},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True, payload
+    assert payload["result"] == "visible"
+
+
+@REQUIRES_LINUX_LOCAL_WORKER
+def test_workspace_env_hook_rejects_symlink_escape(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A `.mindroom/worker-env.sh` symlink that escapes the workspace must fail closed."""
+    _set_sandbox_token(monkeypatch)
+    storage_root = tmp_path / "storage"
+    workspace = storage_root / "agents" / "general" / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "evil.sh"
+    target.write_text("export OPENAI_API_KEY=leaked\n", encoding="utf-8")
+    hook_dir = workspace / ".mindroom"
+    hook_dir.mkdir()
+    (hook_dir / "worker-env.sh").symlink_to(target)
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
+    _refresh_runner_app_from_env()
+
+    with patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=_fake_local_worker_venv_create):
+        response = runner_client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "shell",
+                "function_name": "run_shell_command",
+                "args": [["bash", "-c", "echo should-not-run"]],
+                "kwargs": {},
+                "worker_key": "v1:tenant-123:shared:general",
+                "tool_init_overrides": {"base_dir": "agents/general/workspace"},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["failure_kind"] == "tool"
+    assert "resolves outside" in payload["error"]

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -3494,22 +3494,22 @@ def test_workspace_env_hook_failure_returns_tool_failure(
 
 
 @REQUIRES_LINUX_LOCAL_WORKER
-def test_workspace_env_hook_overlays_worker_routed_subprocess_default_mode(
+def test_workspace_env_hook_overlays_worker_routed_python_default_mode(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Worker-keyed non-shell tools (coding/file/python) get the overlay even in the default inprocess runner mode.
+    """Worker-keyed python gets the overlay even in the default inprocess runner mode.
 
-    These tools take the `tool_name != "shell" and worker_key is not None`
-    branch which always dispatches through `_execute_request_subprocess`, so
-    the overlay must reach `os.environ` of the per-worker subprocess.
+    Worker-keyed non-shell tools take the `tool_name != "shell" and
+    worker_key is not None` branch, which always dispatches through
+    `_execute_request_subprocess`.
     """
     _set_sandbox_token(monkeypatch)
     storage_root = tmp_path / "storage"
     workspace = storage_root / "agents" / "general" / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
-    _write_workspace_env_hook(workspace, "export WORKSPACE_TOOLCHAIN_TOKEN=visible-to-coding-and-file\n")
+    _write_workspace_env_hook(workspace, "export WORKSPACE_TOOLCHAIN_TOKEN=visible-to-python\n")
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
     _refresh_runner_app_from_env()
 
@@ -3538,7 +3538,84 @@ def test_workspace_env_hook_overlays_worker_routed_subprocess_default_mode(
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True, payload
-    assert "visible-to-coding-and-file" in str(payload["result"])
+    assert "visible-to-python" in str(payload["result"])
+
+
+@REQUIRES_LINUX_LOCAL_WORKER
+def test_workspace_env_hook_overlays_worker_routed_coding_default_mode(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Worker-keyed coding sees hook PATH changes in the default inprocess runner mode."""
+    _set_sandbox_token(monkeypatch)
+    storage_root = tmp_path / "storage"
+    workspace = storage_root / "agents" / "general" / "workspace"
+    bin_dir = workspace / ".local" / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    (workspace / "note.txt").write_text("needle\n", encoding="utf-8")
+    fake_rg = bin_dir / "rg"
+    fake_rg.write_text('#!/usr/bin/env bash\necho "hook-rg" >&2\nexit 2\n', encoding="utf-8")
+    fake_rg.chmod(0o755)
+    _write_workspace_env_hook(workspace, 'export PATH="$PWD/.local/bin:$PATH"\n')
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
+    _refresh_runner_app_from_env()
+
+    with patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=_fake_local_worker_venv_create):
+        response = runner_client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "coding",
+                "function_name": "grep",
+                "args": ["needle"],
+                "kwargs": {"path": "."},
+                "worker_key": "v1:tenant-123:shared:general",
+                "tool_init_overrides": {"base_dir": "agents/general/workspace"},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True, payload
+    assert payload["result"] == "Error running grep: hook-rg"
+
+
+@REQUIRES_LINUX_LOCAL_WORKER
+def test_workspace_env_hook_failure_blocks_worker_routed_file_default_mode(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Worker-keyed file requests source the hook before running."""
+    _set_sandbox_token(monkeypatch)
+    storage_root = tmp_path / "storage"
+    workspace = storage_root / "agents" / "general" / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_workspace_env_hook(workspace, 'echo "file hook failed" >&2\nexit 6\n')
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
+    _refresh_runner_app_from_env()
+
+    with patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=_fake_local_worker_venv_create):
+        response = runner_client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "file",
+                "function_name": "save_file",
+                "args": ["should not be written", "note.txt"],
+                "kwargs": {},
+                "worker_key": "v1:tenant-123:shared:general",
+                "tool_init_overrides": {"base_dir": "agents/general/workspace"},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is False, payload
+    assert payload["failure_kind"] == "tool"
+    assert "exited with code 6" in payload["error"]
+    assert not (workspace / "note.txt").exists()
 
 
 @REQUIRES_LINUX_LOCAL_WORKER

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -3494,6 +3494,54 @@ def test_workspace_env_hook_failure_returns_tool_failure(
 
 
 @REQUIRES_LINUX_LOCAL_WORKER
+def test_workspace_env_hook_overlays_worker_routed_subprocess_default_mode(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Worker-keyed non-shell tools (coding/file/python) get the overlay even in the default inprocess runner mode.
+
+    These tools take the `tool_name != "shell" and worker_key is not None`
+    branch which always dispatches through `_execute_request_subprocess`, so
+    the overlay must reach `os.environ` of the per-worker subprocess.
+    """
+    _set_sandbox_token(monkeypatch)
+    storage_root = tmp_path / "storage"
+    workspace = storage_root / "agents" / "general" / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_workspace_env_hook(workspace, "export WORKSPACE_TOOLCHAIN_TOKEN=visible-to-coding-and-file\n")
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
+    _refresh_runner_app_from_env()
+
+    def _venv_with_real_python(_self: object, venv_dir: Path) -> None:
+        bin_dir = venv_dir / "bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        (bin_dir / "python").symlink_to(Path(sys.executable))
+
+    with patch("mindroom.workers.backends.local.venv.EnvBuilder.create", new=_venv_with_real_python):
+        response = runner_client.post(
+            "/api/sandbox-runner/execute",
+            headers=SANDBOX_HEADERS,
+            json={
+                "tool_name": "python",
+                "function_name": "run_python_code",
+                "args": [
+                    'import os\nresult = os.environ.get("WORKSPACE_TOOLCHAIN_TOKEN")',
+                    "result",
+                ],
+                "kwargs": {},
+                "worker_key": "v1:tenant-123:shared:general",
+                "tool_init_overrides": {"base_dir": "agents/general/workspace"},
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True, payload
+    assert "visible-to-coding-and-file" in str(payload["result"])
+
+
+@REQUIRES_LINUX_LOCAL_WORKER
 def test_workspace_env_hook_overlays_python_subprocess(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_workspace_env_hook.py
+++ b/tests/test_workspace_env_hook.py
@@ -1,0 +1,316 @@
+"""Tests for the agent-editable `.mindroom/worker-env.sh` overlay helpers."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mindroom.api import sandbox_exec
+from mindroom.api.sandbox_exec import (
+    WORKSPACE_ENV_HOOK_RELATIVE_PATH,
+    WorkspaceEnvHookError,
+    resolve_workspace_env_hook_path,
+    source_workspace_env_hook,
+)
+
+REQUIRES_BASH = pytest.mark.skipif(
+    sys.platform != "linux" and sys.platform != "darwin",
+    reason="bash hook execution is validated on POSIX hosts",
+)
+
+
+def _write_hook(workspace: Path, body: str) -> Path:
+    hook_dir = workspace / ".mindroom"
+    hook_dir.mkdir(parents=True, exist_ok=True)
+    hook_path = hook_dir / "worker-env.sh"
+    hook_path.write_text(body, encoding="utf-8")
+    return hook_path
+
+
+def test_resolve_workspace_env_hook_path_returns_none_when_missing(tmp_path: Path) -> None:
+    """Resolution returns None when no hook script is present."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    assert resolve_workspace_env_hook_path(workspace) is None
+
+
+def test_resolve_workspace_env_hook_path_returns_resolved_file(tmp_path: Path) -> None:
+    """Resolution returns the resolved file path when the hook exists."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    written = _write_hook(workspace, "export FOO=bar\n")
+
+    resolved = resolve_workspace_env_hook_path(workspace)
+
+    assert resolved == written.resolve()
+
+
+def test_resolve_workspace_env_hook_path_returns_none_for_none_base_dir() -> None:
+    """Resolution skips silently when no base_dir is provided."""
+    assert resolve_workspace_env_hook_path(None) is None
+
+
+def test_resolve_workspace_env_hook_path_rejects_symlink_escape(tmp_path: Path) -> None:
+    """A `.mindroom/worker-env.sh` symlink that escapes the workspace fails closed."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "evil.sh"
+    target.write_text("export FOO=leaked\n", encoding="utf-8")
+    hook_dir = workspace / ".mindroom"
+    hook_dir.mkdir()
+    (hook_dir / "worker-env.sh").symlink_to(target)
+
+    with pytest.raises(WorkspaceEnvHookError, match="resolves outside"):
+        resolve_workspace_env_hook_path(workspace)
+
+
+def test_resolve_workspace_env_hook_path_rejects_oversized_script(tmp_path: Path) -> None:
+    """Hooks larger than the byte cap are rejected during resolution."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    huge_body = "export FOO=" + ("a" * (sandbox_exec._WORKSPACE_ENV_HOOK_MAX_SCRIPT_BYTES + 8)) + "\n"
+    _write_hook(workspace, huge_body)
+
+    with pytest.raises(WorkspaceEnvHookError, match="too large"):
+        resolve_workspace_env_hook_path(workspace)
+
+
+def test_resolve_workspace_env_hook_path_returns_none_for_directory_at_path(tmp_path: Path) -> None:
+    """A directory at the hook path is treated as no hook."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".mindroom" / "worker-env.sh").mkdir(parents=True)
+
+    assert resolve_workspace_env_hook_path(workspace) is None
+
+
+@REQUIRES_BASH
+def test_source_workspace_env_hook_captures_exported_values(tmp_path: Path) -> None:
+    """Sourced exports become overlay entries."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(
+        workspace,
+        "export FOO=bar\nexport NPM_CONFIG_PREFIX=$PWD/.local\n",
+    )
+
+    overlay = source_workspace_env_hook(
+        hook_path=hook_path,
+        base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        cwd=workspace,
+    )
+
+    assert overlay["FOO"] == "bar"
+    assert overlay["NPM_CONFIG_PREFIX"] == f"{workspace}/.local"
+
+
+@REQUIRES_BASH
+def test_source_workspace_env_hook_skips_non_exported_assignments(tmp_path: Path) -> None:
+    """Plain `FOO=bar` assignments without `export` do not persist."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(workspace, "FOO=bar\nexport BAR=baz\n")
+
+    overlay = source_workspace_env_hook(
+        hook_path=hook_path,
+        base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        cwd=workspace,
+    )
+
+    assert "FOO" not in overlay
+    assert overlay["BAR"] == "baz"
+
+
+@REQUIRES_BASH
+def test_source_workspace_env_hook_can_append_to_path(tmp_path: Path) -> None:
+    """Hooks may extend PATH using the inherited base PATH."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(workspace, 'export PATH="$PWD/.local/bin:$PATH"\n')
+    base_path = os.environ.get("PATH", "/usr/bin:/bin")
+
+    overlay = source_workspace_env_hook(
+        hook_path=hook_path,
+        base_env={"PATH": base_path},
+        cwd=workspace,
+    )
+
+    assert overlay["PATH"].startswith(f"{workspace}/.local/bin:")
+    assert overlay["PATH"].endswith(base_path)
+
+
+@REQUIRES_BASH
+def test_source_workspace_env_hook_drops_secret_suffixes(tmp_path: Path) -> None:
+    """Secret-suffixed names are filtered while non-secret tokens stay."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(
+        workspace,
+        "export OPENAI_API_KEY=leaked\n"
+        "export SOMETHING_PASSWORD=leaked\n"
+        "export SOMETHING_SECRET=leaked\n"
+        "export GITEA_TOKEN=keep\n",
+    )
+
+    overlay = source_workspace_env_hook(
+        hook_path=hook_path,
+        base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        cwd=workspace,
+    )
+
+    assert "OPENAI_API_KEY" not in overlay
+    assert "SOMETHING_PASSWORD" not in overlay
+    assert "SOMETHING_SECRET" not in overlay
+    assert overlay["GITEA_TOKEN"] == "keep"  # noqa: S105
+
+
+@REQUIRES_BASH
+def test_source_workspace_env_hook_drops_runner_control_names(tmp_path: Path) -> None:
+    """Runner control names (MINDROOM_SANDBOX_*, MINDROOM_API_KEY, CI_JOB_TOKEN) are filtered."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(
+        workspace,
+        "export MINDROOM_SANDBOX_PROXY_TOKEN=leaked\n"
+        "export MINDROOM_API_KEY=leaked\n"
+        "export MINDROOM_SANDBOX_DEDICATED_WORKER_KEY=leaked\n"
+        "export CI_JOB_TOKEN=leaked\n"
+        "export NPM_CONFIG_PREFIX=keep\n",
+    )
+
+    overlay = source_workspace_env_hook(
+        hook_path=hook_path,
+        base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        cwd=workspace,
+    )
+
+    assert "MINDROOM_SANDBOX_PROXY_TOKEN" not in overlay
+    assert "MINDROOM_API_KEY" not in overlay
+    assert "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY" not in overlay
+    assert "CI_JOB_TOKEN" not in overlay
+    assert overlay["NPM_CONFIG_PREFIX"] == "keep"
+
+
+@REQUIRES_BASH
+def test_source_workspace_env_hook_drops_transient_bookkeeping(tmp_path: Path) -> None:
+    """Bash bookkeeping vars (PWD, OLDPWD, SHLVL, _) are excluded from the overlay."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(workspace, "export NPM_CONFIG_PREFIX=keep\n")
+
+    overlay = source_workspace_env_hook(
+        hook_path=hook_path,
+        base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        cwd=workspace,
+    )
+
+    assert "PWD" not in overlay
+    assert "OLDPWD" not in overlay
+    assert "SHLVL" not in overlay
+    assert "_" not in overlay
+
+
+@REQUIRES_BASH
+def test_source_workspace_env_hook_skips_unchanged_base_values(tmp_path: Path) -> None:
+    """Values identical to the base env do not appear in the overlay."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(workspace, 'export PATH="$PATH"\nexport FOO=bar\n')
+    base_path = os.environ.get("PATH", "/usr/bin:/bin")
+
+    overlay = source_workspace_env_hook(
+        hook_path=hook_path,
+        base_env={"PATH": base_path},
+        cwd=workspace,
+    )
+
+    assert "PATH" not in overlay
+    assert overlay["FOO"] == "bar"
+
+
+@REQUIRES_BASH
+def test_source_workspace_env_hook_raises_on_non_zero_exit(tmp_path: Path) -> None:
+    """A failing hook surfaces as a hook error mentioning the exit code."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(workspace, 'echo "boom" >&2\nexit 7\n')
+
+    with pytest.raises(WorkspaceEnvHookError, match="exited with code 7"):
+        source_workspace_env_hook(
+            hook_path=hook_path,
+            base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+            cwd=workspace,
+        )
+
+
+@REQUIRES_BASH
+def test_source_workspace_env_hook_raises_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Subprocess timeout becomes a hook error."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(workspace, "export FOO=bar\n")
+
+    monkeypatch.setattr(sandbox_exec, "WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS", 0.01)
+
+    def _slow_run(*_args: object, **_kwargs: object) -> object:
+        raise subprocess.TimeoutExpired(cmd="bash", timeout=0.01)
+
+    monkeypatch.setattr(sandbox_exec.subprocess, "run", _slow_run)
+
+    with pytest.raises(WorkspaceEnvHookError, match="timed out"):
+        source_workspace_env_hook(
+            hook_path=hook_path,
+            base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+            cwd=workspace,
+        )
+
+
+def test_source_workspace_env_hook_raises_when_bash_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Missing bash surfaces as a hook error rather than a crash."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(workspace, "export FOO=bar\n")
+
+    monkeypatch.setattr(sandbox_exec.shutil, "which", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(sandbox_exec.Path, "exists", lambda _self: False)
+
+    with pytest.raises(WorkspaceEnvHookError, match="bash is required"):
+        source_workspace_env_hook(
+            hook_path=hook_path,
+            base_env={},
+            cwd=workspace,
+        )
+
+
+@REQUIRES_BASH
+def test_source_workspace_env_hook_ignores_script_stdout_before_marker(tmp_path: Path) -> None:
+    """Script stdout printed before the env capture marker is ignored."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(workspace, 'echo "noisy script output"\nexport FOO=bar\n')
+
+    overlay = source_workspace_env_hook(
+        hook_path=hook_path,
+        base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        cwd=workspace,
+    )
+
+    assert overlay["FOO"] == "bar"
+
+
+def test_workspace_env_hook_relative_path_value() -> None:
+    """The exposed relative path constant matches the documented filename."""
+    assert Path(".mindroom") / "worker-env.sh" == WORKSPACE_ENV_HOOK_RELATIVE_PATH

--- a/tests/test_workspace_env_hook.py
+++ b/tests/test_workspace_env_hook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -18,7 +19,8 @@ from mindroom.api.sandbox_exec import (
 )
 
 REQUIRES_BASH = pytest.mark.skipif(
-    sys.platform != "linux" and sys.platform != "darwin",
+    (sys.platform != "linux" and sys.platform != "darwin")
+    or (shutil.which("bash") is None and not os.access("/bin/bash", os.X_OK)),
     reason="bash hook execution is validated on POSIX hosts",
 )
 
@@ -270,6 +272,25 @@ def test_source_workspace_env_hook_raises_on_timeout(
         )
 
 
+@REQUIRES_BASH
+def test_source_workspace_env_hook_rejects_oversized_stderr_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Successful hooks cannot write unbounded stderr output."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(workspace, "python -c \"import sys; sys.stderr.write('x' * 3000)\"\nexport FOO=bar\n")
+    monkeypatch.setattr(sandbox_exec, "_WORKSPACE_ENV_HOOK_MAX_OUTPUT_BYTES", 2048)
+
+    with pytest.raises(WorkspaceEnvHookError, match="stderr output"):
+        source_workspace_env_hook(
+            hook_path=hook_path,
+            base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+            cwd=workspace,
+        )
+
+
 def test_source_workspace_env_hook_kills_process_group_on_timeout(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -283,14 +304,14 @@ def test_source_workspace_env_hook_kills_process_group_on_timeout(
     class _TimeoutProcess:
         pid = 12345
 
-        def communicate(self, **kwargs: object) -> tuple[bytes, bytes]:
-            timeout = float(kwargs["timeout"])
-            raise subprocess.TimeoutExpired(cmd="bash", timeout=timeout)
-
         def wait(self, **_kwargs: object) -> int:
             return -9
 
-    monkeypatch.setattr(sandbox_exec.subprocess, "run", pytest.fail)
+    def _raise_timeout(_process: object) -> tuple[bytes, bytes]:
+        raise subprocess.TimeoutExpired(cmd="bash", timeout=0.01)
+
+    monkeypatch.setattr(sandbox_exec, "_resolve_bash", lambda _base_env: "/fake/bash")
+    monkeypatch.setattr(sandbox_exec, "_capture_workspace_env_hook_output", _raise_timeout)
     monkeypatch.setattr(sandbox_exec.subprocess, "Popen", lambda *_args, **_kwargs: _TimeoutProcess())
     monkeypatch.setattr(sandbox_exec.os, "getpgid", lambda pid: pid)
     monkeypatch.setattr(sandbox_exec.os, "killpg", lambda pgid, _sig: killed_pgids.append(pgid))

--- a/tests/test_workspace_env_hook.py
+++ b/tests/test_workspace_env_hook.py
@@ -258,16 +258,65 @@ def test_source_workspace_env_hook_raises_on_timeout(
     """Subprocess timeout becomes a hook error."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    hook_path = _write_hook(workspace, "export FOO=bar\n")
+    hook_path = _write_hook(workspace, "sleep 1\nexport FOO=bar\n")
 
     monkeypatch.setattr(sandbox_exec, "WORKSPACE_ENV_HOOK_TIMEOUT_SECONDS", 0.01)
 
-    def _slow_run(*_args: object, **_kwargs: object) -> object:
-        raise subprocess.TimeoutExpired(cmd="bash", timeout=0.01)
+    with pytest.raises(WorkspaceEnvHookError, match="timed out"):
+        source_workspace_env_hook(
+            hook_path=hook_path,
+            base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+            cwd=workspace,
+        )
 
-    monkeypatch.setattr(sandbox_exec.subprocess, "run", _slow_run)
+
+def test_source_workspace_env_hook_kills_process_group_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Hook timeouts kill the whole child process group."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(workspace, "sleep 60\n")
+    killed_pgids: list[int] = []
+
+    class _TimeoutProcess:
+        pid = 12345
+
+        def communicate(self, **kwargs: object) -> tuple[bytes, bytes]:
+            timeout = float(kwargs["timeout"])
+            raise subprocess.TimeoutExpired(cmd="bash", timeout=timeout)
+
+        def wait(self, **_kwargs: object) -> int:
+            return -9
+
+    monkeypatch.setattr(sandbox_exec.subprocess, "run", pytest.fail)
+    monkeypatch.setattr(sandbox_exec.subprocess, "Popen", lambda *_args, **_kwargs: _TimeoutProcess())
+    monkeypatch.setattr(sandbox_exec.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(sandbox_exec.os, "killpg", lambda pgid, _sig: killed_pgids.append(pgid))
 
     with pytest.raises(WorkspaceEnvHookError, match="timed out"):
+        source_workspace_env_hook(
+            hook_path=hook_path,
+            base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+            cwd=workspace,
+        )
+
+    assert killed_pgids == [12345]
+
+
+@REQUIRES_BASH
+def test_source_workspace_env_hook_rejects_overlay_that_exceeds_total_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The total overlay byte cap rejects the first entry that would exceed it."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    hook_path = _write_hook(workspace, "export FIRST=12345\nexport SECOND=12345\n")
+    monkeypatch.setattr(sandbox_exec, "_WORKSPACE_ENV_HOOK_MAX_OVERLAY_BYTES", len("FIRST=12345"))
+
+    with pytest.raises(WorkspaceEnvHookError, match="overlay is too large"):
         source_workspace_env_hook(
             hook_path=hook_path,
             base_env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
@@ -285,7 +334,7 @@ def test_source_workspace_env_hook_raises_when_bash_missing(
     hook_path = _write_hook(workspace, "export FOO=bar\n")
 
     monkeypatch.setattr(sandbox_exec.shutil, "which", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(sandbox_exec.Path, "exists", lambda _self: False)
+    monkeypatch.setattr(sandbox_exec.os, "access", lambda *_args, **_kwargs: False)
 
     with pytest.raises(WorkspaceEnvHookError, match="bash is required"):
         source_workspace_env_hook(


### PR DESCRIPTION
## Summary
- Adds a request-time `.mindroom/worker-env.sh` overlay sourced inside the sandbox runner before each worker-routed shell, python, coding, or file call.
- Exported values merge into the tool's execution env so agents can adjust `PATH`, `PIP_INDEX_URL`, `NPM_CONFIG_PREFIX`, and similar toolchain settings without changing config or redeploying.
- Edits take effect on the next call across both `static_runner` and dedicated Kubernetes worker backends — no Helm, pod-template, or startup-manifest changes.

## Safety
- Reuses the existing shell secret-denylist (drops `*_API_KEY`, `*_PASSWORD`, `*_SECRET`, `MINDROOM_SANDBOX_*`, `CI_JOB_TOKEN`, etc.).
- Bounds script/output/value sizes, rejects symlinks that escape the workspace, and times out at 10 seconds.
- Hook failures surface as `ok=false` with `failure_kind=tool` so a broken script never poisons the worker.

## Test plan
- [ ] `uv run pytest tests/test_workspace_env_hook.py tests/api/test_sandbox_runner_api.py -x -n 0 --no-cov -v`
- [ ] Verify a worker-routed shell call picks up changes after editing `.mindroom/worker-env.sh` (no restart).
- [ ] Confirm secrets in the denylist are stripped from the merged env.
- [ ] Confirm timeout / oversize / symlink-escape produce `ok=false` with `failure_kind=tool`.