### PR TITLE
Avoid blocking Matrix state file locks

### DIFF
--- a/src/mindroom/matrix/state.py
+++ b/src/mindroom/matrix/state.py
@@ -1,9 +1,6 @@
 """Pydantic models for Matrix state."""
 
-import fcntl
 import os
-from collections.abc import Iterator
-from contextlib import contextmanager
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
@@ -61,8 +58,7 @@ class MatrixState(BaseModel):
         data = self.model_dump(mode="json")
 
         state_file = constants.matrix_state_file(runtime_paths=runtime_paths)
-        with _matrix_state_file_lock(state_file):
-            _write_matrix_state_file_locked(state_file, data)
+        _write_matrix_state_file(state_file, data)
 
     def get_account(self, key: str) -> _MatrixAccount | None:
         """Get an account by key."""
@@ -159,12 +155,6 @@ def _migrate_accounts_to_current_schema(state: MatrixState, *, current_domain: s
 
 def _load_matrix_state_file(state_file: Path, *, current_domain: str) -> MatrixState:
     """Load one Matrix state file from disk."""
-    with _matrix_state_file_lock(state_file):
-        return _load_matrix_state_file_locked(state_file, current_domain=current_domain)
-
-
-def _load_matrix_state_file_locked(state_file: Path, *, current_domain: str) -> MatrixState:
-    """Load one Matrix state file while the state file lock is held."""
     if not state_file.exists():
         return MatrixState()
     with state_file.open(encoding="utf-8") as f:
@@ -173,25 +163,12 @@ def _load_matrix_state_file_locked(state_file: Path, *, current_domain: str) -> 
     migrated = _migrate_accounts_to_current_schema(state, current_domain=current_domain)
     normalized_data = state.model_dump(mode="json")
     if migrated or data != normalized_data:
-        _write_matrix_state_file_locked(state_file, normalized_data)
+        _write_matrix_state_file(state_file, normalized_data)
     return state
 
 
-@contextmanager
-def _matrix_state_file_lock(state_file: Path) -> Iterator[None]:
-    """Serialize Matrix state readers and writers across processes."""
-    state_file.parent.mkdir(parents=True, exist_ok=True)
-    lock_file = state_file.with_name(f"{state_file.name}.lock")
-    with lock_file.open("a+", encoding="utf-8") as f:
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
-
-
-def _write_matrix_state_file_locked(state_file: Path, data: dict[str, object]) -> None:
-    """Atomically persist Matrix state while the state file lock is held."""
+def _write_matrix_state_file(state_file: Path, data: dict[str, object]) -> None:
+    """Atomically persist Matrix state without cross-process advisory locking."""
     state_file.parent.mkdir(parents=True, exist_ok=True)
     temp_path: Path | None = None
     try:

--- a/tests/test_matrix_identity.py
+++ b/tests/test_matrix_identity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 from typing import TYPE_CHECKING
 
 import pytest
@@ -263,6 +264,64 @@ class TestHelperFunctions:
         migrated_data = yaml.safe_load(state_file.read_text())
         assert migrated_data["accounts"]["agent_general"]["domain"] == self.config.get_domain(runtime_paths)
         assert "known_user_ids" not in migrated_data["accounts"]["agent_general"]
+
+    def test_matrix_state_load_migrates_without_advisory_lock(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Matrix state loads should stay lock-free even when normalizing old files."""
+        self.config = _bind_runtime_paths(self.config, tmp_path)
+        runtime_paths = runtime_paths_for(self.config)
+        state_file = constants_mod.matrix_state_file(runtime_paths=runtime_paths)
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(
+            yaml.safe_dump(
+                {
+                    "accounts": {
+                        "agent_general": {
+                            "username": "mindroom_general_oldns",
+                            "password": "pw",
+                        },
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        def _fail_flock(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError
+
+        monkeypatch.setattr(fcntl, "flock", _fail_flock)
+
+        state = MatrixState.load(runtime_paths=runtime_paths)
+
+        assert state.accounts["agent_general"].domain == self.config.get_domain(runtime_paths)
+        assert not state_file.with_name("matrix_state.yaml.lock").exists()
+
+    def test_matrix_state_save_is_atomic_without_advisory_lock(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Matrix state saves should use temp-file replacement, not blocking file locks."""
+        self.config = _bind_runtime_paths(self.config, tmp_path)
+        runtime_paths = runtime_paths_for(self.config)
+        state_file = constants_mod.matrix_state_file(runtime_paths=runtime_paths)
+        domain = self.config.get_domain(runtime_paths)
+
+        def _fail_flock(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError
+
+        monkeypatch.setattr(fcntl, "flock", _fail_flock)
+
+        state = MatrixState()
+        state.add_account("agent_general", "mindroom_general", "pw", domain=domain)
+        state.save(runtime_paths=runtime_paths)
+
+        assert yaml.safe_load(state_file.read_text(encoding="utf-8"))["accounts"]["agent_general"]["domain"] == domain
+        assert not state_file.with_name("matrix_state.yaml.lock").exists()
 
     def test_matrix_state_save_keeps_existing_file_when_temp_write_is_interrupted(
         self,


### PR DESCRIPTION
## Summary
- preserve temp-file replacement for Matrix state writes
- remove blocking advisory file locks from Matrix state load/save paths
- add tests that fail if Matrix state load/save uses flock again

## Rationale
Atomic replacement protects readers from partial YAML writes without introducing a cross-process lock dependency. Blocking advisory locks can hang on shared or network-backed filesystems, and these state operations run in startup paths where a stalled lock can prevent the service from becoming healthy.

## Tests
- uv run ruff check src/mindroom/matrix/state.py tests/test_matrix_identity.py
- uv run pytest tests/test_matrix_identity.py tests/test_matrix_spaces.py tests/test_matrix_agent_manager.py