### PR TITLE
Refactor response terminal outcomes

### DIFF
--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -55,6 +55,7 @@ from mindroom.post_response_effects import (
     PostResponseEffectsSupport,
     ResponseOutcome,
 )
+from mindroom.response_terminal import PendingVisibleResponse, build_terminal_stream_transport_outcome
 from mindroom.streaming import (
     PROGRESS_PLACEHOLDER,
     ReplacementStreamingResponse,
@@ -1305,29 +1306,19 @@ class ResponseRunner:
             delivery_failure_reason = str(error)
             self._log_delivery_failure(response_kind="team", error=error)
         if final_delivery_outcome is None and delivery_failure_reason is not None:
-            placeholder_event_id = run_message_id if request.existing_event_id is None else None
-            event_id = (
-                tracked_event_id
-                or placeholder_event_id
-                or (request.existing_event_id if request.existing_event_is_placeholder else None)
-            )
-            placeholder_only = event_id is not None and (
-                event_id == placeholder_event_id
-                or (
-                    request.existing_event_id is not None
-                    and request.existing_event_is_placeholder
-                    and event_id == request.existing_event_id
-                )
-            )
             final_delivery_outcome = await self.deps.delivery_gateway.finalize_streamed_response(
                 FinalizeStreamedResponseRequest(
                     target=delivery_target,
-                    stream_transport_outcome=StreamTransportOutcome(
-                        last_physical_stream_event_id=event_id,
+                    stream_transport_outcome=build_terminal_stream_transport_outcome(
+                        PendingVisibleResponse(
+                            tracked_event_id=tracked_event_id,
+                            run_message_id=run_message_id if request.existing_event_id is None else None,
+                            existing_event_id=request.existing_event_id,
+                            existing_event_is_placeholder=request.existing_event_is_placeholder,
+                        ),
                         terminal_status="cancelled" if delivery_cancelled else "error",
-                        rendered_body=PROGRESS_PLACEHOLDER if placeholder_only else None,
-                        visible_body_state="placeholder_only" if placeholder_only else "none",
                         failure_reason=delivery_failure_reason or "late_stream_delivery_failure",
+                        placeholder_body=PROGRESS_PLACEHOLDER,
                     ),
                     initial_delivery_kind="edited" if request.existing_event_id else "sent",
                     response_kind="team",
@@ -2038,16 +2029,19 @@ class ResponseRunner:
             raise
         except Exception as error:
             self.deps.logger.exception("Error in streaming response", error=str(error))
-            event_id = request.existing_event_id if request.existing_event_is_placeholder else None
             return await self.deps.delivery_gateway.finalize_streamed_response(
                 FinalizeStreamedResponseRequest(
                     target=runtime.resolved_target,
-                    stream_transport_outcome=StreamTransportOutcome(
-                        last_physical_stream_event_id=request.existing_event_id or event_id,
+                    stream_transport_outcome=build_terminal_stream_transport_outcome(
+                        PendingVisibleResponse(
+                            tracked_event_id=request.existing_event_id,
+                            run_message_id=None,
+                            existing_event_id=request.existing_event_id,
+                            existing_event_is_placeholder=request.existing_event_is_placeholder,
+                        ),
                         terminal_status="error",
-                        rendered_body=PROGRESS_PLACEHOLDER if event_id is not None else None,
-                        visible_body_state="placeholder_only" if event_id is not None else "none",
                         failure_reason=str(error),
+                        placeholder_body=PROGRESS_PLACEHOLDER,
                     ),
                     initial_delivery_kind="edited" if request.existing_event_id else "sent",
                     response_kind=response_kind,

--- a/src/mindroom/response_terminal.py
+++ b/src/mindroom/response_terminal.py
@@ -1,0 +1,71 @@
+"""Terminal response outcome helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from mindroom.final_delivery import StreamTransportOutcome, VisibleBodyState
+
+TerminalFailureStatus = Literal["cancelled", "error"]
+
+
+@dataclass(frozen=True)
+class PendingVisibleResponse:
+    """Visible response candidates still pending at terminal cleanup time."""
+
+    tracked_event_id: str | None
+    run_message_id: str | None
+    existing_event_id: str | None
+    existing_event_is_placeholder: bool
+
+    @property
+    def terminal_event_id(self) -> str | None:
+        """Return the Matrix event that terminal cleanup should finalize."""
+        if self.tracked_event_id is not None:
+            return self.tracked_event_id
+        if self.run_message_id is not None:
+            return self.run_message_id
+        if self.existing_event_id is not None and self.existing_event_is_placeholder:
+            return self.existing_event_id
+        return None
+
+    def is_placeholder_only(self, event_id: str | None) -> bool:
+        """Return whether the terminal event only contains the progress placeholder."""
+        if event_id is None:
+            return False
+        if self.run_message_id is not None and event_id == self.run_message_id:
+            return True
+        return (
+            self.existing_event_id is not None
+            and self.existing_event_is_placeholder
+            and event_id == self.existing_event_id
+        )
+
+
+def build_terminal_stream_transport_outcome(
+    pending: PendingVisibleResponse,
+    *,
+    terminal_status: TerminalFailureStatus,
+    failure_reason: str,
+    placeholder_body: str,
+) -> StreamTransportOutcome:
+    """Build the canonical stream outcome for a terminal failure or cancellation."""
+    event_id = pending.terminal_event_id
+    placeholder_only = pending.is_placeholder_only(event_id)
+    rendered_body = placeholder_body if placeholder_only else None
+    visible_body_state: VisibleBodyState = "placeholder_only" if placeholder_only else "none"
+    return StreamTransportOutcome(
+        last_physical_stream_event_id=event_id,
+        terminal_status=terminal_status,
+        rendered_body=rendered_body,
+        visible_body_state=visible_body_state,
+        failure_reason=failure_reason,
+    )
+
+
+__all__ = [
+    "PendingVisibleResponse",
+    "TerminalFailureStatus",
+    "build_terminal_stream_transport_outcome",
+]

--- a/tach.toml
+++ b/tach.toml
@@ -762,6 +762,7 @@ depends_on = [
     "mindroom.orchestration.runtime",
     "mindroom.post_response_effects",
     "mindroom.response_lifecycle",
+    "mindroom.response_terminal",
     "mindroom.streaming",
     "mindroom.teams",
     "mindroom.thread_summary",
@@ -777,6 +778,11 @@ depends_on = [
     "mindroom.post_response_effects",
     "mindroom.tool_system.runtime_context",
 ]
+visibility = ["mindroom.response_runner"]
+
+[[modules]]
+path = "mindroom.response_terminal"
+depends_on = ["mindroom.final_delivery"]
 visibility = ["mindroom.response_runner"]
 
 [[modules]]

--- a/tests/test_response_terminal.py
+++ b/tests/test_response_terminal.py
@@ -1,0 +1,90 @@
+"""Terminal response outcome helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from mindroom.response_terminal import (
+    PendingVisibleResponse,
+    build_terminal_stream_transport_outcome,
+)
+
+
+@pytest.mark.parametrize(
+    ("pending", "expected_event_id", "expected_placeholder_only"),
+    [
+        pytest.param(
+            PendingVisibleResponse(
+                tracked_event_id="$visible",
+                run_message_id="$thinking",
+                existing_event_id=None,
+                existing_event_is_placeholder=False,
+            ),
+            "$visible",
+            False,
+            id="preserves-non-placeholder-visible-stream",
+        ),
+        pytest.param(
+            PendingVisibleResponse(
+                tracked_event_id="$existing",
+                run_message_id=None,
+                existing_event_id="$existing",
+                existing_event_is_placeholder=False,
+            ),
+            "$existing",
+            False,
+            id="keeps-existing-visible-message-without-placeholder-body",
+        ),
+        pytest.param(
+            PendingVisibleResponse(
+                tracked_event_id=None,
+                run_message_id="$thinking",
+                existing_event_id=None,
+                existing_event_is_placeholder=False,
+            ),
+            "$thinking",
+            True,
+            id="uses-new-thinking-placeholder",
+        ),
+        pytest.param(
+            PendingVisibleResponse(
+                tracked_event_id=None,
+                run_message_id=None,
+                existing_event_id="$existing",
+                existing_event_is_placeholder=True,
+            ),
+            "$existing",
+            True,
+            id="uses-adopted-existing-placeholder",
+        ),
+        pytest.param(
+            PendingVisibleResponse(
+                tracked_event_id=None,
+                run_message_id=None,
+                existing_event_id="$existing",
+                existing_event_is_placeholder=False,
+            ),
+            None,
+            False,
+            id="ignores-non-placeholder-existing-message",
+        ),
+    ],
+)
+def test_terminal_stream_outcome_resolves_visible_placeholder_state(
+    pending: PendingVisibleResponse,
+    expected_event_id: str | None,
+    expected_placeholder_only: bool,
+) -> None:
+    """Terminal failures should classify pending visible events in one place."""
+    outcome = build_terminal_stream_transport_outcome(
+        pending,
+        terminal_status="error",
+        failure_reason="delivery failed",
+        placeholder_body="Thinking...",
+    )
+
+    assert outcome.last_physical_stream_event_id == expected_event_id
+    assert outcome.terminal_status == "error"
+    assert outcome.failure_reason == "delivery failed"
+    assert outcome.rendered_body == ("Thinking..." if expected_placeholder_only else None)
+    assert outcome.visible_body_state == ("placeholder_only" if expected_placeholder_only else "none")


### PR DESCRIPTION
## Summary
- add `mindroom.response_terminal` as the focused source of truth for terminal stream outcome classification
- replace inline placeholder/visible-event cleanup logic in `response_runner.py` with the shared helper
- add helper coverage for tracked visible events, thinking placeholders, adopted placeholders, and existing non-placeholder messages
- update Tach boundaries for the new response-terminal module

## Verification
- `uv run pytest tests/test_response_terminal.py tests/test_ai_user_id.py::test_generate_team_response_helper_routes_placeholder_only_late_failure_through_cleanup_boundary -q`
- `uv run pytest tests/test_ai_user_id.py tests/test_response_terminal.py -q`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --all-files`
- `uv run pytest` (5543 passed, 28 skipped)