### PR TITLE
Skip Git worktree scan for unchanged knowledge repos

### DIFF
--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1142,10 +1142,6 @@ class KnowledgeManager:
         self._git_tracked_relative_paths = set(tracked_files)
         return tracked_files
 
-    async def _git_dirty_tracked_files(self) -> set[str]:
-        output = await self._run_git(["diff", "--name-only", "--no-renames", "HEAD"])
-        return {path for path in output.splitlines() if self._include_semantic_relative_path(path)}
-
     async def _ensure_git_repository(self, git_config: KnowledgeGitConfig) -> bool:
         runtime_paths = self.runtime_paths
         knowledge_root = self._knowledge_source_path()
@@ -1197,8 +1193,6 @@ class KnowledgeManager:
             return await self._git_list_tracked_files(), set(), True
 
         before_head = await self._git_rev_parse("HEAD")
-        before_files = await self._git_list_tracked_files()
-        dirty_tracked_files = set() if before_head is None else await self._git_dirty_tracked_files()
 
         remote_ref = f"origin/{git_config.branch}"
         await self._run_git(
@@ -1211,21 +1205,10 @@ class KnowledgeManager:
             raise RuntimeError(msg)
 
         if before_head == remote_head:
-            if not dirty_tracked_files:
-                await self._hydrate_git_lfs_worktree(git_config, current_head=remote_head)
-                return set(), set(), False
-
-            await self._run_git(
-                ["checkout", "--force", "-B", git_config.branch, remote_ref],
-                env=self._git_lfs_skip_smudge_env(git_config),
-            )
-            # Reviewed with Bas (2026-04-17): program-owned checkout, hard reset is the
-            # intentional way to realign it with the configured remote state.
-            await self._run_git(["reset", "--hard", remote_ref], env=self._git_lfs_skip_smudge_env(git_config))
             await self._hydrate_git_lfs_worktree(git_config, current_head=remote_head)
-            after_files = await self._git_list_tracked_files()
-            changed_files = {path for path in dirty_tracked_files if path in after_files}
-            return changed_files, set(), True
+            return set(), set(), False
+
+        before_files = await self._git_list_tracked_files()
 
         await self._run_git(
             ["checkout", "--force", "-B", git_config.branch, remote_ref],
@@ -1247,7 +1230,6 @@ class KnowledgeManager:
         changed_files = (
             {path for path in changed_paths if path in after_files}
             | (after_files - before_files)
-            | {path for path in dirty_tracked_files if path in after_files}
         )
         return changed_files, removed_files, True
 

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -5469,6 +5469,46 @@ async def test_refresh_scheduler_manual_reindex_runs_without_background_queue(
 
 
 @pytest.mark.asyncio
+async def test_sync_git_source_once_unchanged_head_skips_worktree_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Polling an unchanged managed checkout should not scan the working tree."""
+    manager = _git_manager(tmp_path, lfs=True)
+    git_calls: list[list[str]] = []
+
+    async def _fake_ensure_git_repository(_git_config: object) -> bool:
+        return False
+
+    async def _fake_git_rev_parse(ref: str) -> str | None:
+        if ref in {"HEAD", "origin/main"}:
+            return "same"
+        return None
+
+    async def _unexpected_git_list_tracked_files() -> set[str]:
+        msg = "unchanged Git sync should not list tracked files"
+        raise AssertionError(msg)
+
+    async def _fake_run_git(args: list[str], **_: object) -> str:
+        git_calls.append(args)
+        return ""
+
+    monkeypatch.setattr(manager, "_ensure_git_repository", _fake_ensure_git_repository)
+    monkeypatch.setattr(manager, "_git_rev_parse", _fake_git_rev_parse)
+    monkeypatch.setattr(manager, "_git_list_tracked_files", _unexpected_git_list_tracked_files)
+    monkeypatch.setattr(manager, "_run_git", _fake_run_git)
+
+    changed_files, removed_files, updated = await manager._sync_git_source_once(manager._git_config())
+
+    assert updated is False
+    assert changed_files == set()
+    assert removed_files == set()
+    assert ["fetch", "origin", "+refs/heads/main:refs/remotes/origin/main"] in git_calls
+    assert ["lfs", "pull", "origin", "main"] in git_calls
+    assert not any(call[:3] == ["diff", "--name-only", "--no-renames"] for call in git_calls)
+
+
+@pytest.mark.asyncio
 async def test_sync_git_source_once_skips_repeated_lfs_pull_for_already_hydrated_unchanged_head(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- avoid scanning the managed Git knowledge checkout when the fetched remote head is unchanged
- still run Git LFS hydration for unchanged checkouts so missing objects can be recovered
- add a regression test covering the unchanged-head polling path

## Tests
- uv run ruff check src/mindroom/knowledge/manager.py tests/test_knowledge_manager.py
- uv run pytest tests/test_knowledge_manager.py -k 'sync_git_source_once_unchanged_head_skips_worktree_scan or sync_git_source_once_skips_repeated_lfs_pull_for_already_hydrated_unchanged_head or sync_git_source_once_pulls_lfs_after_reset'