### PR TITLE
Refactor response lifecycle dependencies

### DIFF
--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -1,4 +1,4 @@
-"""Shared response lifecycle helpers for ResponseRunner."""
+"""Shared response lifecycle helpers."""
 
 from __future__ import annotations
 
@@ -6,15 +6,21 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypeVar, cast
 
+from agno.db.base import SessionType
+
+from mindroom.agent_storage import get_agent_session, get_team_session
 from mindroom.ai_runtime import queued_message_signal_context
-from mindroom.hooks import is_automation_source_kind
+from mindroom.hooks import EVENT_SESSION_STARTED, SessionHookContext, emit, is_automation_source_kind
 from mindroom.post_response_effects import apply_post_response_effects
+from mindroom.tool_system.runtime_context import resolve_tool_runtime_hook_bindings
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-    from agno.db.base import BaseDb, SessionType
+    from agno.db.base import BaseDb
+    from structlog.stdlib import BoundLogger
 
+    from mindroom.delivery_gateway import ResponseHookService
     from mindroom.final_delivery import FinalDeliveryOutcome
     from mindroom.history import HistoryScope
     from mindroom.hooks import MessageEnvelope
@@ -22,8 +28,6 @@ if TYPE_CHECKING:
     from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutcome
     from mindroom.timing import DispatchPipelineTiming
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
-
-    from .response_runner import ResponseRequest, ResponseRunner
 
 _LockedResponseResult = TypeVar("_LockedResponseResult")
 
@@ -174,23 +178,105 @@ class SessionStartedWatch:
     create_storage: Callable[[], BaseDb]
 
 
+@dataclass(frozen=True)
+class ResponseLifecycleDeps:
+    """Dependencies owned by the response lifecycle boundary."""
+
+    response_hooks: ResponseHookService
+    logger: BoundLogger
+
+
+def _session_exists(
+    *,
+    storage: BaseDb,
+    session_id: str,
+    session_type: SessionType,
+) -> bool:
+    if session_type is SessionType.TEAM:
+        return get_team_session(storage, session_id) is not None
+    return get_agent_session(storage, session_id) is not None
+
+
+def response_outcome_label(final_delivery_outcome: FinalDeliveryOutcome | None) -> str:
+    """Return one pipeline outcome label for the canonical final delivery outcome."""
+    if final_delivery_outcome is not None and final_delivery_outcome.suppressed:
+        return "suppressed"
+    if final_delivery_outcome is not None and final_delivery_outcome.terminal_status == "cancelled":
+        return "cancelled"
+    if final_delivery_outcome is not None and final_delivery_outcome.terminal_status == "error":
+        return "error"
+    if final_delivery_outcome is not None and final_delivery_outcome.delivery_kind is not None:
+        return final_delivery_outcome.delivery_kind
+    if (
+        final_delivery_outcome is not None
+        and final_delivery_outcome.event_id is not None
+        and final_delivery_outcome.is_visible_response
+    ):
+        return "visible_response_preserved"
+    return "no_visible_response"
+
+
 class ResponseLifecycle:
     """Consolidate lifecycle helpers shared across response paths."""
 
     def __init__(
         self,
-        runner: ResponseRunner,
+        deps: ResponseLifecycleDeps,
         *,
         response_kind: str,
-        request: ResponseRequest,
+        pipeline_timing: DispatchPipelineTiming | None,
         response_envelope: MessageEnvelope,
         correlation_id: str,
     ) -> None:
-        self.runner = runner
+        self.deps = deps
         self.response_kind = response_kind
-        self.request = request
+        self.pipeline_timing = pipeline_timing
         self.response_envelope = response_envelope
         self.correlation_id = correlation_id
+
+    def _log_effects_failure_after_visible_delivery(
+        self,
+        *,
+        response_event_id: str,
+        error: BaseException,
+    ) -> None:
+        """Log one non-fatal post-response failure after visible delivery succeeded."""
+        self.deps.logger.error(
+            "Post-response effects failed after visible delivery",
+            response_kind=self.response_kind,
+            response_event_id=response_event_id,
+            failure_reason=str(error),
+            error_type=error.__class__.__name__,
+        )
+
+    def _session_started_watch_is_needed(
+        self,
+        *,
+        tool_context: ToolRuntimeContext | None,
+        session_id: str,
+        session_type: SessionType,
+        create_storage: Callable[[], BaseDb],
+    ) -> bool:
+        if tool_context is None or not tool_context.hook_registry.has_hooks(EVENT_SESSION_STARTED):
+            return False
+        try:
+            storage = create_storage()
+            try:
+                return not _session_exists(
+                    storage=storage,
+                    session_id=session_id,
+                    session_type=session_type,
+                )
+            finally:
+                storage.close()
+        except Exception as error:
+            self.deps.logger.exception(
+                "Failed to probe session storage for session:started eligibility",
+                session_id=session_id,
+                session_type=str(session_type),
+                failure_reason=str(error),
+            )
+            return False
 
     def setup_session_watch(
         self,
@@ -205,7 +291,7 @@ class ResponseLifecycle:
     ) -> SessionStartedWatch:
         """Pre-compute session:started eligibility for one response path."""
         return SessionStartedWatch(
-            should_watch=self.runner._should_watch_session_started(
+            should_watch=self._session_started_watch_is_needed(
                 tool_context=tool_context,
                 session_id=session_id,
                 session_type=session_type,
@@ -221,19 +307,51 @@ class ResponseLifecycle:
             create_storage=create_storage,
         )
 
-    async def emit_session_started(self, watch: SessionStartedWatch) -> None:
-        """Emit session:started using the existing runner-owned safety wrapper."""
-        await self.runner._emit_session_started_safely(
-            tool_context=watch.tool_context,
-            should_watch_session_started=watch.should_watch,
+    async def _maybe_emit_session_started(self, watch: SessionStartedWatch) -> None:
+        if watch.tool_context is None or not watch.should_watch:
+            return
+        storage = watch.create_storage()
+        try:
+            if not _session_exists(storage=storage, session_id=watch.session_id, session_type=watch.session_type):
+                return
+        finally:
+            storage.close()
+
+        bindings = resolve_tool_runtime_hook_bindings(watch.tool_context)
+        context = SessionHookContext(
+            event_name=EVENT_SESSION_STARTED,
+            plugin_name="",
+            settings={},
+            config=watch.tool_context.config,
+            runtime_paths=watch.tool_context.runtime_paths,
+            logger=self.deps.logger.bind(event_name=EVENT_SESSION_STARTED, session_id=watch.session_id),
+            correlation_id=watch.correlation_id,
+            message_sender=bindings.message_sender,
+            matrix_admin=bindings.matrix_admin,
+            room_state_querier=bindings.room_state_querier,
+            room_state_putter=bindings.room_state_putter,
+            agent_name=watch.scope.scope_id if watch.scope.kind == "team" else watch.tool_context.agent_name,
             scope=watch.scope,
             session_id=watch.session_id,
             room_id=watch.room_id,
             thread_id=watch.thread_id,
-            session_type=watch.session_type,
-            correlation_id=watch.correlation_id,
-            create_storage=watch.create_storage,
         )
+        await emit(watch.tool_context.hook_registry, EVENT_SESSION_STARTED, context)
+
+    async def emit_session_started(self, watch: SessionStartedWatch) -> None:
+        """Emit session:started without aborting delivery on ordinary failures."""
+        try:
+            await self._maybe_emit_session_started(watch)
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            self.deps.logger.exception(
+                "Failed to emit session:started",
+                session_id=watch.session_id,
+                room_id=watch.room_id,
+                thread_id=watch.thread_id,
+                failure_reason=str(error),
+            )
 
     async def finalize(
         self,
@@ -251,7 +369,7 @@ class ResponseLifecycle:
                     and final_delivery_outcome.final_visible_body is not None
                     and final_delivery_outcome.delivery_kind is not None
                 ):
-                    await self.runner.deps.delivery_gateway.deps.response_hooks.emit_after_response(
+                    await self.deps.response_hooks.emit_after_response(
                         correlation_id=self.correlation_id,
                         envelope=self.response_envelope,
                         response_text=final_delivery_outcome.final_visible_body,
@@ -261,7 +379,7 @@ class ResponseLifecycle:
                         continue_on_cancelled=True,
                     )
             else:
-                await self.runner.deps.delivery_gateway.deps.response_hooks.emit_cancelled_response(
+                await self.deps.response_hooks.emit_cancelled_response(
                     correlation_id=self.correlation_id,
                     envelope=self.response_envelope,
                     visible_response_event_id=response_event_id,
@@ -271,16 +389,14 @@ class ResponseLifecycle:
         except asyncio.CancelledError as error:
             if response_event_id is None:
                 raise
-            self.runner._log_post_response_effects_failure(
-                response_kind=self.response_kind,
+            self._log_effects_failure_after_visible_delivery(
                 response_event_id=response_event_id,
                 error=error,
             )
         except Exception as error:
             if response_event_id is None:
                 raise
-            self.runner._log_post_response_effects_failure(
-                response_kind=self.response_kind,
+            self._log_effects_failure_after_visible_delivery(
                 response_event_id=response_event_id,
                 error=error,
             )
@@ -289,10 +405,8 @@ class ResponseLifecycle:
             post_response_outcome=lambda: build_post_response_outcome(final_delivery_outcome),
             post_response_deps=post_response_deps,
         )
-        self.runner._emit_pipeline_timing_summary(
-            self.request,
-            outcome=self.runner._response_outcome(final_delivery_outcome),
-        )
+        if self.pipeline_timing is not None:
+            self.pipeline_timing.emit_summary(self.deps.logger, outcome=response_outcome_label(final_delivery_outcome))
         return final_delivery_outcome
 
     async def apply_effects_safely(
@@ -317,16 +431,14 @@ class ResponseLifecycle:
         except asyncio.CancelledError as error:
             if response_event_id is None:
                 raise
-            self.runner._log_post_response_effects_failure(
-                response_kind=self.response_kind,
+            self._log_effects_failure_after_visible_delivery(
                 response_event_id=response_event_id,
                 error=error,
             )
         except Exception as error:
             if response_event_id is None:
                 raise
-            self.runner._log_post_response_effects_failure(
-                response_kind=self.response_kind,
+            self._log_effects_failure_after_visible_delivery(
                 response_event_id=response_event_id,
                 error=error,
             )

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -12,7 +12,6 @@ from zoneinfo import ZoneInfo
 
 from agno.db.base import SessionType
 
-from mindroom.agent_storage import get_agent_session, get_team_session
 from mindroom.agents import show_tool_calls_for_agent
 from mindroom.ai import (
     ai_response,
@@ -32,11 +31,8 @@ from mindroom.history import run_post_response_compaction_check
 from mindroom.history.interrupted_replay import persist_interrupted_replay_snapshot
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.hooks import (
-    EVENT_SESSION_STARTED,
     EnrichmentItem,
     MessageEnvelope,
-    SessionHookContext,
-    emit,
 )
 from mindroom.knowledge import (
     KnowledgeAccessSupport,
@@ -71,7 +67,6 @@ from mindroom.thread_summary import thread_summary_message_count_hint
 from mindroom.timing import DispatchPipelineTiming, timed
 from mindroom.tool_system.runtime_context import (
     ToolDispatchContext,
-    resolve_tool_runtime_hook_bindings,
     runtime_context_from_dispatch_context,
 )
 from mindroom.tool_system.worker_routing import (
@@ -89,7 +84,7 @@ from .delivery_gateway import (
     StreamingDeliveryRequest,
 )
 from .media_inputs import MediaInputs
-from .response_lifecycle import ResponseLifecycle, ResponseLifecycleCoordinator
+from .response_lifecycle import ResponseLifecycle, ResponseLifecycleCoordinator, ResponseLifecycleDeps
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Mapping, Sequence
@@ -111,10 +106,7 @@ if TYPE_CHECKING:
     from mindroom.stop import StopManager
     from mindroom.streaming_delivery import StreamInputChunk
     from mindroom.tool_system.events import ToolTraceEntry
-    from mindroom.tool_system.runtime_context import (
-        ToolRuntimeContext,
-        ToolRuntimeSupport,
-    )
+    from mindroom.tool_system.runtime_context import ToolRuntimeSupport
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 type MatrixEventId = str
@@ -416,22 +408,6 @@ class ResponseRunner:
             error_type=error.__class__.__name__,
         )
 
-    def _log_post_response_effects_failure(
-        self,
-        *,
-        response_kind: str,
-        response_event_id: str,
-        error: BaseException,
-    ) -> None:
-        """Log one non-fatal post-response failure after visible delivery succeeded."""
-        self.deps.logger.error(
-            "Post-response effects failed after visible delivery",
-            response_kind=response_kind,
-            response_event_id=response_event_id,
-            failure_reason=str(error),
-            error_type=error.__class__.__name__,
-        )
-
     def _log_cancelled_response(
         self,
         *,
@@ -666,126 +642,6 @@ class ResponseRunner:
 
         return persist_response_event_id
 
-    def _session_exists(
-        self,
-        *,
-        storage: BaseDb,
-        session_id: str,
-        session_type: SessionType,
-    ) -> bool:
-        if session_type is SessionType.TEAM:
-            return get_team_session(storage, session_id) is not None
-        return get_agent_session(storage, session_id) is not None
-
-    def _should_watch_session_started(
-        self,
-        *,
-        tool_context: ToolRuntimeContext | None,
-        session_id: str,
-        session_type: SessionType,
-        create_storage: Callable[[], BaseDb],
-    ) -> bool:
-        if tool_context is None or not tool_context.hook_registry.has_hooks(EVENT_SESSION_STARTED):
-            return False
-        try:
-            storage = create_storage()
-            try:
-                return not self._session_exists(
-                    storage=storage,
-                    session_id=session_id,
-                    session_type=session_type,
-                )
-            finally:
-                storage.close()
-        except Exception as error:
-            self.deps.logger.exception(
-                "Failed to probe session storage for session:started eligibility",
-                session_id=session_id,
-                session_type=str(session_type),
-                failure_reason=str(error),
-            )
-            return False
-
-    async def _maybe_emit_session_started(
-        self,
-        *,
-        tool_context: ToolRuntimeContext | None,
-        should_watch_session_started: bool,
-        scope: HistoryScope,
-        session_id: str,
-        room_id: str,
-        thread_id: str | None,
-        session_type: SessionType,
-        correlation_id: str,
-        create_storage: Callable[[], BaseDb],
-    ) -> None:
-        if tool_context is None or not should_watch_session_started:
-            return
-        storage = create_storage()
-        try:
-            if not self._session_exists(storage=storage, session_id=session_id, session_type=session_type):
-                return
-        finally:
-            storage.close()
-
-        bindings = resolve_tool_runtime_hook_bindings(tool_context)
-        context = SessionHookContext(
-            event_name=EVENT_SESSION_STARTED,
-            plugin_name="",
-            settings={},
-            config=tool_context.config,
-            runtime_paths=tool_context.runtime_paths,
-            logger=self.deps.logger.bind(event_name=EVENT_SESSION_STARTED, session_id=session_id),
-            correlation_id=correlation_id,
-            message_sender=bindings.message_sender,
-            matrix_admin=bindings.matrix_admin,
-            room_state_querier=bindings.room_state_querier,
-            room_state_putter=bindings.room_state_putter,
-            agent_name=scope.scope_id if scope.kind == "team" else tool_context.agent_name,
-            scope=scope,
-            session_id=session_id,
-            room_id=room_id,
-            thread_id=thread_id,
-        )
-        await emit(tool_context.hook_registry, EVENT_SESSION_STARTED, context)
-
-    async def _emit_session_started_safely(
-        self,
-        *,
-        tool_context: ToolRuntimeContext | None,
-        should_watch_session_started: bool,
-        scope: HistoryScope,
-        session_id: str,
-        room_id: str,
-        thread_id: str | None,
-        session_type: SessionType,
-        correlation_id: str,
-        create_storage: Callable[[], BaseDb],
-    ) -> None:
-        """Emit session:started without aborting delivery on ordinary failures."""
-        try:
-            await self._maybe_emit_session_started(
-                tool_context=tool_context,
-                should_watch_session_started=should_watch_session_started,
-                scope=scope,
-                session_id=session_id,
-                room_id=room_id,
-                thread_id=thread_id,
-                session_type=session_type,
-                correlation_id=correlation_id,
-                create_storage=create_storage,
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception as error:
-            self.deps.logger.exception(
-                "Failed to emit session:started",
-                session_id=session_id,
-                room_id=room_id,
-                thread_id=thread_id,
-                failure_reason=str(error),
-            )
-
     def _request_for_delivery(
         self,
         request: ResponseRequest,
@@ -871,36 +727,6 @@ class ResponseRunner:
             used_streaming=used_streaming,
         )
 
-    def _emit_pipeline_timing_summary(
-        self,
-        request: ResponseRequest,
-        *,
-        outcome: str,
-    ) -> None:
-        """Emit one structured end-to-end timing summary when available."""
-        if request.pipeline_timing is None:
-            return
-        request.pipeline_timing.emit_summary(self.deps.logger, outcome=outcome)
-
-    @staticmethod
-    def _response_outcome(final_delivery_outcome: FinalDeliveryOutcome | None) -> str:
-        """Return one pipeline outcome label for the canonical final delivery outcome."""
-        if final_delivery_outcome is not None and final_delivery_outcome.suppressed:
-            return "suppressed"
-        if final_delivery_outcome is not None and final_delivery_outcome.terminal_status == "cancelled":
-            return "cancelled"
-        if final_delivery_outcome is not None and final_delivery_outcome.terminal_status == "error":
-            return "error"
-        if final_delivery_outcome is not None and final_delivery_outcome.delivery_kind is not None:
-            return final_delivery_outcome.delivery_kind
-        if (
-            final_delivery_outcome is not None
-            and final_delivery_outcome.event_id is not None
-            and final_delivery_outcome.is_visible_response
-        ):
-            return "visible_response_preserved"
-        return "no_visible_response"
-
     def _response_envelope_for_request(
         self,
         request: ResponseRequest,
@@ -950,9 +776,12 @@ class ResponseRunner:
                 resolved_target=request.target,
             )
         return ResponseLifecycle(
-            self,
+            ResponseLifecycleDeps(
+                response_hooks=self.deps.delivery_gateway.deps.response_hooks,
+                logger=self.deps.logger,
+            ),
             response_kind=response_kind,
-            request=request,
+            pipeline_timing=request.pipeline_timing,
             response_envelope=resolved_response_envelope,
             correlation_id=correlation_id or self._correlation_id_for_request(request),
         )

--- a/tach.toml
+++ b/tach.toml
@@ -94,7 +94,7 @@ visibility = [
     "mindroom.history.interrupted_replay",
     "mindroom.history.runtime",
     "mindroom.memory.auto_flush",
-    "mindroom.response_runner",
+    "mindroom.response_lifecycle",
     "mindroom.teams",
     "mindroom.turn_store",
 ]
@@ -748,7 +748,6 @@ depends_on = [
 [[modules]]
 path = "mindroom.response_runner"
 depends_on = [
-    "mindroom.agent_storage",
     "mindroom.agents",
     "mindroom.ai",
     "mindroom.constants",
@@ -772,9 +771,11 @@ depends_on = [
 [[modules]]
 path = "mindroom.response_lifecycle"
 depends_on = [
+    "mindroom.agent_storage",
     "mindroom.ai_runtime",
     "mindroom.hooks",
     "mindroom.post_response_effects",
+    "mindroom.tool_system.runtime_context",
 ]
 visibility = ["mindroom.response_runner"]
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -987,14 +987,24 @@ async def test_should_watch_session_started_returns_false_when_storage_probe_fai
         session_id=target.session_id,
     )
 
-    should_watch = coordinator._should_watch_session_started(
+    lifecycle = coordinator._build_lifecycle(
+        response_kind="ai",
+        request=replace(
+            _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
+            target=target,
+        ),
+    )
+    watch = lifecycle.setup_session_watch(
         tool_context=tool_context,
         session_id=target.session_id,
         session_type=SessionType.AGENT,
+        scope=HistoryScope(kind="agent", scope_id="general"),
+        room_id=target.room_id,
+        thread_id=target.resolved_thread_id,
         create_storage=BrokenStorage,
     )
 
-    assert should_watch is False
+    assert watch.should_watch is False
     coordinator.deps.logger.exception.assert_called_once()
     assert coordinator.deps.logger.exception.call_args.kwargs["session_id"] == target.session_id
     assert coordinator.deps.logger.exception.call_args.kwargs["failure_reason"] == "probe boom"

--- a/tests/test_cancelled_response_hook.py
+++ b/tests/test_cancelled_response_hook.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -42,7 +41,7 @@ from mindroom.logging_config import get_logger
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutcome
-from mindroom.response_lifecycle import ResponseLifecycle
+from mindroom.response_lifecycle import ResponseLifecycle, ResponseLifecycleDeps
 from mindroom.response_runner import ResponseRequest
 from mindroom.turn_store import LoadedTurnRecord
 from tests.conftest import (
@@ -111,6 +110,24 @@ def _response_hook_service(tmp_path: Path, registry: HookRegistry) -> tuple[Conf
         hook_send_message=AsyncMock(),
     )
     return config, ResponseHookService(hook_context=hook_context)
+
+
+def _response_lifecycle(
+    response_hooks: ResponseHookService,
+    *,
+    response_envelope: MessageEnvelope | None = None,
+    correlation_id: str,
+) -> ResponseLifecycle:
+    return ResponseLifecycle(
+        ResponseLifecycleDeps(
+            response_hooks=response_hooks,
+            logger=get_logger("tests.response_lifecycle"),
+        ),
+        response_kind="ai",
+        pipeline_timing=None,
+        response_envelope=response_envelope or _envelope(),
+        correlation_id=correlation_id,
+    )
 
 
 def _team_bot(tmp_path: Path) -> TeamBot:
@@ -502,21 +519,8 @@ async def test_suppressed_final_delivery_emits_cancelled_hook(
         ),
     )
 
-    runner = SimpleNamespace(
-        deps=SimpleNamespace(
-            delivery_gateway=SimpleNamespace(
-                deps=SimpleNamespace(response_hooks=response_hooks),
-            ),
-        ),
-        _log_post_response_effects_failure=MagicMock(),
-        _emit_pipeline_timing_summary=MagicMock(),
-        _response_outcome=MagicMock(return_value=None),
-    )
-    lifecycle = ResponseLifecycle(
-        runner=runner,
-        response_kind="ai",
-        request=MagicMock(),
-        response_envelope=_envelope(),
+    lifecycle = _response_lifecycle(
+        response_hooks,
         correlation_id="corr-suppressed-final",
     )
     finalized = await lifecycle.finalize(
@@ -566,21 +570,8 @@ async def test_late_after_response_cancellation_preserves_delivery_result(
         [_plugin("test-late-after-cancel", [slow_after_response, on_cancelled])],
     )
     _, response_hooks = _response_hook_service(tmp_path, registry)
-    runner = SimpleNamespace(
-        deps=SimpleNamespace(
-            delivery_gateway=SimpleNamespace(
-                deps=SimpleNamespace(response_hooks=response_hooks),
-            ),
-        ),
-        _log_post_response_effects_failure=MagicMock(),
-        _emit_pipeline_timing_summary=MagicMock(),
-        _response_outcome=MagicMock(return_value=None),
-    )
-    lifecycle = ResponseLifecycle(
-        runner=runner,
-        response_kind="ai",
-        request=MagicMock(),
-        response_envelope=_envelope(),
+    lifecycle = _response_lifecycle(
+        response_hooks,
         correlation_id=f"corr-late-{mode}",
     )
 
@@ -667,21 +658,8 @@ async def test_deliver_final_delivery_failure_emits_cancelled_hook(
             ),
         )
 
-    runner = SimpleNamespace(
-        deps=SimpleNamespace(
-            delivery_gateway=SimpleNamespace(
-                deps=SimpleNamespace(response_hooks=response_hooks),
-            ),
-        ),
-        _log_post_response_effects_failure=MagicMock(),
-        _emit_pipeline_timing_summary=MagicMock(),
-        _response_outcome=MagicMock(return_value=None),
-    )
-    lifecycle = ResponseLifecycle(
-        runner=runner,
-        response_kind="ai",
-        request=MagicMock(),
-        response_envelope=_envelope(),
+    lifecycle = _response_lifecycle(
+        response_hooks,
         correlation_id="corr-delivery-failure",
     )
     finalized = await lifecycle.finalize(
@@ -757,21 +735,8 @@ async def test_final_only_provider_runs_before_response_then_after_response_once
         ),
     )
 
-    runner = SimpleNamespace(
-        deps=SimpleNamespace(
-            delivery_gateway=SimpleNamespace(
-                deps=SimpleNamespace(response_hooks=response_hooks),
-            ),
-        ),
-        _log_post_response_effects_failure=MagicMock(),
-        _emit_pipeline_timing_summary=MagicMock(),
-        _response_outcome=MagicMock(return_value=None),
-    )
-    lifecycle = ResponseLifecycle(
-        runner=runner,
-        response_kind="ai",
-        request=MagicMock(),
-        response_envelope=_envelope(),
+    lifecycle = _response_lifecycle(
+        response_hooks,
         correlation_id="corr-final-only-provider",
     )
 
@@ -844,21 +809,8 @@ async def test_suppressed_placeholder_cleanup_failure_returns_typed_outcome_afte
 
     assert outcome.terminal_status == "error"
     assert outcome.final_visible_event_id == "$placeholder"
-    runner = SimpleNamespace(
-        deps=SimpleNamespace(
-            delivery_gateway=SimpleNamespace(
-                deps=SimpleNamespace(response_hooks=response_hooks),
-            ),
-        ),
-        _log_post_response_effects_failure=MagicMock(),
-        _emit_pipeline_timing_summary=MagicMock(),
-        _response_outcome=MagicMock(return_value=None),
-    )
-    lifecycle = ResponseLifecycle(
-        runner=runner,
-        response_kind="ai",
-        request=MagicMock(),
-        response_envelope=_envelope(),
+    lifecycle = _response_lifecycle(
+        response_hooks,
         correlation_id="corr-suppressed-cleanup-fail",
     )
     await lifecycle.finalize(
@@ -927,21 +879,8 @@ async def test_suppressed_placeholder_cleanup_exception_returns_typed_outcome_af
 
     assert outcome.terminal_status == "error"
     assert outcome.final_visible_event_id == "$placeholder"
-    runner = SimpleNamespace(
-        deps=SimpleNamespace(
-            delivery_gateway=SimpleNamespace(
-                deps=SimpleNamespace(response_hooks=response_hooks),
-            ),
-        ),
-        _log_post_response_effects_failure=MagicMock(),
-        _emit_pipeline_timing_summary=MagicMock(),
-        _response_outcome=MagicMock(return_value=None),
-    )
-    lifecycle = ResponseLifecycle(
-        runner=runner,
-        response_kind="ai",
-        request=MagicMock(),
-        response_envelope=_envelope(),
+    lifecycle = _response_lifecycle(
+        response_hooks,
         correlation_id="corr-suppressed-cleanup-exception",
     )
     await lifecycle.finalize(

--- a/tests/test_config_architecture_boundaries.py
+++ b/tests/test_config_architecture_boundaries.py
@@ -15,6 +15,7 @@ CONCRETE_ORCHESTRATOR_IMPORT_ALLOWLIST = {
 RUNTIME_PROTOCOLS_MODULE = Path("src/mindroom/runtime_protocols.py")
 MATRIX_MESSAGE_TOOL_MODULE = Path("src/mindroom/custom_tools/matrix_message.py")
 RESPONSE_RUNNER_MODULE = Path("src/mindroom/response_runner.py")
+RESPONSE_LIFECYCLE_MODULE = Path("src/mindroom/response_lifecycle.py")
 MATRIX_MESSAGE_LOW_LEVEL_IMPORTS = frozenset(
     {
         "mindroom.custom_tools.attachments",
@@ -191,5 +192,33 @@ def test_response_runner_delegates_lifecycle_coordination() -> None:
             found.append(f"{RESPONSE_RUNNER_MODULE}:{node.lineno}: {node.name}")
         if isinstance(node, ast.Name) and node.id in forbidden_names:
             found.append(f"{RESPONSE_RUNNER_MODULE}:{node.lineno}: {node.id}")
+
+    assert found == []
+
+
+def test_response_lifecycle_does_not_reach_into_response_runner_internals() -> None:
+    """Response lifecycle owns its dependencies instead of calling runner-private helpers."""
+    tree = ast.parse(RESPONSE_LIFECYCLE_MODULE.read_text(encoding="utf-8"))
+    forbidden_private_helpers = {
+        "_emit_pipeline_timing_summary",
+        "_emit_session_started_safely",
+        "_log_post_response_effects_failure",
+        "_response_outcome",
+        "_should_watch_session_started",
+    }
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            imported_from_response_runner = (
+                node.level == 1 and node.module == "response_runner"
+            ) or node.module == "mindroom.response_runner"
+            if imported_from_response_runner:
+                found.append(f"{RESPONSE_LIFECYCLE_MODULE}:{node.lineno}: from response_runner")
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name in forbidden_private_helpers:
+            found.append(f"{RESPONSE_LIFECYCLE_MODULE}:{node.lineno}: {node.name}")
+        if isinstance(node, ast.Name) and node.id in {"ResponseRequest", "ResponseRunner", *forbidden_private_helpers}:
+            found.append(f"{RESPONSE_LIFECYCLE_MODULE}:{node.lineno}: {node.id}")
+        if isinstance(node, ast.Attribute) and node.attr in forbidden_private_helpers:
+            found.append(f"{RESPONSE_LIFECYCLE_MODULE}:{node.lineno}: {node.attr}")
 
     assert found == []

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -102,6 +102,7 @@ from mindroom.orchestrator import (
     _SignalAwareUvicornServer,
     main,
 )
+from mindroom.response_lifecycle import response_outcome_label
 from mindroom.response_runner import (
     PostLockRequestPreparationError,
     ResponseRequest,
@@ -3196,7 +3197,7 @@ class TestAgentBot:
     def test_response_outcome_prefers_terminal_status_over_delivery_kind(self) -> None:
         """Pipeline outcome summaries must not report cancelled or error states as plain send/edit success."""
         assert (
-            ResponseRunner._response_outcome(
+            response_outcome_label(
                 _outcome(
                     terminal_status="cancelled",
                     final_visible_event_id="$cancelled",
@@ -3209,7 +3210,7 @@ class TestAgentBot:
             == "cancelled"
         )
         assert (
-            ResponseRunner._response_outcome(
+            response_outcome_label(
                 _outcome(
                     terminal_status="error",
                     final_visible_event_id="$error",

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -51,7 +51,7 @@ from mindroom.matrix.large_messages import _clear_oversized_nonterminal_streamin
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutcome
-from mindroom.response_lifecycle import ResponseLifecycle
+from mindroom.response_lifecycle import ResponseLifecycle, ResponseLifecycleDeps
 from mindroom.response_runner import ResponseRequest
 from mindroom.streaming import (
     CANCELLED_RESPONSE_NOTE,
@@ -4167,20 +4167,13 @@ class TestStreamingBehavior:
         edited_request = gateway.edit_text.await_args.args[0]
         assert edited_request.event_id == "$streaming"
         assert edited_request.new_text == "updated text"
-        runner = SimpleNamespace(
-            deps=SimpleNamespace(
-                delivery_gateway=SimpleNamespace(
-                    deps=SimpleNamespace(response_hooks=response_hooks),
-                ),
-            ),
-            _log_post_response_effects_failure=MagicMock(),
-            _emit_pipeline_timing_summary=MagicMock(),
-            _response_outcome=MagicMock(return_value=None),
-        )
         lifecycle = ResponseLifecycle(
-            runner=runner,
+            ResponseLifecycleDeps(
+                response_hooks=response_hooks,
+                logger=MagicMock(),
+            ),
             response_kind="ai",
-            request=MagicMock(),
+            pipeline_timing=None,
             response_envelope=response_envelope,
             correlation_id="corr-final-transform-success",
         )
@@ -4265,20 +4258,13 @@ class TestStreamingBehavior:
         assert outcome.final_visible_body == "chunk"
         response_hooks.apply_before_response.assert_not_awaited()
         response_hooks.apply_final_response_transform.assert_awaited_once()
-        runner = SimpleNamespace(
-            deps=SimpleNamespace(
-                delivery_gateway=SimpleNamespace(
-                    deps=SimpleNamespace(response_hooks=response_hooks),
-                ),
-            ),
-            _log_post_response_effects_failure=MagicMock(),
-            _emit_pipeline_timing_summary=MagicMock(),
-            _response_outcome=MagicMock(return_value=None),
-        )
         lifecycle = ResponseLifecycle(
-            runner=runner,
+            ResponseLifecycleDeps(
+                response_hooks=response_hooks,
+                logger=MagicMock(),
+            ),
             response_kind="ai",
-            request=MagicMock(),
+            pipeline_timing=None,
             response_envelope=response_envelope,
             correlation_id="corr-final-transform-noop",
         )

--- a/tests/test_streaming_finalize.py
+++ b/tests/test_streaming_finalize.py
@@ -27,7 +27,7 @@ from mindroom.post_response_effects import (
     ResponseOutcome,
     apply_post_response_effects,
 )
-from mindroom.response_lifecycle import ResponseLifecycle
+from mindroom.response_lifecycle import ResponseLifecycle, ResponseLifecycleDeps
 from mindroom.streaming import (
     StreamingResponse,
     send_streaming_response,
@@ -652,20 +652,13 @@ async def test_final_response_transform_failure_keeps_visible_stream_text(tmp_pa
     response_hooks.apply_before_response.assert_not_awaited()
     response_hooks.apply_final_response_transform.assert_awaited_once()
     gateway.edit_text.assert_awaited_once()
-    runner = SimpleNamespace(
-        deps=SimpleNamespace(
-            delivery_gateway=SimpleNamespace(
-                deps=SimpleNamespace(response_hooks=response_hooks),
-            ),
-        ),
-        _log_post_response_effects_failure=Mock(),
-        _emit_pipeline_timing_summary=Mock(),
-        _response_outcome=Mock(return_value=None),
-    )
     lifecycle = ResponseLifecycle(
-        runner=runner,
+        ResponseLifecycleDeps(
+            response_hooks=response_hooks,
+            logger=get_logger("tests.response_lifecycle"),
+        ),
         response_kind="ai",
-        request=Mock(),
+        pipeline_timing=None,
         response_envelope=envelope,
         correlation_id="corr-final-transform-failure",
     )


### PR DESCRIPTION
## Summary
- Move session-started probing/emission, post-response failure logging, response hook finalization dependencies, and pipeline outcome labeling into response_lifecycle.
- Build ResponseLifecycle with explicit ResponseLifecycleDeps instead of a ResponseRunner back-reference.
- Update Tach boundaries and add an architecture guard that response_lifecycle does not import response_runner or call runner-private lifecycle helpers.

## Verification
- uv run pre-commit run --all-files
- uv run tach check --dependencies --interfaces
- uv run pytest tests/ -x -nauto --no-cov -q