### PR TITLE
Fix release artifact publishing

### DIFF
--- a/.github/workflows/build-mindroom.yml
+++ b/.github/workflows/build-mindroom.yml
@@ -2,7 +2,7 @@ name: Build MindRoom
 # Builds MindRoom instance images in parallel using native ARM64 runners
 
 on:
-  # Publish branch-tagged images on direct pushes to main.
+  # Validate MindRoom images on direct pushes to main.
   push:
     branches: [ main ]
   # Build (no push) on PRs to validate Dockerfiles
@@ -15,16 +15,13 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/build-mindroom.yml'
-  # Push images on releases
-  release:
-    types: [ published ]
-  # Manual trigger with push option
+  # Publish release images when dispatched by the CalVer release workflow.
   workflow_dispatch:
     inputs:
-      push_images:
-        description: 'Push images to registry'
-        type: boolean
-        default: false
+      release_ref:
+        description: 'Release tag to publish, for example v2026.4.261'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -65,6 +62,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref }}
         lfs: true
 
     - name: Pull Git LFS objects
@@ -87,15 +85,25 @@ jobs:
     - name: Set build vars
       id: vars
       run: |
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          ref_name="${{ inputs.release_ref }}"
+          if [[ "$ref_name" != v* ]]; then
+            echo "release_ref must be a tag starting with 'v', got '$ref_name'" >&2
+            exit 1
+          fi
+          version="${ref_name#v}"
+        elif [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "push" ]]; then
+          ref_name="$GITHUB_REF_NAME"
+          version="0.0.0"
+        else
+          echo "Unsupported event for Build MindRoom: ${{ github.event_name }}" >&2
+          exit 1
+        fi
+
         echo "timestamp=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
         # Sanitize ref for Docker tag usage (e.g. pull/123/merge -> pull-123-merge)
-        echo "safe_ref=${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT
-        # Extract version from tag (strip 'v' prefix) or use 0.0.0 for non-release builds
-        if [[ "${{ github.ref_name }}" == v* ]]; then
-          echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
-        else
-          echo "version=0.0.0" >> $GITHUB_OUTPUT
-        fi
+        echo "safe_ref=${ref_name//\//-}" >> $GITHUB_OUTPUT
+        echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: Build and push image
       uses: docker/build-push-action@v5
@@ -103,7 +111,7 @@ jobs:
         context: .
         file: ${{ matrix.target.dockerfile }}
         platforms: ${{ matrix.platform }}
-        push: ${{ github.event_name == 'push' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.push_images) }}
+        push: ${{ github.event_name == 'workflow_dispatch' }}
         tags: |
           ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.target.image_name }}:${{ matrix.platform_suffix }}
           ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.target.image_name }}:${{ steps.vars.outputs.safe_ref }}-${{ matrix.platform_suffix }}
@@ -118,7 +126,7 @@ jobs:
   # Create multi-arch manifests after all builds complete when publishing is enabled.
   manifest:
     needs: build
-    if: github.event_name == 'push' || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.push_images)
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -140,13 +148,16 @@ jobs:
     - name: Set safe ref
       id: vars
       run: |
-        echo "safe_ref=${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT
+        ref_name="${{ inputs.release_ref }}"
+        if [[ "$ref_name" != v* ]]; then
+          echo "release_ref must be a tag starting with 'v', got '$ref_name'" >&2
+          exit 1
+        fi
+        echo "safe_ref=${ref_name//\//-}" >> $GITHUB_OUTPUT
 
     - name: Create and push latest manifest
-      if: github.event_name != 'release'
       run: |
-        # Keep latest aligned with direct branch/manual publishes instead of
-        # rebuilding it again during release fan-out.
+        # Keep latest aligned with explicit publishes.
         docker manifest create \
           ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.target.image_name }}:latest \
           ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.target.image_name }}:amd64 \

--- a/.github/workflows/build-platform.yml
+++ b/.github/workflows/build-platform.yml
@@ -7,16 +7,13 @@ on:
     paths:
       - 'saas-platform/**'
       - '.github/workflows/build-platform.yml'
-  # Push images only on releases
-  release:
-    types: [published]
-  # Manual trigger with push option
+  # Publish release images when dispatched by the CalVer release workflow.
   workflow_dispatch:
     inputs:
-      push_images:
-        description: 'Push images to registry'
-        type: boolean
-        default: false
+      release_ref:
+        description: 'Release tag to publish, for example v2026.4.261'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -41,6 +38,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref }}
+
+      - name: Validate release ref
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [[ "${{ inputs.release_ref }}" != v* ]]; then
+            echo "release_ref must be a tag starting with 'v', got '${{ inputs.release_ref }}'" >&2
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -65,8 +72,9 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,format=short
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=amd64,enable={{is_default_branch}}
+            type=raw,value=${{ inputs.release_ref }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=amd64,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -74,7 +82,7 @@ jobs:
           context: ${{ matrix.service.context }}
           file: ${{ matrix.service.context }}/${{ matrix.service.dockerfile }}
           platforms: linux/amd64
-          push: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.push_images) }}
+          push: ${{ github.event_name == 'workflow_dispatch' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/calver-auto-release.yml
+++ b/.github/workflows/calver-auto-release.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
 
 permissions:
+  actions: write
   contents: write
 
 jobs:
@@ -12,7 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create release
+        id: create_release
         uses: basnijholt/calver-auto-release@v1
         with:
-          # A PAT ensures downstream `on: release` workflows are triggered.
-          github_token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dispatch release publishers
+        if: steps.create_release.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISH_WORKFLOW_REF: ${{ github.ref_name }}
+          RELEASE_REF: ${{ steps.create_release.outputs.version }}
+        run: |
+          gh workflow run build-mindroom.yml --ref "$PUBLISH_WORKFLOW_REF" --field release_ref="$RELEASE_REF"
+          gh workflow run build-platform.yml --ref "$PUBLISH_WORKFLOW_REF" --field release_ref="$RELEASE_REF"
+          gh workflow run release.yml --ref "$PUBLISH_WORKFLOW_REF" --field release_ref="$RELEASE_REF"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,12 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_ref:
+        description: 'Release tag to publish, for example v2026.4.261'
+        required: true
+        type: string
 
 jobs:
   deploy:
@@ -11,9 +15,13 @@ jobs:
       name: pypi
       url: https://pypi.org/p/mindroom
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release_ref }}
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Set up Bun

--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -358,7 +358,7 @@ def source_workspace_env_hook(
     Bash sources the script without `set -a`, so agents must write
     `export FOO=bar` for values to overlay; bare `FOO=bar` does not persist.
     A high-entropy capture marker separates anything the script printed to
-    stdout from the NUL-separated `printenv -0` block we read afterwards. The
+    stdout from the NUL-separated exported environment block we read afterwards. The
     runner keeps only entries whose name passes
     `constants.is_workspace_env_overlay_name_allowed` and whose value differs
     from `base_env`.
@@ -368,7 +368,11 @@ def source_workspace_env_hook(
     """
     bash_path = _resolve_bash(base_env)
     capture_marker = secrets.token_hex(16)
-    bash_script = '. "$1"; printf "%s\\0" "$2"; printenv -0'
+    bash_script = (
+        '. "$1"; '
+        'printf "%s\\0" "$2"; '
+        'while IFS= read -r name; do printf "%s=%s\\0" "$name" "${!name}"; done < <(compgen -e)'
+    )
     try:
         process = subprocess.Popen(
             [bash_path, "-c", bash_script, "bash", str(hook_path), capture_marker],


### PR DESCRIPTION
## Summary
- Dispatch Docker and PyPI publishing workflows explicitly from the CalVer release workflow.
- Build release artifacts from the created release tag via required `release_ref`, instead of relying on release-event fan-out.
- Keep push-to-main Docker jobs as validation-only so they do not publish `VERSION=0.0.0` images.
- Remove the PAT fallback and optional publish switch so the release path is a single explicit code path.
- Make workspace env hook capture portable on macOS by avoiding GNU-only `printenv -0`.

## Why
The automatic release workflow was creating GitHub releases, but the downstream `on: release` workflows were not running for recent releases.
GitHub suppresses most workflow runs caused by `GITHUB_TOKEN` events, except `workflow_dispatch` and `repository_dispatch`, so publishing now uses an explicit dispatch with a required release tag.

## Verification
- `git diff --check`
- `uvx --from actionlint-py actionlint .github/workflows/calver-auto-release.yml .github/workflows/build-mindroom.yml .github/workflows/build-platform.yml .github/workflows/release.yml`
- `uv run pre-commit run --files src/mindroom/api/sandbox_exec.py .github/workflows/calver-auto-release.yml .github/workflows/build-mindroom.yml .github/workflows/build-platform.yml .github/workflows/release.yml`
- `uv run pytest tests/test_workspace_env_hook.py -q`
- `uv run pytest -q`

After simplification:
- `uvx --from actionlint-py actionlint .github/workflows/calver-auto-release.yml .github/workflows/build-mindroom.yml .github/workflows/build-platform.yml .github/workflows/release.yml`
- `uv run pre-commit run --files .github/workflows/calver-auto-release.yml .github/workflows/build-mindroom.yml .github/workflows/build-platform.yml .github/workflows/release.yml`
