### PR TITLE
Extract shared agent run knowledge context

### DIFF
--- a/src/mindroom/agent_run_context.py
+++ b/src/mindroom/agent_run_context.py
@@ -1,0 +1,36 @@
+"""Shared agent-run context helpers used by Matrix and OpenAI-compatible adapters."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.hooks import EnrichmentItem
+from mindroom.knowledge import format_knowledge_availability_notice
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from mindroom.knowledge import KnowledgeAvailabilityDetail
+
+
+def append_knowledge_availability_enrichment(
+    system_enrichment_items: Sequence[EnrichmentItem],
+    unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
+) -> tuple[EnrichmentItem, ...]:
+    """Append one volatile knowledge-availability notice when needed."""
+    notice = format_knowledge_availability_notice(unavailable_bases)
+    if notice is None:
+        return tuple(system_enrichment_items)
+    return (
+        *system_enrichment_items,
+        EnrichmentItem(key="knowledge_availability", text=notice, cache_policy="volatile"),
+    )
+
+
+def prepend_knowledge_availability_notice(
+    prompt: str,
+    unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
+) -> str:
+    """Prefix one user prompt with the degraded-knowledge notice when needed."""
+    notice = format_knowledge_availability_notice(unavailable_bases)
+    return f"{notice}\n\n{prompt}" if notice else prompt

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -36,6 +36,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from starlette.background import BackgroundTask
 
+from mindroom.agent_run_context import prepend_knowledge_availability_notice
 from mindroom.ai import AIStreamChunk, ai_response, stream_agent_response
 from mindroom.api import config_lifecycle
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths, runtime_env_flag
@@ -51,7 +52,6 @@ from mindroom.history import (
 )
 from mindroom.knowledge import (
     KnowledgeAvailabilityDetail,
-    format_knowledge_availability_notice,
     resolve_agent_knowledge_access,
 )
 from mindroom.logging_config import get_logger
@@ -84,7 +84,7 @@ _TEAM_MODEL_PREFIX = "team/"
 _RESERVED_MODEL_NAMES = {_AUTO_MODEL_NAME}
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping, Sequence
+    from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
 
     from agno.agent import Agent
     from agno.db.base import BaseDb
@@ -787,15 +787,6 @@ def _log_missing_knowledge_bases(agent_name: str) -> Callable[[list[str]], None]
     )
 
 
-def _prepend_knowledge_availability_notice(
-    prompt: str,
-    unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
-) -> str:
-    """Prefix the prompt with the degraded-knowledge notice when shared bases are unavailable."""
-    availability_hint = format_knowledge_availability_notice(unavailable_bases)
-    return f"{availability_hint}\n\n{prompt}" if availability_hint else prompt
-
-
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -970,9 +961,7 @@ async def chat_completions(  # noqa: C901, PLR0912
                     _log_missing_knowledge_bases(agent_name)(list(knowledge_resolution.missing))
                 knowledge = knowledge_resolution.knowledge
                 unavailable_bases = dict(knowledge_resolution.unavailable)
-            availability_hint = format_knowledge_availability_notice(unavailable_bases)
-            if availability_hint:
-                prompt = f"{availability_hint}\n\n{prompt}"
+            prompt = prepend_knowledge_availability_notice(prompt, unavailable_bases)
             if req.stream:
                 response = await _stream_completion(
                     agent_name,
@@ -1558,7 +1547,7 @@ async def _non_stream_team_completion(
             )
 
             try:
-                prompt = _prepend_knowledge_availability_notice(
+                prompt = prepend_knowledge_availability_notice(
                     prompt,
                     unavailable_bases,
                 )
@@ -1692,7 +1681,7 @@ async def _stream_team_completion(  # noqa: C901, PLR0915
         )
 
         try:
-            prompt = _prepend_knowledge_availability_notice(
+            prompt = prepend_knowledge_availability_notice(
                 prompt,
                 unavailable_bases,
             )

--- a/src/mindroom/custom_tools/delegate.py
+++ b/src/mindroom/custom_tools/delegate.py
@@ -14,12 +14,9 @@ from uuid import uuid4
 from agno.tools import Toolkit
 
 from mindroom.agent_descriptions import describe_agent
+from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.ai import ai_response
-from mindroom.hooks import EnrichmentItem
-from mindroom.knowledge import (
-    format_knowledge_availability_notice,
-    resolve_agent_knowledge_access,
-)
+from mindroom.knowledge import resolve_agent_knowledge_access
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.runtime_context import (
     ToolRuntimeContext,
@@ -113,12 +110,10 @@ class DelegateTools(Toolkit):
                 refresh_scheduler=self._refresh_scheduler,
                 execution_identity=execution_identity,
             )
-            system_enrichment_items: tuple[EnrichmentItem, ...] = ()
-            notice = format_knowledge_availability_notice(knowledge_resolution.unavailable)
-            if notice is not None:
-                system_enrichment_items = (
-                    EnrichmentItem(key="knowledge_availability", text=notice, cache_policy="volatile"),
-                )
+            system_enrichment_items = append_knowledge_availability_enrichment(
+                (),
+                knowledge_resolution.unavailable,
+            )
             logger.info(
                 "Delegating task",
                 from_agent=self._agent_name,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -12,6 +12,7 @@ from zoneinfo import ZoneInfo
 
 from agno.db.base import SessionType
 
+from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.agents import show_tool_calls_for_agent
 from mindroom.ai import (
     ai_response,
@@ -31,11 +32,6 @@ from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.hooks import (
     EnrichmentItem,
     MessageEnvelope,
-)
-from mindroom.knowledge import (
-    KnowledgeAccessSupport,
-    KnowledgeAvailabilityDetail,
-    format_knowledge_availability_notice,
 )
 from mindroom.matrix.client_visible_messages import replace_visible_message
 from mindroom.matrix.identity import is_agent_id
@@ -103,6 +99,7 @@ if TYPE_CHECKING:
     from mindroom.conversation_resolver import ConversationResolver
     from mindroom.conversation_state_writer import ConversationStateWriter
     from mindroom.history import CompactionOutcome, HistoryScope, PostResponseCompactionCheck
+    from mindroom.knowledge import KnowledgeAccessSupport
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.identity import MatrixID
     from mindroom.message_target import MessageTarget
@@ -117,20 +114,6 @@ _ToolContextResult = TypeVar("_ToolContextResult")
 _ToolStreamChunk = TypeVar("_ToolStreamChunk")
 _VISIBLE_TOOL_MARKER_LINE_PATTERN = re.compile(r"^\s*🔧 `[^`]+` \[\d+\](?: ⏳)?\s*$")
 _VISIBLE_TOOL_MARKER_SEPARATOR_PATTERN = re.compile(r"^\s{0,3}---\s*$")
-
-
-def _append_knowledge_availability_enrichment(
-    system_enrichment_items: Sequence[EnrichmentItem],
-    unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
-) -> tuple[EnrichmentItem, ...]:
-    """Append one volatile knowledge-availability notice when needed."""
-    notice = format_knowledge_availability_notice(unavailable_bases)
-    if notice is None:
-        return tuple(system_enrichment_items)
-    return (
-        *system_enrichment_items,
-        EnrichmentItem(key="knowledge_availability", text=notice, cache_policy="volatile"),
-    )
 
 
 def _merge_response_extra_content(
@@ -1495,7 +1478,7 @@ class ResponseRunner:
                 self.deps.agent_name,
                 execution_identity=runtime.tool_dispatch.execution_identity,
             )
-            system_enrichment_items = _append_knowledge_availability_enrichment(
+            system_enrichment_items = append_knowledge_availability_enrichment(
                 request.system_enrichment_items,
                 knowledge_resolution.unavailable,
             )
@@ -1585,7 +1568,7 @@ class ResponseRunner:
             self.deps.agent_name,
             execution_identity=runtime.tool_dispatch.execution_identity,
         )
-        system_enrichment_items = _append_knowledge_availability_enrichment(
+        system_enrichment_items = append_knowledge_availability_enrichment(
             request.system_enrichment_items,
             knowledge_resolution.unavailable,
         )

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -28,6 +28,7 @@ from agno.team import Team
 from pydantic import BaseModel, Field
 
 from mindroom import ai_runtime, model_loading
+from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.agent_storage import get_team_session
 from mindroom.agents import create_agent
 from mindroom.ai import build_matrix_run_metadata
@@ -49,11 +50,7 @@ from mindroom.history import (
 )
 from mindroom.history.interrupted_replay import split_interrupted_tool_trace, tool_execution_call_id
 from mindroom.hooks import EnrichmentItem, render_system_enrichment_block
-from mindroom.knowledge import (
-    KnowledgeAvailabilityDetail,
-    format_knowledge_availability_notice,
-    resolve_agent_knowledge_access,
-)
+from mindroom.knowledge import KnowledgeAvailabilityDetail, resolve_agent_knowledge_access
 from mindroom.logging_config import get_logger
 from mindroom.matrix.rooms import get_room_alias_from_id
 from mindroom.media_fallback import append_inline_media_fallback_prompt, should_retry_without_inline_media
@@ -73,7 +70,7 @@ from mindroom.tool_system.events import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable, Collection, Mapping, Sequence
+    from collections.abc import AsyncIterator, Callable, Collection, Sequence
 
     import nio
     from agno.db.base import BaseDb
@@ -102,20 +99,6 @@ _MATRIX_TEAM_THREAD_HISTORY_RENDER_LIMITS = ThreadHistoryRenderLimits(
     max_message_length=_MAX_CONTEXT_MESSAGE_LENGTH,
     missing_sender_label="Unknown",
 )
-
-
-def _append_knowledge_availability_enrichment(
-    system_enrichment_items: Sequence[EnrichmentItem],
-    unavailable_bases: Mapping[str, KnowledgeAvailabilityDetail],
-) -> tuple[EnrichmentItem, ...]:
-    """Append one volatile knowledge-availability notice when needed."""
-    notice = format_knowledge_availability_notice(unavailable_bases)
-    if notice is None:
-        return tuple(system_enrichment_items)
-    return (
-        *system_enrichment_items,
-        EnrichmentItem(key="knowledge_availability", text=notice, cache_policy="volatile"),
-    )
 
 
 @dataclass
@@ -1510,7 +1493,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
         )
     except ValueError as exc:
         return str(exc)
-    system_enrichment_items = _append_knowledge_availability_enrichment(
+    system_enrichment_items = append_knowledge_availability_enrichment(
         system_enrichment_items,
         unavailable_bases,
     )
@@ -1868,7 +1851,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
     except ValueError as exc:
         yield str(exc)
         return
-    system_enrichment_items = _append_knowledge_availability_enrichment(
+    system_enrichment_items = append_knowledge_availability_enrichment(
         system_enrichment_items,
         unavailable_bases,
     )

--- a/tach.toml
+++ b/tach.toml
@@ -107,6 +107,7 @@ depends_on = [
 ]
 visibility = [
     "mindroom.api.openai_compat",
+    "mindroom.custom_tools.delegate",
     "mindroom.response_runner",
     "mindroom.teams",
 ]
@@ -194,11 +195,11 @@ depends_on = ["mindroom.memory"]
 [[modules]]
 path = "mindroom.custom_tools.delegate"
 depends_on = [
+    "mindroom.agent_run_context",
     "mindroom.agent_descriptions",
     "mindroom.ai",
     "mindroom.config.main",
     "mindroom.constants",
-    "mindroom.hooks",
     "mindroom.knowledge",
     "mindroom.logging_config",
     "mindroom.tool_system.runtime_context",

--- a/tach.toml
+++ b/tach.toml
@@ -100,6 +100,18 @@ visibility = [
 ]
 
 [[modules]]
+path = "mindroom.agent_run_context"
+depends_on = [
+    "mindroom.hooks",
+    "mindroom.knowledge",
+]
+visibility = [
+    "mindroom.api.openai_compat",
+    "mindroom.response_runner",
+    "mindroom.teams",
+]
+
+[[modules]]
 path = "mindroom.agent_prompts"
 depends_on = []
 visibility = ["mindroom.agents"]
@@ -291,6 +303,7 @@ depends_on = [
 [[modules]]
 path = "mindroom.api.openai_compat"
 depends_on = [
+    "mindroom.agent_run_context",
     "mindroom.ai",
     "mindroom.api.config_lifecycle",
     "mindroom.constants",
@@ -748,6 +761,7 @@ depends_on = [
 [[modules]]
 path = "mindroom.response_runner"
 depends_on = [
+    "mindroom.agent_run_context",
     "mindroom.agents",
     "mindroom.ai",
     "mindroom.constants",
@@ -756,7 +770,6 @@ depends_on = [
     "mindroom.history.interrupted_replay",
     "mindroom.history.turn_recorder",
     "mindroom.hooks",
-    "mindroom.knowledge",
     "mindroom.matrix.client_visible_messages",
     "mindroom.memory",
     "mindroom.orchestration.runtime",
@@ -810,6 +823,7 @@ depends_on = [
 [[modules]]
 path = "mindroom.teams"
 depends_on = [
+    "mindroom.agent_run_context",
     "mindroom.agent_storage",
     "mindroom.agents",
     "mindroom.ai",

--- a/tests/test_agent_run_context.py
+++ b/tests/test_agent_run_context.py
@@ -1,0 +1,50 @@
+"""Tests for shared agent-run context helpers."""
+
+from __future__ import annotations
+
+from mindroom.agent_run_context import (
+    append_knowledge_availability_enrichment,
+    prepend_knowledge_availability_notice,
+)
+from mindroom.hooks import EnrichmentItem
+from mindroom.knowledge import KnowledgeAvailability, KnowledgeAvailabilityDetail
+
+
+def test_append_knowledge_availability_enrichment_adds_volatile_notice() -> None:
+    """Unavailable knowledge should add one volatile system enrichment item."""
+    existing = (EnrichmentItem(key="room", text="Room context", cache_policy="ephemeral"),)
+    enriched = append_knowledge_availability_enrichment(
+        existing,
+        {
+            "docs": KnowledgeAvailabilityDetail(
+                availability=KnowledgeAvailability.INITIALIZING,
+                search_available=False,
+            ),
+        },
+    )
+
+    assert enriched[:-1] == existing
+    assert enriched[-1].key == "knowledge_availability"
+    assert enriched[-1].cache_policy == "volatile"
+    assert "Knowledge base `docs` is initializing" in enriched[-1].text
+
+
+def test_prepend_knowledge_availability_notice_leaves_ready_prompt_unchanged() -> None:
+    """Prompts should not change when every configured knowledge base is ready."""
+    assert prepend_knowledge_availability_notice("Answer the question", {}) == "Answer the question"
+
+
+def test_prepend_knowledge_availability_notice_prefixes_degraded_prompt() -> None:
+    """The OpenAI-compatible adapter should receive the same degraded-knowledge wording."""
+    prompt = prepend_knowledge_availability_notice(
+        "Answer the question",
+        {
+            "docs": KnowledgeAvailabilityDetail(
+                availability=KnowledgeAvailability.REFRESH_FAILED,
+                search_available=True,
+            ),
+        },
+    )
+
+    assert prompt.endswith("\n\nAnswer the question")
+    assert "Knowledge base `docs` had a recent refresh failure" in prompt

--- a/tests/test_agent_run_context.py
+++ b/tests/test_agent_run_context.py
@@ -12,7 +12,7 @@ from mindroom.knowledge import KnowledgeAvailability, KnowledgeAvailabilityDetai
 
 def test_append_knowledge_availability_enrichment_adds_volatile_notice() -> None:
     """Unavailable knowledge should add one volatile system enrichment item."""
-    existing = (EnrichmentItem(key="room", text="Room context", cache_policy="ephemeral"),)
+    existing = (EnrichmentItem(key="room", text="Room context", cache_policy="stable"),)
     enriched = append_knowledge_availability_enrichment(
         existing,
         {

--- a/tests/test_config_architecture_boundaries.py
+++ b/tests/test_config_architecture_boundaries.py
@@ -16,6 +16,11 @@ RUNTIME_PROTOCOLS_MODULE = Path("src/mindroom/runtime_protocols.py")
 MATRIX_MESSAGE_TOOL_MODULE = Path("src/mindroom/custom_tools/matrix_message.py")
 RESPONSE_RUNNER_MODULE = Path("src/mindroom/response_runner.py")
 RESPONSE_LIFECYCLE_MODULE = Path("src/mindroom/response_lifecycle.py")
+KNOWLEDGE_AVAILABILITY_NOTICE_OWNER_MODULES = {
+    Path("src/mindroom/agent_run_context.py"),
+    Path("src/mindroom/knowledge/__init__.py"),
+    Path("src/mindroom/knowledge/utils.py"),
+}
 MATRIX_MESSAGE_LOW_LEVEL_IMPORTS = frozenset(
     {
         "mindroom.custom_tools.attachments",
@@ -222,3 +227,21 @@ def test_response_lifecycle_does_not_reach_into_response_runner_internals() -> N
             found.append(f"{RESPONSE_LIFECYCLE_MODULE}:{node.lineno}: {node.attr}")
 
     assert found == []
+
+
+def test_agent_run_context_owns_knowledge_availability_notice_injection() -> None:
+    """Agent-run adapters use the shared helper instead of formatting availability notices inline."""
+    forbidden: list[str] = []
+    for source_path in PRODUCTION_MODULES:
+        if source_path in KNOWLEDGE_AVAILABILITY_NOTICE_OWNER_MODULES:
+            continue
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "mindroom.knowledge":
+                imported_names = [alias.name for alias in node.names]
+                if "format_knowledge_availability_notice" in imported_names:
+                    forbidden.append(f"{source_path}:{node.lineno}: from {node.module}")
+            if isinstance(node, ast.Name) and node.id == "format_knowledge_availability_notice":
+                forbidden.append(f"{source_path}:{node.lineno}: {node.id}")
+
+    assert forbidden == []


### PR DESCRIPTION
## Summary
- Add a shared `agent_run_context` module for degraded knowledge availability notices.
- Reuse it from Matrix response turns, team execution, and the OpenAI-compatible `/v1` adapter.
- Update Tach boundaries and add focused tests for the shared context behavior.

## Verification
- `uv run tach check --dependencies --interfaces`
- `uv run pytest tests/test_agent_run_context.py tests/test_openai_compat.py tests/test_team_media_fallback.py tests/test_streaming_finalize.py tests/test_cancelled_response_hook.py -q -n 0 --no-cov`
- `uv run pre-commit run --all-files`
- `uv run pytest` (`5613 passed, 28 skipped`)