### PR TITLE
feat(workers): make worker pod resources configurable via env

### DIFF
--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -25,6 +25,10 @@ _DEFAULT_CONFIG_PATH = "/app/config.yaml"
 _DEFAULT_STORAGE_MOUNT_PATH = "/app/worker"
 _DEFAULT_SERVICE_ACCOUNT_NAME = "default"
 _DEFAULT_NAME_PREFIX = "mindroom-worker"
+_DEFAULT_MEMORY_REQUEST = "256Mi"
+_DEFAULT_MEMORY_LIMIT = "1Gi"
+_DEFAULT_CPU_REQUEST = "100m"
+_DEFAULT_CPU_LIMIT = "500m"
 
 _WORKER_BACKEND_ENV = "MINDROOM_WORKER_BACKEND"
 _NAMESPACE_ENV = "MINDROOM_KUBERNETES_WORKER_NAMESPACE"
@@ -48,6 +52,10 @@ _COLOCATE_WITH_CONTROL_PLANE_NODE_ENV = "MINDROOM_KUBERNETES_WORKER_COLOCATE_WIT
 _EXTRA_ENV_JSON_ENV = "MINDROOM_KUBERNETES_WORKER_ENV_JSON"
 _EXTRA_LABELS_JSON_ENV = "MINDROOM_KUBERNETES_WORKER_LABELS_JSON"
 _OWNER_DEPLOYMENT_NAME_ENV = "MINDROOM_KUBERNETES_WORKER_OWNER_DEPLOYMENT_NAME"
+_MEMORY_REQUEST_ENV = "MINDROOM_KUBERNETES_WORKER_MEMORY_REQUEST"
+_MEMORY_LIMIT_ENV = "MINDROOM_KUBERNETES_WORKER_MEMORY_LIMIT"
+_CPU_REQUEST_ENV = "MINDROOM_KUBERNETES_WORKER_CPU_REQUEST"
+_CPU_LIMIT_ENV = "MINDROOM_KUBERNETES_WORKER_CPU_LIMIT"
 _POD_NAMESPACE_ENV = "POD_NAMESPACE"
 
 
@@ -126,6 +134,8 @@ class _KubernetesWorkerBackendConfig:
     extra_env: dict[str, str]
     extra_labels: dict[str, str]
     owner_deployment_name: str | None
+    resource_requests: dict[str, str]
+    resource_limits: dict[str, str]
 
     @classmethod
     def from_runtime(cls, runtime_paths: RuntimePaths) -> _KubernetesWorkerBackendConfig:
@@ -144,6 +154,14 @@ class _KubernetesWorkerBackendConfig:
 
         config_map_name = _read_env(env, _CONFIG_MAP_NAME_ENV) or None
         token_secret_name = _read_env(env, _TOKEN_SECRET_NAME_ENV) or None
+        resource_requests = {
+            "memory": _read_env(env, _MEMORY_REQUEST_ENV, _DEFAULT_MEMORY_REQUEST) or _DEFAULT_MEMORY_REQUEST,
+            "cpu": _read_env(env, _CPU_REQUEST_ENV, _DEFAULT_CPU_REQUEST) or _DEFAULT_CPU_REQUEST,
+        }
+        resource_limits = {
+            "memory": _read_env(env, _MEMORY_LIMIT_ENV, _DEFAULT_MEMORY_LIMIT) or _DEFAULT_MEMORY_LIMIT,
+            "cpu": _read_env(env, _CPU_LIMIT_ENV, _DEFAULT_CPU_LIMIT) or _DEFAULT_CPU_LIMIT,
+        }
         return cls(
             namespace=namespace,
             image=image,
@@ -170,6 +188,8 @@ class _KubernetesWorkerBackendConfig:
             extra_env=_read_json_mapping_env(env, _EXTRA_ENV_JSON_ENV),
             extra_labels=_read_json_mapping_env(env, _EXTRA_LABELS_JSON_ENV),
             owner_deployment_name=_read_env(env, _OWNER_DEPLOYMENT_NAME_ENV) or None,
+            resource_requests=resource_requests,
+            resource_limits=resource_limits,
         )
 
 
@@ -183,6 +203,8 @@ def kubernetes_backend_config_signature(
     config = _KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
     extra_env_json = json.dumps(config.extra_env, sort_keys=True, separators=(",", ":"))
     extra_labels_json = json.dumps(config.extra_labels, sort_keys=True, separators=(",", ":"))
+    resource_requests_json = json.dumps(config.resource_requests, sort_keys=True, separators=(",", ":"))
+    resource_limits_json = json.dumps(config.resource_limits, sort_keys=True, separators=(",", ":"))
     return (
         "kubernetes",
         config.namespace,
@@ -206,6 +228,8 @@ def kubernetes_backend_config_signature(
         extra_env_json,
         extra_labels_json,
         config.owner_deployment_name or "",
+        resource_requests_json,
+        resource_limits_json,
         auth_token or "",
         str(storage_root.expanduser().resolve()) if storage_root is not None else "",
     )

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -29,8 +29,6 @@ if TYPE_CHECKING:
     from .kubernetes_config import _KubernetesWorkerBackendConfig
 
 _DEFAULT_NAME_PREFIX = "mindroom-worker"
-_DEFAULT_RESOURCE_REQUESTS = {"memory": "256Mi", "cpu": "100m"}
-_DEFAULT_RESOURCE_LIMITS = {"memory": "1Gi", "cpu": "500m"}
 _READY_POLL_INTERVAL_SECONDS = 1.0
 _DELETE_POLL_INTERVAL_SECONDS = 0.2
 _HOSTNAME_ENV = "HOSTNAME"
@@ -567,8 +565,8 @@ class KubernetesResourceManager:
                         "failureThreshold": 6,
                     },
                     "resources": {
-                        "requests": dict(_DEFAULT_RESOURCE_REQUESTS),
-                        "limits": dict(_DEFAULT_RESOURCE_LIMITS),
+                        "requests": dict(self.config.resource_requests),
+                        "limits": dict(self.config.resource_limits),
                     },
                     "securityContext": {
                         "allowPrivilegeEscalation": False,

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -282,6 +282,8 @@ def _backend(
     runtime_paths: RuntimePaths | None = None,
     tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
     worker_grantable_credentials: frozenset[str] = DEFAULT_WORKER_GRANTABLE_CREDENTIALS,
+    resource_requests: dict[str, str] | None = None,
+    resource_limits: dict[str, str] | None = None,
 ) -> tuple[KubernetesWorkerBackend, _FakeAppsApi, _FakeCoreApi]:
     config = _KubernetesWorkerBackendConfig(
         namespace="chat",
@@ -305,6 +307,8 @@ def _backend(
         extra_env={},
         extra_labels={"mindroom.ai/tenant": "test"},
         owner_deployment_name=owner_deployment_name,
+        resource_requests=resource_requests if resource_requests is not None else {"memory": "256Mi", "cpu": "100m"},
+        resource_limits=resource_limits if resource_limits is not None else {"memory": "1Gi", "cpu": "500m"},
     )
     resolved_runtime_paths = runtime_paths or resolve_primary_runtime_paths(
         config_path=Path("config.yaml"),
@@ -735,6 +739,79 @@ def test_primary_worker_backend_available_uses_runtime_env_values(tmp_path: Path
         proxy_url=None,
         proxy_token=runtime_paths.env_value("MINDROOM_SANDBOX_PROXY_TOKEN"),
     )
+
+
+def test_kubernetes_backend_config_resource_envs_override_defaults(tmp_path: Path) -> None:
+    """Resource request/limit env vars override the built-in defaults."""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    (config_dir / ".env").write_text(
+        (
+            "MINDROOM_WORKER_BACKEND=kubernetes\n"
+            "MINDROOM_KUBERNETES_WORKER_IMAGE=test-image\n"
+            "MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME=test-pvc\n"
+            "MINDROOM_KUBERNETES_WORKER_MEMORY_REQUEST=2Gi\n"
+            "MINDROOM_KUBERNETES_WORKER_MEMORY_LIMIT=8Gi\n"
+            "MINDROOM_KUBERNETES_WORKER_CPU_REQUEST=500m\n"
+            "MINDROOM_KUBERNETES_WORKER_CPU_LIMIT=2\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_primary_runtime_paths(config_path=config_path)
+
+    config = _KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
+
+    assert config.resource_requests == {"memory": "2Gi", "cpu": "500m"}
+    assert config.resource_limits == {"memory": "8Gi", "cpu": "2"}
+
+
+def test_kubernetes_backend_config_resources_default_when_env_unset(tmp_path: Path) -> None:
+    """Resource defaults kick in when no override env vars are present."""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    (config_dir / ".env").write_text(
+        (
+            "MINDROOM_WORKER_BACKEND=kubernetes\n"
+            "MINDROOM_KUBERNETES_WORKER_IMAGE=test-image\n"
+            "MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME=test-pvc\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_primary_runtime_paths(config_path=config_path)
+
+    config = _KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
+
+    assert config.resource_requests == {"memory": "256Mi", "cpu": "100m"}
+    assert config.resource_limits == {"memory": "1Gi", "cpu": "500m"}
+
+
+def test_kubernetes_backend_renders_configured_resources_on_worker_container(tmp_path: Path) -> None:
+    """Configured resource requests/limits land on the rendered worker container."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, _core_api = _backend(
+        runtime_paths=runtime_paths,
+        resource_requests={"memory": "2Gi", "cpu": "500m"},
+        resource_limits={"memory": "8Gi", "cpu": "2"},
+    )
+
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
+
+    container = apps_api.created_bodies[0]["spec"]["template"]["spec"]["containers"][0]
+    assert container["resources"]["requests"] == {"memory": "2Gi", "cpu": "500m"}
+    assert container["resources"]["limits"] == {"memory": "8Gi", "cpu": "2"}
 
 
 def test_kubernetes_backend_rejects_unknown_worker_keys_for_scoped_mounts() -> None:


### PR DESCRIPTION
## Summary

The Kubernetes worker backend hardcodes resource requests at `256Mi`/`100m` and limits at `1Gi`/`500m`. Anything that runs a heavier subprocess inside a worker — a conda/mamba solve, a sizeable build, a notebook with pandas/torch — reliably blows past the 1 GiB memory cap and gets OOM-killed by the kernel.

The failure mode is hostile to debug: because the worker is a Deployment and not a long-lived pod, the OOM-killed pod is replaced under a fresh name. `Restart Count` resets to 0, `kubectl logs --previous` returns nothing, and the calling agent just sees the in-flight HTTP request drop with `Server disconnected without sending a response.` — no surfaced OOMKill, no exit code.

This PR adds four optional env vars on the controller so operators can lift those caps without forking the image:

- `MINDROOM_KUBERNETES_WORKER_MEMORY_REQUEST` (default `256Mi`)
- `MINDROOM_KUBERNETES_WORKER_MEMORY_LIMIT` (default `1Gi`)
- `MINDROOM_KUBERNETES_WORKER_CPU_REQUEST` (default `100m`)
- `MINDROOM_KUBERNETES_WORKER_CPU_LIMIT` (default `500m`)

When unset, behavior is unchanged.

### Implementation notes

- Resource values flow through `_KubernetesWorkerBackendConfig` (`resource_requests`, `resource_limits`) and land in the rendered worker container's `resources` block in `kubernetes_resources.py`.
- The values are part of `kubernetes_backend_config_signature`, so changing them invalidates the worker template hash and forces a recreate on the next reconcile — the same behavior already used for image / config-map / env changes.
- Granular env vars rather than a single JSON blob: matches the existing `MINDROOM_KUBERNETES_WORKER_*` naming convention (e.g. `_PORT`, `_NAMESPACE`, `_IMAGE`) and keeps the surface area discoverable. A JSON blob can be layered on later if there's demand for ephemeral-storage / GPU keys.

## Test plan

- [x] `pytest tests/test_kubernetes_worker_backend.py` — 53 passed (3 new tests, 50 existing).
- [x] `ruff check` + `ruff format --check` clean on all touched files.
- [x] New `test_kubernetes_backend_config_resource_envs_override_defaults` exercises `_KubernetesWorkerBackendConfig.from_runtime` with all four env vars set and asserts the resolved config dicts.
- [x] New `test_kubernetes_backend_config_resources_default_when_env_unset` covers the default path (no env override).
- [x] New `test_kubernetes_backend_renders_configured_resources_on_worker_container` ensures the configured resources land on the rendered worker container's `resources.requests`/`resources.limits`, not just the config object.