### PR TITLE
Trust explicit sandbox env passthrough

### DIFF
--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -243,7 +243,10 @@ If you deploy that mode without Helm, see [Kubernetes Deployment](kubernetes.md)
 
 When `shell` runs through the sandbox proxy, it receives the stricter sandbox runtime env rather than the main process's ordinary committed runtime `.env`.
 Additional env is not forwarded implicitly: configure `extra_env_passthrough` with exact names or glob patterns for exported process env variables you want shell execution to inherit.
-`extra_env_passthrough` does not re-expose config-adjacent `.env` entries that the sandbox contract filtered out.
+`extra_env_passthrough` matches exported process env, not config-adjacent `.env` entries.
+To prevent the runner from leaking its own control-plane credentials to tools, shell passthrough drops names in a small explicit denylist (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`.
+Everything else that matches your configured names or globs passes through, including service tokens and provider credentials.
+If you don't want a value to reach shell commands, don't match it with `extra_env_passthrough`.
 
 If proxied shell commands need extra PATH entries such as wrapper directories, configure `shell_path_prepend`.
 This prepends the configured entries ahead of the runtime PATH while preserving the existing PATH order and removing duplicates.
@@ -277,12 +280,11 @@ The runner sources this script with `bash` before each worker-routed `shell`, `p
 
 **Filtering:**
 
-The overlay reuses the same secret rules that protect `extra_env_passthrough`:
-
-- Names ending in `_API_KEY`, `_API_KEYS`, `_PASSWORD`, or `_SECRET` are dropped.
-- Runner control names (`MINDROOM_SANDBOX_*`, `MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) are dropped.
-- `CI_JOB_TOKEN` and bash bookkeeping (`PWD`, `OLDPWD`, `SHLVL`, `_`, `PIPESTATUS`) are dropped.
-- Non-secret service tokens such as `GITEA_TOKEN` are kept.
+`.mindroom/worker-env.sh` is sourced by bash that inherits the runner's process env, which contains tokens the runner needs to function (sandbox proxy auth, etc.).
+To prevent the runner from leaking its own control-plane credentials to tools, the overlay drops names in a small explicit denylist (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`.
+Bash bookkeeping vars (`PWD`, `OLDPWD`, `SHLVL`, `_`, `PIPESTATUS`) are also dropped because they're noise, not values the script meant to export.
+Everything else passes through, including service tokens and provider credentials you intentionally export from the hook.
+If you don't want a value to reach tools, don't export it.
 
 **Limits and failure handling:**
 

--- a/docs/tools/execution-and-coding.md
+++ b/docs/tools/execution-and-coding.md
@@ -149,7 +149,7 @@ MindRoom marks `shell` as worker-routed by default, so it usually executes in th
 | `base_dir` | `text` | `no` | `null` | Runtime-managed working directory when an agent workspace exists. This field is not normally authored inline in `config.yaml`. |
 | `enable_run_shell_command` | `boolean` | `no` | `true` | Enable `run_shell_command()` and the companion handle APIs. |
 | `all` | `boolean` | `no` | `false` | Enable all shell functions. |
-| `extra_env_passthrough` | `text` | `no` | `null` | Extra exported process env var names or glob patterns exposed to shell execution in addition to MindRoom's sandbox runtime env. This does not re-expose filtered runtime `.env` entries. |
+| `extra_env_passthrough` | `text` | `no` | `null` | Extra exported process env var names or glob patterns exposed to shell execution in addition to MindRoom's sandbox runtime env. This matches exported process env, not config-adjacent `.env` entries. |
 | `shell_path_prepend` | `text` | `no` | `null` | Extra PATH entries prepended for shell subprocesses only. |
 
 ### Example
@@ -177,7 +177,7 @@ kill_shell_command("shell:abcd1234")
 
 ### Notes
 
-- `extra_env_passthrough` only affects `shell`, matches exported process env, and MindRoom excludes known sensitive names and secret-suffixed env vars even when a glob would otherwise match them.
+- `extra_env_passthrough` only affects `shell` and matches exported process env, not config-adjacent `.env` entries. MindRoom drops runner control names (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`; everything else that matches passes through, including service tokens and provider credentials.
 - In authored YAML, `extra_env_passthrough` and `shell_path_prepend` can be written as lists, and MindRoom normalizes them to the tool's comma-or-newline form.
 - Background handles survive multiple requests to the same long-lived runner process, but they do not survive runner restarts.
 - `shell_path_prepend` deduplicates PATH entries and only changes subprocess PATH, not the main MindRoom process PATH.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2443,13 +2443,13 @@ save_file("temporary notes\n", "scratch/notes.txt")
 
 ### Configuration
 
-| Option                     | Type      | Required | Default | Notes                                                                                                                                                                                    |
-| -------------------------- | --------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `base_dir`                 | `text`    | `no`     | `null`  | Runtime-managed working directory when an agent workspace exists. This field is not normally authored inline in `config.yaml`.                                                           |
-| `enable_run_shell_command` | `boolean` | `no`     | `true`  | Enable `run_shell_command()` and the companion handle APIs.                                                                                                                              |
-| `all`                      | `boolean` | `no`     | `false` | Enable all shell functions.                                                                                                                                                              |
-| `extra_env_passthrough`    | `text`    | `no`     | `null`  | Extra exported process env var names or glob patterns exposed to shell execution in addition to MindRoom's sandbox runtime env. This does not re-expose filtered runtime `.env` entries. |
-| `shell_path_prepend`       | `text`    | `no`     | `null`  | Extra PATH entries prepended for shell subprocesses only.                                                                                                                                |
+| Option                     | Type      | Required | Default | Notes                                                                                                                                                                                                  |
+| -------------------------- | --------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `base_dir`                 | `text`    | `no`     | `null`  | Runtime-managed working directory when an agent workspace exists. This field is not normally authored inline in `config.yaml`.                                                                         |
+| `enable_run_shell_command` | `boolean` | `no`     | `true`  | Enable `run_shell_command()` and the companion handle APIs.                                                                                                                                            |
+| `all`                      | `boolean` | `no`     | `false` | Enable all shell functions.                                                                                                                                                                            |
+| `extra_env_passthrough`    | `text`    | `no`     | `null`  | Extra exported process env var names or glob patterns exposed to shell execution in addition to MindRoom's sandbox runtime env. This matches exported process env, not config-adjacent `.env` entries. |
+| `shell_path_prepend`       | `text`    | `no`     | `null`  | Extra PATH entries prepended for shell subprocesses only.                                                                                                                                              |
 
 ### Example
 
@@ -2476,7 +2476,7 @@ kill_shell_command("shell:abcd1234")
 
 ### Notes
 
-- `extra_env_passthrough` only affects `shell`, matches exported process env, and MindRoom excludes known sensitive names and secret-suffixed env vars even when a glob would otherwise match them.
+- `extra_env_passthrough` only affects `shell` and matches exported process env, not config-adjacent `.env` entries. MindRoom drops runner control names (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`; everything else that matches passes through, including service tokens and provider credentials.
 - In authored YAML, `extra_env_passthrough` and `shell_path_prepend` can be written as lists, and MindRoom normalizes them to the tool's comma-or-newline form.
 - Background handles survive multiple requests to the same long-lived runner process, but they do not survive runner restarts.
 - `shell_path_prepend` deduplicates PATH entries and only changes subprocess PATH, not the main MindRoom process PATH.
@@ -12046,7 +12046,7 @@ When `MINDROOM_WORKER_BACKEND=kubernetes`, the primary runtime resolves worker e
 
 ## Shell env and PATH
 
-When `shell` runs through the sandbox proxy, it receives the stricter sandbox runtime env rather than the main process's ordinary committed runtime `.env`. Additional env is not forwarded implicitly: configure `extra_env_passthrough` with exact names or glob patterns for exported process env variables you want shell execution to inherit. `extra_env_passthrough` does not re-expose config-adjacent `.env` entries that the sandbox contract filtered out.
+When `shell` runs through the sandbox proxy, it receives the stricter sandbox runtime env rather than the main process's ordinary committed runtime `.env`. Additional env is not forwarded implicitly: configure `extra_env_passthrough` with exact names or glob patterns for exported process env variables you want shell execution to inherit. `extra_env_passthrough` matches exported process env, not config-adjacent `.env` entries. To prevent the runner from leaking its own control-plane credentials to tools, shell passthrough drops names in a small explicit denylist (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`. Everything else that matches your configured names or globs passes through, including service tokens and provider credentials. If you don't want a value to reach shell commands, don't match it with `extra_env_passthrough`.
 
 If proxied shell commands need extra PATH entries such as wrapper directories, configure `shell_path_prepend`. This prepends the configured entries ahead of the runtime PATH while preserving the existing PATH order and removing duplicates. That keeps PATH handling deployment-specific instead of baking host-specific directories into the shell tool itself.
 
@@ -12075,12 +12075,7 @@ The runner sources this script with `bash` before each worker-routed `shell`, `p
 
 **Filtering:**
 
-The overlay reuses the same secret rules that protect `extra_env_passthrough`:
-
-- Names ending in `_API_KEY`, `_API_KEYS`, `_PASSWORD`, or `_SECRET` are dropped.
-- Runner control names (`MINDROOM_SANDBOX_*`, `MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) are dropped.
-- `CI_JOB_TOKEN` and bash bookkeeping (`PWD`, `OLDPWD`, `SHLVL`, `_`, `PIPESTATUS`) are dropped.
-- Non-secret service tokens such as `GITEA_TOKEN` are kept.
+`.mindroom/worker-env.sh` is sourced by bash that inherits the runner's process env, which contains tokens the runner needs to function (sandbox proxy auth, etc.). To prevent the runner from leaking its own control-plane credentials to tools, the overlay drops names in a small explicit denylist (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`. Bash bookkeeping vars (`PWD`, `OLDPWD`, `SHLVL`, `_`, `PIPESTATUS`) are also dropped because they're noise, not values the script meant to export. Everything else passes through, including service tokens and provider credentials you intentionally export from the hook. If you don't want a value to reach tools, don't export it.
 
 **Limits and failure handling:**
 

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -196,7 +196,7 @@ When `MINDROOM_WORKER_BACKEND=kubernetes`, the primary runtime resolves worker e
 
 ## Shell env and PATH
 
-When `shell` runs through the sandbox proxy, it receives the stricter sandbox runtime env rather than the main process's ordinary committed runtime `.env`. Additional env is not forwarded implicitly: configure `extra_env_passthrough` with exact names or glob patterns for exported process env variables you want shell execution to inherit. `extra_env_passthrough` does not re-expose config-adjacent `.env` entries that the sandbox contract filtered out.
+When `shell` runs through the sandbox proxy, it receives the stricter sandbox runtime env rather than the main process's ordinary committed runtime `.env`. Additional env is not forwarded implicitly: configure `extra_env_passthrough` with exact names or glob patterns for exported process env variables you want shell execution to inherit. `extra_env_passthrough` matches exported process env, not config-adjacent `.env` entries. To prevent the runner from leaking its own control-plane credentials to tools, shell passthrough drops names in a small explicit denylist (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`. Everything else that matches your configured names or globs passes through, including service tokens and provider credentials. If you don't want a value to reach shell commands, don't match it with `extra_env_passthrough`.
 
 If proxied shell commands need extra PATH entries such as wrapper directories, configure `shell_path_prepend`. This prepends the configured entries ahead of the runtime PATH while preserving the existing PATH order and removing duplicates. That keeps PATH handling deployment-specific instead of baking host-specific directories into the shell tool itself.
 
@@ -225,12 +225,7 @@ The runner sources this script with `bash` before each worker-routed `shell`, `p
 
 **Filtering:**
 
-The overlay reuses the same secret rules that protect `extra_env_passthrough`:
-
-- Names ending in `_API_KEY`, `_API_KEYS`, `_PASSWORD`, or `_SECRET` are dropped.
-- Runner control names (`MINDROOM_SANDBOX_*`, `MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) are dropped.
-- `CI_JOB_TOKEN` and bash bookkeeping (`PWD`, `OLDPWD`, `SHLVL`, `_`, `PIPESTATUS`) are dropped.
-- Non-secret service tokens such as `GITEA_TOKEN` are kept.
+`.mindroom/worker-env.sh` is sourced by bash that inherits the runner's process env, which contains tokens the runner needs to function (sandbox proxy auth, etc.). To prevent the runner from leaking its own control-plane credentials to tools, the overlay drops names in a small explicit denylist (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`. Bash bookkeeping vars (`PWD`, `OLDPWD`, `SHLVL`, `_`, `PIPESTATUS`) are also dropped because they're noise, not values the script meant to export. Everything else passes through, including service tokens and provider credentials you intentionally export from the hook. If you don't want a value to reach tools, don't export it.
 
 **Limits and failure handling:**
 

--- a/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
+++ b/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
@@ -113,13 +113,13 @@ save_file("temporary notes\n", "scratch/notes.txt")
 
 ### Configuration
 
-| Option                     | Type      | Required | Default | Notes                                                                                                                                                                                    |
-| -------------------------- | --------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `base_dir`                 | `text`    | `no`     | `null`  | Runtime-managed working directory when an agent workspace exists. This field is not normally authored inline in `config.yaml`.                                                           |
-| `enable_run_shell_command` | `boolean` | `no`     | `true`  | Enable `run_shell_command()` and the companion handle APIs.                                                                                                                              |
-| `all`                      | `boolean` | `no`     | `false` | Enable all shell functions.                                                                                                                                                              |
-| `extra_env_passthrough`    | `text`    | `no`     | `null`  | Extra exported process env var names or glob patterns exposed to shell execution in addition to MindRoom's sandbox runtime env. This does not re-expose filtered runtime `.env` entries. |
-| `shell_path_prepend`       | `text`    | `no`     | `null`  | Extra PATH entries prepended for shell subprocesses only.                                                                                                                                |
+| Option                     | Type      | Required | Default | Notes                                                                                                                                                                                                  |
+| -------------------------- | --------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `base_dir`                 | `text`    | `no`     | `null`  | Runtime-managed working directory when an agent workspace exists. This field is not normally authored inline in `config.yaml`.                                                                         |
+| `enable_run_shell_command` | `boolean` | `no`     | `true`  | Enable `run_shell_command()` and the companion handle APIs.                                                                                                                                            |
+| `all`                      | `boolean` | `no`     | `false` | Enable all shell functions.                                                                                                                                                                            |
+| `extra_env_passthrough`    | `text`    | `no`     | `null`  | Extra exported process env var names or glob patterns exposed to shell execution in addition to MindRoom's sandbox runtime env. This matches exported process env, not config-adjacent `.env` entries. |
+| `shell_path_prepend`       | `text`    | `no`     | `null`  | Extra PATH entries prepended for shell subprocesses only.                                                                                                                                              |
 
 ### Example
 
@@ -146,7 +146,7 @@ kill_shell_command("shell:abcd1234")
 
 ### Notes
 
-- `extra_env_passthrough` only affects `shell`, matches exported process env, and MindRoom excludes known sensitive names and secret-suffixed env vars even when a glob would otherwise match them.
+- `extra_env_passthrough` only affects `shell` and matches exported process env, not config-adjacent `.env` entries. MindRoom drops runner control names (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`; everything else that matches passes through, including service tokens and provider credentials.
 - In authored YAML, `extra_env_passthrough` and `shell_path_prepend` can be written as lists, and MindRoom normalizes them to the tool's comma-or-newline form.
 - Background handles survive multiple requests to the same long-lived runner process, but they do not survive runner restarts.
 - `shell_path_prepend` deduplicates PATH entries and only changes subprocess PATH, not the main MindRoom process PATH.

--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -173,20 +173,25 @@ def request_execution_env(
 def runtime_paths_with_execution_env(
     runtime_paths: RuntimePaths,
     execution_env: dict[str, str],
+    *,
+    trusted_env_overlay: Mapping[str, str] | None = None,
 ) -> RuntimePaths:
     """Return runtime paths overlaid with one execution env snapshot."""
-    if not execution_env:
+    if not execution_env and not trusted_env_overlay:
         return runtime_paths
 
     process_env = dict(runtime_paths.process_env)
     process_env.update(execution_env)
+    env_file_values = dict(runtime_paths.env_file_values)
+    if trusted_env_overlay:
+        env_file_values.update(trusted_env_overlay)
     return constants.RuntimePaths(
         config_path=runtime_paths.config_path,
         config_dir=runtime_paths.config_dir,
         env_path=runtime_paths.env_path,
         storage_root=runtime_paths.storage_root,
         process_env=MappingProxyType(process_env),
-        env_file_values=runtime_paths.env_file_values,
+        env_file_values=MappingProxyType(env_file_values),
     )
 
 

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -245,8 +245,6 @@ def _request_private_agent_names(request: SandboxRunnerExecuteRequest) -> frozen
 def _request_runtime_overrides(
     request: SandboxRunnerExecuteRequest,
     prepared_worker: sandbox_worker_prep.PreparedWorkerRequest | None,
-    *,
-    workspace_env_overlay: dict[str, str] | None = None,
 ) -> dict[str, object] | None:
     """Return runtime overrides for one runner-side tool rebuild."""
     runtime_overrides = sandbox_worker_prep.ready_runtime_overrides(
@@ -265,11 +263,6 @@ def _request_runtime_overrides(
             process_env=request.execution_env,
         )
         resolved_keys.extend(resolved.keys())
-    if workspace_env_overlay:
-        # Expose `.mindroom/worker-env.sh` overlay names through the same
-        # extra_env_passthrough channel so the shell tool reads them out of
-        # the effective runtime_paths.process_env snapshot we just built.
-        resolved_keys.extend(name for name in workspace_env_overlay if name not in resolved_keys)
 
     if not resolved_keys:
         return runtime_overrides
@@ -664,10 +657,11 @@ async def _execute_request_inprocess(
         return overlay_failure
     if overlay:
         execution_env.update(overlay)
-    runtime_overrides = _request_runtime_overrides(request, prepared, workspace_env_overlay=overlay)
+    runtime_overrides = _request_runtime_overrides(request, prepared)
     effective_runtime_paths = sandbox_exec.runtime_paths_with_execution_env(
         runtime_paths,
         execution_env,
+        trusted_env_overlay=overlay,
     )
     execution_identity: ToolExecutionIdentity | None = None
     if request.execution_identity:
@@ -803,9 +797,14 @@ def _execute_request_subprocess_sync(
     if overlay:
         execution_env.update(overlay)
     subprocess_env = sandbox_exec.subprocess_env_for_request(subprocess_env, execution_env)
+    effective_runtime_paths = sandbox_exec.runtime_paths_with_execution_env(
+        runtime_paths,
+        execution_env,
+        trusted_env_overlay=overlay,
+    )
     envelope = sandbox_protocol.serialize_subprocess_envelope(
         request=request.model_dump(mode="json"),
-        runtime_paths=constants.serialize_runtime_paths(runtime_paths),
+        runtime_paths=constants.serialize_runtime_paths(effective_runtime_paths),
         committed_config=base64.b64encode(pickle.dumps(config)).decode("ascii"),
     )
 

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -53,6 +53,9 @@ _RUNTIME_STARTUP_EXCLUDED_NAMES = frozenset(
         "MINDROOM_SANDBOX_PROXY_TOKEN",
     },
 )
+# Startup/public runtime env scoping still withholds common credential suffixes
+# before booting isolated workers. This is separate from explicit shell
+# passthrough and workspace hook overlays, which trust user-selected values.
 _RUNTIME_STARTUP_SECRET_SUFFIXES = (
     "_API_KEY",
     "_API_KEYS",
@@ -68,13 +71,14 @@ _EXECUTION_RUNTIME_EXCLUDED_NAMES = frozenset(
         SANDBOX_STARTUP_MANIFEST_PATH_ENV,
     },
 )
-_SHELL_EXTRA_ENV_EXCLUDED_NAMES = frozenset({*_EXECUTION_RUNTIME_EXCLUDED_NAMES, "CI_JOB_TOKEN"})
-# Suffixes that mark env vars as too sensitive for shell passthrough even when
-# matched by a user-supplied glob.  Narrower than _RUNTIME_STARTUP_SECRET_SUFFIXES
-# because _TOKEN is a common suffix for legitimately passthrough-worthy service
-# tokens (e.g. GITEA_TOKEN) while _API_KEY/_PASSWORD/_SECRET reliably identify
-# provider credentials that should never leak to shell commands.
-_SHELL_EXTRA_ENV_SECRET_SUFFIXES = ("_API_KEY", "_API_KEYS", "_PASSWORD", "_SECRET")
+_RUNNER_CONTROL_ENV_EXCLUDED_NAMES = frozenset(
+    {
+        "MINDROOM_API_KEY",
+        "MINDROOM_LOCAL_CLIENT_SECRET",
+        "MINDROOM_SANDBOX_PROXY_TOKEN",
+        SANDBOX_STARTUP_MANIFEST_PATH_ENV,
+    },
+)
 
 # Bash bookkeeping vars that change every time printenv runs and are never
 # meaningful overlay output from `.mindroom/worker-env.sh`.
@@ -84,16 +88,12 @@ WORKSPACE_ENV_OVERLAY_TRANSIENT_NAMES = frozenset({"PWD", "OLDPWD", "SHLVL", "_"
 def is_workspace_env_overlay_name_allowed(name: str) -> bool:
     """Return whether one env var name may be returned from `.mindroom/worker-env.sh`.
 
-    Reuses the same secret-suffix and excluded-name rules that protect the
-    `extra_env_passthrough` shell config so the agent-editable overlay can
-    never expose provider credentials, runner control tokens, or sandbox
-    auth state, even if the script intentionally re-exports them.
+    The agent-editable overlay only protects runner control-plane names.
+    Other explicitly exported values are user intent and pass through.
     """
     if not name:
         return False
-    if name in _SHELL_EXTRA_ENV_EXCLUDED_NAMES:
-        return False
-    if name.endswith(_SHELL_EXTRA_ENV_SECRET_SUFFIXES):
+    if name in _RUNNER_CONTROL_ENV_EXCLUDED_NAMES:
         return False
     return not name.startswith("MINDROOM_SANDBOX_")
 
@@ -551,9 +551,9 @@ def shell_extra_env_values(
     source_env = os.environ if process_env is None else process_env
 
     for key, value in source_env.items():
-        if key in _SHELL_EXTRA_ENV_EXCLUDED_NAMES:
+        if key in _RUNNER_CONTROL_ENV_EXCLUDED_NAMES:
             continue
-        if key.endswith(_SHELL_EXTRA_ENV_SECRET_SUFFIXES):
+        if key.startswith("MINDROOM_SANDBOX_"):
             continue
         if any(fnmatch.fnmatchcase(key, pattern) for pattern in patterns):
             selected_env[key] = value

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -870,7 +870,6 @@ def test_sandbox_runner_execution_env_excludes_runner_token_and_unrelated_host_e
     """Execution env should carry committed runtime values without leaking control secrets or arbitrary host env."""
     _set_sandbox_token(monkeypatch)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setenv("CI_JOB_TOKEN", "ci-secret")
     monkeypatch.setenv("MINDROOM_API_KEY", "dashboard-secret")
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
@@ -898,7 +897,6 @@ def test_sandbox_runner_execution_env_excludes_runner_token_and_unrelated_host_e
     assert execution_env["MINDROOM_STORAGE_PATH"] == str((tmp_path / "storage").resolve())
     assert "MINDROOM_SANDBOX_PROXY_TOKEN" not in execution_env
     assert "MINDROOM_API_KEY" not in execution_env
-    assert "CI_JOB_TOKEN" not in execution_env
 
 
 @pytest.mark.asyncio
@@ -3416,19 +3414,23 @@ def test_workspace_env_hook_edits_take_effect_on_next_call(
 
 
 @REQUIRES_LINUX_LOCAL_WORKER
-def test_workspace_env_hook_filters_secrets(
+def test_workspace_env_hook_keeps_user_credentials_and_filters_runner_control(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Secret-suffixed exports must not reach the executed shell environment."""
+    """Explicit hook exports pass except for runner control-plane names."""
     _set_sandbox_token(monkeypatch)
     storage_root = tmp_path / "storage"
     workspace = storage_root / "agents" / "general" / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
     _write_workspace_env_hook(
         workspace,
-        "export OPENAI_API_KEY=leaked\nexport GITEA_TOKEN=keep\n",
+        "export OPENAI_API_KEY=from-hook\n"
+        "export STRIPE_SECRET=from-hook\n"
+        "export GITEA_TOKEN=from-hook\n"
+        "export MINDROOM_SANDBOX_PROXY_TOKEN=leaked\n"
+        "export MINDROOM_SANDBOX_FOO=leaked\n",
     )
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_root))
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -3441,7 +3443,20 @@ def test_workspace_env_hook_filters_secrets(
             json={
                 "tool_name": "shell",
                 "function_name": "run_shell_command",
-                "args": [["bash", "-c", 'printf "%s|%s" "${OPENAI_API_KEY:-}" "${GITEA_TOKEN:-}"']],
+                "args": [
+                    [
+                        "bash",
+                        "-c",
+                        (
+                            'printf "%s|%s|%s|%s|%s" '
+                            '"${OPENAI_API_KEY:-}" '
+                            '"${STRIPE_SECRET:-}" '
+                            '"${GITEA_TOKEN:-}" '
+                            '"${MINDROOM_SANDBOX_PROXY_TOKEN:-}" '
+                            '"${MINDROOM_SANDBOX_FOO:-}"'
+                        ),
+                    ],
+                ],
                 "kwargs": {},
                 "worker_key": "v1:tenant-123:shared:general",
                 "tool_init_overrides": {"base_dir": "agents/general/workspace"},
@@ -3451,9 +3466,12 @@ def test_workspace_env_hook_filters_secrets(
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True, payload
-    api_key, token = payload["result"].split("|", 1)
-    assert api_key == ""
-    assert token == "keep"  # noqa: S105
+    api_key, stripe_secret, token, proxy_token, sandbox_value = payload["result"].split("|", 4)
+    assert api_key == "from-hook"
+    assert stripe_secret == "from-hook"  # noqa: S105
+    assert token == "from-hook"  # noqa: S105
+    assert proxy_token == ""
+    assert sandbox_value == ""
 
 
 @REQUIRES_LINUX_LOCAL_WORKER

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -1064,7 +1064,7 @@ async def test_local_shell_exposes_configured_extra_parent_env_without_leaking_c
     credentials_manager = get_runtime_credentials_manager(runtime_paths)
     save_scoped_credentials(
         "shell",
-        {"extra_env_passthrough": "GITEA_*, MINDROOM_*"},
+        {"extra_env_passthrough": "GITEA_*, MINDROOM_*, CI_JOB_TOKEN"},
         credentials_manager=credentials_manager,
         worker_target=None,
     )
@@ -1086,7 +1086,7 @@ async def test_local_shell_exposes_configured_extra_parent_env_without_leaking_c
         ],
     )
 
-    assert result == "visible-gitea-token|||visible-in-shell"
+    assert result == "visible-gitea-token||ci-secret|visible-in-shell"
 
 
 @pytest.mark.asyncio
@@ -1176,7 +1176,6 @@ async def test_proxy_forwards_configured_shell_execution_env_only_for_execution_
         _recording_client_class(captured=captured),
     )
     monkeypatch.setenv("GITEA_TOKEN", "visible-gitea-token")
-    monkeypatch.setenv("CI_JOB_TOKEN", "ci-secret")
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
         "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
@@ -1209,7 +1208,6 @@ async def test_proxy_forwards_configured_shell_execution_env_only_for_execution_
     assert captured["json"]["tool_init_overrides"]["shell_path_prepend"] == "/opt/custom/bin"
     assert "TEST_EXECUTION_ENV" not in captured["json"]["execution_env"]
     assert captured["json"]["execution_env"]["GITEA_TOKEN"] == "visible-gitea-token"  # noqa: S105
-    assert "CI_JOB_TOKEN" not in captured["json"]["execution_env"]
     assert "MINDROOM_SANDBOX_PROXY_TOKEN" not in captured["json"]["execution_env"]
 
     captured.clear()
@@ -1236,7 +1234,6 @@ async def test_proxy_shell_extra_env_passthrough_survives_sandbox_runner_rebuild
     )
     monkeypatch.setenv("MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE", "subprocess")
     monkeypatch.setenv("GITEA_TOKEN", "visible-gitea-token")
-    monkeypatch.setenv("CI_JOB_TOKEN", "ci-secret")
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
         "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
@@ -1277,11 +1274,11 @@ async def test_proxy_shell_extra_env_passthrough_survives_sandbox_runner_rebuild
         [
             "bash",
             "-lc",
-            "printf '%s' \"$GITEA_TOKEN|$CI_JOB_TOKEN|$TEST_EXECUTION_ENV\"",
+            "printf '%s' \"$GITEA_TOKEN|$TEST_EXECUTION_ENV\"",
         ],
     )
 
-    assert result == "visible-gitea-token||visible-in-shell"
+    assert result == "visible-gitea-token|visible-in-shell"
 
 
 @pytest.mark.asyncio
@@ -3227,8 +3224,8 @@ async def test_inprocess_runner_blocks_cross_runtime_secret_leakage(
     assert response.result == "https://whisper.example|"
 
 
-def test_shell_extra_env_excludes_api_key_suffixes() -> None:
-    """Wildcard passthrough must not expose vars ending with secret suffixes."""
+def test_shell_extra_env_trusts_explicit_patterns_except_runner_control() -> None:
+    """Wildcard passthrough keeps matched user env and drops only runner control names."""
     env = {
         "ANTHROPIC_API_KEY": "sk-ant-secret",
         "OPENAI_API_KEY": "sk-oai-secret",
@@ -3239,22 +3236,31 @@ def test_shell_extra_env_excludes_api_key_suffixes() -> None:
         "GITEA_TOKEN": "gitea-token",
         "WHISPER_URL": "https://whisper.example",
         "GITEA_HOST": "gitea.local",
+        "MINDROOM_API_KEY": "runner-api-key",
+        "MINDROOM_LOCAL_CLIENT_SECRET": "runner-client-secret",
+        "MINDROOM_SANDBOX_PROXY_TOKEN": "runner-proxy-token",
+        "MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH": "/var/lib/mindroom/manifest.json",
+        "MINDROOM_SANDBOX_FOO": "runner-sandbox-value",
+        "MINDROOM_LOCAL_CLIENT_ID": "local-client-id",
     }
     result = dict(shell_extra_env_values(extra_env_passthrough="*", process_env=env))
 
-    # Safe non-secret vars should be present
     assert result["WHISPER_URL"] == "https://whisper.example"
     assert result["GITEA_HOST"] == "gitea.local"
-    # _TOKEN suffix is allowed (common for service tokens like GITEA_TOKEN)
     assert result["GITEA_TOKEN"] == "gitea-token"  # noqa: S105
+    assert result["ANTHROPIC_API_KEY"] == "sk-ant-secret"
+    assert result["OPENAI_API_KEY"] == "sk-oai-secret"
+    assert result["GOOGLE_API_KEY"] == "goog-secret"
+    assert result["MY_SERVICE_PASSWORD"] == "pass-secret"  # noqa: S105
+    assert result["WEBHOOK_SECRET"] == "hook-secret"  # noqa: S105
+    assert result["CI_JOB_TOKEN"] == "ci-token"  # noqa: S105
+    assert result["MINDROOM_LOCAL_CLIENT_ID"] == "local-client-id"
 
-    # Provider API keys and passwords/secrets must be excluded
-    assert "ANTHROPIC_API_KEY" not in result
-    assert "OPENAI_API_KEY" not in result
-    assert "GOOGLE_API_KEY" not in result
-    assert "MY_SERVICE_PASSWORD" not in result
-    assert "WEBHOOK_SECRET" not in result
-    assert "CI_JOB_TOKEN" not in result  # also in _SHELL_EXTRA_ENV_EXCLUDED_NAMES
+    assert "MINDROOM_API_KEY" not in result
+    assert "MINDROOM_LOCAL_CLIENT_SECRET" not in result
+    assert "MINDROOM_SANDBOX_PROXY_TOKEN" not in result
+    assert "MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH" not in result
+    assert "MINDROOM_SANDBOX_FOO" not in result
 
 
 def test_shell_extra_env_requires_explicit_patterns_for_service_urls() -> None:

--- a/tests/test_workspace_env_hook.py
+++ b/tests/test_workspace_env_hook.py
@@ -149,16 +149,16 @@ def test_source_workspace_env_hook_can_append_to_path(tmp_path: Path) -> None:
 
 
 @REQUIRES_BASH
-def test_source_workspace_env_hook_drops_secret_suffixes(tmp_path: Path) -> None:
-    """Secret-suffixed names are filtered while non-secret tokens stay."""
+def test_source_workspace_env_hook_keeps_user_exported_credentials(tmp_path: Path) -> None:
+    """Credential-looking names pass when the hook explicitly exports them."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     hook_path = _write_hook(
         workspace,
-        "export OPENAI_API_KEY=leaked\n"
-        "export SOMETHING_PASSWORD=leaked\n"
-        "export SOMETHING_SECRET=leaked\n"
-        "export GITEA_TOKEN=keep\n",
+        "export OPENAI_API_KEY=from-hook\n"
+        "export STRIPE_SECRET=from-hook\n"
+        "export CI_JOB_TOKEN=from-hook\n"
+        "export GITEA_TOKEN=from-hook\n",
     )
 
     overlay = source_workspace_env_hook(
@@ -167,23 +167,24 @@ def test_source_workspace_env_hook_drops_secret_suffixes(tmp_path: Path) -> None
         cwd=workspace,
     )
 
-    assert "OPENAI_API_KEY" not in overlay
-    assert "SOMETHING_PASSWORD" not in overlay
-    assert "SOMETHING_SECRET" not in overlay
-    assert overlay["GITEA_TOKEN"] == "keep"  # noqa: S105
+    assert overlay["OPENAI_API_KEY"] == "from-hook"
+    assert overlay["STRIPE_SECRET"] == "from-hook"  # noqa: S105
+    assert overlay["CI_JOB_TOKEN"] == "from-hook"  # noqa: S105
+    assert overlay["GITEA_TOKEN"] == "from-hook"  # noqa: S105
 
 
 @REQUIRES_BASH
 def test_source_workspace_env_hook_drops_runner_control_names(tmp_path: Path) -> None:
-    """Runner control names (MINDROOM_SANDBOX_*, MINDROOM_API_KEY, CI_JOB_TOKEN) are filtered."""
+    """Only runner control names are filtered from the hook overlay."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     hook_path = _write_hook(
         workspace,
         "export MINDROOM_SANDBOX_PROXY_TOKEN=leaked\n"
         "export MINDROOM_API_KEY=leaked\n"
-        "export MINDROOM_SANDBOX_DEDICATED_WORKER_KEY=leaked\n"
-        "export CI_JOB_TOKEN=leaked\n"
+        "export MINDROOM_LOCAL_CLIENT_SECRET=leaked\n"
+        "export MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH=leaked\n"
+        "export MINDROOM_SANDBOX_FOO=leaked\n"
         "export NPM_CONFIG_PREFIX=keep\n",
     )
 
@@ -195,8 +196,9 @@ def test_source_workspace_env_hook_drops_runner_control_names(tmp_path: Path) ->
 
     assert "MINDROOM_SANDBOX_PROXY_TOKEN" not in overlay
     assert "MINDROOM_API_KEY" not in overlay
-    assert "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY" not in overlay
-    assert "CI_JOB_TOKEN" not in overlay
+    assert "MINDROOM_LOCAL_CLIENT_SECRET" not in overlay
+    assert "MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH" not in overlay
+    assert "MINDROOM_SANDBOX_FOO" not in overlay
     assert overlay["NPM_CONFIG_PREFIX"] == "keep"
 
 


### PR DESCRIPTION
## Summary
- Simplify sandbox env filtering for both worker-env overlays and shell `extra_env_passthrough` to drop only runner control-plane names and `MINDROOM_SANDBOX_*`.
- Allow explicitly exported or matched service/provider credentials such as `OPENAI_API_KEY`, `STRIPE_SECRET`, `GITEA_TOKEN`, and `CI_JOB_TOKEN` to pass through.
- Update sandbox proxy/tool docs and regenerated mindroom-docs skill references.

## Test Plan
- [x] `uv run pytest tests/test_workspace_env_hook.py tests/api/test_sandbox_runner_api.py tests/test_sandbox_proxy.py -x -n 0 --no-cov -v`
- [x] `uv run pre-commit run --all-files`
- [x] `git diff --check`