### PR TITLE
perf(matrix): coalesce streaming edit cache work

### DIFF
--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -46,10 +46,20 @@ class ThreadMutationCacheOps:
         update_coro_factory: Callable[[], Coroutine[Any, Any, object]],
         *,
         name: str,
+        emit_timing: bool = False,
+        coalesce_key: tuple[str, str] | None = None,
+        coalesce_log_context: dict[str, object] | None = None,
     ) -> asyncio.Task[object]:
         """Run one cache mutation under the room-ordered write barrier."""
         coordinator = self.runtime.event_cache_write_coordinator
-        return coordinator.queue_room_update(room_id, update_coro_factory, name=name)
+        return coordinator.queue_room_update(
+            room_id,
+            update_coro_factory,
+            name=name,
+            emit_timing=emit_timing,
+            coalesce_key=coalesce_key,
+            coalesce_log_context=coalesce_log_context,
+        )
 
     def queue_thread_cache_update(
         self,
@@ -58,6 +68,9 @@ class ThreadMutationCacheOps:
         update_coro_factory: Callable[[], Coroutine[Any, Any, object]],
         *,
         name: str,
+        emit_timing: bool = False,
+        coalesce_key: tuple[str, str] | None = None,
+        coalesce_log_context: dict[str, object] | None = None,
     ) -> asyncio.Task[object]:
         """Run one thread-specific cache mutation under the same-thread write barrier."""
         coordinator = self.runtime.event_cache_write_coordinator
@@ -66,6 +79,9 @@ class ThreadMutationCacheOps:
             thread_id,
             update_coro_factory,
             name=name,
+            emit_timing=emit_timing,
+            coalesce_key=coalesce_key,
+            coalesce_log_context=coalesce_log_context,
         )
 
     async def store_events_batch(

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 import nio
 
+from mindroom.constants import STREAM_STATUS_KEY, STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.sync_certification import SyncCacheWriteResult
 from mindroom.matrix.thread_bookkeeping import (
@@ -30,6 +31,9 @@ if TYPE_CHECKING:
     from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
 
 __all__ = ["_collect_sync_timeline_cache_updates"]
+
+
+_NONTERMINAL_STREAM_STATUSES = frozenset({STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING})
 
 
 def _collect_sync_timeline_cache_updates(
@@ -85,6 +89,31 @@ def _threaded_sync_event_cache_update(
     if not isinstance(event_id, str) or not event_id:
         return None
     return room_id, normalize_nio_event_for_cache(event)
+
+
+def _outbound_streaming_edit_coalesce_context(
+    *,
+    event_info: EventInfo,
+    event_id: str,
+    event_source: dict[str, object],
+) -> tuple[tuple[str, str], dict[str, object]] | None:
+    if not event_info.is_edit or not isinstance(event_info.original_event_id, str):
+        return None
+    content = event_source.get("content")
+    if not isinstance(content, dict):
+        return None
+    new_content = typing.cast("dict[str, object]", content).get("m.new_content")
+    if not isinstance(new_content, dict):
+        return None
+    if typing.cast("dict[str, object]", new_content).get(STREAM_STATUS_KEY) not in _NONTERMINAL_STREAM_STATUSES:
+        return None
+    return (
+        ("outbound_streaming_edit", event_info.original_event_id),
+        {
+            "original_event_id": event_info.original_event_id,
+            "latest_event_id": event_id,
+        },
+    )
 
 
 def _mutation_reason(
@@ -274,6 +303,13 @@ class ThreadOutboundWritePolicy:
             event_id = typing.cast("str", event_id_value)
 
             event_info = EventInfo.from_event(normalized_event_source)
+            coalesce_context = _outbound_streaming_edit_coalesce_context(
+                event_info=event_info,
+                event_id=event_id,
+                event_source=normalized_event_source,
+            )
+            coalesce_key, coalesce_log_context = coalesce_context if coalesce_context is not None else (None, None)
+            emit_timing = event_info.is_edit
             if event_info.is_reaction:
                 persisted_batch: list[tuple[str, str, dict[str, object]]] = [
                     (event_id, room_id, normalized_event_source),
@@ -289,6 +325,7 @@ class ThreadOutboundWritePolicy:
                     cancelled_message="Ignoring cancelled outbound cache bookkeeping after successful send",
                     failure_message="Ignoring outbound cache bookkeeping failure after successful send",
                     log_context={"event_id": event_id},
+                    emit_timing=emit_timing,
                 )
                 return
             if not is_thread_affecting_relation(event_info):
@@ -308,6 +345,9 @@ class ThreadOutboundWritePolicy:
                     cancelled_message="Ignoring cancelled outbound cache bookkeeping after successful send",
                     failure_message="Ignoring outbound cache bookkeeping failure after successful send",
                     log_context={"event_id": event_id},
+                    emit_timing=emit_timing,
+                    coalesce_key=coalesce_key,
+                    coalesce_log_context=coalesce_log_context,
                 )
                 return
             # Lookup-dependent outbound mutations stay on the room barrier because earlier outbound writes can create the lookup rows needed to resolve thread impact. Safe parallelization would require reservation-based routing (see ISSUE-189).
@@ -323,6 +363,9 @@ class ThreadOutboundWritePolicy:
                 cancelled_message="Ignoring cancelled outbound cache bookkeeping after successful send",
                 failure_message="Ignoring outbound cache bookkeeping failure after successful send",
                 log_context={"event_id": event_id},
+                emit_timing=emit_timing,
+                coalesce_key=coalesce_key,
+                coalesce_log_context=coalesce_log_context,
             )
         except asyncio.CancelledError as exc:
             raw_event_id = event_source.get("event_id")
@@ -452,6 +495,9 @@ class ThreadOutboundWritePolicy:
         cancelled_message: str,
         failure_message: str,
         log_context: dict[str, object],
+        emit_timing: bool = False,
+        coalesce_key: tuple[str, str] | None = None,
+        coalesce_log_context: dict[str, object] | None = None,
     ) -> None:
         async def safe_update() -> None:
             try:
@@ -476,6 +522,9 @@ class ThreadOutboundWritePolicy:
                 room_id,
                 safe_update,
                 name=name,
+                emit_timing=emit_timing,
+                coalesce_key=coalesce_key,
+                coalesce_log_context=coalesce_log_context,
             )
         except asyncio.CancelledError as exc:
             self._cache_ops.logger.warning(
@@ -502,6 +551,9 @@ class ThreadOutboundWritePolicy:
         cancelled_message: str,
         failure_message: str,
         log_context: dict[str, object],
+        emit_timing: bool = False,
+        coalesce_key: tuple[str, str] | None = None,
+        coalesce_log_context: dict[str, object] | None = None,
     ) -> None:
         async def safe_update() -> None:
             try:
@@ -529,6 +581,9 @@ class ThreadOutboundWritePolicy:
                 thread_id,
                 safe_update,
                 name=name,
+                emit_timing=emit_timing,
+                coalesce_key=coalesce_key,
+                coalesce_log_context=coalesce_log_context,
             )
         except asyncio.CancelledError as exc:
             self._cache_ops.logger.warning(

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 
 _UpdateTask = asyncio.Task[Any]
+_UpdateCoroFactory = typing.Callable[[], typing.Coroutine[Any, Any, object]]
+_CoalesceKey = tuple[str, str]
 
 
 @dataclass(eq=False)
@@ -31,12 +33,21 @@ class _QueuedUpdate:
     kind: typing.Literal["room", "thread"]
     task: _UpdateTask
     start_signal: asyncio.Future[None]
+    update_state: _QueuedUpdateState
     thread_id: str | None = None
     ignore_cancelled_room_fences: bool = False
+    coalesce_key: _CoalesceKey | None = None
     started: bool = False
 
 
 _RoomQueueEntry = _QueuedRoomFence | _QueuedUpdate
+
+
+@dataclass
+class _QueuedUpdateState:
+    update_coro_factory: _UpdateCoroFactory
+    coalesced_update_count: int = 0
+    coalesce_log_context: dict[str, object] = field(default_factory=dict)
 
 
 @dataclass
@@ -53,17 +64,20 @@ class EventCacheWriteCoordinator(Protocol):
     def queue_room_update(
         self,
         room_id: str,
-        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        update_coro_factory: _UpdateCoroFactory,
         *,
         name: str,
         log_exceptions: bool = True,
+        emit_timing: bool = True,
+        coalesce_key: _CoalesceKey | None = None,
+        coalesce_log_context: dict[str, object] | None = None,
     ) -> asyncio.Task[object]:
         """Queue one room-scoped update behind any active predecessor."""
 
     async def run_room_update(
         self,
         room_id: str,
-        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        update_coro_factory: _UpdateCoroFactory,
         *,
         name: str,
     ) -> object:
@@ -73,10 +87,13 @@ class EventCacheWriteCoordinator(Protocol):
         self,
         room_id: str,
         thread_id: str,
-        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        update_coro_factory: _UpdateCoroFactory,
         *,
         name: str,
         log_exceptions: bool = True,
+        emit_timing: bool = False,
+        coalesce_key: _CoalesceKey | None = None,
+        coalesce_log_context: dict[str, object] | None = None,
     ) -> asyncio.Task[object]:
         """Queue one thread-scoped update behind same-thread and room-wide predecessors."""
 
@@ -84,7 +101,7 @@ class EventCacheWriteCoordinator(Protocol):
         self,
         room_id: str,
         thread_id: str,
-        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        update_coro_factory: _UpdateCoroFactory,
         *,
         name: str,
         ignore_cancelled_room_fences: bool = False,
@@ -319,6 +336,76 @@ class _EventCacheWriteCoordinator:
 
         self._cleanup_room_state(room_id)
 
+    def _coalescible_pending_entry(
+        self,
+        state: _RoomSchedulerState,
+        *,
+        kind: typing.Literal["room", "thread"],
+        thread_id: str | None,
+        coalesce_key: _CoalesceKey,
+    ) -> _QueuedUpdate | None:
+        for entry in reversed(state.entries):
+            if not isinstance(entry, _QueuedUpdate):
+                continue
+            if entry.started or entry.task.done():
+                continue
+            same_order_lane = kind == "room" or entry.kind == "room" or entry.thread_id == thread_id
+            if not same_order_lane:
+                continue
+            if entry.kind == kind and entry.thread_id == thread_id and entry.coalesce_key == coalesce_key:
+                return entry
+            return None
+        return None
+
+    def _coalesce_pending_update(
+        self,
+        state: _RoomSchedulerState,
+        *,
+        kind: typing.Literal["room", "thread"],
+        thread_id: str | None,
+        update_coro_factory: _UpdateCoroFactory,
+        coalesce_key: _CoalesceKey | None,
+        coalesce_log_context: dict[str, object] | None,
+    ) -> asyncio.Task[object] | None:
+        if coalesce_key is None:
+            return None
+        entry = self._coalescible_pending_entry(
+            state,
+            kind=kind,
+            thread_id=thread_id,
+            coalesce_key=coalesce_key,
+        )
+        if entry is None:
+            return None
+        entry.update_state.update_coro_factory = update_coro_factory
+        entry.update_state.coalesced_update_count += 1
+        entry.update_state.coalesce_log_context = dict(coalesce_log_context or {})
+        return entry.task
+
+    def _log_coalesced_update_if_needed(
+        self,
+        *,
+        room_id: str,
+        thread_id: str | None,
+        kind: typing.Literal["room", "thread"],
+        name: str,
+        update_state: _QueuedUpdateState,
+    ) -> None:
+        dropped_update_count = update_state.coalesced_update_count
+        if dropped_update_count <= 0:
+            return
+        log_context = {
+            "room_id": room_id,
+            "barrier_kind": kind,
+            "operation": name,
+            "coalesced_update_count": dropped_update_count,
+            "dropped_update_count": dropped_update_count,
+            **update_state.coalesce_log_context,
+        }
+        if thread_id is not None:
+            log_context["thread_id"] = thread_id
+        self.logger.info("Coalesced outbound streaming edit cache updates", **log_context)
+
     def _release_active_entry(
         self,
         room_id: str,
@@ -380,14 +467,31 @@ class _EventCacheWriteCoordinator:
         room_id: str,
         thread_id: str | None,
         kind: typing.Literal["room", "thread"],
-        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        update_coro_factory: _UpdateCoroFactory,
         name: str,
         log_exceptions: bool,
-        emit_room_timing: bool = False,
+        emit_timing: bool = False,
         ignore_cancelled_room_fences: bool = False,
+        coalesce_key: _CoalesceKey | None = None,
+        coalesce_log_context: dict[str, object] | None = None,
     ) -> asyncio.Task[object]:
         room_state = self._room_state(room_id)
-        instrument_timing = emit_room_timing and timing_enabled()
+        coalesced_task = self._coalesce_pending_update(
+            room_state,
+            kind=kind,
+            thread_id=thread_id,
+            update_coro_factory=update_coro_factory,
+            coalesce_key=coalesce_key,
+            coalesce_log_context=coalesce_log_context,
+        )
+        if coalesced_task is not None:
+            return coalesced_task
+
+        update_state = _QueuedUpdateState(
+            update_coro_factory=update_coro_factory,
+            coalesce_log_context=dict(coalesce_log_context or {}),
+        )
+        instrument_timing = emit_timing and timing_enabled()
         predecessor_count = self._pending_chain_length(self._pending_entry_tasks(room_state.entries))
         loop = asyncio.get_running_loop()
         start_signal: asyncio.Future[None] = loop.create_future()
@@ -396,7 +500,14 @@ class _EventCacheWriteCoordinator:
 
             async def run_when_scheduled() -> object:
                 await start_signal
-                return await update_coro_factory()
+                self._log_coalesced_update_if_needed(
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    kind=kind,
+                    name=name,
+                    update_state=update_state,
+                )
+                return await update_state.update_coro_factory()
 
         else:
             queued_at = time.perf_counter()
@@ -407,7 +518,14 @@ class _EventCacheWriteCoordinator:
                 try:
                     await start_signal
                     update_started = time.perf_counter()
-                    return await update_coro_factory()
+                    self._log_coalesced_update_if_needed(
+                        room_id=room_id,
+                        thread_id=thread_id,
+                        kind=kind,
+                        name=name,
+                        update_state=update_state,
+                    )
+                    return await update_state.update_coro_factory()
                 except asyncio.CancelledError:
                     outcome = "cancelled"
                     raise
@@ -423,10 +541,18 @@ class _EventCacheWriteCoordinator:
                     else:
                         predecessor_wait_ms = round((update_started - queued_at) * 1000, 1)
                         update_run_ms = round((finished - update_started) * 1000, 1)
+                    coalescing_context: dict[str, object] = {}
+                    if update_state.coalesced_update_count:
+                        coalescing_context = {
+                            "coalesced_update_count": update_state.coalesced_update_count,
+                            "dropped_update_count": update_state.coalesced_update_count,
+                            **update_state.coalesce_log_context,
+                        }
                     emit_timing_event(
                         "Event cache update timing",
-                        barrier_kind="room",
+                        barrier_kind=kind,
                         room_id=room_id,
+                        thread_id=thread_id,
                         operation=name,
                         predecessor_count=predecessor_count,
                         queued_behind_predecessor=predecessor_count > 0,
@@ -434,6 +560,7 @@ class _EventCacheWriteCoordinator:
                         update_run_ms=update_run_ms,
                         total_ms=total_ms,
                         outcome=outcome,
+                        **coalescing_context,
                     )
 
         task = create_background_task(
@@ -447,8 +574,10 @@ class _EventCacheWriteCoordinator:
             kind=kind,
             task=task,
             start_signal=start_signal,
+            update_state=update_state,
             thread_id=thread_id,
             ignore_cancelled_room_fences=ignore_cancelled_room_fences,
+            coalesce_key=coalesce_key,
         )
 
         room_state.entries.append(entry)
@@ -531,10 +660,13 @@ class _EventCacheWriteCoordinator:
     def queue_room_update(
         self,
         room_id: str,
-        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        update_coro_factory: _UpdateCoroFactory,
         *,
         name: str,
         log_exceptions: bool = True,
+        emit_timing: bool = True,
+        coalesce_key: _CoalesceKey | None = None,
+        coalesce_log_context: dict[str, object] | None = None,
     ) -> asyncio.Task[object]:
         """Schedule one room-scoped cache update behind any active predecessor."""
         return self._queue_update(
@@ -544,13 +676,15 @@ class _EventCacheWriteCoordinator:
             update_coro_factory=update_coro_factory,
             name=name,
             log_exceptions=log_exceptions,
-            emit_room_timing=True,
+            emit_timing=emit_timing,
+            coalesce_key=coalesce_key,
+            coalesce_log_context=coalesce_log_context,
         )
 
     async def run_room_update(
         self,
         room_id: str,
-        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        update_coro_factory: _UpdateCoroFactory,
         *,
         name: str,
     ) -> object:
@@ -566,10 +700,13 @@ class _EventCacheWriteCoordinator:
         self,
         room_id: str,
         thread_id: str,
-        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        update_coro_factory: _UpdateCoroFactory,
         *,
         name: str,
         log_exceptions: bool = True,
+        emit_timing: bool = False,
+        coalesce_key: _CoalesceKey | None = None,
+        coalesce_log_context: dict[str, object] | None = None,
     ) -> asyncio.Task[object]:
         """Schedule one thread-scoped cache update behind room-wide and same-thread predecessors."""
         return self._queue_update(
@@ -579,13 +716,16 @@ class _EventCacheWriteCoordinator:
             update_coro_factory=update_coro_factory,
             name=name,
             log_exceptions=log_exceptions,
+            emit_timing=emit_timing,
+            coalesce_key=coalesce_key,
+            coalesce_log_context=coalesce_log_context,
         )
 
     async def run_thread_update(
         self,
         room_id: str,
         thread_id: str,
-        update_coro_factory: typing.Callable[[], typing.Coroutine[Any, Any, object]],
+        update_coro_factory: _UpdateCoroFactory,
         *,
         name: str,
         ignore_cancelled_room_fences: bool = False,

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import io
 import json
+from time import monotonic
 from typing import Any
 
 import nio
@@ -50,6 +51,8 @@ _SIDECAR_ONLY_MINDROOM_KEYS = frozenset(
 _NONTERMINAL_STREAM_STATUSES = frozenset({STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING})
 _NONTERMINAL_STREAM_PREVIEW_BYTES = 12000
 _MATRIX_EVENT_HARD_LIMIT = 64000
+_OVERSIZED_NONTERMINAL_STREAMING_EDIT_MIN_INTERVAL_SECONDS = 5.0
+_oversized_nonterminal_streaming_edit_sent_at: dict[tuple[str, str], float] = {}
 
 
 def _is_passthrough_preview_key(key: object) -> bool:
@@ -139,6 +142,47 @@ def _is_edit_message(content: dict[str, Any]) -> bool:
 def _is_nonterminal_stream_content(content: dict[str, Any]) -> bool:
     """Return whether content is an in-progress streaming payload."""
     return content.get(STREAM_STATUS_KEY) in _NONTERMINAL_STREAM_STATUSES
+
+
+def _clear_oversized_nonterminal_streaming_edit_rate_limits() -> None:
+    """Reset oversized streaming-edit rate state for tests."""
+    _oversized_nonterminal_streaming_edit_sent_at.clear()
+
+
+def _prune_expired_oversized_nonterminal_streaming_edit_rate_limits(now: float) -> None:
+    expired_keys = [
+        key
+        for key, sent_at in _oversized_nonterminal_streaming_edit_sent_at.items()
+        if now - sent_at >= _OVERSIZED_NONTERMINAL_STREAMING_EDIT_MIN_INTERVAL_SECONDS
+    ]
+    for key in expired_keys:
+        _oversized_nonterminal_streaming_edit_sent_at.pop(key, None)
+
+
+def should_send_oversized_nonterminal_streaming_edit(
+    *,
+    room_id: str,
+    original_event_id: str,
+    edit_content: dict[str, Any],
+) -> bool:
+    """Return whether one oversized non-terminal streaming edit may be sent now."""
+    if not original_event_id or not _is_edit_message(edit_content):
+        return True
+
+    source_content = edit_content.get("m.new_content")
+    if not isinstance(source_content, dict) or not _is_nonterminal_stream_content(source_content):
+        return True
+    if _calculate_event_size(edit_content) <= _EDIT_MESSAGE_LIMIT:
+        return True
+
+    key = (room_id, original_event_id)
+    now = monotonic()
+    _prune_expired_oversized_nonterminal_streaming_edit_rate_limits(now)
+    last_sent_at = _oversized_nonterminal_streaming_edit_sent_at.get(key)
+    if last_sent_at is not None and now - last_sent_at < _OVERSIZED_NONTERMINAL_STREAMING_EDIT_MIN_INTERVAL_SECONDS:
+        return False
+    _oversized_nonterminal_streaming_edit_sent_at[key] = now
+    return True
 
 
 def _build_nonterminal_streaming_edit_preview(

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -21,7 +21,8 @@ from mindroom.constants import (
 )
 from mindroom.final_delivery import StreamTransportOutcome
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client_delivery import edit_message_result, send_message_result
+from mindroom.matrix.client_delivery import build_edit_event_content, edit_message_result, send_message_result
+from mindroom.matrix.large_messages import should_send_oversized_nonterminal_streaming_edit
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.message_target import MessageTarget
 from mindroom.orchestration.runtime import (
@@ -132,6 +133,12 @@ def _build_streaming_delivery_error(
 def _raise_nonterminal_delivery_error(error: Exception) -> NoReturn:
     """Raise one wrapped non-terminal delivery error for unified rollback handling."""
     raise _NonTerminalDeliveryError(error) from error
+
+
+def _complete_capture_completions(capture_completions: tuple[asyncio.Future[None], ...]) -> None:
+    for capture_completion in capture_completions:
+        if not capture_completion.done():
+            capture_completion.set_result(None)
 
 
 def _format_stream_error_note(error: Exception) -> str:
@@ -715,15 +722,16 @@ class StreamingResponse:
     ) -> bool:
         """Send one already-prepared non-terminal or terminal payload."""
         is_initial_send = self.event_id is None
+        if not is_final and not is_initial_send and not self._should_send_prepared_nonterminal_edit(prepared_delivery):
+            _complete_capture_completions(capture_completions)
+            return True
         capture = None
         if not is_final:
             capture = asyncio.get_running_loop().create_future()
             self._inflight_nonterminal_capture = capture
             self._inflight_nonterminal_capture_state = prepared_delivery.committed_state
             capture.set_result(None)
-            for capture_completion in capture_completions:
-                if not capture_completion.done():
-                    capture_completion.set_result(None)
+            _complete_capture_completions(capture_completions)
         try:
             send_succeeded = await self._send_content(
                 client,
@@ -755,6 +763,23 @@ class StreamingResponse:
         else:
             self.placeholder_progress_sent = False
         return True
+
+    def _should_send_prepared_nonterminal_edit(
+        self,
+        prepared_delivery: _PreparedStreamingDelivery,
+    ) -> bool:
+        """Return whether a prepared in-progress edit should hit Matrix now."""
+        assert self.event_id is not None
+        edit_content = build_edit_event_content(
+            event_id=self.event_id,
+            new_content=prepared_delivery.content,
+            new_text=prepared_delivery.display_text,
+        )
+        return should_send_oversized_nonterminal_streaming_edit(
+            room_id=self.room_id,
+            original_event_id=self.event_id,
+            edit_content=edit_content,
+        )
 
     def _prepare_delivery(
         self,

--- a/tach.toml
+++ b/tach.toml
@@ -1039,6 +1039,7 @@ depends_on = []
 [[modules]]
 path = "mindroom.matrix.cache.thread_writes"
 depends_on = [
+    "mindroom.constants",
     "mindroom.matrix.cache.event_normalization",
     "mindroom.matrix.event_info",
     "mindroom.matrix.thread_bookkeeping",

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -15,9 +15,12 @@ from mindroom.constants import (
 from mindroom.matrix.large_messages import (
     _NORMAL_MESSAGE_LIMIT,
     _calculate_event_size,
+    _clear_oversized_nonterminal_streaming_edit_rate_limits,
     _create_preview,
     _is_edit_message,
+    _oversized_nonterminal_streaming_edit_sent_at,
     prepare_large_message,
+    should_send_oversized_nonterminal_streaming_edit,
 )
 from mindroom.tool_system.events import _TOOL_TRACE_KEY
 
@@ -58,6 +61,44 @@ def test__is_edit_message() -> None:
         "msgtype": "m.text",
     }
     assert _is_edit_message(edit2)
+
+
+def test_oversized_nonterminal_streaming_edit_rate_limit_prunes_expired_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Oversized streaming-edit rate state should not retain old streams forever."""
+    _clear_oversized_nonterminal_streaming_edit_rate_limits()
+    body = "x" * 40000
+
+    def oversized_edit_content(original_event_id: str) -> dict[str, object]:
+        return {
+            "body": f"* {body}",
+            "m.new_content": {
+                "body": body,
+                "msgtype": "m.text",
+                STREAM_STATUS_KEY: STREAM_STATUS_STREAMING,
+            },
+            "m.relates_to": {"rel_type": "m.replace", "event_id": original_event_id},
+            "msgtype": "m.text",
+        }
+
+    monotonic_values = iter([100.0, 106.0])
+    monkeypatch.setattr("mindroom.matrix.large_messages.monotonic", lambda: next(monotonic_values))
+
+    assert should_send_oversized_nonterminal_streaming_edit(
+        room_id="!room:server",
+        original_event_id="$old",
+        edit_content=oversized_edit_content("$old"),
+    )
+    assert _oversized_nonterminal_streaming_edit_sent_at == {("!room:server", "$old"): 100.0}
+
+    assert should_send_oversized_nonterminal_streaming_edit(
+        room_id="!room:server",
+        original_event_id="$new",
+        edit_content=oversized_edit_content("$new"),
+    )
+
+    assert _oversized_nonterminal_streaming_edit_sent_at == {("!room:server", "$new"): 106.0}
 
 
 def test__create_preview() -> None:

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -20,7 +20,11 @@ from mindroom.constants import (
     resolve_runtime_paths,
 )
 from mindroom.matrix.client import edit_message_result, send_message_result
-from mindroom.matrix.large_messages import _NORMAL_MESSAGE_LIMIT, prepare_large_message
+from mindroom.matrix.large_messages import (
+    _NORMAL_MESSAGE_LIMIT,
+    _clear_oversized_nonterminal_streaming_edit_rate_limits,
+    prepare_large_message,
+)
 from mindroom.streaming import (
     ReplacementStreamingResponse,
     StreamingResponse,
@@ -392,8 +396,11 @@ async def test_streaming_large_edit_records_transformed_content_to_cache() -> No
 
 
 @pytest.mark.asyncio
-async def test_streaming_multiple_edits_with_growth() -> None:
+async def test_streaming_multiple_edits_with_growth(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test streaming with multiple edits as message grows."""
+    _clear_oversized_nonterminal_streaming_edit_rate_limits()
+    monotonic_values = iter([100.0, 106.0, 112.0])
+    monkeypatch.setattr("mindroom.matrix.large_messages.monotonic", lambda: next(monotonic_values))
     client = MockClient()
     config = MockConfig()
 

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -47,6 +47,7 @@ from mindroom.hooks import MessageEnvelope
 from mindroom.matrix.client import DeliveredMatrixEvent
 from mindroom.matrix.client_delivery import build_edit_event_content
 from mindroom.matrix.identity import MatrixID
+from mindroom.matrix.large_messages import _clear_oversized_nonterminal_streaming_edit_rate_limits
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutcome
@@ -534,6 +535,92 @@ class TestStreamingBehavior:
         content = last_call[1]["content"]
         assert content["m.relates_to"]["rel_type"] == "m.replace"
         assert content["m.relates_to"]["event_id"] == "$stream_123"
+
+    @pytest.mark.asyncio
+    async def test_oversized_nonterminal_sidecar_edits_are_rate_limited(self) -> None:
+        """Oversized in-progress edits should not burst sidecar uploads while final still sends."""
+        _clear_oversized_nonterminal_streaming_edit_rate_limits()
+        mock_client = _make_matrix_client_mock()
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id="$thread_123",
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+        )
+        streaming.event_id = "$stream_123"
+        streaming.accumulated_text = "x" * 40000
+
+        monotonic_values = iter([100.0, 101.0, 106.0])
+
+        async def delivered_edit(
+            _client: nio.AsyncClient,
+            _room_id: str,
+            _event_id: str,
+            new_content: dict[str, object],
+            _new_text: str,
+        ) -> DeliveredMatrixEvent:
+            return DeliveredMatrixEvent(event_id="$edit", content_sent=dict(new_content))
+
+        with (
+            patch(
+                "mindroom.matrix.large_messages.monotonic",
+                side_effect=lambda: next(monotonic_values),
+            ),
+            patch("mindroom.streaming.edit_message_result", new=AsyncMock(side_effect=delivered_edit)) as mock_edit,
+        ):
+            assert await streaming._send_or_edit_message(mock_client)
+            assert mock_edit.await_count == 1
+
+            streaming.accumulated_text += "y"
+            streaming._mark_nonadditive_text_mutation()
+            assert await streaming._send_or_edit_message(mock_client)
+            assert mock_edit.await_count == 1
+
+            streaming.accumulated_text += "z"
+            streaming._mark_nonadditive_text_mutation()
+            assert await streaming._send_or_edit_message(mock_client)
+            assert mock_edit.await_count == 2
+
+            streaming.accumulated_text += " final"
+            assert await streaming._send_or_edit_message(
+                mock_client,
+                is_final=True,
+                stream_status=STREAM_STATUS_COMPLETED,
+            )
+            assert mock_edit.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_oversized_nonterminal_edit_resolves_capture_completion(self) -> None:
+        """Skipping an oversized in-progress edit should still unblock capture waiters."""
+        _clear_oversized_nonterminal_streaming_edit_rate_limits()
+        mock_client = _make_matrix_client_mock()
+        streaming = StreamingResponse(
+            room_id="!test:localhost",
+            reply_to_event_id="$original_123",
+            thread_id="$thread_123",
+            sender_domain="localhost",
+            config=self.config,
+            runtime_paths=runtime_paths_for(self.config),
+        )
+        streaming.event_id = "$stream_123"
+        streaming.accumulated_text = "x" * 40000
+        streaming._send_content = AsyncMock(return_value=True)
+        capture_completion = asyncio.get_running_loop().create_future()
+
+        with patch("mindroom.matrix.large_messages.monotonic", side_effect=[100.0, 101.0]):
+            assert await streaming._send_or_edit_message(mock_client)
+            streaming.accumulated_text += "y"
+            streaming._mark_nonadditive_text_mutation()
+            assert await streaming._send_or_edit_message(
+                mock_client,
+                capture_completions=(capture_completion,),
+            )
+
+        assert streaming._send_content.await_count == 1
+        assert capture_completion.done()
+        assert capture_completion.result() is None
 
     def test_streaming_update_interval_starts_fast_then_slows(self) -> None:
         """Test progressive throttling: frequent edits first, slower later."""

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -31,6 +31,7 @@ from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
+from mindroom.constants import STREAM_STATUS_COMPLETED, STREAM_STATUS_KEY, STREAM_STATUS_STREAMING
 from mindroom.hooks import EVENT_AGENT_STARTED
 from mindroom.matrix import thread_bookkeeping
 from mindroom.matrix.cache import ThreadHistoryResult, thread_writes
@@ -309,6 +310,46 @@ def _message_mutation_event_info(*, original_event_id: str = "$target:localhost"
             },
         },
     )
+
+
+def _outbound_streaming_edit_content(
+    *,
+    body: str,
+    original_event_id: str = "$stream-original:localhost",
+    thread_id: str = "$thread:localhost",
+    stream_status: str = STREAM_STATUS_STREAMING,
+) -> dict[str, object]:
+    """Return one outbound streaming edit content payload."""
+    return {
+        "body": f"* {body}",
+        "msgtype": "m.text",
+        "m.new_content": {
+            "body": body,
+            "msgtype": "m.text",
+            STREAM_STATUS_KEY: stream_status,
+            "m.relates_to": {"rel_type": "m.thread", "event_id": thread_id},
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": original_event_id},
+    }
+
+
+def _outbound_plain_edit_content(
+    *,
+    body: str,
+    original_event_id: str = "$plain-original:localhost",
+    thread_id: str = "$thread:localhost",
+) -> dict[str, object]:
+    """Return one outbound non-streaming edit content payload."""
+    return {
+        "body": f"* {body}",
+        "msgtype": "m.text",
+        "m.new_content": {
+            "body": body,
+            "msgtype": "m.text",
+            "m.relates_to": {"rel_type": "m.thread", "event_id": thread_id},
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": original_event_id},
+    }
 
 
 async def _reopen_event_cache(event_cache: SqliteEventCache) -> SqliteEventCache:
@@ -4562,6 +4603,271 @@ class TestThreadingBehavior:
             await coordinator.close()
 
     @pytest.mark.asyncio
+    async def test_queue_room_cache_update_forwards_false_emit_timing(self) -> None:
+        """Room cache facade must not fall through to the coordinator timing default."""
+        cache_ops, _logger, _event_cache = _thread_mutation_cache_ops()
+        observed_emit_timing: list[bool] = []
+
+        class _RecordingCoordinator:
+            def queue_room_update(
+                self,
+                room_id: str,
+                update_coro_factory: Callable[[], Coroutine[Any, Any, object]],
+                *,
+                name: str,
+                log_exceptions: bool = True,
+                emit_timing: bool = True,
+                coalesce_key: tuple[str, str] | None = None,
+                coalesce_log_context: dict[str, object] | None = None,
+            ) -> asyncio.Task[object]:
+                del room_id, name, log_exceptions, coalesce_key, coalesce_log_context
+                observed_emit_timing.append(emit_timing)
+                return asyncio.create_task(update_coro_factory())
+
+        async def update() -> None:
+            return None
+
+        cache_ops.runtime.event_cache_write_coordinator = _RecordingCoordinator()
+        task = cache_ops.queue_room_cache_update("!room:localhost", update, name="matrix_cache_test_update")
+        await task
+
+        assert observed_emit_timing == [False]
+
+    @pytest.mark.asyncio
+    async def test_queue_thread_cache_update_forwards_default_coordinator_options(self) -> None:
+        """Thread cache facade should always forward the expanded coordinator options."""
+        cache_ops, _logger, _event_cache = _thread_mutation_cache_ops()
+        observed_options: list[tuple[object, object, object]] = []
+
+        class _RecordingCoordinator:
+            def queue_thread_update(
+                self,
+                room_id: str,
+                thread_id: str,
+                update_coro_factory: Callable[[], Coroutine[Any, Any, object]],
+                *,
+                name: str,
+                log_exceptions: bool = True,
+                emit_timing: object = "missing",
+                coalesce_key: object = "missing",
+                coalesce_log_context: object = "missing",
+            ) -> asyncio.Task[object]:
+                del room_id, thread_id, name, log_exceptions
+                observed_options.append((emit_timing, coalesce_key, coalesce_log_context))
+                return asyncio.create_task(update_coro_factory())
+
+        async def update() -> None:
+            return None
+
+        cache_ops.runtime.event_cache_write_coordinator = _RecordingCoordinator()
+        task = cache_ops.queue_thread_cache_update(
+            "!room:localhost",
+            "$thread:localhost",
+            update,
+            name="matrix_cache_test_update",
+        )
+        await task
+
+        assert observed_options == [(False, None, None)]
+
+    @pytest.mark.asyncio
+    async def test_outbound_nonterminal_streaming_edits_coalesce_pending_cache_updates(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Pending outbound stream edits for the same event should collapse to the latest edit."""
+        monkeypatch.setenv("MINDROOM_TIMING", "1")
+        timing_logger = MagicMock()
+        monkeypatch.setattr(timing_module, "logger", timing_logger)
+        event_cache = _runtime_event_cache()
+        coordinator_logger = MagicMock()
+        coordinator = _EventCacheWriteCoordinator(
+            logger=coordinator_logger,
+            background_task_owner=object(),
+        )
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(
+                client=_make_client_mock(),
+                event_cache=event_cache,
+                coordinator=coordinator,
+            ),
+        )
+        blocker_started = asyncio.Event()
+        release_blocker = asyncio.Event()
+
+        async def blocker() -> None:
+            blocker_started.set()
+            await release_blocker.wait()
+
+        try:
+            blocker_task = coordinator.queue_thread_update(
+                "!test:localhost",
+                "$thread:localhost",
+                blocker,
+                name="matrix_cache_blocker",
+            )
+            await asyncio.wait_for(blocker_started.wait(), timeout=1.0)
+
+            for index in range(3):
+                access.notify_outbound_message(
+                    "!test:localhost",
+                    f"$edit-{index}:localhost",
+                    _outbound_streaming_edit_content(body=f"stream update {index}"),
+                )
+
+            release_blocker.set()
+            await blocker_task
+            await asyncio.wait_for(
+                coordinator.wait_for_thread_idle("!test:localhost", "$thread:localhost"),
+                timeout=1.0,
+            )
+        finally:
+            release_blocker.set()
+            await coordinator.close()
+
+        event_cache.append_event.assert_awaited_once()
+        _room_id, _thread_id, appended_event = event_cache.append_event.await_args.args
+        assert appended_event["event_id"] == "$edit-2:localhost"
+        assert appended_event["content"]["m.new_content"]["body"] == "stream update 2"
+        assert any(
+            call.kwargs.get("coalesced_update_count") == 2
+            and call.kwargs.get("original_event_id") == "$stream-original:localhost"
+            for call in coordinator_logger.info.call_args_list
+        )
+        assert any(
+            call.args == ("Event cache update timing",)
+            and call.kwargs["barrier_kind"] == "thread"
+            and call.kwargs["operation"] == "matrix_cache_notify_outbound_event"
+            and call.kwargs["coalesced_update_count"] == 2
+            and call.kwargs["predecessor_wait_ms"] >= 0.0
+            and call.kwargs["update_run_ms"] >= 0.0
+            for call in timing_logger.info.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_outbound_final_streaming_edit_is_preserved_after_coalesced_intermediates(self) -> None:
+        """A final outbound stream edit should stay queued behind the latest intermediate edit."""
+        event_cache = _runtime_event_cache()
+        coordinator = _EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(
+                client=_make_client_mock(),
+                event_cache=event_cache,
+                coordinator=coordinator,
+            ),
+        )
+        blocker_started = asyncio.Event()
+        release_blocker = asyncio.Event()
+
+        async def blocker() -> None:
+            blocker_started.set()
+            await release_blocker.wait()
+
+        try:
+            blocker_task = coordinator.queue_thread_update(
+                "!test:localhost",
+                "$thread:localhost",
+                blocker,
+                name="matrix_cache_blocker",
+            )
+            await asyncio.wait_for(blocker_started.wait(), timeout=1.0)
+
+            access.notify_outbound_message(
+                "!test:localhost",
+                "$edit-1:localhost",
+                _outbound_streaming_edit_content(body="older intermediate"),
+            )
+            access.notify_outbound_message(
+                "!test:localhost",
+                "$edit-2:localhost",
+                _outbound_streaming_edit_content(body="latest intermediate"),
+            )
+            access.notify_outbound_message(
+                "!test:localhost",
+                "$edit-final:localhost",
+                _outbound_streaming_edit_content(
+                    body="final answer",
+                    stream_status=STREAM_STATUS_COMPLETED,
+                ),
+            )
+
+            release_blocker.set()
+            await blocker_task
+            await asyncio.wait_for(
+                coordinator.wait_for_thread_idle("!test:localhost", "$thread:localhost"),
+                timeout=1.0,
+            )
+        finally:
+            release_blocker.set()
+            await coordinator.close()
+
+        appended_event_ids = [call.args[2]["event_id"] for call in event_cache.append_event.await_args_list]
+        assert appended_event_ids == ["$edit-2:localhost", "$edit-final:localhost"]
+        final_content = event_cache.append_event.await_args_list[-1].args[2]["content"]
+        assert final_content["m.new_content"][STREAM_STATUS_KEY] == STREAM_STATUS_COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_outbound_plain_edits_are_not_coalesced(self) -> None:
+        """Normal outbound edits should retain the existing one-cache-update-per-edit behavior."""
+        event_cache = _runtime_event_cache()
+        coordinator = _EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(
+                client=_make_client_mock(),
+                event_cache=event_cache,
+                coordinator=coordinator,
+            ),
+        )
+        blocker_started = asyncio.Event()
+        release_blocker = asyncio.Event()
+
+        async def blocker() -> None:
+            blocker_started.set()
+            await release_blocker.wait()
+
+        try:
+            blocker_task = coordinator.queue_thread_update(
+                "!test:localhost",
+                "$thread:localhost",
+                blocker,
+                name="matrix_cache_blocker",
+            )
+            await asyncio.wait_for(blocker_started.wait(), timeout=1.0)
+
+            access.notify_outbound_message(
+                "!test:localhost",
+                "$plain-edit-1:localhost",
+                _outbound_plain_edit_content(body="plain edit 1"),
+            )
+            access.notify_outbound_message(
+                "!test:localhost",
+                "$plain-edit-2:localhost",
+                _outbound_plain_edit_content(body="plain edit 2"),
+            )
+
+            release_blocker.set()
+            await blocker_task
+            await asyncio.wait_for(
+                coordinator.wait_for_thread_idle("!test:localhost", "$thread:localhost"),
+                timeout=1.0,
+            )
+        finally:
+            release_blocker.set()
+            await coordinator.close()
+
+        appended_event_ids = [call.args[2]["event_id"] for call in event_cache.append_event.await_args_list]
+        assert appended_event_ids == ["$plain-edit-1:localhost", "$plain-edit-2:localhost"]
+
+    @pytest.mark.asyncio
     async def test_queue_room_update_logs_timing_breakdown_when_enabled(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -5112,8 +5418,11 @@ class TestThreadingBehavior:
                 *,
                 name: str,
                 log_exceptions: bool = True,
+                emit_timing: bool = False,
+                coalesce_key: tuple[str, str] | None = None,
+                coalesce_log_context: dict[str, object] | None = None,
             ) -> asyncio.Task[object]:
-                del room_id, name, log_exceptions
+                del room_id, name, log_exceptions, emit_timing, coalesce_key, coalesce_log_context
                 return asyncio.create_task(update_coro_factory())
 
             def queue_thread_update(
@@ -5124,6 +5433,9 @@ class TestThreadingBehavior:
                 *,
                 name: str,
                 log_exceptions: bool = True,
+                emit_timing: bool = False,
+                coalesce_key: tuple[str, str] | None = None,
+                coalesce_log_context: dict[str, object] | None = None,
             ) -> asyncio.Task[object]:
                 del thread_id
                 return self.queue_room_update(
@@ -5131,6 +5443,9 @@ class TestThreadingBehavior:
                     update_coro_factory,
                     name=name,
                     log_exceptions=log_exceptions,
+                    emit_timing=emit_timing,
+                    coalesce_key=coalesce_key,
+                    coalesce_log_context=coalesce_log_context,
                 )
 
         cache_ops.runtime.event_cache_write_coordinator = _InlineCoordinator()


### PR DESCRIPTION
## Summary
- Coalesce pending outbound non-terminal streaming edit cache updates by original event ID, preserving normal edits and terminal streaming edits.
- Rate-limit oversized non-terminal sidecar streaming edits so bursty sidecar updates do not overload Matrix/cache work.
- Add structured coalescing/timing logs and targeted regression coverage.

## Test Plan
- [x] uv run pre-commit run --all-files
- [x] uv run pytest -q (`5468 passed, 28 skipped, 165 warnings`)
