### PR TITLE
Use matrix_state_for_runtime in remaining read-only call sites

### DIFF
--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -11,7 +11,7 @@ import nio
 from mindroom.constants import ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME
 from mindroom.logging_config import get_logger
 from mindroom.matrix.identity import MatrixID, active_internal_sender_ids
-from mindroom.matrix.state import MatrixState
+from mindroom.matrix.state import matrix_state_for_runtime
 from mindroom.matrix_identifiers import managed_room_key_from_alias_localpart, room_alias_localpart
 
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ def _lookup_managed_room_identifiers(
     runtime_paths: RuntimePaths,
 ) -> tuple[str | None, str | None]:
     """Return managed room key + alias from persisted Matrix state for a room ID."""
-    state = MatrixState.load(runtime_paths=runtime_paths)
+    state = matrix_state_for_runtime(runtime_paths)
     for room_key, room in state.rooms.items():
         if room.room_id == room_id:
             return room_key, room.alias

--- a/src/mindroom/avatar_generation.py
+++ b/src/mindroom/avatar_generation.py
@@ -27,7 +27,7 @@ from mindroom.logging_config import get_logger
 from mindroom.matrix.avatar import room_has_avatar, set_room_avatar_from_file
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.rooms import get_room_id
-from mindroom.matrix.state import MatrixState
+from mindroom.matrix.state import MatrixState, matrix_state_for_runtime
 from mindroom.matrix.users import AgentMatrixUser, login_agent_user
 from mindroom.matrix_identifiers import extract_server_name_from_homeserver
 
@@ -447,7 +447,7 @@ async def set_room_avatars_in_matrix(runtime_paths: constants.RuntimePaths, *, f
     console = get_console()
     console.print("\n[bold cyan]Setting room avatars in Matrix...[/bold cyan]")
 
-    state = MatrixState.load(runtime_paths=runtime_paths)
+    state = matrix_state_for_runtime(runtime_paths)
     router_account = state.get_account(f"agent_{ROUTER_AGENT_NAME}")
     if not router_account:
         msg = "No router account found in Matrix state. Make sure mindroom has been started at least once."

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -18,7 +18,7 @@ from mindroom.matrix.invited_rooms_store import (
     should_persist_invited_rooms,
 )
 from mindroom.matrix.rooms import leave_non_dm_rooms
-from mindroom.matrix.state import MatrixState
+from mindroom.matrix.state import matrix_state_for_runtime
 from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 
 if TYPE_CHECKING:
@@ -136,7 +136,7 @@ class BotRoomLifecycle:
         if self.should_persist_invited_rooms():
             configured_rooms.update(self.invited_rooms)
         if self.deps.agent_name == ROUTER_AGENT_NAME:
-            root_space_id = MatrixState.load(runtime_paths=self.deps.runtime_paths).space_room_id
+            root_space_id = matrix_state_for_runtime(self.deps.runtime_paths).space_room_id
             if root_space_id is not None:
                 configured_rooms.add(root_space_id)
 

--- a/src/mindroom/matrix/room_cleanup.py
+++ b/src/mindroom/matrix/room_cleanup.py
@@ -18,7 +18,7 @@ from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_members
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.invited_rooms_store import invited_rooms_path, load_invited_rooms, should_persist_invited_rooms
 from mindroom.matrix.rooms import is_dm_room
-from mindroom.matrix.state import MatrixState, managed_account_usernames
+from mindroom.matrix.state import managed_account_usernames, matrix_state_for_runtime
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
 from mindroom.matrix_identifiers import agent_username_localpart
 
@@ -85,7 +85,7 @@ async def _cleanup_orphaned_bots_in_room(
     """
     # Never evict bots from the root space — the router is the creator/admin
     # and no agents are explicitly configured for it, so every bot looks orphaned.
-    state = MatrixState.load(runtime_paths=runtime_paths)
+    state = matrix_state_for_runtime(runtime_paths)
     if state.space_room_id and room_id == state.space_room_id:
         logger.debug("orphaned_bot_cleanup_skipped_root_space", room_id=room_id)
         return []

--- a/src/mindroom/matrix/users.py
+++ b/src/mindroom/matrix/users.py
@@ -18,7 +18,7 @@ from mindroom.matrix.client_session import (
     restore_login,
 )
 from mindroom.matrix.identity import MatrixID
-from mindroom.matrix.state import MatrixState
+from mindroom.matrix.state import MatrixState, matrix_state_for_runtime
 from mindroom.matrix_identifiers import agent_username_localpart, extract_server_name_from_homeserver
 
 logger = get_logger(__name__)
@@ -76,7 +76,7 @@ def _get_agent_credentials(
         Dictionary with username and password, or None if not found
 
     """
-    state = MatrixState.load(runtime_paths=runtime_paths)
+    state = matrix_state_for_runtime(runtime_paths)
     agent_key = _account_key_for_agent(agent_name)
     account = state.get_account(agent_key)
     if account:

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -44,7 +44,7 @@ from mindroom.matrix.stale_stream_cleanup import (
     auto_resume_interrupted_threads,
     cleanup_stale_streaming_messages,
 )
-from mindroom.matrix.state import MatrixState
+from mindroom.matrix.state import matrix_state_for_runtime
 from mindroom.matrix.users import (
     INTERNAL_USER_ACCOUNT_KEY,
     INTERNAL_USER_AGENT_NAME,
@@ -1475,7 +1475,7 @@ class MultiAgentOrchestrator:
             return authorized_user_ids
         assert router_bot.client is not None
 
-        state = MatrixState.load(runtime_paths=self.runtime_paths)
+        state = matrix_state_for_runtime(self.runtime_paths)
         user_account = state.get_account(INTERNAL_USER_ACCOUNT_KEY)
         if config.mindroom_user is None or not user_account:
             return authorized_user_ids

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -692,7 +692,7 @@ def test_room_specific_permissions_support_managed_room_key(
             ),
         },
     )
-    monkeypatch.setattr("mindroom.authorization.MatrixState.load", lambda **_kwargs: state)
+    monkeypatch.setattr("mindroom.authorization.matrix_state_for_runtime", lambda *_args, **_kwargs: state)
 
     assert is_authorized_sender("@bob:example.com", config, "!lobby:example.com")
     assert not is_authorized_sender("@eve:example.com", config, "!lobby:example.com")

--- a/tests/test_avatar_generation.py
+++ b/tests/test_avatar_generation.py
@@ -738,7 +738,7 @@ async def test_set_room_avatars_in_matrix_includes_team_rooms_and_root_space(
         "load_validated_config",
         lambda *_args, **_kwargs: _config_with_runtime_paths(raw_config, workspace_avatar_dir.parent),
     )
-    monkeypatch.setattr(generate_avatars.MatrixState, "load", staticmethod(lambda **_kwargs: state))
+    monkeypatch.setattr(generate_avatars, "matrix_state_for_runtime", lambda *_args, **_kwargs: state)
     monkeypatch.setattr(generate_avatars, "login_agent_user", AsyncMock(return_value=client))
     monkeypatch.setattr(generate_avatars, "room_has_avatar", AsyncMock(return_value=False))
     monkeypatch.setattr(generate_avatars, "set_room_avatar_from_file", set_room_avatar_from_file)
@@ -803,7 +803,7 @@ async def test_set_room_avatars_in_matrix_skips_rooms_with_existing_matrix_avata
         "load_validated_config",
         lambda *_args, **_kwargs: _config_with_runtime_paths(raw_config, workspace_avatar_dir.parent),
     )
-    monkeypatch.setattr(generate_avatars.MatrixState, "load", staticmethod(lambda **_kwargs: state))
+    monkeypatch.setattr(generate_avatars, "matrix_state_for_runtime", lambda *_args, **_kwargs: state)
     monkeypatch.setattr(generate_avatars, "login_agent_user", AsyncMock(return_value=client))
     monkeypatch.setattr(
         generate_avatars,
@@ -868,7 +868,7 @@ async def test_set_room_avatars_in_matrix_force_replaces_existing_matrix_avatar(
         "load_validated_config",
         lambda *_args, **_kwargs: _config_with_runtime_paths(raw_config, workspace_avatar_dir.parent),
     )
-    monkeypatch.setattr(generate_avatars.MatrixState, "load", staticmethod(lambda **_kwargs: state))
+    monkeypatch.setattr(generate_avatars, "matrix_state_for_runtime", lambda *_args, **_kwargs: state)
     monkeypatch.setattr(generate_avatars, "login_agent_user", AsyncMock(return_value=client))
     monkeypatch.setattr(generate_avatars, "room_has_avatar", room_has_avatar)
     monkeypatch.setattr(generate_avatars, "set_room_avatar_from_file", set_room_avatar_from_file)
@@ -932,7 +932,7 @@ async def test_set_room_avatars_in_matrix_raises_when_room_avatar_updates_fail(
         "load_validated_config",
         lambda *_args, **_kwargs: _config_with_runtime_paths(raw_config, workspace_avatar_dir.parent),
     )
-    monkeypatch.setattr(generate_avatars.MatrixState, "load", staticmethod(lambda **_kwargs: state))
+    monkeypatch.setattr(generate_avatars, "matrix_state_for_runtime", lambda *_args, **_kwargs: state)
     monkeypatch.setattr(generate_avatars, "login_agent_user", AsyncMock(return_value=client))
     monkeypatch.setattr(generate_avatars, "room_has_avatar", AsyncMock(return_value=False))
     monkeypatch.setattr(generate_avatars, "set_room_avatar_from_file", AsyncMock(return_value=False))
@@ -995,7 +995,7 @@ async def test_set_room_avatars_in_matrix_skips_stale_root_space_when_disabled(
         "load_validated_config",
         lambda *_args, **_kwargs: _config_with_runtime_paths(raw_config, workspace_avatar_dir.parent),
     )
-    monkeypatch.setattr(generate_avatars.MatrixState, "load", staticmethod(lambda **_kwargs: state))
+    monkeypatch.setattr(generate_avatars, "matrix_state_for_runtime", lambda *_args, **_kwargs: state)
     monkeypatch.setattr(generate_avatars, "login_agent_user", AsyncMock(return_value=client))
     monkeypatch.setattr(generate_avatars, "set_room_avatar_from_file", set_room_avatar_from_file)
     monkeypatch.setattr(
@@ -1018,7 +1018,7 @@ async def test_set_room_avatars_in_matrix_requires_initialized_router_account(
 ) -> None:
     """Standalone avatar sync should fail fast until MindRoom has initialized the router account."""
     state = SimpleNamespace(get_account=lambda _key: None)
-    monkeypatch.setattr(generate_avatars.MatrixState, "load", staticmethod(lambda **_kwargs: state))
+    monkeypatch.setattr(generate_avatars, "matrix_state_for_runtime", lambda *_args, **_kwargs: state)
 
     with pytest.raises(
         generate_avatars.AvatarSyncError,
@@ -1053,7 +1053,7 @@ async def test_set_room_avatars_in_matrix_wraps_router_login_failures(
         "load_validated_config",
         lambda *_args, **_kwargs: _config_with_runtime_paths(raw_config, tmp_path),
     )
-    monkeypatch.setattr(generate_avatars.MatrixState, "load", staticmethod(lambda **_kwargs: state))
+    monkeypatch.setattr(generate_avatars, "matrix_state_for_runtime", lambda *_args, **_kwargs: state)
     monkeypatch.setattr(
         generate_avatars,
         "login_agent_user",

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -10068,7 +10068,7 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.get_joined_rooms", new=AsyncMock(return_value=list(room_members))),
             patch("mindroom.orchestrator.get_room_members", side_effect=mock_get_room_members),
             patch("mindroom.orchestrator.invite_to_room", mock_invite),
-            patch("mindroom.orchestrator.MatrixState.load", return_value=MatrixState()),
+            patch("mindroom.orchestrator.matrix_state_for_runtime", return_value=MatrixState()),
         ):
             await orchestrator._ensure_room_invitations()
 
@@ -10115,7 +10115,7 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.get_joined_rooms", new=AsyncMock(return_value=["!room1:localhost"])),
             patch("mindroom.orchestrator.get_room_members", side_effect=mock_get_room_members),
             patch("mindroom.orchestrator.invite_to_room", mock_invite),
-            patch("mindroom.orchestrator.MatrixState.load", return_value=MatrixState()),
+            patch("mindroom.orchestrator.matrix_state_for_runtime", return_value=MatrixState()),
         ):
             await orchestrator._ensure_room_invitations()
 
@@ -10157,7 +10157,7 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.get_joined_rooms", new=AsyncMock(return_value=["!room1:localhost"])),
             patch("mindroom.orchestrator.get_room_members", side_effect=mock_get_room_members),
             patch("mindroom.orchestrator.invite_to_room", mock_invite),
-            patch("mindroom.orchestrator.MatrixState.load", return_value=state),
+            patch("mindroom.orchestrator.matrix_state_for_runtime", return_value=state),
         ):
             await orchestrator._ensure_room_invitations()
 
@@ -10194,7 +10194,7 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.get_joined_rooms", new=AsyncMock(return_value=["!ad-hoc:localhost"])),
             patch("mindroom.orchestrator.get_room_members", new=AsyncMock()) as mock_get_room_members,
             patch("mindroom.orchestrator.invite_to_room", AsyncMock()) as mock_invite,
-            patch("mindroom.orchestrator.MatrixState.load", return_value=MatrixState()),
+            patch("mindroom.orchestrator.matrix_state_for_runtime", return_value=MatrixState()),
         ):
             await orchestrator._ensure_room_invitations()
 

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -285,8 +285,8 @@ async def test_router_preserves_root_space_when_leaving_unconfigured_rooms(
     )
     monkeypatch.setattr("mindroom.bot_room_lifecycle.leave_non_dm_rooms", mock_leave_non_dm_rooms)
     monkeypatch.setattr(
-        "mindroom.bot_room_lifecycle.MatrixState.load",
-        lambda **_kwargs: MatrixState(space_room_id="!space:localhost"),
+        "mindroom.bot_room_lifecycle.matrix_state_for_runtime",
+        lambda *_args, **_kwargs: MatrixState(space_room_id="!space:localhost"),
     )
 
     await bot.leave_unconfigured_rooms()


### PR DESCRIPTION
## Summary
Follow-up to #776. The mtime-keyed cache was already wired up via `MatrixState.load`, so the call sites below were already getting the YAML parse cached — but each still paid for the defensive `model_copy(deep=True)` that protects mutators. Switching the read-only sites to `matrix_state_for_runtime` drops the copy and makes the read-only intent explicit.

Sites switched (all confirmed read-only — no mutation, no `save`):

| File:func | Path |
|---|---|
| `authorization._lookup_managed_room_identifiers` | per-message hot path |
| `bot_room_lifecycle.leave_unconfigured_rooms` | router lifecycle |
| `avatar_generation.set_room_avatars_in_matrix` | CLI flow |
| `orchestrator._ensure_room_invitations` | startup + periodic |
| `matrix.room_cleanup._cleanup_orphaned_bots_in_room` | cleanup loop |
| `matrix.users._get_agent_credentials` | auth path |

Mutator sites (`_add_room`, `_remove_room`, `_ensure_root_space_exists`, `_save_agent_credentials`, `load_rooms`) keep using `MatrixState.load` so they still receive an isolated deep copy.

## Tests
- `uv run pytest tests/test_matrix_state_cache.py tests/test_matrix_spaces.py tests/test_matrix_room_access.py tests/test_dm_room_preservation.py tests/test_room_invites.py tests/test_authorization.py tests/test_avatar_generation.py tests/test_multi_agent_bot.py -nauto --no-cov -q` → **359 passed, 4 skipped**
- `uv run ruff check` on touched files
- `uv run ty check` on touched files
- `uv run tach check --dependencies --interfaces`

Test patches that previously targeted `MatrixState.load` now patch `matrix_state_for_runtime` in the same module so they keep suppressing real disk reads.

## Test plan
- [x] read-only sites no longer pay for the deep copy
- [x] mutator sites still receive an isolated deep copy via `MatrixState.load`
- [x] existing test mocks updated for new patch targets