### PR TITLE
fix(matrix): preserve rich streaming edit previews

### DIFF
--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -23,6 +23,7 @@ from mindroom.constants import (
     STREAM_WARMUP_SUFFIX_KEY,
 )
 from mindroom.logging_config import get_logger
+from mindroom.matrix.message_builder import markdown_to_html
 
 logger = get_logger(__name__)
 
@@ -78,6 +79,40 @@ def _copy_edit_wrapper_metadata(source_content: dict[str, Any], target_content: 
     )
 
 
+def _copy_inline_streaming_preview_metadata(source_content: dict[str, Any], target_content: dict[str, Any]) -> None:
+    """Copy metadata that should remain inline on rich streaming previews."""
+    _copy_preview_metadata(source_content, target_content)
+
+
+def _room_is_encrypted(client: nio.AsyncClient, room_id: str | None) -> bool:
+    return bool(room_id and room_id in client.rooms and client.rooms[room_id].encrypted)
+
+
+def _add_sidecar_metadata(
+    target_content: dict[str, Any],
+    *,
+    room_encrypted: bool,
+    mxc_uri: str | None,
+    file_info: dict[str, Any] | None,
+    original_size: int,
+) -> None:
+    if mxc_uri is None or file_info is None:
+        return
+
+    if room_encrypted:
+        target_content["file"] = file_info
+    else:
+        target_content["url"] = mxc_uri
+
+    target_content["io.mindroom.long_text"] = {
+        "version": 2,
+        "encoding": "matrix_event_content_json",
+        "original_event_size": original_size,
+        "preview_size": len(target_content["body"]),
+        "is_complete_content": True,
+    }
+
+
 def _calculate_event_size(content: dict[str, Any]) -> int:
     """Calculate the approximate size of a Matrix event.
 
@@ -110,8 +145,13 @@ def _build_nonterminal_streaming_edit_preview(
     content: dict[str, Any],
     source_content: dict[str, Any],
     preview_text: str,
+    *,
+    room_encrypted: bool,
+    mxc_uri: str | None,
+    file_info: dict[str, Any] | None,
+    original_size: int,
 ) -> dict[str, Any] | None:
-    """Build an in-progress edit preview without uploading an obsolete sidecar."""
+    """Build an in-progress rich edit preview with a fresh full-content sidecar."""
     preview_limit = _NONTERMINAL_STREAM_PREVIEW_BYTES
     while True:
         preview = _create_preview(
@@ -119,14 +159,26 @@ def _build_nonterminal_streaming_edit_preview(
             preview_limit,
             continuation_indicator=_STREAMING_PREVIEW_TRUNCATION_INDICATOR,
         )
+        formatted_preview = markdown_to_html(preview)
         preview_content: dict[str, Any] = {
             "msgtype": source_content.get("msgtype", "m.text"),
             "body": preview,
+            "format": "org.matrix.custom.html",
+            "formatted_body": formatted_preview,
         }
-        _copy_preview_metadata(source_content, preview_content)
+        _copy_inline_streaming_preview_metadata(source_content, preview_content)
+        _add_sidecar_metadata(
+            preview_content,
+            room_encrypted=room_encrypted,
+            mxc_uri=mxc_uri,
+            file_info=file_info,
+            original_size=original_size,
+        )
         modified_content: dict[str, Any] = {
             "msgtype": "m.text",
             "body": f"* {preview}",
+            "format": "org.matrix.custom.html",
+            "formatted_body": formatted_preview,
             "m.new_content": preview_content,
             "m.relates_to": content.get("m.relates_to", {}),
         }
@@ -134,8 +186,9 @@ def _build_nonterminal_streaming_edit_preview(
         if _calculate_event_size(modified_content) <= _MATRIX_EVENT_HARD_LIMIT:
             return modified_content
         if preview_limit == 0:
-            return None
+            break
         preview_limit = max(0, preview_limit // 2)
+    return None
 
 
 def _prefix_by_bytes(text: str, max_bytes: int) -> str:
@@ -290,10 +343,7 @@ async def _build_file_content(
     size_limit: int,
 ) -> tuple[str | None, dict[str, Any] | None, dict[str, Any]]:
     """Upload full original content JSON and build preview ``m.file`` event."""
-    upload_text = json.dumps(full_content, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-    upload_mimetype = "application/json"
-
-    mxc_uri, file_info = await _upload_text_as_mxc(client, upload_text, room_id, mimetype=upload_mimetype)
+    mxc_uri, file_info = await _upload_content_json_sidecar(client, room_id, full_content)
 
     attachment_overhead = 5000  # Conservative estimate for attachment JSON structure
     available = size_limit - attachment_overhead
@@ -307,6 +357,16 @@ async def _build_file_content(
     }
 
     return mxc_uri, file_info, modified_content
+
+
+async def _upload_content_json_sidecar(
+    client: nio.AsyncClient,
+    room_id: str,
+    full_content: dict[str, Any],
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Upload full original content JSON for supported-client hydration."""
+    upload_text = json.dumps(full_content, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return await _upload_text_as_mxc(client, upload_text, room_id, mimetype="application/json")
 
 
 async def prepare_large_message(
@@ -341,7 +401,21 @@ async def prepare_large_message(
     source_content = content["m.new_content"] if is_edit and "m.new_content" in content else content
     preview_text = source_content["body"]
     if is_edit and _is_nonterminal_stream_content(source_content):
-        modified_content = _build_nonterminal_streaming_edit_preview(content, source_content, preview_text)
+        logger.info(
+            "large_streaming_edit_sidecar_upload_started",
+            room_id=room_id,
+            original_size_bytes=current_size,
+        )
+        mxc_uri, file_info = await _upload_content_json_sidecar(client, room_id, content)
+        modified_content = _build_nonterminal_streaming_edit_preview(
+            content,
+            source_content,
+            preview_text,
+            room_encrypted=_room_is_encrypted(client, room_id),
+            mxc_uri=mxc_uri,
+            file_info=file_info,
+            original_size=current_size,
+        )
         if modified_content is not None:
             inner: dict[str, Any] = modified_content["m.new_content"]
             logger.info(
@@ -350,6 +424,7 @@ async def prepare_large_message(
                 original_size_bytes=current_size,
                 preview_length=len(inner["body"]),
                 final_size_bytes=_calculate_event_size(modified_content),
+                has_sidecar="io.mindroom.long_text" in inner,
             )
             return modified_content
 
@@ -369,19 +444,13 @@ async def prepare_large_message(
     )
 
     _copy_preview_metadata(source_content, modified_content)
-
-    if room_id and room_id in client.rooms and client.rooms[room_id].encrypted:
-        modified_content["file"] = file_info
-    else:
-        modified_content["url"] = mxc_uri
-
-    modified_content["io.mindroom.long_text"] = {
-        "version": 2,
-        "encoding": "matrix_event_content_json",
-        "original_event_size": current_size,
-        "preview_size": len(modified_content["body"]),
-        "is_complete_content": True,
-    }
+    _add_sidecar_metadata(
+        modified_content,
+        room_encrypted=_room_is_encrypted(client, room_id),
+        mxc_uri=mxc_uri,
+        file_info=file_info,
+        original_size=current_size,
+    )
 
     if "m.relates_to" in content:
         modified_content["m.relates_to"] = content["m.relates_to"]

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -213,24 +213,36 @@ async def test_prepare_edit_message() -> None:
 
 
 @pytest.mark.asyncio
-async def test_prepare_nonterminal_streaming_edit_uses_preview_without_sidecar() -> None:
-    """In-progress stream edits should not upload obsolete full-content sidecars."""
+async def test_prepare_nonterminal_streaming_edit_uses_rich_inline_preview() -> None:
+    """Oversized in-progress stream edits keep an HTML preview and fresh sidecar."""
 
     class MockClient:
         rooms: dict = {}  # noqa: RUF012
+        uploaded_data: bytes | None = None
 
-        async def upload(self, **_kwargs: object) -> tuple:
-            msg = "non-terminal stream edit should not upload a sidecar"
-            raise AssertionError(msg)
+        async def upload(self, **kwargs) -> tuple:  # noqa: ANN003
+            data_provider = kwargs.get("data_provider")
+            if data_provider:
+                data = data_provider(None, None)
+                self.uploaded_data = data.read()
+            response = nio.UploadResponse.from_dict({"content_uri": "mxc://server/streaming-preview"})
+            return response, None
 
     client = MockClient()
-    text = "streaming " * 10000
+    text = ("streaming **markdown**\n\n🔧 `save_file` [1]\n" * 1000) + "tail"
+    formatted_body = "<p>streaming <strong>markdown</strong></p><p>🔧 <code>save_file</code> [1]</p>" * 1000
+    tool_trace = {"version": 2, "events": [{"type": "tool_call_started", "tool_name": "save_file"}]}
     edit_content = {
         "body": f"* {text}",
+        "format": "org.matrix.custom.html",
+        "formatted_body": formatted_body,
         "m.new_content": {
             "body": text,
+            "format": "org.matrix.custom.html",
+            "formatted_body": formatted_body,
             "msgtype": "m.text",
             STREAM_STATUS_KEY: STREAM_STATUS_STREAMING,
+            _TOOL_TRACE_KEY: tool_trace,
         },
         "m.relates_to": {"rel_type": "m.replace", "event_id": "$abc"},
         "msgtype": "m.text",
@@ -241,12 +253,81 @@ async def test_prepare_nonterminal_streaming_edit_uses_preview_without_sidecar()
     assert result["m.new_content"]["msgtype"] == "m.text"
     assert result["m.new_content"][STREAM_STATUS_KEY] == STREAM_STATUS_STREAMING
     assert result[STREAM_STATUS_KEY] == STREAM_STATUS_STREAMING
-    assert "io.mindroom.long_text" not in result["m.new_content"]
-    assert "url" not in result["m.new_content"]
+    assert result["m.new_content"]["format"] == "org.matrix.custom.html"
+    assert "<strong>markdown</strong>" in result["m.new_content"]["formatted_body"]
+    assert "Streaming preview truncated" in result["m.new_content"]["formatted_body"]
+    assert _TOOL_TRACE_KEY not in result["m.new_content"]
+    assert result["m.new_content"]["io.mindroom.long_text"]["version"] == 2
+    assert result["m.new_content"]["io.mindroom.long_text"]["encoding"] == "matrix_event_content_json"
+    assert result["m.new_content"]["url"] == "mxc://server/streaming-preview"
     assert "file" not in result["m.new_content"]
     assert len(result["m.new_content"]["body"]) < len(text)
     assert "[Streaming preview truncated]" in result["m.new_content"]["body"]
     assert "[Message continues in attached file]" not in result["m.new_content"]["body"]
+    assert client.uploaded_data is not None
+    uploaded_payload = json.loads(client.uploaded_data.decode("utf-8"))
+    assert uploaded_payload == edit_content
+    assert uploaded_payload["m.new_content"][_TOOL_TRACE_KEY] == tool_trace
+    assert _calculate_event_size(result) <= 64000
+
+
+@pytest.mark.asyncio
+async def test_prepare_nonterminal_streaming_edit_keeps_preview_large_with_huge_sidecar_tool_trace() -> None:
+    """Huge tool traces should go to the sidecar instead of shrinking visible preview."""
+
+    class MockClient:
+        rooms: dict = {}  # noqa: RUF012
+        uploaded_data: bytes | None = None
+
+        async def upload(self, **kwargs) -> tuple:  # noqa: ANN003
+            data_provider = kwargs.get("data_provider")
+            if data_provider:
+                data = data_provider(None, None)
+                self.uploaded_data = data.read()
+            response = nio.UploadResponse.from_dict({"content_uri": "mxc://server/huge-trace"})
+            return response, None
+
+    client = MockClient()
+    text = ("streaming **markdown**\n" * 2000) + "tail"
+    huge_tool_trace = {
+        "version": 2,
+        "events": [
+            {
+                "type": "tool_call_completed",
+                "tool_name": "save_file",
+                "result_preview": "x" * 90000,
+            },
+        ],
+    }
+    edit_content = {
+        "body": f"* {text}",
+        "format": "org.matrix.custom.html",
+        "formatted_body": "<p>streaming <strong>markdown</strong></p>" * 2000,
+        "m.new_content": {
+            "body": text,
+            "format": "org.matrix.custom.html",
+            "formatted_body": "<p>streaming <strong>markdown</strong></p>" * 2000,
+            "msgtype": "m.text",
+            STREAM_STATUS_KEY: STREAM_STATUS_STREAMING,
+            _TOOL_TRACE_KEY: huge_tool_trace,
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$abc"},
+        "msgtype": "m.text",
+    }
+
+    result = await prepare_large_message(client, "!room:server", edit_content)
+
+    assert result["m.new_content"]["msgtype"] == "m.text"
+    assert result["m.new_content"]["format"] == "org.matrix.custom.html"
+    assert "<strong>markdown</strong>" in result["m.new_content"]["formatted_body"]
+    assert "Streaming preview truncated" in result["m.new_content"]["formatted_body"]
+    assert len(result["m.new_content"]["body"]) > 5000
+    assert _TOOL_TRACE_KEY not in result["m.new_content"]
+    assert result["m.new_content"]["io.mindroom.long_text"]["version"] == 2
+    assert result["m.new_content"]["url"] == "mxc://server/huge-trace"
+    assert client.uploaded_data is not None
+    uploaded_payload = json.loads(client.uploaded_data.decode("utf-8"))
+    assert uploaded_payload["m.new_content"][_TOOL_TRACE_KEY] == huge_tool_trace
     assert _calculate_event_size(result) <= 64000
 
 

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -431,7 +431,10 @@ async def test_streaming_multiple_edits_with_growth() -> None:
     nonterminal_large_edit = client.messages_sent[-2][2]
     assert nonterminal_large_edit["m.new_content"]["msgtype"] == "m.text"
     assert nonterminal_large_edit["m.new_content"][STREAM_STATUS_KEY] == STREAM_STATUS_STREAMING
-    assert "io.mindroom.long_text" not in nonterminal_large_edit["m.new_content"]
+    assert nonterminal_large_edit["m.new_content"]["format"] == "org.matrix.custom.html"
+    assert "Streaming preview truncated" in nonterminal_large_edit["m.new_content"]["formatted_body"]
+    assert nonterminal_large_edit["m.new_content"]["io.mindroom.long_text"]["version"] == 2
+    assert nonterminal_large_edit["m.new_content"]["io.mindroom.long_text"]["encoding"] == "matrix_event_content_json"
 
     terminal_large_edit = client.messages_sent[-1][2]
     assert terminal_large_edit["m.new_content"]["msgtype"] == "m.file"


### PR DESCRIPTION
## Summary
- fix the oversized streaming-edit regression introduced by [#725](https://github.com/mindroom-ai/mindroom/pull/725)
- restore fresh JSON sidecar uploads for oversized non-terminal streaming edits so supported clients can hydrate and keep showing the full current partial response while it streams
- keep a rich inline `m.text` fallback preview with `format: org.matrix.custom.html`, `formatted_body`, and `[Streaming preview truncated]` for clients that do not hydrate MindRoom long-text sidecars
- keep terminal oversized edits and regular oversized messages on the existing JSON long-text sidecar path

## Regression Context
[#725](https://github.com/mindroom-ai/mindroom/pull/725) stopped uploading sidecars for non-terminal streaming previews. That reduced media churn, but it also removed the only way supported clients could see the full current partial message after a streaming edit crossed the Matrix edit-size limit.

The resulting behavior on `origin/main` is that a stream renders normally before the threshold, then degrades to a truncated inline preview after the threshold. Supported clients no longer have a sidecar to hydrate, and generic clients also lost rich formatted fallback rendering.

This PR restores the pre-#725 supported-client behavior while improving the fallback shape.

## Behavior
Before the large-edit threshold, streaming sends/edits behave as before: the full current partial message is sent inline with normal markdown-derived HTML and MindRoom metadata.

After the large-edit threshold, while the response is still streaming, MindRoom now uploads the full replacement event content as a fresh JSON sidecar and sends a bounded inline replacement preview:
- `m.new_content.msgtype` remains `m.text`
- `body` is truncated and ends with `[Streaming preview truncated]`
- `formatted_body` is rebuilt from that truncated preview so HTML-capable Matrix clients still render formatted fallback content
- `io.mindroom.long_text` plus `url` or encrypted `file` points to the full current replacement content
- large tool-trace metadata stays in the sidecar rather than shrinking the visible preview

Supported clients can hydrate the sidecar on each oversized streaming edit and continue showing the full current partial response. Unsupported clients see the rich truncated preview.

Once the stream is terminal and still oversized, the existing `m.file` / `io.mindroom.long_text` JSON sidecar path is still used for complete final content.

## Comparison
Pre-#725: oversized non-terminal streaming edits uploaded sidecars, but fallback rendering was a plainer file-style preview.

`origin/main` after #725: oversized non-terminal streaming edits avoid sidecars, so supported clients cannot hydrate the full current partial after the threshold.

This PR: oversized non-terminal streaming edits upload fresh sidecars again, and the inline fallback remains rich `m.text`.

## Tests
- `uv run pre-commit run --files src/mindroom/matrix/large_messages.py tests/test_large_messages.py tests/test_large_messages_integration.py`
- `uv run pytest tests/test_large_messages.py tests/test_large_messages_integration.py -n auto --no-cov -q`
- `uv run pytest -n auto --no-cov -q`