### PR TITLE
Cache plugin roots and offload skill snapshots

### DIFF
--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1640,10 +1640,10 @@ async def _watch_skills_task(orchestrator: MultiAgentOrchestrator) -> None:
     """Watch skill roots for changes and clear cached skills."""
     while not orchestrator.running:  # noqa: ASYNC110
         await asyncio.sleep(0.1)
-    last_snapshot = get_skill_snapshot()
+    last_snapshot = await asyncio.to_thread(get_skill_snapshot)
     while orchestrator.running:
         await asyncio.sleep(1.0)
-        snapshot = get_skill_snapshot()
+        snapshot = await asyncio.to_thread(get_skill_snapshot)
         if snapshot != last_snapshot:
             last_snapshot = snapshot
             clear_skill_cache()

--- a/src/mindroom/tool_system/plugins.py
+++ b/src/mindroom/tool_system/plugins.py
@@ -6,7 +6,7 @@ import asyncio
 import sys
 from dataclasses import dataclass
 from importlib import util
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from mindroom.config.plugin import PluginEntryConfig  # noqa: TC001
 from mindroom.hooks import HookRegistry, iter_module_hooks
@@ -36,6 +36,18 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 PluginValidationError = plugin_imports.PluginValidationError
+_CONFIGURED_PLUGIN_ROOT_CACHE_MAX_SIZE = 128
+
+
+class _ConfiguredPluginRootCacheKey(NamedTuple):
+    plugin_entries: tuple[tuple[str, bool], ...]
+    config_path: str
+    config_dir: str
+    storage_root: str
+    sys_path: tuple[str, ...]
+
+
+_CONFIGURED_PLUGIN_ROOT_CACHE: dict[_ConfiguredPluginRootCacheKey, tuple[Path, ...]] = {}
 
 
 @dataclass(frozen=True)
@@ -158,6 +170,11 @@ def get_configured_plugin_roots(
     runtime_paths: RuntimePaths,
 ) -> tuple[Path, ...]:
     """Resolve the enabled plugin roots for one config snapshot."""
+    cache_key = _configured_plugin_root_cache_key(config, runtime_paths)
+    cached = _CONFIGURED_PLUGIN_ROOT_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
     roots: list[Path] = []
     for plugin_entry in config.plugins:
         if not plugin_entry.enabled:
@@ -166,7 +183,29 @@ def get_configured_plugin_roots(
             roots.append(plugin_imports._resolve_plugin_root(plugin_entry.path, runtime_paths))
         except PluginValidationError:
             continue
-    return tuple(dict.fromkeys(roots))
+    configured_roots = tuple(dict.fromkeys(roots))
+    if len(_CONFIGURED_PLUGIN_ROOT_CACHE) >= _CONFIGURED_PLUGIN_ROOT_CACHE_MAX_SIZE:
+        _CONFIGURED_PLUGIN_ROOT_CACHE.clear()
+    _CONFIGURED_PLUGIN_ROOT_CACHE[cache_key] = configured_roots
+    return configured_roots
+
+
+def _configured_plugin_root_cache_key(
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> _ConfiguredPluginRootCacheKey:
+    return _ConfiguredPluginRootCacheKey(
+        plugin_entries=tuple((plugin_entry.path, plugin_entry.enabled) for plugin_entry in config.plugins),
+        config_path=str(runtime_paths.config_path),
+        config_dir=str(runtime_paths.config_dir),
+        storage_root=str(runtime_paths.storage_root),
+        sys_path=tuple(str(path) for path in sys.path),
+    )
+
+
+def _clear_configured_plugin_roots_cache() -> None:
+    """Drop cached configured plugin roots after plugin runtime invalidation."""
+    _CONFIGURED_PLUGIN_ROOT_CACHE.clear()
 
 
 def prepare_plugin_reload(
@@ -272,6 +311,7 @@ def _iter_module_tasks(value: object) -> tuple[asyncio.Task[Any], ...]:
 
 def _clear_plugin_reload_caches() -> None:
     """Drop cached plugin manifests and imported plugin modules before one rebuild."""
+    _clear_configured_plugin_roots_cache()
     plugin_imports._PLUGIN_CACHE.clear()
     plugin_imports._MODULE_IMPORT_CACHE.clear()
 

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yaml
 
+import mindroom.orchestrator as orchestrator_module
 import mindroom.tool_system.plugin_imports as plugin_module
 from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig, CultureConfig, TeamConfig
@@ -25,7 +26,7 @@ from mindroom.matrix.users import AgentMatrixUser
 from mindroom.orchestration.config_updates import ConfigUpdatePlan, _get_changed_agents
 from mindroom.orchestration.plugin_watch import watch_plugins_task
 from mindroom.orchestration.runtime import create_logged_task
-from mindroom.orchestrator import MultiAgentOrchestrator, _ConfigReloadDrainState
+from mindroom.orchestrator import MultiAgentOrchestrator, _ConfigReloadDrainState, _watch_skills_task
 from mindroom.tool_system.plugins import PluginReloadResult
 from mindroom.tool_system.skills import _get_plugin_skill_roots, set_plugin_skill_roots
 from tests.conftest import (
@@ -51,6 +52,46 @@ def setup_test_bot(bot: AgentBot, mock_client: AsyncMock) -> None:
     bot.client = mock_client
     bot.event_cache = make_event_cache_mock()
     bot.event_cache_write_coordinator = make_event_cache_write_coordinator_mock()
+
+
+@pytest.mark.asyncio
+async def test_watch_skills_task_snapshots_off_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The skills watcher should not run recursive skill snapshots on the asyncio loop."""
+
+    class DummyOrchestrator:
+        running = True
+
+    dummy_orchestrator = DummyOrchestrator()
+    snapshot_function_calls: list[object] = []
+    clear_calls = 0
+
+    def direct_snapshot_call() -> object:
+        raise AssertionError
+
+    async def fake_to_thread(function: object, *args: object, **kwargs: object) -> tuple[tuple[str, int, int], ...]:
+        del args, kwargs
+        snapshot_function_calls.append(function)
+        if len(snapshot_function_calls) == 1:
+            return (("before", 1, 1),)
+        dummy_orchestrator.running = False
+        return (("after", 2, 2),)
+
+    async def fake_sleep(delay: float) -> None:
+        del delay
+
+    def fake_clear_skill_cache() -> None:
+        nonlocal clear_calls
+        clear_calls += 1
+
+    monkeypatch.setattr(orchestrator_module, "get_skill_snapshot", direct_snapshot_call)
+    monkeypatch.setattr(orchestrator_module.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(orchestrator_module.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(orchestrator_module, "clear_skill_cache", fake_clear_skill_cache)
+
+    await _watch_skills_task(dummy_orchestrator)  # type: ignore[arg-type]
+
+    assert snapshot_function_calls == [direct_snapshot_call, direct_snapshot_call]
+    assert clear_calls == 1
 
 
 def _write_plugin_removal_test_files(tmp_path: Path) -> Path:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -13,12 +13,13 @@ import pytest
 
 import mindroom.tool_system.metadata as metadata_module
 import mindroom.tool_system.plugin_imports as plugin_module
+import mindroom.tool_system.plugins as plugins_module
 import mindroom.tools  # noqa: F401
 from mindroom.config.main import Config, ConfigRuntimeValidationError, load_config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.hooks import EVENT_MESSAGE_RECEIVED, HookRegistry
 from mindroom.tool_system.metadata import _TOOL_REGISTRY, TOOL_METADATA, get_tool_by_name
-from mindroom.tool_system.plugins import load_plugins, reload_plugins
+from mindroom.tool_system.plugins import get_configured_plugin_roots, load_plugins, reload_plugins
 from mindroom.tool_system.skills import _get_plugin_skill_roots, set_plugin_skill_roots
 from tests.conftest import bind_runtime_paths, runtime_paths_for
 
@@ -367,6 +368,41 @@ def test_resolve_plugin_root_relative_to_config_dir_not_cwd(tmp_path: Path) -> N
         os.chdir(original_cwd)
 
     assert resolved == plugin_root.resolve()
+
+
+def test_get_configured_plugin_roots_memoizes_resolved_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Repeated configured-root reads should not re-resolve paths for the same config snapshot."""
+    plugin_root = tmp_path / "plugins" / "demo"
+    plugin_root.mkdir(parents=True)
+    (plugin_root / "mindroom.plugin.json").write_text(
+        json.dumps({"name": "demo-plugin", "tools_module": None, "skills": []}),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("agents: {}", encoding="utf-8")
+    config = _bind_runtime_paths(Config(plugins=["./plugins/demo"]), config_path)
+    runtime_paths = runtime_paths_for(config)
+    resolve_calls: list[str] = []
+    original_resolve_plugin_root = plugin_module._resolve_plugin_root
+
+    def counted_resolve_plugin_root(plugin_path: str, runtime_paths: RuntimePaths) -> Path:
+        resolve_calls.append(plugin_path)
+        return original_resolve_plugin_root(plugin_path, runtime_paths)
+
+    plugins_module._clear_configured_plugin_roots_cache()
+    monkeypatch.setattr(plugin_module, "_resolve_plugin_root", counted_resolve_plugin_root)
+    try:
+        first_roots = get_configured_plugin_roots(config, runtime_paths)
+        second_roots = get_configured_plugin_roots(config, runtime_paths)
+    finally:
+        plugins_module._clear_configured_plugin_roots_cache()
+
+    assert first_roots == (plugin_root.resolve(),)
+    assert second_roots == first_roots
+    assert resolve_calls == ["./plugins/demo"]
 
 
 def test_load_plugins_uses_bound_runtime_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a bounded cache for get_configured_plugin_roots keyed by plugin entries, runtime paths, and sys.path.
- Clear the configured-root cache with plugin reload caches.
- Move the skills watcher SKILL.md snapshot walk off the asyncio event loop with asyncio.to_thread.
- Add regression tests for both behaviors.

## Testing
- PASS: uv run pytest tests/test_plugins.py::test_get_configured_plugin_roots_memoizes_resolved_roots tests/test_config_reload.py::test_watch_skills_task_snapshots_off_event_loop -q --no-cov
- PASS: uv run pytest tests/test_plugins.py tests/test_config_reload.py -q --no-cov (91 passed, 1 skipped)
- PASS: uv run pre-commit run --all-files
- PASS: uv run pytest --no-cov -k "not postgres" (5469 passed, 50 skipped)
- BLOCKED: uv run pytest --no-cov reached 5480 passed / 50 skipped, but 37 PostgreSQL-parametrized event-cache tests errored because Docker-published Postgres test containers did not expose or accept connections on their mapped ports (for example, docker port reported no public 5432/tcp mapping or psycopg got connection refused).
