### PR TITLE
Add response payload hydration timing

### DIFF
--- a/src/mindroom/attachment_media.py
+++ b/src/mindroom/attachment_media.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 from agno.media import Audio, File, Image, Video
 
 from .attachments import AttachmentRecord, filter_attachments_for_context, resolve_attachments
 from .logging_config import get_logger
+from .timing import emit_elapsed_timing
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -80,22 +82,45 @@ def resolve_attachment_media(
     room/thread context are included. Mismatched records are dropped with a
     debug log.
     """
-    attachment_records = resolve_attachments(storage_path, attachment_ids)
-    if room_id is not None:
-        attachment_records, rejected = filter_attachments_for_context(
-            attachment_records,
-            room_id=room_id,
-            thread_id=thread_id,
-        )
-        if rejected:
-            logger.debug(
-                "Rejected out-of-context attachment IDs",
-                rejected=rejected,
+    started = time.monotonic()
+    rejected_count = 0
+    attachment_records: list[AttachmentRecord] = []
+    attachment_audio: list[Audio] = []
+    attachment_images: list[Image] = []
+    attachment_files: list[File] = []
+    attachment_videos: list[Video] = []
+    try:
+        attachment_records = resolve_attachments(storage_path, attachment_ids)
+        if room_id is not None:
+            attachment_records, rejected = filter_attachments_for_context(
+                attachment_records,
                 room_id=room_id,
                 thread_id=thread_id,
             )
-    resolved_attachment_ids = [record.attachment_id for record in attachment_records]
-    attachment_audio, attachment_images, attachment_files, attachment_videos = _attachment_records_to_media(
-        attachment_records,
-    )
-    return resolved_attachment_ids, attachment_audio, attachment_images, attachment_files, attachment_videos
+            rejected_count = len(rejected)
+            if rejected:
+                logger.debug(
+                    "Rejected out-of-context attachment IDs",
+                    rejected=rejected,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                )
+        resolved_attachment_ids = [record.attachment_id for record in attachment_records]
+        attachment_audio, attachment_images, attachment_files, attachment_videos = _attachment_records_to_media(
+            attachment_records,
+        )
+        return resolved_attachment_ids, attachment_audio, attachment_images, attachment_files, attachment_videos
+    finally:
+        emit_elapsed_timing(
+            "response_payload.resolve_attachment_media",
+            started,
+            room_id=room_id,
+            thread_id=thread_id,
+            requested_attachment_count=len(attachment_ids),
+            resolved_attachment_count=len(attachment_records),
+            rejected_attachment_count=rejected_count,
+            audio_count=len(attachment_audio),
+            image_count=len(attachment_images),
+            file_count=len(attachment_files),
+            video_count=len(attachment_videos),
+        )

--- a/src/mindroom/attachment_media.py
+++ b/src/mindroom/attachment_media.py
@@ -84,43 +84,36 @@ def resolve_attachment_media(
     """
     started = time.monotonic()
     rejected_count = 0
-    attachment_records: list[AttachmentRecord] = []
-    attachment_audio: list[Audio] = []
-    attachment_images: list[Image] = []
-    attachment_files: list[File] = []
-    attachment_videos: list[Video] = []
-    try:
-        attachment_records = resolve_attachments(storage_path, attachment_ids)
-        if room_id is not None:
-            attachment_records, rejected = filter_attachments_for_context(
-                attachment_records,
+    attachment_records = resolve_attachments(storage_path, attachment_ids)
+    if room_id is not None:
+        attachment_records, rejected = filter_attachments_for_context(
+            attachment_records,
+            room_id=room_id,
+            thread_id=thread_id,
+        )
+        rejected_count = len(rejected)
+        if rejected:
+            logger.debug(
+                "Rejected out-of-context attachment IDs",
+                rejected=rejected,
                 room_id=room_id,
                 thread_id=thread_id,
             )
-            rejected_count = len(rejected)
-            if rejected:
-                logger.debug(
-                    "Rejected out-of-context attachment IDs",
-                    rejected=rejected,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                )
-        resolved_attachment_ids = [record.attachment_id for record in attachment_records]
-        attachment_audio, attachment_images, attachment_files, attachment_videos = _attachment_records_to_media(
-            attachment_records,
-        )
-        return resolved_attachment_ids, attachment_audio, attachment_images, attachment_files, attachment_videos
-    finally:
-        emit_elapsed_timing(
-            "response_payload.resolve_attachment_media",
-            started,
-            room_id=room_id,
-            thread_id=thread_id,
-            requested_attachment_count=len(attachment_ids),
-            resolved_attachment_count=len(attachment_records),
-            rejected_attachment_count=rejected_count,
-            audio_count=len(attachment_audio),
-            image_count=len(attachment_images),
-            file_count=len(attachment_files),
-            video_count=len(attachment_videos),
-        )
+    resolved_attachment_ids = [record.attachment_id for record in attachment_records]
+    attachment_audio, attachment_images, attachment_files, attachment_videos = _attachment_records_to_media(
+        attachment_records,
+    )
+    emit_elapsed_timing(
+        "response_payload.resolve_attachment_media",
+        started,
+        room_id=room_id,
+        thread_id=thread_id,
+        requested_attachment_count=len(attachment_ids),
+        resolved_attachment_count=len(attachment_records),
+        rejected_attachment_count=rejected_count,
+        audio_count=len(attachment_audio),
+        image_count=len(attachment_images),
+        file_count=len(attachment_files),
+        video_count=len(attachment_videos),
+    )
+    return resolved_attachment_ids, attachment_audio, attachment_images, attachment_files, attachment_videos

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import mimetypes
 import re
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -19,6 +20,7 @@ import nio
 from .constants import ATTACHMENT_IDS_KEY
 from .logging_config import get_logger
 from .matrix.media import download_media_bytes, media_mime_type, resolve_image_mime_type
+from .timing import emit_elapsed_timing
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -663,64 +665,90 @@ async def resolve_thread_attachment_ids(
     is skipped, avoiding duplicate homeserver calls when the caller already
     fetched the root event for image/audio resolution.
     """
-    event = thread_root_event
-    if event is None:
-        response = await client.room_get_event(room_id, thread_id)
-        if not isinstance(response, nio.RoomGetEventResponse):
-            return []
-        event = response.event
+    started = time.monotonic()
+    outcome = "ok"
+    attachment_count = 0
+    event_kind = "provided" if thread_root_event is not None else "fetched"
+    try:
+        event = thread_root_event
+        if event is None:
+            response = await client.room_get_event(room_id, thread_id)
+            if not isinstance(response, nio.RoomGetEventResponse):
+                outcome = "event_fetch_miss"
+                return []
+            event = response.event
 
-    event_attachment_ids = parse_attachment_ids_from_event_source(event.source)
-    if event_attachment_ids:
-        return event_attachment_ids
+        event_attachment_ids = parse_attachment_ids_from_event_source(event.source)
+        if event_attachment_ids:
+            attachment_count = len(event_attachment_ids)
+            outcome = "event_metadata"
+            return event_attachment_ids
 
-    # Check for an existing attachment record for any media root (file, video,
-    # image, or audio). Audio roots are registered by the voice handler and
-    # can be looked up but not re-downloaded here.
-    is_file_or_video = isinstance(
-        event,
-        nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo,
-    )
-    is_image = isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
-    is_audio = isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio)
-    if not is_file_or_video and not is_image and not is_audio:
-        return []
-
-    existing_attachment_id = _attachment_id_for_event(event.event_id)
-    existing_record = load_attachment(storage_path, existing_attachment_id)
-    if (
-        existing_record is not None
-        and existing_record.room_id == room_id
-        and existing_record.thread_id == thread_id
-        and existing_record.local_path.is_file()
-    ):
-        return [existing_record.attachment_id]
-
-    record: AttachmentRecord | None = None
-    if is_file_or_video:
-        assert isinstance(
+        # Check for an existing attachment record for any media root (file, video,
+        # image, or audio). Audio roots are registered by the voice handler and
+        # can be looked up but not re-downloaded here.
+        is_file_or_video = isinstance(
             event,
             nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo,
         )
-        record = await register_file_or_video_attachment(
-            client,
-            storage_path,
+        is_image = isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
+        is_audio = isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio)
+        if not is_file_or_video and not is_image and not is_audio:
+            outcome = "not_media_root"
+            return []
+
+        existing_attachment_id = _attachment_id_for_event(event.event_id)
+        existing_record = load_attachment(storage_path, existing_attachment_id)
+        if (
+            existing_record is not None
+            and existing_record.room_id == room_id
+            and existing_record.thread_id == thread_id
+            and existing_record.local_path.is_file()
+        ):
+            attachment_count = 1
+            outcome = "existing_record"
+            return [existing_record.attachment_id]
+
+        record: AttachmentRecord | None = None
+        if is_file_or_video:
+            assert isinstance(
+                event,
+                nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo,
+            )
+            record = await register_file_or_video_attachment(
+                client,
+                storage_path,
+                room_id=room_id,
+                thread_id=thread_id,
+                event=event,
+            )
+        elif is_image:
+            assert isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
+            record = await register_image_attachment(
+                client,
+                storage_path,
+                room_id=room_id,
+                thread_id=thread_id,
+                event=event,
+            )
+        # Audio roots cannot be re-registered here (the voice handler owns that
+        # lifecycle), so ``record`` stays ``None``.
+        if record is None:
+            outcome = "no_record"
+            return []
+        attachment_count = 1
+        outcome = "registered_record"
+        return [record.attachment_id]
+    finally:
+        emit_elapsed_timing(
+            "response_payload.resolve_thread_attachment_ids",
+            started,
             room_id=room_id,
             thread_id=thread_id,
-            event=event,
+            outcome=outcome,
+            event_kind=event_kind,
+            attachment_count=attachment_count,
         )
-    elif is_image:
-        assert isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
-        record = await register_image_attachment(
-            client,
-            storage_path,
-            room_id=room_id,
-            thread_id=thread_id,
-            event=event,
-        )
-    # Audio roots cannot be re-registered here (the voice handler owns that
-    # lifecycle), so ``record`` stays ``None``.
-    return [record.attachment_id] if record is not None else []
 
 
 def attachments_for_tool_payload(attachment_records: list[AttachmentRecord]) -> list[dict[str, Any]]:

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -666,80 +666,9 @@ async def resolve_thread_attachment_ids(
     fetched the root event for image/audio resolution.
     """
     started = time.monotonic()
-    outcome = "ok"
-    attachment_count = 0
     event_kind = "provided" if thread_root_event is not None else "fetched"
-    try:
-        event = thread_root_event
-        if event is None:
-            response = await client.room_get_event(room_id, thread_id)
-            if not isinstance(response, nio.RoomGetEventResponse):
-                outcome = "event_fetch_miss"
-                return []
-            event = response.event
 
-        event_attachment_ids = parse_attachment_ids_from_event_source(event.source)
-        if event_attachment_ids:
-            attachment_count = len(event_attachment_ids)
-            outcome = "event_metadata"
-            return event_attachment_ids
-
-        # Check for an existing attachment record for any media root (file, video,
-        # image, or audio). Audio roots are registered by the voice handler and
-        # can be looked up but not re-downloaded here.
-        is_file_or_video = isinstance(
-            event,
-            nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo,
-        )
-        is_image = isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
-        is_audio = isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio)
-        if not is_file_or_video and not is_image and not is_audio:
-            outcome = "not_media_root"
-            return []
-
-        existing_attachment_id = _attachment_id_for_event(event.event_id)
-        existing_record = load_attachment(storage_path, existing_attachment_id)
-        if (
-            existing_record is not None
-            and existing_record.room_id == room_id
-            and existing_record.thread_id == thread_id
-            and existing_record.local_path.is_file()
-        ):
-            attachment_count = 1
-            outcome = "existing_record"
-            return [existing_record.attachment_id]
-
-        record: AttachmentRecord | None = None
-        if is_file_or_video:
-            assert isinstance(
-                event,
-                nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo,
-            )
-            record = await register_file_or_video_attachment(
-                client,
-                storage_path,
-                room_id=room_id,
-                thread_id=thread_id,
-                event=event,
-            )
-        elif is_image:
-            assert isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
-            record = await register_image_attachment(
-                client,
-                storage_path,
-                room_id=room_id,
-                thread_id=thread_id,
-                event=event,
-            )
-        # Audio roots cannot be re-registered here (the voice handler owns that
-        # lifecycle), so ``record`` stays ``None``.
-        if record is None:
-            outcome = "no_record"
-            return []
-        attachment_count = 1
-        outcome = "registered_record"
-        return [record.attachment_id]
-    finally:
+    def finish(attachment_ids: list[str], outcome: str) -> list[str]:
         emit_elapsed_timing(
             "response_payload.resolve_thread_attachment_ids",
             started,
@@ -747,8 +676,70 @@ async def resolve_thread_attachment_ids(
             thread_id=thread_id,
             outcome=outcome,
             event_kind=event_kind,
-            attachment_count=attachment_count,
+            attachment_count=len(attachment_ids),
         )
+        return attachment_ids
+
+    event = thread_root_event
+    if event is None:
+        response = await client.room_get_event(room_id, thread_id)
+        if not isinstance(response, nio.RoomGetEventResponse):
+            return finish([], "event_fetch_miss")
+        event = response.event
+
+    event_attachment_ids = parse_attachment_ids_from_event_source(event.source)
+    if event_attachment_ids:
+        return finish(event_attachment_ids, "event_metadata")
+
+    # Check for an existing attachment record for any media root (file, video,
+    # image, or audio). Audio roots are registered by the voice handler and
+    # can be looked up but not re-downloaded here.
+    is_file_or_video = isinstance(
+        event,
+        nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo,
+    )
+    is_image = isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
+    is_audio = isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio)
+    if not is_file_or_video and not is_image and not is_audio:
+        return finish([], "not_media_root")
+
+    existing_attachment_id = _attachment_id_for_event(event.event_id)
+    existing_record = load_attachment(storage_path, existing_attachment_id)
+    if (
+        existing_record is not None
+        and existing_record.room_id == room_id
+        and existing_record.thread_id == thread_id
+        and existing_record.local_path.is_file()
+    ):
+        return finish([existing_record.attachment_id], "existing_record")
+
+    record: AttachmentRecord | None = None
+    if is_file_or_video:
+        assert isinstance(
+            event,
+            nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo,
+        )
+        record = await register_file_or_video_attachment(
+            client,
+            storage_path,
+            room_id=room_id,
+            thread_id=thread_id,
+            event=event,
+        )
+    elif is_image:
+        assert isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
+        record = await register_image_attachment(
+            client,
+            storage_path,
+            room_id=room_id,
+            thread_id=thread_id,
+            event=event,
+        )
+    # Audio roots cannot be re-registered here (the voice handler owns that
+    # lifecycle), so ``record`` stays ``None``.
+    if record is None:
+        return finish([], "no_record")
+    return finish([record.attachment_id], "registered_record")
 
 
 def attachments_for_tool_payload(attachment_records: list[AttachmentRecord]) -> list[dict[str, Any]]:

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Sequence  # noqa: TC003
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -26,6 +27,7 @@ from mindroom.matrix.message_content import (
 )
 from mindroom.media_inputs import MediaInputs
 from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
+from mindroom.timing import emit_elapsed_timing
 from mindroom.voice_handler import prepare_voice_message
 
 if TYPE_CHECKING:
@@ -279,48 +281,78 @@ class InboundTurnNormalizer:
         request: BatchMediaAttachmentRequest,
     ) -> BatchMediaAttachmentResult:
         """Register media attachments for one coalesced batch."""
+        started = time.monotonic()
+        media_event_count = len(request.media_events)
+        image_event_count = 0
+        file_or_video_event_count = 0
+        attachment_ids: list[str] = []
+        fallback_images: list[Image] = []
         if not request.media_events:
+            emit_elapsed_timing(
+                "response_payload.register_batch_media_attachments",
+                started,
+                room_id=request.room_id,
+                thread_id=request.thread_id,
+                media_event_count=media_event_count,
+                image_event_count=image_event_count,
+                file_or_video_event_count=file_or_video_event_count,
+                attachment_count=0,
+                fallback_image_count=0,
+            )
             return BatchMediaAttachmentResult(attachment_ids=[])
 
         client = self._client()
-        attachment_ids: list[str] = []
-        fallback_images: list[Image] = []
-        for media_event in request.media_events:
-            if isinstance(media_event, nio.RoomMessageImage | nio.RoomEncryptedImage):
-                image = await download_image(client, media_event)
-                if image is None:
-                    msg = "Failed to download image"
-                    raise RuntimeError(msg)
-                attachment_record = await register_image_attachment(
+        try:
+            for media_event in request.media_events:
+                if isinstance(media_event, nio.RoomMessageImage | nio.RoomEncryptedImage):
+                    image_event_count += 1
+                    image = await download_image(client, media_event)
+                    if image is None:
+                        msg = "Failed to download image"
+                        raise RuntimeError(msg)
+                    attachment_record = await register_image_attachment(
+                        client,
+                        self.deps.storage_path,
+                        room_id=request.room_id,
+                        thread_id=request.thread_id,
+                        event=media_event,
+                        image_bytes=image.content,
+                    )
+                    if attachment_record is not None:
+                        attachment_ids.append(attachment_record.attachment_id)
+                    else:
+                        fallback_images.append(image)
+                    continue
+
+                file_or_video_event_count += 1
+                attachment_record = await register_file_or_video_attachment(
                     client,
                     self.deps.storage_path,
                     room_id=request.room_id,
                     thread_id=request.thread_id,
-                    event=media_event,
-                    image_bytes=image.content,
+                    event=self._as_file_or_video_dispatch_event(media_event),
                 )
-                if attachment_record is not None:
-                    attachment_ids.append(attachment_record.attachment_id)
-                else:
-                    fallback_images.append(image)
-                continue
+                if attachment_record is None:
+                    msg = "Failed to register media attachment"
+                    raise RuntimeError(msg)
+                attachment_ids.append(attachment_record.attachment_id)
 
-            attachment_record = await register_file_or_video_attachment(
-                client,
-                self.deps.storage_path,
+            return BatchMediaAttachmentResult(
+                attachment_ids=attachment_ids,
+                fallback_images=fallback_images or None,
+            )
+        finally:
+            emit_elapsed_timing(
+                "response_payload.register_batch_media_attachments",
+                started,
                 room_id=request.room_id,
                 thread_id=request.thread_id,
-                event=self._as_file_or_video_dispatch_event(media_event),
+                media_event_count=media_event_count,
+                image_event_count=image_event_count,
+                file_or_video_event_count=file_or_video_event_count,
+                attachment_count=len(attachment_ids),
+                fallback_image_count=len(fallback_images),
             )
-            if attachment_record is None:
-                msg = "Failed to register media attachment"
-                raise RuntimeError(msg)
-            attachment_ids.append(attachment_record.attachment_id)
-
-        return BatchMediaAttachmentResult(
-            attachment_ids=attachment_ids,
-            fallback_images=fallback_images or None,
-        )
 
     async def build_dispatch_payload_with_attachments(
         self,

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -287,61 +287,8 @@ class InboundTurnNormalizer:
         file_or_video_event_count = 0
         attachment_ids: list[str] = []
         fallback_images: list[Image] = []
-        if not request.media_events:
-            emit_elapsed_timing(
-                "response_payload.register_batch_media_attachments",
-                started,
-                room_id=request.room_id,
-                thread_id=request.thread_id,
-                media_event_count=media_event_count,
-                image_event_count=image_event_count,
-                file_or_video_event_count=file_or_video_event_count,
-                attachment_count=0,
-                fallback_image_count=0,
-            )
-            return BatchMediaAttachmentResult(attachment_ids=[])
 
-        client = self._client()
-        try:
-            for media_event in request.media_events:
-                if isinstance(media_event, nio.RoomMessageImage | nio.RoomEncryptedImage):
-                    image_event_count += 1
-                    image = await download_image(client, media_event)
-                    if image is None:
-                        msg = "Failed to download image"
-                        raise RuntimeError(msg)
-                    attachment_record = await register_image_attachment(
-                        client,
-                        self.deps.storage_path,
-                        room_id=request.room_id,
-                        thread_id=request.thread_id,
-                        event=media_event,
-                        image_bytes=image.content,
-                    )
-                    if attachment_record is not None:
-                        attachment_ids.append(attachment_record.attachment_id)
-                    else:
-                        fallback_images.append(image)
-                    continue
-
-                file_or_video_event_count += 1
-                attachment_record = await register_file_or_video_attachment(
-                    client,
-                    self.deps.storage_path,
-                    room_id=request.room_id,
-                    thread_id=request.thread_id,
-                    event=self._as_file_or_video_dispatch_event(media_event),
-                )
-                if attachment_record is None:
-                    msg = "Failed to register media attachment"
-                    raise RuntimeError(msg)
-                attachment_ids.append(attachment_record.attachment_id)
-
-            return BatchMediaAttachmentResult(
-                attachment_ids=attachment_ids,
-                fallback_images=fallback_images or None,
-            )
-        finally:
+        def emit_registration_timing() -> None:
             emit_elapsed_timing(
                 "response_payload.register_batch_media_attachments",
                 started,
@@ -353,6 +300,51 @@ class InboundTurnNormalizer:
                 attachment_count=len(attachment_ids),
                 fallback_image_count=len(fallback_images),
             )
+
+        if not request.media_events:
+            emit_registration_timing()
+            return BatchMediaAttachmentResult(attachment_ids=[])
+
+        client = self._client()
+        for media_event in request.media_events:
+            if isinstance(media_event, nio.RoomMessageImage | nio.RoomEncryptedImage):
+                image_event_count += 1
+                image = await download_image(client, media_event)
+                if image is None:
+                    msg = "Failed to download image"
+                    raise RuntimeError(msg)
+                attachment_record = await register_image_attachment(
+                    client,
+                    self.deps.storage_path,
+                    room_id=request.room_id,
+                    thread_id=request.thread_id,
+                    event=media_event,
+                    image_bytes=image.content,
+                )
+                if attachment_record is not None:
+                    attachment_ids.append(attachment_record.attachment_id)
+                else:
+                    fallback_images.append(image)
+                continue
+
+            file_or_video_event_count += 1
+            attachment_record = await register_file_or_video_attachment(
+                client,
+                self.deps.storage_path,
+                room_id=request.room_id,
+                thread_id=request.thread_id,
+                event=self._as_file_or_video_dispatch_event(media_event),
+            )
+            if attachment_record is None:
+                msg = "Failed to register media attachment"
+                raise RuntimeError(msg)
+            attachment_ids.append(attachment_record.attachment_id)
+
+        emit_registration_timing()
+        return BatchMediaAttachmentResult(
+            attachment_ids=attachment_ids,
+            fallback_images=fallback_images or None,
+        )
 
     async def build_dispatch_payload_with_attachments(
         self,

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -288,12 +288,13 @@ class InboundTurnNormalizer:
         attachment_ids: list[str] = []
         fallback_images: list[Image] = []
 
-        def emit_registration_timing() -> None:
+        def emit_registration_timing(*, outcome: str) -> None:
             emit_elapsed_timing(
                 "response_payload.register_batch_media_attachments",
                 started,
                 room_id=request.room_id,
                 thread_id=request.thread_id,
+                outcome=outcome,
                 media_event_count=media_event_count,
                 image_event_count=image_event_count,
                 file_or_video_event_count=file_or_video_event_count,
@@ -301,50 +302,54 @@ class InboundTurnNormalizer:
                 fallback_image_count=len(fallback_images),
             )
 
-        if not request.media_events:
-            emit_registration_timing()
-            return BatchMediaAttachmentResult(attachment_ids=[])
+        registration_succeeded = False
+        try:
+            if not request.media_events:
+                registration_succeeded = True
+                return BatchMediaAttachmentResult(attachment_ids=[])
 
-        client = self._client()
-        for media_event in request.media_events:
-            if isinstance(media_event, nio.RoomMessageImage | nio.RoomEncryptedImage):
-                image_event_count += 1
-                image = await download_image(client, media_event)
-                if image is None:
-                    msg = "Failed to download image"
-                    raise RuntimeError(msg)
-                attachment_record = await register_image_attachment(
+            client = self._client()
+            for media_event in request.media_events:
+                if isinstance(media_event, nio.RoomMessageImage | nio.RoomEncryptedImage):
+                    image_event_count += 1
+                    image = await download_image(client, media_event)
+                    if image is None:
+                        msg = "Failed to download image"
+                        raise RuntimeError(msg)
+                    attachment_record = await register_image_attachment(
+                        client,
+                        self.deps.storage_path,
+                        room_id=request.room_id,
+                        thread_id=request.thread_id,
+                        event=media_event,
+                        image_bytes=image.content,
+                    )
+                    if attachment_record is not None:
+                        attachment_ids.append(attachment_record.attachment_id)
+                    else:
+                        fallback_images.append(image)
+                    continue
+
+                file_or_video_event_count += 1
+                attachment_record = await register_file_or_video_attachment(
                     client,
                     self.deps.storage_path,
                     room_id=request.room_id,
                     thread_id=request.thread_id,
-                    event=media_event,
-                    image_bytes=image.content,
+                    event=self._as_file_or_video_dispatch_event(media_event),
                 )
-                if attachment_record is not None:
-                    attachment_ids.append(attachment_record.attachment_id)
-                else:
-                    fallback_images.append(image)
-                continue
+                if attachment_record is None:
+                    msg = "Failed to register media attachment"
+                    raise RuntimeError(msg)
+                attachment_ids.append(attachment_record.attachment_id)
 
-            file_or_video_event_count += 1
-            attachment_record = await register_file_or_video_attachment(
-                client,
-                self.deps.storage_path,
-                room_id=request.room_id,
-                thread_id=request.thread_id,
-                event=self._as_file_or_video_dispatch_event(media_event),
+            registration_succeeded = True
+            return BatchMediaAttachmentResult(
+                attachment_ids=attachment_ids,
+                fallback_images=fallback_images or None,
             )
-            if attachment_record is None:
-                msg = "Failed to register media attachment"
-                raise RuntimeError(msg)
-            attachment_ids.append(attachment_record.attachment_id)
-
-        emit_registration_timing()
-        return BatchMediaAttachmentResult(
-            attachment_ids=attachment_ids,
-            fallback_images=fallback_images or None,
-        )
+        finally:
+            emit_registration_timing(outcome="success" if registration_succeeded else "failed")
 
     async def build_dispatch_payload_with_attachments(
         self,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1039,7 +1039,16 @@ class TurnController:
                 dispatch.context.thread_history = request.thread_history
                 dispatch.context.thread_id = request.thread_id
                 dispatch.context.requires_full_thread_history = False
-                payload = await payload_builder(dispatch.context)
+                payload_builder_started = time.monotonic()
+                try:
+                    payload = await payload_builder(dispatch.context)
+                finally:
+                    emit_elapsed_timing(
+                        "response_payload.builder",
+                        payload_builder_started,
+                        room_id=request.room_id,
+                        thread_id=request.thread_id,
+                    )
                 prepared_payload = await self.deps.ingress_hook_runner.apply_message_enrichment(
                     dispatch,
                     payload,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1040,15 +1040,13 @@ class TurnController:
                 dispatch.context.thread_id = request.thread_id
                 dispatch.context.requires_full_thread_history = False
                 payload_builder_started = time.monotonic()
-                try:
-                    payload = await payload_builder(dispatch.context)
-                finally:
-                    emit_elapsed_timing(
-                        "response_payload.builder",
-                        payload_builder_started,
-                        room_id=request.room_id,
-                        thread_id=request.thread_id,
-                    )
+                payload = await payload_builder(dispatch.context)
+                emit_elapsed_timing(
+                    "response_payload.builder",
+                    payload_builder_started,
+                    room_id=request.room_id,
+                    thread_id=request.thread_id,
+                )
                 prepared_payload = await self.deps.ingress_hook_runner.apply_message_enrichment(
                     dispatch,
                     payload,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1040,13 +1040,18 @@ class TurnController:
                 dispatch.context.thread_id = request.thread_id
                 dispatch.context.requires_full_thread_history = False
                 payload_builder_started = time.monotonic()
-                payload = await payload_builder(dispatch.context)
-                emit_elapsed_timing(
-                    "response_payload.builder",
-                    payload_builder_started,
-                    room_id=request.room_id,
-                    thread_id=request.thread_id,
-                )
+                payload_builder_outcome = "failed"
+                try:
+                    payload = await payload_builder(dispatch.context)
+                    payload_builder_outcome = "success"
+                finally:
+                    emit_elapsed_timing(
+                        "response_payload.builder",
+                        payload_builder_started,
+                        room_id=request.room_id,
+                        thread_id=request.thread_id,
+                        outcome=payload_builder_outcome,
+                    )
                 prepared_payload = await self.deps.ingress_hook_runner.apply_message_enrichment(
                     dispatch,
                     payload,

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -145,62 +145,61 @@ class IngressHookRunner:
         started = time.monotonic()
         hook_registered = self.hook_context.registry.has_hooks(EVENT_MESSAGE_ENRICH)
         item_count = 0
-        try:
-            envelope = MessageEnvelope(
-                source_event_id=dispatch.envelope.source_event_id,
-                room_id=dispatch.envelope.room_id,
-                target=dispatch.envelope.target,
-                requester_id=dispatch.envelope.requester_id,
-                sender_id=dispatch.envelope.sender_id,
-                body=dispatch.envelope.body,
-                attachment_ids=(
-                    tuple(payload.attachment_ids)
-                    if payload.attachment_ids is not None
-                    else dispatch.envelope.attachment_ids
-                ),
-                mentioned_agents=dispatch.envelope.mentioned_agents,
-                agent_name=target_entity_name,
-                source_kind=dispatch.envelope.source_kind,
-                hook_source=dispatch.envelope.hook_source,
-                message_received_depth=dispatch.envelope.message_received_depth,
-            )
-            model_prompt = payload.model_prompt
-            if hook_registered:
-                context = MessageEnrichContext(
-                    **self.hook_context.base_kwargs(EVENT_MESSAGE_ENRICH, dispatch.correlation_id),
-                    envelope=envelope,
-                    target_entity_name=target_entity_name,
-                    target_member_names=target_member_names,
-                )
-                items = await emit_collect(self.hook_context.registry, EVENT_MESSAGE_ENRICH, context)
-                item_count = len(items)
-                if items:
-                    enrichment_block = render_enrichment_block(items)
-                    model_prompt = (
-                        f"{payload.model_prompt.rstrip()}\n\n{enrichment_block}"
-                        if payload.model_prompt
-                        else enrichment_block
-                    )
 
-            return PreparedHookedPayload(
-                payload=DispatchPayload(
-                    prompt=payload.prompt,
-                    model_prompt=model_prompt,
-                    media=payload.media,
-                    attachment_ids=payload.attachment_ids,
-                ),
+        envelope = MessageEnvelope(
+            source_event_id=dispatch.envelope.source_event_id,
+            room_id=dispatch.envelope.room_id,
+            target=dispatch.envelope.target,
+            requester_id=dispatch.envelope.requester_id,
+            sender_id=dispatch.envelope.sender_id,
+            body=dispatch.envelope.body,
+            attachment_ids=(
+                tuple(payload.attachment_ids)
+                if payload.attachment_ids is not None
+                else dispatch.envelope.attachment_ids
+            ),
+            mentioned_agents=dispatch.envelope.mentioned_agents,
+            agent_name=target_entity_name,
+            source_kind=dispatch.envelope.source_kind,
+            hook_source=dispatch.envelope.hook_source,
+            message_received_depth=dispatch.envelope.message_received_depth,
+        )
+        model_prompt = payload.model_prompt
+        if hook_registered:
+            context = MessageEnrichContext(
+                **self.hook_context.base_kwargs(EVENT_MESSAGE_ENRICH, dispatch.correlation_id),
                 envelope=envelope,
-                system_enrichment_items=(),
-            )
-        finally:
-            emit_elapsed_timing(
-                "response_payload.apply_message_enrichment",
-                started,
-                room_id=dispatch.envelope.room_id,
                 target_entity_name=target_entity_name,
-                hook_registered=hook_registered,
-                enrichment_item_count=item_count,
+                target_member_names=target_member_names,
             )
+            items = await emit_collect(self.hook_context.registry, EVENT_MESSAGE_ENRICH, context)
+            item_count = len(items)
+            if items:
+                enrichment_block = render_enrichment_block(items)
+                model_prompt = (
+                    f"{payload.model_prompt.rstrip()}\n\n{enrichment_block}"
+                    if payload.model_prompt
+                    else enrichment_block
+                )
+
+        emit_elapsed_timing(
+            "response_payload.apply_message_enrichment",
+            started,
+            room_id=dispatch.envelope.room_id,
+            target_entity_name=target_entity_name,
+            hook_registered=hook_registered,
+            enrichment_item_count=item_count,
+        )
+        return PreparedHookedPayload(
+            payload=DispatchPayload(
+                prompt=payload.prompt,
+                model_prompt=model_prompt,
+                media=payload.media,
+                attachment_ids=payload.attachment_ids,
+            ),
+            envelope=envelope,
+            system_enrichment_items=(),
+        )
 
     async def apply_system_enrichment(
         self,
@@ -213,28 +212,27 @@ class IngressHookRunner:
         """Run system:enrich and return system-prompt enrichment items."""
         started = time.monotonic()
         hook_registered = self.hook_context.registry.has_hooks(EVENT_SYSTEM_ENRICH)
-        item_count = 0
-        try:
-            if not hook_registered:
-                return []
-            context = SystemEnrichContext(
-                **self.hook_context.base_kwargs(EVENT_SYSTEM_ENRICH, dispatch.correlation_id),
-                envelope=envelope,
-                target_entity_name=target_entity_name,
-                target_member_names=target_member_names,
-            )
-            items = await emit_collect(self.hook_context.registry, EVENT_SYSTEM_ENRICH, context)
-            item_count = len(items)
-            return items
-        finally:
+
+        def finish(items: list[EnrichmentItem]) -> list[EnrichmentItem]:
             emit_elapsed_timing(
                 "response_payload.apply_system_enrichment",
                 started,
                 room_id=dispatch.envelope.room_id,
                 target_entity_name=target_entity_name,
                 hook_registered=hook_registered,
-                enrichment_item_count=item_count,
+                enrichment_item_count=len(items),
             )
+            return items
+
+        if not hook_registered:
+            return finish([])
+        context = SystemEnrichContext(
+            **self.hook_context.base_kwargs(EVENT_SYSTEM_ENRICH, dispatch.correlation_id),
+            envelope=envelope,
+            target_entity_name=target_entity_name,
+            target_member_names=target_member_names,
+        )
+        return finish(await emit_collect(self.hook_context.registry, EVENT_SYSTEM_ENRICH, context))
 
 
 @dataclass(frozen=True)

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -46,7 +47,7 @@ from mindroom.thread_utils import (
     should_agent_respond,
     thread_requires_explicit_agent_targeting,
 )
-from mindroom.timing import timed
+from mindroom.timing import emit_elapsed_timing, timed
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -141,51 +142,65 @@ class IngressHookRunner:
         target_member_names: tuple[str, ...] | None,
     ) -> PreparedHookedPayload:
         """Run message:enrich and return the model-facing payload."""
-        envelope = MessageEnvelope(
-            source_event_id=dispatch.envelope.source_event_id,
-            room_id=dispatch.envelope.room_id,
-            target=dispatch.envelope.target,
-            requester_id=dispatch.envelope.requester_id,
-            sender_id=dispatch.envelope.sender_id,
-            body=dispatch.envelope.body,
-            attachment_ids=(
-                tuple(payload.attachment_ids)
-                if payload.attachment_ids is not None
-                else dispatch.envelope.attachment_ids
-            ),
-            mentioned_agents=dispatch.envelope.mentioned_agents,
-            agent_name=target_entity_name,
-            source_kind=dispatch.envelope.source_kind,
-            hook_source=dispatch.envelope.hook_source,
-            message_received_depth=dispatch.envelope.message_received_depth,
-        )
-        model_prompt = payload.model_prompt
-        if self.hook_context.registry.has_hooks(EVENT_MESSAGE_ENRICH):
-            context = MessageEnrichContext(
-                **self.hook_context.base_kwargs(EVENT_MESSAGE_ENRICH, dispatch.correlation_id),
-                envelope=envelope,
-                target_entity_name=target_entity_name,
-                target_member_names=target_member_names,
+        started = time.monotonic()
+        hook_registered = self.hook_context.registry.has_hooks(EVENT_MESSAGE_ENRICH)
+        item_count = 0
+        try:
+            envelope = MessageEnvelope(
+                source_event_id=dispatch.envelope.source_event_id,
+                room_id=dispatch.envelope.room_id,
+                target=dispatch.envelope.target,
+                requester_id=dispatch.envelope.requester_id,
+                sender_id=dispatch.envelope.sender_id,
+                body=dispatch.envelope.body,
+                attachment_ids=(
+                    tuple(payload.attachment_ids)
+                    if payload.attachment_ids is not None
+                    else dispatch.envelope.attachment_ids
+                ),
+                mentioned_agents=dispatch.envelope.mentioned_agents,
+                agent_name=target_entity_name,
+                source_kind=dispatch.envelope.source_kind,
+                hook_source=dispatch.envelope.hook_source,
+                message_received_depth=dispatch.envelope.message_received_depth,
             )
-            items = await emit_collect(self.hook_context.registry, EVENT_MESSAGE_ENRICH, context)
-            if items:
-                enrichment_block = render_enrichment_block(items)
-                model_prompt = (
-                    f"{payload.model_prompt.rstrip()}\n\n{enrichment_block}"
-                    if payload.model_prompt
-                    else enrichment_block
+            model_prompt = payload.model_prompt
+            if hook_registered:
+                context = MessageEnrichContext(
+                    **self.hook_context.base_kwargs(EVENT_MESSAGE_ENRICH, dispatch.correlation_id),
+                    envelope=envelope,
+                    target_entity_name=target_entity_name,
+                    target_member_names=target_member_names,
                 )
+                items = await emit_collect(self.hook_context.registry, EVENT_MESSAGE_ENRICH, context)
+                item_count = len(items)
+                if items:
+                    enrichment_block = render_enrichment_block(items)
+                    model_prompt = (
+                        f"{payload.model_prompt.rstrip()}\n\n{enrichment_block}"
+                        if payload.model_prompt
+                        else enrichment_block
+                    )
 
-        return PreparedHookedPayload(
-            payload=DispatchPayload(
-                prompt=payload.prompt,
-                model_prompt=model_prompt,
-                media=payload.media,
-                attachment_ids=payload.attachment_ids,
-            ),
-            envelope=envelope,
-            system_enrichment_items=(),
-        )
+            return PreparedHookedPayload(
+                payload=DispatchPayload(
+                    prompt=payload.prompt,
+                    model_prompt=model_prompt,
+                    media=payload.media,
+                    attachment_ids=payload.attachment_ids,
+                ),
+                envelope=envelope,
+                system_enrichment_items=(),
+            )
+        finally:
+            emit_elapsed_timing(
+                "response_payload.apply_message_enrichment",
+                started,
+                room_id=dispatch.envelope.room_id,
+                target_entity_name=target_entity_name,
+                hook_registered=hook_registered,
+                enrichment_item_count=item_count,
+            )
 
     async def apply_system_enrichment(
         self,
@@ -196,15 +211,30 @@ class IngressHookRunner:
         target_member_names: tuple[str, ...] | None,
     ) -> list[EnrichmentItem]:
         """Run system:enrich and return system-prompt enrichment items."""
-        if not self.hook_context.registry.has_hooks(EVENT_SYSTEM_ENRICH):
-            return []
-        context = SystemEnrichContext(
-            **self.hook_context.base_kwargs(EVENT_SYSTEM_ENRICH, dispatch.correlation_id),
-            envelope=envelope,
-            target_entity_name=target_entity_name,
-            target_member_names=target_member_names,
-        )
-        return await emit_collect(self.hook_context.registry, EVENT_SYSTEM_ENRICH, context)
+        started = time.monotonic()
+        hook_registered = self.hook_context.registry.has_hooks(EVENT_SYSTEM_ENRICH)
+        item_count = 0
+        try:
+            if not hook_registered:
+                return []
+            context = SystemEnrichContext(
+                **self.hook_context.base_kwargs(EVENT_SYSTEM_ENRICH, dispatch.correlation_id),
+                envelope=envelope,
+                target_entity_name=target_entity_name,
+                target_member_names=target_member_names,
+            )
+            items = await emit_collect(self.hook_context.registry, EVENT_SYSTEM_ENRICH, context)
+            item_count = len(items)
+            return items
+        finally:
+            emit_elapsed_timing(
+                "response_payload.apply_system_enrichment",
+                started,
+                room_id=dispatch.envelope.room_id,
+                target_entity_name=target_entity_name,
+                hook_registered=hook_registered,
+                enrichment_item_count=item_count,
+            )
 
 
 @dataclass(frozen=True)

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -22,6 +22,7 @@ from mindroom.attachments import (
     register_image_attachment,
     register_local_attachment,
     resolve_attachments,
+    resolve_thread_attachment_ids,
 )
 from tests.conftest import make_visible_message
 
@@ -388,6 +389,84 @@ def test_resolve_attachment_media_drops_cross_thread_ids(tmp_path: Path) -> None
     assert resolved_ids == ["att_ok"]
     assert len(files) == 1
     assert str(files[0].filepath) == str(file_path.resolve())
+
+
+def test_resolve_attachment_media_emits_payload_timing(tmp_path: Path) -> None:
+    """Attachment media resolution timing should report payload counts."""
+    file_path = tmp_path / "payload.txt"
+    file_path.write_text("payload", encoding="utf-8")
+
+    allowed = register_local_attachment(
+        tmp_path,
+        file_path,
+        kind="file",
+        attachment_id="att_ok",
+        room_id="!room:localhost",
+        thread_id="$thread_a",
+    )
+    rejected = register_local_attachment(
+        tmp_path,
+        file_path,
+        kind="file",
+        attachment_id="att_wrong_thread",
+        room_id="!room:localhost",
+        thread_id="$thread_b",
+    )
+    assert allowed is not None
+    assert rejected is not None
+
+    with patch("mindroom.attachment_media.emit_elapsed_timing") as mock_emit:
+        resolved_ids, _, _, files, _ = resolve_attachment_media(
+            tmp_path,
+            ["att_ok", "att_wrong_thread"],
+            room_id="!room:localhost",
+            thread_id="$thread_a",
+        )
+
+    assert resolved_ids == ["att_ok"]
+    assert len(files) == 1
+    mock_emit.assert_called_once()
+    assert mock_emit.call_args.args[0] == "response_payload.resolve_attachment_media"
+    assert isinstance(mock_emit.call_args.args[1], float)
+    assert mock_emit.call_args.kwargs == {
+        "room_id": "!room:localhost",
+        "thread_id": "$thread_a",
+        "requested_attachment_count": 2,
+        "resolved_attachment_count": 1,
+        "rejected_attachment_count": 1,
+        "audio_count": 0,
+        "image_count": 0,
+        "file_count": 1,
+        "video_count": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_thread_attachment_ids_emits_payload_timing(tmp_path: Path) -> None:
+    """Thread attachment ID resolution timing should include outcome and source event kind."""
+    event = MagicMock()
+    event.source = {"content": {"com.mindroom.attachment_ids": ["att_root"]}}
+
+    with patch("mindroom.attachments.emit_elapsed_timing") as mock_emit:
+        attachment_ids = await resolve_thread_attachment_ids(
+            AsyncMock(),
+            tmp_path,
+            room_id="!room:localhost",
+            thread_id="$thread_root",
+            thread_root_event=event,
+        )
+
+    assert attachment_ids == ["att_root"]
+    mock_emit.assert_called_once()
+    assert mock_emit.call_args.args[0] == "response_payload.resolve_thread_attachment_ids"
+    assert isinstance(mock_emit.call_args.args[1], float)
+    assert mock_emit.call_args.kwargs == {
+        "room_id": "!room:localhost",
+        "thread_id": "$thread_root",
+        "outcome": "event_metadata",
+        "event_kind": "provided",
+        "attachment_count": 1,
+    }
 
 
 def test_register_local_attachment_prunes_expired_managed_media(tmp_path: Path) -> None:

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -22,7 +22,9 @@ from mindroom.conversation_resolver import MessageContext
 from mindroom.handled_turns import HandledTurnState
 from mindroom.hooks import (
     EVENT_AGENT_STARTED,
+    EVENT_MESSAGE_ENRICH,
     EVENT_MESSAGE_RECEIVED,
+    EVENT_SYSTEM_ENRICH,
     AfterResponseContext,
     AgentLifecycleContext,
     BeforeResponseContext,
@@ -34,6 +36,7 @@ from mindroom.hooks import (
     MessageReceivedContext,
     ResponseDraft,
     ResponseResult,
+    SystemEnrichContext,
     hook,
 )
 from mindroom.hooks.execution import emit
@@ -850,6 +853,61 @@ async def test_apply_message_enrichment_preserves_hook_chain_metadata(tmp_path: 
 
     assert prepared.envelope.hook_source == "origin-plugin:message:received"
     assert prepared.envelope.message_received_depth == 1
+
+
+@pytest.mark.asyncio
+async def test_payload_enrichment_timing_reports_hook_counts(tmp_path: Path) -> None:
+    """Payload enrichment timing should report registered hooks and collected item counts."""
+    bot = _agent_bot(tmp_path)
+    dispatch = PreparedDispatch(
+        requester_user_id="@user:localhost",
+        context=_dispatch_context(bot),
+        target=MessageTarget.resolve("!room:localhost", "$thread", "$hook-event"),
+        correlation_id="corr-enrich-timing",
+        envelope=_synthetic_envelope(),
+    )
+
+    @hook(EVENT_MESSAGE_ENRICH)
+    async def message_enrich(context: MessageEnrichContext) -> None:
+        context.add_metadata("message-context", "message enrichment")
+
+    @hook(EVENT_SYSTEM_ENRICH)
+    async def system_enrich(context: SystemEnrichContext) -> None:
+        context.add_instruction("system-context", "system enrichment")
+
+    bot.hook_registry = HookRegistry.from_plugins([_plugin("enrich-plugin", [message_enrich, system_enrich])])
+
+    with patch("mindroom.turn_policy.emit_elapsed_timing") as mock_emit:
+        prepared = await bot._ingress_hook_runner.apply_message_enrichment(
+            dispatch,
+            DispatchPayload(prompt="hello"),
+            target_entity_name="code",
+            target_member_names=("code",),
+        )
+        system_items = await bot._ingress_hook_runner.apply_system_enrichment(
+            dispatch,
+            prepared.envelope,
+            target_entity_name="code",
+            target_member_names=("code",),
+        )
+
+    assert "message enrichment" in (prepared.payload.model_prompt or "")
+    assert [item.text for item in system_items] == ["system enrichment"]
+    calls_by_label = {call.args[0]: call for call in mock_emit.call_args_list}
+    assert calls_by_label["response_payload.apply_message_enrichment"].kwargs == {
+        "room_id": "!room:localhost",
+        "target_entity_name": "code",
+        "hook_registered": True,
+        "enrichment_item_count": 1,
+    }
+    assert calls_by_label["response_payload.apply_system_enrichment"].kwargs == {
+        "room_id": "!room:localhost",
+        "target_entity_name": "code",
+        "hook_registered": True,
+        "enrichment_item_count": 1,
+    }
+    assert isinstance(calls_by_label["response_payload.apply_message_enrichment"].args[1], float)
+    assert isinstance(calls_by_label["response_payload.apply_system_enrichment"].args[1], float)
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -28,7 +28,7 @@ from mindroom.config.models import DefaultsConfig, ModelConfig
 from mindroom.constants import ATTACHMENT_IDS_KEY, ORIGINAL_SENDER_KEY, VOICE_RAW_AUDIO_FALLBACK_KEY
 from mindroom.conversation_resolver import MessageContext
 from mindroom.hooks import MessageEnvelope
-from mindroom.inbound_turn_normalizer import DispatchPayload
+from mindroom.inbound_turn_normalizer import BatchMediaAttachmentRequest, DispatchPayload
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
@@ -1549,6 +1549,70 @@ async def test_handle_coalesced_batch_timing_events_include_dispatch_scope(tmp_p
     ]
     assert batch_calls
     assert all(call.kwargs["timing_scope"] == "$m1" for call in batch_calls)
+
+
+@pytest.mark.asyncio
+async def test_register_batch_media_attachments_emits_payload_timing_for_empty_batch(tmp_path: Path) -> None:
+    """Batch media registration timing should report empty payload batches."""
+    bot = _make_bot(tmp_path)
+
+    with patch("mindroom.inbound_turn_normalizer.emit_elapsed_timing") as mock_emit:
+        result = await bot._inbound_turn_normalizer.register_batch_media_attachments(
+            BatchMediaAttachmentRequest(
+                room_id="!room:localhost",
+                thread_id="$thread",
+                media_events=[],
+            ),
+        )
+
+    assert result.attachment_ids == []
+    assert result.fallback_images is None
+    mock_emit.assert_called_once()
+    assert mock_emit.call_args.args[0] == "response_payload.register_batch_media_attachments"
+    assert isinstance(mock_emit.call_args.args[1], float)
+    assert mock_emit.call_args.kwargs == {
+        "room_id": "!room:localhost",
+        "thread_id": "$thread",
+        "outcome": "success",
+        "media_event_count": 0,
+        "image_event_count": 0,
+        "file_or_video_event_count": 0,
+        "attachment_count": 0,
+        "fallback_image_count": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_register_batch_media_attachments_emits_payload_timing_on_failure(tmp_path: Path) -> None:
+    """Batch media registration timing should still emit when attachment hydration fails."""
+    bot = _make_bot(tmp_path)
+
+    with (
+        patch("mindroom.inbound_turn_normalizer.download_image", new=AsyncMock(return_value=None)),
+        patch("mindroom.inbound_turn_normalizer.emit_elapsed_timing") as mock_emit,
+        pytest.raises(RuntimeError, match="Failed to download image"),
+    ):
+        await bot._inbound_turn_normalizer.register_batch_media_attachments(
+            BatchMediaAttachmentRequest(
+                room_id="!room:localhost",
+                thread_id="$thread",
+                media_events=[_image_event(event_id="$img1")],
+            ),
+        )
+
+    mock_emit.assert_called_once()
+    assert mock_emit.call_args.args[0] == "response_payload.register_batch_media_attachments"
+    assert isinstance(mock_emit.call_args.args[1], float)
+    assert mock_emit.call_args.kwargs == {
+        "room_id": "!room:localhost",
+        "thread_id": "$thread",
+        "outcome": "failed",
+        "media_event_count": 1,
+        "image_event_count": 1,
+        "file_or_video_event_count": 0,
+        "attachment_count": 0,
+        "fallback_image_count": 0,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -9572,6 +9572,153 @@ class TestAgentBot:
         assert payload_built is True
 
     @pytest.mark.asyncio
+    async def test_execute_dispatch_action_emits_payload_builder_timing(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Dispatch execution should time the payload builder inside the locked preparation path."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = AsyncMock()
+        _set_turn_store_tracker(bot, MagicMock())
+        bot.logger = MagicMock()
+        _replace_turn_policy_deps(bot, logger=bot.logger)
+
+        room = MagicMock(spec=nio.MatrixRoom)
+        room.room_id = "!room:localhost"
+        event = MagicMock()
+        event.event_id = "$event"
+        dispatch = PreparedDispatch(
+            requester_user_id="@user:localhost",
+            context=MessageContext(
+                am_i_mentioned=False,
+                is_thread=True,
+                thread_id="$thread",
+                thread_history=ThreadHistoryResult([], is_full_history=True),
+                mentioned_agents=[],
+                has_non_agent_mentions=False,
+                requires_full_thread_history=False,
+            ),
+            target=MessageTarget.resolve(
+                room_id=room.room_id,
+                thread_id="$thread",
+                reply_to_event_id=event.event_id,
+            ),
+            correlation_id="corr-payload-builder-timing",
+            envelope=_hook_envelope(body="hello", source_event_id="$event"),
+        )
+
+        mock_generate_response = AsyncMock(return_value="$response")
+        install_generate_response_mock(bot, mock_generate_response)
+        _replace_turn_policy_deps(
+            bot,
+            logger=bot.logger,
+            response_runner=bot._response_runner,
+        )
+
+        async def payload_builder(_context: MessageContext) -> DispatchPayload:
+            return DispatchPayload(prompt="help me")
+
+        with patch("mindroom.turn_controller.emit_elapsed_timing") as mock_emit:
+            await bot._turn_controller._execute_response_action(
+                room,
+                event,
+                dispatch,
+                ResponseAction(kind="individual"),
+                payload_builder,
+                processing_log="processing",
+                dispatch_started_at=0.0,
+                handled_turn=HandledTurnState.from_source_event_id(event.event_id),
+            )
+
+        builder_calls = [
+            call for call in mock_emit.call_args_list if call.args and call.args[0] == "response_payload.builder"
+        ]
+        assert len(builder_calls) == 1
+        assert isinstance(builder_calls[0].args[1], float)
+        assert builder_calls[0].kwargs == {
+            "room_id": "!room:localhost",
+            "thread_id": "$thread",
+            "outcome": "success",
+        }
+
+    @pytest.mark.asyncio
+    async def test_execute_dispatch_action_emits_payload_builder_timing_on_failure(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Payload-builder timing should still emit when locked payload preparation fails."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = AsyncMock()
+        _set_turn_store_tracker(bot, MagicMock())
+        bot.logger = MagicMock()
+        _replace_turn_policy_deps(bot, logger=bot.logger)
+
+        room = MagicMock(spec=nio.MatrixRoom)
+        room.room_id = "!room:localhost"
+        event = MagicMock()
+        event.event_id = "$event"
+        dispatch = PreparedDispatch(
+            requester_user_id="@user:localhost",
+            context=MessageContext(
+                am_i_mentioned=False,
+                is_thread=True,
+                thread_id="$thread",
+                thread_history=ThreadHistoryResult([], is_full_history=True),
+                mentioned_agents=[],
+                has_non_agent_mentions=False,
+                requires_full_thread_history=False,
+            ),
+            target=MessageTarget.resolve(
+                room_id=room.room_id,
+                thread_id="$thread",
+                reply_to_event_id=event.event_id,
+            ),
+            correlation_id="corr-payload-builder-failure-timing",
+            envelope=_hook_envelope(body="hello", source_event_id="$event"),
+        )
+
+        install_generate_response_mock(bot, AsyncMock(return_value="$response"))
+        _replace_turn_policy_deps(
+            bot,
+            logger=bot.logger,
+            response_runner=bot._response_runner,
+        )
+
+        async def payload_builder(_context: MessageContext) -> DispatchPayload:
+            msg = "payload failed"
+            raise RuntimeError(msg)
+
+        with (
+            patch.object(bot._turn_controller, "_finalize_dispatch_failure", new=AsyncMock(return_value="$error")),
+            patch("mindroom.turn_controller.emit_elapsed_timing") as mock_emit,
+        ):
+            await bot._turn_controller._execute_response_action(
+                room,
+                event,
+                dispatch,
+                ResponseAction(kind="individual"),
+                payload_builder,
+                processing_log="processing",
+                dispatch_started_at=0.0,
+                handled_turn=HandledTurnState.from_source_event_id(event.event_id),
+            )
+
+        builder_calls = [
+            call for call in mock_emit.call_args_list if call.args and call.args[0] == "response_payload.builder"
+        ]
+        assert len(builder_calls) == 1
+        assert isinstance(builder_calls[0].args[1], float)
+        assert builder_calls[0].kwargs == {
+            "room_id": "!room:localhost",
+            "thread_id": "$thread",
+            "outcome": "failed",
+        }
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("enable_streaming", [True, False])
     @patch("mindroom.config.main.Config.from_yaml")
     @patch("mindroom.teams.resolve_agent_knowledge_access")


### PR DESCRIPTION
## Summary
- add `MINDROOM_TIMING=1` diagnostics for response payload hydration substeps
- time media attachment registration, thread attachment resolution, attachment media conversion, and enrichment hooks
- add an aggregate payload builder timing marker before response startup latency is logged

## Testing
- `uv run ruff format src/mindroom/inbound_turn_normalizer.py src/mindroom/attachments.py src/mindroom/attachment_media.py src/mindroom/turn_policy.py src/mindroom/turn_controller.py`
- `uv run ruff check src/mindroom/inbound_turn_normalizer.py src/mindroom/attachments.py src/mindroom/attachment_media.py src/mindroom/turn_policy.py src/mindroom/turn_controller.py`
- `uv run pytest -q tests/test_attachments.py tests/test_hook_sender.py::test_apply_message_enrichment_preserves_hook_chain_metadata`
- `uv run pytest -q tests/test_multi_agent_bot.py::TestAgentBot::test_execute_dispatch_action_logs_startup_latency tests/test_multi_agent_bot.py::TestAgentBot::test_execute_dispatch_action_logs_latency_after_locked_payload_preparation`