### PR TITLE
Fix private template handling in dedicated workers

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -667,6 +667,10 @@ async def _execute_request_inprocess(
     if request.execution_identity:
         execution_identity = ToolExecutionIdentity(**request.execution_identity)
     output_path = request.kwargs.get(OUTPUT_PATH_ARGUMENT)
+    kwargs = request.kwargs
+    if output_path is None and OUTPUT_PATH_ARGUMENT in kwargs:
+        kwargs = dict(kwargs)
+        kwargs.pop(OUTPUT_PATH_ARGUMENT, None)
     tool_output_workspace_root = (
         _runner_tool_output_workspace_root(
             config=config,
@@ -703,11 +707,11 @@ async def _execute_request_inprocess(
             if toolkit.requires_connect:
                 await _maybe_await(toolkit.connect())
                 try:
-                    result = await _maybe_await(entrypoint(*request.args, **request.kwargs))
+                    result = await _maybe_await(entrypoint(*request.args, **kwargs))
                 finally:
                     await _maybe_await(toolkit.close())
             else:
-                result = await _maybe_await(entrypoint(*request.args, **request.kwargs))
+                result = await _maybe_await(entrypoint(*request.args, **kwargs))
         except Exception as exc:
             logger.warning(
                 "sandbox_tool_execution_failed",

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -666,6 +666,7 @@ async def _execute_request_inprocess(
     execution_identity: ToolExecutionIdentity | None = None
     if request.execution_identity:
         execution_identity = ToolExecutionIdentity(**request.execution_identity)
+    output_path = request.kwargs.get(OUTPUT_PATH_ARGUMENT)
     tool_output_workspace_root = (
         _runner_tool_output_workspace_root(
             config=config,
@@ -674,7 +675,7 @@ async def _execute_request_inprocess(
             execution_identity=execution_identity,
             routing_agent_name=request.routing_agent_name,
         )
-        if OUTPUT_PATH_ARGUMENT in request.kwargs
+        if output_path is not None
         else None
     )
     with (

--- a/src/mindroom/workspaces.py
+++ b/src/mindroom/workspaces.py
@@ -299,6 +299,15 @@ def _effective_workspace(
     )
 
 
+def _template_unavailable_for_dedicated_worker(template_dir: Path, runtime_paths: RuntimePaths) -> bool:
+    """Return whether a dedicated worker should rely on the control plane's existing scaffold."""
+    return (
+        runtime_paths.env_flag("MINDROOM_SANDBOX_RUNNER_MODE")
+        and bool(runtime_paths.env_value("MINDROOM_SANDBOX_DEDICATED_WORKER_KEY", default=""))
+        and not template_dir.expanduser().is_dir()
+    )
+
+
 def _resolve_workspace(
     agent_name: str,
     config: Config,
@@ -345,7 +354,8 @@ def _resolve_workspace(
         root.mkdir(parents=True, exist_ok=True)
         if template_dir is not None:
             assert template_dir is not None
-            _copy_workspace_template(root, template_dir=template_dir)
+            if not _template_unavailable_for_dedicated_worker(template_dir, runtime_paths):
+                _copy_workspace_template(root, template_dir=template_dir)
 
     context_files = tuple(
         resolve_workspace_relative_path(

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -621,8 +621,8 @@ async def test_execute_request_inprocess_ignores_null_tool_output_path(
     class _FakeToolkit:
         requires_connect = False
 
-    def _fake_entrypoint(**kwargs: object) -> dict[str, object]:
-        return {"kwargs": kwargs}
+    def _fake_entrypoint() -> dict[str, object]:
+        return {"called": True}
 
     def _unexpected_output_root_resolution(**_kwargs: object) -> Path | None:
         pytest.fail("null mindroom_output_path must not resolve a tool output workspace root")
@@ -650,7 +650,7 @@ async def test_execute_request_inprocess_ignores_null_tool_output_path(
     )
 
     assert response.ok is True
-    assert response.result == {"kwargs": {sandbox_runner_module.OUTPUT_PATH_ARGUMENT: None}}
+    assert response.result == {"called": True}
 
 
 def test_execute_request_subprocess_sync_marks_subprocess_timeouts_as_worker_failures(

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -601,6 +601,58 @@ async def test_execute_request_inprocess_marks_tool_failures(
     assert response.failure_kind == "tool"
 
 
+@pytest.mark.asyncio
+async def test_execute_request_inprocess_ignores_null_tool_output_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Null output paths should behave like omitted output paths."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+
+    class _FakeToolkit:
+        requires_connect = False
+
+    def _fake_entrypoint(**kwargs: object) -> dict[str, object]:
+        return {"kwargs": kwargs}
+
+    def _unexpected_output_root_resolution(**_kwargs: object) -> Path | None:
+        pytest.fail("null mindroom_output_path must not resolve a tool output workspace root")
+
+    def _fake_resolve_entrypoint(**kwargs: object) -> tuple[_FakeToolkit, object]:
+        assert kwargs["tool_output_workspace_root"] is None
+        return _FakeToolkit(), _fake_entrypoint
+
+    monkeypatch.setattr(
+        sandbox_runner_module,
+        "_runner_tool_output_workspace_root",
+        _unexpected_output_root_resolution,
+    )
+    monkeypatch.setattr(sandbox_runner_module, "_resolve_entrypoint", _fake_resolve_entrypoint)
+
+    response = await sandbox_runner_module._execute_request_inprocess(
+        sandbox_runner_module.SandboxRunnerExecuteRequest(
+            tool_name="file",
+            function_name="list_files",
+            args=[],
+            kwargs={sandbox_runner_module.OUTPUT_PATH_ARGUMENT: None},
+        ),
+        runtime_paths,
+        sandbox_runner_module._runtime_config_or_empty(runtime_paths),
+    )
+
+    assert response.ok is True
+    assert response.result == {"kwargs": {sandbox_runner_module.OUTPUT_PATH_ARGUMENT: None}}
+
+
 def test_execute_request_subprocess_sync_marks_subprocess_timeouts_as_worker_failures(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -653,6 +653,50 @@ async def test_execute_request_inprocess_ignores_null_tool_output_path(
     assert response.result == {"called": True}
 
 
+@pytest.mark.asyncio
+async def test_execute_request_inprocess_preserves_normal_null_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Only the reserved output-path argument treats null as omission."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+
+    class _FakeToolkit:
+        requires_connect = False
+
+    def _fake_entrypoint(limit: int | None = 10) -> dict[str, object]:
+        return {"limit": limit}
+
+    def _fake_resolve_entrypoint(**kwargs: object) -> tuple[_FakeToolkit, object]:
+        assert kwargs["tool_output_workspace_root"] is None
+        return _FakeToolkit(), _fake_entrypoint
+
+    monkeypatch.setattr(sandbox_runner_module, "_resolve_entrypoint", _fake_resolve_entrypoint)
+
+    response = await sandbox_runner_module._execute_request_inprocess(
+        sandbox_runner_module.SandboxRunnerExecuteRequest(
+            tool_name="fake",
+            function_name="with_optional_limit",
+            args=[],
+            kwargs={"limit": None},
+        ),
+        runtime_paths,
+        sandbox_runner_module._runtime_config_or_empty(runtime_paths),
+    )
+
+    assert response.ok is True
+    assert response.result == {"limit": None}
+
+
 def test_execute_request_subprocess_sync_marks_subprocess_timeouts_as_worker_failures(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2210,6 +2210,57 @@ def test_bind_runtime_paths_allows_missing_private_template_dir_for_dedicated_sa
     assert bound.get_agent("general").private is not None
 
 
+def test_resolve_agent_runtime_skips_missing_private_template_copy_for_dedicated_sandbox_worker(
+    tmp_path: Path,
+) -> None:
+    """Dedicated workers should not need control-plane-only private templates at tool execution time."""
+    config = _test_config()
+    config.agents["general"].private = AgentPrivateConfig(
+        per="user_agent",
+        root="mind_data",
+        template_dir="./missing-template",
+    )
+    execution_identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+        tenant_id="tenant-123",
+    )
+    worker_key = resolve_worker_key("user_agent", execution_identity, agent_name="general")
+    assert worker_key is not None
+    shared_root = tmp_path / "shared-storage"
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=shared_root,
+        process_env={
+            "MINDROOM_SANDBOX_RUNNER_MODE": "true",
+            "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY": worker_key,
+        },
+    )
+    bound = _bind_runtime_paths(config, runtime_paths)
+
+    agent_runtime = resolve_agent_runtime(
+        "general",
+        bound,
+        runtime_paths,
+        execution_identity=execution_identity,
+        create=True,
+    )
+
+    expected_workspace = _private_instance_state_root_path(
+        shared_root,
+        worker_key=worker_key,
+        agent_name="general",
+    ) / "mind_data"
+    assert agent_runtime.workspace is not None
+    assert agent_runtime.workspace.root == expected_workspace
+    assert expected_workspace.is_dir()
+
+
 def test_bind_runtime_paths_rejects_private_template_dir_with_symlinked_content(tmp_path: Path) -> None:
     """Private templates must reject symlinked content instead of copying host files."""
     template_dir = tmp_path / "mind_template"


### PR DESCRIPTION
## Summary
- skip copying unavailable private workspace templates inside dedicated sandbox workers
- only resolve a redirected-output workspace when `mindroom_output_path` is actually non-null
- preserve control-plane validation/copy behavior for normal runtimes
- add regression coverage for both dedicated-worker private templates and null output paths

## Tests
- uv run pytest tests/api/test_sandbox_runner_api.py -k 'null_tool_output_path or private_template_dir_missing' --no-cov -n 0\n- uv run pytest tests/test_agents.py -k 'dedicated_sandbox_worker and private_template' --no-cov -n 0\n- uv run ruff check src/mindroom/api/sandbox_runner.py src/mindroom/workspaces.py tests/api/test_sandbox_runner_api.py tests/test_agents.py