### PR TITLE
Remove Matrix identity naming re-exports

### DIFF
--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -10,13 +10,9 @@ import nio
 
 from mindroom.constants import ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME
 from mindroom.logging_config import get_logger
-from mindroom.matrix.identity import (
-    MatrixID,
-    active_internal_sender_ids,
-    managed_room_key_from_alias_localpart,
-    room_alias_localpart,
-)
+from mindroom.matrix.identity import MatrixID, active_internal_sender_ids
 from mindroom.matrix.state import MatrixState
+from mindroom.matrix_naming import managed_room_key_from_alias_localpart, room_alias_localpart
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/src/mindroom/avatar_generation.py
+++ b/src/mindroom/avatar_generation.py
@@ -25,10 +25,11 @@ from mindroom.credentials_sync import get_secret_from_env
 from mindroom.error_handling import AvatarGenerationError, AvatarSyncError
 from mindroom.logging_config import get_logger
 from mindroom.matrix.avatar import room_has_avatar, set_room_avatar_from_file
-from mindroom.matrix.identity import MatrixID, extract_server_name_from_homeserver
+from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.rooms import get_room_id
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import AgentMatrixUser, login_agent_user
+from mindroom.matrix_naming import extract_server_name_from_homeserver
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import nio
 
 from mindroom.matrix.client_room_admin import add_room_to_space, create_room, get_room_members, invite_to_room
-from mindroom.matrix.identity import extract_server_name_from_homeserver
+from mindroom.matrix_naming import extract_server_name_from_homeserver
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths

--- a/src/mindroom/matrix/identity.py
+++ b/src/mindroom/matrix/identity.py
@@ -6,18 +6,9 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, ClassVar
 
+from mindroom import matrix_naming
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths
 from mindroom.matrix.state import managed_account_usernames
-from mindroom.matrix_naming import (
-    AGENT_USERNAME_PREFIX,
-    agent_username_localpart,
-    extract_server_name_from_homeserver,
-    managed_room_alias_localpart,
-    managed_room_key_from_alias_localpart,
-    managed_space_alias_localpart,
-    mindroom_namespace,
-    room_alias_localpart,
-)
 
 if TYPE_CHECKING:
     from mindroom.config.main import Config
@@ -25,15 +16,8 @@ if TYPE_CHECKING:
 __all__ = [
     "MatrixID",
     "active_internal_sender_ids",
-    "agent_username_localpart",
     "extract_agent_name",
-    "extract_server_name_from_homeserver",
     "is_agent_id",
-    "managed_room_alias_localpart",
-    "managed_room_key_from_alias_localpart",
-    "managed_space_alias_localpart",
-    "mindroom_namespace",
-    "room_alias_localpart",
 ]
 
 
@@ -44,7 +28,7 @@ class MatrixID:
     username: str
     domain: str
 
-    AGENT_PREFIX: ClassVar[str] = AGENT_USERNAME_PREFIX
+    AGENT_PREFIX: ClassVar[str] = matrix_naming.AGENT_USERNAME_PREFIX
 
     @classmethod
     def parse(cls, matrix_id: str) -> MatrixID:
@@ -59,7 +43,7 @@ class MatrixID:
         runtime_paths: RuntimePaths,
     ) -> MatrixID:
         """Create a MatrixID for an agent."""
-        return cls(username=agent_username_localpart(agent_name, runtime_paths), domain=domain)
+        return cls(username=matrix_naming.agent_username_localpart(agent_name, runtime_paths), domain=domain)
 
     @classmethod
     def from_username(cls, username: str, domain: str) -> MatrixID:
@@ -82,7 +66,7 @@ class MatrixID:
 
         persisted_usernames = managed_account_usernames(runtime_paths)
         for account_key, active_name in _active_managed_agent_account_names(config).items():
-            expected_username = persisted_usernames.get(account_key) or agent_username_localpart(
+            expected_username = persisted_usernames.get(account_key) or matrix_naming.agent_username_localpart(
                 active_name,
                 runtime_paths,
             )

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING, Any
 
 from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths
-from mindroom.matrix.identity import MatrixID, mindroom_namespace
+from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.message_builder import build_message_content, markdown_to_html
+from mindroom.matrix_naming import mindroom_namespace
 from mindroom.tool_system.events import build_tool_trace_content, ensure_visible_tool_marker_spacing
 
 if TYPE_CHECKING:

--- a/src/mindroom/matrix/room_cleanup.py
+++ b/src/mindroom/matrix/room_cleanup.py
@@ -15,11 +15,12 @@ import nio
 from mindroom.entity_resolution import configured_bot_usernames_for_room
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_members
-from mindroom.matrix.identity import MatrixID, agent_username_localpart
+from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.invited_rooms_store import invited_rooms_path, load_invited_rooms, should_persist_invited_rooms
 from mindroom.matrix.rooms import is_dm_room
 from mindroom.matrix.state import MatrixState, managed_account_usernames
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
+from mindroom.matrix_naming import agent_username_localpart
 
 if TYPE_CHECKING:
     from mindroom.config.main import Config

--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -25,14 +25,14 @@ from mindroom.matrix.client_room_admin import (
 from mindroom.matrix.client_session import (
     matrix_client,
 )
-from mindroom.matrix.identity import (
-    MatrixID,
+from mindroom.matrix.identity import MatrixID
+from mindroom.matrix.state import MatrixRoom, MatrixState
+from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
+from mindroom.matrix_naming import (
     extract_server_name_from_homeserver,
     managed_room_alias_localpart,
     managed_space_alias_localpart,
 )
-from mindroom.matrix.state import MatrixRoom, MatrixState
-from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
 from mindroom.topic_generator import ensure_room_has_topic, generate_room_topic_ai
 
 if TYPE_CHECKING:

--- a/src/mindroom/matrix/users.py
+++ b/src/mindroom/matrix/users.py
@@ -17,8 +17,9 @@ from mindroom.matrix.client_session import (
     matrix_startup_error,
     restore_login,
 )
-from mindroom.matrix.identity import MatrixID, agent_username_localpart, extract_server_name_from_homeserver
+from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.state import MatrixState
+from mindroom.matrix_naming import agent_username_localpart, extract_server_name_from_homeserver
 
 logger = get_logger(__name__)
 

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -31,7 +31,7 @@ from mindroom.knowledge.watch import KnowledgeSourceWatcher
 from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_members, invite_to_room
 from mindroom.matrix.client_session import PermanentMatrixStartupError
 from mindroom.matrix.health import reset_matrix_sync_health
-from mindroom.matrix.identity import MatrixID, extract_server_name_from_homeserver
+from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.rooms import (
     ensure_all_rooms_exist,
     ensure_root_space,
@@ -50,6 +50,7 @@ from mindroom.matrix.users import (
     INTERNAL_USER_AGENT_NAME,
     create_agent_user,
 )
+from mindroom.matrix_naming import extract_server_name_from_homeserver
 from mindroom.mcp.manager import MCPServerManager
 from mindroom.mcp.registry import mcp_tool_name
 from mindroom.mcp.toolkit import bind_mcp_server_manager

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -24,9 +24,9 @@ from mindroom.constants import (
 )
 from mindroom.credentials_sync import get_secret_from_env
 from mindroom.logging_config import get_logger
-from mindroom.matrix.identity import agent_username_localpart
 from mindroom.matrix.media import download_media_bytes, extract_media_caption, media_mime_type
 from mindroom.matrix.mentions import format_message_with_mentions
+from mindroom.matrix_naming import agent_username_localpart
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tach.toml
+++ b/tach.toml
@@ -669,7 +669,7 @@ depends_on = []
 path = "mindroom.hooks.matrix_admin"
 depends_on = [
     "mindroom.matrix.client_room_admin",
-    "mindroom.matrix.identity",
+    "mindroom.matrix_naming",
 ]
 
 [[modules]]
@@ -678,7 +678,7 @@ depends_on = ["mindroom.matrix.client_session", "mindroom.constants"]
 
 [[modules]]
 path = "mindroom.matrix.room_cleanup"
-depends_on = ["mindroom.entity_resolution", "mindroom.matrix.rooms", "mindroom.matrix.client_room_admin", "mindroom.matrix.users"]
+depends_on = ["mindroom.entity_resolution", "mindroom.matrix.rooms", "mindroom.matrix.client_room_admin", "mindroom.matrix.users", "mindroom.matrix_naming"]
 
 [[modules]]
 path = "mindroom.matrix.rooms"
@@ -688,6 +688,7 @@ depends_on = [
     "mindroom.matrix.client_room_admin",
     "mindroom.matrix.client_session",
     "mindroom.matrix.users",
+    "mindroom.matrix_naming",
     "mindroom.topic_generator",
 ]
 
@@ -698,6 +699,7 @@ depends_on = [
     "mindroom.constants",
     "mindroom.matrix.client_session",
     "mindroom.matrix.provisioning",
+    "mindroom.matrix_naming",
 ]
 
 [[modules]]
@@ -721,6 +723,7 @@ depends_on = [
     "mindroom.matrix.rooms",
     "mindroom.matrix.stale_stream_cleanup",
     "mindroom.matrix.users",
+    "mindroom.matrix_naming",
     "mindroom.memory",
     "mindroom.mcp.manager",
     "mindroom.mcp.registry",
@@ -1573,9 +1576,9 @@ depends_on = [
     "mindroom.credentials_sync",
     "mindroom.logging_config",
     "mindroom.model_loading",
-    "mindroom.matrix.identity",
     "mindroom.matrix.media",
     "mindroom.matrix.mentions",
+    "mindroom.matrix_naming",
 ]
 
 [[modules]]

--- a/tests/test_config_architecture_boundaries.py
+++ b/tests/test_config_architecture_boundaries.py
@@ -1,4 +1,4 @@
-"""Architecture boundary tests for configuration modules."""
+"""Architecture boundary tests for configuration and Matrix identity modules."""
 
 from __future__ import annotations
 
@@ -6,6 +6,19 @@ import ast
 from pathlib import Path
 
 CONFIG_MODULES = tuple(Path("src/mindroom/config").glob("*.py"))
+PRODUCTION_MODULES = tuple(Path("src/mindroom").rglob("*.py"))
+MATRIX_IDENTITY_MODULE = Path("src/mindroom/matrix/identity.py")
+MATRIX_NAMING_HELPERS = frozenset(
+    {
+        "agent_username_localpart",
+        "extract_server_name_from_homeserver",
+        "managed_room_alias_localpart",
+        "managed_room_key_from_alias_localpart",
+        "managed_space_alias_localpart",
+        "mindroom_namespace",
+        "room_alias_localpart",
+    },
+)
 
 
 def _is_matrix_runtime_module(module: str) -> bool:
@@ -26,5 +39,41 @@ def test_config_modules_do_not_import_matrix_runtime_modules() -> None:
                     for alias in node.names
                     if _is_matrix_runtime_module(alias.name)
                 )
+
+    assert forbidden == []
+
+
+def test_matrix_identity_does_not_reexport_naming_helpers() -> None:
+    """Matrix identity owns Matrix IDs; pure naming helpers live in matrix_naming."""
+    tree = ast.parse(MATRIX_IDENTITY_MODULE.read_text(encoding="utf-8"))
+    exported_names: set[str] = set()
+    direct_naming_imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "mindroom.matrix_naming":
+            direct_naming_imports.extend(alias.name for alias in node.names if alias.name in MATRIX_NAMING_HELPERS)
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "__all__" for target in node.targets):
+            continue
+        if isinstance(node.value, ast.List):
+            exported_names.update(item.value for item in node.value.elts if isinstance(item, ast.Constant))
+
+    assert sorted(direct_naming_imports) == []
+    assert sorted(exported_names & MATRIX_NAMING_HELPERS) == []
+
+
+def test_production_code_imports_naming_helpers_from_matrix_naming() -> None:
+    """Callers use the neutral naming module instead of Matrix identity compatibility exports."""
+    forbidden: list[str] = []
+    for source_path in PRODUCTION_MODULES:
+        if source_path == MATRIX_IDENTITY_MODULE:
+            continue
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or node.module != "mindroom.matrix.identity":
+                continue
+            imported_helpers = sorted(alias.name for alias in node.names if alias.name in MATRIX_NAMING_HELPERS)
+            if imported_helpers:
+                forbidden.append(f"{source_path}:{node.lineno}: {', '.join(imported_helpers)}")
 
     assert forbidden == []

--- a/tests/test_config_discovery.py
+++ b/tests/test_config_discovery.py
@@ -15,8 +15,8 @@ from pydantic import ValidationError
 import mindroom.constants as constants_mod
 from mindroom.config.main import Config, load_config
 from mindroom.handled_turns import HandledTurnLedger
-from mindroom.matrix.identity import managed_space_alias_localpart
 from mindroom.matrix.state import MatrixState
+from mindroom.matrix_naming import managed_space_alias_localpart
 
 _RUNTIME_GLOBAL_NAMES = {
     "MATRIX_HOMESERVER",
@@ -984,7 +984,7 @@ class TestRuntimeContextConsumers:
 
     def test_imported_modules_follow_runtime_context_changes_without_reload(self, tmp_path: Path) -> None:
         """Explicit runtime-aware helpers should use the passed runtime context without reloads."""
-        identity_mod = importlib.import_module("mindroom.matrix.identity")
+        naming_mod = importlib.import_module("mindroom.matrix_naming")
         first_dir = tmp_path / "first"
         second_dir = tmp_path / "second"
         first_dir.mkdir(parents=True)
@@ -1004,11 +1004,11 @@ class TestRuntimeContextConsumers:
 
         first_runtime_paths = constants_mod.resolve_primary_runtime_paths(config_path=first_config)
         assert (
-            identity_mod.agent_username_localpart("general", runtime_paths=first_runtime_paths)
+            naming_mod.agent_username_localpart("general", runtime_paths=first_runtime_paths)
             == "mindroom_general_alpha1234"
         )
         assert (
-            identity_mod.extract_server_name_from_homeserver(
+            naming_mod.extract_server_name_from_homeserver(
                 "http://localhost:8008",
                 runtime_paths=first_runtime_paths,
             )
@@ -1017,11 +1017,11 @@ class TestRuntimeContextConsumers:
 
         second_runtime_paths = constants_mod.resolve_primary_runtime_paths(config_path=second_config)
         assert (
-            identity_mod.agent_username_localpart("general", runtime_paths=second_runtime_paths)
+            naming_mod.agent_username_localpart("general", runtime_paths=second_runtime_paths)
             == "mindroom_general_beta1234"
         )
         assert (
-            identity_mod.extract_server_name_from_homeserver(
+            naming_mod.extract_server_name_from_homeserver(
                 "http://localhost:8008",
                 runtime_paths=second_runtime_paths,
             )

--- a/tests/test_matrix_identity.py
+++ b/tests/test_matrix_identity.py
@@ -15,11 +15,11 @@ from mindroom.config.models import ModelConfig
 from mindroom.matrix.identity import (
     MatrixID,
     _ThreadStateKey,
-    agent_username_localpart,
     extract_agent_name,
     is_agent_id,
 )
 from mindroom.matrix.state import MatrixState
+from mindroom.matrix_naming import agent_username_localpart
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 if TYPE_CHECKING:

--- a/tests/test_matrix_spaces.py
+++ b/tests/test_matrix_spaces.py
@@ -13,8 +13,8 @@ from mindroom.config.main import Config
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.matrix import client as matrix_client
 from mindroom.matrix import rooms as matrix_rooms
-from mindroom.matrix.identity import managed_space_alias_localpart, mindroom_namespace
 from mindroom.matrix.state import MatrixState
+from mindroom.matrix_naming import managed_space_alias_localpart, mindroom_namespace
 from mindroom.orchestrator import MultiAgentOrchestrator
 from tests.conftest import bind_runtime_paths, orchestrator_runtime_paths, runtime_paths_for
 


### PR DESCRIPTION
## Summary
- Remove pure Matrix naming helpers from the `mindroom.matrix.identity` public surface.
- Update production and test callers to import naming helpers directly from `mindroom.matrix_naming`.
- Add architecture tests that prevent `matrix.identity` from re-exporting naming helpers or production callers from importing those helpers through identity.

## Test Plan
- `uv run pytest tests/test_config_architecture_boundaries.py -nauto --no-cov -v`
- `uv run tach check --dependencies --interfaces`
- `uv run pytest tests/test_config_architecture_boundaries.py tests/test_matrix_identity.py tests/test_config_discovery.py tests/test_matrix_spaces.py tests/test_matrix_agent_manager.py tests/test_authorization.py -nauto --no-cov -v`
- `uv run pytest tests/ -x -nauto --no-cov -v`
- `uv run pre-commit run --all-files`