### PR TITLE
Run scheduled knowledge refreshes in subprocesses

### DIFF
--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -17,11 +17,6 @@ from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING, Any
 
-from mindroom.config.main import Config
-from mindroom.constants import (
-    resolve_runtime_paths,
-    runtime_env_values,
-)
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.manager import KnowledgeManager, knowledge_source_signature
 from mindroom.knowledge.redaction import redact_credentials_in_text
@@ -52,12 +47,13 @@ from mindroom.knowledge.registry import (
 )
 from mindroom.logging_config import get_logger
 from mindroom.runtime_resolution import resolve_knowledge_binding
-from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
+    from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
+    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 
 logger = get_logger(__name__)
@@ -212,6 +208,7 @@ async def refresh_knowledge_binding_in_subprocess(
         execution_identity=execution_identity,
         force_reindex=force_reindex,
     )
+    runtime_env_values = importlib.import_module("mindroom.constants").runtime_env_values
     env = dict(runtime_env_values(runtime_paths))
     env["MINDROOM_KNOWLEDGE_REFRESH_SUBPROCESS"] = "1"
     process = await asyncio.create_subprocess_exec(
@@ -750,7 +747,8 @@ def _load_subprocess_refresh_request(payload: bytes) -> _SubprocessRefreshReques
 def _execution_identity_from_payload(payload: dict[str, object] | None) -> ToolExecutionIdentity | None:
     if payload is None:
         return None
-    return ToolExecutionIdentity(
+    identity_model = importlib.import_module("mindroom.tool_system.worker_routing").ToolExecutionIdentity
+    return identity_model(
         channel=payload["channel"],  # type: ignore[arg-type]
         agent_name=payload["agent_name"],  # type: ignore[arg-type]
         requester_id=payload.get("requester_id"),  # type: ignore[arg-type]
@@ -765,12 +763,14 @@ def _execution_identity_from_payload(payload: dict[str, object] | None) -> ToolE
 
 async def _run_subprocess_refresh_request(payload: bytes) -> KnowledgeRefreshResult:
     request = _load_subprocess_refresh_request(payload)
-    runtime_paths = resolve_runtime_paths(
+    constants = importlib.import_module("mindroom.constants")
+    runtime_paths = constants.resolve_runtime_paths(
         config_path=Path(request.config_path),
         storage_path=Path(request.storage_root),
         process_env=dict(os.environ),
     )
-    config = Config.validate_with_runtime(request.config_data, runtime_paths)
+    config_model = importlib.import_module("mindroom.config.main").Config
+    config = config_model.validate_with_runtime(request.config_data, runtime_paths)
     execution_identity = _execution_identity_from_payload(request.execution_identity)
     return await refresh_knowledge_binding(
         request.base_id,

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -10,6 +10,7 @@ import json
 import os
 import signal
 import sys
+import tempfile
 from contextlib import asynccontextmanager, suppress
 from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
@@ -84,6 +85,7 @@ _refresh_locks_guard = Lock()
 _active_refresh_counts: dict[KnowledgeRefreshTarget, int] = {}
 _active_refresh_counts_guard = Lock()
 _MAX_REFRESH_LOCKS = 512
+_REFRESH_FILE_LOCK_POLL_SECONDS = 0.1
 
 
 @dataclass
@@ -201,6 +203,14 @@ async def refresh_knowledge_binding_in_subprocess(
     control-plane event loop and its shared thread pool while preserving the
     last-good published index semantics.
     """
+    key = resolve_published_index_key(
+        base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=execution_identity,
+        create=True,
+    )
+    initial_state = await asyncio.to_thread(load_published_index_state, published_index_metadata_path(key))
     request_payload = _serialize_subprocess_refresh_request(
         base_id,
         config=config,
@@ -224,7 +234,20 @@ async def refresh_knowledge_binding_in_subprocess(
             await _send_subprocess_refresh_request(process, request_payload)
         return_code = await process.wait()
     except asyncio.CancelledError:
-        await _terminate_refresh_subprocess(process)
+        cleanup_task = asyncio.create_task(
+            _cleanup_cancelled_refresh_subprocess(
+                process,
+                key,
+                initial_state=initial_state,
+                config=config,
+                runtime_paths=runtime_paths,
+            ),
+        )
+        while not cleanup_task.done():
+            with suppress(asyncio.CancelledError):
+                await asyncio.shield(cleanup_task)
+        with suppress(Exception):
+            cleanup_task.result()
         raise
 
     if return_code != 0:
@@ -267,22 +290,33 @@ async def _send_subprocess_refresh_request(
 
 def _refresh_file_lock_path(key: KnowledgeSourceRoot) -> Path:
     digest = hashlib.sha256(f"{key.storage_root}\0{key.knowledge_path}".encode()).hexdigest()
-    return Path(key.storage_root) / "knowledge_db" / "refresh_locks" / f"{digest}.lock"
+    return Path(tempfile.gettempdir()) / "mindroom" / "knowledge_refresh_locks" / f"{digest}.lock"
 
 
-def _acquire_refresh_file_lock_sync(key: KnowledgeSourceRoot) -> tuple[Any, Any] | None:
+def _open_refresh_file_lock_sync(key: KnowledgeSourceRoot) -> tuple[Any, Any] | None:
     if os.name == "nt":
         return None
     fcntl = importlib.import_module("fcntl")
     lock_path = _refresh_file_lock_path(key)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_file = lock_path.open("a", encoding="utf-8")
+    return fcntl, lock_path.open("a", encoding="utf-8")
+
+
+def _try_acquire_refresh_file_lock_sync(handle: tuple[Any, Any] | None) -> bool:
+    if handle is None:
+        return True
+    fcntl, lock_file = handle
     try:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-    except Exception:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        return False
+    return True
+
+
+def _close_refresh_file_lock_sync(handle: tuple[Any, Any] | None) -> None:
+    if handle is not None:
+        _fcntl, lock_file = handle
         lock_file.close()
-        raise
-    return fcntl, lock_file
 
 
 def _release_refresh_file_lock_sync(handle: tuple[Any, Any] | None) -> None:
@@ -298,11 +332,18 @@ def _release_refresh_file_lock_sync(handle: tuple[Any, Any] | None) -> None:
 @asynccontextmanager
 async def _acquire_refresh_file_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
     """Serialize source-root refresh and mutation work across processes."""
-    handle = await asyncio.to_thread(_acquire_refresh_file_lock_sync, key)
+    handle = _open_refresh_file_lock_sync(key)
+    acquired = False
     try:
+        while not _try_acquire_refresh_file_lock_sync(handle):  # noqa: ASYNC110
+            await asyncio.sleep(_REFRESH_FILE_LOCK_POLL_SECONDS)
+        acquired = True
         yield
     finally:
-        await asyncio.to_thread(_release_refresh_file_lock_sync, handle)
+        if acquired:
+            _release_refresh_file_lock_sync(handle)
+        else:
+            _close_refresh_file_lock_sync(handle)
 
 
 def _subprocess_session_kwargs() -> dict[str, object]:
@@ -328,6 +369,28 @@ async def _terminate_refresh_subprocess(process: asyncio.subprocess.Process) -> 
             with suppress(ProcessLookupError):
                 os.killpg(process.pid, signal.SIGKILL)
         await process.wait()
+
+
+async def _cleanup_cancelled_refresh_subprocess(
+    process: asyncio.subprocess.Process,
+    key: PublishedIndexKey,
+    *,
+    initial_state: PublishedIndexState | None,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> None:
+    try:
+        await _terminate_refresh_subprocess(process)
+        source_root = source_root_for_published_index_key(key)
+        async with _acquire_refresh_lock(source_root), _acquire_refresh_file_lock(source_root):
+            await _reconcile_cancelled_refresh(
+                key,
+                initial_state=initial_state,
+                config=config,
+                runtime_paths=runtime_paths,
+            )
+    except Exception:
+        logger.warning("Failed to reconcile cancelled knowledge refresh subprocess", base_id=key.base_id, exc_info=True)
 
 
 @asynccontextmanager
@@ -687,9 +750,10 @@ async def _reconcile_cancelled_refresh(
 ) -> None:
     state = await asyncio.to_thread(load_published_index_state, published_index_metadata_path(key))
     state_advanced = _published_state_fingerprint(state) != _published_state_fingerprint(initial_state)
+    if not state_advanced:
+        return
     if (
-        state_advanced
-        and state is not None
+        state is not None
         and state.status == "complete"
         and published_index_settings_compatible(state.settings, key.indexing_settings)
         and published_index_availability_for_state(key=key, state=state) is KnowledgeAvailability.READY

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -410,10 +410,7 @@ async def _reconcile_failed_refresh_subprocess(
         source_root = source_root_for_published_index_key(key)
         async with _acquire_refresh_lock(source_root), _acquire_refresh_file_lock(source_root):
             state = await asyncio.to_thread(load_published_index_state, published_index_metadata_path(key))
-            if _published_state_fingerprint(state) not in {
-                _published_state_fingerprint(initial_state),
-                _refresh_running_fingerprint(key, initial_state),
-            }:
+            if not _failed_subprocess_state_can_be_reconciled(key, state, initial_state):
                 return
             await asyncio.to_thread(mark_published_index_refresh_failed_preserving_last_good, key, error=error)
     except Exception:
@@ -792,6 +789,19 @@ def _refresh_running_fingerprint(
             last_error=None,
         ),
     )
+
+
+def _failed_subprocess_state_can_be_reconciled(
+    key: PublishedIndexKey,
+    state: PublishedIndexState | None,
+    initial_state: PublishedIndexState | None,
+) -> bool:
+    if _published_state_fingerprint(state) in {
+        _published_state_fingerprint(initial_state),
+        _refresh_running_fingerprint(key, initial_state),
+    }:
+        return True
+    return state is not None and state.refresh_job == "running" and state.reason == "refreshing"
 
 
 async def _reconcile_cancelled_refresh(

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -254,6 +254,7 @@ async def refresh_knowledge_binding_in_subprocess(
 
     if return_code != 0:
         msg = f"Knowledge refresh subprocess failed for {base_id!r} with exit code {return_code}"
+        await _reconcile_failed_refresh_subprocess(key, error=msg)
         raise RuntimeError(msg)
 
 
@@ -393,6 +394,15 @@ async def _cleanup_cancelled_refresh_subprocess(
             )
     except Exception:
         logger.warning("Failed to reconcile cancelled knowledge refresh subprocess", base_id=key.base_id, exc_info=True)
+
+
+async def _reconcile_failed_refresh_subprocess(key: PublishedIndexKey, *, error: str) -> None:
+    try:
+        source_root = source_root_for_published_index_key(key)
+        async with _acquire_refresh_lock(source_root), _acquire_refresh_file_lock(source_root):
+            await asyncio.to_thread(mark_published_index_refresh_failed_preserving_last_good, key, error=error)
+    except Exception:
+        logger.warning("Failed to reconcile failed knowledge refresh subprocess", base_id=key.base_id, exc_info=True)
 
 
 @asynccontextmanager

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -254,7 +254,7 @@ async def refresh_knowledge_binding_in_subprocess(
 
     if return_code != 0:
         msg = f"Knowledge refresh subprocess failed for {base_id!r} with exit code {return_code}"
-        await _reconcile_failed_refresh_subprocess(key, error=msg)
+        await _reconcile_failed_refresh_subprocess(key, initial_state=initial_state, error=msg)
         raise RuntimeError(msg)
 
 
@@ -396,10 +396,21 @@ async def _cleanup_cancelled_refresh_subprocess(
         logger.warning("Failed to reconcile cancelled knowledge refresh subprocess", base_id=key.base_id, exc_info=True)
 
 
-async def _reconcile_failed_refresh_subprocess(key: PublishedIndexKey, *, error: str) -> None:
+async def _reconcile_failed_refresh_subprocess(
+    key: PublishedIndexKey,
+    *,
+    initial_state: PublishedIndexState | None,
+    error: str,
+) -> None:
     try:
         source_root = source_root_for_published_index_key(key)
         async with _acquire_refresh_lock(source_root), _acquire_refresh_file_lock(source_root):
+            state = await asyncio.to_thread(load_published_index_state, published_index_metadata_path(key))
+            if _published_state_fingerprint(state) not in {
+                _published_state_fingerprint(initial_state),
+                _refresh_running_fingerprint(key, initial_state),
+            }:
+                return
             await asyncio.to_thread(mark_published_index_refresh_failed_preserving_last_good, key, error=error)
     except Exception:
         logger.warning("Failed to reconcile failed knowledge refresh subprocess", base_id=key.base_id, exc_info=True)
@@ -753,6 +764,29 @@ def _published_state_fingerprint(state: PublishedIndexState | None) -> tuple[obj
         state.refresh_job,
         state.reason,
         state.last_error,
+    )
+
+
+def _refresh_running_fingerprint(
+    key: PublishedIndexKey,
+    state: PublishedIndexState | None,
+) -> tuple[object, ...] | None:
+    if state is None:
+        return _published_state_fingerprint(
+            PublishedIndexState(
+                settings=key.indexing_settings,
+                status="indexing",
+                refresh_job="running",
+                reason="refreshing",
+            ),
+        )
+    return _published_state_fingerprint(
+        replace(
+            state,
+            refresh_job="running",
+            reason="refreshing",
+            last_error=None,
+        ),
     )
 
 

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -15,12 +15,12 @@ from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 if os.name != "nt":
     import fcntl
 else:
-    fcntl = None  # type: ignore[assignment]
+    fcntl = None
 
 from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths, runtime_env_values
@@ -82,6 +82,10 @@ class _SubprocessRefreshRequest:
     storage_root: str
     execution_identity: dict[str, object] | None = None
     force_reindex: bool = False
+
+
+class _SubprocessSessionKwargs(TypedDict, total=False):
+    start_new_session: bool
 
 
 _refresh_locks_guard = Lock()
@@ -349,7 +353,7 @@ async def _acquire_refresh_file_lock(key: KnowledgeSourceRoot) -> AsyncIterator[
             _close_refresh_file_lock_sync(handle)
 
 
-def _subprocess_session_kwargs() -> dict[str, object]:
+def _subprocess_session_kwargs() -> _SubprocessSessionKwargs:
     if os.name == "nt":
         return {}
     return {"start_new_session": True}

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -2,13 +2,28 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
-from contextlib import asynccontextmanager, suppress
-from dataclasses import dataclass, field, replace
+import hashlib
+import importlib
+import json
+import os
+import signal
+import sys
+from contextlib import asynccontextmanager, contextmanager, suppress
+from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
+from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
+from mindroom.config.main import Config
+from mindroom.constants import (
+    resolve_runtime_paths,
+    runtime_env_values,
+    safe_replace,
+)
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.manager import KnowledgeManager, knowledge_source_signature
 from mindroom.knowledge.redaction import redact_credentials_in_text
@@ -37,14 +52,17 @@ from mindroom.knowledge.registry import (
     source_root_for_published_index_key,
     source_root_for_refresh_target,
 )
+from mindroom.logging_config import get_logger
 from mindroom.runtime_resolution import resolve_knowledge_binding
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Iterator
 
-    from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
-    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
+
+
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -56,6 +74,16 @@ class KnowledgeRefreshResult:
     index_published: bool
     availability: KnowledgeAvailability
     last_error: str | None = None
+
+
+@dataclass(frozen=True)
+class _SubprocessRefreshRequest:
+    base_id: str
+    config_data: dict[str, object]
+    config_path: str
+    storage_root: str
+    execution_identity: dict[str, object] | None = None
+    force_reindex: bool = False
 
 
 _refresh_locks_guard = Lock()
@@ -162,6 +190,132 @@ def is_refresh_active_for_binding(
     except ValueError:
         return False
     return is_refresh_active(key)
+
+
+async def refresh_knowledge_binding_in_subprocess(
+    base_id: str,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None = None,
+    force_reindex: bool = False,
+) -> None:
+    """Run one knowledge refresh in a child interpreter.
+
+    Scheduled refreshes are best-effort maintenance work. Running them in a
+    subprocess keeps Chroma, embedding, Git, and reader CPU/I/O away from the
+    control-plane event loop and its shared thread pool while preserving the
+    last-good published index semantics.
+    """
+    request_path = _write_subprocess_refresh_request(
+        base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=execution_identity,
+        force_reindex=force_reindex,
+    )
+    env = dict(runtime_env_values(runtime_paths))
+    env["MINDROOM_KNOWLEDGE_REFRESH_SUBPROCESS"] = "1"
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "mindroom.knowledge_refresh_runner",
+        "--request-path",
+        str(request_path),
+        stdin=asyncio.subprocess.DEVNULL,
+        env=env,
+        **_subprocess_session_kwargs(),
+    )
+    try:
+        return_code = await process.wait()
+    except asyncio.CancelledError:
+        await _terminate_refresh_subprocess(process)
+        raise
+    finally:
+        request_path.unlink(missing_ok=True)
+
+    if return_code != 0:
+        msg = f"Knowledge refresh subprocess failed for {base_id!r} with exit code {return_code}"
+        raise RuntimeError(msg)
+
+
+def _subprocess_refresh_request_dir(runtime_paths: RuntimePaths) -> Path:
+    return runtime_paths.storage_root / "knowledge_db" / "refresh_requests"
+
+
+def _write_subprocess_refresh_request(
+    base_id: str,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None,
+    force_reindex: bool,
+) -> Path:
+    request_dir = _subprocess_refresh_request_dir(runtime_paths)
+    request_dir.mkdir(parents=True, exist_ok=True)
+    request_path = request_dir / f"refresh-{uuid4().hex}.json"
+    tmp_path = request_path.with_name(f".{request_path.name}.tmp")
+    payload = _SubprocessRefreshRequest(
+        base_id=base_id,
+        config_data=config.authored_model_dump(),
+        config_path=str(runtime_paths.config_path),
+        storage_root=str(runtime_paths.storage_root),
+        execution_identity=None if execution_identity is None else asdict(execution_identity),
+        force_reindex=force_reindex,
+    )
+    tmp_path.write_text(json.dumps(asdict(payload), sort_keys=True), encoding="utf-8")
+    with suppress(OSError):
+        tmp_path.chmod(0o600)
+    safe_replace(tmp_path, request_path)
+    return request_path
+
+
+def _subprocess_refresh_lock_path(key: KnowledgeSourceRoot) -> Path:
+    digest = hashlib.sha256(f"{key.storage_root}\0{key.knowledge_path}".encode()).hexdigest()
+    return Path(key.storage_root) / "knowledge_db" / "refresh_locks" / f"{digest}.lock"
+
+
+@contextmanager
+def _subprocess_refresh_file_lock(key: KnowledgeSourceRoot) -> Iterator[None]:
+    """Serialize refresh subprocesses for one physical source root."""
+    if os.name == "nt":
+        yield
+        return
+    fcntl = importlib.import_module("fcntl")
+
+    lock_path = _subprocess_refresh_lock_path(key)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _subprocess_session_kwargs() -> dict[str, object]:
+    if os.name == "nt":
+        return {}
+    return {"start_new_session": True}
+
+
+async def _terminate_refresh_subprocess(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    if os.name == "nt":
+        process.terminate()
+    else:
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGTERM)
+    try:
+        await asyncio.wait_for(process.wait(), timeout=10)
+    except TimeoutError:
+        if os.name == "nt":
+            process.kill()
+        else:
+            with suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGKILL)
+        await process.wait()
 
 
 @asynccontextmanager
@@ -538,3 +692,109 @@ async def _reconcile_cancelled_refresh(
             await asyncio.to_thread(mark_published_index_refresh_succeeded, key)
             return
     await asyncio.to_thread(mark_published_index_stale, key, reason="refresh_cancelled", refresh_job="idle")
+
+
+def _load_subprocess_refresh_request(request_path: Path) -> _SubprocessRefreshRequest:
+    raw_payload = json.loads(request_path.read_text(encoding="utf-8"))
+    if not isinstance(raw_payload, dict):
+        msg = "Knowledge refresh subprocess request must be a JSON object"
+        raise TypeError(msg)
+    raw_base_id = raw_payload.get("base_id")
+    raw_config_data = raw_payload.get("config_data")
+    raw_config_path = raw_payload.get("config_path")
+    raw_storage_root = raw_payload.get("storage_root")
+    raw_execution_identity = raw_payload.get("execution_identity")
+    raw_force_reindex = raw_payload.get("force_reindex", False)
+    if not isinstance(raw_base_id, str) or not raw_base_id.strip():
+        msg = "Knowledge refresh subprocess request is missing base_id"
+        raise TypeError(msg)
+    if not isinstance(raw_config_data, dict):
+        msg = "Knowledge refresh subprocess request is missing config_data"
+        raise TypeError(msg)
+    if not isinstance(raw_config_path, str) or not raw_config_path.strip():
+        msg = "Knowledge refresh subprocess request is missing config_path"
+        raise TypeError(msg)
+    if not isinstance(raw_storage_root, str) or not raw_storage_root.strip():
+        msg = "Knowledge refresh subprocess request is missing storage_root"
+        raise TypeError(msg)
+    if raw_execution_identity is not None and not isinstance(raw_execution_identity, dict):
+        msg = "Knowledge refresh subprocess request execution_identity must be an object when present"
+        raise TypeError(msg)
+    return _SubprocessRefreshRequest(
+        base_id=raw_base_id,
+        config_data=raw_config_data,
+        config_path=raw_config_path,
+        storage_root=raw_storage_root,
+        execution_identity=raw_execution_identity,
+        force_reindex=bool(raw_force_reindex),
+    )
+
+
+def _execution_identity_from_payload(payload: dict[str, object] | None) -> ToolExecutionIdentity | None:
+    if payload is None:
+        return None
+    return ToolExecutionIdentity(
+        channel=payload["channel"],  # type: ignore[arg-type]
+        agent_name=payload["agent_name"],  # type: ignore[arg-type]
+        requester_id=payload.get("requester_id"),  # type: ignore[arg-type]
+        room_id=payload.get("room_id"),  # type: ignore[arg-type]
+        thread_id=payload.get("thread_id"),  # type: ignore[arg-type]
+        resolved_thread_id=payload.get("resolved_thread_id"),  # type: ignore[arg-type]
+        session_id=payload.get("session_id"),  # type: ignore[arg-type]
+        tenant_id=payload.get("tenant_id"),  # type: ignore[arg-type]
+        account_id=payload.get("account_id"),  # type: ignore[arg-type]
+    )
+
+
+async def _run_subprocess_refresh_request(request_path: Path) -> KnowledgeRefreshResult:
+    request = _load_subprocess_refresh_request(request_path)
+    runtime_paths = resolve_runtime_paths(
+        config_path=Path(request.config_path),
+        storage_path=Path(request.storage_root),
+        process_env=dict(os.environ),
+    )
+    config = Config.validate_with_runtime(request.config_data, runtime_paths)
+    execution_identity = _execution_identity_from_payload(request.execution_identity)
+    refresh_target = resolve_refresh_target(
+        request.base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=execution_identity,
+        create=True,
+    )
+    with _subprocess_refresh_file_lock(source_root_for_refresh_target(refresh_target)):
+        return await refresh_knowledge_binding(
+            request.base_id,
+            config=config,
+            runtime_paths=runtime_paths,
+            execution_identity=execution_identity,
+            force_reindex=request.force_reindex,
+        )
+
+
+def _parse_refresh_runner_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one internal MindRoom knowledge refresh request.")
+    parser.add_argument("--request-path", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Internal CLI used by scheduled knowledge refresh subprocesses."""
+    args = _parse_refresh_runner_args(argv)
+    try:
+        result = asyncio.run(_run_subprocess_refresh_request(args.request_path))
+    except Exception:
+        logger.exception("Knowledge refresh subprocess failed", request_path=str(args.request_path))
+        return 1
+    logger.info(
+        "Knowledge refresh subprocess completed",
+        base_id=result.key.base_id,
+        indexed_count=result.indexed_count,
+        index_published=result.index_published,
+        availability=result.availability.value,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
-import importlib
 import json
 import os
 import signal
@@ -18,6 +17,13 @@ from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING, Any
 
+if os.name != "nt":
+    import fcntl
+else:
+    fcntl = None  # type: ignore[assignment]
+
+from mindroom.config.main import Config
+from mindroom.constants import RuntimePaths, resolve_runtime_paths, runtime_env_values
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.manager import KnowledgeManager, knowledge_source_signature
 from mindroom.knowledge.redaction import redact_credentials_in_text
@@ -48,13 +54,10 @@ from mindroom.knowledge.registry import (
 )
 from mindroom.logging_config import get_logger
 from mindroom.runtime_resolution import resolve_knowledge_binding
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
-
-    from mindroom.config.main import Config
-    from mindroom.constants import RuntimePaths
-    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 
 logger = get_logger(__name__)
@@ -218,7 +221,6 @@ async def refresh_knowledge_binding_in_subprocess(
         execution_identity=execution_identity,
         force_reindex=force_reindex,
     )
-    runtime_env_values = importlib.import_module("mindroom.constants").runtime_env_values
     env = dict(runtime_env_values(runtime_paths))
     env["MINDROOM_KNOWLEDGE_REFRESH_SUBPROCESS"] = "1"
     process = await asyncio.create_subprocess_exec(
@@ -294,9 +296,9 @@ def _refresh_file_lock_path(key: KnowledgeSourceRoot) -> Path:
 
 
 def _open_refresh_file_lock_sync(key: KnowledgeSourceRoot) -> tuple[Any, Any] | None:
-    if os.name == "nt":
+    if fcntl is None:
         return None
-    fcntl = importlib.import_module("fcntl")
+
     lock_path = _refresh_file_lock_path(key)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     return fcntl, lock_path.open("a", encoding="utf-8")
@@ -738,6 +740,9 @@ def _published_state_fingerprint(state: PublishedIndexState | None) -> tuple[obj
         state.published_revision,
         state.indexed_count,
         state.source_signature,
+        state.refresh_job,
+        state.reason,
+        state.last_error,
     )
 
 
@@ -811,8 +816,7 @@ def _load_subprocess_refresh_request(payload: bytes) -> _SubprocessRefreshReques
 def _execution_identity_from_payload(payload: dict[str, object] | None) -> ToolExecutionIdentity | None:
     if payload is None:
         return None
-    identity_model = importlib.import_module("mindroom.tool_system.worker_routing").ToolExecutionIdentity
-    return identity_model(
+    return ToolExecutionIdentity(
         channel=payload["channel"],  # type: ignore[arg-type]
         agent_name=payload["agent_name"],  # type: ignore[arg-type]
         requester_id=payload.get("requester_id"),  # type: ignore[arg-type]
@@ -827,14 +831,12 @@ def _execution_identity_from_payload(payload: dict[str, object] | None) -> ToolE
 
 async def _run_subprocess_refresh_request(payload: bytes) -> KnowledgeRefreshResult:
     request = _load_subprocess_refresh_request(payload)
-    constants = importlib.import_module("mindroom.constants")
-    runtime_paths = constants.resolve_runtime_paths(
+    runtime_paths = resolve_runtime_paths(
         config_path=Path(request.config_path),
         storage_path=Path(request.storage_root),
         process_env=dict(os.environ),
     )
-    config_model = importlib.import_module("mindroom.config.main").Config
-    config = config_model.validate_with_runtime(request.config_data, runtime_paths)
+    config = Config.validate_with_runtime(request.config_data, runtime_paths)
     execution_identity = _execution_identity_from_payload(request.execution_identity)
     return await refresh_knowledge_binding(
         request.base_id,

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -10,19 +10,17 @@ import json
 import os
 import signal
 import sys
-from contextlib import asynccontextmanager, contextmanager, suppress
+from contextlib import asynccontextmanager, suppress
 from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING
-from uuid import uuid4
+from typing import TYPE_CHECKING, Any
 
 from mindroom.config.main import Config
 from mindroom.constants import (
     resolve_runtime_paths,
     runtime_env_values,
-    safe_replace,
 )
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.manager import KnowledgeManager, knowledge_source_signature
@@ -57,7 +55,7 @@ from mindroom.runtime_resolution import resolve_knowledge_binding
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterator
+    from collections.abc import AsyncIterator
 
     from mindroom.constants import RuntimePaths
 
@@ -207,7 +205,7 @@ async def refresh_knowledge_binding_in_subprocess(
     control-plane event loop and its shared thread pool while preserving the
     last-good published index semantics.
     """
-    request_path = _write_subprocess_refresh_request(
+    request_payload = _serialize_subprocess_refresh_request(
         base_id,
         config=config,
         runtime_paths=runtime_paths,
@@ -220,41 +218,31 @@ async def refresh_knowledge_binding_in_subprocess(
         sys.executable,
         "-m",
         "mindroom.knowledge_refresh_runner",
-        "--request-path",
-        str(request_path),
-        stdin=asyncio.subprocess.DEVNULL,
+        stdin=asyncio.subprocess.PIPE,
         env=env,
         **_subprocess_session_kwargs(),
     )
     try:
+        with suppress(BrokenPipeError, ConnectionResetError):
+            await _send_subprocess_refresh_request(process, request_payload)
         return_code = await process.wait()
     except asyncio.CancelledError:
         await _terminate_refresh_subprocess(process)
         raise
-    finally:
-        request_path.unlink(missing_ok=True)
 
     if return_code != 0:
         msg = f"Knowledge refresh subprocess failed for {base_id!r} with exit code {return_code}"
         raise RuntimeError(msg)
 
 
-def _subprocess_refresh_request_dir(runtime_paths: RuntimePaths) -> Path:
-    return runtime_paths.storage_root / "knowledge_db" / "refresh_requests"
-
-
-def _write_subprocess_refresh_request(
+def _serialize_subprocess_refresh_request(
     base_id: str,
     *,
     config: Config,
     runtime_paths: RuntimePaths,
     execution_identity: ToolExecutionIdentity | None,
     force_reindex: bool,
-) -> Path:
-    request_dir = _subprocess_refresh_request_dir(runtime_paths)
-    request_dir.mkdir(parents=True, exist_ok=True)
-    request_path = request_dir / f"refresh-{uuid4().hex}.json"
-    tmp_path = request_path.with_name(f".{request_path.name}.tmp")
+) -> bytes:
     payload = _SubprocessRefreshRequest(
         base_id=base_id,
         config_data=config.authored_model_dump(),
@@ -263,34 +251,61 @@ def _write_subprocess_refresh_request(
         execution_identity=None if execution_identity is None else asdict(execution_identity),
         force_reindex=force_reindex,
     )
-    tmp_path.write_text(json.dumps(asdict(payload), sort_keys=True), encoding="utf-8")
-    with suppress(OSError):
-        tmp_path.chmod(0o600)
-    safe_replace(tmp_path, request_path)
-    return request_path
+    return json.dumps(asdict(payload), sort_keys=True).encode()
 
 
-def _subprocess_refresh_lock_path(key: KnowledgeSourceRoot) -> Path:
+async def _send_subprocess_refresh_request(
+    process: asyncio.subprocess.Process,
+    payload: bytes,
+) -> None:
+    if process.stdin is None:
+        msg = "Knowledge refresh subprocess was created without stdin"
+        raise RuntimeError(msg)
+    process.stdin.write(payload)
+    await process.stdin.drain()
+    process.stdin.close()
+    with suppress(BrokenPipeError, ConnectionResetError):
+        await process.stdin.wait_closed()
+
+
+def _refresh_file_lock_path(key: KnowledgeSourceRoot) -> Path:
     digest = hashlib.sha256(f"{key.storage_root}\0{key.knowledge_path}".encode()).hexdigest()
     return Path(key.storage_root) / "knowledge_db" / "refresh_locks" / f"{digest}.lock"
 
 
-@contextmanager
-def _subprocess_refresh_file_lock(key: KnowledgeSourceRoot) -> Iterator[None]:
-    """Serialize refresh subprocesses for one physical source root."""
+def _acquire_refresh_file_lock_sync(key: KnowledgeSourceRoot) -> tuple[Any, Any] | None:
     if os.name == "nt":
-        yield
-        return
+        return None
     fcntl = importlib.import_module("fcntl")
-
-    lock_path = _subprocess_refresh_lock_path(key)
+    lock_path = _refresh_file_lock_path(key)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a", encoding="utf-8") as lock_file:
+    lock_file = lock_path.open("a", encoding="utf-8")
+    try:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    except Exception:
+        lock_file.close()
+        raise
+    return fcntl, lock_file
+
+
+def _release_refresh_file_lock_sync(handle: tuple[Any, Any] | None) -> None:
+    if handle is None:
+        return
+    fcntl, lock_file = handle
+    try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    finally:
+        lock_file.close()
+
+
+@asynccontextmanager
+async def _acquire_refresh_file_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
+    """Serialize source-root refresh and mutation work across processes."""
+    handle = await asyncio.to_thread(_acquire_refresh_file_lock_sync, key)
+    try:
+        yield
+    finally:
+        await asyncio.to_thread(_release_refresh_file_lock_sync, handle)
 
 
 def _subprocess_session_kwargs() -> dict[str, object]:
@@ -335,7 +350,8 @@ async def knowledge_binding_mutation_lock(
         execution_identity=execution_identity,
         create=create,
     )
-    async with _acquire_refresh_lock(source_root_for_refresh_target(key)):
+    source_root = source_root_for_refresh_target(key)
+    async with _acquire_refresh_lock(source_root), _acquire_refresh_file_lock(source_root):
         yield
 
 
@@ -356,15 +372,16 @@ async def refresh_knowledge_binding(
         create=True,
     )
     refresh_target = refresh_target_for_published_index_key(key)
+    source_root = source_root_for_published_index_key(key)
     mark_refresh_active(refresh_target)
     try:
-        initial_state = await asyncio.to_thread(
-            load_published_index_state,
-            published_index_metadata_path(key),
-        )
-        try:
-            await _save_refreshing_state(key)
-            async with _acquire_refresh_lock(source_root_for_published_index_key(key)):
+        async with _acquire_refresh_lock(source_root), _acquire_refresh_file_lock(source_root):
+            initial_state = await asyncio.to_thread(
+                load_published_index_state,
+                published_index_metadata_path(key),
+            )
+            try:
+                await _save_refreshing_state(key)
                 return await _refresh_knowledge_binding_locked(
                     key,
                     config=config,
@@ -372,14 +389,14 @@ async def refresh_knowledge_binding(
                     execution_identity=execution_identity,
                     force_reindex=force_reindex,
                 )
-        except asyncio.CancelledError:
-            await _reconcile_cancelled_refresh(
-                key,
-                initial_state=initial_state,
-                config=config,
-                runtime_paths=runtime_paths,
-            )
-            raise
+            except asyncio.CancelledError:
+                await _reconcile_cancelled_refresh(
+                    key,
+                    initial_state=initial_state,
+                    config=config,
+                    runtime_paths=runtime_paths,
+                )
+                raise
     finally:
         mark_refresh_inactive(refresh_target)
         prune_private_index_bookkeeping()
@@ -694,8 +711,8 @@ async def _reconcile_cancelled_refresh(
     await asyncio.to_thread(mark_published_index_stale, key, reason="refresh_cancelled", refresh_job="idle")
 
 
-def _load_subprocess_refresh_request(request_path: Path) -> _SubprocessRefreshRequest:
-    raw_payload = json.loads(request_path.read_text(encoding="utf-8"))
+def _load_subprocess_refresh_request(payload: bytes) -> _SubprocessRefreshRequest:
+    raw_payload = json.loads(payload.decode())
     if not isinstance(raw_payload, dict):
         msg = "Knowledge refresh subprocess request must be a JSON object"
         raise TypeError(msg)
@@ -746,8 +763,8 @@ def _execution_identity_from_payload(payload: dict[str, object] | None) -> ToolE
     )
 
 
-async def _run_subprocess_refresh_request(request_path: Path) -> KnowledgeRefreshResult:
-    request = _load_subprocess_refresh_request(request_path)
+async def _run_subprocess_refresh_request(payload: bytes) -> KnowledgeRefreshResult:
+    request = _load_subprocess_refresh_request(payload)
     runtime_paths = resolve_runtime_paths(
         config_path=Path(request.config_path),
         storage_path=Path(request.storage_root),
@@ -755,36 +772,28 @@ async def _run_subprocess_refresh_request(request_path: Path) -> KnowledgeRefres
     )
     config = Config.validate_with_runtime(request.config_data, runtime_paths)
     execution_identity = _execution_identity_from_payload(request.execution_identity)
-    refresh_target = resolve_refresh_target(
+    return await refresh_knowledge_binding(
         request.base_id,
         config=config,
         runtime_paths=runtime_paths,
         execution_identity=execution_identity,
-        create=True,
+        force_reindex=request.force_reindex,
     )
-    with _subprocess_refresh_file_lock(source_root_for_refresh_target(refresh_target)):
-        return await refresh_knowledge_binding(
-            request.base_id,
-            config=config,
-            runtime_paths=runtime_paths,
-            execution_identity=execution_identity,
-            force_reindex=request.force_reindex,
-        )
 
 
 def _parse_refresh_runner_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run one internal MindRoom knowledge refresh request.")
-    parser.add_argument("--request-path", type=Path, required=True)
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     """Internal CLI used by scheduled knowledge refresh subprocesses."""
-    args = _parse_refresh_runner_args(argv)
+    _parse_refresh_runner_args(argv)
+    payload = sys.stdin.buffer.read()
     try:
-        result = asyncio.run(_run_subprocess_refresh_request(args.request_path))
+        result = asyncio.run(_run_subprocess_refresh_request(payload))
     except Exception:
-        logger.exception("Knowledge refresh subprocess failed", request_path=str(args.request_path))
+        logger.exception("Knowledge refresh subprocess failed")
         return 1
     logger.info(
         "Knowledge refresh subprocess completed",

--- a/src/mindroom/knowledge/refresh_scheduler.py
+++ b/src/mindroom/knowledge/refresh_scheduler.py
@@ -12,6 +12,7 @@ from mindroom.knowledge.refresh_runner import (
     mark_refresh_active,
     mark_refresh_inactive,
     refresh_knowledge_binding,
+    refresh_knowledge_binding_in_subprocess,
 )
 from mindroom.knowledge.registry import KnowledgeRefreshTarget, resolve_refresh_target
 from mindroom.logging_config import get_logger
@@ -180,7 +181,7 @@ class KnowledgeRefreshScheduler:
             self._start_task(key, pending_request)
 
     async def _run_refresh(self, key: KnowledgeRefreshTarget, request: _ScheduledRefresh) -> None:
-        await refresh_knowledge_binding(
+        await refresh_knowledge_binding_in_subprocess(
             key.base_id,
             config=request.config,
             runtime_paths=request.runtime_paths,

--- a/src/mindroom/knowledge/registry.py
+++ b/src/mindroom/knowledge/registry.py
@@ -617,6 +617,22 @@ def _cached_index_still_queryable(index: PublishedIndexHandle) -> bool:
     return vector_db is not None and vector_db.exists()
 
 
+def _cached_index_matches_persisted_state(
+    index: PublishedIndexHandle,
+    state: PublishedIndexState,
+) -> bool:
+    """Return whether a process-local handle still points at persisted metadata."""
+    return (
+        index.state.settings == state.settings
+        and index.state.status == state.status
+        and index.state.collection == state.collection
+        and index.state.last_published_at == state.last_published_at
+        and index.state.published_revision == state.published_revision
+        and index.state.indexed_count == state.indexed_count
+        and index.state.source_signature == state.source_signature
+    )
+
+
 def _load_queryable_index_from_state(
     key: PublishedIndexKey,
     state: PublishedIndexState,
@@ -652,7 +668,14 @@ def get_published_index(
 
     index = _published_indexes.get(key)
     if index is not None:
-        if _cached_index_still_queryable(index):
+        if (
+            state is not None
+            and _cached_index_matches_persisted_state(index, state)
+            and _cached_index_still_queryable(index)
+        ):
+            if index.state != state:
+                index = replace(index, state=state)
+                _published_indexes[key] = index
             return PublishedIndexResolution(
                 key=key,
                 index=index,

--- a/src/mindroom/knowledge_refresh_runner.py
+++ b/src/mindroom/knowledge_refresh_runner.py
@@ -1,0 +1,8 @@
+"""Internal module entrypoint for knowledge refresh subprocesses."""
+
+from __future__ import annotations
+
+from mindroom.knowledge.refresh_runner import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tach.toml
+++ b/tach.toml
@@ -1786,11 +1786,14 @@ depends_on = [
 [[modules]]
 path = "mindroom.knowledge.refresh_runner"
 depends_on = [
+    "mindroom.config.main",
+    "mindroom.constants",
     "mindroom.knowledge.availability",
     "mindroom.knowledge.manager",
     "mindroom.knowledge.redaction",
     "mindroom.knowledge.registry",
     "mindroom.runtime_resolution",
+    "mindroom.tool_system.worker_routing",
 ]
 
 [[modules]]

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -4013,6 +4013,10 @@ async def test_cancelled_subprocess_refresh_reconciles_running_state(
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     runtime_paths = runtime_paths_for(config)
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    knowledge_registry.mark_published_index_stale(key, reason="test_stale")
+    initial_state = load_published_index_state(published_index_metadata_path(key))
+    assert initial_state is not None
+    assert initial_state.refresh_job == "pending"
     wait_entered = asyncio.Event()
     release_wait = asyncio.Event()
     terminated = asyncio.Event()

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -4135,6 +4135,75 @@ async def test_failed_subprocess_refresh_reconciles_running_state(
 
 
 @pytest.mark.asyncio
+async def test_failed_subprocess_refresh_does_not_overwrite_newer_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale failed parent must not mark a newer successful publish as failed."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("refresh me", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    knowledge_registry.mark_published_index_stale(key, reason="test_stale")
+
+    class _Stdin:
+        def write(self, _payload: bytes) -> None:
+            pass
+
+        async def drain(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+        async def wait_closed(self) -> None:
+            pass
+
+    class _Process:
+        returncode = 137
+        stdin = _Stdin()
+
+        async def wait(self) -> int:
+            knowledge_registry.mark_published_index_refresh_running(key)
+            knowledge_registry.save_published_index_state(
+                published_index_metadata_path(key),
+                knowledge_registry.PublishedIndexState(
+                    settings=key.indexing_settings,
+                    status="complete",
+                    collection="newer-success",
+                    last_published_at="2026-04-28T00:00:00+00:00",
+                    published_revision="newer-revision",
+                    indexed_count=1,
+                    source_signature="newer-source",
+                    refresh_job="idle",
+                ),
+            )
+            return self.returncode
+
+    async def _fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> _Process:
+        return _Process()
+
+    monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+
+    with pytest.raises(RuntimeError, match="exit code 137"):
+        await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
+            "docs",
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+
+    state = load_published_index_state(published_index_metadata_path(key))
+    assert state is not None
+    assert state.status == "complete"
+    assert state.collection == "newer-success"
+    assert state.refresh_job == "idle"
+    assert state.reason is None
+    assert state.last_error is None
+
+
+@pytest.mark.asyncio
 async def test_refresh_scheduler_shutdown_suppresses_completed_refresh_failures(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -4077,6 +4077,64 @@ async def test_cancelled_subprocess_refresh_reconciles_running_state(
 
 
 @pytest.mark.asyncio
+async def test_failed_subprocess_refresh_reconciles_running_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crashed child should not leave child-written metadata stuck as refreshing."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("refresh me", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    knowledge_registry.mark_published_index_stale(key, reason="test_stale")
+    initial_state = load_published_index_state(published_index_metadata_path(key))
+    assert initial_state is not None
+    assert initial_state.refresh_job == "pending"
+
+    class _Stdin:
+        def write(self, _payload: bytes) -> None:
+            pass
+
+        async def drain(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+        async def wait_closed(self) -> None:
+            pass
+
+    class _Process:
+        returncode = 137
+        stdin = _Stdin()
+
+        async def wait(self) -> int:
+            knowledge_registry.mark_published_index_refresh_running(key)
+            return self.returncode
+
+    async def _fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> _Process:
+        return _Process()
+
+    monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+
+    with pytest.raises(RuntimeError, match="exit code 137"):
+        await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
+            "docs",
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+
+    state = load_published_index_state(published_index_metadata_path(key))
+    assert state is not None
+    assert state.refresh_job == "failed"
+    assert state.reason == "refresh_failed"
+    assert state.last_error is not None
+    assert "exit code 137" in state.last_error
+
+
+@pytest.mark.asyncio
 async def test_refresh_scheduler_shutdown_suppresses_completed_refresh_failures(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -4274,7 +4274,10 @@ async def test_refresh_status_is_visible_across_scheduler_instances(
         await release.wait()
         return object()
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _blocked_refresh)
+    monkeypatch.setattr(
+        "mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess",
+        _blocked_refresh,
+    )
 
     matrix_scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
     await started.wait()

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
 from threading import Event, Lock, get_ident
 from typing import TYPE_CHECKING, ClassVar
@@ -498,7 +499,10 @@ async def test_ready_index_access_does_not_refresh_unchanged_sources(tmp_path: P
 
 
 @pytest.mark.asyncio
-async def test_shared_local_watch_index_refreshes_on_access_without_blocking_read(tmp_path: Path) -> None:
+async def test_shared_local_watch_index_refreshes_on_access_without_blocking_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Shared local bases with watch=true schedule refresh on access while serving last-good content."""
     docs_path = tmp_path / "docs"
     docs_path.mkdir()
@@ -508,6 +512,10 @@ async def test_shared_local_watch_index_refreshes_on_access_without_blocking_rea
     runtime_paths = runtime_paths_for(config)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     doc.write_text("shared local new", encoding="utf-8")
+    monkeypatch.setattr(
+        "mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess",
+        refresh_knowledge_binding,
+    )
     scheduler = KnowledgeRefreshScheduler()
 
     try:
@@ -520,7 +528,7 @@ async def test_shared_local_watch_index_refreshes_on_access_without_blocking_rea
         assert knowledge is not None
         assert [document.content for document in knowledge.search("shared", max_results=5)] == ["shared local old"]
 
-        for _attempt in range(50):
+        for _attempt in range(500):
             await asyncio.sleep(0.01)
             refreshed = resolve_agent_knowledge_access("helper", config, runtime_paths).knowledge
             if refreshed is not None and [
@@ -1218,21 +1226,21 @@ async def test_cancelled_refresh_after_refreshing_write_keeps_existing_index_sta
 
 
 @pytest.mark.asyncio
-async def test_cancelled_refresh_waiting_for_source_lock_clears_running_state(
+async def test_cancelled_refresh_waiting_for_source_lock_does_not_touch_running_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cancellation while queued behind another refresh must not leave refresh state running."""
+    """Cancellation while queued behind another refresh must not mutate refresh metadata."""
     docs_path = tmp_path / "docs"
     docs_path.mkdir()
     (docs_path / "guide.md").write_text("locked refresh", encoding="utf-8")
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     runtime_paths = runtime_paths_for(config)
-    loop = asyncio.get_running_loop()
     refreshing_write_count = 0
-    second_refreshing_saved = asyncio.Event()
     first_entered = asyncio.Event()
     release_first = asyncio.Event()
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    source_root = knowledge_registry.source_root_for_published_index_key(key)
     original_save_refreshing = knowledge_refresh_runner.mark_published_index_refresh_running
     original_reindex = KnowledgeManager.reindex_all
 
@@ -1240,8 +1248,6 @@ async def test_cancelled_refresh_waiting_for_source_lock_clears_running_state(
         nonlocal refreshing_write_count
         original_save_refreshing(*args, **kwargs)
         refreshing_write_count += 1
-        if refreshing_write_count == 2:
-            loop.call_soon_threadsafe(second_refreshing_saved.set)
 
     async def _blocked_reindex(self: KnowledgeManager) -> int:
         first_entered.set()
@@ -1254,16 +1260,16 @@ async def test_cancelled_refresh_waiting_for_source_lock_clears_running_state(
     first_task = asyncio.create_task(refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths))
     await first_entered.wait()
     second_task = asyncio.create_task(refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths))
-    await second_refreshing_saved.wait()
+    await _wait_for_refresh_lock_borrowers(source_root, 2)
 
     second_task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await second_task
 
-    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
     state = load_published_index_state(published_index_metadata_path(key))
     assert state is not None
-    assert state.refresh_job != "running"
+    assert state.refresh_job == "running"
+    assert refreshing_write_count == 1
 
     release_first.set()
     await first_task
@@ -2477,6 +2483,60 @@ async def test_shared_source_mutation_waits_for_duplicate_base_refresh(
 
     assert mutation_entered.is_set()
     assert doc.read_text(encoding="utf-8") == "mutated"
+
+
+@pytest.mark.asyncio
+async def test_refresh_uses_cross_process_source_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct refreshes should participate in the same source-root file lock as subprocess refreshes."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("index", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    expected_source_root = knowledge_registry.source_root_for_published_index_key(key)
+    locked_roots: list[knowledge_registry.KnowledgeSourceRoot] = []
+
+    @asynccontextmanager
+    async def _record_file_lock(source_root: knowledge_registry.KnowledgeSourceRoot) -> AsyncIterator[None]:
+        locked_roots.append(source_root)
+        yield
+
+    monkeypatch.setattr(knowledge_refresh_runner, "_acquire_refresh_file_lock", _record_file_lock)
+
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert locked_roots == [expected_source_root]
+
+
+@pytest.mark.asyncio
+async def test_mutation_lock_uses_cross_process_source_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Source mutations should participate in the same source-root file lock as refreshes."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    refresh_target = knowledge_registry.resolve_refresh_target("docs", config=config, runtime_paths=runtime_paths)
+    expected_source_root = knowledge_registry.source_root_for_refresh_target(refresh_target)
+    locked_roots: list[knowledge_registry.KnowledgeSourceRoot] = []
+
+    @asynccontextmanager
+    async def _record_file_lock(source_root: knowledge_registry.KnowledgeSourceRoot) -> AsyncIterator[None]:
+        locked_roots.append(source_root)
+        yield
+
+    monkeypatch.setattr(knowledge_refresh_runner, "_acquire_refresh_file_lock", _record_file_lock)
+
+    async with knowledge_binding_mutation_lock("docs", config=config, runtime_paths=runtime_paths):
+        pass
+
+    assert locked_roots == [expected_source_root]
 
 
 @pytest.mark.asyncio
@@ -3787,7 +3847,7 @@ async def test_scheduled_refresh_subprocess_receives_config_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The subprocess helper sends the scheduled config snapshot via a one-shot request file."""
+    """The subprocess helper sends the scheduled config snapshot via stdin."""
     docs_path = tmp_path / "docs"
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     config.knowledge_bases["docs"].chunk_size = 1234
@@ -3795,22 +3855,42 @@ async def test_scheduled_refresh_subprocess_receives_config_snapshot(
     captured_request: dict[str, object] = {}
     captured_args: tuple[object, ...] = ()
     captured_env: dict[str, str] = {}
+    captured_stdin: _Stdin | None = None
+
+    class _Stdin:
+        def __init__(self) -> None:
+            self.payload = bytearray()
+
+        def write(self, payload: bytes) -> None:
+            self.payload.extend(payload)
+
+        async def drain(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+        async def wait_closed(self) -> None:
+            pass
 
     class _Process:
-        returncode = 0
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdin = _Stdin()
 
         async def wait(self) -> int:
             return 0
 
     async def _fake_create_subprocess_exec(*args: object, **kwargs: object) -> _Process:
-        nonlocal captured_args, captured_env
+        nonlocal captured_args, captured_env, captured_stdin
         captured_args = args
         raw_env = kwargs["env"]
         assert isinstance(raw_env, dict)
         captured_env = raw_env
-        request_path = Path(args[-1])
-        captured_request.update(json.loads(request_path.read_text(encoding="utf-8")))
-        return _Process()
+        assert kwargs["stdin"] is asyncio.subprocess.PIPE
+        process = _Process()
+        captured_stdin = process.stdin
+        return process
 
     monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
     monkeypatch.setattr(knowledge_refresh_runner, "_subprocess_session_kwargs", dict)
@@ -3823,14 +3903,16 @@ async def test_scheduled_refresh_subprocess_receives_config_snapshot(
     )
 
     assert captured_args[:3] == (sys.executable, "-m", "mindroom.knowledge_refresh_runner")
+    assert "--request-path" not in captured_args
     assert captured_env["MINDROOM_KNOWLEDGE_REFRESH_SUBPROCESS"] == "1"
+    assert captured_stdin is not None
+    captured_request.update(json.loads(bytes(captured_stdin.payload).decode()))
     assert captured_request["base_id"] == "docs"
     assert captured_request["config_path"] == str(runtime_paths.config_path)
     assert captured_request["storage_root"] == str(runtime_paths.storage_root)
     assert "runtime_paths" not in captured_request
     assert captured_request["config_data"]["knowledge_bases"]["docs"]["chunk_size"] == 1234
     assert captured_request["execution_identity"]["requester_id"] == "@alice:localhost"
-    assert not Path(captured_args[-1]).exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 from contextlib import asynccontextmanager
+from dataclasses import replace
 from pathlib import Path
 from threading import Event, Lock, get_ident
 from typing import TYPE_CHECKING, ClassVar
@@ -2540,6 +2541,53 @@ async def test_mutation_lock_uses_cross_process_source_lock(
 
 
 @pytest.mark.asyncio
+async def test_cancelled_cross_process_file_lock_waiter_closes_unacquired_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled file-lock waiter must not leak a handle that can later acquire the lock."""
+    source_root = knowledge_registry.KnowledgeSourceRoot(storage_root="/storage", knowledge_path="/storage/docs")
+    handle = object()
+    opened = asyncio.Event()
+    closed: list[object] = []
+    released: list[object] = []
+
+    def _open(_source_root: knowledge_registry.KnowledgeSourceRoot) -> object:
+        opened.set()
+        return handle
+
+    def _try_acquire(_handle: object) -> bool:
+        assert _handle is handle
+        return False
+
+    def _close(_handle: object) -> None:
+        closed.append(_handle)
+
+    def _release(_handle: object) -> None:
+        released.append(_handle)
+
+    async def _wait_for_file_lock() -> None:
+        async with knowledge_refresh_runner._acquire_refresh_file_lock(source_root):
+            pytest.fail("lock waiter unexpectedly acquired the file lock")
+
+    monkeypatch.setattr(knowledge_refresh_runner, "_REFRESH_FILE_LOCK_POLL_SECONDS", 0.001)
+    monkeypatch.setattr(knowledge_refresh_runner, "_open_refresh_file_lock_sync", _open)
+    monkeypatch.setattr(knowledge_refresh_runner, "_try_acquire_refresh_file_lock_sync", _try_acquire)
+    monkeypatch.setattr(knowledge_refresh_runner, "_close_refresh_file_lock_sync", _close)
+    monkeypatch.setattr(knowledge_refresh_runner, "_release_refresh_file_lock_sync", _release)
+
+    waiter = asyncio.create_task(_wait_for_file_lock())
+    await opened.wait()
+    await asyncio.sleep(0)
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    assert closed == [handle]
+    assert released == []
+
+
+@pytest.mark.asyncio
 async def test_refresh_generations_keep_latest_index_without_protecting_old_handles(tmp_path: Path) -> None:
     """Old read handles are best effort; refresh cleanup only guarantees the next active index."""
     docs_path = tmp_path / "docs"
@@ -2563,6 +2611,44 @@ async def test_refresh_generations_keep_latest_index_without_protecting_old_hand
     assert latest.index is not None
     assert [document.content for document in latest.index.knowledge.search("generation", max_results=5)] == [
         "generation 6",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_published_index_reopens_when_persisted_collection_changes(tmp_path: Path) -> None:
+    """A child-process publish must invalidate stale parent process read handles."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("parent cached", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    cached_lookup = get_published_index("docs", config=config, runtime_paths=runtime_paths)
+    assert cached_lookup.index is not None
+    assert cached_lookup.state is not None
+    cached_index = cached_lookup.index
+
+    child_collection = "external_child_collection"
+    with _VectorDb.lock:
+        _VectorDb.collections[child_collection] = [
+            {"content": "child published", "metadata": {"path": "doc.md"}},
+        ]
+    child_state = replace(
+        cached_lookup.state,
+        collection=child_collection,
+        last_published_at="2026-04-27T00:00:00+00:00",
+        source_signature="child-source-signature",
+    )
+    knowledge_registry.save_published_index_state(published_index_metadata_path(cached_lookup.key), child_state)
+
+    refreshed_lookup = get_published_index("docs", config=config, runtime_paths=runtime_paths)
+
+    assert refreshed_lookup.index is not None
+    assert refreshed_lookup.index is not cached_index
+    assert refreshed_lookup.index.state == child_state
+    assert [document.content for document in refreshed_lookup.index.knowledge.search("child", max_results=5)] == [
+        "child published",
     ]
 
 
@@ -3913,6 +3999,77 @@ async def test_scheduled_refresh_subprocess_receives_config_snapshot(
     assert "runtime_paths" not in captured_request
     assert captured_request["config_data"]["knowledge_bases"]["docs"]["chunk_size"] == 1234
     assert captured_request["execution_identity"]["requester_id"] == "@alice:localhost"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_subprocess_refresh_reconciles_running_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parent cancellation should not leave child-written metadata stuck as refreshing."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("refresh me", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    wait_entered = asyncio.Event()
+    release_wait = asyncio.Event()
+    terminated = asyncio.Event()
+
+    class _Stdin:
+        def write(self, _payload: bytes) -> None:
+            pass
+
+        async def drain(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+        async def wait_closed(self) -> None:
+            pass
+
+    class _Process:
+        def __init__(self) -> None:
+            self.returncode: int | None = None
+            self.stdin = _Stdin()
+
+        async def wait(self) -> int:
+            knowledge_registry.mark_published_index_refresh_running(key)
+            wait_entered.set()
+            await release_wait.wait()
+            return self.returncode or 0
+
+    async def _fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> _Process:
+        return _Process()
+
+    async def _fake_terminate(process: _Process) -> None:
+        process.returncode = -15
+        release_wait.set()
+        terminated.set()
+
+    monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(knowledge_refresh_runner, "_terminate_refresh_subprocess", _fake_terminate)
+
+    refresh_task = asyncio.create_task(
+        knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
+            "docs",
+            config=config,
+            runtime_paths=runtime_paths,
+        ),
+    )
+    await wait_entered.wait()
+
+    refresh_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await refresh_task
+
+    assert terminated.is_set()
+    state = load_published_index_state(published_index_metadata_path(key))
+    assert state is not None
+    assert state.refresh_job == "idle"
+    assert state.reason == "refresh_cancelled"
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -4204,6 +4204,76 @@ async def test_failed_subprocess_refresh_does_not_overwrite_newer_success(
 
 
 @pytest.mark.asyncio
+async def test_failed_subprocess_refresh_reconciles_running_state_after_newer_publish(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A child crash must clear the running marker it writes on top of a newer publish."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("refresh me", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    knowledge_registry.mark_published_index_stale(key, reason="test_stale")
+
+    class _Stdin:
+        def write(self, _payload: bytes) -> None:
+            pass
+
+        async def drain(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+        async def wait_closed(self) -> None:
+            pass
+
+    class _Process:
+        returncode = 137
+        stdin = _Stdin()
+
+        async def wait(self) -> int:
+            knowledge_registry.save_published_index_state(
+                published_index_metadata_path(key),
+                knowledge_registry.PublishedIndexState(
+                    settings=key.indexing_settings,
+                    status="complete",
+                    collection="newer-success",
+                    last_published_at="2026-04-28T00:00:00+00:00",
+                    published_revision="newer-revision",
+                    indexed_count=1,
+                    source_signature="newer-source",
+                    refresh_job="idle",
+                ),
+            )
+            knowledge_registry.mark_published_index_refresh_running(key)
+            return self.returncode
+
+    async def _fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> _Process:
+        return _Process()
+
+    monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+
+    with pytest.raises(RuntimeError, match="exit code 137"):
+        await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
+            "docs",
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+
+    state = load_published_index_state(published_index_metadata_path(key))
+    assert state is not None
+    assert state.status == "complete"
+    assert state.collection == "newer-success"
+    assert state.refresh_job == "failed"
+    assert state.reason == "refresh_failed"
+    assert state.last_error is not None
+    assert "exit code 137" in state.last_error
+
+
+@pytest.mark.asyncio
 async def test_refresh_scheduler_shutdown_suppresses_completed_refresh_failures(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -7,6 +7,7 @@ import base64
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 from threading import Event, Lock, get_ident
 from typing import TYPE_CHECKING, ClassVar
@@ -3680,7 +3681,7 @@ async def test_refresh_scheduler_runs_independent_per_binding_tasks(
             raise RuntimeError(msg)
         return object()
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("a", config=config, runtime_paths=runtime_paths)
     scheduler.schedule_refresh("a", config=config, runtime_paths=runtime_paths)
@@ -3727,7 +3728,7 @@ async def test_refresh_scheduler_coalesces_duplicate_schedule_while_active(
             second_started.set()
         return object()
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
     await first_started.wait()
@@ -3782,6 +3783,57 @@ async def test_refresh_scheduler_refresh_now_runs_directly_with_force_reindex(
 
 
 @pytest.mark.asyncio
+async def test_scheduled_refresh_subprocess_receives_config_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The subprocess helper sends the scheduled config snapshot via a one-shot request file."""
+    docs_path = tmp_path / "docs"
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    config.knowledge_bases["docs"].chunk_size = 1234
+    runtime_paths = runtime_paths_for(config)
+    captured_request: dict[str, object] = {}
+    captured_args: tuple[object, ...] = ()
+    captured_env: dict[str, str] = {}
+
+    class _Process:
+        returncode = 0
+
+        async def wait(self) -> int:
+            return 0
+
+    async def _fake_create_subprocess_exec(*args: object, **kwargs: object) -> _Process:
+        nonlocal captured_args, captured_env
+        captured_args = args
+        raw_env = kwargs["env"]
+        assert isinstance(raw_env, dict)
+        captured_env = raw_env
+        request_path = Path(args[-1])
+        captured_request.update(json.loads(request_path.read_text(encoding="utf-8")))
+        return _Process()
+
+    monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(knowledge_refresh_runner, "_subprocess_session_kwargs", dict)
+
+    await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
+        "docs",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=_identity("@alice:localhost"),
+    )
+
+    assert captured_args[:3] == (sys.executable, "-m", "mindroom.knowledge_refresh_runner")
+    assert captured_env["MINDROOM_KNOWLEDGE_REFRESH_SUBPROCESS"] == "1"
+    assert captured_request["base_id"] == "docs"
+    assert captured_request["config_path"] == str(runtime_paths.config_path)
+    assert captured_request["storage_root"] == str(runtime_paths.storage_root)
+    assert "runtime_paths" not in captured_request
+    assert captured_request["config_data"]["knowledge_bases"]["docs"]["chunk_size"] == 1234
+    assert captured_request["execution_identity"]["requester_id"] == "@alice:localhost"
+    assert not Path(captured_args[-1]).exists()
+
+
+@pytest.mark.asyncio
 async def test_refresh_scheduler_shutdown_suppresses_completed_refresh_failures(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3797,7 +3849,7 @@ async def test_refresh_scheduler_shutdown_suppresses_completed_refresh_failures(
         msg = "refresh failed"
         raise RuntimeError(msg)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
     await asyncio.sleep(0)
@@ -3852,7 +3904,7 @@ async def test_refresh_status_is_visible_across_scheduler_instances(
         await release.wait()
         return object()
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding", _blocked_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _blocked_refresh)
 
     matrix_scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
     await started.wait()
@@ -5458,6 +5510,7 @@ async def test_refresh_scheduler_manual_reindex_runs_without_background_queue(
         )
 
     monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("docs", config=old_config, runtime_paths=runtime_paths)
     await first_started.wait()


### PR DESCRIPTION
## Summary
- run scheduled/background knowledge refreshes in a child interpreter
- pass the one-shot refresh request to the child over stdin instead of writing request JSON to storage
- serialize subprocess refreshes, direct refreshes, and source mutations with the same source-root file lock
- keep explicit `refresh_now()` on the direct in-process path

## Why
Knowledge refresh can involve expensive Git, embedding, reader, and vector database work. Scheduled refreshes are best-effort maintenance work and should not compete with the main process event loop or shared thread pool. Running the scheduled path in a subprocess isolates that work while preserving last-good published index behavior.

## Tests
- `uv run ruff check src/mindroom/knowledge/refresh_runner.py src/mindroom/knowledge/refresh_scheduler.py src/mindroom/knowledge_refresh_runner.py tests/test_knowledge_manager.py`
- `uv run pytest tests/test_knowledge_manager.py -x -n 0 --no-cov -q`
- `uv run python -m mindroom.knowledge_refresh_runner --help`