### PR TITLE
Simplify knowledge availability plumbing

### DIFF
--- a/frontend/src/components/Knowledge/Knowledge.tsx
+++ b/frontend/src/components/Knowledge/Knowledge.tsx
@@ -374,19 +374,15 @@ export function Knowledge() {
         );
       }
 
-      if (isCurrentRequest()) {
-        setStatus({
-          ...statusData,
-          file_listing_degraded:
-            filesData.file_listing_degraded ?? statusData.file_listing_degraded,
-          file_listing_error:
-            filesData.file_listing_error ??
-            statusData.file_listing_error ??
-            null,
-        });
-        setFiles(filesData.files);
-        setTotalSize(filesData.total_size);
-      }
+      setStatus({
+        ...statusData,
+        file_listing_degraded:
+          filesData.file_listing_degraded ?? statusData.file_listing_degraded,
+        file_listing_error:
+          filesData.file_listing_error ?? statusData.file_listing_error ?? null,
+      });
+      setFiles(filesData.files);
+      setTotalSize(filesData.total_size);
     } catch (err) {
       if (!isCurrentRequest()) {
         return;

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -791,19 +791,12 @@ def _log_missing_knowledge_bases(agent_name: str) -> Callable[[list[str]], None]
     )
 
 
-def _knowledge_availability_system_message(
-    unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
-) -> str | None:
-    """Render one OpenAI-compatible system message for unavailable or stale knowledge."""
-    return format_knowledge_availability_notice(unavailable_bases)
-
-
 def _prepend_knowledge_availability_notice(
     prompt: str,
     unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
 ) -> str:
     """Prefix the prompt with the degraded-knowledge notice when shared bases are unavailable."""
-    availability_hint = _knowledge_availability_system_message(unavailable_bases)
+    availability_hint = format_knowledge_availability_notice(unavailable_bases)
     return f"{availability_hint}\n\n{prompt}" if availability_hint else prompt
 
 
@@ -981,7 +974,7 @@ async def chat_completions(  # noqa: C901, PLR0912
                     _log_missing_knowledge_bases(agent_name)(list(knowledge_resolution.missing))
                 knowledge = knowledge_resolution.knowledge
                 unavailable_bases = dict(knowledge_resolution.unavailable)
-            availability_hint = _knowledge_availability_system_message(unavailable_bases)
+            availability_hint = format_knowledge_availability_notice(unavailable_bases)
             if availability_hint:
                 prompt = f"{availability_hint}\n\n{prompt}"
             if req.stream:
@@ -1416,7 +1409,7 @@ def _build_team(
     execution_identity: ToolExecutionIdentity | None,
     scope_context: ScopeSessionContext | None = None,
     session_id: str | None = None,
-    unavailable_base_details: dict[str, KnowledgeAvailabilityDetail] | None = None,
+    unavailable_bases: dict[str, KnowledgeAvailabilityDetail] | None = None,
     refresh_scheduler: KnowledgeRefreshScheduler | None = None,
 ) -> tuple[list[Agent], Team, TeamMode]:
     """Create member agents and build one agno.Team for a configured team.
@@ -1436,7 +1429,7 @@ def _build_team(
         execution_identity=execution_identity,
         session_id=session_id,
         include_openai_compat_guidance=True,
-        unavailable_base_details=unavailable_base_details,
+        unavailable_bases=unavailable_bases,
         refresh_scheduler=refresh_scheduler,
         reason_prefix=f"Team '{team_name}'",
     )
@@ -1534,7 +1527,7 @@ async def _non_stream_team_completion(
     agents: list[Agent] = []
     team: Team | None = None
     scope_context: ScopeSessionContext | None = None
-    unavailable_base_details: dict[str, KnowledgeAvailabilityDetail] = {}
+    unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
     post_response_compaction_checks: list[PostResponseCompactionCheck] = []
     try:
         with open_bound_scope_session_context(
@@ -1554,7 +1547,7 @@ async def _non_stream_team_completion(
                     execution_identity,
                     scope_context,
                     session_id,
-                    unavailable_base_details,
+                    unavailable_bases,
                     refresh_scheduler,
                 )
             except ValueError as e:
@@ -1571,7 +1564,7 @@ async def _non_stream_team_completion(
             try:
                 prompt = _prepend_knowledge_availability_notice(
                     prompt,
-                    unavailable_base_details,
+                    unavailable_bases,
                 )
                 team_run_input = await _prepare_openai_team_run_input(
                     scope_context=scope_context,
@@ -1654,7 +1647,7 @@ async def _stream_team_completion(  # noqa: C901, PLR0915
     team: Team | None = None
     scope_context: ScopeSessionContext | None = None
     stream: AsyncGenerator[RunOutputEvent | TeamRunOutputEvent | RunOutput | TeamRunOutput, None] | None = None
-    unavailable_base_details: dict[str, KnowledgeAvailabilityDetail] = {}
+    unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
     post_response_compaction_checks: list[PostResponseCompactionCheck] = []
 
     async def _cleanup() -> None:
@@ -1687,7 +1680,7 @@ async def _stream_team_completion(  # noqa: C901, PLR0915
                     execution_identity,
                     scope_context,
                     session_id,
-                    unavailable_base_details,
+                    unavailable_bases,
                     refresh_scheduler,
                 )
         except ValueError as e:
@@ -1705,7 +1698,7 @@ async def _stream_team_completion(  # noqa: C901, PLR0915
         try:
             prompt = _prepend_knowledge_availability_notice(
                 prompt,
-                unavailable_base_details,
+                unavailable_bases,
             )
             team_run_input = await _prepare_openai_team_run_input(
                 scope_context=scope_context,

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -50,7 +50,6 @@ from mindroom.history import (
     run_post_response_compaction_check,
 )
 from mindroom.knowledge import (
-    KnowledgeAvailability,
     KnowledgeAvailabilityDetail,
     format_knowledge_availability_notice,
     resolve_agent_knowledge_access,
@@ -793,7 +792,7 @@ def _log_missing_knowledge_bases(agent_name: str) -> Callable[[list[str]], None]
 
 
 def _knowledge_availability_system_message(
-    unavailable_bases: Mapping[str, KnowledgeAvailability | KnowledgeAvailabilityDetail],
+    unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
 ) -> str | None:
     """Render one OpenAI-compatible system message for unavailable or stale knowledge."""
     return format_knowledge_availability_notice(unavailable_bases)
@@ -801,7 +800,7 @@ def _knowledge_availability_system_message(
 
 def _prepend_knowledge_availability_notice(
     prompt: str,
-    unavailable_bases: Mapping[str, KnowledgeAvailability | KnowledgeAvailabilityDetail],
+    unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
 ) -> str:
     """Prefix the prompt with the degraded-knowledge notice when shared bases are unavailable."""
     availability_hint = _knowledge_availability_system_message(unavailable_bases)
@@ -1417,7 +1416,6 @@ def _build_team(
     execution_identity: ToolExecutionIdentity | None,
     scope_context: ScopeSessionContext | None = None,
     session_id: str | None = None,
-    unavailable_bases: dict[str, KnowledgeAvailability] | None = None,
     unavailable_base_details: dict[str, KnowledgeAvailabilityDetail] | None = None,
     refresh_scheduler: KnowledgeRefreshScheduler | None = None,
 ) -> tuple[list[Agent], Team, TeamMode]:
@@ -1438,7 +1436,6 @@ def _build_team(
         execution_identity=execution_identity,
         session_id=session_id,
         include_openai_compat_guidance=True,
-        unavailable_bases=unavailable_bases,
         unavailable_base_details=unavailable_base_details,
         refresh_scheduler=refresh_scheduler,
         reason_prefix=f"Team '{team_name}'",
@@ -1537,7 +1534,6 @@ async def _non_stream_team_completion(
     agents: list[Agent] = []
     team: Team | None = None
     scope_context: ScopeSessionContext | None = None
-    unavailable_bases: dict[str, KnowledgeAvailability] = {}
     unavailable_base_details: dict[str, KnowledgeAvailabilityDetail] = {}
     post_response_compaction_checks: list[PostResponseCompactionCheck] = []
     try:
@@ -1558,7 +1554,6 @@ async def _non_stream_team_completion(
                     execution_identity,
                     scope_context,
                     session_id,
-                    unavailable_bases,
                     unavailable_base_details,
                     refresh_scheduler,
                 )
@@ -1576,7 +1571,7 @@ async def _non_stream_team_completion(
             try:
                 prompt = _prepend_knowledge_availability_notice(
                     prompt,
-                    unavailable_base_details or unavailable_bases,
+                    unavailable_base_details,
                 )
                 team_run_input = await _prepare_openai_team_run_input(
                     scope_context=scope_context,
@@ -1659,7 +1654,6 @@ async def _stream_team_completion(  # noqa: C901, PLR0915
     team: Team | None = None
     scope_context: ScopeSessionContext | None = None
     stream: AsyncGenerator[RunOutputEvent | TeamRunOutputEvent | RunOutput | TeamRunOutput, None] | None = None
-    unavailable_bases: dict[str, KnowledgeAvailability] = {}
     unavailable_base_details: dict[str, KnowledgeAvailabilityDetail] = {}
     post_response_compaction_checks: list[PostResponseCompactionCheck] = []
 
@@ -1693,7 +1687,6 @@ async def _stream_team_completion(  # noqa: C901, PLR0915
                     execution_identity,
                     scope_context,
                     session_id,
-                    unavailable_bases,
                     unavailable_base_details,
                     refresh_scheduler,
                 )
@@ -1712,7 +1705,7 @@ async def _stream_team_completion(  # noqa: C901, PLR0915
         try:
             prompt = _prepend_knowledge_availability_notice(
                 prompt,
-                unavailable_base_details or unavailable_bases,
+                unavailable_base_details,
             )
             team_run_input = await _prepare_openai_team_run_input(
                 scope_context=scope_context,

--- a/src/mindroom/knowledge/__init__.py
+++ b/src/mindroom/knowledge/__init__.py
@@ -10,13 +10,11 @@ from mindroom.knowledge.utils import (
     KnowledgeAvailabilityDetail,
     KnowledgeResolution,
     format_knowledge_availability_notice,
-    get_agent_knowledge,
     resolve_agent_knowledge_access,
 )
 
 __all__ = [
     "KnowledgeManager",
-    "get_agent_knowledge",
     "KnowledgeAccessSupport",
     "KnowledgeAvailability",
     "KnowledgeAvailabilityDetail",

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -998,10 +998,6 @@ class KnowledgeManager:
             persisted_state.settings != self._indexing_settings or persisted_state.status == _INDEXING_STATUS_RESETTING
         )
 
-    def get_knowledge(self) -> Knowledge:
-        """Return the agno Knowledge instance."""
-        return self._knowledge
-
     def _git_config(self) -> KnowledgeGitConfig | None:
         return self.config.get_knowledge_base_config(self.base_id).git
 
@@ -1706,29 +1702,3 @@ class KnowledgeManager:
             finally:
                 if not candidate_publish_state.index_published:
                     await self._delete_unpublished_candidate_vector_db(candidate_vector_db)
-
-    def get_status(self) -> dict[str, Any]:
-        """Get current knowledge indexing status."""
-        files = self.list_files()
-        status = {
-            "base_id": self.base_id,
-            "folder_path": str(self._knowledge_source_path()),
-            "file_count": len(files),
-            "indexed_count": len(self._indexed_files),
-        }
-        git_config = self._git_config()
-        if git_config is not None:
-            status["git"] = {
-                "repo_url": redact_url_credentials(git_config.repo_url),
-                "branch": git_config.branch,
-                "lfs": git_config.lfs,
-                "syncing": self._git_syncing,
-                "repo_present": self._git_repo_present,
-                "initial_sync_complete": self._git_initial_sync_complete,
-                "last_successful_sync_at": (
-                    self._git_last_successful_sync_at.isoformat() if self._git_last_successful_sync_at else None
-                ),
-                "last_successful_commit": self._git_last_successful_commit,
-                "last_error": self._git_last_error,
-            }
-        return status

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -402,11 +402,29 @@ def resolve_agent_knowledge_access(
         resolved_knowledge[base_id] = (knowledge, availability)
         return resolved_knowledge[base_id]
 
-    return resolve_agent_knowledge(
-        agent_name,
-        config,
-        lambda base_id: _resolve(base_id)[0],
-        get_availability=lambda base_id: _resolve(base_id)[1],
+    base_ids = config.get_agent_knowledge_base_ids(agent_name)
+    if not base_ids:
+        return KnowledgeResolution(knowledge=None)
+
+    missing_base_ids: list[str] = []
+    unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
+    knowledges: list[Knowledge] = []
+    for base_id in base_ids:
+        knowledge, availability = _resolve(base_id)
+        if availability is not KnowledgeAvailability.READY:
+            unavailable_bases[base_id] = KnowledgeAvailabilityDetail(
+                availability=availability,
+                search_available=knowledge is not None,
+            )
+        if knowledge is None:
+            missing_base_ids.append(base_id)
+            continue
+        knowledges.append(knowledge)
+
+    return KnowledgeResolution(
+        knowledge=_merge_knowledge(agent_name, knowledges),
+        missing=tuple(missing_base_ids),
+        unavailable=unavailable_bases,
     )
 
 
@@ -633,40 +651,4 @@ def _merge_knowledge(agent_name: str, knowledges: list[Knowledge]) -> Knowledge 
         name=f"{agent_name}_multi_knowledge",
         vector_db=MultiKnowledgeVectorDb(vector_dbs=vector_db_sources),
         max_results=max(knowledge.max_results for knowledge in knowledges),
-    )
-
-
-def resolve_agent_knowledge(
-    agent_name: str,
-    config: Config,
-    get_knowledge: Callable[[str], Knowledge | None],
-    *,
-    get_availability: Callable[[str], KnowledgeAvailability] | None = None,
-) -> KnowledgeResolution:
-    """Resolve configured knowledge base(s) for an agent with diagnostics."""
-    base_ids = config.get_agent_knowledge_base_ids(agent_name)
-    if not base_ids:
-        return KnowledgeResolution(knowledge=None)
-
-    missing_base_ids: list[str] = []
-    unavailable_base_details: dict[str, KnowledgeAvailabilityDetail] = {}
-    knowledges: list[Knowledge] = []
-    for base_id in base_ids:
-        knowledge = get_knowledge(base_id)
-        if get_availability is not None:
-            availability = get_availability(base_id)
-            if availability is not KnowledgeAvailability.READY:
-                unavailable_base_details[base_id] = KnowledgeAvailabilityDetail(
-                    availability=availability,
-                    search_available=knowledge is not None,
-                )
-        if knowledge is None:
-            missing_base_ids.append(base_id)
-            continue
-        knowledges.append(knowledge)
-
-    return KnowledgeResolution(
-        knowledge=_merge_knowledge(agent_name, knowledges),
-        missing=tuple(missing_base_ids),
-        unavailable=unavailable_base_details,
     )

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -410,35 +410,6 @@ def resolve_agent_knowledge_access(
     )
 
 
-def get_agent_knowledge(
-    agent_name: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    on_missing_bases: Callable[[list[str]], None] | None = None,
-    on_unavailable_bases: Callable[[Mapping[str, KnowledgeAvailability]], None] | None = None,
-    on_unavailable_base_details: Callable[[Mapping[str, KnowledgeAvailabilityDetail]], None] | None = None,
-    refresh_scheduler: KnowledgeRefreshScheduler | None = None,
-    execution_identity: ToolExecutionIdentity | None = None,
-) -> Knowledge | None:
-    """Resolve configured knowledge base(s) for one agent into one Knowledge instance."""
-    resolution = resolve_agent_knowledge_access(
-        agent_name,
-        config,
-        runtime_paths,
-        refresh_scheduler=refresh_scheduler,
-        execution_identity=execution_identity,
-    )
-    if resolution.missing and on_missing_bases is not None:
-        on_missing_bases(list(resolution.missing))
-    if resolution.unavailable and on_unavailable_bases is not None:
-        on_unavailable_bases(
-            {base_id: detail.availability for base_id, detail in resolution.unavailable.items()},
-        )
-    if resolution.unavailable and on_unavailable_base_details is not None:
-        on_unavailable_base_details(resolution.unavailable)
-    return resolution.knowledge
-
-
 def _stale_availability_notice(base_id: str, *, search_available: bool) -> str:
     if search_available:
         return (
@@ -452,20 +423,16 @@ def _stale_availability_notice(base_id: str, *, search_available: bool) -> str:
 
 
 def format_knowledge_availability_notice(
-    unavailable_bases: Mapping[str, KnowledgeAvailability | KnowledgeAvailabilityDetail],
+    unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
 ) -> str | None:
     """Render one user-facing notice for unavailable or stale knowledge bases."""
     if not unavailable_bases:
         return None
 
     lines: list[str] = []
-    for base_id, availability_value in sorted(unavailable_bases.items()):
-        if isinstance(availability_value, KnowledgeAvailabilityDetail):
-            availability = availability_value.availability
-            search_available = availability_value.search_available
-        else:
-            availability = availability_value
-            search_available = True
+    for base_id, detail in sorted(unavailable_bases.items()):
+        availability = detail.availability
+        search_available = detail.search_available
 
         if availability is KnowledgeAvailability.INITIALIZING:
             lines.append(
@@ -611,7 +578,7 @@ class MultiKnowledgeVectorDb:
                 if isinstance(vdb, _AsyncKnowledgeVectorDb):
                     try:
                         results = await vdb.async_search(query=query, limit=limit, filters=filters)
-                    except (NotImplementedError, AttributeError):
+                    except NotImplementedError:
                         results = vdb.search(query=query, limit=limit, filters=filters)
                 else:
                     results = vdb.search(query=query, limit=limit, filters=filters)

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -42,7 +42,6 @@ from mindroom.hooks import (
 )
 from mindroom.knowledge import (
     KnowledgeAccessSupport,
-    KnowledgeAvailability,
     KnowledgeAvailabilityDetail,
     format_knowledge_availability_notice,
 )
@@ -128,7 +127,7 @@ _VISIBLE_TOOL_MARKER_SEPARATOR_PATTERN = re.compile(r"^\s{0,3}---\s*$")
 
 def _append_knowledge_availability_enrichment(
     system_enrichment_items: Sequence[EnrichmentItem],
-    unavailable_bases: Mapping[str, KnowledgeAvailability | KnowledgeAvailabilityDetail],
+    unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
 ) -> tuple[EnrichmentItem, ...]:
     """Append one volatile knowledge-availability notice when needed."""
     notice = format_knowledge_availability_notice(unavailable_bases)

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -50,7 +50,6 @@ from mindroom.history import (
 from mindroom.history.interrupted_replay import split_interrupted_tool_trace, tool_execution_call_id
 from mindroom.hooks import EnrichmentItem, render_system_enrichment_block
 from mindroom.knowledge import (
-    KnowledgeAvailability,
     KnowledgeAvailabilityDetail,
     format_knowledge_availability_notice,
     resolve_agent_knowledge_access,
@@ -107,7 +106,7 @@ _MATRIX_TEAM_THREAD_HISTORY_RENDER_LIMITS = ThreadHistoryRenderLimits(
 
 def _append_knowledge_availability_enrichment(
     system_enrichment_items: Sequence[EnrichmentItem],
-    unavailable_bases: Mapping[str, KnowledgeAvailability | KnowledgeAvailabilityDetail],
+    unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
 ) -> tuple[EnrichmentItem, ...]:
     """Append one volatile knowledge-availability notice when needed."""
     notice = format_knowledge_availability_notice(unavailable_bases)
@@ -1174,7 +1173,6 @@ def materialize_exact_team_members(
     session_id: str | None = None,
     include_openai_compat_guidance: bool = False,
     materializable_agent_names: set[str] | None = None,
-    unavailable_bases: dict[str, KnowledgeAvailability] | None = None,
     unavailable_base_details: dict[str, KnowledgeAvailabilityDetail] | None = None,
     refresh_scheduler: KnowledgeRefreshScheduler | None = None,
     reason_prefix: str = "Team request",
@@ -1196,10 +1194,6 @@ def materialize_exact_team_members(
                 "Knowledge bases not available for team agent",
                 agent_name=agent_name,
                 knowledge_bases=list(knowledge_resolution.missing),
-            )
-        if unavailable_bases is not None:
-            unavailable_bases.update(
-                {base_id: detail.availability for base_id, detail in knowledge_resolution.unavailable.items()},
             )
         if unavailable_base_details is not None:
             unavailable_base_details.update(knowledge_resolution.unavailable)
@@ -1247,7 +1241,6 @@ def _materialize_team_members(
     execution_identity: ToolExecutionIdentity | None,
     *,
     session_id: str | None = None,
-    unavailable_bases: dict[str, KnowledgeAvailability] | None = None,
     unavailable_base_details: dict[str, KnowledgeAvailabilityDetail] | None = None,
     reason_prefix: str = "Team request",
 ) -> ResolvedExactTeamMembers:
@@ -1262,7 +1255,6 @@ def _materialize_team_members(
         execution_identity=execution_identity,
         session_id=session_id,
         materializable_agent_names=resolve_live_shared_agent_names(orchestrator),
-        unavailable_bases=unavailable_bases,
         unavailable_base_details=unavailable_base_details,
         refresh_scheduler=orchestrator.knowledge_refresh_scheduler,
         reason_prefix=reason_prefix,

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1173,7 +1173,7 @@ def materialize_exact_team_members(
     session_id: str | None = None,
     include_openai_compat_guidance: bool = False,
     materializable_agent_names: set[str] | None = None,
-    unavailable_base_details: dict[str, KnowledgeAvailabilityDetail] | None = None,
+    unavailable_bases: dict[str, KnowledgeAvailabilityDetail] | None = None,
     refresh_scheduler: KnowledgeRefreshScheduler | None = None,
     reason_prefix: str = "Team request",
 ) -> ResolvedExactTeamMembers:
@@ -1195,8 +1195,8 @@ def materialize_exact_team_members(
                 agent_name=agent_name,
                 knowledge_bases=list(knowledge_resolution.missing),
             )
-        if unavailable_base_details is not None:
-            unavailable_base_details.update(knowledge_resolution.unavailable)
+        if unavailable_bases is not None:
+            unavailable_bases.update(knowledge_resolution.unavailable)
         return create_agent(
             agent_name,
             config,
@@ -1241,7 +1241,7 @@ def _materialize_team_members(
     execution_identity: ToolExecutionIdentity | None,
     *,
     session_id: str | None = None,
-    unavailable_base_details: dict[str, KnowledgeAvailabilityDetail] | None = None,
+    unavailable_bases: dict[str, KnowledgeAvailabilityDetail] | None = None,
     reason_prefix: str = "Team request",
 ) -> ResolvedExactTeamMembers:
     """Materialize the exact requested team-member set without silent fallback."""
@@ -1255,7 +1255,7 @@ def _materialize_team_members(
         execution_identity=execution_identity,
         session_id=session_id,
         materializable_agent_names=resolve_live_shared_agent_names(orchestrator),
-        unavailable_base_details=unavailable_base_details,
+        unavailable_bases=unavailable_bases,
         refresh_scheduler=orchestrator.knowledge_refresh_scheduler,
         reason_prefix=reason_prefix,
     )
@@ -1504,7 +1504,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
             orchestrator,
             execution_identity,
             session_id=session_id,
-            unavailable_base_details=unavailable_bases,
+            unavailable_bases=unavailable_bases,
             reason_prefix=reason_prefix,
         )
     except ValueError as exc:
@@ -1861,7 +1861,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
             orchestrator,
             execution_identity,
             session_id=session_id,
-            unavailable_base_details=unavailable_bases,
+            unavailable_bases=unavailable_bases,
             reason_prefix=reason_prefix,
         )
     except ValueError as exc:

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -31,7 +31,7 @@ from mindroom.knowledge import (
     KnowledgeAvailability,
     KnowledgeAvailabilityDetail,
     KnowledgeRefreshScheduler,
-    get_agent_knowledge,
+    resolve_agent_knowledge_access,
 )
 from mindroom.knowledge.manager import (
     KnowledgeManager,
@@ -300,11 +300,8 @@ def test_cold_git_status_with_existing_non_checkout_dir_returns_empty_files(tmp_
     )
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
 
-    status = manager.get_status()
-
     assert manager.list_files() == []
-    assert status["file_count"] == 0
-    assert status["git"]["repo_present"] is False
+    assert manager._git_repo_present is False
     assert not (knowledge_path / ".git").exists()
 
 
@@ -346,12 +343,12 @@ def test_missing_shared_knowledge_schedules_refresh_and_returns_none(tmp_path: P
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
 
-    knowledge = get_agent_knowledge(
+    knowledge = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths_for(config),
         refresh_scheduler=scheduler,
-    )
+    ).knowledge
 
     assert knowledge is None
     scheduler.schedule_refresh.assert_called_once()
@@ -371,7 +368,7 @@ def test_initializing_knowledge_skips_duplicate_initial_load_when_scheduler_is_a
     scheduler.is_refreshing = MagicMock(return_value=True)
     scheduler.schedule_refresh = MagicMock()
 
-    knowledge = get_agent_knowledge("helper", config, runtime_paths, refresh_scheduler=scheduler)
+    knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths, refresh_scheduler=scheduler).knowledge
 
     assert knowledge is None
     scheduler.is_refreshing.assert_called_once()
@@ -386,7 +383,9 @@ def test_real_refresh_scheduler_without_running_loop_does_not_mark_active(tmp_pa
     runtime_paths = runtime_paths_for(config)
     scheduler = KnowledgeRefreshScheduler()
 
-    assert get_agent_knowledge("helper", config, runtime_paths, refresh_scheduler=scheduler) is None
+    assert (
+        resolve_agent_knowledge_access("helper", config, runtime_paths, refresh_scheduler=scheduler).knowledge is None
+    )
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
     refresh_target = knowledge_registry.resolve_refresh_target("docs", config=config, runtime_paths=runtime_paths)
 
@@ -466,8 +465,13 @@ async def test_ready_index_access_does_not_refresh_unchanged_sources(tmp_path: P
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
 
-    knowledge = get_agent_knowledge("helper", config, runtime_paths, refresh_scheduler=scheduler)
-    second_knowledge = get_agent_knowledge("helper", config, runtime_paths, refresh_scheduler=scheduler)
+    knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths, refresh_scheduler=scheduler).knowledge
+    second_knowledge = resolve_agent_knowledge_access(
+        "helper",
+        config,
+        runtime_paths,
+        refresh_scheduler=scheduler,
+    ).knowledge
 
     assert knowledge is not None
     assert second_knowledge is not None
@@ -490,13 +494,18 @@ async def test_shared_local_watch_index_refreshes_on_access_without_blocking_rea
     scheduler = KnowledgeRefreshScheduler()
 
     try:
-        knowledge = get_agent_knowledge("helper", config, runtime_paths, refresh_scheduler=scheduler)
+        knowledge = resolve_agent_knowledge_access(
+            "helper",
+            config,
+            runtime_paths,
+            refresh_scheduler=scheduler,
+        ).knowledge
         assert knowledge is not None
         assert [document.content for document in knowledge.search("shared", max_results=5)] == ["shared local old"]
 
         for _attempt in range(50):
             await asyncio.sleep(0.01)
-            refreshed = get_agent_knowledge("helper", config, runtime_paths)
+            refreshed = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
             if refreshed is not None and [
                 document.content for document in refreshed.search("shared", max_results=5)
             ] == ["shared local new"]:
@@ -521,18 +530,15 @@ async def test_shared_local_watch_schedule_refresh_on_access_is_throttled(tmp_pa
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     unavailable_details: dict[str, KnowledgeAvailabilityDetail] = {}
-
-    assert (
-        get_agent_knowledge(
-            "helper",
-            config,
-            runtime_paths,
-            refresh_scheduler=scheduler,
-            on_unavailable_bases=unavailable.update,
-            on_unavailable_base_details=unavailable_details.update,
-        )
-        is not None
+    _resolution = resolve_agent_knowledge_access(
+        "helper",
+        config,
+        runtime_paths,
+        refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    unavailable_details.update(_resolution.unavailable)
+    assert _resolution.knowledge is not None
     assert unavailable == {"docs": KnowledgeAvailability.STALE}
     assert unavailable_details == {
         "docs": KnowledgeAvailabilityDetail(
@@ -545,15 +551,15 @@ async def test_shared_local_watch_schedule_refresh_on_access_is_throttled(tmp_pa
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     unavailable.clear()
     unavailable_details.clear()
-
-    refreshed_knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
         refresh_scheduler=scheduler,
-        on_unavailable_bases=unavailable.update,
-        on_unavailable_base_details=unavailable_details.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    unavailable_details.update(_resolution.unavailable)
+    refreshed_knowledge = _resolution.knowledge
 
     assert refreshed_knowledge is not None
     assert [document.content for document in refreshed_knowledge.search("shared", max_results=5)] == [
@@ -561,28 +567,24 @@ async def test_shared_local_watch_schedule_refresh_on_access_is_throttled(tmp_pa
     ]
     assert unavailable == {}
     assert unavailable_details == {}
-    assert (
-        get_agent_knowledge(
-            "helper",
-            config,
-            runtime_paths,
-            refresh_scheduler=scheduler,
-            on_unavailable_bases=unavailable.update,
-            on_unavailable_base_details=unavailable_details.update,
-        )
-        is not None
+    _resolution = resolve_agent_knowledge_access(
+        "helper",
+        config,
+        runtime_paths,
+        refresh_scheduler=scheduler,
     )
-    assert (
-        get_agent_knowledge(
-            "helper",
-            config,
-            runtime_paths,
-            refresh_scheduler=scheduler,
-            on_unavailable_bases=unavailable.update,
-            on_unavailable_base_details=unavailable_details.update,
-        )
-        is not None
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    unavailable_details.update(_resolution.unavailable)
+    assert _resolution.knowledge is not None
+    _resolution = resolve_agent_knowledge_access(
+        "helper",
+        config,
+        runtime_paths,
+        refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    unavailable_details.update(_resolution.unavailable)
+    assert _resolution.knowledge is not None
     assert unavailable == {}
     assert unavailable_details == {}
 
@@ -628,15 +630,13 @@ async def test_shared_local_watch_file_event_marks_stale_and_schedules_refresh(
 
     assert state is not None
     assert published_index_refresh_state(state) == "stale"
-    assert (
-        get_agent_knowledge(
-            "helper",
-            config,
-            runtime_paths,
-            on_unavailable_base_details=unavailable_details.update,
-        )
-        is not None
+    _resolution = resolve_agent_knowledge_access(
+        "helper",
+        config,
+        runtime_paths,
     )
+    unavailable_details.update(_resolution.unavailable)
+    assert _resolution.knowledge is not None
     refresh_scheduler.schedule_refresh.assert_called_once()
     assert refresh_scheduler.schedule_refresh.call_args.args == ("docs",)
     assert unavailable_details == {
@@ -745,15 +745,15 @@ async def test_schedule_refresh_on_access_reports_stale_while_scheduler_is_activ
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     unavailable_details: dict[str, KnowledgeAvailabilityDetail] = {}
-
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
         refresh_scheduler=scheduler,
-        on_unavailable_bases=unavailable.update,
-        on_unavailable_base_details=unavailable_details.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    unavailable_details.update(_resolution.unavailable)
+    knowledge = _resolution.knowledge
 
     assert knowledge is not None
     assert [document.content for document in knowledge.search("active", max_results=5)] == ["active refresh old"]
@@ -784,21 +784,22 @@ async def test_stale_index_metadata_schedules_refresh_without_source_scan(tmp_pa
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
-
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
         refresh_scheduler=scheduler,
     )
-    second_knowledge = get_agent_knowledge(
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
         refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    second_knowledge = _resolution.knowledge
 
     assert knowledge is not None
     assert second_knowledge is not None
@@ -826,14 +827,14 @@ async def test_stale_index_skips_duplicate_refresh_when_scheduler_is_active(tmp_
     scheduler.is_refreshing = MagicMock(return_value=True)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
-
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
         refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert knowledge is not None
     assert [document.content for document in knowledge.search("index", max_results=5)] == ["ready index"]
@@ -852,7 +853,7 @@ async def test_dashboard_delete_keeps_last_good_best_effort_until_refresh(tmp_pa
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     runtime_paths = runtime_paths_for(config)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
-    initial_knowledge = get_agent_knowledge("helper", config, runtime_paths)
+    initial_knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
     assert initial_knowledge is not None
     assert {document.content for document in initial_knowledge.search("anything", max_results=5)} == {
         "deleted secret",
@@ -876,7 +877,7 @@ async def test_dashboard_delete_keeps_last_good_best_effort_until_refresh(tmp_pa
         key,
         error="refresh failed after delete",
     )
-    stale_knowledge = get_agent_knowledge("helper", config, runtime_paths)
+    stale_knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
 
     assert stale_knowledge is not None
     assert {document.content for document in stale_knowledge.search("anything", max_results=5)} == {
@@ -896,7 +897,7 @@ async def test_dashboard_replacement_upload_keeps_last_good_best_effort_until_re
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     runtime_paths = runtime_paths_for(config)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
-    initial_knowledge = get_agent_knowledge("helper", config, runtime_paths)
+    initial_knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
     assert initial_knowledge is not None
     assert {document.content for document in initial_knowledge.search("anything", max_results=5)} == {
         "replaced secret",
@@ -918,7 +919,7 @@ async def test_dashboard_replacement_upload_keeps_last_good_best_effort_until_re
         main.app.state.knowledge_refresh_scheduler = None
     assert response.status_code == 200
 
-    pending_knowledge = get_agent_knowledge("helper", config, runtime_paths)
+    pending_knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
     assert pending_knowledge is not None
     assert {document.content for document in pending_knowledge.search("anything", max_results=5)} == {
         "replaced secret",
@@ -930,7 +931,7 @@ async def test_dashboard_replacement_upload_keeps_last_good_best_effort_until_re
         key,
         error="refresh failed after replacement",
     )
-    filtered_knowledge = get_agent_knowledge("helper", config, runtime_paths)
+    filtered_knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
 
     assert (docs_path / "guide.md").read_text(encoding="utf-8") == "replacement content"
     assert filtered_knowledge is not None
@@ -1013,8 +1014,8 @@ async def test_ready_index_access_never_recomputes_source_signature(
 
     monkeypatch.setattr("mindroom.knowledge.manager.knowledge_source_signature", _unexpected_signature)
 
-    assert get_agent_knowledge("helper", config, runtime_paths) is not None
-    assert get_agent_knowledge("helper", config, runtime_paths) is not None
+    assert resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge is not None
+    assert resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge is not None
 
 
 def test_knowledge_file_listing_rejects_symlink_file_escape(tmp_path: Path) -> None:
@@ -1068,14 +1069,14 @@ async def test_index_metadata_without_source_signature_is_unavailable_and_schedu
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
-
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
         refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert knowledge is None
     assert unavailable == {"docs": KnowledgeAvailability.REFRESH_FAILED}
@@ -1103,12 +1104,13 @@ async def test_successful_publish_clears_stale_refresh_state(tmp_path: Path) -> 
     state = load_published_index_state(published_index_metadata_path(key))
 
     unavailable: dict[str, KnowledgeAvailability] = {}
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert knowledge is not None
     assert state is not None
@@ -1815,13 +1817,14 @@ def test_passwordless_ssh_username_change_invalidates_published_index(tmp_path: 
     unavailable: dict[str, KnowledgeAvailability] = {}
 
     lookup = get_published_index("docs", config=changed_config, runtime_paths=runtime_paths)
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         changed_config,
         runtime_paths,
         refresh_scheduler=scheduler,
-        on_unavailable_bases=unavailable.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert lookup.index is None
     assert lookup.availability is KnowledgeAvailability.CONFIG_MISMATCH
@@ -1929,14 +1932,14 @@ async def test_git_ready_index_schedules_refresh_after_poll_interval(
         raise AssertionError(msg)
 
     monkeypatch.setattr("mindroom.knowledge.manager.knowledge_source_signature", _unexpected_signature)
-
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
         refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert knowledge is not None
     assert [document.content for document in knowledge.search("git", max_results=5)] == ["git index"]
@@ -1992,15 +1995,15 @@ async def test_private_git_schedule_refresh_on_access_honors_poll_interval(
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
-
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
         execution_identity=identity,
         refresh_scheduler=scheduler,
-        on_unavailable_bases=unavailable.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert knowledge is not None
     assert unavailable == {}
@@ -2015,15 +2018,15 @@ async def test_private_git_schedule_refresh_on_access_honors_poll_interval(
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
     unavailable = {}
-
-    stale_knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
         execution_identity=identity,
         refresh_scheduler=scheduler,
-        on_unavailable_bases=unavailable.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    stale_knowledge = _resolution.knowledge
 
     assert stale_knowledge is not None
     assert unavailable == {base_id: KnowledgeAvailability.STALE}
@@ -2158,7 +2161,7 @@ async def test_existing_published_index_is_used_while_refresh_runs(
         indexed_files: set[str] | None = None,
         indexed_signatures: dict[str, tuple[int, int, str] | None] | None = None,
     ) -> bool:
-        if knowledge is not None and knowledge is not self.get_knowledge() and not started.is_set():
+        if knowledge is not None and knowledge is not self._knowledge and not started.is_set():
             started.set()
             await release.wait()
         return await original_index_file_locked(
@@ -2174,13 +2177,13 @@ async def test_existing_published_index_is_used_while_refresh_runs(
     refresh_task = asyncio.create_task(refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths))
     await started.wait()
 
-    knowledge = get_agent_knowledge("helper", config, runtime_paths)
+    knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
     assert knowledge is not None
     assert [document.content for document in knowledge.search("index", max_results=5)] == ["old index"]
 
     release.set()
     await refresh_task
-    knowledge = get_agent_knowledge("helper", config, runtime_paths)
+    knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
     assert knowledge is not None
     assert [document.content for document in knowledge.search("index", max_results=5)] == ["new index"]
 
@@ -2212,7 +2215,7 @@ async def test_cancelled_refresh_deletes_unpublished_candidate_collection(
         indexed_files: set[str] | None = None,
         indexed_signatures: dict[str, tuple[int, int, str] | None] | None = None,
     ) -> bool:
-        if knowledge is not None and knowledge is not self.get_knowledge():
+        if knowledge is not None and knowledge is not self._knowledge:
             candidate_started.set()
             await asyncio.Event().wait()
         return await original_index_file_locked(
@@ -2235,7 +2238,7 @@ async def test_cancelled_refresh_deletes_unpublished_candidate_collection(
         await refresh_task
 
     assert set(_VectorDb.collections).isdisjoint(cancelled_candidate_collections)
-    knowledge = get_agent_knowledge("helper", config, runtime_paths)
+    knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
     assert knowledge is not None
     assert [document.content for document in knowledge.search("cancel", max_results=5)] == ["cancel stable"]
 
@@ -2619,7 +2622,7 @@ async def test_failed_refresh_preserves_last_good_index(tmp_path: Path, monkeypa
         indexed_files: set[str] | None = None,
         indexed_signatures: dict[str, tuple[int, int, str] | None] | None = None,
     ) -> bool:
-        if knowledge is not None and knowledge is not self.get_knowledge():
+        if knowledge is not None and knowledge is not self._knowledge:
             msg = "candidate failed"
             raise RuntimeError(msg)
         return await original_index_file_locked(
@@ -2636,12 +2639,13 @@ async def test_failed_refresh_preserves_last_good_index(tmp_path: Path, monkeypa
         await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
 
     unavailable: dict[str, KnowledgeAvailability] = {}
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert unavailable == {"docs": KnowledgeAvailability.REFRESH_FAILED}
     assert knowledge is not None
@@ -2679,12 +2683,13 @@ async def test_metadata_save_failure_after_candidate_index_keeps_serving_last_go
         await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
 
     unavailable: dict[str, KnowledgeAvailability] = {}
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert unavailable == {"docs": KnowledgeAvailability.REFRESH_FAILED}
     assert knowledge is not None
@@ -2705,7 +2710,7 @@ async def test_partial_refresh_after_cached_index_updates_failed_availability(
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     runtime_paths = runtime_paths_for(config)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
-    assert get_agent_knowledge("helper", config, runtime_paths) is not None
+    assert resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge is not None
     (docs_path / "bad.md").write_text("bad candidate", encoding="utf-8")
     original_index_file_locked = KnowledgeManager._index_file_locked
 
@@ -2733,12 +2738,13 @@ async def test_partial_refresh_after_cached_index_updates_failed_availability(
 
     result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     unavailable: dict[str, KnowledgeAvailability] = {}
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert result.index_published is False
     assert result.availability is KnowledgeAvailability.REFRESH_FAILED
@@ -2761,14 +2767,14 @@ async def test_embedder_config_mismatch_returns_no_incompatible_index(tmp_path: 
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
-
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         changed_config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
         refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert knowledge is None
     assert unavailable == {"docs": KnowledgeAvailability.CONFIG_MISMATCH}
@@ -2791,8 +2797,14 @@ async def test_config_mismatch_refresh_cooldown_is_settings_aware(tmp_path: Path
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
 
-    assert get_agent_knowledge("helper", changed_config, runtime_paths, refresh_scheduler=scheduler) is not None
-    assert get_agent_knowledge("helper", newer_config, runtime_paths, refresh_scheduler=scheduler) is not None
+    assert (
+        resolve_agent_knowledge_access("helper", changed_config, runtime_paths, refresh_scheduler=scheduler).knowledge
+        is not None
+    )
+    assert (
+        resolve_agent_knowledge_access("helper", newer_config, runtime_paths, refresh_scheduler=scheduler).knowledge
+        is not None
+    )
 
     assert scheduler.schedule_refresh.call_count == 2
     assert scheduler.schedule_refresh.call_args_list[0].kwargs["config"] is changed_config
@@ -2813,8 +2825,14 @@ async def test_initializing_refresh_cooldown_is_settings_aware(tmp_path: Path) -
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
 
-    assert get_agent_knowledge("helper", changed_config, runtime_paths, refresh_scheduler=scheduler) is None
-    assert get_agent_knowledge("helper", newer_config, runtime_paths, refresh_scheduler=scheduler) is None
+    assert (
+        resolve_agent_knowledge_access("helper", changed_config, runtime_paths, refresh_scheduler=scheduler).knowledge
+        is None
+    )
+    assert (
+        resolve_agent_knowledge_access("helper", newer_config, runtime_paths, refresh_scheduler=scheduler).knowledge
+        is None
+    )
 
     assert scheduler.schedule_refresh.call_count == 2
     assert scheduler.schedule_refresh.call_args_list[0].kwargs["config"] is changed_config
@@ -2837,27 +2855,20 @@ async def test_cold_failed_refresh_cooldown_is_settings_aware(tmp_path: Path) ->
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
-
-    assert (
-        get_agent_knowledge(
-            "helper",
-            changed_config,
-            runtime_paths,
-            refresh_scheduler=scheduler,
-            on_unavailable_bases=unavailable.update,
-        )
-        is None
+    _resolution = resolve_agent_knowledge_access(
+        "helper",
+        changed_config,
+        runtime_paths,
+        refresh_scheduler=scheduler,
     )
-    assert (
-        get_agent_knowledge(
-            "helper",
-            newer_config,
-            runtime_paths,
-            refresh_scheduler=scheduler,
-            on_unavailable_bases=unavailable.update,
-        )
-        is None
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    _resolution = resolve_agent_knowledge_access(
+        "helper",
+        newer_config,
+        runtime_paths,
+        refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
 
     assert unavailable == {"docs": KnowledgeAvailability.REFRESH_FAILED}
     assert scheduler.schedule_refresh.call_count == 2
@@ -2890,8 +2901,13 @@ async def test_failed_git_refresh_cooldown_is_credentials_service_aware(tmp_path
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
 
-    assert get_agent_knowledge("helper", config, runtime_paths, refresh_scheduler=scheduler) is None
-    assert get_agent_knowledge("helper", changed_config, runtime_paths, refresh_scheduler=scheduler) is None
+    assert (
+        resolve_agent_knowledge_access("helper", config, runtime_paths, refresh_scheduler=scheduler).knowledge is None
+    )
+    assert (
+        resolve_agent_knowledge_access("helper", changed_config, runtime_paths, refresh_scheduler=scheduler).knowledge
+        is None
+    )
 
     assert scheduler.schedule_refresh.call_count == 2
     assert scheduler.schedule_refresh.call_args_list[0].kwargs["config"] is config
@@ -2922,8 +2938,13 @@ async def test_failed_git_refresh_cooldown_is_embedded_userinfo_aware(tmp_path: 
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
 
-    assert get_agent_knowledge("helper", config, runtime_paths, refresh_scheduler=scheduler) is None
-    assert get_agent_knowledge("helper", changed_config, runtime_paths, refresh_scheduler=scheduler) is None
+    assert (
+        resolve_agent_knowledge_access("helper", config, runtime_paths, refresh_scheduler=scheduler).knowledge is None
+    )
+    assert (
+        resolve_agent_knowledge_access("helper", changed_config, runtime_paths, refresh_scheduler=scheduler).knowledge
+        is None
+    )
 
     assert scheduler.schedule_refresh.call_count == 2
     assert scheduler.schedule_refresh.call_args_list[0].kwargs["config"] is config
@@ -2959,27 +2980,22 @@ async def test_stale_or_failed_index_reports_chunking_config_mismatch_before_coo
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
-
-    assert (
-        get_agent_knowledge(
-            "helper",
-            changed_config,
-            runtime_paths,
-            refresh_scheduler=scheduler,
-            on_unavailable_bases=unavailable.update,
-        )
-        is not None
+    _resolution = resolve_agent_knowledge_access(
+        "helper",
+        changed_config,
+        runtime_paths,
+        refresh_scheduler=scheduler,
     )
-    assert (
-        get_agent_knowledge(
-            "helper",
-            newer_config,
-            runtime_paths,
-            refresh_scheduler=scheduler,
-            on_unavailable_bases=unavailable.update,
-        )
-        is not None
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    assert _resolution.knowledge is not None
+    _resolution = resolve_agent_knowledge_access(
+        "helper",
+        newer_config,
+        runtime_paths,
+        refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    assert _resolution.knowledge is not None
 
     assert unavailable == {"docs": KnowledgeAvailability.CONFIG_MISMATCH}
     assert scheduler.schedule_refresh.call_count == 2
@@ -3034,14 +3050,14 @@ async def test_corpus_changing_config_mismatch_returns_no_index(
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
-
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         changed_config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
         refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert knowledge is None
     assert unavailable == {"docs": KnowledgeAvailability.CONFIG_MISMATCH}
@@ -3159,14 +3175,14 @@ def test_lookup_failure_after_binding_resolution_schedules_repair_refresh(
         raise RuntimeError(msg)
 
     monkeypatch.setattr("mindroom.knowledge.registry._build_published_index_vector_db", _broken_vector_db)
-
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
         refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert knowledge is None
     assert unavailable == {"docs": KnowledgeAvailability.REFRESH_FAILED}
@@ -3338,20 +3354,22 @@ async def test_cold_refresh_exception_surfaces_failed_availability_and_backoff(
     scheduler = MagicMock()
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
-    first = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
         refresh_scheduler=scheduler,
     )
-    second = get_agent_knowledge(
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    first = _resolution.knowledge
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
         refresh_scheduler=scheduler,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    second = _resolution.knowledge
 
     assert first is None
     assert second is None
@@ -3396,7 +3414,7 @@ async def test_api_delete_marks_index_stale_and_keeps_last_good_best_effort(tmp_
     main.initialize_api_app(main.app, runtime_paths)
     _publish_api_config(main.app, config)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
-    before_delete = get_agent_knowledge("helper", config, runtime_paths)
+    before_delete = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
     assert before_delete is not None
     assert [document.content for document in before_delete.search("delete", max_results=5)] == ["delete me now"]
 
@@ -3407,12 +3425,13 @@ async def test_api_delete_marks_index_stale_and_keeps_last_good_best_effort(tmp_
 
     response = client.delete("/api/knowledge/bases/docs/files/guide.md")
     unavailable: dict[str, KnowledgeAvailability] = {}
-    after_delete = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    after_delete = _resolution.knowledge
 
     assert response.status_code == 200
     assert after_delete is not None
@@ -3444,12 +3463,13 @@ async def test_api_replacement_upload_marks_index_stale_and_keeps_last_good_best
         files=[("files", ("guide.md", b"new upload", "text/markdown"))],
     )
     unavailable: dict[str, KnowledgeAvailability] = {}
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
 
     assert response.status_code == 200
     assert knowledge is not None
@@ -3489,12 +3509,13 @@ async def test_api_upload_failure_does_not_commit_earlier_staged_writes(
 
     assert response.status_code == 413
     unavailable: dict[str, KnowledgeAvailability] = {}
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
-        on_unavailable_bases=unavailable.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    knowledge = _resolution.knowledge
     assert knowledge is not None
     assert unavailable == {}
     assert (docs_path / "guide.md").read_text(encoding="utf-8") == "existing upload"
@@ -3809,8 +3830,18 @@ async def test_private_agent_knowledge_publishes_isolated_indexes(tmp_path: Path
 
     await refresh_knowledge_binding(base_id, config=config, runtime_paths=runtime_paths, execution_identity=identity_a)
     await refresh_knowledge_binding(base_id, config=config, runtime_paths=runtime_paths, execution_identity=identity_b)
-    knowledge_a = get_agent_knowledge("helper", config, runtime_paths, execution_identity=identity_a)
-    knowledge_b = get_agent_knowledge("helper", config, runtime_paths, execution_identity=identity_b)
+    knowledge_a = resolve_agent_knowledge_access(
+        "helper",
+        config,
+        runtime_paths,
+        execution_identity=identity_a,
+    ).knowledge
+    knowledge_b = resolve_agent_knowledge_access(
+        "helper",
+        config,
+        runtime_paths,
+        execution_identity=identity_b,
+    ).knowledge
 
     assert key_a != key_b
     assert knowledge_a is not None
@@ -3870,16 +3901,16 @@ async def test_private_agent_knowledge_schedules_refresh_when_source_changes(
 
     monkeypatch.setattr("mindroom.knowledge.manager.knowledge_source_signature", _unexpected_signature)
     monkeypatch.setattr(knowledge_utils, "knowledge_source_signature", _unexpected_signature, raising=False)
-
-    knowledge = get_agent_knowledge(
+    _resolution = resolve_agent_knowledge_access(
         "helper",
         config,
         runtime_paths,
         execution_identity=identity,
         refresh_scheduler=scheduler,
-        on_unavailable_bases=unavailable.update,
-        on_unavailable_base_details=unavailable_details.update,
     )
+    unavailable.update({base_id: detail.availability for (base_id, detail) in _resolution.unavailable.items()})
+    unavailable_details.update(_resolution.unavailable)
+    knowledge = _resolution.knowledge
 
     assert knowledge is not None
     assert [document.content for document in knowledge.search("private", max_results=5)] == ["alice private old"]
@@ -5083,7 +5114,6 @@ async def test_git_query_and_fragment_tokens_stay_out_of_persistent_remote_and_m
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
     metadata_text = published_index_metadata_path(key).read_text(encoding="utf-8")
     git_config_text = (docs_path / ".git" / "config").read_text(encoding="utf-8")
-    status = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths).get_status()
 
     assert result.index_published is True
     assert clone_envs
@@ -5094,7 +5124,7 @@ async def test_git_query_and_fragment_tokens_stay_out_of_persistent_remote_and_m
     assert "frag-secret" not in git_config_text
     assert "query-secret" not in metadata_text
     assert "frag-secret" not in metadata_text
-    assert status["git"]["repo_url"] == clean_url
+    assert redact_url_credentials(config.knowledge_bases["docs"].git.repo_url) == clean_url
 
 
 @pytest.mark.asyncio
@@ -5225,7 +5255,7 @@ async def test_git_worktree_checkout_file_is_detected_for_sync_listing_and_api_s
 
     assert cloned is False
     assert git_checkout_present(docs_path)
-    assert manager.get_status()["git"]["repo_present"] is True
+    assert manager._git_repo_present is True
     assert list_git_tracked_knowledge_files(config, "docs", docs_path) == [docs_path.resolve() / "doc.md"]
 
     main.initialize_api_app(main.app, runtime_paths)

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -1020,27 +1020,6 @@ class TestAgentBot:
         assert [doc.content for doc in docs] == ["research 1", "research 2"]
 
     @pytest.mark.asyncio
-    async def test_multi_knowledge_vector_db_async_falls_back_on_attribute_error(self) -> None:
-        """Async search should fall back to sync search when async_search errors mid-call."""
-
-        class _AttributeErrorAsyncStubVectorDb(_SyncStubVectorDb):
-            async def async_search(
-                self,
-                *,
-                query: str,
-                limit: int,
-                filters: dict[str, Any] | list[Any] | None = None,
-            ) -> list[Document]:
-                _ = (query, limit, filters)
-                error_message = "simulated mid-execution"
-                raise AttributeError(error_message)
-
-        docs = await MultiKnowledgeVectorDb(
-            vector_dbs=[_AttributeErrorAsyncStubVectorDb(documents=[Document(content="fallback doc")])],
-        ).async_search(query="knowledge query", limit=1)
-        assert [doc.content for doc in docs] == ["fallback doc"]
-
-    @pytest.mark.asyncio
     @patch("mindroom.config.main.Config.from_yaml")
     async def test_agent_bot_initialization(
         self,

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -9593,7 +9593,7 @@ class TestAgentBot:
         mock_team_arun: AsyncMock,
         mock_get_model_instance: MagicMock,
         mock_create_agent: MagicMock,
-        mock_get_agent_knowledge: MagicMock,
+        mock_resolve_agent_knowledge_access: MagicMock,
         mock_load_config: MagicMock,
         enable_streaming: bool,
         mock_agent_user: AgentMatrixUser,
@@ -9607,7 +9607,7 @@ class TestAgentBot:
         # Mock get_model_instance to return a mock model
         mock_model = Ollama(id="test-model")
         mock_get_model_instance.return_value = mock_model
-        mock_get_agent_knowledge.return_value = KnowledgeResolution(knowledge=None)
+        mock_resolve_agent_knowledge_access.return_value = KnowledgeResolution(knowledge=None)
         fake_member = MagicMock()
         fake_member.name = "MockAgent"
         fake_member.instructions = []

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -261,7 +261,7 @@ async def test_agent_ignores_other_agents(
 async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR0915
     mock_team_arun: AsyncMock,
     mock_create_agent: MagicMock,
-    mock_get_agent_knowledge: MagicMock,
+    mock_resolve_agent_knowledge_access: MagicMock,
     mock_calculator_agent: AgentMatrixUser,
     tmp_path: Path,
 ) -> None:
@@ -269,7 +269,7 @@ async def test_agent_responds_in_threads_based_on_participation(  # noqa: PLR091
     # Create the config first to get the actual domain
     mock_config = _make_config(tmp_path)
     mock_config.models = {"default": ModelConfig(provider="anthropic", id="claude-3-5-haiku-latest")}
-    mock_get_agent_knowledge.return_value = KnowledgeResolution(knowledge=None)
+    mock_resolve_agent_knowledge_access.return_value = KnowledgeResolution(knowledge=None)
     fake_member = MagicMock()
     fake_member.name = "MockAgent"
     fake_member.instructions = []

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -2878,14 +2878,14 @@ class TestTeamCompletion:
             requested_agent_names: list[str],
             **kwargs: object,
         ) -> ResolvedExactTeamMembers:
-            unavailable_base_details = cast(
+            unavailable_bases = cast(
                 "dict[str, KnowledgeAvailabilityDetail] | None",
-                kwargs["unavailable_base_details"],
+                kwargs["unavailable_bases"],
             )
             refresh_scheduler = kwargs["refresh_scheduler"]
-            assert unavailable_base_details is not None
+            assert unavailable_bases is not None
             assert refresh_scheduler is team_app_client.app.state.knowledge_refresh_scheduler
-            unavailable_base_details["docs"] = KnowledgeAvailabilityDetail(
+            unavailable_bases["docs"] = KnowledgeAvailabilityDetail(
                 availability=KnowledgeAvailability.INITIALIZING,
                 search_available=False,
             )
@@ -3243,14 +3243,14 @@ class TestTeamCompletion:
             requested_agent_names: list[str],
             **kwargs: object,
         ) -> ResolvedExactTeamMembers:
-            unavailable_base_details = cast(
+            unavailable_bases = cast(
                 "dict[str, KnowledgeAvailabilityDetail] | None",
-                kwargs["unavailable_base_details"],
+                kwargs["unavailable_bases"],
             )
             refresh_scheduler = kwargs["refresh_scheduler"]
-            assert unavailable_base_details is not None
+            assert unavailable_bases is not None
             assert refresh_scheduler is team_app_client.app.state.knowledge_refresh_scheduler
-            unavailable_base_details["docs"] = KnowledgeAvailabilityDetail(
+            unavailable_bases["docs"] = KnowledgeAvailabilityDetail(
                 availability=KnowledgeAvailability.CONFIG_MISMATCH,
                 search_available=True,
             )

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -2857,7 +2857,7 @@ class TestTeamCompletion:
 
     def test_team_non_streaming_unready_kb_emits_system_hint(self, team_app_client: TestClient) -> None:
         """Non-streaming team completions should prepend the degraded knowledge notice."""
-        from mindroom.knowledge import KnowledgeAvailability  # noqa: PLC0415
+        from mindroom.knowledge import KnowledgeAvailability, KnowledgeAvailabilityDetail  # noqa: PLC0415
         from mindroom.team_exact_members import ResolvedExactTeamMembers  # noqa: PLC0415
 
         scheduled_base_ids: list[str] = []
@@ -2878,11 +2878,17 @@ class TestTeamCompletion:
             requested_agent_names: list[str],
             **kwargs: object,
         ) -> ResolvedExactTeamMembers:
-            unavailable_bases = cast("dict[str, KnowledgeAvailability] | None", kwargs["unavailable_bases"])
+            unavailable_base_details = cast(
+                "dict[str, KnowledgeAvailabilityDetail] | None",
+                kwargs["unavailable_base_details"],
+            )
             refresh_scheduler = kwargs["refresh_scheduler"]
-            assert unavailable_bases is not None
+            assert unavailable_base_details is not None
             assert refresh_scheduler is team_app_client.app.state.knowledge_refresh_scheduler
-            unavailable_bases["docs"] = KnowledgeAvailability.INITIALIZING
+            unavailable_base_details["docs"] = KnowledgeAvailabilityDetail(
+                availability=KnowledgeAvailability.INITIALIZING,
+                search_available=False,
+            )
             refresh_scheduler.schedule_refresh("docs")
             return ResolvedExactTeamMembers(
                 requested_agent_names=requested_agent_names,
@@ -3212,7 +3218,7 @@ class TestTeamCompletion:
 
     def test_team_streaming_config_mismatch_kb_emits_system_hint(self, team_app_client: TestClient) -> None:
         """Streaming team completions should prepend the stale-knowledge notice."""
-        from mindroom.knowledge import KnowledgeAvailability  # noqa: PLC0415
+        from mindroom.knowledge import KnowledgeAvailability, KnowledgeAvailabilityDetail  # noqa: PLC0415
         from mindroom.team_exact_members import ResolvedExactTeamMembers  # noqa: PLC0415
 
         scheduled_base_ids: list[str] = []
@@ -3237,11 +3243,17 @@ class TestTeamCompletion:
             requested_agent_names: list[str],
             **kwargs: object,
         ) -> ResolvedExactTeamMembers:
-            unavailable_bases = cast("dict[str, KnowledgeAvailability] | None", kwargs["unavailable_bases"])
+            unavailable_base_details = cast(
+                "dict[str, KnowledgeAvailabilityDetail] | None",
+                kwargs["unavailable_base_details"],
+            )
             refresh_scheduler = kwargs["refresh_scheduler"]
-            assert unavailable_bases is not None
+            assert unavailable_base_details is not None
             assert refresh_scheduler is team_app_client.app.state.knowledge_refresh_scheduler
-            unavailable_bases["docs"] = KnowledgeAvailability.CONFIG_MISMATCH
+            unavailable_base_details["docs"] = KnowledgeAvailabilityDetail(
+                availability=KnowledgeAvailability.CONFIG_MISMATCH,
+                search_available=True,
+            )
             refresh_scheduler.schedule_refresh("docs")
             return ResolvedExactTeamMembers(
                 requested_agent_names=requested_agent_names,

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -636,7 +636,7 @@ class TestRoutingRegression:
         mock_ai_response: AsyncMock,
         mock_team_arun: AsyncMock,
         mock_create_agent: MagicMock,
-        mock_get_agent_knowledge: MagicMock,
+        mock_resolve_agent_knowledge_access: MagicMock,
         mock_research_agent: AgentMatrixUser,
         mock_news_agent: AgentMatrixUser,
         tmp_path: Path,
@@ -668,7 +668,7 @@ class TestRoutingRegression:
         # Mock get_model_instance to return a mock model
         mock_model = Ollama(id="test-model")
         mock_get_model_instance.return_value = mock_model
-        mock_get_agent_knowledge.return_value = KnowledgeResolution(knowledge=None)
+        mock_resolve_agent_knowledge_access.return_value = KnowledgeResolution(knowledge=None)
         fake_member = MagicMock()
         fake_member.name = "MockAgent"
         fake_member.instructions = []


### PR DESCRIPTION
## Summary
- remove legacy knowledge access wrappers and dead manager methods
- collapse dual unavailable knowledge maps into one KnowledgeAvailabilityDetail path
- inline the remaining callback-shaped resolver path and trim OpenAI/team naming shims

## Verification
- uv run pytest
- uv run pre-commit run --all-files