### PR TITLE
Type FastAPI app.state and tighten swallowed exceptions

### DIFF
--- a/frontend/src/components/Knowledge/Knowledge.test.tsx
+++ b/frontend/src/components/Knowledge/Knowledge.test.tsx
@@ -481,6 +481,60 @@ describe("Knowledge", () => {
     expect(gitCard).toHaveTextContent("Branch: release");
   });
 
+  it("keeps scp-style git repo URLs visible in git knowledge UI", async () => {
+    mockStore({
+      git_docs: {
+        path: "./knowledge_docs/git_docs",
+        watch: true,
+        git: {
+          repo_url: "git@github.com:org/git-docs.git",
+          branch: "release",
+        },
+      },
+    });
+    setKnowledgeApiMock({
+      git_docs: {
+        status: {
+          base_id: "git_docs",
+          folder_path: "./knowledge_docs/git_docs",
+          watch: true,
+          file_count: 0,
+          indexed_count: 0,
+          git: {
+            repo_url: "git@github.com:org/git-docs.git",
+            branch: "release",
+            lfs: false,
+            syncing: false,
+            repo_present: true,
+            initial_sync_complete: true,
+            last_successful_sync_at: null,
+            last_successful_commit: null,
+            last_error: null,
+          },
+        },
+        files: {
+          base_id: "git_docs",
+          files: [],
+          total_size: 0,
+          file_count: 0,
+        },
+      },
+    });
+
+    render(<Knowledge />);
+    await screen.findByText("Active: git_docs");
+
+    const gitCard = screen.getByRole("button", { name: /git_docs/i });
+    expect(gitCard).toHaveTextContent("git@github.com:org/git-docs.git");
+    expect(
+      (screen.getByLabelText("Current Repository URL") as HTMLInputElement)
+        .value,
+    ).toBe("git@github.com:org/git-docs.git");
+    expect(
+      screen.getAllByText("git@github.com:org/git-docs.git").length,
+    ).toBeGreaterThan(0);
+  });
+
   it("does not render stored git URL credentials in the settings input", async () => {
     mockStore({
       git_docs: {

--- a/frontend/src/components/Knowledge/Knowledge.tsx
+++ b/frontend/src/components/Knowledge/Knowledge.tsx
@@ -120,6 +120,13 @@ function stripPathParams(pathname: string): string {
   return pathname.split(";", 1)[0] ?? "";
 }
 
+function stripFallbackPathParams(value: string): string {
+  return value.replace(
+    /^([a-z][a-z0-9+.-]*:\/\/[^/\s?#]*)(\/[^?#;]*);[^?#]*/i,
+    "$1$2",
+  );
+}
+
 function redactUrlCredentials(value: string): string {
   try {
     const parsed = new URL(value);
@@ -129,7 +136,13 @@ function redactUrlCredentials(value: string): string {
         : parsed.host;
     return `${parsed.protocol}//${authority}${stripPathParams(parsed.pathname)}`;
   } catch {
-    return REDACTED_CREDENTIALS_SENTINEL;
+    const withoutQueryOrFragment = stripFallbackPathParams(
+      value.replace(/[?#].*$/, ""),
+    );
+    return withoutQueryOrFragment.replace(
+      /^([a-z][a-z0-9+.-]*:\/\/)([^@\s/?#]+)@/i,
+      `$1${REDACTED_CREDENTIALS_SENTINEL}@`,
+    );
   }
 }
 

--- a/frontend/src/components/Knowledge/Knowledge.tsx
+++ b/frontend/src/components/Knowledge/Knowledge.tsx
@@ -120,13 +120,6 @@ function stripPathParams(pathname: string): string {
   return pathname.split(";", 1)[0] ?? "";
 }
 
-function stripFallbackPathParams(value: string): string {
-  return value.replace(
-    /^([a-z][a-z0-9+.-]*:\/\/[^/\s?#]*)(\/[^?#;]*);[^?#]*/i,
-    "$1$2",
-  );
-}
-
 function redactUrlCredentials(value: string): string {
   try {
     const parsed = new URL(value);
@@ -136,18 +129,8 @@ function redactUrlCredentials(value: string): string {
         : parsed.host;
     return `${parsed.protocol}//${authority}${stripPathParams(parsed.pathname)}`;
   } catch {
-    const withoutQueryOrFragment = stripFallbackPathParams(
-      value.replace(/[?#].*$/, ""),
-    );
-    return withoutQueryOrFragment.replace(
-      /^([a-z][a-z0-9+.-]*:\/\/)([^@\s/?#]+)@/i,
-      `$1${REDACTED_CREDENTIALS_SENTINEL}@`,
-    );
+    return REDACTED_CREDENTIALS_SENTINEL;
   }
-}
-
-function gitRepoUrlHasRedactionSentinel(value: string): boolean {
-  return value.includes(REDACTED_CREDENTIALS_SENTINEL);
 }
 
 function defaultPathForBase(baseName: string): string {
@@ -376,10 +359,8 @@ export function Knowledge() {
 
       setStatus({
         ...statusData,
-        file_listing_degraded:
-          filesData.file_listing_degraded ?? statusData.file_listing_degraded,
-        file_listing_error:
-          filesData.file_listing_error ?? statusData.file_listing_error ?? null,
+        file_listing_degraded: filesData.file_listing_degraded,
+        file_listing_error: filesData.file_listing_error ?? null,
       });
       setFiles(filesData.files);
       setTotalSize(filesData.total_size);
@@ -469,7 +450,10 @@ export function Knowledge() {
       setError("Repository URL is required when Git source is enabled");
       return;
     }
-    if (gitSettings && gitRepoUrlHasRedactionSentinel(gitSettings.repo_url)) {
+    if (
+      gitSettings &&
+      gitSettings.repo_url.includes(REDACTED_CREDENTIALS_SENTINEL)
+    ) {
       setError("Repository URL contains a redacted credential placeholder");
       return;
     }

--- a/src/mindroom/api/auth.py
+++ b/src/mindroom/api/auth.py
@@ -12,7 +12,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import BaseModel
 
 from mindroom.api import config_lifecycle
-from mindroom.api.config_lifecycle import ApiSnapshot, ApiState
+from mindroom.api.config_lifecycle import ApiSnapshot
 from mindroom.api.config_lifecycle import request_snapshot as request_api_snapshot
 from mindroom.api.config_lifecycle import store_request_snapshot as store_request_api_snapshot
 from mindroom.tool_system.dependencies import auto_install_enabled, auto_install_tool_extra
@@ -76,27 +76,6 @@ class ApiAuthState:
     supabase_auth: _SupabaseClientProtocol | None
 
 
-def _app_state(api_app: FastAPI) -> ApiState:
-    """Return the committed API state holder for one app instance."""
-    try:
-        state = api_app.state.api_state
-    except AttributeError:
-        state = None
-    if not isinstance(state, ApiState):
-        msg = "API context is not initialized"
-        raise TypeError(msg)
-    return state
-
-
-def _app_account_id(api_app: FastAPI) -> str | None:
-    """Return the API ingress-bound account id, when platform auth is configured."""
-    try:
-        account_id = api_app.state.api_auth_account_id
-    except AttributeError:
-        return None
-    return cast("str | None", account_id)
-
-
 def build_auth_settings(runtime_paths: RuntimePaths, *, account_id: str | None = None) -> ApiAuthSettings:
     """Read dashboard auth settings from one explicit runtime context."""
     return ApiAuthSettings(
@@ -110,13 +89,14 @@ def build_auth_settings(runtime_paths: RuntimePaths, *, account_id: str | None =
 
 def app_auth_state(api_app: FastAPI) -> ApiAuthState:
     """Return the committed auth state for one API app instance."""
-    app_state = _app_state(api_app)
-    with app_state.config_lock:
-        snapshot = app_state.snapshot
+    app_state = config_lifecycle.app_state(api_app)
+    api_state = config_lifecycle.require_api_state(api_app)
+    with api_state.config_lock:
+        snapshot = api_state.snapshot
         state = cast("ApiAuthState | None", snapshot.auth_state)
         if state is not None and state.runtime_paths == snapshot.runtime_paths:
             return state
-        settings = build_auth_settings(snapshot.runtime_paths, account_id=_app_account_id(api_app))
+        settings = build_auth_settings(snapshot.runtime_paths, account_id=app_state.api_auth_account_id)
         state = ApiAuthState(
             runtime_paths=snapshot.runtime_paths,
             settings=settings,
@@ -126,7 +106,7 @@ def app_auth_state(api_app: FastAPI) -> ApiAuthState:
                 settings.supabase_anon_key,
             ),
         )
-        app_state.snapshot = replace(snapshot, auth_state=state)
+        api_state.snapshot = replace(snapshot, auth_state=state)
         return state
 
 
@@ -183,6 +163,11 @@ def _get_request_token(
     return None
 
 
+def _supabase_auth_error_class() -> type[Exception]:
+    """Return Supabase's AuthError class for narrow exception handling at the auth boundary."""
+    return cast("type[Exception]", importlib.import_module("gotrue.errors").AuthError)
+
+
 def _validate_supabase_token(token: str, auth_state: ApiAuthState) -> _SupabaseUserProtocol | None:
     """Validate a Supabase access token and return the authenticated user."""
     if auth_state.supabase_auth is None:
@@ -190,7 +175,7 @@ def _validate_supabase_token(token: str, auth_state: ApiAuthState) -> _SupabaseU
 
     try:
         response = auth_state.supabase_auth.auth.get_user(token)
-    except Exception:
+    except _supabase_auth_error_class():
         return None
 
     if not response or not response.user:
@@ -210,12 +195,13 @@ def bind_authenticated_request_snapshot(request: Request) -> ApiSnapshot:
     ):
         return existing
 
-    app_state = _app_state(request.app)
-    with app_state.config_lock:
-        current = app_state.snapshot
+    app_state = config_lifecycle.app_state(request.app)
+    api_state = config_lifecycle.require_api_state(request.app)
+    with api_state.config_lock:
+        current = api_state.snapshot
         auth_state = cast("ApiAuthState | None", current.auth_state)
         if auth_state is None or auth_state.runtime_paths != current.runtime_paths:
-            settings = build_auth_settings(current.runtime_paths, account_id=_app_account_id(request.app))
+            settings = build_auth_settings(current.runtime_paths, account_id=app_state.api_auth_account_id)
             auth_state = ApiAuthState(
                 runtime_paths=current.runtime_paths,
                 settings=settings,
@@ -226,7 +212,7 @@ def bind_authenticated_request_snapshot(request: Request) -> ApiSnapshot:
                 ),
             )
             current = replace(current, auth_state=auth_state)
-            app_state.snapshot = current
+            api_state.snapshot = current
         return store_request_api_snapshot(request, current)
 
 

--- a/src/mindroom/api/auth.py
+++ b/src/mindroom/api/auth.py
@@ -165,7 +165,7 @@ def _get_request_token(
 
 def _supabase_auth_error_class() -> type[Exception]:
     """Return Supabase's AuthError class for narrow exception handling at the auth boundary."""
-    return cast("type[Exception]", importlib.import_module("gotrue.errors").AuthError)
+    return cast("type[Exception]", importlib.import_module("supabase_auth.errors").AuthError)
 
 
 def _validate_supabase_token(token: str, auth_state: ApiAuthState) -> _SupabaseUserProtocol | None:

--- a/src/mindroom/api/config_lifecycle.py
+++ b/src/mindroom/api/config_lifecycle.py
@@ -11,7 +11,7 @@ from contextlib import ExitStack
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import yaml
 from fastapi import FastAPI, HTTPException, Request
@@ -27,6 +27,10 @@ from mindroom.config.main import (
 from mindroom.config.main import load_config as load_runtime_config_model
 from mindroom.file_watcher import watch_file
 from mindroom.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
+    from mindroom.knowledge.watch import KnowledgeSourceWatcher
 
 logger = get_logger(__name__)
 _UNSET = object()
@@ -68,6 +72,48 @@ class ApiState:
 
     config_lock: threading.Lock
     snapshot: ApiSnapshot
+
+
+@dataclass
+class MindroomAppState:
+    """Single typed namespace for FastAPI ``app.state`` attributes used across the API."""
+
+    api_state: ApiState | None = None
+    api_auth_account_id: str | None = None
+    orchestrator_knowledge_refresh_scheduler: KnowledgeRefreshScheduler | None = None
+    knowledge_source_watcher: KnowledgeSourceWatcher | None = None
+    knowledge_refresh_scheduler: KnowledgeRefreshScheduler | None = None
+
+
+_APP_STATE_ATTR = "mindroom_app_state"
+
+
+def ensure_app_state(api_app: FastAPI) -> MindroomAppState:
+    """Bind (or return) the :class:`MindroomAppState` for ``api_app``."""
+    existing = getattr(api_app.state, "mindroom_app_state", None)
+    if isinstance(existing, MindroomAppState):
+        return existing
+    state = MindroomAppState()
+    api_app.state.mindroom_app_state = state
+    return state
+
+
+def app_state(api_app: FastAPI) -> MindroomAppState:
+    """Return the :class:`MindroomAppState` bound to ``api_app``."""
+    state = getattr(api_app.state, "mindroom_app_state", None)
+    if not isinstance(state, MindroomAppState):
+        msg = "MindRoom app state is not initialized"
+        raise TypeError(msg)
+    return state
+
+
+def require_api_state(api_app: FastAPI) -> ApiState:
+    """Return the published :class:`ApiState`, raising ``TypeError`` if not initialized."""
+    api_state = app_state(api_app).api_state
+    if api_state is None:
+        msg = "API context is not initialized"
+        raise TypeError(msg)
+    return api_state
 
 
 def _config_error_detail(
@@ -213,18 +259,6 @@ def _validated_config_payload(
     return validated_config, validated_config.authored_model_dump()
 
 
-def _app_config_state(api_app: FastAPI) -> ApiState:
-    """Return the app-bound API config state."""
-    try:
-        state = api_app.state.api_state
-    except AttributeError:
-        state = None
-    if not isinstance(state, ApiState):
-        msg = "API context is not initialized"
-        raise TypeError(msg)
-    return state
-
-
 def register_api_app(api_app: FastAPI) -> None:
     """Register one live API app so external config writers can advance its snapshot."""
     with _REGISTERED_API_APPS_LOCK:
@@ -238,7 +272,7 @@ def _registered_api_states() -> list[ApiState]:
     states: list[ApiState] = []
     for api_app in apps:
         try:
-            states.append(_app_config_state(api_app))
+            states.append(require_api_state(api_app))
         except TypeError:
             continue
     return states
@@ -261,7 +295,7 @@ def bind_current_request_snapshot(request: Request) -> ApiSnapshot:
     existing = request_snapshot(request)
     if existing is not None:
         return existing
-    app_state = _app_config_state(request.app)
+    app_state = require_api_state(request.app)
     with app_state.config_lock:
         return store_request_snapshot(request, app_state.snapshot)
 
@@ -271,7 +305,7 @@ def _request_or_current_snapshot(request: Request) -> ApiSnapshot:
     bound_snapshot = request_snapshot(request)
     if bound_snapshot is not None:
         return bound_snapshot
-    return _app_config_state(request.app).snapshot
+    return require_api_state(request.app).snapshot
 
 
 def _published_snapshot(
@@ -353,7 +387,7 @@ def _commit_mutated_snapshot[T](
 ) -> T:
     """Commit one previously validated mutation if the targeted snapshot is still current."""
     with initial_state.config_lock:
-        current_state = _app_config_state(api_app)
+        current_state = require_api_state(api_app)
         current = current_state.snapshot
         if current.generation != expected_generation or current.runtime_paths != runtime_paths:
             raise_for_config_load_result(current.config_load_result)
@@ -410,7 +444,7 @@ def _commit_replaced_snapshot(
 ) -> int:
     """Commit one previously validated replacement payload if the snapshot is still current."""
     with initial_state.config_lock:
-        current_state = _app_config_state(api_app)
+        current_state = require_api_state(api_app)
         current = current_state.snapshot
         if current.generation != expected_generation or current.runtime_paths != runtime_paths:
             raise _stale_snapshot_error()
@@ -436,7 +470,7 @@ def _commit_raw_replaced_snapshot(
 ) -> int:
     """Commit one raw replacement payload if the targeted snapshot is still current."""
     with initial_state.config_lock:
-        current_state = _app_config_state(api_app)
+        current_state = require_api_state(api_app)
         current = current_state.snapshot
         if current.generation != expected_generation or current.runtime_paths != runtime_paths:
             raise _stale_snapshot_error()
@@ -458,10 +492,10 @@ def _build_and_commit_mutation[T](
     initial_snapshot: ApiSnapshot | None = None,
 ) -> T:
     """Build one config mutation off-lock and commit it only if still current."""
-    initial_state = _app_config_state(api_app)
+    initial_state = require_api_state(api_app)
     if initial_snapshot is None:
         with initial_state.config_lock:
-            snapshot = _app_config_state(api_app).snapshot
+            snapshot = require_api_state(api_app).snapshot
     else:
         snapshot = initial_snapshot
     try:
@@ -498,10 +532,10 @@ def _build_and_commit_replacement(
     expected_generation: int | None = None,
 ) -> int:
     """Build one replacement payload off-lock and commit it only if still current."""
-    initial_state = _app_config_state(api_app)
+    initial_state = require_api_state(api_app)
     if initial_snapshot is None:
         with initial_state.config_lock:
-            snapshot = _app_config_state(api_app).snapshot
+            snapshot = require_api_state(api_app).snapshot
     else:
         snapshot = initial_snapshot
     try:
@@ -534,10 +568,10 @@ def _build_and_commit_raw_replacement(
     expected_generation: int | None = None,
 ) -> int:
     """Build one raw replacement payload off-lock and commit it only if still current."""
-    initial_state = _app_config_state(api_app)
+    initial_state = require_api_state(api_app)
     if initial_snapshot is None:
         with initial_state.config_lock:
-            snapshot = _app_config_state(api_app).snapshot
+            snapshot = require_api_state(api_app).snapshot
     else:
         snapshot = initial_snapshot
     try:
@@ -577,11 +611,11 @@ def load_config_from_file(
 
 def load_config_into_app(runtime_paths: constants.RuntimePaths, api_app: FastAPI) -> bool:
     """Load config from disk into one API app's committed config cache."""
-    initial_state = _app_config_state(api_app)
+    initial_state = require_api_state(api_app)
     snapshot = initial_state.snapshot
     result, validated_payload, runtime_config = _load_config_result(runtime_paths)
     with initial_state.config_lock:
-        current_state = _app_config_state(api_app)
+        current_state = require_api_state(api_app)
         current = current_state.snapshot
         if current.generation != snapshot.generation or current.runtime_paths != runtime_paths:
             logger.info(
@@ -604,9 +638,9 @@ def read_app_committed_config[T](
     reader: Callable[[dict[str, Any]], T],
 ) -> T:
     """Read committed API config for one app only when the current file is valid."""
-    initial_state = _app_config_state(api_app)
+    initial_state = require_api_state(api_app)
     with initial_state.config_lock:
-        snapshot = _app_config_state(api_app).snapshot
+        snapshot = require_api_state(api_app).snapshot
         raise_for_config_load_result(snapshot.config_load_result)
         if not snapshot.config_data:
             _raise_missing_loaded_config()
@@ -618,9 +652,9 @@ def read_app_committed_config_and_runtime[T](
     reader: Callable[[dict[str, Any]], T],
 ) -> tuple[T, constants.RuntimePaths]:
     """Read committed API config and runtime from one coherent published snapshot."""
-    initial_state = _app_config_state(api_app)
+    initial_state = require_api_state(api_app)
     with initial_state.config_lock:
-        snapshot = _app_config_state(api_app).snapshot
+        snapshot = require_api_state(api_app).snapshot
         raise_for_config_load_result(snapshot.config_load_result)
         if not snapshot.config_data:
             _raise_missing_loaded_config()
@@ -631,9 +665,9 @@ def read_app_committed_runtime_config(
     api_app: FastAPI,
 ) -> tuple[Config, constants.RuntimePaths]:
     """Read one validated runtime config and runtime from the same published snapshot."""
-    initial_state = _app_config_state(api_app)
+    initial_state = require_api_state(api_app)
     with initial_state.config_lock:
-        snapshot = _app_config_state(api_app).snapshot
+        snapshot = require_api_state(api_app).snapshot
         raise_for_config_load_result(snapshot.config_load_result)
         if not snapshot.config_data:
             _raise_missing_loaded_config()

--- a/src/mindroom/api/config_lifecycle.py
+++ b/src/mindroom/api/config_lifecycle.py
@@ -85,9 +85,6 @@ class MindroomAppState:
     knowledge_refresh_scheduler: KnowledgeRefreshScheduler | None = None
 
 
-_APP_STATE_ATTR = "mindroom_app_state"
-
-
 def ensure_app_state(api_app: FastAPI) -> MindroomAppState:
     """Bind (or return) the :class:`MindroomAppState` for ``api_app``."""
     existing = getattr(api_app.state, "mindroom_app_state", None)

--- a/src/mindroom/api/knowledge.py
+++ b/src/mindroom/api/knowledge.py
@@ -140,7 +140,7 @@ async def _list_managed_file_paths(config: Config, base_id: str, root: Path) -> 
             root,
             timeout_seconds=_DASHBOARD_GIT_FILE_LIST_TIMEOUT_SECONDS,
         )
-    except Exception as exc:
+    except (RuntimeError, ValueError) as exc:
         error = redact_credentials_in_text(str(exc)) or "Git file listing timed out"
         logger.warning("Could not list Git-backed knowledge files", base_id=base_id, error=error)
         return set(), error
@@ -148,11 +148,7 @@ async def _list_managed_file_paths(config: Config, base_id: str, root: Path) -> 
 
 
 def _request_refresh_scheduler(request: Request) -> KnowledgeRefreshScheduler | None:
-    try:
-        refresh_scheduler = request.app.state.knowledge_refresh_scheduler
-    except AttributeError:
-        return None
-    return refresh_scheduler
+    return config_lifecycle.app_state(request.app).knowledge_refresh_scheduler
 
 
 def _schedule_refresh(
@@ -253,7 +249,7 @@ def _index_status_sync(
             runtime_paths=runtime_paths,
             create=False,
         )
-    except Exception:
+    except ValueError:
         logger.warning("Could not resolve published knowledge index state", base_id=base_id, exc_info=True)
         return KnowledgeIndexStatus()
 

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -207,18 +207,6 @@ def api_runtime_paths(request: Request) -> constants.RuntimePaths:
     return config_lifecycle.api_runtime_paths(request)
 
 
-def _app_state(api_app: FastAPI) -> ApiState:
-    """Return the committed API state holder for one app instance."""
-    try:
-        state = api_app.state.api_state
-    except AttributeError:
-        state = None
-    if not isinstance(state, ApiState):
-        msg = "API context is not initialized"
-        raise TypeError(msg)
-    return state
-
-
 def _published_snapshot(
     snapshot: ApiSnapshot,
     *,
@@ -251,7 +239,7 @@ def _published_snapshot(
 
 def _app_context(api_app: FastAPI) -> ApiSnapshot:
     """Return the committed API snapshot for one app instance."""
-    return _app_state(api_app).snapshot
+    return config_lifecycle.require_api_state(api_app).snapshot
 
 
 def _app_runtime_paths(api_app: FastAPI) -> constants.RuntimePaths:
@@ -259,20 +247,13 @@ def _app_runtime_paths(api_app: FastAPI) -> constants.RuntimePaths:
     return _app_context(api_app).runtime_paths
 
 
-def _bind_api_auth_ingress_context(api_app: FastAPI, runtime_paths: constants.RuntimePaths) -> None:
-    """Bind tenant/account auth context at the API ingress boundary."""
-    api_app.state.api_auth_account_id = runtime_paths.env_value("ACCOUNT_ID")
-
-
 def initialize_api_app(api_app: FastAPI, runtime_paths: constants.RuntimePaths) -> None:
     """Initialize one API app instance with explicit runtime-bound state."""
-    _bind_api_auth_ingress_context(api_app, runtime_paths)
-    try:
-        previous_state = api_app.state.api_state
-    except AttributeError:
-        previous_state = None
-    if not isinstance(previous_state, ApiState):
-        api_app.state.api_state = ApiState(
+    app_state = config_lifecycle.ensure_app_state(api_app)
+    app_state.api_auth_account_id = runtime_paths.env_value("ACCOUNT_ID")
+    previous_state = app_state.api_state
+    if previous_state is None:
+        app_state.api_state = ApiState(
             config_lock=threading.Lock(),
             snapshot=ApiSnapshot(
                 generation=0,
@@ -286,22 +267,15 @@ def initialize_api_app(api_app: FastAPI, runtime_paths: constants.RuntimePaths) 
         config_lifecycle.register_api_app(api_app)
         return
 
-    config_lock = previous_state.config_lock
-    with config_lock:
-        try:
-            current_state = api_app.state.api_state
-        except AttributeError:
-            current_state = previous_state
-        if not isinstance(current_state, ApiState):
-            current_state = previous_state
-        current_snapshot = current_state.snapshot
+    with previous_state.config_lock:
+        current_snapshot = previous_state.snapshot
         auth_state = current_snapshot.auth_state if current_snapshot.runtime_paths == runtime_paths else None
         config_data = current_snapshot.config_data if current_snapshot.runtime_paths == runtime_paths else {}
         runtime_config = current_snapshot.runtime_config if current_snapshot.runtime_paths == runtime_paths else None
         config_load_result = (
             current_snapshot.config_load_result if current_snapshot.runtime_paths == runtime_paths else None
         )
-        current_state.snapshot = _published_snapshot(
+        previous_state.snapshot = _published_snapshot(
             current_snapshot,
             runtime_paths=runtime_paths,
             config_data=config_data,
@@ -309,31 +283,12 @@ def initialize_api_app(api_app: FastAPI, runtime_paths: constants.RuntimePaths) 
             auth_state=auth_state,
             config_load_result=config_load_result,
         )
-        api_app.state.api_state = current_state
     config_lifecycle.register_api_app(api_app)
-
-
-def _orchestrator_knowledge_refresh_scheduler(api_app: FastAPI) -> KnowledgeRefreshScheduler | None:
-    """Return an orchestrator-provided refresh scheduler when the bundled API is running."""
-    try:
-        refresh_scheduler = api_app.state.orchestrator_knowledge_refresh_scheduler
-    except AttributeError:
-        return None
-    return cast("KnowledgeRefreshScheduler | None", refresh_scheduler)
-
-
-def _standalone_knowledge_source_watcher(api_app: FastAPI) -> KnowledgeSourceWatcher | None:
-    """Return the API-owned filesystem watcher, when running without the orchestrator."""
-    try:
-        source_watcher = api_app.state.knowledge_source_watcher
-    except AttributeError:
-        return None
-    return cast("KnowledgeSourceWatcher | None", source_watcher)
 
 
 async def _sync_standalone_knowledge_watchers(api_app: FastAPI) -> None:
     """Align API-owned knowledge filesystem watchers with the committed config."""
-    source_watcher = _standalone_knowledge_source_watcher(api_app)
+    source_watcher = config_lifecycle.app_state(api_app).knowledge_source_watcher
     if source_watcher is None:
         return
     snapshot = _app_context(api_app)
@@ -404,15 +359,16 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
     logger.info("Syncing API credentials from runtime env")
     sync_env_to_credentials(runtime_paths=runtime_paths)
 
+    app_state = config_lifecycle.app_state(_app)
     api_owned_knowledge_refresh_scheduler: KnowledgeRefreshScheduler | None = None
     standalone_knowledge_source_watcher: KnowledgeSourceWatcher | None = None
-    knowledge_refresh_scheduler = _orchestrator_knowledge_refresh_scheduler(_app)
+    knowledge_refresh_scheduler = app_state.orchestrator_knowledge_refresh_scheduler
     if knowledge_refresh_scheduler is None:
         api_owned_knowledge_refresh_scheduler = KnowledgeRefreshScheduler()
         knowledge_refresh_scheduler = api_owned_knowledge_refresh_scheduler
         standalone_knowledge_source_watcher = KnowledgeSourceWatcher(knowledge_refresh_scheduler)
-        _app.state.knowledge_source_watcher = standalone_knowledge_source_watcher
-    _app.state.knowledge_refresh_scheduler = knowledge_refresh_scheduler
+        app_state.knowledge_source_watcher = standalone_knowledge_source_watcher
+    app_state.knowledge_refresh_scheduler = knowledge_refresh_scheduler
     await _sync_standalone_knowledge_watchers(_app)
     logger.info(
         "Published knowledge index refresh is scheduled by Git polling, filesystem watch, on access, or explicit API actions",
@@ -435,6 +391,14 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
         await standalone_knowledge_source_watcher.shutdown()
     if api_owned_knowledge_refresh_scheduler is not None:
         await api_owned_knowledge_refresh_scheduler.shutdown()
+
+
+def bind_orchestrator_knowledge_refresh_scheduler(
+    api_app: FastAPI,
+    scheduler: KnowledgeRefreshScheduler,
+) -> None:
+    """Attach the orchestrator-owned background refresh scheduler to the bundled API app."""
+    config_lifecycle.app_state(api_app).orchestrator_knowledge_refresh_scheduler = scheduler
 
 
 app = FastAPI(title="MindRoom Dashboard API", lifespan=_lifespan)
@@ -465,10 +429,10 @@ def _reload_api_runtime_config(
     mutate_runtime: Callable[[constants.RuntimePaths], constants.RuntimePaths] | None = None,
 ) -> None:
     """Rebind the API app to one runtime and surface structured config reload failures."""
-    app_state = _app_state(api_app)
-    with app_state.config_lock:
-        current_state = _app_state(api_app)
-        current_snapshot = current_state.snapshot
+    app_state = config_lifecycle.app_state(api_app)
+    api_state = config_lifecycle.require_api_state(api_app)
+    with api_state.config_lock:
+        current_snapshot = api_state.snapshot
         if expected_snapshot is not None and (
             current_snapshot.generation != expected_snapshot.generation
             or current_snapshot.runtime_paths != expected_snapshot.runtime_paths
@@ -478,7 +442,7 @@ def _reload_api_runtime_config(
                 detail="Configuration changed while request was in progress. Retry the operation.",
             )
         target_runtime_paths = runtime_paths if mutate_runtime is None else mutate_runtime(runtime_paths)
-        _bind_api_auth_ingress_context(api_app, target_runtime_paths)
+        app_state.api_auth_account_id = target_runtime_paths.env_value("ACCOUNT_ID")
         auth_state = current_snapshot.auth_state if current_snapshot.runtime_paths == target_runtime_paths else None
         config_data = current_snapshot.config_data if current_snapshot.runtime_paths == target_runtime_paths else {}
         runtime_config = (
@@ -495,9 +459,9 @@ def _reload_api_runtime_config(
             auth_state=auth_state,
             config_load_result=config_load_result,
         )
-        current_state.snapshot = refreshed_snapshot
+        api_state.snapshot = refreshed_snapshot
         result, validated_payload, loaded_runtime_config = config_lifecycle._load_config_result(target_runtime_paths)
-        current_state.snapshot = _published_snapshot(
+        api_state.snapshot = _published_snapshot(
             refreshed_snapshot,
             config_data=validated_payload if validated_payload is not None else refreshed_snapshot.config_data,
             runtime_config=loaded_runtime_config

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -775,11 +775,7 @@ async def _resolve_auto_route(
 
 def _request_knowledge_refresh_scheduler(request: Request) -> KnowledgeRefreshScheduler | None:
     """Return the app-scoped background knowledge refresh scheduler, if configured."""
-    try:
-        refresh_scheduler = request.app.state.knowledge_refresh_scheduler
-    except AttributeError:
-        return None
-    return cast("KnowledgeRefreshScheduler | None", refresh_scheduler)
+    return config_lifecycle.app_state(request.app).knowledge_refresh_scheduler
 
 
 def _log_missing_knowledge_bases(agent_name: str) -> Callable[[list[str]], None]:

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -159,7 +159,7 @@ def is_refresh_active_for_binding(
             execution_identity=execution_identity,
             create=False,
         )
-    except Exception:
+    except ValueError:
         return False
     return is_refresh_active(key)
 

--- a/src/mindroom/knowledge/refresh_scheduler.py
+++ b/src/mindroom/knowledge/refresh_scheduler.py
@@ -75,7 +75,7 @@ class KnowledgeRefreshScheduler:
                 execution_identity=execution_identity,
                 create=False,
             )
-        except Exception:
+        except ValueError:
             return False
         return is_refresh_active(key)
 
@@ -89,7 +89,7 @@ class KnowledgeRefreshScheduler:
         force_reindex: bool = False,
     ) -> KnowledgeRefreshResult:
         """Run a refresh immediately and wait for it."""
-        with suppress(Exception):
+        with suppress(ValueError):
             key = resolve_refresh_target(
                 base_id,
                 config=config,
@@ -137,7 +137,7 @@ class KnowledgeRefreshScheduler:
                 execution_identity=execution_identity,
                 create=False,
             )
-        except Exception:
+        except ValueError:
             logger.exception("Could not resolve knowledge binding for refresh", base_id=base_id)
             return
 

--- a/src/mindroom/knowledge/registry.py
+++ b/src/mindroom/knowledge/registry.py
@@ -671,7 +671,21 @@ def get_published_index(
             schedule_refresh_on_access=binding.incremental_sync_on_access,
         )
 
-    knowledge = _load_queryable_index_from_state(key, state, config=config, runtime_paths=runtime_paths)
+    try:
+        knowledge = _load_queryable_index_from_state(key, state, config=config, runtime_paths=runtime_paths)
+    except Exception:
+        logger.warning(
+            "Published knowledge index handle could not be opened",
+            base_id=base_id,
+            exc_info=True,
+        )
+        return PublishedIndexResolution(
+            key=key,
+            index=None,
+            state=state,
+            availability=KnowledgeAvailability.REFRESH_FAILED,
+            schedule_refresh_on_access=binding.incremental_sync_on_access,
+        )
     if knowledge is None:
         return PublishedIndexResolution(
             key=key,

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -100,7 +100,7 @@ def _lookup_knowledge_for_base(
             runtime_paths=runtime_paths,
             execution_identity=execution_identity,
         )
-    except Exception:
+    except ValueError:
         logger.exception("Published knowledge index lookup failed", base_id=base_id)
         return None
 
@@ -259,28 +259,6 @@ def _schedule_refresh_on_access_due(lookup: PublishedIndexResolution, config: Co
     return _git_poll_due(lookup, config)
 
 
-def _refresh_scheduler_is_refreshing(
-    refresh_scheduler: KnowledgeRefreshScheduler,
-    base_id: str,
-    *,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None,
-) -> bool:
-    """Return whether the scheduler reports an active refresh without requiring a concrete implementation."""
-    try:
-        active = refresh_scheduler.is_refreshing(
-            base_id,
-            config=config,
-            runtime_paths=runtime_paths,
-            execution_identity=execution_identity,
-        )
-    except Exception:
-        logger.debug("Knowledge refresh active check failed", base_id=base_id, exc_info=True)
-        return False
-    return active is True
-
-
 def _schedule_refresh_for_availability(
     refresh_scheduler: KnowledgeRefreshScheduler,
     base_id: str,
@@ -299,8 +277,7 @@ def _schedule_refresh_for_availability(
         if not lookup.schedule_refresh_on_access or not _schedule_refresh_on_access_due(lookup, config):
             return availability
 
-        scheduler_is_refreshing = _refresh_scheduler_is_refreshing(
-            refresh_scheduler,
+        scheduler_is_refreshing = refresh_scheduler.is_refreshing(
             base_id,
             config=config,
             runtime_paths=runtime_paths,
@@ -326,8 +303,7 @@ def _schedule_refresh_for_availability(
         return KnowledgeAvailability.STALE if schedule_due or scheduler_is_refreshing else KnowledgeAvailability.READY
 
     if availability is KnowledgeAvailability.INITIALIZING:
-        scheduler_is_refreshing = _refresh_scheduler_is_refreshing(
-            refresh_scheduler,
+        scheduler_is_refreshing = refresh_scheduler.is_refreshing(
             base_id,
             config=config,
             runtime_paths=runtime_paths,
@@ -344,8 +320,7 @@ def _schedule_refresh_for_availability(
                 runtime_paths=runtime_paths,
                 execution_identity=execution_identity,
             )
-    elif not _refresh_scheduler_is_refreshing(
-        refresh_scheduler,
+    elif not refresh_scheduler.is_refreshing(
         base_id,
         config=config,
         runtime_paths=runtime_paths,

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1653,7 +1653,7 @@ async def _run_api_server(
 
     api_main.initialize_api_app(api_main.app, runtime_paths)
     if knowledge_refresh_scheduler is not None:
-        api_main.app.state.orchestrator_knowledge_refresh_scheduler = knowledge_refresh_scheduler
+        api_main.bind_orchestrator_knowledge_refresh_scheduler(api_main.app, knowledge_refresh_scheduler)
     config = uvicorn.Config(api_main.app, host=host, port=port, log_level=log_level.lower())
     server = _SignalAwareUvicornServer(config, shutdown_requested)
     await server.serve()

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -8,7 +8,7 @@ import time
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from types import TracebackType
+from types import SimpleNamespace, TracebackType
 from typing import Any, NoReturn, cast
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -199,6 +199,45 @@ def test_init_supabase_auth_raises_when_auto_install_fails(monkeypatch: pytest.M
 
     assert install_calls == ["supabase"]
     assert "MINDROOM_NO_AUTO_INSTALL_TOOLS" not in str(err.value)
+
+
+def test_validate_supabase_token_catches_supabase_auth_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Invalid Supabase tokens should fail auth instead of surfacing optional-package internals."""
+
+    class _FakeAuthError(Exception):
+        pass
+
+    class _FakeAuth:
+        @staticmethod
+        def get_user(_token: str) -> NoReturn:
+            msg = "invalid jwt"
+            raise _FakeAuthError(msg)
+
+    class _FakeClient:
+        auth = _FakeAuth()
+
+    imported_modules: list[str] = []
+
+    def _fake_import_module(module_name: str) -> SimpleNamespace:
+        imported_modules.append(module_name)
+        assert module_name == "supabase_auth.errors"
+        return SimpleNamespace(AuthError=_FakeAuthError)
+
+    monkeypatch.setattr(auth.importlib, "import_module", _fake_import_module)
+    auth_state = auth.ApiAuthState(
+        runtime_paths=_runtime_paths(tmp_path),
+        settings=auth.ApiAuthSettings(
+            platform_login_url="https://platform.example.com/login",
+            supabase_url="https://supabase.example.com",
+            supabase_anon_key="anon-key",
+            account_id=None,
+            mindroom_api_key=None,
+        ),
+        supabase_auth=_FakeClient(),
+    )
+
+    assert auth._validate_supabase_token("bad-token", auth_state) is None
+    assert imported_modules == ["supabase_auth.errors"]
 
 
 def test_ensure_frontend_dist_dir_builds_repo_checkout(

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -346,7 +346,7 @@ def test_initialize_api_app_initializes_fresh_app_state(tmp_path: Path) -> None:
 
     assert main._app_runtime_paths(fresh_app) == runtime_paths
     assert main._app_context(fresh_app).config_data == {}
-    assert hasattr(main._app_state(fresh_app).config_lock, "acquire")
+    assert hasattr(config_lifecycle.require_api_state(fresh_app).config_lock, "acquire")
     assert auth.app_auth_state(fresh_app).runtime_paths == runtime_paths
 
 
@@ -574,12 +574,13 @@ def test_read_app_committed_config_uses_current_context_after_runtime_swap(tmp_p
         config_data=_validated_authored_payload(second_runtime, "new"),
         config_load_result=main.ConfigLoadResult(success=True),
     )
-    fresh_app.state.api_state = main.ApiState(
+    fresh_app_state = config_lifecycle.ensure_app_state(fresh_app)
+    fresh_app_state.api_state = main.ApiState(
         config_lock=cast("config_lifecycle.ApiConfigLock", swap_lock),
         snapshot=first_snapshot,
     )
     swap_lock.on_enter = lambda: setattr(
-        fresh_app.state,
+        fresh_app_state,
         "api_state",
         main.ApiState(
             config_lock=cast("config_lifecycle.ApiConfigLock", swap_lock),
@@ -627,12 +628,13 @@ def test_write_app_committed_config_uses_current_context_after_runtime_swap(tmp_
         config_data=_validated_authored_payload(second_runtime, "new"),
         config_load_result=main.ConfigLoadResult(success=True),
     )
-    fresh_app.state.api_state = main.ApiState(
+    fresh_app_state = config_lifecycle.ensure_app_state(fresh_app)
+    fresh_app_state.api_state = main.ApiState(
         config_lock=cast("config_lifecycle.ApiConfigLock", swap_lock),
         snapshot=first_snapshot,
     )
     swap_lock.on_enter = lambda: setattr(
-        fresh_app.state,
+        fresh_app_state,
         "api_state",
         main.ApiState(
             config_lock=cast("config_lifecycle.ApiConfigLock", swap_lock),
@@ -2844,7 +2846,7 @@ def test_write_app_committed_config_restores_original_config_before_releasing_lo
                 assert context.config_data == original_config
             return False
 
-    app_state = main._app_state(main.app)
+    app_state = config_lifecycle.require_api_state(main.app)
     original_lock = app_state.config_lock
     app_state.config_lock = _AssertingLock()
     try:
@@ -2936,7 +2938,7 @@ def test_write_app_committed_config_checks_current_config_load_result_after_acqu
             return False
 
     signaling_lock = _SignalingLock()
-    app_state = main._app_state(main.app)
+    app_state = config_lifecycle.require_api_state(main.app)
     original_lock = app_state.config_lock
     app_state.config_lock = signaling_lock
     error_detail = [{"loc": ("config",), "msg": "current config is invalid", "type": "value_error"}]

--- a/tests/api/test_knowledge_api.py
+++ b/tests/api/test_knowledge_api.py
@@ -19,8 +19,8 @@ from starlette.requests import Request
 
 import mindroom.knowledge.registry as knowledge_registry
 from mindroom import constants
+from mindroom.api import config_lifecycle, main
 from mindroom.api import knowledge as knowledge_api
-from mindroom.api import main
 from mindroom.config.knowledge import KnowledgeBaseConfig, KnowledgeGitConfig
 from mindroom.config.main import Config
 from mindroom.knowledge import KnowledgeAvailability
@@ -113,7 +113,7 @@ def _init_git_checkout(path: Path, *tracked_paths: str) -> None:
 def _test_client(tmp_path: Path) -> TestClient:
     runtime_paths = _runtime_paths(tmp_path)
     main.initialize_api_app(main.app, runtime_paths)
-    main.app.state.knowledge_refresh_scheduler = None
+    config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = None
     return TestClient(main.app)
 
 
@@ -578,7 +578,7 @@ def test_api_lifespan_prefers_orchestrator_refresh_scheduler(tmp_path: Path) -> 
     runtime_paths = _runtime_paths(tmp_path)
     scheduler = _RecordingRefreshScheduler()
     main.initialize_api_app(main.app, runtime_paths)
-    main.app.state.orchestrator_knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(main.app).orchestrator_knowledge_refresh_scheduler = scheduler
 
     try:
         with (
@@ -586,12 +586,12 @@ def test_api_lifespan_prefers_orchestrator_refresh_scheduler(tmp_path: Path) -> 
             TestClient(main.app) as client,
         ):
             assert client.get("/api/health").status_code == 200
-            assert client.app.state.knowledge_refresh_scheduler is scheduler
+            assert config_lifecycle.app_state(client.app).knowledge_refresh_scheduler is scheduler
         api_owned_scheduler.assert_not_called()
     finally:
-        main.app.state.knowledge_refresh_scheduler = None
+        config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = None
         with suppress(AttributeError):
-            del main.app.state.orchestrator_knowledge_refresh_scheduler
+            config_lifecycle.app_state(main.app).orchestrator_knowledge_refresh_scheduler = None
 
 
 def test_upload_schedules_refresh_without_inline_indexing(tmp_path: Path) -> None:
@@ -601,7 +601,7 @@ def test_upload_schedules_refresh_without_inline_indexing(tmp_path: Path) -> Non
     config = _knowledge_config(docs)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = client.post(
@@ -625,7 +625,7 @@ def test_upload_rejects_default_unsupported_extension_before_writing(tmp_path: P
     config = _knowledge_config(docs)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = client.post(
@@ -659,7 +659,7 @@ def test_upload_rejects_configured_extension_filter_exclusions(
     config = Config(agents={}, models={}, knowledge_bases={"research": base_config})
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = client.post(
@@ -681,7 +681,7 @@ def test_upload_rejects_duplicate_normalized_multipart_filenames(tmp_path: Path)
     config = _knowledge_config(docs)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = client.post(
@@ -708,7 +708,7 @@ async def test_empty_upload_parts_are_noop_without_source_change_mark_or_refresh
     config = _knowledge_config(docs)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with (
         patch("mindroom.api.knowledge.mark_knowledge_source_changed_async", side_effect=AssertionError("no mutation")),
@@ -744,7 +744,7 @@ def test_upload_schedules_refresh_for_duplicate_same_source_bases(tmp_path: Path
     _write_index_metadata(config, runtime_paths, base_id="research")
     _write_index_metadata(config, runtime_paths, base_id="summary", collection="summary_collection")
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = client.post(
@@ -773,7 +773,7 @@ def test_upload_source_change_mark_write_runs_off_event_loop(
     _publish_committed_runtime_config(client.app, config)
     _write_index_metadata(config, runtime_paths, base_id="research")
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
     saw_running_loop: bool | None = None
     original_save = knowledge_registry.mark_published_index_stale
 
@@ -814,7 +814,7 @@ def test_upload_source_change_mark_failure_leaves_source_unchanged_and_schedules
     _publish_committed_runtime_config(client.app, config)
     _write_index_metadata(config, runtime_paths, base_id="research")
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     async def _fail_source_change_mark(*_args: object, **_kwargs: object) -> tuple[str, ...]:
         msg = "source change mark failed"
@@ -848,7 +848,7 @@ async def test_upload_cancellation_during_write_removes_temp_file(
     config = _knowledge_config(docs)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     async def _cancel_stream(_upload: UploadFile, destination: Path, _filename: str) -> None:
         destination.write_text("partial", encoding="utf-8")
@@ -889,7 +889,7 @@ async def test_replacement_upload_cancellation_preserves_existing_file(
     config = _knowledge_config(docs)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     async def _cancel_stream(_upload: UploadFile, destination: Path, _filename: str) -> None:
         destination.write_text("partial", encoding="utf-8")
@@ -930,7 +930,7 @@ async def test_upload_cancellation_after_source_change_mark_finalizes_backup_and
     config = _knowledge_config(docs)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
     source_change_started = asyncio.Event()
     release_source_change = asyncio.Event()
 
@@ -982,7 +982,7 @@ def test_upload_write_failure_leaves_ready_index_unchanged_and_skips_refresh(
     _publish_committed_runtime_config(client.app, config)
     _write_index_metadata(config, runtime_paths, base_id="research")
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     async def _fail_write(*_args: object, **_kwargs: object) -> None:
         msg = "write failed"
@@ -1026,7 +1026,7 @@ def test_upload_replace_failure_schedules_refresh_for_partial_commit(
     _publish_committed_runtime_config(client.app, config)
     _write_index_metadata(config, runtime_paths, base_id="research")
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
     original_replace = type(docs).replace
     replace_count = 0
 
@@ -1067,7 +1067,7 @@ def test_git_backed_upload_is_rejected_before_creating_cold_checkout(tmp_path: P
     config = _knowledge_config(docs, git=True)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     response = client.post(
         "/api/knowledge/bases/research/upload",
@@ -1098,7 +1098,7 @@ def test_upload_to_local_base_sharing_git_source_is_rejected(tmp_path: Path) -> 
     )
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     response = client.post(
         "/api/knowledge/bases/research/upload",
@@ -1130,7 +1130,7 @@ def test_upload_to_child_of_git_source_is_rejected(tmp_path: Path) -> None:
     )
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     response = client.post(
         "/api/knowledge/bases/research/upload",
@@ -1162,7 +1162,7 @@ def test_upload_to_parent_alias_over_git_source_path_is_rejected(tmp_path: Path)
     )
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     response = client.post(
         "/api/knowledge/bases/research/upload",
@@ -1185,7 +1185,7 @@ def test_upload_over_existing_directory_is_rejected_before_mutation(tmp_path: Pa
     config = _knowledge_config(docs)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = client.post(
@@ -1211,7 +1211,7 @@ def test_delete_schedules_refresh_without_inline_indexing(tmp_path: Path) -> Non
     config = _knowledge_config(docs)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = client.delete("/api/knowledge/bases/research/files/guide.md")
@@ -1252,7 +1252,7 @@ async def test_delete_uses_once_decoded_route_path_for_percent_bearing_filenames
     _publish_committed_runtime_config(client.app, config)
     _write_index_metadata(config, runtime_paths, base_id="research")
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = await knowledge_api.delete_knowledge_file(
@@ -1291,7 +1291,7 @@ def test_delete_rejects_default_unsupported_extension_without_mutation(tmp_path:
     config = _knowledge_config(docs)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = client.delete("/api/knowledge/bases/research/files/diagram.png")
@@ -1325,7 +1325,7 @@ def test_delete_rejects_configured_extension_filter_exclusions(
     config = Config(agents={}, models={}, knowledge_bases={"research": base_config})
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = client.delete(f"/api/knowledge/bases/research/files/{filename}")
@@ -1349,7 +1349,7 @@ def test_delete_schedules_refresh_for_duplicate_same_source_bases(tmp_path: Path
     _write_index_metadata(config, runtime_paths, base_id="research")
     _write_index_metadata(config, runtime_paths, base_id="summary", collection="summary_collection")
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = client.delete("/api/knowledge/bases/research/files/guide.md")
@@ -1373,7 +1373,7 @@ def test_delete_source_change_mark_failure_keeps_source_change_and_schedules_ref
     _publish_committed_runtime_config(client.app, config)
     _write_index_metadata(config, runtime_paths, base_id="research")
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     async def _fail_source_change_mark(*_args: object, **_kwargs: object) -> tuple[str, ...]:
         msg = "source change mark failed"
@@ -1406,7 +1406,7 @@ async def test_delete_cancellation_after_source_change_mark_removes_backup_and_s
     config = _knowledge_config(docs)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
     source_change_started = asyncio.Event()
     release_source_change = asyncio.Event()
 
@@ -1458,7 +1458,7 @@ def test_delete_filesystem_failure_leaves_ready_index_unchanged_and_skips_refres
     _publish_committed_runtime_config(client.app, config)
     _write_index_metadata(config, runtime_paths, base_id="research")
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     def _fail_delete_stage(*_args: object, **_kwargs: object) -> object:
         msg = "unlink failed"
@@ -1494,7 +1494,7 @@ def test_git_backed_delete_is_rejected_without_mutating_checkout(tmp_path: Path)
     config = _knowledge_config(docs, git=True)
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     response = client.delete("/api/knowledge/bases/research/files/guide.md")
 
@@ -1524,7 +1524,7 @@ def test_delete_from_local_base_sharing_git_source_is_rejected(tmp_path: Path) -
     )
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     response = client.delete("/api/knowledge/bases/research/files/guide.md")
 
@@ -1555,7 +1555,7 @@ def test_delete_from_child_of_git_source_is_rejected(tmp_path: Path) -> None:
     )
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     response = client.delete("/api/knowledge/bases/research/files/guide.md")
 
@@ -1586,7 +1586,7 @@ def test_delete_from_parent_alias_inside_git_source_is_rejected(tmp_path: Path) 
     )
     _publish_committed_runtime_config(client.app, config)
     scheduler = _RecordingRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     response = client.delete("/api/knowledge/bases/research/files/repo/guide.md")
 
@@ -1658,7 +1658,7 @@ def test_explicit_reindex_uses_refresh_scheduler_when_available(tmp_path: Path) 
             )
 
     scheduler = _ManualRefreshScheduler()
-    client.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(client.app).knowledge_refresh_scheduler = scheduler
 
     with patch("mindroom.api.knowledge.refresh_knowledge_binding", new=AsyncMock()) as refresh:
         response = client.post("/api/knowledge/bases/research/reindex")

--- a/tests/api/test_matrix_operations.py
+++ b/tests/api/test_matrix_operations.py
@@ -13,9 +13,9 @@ from mindroom.api import config_lifecycle, main
 
 def _add_test_team_to_runtime_config() -> None:
     """Add a configured team to the API runtime config for one test."""
-    app_state = main._app_state(main.app)
-    with app_state.config_lock:
-        context = app_state.snapshot
+    api_state = config_lifecycle.require_api_state(main.app)
+    with api_state.config_lock:
+        context = api_state.snapshot
         context.config_data["teams"] = {
             "test_team": {
                 "display_name": "Test Team",

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -3210,6 +3210,63 @@ def test_lookup_failure_after_binding_resolution_schedules_repair_refresh(
     scheduler.schedule_refresh.assert_called_once()
 
 
+def test_published_index_handle_open_failure_degrades_and_schedules_repair_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken read handle should not break reply-path knowledge resolution."""
+    docs_path = tmp_path / "docs"
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    collection = "broken_collection"
+    metadata_path = published_index_metadata_path(key)
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "settings": list(key.indexing_settings),
+                "status": "complete",
+                "collection": collection,
+                "indexed_count": 1,
+                "source_signature": "test-source-signature",
+            },
+        ),
+        encoding="utf-8",
+    )
+    _VectorDb.collections[collection] = [
+        {
+            "content": "last good content",
+            "metadata": {"path": "guide.md"},
+        },
+    ]
+    scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
+    scheduler.schedule_refresh = MagicMock()
+
+    def _broken_vector_db(*_args: object, **_kwargs: object) -> object:
+        msg = "cannot open collection"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("mindroom.knowledge.registry._build_published_index_vector_db", _broken_vector_db)
+
+    resolution = resolve_agent_knowledge_access(
+        "helper",
+        config,
+        runtime_paths,
+        refresh_scheduler=scheduler,
+    )
+
+    assert resolution.knowledge is None
+    assert resolution.unavailable == {
+        "docs": KnowledgeAvailabilityDetail(
+            availability=KnowledgeAvailability.REFRESH_FAILED,
+            search_available=False,
+        ),
+    }
+    scheduler.schedule_refresh.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_first_time_partial_refresh_does_not_publish_ready_index(
     tmp_path: Path,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -869,7 +869,6 @@ async def test_dashboard_delete_keeps_last_good_best_effort_until_refresh(tmp_pa
     scheduler = MagicMock()
     scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
-    scheduler.is_refreshing = MagicMock(return_value=False)
     config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = scheduler
     try:
         response = TestClient(main.app).delete("/api/knowledge/bases/docs/files/guide.md")
@@ -914,7 +913,6 @@ async def test_dashboard_replacement_upload_keeps_last_good_best_effort_until_re
     scheduler = MagicMock()
     scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
-    scheduler.is_refreshing = MagicMock(return_value=False)
     config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = scheduler
     try:
         response = TestClient(main.app).post(
@@ -978,7 +976,6 @@ async def test_dashboard_delete_stale_write_failure_keeps_best_effort_source_cha
     scheduler = MagicMock()
     scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
-    scheduler.is_refreshing = MagicMock(return_value=False)
     config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = scheduler
     try:
         with pytest.raises(RuntimeError, match="same-source stale write failed"):

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -22,7 +22,7 @@ import mindroom.knowledge.refresh_runner as knowledge_refresh_runner
 import mindroom.knowledge.refresh_scheduler as knowledge_refresh_scheduler
 import mindroom.knowledge.registry as knowledge_registry
 import mindroom.knowledge.utils as knowledge_utils
-from mindroom.api import main
+from mindroom.api import config_lifecycle, main
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig, AgentPrivateKnowledgeConfig
 from mindroom.config.knowledge import KnowledgeBaseConfig, KnowledgeGitConfig
 from mindroom.config.main import Config
@@ -341,6 +341,7 @@ def test_missing_shared_knowledge_schedules_refresh_and_returns_none(tmp_path: P
         agent_bases=["docs"],
     )
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
 
     knowledge = resolve_agent_knowledge_access(
@@ -463,6 +464,7 @@ async def test_ready_index_access_does_not_refresh_unchanged_sources(tmp_path: P
     runtime_paths = runtime_paths_for(config)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
 
     knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths, refresh_scheduler=scheduler).knowledge
@@ -527,6 +529,7 @@ async def test_shared_local_watch_schedule_refresh_on_access_is_throttled(tmp_pa
     runtime_paths = runtime_paths_for(config)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     unavailable_details: dict[str, KnowledgeAvailabilityDetail] = {}
@@ -782,6 +785,7 @@ async def test_stale_index_metadata_schedules_refresh_without_source_scan(tmp_pa
     knowledge_registry.mark_published_index_stale(key, reason="test_stale")
     clear_published_indexes()
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     _resolution = resolve_agent_knowledge_access(
@@ -863,13 +867,14 @@ async def test_dashboard_delete_keeps_last_good_best_effort_until_refresh(tmp_pa
     main.initialize_api_app(main.app, runtime_paths)
     _publish_api_config(main.app, config)
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     scheduler.is_refreshing = MagicMock(return_value=False)
-    main.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = scheduler
     try:
         response = TestClient(main.app).delete("/api/knowledge/bases/docs/files/guide.md")
     finally:
-        main.app.state.knowledge_refresh_scheduler = None
+        config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = None
     assert response.status_code == 200
 
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
@@ -907,16 +912,17 @@ async def test_dashboard_replacement_upload_keeps_last_good_best_effort_until_re
     main.initialize_api_app(main.app, runtime_paths)
     _publish_api_config(main.app, config)
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     scheduler.is_refreshing = MagicMock(return_value=False)
-    main.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = scheduler
     try:
         response = TestClient(main.app).post(
             "/api/knowledge/bases/docs/upload",
             files=[("files", ("guide.md", b"replacement content", "text/markdown"))],
         )
     finally:
-        main.app.state.knowledge_refresh_scheduler = None
+        config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = None
     assert response.status_code == 200
 
     pending_knowledge = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
@@ -970,14 +976,15 @@ async def test_dashboard_delete_stale_write_failure_keeps_best_effort_source_cha
     main.initialize_api_app(main.app, runtime_paths)
     _publish_api_config(main.app, config)
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     scheduler.is_refreshing = MagicMock(return_value=False)
-    main.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = scheduler
     try:
         with pytest.raises(RuntimeError, match="same-source stale write failed"):
             TestClient(main.app).delete("/api/knowledge/bases/research/files/guide.md")
     finally:
-        main.app.state.knowledge_refresh_scheduler = None
+        config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = None
 
     assert stale_write_count == 2
     assert not (docs_path / "guide.md").exists()
@@ -1067,6 +1074,7 @@ async def test_index_metadata_without_source_signature_is_unavailable_and_schedu
     metadata_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
     clear_published_indexes()
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     _resolution = resolve_agent_knowledge_access(
@@ -1813,6 +1821,7 @@ def test_passwordless_ssh_username_change_invalidates_published_index(tmp_path: 
         git_configs={"docs": KnowledgeGitConfig(repo_url="ssh://deploy@example.com/org/repo.git")},
     )
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
 
@@ -1924,6 +1933,7 @@ async def test_git_ready_index_schedules_refresh_after_poll_interval(
     metadata_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
     clear_published_indexes()
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
 
@@ -1993,6 +2003,7 @@ async def test_private_git_schedule_refresh_on_access_honors_poll_interval(
     monkeypatch.setattr(KnowledgeManager, "sync_git_source", _sync_success)
     await refresh_knowledge_binding(base_id, config=config, runtime_paths=runtime_paths, execution_identity=identity)
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     _resolution = resolve_agent_knowledge_access(
@@ -2016,6 +2027,7 @@ async def test_private_git_schedule_refresh_on_access_honors_poll_interval(
     metadata_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
     clear_published_indexes()
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable = {}
     _resolution = resolve_agent_knowledge_access(
@@ -2765,6 +2777,7 @@ async def test_embedder_config_mismatch_returns_no_incompatible_index(tmp_path: 
     changed_config = config.model_copy(deep=True)
     changed_config.memory.embedder.config.model = "text-embedding-3-large"
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     _resolution = resolve_agent_knowledge_access(
@@ -2795,6 +2808,7 @@ async def test_config_mismatch_refresh_cooldown_is_settings_aware(tmp_path: Path
     newer_config = config.model_copy(deep=True)
     newer_config.knowledge_bases["docs"].chunk_size = 2048
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
 
     assert (
@@ -2823,6 +2837,7 @@ async def test_initializing_refresh_cooldown_is_settings_aware(tmp_path: Path) -
     newer_config = config.model_copy(deep=True)
     newer_config.knowledge_bases["docs"].chunk_size = 2048
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
 
     assert (
@@ -2853,6 +2868,7 @@ async def test_cold_failed_refresh_cooldown_is_settings_aware(tmp_path: Path) ->
     newer_config = config.model_copy(deep=True)
     newer_config.knowledge_bases["docs"].chunk_size = 2048
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     _resolution = resolve_agent_knowledge_access(
@@ -2899,6 +2915,7 @@ async def test_failed_git_refresh_cooldown_is_credentials_service_aware(tmp_path
     assert changed_git_config is not None
     changed_git_config.credentials_service = "new_service"
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
 
     assert (
@@ -2936,6 +2953,7 @@ async def test_failed_git_refresh_cooldown_is_embedded_userinfo_aware(tmp_path: 
     assert changed_git_config is not None
     changed_git_config.repo_url = "https://git-user:new-secret@example.com/org/private.git"
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
 
     assert (
@@ -2978,6 +2996,7 @@ async def test_stale_or_failed_index_reports_chunking_config_mismatch_before_coo
     newer_config = config.model_copy(deep=True)
     newer_config.knowledge_bases["docs"].chunk_size = 2048
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     _resolution = resolve_agent_knowledge_access(
@@ -3048,6 +3067,7 @@ async def test_corpus_changing_config_mismatch_returns_no_index(
     changed_config = config.model_copy(deep=True)
     mutate(changed_config)
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     _resolution = resolve_agent_knowledge_access(
@@ -3167,6 +3187,7 @@ def test_lookup_failure_after_binding_resolution_schedules_repair_refresh(
     )
     knowledge_registry.mark_published_index_refresh_succeeded(key)
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
 
@@ -3352,6 +3373,7 @@ async def test_cold_refresh_exception_surfaces_failed_availability_and_backoff(
     assert lookup.availability is KnowledgeAvailability.REFRESH_FAILED
 
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     _resolution = resolve_agent_knowledge_access(
@@ -3419,8 +3441,9 @@ async def test_api_delete_marks_index_stale_and_keeps_last_good_best_effort(tmp_
     assert [document.content for document in before_delete.search("delete", max_results=5)] == ["delete me now"]
 
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
-    main.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = scheduler
     client = TestClient(main.app)
 
     response = client.delete("/api/knowledge/bases/docs/files/guide.md")
@@ -3454,8 +3477,9 @@ async def test_api_replacement_upload_marks_index_stale_and_keeps_last_good_best
     _publish_api_config(main.app, config)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
-    main.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = scheduler
     client = TestClient(main.app)
 
     response = client.post(
@@ -3494,8 +3518,9 @@ async def test_api_upload_failure_does_not_commit_earlier_staged_writes(
     _publish_api_config(main.app, config)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
-    main.app.state.knowledge_refresh_scheduler = scheduler
+    config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = scheduler
     monkeypatch.setattr("mindroom.api.knowledge._MAX_UPLOAD_BYTES", 5)
     client = TestClient(main.app)
 
@@ -3539,7 +3564,7 @@ async def test_api_status_reports_direct_refresh_runner_reindex(
     runtime_paths = runtime_paths_for(config)
     main.initialize_api_app(main.app, runtime_paths)
     _publish_api_config(main.app, config)
-    main.app.state.knowledge_refresh_scheduler = None
+    config_lifecycle.app_state(main.app).knowledge_refresh_scheduler = None
     started = asyncio.Event()
     release = asyncio.Event()
 
@@ -3891,6 +3916,7 @@ async def test_private_agent_knowledge_schedules_refresh_when_source_changes(
     await refresh_knowledge_binding(base_id, config=config, runtime_paths=runtime_paths, execution_identity=identity)
     note.write_text("alice private new", encoding="utf-8")
     scheduler = MagicMock()
+    scheduler.is_refreshing = MagicMock(return_value=False)
     scheduler.schedule_refresh = MagicMock()
     unavailable: dict[str, KnowledgeAvailability] = {}
     unavailable_details: dict[str, KnowledgeAvailabilityDetail] = {}

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -32,7 +32,7 @@ from starlette.requests import ClientDisconnect
 
 from mindroom import constants
 from mindroom.ai_runtime import QUEUED_MESSAGE_NOTICE_TEXT
-from mindroom.api import openai_compat
+from mindroom.api import config_lifecycle, openai_compat
 from mindroom.api.main import initialize_api_app
 from mindroom.api.openai_compat import (
     _ChatMessage,
@@ -259,7 +259,7 @@ def test_load_config_requires_runtime_paths() -> None:
         },
     )
 
-    with pytest.raises(TypeError, match="API context is not initialized"):
+    with pytest.raises(TypeError, match="MindRoom app state is not initialized"):
         openai_compat._load_config(request)
 
 
@@ -2884,7 +2884,8 @@ class TestTeamCompletion:
             )
             refresh_scheduler = kwargs["refresh_scheduler"]
             assert unavailable_bases is not None
-            assert refresh_scheduler is team_app_client.app.state.knowledge_refresh_scheduler
+            assert isinstance(refresh_scheduler, _FakeRefreshScheduler)
+            assert refresh_scheduler is config_lifecycle.app_state(team_app_client.app).knowledge_refresh_scheduler
             unavailable_bases["docs"] = KnowledgeAvailabilityDetail(
                 availability=KnowledgeAvailability.INITIALIZING,
                 search_available=False,
@@ -2898,7 +2899,7 @@ class TestTeamCompletion:
                 failed_agent_names=[],
             )
 
-        team_app_client.app.state.knowledge_refresh_scheduler = _FakeRefreshScheduler()
+        config_lifecycle.app_state(team_app_client.app).knowledge_refresh_scheduler = _FakeRefreshScheduler()
         with (
             patch("mindroom.api.openai_compat.materialize_exact_team_members", side_effect=fake_materialize),
             patch("mindroom.api.openai_compat.build_materialized_team_instance", return_value=mock_team),
@@ -3249,7 +3250,8 @@ class TestTeamCompletion:
             )
             refresh_scheduler = kwargs["refresh_scheduler"]
             assert unavailable_bases is not None
-            assert refresh_scheduler is team_app_client.app.state.knowledge_refresh_scheduler
+            assert isinstance(refresh_scheduler, _FakeRefreshScheduler)
+            assert refresh_scheduler is config_lifecycle.app_state(team_app_client.app).knowledge_refresh_scheduler
             unavailable_bases["docs"] = KnowledgeAvailabilityDetail(
                 availability=KnowledgeAvailability.CONFIG_MISMATCH,
                 search_available=True,
@@ -3263,7 +3265,7 @@ class TestTeamCompletion:
                 failed_agent_names=[],
             )
 
-        team_app_client.app.state.knowledge_refresh_scheduler = _FakeRefreshScheduler()
+        config_lifecycle.app_state(team_app_client.app).knowledge_refresh_scheduler = _FakeRefreshScheduler()
         with (
             patch("mindroom.api.openai_compat.materialize_exact_team_members", side_effect=fake_materialize),
             patch("mindroom.api.openai_compat.build_materialized_team_instance", return_value=mock_team),
@@ -4751,7 +4753,7 @@ class TestKnowledgeIntegration:
                 on_availability(KnowledgeAvailability.INITIALIZING)
             return _knowledge_lookup(None, base_id=base_id, availability=KnowledgeAvailability.INITIALIZING)
 
-        knowledge_app_client.app.state.knowledge_refresh_scheduler = _FakeRefreshScheduler()
+        config_lifecycle.app_state(knowledge_app_client.app).knowledge_refresh_scheduler = _FakeRefreshScheduler()
         with (
             patch("mindroom.api.openai_compat.ai_response", new_callable=AsyncMock) as mock_ai,
             patch("mindroom.knowledge.utils._lookup_knowledge_for_base", side_effect=fake_lookup_knowledge_for_base),


### PR DESCRIPTION
## Summary

- Replace the four duplicates of `try: app.state.foo; except AttributeError: ...` with a single typed `MindroomAppState` dataclass bound at app creation. Collapses the three `_app_state`/`_app_config_state` helpers into one `require_api_state` accessor.
- Narrow the bare `except Exception` in scheduler/runner resolve paths, knowledge index lookups, git file listing, index status, and Supabase token validation.
- Frontend polish: simplify `redactUrlCredentials`, drop the one-line `gitRepoUrlHasRedactionSentinel`, and remove the `statusData` fallback for `file_listing_*` (filesData is the source of truth).

This is the Group 2 cleanup that follows the Group 1 cleanup of the knowledge snapshot refresh PR.

## Test plan

- [x] `uv run pytest tests/ -n auto` (5439 passed)
- [x] `bun run test --run` (429 passed)
- [x] `uv run pre-commit run` on all changed files (clean)
- [x] `uv run tach check --dependencies --interfaces` (clean)