### PR TITLE
Instrument tool dispatch timing

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -63,7 +63,7 @@ from mindroom.logging_config import get_logger
 from mindroom.media_fallback import should_retry_without_inline_media
 from mindroom.media_inputs import MediaInputs
 from mindroom.memory import MemoryPromptParts, build_memory_prompt_parts, strip_user_turn_time_prefix
-from mindroom.timing import DispatchPipelineTiming, timed
+from mindroom.timing import DispatchPipelineTiming, emit_timing_event, timed
 from mindroom.tool_system.events import (
     complete_pending_tool_block,
     extract_tool_completed_info,
@@ -1270,6 +1270,15 @@ async def _process_stream_events(  # noqa: C901, PLR0912, PLR0915
                 continue
 
             if isinstance(event, ToolCallStartedEvent):
+                tool_execution = event.tool
+                emit_timing_event(
+                    "Dispatch tool-call timing",
+                    phase="agno_tool_call_started",
+                    agent_name=agent_name,
+                    tool_name=tool_execution.tool_name if tool_execution is not None else None,
+                    tool_call_id=tool_execution_call_id(tool_execution) if tool_execution is not None else None,
+                    show_tool_calls=show_tool_calls,
+                )
                 _track_stream_tool_started(
                     state,
                     event,

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -261,6 +261,30 @@ class ThreadOutboundWritePolicy:
         self._cache_ops = cache_ops
         self._require_client = require_client
 
+    def _emit_outbound_schedule_timing(
+        self,
+        *,
+        barrier_kind: str,
+        room_id: str,
+        thread_id: str | None,
+        event_id: str,
+        event_type: str | None,
+        event_info: EventInfo,
+        has_coalesce_key: bool,
+    ) -> None:
+        emit_timing_event(
+            "Event cache outbound schedule timing",
+            operation="matrix_cache_notify_outbound_event",
+            barrier_kind=barrier_kind,
+            room_id=room_id,
+            thread_id=thread_id,
+            event_id=event_id,
+            event_type=event_type,
+            is_edit=event_info.is_edit,
+            is_reaction=event_info.is_reaction,
+            has_coalesce_key=has_coalesce_key,
+        )
+
     async def _apply_outbound_event_notification(
         self,
         room_id: str,
@@ -310,8 +334,19 @@ class ThreadOutboundWritePolicy:
                 event_source=normalized_event_source,
             )
             coalesce_key, coalesce_log_context = coalesce_context if coalesce_context is not None else (None, None)
+            event_type_value = normalized_event_source.get("type")
+            event_type = event_type_value if isinstance(event_type_value, str) else None
             emit_timing = event_info.is_edit
             if event_info.is_reaction:
+                self._emit_outbound_schedule_timing(
+                    barrier_kind="room",
+                    room_id=room_id,
+                    thread_id=None,
+                    event_id=event_id,
+                    event_type=event_type,
+                    event_info=event_info,
+                    has_coalesce_key=coalesce_key is not None,
+                )
                 persisted_batch: list[tuple[str, str, dict[str, object]]] = [
                     (event_id, room_id, normalized_event_source),
                 ]
@@ -333,6 +368,15 @@ class ThreadOutboundWritePolicy:
                 return
             thread_id = event_info.thread_id or event_info.thread_id_from_edit
             if thread_id is not None:
+                self._emit_outbound_schedule_timing(
+                    barrier_kind="thread",
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    event_id=event_id,
+                    event_type=event_type,
+                    event_info=event_info,
+                    has_coalesce_key=coalesce_key is not None,
+                )
                 self._schedule_fail_open_thread_update(
                     room_id,
                     thread_id,
@@ -352,6 +396,15 @@ class ThreadOutboundWritePolicy:
                 )
                 return
             # Lookup-dependent outbound mutations stay on the room barrier because earlier outbound writes can create the lookup rows needed to resolve thread impact. Safe parallelization would require reservation-based routing (see ISSUE-189).
+            self._emit_outbound_schedule_timing(
+                barrier_kind="room",
+                room_id=room_id,
+                thread_id=None,
+                event_id=event_id,
+                event_type=event_type,
+                event_info=event_info,
+                has_coalesce_key=coalesce_key is not None,
+            )
             self._schedule_fail_open_room_update(
                 room_id,
                 lambda: self._apply_outbound_event_notification(

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -18,6 +18,7 @@ from nio.api import Api
 from mindroom.logging_config import get_logger
 from mindroom.matrix.large_messages import prepare_large_message
 from mindroom.matrix.mentions import format_message_with_mentions
+from mindroom.timing import emit_timing_event
 
 if TYPE_CHECKING:
     from mindroom.config.main import Config
@@ -93,7 +94,27 @@ async def send_message_result(
             )
             return None
 
+    message_type = "m.room.message"
+    emit_timing_event(
+        "Matrix send timing",
+        phase="prepare_start",
+        room_id=room_id,
+        message_type=message_type,
+    )
     content_sent = await prepare_large_message(client, room_id, content)
+    emit_timing_event(
+        "Matrix send timing",
+        phase="prepare_finish",
+        room_id=room_id,
+        message_type=message_type,
+    )
+    emit_timing_event(
+        "Matrix send timing",
+        phase="send_start",
+        room_id=room_id,
+        message_type=message_type,
+        cache_bypass=cache_bypass,
+    )
     if cache_bypass:
         access_token = client.access_token
         if not access_token:
@@ -102,7 +123,7 @@ async def send_message_result(
         method, path, data = Api.room_send(
             access_token,
             room_id,
-            "m.room.message",
+            message_type,
             content_sent,
             uuid4(),
         )
@@ -116,10 +137,19 @@ async def send_message_result(
     else:
         response = await client.room_send(
             room_id=room_id,
-            message_type="m.room.message",
+            message_type=message_type,
             content=content_sent,
         )
     if isinstance(response, nio.RoomSendResponse):
+        emit_timing_event(
+            "Matrix send timing",
+            phase="send_finish",
+            room_id=room_id,
+            message_type=message_type,
+            cache_bypass=cache_bypass,
+            outcome="sent",
+            event_id=str(response.event_id),
+        )
         logger.debug(
             "matrix_message_sent",
             room_id=room_id,
@@ -127,6 +157,15 @@ async def send_message_result(
             cache_bypass=cache_bypass,
         )
         return DeliveredMatrixEvent(event_id=str(response.event_id), content_sent=content_sent)
+    emit_timing_event(
+        "Matrix send timing",
+        phase="send_finish",
+        room_id=room_id,
+        message_type=message_type,
+        cache_bypass=cache_bypass,
+        outcome="error",
+        error=str(response),
+    )
     logger.error(
         "matrix_message_send_failed",
         room_id=room_id,

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, NoReturn
 from agno.run.agent import RunCompletedEvent, RunContentEvent, ToolCallCompletedEvent, ToolCallStartedEvent
 
 from mindroom.logging_config import get_logger
+from mindroom.timing import emit_timing_event
 from mindroom.tool_system.events import (
     StructuredStreamChunk,
     ToolTraceEntry,
@@ -132,6 +133,17 @@ def _queue_delivery_request(
             ),
             capture_completion=capture_completion,
         ),
+    )
+    emit_timing_event(
+        "Dispatch tool delivery timing",
+        phase="queued",
+        queue_size=delivery_queue.qsize(),
+        progress_hint=progress_hint,
+        force_refresh=force_refresh,
+        boundary_refresh=boundary_refresh,
+        phase_boundary_flush=phase_boundary_flush,
+        allow_empty_progress=allow_empty_progress,
+        wait_for_capture=wait_for_capture,
     )
     return capture_completion
 

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -25,6 +25,7 @@ from mindroom.hooks import (
     emit_gate,
 )
 from mindroom.logging_config import get_logger
+from mindroom.timing import emit_timing_event
 from mindroom.tool_system.runtime_context import (
     LiveToolDispatchContext,
     ToolDispatchContext,
@@ -279,8 +280,22 @@ def _patch_agno_async_tool_hook_chain() -> None:
 _patch_agno_async_tool_hook_chain()
 
 
-async def _call_tool(func: Callable[..., Any], args: dict[str, Any]) -> ToolHookResult:
-    if inspect.iscoroutinefunction(func):
+async def _call_tool(
+    func: Callable[..., Any],
+    args: dict[str, Any],
+    *,
+    tool_name: str,
+    agent_name: str | None,
+) -> ToolHookResult:
+    async_entrypoint = inspect.iscoroutinefunction(func)
+    emit_timing_event(
+        "Tool hook dispatch timing",
+        phase="tool_entry",
+        tool_name=tool_name,
+        agent_name=agent_name,
+        async_entrypoint=async_entrypoint,
+    )
+    if async_entrypoint:
         result = await func(**args)
     else:
         result = await asyncio.to_thread(func, **args)
@@ -313,6 +328,14 @@ async def _execute_bridge(
     resolved_context = _resolve_tool_context(
         bridge_context=bridge_context,
     )
+    emit_timing_event(
+        "Tool hook dispatch timing",
+        phase="bridge_entry",
+        tool_name=tool_name,
+        agent_name=resolved_context.agent_name or None,
+        has_before_hooks=has_before_hooks,
+        has_after_hooks=has_after_hooks,
+    )
     hook_arguments = deepcopy(args) if has_before_hooks or has_after_hooks else None
 
     if has_before_hooks:
@@ -320,7 +343,22 @@ async def _execute_bridge(
             **resolved_context.hook_context_kwargs(hook_arguments if hook_arguments is not None else deepcopy(args)),
             tool_name=tool_name,
         )
+        before_hooks_started_at = time.perf_counter()
+        emit_timing_event(
+            "Tool hook dispatch timing",
+            phase="before_hooks_start",
+            tool_name=tool_name,
+            agent_name=resolved_context.agent_name or None,
+        )
         await emit_gate(hook_registry, EVENT_TOOL_BEFORE_CALL, before_context)
+        emit_timing_event(
+            "Tool hook dispatch timing",
+            phase="before_hooks_finish",
+            tool_name=tool_name,
+            agent_name=resolved_context.agent_name or None,
+            declined=before_context.declined,
+            duration_ms=round((time.perf_counter() - before_hooks_started_at) * 1000, 2),
+        )
         if before_context.declined:
             result = _format_declined_result(tool_name, before_context.decline_reason)
             if has_after_hooks:
@@ -340,7 +378,12 @@ async def _execute_bridge(
     result: ToolHookResult = None
     error: BaseException | None = None
     try:
-        result = await _call_tool(func, args)
+        result = await _call_tool(
+            func,
+            args,
+            tool_name=tool_name,
+            agent_name=resolved_context.agent_name or None,
+        )
     except BaseException as exc:
         error = exc
         duration_ms = (time.perf_counter() - started_at) * 1000

--- a/tests/test_dispatch_timing_instrumentation.py
+++ b/tests/test_dispatch_timing_instrumentation.py
@@ -1,0 +1,299 @@
+"""Tests for opt-in tool-dispatch timing instrumentation."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, Mock, patch
+
+import nio
+import pytest
+from agno.models.response import ToolExecution
+from agno.run.agent import ToolCallStartedEvent
+
+from mindroom import ai as ai_module
+from mindroom.config.plugin import PluginEntryConfig
+from mindroom.hooks import EVENT_TOOL_BEFORE_CALL, HookRegistry, ToolBeforeCallContext, hook
+from mindroom.matrix.cache.thread_writes import ThreadOutboundWritePolicy
+from mindroom.matrix.client_delivery import send_message_result
+from mindroom.media_inputs import MediaInputs
+from mindroom.streaming_delivery import _queue_delivery_request
+from mindroom.tool_system.tool_hooks import build_tool_hook_bridge
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+def _record_timing_event(
+    events: list[tuple[str, dict[str, object]]],
+    event_name: str,
+    **event_data: object,
+) -> None:
+    events.append((event_name, event_data))
+
+
+@pytest.mark.asyncio
+async def test_stream_processing_marks_tool_call_started() -> None:
+    """AI stream processing should mark the handoff from model stream to tool dispatch."""
+    timing_events: list[tuple[str, dict[str, object]]] = []
+
+    async def stream() -> AsyncIterator[object]:
+        yield ToolCallStartedEvent(
+            tool=ToolExecution(
+                tool_name="run_shell_command",
+                tool_args={"cmd": "date +%s.%N"},
+            ),
+        )
+
+    with patch(
+        "mindroom.ai.emit_timing_event",
+        side_effect=lambda *args, **kwargs: _record_timing_event(timing_events, *args, **kwargs),
+        create=True,
+    ):
+        chunks = [
+            chunk
+            async for chunk in ai_module._process_stream_events(
+                stream(),
+                state=ai_module._StreamingAttemptState(),
+                show_tool_calls=True,
+                agent_name="code",
+                media_inputs=MediaInputs(),
+                retried_without_inline_media=False,
+                timing_scope="test",
+            )
+        ]
+
+    assert len(chunks) == 1
+    assert timing_events == [
+        (
+            "Dispatch tool-call timing",
+            {
+                "phase": "agno_tool_call_started",
+                "agent_name": "code",
+                "tool_name": "run_shell_command",
+                "tool_call_id": None,
+                "show_tool_calls": True,
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_queue_delivery_request_marks_enqueued_delivery() -> None:
+    """Streaming delivery requests should expose when tool-trace Matrix delivery is queued."""
+    timing_events: list[tuple[str, dict[str, object]]] = []
+    delivery_queue: asyncio.Queue[object | None] = asyncio.Queue()
+
+    with patch(
+        "mindroom.streaming_delivery.emit_timing_event",
+        side_effect=lambda *args, **kwargs: _record_timing_event(timing_events, *args, **kwargs),
+        create=True,
+    ):
+        capture_completion = _queue_delivery_request(
+            delivery_queue,
+            progress_hint=True,
+            boundary_refresh=True,
+            wait_for_capture=True,
+        )
+
+    assert capture_completion is not None
+    capture_completion.set_result(None)
+    request = delivery_queue.get_nowait()
+    assert request is not None
+    assert timing_events == [
+        (
+            "Dispatch tool delivery timing",
+            {
+                "phase": "queued",
+                "queue_size": 1,
+                "progress_hint": True,
+                "force_refresh": False,
+                "boundary_refresh": True,
+                "phase_boundary_flush": False,
+                "allow_empty_progress": False,
+                "wait_for_capture": True,
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_message_result_marks_prepare_and_send_phases() -> None:
+    """Matrix sends should mark large-message prep and room-send boundaries."""
+    timing_events: list[tuple[str, dict[str, object]]] = []
+    client = AsyncMock(spec=nio.AsyncClient)
+    room = Mock()
+    room.encrypted = False
+    client.rooms = {"!room:localhost": room}
+    client.room_send.return_value = nio.RoomSendResponse("$evt:localhost", "!room:localhost")
+    prepared_content = {"body": "hello", "msgtype": "m.text"}
+
+    with (
+        patch("mindroom.matrix.client_delivery.prepare_large_message", new=AsyncMock(return_value=prepared_content)),
+        patch(
+            "mindroom.matrix.client_delivery.emit_timing_event",
+            side_effect=lambda *args, **kwargs: _record_timing_event(timing_events, *args, **kwargs),
+            create=True,
+        ),
+    ):
+        result = await send_message_result(client, "!room:localhost", {"body": "hello", "msgtype": "m.text"})
+
+    assert result is not None
+    assert result.event_id == "$evt:localhost"
+    assert timing_events == [
+        (
+            "Matrix send timing",
+            {"phase": "prepare_start", "room_id": "!room:localhost", "message_type": "m.room.message"},
+        ),
+        (
+            "Matrix send timing",
+            {"phase": "prepare_finish", "room_id": "!room:localhost", "message_type": "m.room.message"},
+        ),
+        (
+            "Matrix send timing",
+            {
+                "phase": "send_start",
+                "room_id": "!room:localhost",
+                "message_type": "m.room.message",
+                "cache_bypass": False,
+            },
+        ),
+        (
+            "Matrix send timing",
+            {
+                "phase": "send_finish",
+                "room_id": "!room:localhost",
+                "message_type": "m.room.message",
+                "cache_bypass": False,
+                "outcome": "sent",
+                "event_id": "$evt:localhost",
+            },
+        ),
+    ]
+
+
+def test_notify_outbound_message_marks_cache_schedule() -> None:
+    """Outbound Matrix cache notifications should mark the cache-barrier scheduling point."""
+    timing_events: list[tuple[str, dict[str, object]]] = []
+
+    class CacheOps:
+        def __init__(self) -> None:
+            self.logger = Mock()
+            self.thread_updates: list[tuple[str, str, dict[str, object]]] = []
+
+        def cache_runtime_available(self) -> bool:
+            return True
+
+        def queue_thread_cache_update(
+            self,
+            room_id: str,
+            thread_id: str,
+            update_coro_factory: object,
+            **kwargs: object,
+        ) -> object:
+            del update_coro_factory
+            self.thread_updates.append((room_id, thread_id, dict(kwargs)))
+            return object()
+
+        def queue_room_cache_update(
+            self,
+            room_id: str,
+            update_coro_factory: object,
+            **kwargs: object,
+        ) -> object:
+            del update_coro_factory
+            msg = f"Unexpected room cache update for {room_id}: {kwargs}"
+            raise AssertionError(msg)
+
+    cache_ops = CacheOps()
+    policy = ThreadOutboundWritePolicy(
+        resolver=Mock(),
+        cache_ops=cache_ops,
+        require_client=lambda: SimpleNamespace(user_id="@mindroom_code:localhost"),
+    )
+
+    with patch(
+        "mindroom.matrix.cache.thread_writes.emit_timing_event",
+        side_effect=lambda *args, **kwargs: _record_timing_event(timing_events, *args, **kwargs),
+    ):
+        policy.notify_outbound_message(
+            "!room:localhost",
+            "$tool_use",
+            {
+                "body": "tool started",
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": "$thread",
+                    "is_falling_back": True,
+                },
+            },
+        )
+
+    assert cache_ops.thread_updates
+    assert timing_events == [
+        (
+            "Event cache outbound schedule timing",
+            {
+                "operation": "matrix_cache_notify_outbound_event",
+                "barrier_kind": "thread",
+                "room_id": "!room:localhost",
+                "thread_id": "$thread",
+                "event_id": "$tool_use",
+                "event_type": "m.room.message",
+                "is_edit": False,
+                "is_reaction": False,
+                "has_coalesce_key": False,
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tool_hook_bridge_marks_hook_and_tool_entry() -> None:
+    """Agno tool-hook bridging should mark before-hook timing and actual tool entry."""
+    timing_events: list[tuple[str, dict[str, object]]] = []
+
+    @hook(EVENT_TOOL_BEFORE_CALL)
+    async def before(ctx: ToolBeforeCallContext) -> None:
+        assert ctx.tool_name == "echo"
+
+    registry = HookRegistry.from_plugins(
+        [
+            SimpleNamespace(
+                name="tool-policy",
+                discovered_hooks=(before,),
+                entry_config=PluginEntryConfig(path="./plugins/tool-policy", settings={}),
+                plugin_order=0,
+            ),
+        ],
+    )
+    bridge = build_tool_hook_bridge(registry, agent_name="code")
+
+    async def echo(text: str) -> str:
+        return text.upper()
+
+    with patch(
+        "mindroom.tool_system.tool_hooks.emit_timing_event",
+        side_effect=lambda *args, **kwargs: _record_timing_event(timing_events, *args, **kwargs),
+        create=True,
+    ):
+        result = await bridge("echo", echo, {"text": "hello"})
+
+    assert result == "HELLO"
+    assert [
+        (event_name, event_data["phase"])
+        for event_name, event_data in timing_events
+        if event_name == "Tool hook dispatch timing"
+    ] == [
+        ("Tool hook dispatch timing", "bridge_entry"),
+        ("Tool hook dispatch timing", "before_hooks_start"),
+        ("Tool hook dispatch timing", "before_hooks_finish"),
+        ("Tool hook dispatch timing", "tool_entry"),
+    ]
+    before_finish = timing_events[2][1]
+    assert before_finish["tool_name"] == "echo"
+    assert before_finish["agent_name"] == "code"
+    assert before_finish["declined"] is False
+    assert isinstance(before_finish["duration_ms"], float)

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -693,7 +693,9 @@ def test_postgres_transient_classifier_accepts_connection_timeout() -> None:
 def test_postgres_transient_classifier_accepts_dns_resolution_failure() -> None:
     """Transient Kubernetes DNS gaps should retry later instead of disabling the cache."""
     assert _is_transient_postgres_failure(
-        psycopg.OperationalError("failed to resolve host 'mindroom-cache-postgres': [Errno -2] Name or service not known"),
+        psycopg.OperationalError(
+            "failed to resolve host 'mindroom-cache-postgres': [Errno -2] Name or service not known",
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- Add opt-in `emit_timing_event` marks for tool-call start, streaming delivery queueing, Matrix send phases, outbound cache scheduling, and tool-hook/tool-entry phases.
- Cover the new timing marks with focused unit tests.

## Test plan
- `uv run pytest tests/test_dispatch_timing_instrumentation.py tests/test_timing.py -q` (23 passed)
- `uv run pre-commit run --all-files`
- `uv run pytest` (5598 passed, 28 skipped)