### PR TITLE
Simplify API config lifecycle calls

### DIFF
--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -18,16 +18,6 @@ from mindroom.api import config_lifecycle
 from mindroom.api.auth import ApiAuthState, verify_user
 from mindroom.api.auth import router as auth_router
 from mindroom.api.config_lifecycle import ApiSnapshot, ApiState, ConfigLoadResult
-from mindroom.api.config_lifecycle import api_runtime_paths as api_request_runtime_paths
-from mindroom.api.config_lifecycle import load_config_into_app as load_api_config_into_app
-from mindroom.api.config_lifecycle import raise_for_config_load_result as raise_api_config_load_result
-from mindroom.api.config_lifecycle import read_app_committed_config as read_api_app_committed_config
-from mindroom.api.config_lifecycle import read_committed_config as read_api_committed_config
-from mindroom.api.config_lifecycle import read_raw_config_source as read_api_raw_config_source
-from mindroom.api.config_lifecycle import replace_committed_config as replace_api_committed_config
-from mindroom.api.config_lifecycle import replace_raw_config_source as replace_api_raw_config_source
-from mindroom.api.config_lifecycle import write_app_committed_config as write_api_app_committed_config
-from mindroom.api.config_lifecycle import write_committed_config as write_api_committed_config
 
 # Import routers
 from mindroom.api.credentials import router as credentials_router
@@ -214,7 +204,7 @@ async def _worker_cleanup_loop(
 
 def api_runtime_paths(request: Request) -> constants.RuntimePaths:
     """Return the API request's committed runtime paths."""
-    return api_request_runtime_paths(request)
+    return config_lifecycle.api_runtime_paths(request)
 
 
 def _app_state(api_app: FastAPI) -> ApiState:
@@ -267,16 +257,6 @@ def _app_context(api_app: FastAPI) -> ApiSnapshot:
 def _app_runtime_paths(api_app: FastAPI) -> constants.RuntimePaths:
     """Return the committed runtime paths for one API app instance."""
     return _app_context(api_app).runtime_paths
-
-
-def _app_config_data(api_app: FastAPI) -> dict[str, Any]:
-    """Return the mutable config cache for one app instance."""
-    return _app_context(api_app).config_data
-
-
-def _app_config_lock(api_app: FastAPI) -> threading.Lock:
-    """Return the config lock for one app instance."""
-    return _app_state(api_app).config_lock
 
 
 def _bind_api_auth_ingress_context(api_app: FastAPI, runtime_paths: constants.RuntimePaths) -> None:
@@ -400,7 +380,7 @@ async def _watch_config(
             if current_mtime != last_mtime:
                 last_mtime = current_mtime
                 logger.info("Config file changed", path=str(config_path))
-                _load_config_from_file(runtime_paths, api_app)
+                config_lifecycle.load_config_into_app(runtime_paths, api_app)
                 await _sync_standalone_knowledge_watchers(api_app)
         except (OSError, PermissionError):
             last_mtime = 0.0
@@ -413,7 +393,7 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """Manage application startup and shutdown."""
     runtime_paths = _app_runtime_paths(_app)
     constants.ensure_writable_config_path(create_minimal=True, runtime_paths=runtime_paths)
-    _load_config_from_file(runtime_paths, _app)
+    config_lifecycle.load_config_into_app(runtime_paths, _app)
     logger.info(
         "Initialized API runtime config",
         config_path=str(runtime_paths.config_path),
@@ -477,42 +457,6 @@ app.add_middleware(
 )
 
 
-def _run_config_write[T](
-    api_app: FastAPI,
-    mutate: Callable[[dict[str, Any]], T],
-    *,
-    error_prefix: str,
-) -> T:
-    """Validate, save, and swap config under lock."""
-    return write_api_app_committed_config(api_app, mutate, error_prefix=error_prefix)
-
-
-def _run_request_config_write[T](
-    request: Request,
-    mutate: Callable[[dict[str, Any]], T],
-    *,
-    error_prefix: str,
-) -> T:
-    """Validate, save, and swap config against the request-bound snapshot."""
-    return write_api_committed_config(request, mutate, error_prefix=error_prefix)
-
-
-def _read_committed_config[T](
-    api_app: FastAPI,
-    reader: Callable[[dict[str, Any]], T],
-) -> T:
-    """Read the committed API config only when the current on-disk config is valid."""
-    return read_api_app_committed_config(api_app, reader)
-
-
-def _read_request_committed_config[T](
-    request: Request,
-    reader: Callable[[dict[str, Any]], T],
-) -> T:
-    """Read committed API config from the request-bound snapshot."""
-    return read_api_committed_config(request, reader)
-
-
 def _reload_api_runtime_config(
     api_app: FastAPI,
     runtime_paths: constants.RuntimePaths,
@@ -561,7 +505,7 @@ def _reload_api_runtime_config(
             else refreshed_snapshot.runtime_config,
             config_load_result=result,
         )
-    raise_api_config_load_result(result)
+    config_lifecycle.raise_for_config_load_result(result)
 
 
 def _sanitize_entity_payload(entity_data: dict[str, Any]) -> dict[str, Any]:
@@ -584,11 +528,6 @@ def _resolve_unique_entity_id(base_id: str, entities: dict[str, Any]) -> str:
 def _set_config_generation_header(response: Response, generation: int) -> None:
     """Attach the committed config generation to one API response."""
     response.headers[config_lifecycle.CONFIG_GENERATION_HEADER] = str(generation)
-
-
-def _load_config_from_file(runtime_paths: constants.RuntimePaths, api_app: FastAPI) -> bool:
-    """Load config from YAML file."""
-    return load_api_config_into_app(runtime_paths, api_app)
 
 
 # Include routers
@@ -649,7 +588,7 @@ async def load_config(
 ) -> dict[str, Any]:
     """Load configuration from file."""
     generation = config_lifecycle.committed_generation(request)
-    payload = read_api_committed_config(request, lambda config_data: dict(config_data))
+    payload = config_lifecycle.read_committed_config(request, lambda config_data: dict(config_data))
     _set_config_generation_header(response, generation)
     return payload
 
@@ -663,7 +602,7 @@ async def save_config(
     x_mindroom_config_generation: Annotated[int | None, Header()] = None,
 ) -> dict[str, bool]:
     """Save configuration to file."""
-    generation = replace_api_committed_config(
+    generation = config_lifecycle.replace_committed_config(
         request,
         new_config,
         error_prefix="Failed to save configuration",
@@ -681,7 +620,7 @@ async def get_raw_config_source(
 ) -> dict[str, str]:
     """Return the raw config source text for recovery editing."""
     generation = config_lifecycle.committed_generation(request)
-    payload = {"source": read_api_raw_config_source(request)}
+    payload = {"source": config_lifecycle.read_raw_config_source(request)}
     _set_config_generation_header(response, generation)
     return payload
 
@@ -695,7 +634,7 @@ async def save_raw_config_source(
     x_mindroom_config_generation: Annotated[int | None, Header()] = None,
 ) -> dict[str, bool]:
     """Replace the raw config source text after validating it against the active runtime."""
-    generation = replace_api_raw_config_source(
+    generation = config_lifecycle.replace_raw_config_source(
         request,
         payload.source,
         error_prefix="Failed to save raw configuration",
@@ -739,7 +678,7 @@ async def get_agents(request: Request, _user: Annotated[dict, Depends(verify_use
             agent_list.append(agent)
         return agent_list
 
-    return _read_request_committed_config(request, read_agents)
+    return config_lifecycle.read_committed_config(request, read_agents)
 
 
 @app.put("/api/config/agents/{agent_id}")
@@ -756,7 +695,7 @@ async def update_agent(
             candidate_config["agents"] = {}
         candidate_config["agents"][agent_id] = _sanitize_entity_payload(agent_data)
 
-    _run_request_config_write(
+    config_lifecycle.write_committed_config(
         request,
         mutate,
         error_prefix="Failed to save agent",
@@ -780,7 +719,7 @@ async def create_agent(
         candidate_config["agents"][agent_id] = _sanitize_entity_payload(agent_data)
         return agent_id
 
-    agent_id = _run_request_config_write(
+    agent_id = config_lifecycle.write_committed_config(
         request,
         mutate,
         error_prefix="Failed to create agent",
@@ -801,7 +740,7 @@ async def delete_agent(
             raise HTTPException(status_code=404, detail="Agent not found")
         del candidate_config["agents"][agent_id]
 
-    _run_request_config_write(
+    config_lifecycle.write_committed_config(
         request,
         mutate,
         error_prefix="Failed to delete agent",
@@ -822,7 +761,7 @@ async def get_teams(request: Request, _user: Annotated[dict, Depends(verify_user
             team_list.append(team)
         return team_list
 
-    return _read_request_committed_config(request, read_teams)
+    return config_lifecycle.read_committed_config(request, read_teams)
 
 
 @app.put("/api/config/teams/{team_id}")
@@ -839,7 +778,7 @@ async def update_team(
             candidate_config["teams"] = {}
         candidate_config["teams"][team_id] = _sanitize_entity_payload(team_data)
 
-    _run_request_config_write(
+    config_lifecycle.write_committed_config(
         request,
         mutate,
         error_prefix="Failed to save team",
@@ -863,7 +802,7 @@ async def create_team(
         candidate_config["teams"][team_id] = _sanitize_entity_payload(team_data)
         return team_id
 
-    team_id = _run_request_config_write(
+    team_id = config_lifecycle.write_committed_config(
         request,
         mutate,
         error_prefix="Failed to create team",
@@ -884,7 +823,7 @@ async def delete_team(
             raise HTTPException(status_code=404, detail="Team not found")
         del candidate_config["teams"][team_id]
 
-    _run_request_config_write(
+    config_lifecycle.write_committed_config(
         request,
         mutate,
         error_prefix="Failed to delete team",
@@ -895,7 +834,7 @@ async def delete_team(
 @app.get("/api/config/models")
 async def get_models(request: Request, _user: Annotated[dict, Depends(verify_user)]) -> dict[str, Any]:
     """Get all model configurations."""
-    return _read_request_committed_config(
+    return config_lifecycle.read_committed_config(
         request,
         lambda config_data: dict(config_data.get("models", {})) if config_data.get("models") else {},
     )
@@ -915,7 +854,7 @@ async def update_model(
             candidate_config["models"] = {}
         candidate_config["models"][model_id] = model_data
 
-    _run_request_config_write(
+    config_lifecycle.write_committed_config(
         request,
         mutate,
         error_prefix="Failed to save model",
@@ -926,7 +865,7 @@ async def update_model(
 @app.get("/api/config/room-models")
 async def get_room_models(request: Request, _user: Annotated[dict, Depends(verify_user)]) -> dict[str, Any]:
     """Get room-specific model overrides."""
-    return _read_request_committed_config(
+    return config_lifecycle.read_committed_config(
         request,
         lambda config_data: dict(config_data.get("room_models", {})) if config_data.get("room_models") else {},
     )
@@ -943,7 +882,7 @@ async def update_room_models(
     def mutate(candidate_config: dict[str, Any]) -> None:
         candidate_config["room_models"] = room_models
 
-    _run_request_config_write(
+    config_lifecycle.write_committed_config(
         request,
         mutate,
         error_prefix="Failed to save room models",
@@ -962,7 +901,7 @@ async def get_available_rooms(request: Request, _user: Annotated[dict, Depends(v
             rooms.update(agent_rooms)
         return sorted(rooms)
 
-    return _read_request_committed_config(request, read_rooms)
+    return config_lifecycle.read_committed_config(request, read_rooms)
 
 
 app.include_router(frontend_router)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -9,6 +9,8 @@ import pytest
 import yaml
 from fastapi.testclient import TestClient
 
+from mindroom.api import config_lifecycle
+
 
 @pytest.fixture
 def temp_config_file(tmp_path: Path) -> Generator[Path, None, None]:
@@ -47,7 +49,7 @@ def test_client(temp_config_file: Path) -> TestClient:
     main.initialize_api_app(main.app, runtime_paths)
 
     # Force reload of config
-    main._load_config_from_file(main._app_runtime_paths(main.app), main.app)
+    config_lifecycle.load_config_into_app(main._app_runtime_paths(main.app), main.app)
 
     # Create test client
     return TestClient(main.app)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -109,6 +109,20 @@ def _publish_committed_runtime_config(
     context.auth_state = None
 
 
+def test_api_main_does_not_reexport_config_lifecycle_pass_through_helpers() -> None:
+    """Config lifecycle helpers should live in the lifecycle module only."""
+    for helper_name in (
+        "_app_config_data",
+        "_app_config_lock",
+        "_run_config_write",
+        "_run_request_config_write",
+        "_read_committed_config",
+        "_read_request_committed_config",
+        "_load_config_from_file",
+    ):
+        assert not hasattr(main, helper_name)
+
+
 class _ContextSwapLock:
     def __init__(self, on_enter: Callable[[], None] | None = None) -> None:
         self.on_enter = on_enter
@@ -331,8 +345,8 @@ def test_initialize_api_app_initializes_fresh_app_state(tmp_path: Path) -> None:
     main.initialize_api_app(fresh_app, runtime_paths)
 
     assert main._app_runtime_paths(fresh_app) == runtime_paths
-    assert main._app_config_data(fresh_app) == {}
-    assert hasattr(main._app_config_lock(fresh_app), "acquire")
+    assert main._app_context(fresh_app).config_data == {}
+    assert hasattr(main._app_state(fresh_app).config_lock, "acquire")
     assert auth.app_auth_state(fresh_app).runtime_paths == runtime_paths
 
 
@@ -392,12 +406,12 @@ def test_initialize_api_app_clears_config_cache_when_config_path_changes(tmp_pat
     fresh_app = FastAPI()
 
     main.initialize_api_app(fresh_app, first_runtime)
-    main._load_config_from_file(first_runtime, fresh_app)
-    assert set(main._app_config_data(fresh_app)["agents"]) == {"first"}
+    config_lifecycle.load_config_into_app(first_runtime, fresh_app)
+    assert set(main._app_context(fresh_app).config_data["agents"]) == {"first"}
 
     main.initialize_api_app(fresh_app, second_runtime)
 
-    assert main._app_config_data(fresh_app) == {}
+    assert main._app_context(fresh_app).config_data == {}
 
 
 def test_initialize_api_app_clears_config_cache_when_runtime_changes(tmp_path: Path) -> None:
@@ -417,12 +431,12 @@ def test_initialize_api_app_clears_config_cache_when_runtime_changes(tmp_path: P
     fresh_app = FastAPI()
 
     main.initialize_api_app(fresh_app, runtime_one)
-    main._load_config_from_file(runtime_one, fresh_app)
-    assert set(main._app_config_data(fresh_app)["agents"]) == {"first"}
+    config_lifecycle.load_config_into_app(runtime_one, fresh_app)
+    assert set(main._app_context(fresh_app).config_data["agents"]) == {"first"}
 
     main.initialize_api_app(fresh_app, runtime_two)
 
-    assert main._app_config_data(fresh_app) == {}
+    assert main._app_context(fresh_app).config_data == {}
 
 
 def test_load_config_into_app_discards_stale_results_after_runtime_swap(tmp_path: Path) -> None:
@@ -491,7 +505,7 @@ def test_load_config_into_app_discards_stale_results_after_runtime_swap(tmp_path
     assert set(context.config_data["agents"]) == {"second"}
 
 
-def test_load_config_from_file_ignores_runtime_mismatches_after_api_runtime_swap(tmp_path: Path) -> None:
+def test_load_config_into_app_ignores_runtime_mismatches_after_api_runtime_swap(tmp_path: Path) -> None:
     """Loading one old runtime after a swap must not overwrite the current app context."""
     fresh_app = FastAPI()
     first_runtime = constants.resolve_primary_runtime_paths(
@@ -524,15 +538,15 @@ def test_load_config_from_file_ignores_runtime_mismatches_after_api_runtime_swap
     )
 
     main.initialize_api_app(fresh_app, first_runtime)
-    assert main._load_config_from_file(first_runtime, fresh_app) is True
-    assert set(main._app_config_data(fresh_app)["agents"]) == {"first"}
+    assert config_lifecycle.load_config_into_app(first_runtime, fresh_app) is True
+    assert set(main._app_context(fresh_app).config_data["agents"]) == {"first"}
 
     main.initialize_api_app(fresh_app, second_runtime)
-    assert main._load_config_from_file(second_runtime, fresh_app) is True
-    assert set(main._app_config_data(fresh_app)["agents"]) == {"second"}
+    assert config_lifecycle.load_config_into_app(second_runtime, fresh_app) is True
+    assert set(main._app_context(fresh_app).config_data["agents"]) == {"second"}
 
-    assert main._load_config_from_file(first_runtime, fresh_app) is False
-    assert set(main._app_config_data(fresh_app)["agents"]) == {"second"}
+    assert config_lifecycle.load_config_into_app(first_runtime, fresh_app) is False
+    assert set(main._app_context(fresh_app).config_data["agents"]) == {"second"}
     assert main._app_context(fresh_app).config_load_result == main.ConfigLoadResult(success=True)
 
 
@@ -704,8 +718,8 @@ async def test_watch_config_follows_runtime_swaps(monkeypatch: pytest.MonkeyPatc
     second_runtime = constants.resolve_primary_runtime_paths(config_path=second_config_path, process_env={})
     main.initialize_api_app(main.app, first_runtime)
     monkeypatch.setattr(
-        main,
-        "_load_config_from_file",
+        config_lifecycle,
+        "load_config_into_app",
         lambda runtime_paths, _app: _record_loaded_path(runtime_paths, loaded_paths, load_event),
     )
 
@@ -1582,7 +1596,7 @@ def test_get_tools_uses_one_runtime_snapshot(
 
     def _read_tools_runtime_config(_request: object) -> tuple[Config, constants.RuntimePaths]:
         main.initialize_api_app(main.app, second_runtime)
-        main._load_config_from_file(second_runtime, main.app)
+        config_lifecycle.load_config_into_app(second_runtime, main.app)
         return _config_with_worker_scope("shared"), first_runtime
 
     def _resolve_tool_availability_context(
@@ -2568,7 +2582,7 @@ def test_save_config_can_recover_from_invalid_reload(
     """Full config replacement should recover from an invalid on-disk config."""
     runtime_paths = main._app_runtime_paths(test_client.app)
     temp_config_file.write_text("agents:\n  broken: [\n", encoding="utf-8")
-    assert main._load_config_from_file(runtime_paths, main.app) is False
+    assert config_lifecycle.load_config_into_app(runtime_paths, main.app) is False
 
     valid_config = {
         "models": {"default": {"provider": "openai", "id": "gpt-5.4"}},
@@ -2602,7 +2616,7 @@ def test_get_raw_config_source_returns_current_invalid_file(
     invalid_source = "agents:\n  broken: [\n"
     temp_config_file.write_text(invalid_source, encoding="utf-8")
 
-    assert main._load_config_from_file(runtime_paths, main.app) is False
+    assert config_lifecycle.load_config_into_app(runtime_paths, main.app) is False
 
     response = test_client.get("/api/config/raw")
 
@@ -2618,7 +2632,7 @@ def test_get_raw_config_source_returns_replacement_text_for_non_utf8_invalid_fil
     runtime_paths = main._app_runtime_paths(test_client.app)
     temp_config_file.write_bytes(b"agents:\n  broken: \xff\n")
 
-    assert main._load_config_from_file(runtime_paths, main.app) is False
+    assert config_lifecycle.load_config_into_app(runtime_paths, main.app) is False
 
     response = test_client.get("/api/config/raw")
 
@@ -2634,7 +2648,7 @@ def test_save_raw_config_source_can_recover_from_invalid_reload(
     runtime_paths = main._app_runtime_paths(test_client.app)
     temp_config_file.write_text("agents:\n  broken: [\n", encoding="utf-8")
 
-    assert main._load_config_from_file(runtime_paths, main.app) is False
+    assert config_lifecycle.load_config_into_app(runtime_paths, main.app) is False
 
     valid_source = yaml.safe_dump(
         {
@@ -2804,7 +2818,7 @@ def test_validate_raw_config_source_uses_unique_validation_files(tmp_path: Path)
     assert results[1][1]["agents"] == {"agent_b": {"display_name": "Agent B", "role": "role b", "rooms": []}}
 
 
-def test_run_config_write_restores_original_config_before_releasing_lock(tmp_path: Path) -> None:
+def test_write_app_committed_config_restores_original_config_before_releasing_lock(tmp_path: Path) -> None:
     """Failed config writes should leave committed config unchanged before the lock exits."""
     main.initialize_api_app(
         main.app,
@@ -2835,7 +2849,7 @@ def test_run_config_write_restores_original_config_before_releasing_lock(tmp_pat
     app_state.config_lock = _AssertingLock()
     try:
         with pytest.raises(HTTPException) as exc_info:
-            main._run_config_write(
+            config_lifecycle.write_app_committed_config(
                 main.app,
                 lambda candidate_config: candidate_config.update(
                     {
@@ -2854,7 +2868,7 @@ def test_run_config_write_restores_original_config_before_releasing_lock(tmp_pat
     assert context.config_data == original_config
 
 
-def test_run_config_write_returns_422_for_invalid_plugin_manifest_name(tmp_path: Path) -> None:
+def test_write_app_committed_config_returns_422_for_invalid_plugin_manifest_name(tmp_path: Path) -> None:
     """API config writes should surface invalid plugin manifests as user config errors."""
     plugin_root = tmp_path / "plugins" / "bad-name"
     plugin_root.mkdir(parents=True)
@@ -2875,7 +2889,7 @@ def test_run_config_write_returns_422_for_invalid_plugin_manifest_name(tmp_path:
     }
 
     with pytest.raises(HTTPException) as exc_info:
-        main._run_config_write(
+        config_lifecycle.write_app_committed_config(
             main.app,
             lambda candidate_config: candidate_config.update({"plugins": ["./plugins/bad-name"]}),
             error_prefix="Failed to save configuration",
@@ -2887,7 +2901,7 @@ def test_run_config_write_returns_422_for_invalid_plugin_manifest_name(tmp_path:
     assert exc_info.value.detail[0]["type"] == "value_error"
 
 
-def test_run_config_write_checks_current_config_load_result_after_acquiring_lock(tmp_path: Path) -> None:
+def test_write_app_committed_config_checks_current_config_load_result_after_acquiring_lock(tmp_path: Path) -> None:
     """Config writes should see a reload failure published while they are waiting on the lock."""
     runtime_paths = constants.resolve_primary_runtime_paths(
         config_path=tmp_path / "config.yaml",
@@ -2930,7 +2944,7 @@ def test_run_config_write_checks_current_config_load_result_after_acquiring_lock
 
     def _run_write() -> None:
         try:
-            main._run_config_write(
+            config_lifecycle.write_app_committed_config(
                 main.app,
                 lambda candidate_config: candidate_config["agents"].update(
                     {
@@ -2984,7 +2998,7 @@ def test_api_config_load_accepts_missing_plugin_path_in_degraded_mode(temp_confi
     )
     runtime_paths = constants.resolve_primary_runtime_paths(config_path=temp_config_file, process_env={})
     main.initialize_api_app(main.app, runtime_paths)
-    assert main._load_config_from_file(runtime_paths, main.app) is True
+    assert config_lifecycle.load_config_into_app(runtime_paths, main.app) is True
     client = TestClient(main.app)
 
     response = client.post("/api/config/load")
@@ -2999,7 +3013,7 @@ def test_api_config_load_returns_422_for_malformed_yaml(temp_config_file: Path) 
     temp_config_file.write_text("agents:\n  bad: [\n", encoding="utf-8")
     runtime_paths = constants.resolve_primary_runtime_paths(config_path=temp_config_file, process_env={})
     main.initialize_api_app(main.app, runtime_paths)
-    main._load_config_from_file(runtime_paths, main.app)
+    config_lifecycle.load_config_into_app(runtime_paths, main.app)
     client = TestClient(main.app)
 
     response = client.post("/api/config/load")
@@ -3013,7 +3027,7 @@ def test_api_config_load_does_not_serve_stale_cache_after_invalid_reload(temp_co
     """API config loads should return the latest parse error instead of stale last-known-good data."""
     runtime_paths = constants.resolve_primary_runtime_paths(config_path=temp_config_file, process_env={})
     main.initialize_api_app(main.app, runtime_paths)
-    main._load_config_from_file(runtime_paths, main.app)
+    config_lifecycle.load_config_into_app(runtime_paths, main.app)
     client = TestClient(main.app)
 
     initial_response = client.post("/api/config/load")
@@ -3022,7 +3036,7 @@ def test_api_config_load_does_not_serve_stale_cache_after_invalid_reload(temp_co
 
     temp_config_file.write_text("agents:\n  broken: [\n", encoding="utf-8")
 
-    assert main._load_config_from_file(runtime_paths, main.app) is False
+    assert config_lifecycle.load_config_into_app(runtime_paths, main.app) is False
 
     response = client.post("/api/config/load")
 
@@ -3050,7 +3064,7 @@ def test_api_cached_read_endpoints_refuse_stale_config_after_invalid_reload(
     runtime_paths = main._app_runtime_paths(api_key_client.app)
     temp_config_file.write_text("agents:\n  broken: [\n", encoding="utf-8")
 
-    assert main._load_config_from_file(runtime_paths, main.app) is False
+    assert config_lifecycle.load_config_into_app(runtime_paths, main.app) is False
 
     response = api_key_client.get(path, headers={"Authorization": "Bearer test-key"})
 
@@ -3067,7 +3081,7 @@ def test_api_cached_write_endpoints_refuse_stale_config_after_invalid_reload(
     invalid_source = "agents:\n  broken: [\n"
     temp_config_file.write_text(invalid_source, encoding="utf-8")
 
-    assert main._load_config_from_file(runtime_paths, main.app) is False
+    assert config_lifecycle.load_config_into_app(runtime_paths, main.app) is False
 
     response = api_key_client.put(
         "/api/config/models/default",
@@ -3089,7 +3103,7 @@ def test_api_key_raw_endpoints_recover_from_invalid_reload(
     invalid_source = "agents:\n  broken: [\n"
     temp_config_file.write_text(invalid_source, encoding="utf-8")
 
-    assert main._load_config_from_file(runtime_paths, main.app) is False
+    assert config_lifecycle.load_config_into_app(runtime_paths, main.app) is False
 
     raw_response = api_key_client.get(
         "/api/config/raw",
@@ -3117,7 +3131,7 @@ def test_api_key_raw_endpoints_recover_from_invalid_reload(
     assert load_response.json()["agents"]["recovered"]["display_name"] == "Recovered"
 
 
-def test_load_config_from_file_omits_legacy_null_optional_sections(tmp_path: Path) -> None:
+def test_load_config_into_app_omits_legacy_null_optional_sections(tmp_path: Path) -> None:
     """API config loads should drop legacy null optional sections from authored config data."""
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
@@ -3134,14 +3148,14 @@ def test_load_config_from_file_omits_legacy_null_optional_sections(tmp_path: Pat
     )
     runtime_paths = constants.resolve_primary_runtime_paths(config_path=config_path, process_env={})
 
-    main._load_config_from_file(runtime_paths, main.app)
+    config_lifecycle.load_config_into_app(runtime_paths, main.app)
 
     config_data = main._app_context(main.app).config_data
     assert "teams" not in config_data
     assert "plugins" not in config_data
 
 
-def test_run_config_write_omits_legacy_null_optional_sections(tmp_path: Path) -> None:
+def test_write_app_committed_config_omits_legacy_null_optional_sections(tmp_path: Path) -> None:
     """API config writes should drop legacy null optional sections from authored config data."""
     config_path = tmp_path / "config.yaml"
     main.initialize_api_app(
@@ -3156,7 +3170,7 @@ def test_run_config_write_omits_legacy_null_optional_sections(tmp_path: Path) ->
         "plugins": None,
     }
 
-    main._run_config_write(
+    config_lifecycle.write_app_committed_config(
         main.app,
         lambda _candidate_config: None,
         error_prefix="Failed to save configuration",
@@ -3635,7 +3649,7 @@ def api_key_client(temp_config_file: Path) -> TestClient:
         ),
         supabase_auth=None,
     )
-    main._load_config_from_file(main._app_runtime_paths(main.app), main.app)
+    config_lifecycle.load_config_into_app(main._app_runtime_paths(main.app), main.app)
     return TestClient(main.app)
 
 
@@ -3699,14 +3713,14 @@ def test_protected_read_keeps_auth_time_snapshot_after_runtime_swap(tmp_path: Pa
             },
         },
     }
-    original_read = main.read_api_committed_config
+    original_read = config_lifecycle.read_committed_config
 
     def _swap_then_read(request: Request, reader: Callable[[dict[str, Any]], object]) -> object:
         _publish_committed_runtime_config(main.app, runtime_b, payload_b)
         return original_read(request, reader)
 
     with (
-        patch.object(main, "read_api_committed_config", side_effect=_swap_then_read),
+        patch.object(config_lifecycle, "read_committed_config", side_effect=_swap_then_read),
         TestClient(main.app) as client,
     ):
         _publish_committed_runtime_config(main.app, runtime_a, payload_a)
@@ -3734,7 +3748,7 @@ def test_protected_write_rejects_runtime_swap_after_auth(tmp_path: Path) -> None
     payload_a = _authored_config_payload("old")
     payload_b = _authored_config_payload("new")
     runtime_b.config_path.write_text(yaml.safe_dump(payload_b), encoding="utf-8")
-    original_replace = main.replace_api_committed_config
+    original_replace = config_lifecycle.replace_committed_config
 
     def _swap_then_replace(
         request: Request,
@@ -3752,7 +3766,7 @@ def test_protected_write_rejects_runtime_swap_after_auth(tmp_path: Path) -> None
         )
 
     with (
-        patch.object(main, "replace_api_committed_config", side_effect=_swap_then_replace),
+        patch.object(config_lifecycle, "replace_committed_config", side_effect=_swap_then_replace),
         TestClient(main.app) as client,
     ):
         _publish_committed_runtime_config(main.app, runtime_a, payload_a)
@@ -3785,14 +3799,14 @@ def test_protected_raw_read_keeps_auth_time_snapshot_after_runtime_swap(tmp_path
     source_b = yaml.safe_dump(payload_b, sort_keys=True)
     runtime_a.config_path.write_text(source_a, encoding="utf-8")
     runtime_b.config_path.write_text(source_b, encoding="utf-8")
-    original_read = main.read_api_raw_config_source
+    original_read = config_lifecycle.read_raw_config_source
 
     def _swap_then_read(request: Request) -> str:
         _publish_committed_runtime_config(main.app, runtime_b, payload_b)
         return original_read(request)
 
     with (
-        patch.object(main, "read_api_raw_config_source", side_effect=_swap_then_read),
+        patch.object(config_lifecycle, "read_raw_config_source", side_effect=_swap_then_read),
         TestClient(main.app) as client,
     ):
         _publish_committed_runtime_config(main.app, runtime_a, payload_a)
@@ -3821,7 +3835,7 @@ def test_protected_raw_write_rejects_runtime_swap_after_auth(tmp_path: Path) -> 
     payload_b = _authored_config_payload("new")
     source_b = yaml.safe_dump(payload_b, sort_keys=True)
     runtime_b.config_path.write_text(source_b, encoding="utf-8")
-    original_replace = main.replace_api_raw_config_source
+    original_replace = config_lifecycle.replace_raw_config_source
 
     def _swap_then_replace(
         request: Request,
@@ -3839,7 +3853,7 @@ def test_protected_raw_write_rejects_runtime_swap_after_auth(tmp_path: Path) -> 
         )
 
     with (
-        patch.object(main, "replace_api_raw_config_source", side_effect=_swap_then_replace),
+        patch.object(config_lifecycle, "replace_raw_config_source", side_effect=_swap_then_replace),
         TestClient(main.app) as client,
     ):
         _publish_committed_runtime_config(main.app, runtime_a, payload_a)
@@ -3868,7 +3882,7 @@ def test_protected_crud_write_rejects_runtime_swap_after_auth(tmp_path: Path) ->
     payload_a = _authored_config_payload("old")
     payload_b = _authored_config_payload("new")
     runtime_b.config_path.write_text(yaml.safe_dump(payload_b), encoding="utf-8")
-    original_write = main.write_api_committed_config
+    original_write = config_lifecycle.write_committed_config
 
     def _swap_then_write(
         request: Request,
@@ -3880,7 +3894,7 @@ def test_protected_crud_write_rejects_runtime_swap_after_auth(tmp_path: Path) ->
         return original_write(request, mutate, error_prefix=error_prefix)
 
     with (
-        patch.object(main, "write_api_committed_config", side_effect=_swap_then_write),
+        patch.object(config_lifecycle, "write_committed_config", side_effect=_swap_then_write),
         TestClient(main.app) as client,
     ):
         _publish_committed_runtime_config(main.app, runtime_a, payload_a)

--- a/tests/api/test_file_watcher.py
+++ b/tests/api/test_file_watcher.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import yaml
 from fastapi.testclient import TestClient
 
+from mindroom.api import config_lifecycle
+
 
 def test_file_watcher_detects_changes(test_client: TestClient, temp_config_file: Path) -> None:
     """Test that external config changes can be loaded."""
@@ -33,7 +35,7 @@ def test_file_watcher_detects_changes(test_client: TestClient, temp_config_file:
     # For testing, we manually trigger a reload
     from mindroom.api import main  # noqa: PLC0415
 
-    main._load_config_from_file(main._app_runtime_paths(main.app), main.app)
+    config_lifecycle.load_config_into_app(main._app_runtime_paths(main.app), main.app)
 
     # Check that the config was reloaded
     response = test_client.get("/api/config/agents")

--- a/tests/api/test_matrix_operations.py
+++ b/tests/api/test_matrix_operations.py
@@ -8,7 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from mindroom import constants
-from mindroom.api import main
+from mindroom.api import config_lifecycle, main
 
 
 def _add_test_team_to_runtime_config() -> None:
@@ -406,7 +406,7 @@ def test_matrix_operations_refuse_stale_config_after_invalid_reload(
     """Matrix operations should surface malformed current config instead of stale cached entities."""
     runtime_paths = constants.resolve_primary_runtime_paths(config_path=temp_config_file, process_env={})
     temp_config_file.write_text("agents:\n  broken: [\n", encoding="utf-8")
-    assert main._load_config_from_file(runtime_paths, main.app) is False
+    assert config_lifecycle.load_config_into_app(runtime_paths, main.app) is False
 
     with (
         patch("mindroom.api.matrix_operations.create_agent_user", return_value=mock_agent_user),


### PR DESCRIPTION
## Summary
- Remove FastAPI `main.py` pass-through helpers for config lifecycle loading, reads, and writes.
- Call `config_lifecycle` directly from API handlers and watcher/lifespan code.
- Update tests to use the lifecycle module directly and guard against reintroducing the facade helpers.

## Test Plan
- [x] `uv run pytest tests/api/test_api.py::test_api_main_does_not_reexport_config_lifecycle_pass_through_helpers -q`
- [x] `uv run pytest tests/api/test_api.py tests/api/test_matrix_operations.py tests/api/test_file_watcher.py -q`
- [x] `uv run ruff check src/mindroom/api/main.py tests/api/test_api.py tests/api/test_matrix_operations.py tests/api/test_file_watcher.py tests/api/conftest.py`
- [x] `uv run ruff format --check src/mindroom/api/main.py tests/api/test_api.py tests/api/test_matrix_operations.py tests/api/test_file_watcher.py tests/api/conftest.py`
- [x] `uv run pytest`
- [x] `uv run pre-commit run --all-files`
