### PR TITLE
fix(knowledge): run per-file indexing on a worker thread

### DIFF
--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1536,7 +1536,15 @@ class KnowledgeManager:
                 # Agno/Chroma upsert keys by content hash, so stale chunks from an older
                 # version of the same file can remain unless we clear by source metadata first.
                 await asyncio.to_thread(target_knowledge.remove_vectors_by_metadata, {_SOURCE_PATH_KEY: relative_path})
-            await target_knowledge.ainsert(
+            # Knowledge.ainsert is async by name only: it eventually calls into the
+            # vector database's synchronous batch upsert (e.g. ChromaDB's Rust
+            # _upsert) on the running event loop, blocking every other coroutine
+            # for as long as the embed+upsert batch takes. Use the sync insert API
+            # via asyncio.to_thread so embedding + vector database work runs on a
+            # worker thread and the loop stays responsive to Matrix sync, tool
+            # calls, and cache writes.
+            await asyncio.to_thread(
+                target_knowledge.insert,
                 path=str(resolved_path),
                 metadata=metadata,
                 upsert=upsert,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -138,7 +138,7 @@ class _Knowledge:
     def __init__(self, vector_db: _VectorDb) -> None:
         self.vector_db = vector_db
 
-    async def ainsert(
+    def insert(
         self,
         *,
         path: str,
@@ -151,6 +151,17 @@ class _Knowledge:
             _VectorDb.collections.setdefault(self.vector_db.collection_name, []).append(
                 {"content": Path(path).read_text(encoding="utf-8"), "metadata": dict(metadata)},
             )
+
+    async def ainsert(
+        self,
+        *,
+        path: str,
+        metadata: dict[str, object],
+        upsert: bool,
+        reader: object | None = None,
+    ) -> None:
+        # Match the real Knowledge surface: ainsert delegates to insert.
+        self.insert(path=path, metadata=metadata, upsert=upsert, reader=reader)
 
     def remove_vectors_by_metadata(self, metadata: dict[str, object]) -> bool:
         with _VectorDb.lock:
@@ -3334,7 +3345,7 @@ async def test_cold_refresh_publishes_when_empty_file_produces_no_vectors(
     runtime_paths = runtime_paths_for(config)
 
     class _SkipEmptyKnowledge(_Knowledge):
-        async def ainsert(
+        def insert(
             self,
             *,
             path: str,
@@ -3343,7 +3354,7 @@ async def test_cold_refresh_publishes_when_empty_file_produces_no_vectors(
             reader: object | None = None,
         ) -> None:
             if Path(path).read_text(encoding="utf-8"):
-                await super().ainsert(path=path, metadata=metadata, upsert=upsert, reader=reader)
+                super().insert(path=path, metadata=metadata, upsert=upsert, reader=reader)
 
     monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _SkipEmptyKnowledge)
 
@@ -5948,3 +5959,52 @@ def test_git_url_identity_preserves_passwordless_ssh_usernames() -> None:
     assert credential_free_url_identity(
         "ssh://user:old@example.com/org/repo.git;token=secret?query=secret#frag-secret",
     ) == credential_free_url_identity("ssh://example.com/org/repo.git")
+
+
+@pytest.mark.asyncio
+async def test_index_file_locked_runs_off_event_loop_thread(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-file indexing must run on a worker thread so the asyncio loop stays responsive.
+
+    Knowledge.ainsert in production agno is async by name only: it eventually calls into
+    the vector database's synchronous batch upsert (e.g. ChromaDB's Rust _upsert) on the
+    running event loop, which blocks Matrix sync, tool calls, and cache writes for the
+    full duration of every file's embed+upsert cycle. The manager guards against this by
+    using the sync Knowledge.insert API via asyncio.to_thread; this test pins that
+    behavior so the regression cannot return silently.
+    """
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("hello", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+
+    main_thread_id = get_ident()
+    insert_thread_ids: list[int] = []
+    original_insert = _Knowledge.insert
+
+    def _record_insert(self: _Knowledge, **kwargs: object) -> None:
+        insert_thread_ids.append(get_ident())
+        original_insert(self, **kwargs)  # type: ignore[arg-type]
+
+    async def _forbidden_ainsert(self: _Knowledge, **kwargs: object) -> None:
+        _ = (self, kwargs)
+        msg = (
+            "Knowledge.ainsert was called: indexing must use the sync Knowledge.insert "
+            "API via asyncio.to_thread to keep the event loop responsive."
+        )
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(_Knowledge, "insert", _record_insert)
+    monkeypatch.setattr(_Knowledge, "ainsert", _forbidden_ainsert)
+
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert insert_thread_ids, "expected at least one insert call during refresh"
+    for thread_id in insert_thread_ids:
+        assert thread_id != main_thread_id, (
+            f"Knowledge.insert ran on the asyncio main thread (id={thread_id}); "
+            "it must run on a worker thread via asyncio.to_thread."
+        )


### PR DESCRIPTION
## Summary

`Knowledge.ainsert` (via the agno ChromaDB integration) is async in name only: it eventually calls into the vector database's synchronous batch upsert (ChromaDB's Rust `_upsert`) on the running asyncio event loop. While that batch runs, every other coroutine on the loop is starved.

A py-spy snapshot of a stalled process during indexing shows the asyncio main thread deep here:

```
_upsert (chromadb/api/rust.py)
upsert (chromadb/Collection.py)
_batch_operation (agno/vectordb/chroma/chromadb.py)
_async_upsert (agno/vectordb/chroma/chromadb.py)
async_upsert (agno/vectordb/chroma/chromadb.py)
_ahandle_vector_db_insert (agno/knowledge/knowledge.py)
_aload_from_path (agno/knowledge/knowledge.py)
_aload_content (agno/knowledge/knowledge.py)
ainsert (agno/knowledge/knowledge.py)
_index_file_locked (mindroom/knowledge/manager.py)
```

User-visible effects when the indexer is busy:

- Matrix sync supervisor coroutines miss their tick → `Matrix sync watchdog detected a stalled sync loop`.
- Sandbox-runner streaming reads stall → tool-call HTTP reads back up → ReadTimeouts.
- Outbound matrix-cache write coroutines back up → `predecessor_wait_ms` and `update_run_ms` inflate.
- `Dispatch pipeline timing` records inflated `provider_ttft_ms` even though the LLM responded promptly — bytes from Vertex sit in the kernel buffer because the loop cannot read them.

## Fix

`Knowledge.insert` (the sync sibling of `ainsert`) has an identical signature. Switch the per-file index path to call it through `asyncio.to_thread`, so embed + vector-DB upsert run on a worker thread and the asyncio loop stays responsive throughout indexing.

```python
# before
await target_knowledge.ainsert(
    path=str(resolved_path),
    metadata=metadata,
    upsert=upsert,
    reader=reader,
)

# after
await asyncio.to_thread(
    target_knowledge.insert,
    path=str(resolved_path),
    metadata=metadata,
    upsert=upsert,
    reader=reader,
)
```

The neighbouring `remove_vectors_by_metadata` call already uses this pattern; this just extends it to the upsert path.

## Tests

- New `test_index_file_locked_runs_off_event_loop_thread` pins the off-loop behaviour: forbids `Knowledge.ainsert`, asserts every `Knowledge.insert` call lands on a non-main thread.
- Updated the existing `_SkipEmptyKnowledge` test override to hook `insert` rather than `ainsert`, since the sync path is now the one in use.
- `pytest tests/test_knowledge_manager.py tests/api/test_knowledge_api.py` — 204 passed.
- `ruff check` + `ruff format --check` clean on touched files.

## Verification after deploy

py-spy dump of the running mindroom process during a knowledge refresh should show the asyncio main thread idle in `select` (the loop), with the indexing work happening on an executor thread (`Thread-N`-style worker).