### PR TITLE
Narrow orchestrator runtime interface

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -148,7 +148,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.matrix.cache import ConversationEventCache, EventCacheWriteCoordinator
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
-    from mindroom.orchestrator import MultiAgentOrchestrator
+    from mindroom.runtime_protocols import OrchestratorRuntime
     from mindroom.runtime_support import StartupThreadPrewarmRegistry
     from mindroom.tool_system.events import ToolTraceEntry
 
@@ -571,12 +571,12 @@ class AgentBot:
         self._runtime_view.enable_streaming = value
 
     @property
-    def orchestrator(self) -> MultiAgentOrchestrator | None:
+    def orchestrator(self) -> OrchestratorRuntime | None:
         """Return the current orchestrator."""
         return self._runtime_view.orchestrator
 
     @orchestrator.setter
-    def orchestrator(self, value: MultiAgentOrchestrator | None) -> None:
+    def orchestrator(self, value: OrchestratorRuntime | None) -> None:
         """Update the current orchestrator."""
         self._runtime_view.orchestrator = value
 

--- a/src/mindroom/bot_runtime_view.py
+++ b/src/mindroom/bot_runtime_view.py
@@ -12,7 +12,13 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.matrix.cache import ConversationEventCache, EventCacheWriteCoordinator
-    from mindroom.orchestrator import MultiAgentOrchestrator
+    from mindroom.runtime_protocols import (
+        OrchestratorRuntime,
+        SupportsClientConfig,
+        SupportsClientConfigOrchestrator,
+        SupportsConfig,
+        SupportsConfigOrchestrator,
+    )
     from mindroom.runtime_support import StartupThreadPrewarmRegistry
 
 
@@ -32,7 +38,7 @@ class BotRuntimeView(Protocol):
     def enable_streaming(self) -> bool: ...  # noqa: D102
 
     @property
-    def orchestrator(self) -> MultiAgentOrchestrator | None: ...  # noqa: D102
+    def orchestrator(self) -> OrchestratorRuntime | None: ...  # noqa: D102
 
     @property
     def event_cache(self) -> ConversationEventCache: ...  # noqa: D102
@@ -55,7 +61,7 @@ class BotRuntimeState:
     config: Config
     runtime_paths: RuntimePaths
     enable_streaming: bool
-    orchestrator: MultiAgentOrchestrator | None
+    orchestrator: OrchestratorRuntime | None
     event_cache: ConversationEventCache | None
     event_cache_write_coordinator: EventCacheWriteCoordinator | None
     startup_thread_prewarm_registry: StartupThreadPrewarmRegistry | None = None
@@ -64,3 +70,20 @@ class BotRuntimeState:
     def mark_runtime_started(self) -> None:
         """Record the runtime start time for this bot start."""
         self.runtime_started_at = time.time()
+
+
+if TYPE_CHECKING:
+
+    def _check_runtime_state_satisfies_narrow_protocols(
+        view: BotRuntimeView,
+    ) -> None:
+        """Type-only proof that BotRuntimeView satisfies every narrow protocol.
+
+        This function is never called at runtime. The assignments below
+        will fail static type-check if any narrow protocol drifts out of
+        the BotRuntimeView surface.
+        """
+        _a: SupportsConfig = view
+        _b: SupportsClientConfig = view
+        _c: SupportsConfigOrchestrator = view
+        _d: SupportsClientConfigOrchestrator = view

--- a/src/mindroom/hooks/context.py
+++ b/src/mindroom/hooks/context.py
@@ -164,7 +164,7 @@ class HookContextSupport:
             return self.hook_send_message
         orchestrator = self.runtime.orchestrator
         if orchestrator is not None:
-            sender = orchestrator._hook_message_sender()
+            sender = orchestrator.hook_message_sender()
             if sender is not None:
                 return sender
         return None
@@ -175,7 +175,7 @@ class HookContextSupport:
         fallback = None
         orchestrator = self.runtime.orchestrator
         if self.agent_name != ROUTER_AGENT_NAME and orchestrator is not None:
-            fallback = orchestrator._hook_room_state_querier()
+            fallback = orchestrator.hook_room_state_querier()
         return chain_hook_room_state_queriers(primary, fallback)
 
     def room_state_putter(self) -> HookRoomStatePutter | None:
@@ -184,14 +184,14 @@ class HookContextSupport:
         fallback = None
         orchestrator = self.runtime.orchestrator
         if self.agent_name != ROUTER_AGENT_NAME and orchestrator is not None:
-            fallback = orchestrator._hook_room_state_putter()
+            fallback = orchestrator.hook_room_state_putter()
         return chain_hook_room_state_putters(primary, fallback)
 
     def matrix_admin(self) -> HookMatrixAdmin | None:
         """Return the router-backed Matrix admin helper bound into hook contexts."""
         orchestrator = self.runtime.orchestrator
         if orchestrator is not None:
-            admin = orchestrator._hook_matrix_admin()
+            admin = orchestrator.hook_matrix_admin()
             if admin is not None:
                 return admin
         if self.agent_name == ROUTER_AGENT_NAME and self.runtime.client is not None:

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -911,28 +911,28 @@ class MultiAgentOrchestrator:
         )
         return router_bot
 
-    def _hook_message_sender(self) -> HookMessageSender | None:
+    def hook_message_sender(self) -> HookMessageSender | None:
         """Return a router-backed sender for hook contexts when available."""
         router_bot = self.agent_bots.get(ROUTER_AGENT_NAME)
         if router_bot is None:
             return None
         return router_bot._hook_send_message
 
-    def _hook_room_state_querier(self) -> HookRoomStateQuerier | None:
+    def hook_room_state_querier(self) -> HookRoomStateQuerier | None:
         """Return a router-backed room-state querier for hook contexts when available."""
         router_bot = self.agent_bots.get(ROUTER_AGENT_NAME)
         if router_bot is None or router_bot.client is None:
             return None
         return build_hook_room_state_querier(router_bot.client)
 
-    def _hook_room_state_putter(self) -> HookRoomStatePutter | None:
+    def hook_room_state_putter(self) -> HookRoomStatePutter | None:
         """Return a router-backed room-state putter for hook contexts when available."""
         router_bot = self.agent_bots.get(ROUTER_AGENT_NAME)
         if router_bot is None or router_bot.client is None:
             return None
         return build_hook_room_state_putter(router_bot.client)
 
-    def _hook_matrix_admin(self) -> HookMatrixAdmin | None:
+    def hook_matrix_admin(self) -> HookMatrixAdmin | None:
         """Return a router-backed Matrix admin helper for hook contexts when available."""
         router_bot = self.agent_bots.get(ROUTER_AGENT_NAME)
         if router_bot is None or router_bot.client is None:
@@ -1118,13 +1118,13 @@ class MultiAgentOrchestrator:
             logger=logger.bind(event_name=EVENT_CONFIG_RELOADED),
             correlation_id=f"config-reload:{uuid4().hex}",
             runtime_started_at=(router_bot.runtime_started_at if isinstance(router_bot, AgentBot) else time.time()),
-            message_sender=self._hook_message_sender(),
+            message_sender=self.hook_message_sender(),
             agent_message_snapshot_reader=(
                 router_bot._hook_agent_message_snapshot if isinstance(router_bot, AgentBot) else None
             ),
-            matrix_admin=self._hook_matrix_admin(),
-            room_state_querier=self._hook_room_state_querier(),
-            room_state_putter=self._hook_room_state_putter(),
+            matrix_admin=self.hook_matrix_admin(),
+            room_state_querier=self.hook_room_state_querier(),
+            room_state_putter=self.hook_room_state_putter(),
             changed_entities=tuple(sorted(changed_entities)),
             added_entities=tuple(sorted(added_entities)),
             removed_entities=tuple(sorted(removed_entities)),

--- a/src/mindroom/runtime_protocols.py
+++ b/src/mindroom/runtime_protocols.py
@@ -5,17 +5,56 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
     import nio
 
     from mindroom.config.main import Config
-    from mindroom.orchestrator import MultiAgentOrchestrator
+    from mindroom.constants import RuntimePaths
+    from mindroom.hooks import HookMatrixAdmin, HookMessageSender, HookRoomStatePutter, HookRoomStateQuerier
+    from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
+    from mindroom.tool_system.plugins import PluginReloadResult
 
 __all__ = [
+    "OrchestratorRuntime",
     "SupportsClientConfig",
     "SupportsClientConfigOrchestrator",
     "SupportsConfig",
     "SupportsConfigOrchestrator",
+    "SupportsRunningState",
 ]
+
+
+class SupportsRunningState(Protocol):
+    """Expose whether a managed runtime actor is currently running."""
+
+    running: bool
+
+
+class OrchestratorRuntime(Protocol):
+    """Narrow orchestrator surface used by extracted runtime collaborators."""
+
+    @property
+    def config(self) -> Config | None: ...  # noqa: D102
+
+    @property
+    def runtime_paths(self) -> RuntimePaths: ...  # noqa: D102
+
+    @property
+    def agent_bots(self) -> object: ...  # noqa: D102
+
+    @property
+    def knowledge_refresh_scheduler(self) -> KnowledgeRefreshScheduler: ...  # noqa: D102
+
+    def hook_message_sender(self) -> HookMessageSender | None: ...  # noqa: D102
+
+    def hook_room_state_querier(self) -> HookRoomStateQuerier | None: ...  # noqa: D102
+
+    def hook_room_state_putter(self) -> HookRoomStatePutter | None: ...  # noqa: D102
+
+    def hook_matrix_admin(self) -> HookMatrixAdmin | None: ...  # noqa: D102
+
+    def reload_plugins_now(self, *, source: str) -> Awaitable[PluginReloadResult]: ...  # noqa: D102
 
 
 class SupportsConfig(Protocol):
@@ -39,32 +78,14 @@ class SupportsConfigOrchestrator(SupportsConfig, Protocol):
     """Expose the config plus optional orchestrator handle."""
 
     @property
-    def orchestrator(self) -> MultiAgentOrchestrator | None: ...  # noqa: D102
+    def orchestrator(self) -> OrchestratorRuntime | None: ...  # noqa: D102
 
 
 class SupportsClientConfigOrchestrator(SupportsClientConfig, Protocol):
     """Expose client/config access, orchestrator access, and runtime freshness."""
 
     @property
-    def orchestrator(self) -> MultiAgentOrchestrator | None: ...  # noqa: D102
+    def orchestrator(self) -> OrchestratorRuntime | None: ...  # noqa: D102
 
     @property
     def runtime_started_at(self) -> float: ...  # noqa: D102
-
-
-if TYPE_CHECKING:
-    from mindroom.bot_runtime_view import BotRuntimeView
-
-    def _check_narrow_protocols_are_subsets_of_bot_runtime_view(
-        view: BotRuntimeView,
-    ) -> None:
-        """Type-only proof that BotRuntimeView satisfies every narrow protocol.
-
-        This function is never called at runtime. The assignments below
-        will fail static type-check if any narrow protocol drifts out of
-        the BotRuntimeView surface.
-        """
-        _a: SupportsConfig = view
-        _b: SupportsClientConfig = view
-        _c: SupportsConfigOrchestrator = view
-        _d: SupportsClientConfigOrchestrator = view

--- a/src/mindroom/team_exact_members.py
+++ b/src/mindroom/team_exact_members.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.logging_config import get_logger
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from agno.agent import Agent
 
     from mindroom.config.main import Config
-    from mindroom.orchestrator import MultiAgentOrchestrator
+    from mindroom.runtime_protocols import OrchestratorRuntime, SupportsRunningState
 
 
 logger = get_logger(__name__)
@@ -32,7 +32,7 @@ class ResolvedExactTeamMembers:
 
 
 def resolve_live_shared_agent_names(
-    orchestrator: MultiAgentOrchestrator,
+    orchestrator: OrchestratorRuntime,
     *,
     config: Config | None = None,
 ) -> set[str] | None:
@@ -42,9 +42,10 @@ def resolve_live_shared_agent_names(
     orchestrator_agent_bots = orchestrator.agent_bots
     if not isinstance(orchestrator_agent_bots, dict):
         return None
+    running_agent_bots = cast("dict[str, SupportsRunningState]", orchestrator_agent_bots)
     return {
         name
-        for name, bot in orchestrator_agent_bots.items()
+        for name, bot in running_agent_bots.items()
         if name != ROUTER_AGENT_NAME and name in active_config.agents and bot.running
     }
 

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -86,7 +86,7 @@ if TYPE_CHECKING:
     from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.identity import MatrixID
-    from mindroom.orchestrator import MultiAgentOrchestrator
+    from mindroom.runtime_protocols import OrchestratorRuntime
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 
@@ -1237,7 +1237,7 @@ def _requested_team_agent_names(agent_names: list[str]) -> list[str]:
 
 def _materialize_team_members(
     agent_names: list[str],
-    orchestrator: MultiAgentOrchestrator,
+    orchestrator: OrchestratorRuntime,
     execution_identity: ToolExecutionIdentity | None,
     *,
     session_id: str | None = None,
@@ -1471,7 +1471,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
     agent_names: list[str],
     mode: TeamMode,
     message: str,
-    orchestrator: MultiAgentOrchestrator,
+    orchestrator: OrchestratorRuntime,
     execution_identity: ToolExecutionIdentity | None,
     thread_history: Sequence[ResolvedVisibleMessage] | None = None,
     model_name: str | None = None,
@@ -1819,7 +1819,7 @@ async def _team_response_stream_raw(
 async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
     agent_ids: list[MatrixID],
     message: str,
-    orchestrator: MultiAgentOrchestrator,
+    orchestrator: OrchestratorRuntime,
     execution_identity: ToolExecutionIdentity | None,
     mode: TeamMode = TeamMode.COORDINATE,
     thread_history: Sequence[ResolvedVisibleMessage] | None = None,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -660,7 +660,7 @@ class TurnController:
         orchestrator = self.deps.runtime.orchestrator
         matrix_admin = None
         if orchestrator is not None:
-            matrix_admin = orchestrator._hook_matrix_admin()
+            matrix_admin = orchestrator.hook_matrix_admin()
         elif self.deps.agent_name == ROUTER_AGENT_NAME:
             matrix_admin = build_hook_matrix_admin(self._client(), self.deps.runtime_paths)
         reload_plugins = (

--- a/tach.toml
+++ b/tach.toml
@@ -1078,14 +1078,13 @@ visibility = [
     "mindroom.matrix.conversation_cache",
     "mindroom.matrix.thread_bookkeeping",
     "mindroom.response_runner",
-    "mindroom.runtime_protocols",
     "mindroom.tool_system.runtime_context",
     "mindroom.turn_controller",
 ]
 
 [[modules]]
 path = "mindroom.runtime_protocols"
-depends_on = ["mindroom.bot_runtime_view"]
+depends_on = []
 visibility = [
     "mindroom.bot_room_lifecycle",
     "mindroom.conversation_resolver",
@@ -1914,10 +1913,12 @@ from = ["mindroom.memory"]
 
 [[interfaces]]
 expose = [
+    "OrchestratorRuntime",
     "SupportsClientConfig",
     "SupportsClientConfigOrchestrator",
     "SupportsConfig",
     "SupportsConfigOrchestrator",
+    "SupportsRunningState",
 ]
 from = ["mindroom.runtime_protocols"]
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -315,9 +315,9 @@ def _team_orchestrator(config: Config, runtime_paths: RuntimePaths) -> SimpleNam
         config=config,
         runtime_paths=runtime_paths,
         knowledge_refresh_scheduler=knowledge_refresh_scheduler,
-        _hook_matrix_admin=lambda: matrix_admin,
-        _hook_room_state_querier=lambda: None,
-        _hook_room_state_putter=lambda: None,
+        hook_matrix_admin=lambda: matrix_admin,
+        hook_room_state_querier=lambda: None,
+        hook_room_state_putter=lambda: None,
     )
 
 
@@ -769,9 +769,9 @@ async def test_process_and_respond_emits_session_started_after_first_persisted_t
             history_storage=storage,
             message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
             orchestrator=SimpleNamespace(
-                _hook_matrix_admin=MagicMock(return_value=object()),
-                _hook_room_state_querier=MagicMock(return_value=None),
-                _hook_room_state_putter=MagicMock(return_value=None),
+                hook_matrix_admin=MagicMock(return_value=object()),
+                hook_room_state_querier=MagicMock(return_value=None),
+                hook_room_state_putter=MagicMock(return_value=None),
                 knowledge_refresh_scheduler=SimpleNamespace(
                     schedule_refresh=lambda _base_id: None,
                     is_refreshing=lambda _base_id: False,

--- a/tests/test_config_architecture_boundaries.py
+++ b/tests/test_config_architecture_boundaries.py
@@ -9,6 +9,10 @@ CONFIG_MODULES = tuple(Path("src/mindroom/config").glob("*.py"))
 PRODUCTION_MODULES = tuple(Path("src/mindroom").rglob("*.py"))
 MATRIX_IDENTITY_MODULE = Path("src/mindroom/matrix/identity.py")
 LEGACY_MATRIX_NAMING_MODULE = Path("src/mindroom/matrix_naming.py")
+CONCRETE_ORCHESTRATOR_IMPORT_ALLOWLIST = {
+    Path("src/mindroom/orchestrator.py"),
+}
+RUNTIME_PROTOCOLS_MODULE = Path("src/mindroom/runtime_protocols.py")
 MATRIX_IDENTIFIER_HELPERS = frozenset(
     {
         "agent_username_localpart",
@@ -107,3 +111,35 @@ def test_matrix_naming_compatibility_module_does_not_exist() -> None:
                 )
 
     assert forbidden == []
+
+
+def test_runtime_collaborators_do_not_import_concrete_orchestrator() -> None:
+    """Collaborators depend on a narrow runtime protocol instead of MultiAgentOrchestrator."""
+    forbidden: list[str] = []
+    for source_path in PRODUCTION_MODULES:
+        if source_path in CONCRETE_ORCHESTRATOR_IMPORT_ALLOWLIST:
+            continue
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or node.module != "mindroom.orchestrator":
+                continue
+            if any(alias.name == "MultiAgentOrchestrator" for alias in node.names):
+                forbidden.append(f"{source_path}:{node.lineno}: from {node.module} import MultiAgentOrchestrator")
+
+    assert forbidden == []
+
+
+def test_orchestrator_runtime_protocol_exposes_only_public_members() -> None:
+    """The orchestrator runtime protocol is the public cross-module contract."""
+    tree = ast.parse(RUNTIME_PROTOCOLS_MODULE.read_text(encoding="utf-8"))
+    protocol_class = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == "OrchestratorRuntime"
+    )
+
+    private_members = [
+        node.name
+        for node in protocol_class.body
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("_") and not node.name.startswith("__")
+    ]
+
+    assert private_members == []

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -182,7 +182,7 @@ def test_hook_context_support_prefers_orchestrator_router_matrix_admin(tmp_path:
     config = _config(tmp_path)
     orchestrator = MagicMock()
     sentinel = object()
-    orchestrator._hook_matrix_admin.return_value = sentinel
+    orchestrator.hook_matrix_admin.return_value = sentinel
     runtime = SimpleNamespace(
         client=AsyncMock(spec=nio.AsyncClient),
         orchestrator=orchestrator,
@@ -203,7 +203,7 @@ def test_hook_context_support_prefers_orchestrator_router_matrix_admin(tmp_path:
         admin = support.matrix_admin()
 
     assert admin is sentinel
-    orchestrator._hook_matrix_admin.assert_called_once_with()
+    orchestrator.hook_matrix_admin.assert_called_once_with()
     mock_build.assert_not_called()
 
 
@@ -239,7 +239,7 @@ def test_hook_context_support_falls_back_to_orchestrator_router_matrix_admin(tmp
     config = _config(tmp_path)
     orchestrator = MagicMock()
     sentinel = object()
-    orchestrator._hook_matrix_admin.return_value = sentinel
+    orchestrator.hook_matrix_admin.return_value = sentinel
     runtime = SimpleNamespace(
         client=AsyncMock(spec=nio.AsyncClient),
         orchestrator=orchestrator,
@@ -259,7 +259,7 @@ def test_hook_context_support_falls_back_to_orchestrator_router_matrix_admin(tmp
     admin = support.matrix_admin()
 
     assert admin is sentinel
-    orchestrator._hook_matrix_admin.assert_called_once_with()
+    orchestrator.hook_matrix_admin.assert_called_once_with()
 
 
 def test_hook_context_support_returns_none_without_router_matrix_admin(tmp_path: Path) -> None:

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -5987,7 +5987,7 @@ async def test_index_file_locked_runs_off_event_loop_thread(
 
     def _record_insert(self: _Knowledge, **kwargs: object) -> None:
         insert_thread_ids.append(get_ident())
-        original_insert(self, **kwargs)  # type: ignore[arg-type]
+        original_insert(self, **kwargs)
 
     async def _forbidden_ainsert(self: _Knowledge, **kwargs: object) -> None:
         _ = (self, kwargs)

--- a/tests/test_tach_split_matrix_client_boundaries.py
+++ b/tests/test_tach_split_matrix_client_boundaries.py
@@ -26,10 +26,12 @@ BOT_RUNTIME_VIEW_MODULE = "mindroom.bot_runtime_view"
 RUNTIME_VIEW_STRUCTURAL_MEMBER = "orchestrator"
 RUNTIME_PROTOCOL_PRIVATE_SYMBOL = "_check_narrow_protocols_are_subsets_of_bot_runtime_view"
 RUNTIME_PROTOCOL_PUBLIC_SYMBOLS = [
+    "OrchestratorRuntime",
     "SupportsClientConfig",
     "SupportsClientConfigOrchestrator",
     "SupportsConfig",
     "SupportsConfigOrchestrator",
+    "SupportsRunningState",
 ]
 RUNTIME_PROTOCOL_IMPORTERS = {
     "mindroom.bot_room_lifecycle",
@@ -45,7 +47,6 @@ RUNTIME_PROTOCOL_IMPORTERS = {
 }
 BOT_RUNTIME_VIEW_ALLOWED_IMPORTERS = {
     "mindroom.bot",
-    RUNTIME_PROTOCOL_MODULE,
     "mindroom.matrix.cache.thread_reads",
     "mindroom.matrix.cache.thread_write_cache_ops",
     "mindroom.matrix.conversation_cache",
@@ -273,7 +274,7 @@ def test_bot_runtime_view_visibility_is_limited_to_owner_and_protocol_facade() -
     runtime_protocol_entry = module_entries[RUNTIME_PROTOCOL_MODULE]
     depends_on = runtime_protocol_entry.get("depends_on")
     assert isinstance(depends_on, list)
-    assert BOT_RUNTIME_VIEW_MODULE in depends_on
+    assert BOT_RUNTIME_VIEW_MODULE not in depends_on
 
 
 def test_tach_rejects_forbidden_split_matrix_client_import(tmp_path: Path) -> None:
@@ -405,7 +406,7 @@ def test_ty_rejects_runtime_view_missing_structural_member(tmp_path: Path) -> No
     original_text = bot_runtime_view_path.read_text()
     missing_member_block = (
         "\n    @property\n"
-        f"    def {RUNTIME_VIEW_STRUCTURAL_MEMBER}(self) -> MultiAgentOrchestrator | None: ...  # noqa: D102\n"
+        f"    def {RUNTIME_VIEW_STRUCTURAL_MEMBER}(self) -> OrchestratorRuntime | None: ...  # noqa: D102\n"
     )
     assert missing_member_block in original_text
     bot_runtime_view_path.write_text(original_text.replace(missing_member_block, "\n"))
@@ -415,10 +416,10 @@ def test_ty_rejects_runtime_view_missing_structural_member(tmp_path: Path) -> No
         textwrap.dedent(
             f"""
             from mindroom.bot_runtime_view import BotRuntimeView
-            from mindroom.orchestrator import MultiAgentOrchestrator
+            from mindroom.runtime_protocols import OrchestratorRuntime
 
 
-            def require_orchestrator(view: BotRuntimeView) -> MultiAgentOrchestrator | None:
+            def require_orchestrator(view: BotRuntimeView) -> OrchestratorRuntime | None:
                 return view.{RUNTIME_VIEW_STRUCTURAL_MEMBER}
             """,
         ).lstrip(),


### PR DESCRIPTION
## Summary
- Add an `OrchestratorRuntime` protocol for the small orchestrator surface extracted runtime collaborators use.
- Move bot, team, and runtime-view annotations off the concrete `MultiAgentOrchestrator`.
- Make the orchestrator hook accessors public because they are part of the protocol contract.
- Add architecture guards blocking production collaborators from importing the concrete orchestrator type and preventing private members in `OrchestratorRuntime`; update Tach interfaces/visibility for the new runtime graph.
- Remove one stale type-ignore in `tests/test_knowledge_manager.py` required by the current ty pre-commit hook.

## Test Plan
- `uv run pytest tests/test_config_architecture_boundaries.py::test_runtime_collaborators_do_not_import_concrete_orchestrator -nauto --no-cov -v` failed before implementation, passed after
- `uv run pytest tests/test_config_architecture_boundaries.py::test_orchestrator_runtime_protocol_exposes_only_public_members -nauto --no-cov -v` failed before implementation, passed after
- `git diff --check`
- `uv run ruff check src/mindroom/runtime_protocols.py src/mindroom/orchestrator.py src/mindroom/hooks/context.py src/mindroom/turn_controller.py tests/test_ai_user_id.py tests/test_hook_matrix_admin.py tests/test_config_architecture_boundaries.py`
- `uv run ty check src/mindroom/runtime_protocols.py src/mindroom/orchestrator.py src/mindroom/hooks/context.py src/mindroom/turn_controller.py tests/test_ai_user_id.py tests/test_hook_matrix_admin.py tests/test_config_architecture_boundaries.py`
- `uv run tach check --dependencies --interfaces`
- `uv run pytest tests/test_config_architecture_boundaries.py tests/test_hook_matrix_admin.py tests/test_ai_user_id.py tests/test_dynamic_config_update.py -nauto --no-cov -v` -> `139 passed`
- `uv run pre-commit run --all-files`
- `uv run pytest tests/ -x -nauto --no-cov -q` -> `5470 passed, 28 skipped`