### PR TITLE
Move config runtime resolution behind resolvers

### DIFF
--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -44,25 +44,20 @@ from mindroom.constants import (
     RuntimePaths,
     resolve_config_relative_path,
     resolve_runtime_paths,
-    runtime_matrix_homeserver,
     safe_replace,
 )
 
 # config layer loads BEFORE the history runtime; import leaf types so config load does not drag in agents+tools.
 from mindroom.history.types import HistoryPolicy, ResolvedHistorySettings
 from mindroom.logging_config import get_logger
-from mindroom.matrix.identity import (
-    agent_username_localpart,
-    managed_room_alias_localpart,
-    managed_space_alias_localpart,
-)
+from mindroom.matrix_naming import agent_username_localpart, managed_room_alias_localpart, managed_space_alias_localpart
 from mindroom.mcp.config import MCPServerConfig, normalize_mcp_server_id
 from mindroom.tool_system.plugin_imports import PluginValidationError
 from mindroom.tool_system.worker_routing import unsupported_shared_only_integration_names
 from mindroom.workspaces import validate_workspace_template_dir
 
 if TYPE_CHECKING:
-    from mindroom.matrix.identity import MatrixID
+    from mindroom.entity_resolution import MatrixID
     from mindroom.tool_system.catalog import ToolValidationInfo
     from mindroom.tool_system.worker_routing import WorkerScope
 
@@ -199,50 +194,6 @@ def _history_policy_from_limits(
     if num_history_runs is not None:
         return HistoryPolicy(mode="runs", limit=num_history_runs)
     return HistoryPolicy(mode="all")
-
-
-def _resolve_agent_thread_mode(
-    agent_config: AgentConfig,
-    room_id: str | None,
-    runtime_paths: RuntimePaths,
-) -> Literal["thread", "room"]:
-    """Resolve one agent's effective thread mode for an optional room context.
-
-    Resolution order is:
-    1. Explicit room ID key match in ``room_thread_modes``.
-    2. Reverse alias lookup from room ID to managed room key.
-    3. Any ``room_thread_modes`` key that resolves to the active room ID.
-    4. Fallback to ``thread_mode``.
-    """
-    default_mode = agent_config.thread_mode
-    if room_id is None or not agent_config.room_thread_modes:
-        return default_mode
-
-    overrides = agent_config.room_thread_modes
-
-    # Fast path: direct room-id key.
-    direct_mode = overrides.get(room_id)
-    if direct_mode is not None:
-        return direct_mode
-
-    # Keep this import local to avoid config<->matrix import cycles during module initialization.
-    from mindroom.matrix.rooms import get_room_alias_from_id, resolve_room_aliases  # noqa: PLC0415
-
-    room_alias = get_room_alias_from_id(room_id, runtime_paths)
-    if room_alias:
-        alias_mode = overrides.get(room_alias)
-        if alias_mode is not None:
-            return alias_mode
-
-    for override_key, resolved_room_id in zip(
-        overrides,
-        resolve_room_aliases(list(overrides), runtime_paths),
-        strict=False,
-    ):
-        if resolved_room_id == room_id:
-            return overrides[override_key]
-
-    return default_mode
 
 
 def _normalize_optional_config_sections(data: dict[str, object]) -> None:
@@ -384,37 +335,6 @@ def _skip_private_template_dir_validation(runtime_paths: RuntimePaths | None) ->
     return runtime_paths.env_flag("MINDROOM_SANDBOX_RUNNER_MODE") and bool(
         runtime_paths.env_value("MINDROOM_SANDBOX_DEDICATED_WORKER_KEY", default=""),
     )
-
-
-def _router_agents_for_room(
-    agents: dict[str, AgentConfig],
-    teams: dict[str, TeamConfig],
-    room_id: str | None,
-    runtime_paths: RuntimePaths,
-) -> set[str]:
-    """Return agents relevant for router mode resolution in one room context.
-
-    Includes:
-    - Agents directly configured for the room.
-    - Agents brought into the room via ``teams.<name>.rooms`` mappings.
-
-    Falls back to all agents when no room-specific subset is found.
-    """
-    if room_id is None:
-        return set(agents)
-
-    # Keep this import local to avoid config<->matrix import cycles during module initialization.
-    from mindroom.matrix.rooms import resolve_room_aliases  # noqa: PLC0415
-
-    router_agents: set[str] = set()
-    for agent_name, agent_cfg in agents.items():
-        if room_id in set(resolve_room_aliases(agent_cfg.rooms, runtime_paths)):
-            router_agents.add(agent_name)
-    for team_cfg in teams.values():
-        if room_id not in set(resolve_room_aliases(team_cfg.rooms, runtime_paths)):
-            continue
-        router_agents.update(agent_name for agent_name in team_cfg.agents if agent_name in agents)
-    return router_agents or set(agents)
 
 
 class Config(BaseModel):
@@ -955,10 +875,9 @@ class Config(BaseModel):
 
     def get_domain(self, runtime_paths: RuntimePaths) -> str:
         """Extract the Matrix domain for one explicit runtime context."""
-        from mindroom.matrix.identity import extract_server_name_from_homeserver  # noqa: PLC0415
+        from mindroom.entity_resolution import matrix_domain  # noqa: PLC0415
 
-        homeserver = runtime_matrix_homeserver(runtime_paths)
-        return extract_server_name_from_homeserver(homeserver, runtime_paths)
+        return matrix_domain(runtime_paths)
 
     def get_ids(self, runtime_paths: RuntimePaths) -> dict[str, MatrixID]:
         """Get MatrixID objects for all agents and teams.
@@ -967,30 +886,15 @@ class Config(BaseModel):
             Dictionary mapping agent/team names to their MatrixID objects.
 
         """
-        from mindroom.matrix.identity import MatrixID  # noqa: PLC0415
+        from mindroom.entity_resolution import entity_matrix_ids  # noqa: PLC0415
 
-        mapping: dict[str, MatrixID] = {}
-        domain = self.get_domain(runtime_paths)
-
-        # Add all agents
-        for agent_name in self.agents:
-            mapping[agent_name] = MatrixID.from_agent(agent_name, domain, runtime_paths)
-
-        # Add router agent separately (it's not in config.agents)
-        mapping[ROUTER_AGENT_NAME] = MatrixID.from_agent(ROUTER_AGENT_NAME, domain, runtime_paths)
-
-        # Add all teams
-        for team_name in self.teams:
-            mapping[team_name] = MatrixID.from_agent(team_name, domain, runtime_paths)
-        return mapping
+        return entity_matrix_ids(self, runtime_paths)
 
     def get_mindroom_user_id(self, runtime_paths: RuntimePaths) -> str | None:
         """Get the full Matrix user ID for the configured internal user."""
-        if self.mindroom_user is None:
-            return None
-        from mindroom.matrix.identity import MatrixID  # noqa: PLC0415
+        from mindroom.entity_resolution import mindroom_user_id  # noqa: PLC0415
 
-        return MatrixID.from_username(self.mindroom_user.username, self.get_domain(runtime_paths)).full_id
+        return mindroom_user_id(self, runtime_paths)
 
     @classmethod
     def validate_with_runtime(
@@ -1676,8 +1580,10 @@ class Config(BaseModel):
         Router inherits a mode only when all relevant configured agents share it.
         In ambiguous cases, default to "thread".
         """
+        from mindroom.entity_resolution import resolve_agent_thread_mode, router_agents_for_room  # noqa: PLC0415
+
         if entity_name in self.agents:
-            return _resolve_agent_thread_mode(
+            return resolve_agent_thread_mode(
                 self.agents[entity_name],
                 room_id,
                 runtime_paths,
@@ -1685,7 +1591,7 @@ class Config(BaseModel):
 
         if entity_name in self.teams:
             team_modes: set[Literal["thread", "room"]] = {
-                _resolve_agent_thread_mode(
+                resolve_agent_thread_mode(
                     self.agents[name],
                     room_id,
                     runtime_paths,
@@ -1697,14 +1603,14 @@ class Config(BaseModel):
                 return next(iter(team_modes))
 
         if entity_name == ROUTER_AGENT_NAME:
-            router_agents = _router_agents_for_room(
+            router_agents = router_agents_for_room(
                 self.agents,
                 self.teams,
                 room_id,
                 runtime_paths,
             )
             configured_modes: set[Literal["thread", "room"]] = {
-                _resolve_agent_thread_mode(
+                resolve_agent_thread_mode(
                     self.agents[agent_name],
                     room_id,
                     runtime_paths,
@@ -1755,15 +1661,9 @@ class Config(BaseModel):
         runtime_paths: RuntimePaths,
     ) -> str:
         """Return the effective model for one entity in one room context."""
-        if entity_name not in self.agents and entity_name not in self.teams and entity_name != ROUTER_AGENT_NAME:
-            return "default"
-        if room_id is not None:
-            from mindroom.matrix.rooms import get_room_alias_from_id  # noqa: PLC0415
+        from mindroom.entity_resolution import effective_entity_model_name  # noqa: PLC0415
 
-            room_alias = get_room_alias_from_id(room_id, runtime_paths)
-            if room_alias and room_alias in self.room_models:
-                return self.room_models[room_alias]
-        return self.get_entity_model_name(entity_name)
+        return effective_entity_model_name(self, entity_name, room_id, runtime_paths)
 
     def resolve_runtime_model(
         self,

--- a/src/mindroom/config/matrix.py
+++ b/src/mindroom/config/matrix.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from mindroom.constants import resolve_config_relative_path
-from mindroom.matrix.identity import managed_room_key_from_alias_localpart, room_alias_localpart
+from mindroom.matrix_naming import managed_room_key_from_alias_localpart, room_alias_localpart
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/mindroom/entity_resolution.py
+++ b/src/mindroom/entity_resolution.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
-from mindroom.constants import ROUTER_AGENT_NAME
-from mindroom.matrix.identity import agent_username_localpart
-from mindroom.matrix.rooms import resolve_room_aliases
+import mindroom.matrix.rooms as matrix_rooms
+from mindroom.constants import ROUTER_AGENT_NAME, runtime_matrix_homeserver
+from mindroom.matrix.identity import MatrixID
+from mindroom.matrix_naming import agent_username_localpart, extract_server_name_from_homeserver
 
 if TYPE_CHECKING:
+    from mindroom.config.agent import AgentConfig, TeamConfig
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
 
@@ -22,12 +24,12 @@ def configured_bot_usernames_for_room(
     configured_bots: set[str] = set()
 
     for agent_name, agent_config in config.agents.items():
-        resolved_rooms = set(resolve_room_aliases(agent_config.rooms, runtime_paths))
+        resolved_rooms = set(matrix_rooms.resolve_room_aliases(agent_config.rooms, runtime_paths))
         if room_id in resolved_rooms:
             configured_bots.add(agent_username_localpart(agent_name, runtime_paths))
 
     for team_name, team_config in config.teams.items():
-        resolved_rooms = set(resolve_room_aliases(team_config.rooms, runtime_paths))
+        resolved_rooms = set(matrix_rooms.resolve_room_aliases(team_config.rooms, runtime_paths))
         if room_id in resolved_rooms:
             configured_bots.add(agent_username_localpart(team_name, runtime_paths))
 
@@ -35,3 +37,98 @@ def configured_bot_usernames_for_room(
         configured_bots.add(agent_username_localpart(ROUTER_AGENT_NAME, runtime_paths))
 
     return configured_bots
+
+
+def matrix_domain(runtime_paths: RuntimePaths) -> str:
+    """Return the Matrix domain for one explicit runtime context."""
+    homeserver = runtime_matrix_homeserver(runtime_paths)
+    return extract_server_name_from_homeserver(homeserver, runtime_paths)
+
+
+def entity_matrix_ids(config: Config, runtime_paths: RuntimePaths) -> dict[str, MatrixID]:
+    """Return Matrix IDs for configured agents, teams, and the router."""
+    domain = matrix_domain(runtime_paths)
+    mapping: dict[str, MatrixID] = {
+        agent_name: MatrixID.from_agent(agent_name, domain, runtime_paths) for agent_name in config.agents
+    }
+    mapping[ROUTER_AGENT_NAME] = MatrixID.from_agent(ROUTER_AGENT_NAME, domain, runtime_paths)
+    mapping.update(
+        {team_name: MatrixID.from_agent(team_name, domain, runtime_paths) for team_name in config.teams},
+    )
+    return mapping
+
+
+def mindroom_user_id(config: Config, runtime_paths: RuntimePaths) -> str | None:
+    """Return the configured internal user's full Matrix ID."""
+    if config.mindroom_user is None:
+        return None
+    return MatrixID.from_username(config.mindroom_user.username, matrix_domain(runtime_paths)).full_id
+
+
+def resolve_agent_thread_mode(
+    agent_config: AgentConfig,
+    room_id: str | None,
+    runtime_paths: RuntimePaths,
+) -> Literal["thread", "room"]:
+    """Resolve one agent's effective thread mode for an optional room context."""
+    default_mode = agent_config.thread_mode
+    if room_id is None or not agent_config.room_thread_modes:
+        return default_mode
+
+    overrides = agent_config.room_thread_modes
+    direct_mode = overrides.get(room_id)
+    if direct_mode is not None:
+        return direct_mode
+
+    room_alias = matrix_rooms.get_room_alias_from_id(room_id, runtime_paths)
+    if room_alias:
+        alias_mode = overrides.get(room_alias)
+        if alias_mode is not None:
+            return alias_mode
+
+    for override_key, resolved_room_id in zip(
+        overrides,
+        matrix_rooms.resolve_room_aliases(list(overrides), runtime_paths),
+        strict=False,
+    ):
+        if resolved_room_id == room_id:
+            return overrides[override_key]
+
+    return default_mode
+
+
+def router_agents_for_room(
+    agents: dict[str, AgentConfig],
+    teams: dict[str, TeamConfig],
+    room_id: str | None,
+    runtime_paths: RuntimePaths,
+) -> set[str]:
+    """Return agents relevant for router mode resolution in one room context."""
+    if room_id is None:
+        return set(agents)
+
+    router_agents: set[str] = set()
+    for agent_name, agent_cfg in agents.items():
+        if room_id in set(matrix_rooms.resolve_room_aliases(agent_cfg.rooms, runtime_paths)):
+            router_agents.add(agent_name)
+    for team_cfg in teams.values():
+        if room_id not in set(matrix_rooms.resolve_room_aliases(team_cfg.rooms, runtime_paths)):
+            continue
+        router_agents.update(agent_name for agent_name in team_cfg.agents if agent_name in agents)
+    return router_agents or set(agents)
+
+
+def effective_entity_model_name(
+    config: Config,
+    entity_name: str,
+    room_id: str | None,
+    runtime_paths: RuntimePaths,
+) -> str:
+    """Return the effective model for one entity in one room context."""
+    if entity_name not in config.agents and entity_name not in config.teams and entity_name != ROUTER_AGENT_NAME:
+        return "default"
+    if room_id is not None:
+        room_alias = matrix_rooms.get_room_alias_from_id(room_id, runtime_paths)
+        if room_alias and room_alias in config.room_models:
+            return config.room_models[room_alias]
+    return config.get_entity_model_name(entity_name)

--- a/src/mindroom/matrix/identity.py
+++ b/src/mindroom/matrix/identity.py
@@ -2,65 +2,39 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, ClassVar
 
-from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths, runtime_matrix_server_name, runtime_mindroom_namespace
+from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths
 from mindroom.matrix.state import managed_account_usernames
+from mindroom.matrix_naming import (
+    AGENT_USERNAME_PREFIX,
+    agent_username_localpart,
+    extract_server_name_from_homeserver,
+    managed_room_alias_localpart,
+    managed_room_key_from_alias_localpart,
+    managed_space_alias_localpart,
+    mindroom_namespace,
+    room_alias_localpart,
+)
 
 if TYPE_CHECKING:
     from mindroom.config.main import Config
 
-_NAMESPACE_PATTERN = re.compile(r"^[a-z0-9]{4,32}$")
-
-
-def _normalize_namespace(namespace: str | None) -> str | None:
-    """Normalize and validate an installation namespace."""
-    if namespace is None:
-        return None
-    normalized = namespace.strip().lower()
-    if not normalized:
-        return None
-    if not _NAMESPACE_PATTERN.fullmatch(normalized):
-        msg = f"MINDROOM_NAMESPACE must match ^[a-z0-9]{{4,32}}$ (got: {namespace!r})"
-        raise ValueError(msg)
-    return normalized
-
-
-def mindroom_namespace(runtime_paths: RuntimePaths) -> str | None:
-    """Return the configured installation namespace for one explicit runtime context."""
-    return _normalize_namespace(runtime_mindroom_namespace(runtime_paths))
-
-
-def managed_room_alias_localpart(room_key: str, runtime_paths: RuntimePaths) -> str:
-    """Build the managed room alias localpart for a room key."""
-    namespace = mindroom_namespace(runtime_paths)
-    if not namespace:
-        return room_key
-    return f"{room_key}_{namespace}"
-
-
-def managed_space_alias_localpart(runtime_paths: RuntimePaths) -> str:
-    """Build the reserved alias localpart for the root MindRoom Space."""
-    return managed_room_alias_localpart("_mindroom_root_space", runtime_paths)
-
-
-def managed_room_key_from_alias_localpart(
-    alias_localpart: str,
-    runtime_paths: RuntimePaths,
-) -> str | None:
-    """Extract the configured managed room key from an alias localpart."""
-    namespace = mindroom_namespace(runtime_paths)
-    if not namespace:
-        return alias_localpart
-
-    suffix = f"_{namespace}"
-    if not alias_localpart.endswith(suffix):
-        return None
-    room_key = alias_localpart[: -len(suffix)]
-    return room_key or None
+__all__ = [
+    "MatrixID",
+    "active_internal_sender_ids",
+    "agent_username_localpart",
+    "extract_agent_name",
+    "extract_server_name_from_homeserver",
+    "is_agent_id",
+    "managed_room_alias_localpart",
+    "managed_room_key_from_alias_localpart",
+    "managed_space_alias_localpart",
+    "mindroom_namespace",
+    "room_alias_localpart",
+]
 
 
 @dataclass(frozen=True)
@@ -70,7 +44,7 @@ class MatrixID:
     username: str
     domain: str
 
-    AGENT_PREFIX: ClassVar[str] = "mindroom_"
+    AGENT_PREFIX: ClassVar[str] = AGENT_USERNAME_PREFIX
 
     @classmethod
     def parse(cls, matrix_id: str) -> MatrixID:
@@ -227,39 +201,3 @@ def active_internal_sender_ids(config: Config, runtime_paths: RuntimePaths) -> f
             continue
         sender_ids.add(MatrixID.from_username(username, current_domain).full_id)
     return frozenset(sender_ids)
-
-
-def agent_username_localpart(agent_name: str, runtime_paths: RuntimePaths) -> str:
-    """Build the Matrix username localpart for an agent-like entity."""
-    namespace = mindroom_namespace(runtime_paths)
-    if namespace:
-        return f"{MatrixID.AGENT_PREFIX}{agent_name}_{namespace}"
-    return f"{MatrixID.AGENT_PREFIX}{agent_name}"
-
-
-def room_alias_localpart(room_alias: str) -> str | None:
-    """Extract the localpart from a room alias like '#lobby:example.com' → 'lobby'."""
-    if not room_alias.startswith("#") or ":" not in room_alias:
-        return None
-    return room_alias[1:].split(":", 1)[0]
-
-
-def extract_server_name_from_homeserver(homeserver: str, runtime_paths: RuntimePaths) -> str:
-    """Extract server name from a homeserver URL like "http://localhost:8008".
-
-    If MATRIX_SERVER_NAME environment variable is set, use that instead.
-    This is needed for federation setups where the internal hostname differs
-    from the actual Matrix server name.
-    """
-    # Check for explicit server name override (for federation/docker setups)
-    if server_name := runtime_matrix_server_name(runtime_paths):
-        return server_name
-
-    # Otherwise extract from homeserver URL
-    # Remove protocol
-    server_part = homeserver.split("://", 1)[1] if "://" in homeserver else homeserver
-
-    # Remove port if present
-    if ":" in server_part:
-        return server_part.split(":", 1)[0]
-    return server_part

--- a/src/mindroom/matrix_naming.py
+++ b/src/mindroom/matrix_naming.py
@@ -1,0 +1,83 @@
+"""Matrix naming helpers that do not depend on Matrix runtime modules."""
+
+from __future__ import annotations
+
+import re
+
+from mindroom.constants import RuntimePaths, runtime_matrix_server_name, runtime_mindroom_namespace
+
+AGENT_USERNAME_PREFIX = "mindroom_"
+_NAMESPACE_PATTERN = re.compile(r"^[a-z0-9]{4,32}$")
+
+
+def _normalize_namespace(namespace: str | None) -> str | None:
+    """Normalize and validate an installation namespace."""
+    if namespace is None:
+        return None
+    normalized = namespace.strip().lower()
+    if not normalized:
+        return None
+    if not _NAMESPACE_PATTERN.fullmatch(normalized):
+        msg = f"MINDROOM_NAMESPACE must match ^[a-z0-9]{{4,32}}$ (got: {namespace!r})"
+        raise ValueError(msg)
+    return normalized
+
+
+def mindroom_namespace(runtime_paths: RuntimePaths) -> str | None:
+    """Return the configured installation namespace for one explicit runtime context."""
+    return _normalize_namespace(runtime_mindroom_namespace(runtime_paths))
+
+
+def agent_username_localpart(agent_name: str, runtime_paths: RuntimePaths) -> str:
+    """Build the Matrix username localpart for an agent-like entity."""
+    namespace = mindroom_namespace(runtime_paths)
+    if namespace:
+        return f"{AGENT_USERNAME_PREFIX}{agent_name}_{namespace}"
+    return f"{AGENT_USERNAME_PREFIX}{agent_name}"
+
+
+def managed_room_alias_localpart(room_key: str, runtime_paths: RuntimePaths) -> str:
+    """Build the managed room alias localpart for a room key."""
+    namespace = mindroom_namespace(runtime_paths)
+    if not namespace:
+        return room_key
+    return f"{room_key}_{namespace}"
+
+
+def managed_space_alias_localpart(runtime_paths: RuntimePaths) -> str:
+    """Build the reserved alias localpart for the root MindRoom Space."""
+    return managed_room_alias_localpart("_mindroom_root_space", runtime_paths)
+
+
+def managed_room_key_from_alias_localpart(
+    alias_localpart: str,
+    runtime_paths: RuntimePaths,
+) -> str | None:
+    """Extract the configured managed room key from an alias localpart."""
+    namespace = mindroom_namespace(runtime_paths)
+    if not namespace:
+        return alias_localpart
+
+    suffix = f"_{namespace}"
+    if not alias_localpart.endswith(suffix):
+        return None
+    room_key = alias_localpart[: -len(suffix)]
+    return room_key or None
+
+
+def room_alias_localpart(room_alias: str) -> str | None:
+    """Extract the localpart from a room alias like '#lobby:example.com'."""
+    if not room_alias.startswith("#") or ":" not in room_alias:
+        return None
+    return room_alias[1:].split(":", 1)[0]
+
+
+def extract_server_name_from_homeserver(homeserver: str, runtime_paths: RuntimePaths) -> str:
+    """Extract the Matrix server name from a homeserver URL."""
+    if server_name := runtime_matrix_server_name(runtime_paths):
+        return server_name
+
+    server_part = homeserver.split("://", 1)[1] if "://" in homeserver else homeserver
+    if ":" in server_part:
+        return server_part.split(":", 1)[0]
+    return server_part

--- a/tach.toml
+++ b/tach.toml
@@ -164,6 +164,7 @@ depends_on = [
     "mindroom.constants",
     "mindroom.matrix.identity",
     "mindroom.matrix.rooms",
+    "mindroom.matrix_naming",
 ]
 
 [[modules]]
@@ -811,10 +812,10 @@ depends_on = [
     "mindroom.config.plugin",
     "mindroom.config.voice",
     "mindroom.constants",
+    "mindroom.entity_resolution",
     "mindroom.history.types",
     "mindroom.logging_config",
-    "mindroom.matrix.identity",
-    "mindroom.matrix.rooms",
+    "mindroom.matrix_naming",
     "mindroom.mcp.config",
     "mindroom.tool_system.catalog",
     "mindroom.tool_system.plugin_imports",
@@ -1098,6 +1099,10 @@ visibility = [
 [[modules]]
 path = "mindroom.constants"
 depends_on = []
+
+[[modules]]
+path = "mindroom.matrix_naming"
+depends_on = ["mindroom.constants"]
 
 [[modules]]
 path = "mindroom.cancellation"

--- a/tests/test_config_architecture_boundaries.py
+++ b/tests/test_config_architecture_boundaries.py
@@ -1,0 +1,30 @@
+"""Architecture boundary tests for configuration modules."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+CONFIG_MODULES = tuple(Path("src/mindroom/config").glob("*.py"))
+
+
+def _is_matrix_runtime_module(module: str) -> bool:
+    return module == "mindroom.matrix" or module.startswith("mindroom.matrix.")
+
+
+def test_config_modules_do_not_import_matrix_runtime_modules() -> None:
+    """Config models stay authored-data focused and avoid Matrix runtime imports."""
+    forbidden: list[str] = []
+    for source_path in CONFIG_MODULES:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module and _is_matrix_runtime_module(node.module):
+                forbidden.append(f"{source_path}:{node.lineno}: from {node.module}")
+            if isinstance(node, ast.Import):
+                forbidden.extend(
+                    f"{source_path}:{node.lineno}: import {alias.name}"
+                    for alias in node.names
+                    if _is_matrix_runtime_module(alias.name)
+                )
+
+    assert forbidden == []


### PR DESCRIPTION
## Summary
- Move pure Matrix naming helpers into `mindroom.matrix_naming` so config code can use naming without importing Matrix runtime modules.
- Move runtime-derived config resolution for domains, Matrix IDs, thread modes, router room agents, and room model overrides into `mindroom.entity_resolution`.
- Update Tach boundaries and add an architecture test that prevents config modules from importing `mindroom.matrix.*`.

## Test Plan
- `uv run ruff check src/mindroom/config/main.py src/mindroom/config/matrix.py src/mindroom/entity_resolution.py src/mindroom/matrix/identity.py src/mindroom/matrix_naming.py tests/test_config_architecture_boundaries.py`
- `uv run tach check --dependencies --interfaces`
- `uv run pytest tests/test_config_architecture_boundaries.py tests/test_entity_resolution.py tests/test_config_discovery.py tests/test_matrix_identity.py tests/test_authorization.py tests/test_authorization_config_update.py tests/test_agno_history.py::test_resolve_runtime_model_uses_room_override_for_team tests/test_agno_history.py::test_resolve_runtime_model_uses_room_override_for_agent -nauto --no-cov -v`
- `uv run pytest tests/ -x -nauto --no-cov -v`
- `uv run pre-commit run --all-files`