### PR TITLE
Add Postgres Matrix event cache backend

### DIFF
--- a/src/mindroom/config/matrix.py
+++ b/src/mindroom/config/matrix.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from mindroom.constants import resolve_config_relative_path
+from mindroom.constants import (
+    is_runtime_database_url_env_name,
+    resolve_config_relative_path,
+    runtime_mindroom_namespace,
+)
 from mindroom.matrix_identifiers import managed_room_key_from_alias_localpart, room_alias_localpart
 
 if TYPE_CHECKING:
@@ -185,6 +189,10 @@ class CacheConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    backend: Literal["sqlite", "postgres"] = Field(
+        default="sqlite",
+        description="Storage backend for the always-on Matrix event cache.",
+    )
     db_path: str | None = Field(
         default=None,
         description=(
@@ -193,9 +201,64 @@ class CacheConfig(BaseModel):
             "Changing this path requires a restart because hot reload intentionally keeps the active cache file."
         ),
     )
+    database_url: str | None = Field(
+        default=None,
+        description=(
+            "PostgreSQL connection URL for the always-on Matrix event cache. Prefer database_url_env for secrets."
+        ),
+    )
+    database_url_env: str = Field(
+        default="MINDROOM_EVENT_CACHE_DATABASE_URL",
+        description=(
+            "Runtime env var that contains the PostgreSQL event-cache connection URL. "
+            "Must be DATABASE_URL or end with _DATABASE_URL so runtime secret filters withhold it."
+        ),
+    )
+    namespace: str | None = Field(
+        default=None,
+        description=(
+            "Logical namespace for PostgreSQL event-cache rows. "
+            "Defaults to MINDROOM_NAMESPACE when set, otherwise 'default'."
+        ),
+    )
+
+    @field_validator("database_url_env")
+    @classmethod
+    def validate_database_url_env(cls, env_name: str) -> str:
+        """Require custom DSN env names to match runtime secret-filter conventions."""
+        normalized = env_name.strip()
+        if normalized and not is_runtime_database_url_env_name(normalized):
+            msg = "cache.database_url_env must be DATABASE_URL or end with _DATABASE_URL"
+            raise ValueError(msg)
+        return normalized
 
     def resolve_db_path(self, runtime_paths: RuntimePaths) -> Path:
         """Resolve the configured database path for the active runtime startup."""
         if self.db_path is None:
             return runtime_paths.storage_root / "event_cache.db"
         return resolve_config_relative_path(self.db_path, runtime_paths)
+
+    def resolve_postgres_database_url(self, runtime_paths: RuntimePaths) -> str:
+        """Resolve the configured PostgreSQL connection URL for the active runtime."""
+        configured_url = (self.database_url or "").strip()
+        if configured_url:
+            return configured_url
+        env_name = self.database_url_env.strip()
+        if env_name:
+            env_url = (runtime_paths.env_value(env_name) or "").strip()
+            if env_url:
+                return env_url
+        msg = (
+            f"PostgreSQL event cache requires cache.database_url or {self.database_url_env} in the runtime environment"
+        )
+        raise ValueError(msg)
+
+    def resolve_namespace(self, runtime_paths: RuntimePaths) -> str:
+        """Resolve the logical cache namespace for shared PostgreSQL databases."""
+        configured_namespace = (self.namespace or "").strip()
+        if configured_namespace:
+            return configured_namespace
+        runtime_namespace = runtime_mindroom_namespace(runtime_paths)
+        if runtime_namespace is not None:
+            return runtime_namespace
+        return "default"

--- a/src/mindroom/config_template.yaml
+++ b/src/mindroom/config_template.yaml
@@ -54,9 +54,16 @@ matrix_space:
 
 # Persistent Matrix thread history cache.
 # This cache is always enabled.
-# `db_path` is read at startup and changing it requires a restart.
+# SQLite is the default for local installs.
+# For shared runtime storage, set backend: postgres and provide MINDROOM_EVENT_CACHE_DATABASE_URL.
+# MindRoom auto-installs the postgres extra when psycopg is missing.
+# Set MINDROOM_NO_AUTO_INSTALL_TOOLS=1 to disable optional dependency installation.
+# Cache backend settings are read at startup and changing them requires a restart.
 cache:
+  backend: sqlite
   db_path: mindroom_data/event_cache.db
+  # database_url_env: MINDROOM_EVENT_CACHE_DATABASE_URL
+  # namespace: default
 
 # Optional debug logging for pre-provider LLM request assembly data.
 # This writes sensitive prompts, messages, tools, and model params to JSONL.

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -49,6 +49,7 @@ _RUNTIME_STARTUP_ENV_EXTRA_KEYS = frozenset(
 _ISOLATED_RUNTIME_ENV_EXTRA_KEYS = frozenset({"ACCOUNT_ID", "CUSTOMER_ID", "POD_NAMESPACE"})
 _RUNTIME_STARTUP_EXCLUDED_NAMES = frozenset(
     {
+        "MINDROOM_EVENT_CACHE_DATABASE_URL",
         "MINDROOM_LOCAL_CLIENT_ID",
         "MINDROOM_SANDBOX_PROXY_TOKEN",
     },
@@ -63,6 +64,8 @@ _RUNTIME_STARTUP_SECRET_SUFFIXES = (
     "_SECRET",
     "_TOKEN",
 )
+_RUNTIME_DATABASE_URL_NAMES = frozenset({"DATABASE_URL"})
+_RUNTIME_DATABASE_URL_SUFFIXES = ("_DATABASE_URL",)
 _EXECUTION_RUNTIME_EXCLUDED_NAMES = frozenset(
     {
         *_RUNTIME_STARTUP_EXCLUDED_NAMES,
@@ -289,6 +292,8 @@ def serialize_runtime_paths(runtime_paths: RuntimePaths) -> dict[str, object]:
 def _is_public_runtime_startup_env_name(name: str) -> bool:
     if name in _RUNTIME_STARTUP_EXCLUDED_NAMES:
         return False
+    if is_runtime_database_url_env_name(name):
+        return False
     if not (name.startswith(_RUNTIME_STARTUP_ENV_PREFIXES) or name in _RUNTIME_STARTUP_ENV_EXTRA_KEYS):
         return False
     return not name.endswith(_RUNTIME_STARTUP_SECRET_SUFFIXES)
@@ -296,6 +301,8 @@ def _is_public_runtime_startup_env_name(name: str) -> bool:
 
 def _is_isolated_runtime_public_env_name(name: str) -> bool:
     if name in _EXECUTION_RUNTIME_EXCLUDED_NAMES:
+        return False
+    if is_runtime_database_url_env_name(name):
         return False
     if not (name.startswith(_RUNTIME_STARTUP_ENV_PREFIXES) or name in _ISOLATED_RUNTIME_ENV_EXTRA_KEYS):
         return False
@@ -491,6 +498,11 @@ def _is_known_worker_credential_env_name(name: str) -> bool:
     }
 
 
+def is_runtime_database_url_env_name(name: str) -> bool:
+    """Return whether an env name conventionally carries a database connection URL."""
+    return name in _RUNTIME_DATABASE_URL_NAMES or name.endswith(_RUNTIME_DATABASE_URL_SUFFIXES)
+
+
 def _is_execution_runtime_process_env_name(
     name: str,
 ) -> bool:
@@ -502,7 +514,7 @@ def _is_execution_runtime_process_env_name(
 def _is_allowed_execution_runtime_env_file_name(
     name: str,
 ) -> bool:
-    return name not in _EXECUTION_RUNTIME_EXCLUDED_NAMES
+    return name not in _EXECUTION_RUNTIME_EXCLUDED_NAMES and not is_runtime_database_url_env_name(name)
 
 
 def _execution_runtime_env_layers(

--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -4,14 +4,16 @@ Developer note:
 - `event_cache.py` owns the storage-agnostic durable cache protocol.
 - `event_normalization.py` owns storage-agnostic event payload shaping before backend writes.
 - `sqlite_event_cache.py` owns the SQLite implementation, runtime, locking, and schema lifecycle.
+- `postgres_event_cache.py` owns the PostgreSQL implementation, runtime, advisory locking, and schema lifecycle.
 - `sqlite_event_cache_events.py` owns SQLite lookup/index rows, edits, and redaction tombstones.
 - `sqlite_event_cache_threads.py` owns thread snapshot rows, cache-state reads, and thread/room invalidation state.
 - `sqlite_agent_message_snapshot.py` owns SQLite reads for latest cached agent message snapshots.
+- `postgres_event_cache_events.py`, `postgres_event_cache_threads.py`, and `postgres_agent_message_snapshot.py` own the equivalent PostgreSQL row helpers.
 - `thread_writes.py` owns live, outbound, and sync mutation flows; `thread_bookkeeping.py` resolves thread impact and `thread_write_cache_ops.py` applies queued cache mutations.
 
 Package boundary:
 - `mindroom.matrix.cache` is the package-level import surface for cache-facing contracts and shared helpers used above the cache package.
-- `SqliteEventCache` and `_EventCacheWriteCoordinator` remain private concrete services used by `runtime_support.py` through their concrete owner modules.
+- `SqliteEventCache`, `PostgresEventCache`, and `_EventCacheWriteCoordinator` remain private concrete services used by `runtime_support.py` through their concrete owner modules.
 - `MatrixConversationCache` remains the higher-level conversation read/write facade above the cache package and may use specific cache helper submodules through narrow Tach visibility.
 
 Main invariants:

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -27,6 +27,10 @@ class ConversationEventCache(Protocol):
     def durable_writes_available(self) -> bool:
         """Return whether cache writes can durably persist data."""
 
+    @property
+    def is_initialized(self) -> bool:
+        """Return whether the backing storage is currently initialized."""
+
     async def initialize(self) -> None:
         """Initialize any backing storage."""
 

--- a/src/mindroom/matrix/cache/postgres_agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/postgres_agent_message_snapshot.py
@@ -1,0 +1,235 @@
+"""PostgreSQL snapshot reads for the latest visible agent message in one cached scope."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import psycopg
+
+from . import postgres_event_cache_events, postgres_event_cache_threads
+from .agent_message_snapshot import AgentMessageSnapshot, AgentMessageSnapshotUnavailable
+from .thread_cache_helpers import thread_cache_rejection_reason
+
+if TYPE_CHECKING:
+    from psycopg import AsyncConnection, AsyncCursor
+
+
+@dataclass(frozen=True, slots=True)
+class _SnapshotLookupResult:
+    """Outcome for one matching scope event during latest-message lookup."""
+
+    snapshot: AgentMessageSnapshot | None
+    stop_scanning: bool = False
+
+
+_THREAD_CACHE_REJECTION_NONE_REASONS = frozenset({"no_cache_state", "cache_never_validated"})
+
+
+def _content_dict(content: object) -> dict[str, Any]:
+    if not isinstance(content, dict):
+        return {}
+    return {key: value for key, value in content.items() if isinstance(key, str)}
+
+
+def _relation_type(event: dict[str, Any]) -> str | None:
+    content = _content_dict(event.get("content"))
+    relates_to = content.get("m.relates_to")
+    if not isinstance(relates_to, dict):
+        return None
+    relation_type = relates_to.get("rel_type")
+    return relation_type if isinstance(relation_type, str) else None
+
+
+def _visible_content(event: dict[str, Any]) -> dict[str, Any]:
+    content = _content_dict(event.get("content"))
+    new_content = _content_dict(content.get("m.new_content"))
+    return new_content or content
+
+
+def _event_matches_scope(
+    event: dict[str, Any],
+    *,
+    thread_id: str | None,
+    sender: str,
+) -> bool:
+    if event.get("type") != "m.room.message" or event.get("sender") != sender:
+        return False
+    relation_type = _relation_type(event)
+    if relation_type == "m.replace":
+        return False
+    return not (thread_id is None and relation_type == "m.thread")
+
+
+async def _thread_scope_has_no_snapshot(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str | None,
+) -> bool:
+    if thread_id is None:
+        return False
+
+    rejection_reason = thread_cache_rejection_reason(
+        await postgres_event_cache_threads.load_thread_cache_state(
+            db,
+            namespace=namespace,
+            room_id=room_id,
+            thread_id=thread_id,
+        ),
+    )
+    if rejection_reason in _THREAD_CACHE_REJECTION_NONE_REASONS:
+        return True
+    if rejection_reason is not None:
+        msg = f"Thread cache snapshot is not usable: {rejection_reason}"
+        raise AgentMessageSnapshotUnavailable(msg)
+    return False
+
+
+async def _snapshot_from_event(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str | None,
+    event: dict[str, Any],
+    cached_at: float | None,
+    runtime_started_at: float | None,
+) -> _SnapshotLookupResult:
+    event_id = event.get("event_id")
+    if not isinstance(event_id, str) or not event_id:
+        return _SnapshotLookupResult(snapshot=None)
+
+    latest_edit = await postgres_event_cache_events.load_latest_edit_row(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        original_event_id=event_id,
+    )
+    latest_event = latest_edit.event if latest_edit is not None else event
+    visible_cached_at = latest_edit.cached_at if latest_edit is not None else cached_at
+    if (
+        thread_id is None
+        and runtime_started_at is not None
+        and (visible_cached_at is None or visible_cached_at < runtime_started_at)
+    ):
+        return _SnapshotLookupResult(snapshot=None, stop_scanning=True)
+
+    timestamp = latest_event.get("origin_server_ts")
+    if not isinstance(timestamp, int) or isinstance(timestamp, bool):
+        return _SnapshotLookupResult(snapshot=None)
+
+    return _SnapshotLookupResult(
+        snapshot=AgentMessageSnapshot(
+            content=_visible_content(latest_event),
+            origin_server_ts=timestamp,
+        ),
+    )
+
+
+async def _iter_scope_events(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str | None,
+) -> AsyncCursor[tuple[str, float | None]]:
+    if thread_id is None:
+        return await db.execute(
+            """
+            SELECT event_json, cached_at
+            FROM mindroom_event_cache_events
+            WHERE namespace = %s AND room_id = %s
+            ORDER BY origin_server_ts DESC, write_seq DESC
+            """,
+            (namespace, room_id),
+        )
+    return await db.execute(
+        """
+        SELECT event_json, NULL AS cached_at
+        FROM mindroom_event_cache_thread_events
+        WHERE namespace = %s AND room_id = %s AND thread_id = %s
+        ORDER BY origin_server_ts DESC, write_seq DESC
+        """,
+        (namespace, room_id, thread_id),
+    )
+
+
+async def _load_scope_snapshot(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str | None,
+    sender: str,
+    runtime_started_at: float | None,
+) -> AgentMessageSnapshot | None:
+    cursor = await _iter_scope_events(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    try:
+        while True:
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+            event = json.loads(row[0])
+            if not _event_matches_scope(
+                event,
+                thread_id=thread_id,
+                sender=sender,
+            ):
+                continue
+            result = await _snapshot_from_event(
+                db,
+                namespace=namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+                event=event,
+                cached_at=None if row[1] is None else float(row[1]),
+                runtime_started_at=runtime_started_at,
+            )
+            if result.stop_scanning:
+                return None
+            if result.snapshot is not None:
+                return result.snapshot
+    finally:
+        await cursor.close()
+
+
+async def load_postgres_agent_message_snapshot(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str | None,
+    sender: str,
+    runtime_started_at: float | None,
+) -> AgentMessageSnapshot | None:
+    """Return the latest visible message from ``sender`` in the given scope."""
+    try:
+        if await _thread_scope_has_no_snapshot(
+            db,
+            namespace=namespace,
+            room_id=room_id,
+            thread_id=thread_id,
+        ):
+            return None
+        return await _load_scope_snapshot(
+            db,
+            namespace=namespace,
+            room_id=room_id,
+            thread_id=thread_id,
+            sender=sender,
+            runtime_started_at=runtime_started_at,
+        )
+    except json.JSONDecodeError as exc:
+        msg = "Cached Matrix event JSON is corrupt"
+        raise AgentMessageSnapshotUnavailable(msg) from exc
+    except psycopg.Error as exc:
+        msg = "Failed to read Matrix event cache snapshot"
+        raise AgentMessageSnapshotUnavailable(msg) from exc

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -1,0 +1,803 @@
+"""PostgreSQL runtime and lifecycle ownership for the Matrix event cache."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import OrderedDict
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, TypeVar
+
+import psycopg
+
+from mindroom.logging_config import get_logger
+
+from . import postgres_event_cache_events, postgres_event_cache_threads
+from .event_normalization import normalize_event_source_for_cache
+from .postgres_agent_message_snapshot import load_postgres_agent_message_snapshot
+from .postgres_redaction import redact_postgres_connection_info
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Awaitable, Callable
+
+    from psycopg import AsyncConnection
+
+    from .agent_message_snapshot import AgentMessageSnapshot
+    from .event_cache import ThreadCacheState
+
+
+POSTGRES_EVENT_CACHE_SCHEMA_VERSION = 1
+_LOCK_WAIT_LOG_THRESHOLD_SECONDS = 0.1
+_MAX_CACHED_ROOM_LOCKS = 256
+T = TypeVar("T")
+
+logger = get_logger(__name__)
+
+
+async def initialize_postgres_event_cache_db(database_url: str) -> psycopg.AsyncConnection:
+    """Open the PostgreSQL database and ensure the event-cache schema exists."""
+    db = await psycopg.AsyncConnection.connect(database_url)
+    try:
+        await create_postgres_event_cache_schema(db)
+        await validate_postgres_event_cache_schema(db)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        await db.close()
+        raise
+    return db
+
+
+async def create_postgres_event_cache_schema(db: AsyncConnection) -> None:
+    """Create the current PostgreSQL cache schema in one connection."""
+    await db.execute("CREATE SEQUENCE IF NOT EXISTS mindroom_event_cache_write_seq")
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mindroom_event_cache_thread_events (
+            namespace TEXT NOT NULL,
+            room_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            origin_server_ts BIGINT NOT NULL,
+            event_json TEXT NOT NULL,
+            write_seq BIGINT NOT NULL DEFAULT nextval('mindroom_event_cache_write_seq'),
+            PRIMARY KEY (namespace, room_id, event_id)
+        )
+        """,
+    )
+    await db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_mindroom_event_cache_thread_events_room_thread_ts
+        ON mindroom_event_cache_thread_events(namespace, room_id, thread_id, origin_server_ts)
+        """,
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mindroom_event_cache_events (
+            namespace TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            room_id TEXT NOT NULL,
+            origin_server_ts BIGINT NOT NULL,
+            event_json TEXT NOT NULL,
+            cached_at DOUBLE PRECISION NOT NULL,
+            write_seq BIGINT NOT NULL DEFAULT nextval('mindroom_event_cache_write_seq'),
+            PRIMARY KEY (namespace, event_id)
+        )
+        """,
+    )
+    await db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_mindroom_event_cache_events_room_origin_ts
+        ON mindroom_event_cache_events(namespace, room_id, origin_server_ts DESC)
+        """,
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mindroom_event_cache_event_edits (
+            namespace TEXT NOT NULL,
+            edit_event_id TEXT NOT NULL,
+            room_id TEXT NOT NULL,
+            original_event_id TEXT NOT NULL,
+            origin_server_ts BIGINT NOT NULL,
+            PRIMARY KEY (namespace, edit_event_id)
+        )
+        """,
+    )
+    await db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_mindroom_event_cache_event_edits_room_original_ts
+        ON mindroom_event_cache_event_edits(
+            namespace,
+            room_id,
+            original_event_id,
+            origin_server_ts DESC,
+            edit_event_id DESC
+        )
+        """,
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mindroom_event_cache_event_threads (
+            namespace TEXT NOT NULL,
+            room_id TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL,
+            PRIMARY KEY (namespace, room_id, event_id)
+        )
+        """,
+    )
+    await db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_mindroom_event_cache_event_threads_room_thread
+        ON mindroom_event_cache_event_threads(namespace, room_id, thread_id, event_id)
+        """,
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mindroom_event_cache_redacted_events (
+            namespace TEXT NOT NULL,
+            room_id TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            PRIMARY KEY (namespace, room_id, event_id)
+        )
+        """,
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mindroom_event_cache_mxc_text (
+            namespace TEXT NOT NULL,
+            mxc_url TEXT NOT NULL,
+            text_content TEXT NOT NULL,
+            cached_at DOUBLE PRECISION NOT NULL,
+            PRIMARY KEY (namespace, mxc_url)
+        )
+        """,
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mindroom_event_cache_thread_state (
+            namespace TEXT NOT NULL,
+            room_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL,
+            validated_at DOUBLE PRECISION,
+            invalidated_at DOUBLE PRECISION,
+            invalidation_reason TEXT,
+            PRIMARY KEY (namespace, room_id, thread_id)
+        )
+        """,
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mindroom_event_cache_room_state (
+            namespace TEXT NOT NULL,
+            room_id TEXT NOT NULL,
+            invalidated_at DOUBLE PRECISION,
+            invalidation_reason TEXT,
+            PRIMARY KEY (namespace, room_id)
+        )
+        """,
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mindroom_event_cache_metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        """,
+    )
+
+
+async def postgres_schema_version(db: AsyncConnection) -> int | None:
+    """Return the current PostgreSQL schema version for this cache."""
+    cursor = await db.execute(
+        """
+        SELECT value
+        FROM mindroom_event_cache_metadata
+        WHERE key = 'schema_version'
+        """,
+    )
+    try:
+        row = await cursor.fetchone()
+    finally:
+        await cursor.close()
+    return None if row is None else int(row[0])
+
+
+async def validate_postgres_event_cache_schema(db: AsyncConnection) -> None:
+    """Store or validate the PostgreSQL cache schema version."""
+    current_schema_version = await postgres_schema_version(db)
+    if current_schema_version is None:
+        await db.execute(
+            """
+            INSERT INTO mindroom_event_cache_metadata(key, value)
+            VALUES ('schema_version', %s)
+            ON CONFLICT(key) DO NOTHING
+            """,
+            (str(POSTGRES_EVENT_CACHE_SCHEMA_VERSION),),
+        )
+        current_schema_version = await postgres_schema_version(db)
+        if current_schema_version is None:
+            msg = "PostgreSQL Matrix event cache schema version was not initialized"
+            raise RuntimeError(msg)
+    if current_schema_version == POSTGRES_EVENT_CACHE_SCHEMA_VERSION:
+        return
+    msg = (
+        "PostgreSQL Matrix event cache schema version "
+        f"{current_schema_version} is not compatible with expected version "
+        f"{POSTGRES_EVENT_CACHE_SCHEMA_VERSION}"
+    )
+    raise RuntimeError(msg)
+
+
+@dataclass
+class _RoomLockEntry:
+    """Track one room lock plus queued users that still rely on it."""
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    active_users: int = 0
+
+
+class _PostgresEventCacheRuntime:
+    """Own runtime-only lifecycle, locking, and disable state for one cache instance."""
+
+    def __init__(self, database_url: str, namespace: str) -> None:
+        self._database_url = database_url
+        self._namespace = namespace
+        self._db: psycopg.AsyncConnection | None = None
+        self._disabled_reason: str | None = None
+        self._db_lock = asyncio.Lock()
+        self._room_locks: OrderedDict[str, _RoomLockEntry] = OrderedDict()
+
+    @property
+    def database_url(self) -> str:
+        """Return the PostgreSQL connection URL for this cache instance."""
+        return self._database_url
+
+    @property
+    def redacted_database_url(self) -> str:
+        """Return the log-safe PostgreSQL connection URL for this cache instance."""
+        return redact_postgres_connection_info(self._database_url)
+
+    @property
+    def namespace(self) -> str:
+        """Return the logical cache namespace."""
+        return self._namespace
+
+    @property
+    def db(self) -> psycopg.AsyncConnection | None:
+        """Return the active PostgreSQL connection, if initialized."""
+        return self._db
+
+    @property
+    def room_locks(self) -> dict[str, _RoomLockEntry]:
+        """Return the cached room-lock table for observability and tests."""
+        return self._room_locks
+
+    @property
+    def is_initialized(self) -> bool:
+        """Return whether the PostgreSQL connection is currently open."""
+        return self._db is not None
+
+    @property
+    def is_disabled(self) -> bool:
+        """Return whether the advisory cache is disabled for this runtime."""
+        return self._disabled_reason is not None
+
+    def disable(self, reason: str) -> None:
+        """Disable the advisory cache for the rest of the runtime."""
+        if self._disabled_reason is not None:
+            return
+        self._disabled_reason = reason
+        logger.warning(
+            "Disabling advisory Matrix event cache",
+            database_url=self.redacted_database_url,
+            namespace=self._namespace,
+            reason=reason,
+        )
+
+    async def initialize(self) -> None:
+        """Open the PostgreSQL database and create the cache schema."""
+        async with self._db_lock:
+            if self._disabled_reason is not None or self._db is not None:
+                return
+            self._db = await initialize_postgres_event_cache_db(self._database_url)
+
+    async def close(self) -> None:
+        """Close the PostgreSQL connection when the cache is no longer needed."""
+        async with self._db_lock:
+            if self._db is None:
+                return
+            await self._db.close()
+            self._db = None
+            self._room_locks.clear()
+
+    def room_lock_entry(self, room_id: str, *, active_user_increment: int = 0) -> _RoomLockEntry:
+        """Return the cached room lock entry, creating it on demand."""
+        entry = self._room_locks.get(room_id)
+        if entry is None:
+            entry = _RoomLockEntry(active_users=active_user_increment)
+        else:
+            entry.active_users += active_user_increment
+        self._room_locks[room_id] = entry
+        self._room_locks.move_to_end(room_id)
+        self._prune_room_locks()
+        return entry
+
+    @asynccontextmanager
+    async def acquire_room_lock(self, room_id: str, *, operation: str) -> AsyncIterator[None]:
+        """Serialize runtime-visible work for one room."""
+        entry = self.room_lock_entry(room_id, active_user_increment=1)
+        wait_started = time.perf_counter()
+        acquired = False
+        try:
+            await entry.lock.acquire()
+            acquired = True
+            wait_time = time.perf_counter() - wait_started
+            if wait_time > _LOCK_WAIT_LOG_THRESHOLD_SECONDS:
+                logger.debug(
+                    "Waited for PostgresEventCache room lock",
+                    room_id=room_id,
+                    namespace=self._namespace,
+                    operation=operation,
+                    wait_time_ms=round(wait_time * 1000, 2),
+                )
+            yield
+        finally:
+            if acquired:
+                entry.lock.release()
+            entry.active_users -= 1
+            if entry.active_users == 0:
+                self._prune_room_locks()
+
+    @asynccontextmanager
+    async def acquire_db_operation(
+        self,
+        room_id: str,
+        *,
+        operation: str,
+    ) -> AsyncIterator[psycopg.AsyncConnection]:
+        """Serialize one DB operation with lifecycle changes and room ordering."""
+        if self._db is None:
+            await self.initialize()
+        async with self._db_lock, self.acquire_room_lock(room_id, operation=operation):
+            db = self.require_db()
+            await db.execute(
+                "SELECT pg_advisory_xact_lock(hashtext(%s), hashtext(%s))",
+                (self._namespace, room_id),
+            )
+            yield db
+
+    def require_db(self) -> psycopg.AsyncConnection:
+        """Return the active PostgreSQL connection or raise if uninitialized."""
+        if self._db is None:
+            msg = "PostgresEventCache has not been initialized"
+            raise RuntimeError(msg)
+        return self._db
+
+    def _prune_room_locks(self) -> None:
+        while len(self._room_locks) > _MAX_CACHED_ROOM_LOCKS:
+            evicted_room_id: str | None = None
+            for cached_room_id, cached_entry in self._room_locks.items():
+                if cached_entry.active_users > 0:
+                    continue
+                evicted_room_id = cached_room_id
+                break
+            if evicted_room_id is None:
+                return
+            self._room_locks.pop(evicted_room_id, None)
+
+
+RoomLockEntry = _RoomLockEntry
+PostgresEventCacheRuntime = _PostgresEventCacheRuntime
+
+
+class PostgresEventCache:
+    """PostgreSQL-backed ConversationEventCache implementation."""
+
+    def __init__(self, *, database_url: str, namespace: str) -> None:
+        self._runtime = _PostgresEventCacheRuntime(database_url, namespace)
+
+    @property
+    def database_url(self) -> str:
+        """Return the PostgreSQL connection URL for this cache instance."""
+        return self._runtime.database_url
+
+    @property
+    def namespace(self) -> str:
+        """Return the logical cache namespace."""
+        return self._runtime.namespace
+
+    @property
+    def is_initialized(self) -> bool:
+        """Return whether the PostgreSQL connection is currently open."""
+        return self._runtime.is_initialized
+
+    @property
+    def durable_writes_available(self) -> bool:
+        """Return whether cache writes can durably persist data."""
+        return self._runtime.is_initialized and not self._runtime.is_disabled
+
+    async def initialize(self) -> None:
+        """Open the PostgreSQL database and create the cache schema."""
+        await self._runtime.initialize()
+
+    def disable(self, reason: str) -> None:
+        """Disable the advisory cache for the rest of the runtime."""
+        self._runtime.disable(reason)
+
+    async def close(self) -> None:
+        """Close the PostgreSQL connection when the cache is no longer needed."""
+        await self._runtime.close()
+
+    async def _read_operation(
+        self,
+        room_id: str,
+        *,
+        operation: str,
+        disabled_result: T,
+        reader: Callable[[psycopg.AsyncConnection], Awaitable[T]],
+    ) -> T:
+        if self._runtime.is_disabled:
+            return disabled_result
+        async with self._runtime.acquire_db_operation(room_id, operation=operation) as db:
+            try:
+                result = await reader(db)
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+        return result
+
+    async def _write_operation(
+        self,
+        room_id: str,
+        *,
+        operation: str,
+        disabled_result: T,
+        writer: Callable[[psycopg.AsyncConnection], Awaitable[T]],
+    ) -> T:
+        if self._runtime.is_disabled:
+            return disabled_result
+        async with self._runtime.acquire_db_operation(room_id, operation=operation) as db:
+            try:
+                result = await writer(db)
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+        return result
+
+    async def get_thread_events(self, room_id: str, thread_id: str) -> list[dict[str, Any]] | None:
+        """Return cached events for one thread sorted by timestamp."""
+        return await self._read_operation(
+            room_id,
+            operation="get_thread_events",
+            disabled_result=None,
+            reader=lambda db: postgres_event_cache_threads.load_thread_events(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+            ),
+        )
+
+    async def get_recent_room_thread_ids(self, room_id: str, *, limit: int) -> list[str]:
+        """Return locally known thread IDs for one room ordered by newest cached activity."""
+        return await self._read_operation(
+            room_id,
+            operation="get_recent_room_thread_ids",
+            disabled_result=[],
+            reader=lambda db: postgres_event_cache_threads.load_recent_room_thread_ids(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                limit=limit,
+            ),
+        )
+
+    async def get_thread_cache_state(self, room_id: str, thread_id: str) -> ThreadCacheState | None:
+        """Return durable freshness metadata for one cached thread."""
+        return await self._read_operation(
+            room_id,
+            operation="get_thread_cache_state",
+            disabled_result=None,
+            reader=lambda db: postgres_event_cache_threads.load_thread_cache_state(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+            ),
+        )
+
+    async def get_event(self, room_id: str, event_id: str) -> dict[str, Any] | None:
+        """Return one cached event payload by event ID."""
+        return await self._read_operation(
+            room_id,
+            operation="get_event",
+            disabled_result=None,
+            reader=lambda db: postgres_event_cache_events.load_event(
+                db,
+                namespace=self._runtime.namespace,
+                event_id=event_id,
+            ),
+        )
+
+    async def get_latest_edit(self, room_id: str, original_event_id: str) -> dict[str, Any] | None:
+        """Return the latest cached edit event for one original event."""
+        return await self._read_operation(
+            room_id,
+            operation="get_latest_edit",
+            disabled_result=None,
+            reader=lambda db: postgres_event_cache_events.load_latest_edit(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                original_event_id=original_event_id,
+            ),
+        )
+
+    async def get_latest_agent_message_snapshot(
+        self,
+        room_id: str,
+        thread_id: str | None,
+        sender: str,
+        *,
+        runtime_started_at: float | None,
+    ) -> AgentMessageSnapshot | None:
+        """Return the latest visible cached message from one sender in the given scope."""
+        return await self._read_operation(
+            room_id,
+            operation="get_latest_agent_message_snapshot",
+            disabled_result=None,
+            reader=lambda db: load_postgres_agent_message_snapshot(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+                sender=sender,
+                runtime_started_at=runtime_started_at,
+            ),
+        )
+
+    async def get_mxc_text(self, room_id: str, mxc_url: str) -> str | None:
+        """Return one durably cached MXC text payload when present."""
+        return await self._read_operation(
+            room_id,
+            operation="get_mxc_text",
+            disabled_result=None,
+            reader=lambda db: postgres_event_cache_events.load_mxc_text(
+                db,
+                namespace=self._runtime.namespace,
+                mxc_url=mxc_url,
+            ),
+        )
+
+    async def store_event(self, event_id: str, room_id: str, event_data: dict[str, Any]) -> None:
+        """Insert or replace one individually cached Matrix event."""
+        await self.store_events_batch([(event_id, room_id, event_data)])
+
+    async def store_events_batch(self, events: list[tuple[str, str, dict[str, Any]]]) -> None:
+        """Insert or replace one batch of individually cached Matrix events."""
+        if self._runtime.is_disabled or not events:
+            return
+
+        cached_at = time.time()
+        events_by_room: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+        for event_id, room_id, event_data in events:
+            normalized_event = normalize_event_source_for_cache(event_data, event_id=event_id)
+            events_by_room.setdefault(room_id, []).append((event_id, normalized_event))
+
+        for room_id, room_events in events_by_room.items():
+            await self._write_operation(
+                room_id,
+                operation="store_events_batch",
+                disabled_result=None,
+                writer=lambda db, room_id=room_id, room_events=room_events, cached_at=cached_at: (
+                    postgres_event_cache_events.persist_lookup_events(
+                        db,
+                        namespace=self._runtime.namespace,
+                        room_id=room_id,
+                        room_events=room_events,
+                        cached_at=cached_at,
+                    )
+                ),
+            )
+
+    async def store_mxc_text(self, room_id: str, mxc_url: str, text: str) -> None:
+        """Insert or replace one durably cached MXC text payload."""
+        await self._write_operation(
+            room_id,
+            operation="store_mxc_text",
+            disabled_result=None,
+            writer=lambda db: postgres_event_cache_events.persist_mxc_text(
+                db,
+                namespace=self._runtime.namespace,
+                mxc_url=mxc_url,
+                text=text,
+                cached_at=time.time(),
+            ),
+        )
+
+    async def replace_thread(
+        self,
+        room_id: str,
+        thread_id: str,
+        events: list[dict[str, Any]],
+        *,
+        validated_at: float | None = None,
+    ) -> None:
+        """Atomically replace one cached thread snapshot."""
+        await self._write_operation(
+            room_id,
+            operation="replace_thread",
+            disabled_result=None,
+            writer=lambda db: postgres_event_cache_threads.replace_thread_locked(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+                events=events,
+                validated_at=time.time() if validated_at is None else validated_at,
+            ),
+        )
+
+    async def replace_thread_if_not_newer(
+        self,
+        room_id: str,
+        thread_id: str,
+        events: list[dict[str, Any]],
+        *,
+        fetch_started_at: float,
+        validated_at: float | None = None,
+    ) -> bool:
+        """Replace one cached thread snapshot only when nothing newer touched it after fetch start."""
+        replacement_validated_at = fetch_started_at if validated_at is None else min(validated_at, fetch_started_at)
+
+        async def replace_if_still_safe(db: psycopg.AsyncConnection) -> bool:
+            return await postgres_event_cache_threads.replace_thread_locked_if_not_newer(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+                events=events,
+                fetch_started_at=fetch_started_at,
+                validated_at=replacement_validated_at,
+            )
+
+        return bool(
+            await self._write_operation(
+                room_id,
+                operation="replace_thread_if_not_newer",
+                disabled_result=False,
+                writer=replace_if_still_safe,
+            ),
+        )
+
+    async def invalidate_thread(self, room_id: str, thread_id: str) -> None:
+        """Delete cached events for one thread."""
+        await self._write_operation(
+            room_id,
+            operation="invalidate_thread",
+            disabled_result=None,
+            writer=lambda db: postgres_event_cache_threads.invalidate_thread_locked(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+            ),
+        )
+
+    async def invalidate_room_threads(self, room_id: str) -> None:
+        """Delete every cached thread snapshot for one room."""
+        await self._write_operation(
+            room_id,
+            operation="invalidate_room_threads",
+            disabled_result=None,
+            writer=lambda db: postgres_event_cache_threads.invalidate_room_threads_locked(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+            ),
+        )
+
+    async def mark_thread_stale(self, room_id: str, thread_id: str, *, reason: str) -> None:
+        """Persist one durable thread invalidation marker."""
+        await self._write_operation(
+            room_id,
+            operation="mark_thread_stale",
+            disabled_result=None,
+            writer=lambda db: postgres_event_cache_threads.mark_thread_stale_locked(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+                reason=reason,
+            ),
+        )
+
+    async def mark_room_threads_stale(self, room_id: str, *, reason: str) -> None:
+        """Persist a durable invalidate-and-refetch marker for every cached thread in one room."""
+        await self._write_operation(
+            room_id,
+            operation="mark_room_threads_stale",
+            disabled_result=None,
+            writer=lambda db: postgres_event_cache_threads.mark_room_stale_locked(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                reason=reason,
+            ),
+        )
+
+    async def append_event(self, room_id: str, thread_id: str, event: dict[str, Any]) -> bool:
+        """Append one event when the thread already has cached data."""
+        normalized_event = normalize_event_source_for_cache(event)
+        return bool(
+            await self._write_operation(
+                room_id,
+                operation="append_event",
+                disabled_result=False,
+                writer=lambda db: postgres_event_cache_threads.append_existing_thread_event(
+                    db,
+                    namespace=self._runtime.namespace,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    normalized_event=normalized_event,
+                ),
+            ),
+        )
+
+    async def revalidate_thread_after_incremental_update(
+        self,
+        room_id: str,
+        thread_id: str,
+    ) -> bool:
+        """Refresh one thread's validated timestamp after a safe incremental update."""
+        return bool(
+            await self._write_operation(
+                room_id,
+                operation="revalidate_thread_after_incremental_update",
+                disabled_result=False,
+                writer=lambda db: postgres_event_cache_threads.revalidate_thread_after_incremental_update_locked(
+                    db,
+                    namespace=self._runtime.namespace,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                ),
+            ),
+        )
+
+    async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
+        """Return the cached thread ID for one event."""
+        return await self._read_operation(
+            room_id,
+            operation="get_thread_id_for_event",
+            disabled_result=None,
+            reader=lambda db: postgres_event_cache_events.load_thread_id_for_event(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                event_id=event_id,
+            ),
+        )
+
+    async def redact_event(
+        self,
+        room_id: str,
+        event_id: str,
+    ) -> bool:
+        """Delete one cached event after a redaction."""
+        return bool(
+            await self._write_operation(
+                room_id,
+                operation="redact_event",
+                disabled_result=False,
+                writer=lambda db: postgres_event_cache_events.redact_event_locked(
+                    db,
+                    namespace=self._runtime.namespace,
+                    room_id=room_id,
+                    event_id=event_id,
+                ),
+            ),
+        )

--- a/src/mindroom/matrix/cache/postgres_event_cache_events.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_events.py
@@ -1,0 +1,642 @@
+"""PostgreSQL event lookup, index, and redaction storage for the Matrix event cache."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, LiteralString
+
+from mindroom.matrix.event_info import EventInfo
+
+if TYPE_CHECKING:
+    from psycopg import AsyncConnection
+
+
+@dataclass(frozen=True, slots=True)
+class SerializedCachedEvent:
+    """One normalized cached event plus its serialized storage row."""
+
+    event_id: str
+    origin_server_ts: int
+    event_json: str
+    event: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class CachedEventRow:
+    """One cached event payload plus the time its visible row was written."""
+
+    event: dict[str, Any]
+    cached_at: float | None
+
+
+async def _fetchone(
+    db: AsyncConnection,
+    query: LiteralString,
+    params: tuple[object, ...],
+) -> tuple[Any, ...] | None:
+    cursor = await db.execute(query, params)
+    try:
+        return await cursor.fetchone()
+    finally:
+        await cursor.close()
+
+
+async def _fetchall(
+    db: AsyncConnection,
+    query: LiteralString,
+    params: tuple[object, ...],
+) -> list[tuple[Any, ...]]:
+    cursor = await db.execute(query, params)
+    try:
+        rows = await cursor.fetchall()
+        return [tuple(row) for row in rows]
+    finally:
+        await cursor.close()
+
+
+async def _rowcount(
+    db: AsyncConnection,
+    query: LiteralString,
+    params: tuple[object, ...],
+) -> int:
+    cursor = await db.execute(query, params)
+    try:
+        return 0 if cursor.rowcount is None else int(cursor.rowcount)
+    finally:
+        await cursor.close()
+
+
+def event_id_for_cache(event: dict[str, Any]) -> str:
+    """Return the required event ID from one normalized cached event."""
+    event_id = event.get("event_id")
+    if isinstance(event_id, str) and event_id:
+        return event_id
+    msg = "Cached Matrix event is missing event_id"
+    raise ValueError(msg)
+
+
+def event_timestamp_for_cache(event: dict[str, Any]) -> int:
+    """Return the required origin-server timestamp from one normalized cached event."""
+    timestamp = event.get("origin_server_ts")
+    if isinstance(timestamp, int) and not isinstance(timestamp, bool):
+        return timestamp
+    msg = f"Cached Matrix event {event_id_for_cache(event)} is missing origin_server_ts"
+    raise ValueError(msg)
+
+
+def serialize_cached_event(event_id: str, event: dict[str, Any]) -> SerializedCachedEvent:
+    """Serialize one normalized cached event for PostgreSQL writes."""
+    return SerializedCachedEvent(
+        event_id=event_id,
+        origin_server_ts=event_timestamp_for_cache(event),
+        event_json=json.dumps(event, separators=(",", ":")),
+        event=event,
+    )
+
+
+def serialize_cacheable_events(
+    cacheable_events: list[tuple[str, dict[str, Any]]],
+) -> list[SerializedCachedEvent]:
+    """Serialize one batch of normalized cacheable events."""
+    return [serialize_cached_event(event_id, event) for event_id, event in cacheable_events]
+
+
+async def load_event(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    event_id: str,
+) -> dict[str, Any] | None:
+    """Return one cached event payload by event ID."""
+    row = await _fetchone(
+        db,
+        """
+        SELECT event_json
+        FROM mindroom_event_cache_events
+        WHERE namespace = %s AND event_id = %s
+        """,
+        (namespace, event_id),
+    )
+    return None if row is None else json.loads(row[0])
+
+
+async def load_latest_edit(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    original_event_id: str,
+) -> dict[str, Any] | None:
+    """Return the latest cached edit event for one original event."""
+    row = await _fetchone(
+        db,
+        """
+        SELECT mindroom_event_cache_events.event_json
+        FROM mindroom_event_cache_event_edits
+        JOIN mindroom_event_cache_events
+            ON mindroom_event_cache_events.namespace = mindroom_event_cache_event_edits.namespace
+            AND mindroom_event_cache_events.event_id = mindroom_event_cache_event_edits.edit_event_id
+        WHERE mindroom_event_cache_event_edits.namespace = %s
+            AND mindroom_event_cache_event_edits.room_id = %s
+            AND mindroom_event_cache_event_edits.original_event_id = %s
+        ORDER BY mindroom_event_cache_event_edits.origin_server_ts DESC, mindroom_event_cache_events.write_seq DESC
+        LIMIT 1
+        """,
+        (namespace, room_id, original_event_id),
+    )
+    return None if row is None else json.loads(row[0])
+
+
+async def load_latest_edit_row(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    original_event_id: str,
+) -> CachedEventRow | None:
+    """Return the latest cached edit event plus its lookup-row write time."""
+    row = await _fetchone(
+        db,
+        """
+        SELECT mindroom_event_cache_events.event_json, mindroom_event_cache_events.cached_at
+        FROM mindroom_event_cache_event_edits
+        JOIN mindroom_event_cache_events
+            ON mindroom_event_cache_events.namespace = mindroom_event_cache_event_edits.namespace
+            AND mindroom_event_cache_events.event_id = mindroom_event_cache_event_edits.edit_event_id
+        WHERE mindroom_event_cache_event_edits.namespace = %s
+            AND mindroom_event_cache_event_edits.room_id = %s
+            AND mindroom_event_cache_event_edits.original_event_id = %s
+        ORDER BY mindroom_event_cache_event_edits.origin_server_ts DESC, mindroom_event_cache_events.write_seq DESC
+        LIMIT 1
+        """,
+        (namespace, room_id, original_event_id),
+    )
+    if row is None:
+        return None
+    return CachedEventRow(
+        event=json.loads(row[0]),
+        cached_at=None if row[1] is None else float(row[1]),
+    )
+
+
+async def load_mxc_text(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    mxc_url: str,
+) -> str | None:
+    """Return one durably cached MXC text payload when present."""
+    row = await _fetchone(
+        db,
+        """
+        SELECT text_content
+        FROM mindroom_event_cache_mxc_text
+        WHERE namespace = %s AND mxc_url = %s
+        """,
+        (namespace, mxc_url),
+    )
+    return None if row is None else str(row[0])
+
+
+async def persist_mxc_text(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    mxc_url: str,
+    text: str,
+    cached_at: float,
+) -> None:
+    """Insert or replace one durably cached MXC text payload."""
+    await db.execute(
+        """
+        INSERT INTO mindroom_event_cache_mxc_text(namespace, mxc_url, text_content, cached_at)
+        VALUES (%s, %s, %s, %s)
+        ON CONFLICT(namespace, mxc_url) DO UPDATE SET
+            text_content = excluded.text_content,
+            cached_at = excluded.cached_at
+        """,
+        (namespace, mxc_url, text, cached_at),
+    )
+
+
+async def persist_lookup_events(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    room_events: list[tuple[str, dict[str, Any]]],
+    cached_at: float,
+    thread_id: str | None = None,
+) -> None:
+    """Persist point-lookups and derived indexes for one room-scoped event batch."""
+    cacheable_events = await filter_cacheable_events(db, namespace, room_id, room_events)
+    await write_lookup_index_rows(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        serialized_events=serialize_cacheable_events(cacheable_events),
+        cached_at=cached_at,
+        thread_id=thread_id,
+    )
+
+
+async def load_thread_id_for_event(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    event_id: str,
+) -> str | None:
+    """Return the cached thread ID for one event."""
+    row = await _fetchone(
+        db,
+        """
+        SELECT thread_id
+        FROM mindroom_event_cache_event_threads
+        WHERE namespace = %s AND room_id = %s AND event_id = %s
+        """,
+        (namespace, room_id, event_id),
+    )
+    return None if row is None else str(row[0])
+
+
+async def redact_event_locked(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    event_id: str,
+) -> bool:
+    """Delete one cached event after a redaction within an existing transaction."""
+    dependent_edit_ids = await dependent_edit_event_ids(
+        db,
+        namespace,
+        room_id,
+        original_event_id=event_id,
+    )
+    removed_event_ids = list(dict.fromkeys([event_id, *dependent_edit_ids]))
+    deleted_thread_rows = await _delete_room_thread_events(
+        db,
+        namespace,
+        room_id,
+        event_ids=removed_event_ids,
+    )
+    deleted_event_rows = await delete_cached_events(db, namespace=namespace, event_ids=removed_event_ids)
+    deleted_edit_rows = await delete_event_edit_rows(
+        db,
+        namespace,
+        room_id,
+        event_ids=removed_event_ids,
+        original_event_id=event_id,
+    )
+    deleted_thread_index_rows = await delete_event_thread_rows(
+        db,
+        namespace,
+        room_id,
+        event_ids=removed_event_ids,
+    )
+    await _record_redacted_events(
+        db,
+        namespace,
+        room_id,
+        event_ids=removed_event_ids,
+    )
+    return deleted_thread_rows > 0 or deleted_event_rows > 0 or deleted_edit_rows > 0 or deleted_thread_index_rows > 0
+
+
+async def event_or_original_is_redacted(
+    db: AsyncConnection,
+    namespace: str,
+    room_id: str,
+    *,
+    event_id: str,
+    event: dict[str, Any],
+) -> bool:
+    """Return whether this event or its edited original was durably redacted."""
+    event_info = EventInfo.from_event(event)
+    candidate_ids = {event_id}
+    if event_info.is_edit and isinstance(event_info.original_event_id, str):
+        candidate_ids.add(event_info.original_event_id)
+    return bool(
+        await _redacted_event_ids_for_candidates(
+            db,
+            namespace,
+            room_id,
+            event_ids=candidate_ids,
+        ),
+    )
+
+
+async def filter_cacheable_events(
+    db: AsyncConnection,
+    namespace: str,
+    room_id: str,
+    room_events: list[tuple[str, dict[str, Any]]],
+) -> list[tuple[str, dict[str, Any]]]:
+    """Drop events that target durable redaction tombstones before persisting them."""
+    candidate_ids: set[str] = set()
+    for event_id, event_data in room_events:
+        candidate_ids.add(event_id)
+        event_info = EventInfo.from_event(event_data)
+        if event_info.is_edit and isinstance(event_info.original_event_id, str):
+            candidate_ids.add(event_info.original_event_id)
+    redacted_event_ids = await _redacted_event_ids_for_candidates(
+        db,
+        namespace,
+        room_id,
+        event_ids=candidate_ids,
+    )
+    if not redacted_event_ids:
+        return room_events
+
+    cacheable_events: list[tuple[str, dict[str, Any]]] = []
+    for event_id, event_data in room_events:
+        event_info = EventInfo.from_event(event_data)
+        original_event_id = event_info.original_event_id if event_info.is_edit else None
+        if event_id in redacted_event_ids:
+            continue
+        if isinstance(original_event_id, str) and original_event_id in redacted_event_ids:
+            continue
+        cacheable_events.append((event_id, event_data))
+    return cacheable_events
+
+
+async def write_lookup_index_rows(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    serialized_events: list[SerializedCachedEvent],
+    cached_at: float,
+    thread_id: str | None = None,
+) -> None:
+    """Persist point-lookup, edit-index, and thread-index rows for cached events."""
+    if not serialized_events:
+        return
+    for event in serialized_events:
+        await db.execute(
+            """
+            INSERT INTO mindroom_event_cache_events(namespace, event_id, room_id, origin_server_ts, event_json, cached_at)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            ON CONFLICT(namespace, event_id) DO UPDATE SET
+                room_id = excluded.room_id,
+                origin_server_ts = excluded.origin_server_ts,
+                event_json = excluded.event_json,
+                cached_at = excluded.cached_at,
+                write_seq = nextval('mindroom_event_cache_write_seq')
+            """,
+            (
+                namespace,
+                event.event_id,
+                room_id,
+                event.origin_server_ts,
+                event.event_json,
+                cached_at,
+            ),
+        )
+
+    edit_rows = [
+        row
+        for row in (_edit_cache_row(namespace, room_id, event.event) for event in serialized_events)
+        if row is not None
+    ]
+    for row in edit_rows:
+        await db.execute(
+            """
+            INSERT INTO mindroom_event_cache_event_edits(namespace, edit_event_id, room_id, original_event_id, origin_server_ts)
+            VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT(namespace, edit_event_id) DO UPDATE SET
+                room_id = excluded.room_id,
+                original_event_id = excluded.original_event_id,
+                origin_server_ts = excluded.origin_server_ts
+            """,
+            row,
+        )
+
+    thread_rows = (
+        [(namespace, room_id, event.event_id, thread_id) for event in serialized_events]
+        if thread_id is not None
+        else [
+            row
+            for row in (_event_thread_row(namespace, room_id, event.event) for event in serialized_events)
+            if row is not None
+        ]
+    )
+    if thread_rows:
+        for row in _with_thread_root_self_rows(thread_rows):
+            await db.execute(
+                """
+                INSERT INTO mindroom_event_cache_event_threads(namespace, room_id, event_id, thread_id)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT(namespace, room_id, event_id) DO UPDATE SET
+                    thread_id = excluded.thread_id
+                """,
+                row,
+            )
+
+
+async def dependent_edit_event_ids(
+    db: AsyncConnection,
+    namespace: str,
+    room_id: str,
+    *,
+    original_event_id: str,
+) -> list[str]:
+    """Return cached edit event IDs that target one original event."""
+    rows = await _fetchall(
+        db,
+        """
+        SELECT edit_event_id
+        FROM mindroom_event_cache_event_edits
+        WHERE namespace = %s AND room_id = %s AND original_event_id = %s
+        """,
+        (namespace, room_id, original_event_id),
+    )
+    return [str(row[0]) for row in rows]
+
+
+async def delete_cached_events(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    event_ids: list[str],
+) -> int:
+    """Delete point-lookup cache rows for the provided event IDs."""
+    if not event_ids:
+        return 0
+    return await _rowcount(
+        db,
+        """
+        DELETE FROM mindroom_event_cache_events
+        WHERE namespace = %s AND event_id = ANY(%s)
+        """,
+        (namespace, event_ids),
+    )
+
+
+async def delete_event_thread_rows(
+    db: AsyncConnection,
+    namespace: str,
+    room_id: str,
+    *,
+    event_ids: list[str],
+) -> int:
+    """Delete durable event-to-thread rows for the provided event IDs."""
+    if not event_ids:
+        return 0
+    return await _rowcount(
+        db,
+        """
+        DELETE FROM mindroom_event_cache_event_threads
+        WHERE namespace = %s AND room_id = %s AND event_id = ANY(%s)
+        """,
+        (namespace, room_id, event_ids),
+    )
+
+
+async def delete_event_edit_rows(
+    db: AsyncConnection,
+    namespace: str,
+    room_id: str,
+    *,
+    event_ids: list[str],
+    original_event_id: str | None,
+) -> int:
+    """Delete derived edit-index rows affected by one event redaction."""
+    deleted_rows = 0
+    if event_ids:
+        deleted_rows += await _rowcount(
+            db,
+            """
+            DELETE FROM mindroom_event_cache_event_edits
+            WHERE namespace = %s AND room_id = %s AND edit_event_id = ANY(%s)
+            """,
+            (namespace, room_id, event_ids),
+        )
+    if original_event_id is not None:
+        deleted_rows += await _rowcount(
+            db,
+            """
+            DELETE FROM mindroom_event_cache_event_edits
+            WHERE namespace = %s AND room_id = %s AND original_event_id = %s
+            """,
+            (namespace, room_id, original_event_id),
+        )
+    return deleted_rows
+
+
+def _event_thread_row(
+    namespace: str,
+    room_id: str,
+    event: dict[str, Any],
+) -> tuple[str, str, str, str] | None:
+    """Return one durable event-to-thread mapping row when thread membership is explicit."""
+    event_id = event.get("event_id")
+    if not isinstance(event_id, str) or not event_id:
+        return None
+    event_info = EventInfo.from_event(event)
+    thread_id = event_info.thread_id
+    if not isinstance(thread_id, str):
+        thread_id = event_info.thread_id_from_edit
+    if not isinstance(thread_id, str) or not thread_id:
+        return None
+    return namespace, room_id, event_id, thread_id
+
+
+def _with_thread_root_self_rows(
+    thread_rows: list[tuple[str, str, str, str]],
+) -> list[tuple[str, str, str, str]]:
+    """Ensure any learned thread membership also records the root's own lookup row."""
+    if not thread_rows:
+        return thread_rows
+    return list(
+        dict.fromkeys(
+            [
+                *thread_rows,
+                *(
+                    (namespace, room_id, thread_id, thread_id)
+                    for namespace, room_id, _event_id, thread_id in thread_rows
+                ),
+            ],
+        ),
+    )
+
+
+def _edit_cache_row(namespace: str, room_id: str, event: dict[str, Any]) -> tuple[str, str, str, str, int] | None:
+    """Return one edit-index row for a cached event when it is an edit."""
+    if event.get("type") != "m.room.message":
+        return None
+
+    event_info = EventInfo.from_event(event)
+    if not event_info.is_edit or not isinstance(event_info.original_event_id, str):
+        return None
+
+    return (
+        namespace,
+        event_id_for_cache(event),
+        room_id,
+        event_info.original_event_id,
+        event_timestamp_for_cache(event),
+    )
+
+
+async def _delete_room_thread_events(
+    db: AsyncConnection,
+    namespace: str,
+    room_id: str,
+    *,
+    event_ids: list[str],
+) -> int:
+    """Delete cached thread rows for the provided event IDs within one room."""
+    if not event_ids:
+        return 0
+    return await _rowcount(
+        db,
+        """
+        DELETE FROM mindroom_event_cache_thread_events
+        WHERE namespace = %s AND room_id = %s AND event_id = ANY(%s)
+        """,
+        (namespace, room_id, event_ids),
+    )
+
+
+async def _record_redacted_events(
+    db: AsyncConnection,
+    namespace: str,
+    room_id: str,
+    *,
+    event_ids: list[str],
+) -> None:
+    """Persist durable tombstones for redacted event IDs."""
+    for event_id in event_ids:
+        await db.execute(
+            """
+            INSERT INTO mindroom_event_cache_redacted_events(namespace, room_id, event_id)
+            VALUES (%s, %s, %s)
+            ON CONFLICT(namespace, room_id, event_id) DO NOTHING
+            """,
+            (namespace, room_id, event_id),
+        )
+
+
+async def _redacted_event_ids_for_candidates(
+    db: AsyncConnection,
+    namespace: str,
+    room_id: str,
+    *,
+    event_ids: set[str],
+) -> frozenset[str]:
+    """Return the subset of candidate event IDs that are durably tombstoned."""
+    if not event_ids:
+        return frozenset()
+    rows = await _fetchall(
+        db,
+        """
+        SELECT event_id
+        FROM mindroom_event_cache_redacted_events
+        WHERE namespace = %s AND room_id = %s AND event_id = ANY(%s)
+        """,
+        (namespace, room_id, sorted(event_ids)),
+    )
+    return frozenset(str(row[0]) for row in rows)

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -1,0 +1,639 @@
+"""PostgreSQL thread snapshot and freshness storage helpers for the Matrix event cache."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING, Any, LiteralString
+
+from .event_cache import ThreadCacheState
+from .event_normalization import normalize_event_source_for_cache
+from .postgres_event_cache_events import (
+    delete_cached_events,
+    delete_event_edit_rows,
+    delete_event_thread_rows,
+    event_id_for_cache,
+    event_or_original_is_redacted,
+    filter_cacheable_events,
+    serialize_cacheable_events,
+    serialize_cached_event,
+    write_lookup_index_rows,
+)
+
+if TYPE_CHECKING:
+    from psycopg import AsyncConnection
+
+
+_INCREMENTAL_THREAD_REVALIDATION_REASONS = frozenset(
+    {
+        "live_thread_mutation",
+        "sync_thread_mutation",
+        "outbound_thread_mutation",
+    },
+)
+
+
+async def _fetchone(
+    db: AsyncConnection,
+    query: LiteralString,
+    params: tuple[object, ...],
+) -> tuple[Any, ...] | None:
+    cursor = await db.execute(query, params)
+    try:
+        return await cursor.fetchone()
+    finally:
+        await cursor.close()
+
+
+async def _fetchall(
+    db: AsyncConnection,
+    query: LiteralString,
+    params: tuple[object, ...],
+) -> list[tuple[Any, ...]]:
+    cursor = await db.execute(query, params)
+    try:
+        rows = await cursor.fetchall()
+        return [tuple(row) for row in rows]
+    finally:
+        await cursor.close()
+
+
+async def load_thread_events(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+) -> list[dict[str, Any]] | None:
+    """Return cached events for one thread sorted by timestamp."""
+    rows = await _fetchall(
+        db,
+        """
+        SELECT event_json
+        FROM mindroom_event_cache_thread_events
+        WHERE namespace = %s AND room_id = %s AND thread_id = %s
+        ORDER BY origin_server_ts ASC, write_seq ASC
+        """,
+        (namespace, room_id, thread_id),
+    )
+    if not rows:
+        return None
+    return [json.loads(row[0]) for row in rows]
+
+
+async def load_recent_room_thread_ids(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    limit: int,
+) -> list[str]:
+    """Return thread IDs for one room ordered by the newest locally cached event timestamp."""
+    rows = await _fetchall(
+        db,
+        """
+        SELECT thread_id
+        FROM mindroom_event_cache_thread_events
+        WHERE namespace = %s AND room_id = %s
+        GROUP BY thread_id
+        ORDER BY MAX(origin_server_ts) DESC, thread_id ASC
+        LIMIT %s
+        """,
+        (namespace, room_id, limit),
+    )
+    return [str(row[0]) for row in rows]
+
+
+async def load_thread_cache_state_row(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+) -> tuple[float | None, float | None, str | None, float | None, str | None] | None:
+    """Return one raw thread-cache-state row joined with room invalidation state."""
+    row = await _fetchone(
+        db,
+        """
+        SELECT
+            mindroom_event_cache_thread_state.validated_at,
+            mindroom_event_cache_thread_state.invalidated_at,
+            mindroom_event_cache_thread_state.invalidation_reason,
+            mindroom_event_cache_room_state.invalidated_at,
+            mindroom_event_cache_room_state.invalidation_reason
+        FROM (SELECT %s AS requested_namespace, %s AS requested_room_id, %s AS requested_thread_id) AS requested
+        LEFT JOIN mindroom_event_cache_thread_state
+            ON mindroom_event_cache_thread_state.namespace = requested.requested_namespace
+            AND mindroom_event_cache_thread_state.room_id = requested.requested_room_id
+            AND mindroom_event_cache_thread_state.thread_id = requested.requested_thread_id
+        LEFT JOIN mindroom_event_cache_room_state
+            ON mindroom_event_cache_room_state.namespace = requested.requested_namespace
+            AND mindroom_event_cache_room_state.room_id = requested.requested_room_id
+        """,
+        (namespace, room_id, thread_id),
+    )
+    if row is None or all(value is None for value in row):
+        return None
+    return (
+        None if row[0] is None else float(row[0]),
+        None if row[1] is None else float(row[1]),
+        row[2] if isinstance(row[2], str) else None,
+        None if row[3] is None else float(row[3]),
+        row[4] if isinstance(row[4], str) else None,
+    )
+
+
+async def load_thread_cache_state(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+) -> ThreadCacheState | None:
+    """Return one thread cache state object joined with room invalidation state."""
+    row = await load_thread_cache_state_row(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    if row is None:
+        return None
+    return ThreadCacheState(
+        validated_at=row[0],
+        invalidated_at=row[1],
+        invalidation_reason=row[2],
+        room_invalidated_at=row[3],
+        room_invalidation_reason=row[4],
+    )
+
+
+async def store_thread_events_locked(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+    events: list[dict[str, Any]],
+    validated_at: float,
+) -> None:
+    """Persist one authoritative thread snapshot within an existing DB transaction."""
+    if not events:
+        await _upsert_thread_cache_state(
+            db,
+            namespace=namespace,
+            room_id=room_id,
+            thread_id=thread_id,
+            validated_at=validated_at,
+        )
+        return
+
+    normalized_events = [normalize_event_source_for_cache(event) for event in events]
+    cacheable_events = await filter_cacheable_events(
+        db,
+        namespace,
+        room_id,
+        [(event_id_for_cache(event), event) for event in normalized_events],
+    )
+    serialized_events = serialize_cacheable_events(cacheable_events)
+    for event in serialized_events:
+        await db.execute(
+            """
+            INSERT INTO mindroom_event_cache_thread_events(namespace, room_id, thread_id, event_id, origin_server_ts, event_json)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            ON CONFLICT(namespace, room_id, event_id) DO UPDATE SET
+                thread_id = excluded.thread_id,
+                origin_server_ts = excluded.origin_server_ts,
+                event_json = excluded.event_json,
+                write_seq = nextval('mindroom_event_cache_write_seq')
+            """,
+            (
+                namespace,
+                room_id,
+                thread_id,
+                event.event_id,
+                event.origin_server_ts,
+                event.event_json,
+            ),
+        )
+    await write_lookup_index_rows(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        serialized_events=serialized_events,
+        cached_at=validated_at,
+        thread_id=thread_id,
+    )
+    await _upsert_thread_cache_state(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+        validated_at=validated_at,
+    )
+
+
+async def replace_thread_locked(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+    events: list[dict[str, Any]],
+    validated_at: float,
+) -> None:
+    """Replace one thread snapshot atomically within an existing DB transaction."""
+    existing_event_ids = await _thread_event_ids_for_thread(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    await db.execute(
+        """
+        DELETE FROM mindroom_event_cache_thread_events
+        WHERE namespace = %s AND room_id = %s AND thread_id = %s
+        """,
+        (namespace, room_id, thread_id),
+    )
+    if existing_event_ids:
+        await delete_cached_events(db, namespace=namespace, event_ids=existing_event_ids)
+        await delete_event_edit_rows(
+            db,
+            namespace,
+            room_id,
+            event_ids=existing_event_ids,
+            original_event_id=None,
+        )
+        await delete_event_thread_rows(
+            db,
+            namespace,
+            room_id,
+            event_ids=existing_event_ids,
+        )
+    await store_thread_events_locked(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+        events=events,
+        validated_at=validated_at,
+    )
+
+
+def _thread_cache_state_changed_after(
+    cache_state_row: tuple[float | None, float | None, str | None, float | None, str | None] | None,
+    *,
+    fetch_started_at: float,
+) -> bool:
+    """Return whether this thread or room cache state changed after one fetch began."""
+    if cache_state_row is None:
+        return False
+    validated_at, invalidated_at, _invalidation_reason, room_invalidated_at, _room_invalidation_reason = cache_state_row
+    return any(
+        timestamp is not None and timestamp > fetch_started_at
+        for timestamp in (validated_at, invalidated_at, room_invalidated_at)
+    )
+
+
+async def replace_thread_locked_if_not_newer(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+    events: list[dict[str, Any]],
+    fetch_started_at: float,
+    validated_at: float,
+) -> bool:
+    """Replace one thread snapshot only when nothing newer touched this room after the fetch began."""
+    cache_state_row = await load_thread_cache_state_row(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    if _thread_cache_state_changed_after(cache_state_row, fetch_started_at=fetch_started_at):
+        return False
+    await replace_thread_locked(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+        events=events,
+        validated_at=validated_at,
+    )
+    return True
+
+
+async def invalidate_thread_locked(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+) -> None:
+    """Delete cached events and state for one thread within an existing transaction."""
+    event_ids = await _thread_event_ids_for_thread(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    await db.execute(
+        """
+        DELETE FROM mindroom_event_cache_thread_events
+        WHERE namespace = %s AND room_id = %s AND thread_id = %s
+        """,
+        (namespace, room_id, thread_id),
+    )
+    if event_ids:
+        await delete_cached_events(db, namespace=namespace, event_ids=event_ids)
+        await delete_event_edit_rows(
+            db,
+            namespace,
+            room_id,
+            event_ids=event_ids,
+            original_event_id=None,
+        )
+        await delete_event_thread_rows(
+            db,
+            namespace,
+            room_id,
+            event_ids=event_ids,
+        )
+    await db.execute(
+        """
+        DELETE FROM mindroom_event_cache_thread_state
+        WHERE namespace = %s AND room_id = %s AND thread_id = %s
+        """,
+        (namespace, room_id, thread_id),
+    )
+
+
+async def invalidate_room_threads_locked(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+) -> None:
+    """Delete every cached thread snapshot and room state for one room."""
+    event_ids = await _thread_event_ids_for_room(db, namespace=namespace, room_id=room_id)
+    await db.execute(
+        """
+        DELETE FROM mindroom_event_cache_thread_events
+        WHERE namespace = %s AND room_id = %s
+        """,
+        (namespace, room_id),
+    )
+    if event_ids:
+        await delete_cached_events(db, namespace=namespace, event_ids=event_ids)
+        await delete_event_edit_rows(
+            db,
+            namespace,
+            room_id,
+            event_ids=event_ids,
+            original_event_id=None,
+        )
+        await delete_event_thread_rows(
+            db,
+            namespace,
+            room_id,
+            event_ids=event_ids,
+        )
+    await db.execute(
+        """
+        DELETE FROM mindroom_event_cache_thread_state
+        WHERE namespace = %s AND room_id = %s
+        """,
+        (namespace, room_id),
+    )
+    await db.execute(
+        """
+        DELETE FROM mindroom_event_cache_room_state
+        WHERE namespace = %s AND room_id = %s
+        """,
+        (namespace, room_id),
+    )
+
+
+async def mark_thread_stale_locked(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+    reason: str,
+) -> None:
+    """Persist a durable invalidate-and-refetch marker within an active transaction."""
+    await db.execute(
+        """
+        INSERT INTO mindroom_event_cache_thread_state(
+            namespace,
+            room_id,
+            thread_id,
+            validated_at,
+            invalidated_at,
+            invalidation_reason
+        )
+        VALUES (%s, %s, %s, NULL, %s, %s)
+        ON CONFLICT(namespace, room_id, thread_id) DO UPDATE SET
+            invalidated_at = excluded.invalidated_at,
+            invalidation_reason = excluded.invalidation_reason
+        """,
+        (namespace, room_id, thread_id, time.time(), reason),
+    )
+
+
+async def revalidate_thread_after_incremental_update_locked(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+) -> bool:
+    """Mark one thread cache fresh after a safe incremental update."""
+    row = await load_thread_cache_state_row(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    if row is None:
+        return False
+    validated_at, invalidated_at, invalidation_reason, room_invalidated_at, _room_invalidation_reason = row
+    can_revalidate = (
+        validated_at is not None
+        and invalidated_at is not None
+        and invalidation_reason in _INCREMENTAL_THREAD_REVALIDATION_REASONS
+        and not (room_invalidated_at is not None and room_invalidated_at >= validated_at)
+    )
+    if not can_revalidate:
+        return False
+    await db.execute(
+        """
+        UPDATE mindroom_event_cache_thread_state
+        SET validated_at = %s, invalidated_at = NULL, invalidation_reason = NULL
+        WHERE namespace = %s AND room_id = %s AND thread_id = %s
+        """,
+        (time.time(), namespace, room_id, thread_id),
+    )
+    return True
+
+
+async def mark_room_stale_locked(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    reason: str,
+) -> None:
+    """Persist one durable room-scoped invalidate-and-refetch marker."""
+    await db.execute(
+        """
+        INSERT INTO mindroom_event_cache_room_state(namespace, room_id, invalidated_at, invalidation_reason)
+        VALUES (%s, %s, %s, %s)
+        ON CONFLICT(namespace, room_id) DO UPDATE SET
+            invalidated_at = excluded.invalidated_at,
+            invalidation_reason = excluded.invalidation_reason
+        """,
+        (namespace, room_id, time.time(), reason),
+    )
+
+
+async def append_existing_thread_event(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+    normalized_event: dict[str, Any],
+) -> bool:
+    """Append one event to an existing cached thread."""
+    event_id = event_id_for_cache(normalized_event)
+    if await event_or_original_is_redacted(
+        db,
+        namespace,
+        room_id,
+        event_id=event_id,
+        event=normalized_event,
+    ):
+        return False
+
+    serialized_event = serialize_cached_event(event_id, normalized_event)
+    row = await _fetchone(
+        db,
+        """
+        SELECT 1
+        FROM mindroom_event_cache_thread_events
+        WHERE namespace = %s AND room_id = %s AND thread_id = %s
+        LIMIT 1
+        """,
+        (namespace, room_id, thread_id),
+    )
+    if row is None:
+        await write_lookup_index_rows(
+            db,
+            namespace=namespace,
+            room_id=room_id,
+            serialized_events=[serialized_event],
+            cached_at=time.time(),
+            thread_id=thread_id,
+        )
+        return False
+
+    await db.execute(
+        """
+        INSERT INTO mindroom_event_cache_thread_events(namespace, room_id, thread_id, event_id, origin_server_ts, event_json)
+        VALUES (%s, %s, %s, %s, %s, %s)
+        ON CONFLICT(namespace, room_id, event_id) DO UPDATE SET
+            thread_id = excluded.thread_id,
+            origin_server_ts = excluded.origin_server_ts,
+            event_json = excluded.event_json,
+            write_seq = nextval('mindroom_event_cache_write_seq')
+        """,
+        (
+            namespace,
+            room_id,
+            thread_id,
+            serialized_event.event_id,
+            serialized_event.origin_server_ts,
+            serialized_event.event_json,
+        ),
+    )
+    await write_lookup_index_rows(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        serialized_events=[serialized_event],
+        cached_at=time.time(),
+        thread_id=thread_id,
+    )
+    return True
+
+
+async def _upsert_thread_cache_state(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+    validated_at: float,
+) -> None:
+    await db.execute(
+        """
+        INSERT INTO mindroom_event_cache_thread_state(
+            namespace,
+            room_id,
+            thread_id,
+            validated_at,
+            invalidated_at,
+            invalidation_reason
+        )
+        VALUES (%s, %s, %s, %s, NULL, NULL)
+        ON CONFLICT(namespace, room_id, thread_id) DO UPDATE SET
+            validated_at = excluded.validated_at,
+            invalidated_at = NULL,
+            invalidation_reason = NULL
+        """,
+        (namespace, room_id, thread_id, validated_at),
+    )
+
+
+async def _thread_event_ids_for_thread(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+) -> list[str]:
+    """Return cached event IDs currently stored for one thread."""
+    rows = await _fetchall(
+        db,
+        """
+        SELECT event_id
+        FROM mindroom_event_cache_thread_events
+        WHERE namespace = %s AND room_id = %s AND thread_id = %s
+        """,
+        (namespace, room_id, thread_id),
+    )
+    return [str(row[0]) for row in rows]
+
+
+async def _thread_event_ids_for_room(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+) -> list[str]:
+    """Return cached event IDs currently stored for every thread in one room."""
+    rows = await _fetchall(
+        db,
+        """
+        SELECT event_id
+        FROM mindroom_event_cache_thread_events
+        WHERE namespace = %s AND room_id = %s
+        """,
+        (namespace, room_id),
+    )
+    return [str(row[0]) for row in rows]

--- a/src/mindroom/matrix/cache/postgres_redaction.py
+++ b/src/mindroom/matrix/cache/postgres_redaction.py
@@ -1,0 +1,53 @@
+"""Secret redaction helpers for PostgreSQL connection strings."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import parse_qsl, quote_plus, urlsplit, urlunsplit
+
+_REDACTED = "***"
+_POSTGRES_SECRET_KEYS = frozenset({"password", "passfile", "sslpassword"})
+_LIBPQ_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<prefix>(?<!\S)(?:password|passfile|sslpassword)\s*=\s*)"
+    r"(?P<value>'(?:\\.|[^\\'])*'|\"(?:\\.|[^\\\"])*\"|\S*)",
+    re.IGNORECASE,
+)
+
+
+def _redact_url_query(query: str) -> str:
+    if not query:
+        return query
+    query_items = parse_qsl(query, keep_blank_values=True)
+    redacted_parts = []
+    for key, value in query_items:
+        encoded_key = quote_plus(key)
+        encoded_value = _REDACTED if key.lower() in _POSTGRES_SECRET_KEYS else quote_plus(value)
+        redacted_parts.append(f"{encoded_key}={encoded_value}")
+    return "&".join(redacted_parts)
+
+
+def _redact_url_conninfo(conninfo: str) -> str:
+    parts = urlsplit(conninfo)
+    netloc = parts.netloc
+    if "@" in netloc:
+        netloc = f"{_REDACTED}@{netloc.rsplit('@', 1)[1]}"
+    return urlunsplit(
+        (
+            parts.scheme,
+            netloc,
+            parts.path,
+            _redact_url_query(parts.query),
+            parts.fragment,
+        ),
+    )
+
+
+def _redact_libpq_conninfo(conninfo: str) -> str:
+    return _LIBPQ_SECRET_ASSIGNMENT_PATTERN.sub(lambda match: f"{match.group('prefix')}{_REDACTED}", conninfo)
+
+
+def redact_postgres_connection_info(conninfo: str) -> str:
+    """Return a log-safe PostgreSQL URL or libpq conninfo string."""
+    if "://" in conninfo:
+        return _redact_url_conninfo(conninfo)
+    return _redact_libpq_conninfo(conninfo)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -306,7 +306,8 @@ class MultiAgentOrchestrator:
         """Ensure the runtime has one initialized shared event-cache service."""
         self._runtime_support = await sync_owned_runtime_support(
             self._runtime_support,
-            db_path=config.cache.resolve_db_path(self.runtime_paths),
+            cache_config=config.cache,
+            runtime_paths=self.runtime_paths,
             logger=logger,
             background_task_owner=self._event_cache_write_task_owner,
             init_failure_reason_prefix="shared_runtime_init_failed",

--- a/src/mindroom/runtime_support.py
+++ b/src/mindroom/runtime_support.py
@@ -4,15 +4,23 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from importlib import import_module
+from typing import TYPE_CHECKING, cast
 
+from mindroom.config.matrix import CacheConfig
+from mindroom.constants import RuntimePaths
+from mindroom.matrix.cache.postgres_redaction import redact_postgres_connection_info
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
+from mindroom.tool_system.dependencies import ensure_optional_deps
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     import structlog
+
+    from mindroom.matrix.cache import ConversationEventCache
+    from mindroom.matrix.cache.postgres_event_cache import PostgresEventCache
 
 
 class StartupThreadPrewarmRegistry:
@@ -36,61 +44,159 @@ class StartupThreadPrewarmRegistry:
             self._claimed_room_ids.discard(room_id)
 
 
+@dataclass(frozen=True, slots=True)
+class EventCacheRuntimeIdentity:
+    """Comparable runtime identity for one event-cache backend binding."""
+
+    backend: str
+    location: str
+    namespace: str | None = None
+
+    @property
+    def redacted_location(self) -> str:
+        """Return a log-safe description of the backing store location."""
+        if self.backend != "postgres":
+            return self.location
+        return redact_postgres_connection_info(self.location)
+
+
 @dataclass(slots=True)
 class OwnedRuntimeSupport:
     """Concrete event-cache services owned by one runtime lifecycle."""
 
-    event_cache: SqliteEventCache
+    event_cache: ConversationEventCache
     event_cache_write_coordinator: _EventCacheWriteCoordinator
     startup_thread_prewarm_registry: StartupThreadPrewarmRegistry
+    event_cache_identity: EventCacheRuntimeIdentity
+
+
+def event_cache_runtime_identity(
+    cache_config: CacheConfig,
+    runtime_paths: RuntimePaths,
+) -> EventCacheRuntimeIdentity:
+    """Return the concrete event-cache runtime identity implied by config."""
+    if cache_config.backend != "postgres":
+        return EventCacheRuntimeIdentity(
+            backend="sqlite",
+            location=str(cache_config.resolve_db_path(runtime_paths)),
+        )
+    return EventCacheRuntimeIdentity(
+        backend="postgres",
+        location=cache_config.resolve_postgres_database_url(runtime_paths),
+        namespace=cache_config.resolve_namespace(runtime_paths),
+    )
+
+
+def _load_postgres_event_cache_class(runtime_paths: RuntimePaths) -> type[PostgresEventCache]:
+    """Ensure Postgres dependencies are importable, then load the concrete backend class."""
+    ensure_optional_deps(["psycopg"], "postgres", runtime_paths)
+    postgres_module = import_module("mindroom.matrix.cache.postgres_event_cache")
+    return cast("type[PostgresEventCache]", postgres_module.PostgresEventCache)
+
+
+def build_event_cache(
+    cache_config: CacheConfig,
+    runtime_paths: RuntimePaths,
+) -> ConversationEventCache:
+    """Build the configured event-cache backend without initializing it."""
+    if cache_config.backend != "postgres":
+        return SqliteEventCache(cache_config.resolve_db_path(runtime_paths))
+
+    database_url = cache_config.resolve_postgres_database_url(runtime_paths)
+    namespace = cache_config.resolve_namespace(runtime_paths)
+    postgres_event_cache_class = _load_postgres_event_cache_class(runtime_paths)
+    return postgres_event_cache_class(database_url=database_url, namespace=namespace)
 
 
 def build_owned_runtime_support(
     *,
-    db_path: Path,
+    db_path: Path | None = None,
+    cache_config: CacheConfig | None = None,
+    runtime_paths: RuntimePaths | None = None,
     logger: structlog.stdlib.BoundLogger,
     background_task_owner: object,
 ) -> OwnedRuntimeSupport:
     """Build one owned runtime-support bundle without initializing the cache."""
+    if cache_config is None:
+        if db_path is None:
+            msg = "build_owned_runtime_support requires db_path or cache_config"
+            raise ValueError(msg)
+        cache_config = CacheConfig(db_path=str(db_path))
+    if runtime_paths is None:
+        if db_path is None:
+            msg = "build_owned_runtime_support requires runtime_paths when db_path is omitted"
+            raise ValueError(msg)
+        runtime_paths = RuntimePaths(
+            config_path=db_path.parent / "config.yaml",
+            config_dir=db_path.parent,
+            env_path=db_path.parent / ".env",
+            storage_root=db_path.parent,
+        )
+    cache_identity = event_cache_runtime_identity(cache_config, runtime_paths)
     return OwnedRuntimeSupport(
-        event_cache=SqliteEventCache(db_path),
+        event_cache=build_event_cache(cache_config, runtime_paths),
         event_cache_write_coordinator=_EventCacheWriteCoordinator(
             logger=logger,
             background_task_owner=background_task_owner,
         ),
         startup_thread_prewarm_registry=StartupThreadPrewarmRegistry(),
+        event_cache_identity=cache_identity,
     )
 
 
 async def sync_owned_runtime_support(
     support: OwnedRuntimeSupport | None,
     *,
-    db_path: Path,
+    db_path: Path | None = None,
+    cache_config: CacheConfig | None = None,
+    runtime_paths: RuntimePaths | None = None,
     logger: structlog.stdlib.BoundLogger,
     background_task_owner: object,
     init_failure_reason_prefix: str,
     log_db_path_change: bool,
 ) -> OwnedRuntimeSupport:
     """Build, rebind, and initialize one owned runtime-support bundle."""
+    if cache_config is None:
+        if db_path is None:
+            msg = "sync_owned_runtime_support requires db_path or cache_config"
+            raise ValueError(msg)
+        cache_config = CacheConfig(db_path=str(db_path))
+    if runtime_paths is None:
+        if db_path is None:
+            msg = "sync_owned_runtime_support requires runtime_paths when db_path is omitted"
+            raise ValueError(msg)
+        runtime_paths = RuntimePaths(
+            config_path=db_path.parent / "config.yaml",
+            config_dir=db_path.parent,
+            env_path=db_path.parent / ".env",
+            storage_root=db_path.parent,
+        )
+    target_identity = event_cache_runtime_identity(cache_config, runtime_paths)
     if support is None:
         support = build_owned_runtime_support(
-            db_path=db_path,
+            cache_config=cache_config,
+            runtime_paths=runtime_paths,
             logger=logger,
             background_task_owner=background_task_owner,
         )
     else:
         support.event_cache_write_coordinator.background_task_owner = background_task_owner
-        if not support.event_cache.is_initialized and support.event_cache.db_path != db_path:
+        if not support.event_cache.is_initialized and support.event_cache_identity != target_identity:
             support = build_owned_runtime_support(
-                db_path=db_path,
+                cache_config=cache_config,
+                runtime_paths=runtime_paths,
                 logger=logger,
                 background_task_owner=background_task_owner,
             )
-        elif support.event_cache.db_path != db_path and log_db_path_change:
+        elif support.event_cache_identity != target_identity and log_db_path_change:
             logger.info(
-                "Event cache db_path change will apply after restart",
-                active_db_path=str(support.event_cache.db_path),
-                configured_db_path=str(db_path),
+                "Event cache backend change will apply after restart",
+                active_backend=support.event_cache_identity.backend,
+                active_location=support.event_cache_identity.redacted_location,
+                active_namespace=support.event_cache_identity.namespace,
+                configured_backend=target_identity.backend,
+                configured_location=target_identity.redacted_location,
+                configured_namespace=target_identity.namespace,
             )
 
     if support.event_cache.is_initialized:
@@ -102,7 +208,9 @@ async def sync_owned_runtime_support(
         support.event_cache.disable(f"{init_failure_reason_prefix}:{exc}")
         logger.warning(
             "Event cache init failed; continuing without advisory cache",
-            db_path=str(support.event_cache.db_path),
+            backend=support.event_cache_identity.backend,
+            location=support.event_cache_identity.redacted_location,
+            namespace=support.event_cache_identity.namespace,
             error=str(exc),
         )
     return support

--- a/tach.toml
+++ b/tach.toml
@@ -981,11 +981,29 @@ depends_on = [
 visibility = ["mindroom.matrix.cache.sqlite_event_cache"]
 
 [[modules]]
+path = "mindroom.matrix.cache.postgres_agent_message_snapshot"
+depends_on = [
+    "mindroom.matrix.cache.agent_message_snapshot",
+    "mindroom.matrix.cache.postgres_event_cache_events",
+    "mindroom.matrix.cache.postgres_event_cache_threads",
+    "mindroom.matrix.cache.thread_cache_helpers",
+]
+visibility = ["mindroom.matrix.cache.postgres_event_cache"]
+
+[[modules]]
 path = "mindroom.matrix.cache.sqlite_event_cache_threads"
 depends_on = [
     "mindroom.matrix.cache.event_cache",
     "mindroom.matrix.cache.event_normalization",
     "mindroom.matrix.cache.sqlite_event_cache_events",
+]
+
+[[modules]]
+path = "mindroom.matrix.cache.postgres_event_cache_threads"
+depends_on = [
+    "mindroom.matrix.cache.event_cache",
+    "mindroom.matrix.cache.event_normalization",
+    "mindroom.matrix.cache.postgres_event_cache_events",
 ]
 
 [[modules]]
@@ -1022,6 +1040,16 @@ depends_on = [
 ]
 
 [[modules]]
+path = "mindroom.matrix.cache.postgres_event_cache_events"
+depends_on = [
+    "mindroom.matrix.event_info",
+]
+
+[[modules]]
+path = "mindroom.matrix.cache.postgres_redaction"
+depends_on = []
+
+[[modules]]
 path = "mindroom.matrix.cache.sqlite_event_cache"
 depends_on = [
     "mindroom.matrix.cache.event_normalization",
@@ -1029,6 +1057,18 @@ depends_on = [
     "mindroom.matrix.cache.sqlite_agent_message_snapshot",
     "mindroom.matrix.cache.sqlite_event_cache_events",
     "mindroom.matrix.cache.sqlite_event_cache_threads",
+]
+visibility = ["mindroom.runtime_support"]
+
+[[modules]]
+path = "mindroom.matrix.cache.postgres_event_cache"
+depends_on = [
+    "mindroom.matrix.cache.event_normalization",
+    "mindroom.logging_config",
+    "mindroom.matrix.cache.postgres_agent_message_snapshot",
+    "mindroom.matrix.cache.postgres_event_cache_events",
+    "mindroom.matrix.cache.postgres_event_cache_threads",
+    "mindroom.matrix.cache.postgres_redaction",
 ]
 visibility = ["mindroom.runtime_support"]
 
@@ -1065,8 +1105,13 @@ depends_on = [
 [[modules]]
 path = "mindroom.runtime_support"
 depends_on = [
+    "mindroom.config.matrix",
+    "mindroom.constants",
+    "mindroom.matrix.cache.postgres_event_cache",
+    "mindroom.matrix.cache.postgres_redaction",
     "mindroom.matrix.cache.sqlite_event_cache",
     "mindroom.matrix.cache.write_coordinator",
+    "mindroom.tool_system.dependencies",
 ]
 
 [[modules]]
@@ -1954,6 +1999,12 @@ exclusive = true
 [[interfaces]]
 expose = ["SqliteEventCache"]
 from = ["mindroom.matrix.cache.sqlite_event_cache"]
+visibility = ["mindroom.runtime_support"]
+exclusive = true
+
+[[interfaces]]
+expose = ["PostgresEventCache"]
+from = ["mindroom.matrix.cache.postgres_event_cache"]
 visibility = ["mindroom.runtime_support"]
 exclusive = true
 

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -495,10 +495,17 @@ def test_public_startup_runtime_payload_excludes_runner_token(tmp_path: Path) ->
     """Public startup runtime payloads should not serialize the runner auth token."""
     config_path = tmp_path / "config.yaml"
     config_path.write_text("models: {}\nagents: {}\n", encoding="utf-8")
+    (tmp_path / ".env").write_text(
+        "MINDROOM_EVENT_CACHE_DATABASE_URL=postgresql://cache:file-secret@db/mindroom\n"
+        "MINDROOM_CACHE_DATABASE_URL=postgresql://cache:custom-file-secret@db/mindroom\n",
+        encoding="utf-8",
+    )
     runtime_paths = resolve_primary_runtime_paths(
         config_path=config_path,
         storage_path=tmp_path / "storage",
         process_env={
+            "MINDROOM_EVENT_CACHE_DATABASE_URL": "postgresql://cache:process-secret@db/mindroom",
+            "MINDROOM_CACHE_DATABASE_URL": "postgresql://cache:custom-process-secret@db/mindroom",
             "MINDROOM_SANDBOX_PROXY_TOKEN": "secret-token",
             "MINDROOM_NAMESPACE": "alpha1234",
         },
@@ -511,6 +518,8 @@ def test_public_startup_runtime_payload_excludes_runner_token(tmp_path: Path) ->
         "MINDROOM_NAMESPACE": "alpha1234",
         "MINDROOM_STORAGE_PATH": str((tmp_path / "storage").resolve()),
     }
+    assert "MINDROOM_EVENT_CACHE_DATABASE_URL" not in payload["env_file_values"]
+    assert "MINDROOM_CACHE_DATABASE_URL" not in payload["env_file_values"]
 
 
 def test_public_startup_runtime_still_allows_python_execution_env(
@@ -973,13 +982,20 @@ def test_sandbox_runner_execution_env_excludes_runner_token_and_unrelated_host_e
         encoding="utf-8",
     )
     (tmp_path / ".env").write_text(
-        "OPENAI_API_KEY=dotenv-secret\nTEST_EXECUTION_ENV=visible-in-shell\n",
+        "OPENAI_API_KEY=dotenv-secret\n"
+        "TEST_EXECUTION_ENV=visible-in-shell\n"
+        "MINDROOM_EVENT_CACHE_DATABASE_URL=postgresql://cache:dotenv-secret@db/mindroom\n"
+        "MINDROOM_CACHE_DATABASE_URL=postgresql://cache:custom-dotenv-secret@db/mindroom\n",
         encoding="utf-8",
     )
     runtime_paths = resolve_primary_runtime_paths(
         config_path=config_path,
         storage_path=tmp_path / "storage",
-        process_env=dict(os.environ),
+        process_env={
+            **dict(os.environ),
+            "MINDROOM_EVENT_CACHE_DATABASE_URL": "postgresql://cache:process-secret@db/mindroom",
+            "MINDROOM_CACHE_DATABASE_URL": "postgresql://cache:custom-process-secret@db/mindroom",
+        },
     )
 
     execution_env = sandbox_exec_module.request_execution_env(
@@ -991,6 +1007,8 @@ def test_sandbox_runner_execution_env_excludes_runner_token_and_unrelated_host_e
     assert execution_env["OPENAI_API_KEY"] == "dotenv-secret"
     assert execution_env["TEST_EXECUTION_ENV"] == "visible-in-shell"
     assert execution_env["MINDROOM_STORAGE_PATH"] == str((tmp_path / "storage").resolve())
+    assert "MINDROOM_EVENT_CACHE_DATABASE_URL" not in execution_env
+    assert "MINDROOM_CACHE_DATABASE_URL" not in execution_env
     assert "MINDROOM_SANDBOX_PROXY_TOKEN" not in execution_env
     assert "MINDROOM_API_KEY" not in execution_env
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,16 @@
 
 import os
 import re
+import shutil
+import subprocess
+import time
+import uuid
 from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Iterator, Mapping, MutableMapping
 from contextlib import ExitStack, contextmanager
 from dataclasses import replace
 from itertools import count
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -33,6 +38,9 @@ from mindroom.turn_controller import TurnController
 from mindroom.turn_policy import TurnPolicy
 from mindroom.turn_store import TurnStore
 
+if TYPE_CHECKING:
+    from mindroom.matrix.cache import ConversationEventCache
+
 __all__ = [
     "TEST_ACCESS_TOKEN",
     "TEST_PASSWORD",
@@ -44,6 +52,8 @@ __all__ = [
     "create_mock_room",
     "delivered_matrix_event",
     "delivered_matrix_side_effect",
+    "event_cache",
+    "event_cache_factory",
     "install_edit_message_mock",
     "install_generate_response_mock",
     "install_runtime_cache_support",
@@ -56,6 +66,7 @@ __all__ = [
     "normalize_console_output",
     "orchestrator_runtime_paths",
     "patch_response_runner_module",
+    "postgres_event_cache_url",
     "replace_delivery_gateway_deps",
     "replace_edit_regenerator_deps",
     "replace_response_runner_deps",
@@ -75,6 +86,122 @@ _VISIBLE_MESSAGE_IDS = count(1)
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 _SOFT_WRAP_RE = re.compile(r"(?<=\S)\n(?=\S)")
 RuntimeBot = AgentBot | TeamBot
+
+
+def _wait_for_postgres_container(database_url: str) -> None:
+    import psycopg  # noqa: PLC0415
+
+    deadline = time.monotonic() + 30
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with psycopg.connect(database_url, connect_timeout=1):
+                return
+        except psycopg.OperationalError as exc:
+            last_error = exc
+            time.sleep(0.25)
+    msg = "Postgres test container did not become ready"
+    raise RuntimeError(msg) from last_error
+
+
+def _postgres_url_from_container_port(docker: str, container_name: str) -> str:
+    result = subprocess.run(
+        [docker, "port", container_name, "5432/tcp"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    mapped_port = result.stdout.strip().splitlines()[-1]
+    host, port = mapped_port.rsplit(":", 1)
+    return f"postgresql://cache:test@{host.removeprefix('[').removesuffix(']')}:{port}/mindroom"
+
+
+@pytest.fixture(scope="session")
+def postgres_event_cache_url() -> Iterator[str]:
+    """Start a disposable Postgres server when Docker is available."""
+    docker = shutil.which("docker")
+    if docker is None:
+        pytest.skip("Docker is required for Postgres event-cache integration tests")
+
+    info_result = subprocess.run(
+        [docker, "info"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if info_result.returncode != 0:
+        pytest.skip("Docker daemon is unavailable for Postgres event-cache integration tests")
+
+    container_name = f"mindroom-postgres-cache-test-{uuid.uuid4().hex}"
+    run_result = subprocess.run(
+        [
+            docker,
+            "run",
+            "--rm",
+            "-d",
+            "--name",
+            container_name,
+            "-e",
+            "POSTGRES_USER=cache",
+            "-e",
+            "POSTGRES_PASSWORD=test",
+            "-e",
+            "POSTGRES_DB=mindroom",
+            "-p",
+            "127.0.0.1::5432",
+            "postgres:15-alpine",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if run_result.returncode != 0:
+        pytest.skip(f"Could not start Postgres test container: {run_result.stderr.strip()}")
+
+    try:
+        database_url = _postgres_url_from_container_port(docker, container_name)
+        _wait_for_postgres_container(database_url)
+        yield database_url
+    finally:
+        subprocess.run(
+            [docker, "rm", "-f", container_name],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+
+@pytest.fixture(params=("sqlite", "postgres"), ids=("sqlite", "postgres"))
+def event_cache_factory(
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> Callable[[], "ConversationEventCache"]:
+    """Return a cache factory for backend-neutral event-cache contract tests."""
+    backend = str(request.param)
+    if backend == "sqlite":
+        db_path = tmp_path / "event_cache.db"
+        return lambda: SqliteEventCache(db_path)
+    if backend == "postgres":
+        from mindroom.matrix.cache.postgres_event_cache import PostgresEventCache  # noqa: PLC0415
+
+        database_url = request.getfixturevalue("postgres_event_cache_url")
+        namespace = f"test_{uuid.uuid4().hex}"
+        return lambda: PostgresEventCache(database_url=database_url, namespace=namespace)
+    msg = f"Unsupported event cache backend fixture: {backend}"
+    raise AssertionError(msg)
+
+
+@pytest_asyncio.fixture
+async def event_cache(
+    event_cache_factory: Callable[[], "ConversationEventCache"],
+) -> AsyncGenerator["ConversationEventCache", None]:
+    """Return one initialized event cache backend for backend-neutral contract tests."""
+    cache = event_cache_factory()
+    await cache.initialize()
+    try:
+        yield cache
+    finally:
+        await cache.close()
 
 
 async def _empty_async_iterator() -> AsyncGenerator[object, None]:

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -14,7 +14,12 @@ import pytest
 from nio.api import RelationshipType
 
 import mindroom.matrix.cache.sqlite_event_cache as event_cache_module
-from mindroom.matrix.cache import event_normalization, sqlite_event_cache_events, sqlite_event_cache_threads
+from mindroom.matrix.cache import (
+    ConversationEventCache,
+    event_normalization,
+    sqlite_event_cache_events,
+    sqlite_event_cache_threads,
+)
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.client_thread_history import fetch_thread_history
 from mindroom.matrix.conversation_cache import _cached_room_get_event as cached_room_get_event
@@ -23,7 +28,7 @@ from mindroom.matrix.message_content import _clear_mxc_cache
 from mindroom.timing import DispatchPipelineTiming
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
     from pathlib import Path
 
 
@@ -140,7 +145,7 @@ def _make_relations_client(
 
 
 async def _seed_thread_cache(
-    cache: SqliteEventCache,
+    cache: ConversationEventCache,
     *,
     room_id: str,
     thread_id: str,
@@ -221,10 +226,9 @@ async def test_thread_snapshot_storage_exposes_direct_cache_state_reads(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_event_cache_store_and_retrieve(tmp_path: Path) -> None:
+async def test_event_cache_store_and_retrieve(event_cache: ConversationEventCache) -> None:
     """Stored events should round-trip in timestamp order."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     try:
         await _seed_thread_cache(
@@ -262,10 +266,11 @@ async def test_event_cache_store_and_retrieve(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_recent_room_thread_ids_orders_by_latest_event_in_each_thread(tmp_path: Path) -> None:
+async def test_get_recent_room_thread_ids_orders_by_latest_event_in_each_thread(
+    event_cache: ConversationEventCache,
+) -> None:
     """Recent thread IDs should be ordered by the freshest cached event per thread, not by root timestamp."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     try:
         await _seed_thread_cache(
@@ -338,10 +343,11 @@ async def test_get_recent_room_thread_ids_orders_by_latest_event_in_each_thread(
 
 
 @pytest.mark.asyncio
-async def test_event_cache_preserves_insertion_order_for_same_timestamp_events(tmp_path: Path) -> None:
+async def test_event_cache_preserves_insertion_order_for_same_timestamp_events(
+    event_cache: ConversationEventCache,
+) -> None:
     """Cached reads should preserve the stored order when timestamps tie."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     try:
         await _seed_thread_cache(
@@ -394,10 +400,9 @@ async def test_event_cache_preserves_insertion_order_for_same_timestamp_events(t
 
 
 @pytest.mark.asyncio
-async def test_individual_event_cache_store_and_retrieve(tmp_path: Path) -> None:
+async def test_individual_event_cache_store_and_retrieve(event_cache: ConversationEventCache) -> None:
     """Individually cached events should round-trip by event ID."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     try:
         await cache.store_events_batch(
@@ -635,10 +640,9 @@ async def test_event_cache_initialize_clears_half_initialized_connection_on_fail
 
 
 @pytest.mark.asyncio
-async def test_individual_event_cache_strips_runtime_timing_marker(tmp_path: Path) -> None:
+async def test_individual_event_cache_strips_runtime_timing_marker(event_cache: ConversationEventCache) -> None:
     """Batch event caching should drop in-memory timing objects before serialization."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     reply_event = _make_text_event(
         event_id="$reply",
@@ -665,10 +669,9 @@ async def test_individual_event_cache_strips_runtime_timing_marker(tmp_path: Pat
 
 
 @pytest.mark.asyncio
-async def test_thread_cache_store_populates_individual_event_lookup(tmp_path: Path) -> None:
+async def test_thread_cache_store_populates_individual_event_lookup(event_cache: ConversationEventCache) -> None:
     """Thread cache writes should also populate the individual event table."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     root_event = _make_text_event(
         event_id="$thread_root",
@@ -705,10 +708,9 @@ async def test_thread_cache_store_populates_individual_event_lookup(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_thread_event_cache_strips_runtime_timing_marker(tmp_path: Path) -> None:
+async def test_thread_event_cache_strips_runtime_timing_marker(event_cache: ConversationEventCache) -> None:
     """Thread cache writes should strip runtime-only timing markers before JSON storage."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     reply_event = _make_text_event(
         event_id="$reply",
@@ -745,10 +747,9 @@ async def test_thread_event_cache_strips_runtime_timing_marker(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_cached_room_get_event_cache_hit_avoids_network_call(tmp_path: Path) -> None:
+async def test_cached_room_get_event_cache_hit_avoids_network_call(event_cache: ConversationEventCache) -> None:
     """Cached room get event lookups should reconstruct nio responses without I/O."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     reply_event = _make_text_event(
         event_id="$reply",
@@ -773,10 +774,11 @@ async def test_cached_room_get_event_cache_hit_avoids_network_call(tmp_path: Pat
 
 
 @pytest.mark.asyncio
-async def test_cached_room_get_event_cache_hit_returns_latest_visible_edit(tmp_path: Path) -> None:
+async def test_cached_room_get_event_cache_hit_returns_latest_visible_edit(
+    event_cache: ConversationEventCache,
+) -> None:
     """Point-event cache hits should surface the latest edited content for originals."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     original_event = _make_text_event(
         event_id="$reply",
@@ -822,10 +824,11 @@ async def test_cached_room_get_event_cache_hit_returns_latest_visible_edit(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_cached_room_get_event_network_fetch_merges_cached_latest_edit(tmp_path: Path) -> None:
+async def test_cached_room_get_event_network_fetch_merges_cached_latest_edit(
+    event_cache: ConversationEventCache,
+) -> None:
     """Network fetches should still project originals through cached latest edits."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     original_event = _make_text_event(
         event_id="$reply",
@@ -861,10 +864,9 @@ async def test_cached_room_get_event_network_fetch_merges_cached_latest_edit(tmp
 
 
 @pytest.mark.asyncio
-async def test_redacting_latest_edit_falls_back_to_previous_cached_edit(tmp_path: Path) -> None:
+async def test_redacting_latest_edit_falls_back_to_previous_cached_edit(event_cache: ConversationEventCache) -> None:
     """Removing the newest edit should expose the previous cached visible state."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     original_event = _make_text_event(
         event_id="$reply",
@@ -921,10 +923,9 @@ async def test_redacting_latest_edit_falls_back_to_previous_cached_edit(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_redaction_removes_individual_event_cache_entry(tmp_path: Path) -> None:
+async def test_redaction_removes_individual_event_cache_entry(event_cache: ConversationEventCache) -> None:
     """Redactions should also remove individually cached events."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     root_event = _make_text_event(
         event_id="$thread_root",
@@ -961,10 +962,11 @@ async def test_redaction_removes_individual_event_cache_entry(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_redacting_original_removes_dependent_cached_edits_from_thread_history(tmp_path: Path) -> None:
+async def test_redacting_original_removes_dependent_cached_edits_from_thread_history(
+    event_cache: ConversationEventCache,
+) -> None:
     """Redacting an original must also remove cached edits that would resurrect it."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     root_event = _make_text_event(
         event_id="$thread_root",
@@ -1032,10 +1034,11 @@ async def test_redacting_original_removes_dependent_cached_edits_from_thread_his
 
 
 @pytest.mark.asyncio
-async def test_invalidate_thread_preserves_separately_cached_latest_edit(tmp_path: Path) -> None:
+async def test_invalidate_thread_preserves_separately_cached_latest_edit(
+    event_cache: ConversationEventCache,
+) -> None:
     """Thread invalidation should not sever edit projection for separately cached edits."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     root_event = _make_text_event(
         event_id="$thread_root",
@@ -1091,10 +1094,9 @@ async def test_invalidate_thread_preserves_separately_cached_latest_edit(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_invalidate_thread_removes_event_thread_rows(tmp_path: Path) -> None:
+async def test_invalidate_thread_removes_event_thread_rows(event_cache: ConversationEventCache) -> None:
     """Thread invalidation must also clear durable event-to-thread mappings."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     root_event = _make_text_event(
         event_id="$thread_root",
@@ -1132,10 +1134,11 @@ async def test_invalidate_thread_removes_event_thread_rows(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_redaction_removes_event_thread_rows_and_blocks_late_edit_resurrection(tmp_path: Path) -> None:
+async def test_redaction_removes_event_thread_rows_and_blocks_late_edit_resurrection(
+    event_cache: ConversationEventCache,
+) -> None:
     """Redacting a reply must clear durable thread mapping and ignore late edits for that reply."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     root_event = _make_text_event(
         event_id="$thread_root",
@@ -1202,11 +1205,10 @@ async def test_redaction_removes_event_thread_rows_and_blocks_late_edit_resurrec
 
 @pytest.mark.asyncio
 async def test_store_events_batch_records_thread_root_self_mapping_from_explicit_thread_child(
-    tmp_path: Path,
+    event_cache: ConversationEventCache,
 ) -> None:
     """Explicit threaded children should also make the root resolve to its own thread id."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     reply_event = _make_text_event(
         event_id="$reply",
@@ -1231,10 +1233,11 @@ async def test_store_events_batch_records_thread_root_self_mapping_from_explicit
 
 
 @pytest.mark.asyncio
-async def test_store_events_batch_rolls_back_on_index_derivation_failure(tmp_path: Path) -> None:
+async def test_store_events_batch_rolls_back_on_index_derivation_failure(
+    event_cache: ConversationEventCache,
+) -> None:
     """Failed batch writes must not leak partial point-lookup rows into later commits."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     valid_event = _cache_source(
         _make_text_event(
@@ -1354,10 +1357,11 @@ async def test_initialize_resets_stale_old_cache_schema(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_disabled_event_cache_skips_latest_agent_message_snapshot_reads(tmp_path: Path) -> None:
+async def test_disabled_event_cache_skips_latest_agent_message_snapshot_reads(
+    event_cache: ConversationEventCache,
+) -> None:
     """Disabled caches should fail open for latest-agent-message snapshot reads."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
     try:
         await cache.store_events_batch(
             [
@@ -1389,10 +1393,9 @@ async def test_disabled_event_cache_skips_latest_agent_message_snapshot_reads(tm
 
 
 @pytest.mark.asyncio
-async def test_fetch_thread_history_cache_hit_avoids_full_fetch_calls(tmp_path: Path) -> None:
+async def test_fetch_thread_history_cache_hit_avoids_full_fetch_calls(event_cache: ConversationEventCache) -> None:
     """Cache hits should bypass the full root-plus-relations fetch path."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     root_event = _make_text_event(
         event_id="$thread_root",
@@ -1437,10 +1440,9 @@ async def test_fetch_thread_history_cache_hit_avoids_full_fetch_calls(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_fetch_thread_history_cache_miss_does_full_fetch(tmp_path: Path) -> None:
+async def test_fetch_thread_history_cache_miss_does_full_fetch(event_cache: ConversationEventCache) -> None:
     """Cache misses should scan room history and populate the cache."""
-    cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await cache.initialize()
+    cache = event_cache
 
     root_event = _make_text_event(
         event_id="$thread_root",
@@ -1482,10 +1484,11 @@ async def test_fetch_thread_history_cache_miss_does_full_fetch(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_mxc_text_cache_round_trips_across_event_cache_reopen(tmp_path: Path) -> None:
+async def test_mxc_text_cache_round_trips_across_event_cache_reopen(
+    event_cache_factory: Callable[[], ConversationEventCache],
+) -> None:
     """Durable MXC text rows should survive closing and reopening the event cache."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
 
     try:
@@ -1493,7 +1496,7 @@ async def test_mxc_text_cache_round_trips_across_event_cache_reopen(tmp_path: Pa
     finally:
         await cache.close()
 
-    reopened_cache = SqliteEventCache(db_path)
+    reopened_cache = event_cache_factory()
     await reopened_cache.initialize()
     try:
         cached_text = await reopened_cache.get_mxc_text("!room:localhost", "mxc://server/sidecar")
@@ -1504,10 +1507,11 @@ async def test_mxc_text_cache_round_trips_across_event_cache_reopen(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_fetch_thread_history_reuses_durable_mxc_text_after_restart(tmp_path: Path) -> None:
+async def test_fetch_thread_history_reuses_durable_mxc_text_after_restart(
+    event_cache_factory: Callable[[], ConversationEventCache],
+) -> None:
     """Cached full-history reads should reuse durable sidecar text after a restart."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     _clear_mxc_cache()
 
@@ -1561,7 +1565,7 @@ async def test_fetch_thread_history_reuses_durable_mxc_text_after_restart(tmp_pa
 
     _clear_mxc_cache()
 
-    reopened_cache = SqliteEventCache(db_path)
+    reopened_cache = event_cache_factory()
     await reopened_cache.initialize()
     second_client = MagicMock()
     second_client.download = AsyncMock(

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -1,0 +1,394 @@
+"""Runtime selection for Matrix event-cache backends."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom.config.matrix import CacheConfig
+from mindroom.constants import RuntimePaths, resolve_runtime_paths
+from mindroom.matrix.cache.postgres_event_cache import PostgresEventCache, PostgresEventCacheRuntime
+from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from mindroom.runtime_support import EventCacheRuntimeIdentity, build_event_cache
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _message_event(
+    *,
+    event_id: str,
+    sender: str,
+    body: str,
+    origin_server_ts: int,
+    thread_id: str | None = None,
+) -> dict[str, object]:
+    content: dict[str, object] = {
+        "msgtype": "m.text",
+        "body": body,
+    }
+    if thread_id is not None:
+        content["m.relates_to"] = {
+            "rel_type": "m.thread",
+            "event_id": thread_id,
+        }
+    return {
+        "type": "m.room.message",
+        "event_id": event_id,
+        "sender": sender,
+        "origin_server_ts": origin_server_ts,
+        "content": content,
+    }
+
+
+def _edit_event(
+    *,
+    event_id: str,
+    sender: str,
+    original_event_id: str,
+    body: str,
+    origin_server_ts: int,
+) -> dict[str, object]:
+    return {
+        "type": "m.room.message",
+        "event_id": event_id,
+        "sender": sender,
+        "origin_server_ts": origin_server_ts,
+        "content": {
+            "msgtype": "m.text",
+            "body": f"* {body}",
+            "m.new_content": {
+                "msgtype": "m.text",
+                "body": body,
+            },
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": original_event_id,
+            },
+        },
+    }
+
+
+def _runtime_paths(tmp_path: Path, *, env: dict[str, str] | None = None) -> RuntimePaths:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("router:\n  model: default\n", encoding="utf-8")
+    process_env = {
+        "MATRIX_HOMESERVER": "http://localhost:8008",
+        "MINDROOM_NAMESPACE": "",
+    }
+    if env is not None:
+        process_env.update(env)
+    return resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "mindroom_data",
+        process_env=process_env,
+    )
+
+
+async def _assert_thread_lookup_behavior(
+    cache: PostgresEventCache,
+    shared_cache: PostgresEventCache,
+    isolated_cache: PostgresEventCache,
+    *,
+    room_id: str,
+    thread_id: str,
+    root_event: dict[str, object],
+    reply_event: dict[str, object],
+) -> None:
+    await cache.replace_thread(room_id, thread_id, [reply_event, root_event], validated_at=100.0)
+
+    cached_thread = await cache.get_thread_events(room_id, thread_id)
+    assert cached_thread is not None
+    assert [event["event_id"] for event in cached_thread] == [thread_id, "$reply"]
+    assert await cache.get_recent_room_thread_ids(room_id, limit=5) == [thread_id]
+    assert await cache.get_event(room_id, "$reply") == reply_event
+    assert await cache.get_thread_id_for_event(room_id, "$reply") == thread_id
+    assert await cache.get_thread_id_for_event(room_id, thread_id) == thread_id
+
+    assert await shared_cache.get_thread_events(room_id, thread_id) == cached_thread
+    assert await shared_cache.get_event(room_id, "$reply") == reply_event
+    assert await shared_cache.get_thread_id_for_event(room_id, "$reply") == thread_id
+
+    assert await isolated_cache.get_thread_events(room_id, thread_id) is None
+    assert await isolated_cache.get_event(room_id, "$reply") is None
+
+
+async def _assert_edit_snapshot_and_mxc_behavior(
+    cache: PostgresEventCache,
+    *,
+    room_id: str,
+    thread_id: str,
+    sender: str,
+    old_edit: dict[str, object],
+    latest_edit: dict[str, object],
+) -> None:
+    await cache.store_events_batch(
+        [
+            ("$edit-old", room_id, old_edit),
+            ("$edit-latest", room_id, latest_edit),
+        ],
+    )
+    assert await cache.get_latest_edit(room_id, "$reply") == latest_edit
+    snapshot = await cache.get_latest_agent_message_snapshot(
+        room_id,
+        thread_id,
+        sender,
+        runtime_started_at=None,
+    )
+    assert snapshot is not None
+    assert snapshot.content["body"] == "latest edit"
+    assert snapshot.origin_server_ts == 1030
+
+    await cache.store_mxc_text(room_id, "mxc://localhost/media", "downloaded text")
+    assert await cache.get_mxc_text(room_id, "mxc://localhost/media") == "downloaded text"
+
+
+async def _assert_staleness_and_redaction_behavior(
+    cache: PostgresEventCache,
+    *,
+    room_id: str,
+    thread_id: str,
+    latest_edit: dict[str, object],
+) -> None:
+    await cache.mark_thread_stale(room_id, thread_id, reason="live_thread_mutation")
+    stale_state = await cache.get_thread_cache_state(room_id, thread_id)
+    assert stale_state is not None
+    assert stale_state.invalidated_at is not None
+    assert stale_state.invalidation_reason == "live_thread_mutation"
+    assert await cache.revalidate_thread_after_incremental_update(room_id, thread_id) is True
+    fresh_state = await cache.get_thread_cache_state(room_id, thread_id)
+    assert fresh_state is not None
+    assert fresh_state.invalidated_at is None
+    assert fresh_state.invalidation_reason is None
+
+    assert await cache.redact_event(room_id, "$reply") is True
+    assert await cache.get_event(room_id, "$reply") is None
+    assert await cache.get_latest_edit(room_id, "$reply") is None
+    redacted_thread = await cache.get_thread_events(room_id, thread_id)
+    assert redacted_thread is not None
+    assert [event["event_id"] for event in redacted_thread] == [thread_id]
+
+    await cache.store_event("$edit-latest", room_id, latest_edit)
+    assert await cache.get_latest_edit(room_id, "$reply") is None
+
+
+def test_cache_config_resolves_postgres_url_and_namespace_from_runtime_env(tmp_path: Path) -> None:
+    """Postgres cache config should keep secrets in runtime env and scope rows by namespace."""
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        env={
+            "MINDROOM_EVENT_CACHE_DATABASE_URL": "postgresql://cache:test@localhost/mindroom",
+            "MINDROOM_NAMESPACE": "tenant-a",
+        },
+    )
+    cache_config = CacheConfig(backend="postgres")
+
+    assert cache_config.resolve_postgres_database_url(runtime_paths) == "postgresql://cache:test@localhost/mindroom"
+    assert cache_config.resolve_namespace(runtime_paths) == "tenant-a"
+
+
+def test_cache_config_accepts_custom_secret_filtered_postgres_url_env(tmp_path: Path) -> None:
+    """Custom Postgres DSN env names must use the secret-filtered DATABASE_URL shape."""
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        env={
+            "MINDROOM_CACHE_DATABASE_URL": "postgresql://cache:test@localhost/mindroom",
+        },
+    )
+    cache_config = CacheConfig(backend="postgres", database_url_env="MINDROOM_CACHE_DATABASE_URL")
+
+    assert cache_config.resolve_postgres_database_url(runtime_paths) == "postgresql://cache:test@localhost/mindroom"
+
+
+def test_cache_config_rejects_custom_postgres_url_env_without_database_url_suffix() -> None:
+    """Unsafe custom DSN env names would bypass runtime secret filters."""
+    with pytest.raises(ValueError, match="DATABASE_URL"):
+        CacheConfig(backend="postgres", database_url_env="MINDROOM_CACHE_URL")
+
+
+def test_build_event_cache_defaults_to_sqlite(tmp_path: Path) -> None:
+    """SQLite should remain the default cache backend for local installs."""
+    runtime_paths = _runtime_paths(tmp_path)
+    cache = build_event_cache(CacheConfig(), runtime_paths)
+
+    assert isinstance(cache, SqliteEventCache)
+    assert cache.db_path == tmp_path / "mindroom_data" / "event_cache.db"
+
+
+def test_build_event_cache_uses_postgres_when_configured(tmp_path: Path) -> None:
+    """The runtime factory should construct the Postgres cache backend only when requested."""
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        env={
+            "MINDROOM_EVENT_CACHE_DATABASE_URL": "postgresql://cache:test@localhost/mindroom",
+            "MINDROOM_NAMESPACE": "tenant-a",
+        },
+    )
+    cache = build_event_cache(CacheConfig(backend="postgres"), runtime_paths)
+
+    assert isinstance(cache, PostgresEventCache)
+    assert cache.database_url == "postgresql://cache:test@localhost/mindroom"
+    assert cache.namespace == "tenant-a"
+
+
+def test_build_event_cache_auto_installs_postgres_extra_before_import(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The runtime factory should satisfy psycopg before importing the Postgres backend."""
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        env={
+            "MINDROOM_EVENT_CACHE_DATABASE_URL": "postgresql://cache:test@localhost/mindroom",
+            "MINDROOM_NAMESPACE": "tenant-a",
+        },
+    )
+    install_calls: list[tuple[list[str], str, RuntimePaths]] = []
+
+    class FakePostgresEventCache:
+        def __init__(self, *, database_url: str, namespace: str) -> None:
+            self.database_url = database_url
+            self.namespace = namespace
+
+    def fake_ensure_optional_deps(
+        dependencies: list[str],
+        extra_name: str,
+        runtime_paths_arg: RuntimePaths,
+    ) -> None:
+        install_calls.append((dependencies, extra_name, runtime_paths_arg))
+
+    def fake_import_module(module_name: str) -> SimpleNamespace:
+        assert install_calls == [(["psycopg"], "postgres", runtime_paths)]
+        assert module_name == "mindroom.matrix.cache.postgres_event_cache"
+        return SimpleNamespace(PostgresEventCache=FakePostgresEventCache)
+
+    monkeypatch.setattr("mindroom.runtime_support.ensure_optional_deps", fake_ensure_optional_deps)
+    monkeypatch.setattr("mindroom.runtime_support.import_module", fake_import_module)
+
+    cache = build_event_cache(CacheConfig(backend="postgres"), runtime_paths)
+
+    assert isinstance(cache, FakePostgresEventCache)
+    assert cache.database_url == "postgresql://cache:test@localhost/mindroom"
+    assert cache.namespace == "tenant-a"
+
+
+@pytest.mark.asyncio
+async def test_postgres_event_cache_round_trips_core_conversation_cache_behavior(
+    postgres_event_cache_url: str,
+) -> None:
+    """The Postgres backend should preserve the same durable cache semantics as SQLite."""
+    room_id = "!room:localhost"
+    thread_id = "$thread"
+    sender = "@mindroom_agent:localhost"
+    root_event = _message_event(
+        event_id=thread_id,
+        sender="@user:localhost",
+        body="thread root",
+        origin_server_ts=1000,
+    )
+    reply_event = _message_event(
+        event_id="$reply",
+        sender=sender,
+        body="first reply",
+        origin_server_ts=1010,
+        thread_id=thread_id,
+    )
+    old_edit = _edit_event(
+        event_id="$edit-old",
+        sender=sender,
+        original_event_id="$reply",
+        body="old edit",
+        origin_server_ts=1020,
+    )
+    latest_edit = _edit_event(
+        event_id="$edit-latest",
+        sender=sender,
+        original_event_id="$reply",
+        body="latest edit",
+        origin_server_ts=1030,
+    )
+    namespace = f"tenant_{uuid.uuid4().hex}"
+    isolated_namespace = f"tenant_{uuid.uuid4().hex}"
+    cache = PostgresEventCache(database_url=postgres_event_cache_url, namespace=namespace)
+    shared_cache = PostgresEventCache(database_url=postgres_event_cache_url, namespace=namespace)
+    isolated_cache = PostgresEventCache(database_url=postgres_event_cache_url, namespace=isolated_namespace)
+
+    await cache.initialize()
+    await shared_cache.initialize()
+    await isolated_cache.initialize()
+    try:
+        assert cache.durable_writes_available is True
+
+        await _assert_thread_lookup_behavior(
+            cache,
+            shared_cache,
+            isolated_cache,
+            room_id=room_id,
+            thread_id=thread_id,
+            root_event=root_event,
+            reply_event=reply_event,
+        )
+        await _assert_edit_snapshot_and_mxc_behavior(
+            cache,
+            room_id=room_id,
+            thread_id=thread_id,
+            sender=sender,
+            old_edit=old_edit,
+            latest_edit=latest_edit,
+        )
+        await _assert_staleness_and_redaction_behavior(
+            cache,
+            room_id=room_id,
+            thread_id=thread_id,
+            latest_edit=latest_edit,
+        )
+    finally:
+        await cache.close()
+        await shared_cache.close()
+        await isolated_cache.close()
+
+
+def test_build_event_cache_requires_postgres_database_url(tmp_path: Path) -> None:
+    """Postgres should fail during cache construction when no database URL is available."""
+    runtime_paths = _runtime_paths(tmp_path)
+
+    with pytest.raises(ValueError, match="MINDROOM_EVENT_CACHE_DATABASE_URL"):
+        build_event_cache(CacheConfig(backend="postgres"), runtime_paths)
+
+
+@pytest.mark.parametrize(
+    ("conninfo", "expected"),
+    [
+        (
+            "postgresql://cache:secret@db.internal/mindroom",
+            "postgresql://***@db.internal/mindroom",
+        ),
+        (
+            "postgresql://db.internal/mindroom?user=cache&password=secret&sslmode=require",
+            "postgresql://db.internal/mindroom?user=cache&password=***&sslmode=require",
+        ),
+        (
+            "host=db.internal user=cache password='secret value' dbname=mindroom",
+            "host=db.internal user=cache password=*** dbname=mindroom",
+        ),
+    ],
+)
+def test_postgres_connection_info_redaction_hides_secret_forms(conninfo: str, expected: str) -> None:
+    """Postgres connection redaction should cover URL and libpq secret forms."""
+    runtime = PostgresEventCacheRuntime(conninfo, namespace="tenant-a")
+
+    assert runtime.redacted_database_url == expected
+
+
+def test_event_cache_runtime_identity_uses_shared_postgres_redaction() -> None:
+    """Runtime backend-change logs should use the same Postgres redaction policy."""
+    identity = EventCacheRuntimeIdentity(
+        backend="postgres",
+        location="postgresql://db.internal/mindroom?user=cache&password=secret",
+        namespace="tenant-a",
+    )
+
+    assert identity.redacted_location == "postgresql://db.internal/mindroom?user=cache&password=***"

--- a/tests/test_matrix_cache_agent_message_snapshot.py
+++ b/tests/test_matrix_cache_agent_message_snapshot.py
@@ -7,11 +7,10 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from mindroom.matrix.cache import AgentMessageSnapshot, AgentMessageSnapshotUnavailable
-from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from mindroom.matrix.cache import AgentMessageSnapshot, AgentMessageSnapshotUnavailable, ConversationEventCache
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from collections.abc import Callable
 
 
 def _message_event(
@@ -44,14 +43,14 @@ def _message_event(
 
 
 async def _read_snapshot(
-    db_path: Path,
+    cache_factory: Callable[[], ConversationEventCache],
     *,
     room_id: str,
     thread_id: str | None,
     sender: str,
     runtime_started_at: float | None,
 ) -> AgentMessageSnapshot | None:
-    cache = SqliteEventCache(db_path)
+    cache = cache_factory()
     await cache.initialize()
     try:
         return await cache.get_latest_agent_message_snapshot(
@@ -66,11 +65,10 @@ async def _read_snapshot(
 
 @pytest.mark.asyncio
 async def test_get_latest_agent_message_snapshot_returns_unedited_thread_message(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Thread-scope reads should return the latest unedited agent message."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.replace_thread(
@@ -96,7 +94,7 @@ async def test_get_latest_agent_message_snapshot_returns_unedited_thread_message
         await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id="$thread-root",
         sender="@agent:localhost",
@@ -115,11 +113,10 @@ async def test_get_latest_agent_message_snapshot_returns_unedited_thread_message
 
 @pytest.mark.asyncio
 async def test_get_latest_agent_message_snapshot_returns_streaming_status_for_threaded_message(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Edited threaded messages should surface the latest visible stream status."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.replace_thread(
@@ -156,7 +153,7 @@ async def test_get_latest_agent_message_snapshot_returns_streaming_status_for_th
         await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id="$thread-root",
         sender="@agent:localhost",
@@ -175,11 +172,10 @@ async def test_get_latest_agent_message_snapshot_returns_streaming_status_for_th
 
 @pytest.mark.asyncio
 async def test_get_latest_agent_message_snapshot_returns_room_level_message_when_thread_id_none(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Room-scope reads should skip threaded replies and stay on the room timeline."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.store_events_batch(
@@ -215,7 +211,7 @@ async def test_get_latest_agent_message_snapshot_returns_room_level_message_when
         await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",
@@ -230,11 +226,10 @@ async def test_get_latest_agent_message_snapshot_returns_room_level_message_when
 
 @pytest.mark.asyncio
 async def test_get_latest_agent_message_snapshot_returns_none_when_sender_has_no_message(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Missing sender matches should return None instead of raising."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.store_events_batch(
@@ -255,7 +250,7 @@ async def test_get_latest_agent_message_snapshot_returns_none_when_sender_has_no
         await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",
@@ -267,16 +262,15 @@ async def test_get_latest_agent_message_snapshot_returns_none_when_sender_has_no
 
 @pytest.mark.asyncio
 async def test_get_latest_agent_message_snapshot_returns_none_when_cache_has_no_rows(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Empty cache files should return None for any scope lookup."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id="$thread-root",
         sender="@agent:localhost",
@@ -288,11 +282,10 @@ async def test_get_latest_agent_message_snapshot_returns_none_when_cache_has_no_
 
 @pytest.mark.asyncio
 async def test_room_scope_ignores_messages_cached_before_current_runtime(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Room-scope reads should ignore stale message rows from a prior runtime."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.store_events_batch(
@@ -313,7 +306,7 @@ async def test_room_scope_ignores_messages_cached_before_current_runtime(
         await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",
@@ -325,11 +318,10 @@ async def test_room_scope_ignores_messages_cached_before_current_runtime(
 
 @pytest.mark.asyncio
 async def test_room_scope_keeps_visible_edit_cached_in_current_runtime(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Room-scope reads should keep a message whose visible edit was cached after restart."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.store_events_batch(
@@ -370,7 +362,7 @@ async def test_room_scope_keeps_visible_edit_cached_in_current_runtime(
         await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",
@@ -389,11 +381,10 @@ async def test_room_scope_keeps_visible_edit_cached_in_current_runtime(
 
 @pytest.mark.asyncio
 async def test_room_scope_does_not_fall_back_to_older_fresh_message_when_latest_is_stale(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Room-scope reads should fail closed when the latest sender message is stale."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.store_events_batch(
@@ -429,7 +420,7 @@ async def test_room_scope_does_not_fall_back_to_older_fresh_message_when_latest_
         await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",
@@ -441,11 +432,10 @@ async def test_room_scope_does_not_fall_back_to_older_fresh_message_when_latest_
 
 @pytest.mark.asyncio
 async def test_accessor_accepts_old_thread_cache_without_stale_marker(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Threaded reads should trust old snapshots unless a stale marker exists."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.replace_thread(
@@ -472,7 +462,7 @@ async def test_accessor_accepts_old_thread_cache_without_stale_marker(
         await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id="$thread-root",
         sender="@agent:localhost",
@@ -491,11 +481,10 @@ async def test_accessor_accepts_old_thread_cache_without_stale_marker(
 
 @pytest.mark.asyncio
 async def test_accessor_reuses_thread_cache_from_prior_bot_run(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Threaded reads should trust snapshots unless an explicit stale marker exists."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.replace_thread(
@@ -522,7 +511,7 @@ async def test_accessor_reuses_thread_cache_from_prior_bot_run(
         await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id="$thread-root",
         sender="@agent:localhost",
@@ -541,11 +530,10 @@ async def test_accessor_reuses_thread_cache_from_prior_bot_run(
 
 @pytest.mark.asyncio
 async def test_accessor_rejects_invalidated_thread_cache(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Threaded reads should fail closed after durable invalidation."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.replace_thread(
@@ -578,7 +566,7 @@ async def test_accessor_rejects_invalidated_thread_cache(
 
     with pytest.raises(AgentMessageSnapshotUnavailable, match="thread_invalidated_after_validation"):
         await _read_snapshot(
-            db_path,
+            event_cache_factory,
             room_id="!room:localhost",
             thread_id="$thread-root",
             sender="@agent:localhost",
@@ -588,11 +576,10 @@ async def test_accessor_rejects_invalidated_thread_cache(
 
 @pytest.mark.asyncio
 async def test_room_scope_returns_latest_by_origin_server_ts_not_cached_at(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Room-scope reads should follow Matrix timeline order, not cache write time."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.store_events_batch(
@@ -633,7 +620,7 @@ async def test_room_scope_returns_latest_by_origin_server_ts_not_cached_at(
         await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",
@@ -648,11 +635,10 @@ async def test_room_scope_returns_latest_by_origin_server_ts_not_cached_at(
 
 @pytest.mark.asyncio
 async def test_room_scope_preserves_cache_insert_order_for_same_timestamp_messages(
-    tmp_path: Path,
+    event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:
     """Room-scope reads should keep the later cached sender message when timestamps tie."""
-    db_path = tmp_path / "event_cache.db"
-    cache = SqliteEventCache(db_path)
+    cache = event_cache_factory()
     await cache.initialize()
     try:
         await cache.store_events_batch(
@@ -687,7 +673,7 @@ async def test_room_scope_preserves_cache_insert_order_for_same_timestamp_messag
         await cache.close()
 
     snapshot = await _read_snapshot(
-        db_path,
+        event_cache_factory,
         room_id="!room:localhost",
         thread_id=None,
         sender="@agent:localhost",

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -10314,7 +10314,8 @@ class TestMultiAgentOrchestrator:
         sync_owned_runtime_support.assert_awaited_once()
         assert sync_owned_runtime_support.await_args.args == (initial_support,)
         assert sync_owned_runtime_support.await_args.kwargs == {
-            "db_path": config.cache.resolve_db_path(orchestrator.runtime_paths),
+            "cache_config": config.cache,
+            "runtime_paths": orchestrator.runtime_paths,
             "logger": ANY,
             "background_task_owner": orchestrator._event_cache_write_task_owner,
             "init_failure_reason_prefix": "shared_runtime_init_failed",


### PR DESCRIPTION
## Summary
- add a configurable Postgres backend for the Matrix event cache while keeping SQLite as the default
- auto-install the postgres optional extra before loading the Postgres backend when psycopg is missing
- add Postgres schema, advisory room locking, namespace scoping, event/edit/thread/MXC/redaction storage helpers, and runtime backend identity handling
- add Docker-backed Postgres behavior coverage for thread snapshots, lookup indexes, edit snapshots, MXC text, staleness, redaction, namespace isolation, and cross-connection visibility

## Tests
- uv run pytest tests/test_event_cache_backends.py -n 0 --no-cov -q
- uv run ty check src/mindroom/runtime_support.py tests/test_event_cache_backends.py
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --all-files
- uv run pytest -m "not requires_matrix" --no-cov -q