### PR TITLE
Cache matrix_state.yaml reads on the per-message hot path

### DIFF
--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -26,7 +26,7 @@ from mindroom.matrix.client_session import (
     matrix_client,
 )
 from mindroom.matrix.identity import MatrixID
-from mindroom.matrix.state import MatrixRoom, MatrixState
+from mindroom.matrix.state import MatrixRoom, MatrixState, matrix_state_for_runtime
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
 from mindroom.matrix_identifiers import (
     extract_server_name_from_homeserver,
@@ -168,20 +168,17 @@ def _room_key_to_name(room_key: str) -> str:
 
 def load_rooms(runtime_paths: RuntimePaths) -> dict[str, MatrixRoom]:
     """Load room state from YAML file."""
-    state = MatrixState.load(runtime_paths=runtime_paths)
-    return state.rooms
+    return matrix_state_for_runtime(runtime_paths).rooms
 
 
 def _get_room_aliases(runtime_paths: RuntimePaths) -> dict[str, str]:
     """Get mapping of room aliases to room IDs."""
-    state = MatrixState.load(runtime_paths=runtime_paths)
-    return state.get_room_aliases()
+    return matrix_state_for_runtime(runtime_paths).get_room_aliases()
 
 
 def get_room_id(room_key: str, runtime_paths: RuntimePaths) -> str | None:
     """Get room ID for a given room key/alias."""
-    state = MatrixState.load(runtime_paths=runtime_paths)
-    room = state.get_room(room_key)
+    room = matrix_state_for_runtime(runtime_paths).get_room(room_key)
     return room.room_id if room else None
 
 

--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -167,8 +167,13 @@ def _room_key_to_name(room_key: str) -> str:
 
 
 def load_rooms(runtime_paths: RuntimePaths) -> dict[str, MatrixRoom]:
-    """Load room state from YAML file."""
-    return matrix_state_for_runtime(runtime_paths).rooms
+    """Load room state from YAML file.
+
+    Returns an isolated copy of the rooms map so callers may mutate the dict
+    or its ``MatrixRoom`` values without corrupting cached state used by other
+    readers.
+    """
+    return MatrixState.load(runtime_paths=runtime_paths).rooms
 
 
 def _get_room_aliases(runtime_paths: RuntimePaths) -> dict[str, str]:

--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -543,7 +543,7 @@ async def ensure_user_in_rooms(
         runtime_paths: Explicit runtime context for server-name resolution.
 
     """
-    state = MatrixState.load(runtime_paths=runtime_paths)
+    state = matrix_state_for_runtime(runtime_paths)
     user_account = state.get_account(INTERNAL_USER_ACCOUNT_KEY)
     if not user_account:
         logger.warning("No user account found, skipping user room membership")

--- a/src/mindroom/matrix/state.py
+++ b/src/mindroom/matrix/state.py
@@ -102,13 +102,24 @@ class MatrixState(BaseModel):
         self.space_room_id = room_id
 
 
-def managed_account_usernames(runtime_paths: constants.RuntimePaths) -> dict[str, str]:
-    """Return current persisted managed Matrix usernames keyed by state account key."""
+def matrix_state_for_runtime(runtime_paths: constants.RuntimePaths) -> MatrixState:
+    """Return persisted Matrix state for one runtime, cached by file mtime/size.
+
+    Mutating callers must continue to use ``MatrixState.load`` so they receive a
+    fresh, isolated copy that can be safely modified before ``save``. Read-only
+    hot paths should prefer this helper to avoid re-parsing the YAML on every
+    call.
+    """
     state_file = constants.matrix_state_file(runtime_paths=runtime_paths)
-    state = _load_matrix_state_file_for_accounts(
+    return _load_matrix_state_file_cached(
         *_matrix_state_cache_key(state_file),
         current_domain=_current_runtime_domain(runtime_paths),
     )
+
+
+def managed_account_usernames(runtime_paths: constants.RuntimePaths) -> dict[str, str]:
+    """Return current persisted managed Matrix usernames keyed by state account key."""
+    state = matrix_state_for_runtime(runtime_paths)
     return {key: account.username for key, account in state.accounts.items() if key.startswith("agent_")}
 
 
@@ -121,14 +132,14 @@ def _matrix_state_cache_key(state_file: Path) -> tuple[Path, int | None, int | N
 
 
 @lru_cache(maxsize=64)
-def _load_matrix_state_file_for_accounts(
+def _load_matrix_state_file_cached(
     state_file: Path,
     mtime_ns: int | None,
     size: int | None,
     *,
     current_domain: str,
 ) -> MatrixState:
-    """Load Matrix state through a file-change-sensitive cache for account reads."""
+    """Load Matrix state through a file-change-sensitive cache."""
     del mtime_ns, size
     return _load_matrix_state_file(state_file, current_domain=current_domain)
 

--- a/src/mindroom/matrix/state.py
+++ b/src/mindroom/matrix/state.py
@@ -45,12 +45,14 @@ class MatrixState(BaseModel):
 
     @classmethod
     def load(cls, runtime_paths: constants.RuntimePaths) -> "MatrixState":
-        """Load state from file."""
-        state_file = constants.matrix_state_file(runtime_paths=runtime_paths)
-        return _load_matrix_state_file(
-            state_file,
-            current_domain=_current_runtime_domain(runtime_paths),
-        )
+        """Load state from file.
+
+        Reads come from a process-wide cache keyed by the state file's
+        ``(path, st_mtime_ns, st_size)`` so repeated calls against an unchanged
+        file skip the YAML parse. A deep copy is returned so callers may safely
+        mutate the result before ``save`` without polluting the cache.
+        """
+        return matrix_state_for_runtime(runtime_paths).model_copy(deep=True)
 
     def save(self, runtime_paths: constants.RuntimePaths) -> None:
         """Save state to file."""
@@ -105,10 +107,10 @@ class MatrixState(BaseModel):
 def matrix_state_for_runtime(runtime_paths: constants.RuntimePaths) -> MatrixState:
     """Return persisted Matrix state for one runtime, cached by file mtime/size.
 
-    Mutating callers must continue to use ``MatrixState.load`` so they receive a
-    fresh, isolated copy that can be safely modified before ``save``. Read-only
-    hot paths should prefer this helper to avoid re-parsing the YAML on every
-    call.
+    The returned object is shared across callers; **read-only callers** should
+    prefer this helper for the lowest overhead. Callers that intend to mutate
+    the result must use :py:meth:`MatrixState.load`, which returns a deep copy
+    backed by the same cache.
     """
     state_file = constants.matrix_state_file(runtime_paths=runtime_paths)
     return _load_matrix_state_file_cached(

--- a/tests/test_matrix_state_cache.py
+++ b/tests/test_matrix_state_cache.py
@@ -94,6 +94,32 @@ def test_matrix_state_load_returns_isolated_deep_copy(tmp_path: Path) -> None:
     assert mutated is not cached
 
 
+def test_load_rooms_returns_isolated_dict(tmp_path: Path) -> None:
+    """``load_rooms`` must hand back an isolated copy that mutators cannot leak via the cache."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    _seed_state(runtime_paths, "dev", "!dev:localhost")
+    _load_matrix_state_file_cached.cache_clear()
+
+    rooms = matrix_rooms.load_rooms(runtime_paths)
+    assert "dev" in rooms
+    rooms.clear()
+    rooms_after_mutation = matrix_rooms.load_rooms(runtime_paths)
+    assert rooms_after_mutation.get("dev") is not None
+    assert rooms_after_mutation["dev"].room_id == "!dev:localhost"
+
+
+def test_load_rooms_room_value_is_isolated(tmp_path: Path) -> None:
+    """Mutating a ``MatrixRoom`` returned by ``load_rooms`` must not leak into cached state."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    _seed_state(runtime_paths, "dev", "!dev:localhost")
+    _load_matrix_state_file_cached.cache_clear()
+
+    rooms = matrix_rooms.load_rooms(runtime_paths)
+    rooms["dev"].room_id = "!corrupted:localhost"
+    rooms_after_mutation = matrix_rooms.load_rooms(runtime_paths)
+    assert rooms_after_mutation["dev"].room_id == "!dev:localhost"
+
+
 def test_resolve_room_aliases_does_not_reparse_yaml(
     tmp_path: Path,
     monkeypatch,  # noqa: ANN001

--- a/tests/test_matrix_state_cache.py
+++ b/tests/test_matrix_state_cache.py
@@ -80,6 +80,20 @@ def test_get_room_aliases_uses_cached_state(tmp_path: Path) -> None:
     assert info.hits >= 1
 
 
+def test_matrix_state_load_returns_isolated_deep_copy(tmp_path: Path) -> None:
+    """``MatrixState.load`` must return a fresh copy that mutators cannot leak through the cache."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    _seed_state(runtime_paths, "dev", "!dev:localhost")
+    _load_matrix_state_file_cached.cache_clear()
+
+    mutated = MatrixState.load(runtime_paths=runtime_paths)
+    mutated.add_room("scratch", room_id="!scratch:localhost", alias="#scratch:localhost", name="scratch")
+
+    cached = matrix_state_for_runtime(runtime_paths)
+    assert cached.get_room("scratch") is None
+    assert mutated is not cached
+
+
 def test_resolve_room_aliases_does_not_reparse_yaml(
     tmp_path: Path,
     monkeypatch,  # noqa: ANN001

--- a/tests/test_matrix_state_cache.py
+++ b/tests/test_matrix_state_cache.py
@@ -1,0 +1,106 @@
+"""Tests for the file-mtime-keyed cache around the Matrix state YAML."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from mindroom import constants
+from mindroom.matrix import rooms as matrix_rooms
+from mindroom.matrix import state as matrix_state
+from mindroom.matrix.state import (
+    MatrixState,
+    _load_matrix_state_file_cached,
+    matrix_state_for_runtime,
+)
+from tests.conftest import test_runtime_paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _seed_state(runtime_paths: constants.RuntimePaths, room_key: str, room_id: str) -> Path:
+    """Persist one MatrixState and return the on-disk path used by the cache."""
+    state = MatrixState()
+    state.add_room(room_key, room_id=room_id, alias=f"#{room_key}:localhost", name=room_key)
+    state.save(runtime_paths=runtime_paths)
+    return constants.matrix_state_file(runtime_paths=runtime_paths)
+
+
+def test_matrix_state_cache_hits_when_file_unchanged(tmp_path: Path) -> None:
+    """Two reads of an unmodified state file should return the same cached object."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    _seed_state(runtime_paths, "dev", "!dev:localhost")
+    _load_matrix_state_file_cached.cache_clear()
+
+    first = matrix_state_for_runtime(runtime_paths)
+    second = matrix_state_for_runtime(runtime_paths)
+
+    assert first is second
+    info = _load_matrix_state_file_cached.cache_info()
+    assert info.hits == 1
+    assert info.misses == 1
+
+
+def test_matrix_state_cache_invalidates_when_file_mtime_changes(tmp_path: Path) -> None:
+    """Touching the state file should bypass the cache and produce a fresh state."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    state_file = _seed_state(runtime_paths, "dev", "!dev:localhost")
+    _load_matrix_state_file_cached.cache_clear()
+
+    first = matrix_state_for_runtime(runtime_paths)
+    assert first.get_room("dev") is not None
+    assert first.get_room("research") is None
+
+    fresh = MatrixState.load(runtime_paths=runtime_paths)
+    fresh.add_room("research", room_id="!research:localhost", alias="#research:localhost", name="research")
+    fresh.save(runtime_paths=runtime_paths)
+
+    stat = state_file.stat()
+    os.utime(state_file, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+
+    second = matrix_state_for_runtime(runtime_paths)
+    assert second is not first
+    assert second.get_room("research") is not None
+
+
+def test_get_room_aliases_uses_cached_state(tmp_path: Path) -> None:
+    """The per-message ``_get_room_aliases`` path should hit the shared cache."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    _seed_state(runtime_paths, "dev", "!dev:localhost")
+    _load_matrix_state_file_cached.cache_clear()
+
+    aliases_first = matrix_rooms._get_room_aliases(runtime_paths)
+    aliases_second = matrix_rooms._get_room_aliases(runtime_paths)
+
+    assert aliases_first == {"dev": "!dev:localhost"}
+    assert aliases_second == aliases_first
+    info = _load_matrix_state_file_cached.cache_info()
+    assert info.misses == 1
+    assert info.hits >= 1
+
+
+def test_resolve_room_aliases_does_not_reparse_yaml(
+    tmp_path: Path,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """Repeated alias resolution must not re-invoke ``yaml.safe_load`` per call."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    _seed_state(runtime_paths, "dev", "!dev:localhost")
+    _load_matrix_state_file_cached.cache_clear()
+
+    safe_load_calls = 0
+    real_safe_load = matrix_state.yaml.safe_load
+
+    def _counting_safe_load(stream: object) -> object:
+        nonlocal safe_load_calls
+        safe_load_calls += 1
+        return real_safe_load(stream)
+
+    monkeypatch.setattr(matrix_state.yaml, "safe_load", _counting_safe_load)
+
+    matrix_rooms.resolve_room_aliases(["dev", "#external:localhost"], runtime_paths)
+    matrix_rooms.resolve_room_aliases(["dev", "#external:localhost"], runtime_paths)
+    matrix_rooms.resolve_room_aliases(["dev"], runtime_paths)
+
+    assert safe_load_calls == 1


### PR DESCRIPTION
## Summary
- route read-only callers (`_get_room_aliases`, `get_room_id`, `load_rooms`) through the existing mtime/size-keyed LRU cache instead of re-parsing `matrix_state.yaml` on every call
- expose the cached read as `matrix_state_for_runtime` and rename the private helper from `_load_matrix_state_file_for_accounts` to `_load_matrix_state_file_cached` since it now serves more than the accounts entry point
- mutating call sites (`MatrixState.load` → `add_room` / `save`) remain unchanged and still receive a fresh, isolated state object

## Why
`py-spy` against a long-running deployment showed the chain
`_handle_message_inner → handle_text_event → _on_message → router_agents_for_room → resolve_room_aliases → _get_room_aliases → _load_matrix_state_file → yaml.safe_load → compose_node` on the asyncio main thread for ~7% of active main-thread samples — i.e. every Matrix message re-reads and re-parses the state YAML. The cache key is invalidated whenever the file's `st_mtime_ns` or `st_size` changes, so a `save` (or any external rewrite) is picked up on the next call.

## Tests
- `uv run pytest tests/test_matrix_state_cache.py -x -n 0 --no-cov -q`
- `uv run pytest tests/test_matrix_spaces.py tests/test_matrix_room_access.py tests/test_dm_room_preservation.py tests/test_room_invites.py -x -nauto --no-cov -q`
- `uv run ruff check src/mindroom/matrix/state.py src/mindroom/matrix/rooms.py tests/test_matrix_state_cache.py`
- `uv run ty check src/mindroom/matrix/state.py src/mindroom/matrix/rooms.py tests/test_matrix_state_cache.py`
- `uv run tach check --dependencies --interfaces`

## Test plan
- [x] new cache hits when state file is unchanged
- [x] cache invalidates when state file `st_mtime_ns` advances
- [x] `_get_room_aliases` reuses the cached state across calls
- [x] repeated `resolve_room_aliases` calls trigger `yaml.safe_load` exactly once per file generation