### PR TITLE
Recover Postgres event cache after transient connection loss

### DIFF
--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -38,15 +38,15 @@ T = TypeVar("T")
 # fresh connection.
 _TRANSIENT_SQLSTATES: frozenset[str] = frozenset(
     {
-        "08000",
-        "08001",
-        "08003",
-        "08004",
-        "08006",
-        "08007",
-        "57P01",
-        "57P02",
-        "57P03",
+        "08000",  # connection_exception (generic 08xxx class)
+        "08001",  # sqlclient_unable_to_establish_sqlconnection
+        "08003",  # connection_does_not_exist
+        "08004",  # sqlserver_rejected_establishment_of_sqlconnection
+        "08006",  # connection_failure
+        "08007",  # transaction_resolution_unknown
+        "57P01",  # admin_shutdown (terminating connection due to administrator command)
+        "57P02",  # crash_shutdown (postmaster has crashed)
+        "57P03",  # cannot_connect_now (server still starting up)
     },
 )
 _TRANSIENT_MESSAGE_FRAGMENTS: tuple[str, ...] = (

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -67,8 +67,10 @@ def _is_transient_db_error(exc: BaseException) -> bool:
     if isinstance(exc, psycopg.InterfaceError):
         return True
     if isinstance(exc, psycopg.OperationalError):
-        diag = getattr(exc, "diag", None)
-        sqlstate = getattr(diag, "sqlstate", None) if diag is not None else None
+        sqlstate = getattr(exc, "sqlstate", None)
+        if sqlstate is None:
+            diag = getattr(exc, "diag", None)
+            sqlstate = getattr(diag, "sqlstate", None) if diag is not None else None
         if sqlstate in _TRANSIENT_SQLSTATES:
             return True
         message = str(exc).lower()
@@ -360,9 +362,9 @@ class _PostgresEventCacheRuntime:
         """Drop the dead connection so the next acquire opens a fresh one.
 
         Caller must have already determined that *exc* is transient via
-        :func:`_is_transient_db_error`. Cleaning up the connection is best-effort —
-        if the close itself raises, we log and proceed with reconnection on the
-        next acquire.
+        :func:`_is_transient_db_error`. Cleaning up the connection is best
+        effort: if the close itself raises, we log and proceed with reconnection
+        on the next acquire.
         """
         async with self._db_lock:
             if self._db is not None:

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -32,6 +32,49 @@ _LOCK_WAIT_LOG_THRESHOLD_SECONDS = 0.1
 _MAX_CACHED_ROOM_LOCKS = 256
 T = TypeVar("T")
 
+# PostgreSQL SQLSTATE codes that indicate a transient connection-level failure.
+# 08xxx: connection_exception family. 57P01-57P03: server-side admin / shutdown
+# events. Operations that fail with one of these states are safe to retry on a
+# fresh connection.
+_TRANSIENT_SQLSTATES: frozenset[str] = frozenset(
+    {
+        "08000",
+        "08001",
+        "08003",
+        "08004",
+        "08006",
+        "08007",
+        "57P01",
+        "57P02",
+        "57P03",
+    },
+)
+_TRANSIENT_MESSAGE_FRAGMENTS: tuple[str, ...] = (
+    "the connection is closed",
+    "connection already closed",
+    "server closed the connection",
+    "terminating connection",
+)
+
+
+def _is_transient_db_error(exc: BaseException) -> bool:
+    """Return whether *exc* represents a transient PostgreSQL connection failure.
+
+    Transient errors include connection-establishment failures (08xxx), normal
+    server-side shutdown signals (57P01-57P03), and the ``InterfaceError`` that
+    psycopg raises when the underlying socket has already been closed.
+    """
+    if isinstance(exc, psycopg.InterfaceError):
+        return True
+    if isinstance(exc, psycopg.OperationalError):
+        diag = getattr(exc, "diag", None)
+        sqlstate = getattr(diag, "sqlstate", None) if diag is not None else None
+        if sqlstate in _TRANSIENT_SQLSTATES:
+            return True
+        message = str(exc).lower()
+        return any(fragment in message for fragment in _TRANSIENT_MESSAGE_FRAGMENTS)
+    return False
+
 logger = get_logger(__name__)
 
 
@@ -248,6 +291,8 @@ class _PostgresEventCacheRuntime:
         self._disabled_reason: str | None = None
         self._db_lock = asyncio.Lock()
         self._room_locks: OrderedDict[str, _RoomLockEntry] = OrderedDict()
+        self._reconnect_attempts = 0
+        self._unavailable_reason: str | None = None
 
     @property
     def database_url(self) -> str:
@@ -284,6 +329,21 @@ class _PostgresEventCacheRuntime:
         """Return whether the advisory cache is disabled for this runtime."""
         return self._disabled_reason is not None
 
+    @property
+    def disabled_reason(self) -> str | None:
+        """Return the reason this runtime was permanently disabled, if any."""
+        return self._disabled_reason
+
+    @property
+    def unavailable_reason(self) -> str | None:
+        """Return the most recent transient unavailability cause, if any."""
+        return self._unavailable_reason
+
+    @property
+    def reconnect_attempts(self) -> int:
+        """Return the number of times this runtime has reopened its connection."""
+        return self._reconnect_attempts
+
     def disable(self, reason: str) -> None:
         """Disable the advisory cache for the rest of the runtime."""
         if self._disabled_reason is not None:
@@ -294,6 +354,37 @@ class _PostgresEventCacheRuntime:
             database_url=self.redacted_database_url,
             namespace=self._namespace,
             reason=reason,
+        )
+
+    async def handle_transient_failure(self, exc: BaseException, *, operation: str) -> None:
+        """Drop the dead connection so the next acquire opens a fresh one.
+
+        Caller must have already determined that *exc* is transient via
+        :func:`_is_transient_db_error`. Cleaning up the connection is best-effort —
+        if the close itself raises, we log and proceed with reconnection on the
+        next acquire.
+        """
+        async with self._db_lock:
+            if self._db is not None:
+                try:
+                    await self._db.close()
+                except Exception as close_exc:
+                    logger.debug(
+                        "Ignoring error while closing dead Postgres event cache connection",
+                        namespace=self._namespace,
+                        operation=operation,
+                        error=str(close_exc),
+                    )
+                self._db = None
+            self._reconnect_attempts += 1
+            self._unavailable_reason = type(exc).__name__
+        logger.info(
+            "Reconnecting Postgres event cache after transient failure",
+            database_url=self.redacted_database_url,
+            namespace=self._namespace,
+            operation=operation,
+            error=str(exc),
+            reconnect_attempts=self._reconnect_attempts,
         )
 
     async def initialize(self) -> None:
@@ -418,6 +509,21 @@ class PostgresEventCache:
         """Return whether cache writes can durably persist data."""
         return self._runtime.is_initialized and not self._runtime.is_disabled
 
+    @property
+    def disabled_reason(self) -> str | None:
+        """Return the reason this cache was permanently disabled, if any."""
+        return self._runtime.disabled_reason
+
+    @property
+    def unavailable_reason(self) -> str | None:
+        """Return the most recent transient unavailability cause, if any."""
+        return self._runtime.unavailable_reason
+
+    @property
+    def reconnect_attempts(self) -> int:
+        """Return the total reconnection attempts for this cache instance."""
+        return self._runtime.reconnect_attempts
+
     async def initialize(self) -> None:
         """Open the PostgreSQL database and create the cache schema."""
         await self._runtime.initialize()
@@ -440,14 +546,24 @@ class PostgresEventCache:
     ) -> T:
         if self._runtime.is_disabled:
             return disabled_result
-        async with self._runtime.acquire_db_operation(room_id, operation=operation) as db:
+        for attempt in (1, 2):
             try:
-                result = await reader(db)
-                await db.commit()
-            except Exception:
-                await db.rollback()
+                async with self._runtime.acquire_db_operation(room_id, operation=operation) as db:
+                    try:
+                        result = await reader(db)
+                        await db.commit()
+                    except Exception:
+                        await db.rollback()
+                        raise
+            except Exception as exc:
+                if attempt == 1 and _is_transient_db_error(exc):
+                    await self._runtime.handle_transient_failure(exc, operation=operation)
+                    continue
                 raise
-        return result
+            else:
+                return result
+        msg = "transient retry loop exited without returning"
+        raise RuntimeError(msg)
 
     async def _write_operation(
         self,
@@ -459,14 +575,24 @@ class PostgresEventCache:
     ) -> T:
         if self._runtime.is_disabled:
             return disabled_result
-        async with self._runtime.acquire_db_operation(room_id, operation=operation) as db:
+        for attempt in (1, 2):
             try:
-                result = await writer(db)
-                await db.commit()
-            except Exception:
-                await db.rollback()
+                async with self._runtime.acquire_db_operation(room_id, operation=operation) as db:
+                    try:
+                        result = await writer(db)
+                        await db.commit()
+                    except Exception:
+                        await db.rollback()
+                        raise
+            except Exception as exc:
+                if attempt == 1 and _is_transient_db_error(exc):
+                    await self._runtime.handle_transient_failure(exc, operation=operation)
+                    continue
                 raise
-        return result
+            else:
+                return result
+        msg = "transient retry loop exited without returning"
+        raise RuntimeError(msg)
 
     async def get_thread_events(self, room_id: str, thread_id: str) -> list[dict[str, Any]] | None:
         """Return cached events for one thread sorted by timestamp."""

--- a/tests/test_postgres_event_cache_recovery.py
+++ b/tests/test_postgres_event_cache_recovery.py
@@ -55,8 +55,17 @@ async def test_is_transient_db_error_classifies_admin_shutdown() -> None:
     assert _is_transient_db_error(err)
 
 
-async def test_is_transient_db_error_classifies_sqlstate() -> None:
-    """SQLSTATE-only classification path should also flag transient codes."""
+async def test_is_transient_db_error_classifies_typed_psycopg_errors() -> None:
+    """Real psycopg typed errors should be classified by their ``sqlstate`` attribute."""
+    assert _is_transient_db_error(psycopg.errors.AdminShutdown("admin"))
+    assert _is_transient_db_error(psycopg.errors.CrashShutdown("crash"))
+    assert _is_transient_db_error(psycopg.errors.CannotConnectNow("starting"))
+    assert _is_transient_db_error(psycopg.errors.ConnectionFailure("conn fail"))
+    assert not _is_transient_db_error(psycopg.errors.SyntaxError("bad sql"))
+
+
+async def test_is_transient_db_error_classifies_sqlstate_via_diag() -> None:
+    """Errors that only expose ``diag.sqlstate`` (no top-level attr) should still classify."""
 
     class _FakeDiag:
         def __init__(self, sqlstate: str) -> None:

--- a/tests/test_postgres_event_cache_recovery.py
+++ b/tests/test_postgres_event_cache_recovery.py
@@ -1,0 +1,139 @@
+"""Recovery behavior of the Postgres event cache after transient connection loss."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import psycopg
+import pytest
+import pytest_asyncio
+
+from mindroom.matrix.cache.postgres_event_cache import (
+    PostgresEventCache,
+    _is_transient_db_error,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _build_event(event_id: str, thread_id: str, ts: int) -> dict[str, object]:
+    return {
+        "type": "m.room.message",
+        "event_id": event_id,
+        "sender": "@alice:localhost",
+        "origin_server_ts": ts,
+        "content": {
+            "msgtype": "m.text",
+            "body": event_id,
+            "m.relates_to": {"rel_type": "m.thread", "event_id": thread_id},
+        },
+    }
+
+
+@pytest_asyncio.fixture
+async def postgres_event_cache(postgres_event_cache_url: str) -> AsyncIterator[PostgresEventCache]:
+    """Yield a fresh PostgresEventCache rooted at a unique namespace."""
+    namespace = uuid.uuid4().hex
+    cache = PostgresEventCache(database_url=postgres_event_cache_url, namespace=namespace)
+    await cache.initialize()
+    try:
+        yield cache
+    finally:
+        await cache.close()
+
+
+async def test_is_transient_db_error_classifies_admin_shutdown() -> None:
+    """Admin-shutdown style errors should be classified as transient via message match."""
+    err = psycopg.OperationalError(
+        "terminating connection due to administrator command",
+    )
+    assert _is_transient_db_error(err)
+
+
+async def test_is_transient_db_error_classifies_sqlstate() -> None:
+    """SQLSTATE-only classification path should also flag transient codes."""
+
+    class _FakeDiag:
+        def __init__(self, sqlstate: str) -> None:
+            self.sqlstate = sqlstate
+
+    class _FakeOperationalError(psycopg.OperationalError):
+        def __init__(self, sqlstate: str) -> None:
+            super().__init__("connection closed")
+            self._fake_diag = _FakeDiag(sqlstate)
+
+        @property
+        def diag(self) -> _FakeDiag:  # type: ignore[override]
+            return self._fake_diag
+
+    assert _is_transient_db_error(_FakeOperationalError("57P01"))
+    assert _is_transient_db_error(_FakeOperationalError("08006"))
+    assert not _is_transient_db_error(_FakeOperationalError("42601"))
+
+
+async def test_is_transient_db_error_classifies_interface_error() -> None:
+    """``InterfaceError`` raised on a closed connection should be classified as transient."""
+    assert _is_transient_db_error(psycopg.InterfaceError("the connection is closed"))
+
+
+async def test_is_transient_db_error_rejects_logic_errors() -> None:
+    """Programming-style errors should not be retried."""
+    assert not _is_transient_db_error(psycopg.ProgrammingError("syntax error"))
+    assert not _is_transient_db_error(ValueError("not a db error"))
+
+
+async def test_invalidate_thread_recovers_after_connection_close(
+    postgres_event_cache: PostgresEventCache,
+) -> None:
+    """A force-closed connection during a write must reconnect and complete the operation."""
+    room_id = "!recovery:localhost"
+    thread_id = "$thread_recovery:localhost"
+    await postgres_event_cache.replace_thread(
+        room_id,
+        thread_id,
+        events=[_build_event("$ev1", thread_id, ts=1)],
+        validated_at=1.0,
+    )
+    cached_before = await postgres_event_cache.get_thread_events(room_id, thread_id)
+    assert cached_before is not None
+    assert len(cached_before) == 1
+
+    db = postgres_event_cache._runtime.require_db()
+    await db.close()
+
+    await postgres_event_cache.invalidate_thread(room_id, thread_id)
+
+    assert postgres_event_cache.disabled_reason is None
+    assert postgres_event_cache.reconnect_attempts == 1
+    assert postgres_event_cache.unavailable_reason is not None
+
+    cached_after = await postgres_event_cache.get_thread_events(room_id, thread_id)
+    assert cached_after is None or cached_after == []
+
+
+async def test_read_after_connection_close_recovers(
+    postgres_event_cache: PostgresEventCache,
+) -> None:
+    """Reads should also reconnect on transient connection failures."""
+    room_id = "!read_recovery:localhost"
+    thread_id = "$thread_read_recovery:localhost"
+    await postgres_event_cache.replace_thread(
+        room_id,
+        thread_id,
+        events=[_build_event("$ev_r1", thread_id, ts=1)],
+        validated_at=1.0,
+    )
+
+    db = postgres_event_cache._runtime.require_db()
+    await db.close()
+
+    events = await postgres_event_cache.get_thread_events(room_id, thread_id)
+    assert events is not None
+    assert len(events) == 1
+    assert postgres_event_cache.disabled_reason is None
+    assert postgres_event_cache.reconnect_attempts == 1


### PR DESCRIPTION
## Summary
A single transient PostgreSQL connection failure (admin shutdown, server-closed socket, psycopg `InterfaceError`) currently cascades into a permanent `disable()` of the in-process event cache for the rest of the runtime. The DB still has valid rows, but every subsequent read returns `no_cache_state`, forcing the caller to fall back to a homeserver paginate-and-scan loop.

This change:
- classifies a tight set of connection-level errors as transient (`08xxx`, `57P01-57P03`, `psycopg.InterfaceError`, plus a small allow-list of message fragments like "the connection is closed" / "terminating connection"),
- drops the dead connection on the runtime so `acquire_db_operation` reopens it,
- retries the failing read or write **once** on a fresh connection,
- leaves the permanent `disable()` path intact for non-recoverable fail-closed scenarios (e.g. `_fail_closed_thread_invalidation` after the retry has already been spent).

It also exposes `disabled_reason`, `unavailable_reason`, and `reconnect_attempts` on the cache facade so future diagnostics can explain why writes were skipped instead of just logging `cache_runtime_available=False`.

## Tests
- `uv run pytest tests/test_postgres_event_cache_recovery.py -x -n 0 --no-cov -q` → 6 passed
  - 4 unit tests covering `_is_transient_db_error` classification (sqlstate, `InterfaceError`, message-match, rejected codes)
  - 2 live-Postgres scenarios that force-close the underlying connection mid-flight and verify the next read/write reconnects, completes, and leaves `disabled_reason` unset (`reconnect_attempts == 1`)
- `uv run pytest tests/test_event_cache_backends.py tests/test_event_cache.py -nauto --no-cov -q` → 68 passed (no regression)
- `uv run ruff check src/mindroom/matrix/cache/postgres_event_cache.py tests/test_postgres_event_cache_recovery.py`
- `uv run tach check --dependencies --interfaces`

## Test plan
- [x] transient sqlstates and `InterfaceError` classified correctly
- [x] non-transient errors propagate without retry
- [x] `invalidate_thread` recovers after a force-closed connection
- [x] `get_thread_events` recovers after a force-closed connection
- [x] `disabled_reason` / `unavailable_reason` / `reconnect_attempts` exposed on the cache