### PR TITLE
Handle Matrix delivery failures in coalesced responses

### DIFF
--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -14,6 +14,7 @@ from .attachments import merge_attachment_ids, parse_attachment_ids_from_event_s
 from .commands.parsing import command_parser
 from .constants import ATTACHMENT_IDS_KEY, ORIGINAL_SENDER_KEY, VOICE_RAW_AUDIO_FALLBACK_KEY
 from .hooks.ingress import is_voice_event
+from .logging_config import get_logger
 from .matrix.media import extract_media_caption
 from .timing import emit_elapsed_timing, event_timing_scope
 
@@ -39,6 +40,7 @@ __all__ = [
 _UPLOAD_GRACE_HARD_CAP_MULTIPLIER = 4.0
 _UPLOAD_GRACE_MAX_HARD_CAP_SECONDS = 2.0
 _COALESCING_EXEMPT_SOURCE_KINDS: frozenset[str] = frozenset({"hook", "hook_dispatch"})
+logger = get_logger(__name__)
 
 
 class GatePhase(enum.Enum):
@@ -554,18 +556,38 @@ class CoalescingGate:
                 await asyncio.sleep(max(delay, 0.0))
             except asyncio.CancelledError:
                 return
-            current_key, current_gate = self._resolve_gate_entry(key, gate)
-            if current_key is None or current_gate is None or current_gate.timer_task is not asyncio.current_task():
+            current_key: CoalescingKey | None = None
+            try:
+                current_key, current_gate = self._resolve_gate_entry(key, gate)
+                if current_key is None or current_gate is None or current_gate.timer_task is not asyncio.current_task():
+                    return
+                # Keep timer_task alive through the flush so drain_all can await it.
+                await self._flush(current_key, bypass_grace=phase is GatePhase.GRACE)
+                current_key, current_gate = self._resolve_gate_entry(current_key, gate)
+                if (
+                    current_key is not None
+                    and current_gate is not None
+                    and current_gate.timer_task is asyncio.current_task()
+                ):
+                    current_gate.timer_task = None
+            except asyncio.CancelledError:
                 return
-            # Keep timer_task alive through the flush so drain_all can await it.
-            await self._flush(current_key, bypass_grace=phase is GatePhase.GRACE)
-            current_key, current_gate = self._resolve_gate_entry(current_key, gate)
-            if (
-                current_key is not None
-                and current_gate is not None
-                and current_gate.timer_task is asyncio.current_task()
-            ):
-                current_gate.timer_task = None
+            except Exception as error:
+                log_key = current_key or key
+                logger.exception(
+                    "Coalescing timer callback failed",
+                    room_id=log_key[0],
+                    thread_id=log_key[1],
+                    requester_user_id=log_key[2],
+                    error=str(error),
+                )
+                current_key, current_gate = self._resolve_gate_entry(log_key, gate)
+                if (
+                    current_key is not None
+                    and current_gate is not None
+                    and current_gate.timer_task is asyncio.current_task()
+                ):
+                    current_gate.timer_task = None
 
         gate.timer_task = asyncio.create_task(_timer_callback())
 

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -579,7 +579,8 @@ class CoalescingGate:
                     room_id=log_key[0],
                     thread_id=log_key[1],
                     requester_user_id=log_key[2],
-                    error=str(error),
+                    exception_type=error.__class__.__name__,
+                    error_message="Coalesced dispatch failed.",
                 )
                 current_key, current_gate = self._resolve_gate_entry(log_key, gate)
                 if (

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -61,6 +61,22 @@ if TYPE_CHECKING:
     from mindroom.timing import DispatchPipelineTiming
     from mindroom.tool_system.events import ToolTraceEntry
 
+_PLACEHOLDER_DELIVERY_FAILURE_TEXT = "Response delivery failed. Please retry."
+_PLACEHOLDER_DELIVERY_FAILURE_REASONS = frozenset(
+    {
+        "delivery_failed",
+        "terminal_update_cancelled",
+        "terminal_update_failed",
+    },
+)
+
+
+def _is_placeholder_delivery_failure(failure_reason: str) -> bool:
+    """Return whether a placeholder-only error came from Matrix delivery itself."""
+    return failure_reason in _PLACEHOLDER_DELIVERY_FAILURE_REASONS or failure_reason.startswith(
+        "terminal_update_exception:",
+    )
+
 
 @dataclass
 class ResponseHookService:
@@ -436,6 +452,60 @@ class DeliveryGateway:
             return failure_reason or f"failed to redact suppressed response {event_id}"
         return None
 
+    async def _deliver_placeholder_failure_update(
+        self,
+        *,
+        target: MessageTarget,
+        event_id: str,
+        response_kind: str,
+        response_envelope: MessageEnvelope,
+        correlation_id: str,
+        failure_reason: str,
+        tool_trace: list[ToolTraceEntry] | None,
+        extra_content: dict[str, Any] | None,
+    ) -> FinalDeliveryOutcome:
+        """Best-effort terminal error edit for a visible placeholder."""
+        failure_extra_content = dict(extra_content or {})
+        failure_extra_content[constants.STREAM_STATUS_KEY] = constants.STREAM_STATUS_ERROR
+        edited = await self.edit_text(
+            EditTextRequest(
+                target=target,
+                event_id=event_id,
+                new_text=_PLACEHOLDER_DELIVERY_FAILURE_TEXT,
+                tool_trace=tool_trace,
+                extra_content=failure_extra_content,
+            ),
+        )
+        if edited:
+            return FinalDeliveryOutcome(
+                terminal_status="error",
+                event_id=event_id,
+                is_visible_response=True,
+                final_visible_body=_PLACEHOLDER_DELIVERY_FAILURE_TEXT,
+                delivery_kind="edited",
+                failure_reason=failure_reason,
+                tool_trace=tuple(tool_trace or ()),
+                extra_content=failure_extra_content,
+            )
+
+        self.deps.logger.error(
+            "Failed to deliver placeholder failure update",
+            room_id=target.room_id,
+            event_id=event_id,
+            response_kind=response_kind,
+            source_event_id=response_envelope.source_event_id,
+            correlation_id=correlation_id,
+            failure_reason=failure_reason,
+        )
+        return FinalDeliveryOutcome(
+            terminal_status="error",
+            event_id=event_id,
+            is_visible_response=True,
+            failure_reason=failure_reason,
+            tool_trace=tuple(tool_trace or ()),
+            extra_content=failure_extra_content,
+        )
+
     async def send_text(self, request: SendTextRequest) -> str | None:
         """Send one response message to a room."""
         client = self._client()
@@ -709,29 +779,14 @@ class DeliveryGateway:
                 )
 
             if request.existing_event_is_placeholder:
-                cleanup_failure = await self._redact_visible_response_event(
-                    room_id=request.target.room_id,
+                return await self._deliver_placeholder_failure_update(
+                    target=request.target,
                     event_id=request.existing_event_id,
                     response_kind=request.response_kind,
                     response_envelope=request.response_envelope,
                     correlation_id=request.correlation_id,
-                    redaction_reason="Failed placeholder response",
                     failure_reason="delivery_failed",
-                )
-                if cleanup_failure is not None:
-                    return FinalDeliveryOutcome(
-                        terminal_status="error",
-                        event_id=request.existing_event_id,
-                        is_visible_response=True,
-                        failure_reason=cleanup_failure,
-                        tool_trace=tuple(draft.tool_trace or ()),
-                        extra_content=draft.extra_content,
-                    )
-                return FinalDeliveryOutcome(
-                    terminal_status="error",
-                    event_id=None,
-                    failure_reason="delivery_failed",
-                    tool_trace=tuple(draft.tool_trace or ()),
+                    tool_trace=draft.tool_trace,
                     extra_content=draft.extra_content,
                 )
             return FinalDeliveryOutcome(
@@ -1134,7 +1189,26 @@ class DeliveryGateway:
                         )
                 failure_reason = stream_outcome.failure_reason or "stream_finalize_error"
                 if stream_outcome.visible_body_state == "placeholder_only":
-                    cleanup_outcome = await self._cleanup_completed_placeholder_only_stream(
+                    if stream_outcome.last_physical_stream_event_id is None:
+                        return FinalDeliveryOutcome(
+                            terminal_status="error",
+                            event_id=None,
+                            failure_reason=failure_reason,
+                            tool_trace=tuple(request.tool_trace or ()),
+                            extra_content=request.extra_content,
+                        )
+                    if _is_placeholder_delivery_failure(failure_reason):
+                        return await self._deliver_placeholder_failure_update(
+                            target=request.target,
+                            event_id=stream_outcome.last_physical_stream_event_id,
+                            response_kind=request.response_kind,
+                            response_envelope=request.response_envelope,
+                            correlation_id=request.correlation_id,
+                            failure_reason=failure_reason,
+                            tool_trace=request.tool_trace,
+                            extra_content=request.extra_content,
+                        )
+                    return await self._cleanup_completed_placeholder_only_stream(
                         room_id=request.target.room_id,
                         streamed_event_id=stream_outcome.last_physical_stream_event_id,
                         response_kind=request.response_kind,
@@ -1142,15 +1216,6 @@ class DeliveryGateway:
                         correlation_id=request.correlation_id,
                         failure_reason=failure_reason,
                         tool_trace=request.tool_trace,
-                        extra_content=request.extra_content,
-                    )
-                    if cleanup_outcome.event_id is not None:
-                        return cleanup_outcome
-                    return FinalDeliveryOutcome(
-                        terminal_status="error",
-                        event_id=None,
-                        failure_reason=failure_reason,
-                        tool_trace=tuple(request.tool_trace or ()),
                         extra_content=request.extra_content,
                     )
 

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 import nio
 from nio import crypto
 from nio.api import Api
+from nio.exceptions import OlmTrustError
 
 from mindroom.logging_config import get_logger
 from mindroom.matrix.large_messages import prepare_large_message
@@ -27,6 +28,9 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_MATRIX_TRUST_DELIVERY_ERROR_MESSAGE = "Matrix encrypted delivery rejected by local device trust policy."
+_MATRIX_GENERIC_DELIVERY_ERROR_MESSAGE = "Matrix delivery raised an unexpected local exception."
+
 
 @dataclass(frozen=True, slots=True)
 class DeliveredMatrixEvent:
@@ -34,6 +38,83 @@ class DeliveredMatrixEvent:
 
     event_id: str
     content_sent: dict[str, Any]
+
+
+def _sanitized_delivery_error_message(error: Exception) -> str:
+    """Return a log-safe Matrix delivery failure message."""
+    if isinstance(error, OlmTrustError):
+        return _MATRIX_TRUST_DELIVERY_ERROR_MESSAGE
+    return _MATRIX_GENERIC_DELIVERY_ERROR_MESSAGE
+
+
+def _log_matrix_delivery_exception(
+    error: Exception,
+    *,
+    room_id: str,
+    operation: str,
+    cache_bypass: bool,
+) -> None:
+    """Log one local Matrix send/edit exception without exposing device details."""
+    logger.error(
+        "matrix_message_delivery_exception",
+        room_id=room_id,
+        operation=operation,
+        cache_bypass=cache_bypass,
+        exception_type=error.__class__.__name__,
+        error_message=_sanitized_delivery_error_message(error),
+    )
+
+
+async def _send_prepared_room_message(
+    client: nio.AsyncClient,
+    room_id: str,
+    content_sent: dict[str, Any],
+    *,
+    message_type: str,
+    cache_bypass: bool,
+    operation: str,
+) -> object | None:
+    """Send one prepared Matrix room message and normalize local delivery exceptions."""
+    try:
+        if cache_bypass:
+            access_token = client.access_token
+            if not access_token:
+                _log_matrix_delivery_exception(
+                    nio.LocalProtocolError("Matrix client access token is required to send a message."),
+                    room_id=room_id,
+                    operation=operation,
+                    cache_bypass=cache_bypass,
+                )
+                return None
+            method, path, data = Api.room_send(
+                access_token,
+                room_id,
+                message_type,
+                content_sent,
+                uuid4(),
+            )
+            return await client._send(
+                nio.RoomSendResponse,
+                method,
+                path,
+                data,
+                response_data=(room_id,),
+            )
+        return await client.room_send(
+            room_id=room_id,
+            message_type=message_type,
+            content=content_sent,
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as error:
+        _log_matrix_delivery_exception(
+            error,
+            room_id=room_id,
+            operation=operation,
+            cache_bypass=cache_bypass,
+        )
+        return None
 
 
 def cached_room(client: nio.AsyncClient, room_id: str) -> nio.MatrixRoom | None:
@@ -65,9 +146,11 @@ async def send_message_result(
     client: nio.AsyncClient,
     room_id: str,
     content: dict[str, Any],
+    *,
+    operation: str = "send_message",
 ) -> DeliveredMatrixEvent | None:
     """Send a message to a Matrix room and return the exact delivered payload."""
-    if not _can_send_to_encrypted_room(client, room_id, operation="send_message"):
+    if not _can_send_to_encrypted_room(client, room_id, operation=operation):
         return None
 
     rooms = client.rooms
@@ -79,7 +162,7 @@ async def send_message_result(
             logger.error(
                 "matrix_encrypted_room_send_requires_synced_room_cache",
                 room_id=room_id,
-                operation="send_message",
+                operation=operation,
                 hint="Wait for initial sync to populate nio's room cache before sending to encrypted rooms.",
             )
             return None
@@ -89,7 +172,7 @@ async def send_message_result(
             logger.error(
                 "matrix_room_send_requires_known_encryption_state",
                 room_id=room_id,
-                operation="send_message",
+                operation=operation,
                 hint="Unable to determine whether the room is encrypted while nio's room cache is empty.",
             )
             return None
@@ -115,31 +198,25 @@ async def send_message_result(
         message_type=message_type,
         cache_bypass=cache_bypass,
     )
-    if cache_bypass:
-        access_token = client.access_token
-        if not access_token:
-            msg = "Matrix client access token is required to send a message."
-            raise nio.LocalProtocolError(msg)
-        method, path, data = Api.room_send(
-            access_token,
-            room_id,
-            message_type,
-            content_sent,
-            uuid4(),
-        )
-        response = await client._send(
-            nio.RoomSendResponse,
-            method,
-            path,
-            data,
-            response_data=(room_id,),
-        )
-    else:
-        response = await client.room_send(
+    response = await _send_prepared_room_message(
+        client,
+        room_id,
+        content_sent,
+        message_type=message_type,
+        cache_bypass=cache_bypass,
+        operation=operation,
+    )
+    if response is None:
+        emit_timing_event(
+            "Matrix send timing",
+            phase="send_finish",
             room_id=room_id,
             message_type=message_type,
-            content=content_sent,
+            cache_bypass=cache_bypass,
+            outcome="error",
+            error="delivery_exception",
         )
+        return None
     if isinstance(response, nio.RoomSendResponse):
         emit_timing_event(
             "Matrix send timing",
@@ -396,7 +473,7 @@ async def edit_message_result(
         extra_content=extra_content,
     )
 
-    return await send_message_result(client, room_id, edit_content)
+    return await send_message_result(client, room_id, edit_content, operation="edit_message")
 
 
 __all__ = [

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -1650,6 +1650,50 @@ async def test_flush_logs_failed_outcome_when_dispatch_batch_raises() -> None:
 
 
 @pytest.mark.asyncio
+async def test_timer_flush_logs_dispatch_failure_without_unhandled_task() -> None:
+    """Timer callbacks should consume dispatch failures instead of leaking task exceptions."""
+    room = _make_room()
+    loop = asyncio.get_running_loop()
+    loop_exceptions: list[dict[str, object]] = []
+    previous_exception_handler = loop.get_exception_handler()
+
+    async def failing_dispatch_batch(_batch: object) -> None:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    gate = CoalescingGate(
+        dispatch_batch=failing_dispatch_batch,
+        debounce_seconds=lambda: 0.01,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+
+    def capture_loop_exception(_loop: asyncio.AbstractEventLoop, context: dict[str, object]) -> None:
+        loop_exceptions.append(context)
+
+    loop.set_exception_handler(capture_loop_exception)
+    try:
+        with patch("mindroom.coalescing.logger.exception") as mock_exception:
+            await gate.enqueue(
+                ("!room:localhost", None, "@user:localhost"),
+                PendingEvent(
+                    event=_text_event(event_id="$m1", body="first"),
+                    room=room,
+                    source_kind="message",
+                ),
+            )
+            await _wait_for(lambda: mock_exception.called)
+    finally:
+        loop.set_exception_handler(previous_exception_handler)
+
+    assert loop_exceptions == []
+    mock_exception.assert_called_once()
+    assert mock_exception.call_args.args == ("Coalescing timer callback failed",)
+    assert mock_exception.call_args.kwargs["error"] == "boom"
+    assert gate.is_idle()
+
+
+@pytest.mark.asyncio
 async def test_cleanup_drains_pending_debounce_tasks(tmp_path: Path) -> None:
     """Drain pending debounce tasks when a bot is cleaned up."""
     bot = _make_bot(tmp_path, debounce_ms=1000)

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -1689,7 +1689,8 @@ async def test_timer_flush_logs_dispatch_failure_without_unhandled_task() -> Non
     assert loop_exceptions == []
     mock_exception.assert_called_once()
     assert mock_exception.call_args.args == ("Coalescing timer callback failed",)
-    assert mock_exception.call_args.kwargs["error"] == "boom"
+    assert mock_exception.call_args.kwargs["exception_type"] == "RuntimeError"
+    assert mock_exception.call_args.kwargs["error_message"] == "Coalesced dispatch failed."
     assert gate.is_idle()
 
 

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import nio
 import pytest
+from nio.exceptions import OlmUnverifiedDeviceError
 
 from mindroom.matrix.client import DeliveredMatrixEvent, join_room
 from mindroom.matrix.client_delivery import (
     _msgtype_for_mimetype,
     _upload_file_as_mxc,
+    edit_message_result,
     send_file_message,
     send_message_result,
 )
@@ -513,6 +516,83 @@ class TestSendMessageResult:
         assert result is not None
         assert result.event_id == "$evt:localhost"
         client.room_send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_room_send_raises_unverified_device_error(self) -> None:
+        """Local E2EE trust failures should not escape text send delivery."""
+        client = _mock_client()
+        client.room_send.side_effect = OlmUnverifiedDeviceError(
+            SimpleNamespace(user_id="@private:localhost", device_id="SECRETDEVICE"),
+            "unverified device @private:localhost SECRETDEVICE",
+        )
+
+        with (
+            patch(
+                "mindroom.matrix.client_delivery.prepare_large_message",
+                new=AsyncMock(side_effect=lambda *_: {"body": "hello", "msgtype": "m.text"}),
+            ),
+            patch("mindroom.matrix.client_delivery.logger.error") as mock_error,
+        ):
+            result = await send_message_result(client, "!room:localhost", {"body": "hello", "msgtype": "m.text"})
+
+        assert result is None
+        mock_error.assert_called_once()
+        assert mock_error.call_args.args == ("matrix_message_delivery_exception",)
+        assert mock_error.call_args.kwargs["exception_type"] == "OlmUnverifiedDeviceError"
+        assert mock_error.call_args.kwargs["error_message"] == (
+            "Matrix encrypted delivery rejected by local device trust policy."
+        )
+
+    @pytest.mark.asyncio
+    async def test_edit_returns_none_when_room_send_raises_unverified_device_error(self) -> None:
+        """Local E2EE trust failures should not escape edit delivery."""
+        client = _mock_client()
+        client.room_send.side_effect = OlmUnverifiedDeviceError(
+            SimpleNamespace(user_id="@private:localhost", device_id="SECRETDEVICE"),
+            "unverified device @private:localhost SECRETDEVICE",
+        )
+
+        with (
+            patch(
+                "mindroom.matrix.client_delivery.prepare_large_message",
+                new=AsyncMock(side_effect=lambda *_: {"body": "hello", "msgtype": "m.text"}),
+            ),
+            patch("mindroom.matrix.client_delivery.logger.error") as mock_error,
+        ):
+            result = await edit_message_result(
+                client,
+                "!room:localhost",
+                "$placeholder",
+                {"body": "hello", "msgtype": "m.text"},
+                "hello",
+            )
+
+        assert result is None
+        assert mock_error.call_args.args == ("matrix_message_delivery_exception",)
+        assert mock_error.call_args.kwargs["operation"] == "edit_message"
+        assert mock_error.call_args.kwargs["exception_type"] == "OlmUnverifiedDeviceError"
+
+    @pytest.mark.asyncio
+    async def test_unexpected_room_send_exception_logs_generic_sanitized_message(self) -> None:
+        """Unexpected local delivery exceptions should log type plus a safe generic message."""
+        client = _mock_client()
+        client.room_send.side_effect = RuntimeError(
+            "failed token=supersecret for @private:localhost via https://matrix.example/private",
+        )
+
+        with (
+            patch(
+                "mindroom.matrix.client_delivery.prepare_large_message",
+                new=AsyncMock(side_effect=lambda *_: {"body": "hello", "msgtype": "m.text"}),
+            ),
+            patch("mindroom.matrix.client_delivery.logger.error") as mock_error,
+        ):
+            result = await send_message_result(client, "!room:localhost", {"body": "hello", "msgtype": "m.text"})
+
+        assert result is None
+        assert mock_error.call_args.args == ("matrix_message_delivery_exception",)
+        assert mock_error.call_args.kwargs["exception_type"] == "RuntimeError"
+        assert mock_error.call_args.kwargs["error_message"] == "Matrix delivery raised an unexpected local exception."
 
 
 class TestJoinRoom:

--- a/tests/test_streaming_finalize.py
+++ b/tests/test_streaming_finalize.py
@@ -15,7 +15,13 @@ from mindroom import interactive
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
-from mindroom.delivery_gateway import DeliveryGateway, DeliveryGatewayDeps, FinalizeStreamedResponseRequest
+from mindroom.constants import STREAM_STATUS_ERROR, STREAM_STATUS_KEY
+from mindroom.delivery_gateway import (
+    DeliveryGateway,
+    DeliveryGatewayDeps,
+    FinalDeliveryRequest,
+    FinalizeStreamedResponseRequest,
+)
 from mindroom.final_delivery import StreamTransportOutcome
 from mindroom.hooks import MessageEnvelope
 from mindroom.logging_config import get_logger
@@ -365,6 +371,133 @@ async def test_transport_empty_adopted_placeholder_finishes_as_error_note(tmp_pa
     assert outcome.terminal_status == "completed"
     assert outcome.rendered_body == "Thinking..."
     assert outcome.visible_body_state == "placeholder_only"
+
+
+@pytest.mark.asyncio
+async def test_final_delivery_failure_replaces_placeholder_with_failure_update(tmp_path: Path) -> None:
+    """A failed final placeholder edit should get one clear terminal failure update when possible."""
+    config = _config(tmp_path)
+    response_hooks = SimpleNamespace(
+        apply_before_response=AsyncMock(
+            return_value=SimpleNamespace(
+                response_text="final answer",
+                response_kind="ai",
+                tool_trace=None,
+                extra_content=None,
+                envelope=_envelope(),
+                suppress=False,
+            ),
+        ),
+        apply_final_response_transform=AsyncMock(),
+        emit_after_response=AsyncMock(),
+        emit_cancelled_response=AsyncMock(),
+    )
+    gateway = DeliveryGateway(
+        DeliveryGatewayDeps(
+            runtime=SimpleNamespace(client=_client(), orchestrator=None, config=config, runtime_started_at=0.0),
+            runtime_paths=runtime_paths_for(config),
+            agent_name="code",
+            logger=Mock(),
+            redact_message_event=AsyncMock(return_value=True),
+            sender_domain="localhost",
+            resolver=Mock(),
+            response_hooks=response_hooks,
+        ),
+    )
+    edit_outcomes = [False, True]
+    object.__setattr__(
+        gateway,
+        "edit_text",
+        AsyncMock(side_effect=lambda _request: edit_outcomes.pop(0)),
+    )
+
+    outcome = await gateway.deliver_final(
+        FinalDeliveryRequest(
+            target=MessageTarget.resolve("!room:localhost", None, "$reply"),
+            existing_event_id="$placeholder",
+            existing_event_is_placeholder=True,
+            response_text="final answer",
+            response_kind="ai",
+            response_envelope=_envelope(),
+            correlation_id="corr-final-delivery-failure",
+            tool_trace=None,
+            extra_content=None,
+        ),
+    )
+
+    assert outcome.terminal_status == "error"
+    assert outcome.final_visible_event_id == "$placeholder"
+    assert outcome.final_visible_body == "Response delivery failed. Please retry."
+    assert outcome.delivery_kind == "edited"
+    assert outcome.failure_reason == "delivery_failed"
+    assert gateway.edit_text.await_count == 2
+    failure_update_request = gateway.edit_text.await_args_list[-1].args[0]
+    assert failure_update_request.new_text == "Response delivery failed. Please retry."
+    assert failure_update_request.extra_content[STREAM_STATUS_KEY] == STREAM_STATUS_ERROR
+
+
+@pytest.mark.asyncio
+async def test_streaming_placeholder_delivery_failure_stays_terminal_when_failure_update_fails(
+    tmp_path: Path,
+) -> None:
+    """If Matrix rejects the failure update too, finalization still returns a failed visible outcome."""
+    config = _config(tmp_path)
+    response_hooks = SimpleNamespace(
+        apply_before_response=AsyncMock(),
+        apply_final_response_transform=AsyncMock(),
+        emit_after_response=AsyncMock(),
+        emit_cancelled_response=AsyncMock(),
+    )
+    logger = Mock()
+    gateway = DeliveryGateway(
+        DeliveryGatewayDeps(
+            runtime=SimpleNamespace(client=_client(), orchestrator=None, config=config, runtime_started_at=0.0),
+            runtime_paths=runtime_paths_for(config),
+            agent_name="code",
+            logger=logger,
+            redact_message_event=AsyncMock(return_value=True),
+            sender_domain="localhost",
+            resolver=Mock(),
+            response_hooks=response_hooks,
+        ),
+    )
+    object.__setattr__(gateway, "edit_text", AsyncMock(return_value=False))
+
+    outcome = await gateway.finalize_streamed_response(
+        FinalizeStreamedResponseRequest(
+            target=MessageTarget.resolve("!room:localhost", None, "$reply"),
+            stream_transport_outcome=StreamTransportOutcome(
+                last_physical_stream_event_id="$placeholder",
+                terminal_status="error",
+                rendered_body="Thinking...",
+                visible_body_state="placeholder_only",
+                failure_reason="terminal_update_failed",
+            ),
+            initial_delivery_kind="edited",
+            response_kind="ai",
+            response_envelope=_envelope(),
+            correlation_id="corr-stream-delivery-failure",
+            tool_trace=None,
+            extra_content=None,
+            existing_event_id="$placeholder",
+            existing_event_is_placeholder=True,
+        ),
+    )
+
+    assert outcome.terminal_status == "error"
+    assert outcome.final_visible_event_id == "$placeholder"
+    assert outcome.final_visible_body is None
+    assert outcome.failure_reason == "terminal_update_failed"
+    assert outcome.mark_handled is True
+    logger.error.assert_called_once_with(
+        "Failed to deliver placeholder failure update",
+        room_id="!room:localhost",
+        event_id="$placeholder",
+        response_kind="ai",
+        source_event_id="$reply",
+        correlation_id="corr-stream-delivery-failure",
+        failure_reason="terminal_update_failed",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- normalize local Matrix send/edit exceptions into failed delivery results with sanitized structured logs
- turn placeholder delivery failures into terminal response outcomes, with a best-effort visible error update
- guard coalescing timer callbacks so dispatch failures do not leak as unhandled task exceptions

## Tests
- uv run pytest
- uv run pytest tests/test_send_file_message.py tests/test_streaming_finalize.py tests/test_live_message_coalescing.py tests/test_event_cache_backends.py -n 0 --no-cov -v
- uv run pre-commit run --all-files