### PR TITLE
Refactor response lifecycle coordination

### DIFF
--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -3,23 +3,160 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, TypeVar, cast
 
+from mindroom.ai_runtime import queued_message_signal_context
+from mindroom.hooks import is_automation_source_kind
 from mindroom.post_response_effects import apply_post_response_effects
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Awaitable, Callable
 
     from agno.db.base import BaseDb, SessionType
 
     from mindroom.final_delivery import FinalDeliveryOutcome
     from mindroom.history import HistoryScope
     from mindroom.hooks import MessageEnvelope
+    from mindroom.message_target import MessageTarget
     from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutcome
+    from mindroom.timing import DispatchPipelineTiming
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
 
     from .response_runner import ResponseRequest, ResponseRunner
+
+_LockedResponseResult = TypeVar("_LockedResponseResult")
+
+
+@dataclass
+class _QueuedMessageState:
+    """Track queued human ingress while one response lifecycle holds the lock."""
+
+    pending_human_messages: int = 0
+    _active_response_turns: int = 0
+    _event: asyncio.Event = field(default_factory=asyncio.Event)
+
+    def begin_response_turn(self) -> bool:
+        existing_turn = self._active_response_turns > 0
+        self._active_response_turns += 1
+        return existing_turn
+
+    def finish_response_turn(self) -> None:
+        if self._active_response_turns == 0:
+            return
+        self._active_response_turns -= 1
+
+    def add_waiting_human_message(self) -> None:
+        self.pending_human_messages += 1
+        self._event.set()
+
+    def consume_waiting_human_message(self) -> None:
+        if self.pending_human_messages == 0:
+            return
+        self.pending_human_messages -= 1
+        if self.pending_human_messages == 0:
+            self._event.clear()
+
+    def has_pending_human_messages(self) -> bool:
+        return self.pending_human_messages > 0
+
+    def has_active_response_turn(self) -> bool:
+        return self._active_response_turns > 0
+
+    async def wait(self) -> None:
+        await self._event.wait()
+
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+
+@dataclass
+class ResponseLifecycleCoordinator:
+    """Serialize response turns and signal active turns about queued human ingress."""
+
+    _response_lifecycle_locks: dict[tuple[str, str | None], asyncio.Lock] = field(default_factory=dict)
+    _thread_queued_signals: dict[tuple[str, str | None], _QueuedMessageState] = field(default_factory=dict)
+
+    def has_active_response_for_target(self, target: MessageTarget) -> bool:
+        """Return whether one canonical conversation target already has an active turn."""
+        thread_key = (target.room_id, target.resolved_thread_id)
+        queued_signal = self._thread_queued_signals.get(thread_key)
+        if queued_signal is not None and queued_signal.has_active_response_turn():
+            return True
+        lifecycle_lock = self._response_lifecycle_locks.get(thread_key)
+        return lifecycle_lock.locked() if lifecycle_lock is not None else False
+
+    def _response_lifecycle_lock(self, target: MessageTarget) -> asyncio.Lock:
+        """Return the per-target lock that serializes one response lifecycle."""
+        lock_key = (target.room_id, target.resolved_thread_id)
+        lock = self._response_lifecycle_locks.get(lock_key)
+        if lock is not None:
+            return lock
+        if len(self._response_lifecycle_locks) >= 100:
+            for candidate, candidate_lock in list(self._response_lifecycle_locks.items()):
+                if len(self._response_lifecycle_locks) < 100:
+                    break
+                if candidate_lock.locked():
+                    continue
+                self._response_lifecycle_locks.pop(candidate, None)
+                self._thread_queued_signals.pop(candidate, None)
+        lock = asyncio.Lock()
+        self._response_lifecycle_locks[lock_key] = lock
+        return lock
+
+    def _get_or_create_queued_signal(self, target: MessageTarget) -> _QueuedMessageState:
+        """Return the queued-message signal for one canonical conversation thread."""
+        thread_key = (target.room_id, target.resolved_thread_id)
+        signal = self._thread_queued_signals.get(thread_key)
+        if signal is not None:
+            return signal
+        signal = _QueuedMessageState()
+        self._thread_queued_signals[thread_key] = signal
+        return signal
+
+    @staticmethod
+    def _should_signal_queued_message(response_envelope: MessageEnvelope | None) -> bool:
+        """Return whether one queued ingress should interrupt the active turn."""
+        return response_envelope is not None and not is_automation_source_kind(response_envelope.source_kind)
+
+    async def run_locked_response(
+        self,
+        *,
+        target: MessageTarget,
+        response_envelope: MessageEnvelope | None,
+        pipeline_timing: DispatchPipelineTiming | None,
+        locked_operation: Callable[[MessageTarget], Awaitable[_LockedResponseResult]],
+    ) -> _LockedResponseResult:
+        """Run one locked response operation with shared queued-message bookkeeping."""
+        lifecycle_lock = self._response_lifecycle_lock(target)
+        queued_signal = self._get_or_create_queued_signal(target)
+        existing_turn = queued_signal.begin_response_turn()
+        queued_human_message = (existing_turn or lifecycle_lock.locked()) and self._should_signal_queued_message(
+            response_envelope,
+        )
+        if queued_human_message:
+            queued_signal.add_waiting_human_message()
+        lock_acquired = False
+        try:
+            if pipeline_timing is not None:
+                pipeline_timing.mark("lock_wait_start")
+            await lifecycle_lock.acquire()
+            lock_acquired = True
+            if pipeline_timing is not None:
+                pipeline_timing.mark("lock_acquired")
+            try:
+                if queued_human_message:
+                    queued_signal.consume_waiting_human_message()
+                    queued_human_message = False
+                with queued_message_signal_context(queued_signal):
+                    return await locked_operation(target)
+            finally:
+                if lock_acquired:
+                    lifecycle_lock.release()
+        finally:
+            if queued_human_message:
+                queued_signal.consume_waiting_human_message()
+            queued_signal.finish_response_turn()
 
 
 @dataclass(frozen=True)

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -19,7 +19,6 @@ from mindroom.ai import (
     build_matrix_run_metadata,
     stream_agent_response,
 )
-from mindroom.ai_runtime import queued_message_signal_context
 from mindroom.background_tasks import create_background_task
 from mindroom.constants import (
     ATTACHMENT_IDS_KEY,
@@ -38,7 +37,6 @@ from mindroom.hooks import (
     MessageEnvelope,
     SessionHookContext,
     emit,
-    is_automation_source_kind,
 )
 from mindroom.knowledge import (
     KnowledgeAccessSupport,
@@ -91,7 +89,7 @@ from .delivery_gateway import (
     StreamingDeliveryRequest,
 )
 from .media_inputs import MediaInputs
-from .response_lifecycle import ResponseLifecycle
+from .response_lifecycle import ResponseLifecycle, ResponseLifecycleCoordinator
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Mapping, Sequence
@@ -313,48 +311,6 @@ def prepare_memory_and_model_context(
     return prompt, thread_history, model_prompt_text, model_thread_history
 
 
-@dataclass
-class _QueuedMessageState:
-    """Track queued human ingress while one response lifecycle holds the lock."""
-
-    pending_human_messages: int = 0
-    _active_response_turns: int = 0
-    _event: asyncio.Event = field(default_factory=asyncio.Event)
-
-    def begin_response_turn(self) -> bool:
-        existing_turn = self._active_response_turns > 0
-        self._active_response_turns += 1
-        return existing_turn
-
-    def finish_response_turn(self) -> None:
-        if self._active_response_turns == 0:
-            return
-        self._active_response_turns -= 1
-
-    def add_waiting_human_message(self) -> None:
-        self.pending_human_messages += 1
-        self._event.set()
-
-    def consume_waiting_human_message(self) -> None:
-        if self.pending_human_messages == 0:
-            return
-        self.pending_human_messages -= 1
-        if self.pending_human_messages == 0:
-            self._event.clear()
-
-    def has_pending_human_messages(self) -> bool:
-        return self.pending_human_messages > 0
-
-    def has_active_response_turn(self) -> bool:
-        return self._active_response_turns > 0
-
-    async def wait(self) -> None:
-        await self._event.wait()
-
-    def is_set(self) -> bool:
-        return self._event.is_set()
-
-
 @dataclass(frozen=True)
 class ResponseRequest:
     """Typed carrier for one response lifecycle request."""
@@ -432,8 +388,10 @@ class ResponseRunner:
     """Run one response lifecycle while keeping bot seams patchable."""
 
     deps: ResponseRunnerDeps
-    _response_lifecycle_locks: dict[tuple[str, str | None], asyncio.Lock] = field(default_factory=dict, init=False)
-    _thread_queued_signals: dict[tuple[str, str | None], _QueuedMessageState] = field(default_factory=dict, init=False)
+    _lifecycle_coordinator: ResponseLifecycleCoordinator = field(
+        default_factory=ResponseLifecycleCoordinator,
+        init=False,
+    )
     _in_flight_response_count: int = field(default=0, init=False)
 
     def _client(self) -> nio.AsyncClient:
@@ -617,12 +575,7 @@ class ResponseRunner:
 
     def has_active_response_for_target(self, target: MessageTarget) -> bool:
         """Return whether one canonical conversation target already has an active turn."""
-        thread_key = (target.room_id, target.resolved_thread_id)
-        queued_signal = self._thread_queued_signals.get(thread_key)
-        if queued_signal is not None and queued_signal.has_active_response_turn():
-            return True
-        lifecycle_lock = self._response_lifecycle_locks.get(thread_key)
-        return lifecycle_lock.locked() if lifecycle_lock is not None else False
+        return self._lifecycle_coordinator.has_active_response_for_target(target)
 
     async def _run_in_tool_context(
         self,
@@ -666,39 +619,6 @@ class ResponseRunner:
             )
         )
 
-    def _response_lifecycle_lock(self, target: MessageTarget) -> asyncio.Lock:
-        """Return the per-target lock that serializes one response lifecycle."""
-        lock_key = (target.room_id, target.resolved_thread_id)
-        lock = self._response_lifecycle_locks.get(lock_key)
-        if lock is not None:
-            return lock
-        if len(self._response_lifecycle_locks) >= 100:
-            for candidate, candidate_lock in list(self._response_lifecycle_locks.items()):
-                if len(self._response_lifecycle_locks) < 100:
-                    break
-                if candidate_lock.locked():
-                    continue
-                self._response_lifecycle_locks.pop(candidate, None)
-                self._thread_queued_signals.pop(candidate, None)
-        lock = asyncio.Lock()
-        self._response_lifecycle_locks[lock_key] = lock
-        return lock
-
-    def _get_or_create_queued_signal(self, target: MessageTarget) -> _QueuedMessageState:
-        """Return the queued-message signal for one canonical conversation thread."""
-        thread_key = (target.room_id, target.resolved_thread_id)
-        signal = self._thread_queued_signals.get(thread_key)
-        if signal is not None:
-            return signal
-        signal = _QueuedMessageState()
-        self._thread_queued_signals[thread_key] = signal
-        return signal
-
-    @staticmethod
-    def _should_signal_queued_message(response_envelope: MessageEnvelope | None) -> bool:
-        """Return whether one queued ingress should interrupt the active turn."""
-        return response_envelope is not None and not is_automation_source_kind(response_envelope.source_kind)
-
     def _active_response_event_ids(self, room_id: str) -> set[str]:
         """Return still-running response event IDs for one room."""
         return {
@@ -715,35 +635,12 @@ class ResponseRunner:
     ) -> str | None:
         """Run one locked response operation with shared queued-message bookkeeping."""
         resolved_target = self._resolve_request_target(request)
-        lifecycle_lock = self._response_lifecycle_lock(resolved_target)
-        queued_signal = self._get_or_create_queued_signal(resolved_target)
-        existing_turn = queued_signal.begin_response_turn()
-        queued_human_message = (existing_turn or lifecycle_lock.locked()) and self._should_signal_queued_message(
-            request.response_envelope,
+        return await self._lifecycle_coordinator.run_locked_response(
+            target=resolved_target,
+            response_envelope=request.response_envelope,
+            pipeline_timing=request.pipeline_timing,
+            locked_operation=locked_operation,
         )
-        if queued_human_message:
-            queued_signal.add_waiting_human_message()
-        lock_acquired = False
-        try:
-            if request.pipeline_timing is not None:
-                request.pipeline_timing.mark("lock_wait_start")
-            await lifecycle_lock.acquire()
-            lock_acquired = True
-            if request.pipeline_timing is not None:
-                request.pipeline_timing.mark("lock_acquired")
-            try:
-                if queued_human_message:
-                    queued_signal.consume_waiting_human_message()
-                    queued_human_message = False
-                with queued_message_signal_context(queued_signal):
-                    return await locked_operation(resolved_target)
-            finally:
-                if lock_acquired:
-                    lifecycle_lock.release()
-        finally:
-            if queued_human_message:
-                queued_signal.consume_waiting_human_message()
-            queued_signal.finish_response_turn()
 
     def _build_persist_response_event_id_effect(
         self,

--- a/tach.toml
+++ b/tach.toml
@@ -116,7 +116,7 @@ visibility = [
     "mindroom.api.openai_compat",
     "mindroom.execution_preparation",
     "mindroom.history.runtime",
-    "mindroom.response_runner",
+    "mindroom.response_lifecycle",
     "mindroom.teams",
     "mindroom.thread_summary",
     "mindroom.topic_generator",
@@ -751,7 +751,6 @@ depends_on = [
     "mindroom.agent_storage",
     "mindroom.agents",
     "mindroom.ai",
-    "mindroom.ai_runtime",
     "mindroom.constants",
     "mindroom.delivery_gateway",
     "mindroom.history",
@@ -763,11 +762,21 @@ depends_on = [
     "mindroom.memory",
     "mindroom.orchestration.runtime",
     "mindroom.post_response_effects",
+    "mindroom.response_lifecycle",
     "mindroom.streaming",
     "mindroom.teams",
     "mindroom.thread_summary",
     "mindroom.tool_system.runtime_context", "mindroom.tool_system.worker_routing",
 ]
+
+[[modules]]
+path = "mindroom.response_lifecycle"
+depends_on = [
+    "mindroom.ai_runtime",
+    "mindroom.hooks",
+    "mindroom.post_response_effects",
+]
+visibility = ["mindroom.response_runner"]
 
 [[modules]]
 path = "mindroom.routing"

--- a/tests/test_config_architecture_boundaries.py
+++ b/tests/test_config_architecture_boundaries.py
@@ -14,6 +14,7 @@ CONCRETE_ORCHESTRATOR_IMPORT_ALLOWLIST = {
 }
 RUNTIME_PROTOCOLS_MODULE = Path("src/mindroom/runtime_protocols.py")
 MATRIX_MESSAGE_TOOL_MODULE = Path("src/mindroom/custom_tools/matrix_message.py")
+RESPONSE_RUNNER_MODULE = Path("src/mindroom/response_runner.py")
 MATRIX_MESSAGE_LOW_LEVEL_IMPORTS = frozenset(
     {
         "mindroom.custom_tools.attachments",
@@ -171,3 +172,24 @@ def test_matrix_message_tool_uses_conversation_operations_boundary() -> None:
             )
 
     assert forbidden == []
+
+
+def test_response_runner_delegates_lifecycle_coordination() -> None:
+    """ResponseRunner should delegate lock and queued-turn state to response_lifecycle."""
+    tree = ast.parse(RESPONSE_RUNNER_MODULE.read_text(encoding="utf-8"))
+    forbidden_names = {
+        "_QueuedMessageState",
+        "_get_or_create_queued_signal",
+        "_response_lifecycle_lock",
+        "_response_lifecycle_locks",
+        "_should_signal_queued_message",
+        "_thread_queued_signals",
+    }
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef) and node.name in forbidden_names:
+            found.append(f"{RESPONSE_RUNNER_MODULE}:{node.lineno}: {node.name}")
+        if isinstance(node, ast.Name) and node.id in forbidden_names:
+            found.append(f"{RESPONSE_RUNNER_MODULE}:{node.lineno}: {node.id}")
+
+    assert found == []

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -5304,8 +5304,9 @@ class TestAgentBot:
         ).with_thread_root("$root_b")
 
         coordinator = unwrap_extracted_collaborator(bot._response_runner)
-        assert coordinator._response_lifecycle_lock(first) is coordinator._response_lifecycle_lock(first)
-        assert coordinator._response_lifecycle_lock(first) is not coordinator._response_lifecycle_lock(second)
+        lifecycle = coordinator._lifecycle_coordinator
+        assert lifecycle._response_lifecycle_lock(first) is lifecycle._response_lifecycle_lock(first)
+        assert lifecycle._response_lifecycle_lock(first) is not lifecycle._response_lifecycle_lock(second)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -447,8 +447,9 @@ async def test_generate_response_sets_queued_signal_for_human_ingress(tmp_path: 
     response_envelope = _envelope()
     response_target = response_envelope.target
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
-    lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
-    queued_signal = coordinator._get_or_create_queued_signal(response_target)
+    lifecycle = coordinator._lifecycle_coordinator
+    lifecycle_lock = lifecycle._response_lifecycle_lock(response_target)
+    queued_signal = lifecycle._get_or_create_queued_signal(response_target)
     await lifecycle_lock.acquire()
 
     try:
@@ -486,8 +487,9 @@ async def test_generate_response_skips_signal_for_automation_ingress(tmp_path: P
     response_envelope = _envelope(source_kind="scheduled")
     response_target = response_envelope.target
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
-    lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
-    queued_signal = coordinator._get_or_create_queued_signal(response_target)
+    lifecycle = coordinator._lifecycle_coordinator
+    lifecycle_lock = lifecycle._response_lifecycle_lock(response_target)
+    queued_signal = lifecycle._get_or_create_queued_signal(response_target)
     await lifecycle_lock.acquire()
 
     try:
@@ -536,12 +538,12 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
     ) -> str:
         del resolved_target
         user_id = str(request.user_id)
-        queued_signal = coordinator._get_or_create_queued_signal(response_target)
+        queued_signal = coordinator._lifecycle_coordinator._get_or_create_queued_signal(response_target)
         observed_pending[user_id] = queued_signal.pending_human_messages
         return user_id
 
     with (
-        patch.object(coordinator, "_response_lifecycle_lock", return_value=lock),
+        patch.object(coordinator._lifecycle_coordinator, "_response_lifecycle_lock", return_value=lock),
         patch.object(ResponseRunner, "generate_response_locked", new=fake_generate_response_locked),
     ):
         first_task = asyncio.create_task(
@@ -585,7 +587,7 @@ async def test_generate_response_waits_for_lock_before_starting_placeholder_life
     response_envelope = _envelope(source_kind="scheduled")
     response_target = response_envelope.target
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
-    lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
+    lifecycle_lock = coordinator._lifecycle_coordinator._response_lifecycle_lock(response_target)
     await lifecycle_lock.acquire()
     lifecycle_started = asyncio.Event()
 
@@ -707,8 +709,9 @@ async def test_generate_team_response_helper_sets_queued_signal(tmp_path: Path) 
     response_envelope = _envelope()
     response_target = response_envelope.target
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
-    lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
-    queued_signal = coordinator._get_or_create_queued_signal(response_target)
+    lifecycle = coordinator._lifecycle_coordinator
+    lifecycle_lock = lifecycle._response_lifecycle_lock(response_target)
+    queued_signal = lifecycle._get_or_create_queued_signal(response_target)
     await lifecycle_lock.acquire()
 
     try:
@@ -748,8 +751,9 @@ async def test_generate_response_preserves_later_queued_human_message(tmp_path: 
     response_envelope = _envelope()
     response_target = response_envelope.target
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
-    lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
-    queued_signal = coordinator._get_or_create_queued_signal(response_target)
+    lifecycle = coordinator._lifecycle_coordinator
+    lifecycle_lock = lifecycle._response_lifecycle_lock(response_target)
+    queued_signal = lifecycle._get_or_create_queued_signal(response_target)
     observed_pending: list[bool] = []
     second_turn_started = asyncio.Event()
     allow_turns_to_finish = asyncio.Event()
@@ -815,8 +819,9 @@ async def test_generate_team_response_preserves_later_queued_human_message(tmp_p
     response_envelope = _envelope()
     response_target = response_envelope.target
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
-    lifecycle_lock = coordinator._response_lifecycle_lock(response_target)
-    queued_signal = coordinator._get_or_create_queued_signal(response_target)
+    lifecycle = coordinator._lifecycle_coordinator
+    lifecycle_lock = lifecycle._response_lifecycle_lock(response_target)
+    queued_signal = lifecycle._get_or_create_queued_signal(response_target)
     observed_pending: list[bool] = []
     second_turn_started = asyncio.Event()
     allow_turns_to_finish = asyncio.Event()
@@ -914,7 +919,7 @@ async def test_coalesced_dispatch_never_creates_queued_signal(tmp_path: Path) ->
     assert bot._turn_store.is_handled("$older")
     mock_plan.assert_not_awaited()
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
-    assert coordinator._thread_queued_signals == {}
+    assert coordinator._lifecycle_coordinator._thread_queued_signals == {}
 
 
 def test_notice_hook_keeps_single_notice_at_end_and_skips_stop_after_tool_call() -> None:


### PR DESCRIPTION
## Summary
- move per-target response locks and queued-human-message state from ResponseRunner into ResponseLifecycleCoordinator
- delegate active response checks and locked response execution through the lifecycle module
- add a boundary guard and Tach module entry so lifecycle coordination stays out of ResponseRunner

## Verification
- uv run pre-commit run --all-files
- uv run tach check --dependencies --interfaces
- uv run pytest tests/ -x -nauto --no-cov -q