### PR TITLE
Add runtime-only Helm chart

### DIFF
--- a/cluster/k8s/runtime/Chart.yaml
+++ b/cluster/k8s/runtime/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: mindroom-runtime
+description: Runtime-only MindRoom chart for clusters that provide Matrix, storage, and platform services externally
+type: application
+version: 0.1.0
+appVersion: "0.0.0"

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -1,0 +1,92 @@
+# MindRoom Runtime Chart
+
+This chart deploys only the MindRoom runtime. It is for clusters that already
+provide the surrounding platform pieces such as Matrix, ingress, storage,
+secrets, model gateways, and optional backing services.
+
+Use the instance chart in `cluster/k8s/instance` when you want a complete
+MindRoom instance with its own Matrix homeserver. Use this chart when MindRoom
+should run inside an existing platform.
+
+## Minimal Install
+
+```bash
+helm upgrade --install mindroom-runtime ./cluster/k8s/runtime \
+  --namespace mindroom \
+  --create-namespace
+```
+
+The default values render a self-contained Deployment, Service, ConfigMap, and
+PVC. A real deployment should provide a useful config and Matrix settings.
+
+## Existing Platform Example
+
+```yaml
+image:
+  repository: ghcr.io/mindroom-ai/mindroom
+  tag: latest
+
+config:
+  create: false
+  existingConfigMap: mindroom-config
+  key: config.yaml
+
+storage:
+  create: false
+  existingClaim: mindroom-data
+  mountPath: /app/agent_data
+
+matrix:
+  homeserverUrl: http://matrix.example.svc.cluster.local:8008
+  serverName: example.com
+  registrationToken:
+    existingSecret: mindroom-secrets
+    key: MATRIX_REGISTRATION_TOKEN
+
+env:
+  envFrom:
+    - secretRef:
+        name: mindroom-secrets
+    - configMapRef:
+        name: mindroom-env
+
+workers:
+  backend: kubernetes
+  sandbox:
+    proxyTools: shell,file,python,coding
+    proxyToken:
+      existingSecret: mindroom-sandbox-proxy
+      key: MINDROOM_SANDBOX_PROXY_TOKEN
+  kubernetes:
+    serviceAccount:
+      name: mindroom-worker
+    port: 8766
+    storageSubpathPrefix: workers
+    readyTimeoutSeconds: 180
+    idleTimeoutSeconds: 3600
+```
+
+## Notes
+
+- The chart does not create ingress or a Matrix homeserver.
+- Set `workers.sandbox.proxyToken.existingSecret` or
+  `workers.sandbox.proxyToken.value` when sandbox proxying is enabled.
+- `workers.backend: static_runner` adds a sandbox-runner sidecar to the runtime
+  pod.
+- `workers.backend: kubernetes` lets the runtime create dedicated worker
+  Deployments and Services on demand. The chart can create the worker-manager
+  RBAC and a worker NetworkPolicy for the same namespace.
+- If workers run in a different namespace, provide storage, service accounts,
+  and network policy behavior that are valid for that namespace. Kubernetes
+  owner references are only set by default for same-namespace workers. When
+  using an existing sandbox proxy token secret, create it in both the runtime
+  namespace and the worker namespace. When using
+  `workers.sandbox.proxyToken.value`, the chart creates both copies.
+- Mount arbitrary platform-specific files, projected secrets, ConfigMaps, init
+  containers, and sidecars through `extraVolumes`, `extraVolumeMounts`,
+  `initContainers`, and `extraContainers`.
+- Use `nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`,
+  and `podDisruptionBudget` for cluster-specific scheduling and availability
+  policy.
+- Override `probes.*.spec` when a deployment needs custom Kubernetes
+  startup, readiness, or liveness probes.

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -88,5 +88,54 @@ workers:
 - Use `nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`,
   and `podDisruptionBudget` for cluster-specific scheduling and availability
   policy.
-- Override `probes.*.spec` when a deployment needs custom Kubernetes
+- Set `selectorLabels` when adopting an existing Deployment with an immutable
+  selector.
+- Set `storage.volumeName` or `workers.kubernetes.networkPolicy.name` when
+  adopting existing resources with established names.
+- Override `probes.*.custom` when a deployment needs custom Kubernetes
   startup, readiness, or liveness probes.
+
+## Adopting Existing Resources
+
+When replacing hand-written manifests for an existing runtime, keep immutable
+and externally referenced names stable in values:
+
+```yaml
+fullnameOverride: mindroom
+
+selectorLabels:
+  app: mindroom
+
+config:
+  create: false
+  existingConfigMap: mindroom-config
+  key: config.yaml
+
+storage:
+  create: false
+  existingClaim: mindroom-data
+  volumeName: data
+
+workers:
+  backend: kubernetes
+  kubernetes:
+    networkPolicy:
+      name: mindroom-workers
+
+probes:
+  liveness:
+    custom:
+      tcpSocket:
+        port: api
+      periodSeconds: 30
+      timeoutSeconds: 10
+      failureThreshold: 6
+```
+
+Render and diff the chart before applying it to existing objects:
+
+```bash
+helm template mindroom ./cluster/k8s/runtime \
+  --namespace mindroom \
+  -f runtime-values.yaml
+```

--- a/cluster/k8s/runtime/templates/NOTES.txt
+++ b/cluster/k8s/runtime/templates/NOTES.txt
@@ -1,0 +1,12 @@
+MindRoom runtime chart rendered.
+
+Service:
+  {{ include "mindroom-runtime.fullname" . }}:{{ .Values.service.port }}
+
+Configuration:
+  ConfigMap: {{ include "mindroom-runtime.configMapName" . }}
+  Storage PVC: {{ include "mindroom-runtime.storageClaimName" . }}
+  Worker backend: {{ .Values.workers.backend }}
+
+For production use, provide Matrix settings, runtime secrets, and either an
+existing config ConfigMap or a chart-managed config value.

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -1,0 +1,116 @@
+{{/*
+Expand the chart name.
+*/}}
+{{- define "mindroom-runtime.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "mindroom-runtime.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | quote }}
+app.kubernetes.io/name: {{ include "mindroom-runtime.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- end -}}
+
+{{- define "mindroom-runtime.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mindroom-runtime.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/component: runtime
+{{- end -}}
+
+{{- define "mindroom-runtime.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s:%s@%s" .Values.image.repository $tag .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.workerImage" -}}
+{{- $image := .Values.workers.kubernetes.image -}}
+{{- if $image.repository -}}
+{{- $tag := $image.tag | default .Values.image.tag | default .Chart.AppVersion -}}
+{{- $digest := $image.digest | default .Values.image.digest -}}
+{{- if $digest -}}
+{{- printf "%s:%s@%s" $image.repository $tag $digest -}}
+{{- else -}}
+{{- printf "%s:%s" $image.repository $tag -}}
+{{- end -}}
+{{- else -}}
+{{- include "mindroom-runtime.image" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.configMapName" -}}
+{{- if .Values.config.existingConfigMap -}}
+{{- .Values.config.existingConfigMap -}}
+{{- else -}}
+{{- printf "%s-config" (include "mindroom-runtime.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.storageClaimName" -}}
+{{- if .Values.storage.existingClaim -}}
+{{- .Values.storage.existingClaim -}}
+{{- else -}}
+{{- printf "%s-storage" (include "mindroom-runtime.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "mindroom-runtime.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.workerServiceAccountName" -}}
+{{- if .Values.workers.kubernetes.serviceAccount.create -}}
+{{- default (printf "%s-worker" (include "mindroom-runtime.fullname" .)) .Values.workers.kubernetes.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.workers.kubernetes.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.proxyTokenSecretName" -}}
+{{- if .Values.workers.sandbox.proxyToken.existingSecret -}}
+{{- .Values.workers.sandbox.proxyToken.existingSecret -}}
+{{- else if .Values.workers.sandbox.proxyToken.value -}}
+{{- printf "%s-sandbox-proxy" (include "mindroom-runtime.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.workerConfigMapName" -}}
+{{- default (include "mindroom-runtime.configMapName" .) .Values.workers.kubernetes.configMapName -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.workerConfigKey" -}}
+{{- default .Values.config.key .Values.workers.kubernetes.configKey -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.workerConfigPath" -}}
+{{- default .Values.config.mountPath .Values.workers.kubernetes.configPath -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.workerNamespace" -}}
+{{- default .Release.Namespace .Values.workers.kubernetes.namespace -}}
+{{- end -}}

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -30,9 +30,13 @@ app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 {{- end -}}
 
 {{- define "mindroom-runtime.selectorLabels" -}}
+{{- if .Values.selectorLabels -}}
+{{- toYaml .Values.selectorLabels -}}
+{{- else -}}
 app.kubernetes.io/name: {{ include "mindroom-runtime.name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.kubernetes.io/component: runtime
+{{- end -}}
 {{- end -}}
 
 {{- define "mindroom-runtime.image" -}}
@@ -75,6 +79,10 @@ app.kubernetes.io/component: runtime
 {{- end -}}
 {{- end -}}
 
+{{- define "mindroom-runtime.storageVolumeName" -}}
+{{- default "storage" .Values.storage.volumeName -}}
+{{- end -}}
+
 {{- define "mindroom-runtime.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "mindroom-runtime.fullname" .) .Values.serviceAccount.name -}}
@@ -113,4 +121,8 @@ app.kubernetes.io/component: runtime
 
 {{- define "mindroom-runtime.workerNamespace" -}}
 {{- default .Release.Namespace .Values.workers.kubernetes.namespace -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.workerNetworkPolicyName" -}}
+{{- default (printf "%s-workers" (include "mindroom-runtime.fullname" .)) .Values.workers.kubernetes.networkPolicy.name -}}
 {{- end -}}

--- a/cluster/k8s/runtime/templates/configmap.yaml
+++ b/cluster/k8s/runtime/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.config.create (not .Values.config.existingConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mindroom-runtime.configMapName" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+data:
+  {{ .Values.config.key }}: |
+{{ .Values.config.data | indent 4 }}
+{{- end }}

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -1,0 +1,287 @@
+{{- $fullname := include "mindroom-runtime.fullname" . -}}
+{{- $proxyTokenSecretName := include "mindroom-runtime.proxyTokenSecretName" . -}}
+{{- $workerNamespace := include "mindroom-runtime.workerNamespace" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullname }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "mindroom-runtime.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mindroom-runtime.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "mindroom-runtime.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: mindroom
+          image: {{ include "mindroom-runtime.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /app/.venv/bin/mindroom
+            - run
+            - --api-host
+            - {{ .Values.runtime.apiHost | quote }}
+            - --api-port
+            - {{ .Values.runtime.apiPort | quote }}
+          ports:
+            - name: api
+              containerPort: {{ .Values.runtime.apiPort }}
+              protocol: TCP
+          env:
+            - name: MINDROOM_STORAGE_PATH
+              value: {{ .Values.storage.mountPath | quote }}
+            - name: MINDROOM_CONFIG_PATH
+              value: {{ .Values.config.mountPath | quote }}
+            - name: HOME
+              value: {{ .Values.storage.mountPath | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.runtime.logLevel | quote }}
+            {{- if .Values.runtime.timezone }}
+            - name: TZ
+              value: {{ .Values.runtime.timezone | quote }}
+            {{- end }}
+            {{- if .Values.runtime.timing }}
+            - name: MINDROOM_TIMING
+              value: "1"
+            {{- end }}
+            - name: MINDROOM_WORKER_BACKEND
+              value: {{ .Values.workers.backend | quote }}
+            - name: MINDROOM_WORKER_CLEANUP_INTERVAL_SECONDS
+              value: {{ .Values.workers.cleanupIntervalSeconds | quote }}
+            - name: MINDROOM_SANDBOX_EXECUTION_MODE
+              value: {{ .Values.workers.sandbox.executionMode | quote }}
+            - name: MINDROOM_SANDBOX_PROXY_TOOLS
+              value: {{ .Values.workers.sandbox.proxyTools | quote }}
+            {{- if $proxyTokenSecretName }}
+            - name: MINDROOM_SANDBOX_PROXY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $proxyTokenSecretName }}
+                  key: {{ .Values.workers.sandbox.proxyToken.key }}
+            {{- end }}
+            {{- if eq .Values.workers.backend "static_runner" }}
+            - name: MINDROOM_SANDBOX_PROXY_URL
+              value: {{ printf "http://localhost:%v" .Values.workers.staticRunner.port | quote }}
+            {{- else if eq .Values.workers.backend "kubernetes" }}
+            - name: MINDROOM_KUBERNETES_WORKER_NAMESPACE
+              value: {{ include "mindroom-runtime.workerNamespace" . | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_IMAGE
+              value: {{ include "mindroom-runtime.workerImage" . | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_IMAGE_PULL_POLICY
+              value: {{ default .Values.image.pullPolicy .Values.workers.kubernetes.image.pullPolicy | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_PORT
+              value: {{ .Values.workers.kubernetes.port | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_SERVICE_ACCOUNT_NAME
+              value: {{ include "mindroom-runtime.workerServiceAccountName" . | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME
+              value: {{ include "mindroom-runtime.storageClaimName" . | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_STORAGE_MOUNT_PATH
+              value: {{ .Values.storage.mountPath | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_STORAGE_SUBPATH_PREFIX
+              value: {{ .Values.workers.kubernetes.storageSubpathPrefix | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_CONFIG_MAP_NAME
+              value: {{ include "mindroom-runtime.workerConfigMapName" . | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_CONFIG_KEY
+              value: {{ include "mindroom-runtime.workerConfigKey" . | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_CONFIG_PATH
+              value: {{ include "mindroom-runtime.workerConfigPath" . | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_IDLE_TIMEOUT_SECONDS
+              value: {{ .Values.workers.kubernetes.idleTimeoutSeconds | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_READY_TIMEOUT_SECONDS
+              value: {{ .Values.workers.kubernetes.readyTimeoutSeconds | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_NAME_PREFIX
+              value: {{ .Values.workers.kubernetes.namePrefix | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_LABELS_JSON
+              value: {{ toJson .Values.workers.kubernetes.extraLabels | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_MEMORY_REQUEST
+              value: {{ .Values.workers.kubernetes.resources.requests.memory | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_MEMORY_LIMIT
+              value: {{ .Values.workers.kubernetes.resources.limits.memory | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_CPU_REQUEST
+              value: {{ .Values.workers.kubernetes.resources.requests.cpu | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_CPU_LIMIT
+              value: {{ .Values.workers.kubernetes.resources.limits.cpu | quote }}
+            {{- if $proxyTokenSecretName }}
+            - name: MINDROOM_KUBERNETES_WORKER_TOKEN_SECRET_NAME
+              value: {{ $proxyTokenSecretName | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_TOKEN_SECRET_KEY
+              value: {{ .Values.workers.sandbox.proxyToken.key | quote }}
+            {{- end }}
+            {{- if .Values.workers.kubernetes.nodeName }}
+            - name: MINDROOM_KUBERNETES_WORKER_NODE_NAME
+              value: {{ .Values.workers.kubernetes.nodeName | quote }}
+            {{- end }}
+            {{- if .Values.workers.kubernetes.colocateWithControlPlaneNode }}
+            - name: MINDROOM_KUBERNETES_WORKER_COLOCATE_WITH_CONTROL_PLANE_NODE
+              value: "true"
+            {{- end }}
+            {{- if .Values.workers.kubernetes.extraEnv }}
+            - name: MINDROOM_KUBERNETES_WORKER_ENV_JSON
+              value: {{ toJson .Values.workers.kubernetes.extraEnv | quote }}
+            {{- end }}
+            {{- if or .Values.workers.kubernetes.ownerDeploymentName (eq $workerNamespace .Release.Namespace) }}
+            - name: MINDROOM_KUBERNETES_WORKER_OWNER_DEPLOYMENT_NAME
+              value: {{ default $fullname .Values.workers.kubernetes.ownerDeploymentName | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.matrix.homeserverUrl }}
+            - name: MATRIX_HOMESERVER
+              value: {{ .Values.matrix.homeserverUrl | quote }}
+            {{- end }}
+            {{- if .Values.matrix.serverName }}
+            - name: MATRIX_SERVER_NAME
+              value: {{ .Values.matrix.serverName | quote }}
+            {{- end }}
+            {{- if .Values.matrix.startupTimeoutSeconds }}
+            - name: MINDROOM_MATRIX_HOMESERVER_STARTUP_TIMEOUT_SECONDS
+              value: {{ .Values.matrix.startupTimeoutSeconds | quote }}
+            {{- end }}
+            {{- if .Values.matrix.registrationToken.existingSecret }}
+            - name: MATRIX_REGISTRATION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.matrix.registrationToken.existingSecret }}
+                  key: {{ .Values.matrix.registrationToken.key }}
+            {{- end }}
+            {{- with .Values.env.extra }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.env.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            {{- toYaml .Values.probes.startup.spec | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            {{- toYaml .Values.probes.readiness.spec | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            {{- toYaml .Values.probes.liveness.spec | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: {{ .Values.config.mountPath }}
+              subPath: {{ .Values.config.key }}
+              readOnly: true
+            - name: storage
+              mountPath: {{ .Values.storage.mountPath }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- if eq .Values.workers.backend "static_runner" }}
+        - name: sandbox-runner
+          image: {{ include "mindroom-runtime.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /app/run-sandbox-runner.sh
+          ports:
+            - name: sandbox
+              containerPort: {{ .Values.workers.staticRunner.port }}
+              protocol: TCP
+          env:
+            - name: MINDROOM_SANDBOX_RUNNER_MODE
+              value: "true"
+            - name: MINDROOM_SANDBOX_RUNNER_PORT
+              value: {{ .Values.workers.staticRunner.port | quote }}
+            - name: MINDROOM_CONFIG_PATH
+              value: {{ .Values.config.mountPath | quote }}
+            - name: MINDROOM_STORAGE_PATH
+              value: {{ .Values.storage.mountPath | quote }}
+            - name: MINDROOM_SANDBOX_WORKER_ROOT
+              value: {{ default (printf "%s/workers" .Values.storage.mountPath) .Values.workers.staticRunner.workerRoot | quote }}
+            - name: HOME
+              value: {{ .Values.storage.mountPath | quote }}
+            {{- if $proxyTokenSecretName }}
+            - name: MINDROOM_SANDBOX_PROXY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $proxyTokenSecretName }}
+                  key: {{ .Values.workers.sandbox.proxyToken.key }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.workers.staticRunner.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: {{ .Values.config.mountPath }}
+              subPath: {{ .Values.config.key }}
+              readOnly: true
+            - name: storage
+              mountPath: {{ .Values.storage.mountPath }}
+            - name: sandbox-workspace
+              mountPath: /app/workspace
+        {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "mindroom-runtime.configMapName" . }}
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ include "mindroom-runtime.storageClaimName" . }}
+        {{- if eq .Values.workers.backend "static_runner" }}
+        - name: sandbox-workspace
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -54,8 +54,10 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
@@ -82,8 +84,10 @@ spec:
               value: {{ .Values.config.mountPath | quote }}
             - name: HOME
               value: {{ .Values.storage.mountPath | quote }}
+            {{- if .Values.runtime.logLevel }}
             - name: LOG_LEVEL
               value: {{ .Values.runtime.logLevel | quote }}
+            {{- end }}
             {{- if .Values.runtime.timezone }}
             - name: TZ
               value: {{ .Values.runtime.timezone | quote }}
@@ -200,26 +204,55 @@ spec:
           {{- end }}
           {{- if .Values.probes.startup.enabled }}
           startupProbe:
-            {{- toYaml .Values.probes.startup.spec | nindent 12 }}
+            {{- if .Values.probes.startup.custom }}
+            {{- toYaml .Values.probes.startup.custom | nindent 12 }}
+            {{- else }}
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: {{ .Values.probes.startup.port }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            {{- end }}
           {{- end }}
           {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
-            {{- toYaml .Values.probes.readiness.spec | nindent 12 }}
+            {{- if .Values.probes.readiness.custom }}
+            {{- toYaml .Values.probes.readiness.custom | nindent 12 }}
+            {{- else }}
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: {{ .Values.probes.readiness.port }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+            {{- end }}
           {{- end }}
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
-            {{- toYaml .Values.probes.liveness.spec | nindent 12 }}
+            {{- if .Values.probes.liveness.custom }}
+            {{- toYaml .Values.probes.liveness.custom | nindent 12 }}
+            {{- else }}
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: {{ .Values.probes.liveness.port }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+            {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: {{ .Values.config.mountPath }}
               subPath: {{ .Values.config.key }}
               readOnly: true
-            - name: storage
+            - name: {{ include "mindroom-runtime.storageVolumeName" . }}
               mountPath: {{ .Values.storage.mountPath }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -256,14 +289,16 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.workers.staticRunner.resources | nindent 12 }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: {{ .Values.config.mountPath }}
               subPath: {{ .Values.config.key }}
               readOnly: true
-            - name: storage
+            - name: {{ include "mindroom-runtime.storageVolumeName" . }}
               mountPath: {{ .Values.storage.mountPath }}
             - name: sandbox-workspace
               mountPath: /app/workspace
@@ -275,7 +310,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "mindroom-runtime.configMapName" . }}
-        - name: storage
+        - name: {{ include "mindroom-runtime.storageVolumeName" . }}
           persistentVolumeClaim:
             claimName: {{ include "mindroom-runtime.storageClaimName" . }}
         {{- if eq .Values.workers.backend "static_runner" }}

--- a/cluster/k8s/runtime/templates/networkpolicy.yaml
+++ b/cluster/k8s/runtime/templates/networkpolicy.yaml
@@ -1,0 +1,31 @@
+{{- if and (eq .Values.workers.backend "kubernetes") .Values.workers.kubernetes.networkPolicy.create }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mindroom-runtime.fullname" . }}-workers
+  namespace: {{ include "mindroom-runtime.workerNamespace" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: worker
+      app.kubernetes.io/managed-by: mindroom
+      app.kubernetes.io/name: mindroom-worker
+      {{- with .Values.workers.kubernetes.extraLabels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+          podSelector:
+            matchLabels:
+              {{- include "mindroom-runtime.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.workers.kubernetes.port }}
+{{- end }}

--- a/cluster/k8s/runtime/templates/networkpolicy.yaml
+++ b/cluster/k8s/runtime/templates/networkpolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "mindroom-runtime.fullname" . }}-workers
+  name: {{ include "mindroom-runtime.workerNetworkPolicyName" . }}
   namespace: {{ include "mindroom-runtime.workerNamespace" . }}
   labels:
     {{- include "mindroom-runtime.labels" . | nindent 4 }}

--- a/cluster/k8s/runtime/templates/pdb.yaml
+++ b/cluster/k8s/runtime/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "mindroom-runtime.fullname" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mindroom-runtime.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/cluster/k8s/runtime/templates/pvc.yaml
+++ b/cluster/k8s/runtime/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.storage.create (not .Values.storage.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mindroom-runtime.storageClaimName" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.storage.accessModes | nindent 4 }}
+  {{- if .Values.storage.storageClassName }}
+  storageClassName: {{ .Values.storage.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.size | quote }}
+{{- end }}

--- a/cluster/k8s/runtime/templates/rbac.yaml
+++ b/cluster/k8s/runtime/templates/rbac.yaml
@@ -1,0 +1,60 @@
+{{- if and (eq .Values.workers.backend "kubernetes") .Values.workers.kubernetes.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "mindroom-runtime.fullname" . }}-worker-manager
+  namespace: {{ include "mindroom-runtime.workerNamespace" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "mindroom-runtime.fullname" . }}-worker-manager
+  namespace: {{ include "mindroom-runtime.workerNamespace" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mindroom-runtime.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "mindroom-runtime.fullname" . }}-worker-manager
+{{- end }}

--- a/cluster/k8s/runtime/templates/secret.yaml
+++ b/cluster/k8s/runtime/templates/secret.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.workers.sandbox.proxyToken.value }}
+{{- $proxyTokenSecretName := include "mindroom-runtime.proxyTokenSecretName" . -}}
+{{- $workerNamespace := include "mindroom-runtime.workerNamespace" . -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $proxyTokenSecretName }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.workers.sandbox.proxyToken.key }}: {{ .Values.workers.sandbox.proxyToken.value | quote }}
+{{- if and (eq .Values.workers.backend "kubernetes") (ne $workerNamespace .Release.Namespace) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $proxyTokenSecretName }}
+  namespace: {{ $workerNamespace }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.workers.sandbox.proxyToken.key }}: {{ .Values.workers.sandbox.proxyToken.value | quote }}
+{{- end }}
+{{- end }}

--- a/cluster/k8s/runtime/templates/service.yaml
+++ b/cluster/k8s/runtime/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mindroom-runtime.fullname" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: api
+      protocol: TCP
+      name: api
+  selector:
+    {{- include "mindroom-runtime.selectorLabels" . | nindent 4 }}

--- a/cluster/k8s/runtime/templates/serviceaccount.yaml
+++ b/cluster/k8s/runtime/templates/serviceaccount.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mindroom-runtime.serviceAccountName" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
+{{- if and (eq .Values.workers.backend "kubernetes") .Values.workers.kubernetes.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mindroom-runtime.workerServiceAccountName" . }}
+  namespace: {{ include "mindroom-runtime.workerNamespace" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+  {{- with .Values.workers.kubernetes.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.workers.kubernetes.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -1,0 +1,194 @@
+# Runtime-only MindRoom chart.
+# This chart intentionally avoids platform-specific defaults. Use existing
+# ConfigMaps, Secrets, PVCs, and service URLs from your own cluster.
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/mindroom-ai/mindroom
+  tag: latest
+  digest: ""
+  pullPolicy: Always
+
+imagePullSecrets: []
+
+deploymentAnnotations: {}
+podAnnotations: {}
+podLabels: {}
+priorityClassName: ""
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: true
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  runAsNonRoot: true
+  fsGroupChangePolicy: OnRootMismatch
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 8765
+  annotations: {}
+
+podDisruptionBudget:
+  create: false
+  maxUnavailable: 1
+  minAvailable: ""
+
+runtime:
+  apiHost: 0.0.0.0
+  apiPort: 8765
+  logLevel: INFO
+  timezone: ""
+  timing: false
+
+config:
+  create: true
+  existingConfigMap: ""
+  key: config.yaml
+  mountPath: /app/config.yaml
+  data: |
+    agents: {}
+    models: {}
+
+storage:
+  create: true
+  existingClaim: ""
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ""
+  size: 10Gi
+  mountPath: /app/agent_data
+
+env:
+  # Raw Kubernetes EnvVar entries appended to the MindRoom container.
+  extra: []
+  # Raw Kubernetes EnvFromSource entries appended to the MindRoom container.
+  envFrom: []
+
+matrix:
+  homeserverUrl: ""
+  serverName: ""
+  startupTimeoutSeconds: ""
+  registrationToken:
+    existingSecret: ""
+    key: MATRIX_REGISTRATION_TOKEN
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    memory: 2Gi
+
+probes:
+  startup:
+    enabled: true
+    spec:
+      httpGet:
+        path: /api/ready
+        port: api
+      periodSeconds: 5
+      timeoutSeconds: 10
+      failureThreshold: 120
+  readiness:
+    enabled: true
+    spec:
+      httpGet:
+        path: /api/ready
+        port: api
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+  liveness:
+    enabled: true
+    spec:
+      httpGet:
+        path: /api/health
+        port: api
+      periodSeconds: 30
+      timeoutSeconds: 10
+      failureThreshold: 6
+
+workers:
+  # static_runner keeps a sandbox-runner sidecar in this pod.
+  # kubernetes lets the MindRoom runtime create worker Deployments on demand.
+  backend: static_runner
+  cleanupIntervalSeconds: 30
+  sandbox:
+    executionMode: selective
+    proxyTools: shell,file,python
+    proxyToken:
+      # Prefer existingSecret in production. value creates a chart-managed Secret.
+      existingSecret: ""
+      key: MINDROOM_SANDBOX_PROXY_TOKEN
+      value: ""
+  staticRunner:
+    port: 8766
+    workerRoot: ""
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
+  kubernetes:
+    namespace: ""
+    image:
+      repository: ""
+      tag: ""
+      digest: ""
+      pullPolicy: ""
+    serviceAccount:
+      create: true
+      name: ""
+      annotations: {}
+      automountServiceAccountToken: false
+    rbac:
+      create: true
+    networkPolicy:
+      create: true
+    port: 8766
+    readyTimeoutSeconds: 60
+    idleTimeoutSeconds: 1800
+    namePrefix: mindroom-worker
+    storageSubpathPrefix: workers
+    configMapName: ""
+    configKey: ""
+    configPath: ""
+    ownerDeploymentName: ""
+    nodeName: ""
+    colocateWithControlPlaneNode: false
+    extraEnv: {}
+    extraLabels: {}
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
+
+initContainers: []
+extraContainers: []
+extraVolumes: []
+extraVolumeMounts: []

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -18,6 +18,9 @@ imagePullSecrets: []
 deploymentAnnotations: {}
 podAnnotations: {}
 podLabels: {}
+# Leave empty for the chart default. Set this when adopting an existing
+# Deployment whose selector is immutable.
+selectorLabels: {}
 priorityClassName: ""
 nodeSelector: {}
 tolerations: []
@@ -31,10 +34,7 @@ serviceAccount:
   automountServiceAccountToken: true
 
 podSecurityContext:
-  runAsUser: 1000
-  runAsGroup: 1000
   fsGroup: 1000
-  runAsNonRoot: true
   fsGroupChangePolicy: OnRootMismatch
 
 securityContext:
@@ -72,6 +72,7 @@ config:
 storage:
   create: true
   existingClaim: ""
+  volumeName: storage
   accessModes:
     - ReadWriteOnce
   storageClassName: ""
@@ -102,31 +103,28 @@ resources:
 probes:
   startup:
     enabled: true
-    spec:
-      httpGet:
-        path: /api/ready
-        port: api
-      periodSeconds: 5
-      timeoutSeconds: 10
-      failureThreshold: 120
+    custom: {}
+    path: /api/ready
+    port: api
+    periodSeconds: 5
+    timeoutSeconds: 10
+    failureThreshold: 120
   readiness:
     enabled: true
-    spec:
-      httpGet:
-        path: /api/ready
-        port: api
-      periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 6
+    custom: {}
+    path: /api/ready
+    port: api
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
   liveness:
     enabled: true
-    spec:
-      httpGet:
-        path: /api/health
-        port: api
-      periodSeconds: 30
-      timeoutSeconds: 10
-      failureThreshold: 6
+    custom: {}
+    path: /api/health
+    port: api
+    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 6
 
 workers:
   # static_runner keeps a sandbox-runner sidecar in this pod.
@@ -167,6 +165,7 @@ workers:
       create: true
     networkPolicy:
       create: true
+      name: ""
     port: 8766
     readyTimeoutSeconds: 60
     idleTimeoutSeconds: 1800

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -8,10 +8,11 @@ Deploy MindRoom on Kubernetes for production multi-tenant deployments.
 
 ## Architecture
 
-MindRoom uses two Helm charts:
+MindRoom uses three Helm charts:
 
 - **Instance Chart** (`cluster/k8s/instance/`) - Individual MindRoom runtime with bundled dashboard/API plus Matrix/Synapse
 - **Platform Chart** (`cluster/k8s/platform/`) - SaaS control plane (API, frontend, provisioner)
+- **Runtime Chart** (`cluster/k8s/runtime/`) - MindRoom runtime only, for clusters that provide Matrix, storage, secrets, ingress, and platform services externally
 
 ## Prerequisites
 
@@ -51,9 +52,57 @@ helm upgrade --install instance-1 ./cluster/k8s/instance \
   --set supabaseServiceKey="your-service-key"
 ```
 
+## Runtime-Only Deployment
+
+Use the runtime chart when you already operate the surrounding platform and only
+want Kubernetes to run the MindRoom runtime. The chart intentionally does not
+create Matrix, ingress, a model gateway, or platform services.
+
+```bash
+helm upgrade --install mindroom-runtime ./cluster/k8s/runtime \
+  --namespace mindroom \
+  --create-namespace \
+  -f runtime-values.yaml
+```
+
+Typical production values point at existing resources:
+
+```yaml
+config:
+  create: false
+  existingConfigMap: mindroom-config
+  key: config.yaml
+
+storage:
+  create: false
+  existingClaim: mindroom-data
+
+matrix:
+  homeserverUrl: http://matrix.example.svc.cluster.local:8008
+  serverName: example.com
+  registrationToken:
+    existingSecret: mindroom-secrets
+    key: MATRIX_REGISTRATION_TOKEN
+
+env:
+  envFrom:
+    - secretRef:
+        name: mindroom-secrets
+
+workers:
+  backend: kubernetes
+  sandbox:
+    proxyToken:
+      existingSecret: mindroom-sandbox-proxy
+      key: MINDROOM_SANDBOX_PROXY_TOKEN
+```
+
+See `cluster/k8s/runtime/README.md` and `cluster/k8s/runtime/values.yaml` for
+the full values surface.
+
 ## Worker Backends
 
-The instance chart supports two worker backend modes for worker-routed tools such as `shell`, `file`, and `python`.
+The instance and runtime charts support two worker backend modes for worker-routed tools such as `shell`, `file`, and `python`.
 The dedicated-worker provisioning flow is implemented today.
 Both modes store agent data in the same per-agent directory structure.
 
@@ -100,6 +149,8 @@ kubernetesWorkerReadyTimeoutSeconds: 60
 kubernetesWorkerIdleTimeoutSeconds: 1800
 sandbox_proxy_token: "replace-me"
 ```
+
+The runtime chart exposes the same concepts under the nested `workers.*` values.
 
 Important behavior and constraints:
 


### PR DESCRIPTION
## Summary
- add a runtime-only Helm chart for deploying MindRoom into clusters that already provide Matrix, storage, secrets, ingress, and platform services
- support static sandbox-runner sidecar mode and Kubernetes worker mode with service accounts, RBAC, worker NetworkPolicy, PDB, existing ConfigMap/PVC references, env hooks, extra volumes, init containers, sidecars, and scheduling knobs
- document adoption settings for existing deployments, including immutable selector labels, stable volume/resource names, and custom probe specs

## Validation
- `helm lint ./cluster/k8s/runtime`
- rendered default static-runner mode
- rendered Kubernetes worker mode
- rendered cross-namespace Kubernetes worker mode
- rendered custom TCP liveness probe mode
- rendered an existing-deployment adoption build through Kustomize and ran `kubectl apply --dry-run=client --validate=false`
- scanned the chart/docs for deployment-specific private terms
