### PR TITLE
Extract response attempt runner

### DIFF
--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -80,10 +80,14 @@ It still needs more cleanup, but normal turn control, edit regeneration, and int
 Interactive reactions and numeric text selections now share the same controller-owned execution path.
 That path sends the acknowledgment, runs response generation, and records the handled turn once.
 
+`ResponseAttemptRunner` now owns visible response attempts.
+It sends thinking placeholders, registers stop tracking, runs the cancellable response task, logs cancellation provenance, and clears stop tracking.
+`ResponseRunner` keeps the existing attempt entry point, but delegates attempt mechanics through this deeper module.
+
 ## Next Simplification Work
 
 Shrink `ResponseRunner`.
-It should keep placeholder, locking, streaming, cancellation, AI or team execution, and post-response effects, but it should stop accumulating unrelated side paths.
+It should keep locking, streaming, AI or team execution, and post-response effects, but it should stop accumulating unrelated side paths.
 
 Revisit `IngressHookRunner`.
 It may stay as a helper, but it should not grow into another top-level orchestration object.

--- a/src/mindroom/response_attempt.py
+++ b/src/mindroom/response_attempt.py
@@ -1,0 +1,184 @@
+"""Run one visible response attempt with cancellation tracking."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from mindroom.constants import STREAM_STATUS_KEY, STREAM_STATUS_PENDING
+from mindroom.delivery_gateway import SendTextRequest
+from mindroom.logging_config import bound_log_context
+from mindroom.matrix.presence import is_user_online
+from mindroom.orchestration.runtime import cancel_failure_reason, classify_cancel_source
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
+    import nio
+    import structlog
+
+    from mindroom.delivery_gateway import DeliveryGateway
+    from mindroom.message_target import MessageTarget
+    from mindroom.stop import StopManager
+    from mindroom.timing import DispatchPipelineTiming
+
+type MatrixEventId = str
+
+
+@dataclass(frozen=True)
+class ResponseAttemptDeps:
+    """Collaborators needed to run a visible response attempt."""
+
+    client: nio.AsyncClient
+    delivery_gateway: DeliveryGateway
+    stop_manager: StopManager
+    logger: structlog.stdlib.BoundLogger
+    show_stop_button: Callable[[], bool]
+    notify_outbound_event: Callable[[str, dict[str, object]], None]
+    notify_outbound_redaction: Callable[[str, str], None]
+
+
+@dataclass(frozen=True)
+class ResponseAttemptRequest:
+    """Inputs for one cancellable response attempt."""
+
+    target: MessageTarget
+    response_function: Callable[[str | None], Coroutine[Any, Any, None]]
+    thinking_message: str | None = None
+    existing_event_id: str | None = None
+    user_id: str | None = None
+    run_id: str | None = None
+    pipeline_timing: DispatchPipelineTiming | None = None
+    on_cancelled: Callable[[str], None] | None = None
+
+
+def log_cancelled_response(
+    logger: structlog.stdlib.BoundLogger,
+    *,
+    exc: asyncio.CancelledError,
+    message_id: str | None,
+    restart_message: str,
+    user_stop_message: str,
+    interrupted_message: str,
+) -> None:
+    """Log one CancelledError with the right provenance label."""
+    cancel_source = classify_cancel_source(exc)
+    if cancel_source == "sync_restart":
+        logger.info(restart_message, message_id=message_id)
+    elif cancel_source == "user_stop":
+        logger.info(user_stop_message, message_id=message_id)
+    else:
+        logger.warning(
+            interrupted_message,
+            message_id=message_id,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+
+
+@dataclass(frozen=True)
+class ResponseAttemptRunner:
+    """Own placeholder delivery, stop tracking, and attempt task cleanup."""
+
+    deps: ResponseAttemptDeps
+
+    async def _send_thinking_message(self, request: ResponseAttemptRequest) -> MatrixEventId | None:
+        message_id = await self.deps.delivery_gateway.send_text(
+            SendTextRequest(
+                target=request.target,
+                response_text=request.thinking_message or "",
+                extra_content={STREAM_STATUS_KEY: STREAM_STATUS_PENDING},
+            ),
+        )
+        if message_id is not None and request.pipeline_timing is not None:
+            request.pipeline_timing.mark("placeholder_sent")
+            request.pipeline_timing.mark_first_visible_reply("placeholder")
+        return message_id
+
+    async def _should_show_stop_button(self, request: ResponseAttemptRequest, message_id: str) -> bool:
+        show_stop_button = self.deps.show_stop_button()
+        if not show_stop_button or request.user_id is None:
+            return show_stop_button
+        user_is_online = await is_user_online(
+            self.deps.client,
+            request.user_id,
+            room_id=request.target.room_id,
+        )
+        self.deps.logger.info(
+            "Stop button decision",
+            message_id=message_id,
+            user_online=user_is_online,
+            show_button=user_is_online,
+        )
+        return user_is_online
+
+    async def run(self, request: ResponseAttemptRequest) -> MatrixEventId | None:
+        """Run one response coroutine under visible message tracking."""
+        if request.thinking_message is not None and request.existing_event_id is not None:
+            msg = "thinking_message and existing_event_id are mutually exclusive"
+            raise ValueError(msg)
+
+        with bound_log_context(**request.target.log_context):
+            initial_message_id = None
+            if request.thinking_message is not None:
+                initial_message_id = await self._send_thinking_message(request)
+
+            message_id = request.existing_event_id or initial_message_id
+            task: asyncio.Task[None] = asyncio.create_task(request.response_function(message_id))
+            tracked_message_id = message_id or f"__pending_response__:{id(task)}"
+            show_stop_button = False
+
+            self.deps.stop_manager.set_current(
+                tracked_message_id,
+                request.target,
+                task,
+                None,
+                run_id=request.run_id,
+            )
+
+            if message_id is not None:
+                show_stop_button = await self._should_show_stop_button(request, message_id)
+                if show_stop_button:
+                    self.deps.logger.info("Adding stop button", message_id=message_id)
+                    await self.deps.stop_manager.add_stop_button(
+                        self.deps.client,
+                        message_id,
+                        notify_outbound_event=self.deps.notify_outbound_event,
+                    )
+
+            try:
+                await task
+            except asyncio.CancelledError as exc:
+                failure_reason = cancel_failure_reason(classify_cancel_source(exc))
+                if request.on_cancelled is not None:
+                    request.on_cancelled(failure_reason)
+                log_cancelled_response(
+                    self.deps.logger,
+                    exc=exc,
+                    message_id=message_id or tracked_message_id,
+                    restart_message="Response interrupted by sync restart",
+                    user_stop_message="Response cancelled by user",
+                    interrupted_message="Response interrupted — traceback for diagnosis",
+                )
+            except Exception as error:
+                self.deps.logger.exception("Error during response generation", error=str(error))
+                raise
+            finally:
+                tracked = self.deps.stop_manager.tracked_messages.get(tracked_message_id)
+                button_already_removed = tracked is None or tracked.reaction_event_id is None
+                self.deps.stop_manager.clear_message(
+                    tracked_message_id,
+                    self.deps.client,
+                    remove_button=show_stop_button and not button_already_removed,
+                    notify_outbound_redaction=self.deps.notify_outbound_redaction,
+                )
+
+            return message_id
+
+
+__all__ = [
+    "ResponseAttemptDeps",
+    "ResponseAttemptRequest",
+    "ResponseAttemptRunner",
+    "log_cancelled_response",
+]

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -23,8 +23,6 @@ from mindroom.constants import (
     ATTACHMENT_IDS_KEY,
     ORIGINAL_SENDER_KEY,
     ROUTER_AGENT_NAME,
-    STREAM_STATUS_KEY,
-    STREAM_STATUS_PENDING,
 )
 from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
 from mindroom.history import run_post_response_compaction_check
@@ -39,10 +37,9 @@ from mindroom.knowledge import (
     KnowledgeAvailabilityDetail,
     format_knowledge_availability_notice,
 )
-from mindroom.logging_config import bound_log_context
 from mindroom.matrix.client_visible_messages import replace_visible_message
 from mindroom.matrix.identity import is_agent_id
-from mindroom.matrix.presence import is_user_online, should_use_streaming
+from mindroom.matrix.presence import should_use_streaming
 from mindroom.matrix.typing import typing_indicator
 from mindroom.memory import (
     mark_auto_flush_dirty_session,
@@ -54,6 +51,12 @@ from mindroom.orchestration.runtime import cancel_failure_reason, classify_cance
 from mindroom.post_response_effects import (
     PostResponseEffectsSupport,
     ResponseOutcome,
+)
+from mindroom.response_attempt import (
+    ResponseAttemptDeps,
+    ResponseAttemptRequest,
+    ResponseAttemptRunner,
+    log_cancelled_response,
 )
 from mindroom.response_terminal import PendingVisibleResponse, build_terminal_stream_transport_outcome
 from mindroom.streaming import (
@@ -81,7 +84,6 @@ from .delivery_gateway import (
     FinalDeliveryRequest,
     FinalizeStreamedResponseRequest,
     MatrixCompactionLifecycle,
-    SendTextRequest,
     StreamingDeliveryRequest,
 )
 from .media_inputs import MediaInputs
@@ -408,28 +410,6 @@ class ResponseRunner:
             failure_reason=str(error),
             error_type=error.__class__.__name__,
         )
-
-    def _log_cancelled_response(
-        self,
-        *,
-        exc: asyncio.CancelledError,
-        message_id: str | None,
-        restart_message: str,
-        user_stop_message: str,
-        interrupted_message: str,
-    ) -> None:
-        """Log one CancelledError with the right provenance label."""
-        cancel_source = classify_cancel_source(exc)
-        if cancel_source == "sync_restart":
-            self.deps.logger.info(restart_message, message_id=message_id)
-        elif cancel_source == "user_stop":
-            self.deps.logger.info(user_stop_message, message_id=message_id)
-        else:
-            self.deps.logger.warning(
-                interrupted_message,
-                message_id=message_id,
-                exc_info=(type(exc), exc, exc.__traceback__),
-            )
 
     @property
     def in_flight_response_count(self) -> int:
@@ -1166,7 +1146,8 @@ class ResponseRunner:
                     finally:
                         await lifecycle.emit_session_started(session_started_watch)
                 except asyncio.CancelledError as exc:
-                    self._log_cancelled_response(
+                    log_cancelled_response(
+                        self.deps.logger,
                         exc=exc,
                         message_id=message_id,
                         restart_message="Team non-streaming response interrupted by sync restart",
@@ -1377,96 +1358,32 @@ class ResponseRunner:
             thread_id=thread_id,
             reply_to_event_id=reply_to_event_id,
         )
-
-        assert not (thinking_message and existing_event_id), (
-            "thinking_message and existing_event_id are mutually exclusive"
-        )
-
         try:
             self.in_flight_response_count += 1
-            with bound_log_context(**resolved_target.log_context):
-                initial_message_id = None
-                if thinking_message:
-                    assert not existing_event_id
-                    initial_message_id = await self.deps.delivery_gateway.send_text(
-                        SendTextRequest(
-                            target=resolved_target,
-                            response_text=thinking_message,
-                            extra_content={STREAM_STATUS_KEY: STREAM_STATUS_PENDING},
-                        ),
-                    )
-                    if initial_message_id is not None and pipeline_timing is not None:
-                        pipeline_timing.mark("placeholder_sent")
-                        pipeline_timing.mark_first_visible_reply("placeholder")
-
-                message_id = existing_event_id or initial_message_id
-                task: asyncio.Task[None] = asyncio.create_task(response_function(message_id))
-
-                message_to_track = existing_event_id or initial_message_id
-                tracked_message_id = message_to_track or f"__pending_response__:{id(task)}"
-                show_stop_button = False
-
-                self.deps.stop_manager.set_current(
-                    tracked_message_id,
-                    resolved_target,
-                    task,
-                    None,
+            return await ResponseAttemptRunner(
+                ResponseAttemptDeps(
+                    client=self._client(),
+                    delivery_gateway=self.deps.delivery_gateway,
+                    stop_manager=self.deps.stop_manager,
+                    logger=self.deps.logger,
+                    show_stop_button=lambda: self.deps.runtime.config.defaults.show_stop_button,
+                    notify_outbound_event=self.deps.resolver.deps.conversation_cache.notify_outbound_event,
+                    notify_outbound_redaction=(
+                        self.deps.post_response_effects.conversation_cache.notify_outbound_redaction
+                    ),
+                ),
+            ).run(
+                ResponseAttemptRequest(
+                    target=resolved_target,
+                    response_function=response_function,
+                    thinking_message=thinking_message,
+                    existing_event_id=existing_event_id,
+                    user_id=user_id,
                     run_id=run_id,
-                )
-
-                if message_to_track:
-                    show_stop_button = self.deps.runtime.config.defaults.show_stop_button
-                    if show_stop_button and user_id:
-                        user_is_online = await is_user_online(
-                            self._client(),
-                            user_id,
-                            room_id=room_id,
-                        )
-                        show_stop_button = user_is_online
-                        self.deps.logger.info(
-                            "Stop button decision",
-                            message_id=message_to_track,
-                            user_online=user_is_online,
-                            show_button=show_stop_button,
-                        )
-
-                    if show_stop_button:
-                        self.deps.logger.info("Adding stop button", message_id=message_to_track)
-                        await self.deps.stop_manager.add_stop_button(
-                            self._client(),
-                            message_to_track,
-                            notify_outbound_event=self.deps.resolver.deps.conversation_cache.notify_outbound_event,
-                        )
-
-                try:
-                    await task
-                except asyncio.CancelledError as exc:
-                    failure_reason = cancel_failure_reason(classify_cancel_source(exc))
-                    if on_cancelled is not None:
-                        on_cancelled(failure_reason)
-                    self._log_cancelled_response(
-                        exc=exc,
-                        message_id=message_to_track or tracked_message_id,
-                        restart_message="Response interrupted by sync restart",
-                        user_stop_message="Response cancelled by user",
-                        interrupted_message="Response interrupted — traceback for diagnosis",
-                    )
-                except Exception as error:
-                    self.deps.logger.exception("Error during response generation", error=str(error))
-                    raise
-                finally:
-                    tracked = self.deps.stop_manager.tracked_messages.get(tracked_message_id)
-                    button_already_removed = tracked is None or tracked.reaction_event_id is None
-                    self.deps.stop_manager.clear_message(
-                        tracked_message_id,
-                        client=self._client(),
-                        remove_button=show_stop_button and not button_already_removed,
-                        notify_outbound_redaction=(
-                            self.deps.post_response_effects.conversation_cache.notify_outbound_redaction
-                        ),
-                    )
-
-                return message_id
+                    pipeline_timing=pipeline_timing,
+                    on_cancelled=on_cancelled,
+                ),
+            )
         finally:
             self.in_flight_response_count -= 1
 
@@ -1819,7 +1736,8 @@ class ResponseRunner:
                 await lifecycle.emit_session_started(session_started_watch)
         except asyncio.CancelledError as exc:
             cancel_source = classify_cancel_source(exc)
-            self._log_cancelled_response(
+            log_cancelled_response(
+                self.deps.logger,
                 exc=exc,
                 message_id=request.existing_event_id,
                 restart_message="Non-streaming response interrupted by sync restart",
@@ -2019,7 +1937,8 @@ class ResponseRunner:
                 ),
             )
         except asyncio.CancelledError as exc:
-            self._log_cancelled_response(
+            log_cancelled_response(
+                self.deps.logger,
                 exc=exc,
                 message_id=request.existing_event_id,
                 restart_message="Bot streaming response interrupted by sync restart",

--- a/tach.toml
+++ b/tach.toml
@@ -761,6 +761,7 @@ depends_on = [
     "mindroom.memory",
     "mindroom.orchestration.runtime",
     "mindroom.post_response_effects",
+    "mindroom.response_attempt",
     "mindroom.response_lifecycle",
     "mindroom.response_terminal",
     "mindroom.streaming",
@@ -777,6 +778,17 @@ depends_on = [
     "mindroom.hooks",
     "mindroom.post_response_effects",
     "mindroom.tool_system.runtime_context",
+]
+visibility = ["mindroom.response_runner"]
+
+[[modules]]
+path = "mindroom.response_attempt"
+depends_on = [
+    "mindroom.constants",
+    "mindroom.delivery_gateway",
+    "mindroom.logging_config",
+    "mindroom.matrix.presence",
+    "mindroom.orchestration.runtime",
 ]
 visibility = ["mindroom.response_runner"]
 

--- a/tests/test_response_attempt.py
+++ b/tests/test_response_attempt.py
@@ -1,0 +1,241 @@
+"""Response attempt lifecycle helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mindroom import response_attempt as response_attempt_module
+from mindroom.cancellation import SYNC_RESTART_CANCEL_MSG, USER_STOP_CANCEL_MSG
+from mindroom.constants import STREAM_STATUS_KEY, STREAM_STATUS_PENDING
+from mindroom.message_target import MessageTarget
+from mindroom.response_attempt import ResponseAttemptDeps, ResponseAttemptRequest, ResponseAttemptRunner
+
+
+@dataclass
+class _TrackedMessage:
+    reaction_event_id: str | None = None
+
+
+class _StopManager:
+    def __init__(self) -> None:
+        self.tracked_messages: dict[str, _TrackedMessage] = {}
+        self.set_current_calls: list[tuple[str, MessageTarget, object, str | None]] = []
+        self.added_buttons: list[str] = []
+        self.cleared_messages: list[tuple[str, bool]] = []
+        self.add_stop_button_kwargs: list[dict[str, object]] = []
+        self.clear_message_kwargs: list[dict[str, object]] = []
+
+    def set_current(
+        self,
+        message_id: str,
+        target: MessageTarget,
+        task: object,
+        _reaction_event_id: str | None = None,
+        run_id: str | None = None,
+    ) -> None:
+        self.tracked_messages[message_id] = _TrackedMessage()
+        self.set_current_calls.append((message_id, target, task, run_id))
+
+    async def add_stop_button(
+        self,
+        _client: object,
+        message_id: str,
+        **_kwargs: object,
+    ) -> str:
+        self.added_buttons.append(message_id)
+        self.add_stop_button_kwargs.append(_kwargs)
+        self.tracked_messages[message_id].reaction_event_id = "$reaction"
+        return "$reaction"
+
+    def clear_message(
+        self,
+        message_id: str,
+        _client: object,
+        *,
+        remove_button: bool,
+        **_kwargs: object,
+    ) -> None:
+        self.cleared_messages.append((message_id, remove_button))
+        self.clear_message_kwargs.append(_kwargs)
+
+
+class _DeliveryGateway:
+    def __init__(self, event_id: str | None = "$thinking") -> None:
+        self.event_id = event_id
+        self.sent_requests: list[Any] = []
+
+    async def send_text(self, request: object) -> str | None:
+        self.sent_requests.append(request)
+        return self.event_id
+
+
+def _runner(
+    *,
+    delivery_gateway: _DeliveryGateway | None = None,
+    stop_manager: _StopManager | None = None,
+    show_stop_button: bool = False,
+) -> tuple[ResponseAttemptRunner, _DeliveryGateway, _StopManager]:
+    resolved_delivery_gateway = delivery_gateway or _DeliveryGateway()
+    resolved_stop_manager = stop_manager or _StopManager()
+    return (
+        ResponseAttemptRunner(
+            ResponseAttemptDeps(
+                client=MagicMock(user_id="@mindroom_agent:localhost"),
+                delivery_gateway=resolved_delivery_gateway,
+                stop_manager=resolved_stop_manager,
+                logger=MagicMock(),
+                show_stop_button=lambda: show_stop_button,
+                notify_outbound_event=MagicMock(),
+                notify_outbound_redaction=MagicMock(),
+            ),
+        ),
+        resolved_delivery_gateway,
+        resolved_stop_manager,
+    )
+
+
+@pytest.mark.asyncio
+async def test_response_attempt_sends_pending_placeholder_and_tracks_visible_task() -> None:
+    """Thinking messages should be sent as tracked pending placeholders."""
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$reply")
+    runner, delivery_gateway, stop_manager = _runner()
+    seen_message_ids: list[str | None] = []
+
+    async def response_function(message_id: str | None) -> None:
+        seen_message_ids.append(message_id)
+
+    message_id = await runner.run(
+        ResponseAttemptRequest(
+            target=target,
+            response_function=response_function,
+            thinking_message="Thinking...",
+            run_id="run-1",
+        ),
+    )
+
+    assert message_id == "$thinking"
+    assert seen_message_ids == ["$thinking"]
+    assert delivery_gateway.sent_requests[0].target == target
+    assert delivery_gateway.sent_requests[0].response_text == "Thinking..."
+    assert delivery_gateway.sent_requests[0].extra_content == {STREAM_STATUS_KEY: STREAM_STATUS_PENDING}
+    assert stop_manager.set_current_calls[0][0] == "$thinking"
+    assert stop_manager.set_current_calls[0][1] == target
+    assert stop_manager.set_current_calls[0][3] == "run-1"
+    assert stop_manager.cleared_messages == [("$thinking", False)]
+
+
+@pytest.mark.asyncio
+async def test_response_attempt_uses_pending_tracking_key_without_visible_message() -> None:
+    """Responses without a visible message should still be tracked until cleanup."""
+    target = MessageTarget.resolve("!room:localhost", None, "$reply", room_mode=True)
+    runner, delivery_gateway, stop_manager = _runner(delivery_gateway=_DeliveryGateway(event_id=None))
+    seen_message_ids: list[str | None] = []
+
+    async def response_function(message_id: str | None) -> None:
+        seen_message_ids.append(message_id)
+
+    message_id = await runner.run(
+        ResponseAttemptRequest(
+            target=target,
+            response_function=response_function,
+        ),
+    )
+
+    assert message_id is None
+    assert seen_message_ids == [None]
+    assert delivery_gateway.sent_requests == []
+    tracked_id = stop_manager.set_current_calls[0][0]
+    assert tracked_id.startswith("__pending_response__:")
+    assert stop_manager.cleared_messages == [(tracked_id, False)]
+
+
+@pytest.mark.asyncio
+async def test_response_attempt_adds_stop_button_for_online_user_and_removes_it_on_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Online users get a stop reaction that is removed during cleanup."""
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$reply")
+    runner, _delivery_gateway, stop_manager = _runner(show_stop_button=True)
+    is_user_online = AsyncMock(return_value=True)
+    monkeypatch.setattr(response_attempt_module, "is_user_online", is_user_online)
+
+    async def response_function(_message_id: str | None) -> None:
+        return None
+
+    message_id = await runner.run(
+        ResponseAttemptRequest(
+            target=target,
+            response_function=response_function,
+            thinking_message="Thinking...",
+            user_id="@user:localhost",
+        ),
+    )
+
+    assert message_id == "$thinking"
+    is_user_online.assert_awaited_once_with(
+        runner.deps.client,
+        "@user:localhost",
+        room_id="!room:localhost",
+    )
+    assert stop_manager.added_buttons == ["$thinking"]
+    assert stop_manager.add_stop_button_kwargs == [
+        {"notify_outbound_event": runner.deps.notify_outbound_event},
+    ]
+    assert stop_manager.cleared_messages == [("$thinking", True)]
+    assert stop_manager.clear_message_kwargs == [
+        {"notify_outbound_redaction": runner.deps.notify_outbound_redaction},
+    ]
+    runner.deps.logger.info.assert_any_call(
+        "Stop button decision",
+        message_id="$thinking",
+        user_online=True,
+        show_button=True,
+    )
+    runner.deps.logger.info.assert_any_call("Adding stop button", message_id="$thinking")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("cancel_args", "expected_reason", "log_method", "log_message"),
+    [
+        ((USER_STOP_CANCEL_MSG,), "cancelled_by_user", "info", "Response cancelled by user"),
+        ((SYNC_RESTART_CANCEL_MSG,), "sync_restart_cancelled", "info", "Response interrupted by sync restart"),
+        ((), "interrupted", "warning", "Response interrupted — traceback for diagnosis"),
+    ],
+)
+async def test_response_attempt_cancellation_records_reason_logs_provenance_and_clears_tracking(
+    cancel_args: tuple[str, ...],
+    expected_reason: str,
+    log_method: str,
+    log_message: str,
+) -> None:
+    """Cancelled attempts should classify provenance and always clear tracking."""
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$reply")
+    runner, delivery_gateway, stop_manager = _runner()
+    cancellation_reasons: list[str] = []
+
+    async def response_function(_message_id: str | None) -> None:
+        raise asyncio.CancelledError(*cancel_args)
+
+    message_id = await runner.run(
+        ResponseAttemptRequest(
+            target=target,
+            response_function=response_function,
+            existing_event_id="$existing",
+            on_cancelled=cancellation_reasons.append,
+        ),
+    )
+
+    assert message_id == "$existing"
+    assert delivery_gateway.sent_requests == []
+    assert cancellation_reasons == [expected_reason]
+    assert stop_manager.cleared_messages == [("$existing", False)]
+    getattr(runner.deps.logger, log_method).assert_called_once()
+    log_call = getattr(runner.deps.logger, log_method).call_args
+    assert log_call.args[0] == log_message
+    assert log_call.kwargs["message_id"] == "$existing"

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -108,7 +108,7 @@ class TestRoutingRegression:
     """Regression tests for routing behavior."""
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_runner.is_user_online")
+    @patch("mindroom.response_attempt.is_user_online")
     @patch("mindroom.response_runner.ai_response")
     @patch("mindroom.turn_controller.suggest_agent_for_message")
     async def test_router_does_not_respond_when_agent_mentioned(
@@ -739,7 +739,7 @@ class TestRoutingRegression:
         assert mock_team_arun.call_count == 1  # Team formed once
 
     @pytest.mark.asyncio
-    @patch("mindroom.response_runner.is_user_online")
+    @patch("mindroom.response_attempt.is_user_online")
     @patch("mindroom.response_runner.ai_response")
     async def test_router_message_has_completion_marker(
         self,

--- a/tests/test_streaming_e2e.py
+++ b/tests/test_streaming_e2e.py
@@ -182,7 +182,7 @@ async def test_streaming_e2e_worker_warmup_edit_sequence(tmp_path: Path) -> None
 @pytest.mark.e2e  # Mark as end-to-end test
 @pytest.mark.requires_matrix  # Requires real Matrix server for streaming e2e test
 @pytest.mark.timeout(10)  # Add timeout to prevent hanging on real server connection
-@patch("mindroom.response_runner.is_user_online")
+@patch("mindroom.response_attempt.is_user_online")
 @patch("mindroom.matrix.users._ensure_all_agent_users")
 @patch("mindroom.bot.login_agent_user")
 @patch("mindroom.bot.AgentBot.ensure_user_account")


### PR DESCRIPTION
## Summary
- Move visible response attempt mechanics into `ResponseAttemptRunner`: pending placeholder send, stop tracking, cancellation provenance logging, and cleanup.
- Keep `ResponseRunner.run_cancellable_response` as the existing entry point while delegating the attempt mechanics to the narrower module.
- Update Tach boundaries, architecture notes, and lifecycle tests to make the new owner explicit.
- Include pre-commit formatting for the newly rebased upstream Postgres DNS regression test.

## Verification
- `uv sync --all-extras`
- `uv run pytest` -> 5595 passed, 28 skipped
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --all-files`
- `uv run pytest tests/test_response_attempt.py tests/test_event_cache_backends.py::test_postgres_transient_classifier_accepts_dns_resolution_failure -q` -> 3 passed
