### PR TITLE
Recover Postgres event cache after transient disconnects

### DIFF
--- a/.github/workflows/smoke-stacks.yml
+++ b/.github/workflows/smoke-stacks.yml
@@ -66,6 +66,20 @@ jobs:
           skipClusterDeletion: true
           skipClusterLogsExport: true
 
+      - name: Free runner disk space
+        run: |
+          echo "Disk usage before cleanup:"
+          df -h /
+
+          echo "Removing preinstalled .NET SDKs to make room for smoke images..."
+          sudo rm -rf /usr/share/dotnet
+
+          echo "Removing preinstalled Android SDK to make room for smoke images..."
+          sudo rm -rf /usr/local/lib/android
+
+          echo "Disk usage after cleanup:"
+          df -h /
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/smoke-stacks.yml
+++ b/.github/workflows/smoke-stacks.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Create kind cluster
         run: bash cluster/k8s/kind/up.sh
+        env:
+          KIND_CONFIG: cluster/k8s/kind/kind-config-smoke.yaml
 
       - name: Build and load images
         run: bash cluster/k8s/kind/build_load_images.sh

--- a/cluster/k8s/kind/kind-config-smoke.yaml
+++ b/cluster/k8s/kind/kind-config-smoke.yaml
@@ -1,0 +1,18 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: mindroom
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 30080
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 30443
+    protocol: TCP

--- a/cluster/k8s/kind/up.sh
+++ b/cluster/k8s/kind/up.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # Create a local kind cluster for MindRoom with ingress
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CLUSTER_NAME="mindroom"
-KIND_CONFIG="${SCRIPT_DIR}/kind-config.yaml"
+CLUSTER_NAME="${CLUSTER_NAME:-mindroom}"
+KIND_CONFIG="${KIND_CONFIG:-${SCRIPT_DIR}/kind-config.yaml}"
 
 echo "[kind] Bringing up cluster '${CLUSTER_NAME}'..."
 

--- a/cluster/k8s/kind/up.sh
+++ b/cluster/k8s/kind/up.sh
@@ -34,9 +34,8 @@ echo "[kind] Installing ingress-nginx for kind..."
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
 
 echo "[kind] Waiting for ingress controller to be ready..."
-kubectl wait --namespace ingress-nginx \
-  --for=condition=ready pod \
-  --selector=app.kubernetes.io/component=controller \
+kubectl rollout status deployment/ingress-nginx-controller \
+  --namespace ingress-nginx \
   --timeout=180s
 
 echo "[kind] Cluster '${CLUSTER_NAME}' is ready."

--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -26,7 +26,7 @@ from .agent_message_snapshot import (
     AgentMessageSnapshot,
     AgentMessageSnapshotUnavailable,
 )
-from .event_cache import ConversationEventCache, EventCacheBackendUnavailable, ThreadCacheState
+from .event_cache import ConversationEventCache, EventCacheBackendUnavailableError, ThreadCacheState
 from .event_normalization import normalize_event_source_for_cache, normalize_nio_event_for_cache
 from .thread_cache_helpers import thread_cache_rejection_reason, thread_cache_state_is_usable
 from .thread_history_result import (
@@ -53,7 +53,7 @@ __all__ = [
     "AgentMessageSnapshot",
     "AgentMessageSnapshotUnavailable",
     "ConversationEventCache",
-    "EventCacheBackendUnavailable",
+    "EventCacheBackendUnavailableError",
     "EventCacheWriteCoordinator",
     "ThreadCacheState",
     "ThreadHistoryResult",

--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -26,7 +26,7 @@ from .agent_message_snapshot import (
     AgentMessageSnapshot,
     AgentMessageSnapshotUnavailable,
 )
-from .event_cache import ConversationEventCache, ThreadCacheState
+from .event_cache import ConversationEventCache, EventCacheBackendUnavailable, ThreadCacheState
 from .event_normalization import normalize_event_source_for_cache, normalize_nio_event_for_cache
 from .thread_cache_helpers import thread_cache_rejection_reason, thread_cache_state_is_usable
 from .thread_history_result import (
@@ -53,6 +53,7 @@ __all__ = [
     "AgentMessageSnapshot",
     "AgentMessageSnapshotUnavailable",
     "ConversationEventCache",
+    "EventCacheBackendUnavailable",
     "EventCacheWriteCoordinator",
     "ThreadCacheState",
     "ThreadHistoryResult",

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -136,3 +136,9 @@ class ConversationEventCache(Protocol):
 
     def runtime_diagnostics(self) -> dict[str, object]:
         """Return log-safe runtime state for sync certification diagnostics."""
+
+    def pending_durable_write_room_ids(self) -> tuple[str, ...]:
+        """Return rooms with runtime-only writes that must persist before certifying a sync token."""
+
+    async def flush_pending_durable_writes(self, room_id: str) -> None:
+        """Persist runtime-only writes for one room before certifying a sync token."""

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -20,7 +20,7 @@ class ThreadCacheState:
     room_invalidation_reason: str | None
 
 
-class EventCacheBackendUnavailable(RuntimeError):
+class EventCacheBackendUnavailableError(RuntimeError):
     """Raised when cache storage is temporarily unreachable but not logically corrupt."""
 
 

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -20,6 +20,10 @@ class ThreadCacheState:
     room_invalidation_reason: str | None
 
 
+class EventCacheBackendUnavailable(RuntimeError):
+    """Raised when cache storage is temporarily unreachable but not logically corrupt."""
+
+
 class ConversationEventCache(Protocol):
     """Storage-agnostic cache API for Matrix event and thread lookups."""
 

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -133,3 +133,6 @@ class ConversationEventCache(Protocol):
 
     def disable(self, reason: str) -> None:
         """Disable the advisory cache for the rest of the runtime."""
+
+    def runtime_diagnostics(self) -> dict[str, object]:
+        """Return log-safe runtime state for sync certification diagnostics."""

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -47,7 +47,6 @@ _TRANSIENT_SQLSTATES: frozenset[str] = frozenset(
 _TRANSIENT_ERROR_TEXT: tuple[str, ...] = (
     "connection is closed",
     "connection already closed",
-    "connection failed",
     "connection refused",
     "could not connect",
     "network is unreachable",
@@ -60,11 +59,12 @@ _TRANSIENT_ERROR_TEXT: tuple[str, ...] = (
 
 def _postgres_error_sqlstate(exc: BaseException) -> str | None:
     """Return the SQLSTATE attached to a psycopg error when available."""
-    sqlstate = getattr(exc, "sqlstate", None)
+    if not isinstance(exc, psycopg.Error):
+        return None
+    sqlstate = exc.sqlstate
     if isinstance(sqlstate, str):
         return sqlstate
-    diag = getattr(exc, "diag", None)
-    diag_sqlstate = getattr(diag, "sqlstate", None) if diag is not None else None
+    diag_sqlstate = exc.diag.sqlstate
     return diag_sqlstate if isinstance(diag_sqlstate, str) else None
 
 
@@ -509,7 +509,7 @@ class _PostgresEventCacheRuntime:
 
     def connection_is_closed(self, db: psycopg.AsyncConnection) -> bool:
         """Return whether psycopg considers one connection closed."""
-        return bool(getattr(db, "closed", False))
+        return bool(db.closed)
 
     def _unavailable_reason_from_exception(self, exc: BaseException) -> str:
         message = str(exc)

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -14,7 +14,7 @@ import psycopg
 from mindroom.logging_config import get_logger
 
 from . import postgres_event_cache_events, postgres_event_cache_threads
-from .event_cache import EventCacheBackendUnavailable
+from .event_cache import EventCacheBackendUnavailableError
 from .event_normalization import normalize_event_source_for_cache
 from .postgres_agent_message_snapshot import load_postgres_agent_message_snapshot
 from .postgres_redaction import redact_postgres_connection_info
@@ -79,10 +79,10 @@ def _is_transient_postgres_failure(exc: BaseException) -> bool:
     return any(fragment in message for fragment in _TRANSIENT_ERROR_TEXT)
 
 
-def _cache_backend_unavailable(operation: str, exc: BaseException) -> EventCacheBackendUnavailable:
+def _cache_backend_unavailable(operation: str, exc: BaseException) -> EventCacheBackendUnavailableError:
     message = str(exc)
     detail = f"{type(exc).__name__}: {message}" if message else type(exc).__name__
-    return EventCacheBackendUnavailable(f"Postgres event cache unavailable during {operation}: {detail}")
+    return EventCacheBackendUnavailableError(f"Postgres event cache unavailable during {operation}: {detail}")
 
 
 async def initialize_postgres_event_cache_db(database_url: str) -> psycopg.AsyncConnection:
@@ -682,7 +682,7 @@ class PostgresEventCache:
                     except Exception:
                         await self._rollback_best_effort(db, operation=operation)
                         raise
-            except EventCacheBackendUnavailable as exc:
+            except EventCacheBackendUnavailableError as exc:
                 transient_error = exc
                 if attempt + 1 < _MAX_TRANSIENT_OPERATION_ATTEMPTS:
                     continue
@@ -1007,7 +1007,7 @@ class PostgresEventCache:
                     reason=reason,
                 ),
             )
-        except EventCacheBackendUnavailable:
+        except EventCacheBackendUnavailableError:
             self._runtime.record_pending_thread_invalidation(
                 room_id,
                 thread_id,
@@ -1032,7 +1032,7 @@ class PostgresEventCache:
                     reason=reason,
                 ),
             )
-        except EventCacheBackendUnavailable:
+        except EventCacheBackendUnavailableError:
             self._runtime.record_pending_room_invalidation(
                 room_id,
                 invalidated_at=invalidated_at,

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -449,7 +449,11 @@ class _PostgresEventCacheRuntime:
         reason: str,
     ) -> None:
         """Remember a best-effort stale marker that must be persisted before trusting cache rows."""
-        self._pending_thread_invalidations[(room_id, thread_id)] = _PendingInvalidation(
+        key = (room_id, thread_id)
+        existing = self._pending_thread_invalidations.get(key)
+        if existing is not None and existing.invalidated_at >= invalidated_at:
+            return
+        self._pending_thread_invalidations[key] = _PendingInvalidation(
             invalidated_at=invalidated_at,
             reason=reason,
         )
@@ -462,6 +466,9 @@ class _PostgresEventCacheRuntime:
         reason: str,
     ) -> None:
         """Remember a best-effort room stale marker that must be persisted before trusting cache rows."""
+        existing = self._pending_room_invalidations.get(room_id)
+        if existing is not None and existing.invalidated_at >= invalidated_at:
+            return
         self._pending_room_invalidations[room_id] = _PendingInvalidation(
             invalidated_at=invalidated_at,
             reason=reason,

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -47,7 +47,13 @@ _TRANSIENT_SQLSTATES: frozenset[str] = frozenset(
 _TRANSIENT_ERROR_TEXT: tuple[str, ...] = (
     "connection is closed",
     "connection already closed",
+    "connection failed",
+    "connection refused",
+    "could not connect",
+    "network is unreachable",
+    "no route to host",
     "server closed the connection",
+    "temporary failure in name resolution",
     "terminating connection",
 )
 
@@ -460,22 +466,25 @@ class _PostgresEventCacheRuntime:
             reason=reason,
         )
 
-    def pending_room_invalidations(self, room_id: str) -> tuple[tuple[str, str | None, _PendingInvalidation], ...]:
-        """Return pending invalidations for one room as (kind, thread_id, pending)."""
-        pending: list[tuple[str, str | None, _PendingInvalidation]] = []
-        room_pending = self._pending_room_invalidations.get(room_id)
-        if room_pending is not None:
-            pending.append(("room", None, room_pending))
-        for (pending_room_id, thread_id), thread_pending in self._pending_thread_invalidations.items():
-            if pending_room_id == room_id:
-                pending.append(("thread", thread_id, thread_pending))
-        return tuple(pending)
+    def pending_room_invalidation(self, room_id: str) -> _PendingInvalidation | None:
+        """Return one pending room invalidation, if any."""
+        return self._pending_room_invalidations.get(room_id)
 
-    def forget_pending_room_invalidation(self, room_id: str) -> None:
-        """Forget one persisted room invalidation and redundant thread invalidations."""
+    def pending_thread_invalidations(self, room_id: str) -> tuple[tuple[str, _PendingInvalidation], ...]:
+        """Return pending thread invalidations for one room."""
+        return tuple(
+            (thread_id, pending)
+            for (pending_room_id, thread_id), pending in self._pending_thread_invalidations.items()
+            if pending_room_id == room_id
+        )
+
+    def forget_pending_room_invalidation(self, room_id: str, *, invalidated_at: float) -> None:
+        """Forget one persisted room invalidation and thread markers covered by it."""
         self._pending_room_invalidations.pop(room_id, None)
         self._pending_thread_invalidations = {
-            key: pending for key, pending in self._pending_thread_invalidations.items() if key[0] != room_id
+            key: pending
+            for key, pending in self._pending_thread_invalidations.items()
+            if key[0] != room_id or pending.invalidated_at > invalidated_at
         }
 
     def forget_pending_thread_invalidation(self, room_id: str, thread_id: str) -> None:
@@ -672,7 +681,7 @@ class PostgresEventCache:
             return disabled_result
         transient_error: BaseException | None = None
         for attempt in range(_MAX_TRANSIENT_OPERATION_ATTEMPTS):
-            flushed_pending: tuple[tuple[str, str | None], ...] = ()
+            flushed_pending: tuple[tuple[str, str | None, float], ...] = ()
             try:
                 async with self._runtime.acquire_db_operation(room_id, operation=operation) as db:
                     try:
@@ -716,23 +725,22 @@ class PostgresEventCache:
         self,
         db: psycopg.AsyncConnection,
         room_id: str,
-    ) -> tuple[tuple[str, str | None], ...]:
-        pending = self._runtime.pending_room_invalidations(room_id)
-        if not pending:
-            return ()
-        flushed: list[tuple[str, str | None]] = []
-        for kind, thread_id, pending_invalidation in pending:
-            if kind == "room":
-                await postgres_event_cache_threads.mark_room_stale_locked(
-                    db,
-                    namespace=self._runtime.namespace,
-                    room_id=room_id,
-                    invalidated_at=pending_invalidation.invalidated_at,
-                    reason=pending_invalidation.reason,
-                )
-                flushed.append(("room", None))
-                break
-            if thread_id is None:
+    ) -> tuple[tuple[str, str | None, float], ...]:
+        flushed: list[tuple[str, str | None, float]] = []
+        room_pending = self._runtime.pending_room_invalidation(room_id)
+        thread_pending = self._runtime.pending_thread_invalidations(room_id)
+        if room_pending is not None:
+            await postgres_event_cache_threads.mark_room_stale_locked(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                invalidated_at=room_pending.invalidated_at,
+                reason=room_pending.reason,
+            )
+            flushed.append(("room", None, room_pending.invalidated_at))
+
+        for thread_id, pending_invalidation in thread_pending:
+            if room_pending is not None and pending_invalidation.invalidated_at <= room_pending.invalidated_at:
                 continue
             await postgres_event_cache_threads.mark_thread_stale_locked(
                 db,
@@ -742,17 +750,17 @@ class PostgresEventCache:
                 invalidated_at=pending_invalidation.invalidated_at,
                 reason=pending_invalidation.reason,
             )
-            flushed.append(("thread", thread_id))
+            flushed.append(("thread", thread_id, pending_invalidation.invalidated_at))
         return tuple(flushed)
 
     def _forget_flushed_pending_invalidations(
         self,
         room_id: str,
-        flushed_pending: tuple[tuple[str, str | None], ...],
+        flushed_pending: tuple[tuple[str, str | None, float], ...],
     ) -> None:
-        for kind, thread_id in flushed_pending:
+        for kind, thread_id, invalidated_at in flushed_pending:
             if kind == "room":
-                self._runtime.forget_pending_room_invalidation(room_id)
+                self._runtime.forget_pending_room_invalidation(room_id, invalidated_at=invalidated_at)
                 continue
             if thread_id is not None:
                 self._runtime.forget_pending_thread_invalidation(room_id, thread_id)

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -14,6 +14,7 @@ import psycopg
 from mindroom.logging_config import get_logger
 
 from . import postgres_event_cache_events, postgres_event_cache_threads
+from .event_cache import EventCacheBackendUnavailable
 from .event_normalization import normalize_event_source_for_cache
 from .postgres_agent_message_snapshot import load_postgres_agent_message_snapshot
 from .postgres_redaction import redact_postgres_connection_info
@@ -30,9 +31,58 @@ if TYPE_CHECKING:
 POSTGRES_EVENT_CACHE_SCHEMA_VERSION = 1
 _LOCK_WAIT_LOG_THRESHOLD_SECONDS = 0.1
 _MAX_CACHED_ROOM_LOCKS = 256
+_MAX_TRANSIENT_OPERATION_ATTEMPTS = 2
 T = TypeVar("T")
 
 logger = get_logger(__name__)
+
+_TRANSIENT_SQLSTATE_PREFIXES: tuple[str, ...] = ("08",)
+_TRANSIENT_SQLSTATES: frozenset[str] = frozenset(
+    {
+        "57P01",  # admin_shutdown
+        "57P02",  # crash_shutdown
+        "57P03",  # cannot_connect_now
+    },
+)
+_TRANSIENT_ERROR_TEXT: tuple[str, ...] = (
+    "connection is closed",
+    "connection already closed",
+    "server closed the connection",
+    "terminating connection",
+)
+
+
+def _postgres_error_sqlstate(exc: BaseException) -> str | None:
+    """Return the SQLSTATE attached to a psycopg error when available."""
+    sqlstate = getattr(exc, "sqlstate", None)
+    if isinstance(sqlstate, str):
+        return sqlstate
+    diag = getattr(exc, "diag", None)
+    diag_sqlstate = getattr(diag, "sqlstate", None) if diag is not None else None
+    return diag_sqlstate if isinstance(diag_sqlstate, str) else None
+
+
+def _is_transient_postgres_failure(exc: BaseException) -> bool:
+    """Return whether one PostgreSQL failure should be retried on a new connection."""
+    if isinstance(exc, psycopg.InterfaceError):
+        return True
+    if not isinstance(exc, psycopg.OperationalError):
+        return False
+
+    sqlstate = _postgres_error_sqlstate(exc)
+    if sqlstate in _TRANSIENT_SQLSTATES:
+        return True
+    if sqlstate is not None and sqlstate.startswith(_TRANSIENT_SQLSTATE_PREFIXES):
+        return True
+
+    message = str(exc).lower()
+    return any(fragment in message for fragment in _TRANSIENT_ERROR_TEXT)
+
+
+def _cache_backend_unavailable(operation: str, exc: BaseException) -> EventCacheBackendUnavailable:
+    message = str(exc)
+    detail = f"{type(exc).__name__}: {message}" if message else type(exc).__name__
+    return EventCacheBackendUnavailable(f"Postgres event cache unavailable during {operation}: {detail}")
 
 
 async def initialize_postgres_event_cache_db(database_url: str) -> psycopg.AsyncConnection:
@@ -238,6 +288,14 @@ class _RoomLockEntry:
     active_users: int = 0
 
 
+@dataclass(frozen=True)
+class _PendingInvalidation:
+    """Stale marker that must be persisted before cache rows can be trusted again."""
+
+    invalidated_at: float
+    reason: str
+
+
 class _PostgresEventCacheRuntime:
     """Own runtime-only lifecycle, locking, and disable state for one cache instance."""
 
@@ -246,8 +304,15 @@ class _PostgresEventCacheRuntime:
         self._namespace = namespace
         self._db: psycopg.AsyncConnection | None = None
         self._disabled_reason: str | None = None
+        self._unavailable_reason: str | None = None
+        self._transient_failure_count = 0
+        self._reconnect_count = 0
+        self._reconnect_after_transient = False
+        self._explicitly_closed = False
         self._db_lock = asyncio.Lock()
         self._room_locks: OrderedDict[str, _RoomLockEntry] = OrderedDict()
+        self._pending_thread_invalidations: dict[tuple[str, str], _PendingInvalidation] = {}
+        self._pending_room_invalidations: dict[str, _PendingInvalidation] = {}
 
     @property
     def database_url(self) -> str:
@@ -277,12 +342,47 @@ class _PostgresEventCacheRuntime:
     @property
     def is_initialized(self) -> bool:
         """Return whether the PostgreSQL connection is currently open."""
-        return self._db is not None
+        return self._db is not None and not self.connection_is_closed(self._db)
 
     @property
     def is_disabled(self) -> bool:
         """Return whether the advisory cache is disabled for this runtime."""
         return self._disabled_reason is not None
+
+    @property
+    def disabled_reason(self) -> str | None:
+        """Return the permanent disable reason, if any."""
+        return self._disabled_reason
+
+    @property
+    def unavailable_reason(self) -> str | None:
+        """Return the latest transient backend failure reason, if any."""
+        return self._unavailable_reason
+
+    @property
+    def transient_failure_count(self) -> int:
+        """Return the number of transient backend failures observed by this runtime."""
+        return self._transient_failure_count
+
+    @property
+    def reconnect_count(self) -> int:
+        """Return the number of replacement connections opened by this runtime."""
+        return self._reconnect_count
+
+    @property
+    def pending_thread_invalidation_count(self) -> int:
+        """Return how many thread invalidations still need to be persisted."""
+        return len(self._pending_thread_invalidations)
+
+    @property
+    def pending_room_invalidation_count(self) -> int:
+        """Return how many room invalidations still need to be persisted."""
+        return len(self._pending_room_invalidations)
+
+    @property
+    def explicitly_closed(self) -> bool:
+        """Return whether this runtime was intentionally closed."""
+        return self._explicitly_closed
 
     def disable(self, reason: str) -> None:
         """Disable the advisory cache for the rest of the runtime."""
@@ -296,21 +396,147 @@ class _PostgresEventCacheRuntime:
             reason=reason,
         )
 
+    def runtime_diagnostics(self) -> dict[str, object]:
+        """Return log-safe runtime state for sync certification diagnostics."""
+        diagnostics: dict[str, object] = {
+            "cache_backend": "postgres",
+            "cache_postgres_initialized": self.is_initialized,
+            "cache_postgres_disabled": self.is_disabled,
+            "cache_postgres_transient_failure_count": self._transient_failure_count,
+            "cache_postgres_reconnect_count": self._reconnect_count,
+            "cache_postgres_pending_thread_invalidations": len(self._pending_thread_invalidations),
+            "cache_postgres_pending_room_invalidations": len(self._pending_room_invalidations),
+            "cache_postgres_explicitly_closed": self._explicitly_closed,
+        }
+        if self._disabled_reason is not None:
+            diagnostics["cache_postgres_disabled_reason"] = self._disabled_reason
+        if self._unavailable_reason is not None:
+            diagnostics["cache_postgres_unavailable_reason"] = self._unavailable_reason
+        return diagnostics
+
     async def initialize(self) -> None:
         """Open the PostgreSQL database and create the cache schema."""
         async with self._db_lock:
-            if self._disabled_reason is not None or self._db is not None:
+            if self._disabled_reason is not None:
                 return
-            self._db = await initialize_postgres_event_cache_db(self._database_url)
+            self._explicitly_closed = False
+            if self._db is not None and not self.connection_is_closed(self._db):
+                return
+            had_previous_connection = self._db is not None
+            await self._close_db_locked(operation="initialize")
+            try:
+                self._db = await initialize_postgres_event_cache_db(self._database_url)
+            except Exception as exc:
+                if _is_transient_postgres_failure(exc):
+                    self._transient_failure_count += 1
+                    self._unavailable_reason = self._unavailable_reason_from_exception(exc)
+                    operation = "initialize"
+                    raise _cache_backend_unavailable(operation, exc) from exc
+                raise
+            if had_previous_connection or self._reconnect_after_transient:
+                self._reconnect_count += 1
+            self._reconnect_after_transient = False
+            self._unavailable_reason = None
 
     async def close(self) -> None:
         """Close the PostgreSQL connection when the cache is no longer needed."""
         async with self._db_lock:
-            if self._db is None:
-                return
-            await self._db.close()
-            self._db = None
+            self._explicitly_closed = True
+            self._reconnect_after_transient = False
+            await self._close_db_locked(operation="close")
             self._room_locks.clear()
+
+    async def handle_transient_failure(self, exc: BaseException, *, operation: str) -> None:
+        """Drop a dead connection and leave the runtime eligible for later reconnect."""
+        async with self._db_lock:
+            self._transient_failure_count += 1
+            self._unavailable_reason = self._unavailable_reason_from_exception(exc)
+            self._reconnect_after_transient = True
+            await self._close_db_locked(operation=operation)
+        logger.info(
+            "Postgres event cache temporarily unavailable",
+            database_url=self.redacted_database_url,
+            namespace=self._namespace,
+            operation=operation,
+            error_type=type(exc).__name__,
+            error=str(exc),
+            transient_failure_count=self._transient_failure_count,
+        )
+
+    def record_pending_thread_invalidation(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        invalidated_at: float,
+        reason: str,
+    ) -> None:
+        """Remember a stale marker that must be persisted before trusting cache rows."""
+        self._pending_thread_invalidations[(room_id, thread_id)] = _PendingInvalidation(
+            invalidated_at=invalidated_at,
+            reason=reason,
+        )
+
+    def record_pending_room_invalidation(
+        self,
+        room_id: str,
+        *,
+        invalidated_at: float,
+        reason: str,
+    ) -> None:
+        """Remember a room stale marker that must be persisted before trusting cache rows."""
+        self._pending_room_invalidations[room_id] = _PendingInvalidation(
+            invalidated_at=invalidated_at,
+            reason=reason,
+        )
+
+    def pending_room_invalidations(self, room_id: str) -> tuple[tuple[str, str | None, _PendingInvalidation], ...]:
+        """Return pending invalidations for one room as (kind, thread_id, pending)."""
+        pending: list[tuple[str, str | None, _PendingInvalidation]] = []
+        room_pending = self._pending_room_invalidations.get(room_id)
+        if room_pending is not None:
+            pending.append(("room", None, room_pending))
+        for (pending_room_id, thread_id), thread_pending in self._pending_thread_invalidations.items():
+            if pending_room_id == room_id:
+                pending.append(("thread", thread_id, thread_pending))
+        return tuple(pending)
+
+    def forget_pending_room_invalidation(self, room_id: str) -> None:
+        """Forget one persisted room invalidation and redundant thread invalidations."""
+        self._pending_room_invalidations.pop(room_id, None)
+        self._pending_thread_invalidations = {
+            key: pending for key, pending in self._pending_thread_invalidations.items() if key[0] != room_id
+        }
+
+    def forget_pending_thread_invalidation(self, room_id: str, thread_id: str) -> None:
+        """Forget one persisted thread invalidation."""
+        self._pending_thread_invalidations.pop((room_id, thread_id), None)
+
+    async def _close_db_locked(self, *, operation: str) -> None:
+        """Close the active connection best-effort. Caller must hold ``_db_lock``."""
+        db = self._db
+        self._db = None
+        if db is None:
+            return
+        try:
+            await db.close()
+        except Exception as exc:
+            logger.debug(
+                "Ignoring error while closing Postgres event cache connection",
+                namespace=self._namespace,
+                operation=operation,
+                error=str(exc),
+            )
+
+    def connection_is_closed(self, db: psycopg.AsyncConnection) -> bool:
+        """Return whether psycopg considers one connection closed."""
+        return bool(getattr(db, "closed", False))
+
+    def _unavailable_reason_from_exception(self, exc: BaseException) -> str:
+        message = str(exc)
+        if not message:
+            return type(exc).__name__
+        return f"{type(exc).__name__}: {message[:200]}"
 
     def room_lock_entry(self, room_id: str, *, active_user_increment: int = 0) -> _RoomLockEntry:
         """Return the cached room lock entry, creating it on demand."""
@@ -358,7 +584,7 @@ class _PostgresEventCacheRuntime:
         operation: str,
     ) -> AsyncIterator[psycopg.AsyncConnection]:
         """Serialize one DB operation with lifecycle changes and room ordering."""
-        if self._db is None:
+        if self._db is None or self.connection_is_closed(self._db):
             await self.initialize()
         async with self._db_lock, self.acquire_room_lock(room_id, operation=operation):
             db = self.require_db()
@@ -416,11 +642,15 @@ class PostgresEventCache:
     @property
     def durable_writes_available(self) -> bool:
         """Return whether cache writes can durably persist data."""
-        return self._runtime.is_initialized and not self._runtime.is_disabled
+        return not self._runtime.is_disabled and not self._runtime.explicitly_closed
 
     async def initialize(self) -> None:
         """Open the PostgreSQL database and create the cache schema."""
         await self._runtime.initialize()
+
+    def runtime_diagnostics(self) -> dict[str, object]:
+        """Return log-safe runtime state for sync certification diagnostics."""
+        return self._runtime.runtime_diagnostics()
 
     def disable(self, reason: str) -> None:
         """Disable the advisory cache for the rest of the runtime."""
@@ -438,16 +668,12 @@ class PostgresEventCache:
         disabled_result: T,
         reader: Callable[[psycopg.AsyncConnection], Awaitable[T]],
     ) -> T:
-        if self._runtime.is_disabled:
-            return disabled_result
-        async with self._runtime.acquire_db_operation(room_id, operation=operation) as db:
-            try:
-                result = await reader(db)
-                await db.commit()
-            except Exception:
-                await db.rollback()
-                raise
-        return result
+        return await self._operation(
+            room_id,
+            operation=operation,
+            disabled_result=disabled_result,
+            callback=reader,
+        )
 
     async def _write_operation(
         self,
@@ -457,16 +683,109 @@ class PostgresEventCache:
         disabled_result: T,
         writer: Callable[[psycopg.AsyncConnection], Awaitable[T]],
     ) -> T:
+        return await self._operation(
+            room_id,
+            operation=operation,
+            disabled_result=disabled_result,
+            callback=writer,
+        )
+
+    async def _operation(
+        self,
+        room_id: str,
+        *,
+        operation: str,
+        disabled_result: T,
+        callback: Callable[[psycopg.AsyncConnection], Awaitable[T]],
+    ) -> T:
         if self._runtime.is_disabled:
             return disabled_result
-        async with self._runtime.acquire_db_operation(room_id, operation=operation) as db:
+        transient_error: BaseException | None = None
+        for attempt in range(_MAX_TRANSIENT_OPERATION_ATTEMPTS):
+            flushed_pending: tuple[tuple[str, str | None], ...] = ()
             try:
-                result = await writer(db)
-                await db.commit()
-            except Exception:
-                await db.rollback()
+                async with self._runtime.acquire_db_operation(room_id, operation=operation) as db:
+                    try:
+                        flushed_pending = await self._flush_pending_invalidations(db, room_id)
+                        result = await callback(db)
+                        await db.commit()
+                    except Exception:
+                        await self._rollback_best_effort(db, operation=operation)
+                        raise
+            except EventCacheBackendUnavailable as exc:
+                transient_error = exc
+                if attempt + 1 < _MAX_TRANSIENT_OPERATION_ATTEMPTS:
+                    continue
                 raise
-        return result
+            except Exception as exc:
+                if not _is_transient_postgres_failure(exc):
+                    raise
+                transient_error = exc
+                await self._runtime.handle_transient_failure(exc, operation=operation)
+                if attempt + 1 < _MAX_TRANSIENT_OPERATION_ATTEMPTS:
+                    continue
+                raise _cache_backend_unavailable(operation, exc) from exc
+            else:
+                self._forget_flushed_pending_invalidations(room_id, flushed_pending)
+                return result
+        raise _cache_backend_unavailable(operation, transient_error or RuntimeError("operation did not run"))
+
+    async def _rollback_best_effort(self, db: psycopg.AsyncConnection, *, operation: str) -> None:
+        try:
+            await db.rollback()
+        except Exception as exc:
+            logger.debug(
+                "Ignoring Postgres event cache rollback failure",
+                namespace=self._runtime.namespace,
+                operation=operation,
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+
+    async def _flush_pending_invalidations(
+        self,
+        db: psycopg.AsyncConnection,
+        room_id: str,
+    ) -> tuple[tuple[str, str | None], ...]:
+        pending = self._runtime.pending_room_invalidations(room_id)
+        if not pending:
+            return ()
+        flushed: list[tuple[str, str | None]] = []
+        for kind, thread_id, pending_invalidation in pending:
+            if kind == "room":
+                await postgres_event_cache_threads.mark_room_stale_locked(
+                    db,
+                    namespace=self._runtime.namespace,
+                    room_id=room_id,
+                    invalidated_at=pending_invalidation.invalidated_at,
+                    reason=pending_invalidation.reason,
+                )
+                flushed.append(("room", None))
+                break
+            if thread_id is None:
+                continue
+            await postgres_event_cache_threads.mark_thread_stale_locked(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+                invalidated_at=pending_invalidation.invalidated_at,
+                reason=pending_invalidation.reason,
+            )
+            flushed.append(("thread", thread_id))
+        return tuple(flushed)
+
+    def _forget_flushed_pending_invalidations(
+        self,
+        room_id: str,
+        flushed_pending: tuple[tuple[str, str | None], ...],
+    ) -> None:
+        for kind, thread_id in flushed_pending:
+            if kind == "room":
+                self._runtime.forget_pending_room_invalidation(room_id)
+                continue
+            if thread_id is not None:
+                self._runtime.forget_pending_thread_invalidation(room_id, thread_id)
 
     async def get_thread_events(self, room_id: str, thread_id: str) -> list[dict[str, Any]] | None:
         """Return cached events for one thread sorted by timestamp."""
@@ -703,32 +1022,53 @@ class PostgresEventCache:
 
     async def mark_thread_stale(self, room_id: str, thread_id: str, *, reason: str) -> None:
         """Persist one durable thread invalidation marker."""
-        await self._write_operation(
-            room_id,
-            operation="mark_thread_stale",
-            disabled_result=None,
-            writer=lambda db: postgres_event_cache_threads.mark_thread_stale_locked(
-                db,
-                namespace=self._runtime.namespace,
-                room_id=room_id,
-                thread_id=thread_id,
+        invalidated_at = time.time()
+        try:
+            await self._write_operation(
+                room_id,
+                operation="mark_thread_stale",
+                disabled_result=None,
+                writer=lambda db: postgres_event_cache_threads.mark_thread_stale_locked(
+                    db,
+                    namespace=self._runtime.namespace,
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    invalidated_at=invalidated_at,
+                    reason=reason,
+                ),
+            )
+        except EventCacheBackendUnavailable:
+            self._runtime.record_pending_thread_invalidation(
+                room_id,
+                thread_id,
+                invalidated_at=invalidated_at,
                 reason=reason,
-            ),
-        )
+            )
+            raise
 
     async def mark_room_threads_stale(self, room_id: str, *, reason: str) -> None:
         """Persist a durable invalidate-and-refetch marker for every cached thread in one room."""
-        await self._write_operation(
-            room_id,
-            operation="mark_room_threads_stale",
-            disabled_result=None,
-            writer=lambda db: postgres_event_cache_threads.mark_room_stale_locked(
-                db,
-                namespace=self._runtime.namespace,
-                room_id=room_id,
+        invalidated_at = time.time()
+        try:
+            await self._write_operation(
+                room_id,
+                operation="mark_room_threads_stale",
+                disabled_result=None,
+                writer=lambda db: postgres_event_cache_threads.mark_room_stale_locked(
+                    db,
+                    namespace=self._runtime.namespace,
+                    room_id=room_id,
+                    invalidated_at=invalidated_at,
+                    reason=reason,
+                ),
+            )
+        except EventCacheBackendUnavailable:
+            self._runtime.record_pending_room_invalidation(
+                room_id,
+                invalidated_at=invalidated_at,
                 reason=reason,
-            ),
-        )
+            )
+            raise
 
     async def append_event(self, room_id: str, thread_id: str, event: dict[str, Any]) -> bool:
         """Append one event when the thread already has cached data."""

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -48,6 +48,7 @@ _TRANSIENT_ERROR_TEXT: tuple[str, ...] = (
     "connection is closed",
     "connection already closed",
     "connection refused",
+    "connection timeout expired",
     "could not connect",
     "network is unreachable",
     "no route to host",
@@ -478,6 +479,12 @@ class _PostgresEventCacheRuntime:
             if pending_room_id == room_id
         )
 
+    def pending_invalidation_room_ids(self) -> tuple[str, ...]:
+        """Return rooms with runtime-only invalidation markers pending durable persistence."""
+        room_ids = set(self._pending_room_invalidations)
+        room_ids.update(room_id for room_id, _thread_id in self._pending_thread_invalidations)
+        return tuple(sorted(room_ids))
+
     def forget_pending_room_invalidation(self, room_id: str, pending: _PendingInvalidation) -> None:
         """Forget one persisted room invalidation and thread markers covered by it."""
         if self._pending_room_invalidations.get(room_id) == pending:
@@ -638,6 +645,23 @@ class PostgresEventCache:
     def runtime_diagnostics(self) -> dict[str, object]:
         """Return log-safe runtime state for sync certification diagnostics."""
         return self._runtime.runtime_diagnostics()
+
+    def pending_durable_write_room_ids(self) -> tuple[str, ...]:
+        """Return rooms with runtime-only writes that must persist before certifying a sync token."""
+        return self._runtime.pending_invalidation_room_ids()
+
+    async def flush_pending_durable_writes(self, room_id: str) -> None:
+        """Persist runtime-only writes for one room before certifying a sync token."""
+
+        async def flush_only(_db: psycopg.AsyncConnection) -> None:
+            return None
+
+        await self._write_operation(
+            room_id,
+            operation="flush_pending_durable_writes",
+            disabled_result=None,
+            writer=flush_only,
+        )
 
     def disable(self, reason: str) -> None:
         """Disable the advisory cache for the rest of the runtime."""

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -350,39 +350,9 @@ class _PostgresEventCacheRuntime:
         return self._disabled_reason is not None
 
     @property
-    def disabled_reason(self) -> str | None:
-        """Return the permanent disable reason, if any."""
-        return self._disabled_reason
-
-    @property
-    def unavailable_reason(self) -> str | None:
-        """Return the latest transient backend failure reason, if any."""
-        return self._unavailable_reason
-
-    @property
-    def transient_failure_count(self) -> int:
-        """Return the number of transient backend failures observed by this runtime."""
-        return self._transient_failure_count
-
-    @property
-    def reconnect_count(self) -> int:
-        """Return the number of replacement connections opened by this runtime."""
-        return self._reconnect_count
-
-    @property
-    def pending_thread_invalidation_count(self) -> int:
-        """Return how many thread invalidations still need to be persisted."""
-        return len(self._pending_thread_invalidations)
-
-    @property
-    def pending_room_invalidation_count(self) -> int:
-        """Return how many room invalidations still need to be persisted."""
-        return len(self._pending_room_invalidations)
-
-    @property
-    def explicitly_closed(self) -> bool:
-        """Return whether this runtime was intentionally closed."""
-        return self._explicitly_closed
+    def durable_writes_available(self) -> bool:
+        """Return whether callers should still attempt durable cache writes."""
+        return not self.is_disabled and not self._explicitly_closed
 
     def disable(self, reason: str) -> None:
         """Disable the advisory cache for the rest of the runtime."""
@@ -642,7 +612,7 @@ class PostgresEventCache:
     @property
     def durable_writes_available(self) -> bool:
         """Return whether cache writes can durably persist data."""
-        return not self._runtime.is_disabled and not self._runtime.explicitly_closed
+        return self._runtime.durable_writes_available
 
     async def initialize(self) -> None:
         """Open the PostgreSQL database and create the cache schema."""

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -36,7 +36,7 @@ T = TypeVar("T")
 
 logger = get_logger(__name__)
 
-_TRANSIENT_SQLSTATE_PREFIXES: tuple[str, ...] = ("08",)
+_TRANSIENT_SQLSTATE_PREFIXES: tuple[str, ...] = ("08",)  # Safe here because cache writes are idempotent upserts.
 _TRANSIENT_SQLSTATES: frozenset[str] = frozenset(
     {
         "57P01",  # admin_shutdown
@@ -447,7 +447,7 @@ class _PostgresEventCacheRuntime:
         invalidated_at: float,
         reason: str,
     ) -> None:
-        """Remember a stale marker that must be persisted before trusting cache rows."""
+        """Remember a best-effort stale marker that must be persisted before trusting cache rows."""
         self._pending_thread_invalidations[(room_id, thread_id)] = _PendingInvalidation(
             invalidated_at=invalidated_at,
             reason=reason,
@@ -460,7 +460,7 @@ class _PostgresEventCacheRuntime:
         invalidated_at: float,
         reason: str,
     ) -> None:
-        """Remember a room stale marker that must be persisted before trusting cache rows."""
+        """Remember a best-effort room stale marker that must be persisted before trusting cache rows."""
         self._pending_room_invalidations[room_id] = _PendingInvalidation(
             invalidated_at=invalidated_at,
             reason=reason,
@@ -478,18 +478,26 @@ class _PostgresEventCacheRuntime:
             if pending_room_id == room_id
         )
 
-    def forget_pending_room_invalidation(self, room_id: str, *, invalidated_at: float) -> None:
+    def forget_pending_room_invalidation(self, room_id: str, pending: _PendingInvalidation) -> None:
         """Forget one persisted room invalidation and thread markers covered by it."""
-        self._pending_room_invalidations.pop(room_id, None)
+        if self._pending_room_invalidations.get(room_id) == pending:
+            self._pending_room_invalidations.pop(room_id, None)
         self._pending_thread_invalidations = {
-            key: pending
-            for key, pending in self._pending_thread_invalidations.items()
-            if key[0] != room_id or pending.invalidated_at > invalidated_at
+            key: thread_pending
+            for key, thread_pending in self._pending_thread_invalidations.items()
+            if key[0] != room_id or thread_pending.invalidated_at > pending.invalidated_at
         }
 
-    def forget_pending_thread_invalidation(self, room_id: str, thread_id: str) -> None:
+    def forget_pending_thread_invalidation(
+        self,
+        room_id: str,
+        thread_id: str,
+        pending: _PendingInvalidation,
+    ) -> None:
         """Forget one persisted thread invalidation."""
-        self._pending_thread_invalidations.pop((room_id, thread_id), None)
+        key = (room_id, thread_id)
+        if self._pending_thread_invalidations.get(key) == pending:
+            self._pending_thread_invalidations.pop(key, None)
 
     async def _close_db_locked(self, *, operation: str) -> None:
         """Close the active connection best-effort. Caller must hold ``_db_lock``."""
@@ -677,11 +685,12 @@ class PostgresEventCache:
         disabled_result: T,
         callback: Callable[[psycopg.AsyncConnection], Awaitable[T]],
     ) -> T:
+        """Run one cache operation, flushing pending stale markers first even for reads."""
         if self._runtime.is_disabled:
             return disabled_result
         transient_error: BaseException | None = None
         for attempt in range(_MAX_TRANSIENT_OPERATION_ATTEMPTS):
-            flushed_pending: tuple[tuple[str, str | None, float], ...] = ()
+            flushed_pending: tuple[tuple[str, str | None, _PendingInvalidation], ...] = ()
             try:
                 async with self._runtime.acquire_db_operation(room_id, operation=operation) as db:
                     try:
@@ -725,8 +734,8 @@ class PostgresEventCache:
         self,
         db: psycopg.AsyncConnection,
         room_id: str,
-    ) -> tuple[tuple[str, str | None, float], ...]:
-        flushed: list[tuple[str, str | None, float]] = []
+    ) -> tuple[tuple[str, str | None, _PendingInvalidation], ...]:
+        flushed: list[tuple[str, str | None, _PendingInvalidation]] = []
         room_pending = self._runtime.pending_room_invalidation(room_id)
         thread_pending = self._runtime.pending_thread_invalidations(room_id)
         if room_pending is not None:
@@ -737,7 +746,7 @@ class PostgresEventCache:
                 invalidated_at=room_pending.invalidated_at,
                 reason=room_pending.reason,
             )
-            flushed.append(("room", None, room_pending.invalidated_at))
+            flushed.append(("room", None, room_pending))
 
         for thread_id, pending_invalidation in thread_pending:
             if room_pending is not None and pending_invalidation.invalidated_at <= room_pending.invalidated_at:
@@ -750,20 +759,20 @@ class PostgresEventCache:
                 invalidated_at=pending_invalidation.invalidated_at,
                 reason=pending_invalidation.reason,
             )
-            flushed.append(("thread", thread_id, pending_invalidation.invalidated_at))
+            flushed.append(("thread", thread_id, pending_invalidation))
         return tuple(flushed)
 
     def _forget_flushed_pending_invalidations(
         self,
         room_id: str,
-        flushed_pending: tuple[tuple[str, str | None, float], ...],
+        flushed_pending: tuple[tuple[str, str | None, _PendingInvalidation], ...],
     ) -> None:
-        for kind, thread_id, invalidated_at in flushed_pending:
+        for kind, thread_id, pending in flushed_pending:
             if kind == "room":
-                self._runtime.forget_pending_room_invalidation(room_id, invalidated_at=invalidated_at)
+                self._runtime.forget_pending_room_invalidation(room_id, pending)
                 continue
             if thread_id is not None:
-                self._runtime.forget_pending_thread_invalidation(room_id, thread_id)
+                self._runtime.forget_pending_thread_invalidation(room_id, thread_id, pending)
 
     async def get_thread_events(self, room_id: str, thread_id: str) -> list[dict[str, Any]] | None:
         """Return cached events for one thread sorted by timestamp."""

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -440,10 +440,12 @@ async def mark_thread_stale_locked(
         )
         VALUES (%s, %s, %s, NULL, %s, %s)
         ON CONFLICT(namespace, room_id, thread_id) DO UPDATE SET
-            invalidated_at = GREATEST(
-                mindroom_event_cache_thread_state.invalidated_at,
-                excluded.invalidated_at
-            ),
+            invalidated_at = CASE
+                WHEN mindroom_event_cache_thread_state.invalidated_at IS NULL
+                    OR excluded.invalidated_at >= mindroom_event_cache_thread_state.invalidated_at
+                    THEN excluded.invalidated_at
+                ELSE mindroom_event_cache_thread_state.invalidated_at
+            END,
             invalidation_reason = CASE
                 WHEN mindroom_event_cache_thread_state.invalidated_at IS NULL
                     OR excluded.invalidated_at >= mindroom_event_cache_thread_state.invalidated_at
@@ -506,10 +508,12 @@ async def mark_room_stale_locked(
         INSERT INTO mindroom_event_cache_room_state(namespace, room_id, invalidated_at, invalidation_reason)
         VALUES (%s, %s, %s, %s)
         ON CONFLICT(namespace, room_id) DO UPDATE SET
-            invalidated_at = GREATEST(
-                mindroom_event_cache_room_state.invalidated_at,
-                excluded.invalidated_at
-            ),
+            invalidated_at = CASE
+                WHEN mindroom_event_cache_room_state.invalidated_at IS NULL
+                    OR excluded.invalidated_at >= mindroom_event_cache_room_state.invalidated_at
+                    THEN excluded.invalidated_at
+                ELSE mindroom_event_cache_room_state.invalidated_at
+            END,
             invalidation_reason = CASE
                 WHEN mindroom_event_cache_room_state.invalidated_at IS NULL
                     OR excluded.invalidated_at >= mindroom_event_cache_room_state.invalidated_at

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -424,8 +424,10 @@ async def mark_thread_stale_locked(
     room_id: str,
     thread_id: str,
     reason: str,
+    invalidated_at: float | None = None,
 ) -> None:
     """Persist a durable invalidate-and-refetch marker within an active transaction."""
+    stale_at = time.time() if invalidated_at is None else invalidated_at
     await db.execute(
         """
         INSERT INTO mindroom_event_cache_thread_state(
@@ -441,7 +443,7 @@ async def mark_thread_stale_locked(
             invalidated_at = excluded.invalidated_at,
             invalidation_reason = excluded.invalidation_reason
         """,
-        (namespace, room_id, thread_id, time.time(), reason),
+        (namespace, room_id, thread_id, stale_at, reason),
     )
 
 
@@ -487,8 +489,10 @@ async def mark_room_stale_locked(
     namespace: str,
     room_id: str,
     reason: str,
+    invalidated_at: float | None = None,
 ) -> None:
     """Persist one durable room-scoped invalidate-and-refetch marker."""
+    stale_at = time.time() if invalidated_at is None else invalidated_at
     await db.execute(
         """
         INSERT INTO mindroom_event_cache_room_state(namespace, room_id, invalidated_at, invalidation_reason)
@@ -497,7 +501,7 @@ async def mark_room_stale_locked(
             invalidated_at = excluded.invalidated_at,
             invalidation_reason = excluded.invalidation_reason
         """,
-        (namespace, room_id, time.time(), reason),
+        (namespace, room_id, stale_at, reason),
     )
 
 

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -440,8 +440,16 @@ async def mark_thread_stale_locked(
         )
         VALUES (%s, %s, %s, NULL, %s, %s)
         ON CONFLICT(namespace, room_id, thread_id) DO UPDATE SET
-            invalidated_at = excluded.invalidated_at,
-            invalidation_reason = excluded.invalidation_reason
+            invalidated_at = GREATEST(
+                mindroom_event_cache_thread_state.invalidated_at,
+                excluded.invalidated_at
+            ),
+            invalidation_reason = CASE
+                WHEN mindroom_event_cache_thread_state.invalidated_at IS NULL
+                    OR excluded.invalidated_at >= mindroom_event_cache_thread_state.invalidated_at
+                    THEN excluded.invalidation_reason
+                ELSE mindroom_event_cache_thread_state.invalidation_reason
+            END
         """,
         (namespace, room_id, thread_id, stale_at, reason),
     )
@@ -498,8 +506,16 @@ async def mark_room_stale_locked(
         INSERT INTO mindroom_event_cache_room_state(namespace, room_id, invalidated_at, invalidation_reason)
         VALUES (%s, %s, %s, %s)
         ON CONFLICT(namespace, room_id) DO UPDATE SET
-            invalidated_at = excluded.invalidated_at,
-            invalidation_reason = excluded.invalidation_reason
+            invalidated_at = GREATEST(
+                mindroom_event_cache_room_state.invalidated_at,
+                excluded.invalidated_at
+            ),
+            invalidation_reason = CASE
+                WHEN mindroom_event_cache_room_state.invalidated_at IS NULL
+                    OR excluded.invalidated_at >= mindroom_event_cache_room_state.invalidated_at
+                    THEN excluded.invalidation_reason
+                ELSE mindroom_event_cache_room_state.invalidation_reason
+            END
         """,
         (namespace, room_id, stale_at, reason),
     )

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -385,6 +385,14 @@ class SqliteEventCache:
         """Return whether cache writes can durably persist data."""
         return self._runtime.is_initialized and not self._runtime.is_disabled
 
+    def runtime_diagnostics(self) -> dict[str, object]:
+        """Return log-safe runtime state for sync certification diagnostics."""
+        return {
+            "cache_backend": "sqlite",
+            "cache_sqlite_initialized": self._runtime.is_initialized,
+            "cache_sqlite_disabled": self._runtime.is_disabled,
+        }
+
     async def initialize(self) -> None:
         """Open the SQLite database and create the cache schema."""
         await self._runtime.initialize()

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -393,6 +393,14 @@ class SqliteEventCache:
             "cache_sqlite_disabled": self._runtime.is_disabled,
         }
 
+    def pending_durable_write_room_ids(self) -> tuple[str, ...]:
+        """Return rooms with runtime-only writes that must persist before certifying a sync token."""
+        return ()
+
+    async def flush_pending_durable_writes(self, room_id: str) -> None:
+        """Persist runtime-only writes for one room before certifying a sync token."""
+        _ = room_id
+
     async def initialize(self) -> None:
         """Open the SQLite database and create the cache schema."""
         await self._runtime.initialize()

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -398,8 +398,13 @@ async def mark_thread_stale_locked(
         )
         VALUES (?, ?, NULL, ?, ?)
         ON CONFLICT(room_id, thread_id) DO UPDATE SET
-            invalidated_at = excluded.invalidated_at,
-            invalidation_reason = excluded.invalidation_reason
+            invalidated_at = MAX(thread_cache_state.invalidated_at, excluded.invalidated_at),
+            invalidation_reason = CASE
+                WHEN thread_cache_state.invalidated_at IS NULL
+                    OR excluded.invalidated_at >= thread_cache_state.invalidated_at
+                    THEN excluded.invalidation_reason
+                ELSE thread_cache_state.invalidation_reason
+            END
         """,
         (room_id, thread_id, time.time(), reason),
     )
@@ -455,8 +460,13 @@ async def mark_room_stale_locked(
         )
         VALUES (?, ?, ?)
         ON CONFLICT(room_id) DO UPDATE SET
-            invalidated_at = excluded.invalidated_at,
-            invalidation_reason = excluded.invalidation_reason
+            invalidated_at = MAX(room_cache_state.invalidated_at, excluded.invalidated_at),
+            invalidation_reason = CASE
+                WHEN room_cache_state.invalidated_at IS NULL
+                    OR excluded.invalidated_at >= room_cache_state.invalidated_at
+                    THEN excluded.invalidation_reason
+                ELSE room_cache_state.invalidation_reason
+            END
         """,
         (room_id, time.time(), reason),
     )

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -398,7 +398,12 @@ async def mark_thread_stale_locked(
         )
         VALUES (?, ?, NULL, ?, ?)
         ON CONFLICT(room_id, thread_id) DO UPDATE SET
-            invalidated_at = MAX(thread_cache_state.invalidated_at, excluded.invalidated_at),
+            invalidated_at = CASE
+                WHEN thread_cache_state.invalidated_at IS NULL
+                    OR excluded.invalidated_at >= thread_cache_state.invalidated_at
+                    THEN excluded.invalidated_at
+                ELSE thread_cache_state.invalidated_at
+            END,
             invalidation_reason = CASE
                 WHEN thread_cache_state.invalidated_at IS NULL
                     OR excluded.invalidated_at >= thread_cache_state.invalidated_at
@@ -460,7 +465,12 @@ async def mark_room_stale_locked(
         )
         VALUES (?, ?, ?)
         ON CONFLICT(room_id) DO UPDATE SET
-            invalidated_at = MAX(room_cache_state.invalidated_at, excluded.invalidated_at),
+            invalidated_at = CASE
+                WHEN room_cache_state.invalidated_at IS NULL
+                    OR excluded.invalidated_at >= room_cache_state.invalidated_at
+                    THEN excluded.invalidated_at
+                ELSE room_cache_state.invalidated_at
+            END,
             invalidation_reason = CASE
                 WHEN room_cache_state.invalidated_at IS NULL
                     OR excluded.invalidated_at >= room_cache_state.invalidated_at

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any
 
 from mindroom.matrix.thread_bookkeeping import MutationThreadImpact, MutationThreadImpactState
 
+from .event_cache import EventCacheBackendUnavailable
+
 if TYPE_CHECKING:
     import asyncio
     from collections.abc import Callable, Coroutine, Sequence
@@ -39,6 +41,18 @@ class ThreadMutationCacheOps:
             and self.runtime.event_cache_write_coordinator is not None
             and self.runtime.event_cache.durable_writes_available
         )
+
+    def cache_runtime_diagnostics(self) -> dict[str, object]:
+        """Return log-safe event-cache runtime diagnostics for sync certification."""
+        if self.runtime.event_cache is None:
+            return {"cache_backend": "none"}
+        diagnostics = getattr(self.runtime.event_cache, "runtime_diagnostics", None)
+        if callable(diagnostics):
+            return dict(diagnostics())
+        return {
+            "cache_backend": type(self.runtime.event_cache).__name__,
+            "cache_initialized": getattr(self.runtime.event_cache, "is_initialized", None),
+        }
 
     def queue_room_cache_update(
         self,
@@ -284,6 +298,16 @@ class ThreadMutationCacheOps:
         try:
             await self.runtime.event_cache.invalidate_thread(room_id, thread_id)
         except Exception as invalidate_exc:
+            if isinstance(stale_marker_error, EventCacheBackendUnavailable):
+                self.logger.warning(
+                    "Cached thread stale marker is pending because cache backend is temporarily unavailable",
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    reason=reason,
+                    stale_marker_error=str(stale_marker_error),
+                    error=str(invalidate_exc),
+                )
+                return
             self.logger.warning(
                 "Failed to delete cached thread rows after stale-marker failure; disabling cache",
                 room_id=room_id,
@@ -310,6 +334,15 @@ class ThreadMutationCacheOps:
         try:
             await self.runtime.event_cache.invalidate_room_threads(room_id)
         except Exception as invalidate_exc:
+            if isinstance(stale_marker_error, EventCacheBackendUnavailable):
+                self.logger.warning(
+                    "Cached room stale marker is pending because cache backend is temporarily unavailable",
+                    room_id=room_id,
+                    reason=reason,
+                    stale_marker_error=str(stale_marker_error),
+                    error=str(invalidate_exc),
+                )
+                return
             self.logger.warning(
                 "Failed to delete cached room thread rows after stale-marker failure; disabling cache",
                 room_id=room_id,

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -46,13 +46,7 @@ class ThreadMutationCacheOps:
         """Return log-safe event-cache runtime diagnostics for sync certification."""
         if self.runtime.event_cache is None:
             return {"cache_backend": "none"}
-        diagnostics = getattr(self.runtime.event_cache, "runtime_diagnostics", None)
-        if callable(diagnostics):
-            return dict(diagnostics())
-        return {
-            "cache_backend": type(self.runtime.event_cache).__name__,
-            "cache_initialized": getattr(self.runtime.event_cache, "is_initialized", None),
-        }
+        return self.runtime.event_cache.runtime_diagnostics()
 
     def queue_room_cache_update(
         self,

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -48,6 +48,28 @@ class ThreadMutationCacheOps:
             return {"cache_backend": "none"}
         return self.runtime.event_cache.runtime_diagnostics()
 
+    def pending_durable_write_room_ids(self) -> tuple[str, ...]:
+        """Return rooms with runtime-only writes that must persist before sync certification."""
+        if self.runtime.event_cache is None:
+            return ()
+        return self.runtime.event_cache.pending_durable_write_room_ids()
+
+    def queue_pending_durable_write_flushes(self) -> tuple[asyncio.Task[object], ...]:
+        """Queue flushes for runtime-only writes that are not tied to the current sync response."""
+        event_cache = self.runtime.event_cache
+        if event_cache is None or not self.cache_runtime_available():
+            return ()
+        return tuple(
+            (
+                self.queue_room_cache_update(
+                    room_id,
+                    lambda room_id=room_id: event_cache.flush_pending_durable_writes(room_id),
+                    name="matrix_cache_flush_pending_writes",
+                )
+            )
+            for room_id in event_cache.pending_durable_write_room_ids()
+        )
+
     def queue_room_cache_update(
         self,
         room_id: str,

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from mindroom.matrix.thread_bookkeeping import MutationThreadImpact, MutationThreadImpactState
 
-from .event_cache import EventCacheBackendUnavailable
+from .event_cache import EventCacheBackendUnavailableError
 
 if TYPE_CHECKING:
     import asyncio
@@ -298,7 +298,7 @@ class ThreadMutationCacheOps:
         try:
             await self.runtime.event_cache.invalidate_thread(room_id, thread_id)
         except Exception as invalidate_exc:
-            if isinstance(stale_marker_error, EventCacheBackendUnavailable):
+            if isinstance(stale_marker_error, EventCacheBackendUnavailableError):
                 self.logger.warning(
                     "Cached thread stale marker is pending because cache backend is temporarily unavailable",
                     room_id=room_id,
@@ -334,7 +334,7 @@ class ThreadMutationCacheOps:
         try:
             await self.runtime.event_cache.invalidate_room_threads(room_id)
         except Exception as invalidate_exc:
-            if isinstance(stale_marker_error, EventCacheBackendUnavailable):
+            if isinstance(stale_marker_error, EventCacheBackendUnavailableError):
                 self.logger.warning(
                     "Cached room stale marker is pending because cache backend is temporarily unavailable",
                     room_id=room_id,

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -34,6 +34,7 @@ __all__ = ["_collect_sync_timeline_cache_updates"]
 
 
 _NONTERMINAL_STREAM_STATUSES = frozenset({STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING})
+_SYNC_TIMELINE_WRITE_FAILED_REASON = "sync_timeline_write_failed"
 
 
 def _collect_sync_timeline_cache_updates(
@@ -979,45 +980,53 @@ class ThreadSyncWritePolicy:
         *,
         raise_on_cache_write_failure: bool,
     ) -> None:
-        plain_batch = [
-            (event_id, room_id, event_source)
-            for event_source in plain_events
-            if isinstance((event_id := event_source.get("event_id")), str) and event_id
-        ]
-        threaded_batch = [
-            (event_id, room_id, event_source)
-            for event_source in threaded_events
-            if isinstance((event_id := event_source.get("event_id")), str) and event_id
-        ]
-        await self._cache_ops.store_events_batch(
-            room_id,
-            plain_batch,
-            failure_message="Failed to persist sync events to cache",
-            raise_on_failure=raise_on_cache_write_failure,
-        )
-        await self._cache_ops.store_events_batch(
-            room_id,
-            threaded_batch,
-            failure_message="Failed to persist sync threaded events to cache",
-            raise_on_failure=raise_on_cache_write_failure,
-        )
-        resolution_context = await self._resolver.build_sync_mutation_resolution_context(
-            room_id,
-            plain_events=plain_events,
-            threaded_events=threaded_events,
-        )
-        await self._persist_threaded_sync_events(
-            room_id,
-            threaded_events,
-            resolution_context=resolution_context,
-            raise_on_cache_write_failure=raise_on_cache_write_failure,
-        )
-        await self._apply_sync_redactions(
-            room_id,
-            redacted_event_ids,
-            resolution_context=resolution_context,
-            raise_on_cache_write_failure=raise_on_cache_write_failure,
-        )
+        try:
+            plain_batch = [
+                (event_id, room_id, event_source)
+                for event_source in plain_events
+                if isinstance((event_id := event_source.get("event_id")), str) and event_id
+            ]
+            threaded_batch = [
+                (event_id, room_id, event_source)
+                for event_source in threaded_events
+                if isinstance((event_id := event_source.get("event_id")), str) and event_id
+            ]
+            await self._cache_ops.store_events_batch(
+                room_id,
+                plain_batch,
+                failure_message="Failed to persist sync events to cache",
+                raise_on_failure=raise_on_cache_write_failure,
+            )
+            await self._cache_ops.store_events_batch(
+                room_id,
+                threaded_batch,
+                failure_message="Failed to persist sync threaded events to cache",
+                raise_on_failure=raise_on_cache_write_failure,
+            )
+            resolution_context = await self._resolver.build_sync_mutation_resolution_context(
+                room_id,
+                plain_events=plain_events,
+                threaded_events=threaded_events,
+            )
+            await self._persist_threaded_sync_events(
+                room_id,
+                threaded_events,
+                resolution_context=resolution_context,
+                raise_on_cache_write_failure=raise_on_cache_write_failure,
+            )
+            await self._apply_sync_redactions(
+                room_id,
+                redacted_event_ids,
+                resolution_context=resolution_context,
+                raise_on_cache_write_failure=raise_on_cache_write_failure,
+            )
+        except Exception:
+            if raise_on_cache_write_failure:
+                await self._cache_ops.invalidate_room_threads(
+                    room_id,
+                    reason=_SYNC_TIMELINE_WRITE_FAILED_REASON,
+                )
+            raise
 
     def _group_sync_timeline_updates(
         self,

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -1130,7 +1130,12 @@ class ThreadSyncWritePolicy:
     ) -> SyncCacheWriteResult:
         """Persist sync timeline data and report whether it certifies the sync token."""
         if not self._cache_ops.cache_runtime_available():
-            return SyncCacheWriteResult(complete=False, runtime_available=False, task_count=0)
+            return SyncCacheWriteResult(
+                complete=False,
+                runtime_available=False,
+                task_count=0,
+                runtime_diagnostics=self._cache_ops.cache_runtime_diagnostics(),
+            )
 
         limited_room_ids, validation_errors = self._limited_sync_timeline_room_ids(response)
         if validation_errors:
@@ -1138,6 +1143,7 @@ class ThreadSyncWritePolicy:
                 complete=False,
                 errors=validation_errors,
                 runtime_available=self._cache_ops.cache_runtime_available(),
+                runtime_diagnostics=self._cache_ops.cache_runtime_diagnostics(),
             )
 
         try:
@@ -1152,6 +1158,7 @@ class ThreadSyncWritePolicy:
                 limited_room_ids=limited_room_ids,
                 errors=(exc,),
                 runtime_available=self._cache_ops.cache_runtime_available(),
+                runtime_diagnostics=self._cache_ops.cache_runtime_diagnostics(),
             )
 
         results: list[object | BaseException] = []
@@ -1166,4 +1173,5 @@ class ThreadSyncWritePolicy:
             errors=errors,
             runtime_available=runtime_available,
             task_count=len(tasks),
+            runtime_diagnostics=self._cache_ops.cache_runtime_diagnostics(),
         )

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -1148,6 +1148,7 @@ class ThreadSyncWritePolicy:
 
         try:
             tasks = self.cache_sync_timeline(response, raise_on_cache_write_failure=True)
+            tasks.extend(self._cache_ops.queue_pending_durable_write_flushes())
         except (KeyboardInterrupt, SystemExit):
             raise
         except asyncio.CancelledError:
@@ -1166,7 +1167,8 @@ class ThreadSyncWritePolicy:
             results = await asyncio.gather(*tasks, return_exceptions=True)
         errors = self._cache_task_errors(results)
         runtime_available = self._cache_ops.cache_runtime_available()
-        complete = runtime_available and not errors and not limited_room_ids
+        pending_durable_write_room_ids = self._cache_ops.pending_durable_write_room_ids()
+        complete = runtime_available and not errors and not limited_room_ids and not pending_durable_write_room_ids
         return SyncCacheWriteResult(
             complete=complete,
             limited_room_ids=limited_room_ids,

--- a/src/mindroom/matrix/sync_certification.py
+++ b/src/mindroom/matrix/sync_certification.py
@@ -32,6 +32,7 @@ class SyncCacheWriteResult:
     errors: tuple[BaseException, ...] = ()
     runtime_available: bool | None = None
     task_count: int | None = None
+    runtime_diagnostics: dict[str, object] | None = None
 
     @property
     def certified(self) -> bool:
@@ -162,6 +163,8 @@ def sync_cache_write_diagnostics(cache_result: SyncCacheWriteResult) -> dict[str
         diagnostics["cache_runtime_available"] = cache_result.runtime_available
     if cache_result.task_count is not None:
         diagnostics["cache_task_count"] = cache_result.task_count
+    if cache_result.runtime_diagnostics:
+        diagnostics.update(cache_result.runtime_diagnostics)
     if cache_result.limited_room_ids:
         diagnostics["cache_limited_room_ids"] = cache_result.limited_room_ids[:5]
     if cache_result.errors:

--- a/src/mindroom/runtime_support.py
+++ b/src/mindroom/runtime_support.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, cast
 
 from mindroom.config.matrix import CacheConfig
 from mindroom.constants import RuntimePaths
+from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailable
 from mindroom.matrix.cache.postgres_redaction import redact_postgres_connection_info
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
@@ -144,6 +145,36 @@ def build_owned_runtime_support(
     )
 
 
+async def initialize_event_cache_best_effort(
+    support: OwnedRuntimeSupport,
+    *,
+    logger: structlog.stdlib.BoundLogger,
+    init_failure_reason_prefix: str,
+) -> None:
+    """Initialize event-cache storage without permanently disabling on transient outages."""
+    if support.event_cache.is_initialized:
+        return
+    try:
+        await support.event_cache.initialize()
+    except EventCacheBackendUnavailable as exc:
+        logger.warning(
+            "Event cache backend temporarily unavailable during init; will retry on demand",
+            backend=support.event_cache_identity.backend,
+            location=support.event_cache_identity.redacted_location,
+            namespace=support.event_cache_identity.namespace,
+            error=str(exc),
+        )
+    except Exception as exc:
+        support.event_cache.disable(f"{init_failure_reason_prefix}:{exc}")
+        logger.warning(
+            "Event cache init failed; continuing without advisory cache",
+            backend=support.event_cache_identity.backend,
+            location=support.event_cache_identity.redacted_location,
+            namespace=support.event_cache_identity.namespace,
+            error=str(exc),
+        )
+
+
 async def sync_owned_runtime_support(
     support: OwnedRuntimeSupport | None,
     *,
@@ -199,20 +230,11 @@ async def sync_owned_runtime_support(
                 configured_namespace=target_identity.namespace,
             )
 
-    if support.event_cache.is_initialized:
-        return support
-
-    try:
-        await support.event_cache.initialize()
-    except Exception as exc:
-        support.event_cache.disable(f"{init_failure_reason_prefix}:{exc}")
-        logger.warning(
-            "Event cache init failed; continuing without advisory cache",
-            backend=support.event_cache_identity.backend,
-            location=support.event_cache_identity.redacted_location,
-            namespace=support.event_cache_identity.namespace,
-            error=str(exc),
-        )
+    await initialize_event_cache_best_effort(
+        support,
+        logger=logger,
+        init_failure_reason_prefix=init_failure_reason_prefix,
+    )
     return support
 
 

--- a/src/mindroom/runtime_support.py
+++ b/src/mindroom/runtime_support.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, cast
 
 from mindroom.config.matrix import CacheConfig
 from mindroom.constants import RuntimePaths
-from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailable
+from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailableError
 from mindroom.matrix.cache.postgres_redaction import redact_postgres_connection_info
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
@@ -156,7 +156,7 @@ async def initialize_event_cache_best_effort(
         return
     try:
         await support.event_cache.initialize()
-    except EventCacheBackendUnavailable as exc:
+    except EventCacheBackendUnavailableError as exc:
         logger.warning(
             "Event cache backend temporarily unavailable during init; will retry on demand",
             backend=support.event_cache_identity.backend,

--- a/tach.toml
+++ b/tach.toml
@@ -2027,7 +2027,7 @@ expose = [
 from = ["mindroom.matrix.cache"]
 
 [[interfaces]]
-expose = ["ConversationEventCache", "EventCacheBackendUnavailable", "ThreadCacheState"]
+expose = ["ConversationEventCache", "EventCacheBackendUnavailableError", "ThreadCacheState"]
 from = ["mindroom.matrix.cache.event_cache"]
 visibility = ["mindroom.matrix.cache"]
 exclusive = true

--- a/tach.toml
+++ b/tach.toml
@@ -1059,7 +1059,10 @@ depends_on = []
 
 [[modules]]
 path = "mindroom.matrix.cache.thread_write_cache_ops"
-depends_on = [ "mindroom.matrix.thread_bookkeeping"]
+depends_on = [
+    "mindroom.matrix.cache.event_cache",
+    "mindroom.matrix.thread_bookkeeping",
+]
 
 [[modules]]
 path = "mindroom.matrix.cache.sqlite_event_cache_events"
@@ -1091,6 +1094,7 @@ visibility = ["mindroom.runtime_support"]
 [[modules]]
 path = "mindroom.matrix.cache.postgres_event_cache"
 depends_on = [
+    "mindroom.matrix.cache.event_cache",
     "mindroom.matrix.cache.event_normalization",
     "mindroom.logging_config",
     "mindroom.matrix.cache.postgres_agent_message_snapshot",
@@ -1135,6 +1139,7 @@ path = "mindroom.runtime_support"
 depends_on = [
     "mindroom.config.matrix",
     "mindroom.constants",
+    "mindroom.matrix.cache.event_cache",
     "mindroom.matrix.cache.postgres_event_cache",
     "mindroom.matrix.cache.postgres_redaction",
     "mindroom.matrix.cache.sqlite_event_cache",
@@ -2022,7 +2027,7 @@ expose = [
 from = ["mindroom.matrix.cache"]
 
 [[interfaces]]
-expose = ["ConversationEventCache", "ThreadCacheState"]
+expose = ["ConversationEventCache", "EventCacheBackendUnavailable", "ThreadCacheState"]
 from = ["mindroom.matrix.cache.event_cache"]
 visibility = ["mindroom.matrix.cache"]
 exclusive = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,6 +371,7 @@ def make_event_cache_mock() -> AsyncMock:
     event_cache.get_thread_cache_state.return_value = None
     event_cache.get_thread_id_for_event.return_value = None
     event_cache.get_latest_agent_message_snapshot.return_value = None
+    event_cache.runtime_diagnostics.return_value = {"cache_backend": "mock"}
     event_cache.append_event.return_value = True
     event_cache.redact_event.return_value = False
     return event_cache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,7 +371,9 @@ def make_event_cache_mock() -> AsyncMock:
     event_cache.get_thread_cache_state.return_value = None
     event_cache.get_thread_id_for_event.return_value = None
     event_cache.get_latest_agent_message_snapshot.return_value = None
+    event_cache.pending_durable_write_room_ids.return_value = ()
     event_cache.runtime_diagnostics.return_value = {"cache_backend": "mock"}
+    event_cache.flush_pending_durable_writes.return_value = None
     event_cache.append_event.return_value = True
     event_cache.redact_event.return_value = False
     return event_cache

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -226,6 +226,53 @@ async def test_thread_snapshot_storage_exposes_direct_cache_state_reads(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_sqlite_stale_markers_are_monotonic(tmp_path: Path) -> None:
+    """Older stale markers should not downgrade newer thread or room invalidations."""
+    db = await event_cache_module.initialize_event_cache_db(tmp_path / "event_cache.db")
+
+    try:
+        with patch("mindroom.matrix.cache.sqlite_event_cache_threads.time.time", return_value=200.0):
+            await sqlite_event_cache_threads.mark_thread_stale_locked(
+                db,
+                room_id="!room:localhost",
+                thread_id="$thread_root",
+                reason="newer_thread_marker",
+            )
+            await sqlite_event_cache_threads.mark_room_stale_locked(
+                db,
+                room_id="!room:localhost",
+                reason="newer_room_marker",
+            )
+        with patch("mindroom.matrix.cache.sqlite_event_cache_threads.time.time", return_value=100.0):
+            await sqlite_event_cache_threads.mark_thread_stale_locked(
+                db,
+                room_id="!room:localhost",
+                thread_id="$thread_root",
+                reason="older_thread_marker",
+            )
+            await sqlite_event_cache_threads.mark_room_stale_locked(
+                db,
+                room_id="!room:localhost",
+                reason="older_room_marker",
+            )
+        await db.commit()
+
+        state = await sqlite_event_cache_threads.load_thread_cache_state(
+            db,
+            room_id="!room:localhost",
+            thread_id="$thread_root",
+        )
+    finally:
+        await db.close()
+
+    assert state is not None
+    assert state.invalidated_at == 200.0
+    assert state.invalidation_reason == "newer_thread_marker"
+    assert state.room_invalidated_at == 200.0
+    assert state.room_invalidation_reason == "newer_room_marker"
+
+
+@pytest.mark.asyncio
 async def test_event_cache_store_and_retrieve(event_cache: ConversationEventCache) -> None:
     """Stored events should round-trip in timestamp order."""
     cache = event_cache

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -19,6 +19,7 @@ from mindroom.matrix.cache import (
     event_normalization,
     sqlite_event_cache_events,
     sqlite_event_cache_threads,
+    thread_cache_rejection_reason,
 )
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.client_thread_history import fetch_thread_history
@@ -198,17 +199,18 @@ async def test_thread_snapshot_storage_exposes_direct_cache_state_reads(tmp_path
             ],
             validated_at=100.0,
         )
-        await sqlite_event_cache_threads.mark_thread_stale_locked(
-            db,
-            room_id="!room:localhost",
-            thread_id="$thread_root",
-            reason="thread_stale",
-        )
-        await sqlite_event_cache_threads.mark_room_stale_locked(
-            db,
-            room_id="!room:localhost",
-            reason="room_stale",
-        )
+        with patch("mindroom.matrix.cache.sqlite_event_cache_threads.time.time", return_value=200.0):
+            await sqlite_event_cache_threads.mark_thread_stale_locked(
+                db,
+                room_id="!room:localhost",
+                thread_id="$thread_root",
+                reason="thread_stale",
+            )
+            await sqlite_event_cache_threads.mark_room_stale_locked(
+                db,
+                room_id="!room:localhost",
+                reason="room_stale",
+            )
         await db.commit()
 
         state = await sqlite_event_cache_threads.load_thread_cache_state(
@@ -221,8 +223,11 @@ async def test_thread_snapshot_storage_exposes_direct_cache_state_reads(tmp_path
 
     assert state is not None
     assert state.validated_at == 100.0
+    assert state.invalidated_at == 200.0
     assert state.invalidation_reason == "thread_stale"
+    assert state.room_invalidated_at == 200.0
     assert state.room_invalidation_reason == "room_stale"
+    assert thread_cache_rejection_reason(state) == "thread_invalidated_after_validation"
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -607,6 +607,11 @@ def test_postgres_transient_classifier_accepts_startup_connection_refused() -> N
     assert _is_transient_postgres_failure(psycopg.OperationalError("connection failed: Connection refused"))
 
 
+def test_postgres_transient_classifier_accepts_connection_timeout() -> None:
+    """Startup connection timeouts should retry later instead of disabling the cache."""
+    assert _is_transient_postgres_failure(psycopg.errors.ConnectionTimeout("connection timeout expired"))
+
+
 def test_postgres_transient_classifier_rejects_authentication_failures_without_sqlstate() -> None:
     """Authentication failures should disable the cache instead of retrying forever."""
     exc = psycopg.OperationalError(

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -4,23 +4,37 @@ from __future__ import annotations
 
 import uuid
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, Mock
 
 import psycopg
 import pytest
 
 from mindroom.config.matrix import CacheConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
+from mindroom.logging_config import get_logger
+from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailableError
 from mindroom.matrix.cache.postgres_event_cache import (
     PostgresEventCache,
     PostgresEventCacheRuntime,
     _is_transient_postgres_failure,
 )
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
-from mindroom.runtime_support import EventCacheRuntimeIdentity, build_event_cache
+from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
+from mindroom.runtime_support import (
+    EventCacheRuntimeIdentity,
+    OwnedRuntimeSupport,
+    StartupThreadPrewarmRegistry,
+    build_event_cache,
+    event_cache_runtime_identity,
+    initialize_event_cache_best_effort,
+    sync_owned_runtime_support,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from mindroom.matrix.cache import ConversationEventCache
 
 
 def _message_event(
@@ -514,6 +528,70 @@ async def test_postgres_event_cache_flushes_newer_thread_marker_with_pending_roo
 def test_postgres_transient_classifier_accepts_startup_connection_refused() -> None:
     """Startup connection-refused errors should retry later instead of disabling the cache."""
     assert _is_transient_postgres_failure(psycopg.OperationalError("connection failed: Connection refused"))
+
+
+def test_postgres_transient_classifier_rejects_authentication_failures_without_sqlstate() -> None:
+    """Authentication failures should disable the cache instead of retrying forever."""
+    exc = psycopg.OperationalError(
+        'connection failed: connection to server at "127.0.0.1", port 5432 failed: '
+        'FATAL: password authentication failed for user "cache"',
+    )
+
+    assert not _is_transient_postgres_failure(exc)
+
+
+@pytest.mark.asyncio
+async def test_event_cache_startup_backend_unavailable_retries_without_disabling(tmp_path: Path) -> None:
+    """A transient startup outage should leave the cache enabled for the next sync retry."""
+    runtime_paths = _runtime_paths(tmp_path)
+    cache_config = CacheConfig()
+    cache = Mock()
+    cache.is_initialized = False
+    cache.initialize = AsyncMock()
+    cache.disable = Mock()
+    initialize_attempts = 0
+
+    async def initialize() -> None:
+        nonlocal initialize_attempts
+        initialize_attempts += 1
+        if initialize_attempts == 1:
+            reason = "postgres unavailable"
+            raise EventCacheBackendUnavailableError(reason)
+        cache.is_initialized = True
+
+    cache.initialize.side_effect = initialize
+    logger = get_logger("tests.event_cache_backends")
+    support = OwnedRuntimeSupport(
+        event_cache=cast("ConversationEventCache", cache),
+        event_cache_write_coordinator=_EventCacheWriteCoordinator(logger=logger),
+        startup_thread_prewarm_registry=StartupThreadPrewarmRegistry(),
+        event_cache_identity=event_cache_runtime_identity(cache_config, runtime_paths),
+    )
+
+    await initialize_event_cache_best_effort(
+        support,
+        logger=logger,
+        init_failure_reason_prefix="test_startup",
+    )
+
+    assert initialize_attempts == 1
+    assert cache.is_initialized is False
+    cache.disable.assert_not_called()
+
+    retried_support = await sync_owned_runtime_support(
+        support,
+        cache_config=cache_config,
+        runtime_paths=runtime_paths,
+        logger=logger,
+        background_task_owner=object(),
+        init_failure_reason_prefix="test_retry",
+        log_db_path_change=False,
+    )
+
+    assert retried_support is support
+    assert initialize_attempts == 2
+    assert cache.is_initialized is True
+    cache.disable.assert_not_called()
 
 
 def test_build_event_cache_requires_postgres_database_url(tmp_path: Path) -> None:

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -11,7 +11,11 @@ import pytest
 
 from mindroom.config.matrix import CacheConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
-from mindroom.matrix.cache.postgres_event_cache import PostgresEventCache, PostgresEventCacheRuntime
+from mindroom.matrix.cache.postgres_event_cache import (
+    PostgresEventCache,
+    PostgresEventCacheRuntime,
+    _is_transient_postgres_failure,
+)
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.runtime_support import EventCacheRuntimeIdentity, build_event_cache
 
@@ -448,6 +452,68 @@ async def test_postgres_event_cache_flushes_pending_invalidations_before_guarded
         assert cache.runtime_diagnostics()["cache_postgres_pending_thread_invalidations"] == 0
     finally:
         await cache.close()
+
+
+@pytest.mark.asyncio
+async def test_postgres_event_cache_flushes_newer_thread_marker_with_pending_room_marker(
+    postgres_event_cache_url: str,
+) -> None:
+    """A pending room marker must not hide a newer pending thread marker."""
+    room_id = "!room:localhost"
+    thread_id = "$thread"
+    root_event = _message_event(
+        event_id=thread_id,
+        sender="@user:localhost",
+        body="thread root",
+        origin_server_ts=1000,
+    )
+    replacement_event = _message_event(
+        event_id=thread_id,
+        sender="@user:localhost",
+        body="replacement root",
+        origin_server_ts=2000,
+    )
+    namespace = f"tenant_{uuid.uuid4().hex}"
+    cache = PostgresEventCache(database_url=postgres_event_cache_url, namespace=namespace)
+
+    await cache.initialize()
+    try:
+        await cache.replace_thread(room_id, thread_id, [root_event], validated_at=50.0)
+        cache._runtime.record_pending_room_invalidation(
+            room_id,
+            invalidated_at=100.0,
+            reason="unknown_room_mutation",
+        )
+        cache._runtime.record_pending_thread_invalidation(
+            room_id,
+            thread_id,
+            invalidated_at=200.0,
+            reason="live_thread_mutation",
+        )
+
+        replaced = await cache.replace_thread_if_not_newer(
+            room_id,
+            thread_id,
+            [replacement_event],
+            fetch_started_at=150.0,
+        )
+
+        assert replaced is False
+        state = await cache.get_thread_cache_state(room_id, thread_id)
+        assert state is not None
+        assert state.room_invalidated_at == 100.0
+        assert state.invalidated_at == 200.0
+        assert state.invalidation_reason == "live_thread_mutation"
+        diagnostics = cache.runtime_diagnostics()
+        assert diagnostics["cache_postgres_pending_room_invalidations"] == 0
+        assert diagnostics["cache_postgres_pending_thread_invalidations"] == 0
+    finally:
+        await cache.close()
+
+
+def test_postgres_transient_classifier_accepts_startup_connection_refused() -> None:
+    """Startup connection-refused errors should retry later instead of disabling the cache."""
+    assert _is_transient_postgres_failure(psycopg.OperationalError("connection failed: Connection refused"))
 
 
 def test_build_event_cache_requires_postgres_database_url(tmp_path: Path) -> None:

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -13,6 +13,7 @@ import pytest
 from mindroom.config.matrix import CacheConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.logging_config import get_logger
+from mindroom.matrix.cache import postgres_event_cache_threads
 from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailableError
 from mindroom.matrix.cache.postgres_event_cache import (
     PostgresEventCache,
@@ -520,6 +521,82 @@ async def test_postgres_event_cache_flushes_newer_thread_marker_with_pending_roo
         assert state.invalidation_reason == "live_thread_mutation"
         diagnostics = cache.runtime_diagnostics()
         assert diagnostics["cache_postgres_pending_room_invalidations"] == 0
+        assert diagnostics["cache_postgres_pending_thread_invalidations"] == 0
+    finally:
+        await cache.close()
+
+
+@pytest.mark.asyncio
+async def test_postgres_event_cache_preserves_pending_marker_recorded_during_flush(
+    postgres_event_cache_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A marker recorded while an older marker flushes must remain pending for a later operation."""
+    room_id = "!room:localhost"
+    thread_id = "$thread"
+    root_event = _message_event(
+        event_id=thread_id,
+        sender="@user:localhost",
+        body="thread root",
+        origin_server_ts=1000,
+    )
+    replacement_event = _message_event(
+        event_id=thread_id,
+        sender="@user:localhost",
+        body="replacement root",
+        origin_server_ts=2000,
+    )
+    namespace = f"tenant_{uuid.uuid4().hex}"
+    cache = PostgresEventCache(database_url=postgres_event_cache_url, namespace=namespace)
+    original_mark_thread_stale_locked = postgres_event_cache_threads.mark_thread_stale_locked
+    injected_newer_pending_marker = False
+
+    async def racing_mark_thread_stale_locked(*args: object, **kwargs: object) -> None:
+        nonlocal injected_newer_pending_marker
+        if kwargs.get("thread_id") == thread_id and kwargs.get("invalidated_at") == 200.0:
+            injected_newer_pending_marker = True
+            cache._runtime.record_pending_thread_invalidation(
+                room_id,
+                thread_id,
+                invalidated_at=300.0,
+                reason="later_live_thread_mutation",
+            )
+        await original_mark_thread_stale_locked(*args, **kwargs)
+
+    monkeypatch.setattr(
+        postgres_event_cache_threads,
+        "mark_thread_stale_locked",
+        racing_mark_thread_stale_locked,
+    )
+
+    await cache.initialize()
+    try:
+        await cache.replace_thread(room_id, thread_id, [root_event], validated_at=50.0)
+        cache._runtime.record_pending_thread_invalidation(
+            room_id,
+            thread_id,
+            invalidated_at=200.0,
+            reason="live_thread_mutation",
+        )
+
+        replaced = await cache.replace_thread_if_not_newer(
+            room_id,
+            thread_id,
+            [replacement_event],
+            fetch_started_at=150.0,
+        )
+
+        assert replaced is False
+        assert injected_newer_pending_marker is True
+        diagnostics = cache.runtime_diagnostics()
+        assert diagnostics["cache_postgres_pending_thread_invalidations"] == 1
+
+        state = await cache.get_thread_cache_state(room_id, thread_id)
+
+        assert state is not None
+        assert state.invalidated_at == 300.0
+        assert state.invalidation_reason == "later_live_thread_mutation"
+        diagnostics = cache.runtime_diagnostics()
         assert diagnostics["cache_postgres_pending_thread_invalidations"] == 0
     finally:
         await cache.close()

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -6,6 +6,7 @@ import uuid
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
+import psycopg
 import pytest
 
 from mindroom.config.matrix import CacheConfig
@@ -349,6 +350,104 @@ async def test_postgres_event_cache_round_trips_core_conversation_cache_behavior
         await cache.close()
         await shared_cache.close()
         await isolated_cache.close()
+
+
+@pytest.mark.asyncio
+async def test_postgres_event_cache_recovers_after_backend_connection_termination(
+    postgres_event_cache_url: str,
+) -> None:
+    """A transient Postgres disconnect should reconnect instead of disabling cache."""
+    room_id = "!room:localhost"
+    thread_id = "$thread"
+    root_event = _message_event(
+        event_id=thread_id,
+        sender="@user:localhost",
+        body="thread root",
+        origin_server_ts=1000,
+    )
+    namespace = f"tenant_{uuid.uuid4().hex}"
+    cache = PostgresEventCache(database_url=postgres_event_cache_url, namespace=namespace)
+
+    await cache.initialize()
+    try:
+        await cache.replace_thread(room_id, thread_id, [root_event], validated_at=100.0)
+        assert cache._runtime.db is not None
+        cursor = await cache._runtime.db.execute("SELECT pg_backend_pid()")
+        row = await cursor.fetchone()
+        assert row is not None
+        pid = int(row[0])
+
+        admin = await psycopg.AsyncConnection.connect(postgres_event_cache_url)
+        try:
+            terminate_cursor = await admin.execute("SELECT pg_terminate_backend(%s)", (pid,))
+            terminate_row = await terminate_cursor.fetchone()
+            assert terminate_row == (True,)
+            await admin.commit()
+        finally:
+            await admin.close()
+
+        await cache.mark_thread_stale(room_id, thread_id, reason="live_thread_mutation")
+
+        state = await cache.get_thread_cache_state(room_id, thread_id)
+        assert state is not None
+        assert state.invalidated_at is not None
+        assert state.invalidation_reason == "live_thread_mutation"
+        assert cache.durable_writes_available is True
+        diagnostics = cache.runtime_diagnostics()
+        assert diagnostics["cache_postgres_disabled"] is False
+        assert diagnostics["cache_postgres_reconnect_count"] >= 1
+        assert diagnostics["cache_postgres_transient_failure_count"] >= 1
+    finally:
+        await cache.close()
+
+
+@pytest.mark.asyncio
+async def test_postgres_event_cache_flushes_pending_invalidations_before_guarded_replace(
+    postgres_event_cache_url: str,
+) -> None:
+    """A deferred stale marker must be persisted before a guarded cache replacement can win."""
+    room_id = "!room:localhost"
+    thread_id = "$thread"
+    root_event = _message_event(
+        event_id=thread_id,
+        sender="@user:localhost",
+        body="thread root",
+        origin_server_ts=1000,
+    )
+    replacement_event = _message_event(
+        event_id=thread_id,
+        sender="@user:localhost",
+        body="replacement root",
+        origin_server_ts=2000,
+    )
+    namespace = f"tenant_{uuid.uuid4().hex}"
+    cache = PostgresEventCache(database_url=postgres_event_cache_url, namespace=namespace)
+
+    await cache.initialize()
+    try:
+        await cache.replace_thread(room_id, thread_id, [root_event], validated_at=100.0)
+        cache._runtime.record_pending_thread_invalidation(
+            room_id,
+            thread_id,
+            invalidated_at=200.0,
+            reason="live_thread_mutation",
+        )
+
+        replaced = await cache.replace_thread_if_not_newer(
+            room_id,
+            thread_id,
+            [replacement_event],
+            fetch_started_at=150.0,
+        )
+
+        assert replaced is False
+        state = await cache.get_thread_cache_state(room_id, thread_id)
+        assert state is not None
+        assert state.invalidated_at == 200.0
+        assert state.invalidation_reason == "live_thread_mutation"
+        assert cache.runtime_diagnostics()["cache_postgres_pending_thread_invalidations"] == 0
+    finally:
+        await cache.close()
 
 
 def test_build_event_cache_requires_postgres_database_url(tmp_path: Path) -> None:

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -602,6 +602,84 @@ async def test_postgres_event_cache_preserves_pending_marker_recorded_during_flu
         await cache.close()
 
 
+@pytest.mark.asyncio
+async def test_postgres_event_cache_pending_thread_flush_does_not_downgrade_newer_durable_marker(
+    postgres_event_cache_url: str,
+) -> None:
+    """An older pending thread marker must not overwrite a newer durable invalidation."""
+    room_id = "!room:localhost"
+    thread_id = "$thread"
+    namespace = f"tenant_{uuid.uuid4().hex}"
+    cache = PostgresEventCache(database_url=postgres_event_cache_url, namespace=namespace)
+
+    await cache.initialize()
+    try:
+        cache._runtime.record_pending_thread_invalidation(
+            room_id,
+            thread_id,
+            invalidated_at=100.0,
+            reason="older_pending_marker",
+        )
+        async with cache._runtime.acquire_db_operation(room_id, operation="test_newer_thread_marker") as db:
+            await postgres_event_cache_threads.mark_thread_stale_locked(
+                db,
+                namespace=namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+                invalidated_at=200.0,
+                reason="newer_durable_marker",
+            )
+            await db.commit()
+
+        await cache.flush_pending_durable_writes(room_id)
+        state = await cache.get_thread_cache_state(room_id, thread_id)
+
+        assert state is not None
+        assert state.invalidated_at == 200.0
+        assert state.invalidation_reason == "newer_durable_marker"
+        assert cache.pending_durable_write_room_ids() == ()
+    finally:
+        await cache.close()
+
+
+@pytest.mark.asyncio
+async def test_postgres_event_cache_pending_room_flush_does_not_downgrade_newer_durable_marker(
+    postgres_event_cache_url: str,
+) -> None:
+    """An older pending room marker must not overwrite a newer durable invalidation."""
+    room_id = "!room:localhost"
+    thread_id = "$thread"
+    namespace = f"tenant_{uuid.uuid4().hex}"
+    cache = PostgresEventCache(database_url=postgres_event_cache_url, namespace=namespace)
+
+    await cache.initialize()
+    try:
+        cache._runtime.record_pending_room_invalidation(
+            room_id,
+            invalidated_at=100.0,
+            reason="older_pending_room_marker",
+        )
+        async with cache._runtime.acquire_db_operation(room_id, operation="test_newer_room_marker") as db:
+            await postgres_event_cache_threads.mark_room_stale_locked(
+                db,
+                namespace=namespace,
+                room_id=room_id,
+                invalidated_at=200.0,
+                reason="newer_durable_room_marker",
+            )
+            await db.commit()
+
+        await cache.flush_pending_durable_writes(room_id)
+        state = await cache.get_thread_cache_state(room_id, thread_id)
+
+        assert state is not None
+        assert state.room_invalidated_at == 200.0
+        assert state.room_invalidation_reason == "newer_durable_room_marker"
+        assert cache.pending_durable_write_room_ids() == ()
+    finally:
+        await cache.close()
+
+
 def test_postgres_transient_classifier_accepts_startup_connection_refused() -> None:
     """Startup connection-refused errors should retry later instead of disabling the cache."""
     assert _is_transient_postgres_failure(psycopg.OperationalError("connection failed: Connection refused"))
@@ -620,6 +698,44 @@ def test_postgres_transient_classifier_rejects_authentication_failures_without_s
     )
 
     assert not _is_transient_postgres_failure(exc)
+
+
+def test_postgres_pending_invalidation_records_are_monotonic() -> None:
+    """Pending invalidation buffers should keep the newest marker for each scope."""
+    runtime = PostgresEventCacheRuntime("postgresql://cache:secret@db.internal/mindroom", namespace="tenant")
+
+    runtime.record_pending_thread_invalidation(
+        "!room:localhost",
+        "$thread",
+        invalidated_at=200.0,
+        reason="newer_thread_marker",
+    )
+    runtime.record_pending_thread_invalidation(
+        "!room:localhost",
+        "$thread",
+        invalidated_at=100.0,
+        reason="older_thread_marker",
+    )
+    runtime.record_pending_room_invalidation(
+        "!room:localhost",
+        invalidated_at=200.0,
+        reason="newer_room_marker",
+    )
+    runtime.record_pending_room_invalidation(
+        "!room:localhost",
+        invalidated_at=100.0,
+        reason="older_room_marker",
+    )
+
+    thread_pending = runtime.pending_thread_invalidations("!room:localhost")
+    room_pending = runtime.pending_room_invalidation("!room:localhost")
+
+    assert thread_pending == (("$thread", runtime._pending_thread_invalidations[("!room:localhost", "$thread")]),)
+    assert thread_pending[0][1].invalidated_at == 200.0
+    assert thread_pending[0][1].reason == "newer_thread_marker"
+    assert room_pending is not None
+    assert room_pending.invalidated_at == 200.0
+    assert room_pending.reason == "newer_room_marker"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync_certification.py
+++ b/tests/test_sync_certification.py
@@ -104,6 +104,10 @@ def test_sync_cache_write_diagnostics_explains_uncertainty() -> None:
             errors=(RuntimeError("cache failed"),),
             runtime_available=False,
             task_count=3,
+            runtime_diagnostics={
+                "cache_backend": "postgres",
+                "cache_postgres_unavailable_reason": "connection closed",
+            },
         ),
     )
 
@@ -114,6 +118,8 @@ def test_sync_cache_write_diagnostics_explains_uncertainty() -> None:
         "cache_error_count": 1,
         "cache_runtime_available": False,
         "cache_task_count": 3,
+        "cache_backend": "postgres",
+        "cache_postgres_unavailable_reason": "connection closed",
         "cache_limited_room_ids": ("!room:localhost",),
         "cache_error_types": ("RuntimeError",),
         "cache_error_messages": ("cache failed",),

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -2145,6 +2145,81 @@ class TestThreadingBehavior:
         event_cache.flush_pending_durable_writes.assert_awaited_once_with("!pending:localhost")
 
     @pytest.mark.asyncio
+    async def test_sync_write_failure_marks_room_stale_before_certification_retry(self, bot: AgentBot) -> None:
+        """A failed sync timeline write must protect cached room threads before a later token can certify."""
+        room_id = "!room:localhost"
+        event_cache = _runtime_event_cache()
+        event_cache.store_events_batch = AsyncMock(side_effect=RuntimeError("postgres write failed"))
+        bot.event_cache = event_cache
+        _install_runtime_write_coordinator(bot)
+        message_event = nio.RoomMessageText.from_dict(
+            {
+                "content": {"body": "Fresh message", "msgtype": "m.text"},
+                "event_id": "$message:localhost",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "room_id": room_id,
+                "type": "m.room.message",
+            },
+        )
+
+        result = await bot._conversation_cache.cache_sync_timeline_for_certification(
+            self._sync_response({room_id: MagicMock(timeline=MagicMock(events=[message_event], limited=False))}),
+        )
+
+        assert result.complete is False
+        assert [type(error) for error in result.errors] == [RuntimeError]
+        event_cache.mark_room_threads_stale.assert_awaited_once_with(
+            room_id,
+            reason="sync_timeline_write_failed",
+        )
+
+    @pytest.mark.asyncio
+    async def test_sync_write_transient_failure_records_pending_room_stale_marker(self, bot: AgentBot) -> None:
+        """Transient sync write loss should block later certification until the room marker is flushed."""
+        room_id = "!room:localhost"
+        backend_error = EventCacheBackendUnavailableError("postgres unavailable")
+        pending_room_ids: set[str] = set()
+        event_cache = _runtime_event_cache()
+        event_cache.store_events_batch = AsyncMock(side_effect=backend_error)
+        event_cache.pending_durable_write_room_ids.side_effect = lambda: tuple(sorted(pending_room_ids))
+
+        async def mark_room_threads_stale(room_id_arg: str, *, reason: str) -> None:
+            assert reason == "sync_timeline_write_failed"
+            pending_room_ids.add(room_id_arg)
+            raise backend_error
+
+        event_cache.mark_room_threads_stale = AsyncMock(side_effect=mark_room_threads_stale)
+        event_cache.invalidate_room_threads = AsyncMock(side_effect=backend_error)
+        event_cache.disable = Mock()
+        bot.event_cache = event_cache
+        _install_runtime_write_coordinator(bot)
+        message_event = nio.RoomMessageText.from_dict(
+            {
+                "content": {"body": "Fresh message", "msgtype": "m.text"},
+                "event_id": "$message:localhost",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "room_id": room_id,
+                "type": "m.room.message",
+            },
+        )
+
+        result = await bot._conversation_cache.cache_sync_timeline_for_certification(
+            self._sync_response({room_id: MagicMock(timeline=MagicMock(events=[message_event], limited=False))}),
+        )
+
+        assert result.complete is False
+        assert result.errors == (backend_error,)
+        assert result.runtime_diagnostics == {"cache_backend": "mock"}
+        assert event_cache.pending_durable_write_room_ids() == (room_id,)
+        event_cache.mark_room_threads_stale.assert_awaited_once_with(
+            room_id,
+            reason="sync_timeline_write_failed",
+        )
+        event_cache.disable.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_sync_error_keeps_watchdog_clock_on_latest_activity(self, bot: AgentBot) -> None:
         """Sync errors should keep the watchdog alive using the latest observed sync activity."""
         sync_response = MagicMock()

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -35,7 +35,7 @@ from mindroom.constants import STREAM_STATUS_COMPLETED, STREAM_STATUS_KEY, STREA
 from mindroom.hooks import EVENT_AGENT_STARTED
 from mindroom.matrix import thread_bookkeeping
 from mindroom.matrix.cache import ThreadHistoryResult, thread_writes
-from mindroom.matrix.cache.event_cache import ThreadCacheState
+from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailable, ThreadCacheState
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_history_result import (
     THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC,
@@ -1485,6 +1485,47 @@ class TestMatrixConversationCacheThreadReads:
         )
 
         event_cache.invalidate_room_threads.assert_awaited_once_with("!room:localhost")
+
+    @pytest.mark.asyncio
+    async def test_invalidate_known_thread_keeps_cache_enabled_when_backend_is_temporarily_unavailable(self) -> None:
+        """Transient backend loss should not permanently disable a cache that tracks pending markers."""
+        event_cache = _runtime_event_cache()
+        backend_error = EventCacheBackendUnavailable("postgres unavailable")
+        event_cache.mark_thread_stale = AsyncMock(side_effect=backend_error)
+        event_cache.invalidate_thread = AsyncMock(side_effect=backend_error)
+        event_cache.disable = Mock()
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(event_cache=event_cache),
+        )
+
+        await access._write_cache_ops.invalidate_known_thread(
+            "!room:localhost",
+            "$thread:localhost",
+            reason="test_failure",
+        )
+
+        event_cache.disable.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalidate_room_threads_keeps_cache_enabled_when_backend_is_temporarily_unavailable(self) -> None:
+        """Transient backend loss should not turn a reconnectable Postgres cache into a permanent miss."""
+        event_cache = _runtime_event_cache()
+        backend_error = EventCacheBackendUnavailable("postgres unavailable")
+        event_cache.mark_room_threads_stale = AsyncMock(side_effect=backend_error)
+        event_cache.invalidate_room_threads = AsyncMock(side_effect=backend_error)
+        event_cache.disable = Mock()
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(event_cache=event_cache),
+        )
+
+        await access._write_cache_ops.invalidate_room_threads(
+            "!room:localhost",
+            reason="test_failure",
+        )
+
+        event_cache.disable.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_lookup_miss_invalidation_survives_restart_and_refetches_next_read(self, tmp_path: Path) -> None:

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -2111,6 +2111,40 @@ class TestThreadingBehavior:
         assert token_record.checkpoint == SyncCheckpoint("s_after_empty")
 
     @pytest.mark.asyncio
+    async def test_empty_sync_flushes_pending_cache_writes_before_certifying(self, bot: AgentBot) -> None:
+        """Sync-token certification should include pending runtime-only cache writes."""
+        pending_room_ids = {"!pending:localhost"}
+        event_cache = _runtime_event_cache()
+        event_cache.pending_durable_write_room_ids.side_effect = lambda: tuple(sorted(pending_room_ids))
+
+        async def flush_pending_durable_writes(room_id: str) -> None:
+            pending_room_ids.discard(room_id)
+
+        event_cache.flush_pending_durable_writes.side_effect = flush_pending_durable_writes
+        bot.event_cache = event_cache
+        _install_runtime_write_coordinator(bot)
+
+        result = await bot._conversation_cache.cache_sync_timeline_for_certification(self._sync_response({}))
+
+        assert result.complete is True
+        assert result.task_count == 1
+        event_cache.flush_pending_durable_writes.assert_awaited_once_with("!pending:localhost")
+
+    @pytest.mark.asyncio
+    async def test_empty_sync_does_not_certify_while_pending_cache_writes_remain(self, bot: AgentBot) -> None:
+        """A sync token is not cache-certified while runtime-only writes remain in memory."""
+        event_cache = _runtime_event_cache()
+        event_cache.pending_durable_write_room_ids.return_value = ("!pending:localhost",)
+        bot.event_cache = event_cache
+        _install_runtime_write_coordinator(bot)
+
+        result = await bot._conversation_cache.cache_sync_timeline_for_certification(self._sync_response({}))
+
+        assert result.complete is False
+        assert result.task_count == 1
+        event_cache.flush_pending_durable_writes.assert_awaited_once_with("!pending:localhost")
+
+    @pytest.mark.asyncio
     async def test_sync_error_keeps_watchdog_clock_on_latest_activity(self, bot: AgentBot) -> None:
         """Sync errors should keep the watchdog alive using the latest observed sync activity."""
         sync_response = MagicMock()

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -35,7 +35,7 @@ from mindroom.constants import STREAM_STATUS_COMPLETED, STREAM_STATUS_KEY, STREA
 from mindroom.hooks import EVENT_AGENT_STARTED
 from mindroom.matrix import thread_bookkeeping
 from mindroom.matrix.cache import ThreadHistoryResult, thread_writes
-from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailable, ThreadCacheState
+from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailableError, ThreadCacheState
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_history_result import (
     THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC,
@@ -1490,7 +1490,7 @@ class TestMatrixConversationCacheThreadReads:
     async def test_invalidate_known_thread_keeps_cache_enabled_when_backend_is_temporarily_unavailable(self) -> None:
         """Transient backend loss should not permanently disable a cache that tracks pending markers."""
         event_cache = _runtime_event_cache()
-        backend_error = EventCacheBackendUnavailable("postgres unavailable")
+        backend_error = EventCacheBackendUnavailableError("postgres unavailable")
         event_cache.mark_thread_stale = AsyncMock(side_effect=backend_error)
         event_cache.invalidate_thread = AsyncMock(side_effect=backend_error)
         event_cache.disable = Mock()
@@ -1511,7 +1511,7 @@ class TestMatrixConversationCacheThreadReads:
     async def test_invalidate_room_threads_keeps_cache_enabled_when_backend_is_temporarily_unavailable(self) -> None:
         """Transient backend loss should not turn a reconnectable Postgres cache into a permanent miss."""
         event_cache = _runtime_event_cache()
-        backend_error = EventCacheBackendUnavailable("postgres unavailable")
+        backend_error = EventCacheBackendUnavailableError("postgres unavailable")
         event_cache.mark_room_threads_stale = AsyncMock(side_effect=backend_error)
         event_cache.invalidate_room_threads = AsyncMock(side_effect=backend_error)
         event_cache.disable = Mock()


### PR DESCRIPTION
## Summary
- classify transient Postgres event-cache disconnects separately from permanent cache corruption
- reconnect and retry cache operations after transient connection loss
- preserve pending stale markers and flush them before trusting cached rows again
- add runtime diagnostics to sync-cache certification logs
- make smoke-stack CI fit GitHub-hosted runners by freeing unused SDK disk space before image builds
- run smoke-stack CI against a smaller single-node kind cluster selected through the new `KIND_CONFIG` override

## Tests / validation
- uv run ruff check src/mindroom/matrix/cache/postgres_event_cache.py src/mindroom/matrix/cache/postgres_event_cache_threads.py src/mindroom/matrix/cache/thread_write_cache_ops.py src/mindroom/matrix/cache/thread_writes.py src/mindroom/matrix/sync_certification.py src/mindroom/runtime_support.py tests/test_event_cache_backends.py tests/test_threading_error.py tests/test_sync_certification.py
- uv run tach check --dependencies --interfaces
- uv run --extra postgres pytest tests/test_event_cache_backends.py -q -n 0 --no-cov
- uv run pytest tests/test_threading_error.py -q -n 0 --no-cov
- uv run pytest tests/test_sync_certification.py -q --no-cov
- GitHub Actions Smoke Stacks workflow validates the runner disk cleanup and `KIND_CONFIG=cluster/k8s/kind/kind-config-smoke.yaml` single-node kind path on PRs
