### PR TITLE
Reject cached thread history that omits the root

### DIFF
--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -327,6 +327,15 @@ async def _load_stale_cached_thread_history(
         return None
     if cached_event_sources is None:
         return None
+    if not _thread_history_fetch_is_cacheable(cached_event_sources, thread_id=thread_id):
+        logger.warning(
+            "Stale thread cache missing root; refusing degraded history",
+            room_id=room_id,
+            thread_id=thread_id,
+            error=str(fetch_error),
+        )
+        await _invalidate_thread_cache_entry(event_cache, room_id=room_id, thread_id=thread_id)
+        return None
 
     resolution_started = time.perf_counter()
     resolved_history, sidecar_hydration_ms = await _resolve_cached_thread_history(
@@ -451,6 +460,18 @@ async def _load_cached_thread_history_if_usable(
         return None, {
             THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "cache_rows_missing",
         }
+    if not _thread_history_fetch_is_cacheable(cached_event_sources, thread_id=thread_id):
+        await _invalidate_thread_cache_entry(event_cache, room_id=room_id, thread_id=thread_id)
+        cache_reject_diagnostics = {
+            THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "cache_missing_thread_root",
+        }
+        logger.info(
+            "Thread cache rejected for read",
+            room_id=room_id,
+            thread_id=thread_id,
+            **cache_reject_diagnostics,
+        )
+        return None, cache_reject_diagnostics
 
     resolution_started = time.perf_counter()
     resolved_history, sidecar_hydration_ms = await _resolve_cached_thread_history(

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -2426,6 +2426,60 @@ class TestThreadHistoryCache:
         assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_CACHE
 
     @pytest.mark.asyncio
+    async def test_fetch_dispatch_thread_history_refetches_cache_missing_thread_root(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A cached thread snapshot without its root is incomplete and must not drive prompts."""
+        cache = _EventCache(tmp_path / "event_cache.db")
+        await cache.initialize()
+
+        root_event = self._make_text_event(
+            event_id="$thread_root",
+            sender="@user:localhost",
+            body="Root message",
+            server_timestamp=1000,
+            source_content={"body": "Root message"},
+        )
+        reply_event = self._make_text_event(
+            event_id="$reply",
+            sender="@user:localhost",
+            body="Follow-up in thread",
+            server_timestamp=2000,
+            source_content={
+                "body": "Follow-up in thread",
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+        )
+        await self._seed_thread_cache(
+            cache,
+            room_id="!room:localhost",
+            thread_id="$thread_root",
+            events=[self._cache_source(reply_event)],
+        )
+
+        client = MagicMock()
+        page = MagicMock(spec=nio.RoomMessagesResponse)
+        page.chunk = [reply_event, root_event]
+        page.end = None
+        client.room_messages = AsyncMock(return_value=page)
+
+        try:
+            history = await matrix_client_module.fetch_dispatch_thread_history(
+                client,
+                "!room:localhost",
+                "$thread_root",
+                event_cache=cache,
+            )
+        finally:
+            await cache.close()
+
+        assert [message.event_id for message in history] == ["$thread_root", "$reply"]
+        assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_HOMESERVER
+        assert history.diagnostics[THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC] == "cache_missing_thread_root"
+        client.room_messages.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_fetch_dispatch_thread_snapshot_uses_fresh_durable_cache(self, tmp_path: Path) -> None:
         """Strict dispatch snapshots should reuse fresh durable cache instead of refetching."""
         cache = _EventCache(tmp_path / "event_cache.db")


### PR DESCRIPTION
## Summary
- reject and invalidate cached Matrix thread snapshots that do not include the thread root
- refuse stale cached fallback when the cached snapshot is missing the root
- add a regression test that seeds a rootless cached thread and verifies dispatch refetches full root-first history

## Testing
- `uv run ruff check src/mindroom/matrix/client_thread_history.py tests/test_thread_history.py`
- `uv run pytest tests/test_thread_history.py -q`