### PR TITLE
Fix Git LFS hydration for knowledge sync

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -206,7 +206,7 @@ knowledge_bases:
 | `branch` | string | `main` | Branch to track |
 | `poll_interval_seconds` | int | `300` | Interval for scheduling background Git refreshes |
 | `credentials_service` | string | `null` | Service name in CredentialsManager for private repos |
-| `lfs` | bool | `false` | Enable Git LFS support and run `git lfs pull` after sync. Requires `git-lfs` on the machine running MindRoom |
+| `lfs` | bool | `false` | Enable Git LFS support and hydrate the checkout after sync. Requires `git-lfs` on the machine running MindRoom |
 | `sync_timeout_seconds` | int | `3600` | Abort one Git command if it exceeds this timeout |
 | `skip_hidden` | bool | `true` | Skip files/folders starting with `.` |
 | `include_patterns` | list | `[]` | Root-anchored glob patterns to include |
@@ -220,7 +220,7 @@ Bundled container images already include it.
 - Chat and runtime requests never wait for Git sync or indexing.
 - Missing, stale, or failed knowledge schedules a per-binding refresh and the current request continues with availability metadata.
 - Explicit dashboard/API reindex runs Git sync first for Git-backed bases and then rebuilds a candidate index.
-- When `lfs: true`, MindRoom runs `git lfs pull origin <branch>` when a checkout is first hydrated or when sync advances to a new Git head.
+- When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
 - Git-backed bases reject dashboard/API file upload and delete mutations; update the repository and reindex instead.
 - Successful refresh publishes a new last successfully published index while failed refresh preserves the previous one and records the error in status metadata.

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1096,6 +1096,14 @@ class KnowledgeManager:
         await self._run_git(["lfs", "install", "--local"], cwd=repo_root)
         self._git_lfs_repository_ready = True
 
+    def _git_lfs_skip_smudge_env(self, git_config: KnowledgeGitConfig) -> dict[str, str] | None:
+        if not git_config.lfs:
+            return None
+        return {"GIT_LFS_SKIP_SMUDGE": "1"}
+
+    def _git_lfs_pull_args(self, git_config: KnowledgeGitConfig) -> list[str]:
+        return ["lfs", "pull", "origin", git_config.branch]
+
     async def _hydrate_git_lfs_worktree(
         self,
         git_config: KnowledgeGitConfig,
@@ -1111,7 +1119,7 @@ class KnowledgeManager:
             if hydrated_head == resolved_head:
                 return
         await self._run_git(
-            ["lfs", "pull", "origin", git_config.branch],
+            self._git_lfs_pull_args(git_config),
             cwd=repo_root or self._knowledge_source_path(),
             env=_git_auth_env(git_config.repo_url, git_config.credentials_service, self.runtime_paths),
         )
@@ -1173,7 +1181,7 @@ class KnowledgeManager:
             cwd=knowledge_root.parent,
             env=_merge_git_env(
                 _git_auth_env(git_config.repo_url, git_config.credentials_service, runtime_paths),
-                {"GIT_LFS_SKIP_SMUDGE": "1"} if git_config.lfs else None,
+                self._git_lfs_skip_smudge_env(git_config),
             ),
         )
         self._git_repo_present = True
@@ -1207,19 +1215,25 @@ class KnowledgeManager:
                 await self._hydrate_git_lfs_worktree(git_config, current_head=remote_head)
                 return set(), set(), False
 
-            await self._run_git(["checkout", "--force", "-B", git_config.branch, remote_ref])
+            await self._run_git(
+                ["checkout", "--force", "-B", git_config.branch, remote_ref],
+                env=self._git_lfs_skip_smudge_env(git_config),
+            )
             # Reviewed with Bas (2026-04-17): program-owned checkout, hard reset is the
             # intentional way to realign it with the configured remote state.
-            await self._run_git(["reset", "--hard", remote_ref])
+            await self._run_git(["reset", "--hard", remote_ref], env=self._git_lfs_skip_smudge_env(git_config))
             await self._hydrate_git_lfs_worktree(git_config, current_head=remote_head)
             after_files = await self._git_list_tracked_files()
             changed_files = {path for path in dirty_tracked_files if path in after_files}
             return changed_files, set(), True
 
-        await self._run_git(["checkout", "--force", "-B", git_config.branch, remote_ref])
+        await self._run_git(
+            ["checkout", "--force", "-B", git_config.branch, remote_ref],
+            env=self._git_lfs_skip_smudge_env(git_config),
+        )
         # Reviewed with Bas (2026-04-17): program-owned checkout, hard reset is the
         # intentional way to realign it with the configured remote state.
-        await self._run_git(["reset", "--hard", remote_ref])
+        await self._run_git(["reset", "--hard", remote_ref], env=self._git_lfs_skip_smudge_env(git_config))
         await self._hydrate_git_lfs_worktree(git_config, current_head=remote_head)
 
         after_files = await self._git_list_tracked_files()

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -269,6 +269,7 @@ def _git_manager(
     tmp_path: Path,
     *,
     lfs: bool = False,
+    include_extensions: list[str] | None = None,
     sync_timeout_seconds: int = 3600,
 ) -> KnowledgeManager:
     knowledge_path = tmp_path / "knowledge"
@@ -285,6 +286,8 @@ def _git_manager(
             ),
         },
     )
+    if include_extensions is not None:
+        config.knowledge_bases["docs"].include_extensions = include_extensions
     return KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
 
 
@@ -5531,6 +5534,7 @@ async def test_sync_git_source_once_pulls_lfs_after_reset(
     """LFS-enabled repos should explicitly pull LFS objects after resetting to the remote branch."""
     manager = _git_manager(tmp_path, lfs=True)
     git_calls: list[list[str]] = []
+    git_envs: list[tuple[list[str], dict[str, str] | None]] = []
 
     async def _fake_ensure_git_repository(_git_config: object) -> bool:
         return False
@@ -5547,8 +5551,14 @@ async def test_sync_git_source_once_pulls_lfs_after_reset(
     async def _fake_git_list_tracked_files() -> set[str]:
         return next(list_tracked_files_results)
 
-    async def _fake_run_git(args: list[str], **_: object) -> str:
+    async def _fake_run_git(
+        args: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        **_: object,
+    ) -> str:
         git_calls.append(args)
+        git_envs.append((args, env))
         if args[:3] == ["diff", "--name-only", "--no-renames"]:
             return "doc.md\n"
         return ""
@@ -5563,6 +5573,35 @@ async def test_sync_git_source_once_pulls_lfs_after_reset(
     assert updated is True
     assert changed_files == {"doc.md"}
     assert removed_files == set()
+    assert ["lfs", "pull", "origin", "main"] in git_calls
+    assert (
+        ["checkout", "--force", "-B", "main", "origin/main"],
+        {"GIT_LFS_SKIP_SMUDGE": "1"},
+    ) in git_envs
+    assert (["reset", "--hard", "origin/main"], {"GIT_LFS_SKIP_SMUDGE": "1"}) in git_envs
+
+
+@pytest.mark.asyncio
+async def test_hydrate_git_lfs_worktree_ignores_index_extension_filters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Index extension filters must not make the Git checkout incomplete."""
+    manager = _git_manager(tmp_path, lfs=True, include_extensions=[".md", ".mdx", ".rst"])
+    git_calls: list[list[str]] = []
+
+    async def _fake_run_git(args: list[str], **_: object) -> str:
+        git_calls.append(args)
+        return ""
+
+    async def _fake_git_rev_parse(_ref: str) -> str | None:
+        return "head"
+
+    monkeypatch.setattr(manager, "_run_git", _fake_run_git)
+    monkeypatch.setattr(manager, "_git_rev_parse", _fake_git_rev_parse)
+
+    await manager._hydrate_git_lfs_worktree(manager._git_config())
+
     assert ["lfs", "pull", "origin", "main"] in git_calls
 
 


### PR DESCRIPTION
## Summary
- Disable implicit LFS smudge during knowledge repo clone/checkout/reset.
- Keep LFS hydration complete so the on-disk checkout matches the repository even when indexing filters only include some file types.
- Document the LFS hydration behavior.

## Tests
- `uv run pytest tests/test_knowledge_manager.py -k 'lfs or git_source_once_pulls_lfs_after_reset'`
- `uv run ruff check src/mindroom/knowledge/manager.py tests/test_knowledge_manager.py`
- `uv run ruff format --check src/mindroom/knowledge/manager.py tests/test_knowledge_manager.py`