### PR TITLE
Add diagnostics for thread cache store skips

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -51,6 +51,7 @@ from mindroom.matrix.sync_certification import (
     certify_sync_response,
     handle_unknown_pos,
     start_from_loaded_token,
+    sync_cache_write_diagnostics,
 )
 from mindroom.matrix.sync_tokens import clear_sync_token, load_sync_token_record, save_sync_token
 from mindroom.matrix.users import (
@@ -996,7 +997,12 @@ class AgentBot:
         except OSError as exc:
             self.logger.warning("matrix_sync_token_clear_failed", error=str(exc))
 
-    def _apply_sync_certification_decision(self, decision: SyncCertificationDecision) -> None:
+    def _apply_sync_certification_decision(
+        self,
+        decision: SyncCertificationDecision,
+        *,
+        cache_result: SyncCacheWriteResult | None = None,
+    ) -> None:
         """Apply a certifier decision to runtime state and token storage."""
         self._sync_trust_state = decision.state
         self._sync_checkpoint = decision.checkpoint_to_save
@@ -1008,9 +1014,11 @@ class AgentBot:
         if decision.checkpoint_to_save is not None:
             self._save_sync_checkpoint(decision.checkpoint_to_save)
         if decision.reason is not None:
+            diagnostics = sync_cache_write_diagnostics(cache_result) if cache_result is not None else {}
             self.logger.warning(
                 "matrix_sync_certification_uncertain",
                 reason=decision.reason,
+                **diagnostics,
             )
 
     async def _sync_cache_result_for_certification(self, response: nio.SyncResponse) -> SyncCacheWriteResult:
@@ -1051,19 +1059,20 @@ class AgentBot:
             try:
                 cache_result = await self._sync_cache_result_for_certification(_response)
             except asyncio.CancelledError as exc:
+                cache_result = SyncCacheWriteResult(complete=False, errors=(exc,))
                 decision = self._sync_certification_decision(
                     _response,
-                    cache_result=SyncCacheWriteResult(complete=False, errors=(exc,)),
+                    cache_result=cache_result,
                     first_sync_response=first_sync_response,
                 )
-                self._apply_sync_certification_decision(decision)
+                self._apply_sync_certification_decision(decision, cache_result=cache_result)
                 raise
             decision = self._sync_certification_decision(
                 _response,
                 cache_result=cache_result,
                 first_sync_response=first_sync_response,
             )
-            self._apply_sync_certification_decision(decision)
+            self._apply_sync_certification_decision(decision, cache_result=cache_result)
         self._first_sync_done = True
 
         if first_sync_response:

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -1130,11 +1130,15 @@ class ThreadSyncWritePolicy:
     ) -> SyncCacheWriteResult:
         """Persist sync timeline data and report whether it certifies the sync token."""
         if not self._cache_ops.cache_runtime_available():
-            return SyncCacheWriteResult(complete=False)
+            return SyncCacheWriteResult(complete=False, runtime_available=False, task_count=0)
 
         limited_room_ids, validation_errors = self._limited_sync_timeline_room_ids(response)
         if validation_errors:
-            return SyncCacheWriteResult(complete=False, errors=validation_errors)
+            return SyncCacheWriteResult(
+                complete=False,
+                errors=validation_errors,
+                runtime_available=self._cache_ops.cache_runtime_available(),
+            )
 
         try:
             tasks = self.cache_sync_timeline(response, raise_on_cache_write_failure=True)
@@ -1147,15 +1151,19 @@ class ThreadSyncWritePolicy:
                 complete=False,
                 limited_room_ids=limited_room_ids,
                 errors=(exc,),
+                runtime_available=self._cache_ops.cache_runtime_available(),
             )
 
         results: list[object | BaseException] = []
         if tasks:
             results = await asyncio.gather(*tasks, return_exceptions=True)
         errors = self._cache_task_errors(results)
-        complete = self._cache_ops.cache_runtime_available() and not errors and not limited_room_ids
+        runtime_available = self._cache_ops.cache_runtime_available()
+        complete = runtime_available and not errors and not limited_room_ids
         return SyncCacheWriteResult(
             complete=complete,
             limited_room_ids=limited_room_ids,
             errors=errors,
+            runtime_available=runtime_available,
+            task_count=len(tasks),
         )

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -577,12 +577,36 @@ async def refresh_thread_history_from_source(
                 return stale_history
         raise
     if _thread_history_fetch_is_cacheable(fetch_result.event_sources, thread_id=thread_id):
-        await _store_thread_history_cache(
+        cache_store_written = await _store_thread_history_cache(
             event_cache,
             room_id=room_id,
             thread_id=thread_id,
             event_sources=fetch_result.event_sources,
             fetch_started_at=fetch_started_at,
+        )
+        logger.info(
+            "Thread history cache store completed",
+            room_id=room_id,
+            thread_id=thread_id,
+            cache_store_outcome="stored" if cache_store_written else "not_replaced",
+            cache_store_written=cache_store_written,
+            event_count=len(fetch_result.event_sources),
+            homeserver_scan_pages=fetch_result.room_scan_pages,
+            homeserver_scanned_event_count=fetch_result.scanned_event_count,
+            homeserver_thread_event_count=len(fetch_result.event_sources),
+        )
+    else:
+        logger.info(
+            "Thread history cache store skipped",
+            room_id=room_id,
+            thread_id=thread_id,
+            cache_store_skipped_reason="missing_thread_root",
+            has_thread_root=False,
+            event_count=len(fetch_result.event_sources),
+            history_event_count=len(fetch_result.history),
+            homeserver_scan_pages=fetch_result.room_scan_pages,
+            homeserver_scanned_event_count=fetch_result.scanned_event_count,
+            homeserver_thread_event_count=len(fetch_result.event_sources),
         )
     diagnostics: dict[str, str | int | float | bool] = {
         "cache_read_ms": 0.0,
@@ -625,6 +649,9 @@ async def _store_thread_history_cache(
             "Event cache write failed; continuing without cache",
             room_id=room_id,
             thread_id=thread_id,
+            cache_store_outcome="failed",
+            event_count=len(event_sources),
+            error_type=type(exc).__name__,
             error=str(exc),
         )
         return False

--- a/src/mindroom/matrix/sync_certification.py
+++ b/src/mindroom/matrix/sync_certification.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 
 class SyncTrustState(Enum):
@@ -29,6 +30,8 @@ class SyncCacheWriteResult:
     complete: bool
     limited_room_ids: tuple[str, ...] = ()
     errors: tuple[BaseException, ...] = ()
+    runtime_available: bool | None = None
+    task_count: int | None = None
 
     @property
     def certified(self) -> bool:
@@ -145,3 +148,23 @@ def handle_unknown_pos() -> SyncCertificationDecision:
         reason="unknown_pos",
         reset_client_token=True,
     )
+
+
+def sync_cache_write_diagnostics(cache_result: SyncCacheWriteResult) -> dict[str, Any]:
+    """Return structured log fields explaining one sync cache-write result."""
+    diagnostics: dict[str, Any] = {
+        "cache_write_complete": cache_result.complete,
+        "cache_write_certified": cache_result.certified,
+        "cache_limited_room_count": len(cache_result.limited_room_ids),
+        "cache_error_count": len(cache_result.errors),
+    }
+    if cache_result.runtime_available is not None:
+        diagnostics["cache_runtime_available"] = cache_result.runtime_available
+    if cache_result.task_count is not None:
+        diagnostics["cache_task_count"] = cache_result.task_count
+    if cache_result.limited_room_ids:
+        diagnostics["cache_limited_room_ids"] = cache_result.limited_room_ids[:5]
+    if cache_result.errors:
+        diagnostics["cache_error_types"] = tuple(type(error).__name__ for error in cache_result.errors[:5])
+        diagnostics["cache_error_messages"] = tuple(str(error)[:200] for error in cache_result.errors[:5])
+    return diagnostics

--- a/tests/test_sync_certification.py
+++ b/tests/test_sync_certification.py
@@ -13,6 +13,7 @@ from mindroom.matrix.sync_certification import (
     certify_sync_response,
     handle_unknown_pos,
     start_from_loaded_token,
+    sync_cache_write_diagnostics,
 )
 
 
@@ -92,6 +93,31 @@ def test_uncertain_sync_fails_closed(cache_result: SyncCacheWriteResult, reason:
     assert decision.clear_saved_token is True
     assert decision.reset_client_token is False
     assert decision.reason == reason
+
+
+def test_sync_cache_write_diagnostics_explains_uncertainty() -> None:
+    """Sync-certification logs should expose the cache-write details behind uncertainty."""
+    diagnostics = sync_cache_write_diagnostics(
+        SyncCacheWriteResult(
+            complete=False,
+            limited_room_ids=("!room:localhost",),
+            errors=(RuntimeError("cache failed"),),
+            runtime_available=False,
+            task_count=3,
+        ),
+    )
+
+    assert diagnostics == {
+        "cache_write_complete": False,
+        "cache_write_certified": False,
+        "cache_limited_room_count": 1,
+        "cache_error_count": 1,
+        "cache_runtime_available": False,
+        "cache_task_count": 3,
+        "cache_limited_room_ids": ("!room:localhost",),
+        "cache_error_types": ("RuntimeError",),
+        "cache_error_messages": ("cache failed",),
+    }
 
 
 def test_pending_first_sync_uncertainty_resets_client_token() -> None:

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -659,6 +659,59 @@ class TestThreadHistory:
         mock_store.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_fetch_thread_history_logs_cache_store_skip_for_missing_root(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Skipped homeserver refills should expose why the advisory cache was not repopulated."""
+        client = AsyncMock()
+        logger = MagicMock()
+        fallback_history = [
+            ResolvedVisibleMessage.synthetic(
+                sender="@user:localhost",
+                body="reply",
+                event_id="$reply",
+                content={"body": "reply"},
+            ),
+        ]
+        monkeypatch.setattr(matrix_client_module, "logger", logger)
+
+        with (
+            patch(
+                "mindroom.matrix.client_thread_history._fetch_thread_history_with_events",
+                new=AsyncMock(
+                    return_value=MagicMock(
+                        history=fallback_history,
+                        event_sources=[{"event_id": "$reply"}],
+                        fetch_ms=10.0,
+                        room_scan_pages=73,
+                        scanned_event_count=7300,
+                        resolution_ms=0.0,
+                        sidecar_hydration_ms=0.0,
+                    ),
+                ),
+            ),
+            patch("mindroom.matrix.client_thread_history._store_thread_history_cache", new=AsyncMock()) as mock_store,
+        ):
+            await fetch_thread_history(
+                client,
+                "!room:localhost",
+                "$thread_root",
+                event_cache=make_event_cache_mock(),
+            )
+
+        mock_store.assert_not_awaited()
+        logger.info.assert_any_call(
+            "Thread history cache store skipped",
+            room_id="!room:localhost",
+            thread_id="$thread_root",
+            cache_store_skipped_reason="missing_thread_root",
+            has_thread_root=False,
+            event_count=1,
+            history_event_count=1,
+            homeserver_scan_pages=73,
+            homeserver_scanned_event_count=7300,
+            homeserver_thread_event_count=1,
+        )
+
+    @pytest.mark.asyncio
     async def test_fetch_thread_snapshot_miss_uses_authoritative_refresh_path(self) -> None:
         """Snapshot misses should reuse the authoritative refresh path instead of a separate fast path."""
         refreshed_history = ThreadHistoryResult(


### PR DESCRIPTION
## Summary
- log why homeserver thread refreshes skip advisory cache stores, including missing-root skips and scan counts
- include store outcomes for successful/refused thread cache writes
- add structured sync cache certification diagnostics for incomplete, limited, or failed cache writes

## Tests
- uv run ruff check src/mindroom/matrix/client_thread_history.py src/mindroom/matrix/sync_certification.py src/mindroom/matrix/cache/thread_writes.py src/mindroom/bot.py tests/test_thread_history.py tests/test_sync_certification.py
- uv run tach check --dependencies --interfaces
- uv run pytest tests/test_sync_certification.py tests/test_thread_history.py -k 'sync_cache_write_diagnostics or cache_store_skip_for_missing_root or skips_cache_store_for_degraded_room_scan_result or delegates_to_room_scan_helper' -n 0 --no-cov -q\n- uv run pytest tests/test_threading_error.py -k 'sync or certification or cache_failure_clears_token or empty_joined_rooms_first_sync_certifies_checkpoint or non_first_sync_waits_for_cache_write' -n 0 --no-cov -q\n- uv run pytest tests/test_sync_certification.py tests/test_thread_history.py -n 0 --no-cov -q