### PR TITLE
Cache Kubernetes worker validation snapshots

### DIFF
--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -8802,17 +8802,17 @@ knowledge_bases:
 
 ### Git Configuration Fields
 
-| Field                   | Type   | Default    | Description                                                                                                  |
-| ----------------------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------ |
-| `repo_url`              | string | *required* | HTTPS repository URL to clone/fetch                                                                          |
-| `branch`                | string | `main`     | Branch to track                                                                                              |
-| `poll_interval_seconds` | int    | `300`      | Interval for scheduling background Git refreshes                                                             |
-| `credentials_service`   | string | `null`     | Service name in CredentialsManager for private repos                                                         |
-| `lfs`                   | bool   | `false`    | Enable Git LFS support and run `git lfs pull` after sync. Requires `git-lfs` on the machine running MindRoom |
-| `sync_timeout_seconds`  | int    | `3600`     | Abort one Git command if it exceeds this timeout                                                             |
-| `skip_hidden`           | bool   | `true`     | Skip files/folders starting with `.`                                                                         |
-| `include_patterns`      | list   | `[]`       | Root-anchored glob patterns to include                                                                       |
-| `exclude_patterns`      | list   | `[]`       | Root-anchored glob patterns to exclude                                                                       |
+| Field                   | Type   | Default    | Description                                                                                                    |
+| ----------------------- | ------ | ---------- | -------------------------------------------------------------------------------------------------------------- |
+| `repo_url`              | string | *required* | HTTPS repository URL to clone/fetch                                                                            |
+| `branch`                | string | `main`     | Branch to track                                                                                                |
+| `poll_interval_seconds` | int    | `300`      | Interval for scheduling background Git refreshes                                                               |
+| `credentials_service`   | string | `null`     | Service name in CredentialsManager for private repos                                                           |
+| `lfs`                   | bool   | `false`    | Enable Git LFS support and hydrate the checkout after sync. Requires `git-lfs` on the machine running MindRoom |
+| `sync_timeout_seconds`  | int    | `3600`     | Abort one Git command if it exceeds this timeout                                                               |
+| `skip_hidden`           | bool   | `true`     | Skip files/folders starting with `.`                                                                           |
+| `include_patterns`      | list   | `[]`       | Root-anchored glob patterns to include                                                                         |
+| `exclude_patterns`      | list   | `[]`       | Root-anchored glob patterns to exclude                                                                         |
 
 When `lfs: true`, install `git-lfs` on the runtime host for `uv run` or `uvx` flows. Bundled container images already include it.
 
@@ -8821,7 +8821,7 @@ When `lfs: true`, install `git-lfs` on the runtime host for `uv run` or `uvx` fl
 - Chat and runtime requests never wait for Git sync or indexing.
 - Missing, stale, or failed knowledge schedules a per-binding refresh and the current request continues with availability metadata.
 - Explicit dashboard/API reindex runs Git sync first for Git-backed bases and then rebuilds a candidate index.
-- When `lfs: true`, MindRoom runs `git lfs pull origin <branch>` when a checkout is first hydrated or when sync advances to a new Git head.
+- When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
 - Git-backed bases reject dashboard/API file upload and delete mutations; update the repository and reindex instead.
 - Successful refresh publishes a new last successfully published index while failed refresh preserves the previous one and records the error in status metadata.

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -173,17 +173,17 @@ knowledge_bases:
 
 ### Git Configuration Fields
 
-| Field                   | Type   | Default    | Description                                                                                                  |
-| ----------------------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------ |
-| `repo_url`              | string | *required* | HTTPS repository URL to clone/fetch                                                                          |
-| `branch`                | string | `main`     | Branch to track                                                                                              |
-| `poll_interval_seconds` | int    | `300`      | Interval for scheduling background Git refreshes                                                             |
-| `credentials_service`   | string | `null`     | Service name in CredentialsManager for private repos                                                         |
-| `lfs`                   | bool   | `false`    | Enable Git LFS support and run `git lfs pull` after sync. Requires `git-lfs` on the machine running MindRoom |
-| `sync_timeout_seconds`  | int    | `3600`     | Abort one Git command if it exceeds this timeout                                                             |
-| `skip_hidden`           | bool   | `true`     | Skip files/folders starting with `.`                                                                         |
-| `include_patterns`      | list   | `[]`       | Root-anchored glob patterns to include                                                                       |
-| `exclude_patterns`      | list   | `[]`       | Root-anchored glob patterns to exclude                                                                       |
+| Field                   | Type   | Default    | Description                                                                                                    |
+| ----------------------- | ------ | ---------- | -------------------------------------------------------------------------------------------------------------- |
+| `repo_url`              | string | *required* | HTTPS repository URL to clone/fetch                                                                            |
+| `branch`                | string | `main`     | Branch to track                                                                                                |
+| `poll_interval_seconds` | int    | `300`      | Interval for scheduling background Git refreshes                                                               |
+| `credentials_service`   | string | `null`     | Service name in CredentialsManager for private repos                                                           |
+| `lfs`                   | bool   | `false`    | Enable Git LFS support and hydrate the checkout after sync. Requires `git-lfs` on the machine running MindRoom |
+| `sync_timeout_seconds`  | int    | `3600`     | Abort one Git command if it exceeds this timeout                                                               |
+| `skip_hidden`           | bool   | `true`     | Skip files/folders starting with `.`                                                                           |
+| `include_patterns`      | list   | `[]`       | Root-anchored glob patterns to include                                                                         |
+| `exclude_patterns`      | list   | `[]`       | Root-anchored glob patterns to exclude                                                                         |
 
 When `lfs: true`, install `git-lfs` on the runtime host for `uv run` or `uvx` flows. Bundled container images already include it.
 
@@ -192,7 +192,7 @@ When `lfs: true`, install `git-lfs` on the runtime host for `uv run` or `uvx` fl
 - Chat and runtime requests never wait for Git sync or indexing.
 - Missing, stale, or failed knowledge schedules a per-binding refresh and the current request continues with availability metadata.
 - Explicit dashboard/API reindex runs Git sync first for Git-backed bases and then rebuilds a candidate index.
-- When `lfs: true`, MindRoom runs `git lfs pull origin <branch>` when a checkout is first hydrated or when sync advances to a new Git head.
+- When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
 - Git-backed bases reject dashboard/API file upload and delete mutations; update the repository and reindex instead.
 - Successful refresh publishes a new last successfully published index while failed refresh preserves the previous one and records the error in status metadata.

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -430,7 +430,6 @@ def _reload_api_runtime_config(
     mutate_runtime: Callable[[constants.RuntimePaths], constants.RuntimePaths] | None = None,
 ) -> None:
     """Rebind the API app to one runtime and surface structured config reload failures."""
-    clear_worker_validation_snapshot_cache()
     app_state = config_lifecycle.app_state(api_app)
     api_state = config_lifecycle.require_api_state(api_app)
     with api_state.config_lock:
@@ -472,6 +471,7 @@ def _reload_api_runtime_config(
             config_load_result=result,
         )
     config_lifecycle.raise_for_config_load_result(result)
+    clear_worker_validation_snapshot_cache()
 
 
 def _sanitize_entity_payload(entity_data: dict[str, Any]) -> dict[str, Any]:

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -41,6 +41,7 @@ from mindroom.orchestration.runtime import matrix_sync_startup_timeout_seconds
 from mindroom.runtime_state import get_runtime_state
 from mindroom.tool_system.sandbox_proxy import sandbox_proxy_config
 from mindroom.workers.runtime import (
+    clear_worker_validation_snapshot_cache,
     get_primary_worker_manager,
     primary_worker_backend_available,
     primary_worker_backend_name,
@@ -429,6 +430,7 @@ def _reload_api_runtime_config(
     mutate_runtime: Callable[[constants.RuntimePaths], constants.RuntimePaths] | None = None,
 ) -> None:
     """Rebind the API app to one runtime and surface structured config reload failures."""
+    clear_worker_validation_snapshot_cache()
     app_state = config_lifecycle.app_state(api_app)
     api_state = config_lifecycle.require_api_state(api_app)
     with api_state.config_lock:

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1227,10 +1227,7 @@ class KnowledgeManager:
             changed_paths = {path for path in diff_output.splitlines() if self._include_semantic_relative_path(path)}
 
         removed_files = before_files - after_files
-        changed_files = (
-            {path for path in changed_paths if path in after_files}
-            | (after_files - before_files)
-        )
+        changed_files = {path for path in changed_paths if path in after_files} | (after_files - before_files)
         return changed_files, removed_files, True
 
     def list_files(self) -> list[Path]:

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -742,7 +742,6 @@ class MultiAgentOrchestrator:
                 source=source,
                 changed_paths=[str(path) for path in changed_paths],
             )
-            clear_worker_validation_snapshot_cache()
             try:
                 result = reload_plugins(config, self.runtime_paths)
             except Exception:
@@ -751,10 +750,12 @@ class MultiAgentOrchestrator:
                     self.runtime_paths,
                 )
                 self._activate_hook_registry(recovery_result.hook_registry)
+                clear_worker_validation_snapshot_cache()
                 self._refresh_plugin_watch_state(config)
                 logger.warning(warning_message, source=source, **warning_kwargs)
                 raise
             self._activate_hook_registry(result.hook_registry)
+            clear_worker_validation_snapshot_cache()
             self._refresh_plugin_watch_state(config)
             logger.info(
                 "Plugin reload complete",
@@ -795,6 +796,7 @@ class MultiAgentOrchestrator:
                 prepared_plugin_root_snapshots,
             )
             self._activate_hook_registry(new_hook_registry)
+            clear_worker_validation_snapshot_cache()
             return pre_stopped_mcp_entities
 
     async def _start_entities_once(
@@ -1067,6 +1069,7 @@ class MultiAgentOrchestrator:
         self._activate_hook_registry(hook_registry)
         await self._sync_mcp_manager(new_config)
         await self._sync_runtime_support_services(new_config, start_watcher=self.running)
+        clear_worker_validation_snapshot_cache()
         return False
 
     async def _update_unchanged_bots(self, plan: ConfigUpdatePlan) -> None:
@@ -1191,6 +1194,7 @@ class MultiAgentOrchestrator:
         async with self._mcp_catalog_change_lock:
             if not self.running or self.config is None:
                 return
+            clear_worker_validation_snapshot_cache()
             changed_entities = self.config.get_entities_referencing_tools({mcp_tool_name(server_id)})
             if not changed_entities:
                 return
@@ -1233,7 +1237,6 @@ class MultiAgentOrchestrator:
     async def update_config(self) -> bool:
         """Reload configuration, restart affected entities, and reconcile room state."""
         new_config = load_config(self.runtime_paths, tolerate_plugin_load_errors=True)
-        clear_worker_validation_snapshot_cache()
 
         if not self.config:
             return await self._load_initial_config(new_config, self._build_hook_registry(new_config))
@@ -1269,6 +1272,7 @@ class MultiAgentOrchestrator:
             self.config = new_config
             self._sync_plugin_watch_roots(new_config)
             self._activate_hook_registry(self.hook_registry)
+            clear_worker_validation_snapshot_cache()
         changed_runtime_mcp_servers = await self._sync_mcp_manager(new_config)
         await self._sync_event_cache_service(new_config)
         logger.info(

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -70,6 +70,7 @@ from mindroom.tool_system.plugins import (
     reload_plugins,
 )
 from mindroom.tool_system.skills import clear_skill_cache, get_skill_snapshot
+from mindroom.workers.runtime import clear_worker_validation_snapshot_cache
 
 from . import file_watcher
 from .bot import AgentBot, TeamBot, create_bot_for_entity
@@ -741,6 +742,7 @@ class MultiAgentOrchestrator:
                 source=source,
                 changed_paths=[str(path) for path in changed_paths],
             )
+            clear_worker_validation_snapshot_cache()
             try:
                 result = reload_plugins(config, self.runtime_paths)
             except Exception:
@@ -1231,6 +1233,7 @@ class MultiAgentOrchestrator:
     async def update_config(self) -> bool:
         """Reload configuration, restart affected entities, and reconcile room state."""
         new_config = load_config(self.runtime_paths, tolerate_plugin_load_errors=True)
+        clear_worker_validation_snapshot_cache()
 
         if not self.config:
             return await self._load_initial_config(new_config, self._build_hook_registry(new_config))

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import threading
+from copy import deepcopy
+from hashlib import sha256
 from typing import TYPE_CHECKING
 
 from mindroom.constants import DEFAULT_WORKER_GRANTABLE_CREDENTIALS
@@ -22,6 +24,39 @@ _PRIMARY_WORKER_BACKEND_ENV = "MINDROOM_WORKER_BACKEND"
 _PRIMARY_WORKER_MANAGER: WorkerManager | None = None
 _PRIMARY_WORKER_MANAGER_CONFIG: tuple[str, ...] | None = None
 _PRIMARY_WORKER_MANAGER_LOCK = threading.Lock()
+_WORKER_VALIDATION_SNAPSHOT_CACHE: dict[tuple[str, ...], dict[str, dict[str, object]]] = {}
+_WORKER_VALIDATION_SNAPSHOT_CACHE_LOCK = threading.Lock()
+
+
+def _stable_json_digest(payload: object) -> str:
+    """Return a stable in-memory identity for JSON-like config payloads."""
+    serialized = json.dumps(payload, default=repr, separators=(",", ":"), sort_keys=True)
+    return sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _worker_validation_snapshot_cache_key(
+    runtime_paths: RuntimePaths,
+    runtime_config: Config,
+) -> tuple[str, ...]:
+    """Return the cheap explicit inputs that affect worker validation metadata."""
+    plugins_identity = [plugin_entry.model_dump(mode="json") for plugin_entry in runtime_config.plugins]
+    mcp_identity = {
+        server_id: server_config.model_dump(mode="json")
+        for server_id, server_config in runtime_config.mcp_servers.items()
+    }
+    return (
+        str(runtime_paths.config_path),
+        str(runtime_paths.config_dir),
+        str(runtime_paths.storage_root),
+        _stable_json_digest(plugins_identity),
+        _stable_json_digest(mcp_identity),
+    )
+
+
+def clear_worker_validation_snapshot_cache() -> None:
+    """Clear cached Kubernetes worker validation snapshots."""
+    with _WORKER_VALIDATION_SNAPSHOT_CACHE_LOCK:
+        _WORKER_VALIDATION_SNAPSHOT_CACHE.clear()
 
 
 def serialized_kubernetes_worker_validation_snapshot(
@@ -30,17 +65,29 @@ def serialized_kubernetes_worker_validation_snapshot(
     runtime_config: Config | None = None,
 ) -> dict[str, dict[str, object]]:
     """Build the authoritative worker validation snapshot in the primary runtime."""
-    from mindroom.config.main import load_config  # noqa: PLC0415
-    from mindroom.tool_system.catalog import (  # noqa: PLC0415
-        resolved_tool_validation_snapshot_for_runtime,
-        serialize_tool_validation_snapshot,
-    )
+    if runtime_config is None:
+        from mindroom.config.main import load_config  # noqa: PLC0415
 
-    snapshot = resolved_tool_validation_snapshot_for_runtime(
-        runtime_paths,
-        runtime_config or load_config(runtime_paths),
-    )
-    return serialize_tool_validation_snapshot(snapshot)
+        config = load_config(runtime_paths)
+    else:
+        config = runtime_config
+
+    with _WORKER_VALIDATION_SNAPSHOT_CACHE_LOCK:
+        cache_key = _worker_validation_snapshot_cache_key(runtime_paths, config)
+        cached_snapshot = _WORKER_VALIDATION_SNAPSHOT_CACHE.get(cache_key)
+        if cached_snapshot is None:
+            from mindroom.tool_system.catalog import (  # noqa: PLC0415
+                resolved_tool_validation_snapshot_for_runtime,
+                serialize_tool_validation_snapshot,
+            )
+
+            snapshot = resolved_tool_validation_snapshot_for_runtime(
+                runtime_paths,
+                config,
+            )
+            cached_snapshot = serialize_tool_validation_snapshot(snapshot)
+            _WORKER_VALIDATION_SNAPSHOT_CACHE[cache_key] = cached_snapshot
+        return deepcopy(cached_snapshot)
 
 
 def _normalize_backend_name(raw_value: str | None) -> str:
@@ -225,3 +272,4 @@ def _reset_primary_worker_manager() -> None:
     with _PRIMARY_WORKER_MANAGER_LOCK:
         _PRIMARY_WORKER_MANAGER = None
         _PRIMARY_WORKER_MANAGER_CONFIG = None
+    clear_worker_validation_snapshot_cache()

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -589,6 +589,24 @@ def test_load_config_into_app_ignores_runtime_mismatches_after_api_runtime_swap(
     assert main._app_context(fresh_app).config_load_result == main.ConfigLoadResult(success=True)
 
 
+def test_reload_api_runtime_config_does_not_clear_worker_snapshot_on_failed_load(tmp_path: Path) -> None:
+    """Failed API config loads should keep the last-good worker validation cache."""
+    fresh_app = FastAPI()
+    runtime_paths = _runtime_paths(tmp_path)
+    main.initialize_api_app(fresh_app, runtime_paths)
+    failure = main.ConfigLoadResult(success=False, error_status_code=422, error_detail="bad config")
+
+    with (
+        patch.object(config_lifecycle, "_load_config_result", return_value=(failure, None, None)),
+        patch("mindroom.api.main.clear_worker_validation_snapshot_cache") as mock_clear_snapshot_cache,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        main._reload_api_runtime_config(fresh_app, runtime_paths)
+
+    assert exc_info.value.status_code == 422
+    mock_clear_snapshot_cache.assert_not_called()
+
+
 def test_read_app_committed_config_uses_current_context_after_runtime_swap(tmp_path: Path) -> None:
     """Read helpers should use the runtime context that is current after locking."""
     fresh_app = FastAPI()

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2251,11 +2251,14 @@ def test_resolve_agent_runtime_skips_missing_private_template_copy_for_dedicated
         create=True,
     )
 
-    expected_workspace = _private_instance_state_root_path(
-        shared_root,
-        worker_key=worker_key,
-        agent_name="general",
-    ) / "mind_data"
+    expected_workspace = (
+        _private_instance_state_root_path(
+            shared_root,
+            worker_key=worker_key,
+            agent_name="general",
+        )
+        / "mind_data"
+    )
     assert agent_runtime.workspace is not None
     assert agent_runtime.workspace.root == expected_workspace
     assert expected_workspace.is_dir()

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -110,6 +110,7 @@ async def test_handle_mcp_catalog_change_restarts_dependent_entities(tmp_path: P
             new=AsyncMock(return_value=EntityStartResults(retryable_entities=["code"])),
         ) as mock_create_and_start,
         patch.object(orchestrator, "_schedule_bot_start_retry", new=AsyncMock()) as mock_schedule_retry,
+        patch("mindroom.orchestrator.clear_worker_validation_snapshot_cache") as mock_clear_snapshot_cache,
     ):
         await orchestrator._handle_mcp_catalog_change("demo")
 
@@ -119,6 +120,7 @@ async def test_handle_mcp_catalog_change_restarts_dependent_entities(tmp_path: P
     assert mock_create_and_start.await_args.kwargs["start_sync_tasks"] is True
     assert {args.args[0] for args in mock_cancel.await_args_list} == {"code", "dev_team"}
     mock_schedule_retry.assert_awaited_once_with("code")
+    mock_clear_snapshot_cache.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -11030,6 +11030,7 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.load_plugins", return_value=[]),
             patch("mindroom.orchestrator.HookRegistry.from_plugins", return_value=new_hook_registry),
             patch("mindroom.orchestrator.set_scheduling_hook_registry") as mock_set_scheduling_hook_registry,
+            patch("mindroom.orchestrator.clear_worker_validation_snapshot_cache") as mock_clear_snapshot_cache,
             patch("mindroom.orchestrator.build_config_update_plan", return_value=plan),
             patch.object(
                 orchestrator,
@@ -11043,6 +11044,7 @@ class TestMultiAgentOrchestrator:
         assert orchestrator.config is current_config
         assert orchestrator.hook_registry is old_hook_registry
         mock_set_scheduling_hook_registry.assert_not_called()
+        mock_clear_snapshot_cache.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_update_config_does_not_stop_mcp_entities_before_plugin_reload_succeeds(
@@ -11094,6 +11096,7 @@ class TestMultiAgentOrchestrator:
                 "mindroom.orchestrator.prepare_plugin_reload",
                 side_effect=RuntimeError("broken plugin"),
             ),
+            patch("mindroom.orchestrator.clear_worker_validation_snapshot_cache") as mock_clear_snapshot_cache,
             pytest.raises(RuntimeError, match="broken plugin"),
         ):
             await orchestrator.update_config()
@@ -11101,6 +11104,7 @@ class TestMultiAgentOrchestrator:
         stop_entities_before_mcp_sync.assert_not_awaited()
         assert bot.running is True
         assert orchestrator.config is current_config
+        mock_clear_snapshot_cache.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_update_config_does_not_leak_plugin_state_before_config_commit(

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -43,6 +43,7 @@ from mindroom.tool_system.metadata import (
     ConfigField,
     ToolCategory,
     ToolInitOverrideError,
+    ToolValidationInfo,
     get_tool_by_name,
     register_tool_with_metadata,
     resolved_tool_validation_snapshot_for_runtime,
@@ -2179,6 +2180,62 @@ def test_get_worker_manager_passes_committed_snapshot_from_tool_runtime_context(
         sandbox_proxy_module._get_worker_manager(runtime_paths, proxy_config)
 
     assert captured_kwargs["kubernetes_tool_validation_snapshot"] is not None
+
+
+def test_get_worker_manager_reuses_cached_kubernetes_validation_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated proxy worker-manager access should not repeatedly resolve validation metadata."""
+    workers_runtime_module.clear_worker_validation_snapshot_cache()
+    monkeypatch.setenv("MINDROOM_WORKER_BACKEND", "kubernetes")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_IMAGE", "ghcr.io/mindroom-ai/mindroom:latest")
+    monkeypatch.setenv("MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME", "mindroom-storage")
+    runtime_paths = _configure_proxy_runtime(
+        monkeypatch,
+        proxy_url=None,
+        proxy_token=_TEST_AUTH_TOKEN,
+        execution_mode="off",
+    )
+    runtime_config = Config()
+    resolver_call_count = 0
+    captured_snapshots: list[dict[str, dict[str, object]]] = []
+
+    def fake_resolver(*_args: object, **_kwargs: object) -> dict[str, ToolValidationInfo]:
+        nonlocal resolver_call_count
+        resolver_call_count += 1
+        return {"fake": ToolValidationInfo(name="fake")}
+
+    def fake_get_primary_worker_manager(*_args: object, **kwargs: object) -> object:
+        captured_snapshots.append(kwargs["kubernetes_tool_validation_snapshot"])
+        return object()
+
+    runtime_context = ToolRuntimeContext(
+        agent_name="code",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        requester_id="@user:example.org",
+        client=object(),
+        config=runtime_config,
+        runtime_paths=runtime_paths,
+        event_cache=make_event_cache_mock(),
+        conversation_cache=make_conversation_cache_mock(),
+    )
+    proxy_config = sandbox_proxy_module.sandbox_proxy_config(runtime_paths)
+    monkeypatch.setattr(
+        "mindroom.tool_system.catalog.resolved_tool_validation_snapshot_for_runtime",
+        fake_resolver,
+    )
+    monkeypatch.setattr(sandbox_proxy_module, "get_primary_worker_manager", fake_get_primary_worker_manager)
+
+    with tool_runtime_context(runtime_context):
+        sandbox_proxy_module._get_worker_manager(runtime_paths, proxy_config)
+        sandbox_proxy_module._get_worker_manager(runtime_paths, proxy_config)
+
+    assert resolver_call_count == 1
+    assert len(captured_snapshots) == 2
+    assert captured_snapshots[0] == captured_snapshots[1]
+    assert captured_snapshots[0] is not captured_snapshots[1]
 
 
 def test_worker_tools_override_can_use_kubernetes_backend_without_proxy_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -1,0 +1,215 @@
+"""Tests for primary-runtime worker validation snapshot caching."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom.config.main import Config
+from mindroom.constants import RuntimePaths, resolve_runtime_paths
+from mindroom.tool_system.metadata import ToolValidationInfo
+from mindroom.workers import runtime as workers_runtime_module
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _clear_worker_validation_snapshot_cache() -> Iterator[None]:
+    """Isolate the process-local worker validation snapshot cache."""
+    workers_runtime_module.clear_worker_validation_snapshot_cache()
+    yield
+    workers_runtime_module.clear_worker_validation_snapshot_cache()
+
+
+def _runtime_paths(tmp_path: Path) -> RuntimePaths:
+    """Return a runtime path set rooted under one pytest temp directory."""
+    return resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+
+
+def test_serialized_kubernetes_worker_validation_snapshot_reuses_cached_resolver_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Repeated snapshot requests for one config should invoke the resolver once."""
+    runtime_paths = _runtime_paths(tmp_path)
+    runtime_config = Config()
+    calls: list[Config] = []
+
+    def fake_resolver(*_args: object, **_kwargs: object) -> dict[str, ToolValidationInfo]:
+        calls.append(runtime_config)
+        return {"fake": ToolValidationInfo(name="fake")}
+
+    monkeypatch.setattr(
+        "mindroom.tool_system.catalog.resolved_tool_validation_snapshot_for_runtime",
+        fake_resolver,
+    )
+
+    first_snapshot = workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=runtime_config,
+    )
+    second_snapshot = workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=runtime_config,
+    )
+
+    assert len(calls) == 1
+    assert first_snapshot == second_snapshot
+
+
+def test_serialized_kubernetes_worker_validation_snapshot_clear_recomputes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Manual invalidation should force a fresh resolver call."""
+    runtime_paths = _runtime_paths(tmp_path)
+    runtime_config = Config()
+    calls = 0
+
+    def fake_resolver(*_args: object, **_kwargs: object) -> dict[str, ToolValidationInfo]:
+        nonlocal calls
+        calls += 1
+        return {"fake": ToolValidationInfo(name="fake")}
+
+    monkeypatch.setattr(
+        "mindroom.tool_system.catalog.resolved_tool_validation_snapshot_for_runtime",
+        fake_resolver,
+    )
+
+    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=runtime_config,
+    )
+    workers_runtime_module.clear_worker_validation_snapshot_cache()
+    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=runtime_config,
+    )
+
+    assert calls == 2
+
+
+def test_serialized_kubernetes_worker_validation_snapshot_returns_independent_copies(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Callers should not be able to mutate the cached snapshot payload."""
+    runtime_paths = _runtime_paths(tmp_path)
+    runtime_config = Config()
+    calls = 0
+
+    def fake_resolver(*_args: object, **_kwargs: object) -> dict[str, ToolValidationInfo]:
+        nonlocal calls
+        calls += 1
+        return {"fake": ToolValidationInfo(name="fake")}
+
+    monkeypatch.setattr(
+        "mindroom.tool_system.catalog.resolved_tool_validation_snapshot_for_runtime",
+        fake_resolver,
+    )
+
+    first_snapshot = workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=runtime_config,
+    )
+    first_snapshot["fake"]["config_fields"].append({"name": "mutated"})
+    second_snapshot = workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=runtime_config,
+    )
+
+    assert calls == 1
+    assert second_snapshot["fake"]["config_fields"] == []
+
+
+def test_serialized_kubernetes_worker_validation_snapshot_cache_key_includes_mcp_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """MCP config changes should produce a distinct validation snapshot cache key."""
+    runtime_paths = _runtime_paths(tmp_path)
+    first_config = Config(
+        mcp_servers={
+            "alpha": {
+                "transport": "stdio",
+                "command": "alpha-server",
+            },
+        },
+    )
+    second_config = Config(
+        mcp_servers={
+            "beta": {
+                "transport": "stdio",
+                "command": "beta-server",
+            },
+        },
+    )
+    calls = 0
+
+    def fake_resolver(*_args: object, **_kwargs: object) -> dict[str, ToolValidationInfo]:
+        nonlocal calls
+        calls += 1
+        return {"fake": ToolValidationInfo(name="fake")}
+
+    monkeypatch.setattr(
+        "mindroom.tool_system.catalog.resolved_tool_validation_snapshot_for_runtime",
+        fake_resolver,
+    )
+
+    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=first_config,
+    )
+    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=first_config,
+    )
+    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=second_config,
+    )
+
+    assert calls == 2
+
+
+def test_serialized_kubernetes_worker_validation_snapshot_cache_key_includes_plugin_entries(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Plugin config changes should produce a distinct validation snapshot cache key."""
+    runtime_paths = _runtime_paths(tmp_path)
+    first_config = Config(plugins=[{"path": "plugins/one"}])
+    second_config = Config(plugins=[{"path": "plugins/two"}])
+    calls = 0
+
+    def fake_resolver(*_args: object, **_kwargs: object) -> dict[str, ToolValidationInfo]:
+        nonlocal calls
+        calls += 1
+        return {"fake": ToolValidationInfo(name="fake")}
+
+    monkeypatch.setattr(
+        "mindroom.tool_system.catalog.resolved_tool_validation_snapshot_for_runtime",
+        fake_resolver,
+    )
+
+    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=first_config,
+    )
+    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=first_config,
+    )
+    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+        runtime_paths,
+        runtime_config=second_config,
+    )
+
+    assert calls == 2


### PR DESCRIPTION
## Summary
- cache serialized Kubernetes worker validation snapshots by explicit runtime/config/plugin/MCP identity
- clear the cache only after successful config/API/plugin activation, plus explicit MCP catalog-change notifications
- return deep-copied snapshots so callers cannot mutate cached state
- add unit coverage for reuse, invalidation, copy safety, plugin/MCP keying, sandbox worker-manager reuse, and failed reload cache preservation
- include the hook-generated docs and formatting fixes from `pre-commit run --all-files`

## Validation
- `uv run pytest tests/test_worker_runtime.py tests/test_sandbox_proxy.py::test_get_worker_manager_reuses_cached_kubernetes_validation_snapshot tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_update_config_does_not_swap_hook_runtime_on_failed_reload tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_update_config_does_not_stop_mcp_entities_before_plugin_reload_succeeds tests/test_mcp_orchestrator.py::test_handle_mcp_catalog_change_restarts_dependent_entities tests/api/test_api.py::test_reload_api_runtime_config_does_not_clear_worker_snapshot_on_failed_load -q -n 0 --no-cov`
- `uv run ruff check src/mindroom/workers/runtime.py src/mindroom/orchestrator.py src/mindroom/api/main.py tests/test_worker_runtime.py tests/test_sandbox_proxy.py tests/test_multi_agent_bot.py tests/test_mcp_orchestrator.py tests/api/test_api.py src/mindroom/knowledge/manager.py tests/test_agents.py`
- `uv run ruff format --check src/mindroom/workers/runtime.py src/mindroom/orchestrator.py src/mindroom/api/main.py tests/test_worker_runtime.py tests/test_sandbox_proxy.py tests/test_multi_agent_bot.py tests/test_mcp_orchestrator.py tests/api/test_api.py src/mindroom/knowledge/manager.py tests/test_agents.py`
- `uv run pre-commit run --all-files`
- `uv run pytest` (`5432 passed, 50 skipped`)

## Notes
- `uv sync --all-extras` failed locally while building `python-olm==3.2.16` due a libolm C++ compile error, but the existing environment was usable and the full test suite passed.
