### PR TITLE
Rename Matrix naming helpers to identifiers

### DIFF
--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -12,7 +12,7 @@ from mindroom.constants import ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME
 from mindroom.logging_config import get_logger
 from mindroom.matrix.identity import MatrixID, active_internal_sender_ids
 from mindroom.matrix.state import MatrixState
-from mindroom.matrix_naming import managed_room_key_from_alias_localpart, room_alias_localpart
+from mindroom.matrix_identifiers import managed_room_key_from_alias_localpart, room_alias_localpart
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/src/mindroom/avatar_generation.py
+++ b/src/mindroom/avatar_generation.py
@@ -29,7 +29,7 @@ from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.rooms import get_room_id
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import AgentMatrixUser, login_agent_user
-from mindroom.matrix_naming import extract_server_name_from_homeserver
+from mindroom.matrix_identifiers import extract_server_name_from_homeserver
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -50,7 +50,11 @@ from mindroom.constants import (
 # config layer loads BEFORE the history runtime; import leaf types so config load does not drag in agents+tools.
 from mindroom.history.types import HistoryPolicy, ResolvedHistorySettings
 from mindroom.logging_config import get_logger
-from mindroom.matrix_naming import agent_username_localpart, managed_room_alias_localpart, managed_space_alias_localpart
+from mindroom.matrix_identifiers import (
+    agent_username_localpart,
+    managed_room_alias_localpart,
+    managed_space_alias_localpart,
+)
 from mindroom.mcp.config import MCPServerConfig, normalize_mcp_server_id
 from mindroom.tool_system.plugin_imports import PluginValidationError
 from mindroom.tool_system.worker_routing import unsupported_shared_only_integration_names

--- a/src/mindroom/config/matrix.py
+++ b/src/mindroom/config/matrix.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from mindroom.constants import resolve_config_relative_path
-from mindroom.matrix_naming import managed_room_key_from_alias_localpart, room_alias_localpart
+from mindroom.matrix_identifiers import managed_room_key_from_alias_localpart, room_alias_localpart
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/mindroom/entity_resolution.py
+++ b/src/mindroom/entity_resolution.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Literal
 import mindroom.matrix.rooms as matrix_rooms
 from mindroom.constants import ROUTER_AGENT_NAME, runtime_matrix_homeserver
 from mindroom.matrix.identity import MatrixID
-from mindroom.matrix_naming import agent_username_localpart, extract_server_name_from_homeserver
+from mindroom.matrix_identifiers import agent_username_localpart, extract_server_name_from_homeserver
 
 if TYPE_CHECKING:
     from mindroom.config.agent import AgentConfig, TeamConfig

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import nio
 
 from mindroom.matrix.client_room_admin import add_room_to_space, create_room, get_room_members, invite_to_room
-from mindroom.matrix_naming import extract_server_name_from_homeserver
+from mindroom.matrix_identifiers import extract_server_name_from_homeserver
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths

--- a/src/mindroom/matrix/identity.py
+++ b/src/mindroom/matrix/identity.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, ClassVar
 
-from mindroom import matrix_naming
+from mindroom import matrix_identifiers as _matrix_identifiers
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths
 from mindroom.matrix.state import managed_account_usernames
 
@@ -28,7 +28,7 @@ class MatrixID:
     username: str
     domain: str
 
-    AGENT_PREFIX: ClassVar[str] = matrix_naming.AGENT_USERNAME_PREFIX
+    AGENT_PREFIX: ClassVar[str] = _matrix_identifiers.AGENT_USERNAME_PREFIX
 
     @classmethod
     def parse(cls, matrix_id: str) -> MatrixID:
@@ -43,7 +43,7 @@ class MatrixID:
         runtime_paths: RuntimePaths,
     ) -> MatrixID:
         """Create a MatrixID for an agent."""
-        return cls(username=matrix_naming.agent_username_localpart(agent_name, runtime_paths), domain=domain)
+        return cls(username=_matrix_identifiers.agent_username_localpart(agent_name, runtime_paths), domain=domain)
 
     @classmethod
     def from_username(cls, username: str, domain: str) -> MatrixID:
@@ -66,7 +66,7 @@ class MatrixID:
 
         persisted_usernames = managed_account_usernames(runtime_paths)
         for account_key, active_name in _active_managed_agent_account_names(config).items():
-            expected_username = persisted_usernames.get(account_key) or matrix_naming.agent_username_localpart(
+            expected_username = persisted_usernames.get(account_key) or _matrix_identifiers.agent_username_localpart(
                 active_name,
                 runtime_paths,
             )

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -9,7 +9,7 @@ from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.message_builder import build_message_content, markdown_to_html
-from mindroom.matrix_naming import mindroom_namespace
+from mindroom.matrix_identifiers import mindroom_namespace
 from mindroom.tool_system.events import build_tool_trace_content, ensure_visible_tool_marker_spacing
 
 if TYPE_CHECKING:

--- a/src/mindroom/matrix/room_cleanup.py
+++ b/src/mindroom/matrix/room_cleanup.py
@@ -20,7 +20,7 @@ from mindroom.matrix.invited_rooms_store import invited_rooms_path, load_invited
 from mindroom.matrix.rooms import is_dm_room
 from mindroom.matrix.state import MatrixState, managed_account_usernames
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
-from mindroom.matrix_naming import agent_username_localpart
+from mindroom.matrix_identifiers import agent_username_localpart
 
 if TYPE_CHECKING:
     from mindroom.config.main import Config

--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -28,7 +28,7 @@ from mindroom.matrix.client_session import (
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.state import MatrixRoom, MatrixState
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
-from mindroom.matrix_naming import (
+from mindroom.matrix_identifiers import (
     extract_server_name_from_homeserver,
     managed_room_alias_localpart,
     managed_space_alias_localpart,

--- a/src/mindroom/matrix/users.py
+++ b/src/mindroom/matrix/users.py
@@ -19,7 +19,7 @@ from mindroom.matrix.client_session import (
 )
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.state import MatrixState
-from mindroom.matrix_naming import agent_username_localpart, extract_server_name_from_homeserver
+from mindroom.matrix_identifiers import agent_username_localpart, extract_server_name_from_homeserver
 
 logger = get_logger(__name__)
 

--- a/src/mindroom/matrix_identifiers.py
+++ b/src/mindroom/matrix_identifiers.py
@@ -1,4 +1,4 @@
-"""Matrix naming helpers that do not depend on Matrix runtime modules."""
+"""Matrix identifier helpers that do not depend on Matrix runtime modules."""
 
 from __future__ import annotations
 

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -50,7 +50,7 @@ from mindroom.matrix.users import (
     INTERNAL_USER_AGENT_NAME,
     create_agent_user,
 )
-from mindroom.matrix_naming import extract_server_name_from_homeserver
+from mindroom.matrix_identifiers import extract_server_name_from_homeserver
 from mindroom.mcp.manager import MCPServerManager
 from mindroom.mcp.registry import mcp_tool_name
 from mindroom.mcp.toolkit import bind_mcp_server_manager

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -26,7 +26,7 @@ from mindroom.credentials_sync import get_secret_from_env
 from mindroom.logging_config import get_logger
 from mindroom.matrix.media import download_media_bytes, extract_media_caption, media_mime_type
 from mindroom.matrix.mentions import format_message_with_mentions
-from mindroom.matrix_naming import agent_username_localpart
+from mindroom.matrix_identifiers import agent_username_localpart
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tach.toml
+++ b/tach.toml
@@ -164,7 +164,7 @@ depends_on = [
     "mindroom.constants",
     "mindroom.matrix.identity",
     "mindroom.matrix.rooms",
-    "mindroom.matrix_naming",
+    "mindroom.matrix_identifiers",
 ]
 
 [[modules]]
@@ -669,7 +669,7 @@ depends_on = []
 path = "mindroom.hooks.matrix_admin"
 depends_on = [
     "mindroom.matrix.client_room_admin",
-    "mindroom.matrix_naming",
+    "mindroom.matrix_identifiers",
 ]
 
 [[modules]]
@@ -678,7 +678,7 @@ depends_on = ["mindroom.matrix.client_session", "mindroom.constants"]
 
 [[modules]]
 path = "mindroom.matrix.room_cleanup"
-depends_on = ["mindroom.entity_resolution", "mindroom.matrix.rooms", "mindroom.matrix.client_room_admin", "mindroom.matrix.users", "mindroom.matrix_naming"]
+depends_on = ["mindroom.entity_resolution", "mindroom.matrix.rooms", "mindroom.matrix.client_room_admin", "mindroom.matrix.users", "mindroom.matrix_identifiers"]
 
 [[modules]]
 path = "mindroom.matrix.rooms"
@@ -688,7 +688,7 @@ depends_on = [
     "mindroom.matrix.client_room_admin",
     "mindroom.matrix.client_session",
     "mindroom.matrix.users",
-    "mindroom.matrix_naming",
+    "mindroom.matrix_identifiers",
     "mindroom.topic_generator",
 ]
 
@@ -699,7 +699,7 @@ depends_on = [
     "mindroom.constants",
     "mindroom.matrix.client_session",
     "mindroom.matrix.provisioning",
-    "mindroom.matrix_naming",
+    "mindroom.matrix_identifiers",
 ]
 
 [[modules]]
@@ -723,7 +723,7 @@ depends_on = [
     "mindroom.matrix.rooms",
     "mindroom.matrix.stale_stream_cleanup",
     "mindroom.matrix.users",
-    "mindroom.matrix_naming",
+    "mindroom.matrix_identifiers",
     "mindroom.memory",
     "mindroom.mcp.manager",
     "mindroom.mcp.registry",
@@ -818,7 +818,7 @@ depends_on = [
     "mindroom.entity_resolution",
     "mindroom.history.types",
     "mindroom.logging_config",
-    "mindroom.matrix_naming",
+    "mindroom.matrix_identifiers",
     "mindroom.mcp.config",
     "mindroom.tool_system.catalog",
     "mindroom.tool_system.plugin_imports",
@@ -1104,7 +1104,7 @@ path = "mindroom.constants"
 depends_on = []
 
 [[modules]]
-path = "mindroom.matrix_naming"
+path = "mindroom.matrix_identifiers"
 depends_on = ["mindroom.constants"]
 
 [[modules]]
@@ -1578,7 +1578,7 @@ depends_on = [
     "mindroom.model_loading",
     "mindroom.matrix.media",
     "mindroom.matrix.mentions",
-    "mindroom.matrix_naming",
+    "mindroom.matrix_identifiers",
 ]
 
 [[modules]]

--- a/tests/test_config_architecture_boundaries.py
+++ b/tests/test_config_architecture_boundaries.py
@@ -8,7 +8,8 @@ from pathlib import Path
 CONFIG_MODULES = tuple(Path("src/mindroom/config").glob("*.py"))
 PRODUCTION_MODULES = tuple(Path("src/mindroom").rglob("*.py"))
 MATRIX_IDENTITY_MODULE = Path("src/mindroom/matrix/identity.py")
-MATRIX_NAMING_HELPERS = frozenset(
+LEGACY_MATRIX_NAMING_MODULE = Path("src/mindroom/matrix_naming.py")
+MATRIX_IDENTIFIER_HELPERS = frozenset(
     {
         "agent_username_localpart",
         "extract_server_name_from_homeserver",
@@ -43,14 +44,21 @@ def test_config_modules_do_not_import_matrix_runtime_modules() -> None:
     assert forbidden == []
 
 
-def test_matrix_identity_does_not_reexport_naming_helpers() -> None:
-    """Matrix identity owns Matrix IDs; pure naming helpers live in matrix_naming."""
+def test_matrix_identity_does_not_reexport_identifier_helpers() -> None:
+    """Matrix identity owns Matrix IDs; pure identifier helpers live in matrix_identifiers."""
     tree = ast.parse(MATRIX_IDENTITY_MODULE.read_text(encoding="utf-8"))
     exported_names: set[str] = set()
     direct_naming_imports: list[str] = []
+    public_identifier_module_imports: list[str] = []
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module == "mindroom.matrix_naming":
-            direct_naming_imports.extend(alias.name for alias in node.names if alias.name in MATRIX_NAMING_HELPERS)
+        if isinstance(node, ast.ImportFrom) and node.module == "mindroom":
+            public_identifier_module_imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name == "matrix_identifiers" and not (alias.asname or "").startswith("_")
+            )
+        if isinstance(node, ast.ImportFrom) and node.module == "mindroom.matrix_identifiers":
+            direct_naming_imports.extend(alias.name for alias in node.names if alias.name in MATRIX_IDENTIFIER_HELPERS)
         if not isinstance(node, ast.Assign):
             continue
         if not any(isinstance(target, ast.Name) and target.id == "__all__" for target in node.targets):
@@ -58,12 +66,13 @@ def test_matrix_identity_does_not_reexport_naming_helpers() -> None:
         if isinstance(node.value, ast.List):
             exported_names.update(item.value for item in node.value.elts if isinstance(item, ast.Constant))
 
+    assert public_identifier_module_imports == []
     assert sorted(direct_naming_imports) == []
-    assert sorted(exported_names & MATRIX_NAMING_HELPERS) == []
+    assert sorted(exported_names & MATRIX_IDENTIFIER_HELPERS) == []
 
 
-def test_production_code_imports_naming_helpers_from_matrix_naming() -> None:
-    """Callers use the neutral naming module instead of Matrix identity compatibility exports."""
+def test_production_code_imports_identifier_helpers_from_matrix_identifiers() -> None:
+    """Callers use the neutral identifier module instead of Matrix identity compatibility exports."""
     forbidden: list[str] = []
     for source_path in PRODUCTION_MODULES:
         if source_path == MATRIX_IDENTITY_MODULE:
@@ -72,8 +81,29 @@ def test_production_code_imports_naming_helpers_from_matrix_naming() -> None:
         for node in ast.walk(tree):
             if not isinstance(node, ast.ImportFrom) or node.module != "mindroom.matrix.identity":
                 continue
-            imported_helpers = sorted(alias.name for alias in node.names if alias.name in MATRIX_NAMING_HELPERS)
+            imported_helpers = sorted(alias.name for alias in node.names if alias.name in MATRIX_IDENTIFIER_HELPERS)
             if imported_helpers:
                 forbidden.append(f"{source_path}:{node.lineno}: {', '.join(imported_helpers)}")
+
+    assert forbidden == []
+
+
+def test_matrix_naming_compatibility_module_does_not_exist() -> None:
+    """Pure Matrix identifier helpers live in matrix_identifiers with no legacy re-export module."""
+    forbidden: list[str] = []
+    if LEGACY_MATRIX_NAMING_MODULE.exists():
+        forbidden.append(str(LEGACY_MATRIX_NAMING_MODULE))
+
+    for source_path in PRODUCTION_MODULES:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "mindroom.matrix_naming":
+                forbidden.append(f"{source_path}:{node.lineno}: from {node.module}")
+            if isinstance(node, ast.Import):
+                forbidden.extend(
+                    f"{source_path}:{node.lineno}: import {alias.name}"
+                    for alias in node.names
+                    if alias.name == "mindroom.matrix_naming"
+                )
 
     assert forbidden == []

--- a/tests/test_config_discovery.py
+++ b/tests/test_config_discovery.py
@@ -16,7 +16,7 @@ import mindroom.constants as constants_mod
 from mindroom.config.main import Config, load_config
 from mindroom.handled_turns import HandledTurnLedger
 from mindroom.matrix.state import MatrixState
-from mindroom.matrix_naming import managed_space_alias_localpart
+from mindroom.matrix_identifiers import managed_space_alias_localpart
 
 _RUNTIME_GLOBAL_NAMES = {
     "MATRIX_HOMESERVER",
@@ -984,7 +984,7 @@ class TestRuntimeContextConsumers:
 
     def test_imported_modules_follow_runtime_context_changes_without_reload(self, tmp_path: Path) -> None:
         """Explicit runtime-aware helpers should use the passed runtime context without reloads."""
-        naming_mod = importlib.import_module("mindroom.matrix_naming")
+        naming_mod = importlib.import_module("mindroom.matrix_identifiers")
         first_dir = tmp_path / "first"
         second_dir = tmp_path / "second"
         first_dir.mkdir(parents=True)

--- a/tests/test_matrix_identity.py
+++ b/tests/test_matrix_identity.py
@@ -19,7 +19,7 @@ from mindroom.matrix.identity import (
     is_agent_id,
 )
 from mindroom.matrix.state import MatrixState
-from mindroom.matrix_naming import agent_username_localpart
+from mindroom.matrix_identifiers import agent_username_localpart
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 if TYPE_CHECKING:

--- a/tests/test_matrix_spaces.py
+++ b/tests/test_matrix_spaces.py
@@ -14,7 +14,7 @@ from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.matrix import client as matrix_client
 from mindroom.matrix import rooms as matrix_rooms
 from mindroom.matrix.state import MatrixState
-from mindroom.matrix_naming import managed_space_alias_localpart, mindroom_namespace
+from mindroom.matrix_identifiers import managed_space_alias_localpart, mindroom_namespace
 from mindroom.orchestrator import MultiAgentOrchestrator
 from tests.conftest import bind_runtime_paths, orchestrator_runtime_paths, runtime_paths_for
 


### PR DESCRIPTION
## Summary
- Rename the pure Matrix helper module from `mindroom.matrix_naming` to `mindroom.matrix_identifiers`.
- Update all callers and Tach dependencies directly, with no legacy compatibility re-export module.
- Keep `matrix.identity` using the helper module through a private internal alias and guard against public helper/module re-export surfaces.
- Add an architecture guard that fails if `src/mindroom/matrix_naming.py` returns or production code imports the legacy path.

## Compatibility export audit
- Rechecked the recent architecture PRs for compatibility re-export shims.
- The only direct one was the `matrix.identity` helper export path introduced in #758 and removed in #759; this PR finishes that cleanup by deleting the legacy module name itself.
- Other hits were intentional package surfaces, runtime/state compatibility, or OpenAI/OpenClaw compatibility features, not import shim exports.

## Verification
- Initial rename commit: `uv run pytest tests/test_config_architecture_boundaries.py::test_matrix_naming_compatibility_module_does_not_exist -nauto --no-cov -v` failed before the rename, then passed after implementation.
- Initial rename commit: `uv run pytest tests/test_config_architecture_boundaries.py -nauto --no-cov -v`
- Initial rename commit: `uv run ruff check src/mindroom/authorization.py src/mindroom/avatar_generation.py src/mindroom/config/main.py src/mindroom/config/matrix.py src/mindroom/entity_resolution.py src/mindroom/hooks/matrix_admin.py src/mindroom/matrix/identity.py src/mindroom/matrix/mentions.py src/mindroom/matrix/room_cleanup.py src/mindroom/matrix/rooms.py src/mindroom/matrix/users.py src/mindroom/matrix_identifiers.py src/mindroom/orchestrator.py src/mindroom/voice_handler.py tests/test_config_architecture_boundaries.py tests/test_config_discovery.py tests/test_matrix_identity.py tests/test_matrix_spaces.py`
- Initial rename commit: `uv run tach check --dependencies --interfaces`
- Initial rename commit: `uv run pytest tests/test_config_architecture_boundaries.py tests/test_matrix_identity.py tests/test_config_discovery.py tests/test_matrix_spaces.py tests/test_matrix_agent_manager.py tests/test_authorization.py tests/test_entity_resolution.py -nauto --no-cov -v`
- Initial rename commit: `uv run pytest tests/ -x -nauto --no-cov -v`
- Initial rename commit: `uv run pre-commit run --all-files`
- Amended commit after review cleanup: `uv run ruff check src/mindroom/matrix/identity.py tests/test_config_architecture_boundaries.py`
- Amended commit after review cleanup: commit-time pre-commit hooks, including `ruff check`, `ruff format`, `ty`, and `Enforce narrow Tach boundaries`

Per review request, pytest was not rerun after the private-alias cleanup.