### PR TITLE
Fix Vertex Claude strict tool payloads

### DIFF
--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -13,7 +13,6 @@ from agno.models.groq import Groq
 from agno.models.ollama import Ollama
 from agno.models.openai import OpenAIChat
 from agno.models.openrouter import OpenRouter
-from agno.models.vertexai.claude import Claude as VertexAIClaude
 
 from mindroom.codex_model import CodexResponses, derive_codex_prompt_cache_key, normalize_codex_model_id
 from mindroom.constants import RuntimePaths, runtime_env_path
@@ -21,6 +20,7 @@ from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host
 from mindroom.llm_request_logging import install_llm_request_logging
 from mindroom.logging_config import get_logger
+from mindroom.vertex_claude_compat import MindroomVertexAIClaude
 from mindroom.vertex_claude_prompt_cache import install_vertex_claude_prompt_cache_hook
 
 if TYPE_CHECKING:
@@ -116,7 +116,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0912
         "anthropic": Claude,
         "gemini": Gemini,
         "google": Gemini,
-        "vertexai_claude": VertexAIClaude,
+        "vertexai_claude": MindroomVertexAIClaude,
         "cerebras": Cerebras,
         "groq": Groq,
         "deepseek": DeepSeek,

--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -1,0 +1,72 @@
+"""Mindroom compatibility helpers for Vertex Claude models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agno.models.vertexai.claude import Claude as VertexAIClaude
+
+
+def strip_vertex_claude_tool_strict(
+    tools: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]] | None:
+    """Return Vertex-compatible tool definitions without mutating the caller's list.
+
+    Agno 2.5.13 can emit OpenAI-style ``strict`` flags on tool definitions.
+    Anthropic-on-Vertex rejects those provider-level fields with a 400 error
+    (``tools.0.custom.strict``), while schema properties named ``strict`` are
+    valid user data and must be preserved. Strip only the provider metadata here
+    until Agno normalizes Vertex Claude tool payloads itself.
+    """
+    if not tools:
+        return tools
+
+    changed = False
+    sanitized: list[dict[str, Any]] = []
+    for tool in tools:
+        next_tool = tool
+        if "strict" in next_tool:
+            next_tool = dict(next_tool)
+            next_tool.pop("strict", None)
+            changed = True
+
+        function = next_tool.get("function")
+        if isinstance(function, dict) and "strict" in function:
+            if next_tool is tool:
+                next_tool = dict(next_tool)
+            next_function = dict(function)
+            next_function.pop("strict", None)
+            next_tool["function"] = next_function
+            changed = True
+
+        sanitized.append(next_tool)
+
+    return sanitized if changed else tools
+
+
+class MindroomVertexAIClaude(VertexAIClaude):
+    """Vertex Claude model with Mindroom-specific provider compatibility fixes."""
+
+    def _prepare_request_kwargs(
+        self,
+        system_message: str,
+        tools: list[dict[str, Any]] | None = None,
+        response_format: dict[str, Any] | type[Any] | None = None,
+        messages: list[Any] | None = None,
+    ) -> dict[str, Any]:
+        return super()._prepare_request_kwargs(
+            system_message=system_message,
+            tools=strip_vertex_claude_tool_strict(tools),
+            response_format=response_format,
+            messages=messages,
+        )
+
+    def _has_beta_features(
+        self,
+        response_format: dict[str, Any] | type[Any] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> bool:
+        return super()._has_beta_features(
+            response_format=response_format,
+            tools=strip_vertex_claude_tool_strict(tools),
+        )

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -15,6 +15,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.model_loading import get_model_instance
+from mindroom.vertex_claude_compat import MindroomVertexAIClaude, strip_vertex_claude_tool_strict
 from mindroom.vertex_claude_prompt_cache import (
     copy_messages_with_vertex_prompt_cache_breakpoint,
     install_vertex_claude_prompt_cache_hook,
@@ -293,6 +294,7 @@ def test_vertexai_claude_provider() -> None:
     model = get_model_instance(config, runtime_paths, "vertex_claude_model")
 
     assert isinstance(model, VertexAIClaude)
+    assert isinstance(model, MindroomVertexAIClaude)
     assert model.id == "claude-sonnet-4@20250514"
     assert model.provider == "VertexAI"
     assert model.cache_system_prompt is True
@@ -321,6 +323,67 @@ def test_vertexai_prompt_cache_breakpoint_marks_last_user_block() -> None:
         {"type": "text", "text": "Current turn"},
         {"type": "image", "source": "x", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
     ]
+
+
+def _strict_tool_definition() -> dict[str, object]:
+    return {
+        "type": "function",
+        "function": {
+            "name": "update_profile",
+            "description": "Update profile",
+            "strict": True,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "strict": {"type": "boolean"},
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def test_strip_vertex_claude_tool_strict_preserves_schema_and_input() -> None:
+    """Vertex Claude rejects provider-level strict, but schema fields named strict are valid."""
+    tool = _strict_tool_definition()
+
+    sanitized = strip_vertex_claude_tool_strict([tool])
+
+    assert sanitized is not None
+    assert "strict" not in sanitized[0]["function"]
+    assert "strict" in sanitized[0]["function"]["parameters"]["properties"]
+    assert tool["function"]["strict"] is True
+
+
+def test_mindroom_vertexai_claude_request_kwargs_strip_tool_strict() -> None:
+    """Mindroom's Vertex Claude model should not send strict in the provider tool payload."""
+    model = MindroomVertexAIClaude(
+        id="claude-sonnet-4-6",
+        project_id="demo-project",
+        region="us-central1",
+        cache_system_prompt=False,
+    )
+
+    request_kwargs = model._prepare_request_kwargs("", tools=[_strict_tool_definition()])
+
+    assert request_kwargs["tools"] == [
+        {
+            "name": "update_profile",
+            "description": "Update profile",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": ""},
+                    "strict": {"type": "boolean", "description": ""},
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        },
+    ]
+    assert model._has_beta_features(tools=[_strict_tool_definition()]) is False
 
 
 def _vertex_claude_model(*, extended_cache_time: bool = True) -> VertexAIClaude:


### PR DESCRIPTION
## Summary
- use a Mindroom Vertex Claude subclass that strips provider-level `strict` from tool definitions before request preparation
- preserve schemas and caller inputs while avoiding unsupported Vertex Claude payload fields
- keep the compatibility fix scoped to the `vertexai_claude` provider

## Tests
- `uv run pytest tests/test_extra_kwargs.py -q`
- `uv run ruff check src/mindroom/model_loading.py src/mindroom/vertex_claude_compat.py tests/test_extra_kwargs.py`
- `uv run ty check src/mindroom/vertex_claude_compat.py src/mindroom/model_loading.py tests/test_extra_kwargs.py`