### PR TITLE
Fix shell reader hang after foreground exit

### DIFF
--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -62,6 +62,8 @@ _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS = frozenset(
 _STALE_RECORD_SECONDS = 600  # 10 minutes
 _MAX_BACKGROUNDED = 16
 _MAX_OUTPUT_LINES = 10_000
+_PROCESS_EXIT_POLL_INTERVAL_SECONDS = 0.05
+_POST_EXIT_READER_GRACE_SECONDS = 0.5
 _SHELL_ARGS_ERROR = '\'args\' must be a flat list of strings. Send args like ["bash", "-lc", "ls"].'
 
 # Module-level process registry shared across all MindRoomShellTools instances.
@@ -343,7 +345,7 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
 
             try:
                 try:
-                    await asyncio.wait_for(process.wait(), timeout=timeout)
+                    await _await_foreground_process_exit(process, timeout_seconds=timeout)
                 except TimeoutError:
                     active = sum(1 for r in self._processes.values() if not r.finished)
                     if active >= _MAX_BACKGROUNDED:
@@ -379,14 +381,18 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
                         f"kill_shell_command('{handle}') to stop."
                     )
 
-                await stdout_reader
-                await stderr_reader
+                await _await_reader_tasks_with_grace(
+                    stdout_reader,
+                    stderr_reader,
+                    grace_seconds=_POST_EXIT_READER_GRACE_SECONDS,
+                )
             except asyncio.CancelledError:
                 if background_handle is not None:
                     self._processes.pop(background_handle, None)
                 if background_monitor_task is not None:
                     background_monitor_task.cancel()
-                await _terminate_process_group(process)
+                if process.returncode is None:
+                    await _terminate_process_group(process)
                 await _cancel_pending_tasks(stdout_reader, stderr_reader)
                 if background_monitor_task is not None:
                     with contextlib.suppress(asyncio.CancelledError):
@@ -502,6 +508,59 @@ async def _cancel_pending_tasks(*tasks: asyncio.Task[None]) -> None:
     for task in pending_tasks:
         with contextlib.suppress(asyncio.CancelledError):
             await task
+
+
+async def _await_foreground_process_exit(
+    process: asyncio.subprocess.Process,
+    *,
+    timeout_seconds: float,
+) -> None:
+    """Wait for the foreground process to exit without depending on pipe EOF."""
+    if process.returncode is not None:
+        return
+    if timeout_seconds <= 0:
+        raise TimeoutError
+
+    wait_task = asyncio.create_task(process.wait())
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    try:
+        while process.returncode is None:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise TimeoutError
+            done_tasks, _pending_tasks = await asyncio.wait(
+                (wait_task,),
+                timeout=min(_PROCESS_EXIT_POLL_INTERVAL_SECONDS, remaining),
+            )
+            if wait_task in done_tasks:
+                await wait_task
+                return
+    finally:
+        if not wait_task.done():
+            wait_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await wait_task
+
+
+async def _await_reader_tasks_with_grace(
+    stdout_reader: asyncio.Task[None],
+    stderr_reader: asyncio.Task[None],
+    *,
+    grace_seconds: float,
+) -> None:
+    """Drain reader tasks briefly after foreground exit, then stop waiting for EOF."""
+    reader_tasks = (stdout_reader, stderr_reader)
+    done_tasks, pending_tasks = await asyncio.wait(reader_tasks, timeout=grace_seconds)
+
+    try:
+        for task in done_tasks:
+            await task
+    finally:
+        for task in pending_tasks:
+            task.cancel()
+        for task in pending_tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
 
 async def _terminate_process_group(

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import os
+import signal
+import sys
 import time
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -41,6 +45,64 @@ def _get_toolkit(tmp_path: Path) -> Toolkit:
     return get_tool_by_name("shell", runtime_paths, disable_sandbox_proxy=True, worker_target=None)
 
 
+def _fork_child_holding_stdio_script(*, parent_stderr: str = "", parent_exit_code: int = 0) -> str:
+    return (
+        "import os\n"
+        "import pathlib\n"
+        "import signal\n"
+        "import sys\n"
+        "import time\n"
+        "stop_file = pathlib.Path(sys.argv[2])\n"
+        "def stop_child(signum, frame):\n"
+        "    stop_file.write_text('stopped', encoding='utf-8')\n"
+        "    os._exit(0)\n"
+        f"sys.stderr.write({parent_stderr!r})\n"
+        "sys.stderr.flush()\n"
+        "pid = os.fork()\n"
+        "if pid:\n"
+        "    pathlib.Path(sys.argv[1]).write_text(str(pid), encoding='utf-8')\n"
+        f"    sys.exit({parent_exit_code})\n"
+        "signal.signal(signal.SIGTERM, stop_child)\n"
+        "time.sleep(30)\n"
+    )
+
+
+async def _wait_for_pid_file(pid_file: Path) -> int:
+    for _ in range(50):
+        if pid_file.exists():
+            return int(pid_file.read_text(encoding="utf-8").strip())
+        await asyncio.sleep(0.05)
+    message = f"PID file was not written: {pid_file}"
+    raise AssertionError(message)
+
+
+async def _stop_recorded_child(pid: int, stop_file: Path) -> None:
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.kill(pid, signal.SIGTERM)
+
+    for _ in range(20):
+        if stop_file.exists():
+            return
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        await asyncio.sleep(0.05)
+
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.kill(pid, signal.SIGKILL)
+
+    for _ in range(20):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        await asyncio.sleep(0.05)
+
+    message = f"Child process {pid} did not stop"
+    raise AssertionError(message)
+
+
 def _get_run_shell_command_function(tool: Toolkit) -> Function:
     return tool.async_functions["run_shell_command"]
 
@@ -63,6 +125,17 @@ async def test_run_shell_command_returns_output(tmp_path: Path) -> None:
 
     result = await entrypoint(["echo", "hello world"])
     assert result == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_run_shell_command_bash_echo_returns_output(tmp_path: Path) -> None:
+    """Normal shell output should still be returned."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    result = await entrypoint(["bash", "-lc", "echo hello"])
+    assert result == "hello"
 
 
 def test_run_shell_command_schema_keeps_args_as_string_array(tmp_path: Path) -> None:
@@ -145,6 +218,74 @@ async def test_run_shell_command_returns_error_on_nonzero_exit(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+async def test_run_shell_command_returns_after_foreground_exit_with_inherited_pipe_child(tmp_path: Path) -> None:
+    """Regression: tmux/auth helpers/watchers/daemons can inherit pipes after foreground exit."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    pid_file = tmp_path / "child.pid"
+    stop_file = tmp_path / "child.stopped"
+    command = [sys.executable, "-c", _fork_child_holding_stdio_script(), str(pid_file), str(stop_file)]
+    started = time.perf_counter()
+    task = asyncio.create_task(entrypoint(command, timeout=10))
+    child_pid: int | None = None
+
+    try:
+        child_pid = await _wait_for_pid_file(pid_file)
+        result = await asyncio.wait_for(task, timeout=2)
+    finally:
+        if child_pid is not None:
+            await _stop_recorded_child(child_pid, stop_file)
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    elapsed = time.perf_counter() - started
+    assert elapsed < 2
+    assert result == ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+async def test_run_shell_command_nonzero_foreground_exit_with_inherited_pipe_child(tmp_path: Path) -> None:
+    """Nonzero foreground exit should return buffered stderr without waiting for descendant EOF."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    pid_file = tmp_path / "child-error.pid"
+    stop_file = tmp_path / "child-error.stopped"
+    command = [
+        sys.executable,
+        "-c",
+        _fork_child_holding_stdio_script(parent_stderr="foreground failed\n", parent_exit_code=7),
+        str(pid_file),
+        str(stop_file),
+    ]
+    started = time.perf_counter()
+    task = asyncio.create_task(entrypoint(command, timeout=10))
+    child_pid: int | None = None
+
+    try:
+        child_pid = await _wait_for_pid_file(pid_file)
+        result = await asyncio.wait_for(task, timeout=2)
+    finally:
+        if child_pid is not None:
+            await _stop_recorded_child(child_pid, stop_file)
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    elapsed = time.perf_counter() - started
+    assert elapsed < 2
+    assert result == "Error: foreground failed"
+
+
+@pytest.mark.asyncio
 async def test_run_shell_command_tail_parameter(tmp_path: Path) -> None:
     """Only the last N lines should be returned."""
     tool = _get_toolkit(tmp_path)
@@ -161,7 +302,9 @@ async def test_run_shell_command_returns_handle_on_timeout(tmp_path: Path) -> No
     """Command exceeding timeout should return a handle."""
     tool = _get_toolkit(tmp_path)
     entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    check_fn = tool.functions["check_shell_command"].entrypoint
     assert entrypoint is not None
+    assert check_fn is not None
 
     result = await entrypoint(["sleep", "300"], timeout=1)
 
@@ -171,6 +314,7 @@ async def test_run_shell_command_returns_handle_on_timeout(tmp_path: Path) -> No
 
     # Extract handle and clean up
     handle = result.split("Handle: ")[1].split("\n")[0]
+    assert "RUNNING" in check_fn(handle)
     kill_fn = tool.functions["kill_shell_command"].entrypoint
     kill_fn(handle, force=True)
     await asyncio.sleep(0.1)

--- a/tests/test_shell_cancel.py
+++ b/tests/test_shell_cancel.py
@@ -9,7 +9,7 @@ import signal
 import sys
 import time
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -64,6 +64,44 @@ async def _assert_pid_dead(pid: int) -> None:
     raise AssertionError(message)
 
 
+def _fork_child_holding_stdio_script() -> str:
+    return (
+        "import os\n"
+        "import pathlib\n"
+        "import signal\n"
+        "import sys\n"
+        "import time\n"
+        "stop_file = pathlib.Path(sys.argv[2])\n"
+        "def stop_child(signum, frame):\n"
+        "    stop_file.write_text('stopped', encoding='utf-8')\n"
+        "    os._exit(0)\n"
+        "pid = os.fork()\n"
+        "if pid:\n"
+        "    pathlib.Path(sys.argv[1]).write_text(str(pid), encoding='utf-8')\n"
+        "    sys.exit(0)\n"
+        "signal.signal(signal.SIGTERM, stop_child)\n"
+        "time.sleep(30)\n"
+    )
+
+
+async def _stop_recorded_child(pid: int, stop_file: Path) -> None:
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.kill(pid, signal.SIGTERM)
+
+    for _ in range(20):
+        if stop_file.exists():
+            return
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        await asyncio.sleep(0.05)
+
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.kill(pid, signal.SIGKILL)
+    await _assert_pid_dead(pid)
+
+
 @pytest.fixture(autouse=True)
 def clear_process_registry() -> Iterator[None]:
     """Ensure subprocess registry state does not leak between tests."""
@@ -91,17 +129,19 @@ async def test_run_shell_command_cancellation_kills_subprocess(tmp_path: Path) -
         str(pid_file),
     ]
 
-    task = asyncio.create_task(run_shell_command(command, timeout=120))
-    pid = await _wait_for_pid(pid_file)
-    await asyncio.sleep(0.1)
+    with patch("mindroom.tools.shell.os.killpg", wraps=os.killpg) as killpg_mock:
+        task = asyncio.create_task(run_shell_command(command, timeout=120))
+        pid = await _wait_for_pid(pid_file)
+        await asyncio.sleep(0.1)
 
-    started_cancel = time.perf_counter()
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
-    elapsed = time.perf_counter() - started_cancel
+        started_cancel = time.perf_counter()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        elapsed = time.perf_counter() - started_cancel
 
     await _assert_pid_dead(pid)
+    killpg_mock.assert_called()
     assert elapsed < 2.0
     assert _process_registry == {}
 
@@ -178,4 +218,53 @@ async def test_run_shell_command_cancellation_cleans_up_background_handle(tmp_pa
             await task
 
     await _assert_pid_dead(pid)
+    assert _process_registry == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+async def test_run_shell_command_cancellation_after_foreground_exit_does_not_terminate_group(tmp_path: Path) -> None:
+    """Cancelling after foreground exit should cancel readers without process-group termination."""
+    run_shell_command = _get_run_shell_command(tmp_path)
+    pid_file = tmp_path / "inherited-child.pid"
+    stop_file = tmp_path / "inherited-child.stopped"
+    command = [sys.executable, "-c", _fork_child_holding_stdio_script(), str(pid_file), str(stop_file)]
+    grace_entered = asyncio.Event()
+    release_grace = asyncio.Event()
+
+    async def blocked_reader_grace(
+        stdout_reader: object,
+        stderr_reader: object,
+        *,
+        grace_seconds: float,
+    ) -> None:
+        del stdout_reader, stderr_reader, grace_seconds
+        grace_entered.set()
+        await release_grace.wait()
+
+    child_pid: int | None = None
+    terminate_process_group = AsyncMock()
+
+    with (
+        patch("mindroom.tools.shell._await_reader_tasks_with_grace", new=blocked_reader_grace),
+        patch("mindroom.tools.shell._terminate_process_group", new=terminate_process_group),
+    ):
+        task = asyncio.create_task(run_shell_command(command, timeout=120))
+        try:
+            child_pid = await _wait_for_pid(pid_file)
+            await asyncio.wait_for(grace_entered.wait(), timeout=2)
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            release_grace.set()
+            if child_pid is not None:
+                await _stop_recorded_child(child_pid, stop_file)
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+    terminate_process_group.assert_not_awaited()
     assert _process_registry == {}


### PR DESCRIPTION
## Summary
- Bound post-foreground-exit stdout/stderr reader waits so completed shell commands do not hang when a descendant keeps inherited pipes open.
- Preserve buffered output/error handling and the existing timeout-to-background-handle path.
- Avoid process-group termination on external cancellation after the foreground process has already exited.

## Rationale
This bug makes completed shell commands look like multi-minute hangs when they spawn tmux/auth helpers/watchers/daemons that inherit stdout/stderr.
The parent cannot force EOF for write FDs held by descendants, so the tool should stop waiting for EOF after the foreground process exits.

## Tests
- `uv run pre-commit run --all-files`
- `uv run pytest tests/test_shell_async.py tests/test_shell_cancel.py -q`
- `uv run pytest` (5436 passed, 50 skipped)

## Note
- `uv sync --all-extras` was attempted first but failed locally while rebuilding `python-olm==3.2.16` on macOS/clang.
  The existing `.venv` was usable for pre-commit and pytest.
