### PR TITLE
Fix mixed-backend team memory writes

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -12,6 +12,8 @@ MindRoom supports three memory backends:
 
 Set the global default backend with `memory.backend`.
 Override the backend per agent with `agents.<name>.memory_backend`.
+Team memory writes follow each member's effective backend.
+In mixed teams, file-backed members receive shared team memory in file team scope, and Mem0-backed members receive it in Mem0 team scope.
 When an agent uses `memory_backend: file`, its file memory lives in its canonical workspace root.
 When an agent uses `memory_backend: none`, MindRoom skips prompt memory lookup, automatic memory persistence, and the explicit `memory` tool for that agent.
 Use `agents.<name>.private` when one shared agent definition should keep file memory inside a requester-local private root.
@@ -190,7 +192,8 @@ Agent file memory is stored under each agent's canonical workspace root:
 - `agents/<agent>/workspace/MEMORY.md`
 - `agents/<agent>/workspace/memory/YYYY-MM-DD.md`
 
-Team file memory is mirrored under each participating agent's storage directory:
+For all-file teams, team file memory is mirrored under each participating agent's storage directory.
+For mixed teams, it is written only under file-backed members' storage directories while the scope ID still names the full team:
 
 - `agents/<agent>/memory_files/team_<sorted_members>/MEMORY.md`
 - `agents/<agent>/memory_files/team_<sorted_members>/memory/YYYY-MM-DD.md`

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -11582,6 +11582,8 @@ MindRoom supports three memory backends:
 
 Set the global default backend with `memory.backend`.
 Override the backend per agent with `agents.<name>.memory_backend`.
+Team memory writes follow each member's effective backend.
+In mixed teams, file-backed members receive shared team memory in file team scope, and Mem0-backed members receive it in Mem0 team scope.
 When an agent uses `memory_backend: file`, its file memory lives in its canonical workspace root.
 When an agent uses `memory_backend: none`, MindRoom skips prompt memory lookup, automatic memory persistence, and the explicit `memory` tool for that agent.
 Use `agents.<name>.private` when one shared agent definition should keep file memory inside a requester-local private root.
@@ -11760,7 +11762,8 @@ Agent file memory is stored under each agent's canonical workspace root:
 - `agents/<agent>/workspace/MEMORY.md`
 - `agents/<agent>/workspace/memory/YYYY-MM-DD.md`
 
-Team file memory is mirrored under each participating agent's storage directory:
+For all-file teams, team file memory is mirrored under each participating agent's storage directory.
+For mixed teams, it is written only under file-backed members' storage directories while the scope ID still names the full team:
 
 - `agents/<agent>/memory_files/team_<sorted_members>/MEMORY.md`
 - `agents/<agent>/memory_files/team_<sorted_members>/memory/YYYY-MM-DD.md`

--- a/skills/mindroom-docs/references/page__memory__index.md
+++ b/skills/mindroom-docs/references/page__memory__index.md
@@ -8,6 +8,8 @@ MindRoom supports three memory backends:
 
 Set the global default backend with `memory.backend`.
 Override the backend per agent with `agents.<name>.memory_backend`.
+Team memory writes follow each member's effective backend.
+In mixed teams, file-backed members receive shared team memory in file team scope, and Mem0-backed members receive it in Mem0 team scope.
 When an agent uses `memory_backend: file`, its file memory lives in its canonical workspace root.
 When an agent uses `memory_backend: none`, MindRoom skips prompt memory lookup, automatic memory persistence, and the explicit `memory` tool for that agent.
 Use `agents.<name>.private` when one shared agent definition should keep file memory inside a requester-local private root.
@@ -186,7 +188,8 @@ Agent file memory is stored under each agent's canonical workspace root:
 - `agents/<agent>/workspace/MEMORY.md`
 - `agents/<agent>/workspace/memory/YYYY-MM-DD.md`
 
-Team file memory is mirrored under each participating agent's storage directory:
+For all-file teams, team file memory is mirrored under each participating agent's storage directory.
+For mixed teams, it is written only under file-backed members' storage directories while the scope ID still names the full team:
 
 - `agents/<agent>/memory_files/team_<sorted_members>/MEMORY.md`
 - `agents/<agent>/memory_files/team_<sorted_members>/memory/YYYY-MM-DD.md`

--- a/src/mindroom/memory/_file_backend.py
+++ b/src/mindroom/memory/_file_backend.py
@@ -14,12 +14,14 @@ from mindroom.timing import timed
 from ._policy import (
     agent_name_from_scope_user_id,
     agent_scope_user_id,
-    allowed_scope_storage_paths,
     build_team_user_id,
     effective_storage_paths_for_context,
+    get_allowed_memory_user_ids,
     get_team_ids_for_agent,
     resolve_file_memory_resolution,
     storage_paths_for_scope_user_id,
+    team_members_by_memory_backend,
+    team_members_from_scope_user_id,
 )
 from ._shared import (
     FILE_MEMORY_DAILY_DIR,
@@ -456,24 +458,27 @@ def _find_file_anchor_memory_result(
     runtime_paths: RuntimePaths,
     *,
     execution_identity: ToolExecutionIdentity | None = None,
+    target_agent_names: list[str] | None = None,
 ) -> MemoryResult | None:
-    for scope_user_id, target_storage_path in allowed_scope_storage_paths(
-        caller_context,
-        storage_path,
-        config,
-        runtime_paths,
-        execution_identity=execution_identity,
-    ):
-        resolution = resolve_file_memory_resolution(
-            target_storage_path,
+    for scope_user_id in sorted(get_allowed_memory_user_ids(caller_context, config)):
+        for target_storage_path in _file_storage_paths_for_scope_user_id(
+            scope_user_id,
+            storage_path,
             config,
             runtime_paths,
-            agent_name=agent_name_from_scope_user_id(scope_user_id),
-            original_storage_path=storage_path,
             execution_identity=execution_identity,
-        )
-        if result := _get_scope_memory_by_id(scope_user_id, memory_id, resolution, config):
-            return result
+            target_agent_names=target_agent_names,
+        ):
+            resolution = resolve_file_memory_resolution(
+                target_storage_path,
+                config,
+                runtime_paths,
+                agent_name=agent_name_from_scope_user_id(scope_user_id),
+                original_storage_path=storage_path,
+                execution_identity=execution_identity,
+            )
+            if result := _get_scope_memory_by_id(scope_user_id, memory_id, resolution, config):
+                return result
     return None
 
 
@@ -503,15 +508,17 @@ def _mutate_file_memory_targets(
     runtime_paths: RuntimePaths,
     anchor_result: MemoryResult,
     execution_identity: ToolExecutionIdentity | None = None,
+    target_agent_names: list[str] | None = None,
 ) -> tuple[str, int]:
     updated_targets = 0
     scope_user_id = anchor_result["user_id"]
-    for target_storage_path in storage_paths_for_scope_user_id(
+    for target_storage_path in _file_storage_paths_for_scope_user_id(
         scope_user_id,
         storage_path,
         config,
         runtime_paths,
         execution_identity=execution_identity,
+        target_agent_names=target_agent_names,
     ):
         resolution = resolve_file_memory_resolution(
             target_storage_path,
@@ -619,6 +626,37 @@ def _search_team_file_scope_memories(
     )
 
 
+def _file_team_storage_agent_names(scope_user_id: str, config: Config) -> list[str] | None:
+    team_members = team_members_from_scope_user_id(scope_user_id, config)
+    if team_members is None:
+        return None
+    return team_members_by_memory_backend(config, team_members)["file"]
+
+
+def _file_storage_paths_for_scope_user_id(
+    scope_user_id: str,
+    storage_path: Path,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None = None,
+    *,
+    target_agent_names: list[str] | None = None,
+) -> list[Path]:
+    storage_target_agent_names = target_agent_names
+    if storage_target_agent_names is None:
+        storage_target_agent_names = _file_team_storage_agent_names(scope_user_id, config)
+        if storage_target_agent_names == []:
+            return []
+    return storage_paths_for_scope_user_id(
+        scope_user_id,
+        storage_path,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
+        target_agent_names=storage_target_agent_names,
+    )
+
+
 def search_file_agent_memories(
     query: str,
     agent_name: str,
@@ -648,7 +686,7 @@ def search_file_agent_memories(
     )
     existing_memories = {result.get("memory", "") for result in results}
     for team_id in get_team_ids_for_agent(agent_name, config):
-        for target_storage_path in storage_paths_for_scope_user_id(
+        for target_storage_path in _file_storage_paths_for_scope_user_id(
             team_id,
             storage_path,
             config,
@@ -710,6 +748,8 @@ def get_file_agent_memory(
     config: Config,
     runtime_paths: RuntimePaths,
     execution_identity: ToolExecutionIdentity | None = None,
+    *,
+    target_agent_names: list[str] | None = None,
 ) -> MemoryResult | None:
     """Return one file-backed memory visible to the caller."""
     return _find_file_anchor_memory_result(
@@ -719,6 +759,7 @@ def get_file_agent_memory(
         config,
         runtime_paths,
         execution_identity=execution_identity,
+        target_agent_names=target_agent_names,
     )
 
 
@@ -730,6 +771,8 @@ def update_file_agent_memory(
     config: Config,
     runtime_paths: RuntimePaths,
     execution_identity: ToolExecutionIdentity | None = None,
+    *,
+    target_agent_names: list[str] | None = None,
 ) -> None:
     """Update one file-backed memory across its replica targets."""
     if (
@@ -740,6 +783,7 @@ def update_file_agent_memory(
             config,
             runtime_paths,
             execution_identity=execution_identity,
+            target_agent_names=target_agent_names,
         )
     ) is None:
         raise MemoryNotFoundError(memory_id)
@@ -752,6 +796,7 @@ def update_file_agent_memory(
         runtime_paths=runtime_paths,
         anchor_result=anchor_result,
         execution_identity=execution_identity,
+        target_agent_names=target_agent_names,
     )
     if updated_targets > 0:
         logger.info(
@@ -771,6 +816,8 @@ def delete_file_agent_memory(
     config: Config,
     runtime_paths: RuntimePaths,
     execution_identity: ToolExecutionIdentity | None = None,
+    *,
+    target_agent_names: list[str] | None = None,
 ) -> None:
     """Delete one file-backed memory across its replica targets."""
     if (
@@ -781,6 +828,7 @@ def delete_file_agent_memory(
             config,
             runtime_paths,
             execution_identity=execution_identity,
+            target_agent_names=target_agent_names,
         )
     ) is None:
         raise MemoryNotFoundError(memory_id)
@@ -793,6 +841,7 @@ def delete_file_agent_memory(
         runtime_paths=runtime_paths,
         anchor_result=anchor_result,
         execution_identity=execution_identity,
+        target_agent_names=target_agent_names,
     )
     if deleted_targets > 0:
         logger.info(
@@ -812,21 +861,27 @@ def store_file_conversation_memory(
     config: Config,
     runtime_paths: RuntimePaths,
     execution_identity: ToolExecutionIdentity | None = None,
+    *,
+    target_agent_names: list[str] | None = None,
+    memory_id: str | None = None,
 ) -> None:
     """Persist condensed conversation text to file-backed memory scopes."""
     condensed_prompt = " ".join(prompt.strip().split())
     if not condensed_prompt:
         return
 
+    target_context: str | list[str] = agent_name
+    if target_agent_names is not None:
+        target_context = target_agent_names
     target_storage_paths = effective_storage_paths_for_context(
-        agent_name,
+        target_context,
         storage_path,
         config,
         runtime_paths,
         execution_identity=execution_identity,
     )
     scope_user_id = agent_scope_user_id(agent_name) if isinstance(agent_name, str) else build_team_user_id(agent_name)
-    team_memory_id = new_memory_id() if isinstance(agent_name, list) else None
+    team_memory_id = (memory_id or new_memory_id()) if isinstance(agent_name, list) else None
 
     for target_storage_path in target_storage_paths:
         resolution = resolve_file_memory_resolution(

--- a/src/mindroom/memory/_mem0_backend.py
+++ b/src/mindroom/memory/_mem0_backend.py
@@ -10,12 +10,13 @@ from mindroom.timing import timed
 
 from ._policy import (
     agent_scope_user_id,
-    allowed_scope_storage_paths,
     build_team_user_id,
     effective_storage_paths_for_context,
     get_allowed_memory_user_ids,
     get_team_ids_for_agent,
     storage_paths_for_scope_user_id,
+    team_members_by_memory_backend,
+    team_members_from_scope_user_id,
 )
 from ._shared import MEM0_REPLICA_KEY, MemoryNotFoundError, MemoryResult, ScopedMemoryCrud, ScopedMemoryWriter
 
@@ -95,6 +96,37 @@ async def _search_mem0_team_scope(
     limit: int,
 ) -> list[MemoryResult]:
     return _mem0_results(await memory.search(query, filters=_scope_filter(team_id), top_k=limit))
+
+
+def _mem0_team_storage_agent_names(scope_user_id: str, config: Config) -> list[str] | None:
+    team_members = team_members_from_scope_user_id(scope_user_id, config)
+    if team_members is None:
+        return None
+    return team_members_by_memory_backend(config, team_members)["mem0"]
+
+
+def _mem0_storage_paths_for_scope_user_id(
+    scope_user_id: str,
+    storage_path: Path,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None = None,
+    *,
+    target_agent_names: list[str] | None = None,
+) -> list[Path]:
+    storage_target_agent_names = target_agent_names
+    if storage_target_agent_names is None:
+        storage_target_agent_names = _mem0_team_storage_agent_names(scope_user_id, config)
+        if storage_target_agent_names == []:
+            return []
+    return storage_paths_for_scope_user_id(
+        scope_user_id,
+        storage_path,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
+        target_agent_names=storage_target_agent_names,
+    )
 
 
 async def _get_scoped_memory_by_id(
@@ -182,17 +214,20 @@ async def _find_mem0_anchor_memory_result(
     *,
     create_memory: _MemoryFactory,
     execution_identity: ToolExecutionIdentity | None = None,
+    target_agent_names: list[str] | None = None,
 ) -> MemoryResult | None:
-    for _scope_user_id, target_storage_path in allowed_scope_storage_paths(
-        caller_context,
-        storage_path,
-        config,
-        runtime_paths,
-        execution_identity=execution_identity,
-    ):
-        memory = await create_memory(target_storage_path, config)
-        if result := await _get_scoped_memory_by_id(memory, memory_id, caller_context, config):
-            return result
+    for scope_user_id in sorted(get_allowed_memory_user_ids(caller_context, config)):
+        for target_storage_path in _mem0_storage_paths_for_scope_user_id(
+            scope_user_id,
+            storage_path,
+            config,
+            runtime_paths,
+            execution_identity=execution_identity,
+            target_agent_names=target_agent_names,
+        ):
+            memory = await create_memory(target_storage_path, config)
+            if result := await _get_scoped_memory_by_id(memory, memory_id, caller_context, config):
+                return result
     return None
 
 
@@ -226,15 +261,17 @@ async def _mutate_mem0_memory_targets(
     anchor_result: MemoryResult,
     create_memory: _MemoryFactory,
     execution_identity: ToolExecutionIdentity | None = None,
+    target_agent_names: list[str] | None = None,
 ) -> int:
     mutated_targets = 0
     scope_user_id = anchor_result["user_id"]
-    for target_storage_path in storage_paths_for_scope_user_id(
+    for target_storage_path in _mem0_storage_paths_for_scope_user_id(
         scope_user_id,
         storage_path,
         config,
         runtime_paths,
         execution_identity=execution_identity,
+        target_agent_names=target_agent_names,
     ):
         memory = await create_memory(target_storage_path, config)
         target_ids = await _mem0_mutation_target_ids(
@@ -372,6 +409,7 @@ async def get_mem0_agent_memory(
     execution_identity: ToolExecutionIdentity | None = None,
     *,
     create_memory: _MemoryFactory,
+    target_agent_names: list[str] | None = None,
 ) -> MemoryResult | None:
     """Return one mem0 memory visible to the caller."""
     return await _find_mem0_anchor_memory_result(
@@ -382,6 +420,7 @@ async def get_mem0_agent_memory(
         runtime_paths,
         create_memory=create_memory,
         execution_identity=execution_identity,
+        target_agent_names=target_agent_names,
     )
 
 
@@ -395,6 +434,7 @@ async def update_mem0_agent_memory(
     execution_identity: ToolExecutionIdentity | None = None,
     *,
     create_memory: _MemoryFactory,
+    target_agent_names: list[str] | None = None,
 ) -> None:
     """Update one mem0 memory across its replica targets."""
     if (
@@ -406,6 +446,7 @@ async def update_mem0_agent_memory(
             runtime_paths,
             create_memory=create_memory,
             execution_identity=execution_identity,
+            target_agent_names=target_agent_names,
         )
     ) is None:
         raise MemoryNotFoundError(memory_id)
@@ -421,6 +462,7 @@ async def update_mem0_agent_memory(
         anchor_result=anchor_result,
         create_memory=create_memory,
         execution_identity=execution_identity,
+        target_agent_names=target_agent_names,
     )
     if updated_targets > 0:
         logger.info("Memory updated", memory_id=memory_id, storage_targets=updated_targets)
@@ -437,6 +479,7 @@ async def delete_mem0_agent_memory(
     execution_identity: ToolExecutionIdentity | None = None,
     *,
     create_memory: _MemoryFactory,
+    target_agent_names: list[str] | None = None,
 ) -> None:
     """Delete one mem0 memory across its replica targets."""
     if (
@@ -448,6 +491,7 @@ async def delete_mem0_agent_memory(
             runtime_paths,
             create_memory=create_memory,
             execution_identity=execution_identity,
+            target_agent_names=target_agent_names,
         )
     ) is None:
         raise MemoryNotFoundError(memory_id)
@@ -463,6 +507,7 @@ async def delete_mem0_agent_memory(
         anchor_result=anchor_result,
         create_memory=create_memory,
         execution_identity=execution_identity,
+        target_agent_names=target_agent_names,
     )
     if deleted_targets > 0:
         logger.info("Memory deleted", memory_id=memory_id, storage_targets=deleted_targets)
@@ -481,10 +526,14 @@ async def store_mem0_conversation_memory(
     *,
     replica_key: str | None,
     create_memory: _MemoryFactory,
+    target_agent_names: list[str] | None = None,
 ) -> None:
     """Persist conversation messages to mem0-backed memory scopes."""
+    target_context: str | list[str] = agent_name
+    if target_agent_names is not None:
+        target_context = target_agent_names
     target_storage_paths = effective_storage_paths_for_context(
-        agent_name,
+        target_context,
         storage_path,
         config,
         runtime_paths,

--- a/src/mindroom/memory/_mem0_backend.py
+++ b/src/mindroom/memory/_mem0_backend.py
@@ -114,6 +114,8 @@ def _mem0_storage_paths_for_scope_user_id(
     *,
     target_agent_names: list[str] | None = None,
 ) -> list[Path]:
+    if target_agent_names is not None and team_members_from_scope_user_id(scope_user_id, config) is None:
+        return []
     storage_target_agent_names = target_agent_names
     if storage_target_agent_names is None:
         storage_target_agent_names = _mem0_team_storage_agent_names(scope_user_id, config)

--- a/src/mindroom/memory/_policy.py
+++ b/src/mindroom/memory/_policy.py
@@ -9,7 +9,6 @@ from mindroom.runtime_resolution import resolve_agent_runtime
 from ._shared import FileMemoryResolution
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
     from pathlib import Path
 
     from mindroom.config.main import Config
@@ -35,26 +34,39 @@ def caller_uses_file_memory_backend(config: Config, caller_context: str | list[s
     """Return whether the caller context resolves to file-backed memory."""
     if isinstance(caller_context, str):
         return use_file_memory_backend(config, agent_name=caller_context)
-    return team_uses_file_memory_backend(config, caller_context)
+    return _team_uses_file_memory_backend(config, caller_context)
 
 
 def caller_uses_disabled_memory_backend(config: Config, caller_context: str | list[str]) -> bool:
     """Return whether the caller context resolves to disabled memory."""
     if isinstance(caller_context, str):
         return use_disabled_memory_backend(config, agent_name=caller_context)
-    return team_uses_disabled_memory_backend(config, caller_context)
+    return _team_uses_disabled_memory_backend(config, caller_context)
 
 
-def team_uses_file_memory_backend(config: Config, agent_names: list[str]) -> bool:
+def _team_uses_file_memory_backend(config: Config, agent_names: list[str]) -> bool:
     """Return whether all team members resolve to file-backed memory."""
     config.assert_team_agents_supported(agent_names)
     return all(use_file_memory_backend(config, agent_name=agent_name) for agent_name in agent_names)
 
 
-def team_uses_disabled_memory_backend(config: Config, agent_names: list[str]) -> bool:
+def _team_uses_disabled_memory_backend(config: Config, agent_names: list[str]) -> bool:
     """Return whether all team members resolve to disabled memory."""
     config.assert_team_agents_supported(agent_names)
     return all(use_disabled_memory_backend(config, agent_name=agent_name) for agent_name in agent_names)
+
+
+def team_members_by_memory_backend(config: Config, agent_names: list[str]) -> dict[str, list[str]]:
+    """Group team members by their effective memory backend."""
+    config.assert_team_agents_supported(agent_names)
+    members_by_backend: dict[str, list[str]] = {"mem0": [], "file": [], "none": []}
+    for member_name in agent_names:
+        backend = config.get_agent_memory_backend(member_name)
+        if backend not in members_by_backend:
+            msg = f"Unsupported memory backend for team member {member_name}: {backend}"
+            raise ValueError(msg)
+        members_by_backend[backend].append(member_name)
+    return members_by_backend
 
 
 def effective_storage_paths_for_context(
@@ -120,7 +132,8 @@ def get_team_ids_for_agent(agent_name: str, config: Config) -> list[str]:
     return team_ids
 
 
-def _team_members_from_scope_user_id(scope_user_id: str, config: Config) -> list[str] | None:
+def team_members_from_scope_user_id(scope_user_id: str, config: Config) -> list[str] | None:
+    """Resolve team member names from a team-scoped memory user ID."""
     if not scope_user_id.startswith("team_"):
         return None
     if config.teams:
@@ -137,11 +150,20 @@ def storage_paths_for_scope_user_id(
     config: Config,
     runtime_paths: RuntimePaths,
     execution_identity: ToolExecutionIdentity | None = None,
+    *,
+    target_agent_names: list[str] | None = None,
 ) -> list[Path]:
     """Return the canonical storage roots for one memory scope."""
-    if (team_members := _team_members_from_scope_user_id(scope_user_id, config)) is not None:
+    if (team_members := team_members_from_scope_user_id(scope_user_id, config)) is not None:
+        storage_members = team_members
+        if target_agent_names is not None:
+            unsupported_members = [agent_name for agent_name in target_agent_names if agent_name not in team_members]
+            if unsupported_members:
+                msg = f"Target agents are not members of {scope_user_id}: {unsupported_members}"
+                raise ValueError(msg)
+            storage_members = target_agent_names
         return effective_storage_paths_for_context(
-            team_members,
+            storage_members,
             storage_path,
             config,
             runtime_paths,
@@ -151,24 +173,6 @@ def storage_paths_for_scope_user_id(
         return [_effective_storage_path_for_agent(agent_name, config, runtime_paths, execution_identity)]
     msg = f"Unsupported memory scope user_id: {scope_user_id}"
     raise ValueError(msg)
-
-
-def allowed_scope_storage_paths(
-    caller_context: str | list[str],
-    storage_path: Path,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-) -> Iterator[tuple[str, Path]]:
-    for scope_user_id in sorted(get_allowed_memory_user_ids(caller_context, config)):
-        for target_storage_path in storage_paths_for_scope_user_id(
-            scope_user_id,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-        ):
-            yield scope_user_id, target_storage_path
 
 
 def get_allowed_memory_user_ids(caller_context: str | list[str], config: Config) -> set[str]:

--- a/src/mindroom/memory/functions.py
+++ b/src/mindroom/memory/functions.py
@@ -35,13 +35,13 @@ from ._policy import (
     caller_uses_disabled_memory_backend,
     caller_uses_file_memory_backend,
     resolve_file_memory_resolution,
-    team_uses_disabled_memory_backend,
-    team_uses_file_memory_backend,
+    team_members_by_memory_backend,
+    team_members_from_scope_user_id,
     use_disabled_memory_backend,
     use_file_memory_backend,
 )
 from ._prompting import build_memory_messages, format_memories_as_context
-from ._shared import MemoryResult, new_memory_id
+from ._shared import MEM0_REPLICA_KEY, MemoryNotFoundError, MemoryResult, new_memory_id
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
@@ -55,6 +55,36 @@ if TYPE_CHECKING:
     from ._shared import ScopedMemoryCrud
 
 logger = get_logger(__name__)
+
+
+def _has_mixed_team_memory_backends(members_by_backend: dict[str, list[str]]) -> bool:
+    return bool(members_by_backend["file"] and members_by_backend["mem0"])
+
+
+def _requires_partitioned_team_memory_backend(members_by_backend: dict[str, list[str]]) -> bool:
+    return bool(members_by_backend["none"] or _has_mixed_team_memory_backends(members_by_backend))
+
+
+def _mem0_replica_key(memory: MemoryResult | None) -> str | None:
+    if memory is None:
+        return None
+    metadata = memory.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    replica_key = metadata.get(MEM0_REPLICA_KEY)
+    return replica_key if isinstance(replica_key, str) and replica_key else None
+
+
+@dataclass(frozen=True)
+class _MixedTeamMemoryTargetIds:
+    file: str | None
+    mem0: str | None
+
+
+@dataclass(frozen=True)
+class _PartitionedTeamMemoryContext:
+    team_members: list[str]
+    members_by_backend: dict[str, list[str]]
 
 
 @dataclass(frozen=True)
@@ -269,6 +299,243 @@ async def list_all_agent_memories(
     )
 
 
+async def _get_mixed_team_agent_memory(
+    memory_id: str,
+    caller_context: list[str],
+    storage_path: Path,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None,
+    *,
+    file_member_names: list[str],
+    mem0_member_names: list[str],
+) -> MemoryResult | None:
+    if file_member_names:
+        file_result = get_file_agent_memory(
+            memory_id,
+            caller_context,
+            storage_path,
+            config,
+            runtime_paths,
+            execution_identity=execution_identity,
+            target_agent_names=file_member_names,
+        )
+        if file_result is not None:
+            return file_result
+    if not mem0_member_names:
+        return None
+    return await get_mem0_agent_memory(
+        memory_id,
+        caller_context,
+        storage_path,
+        config,
+        runtime_paths,
+        create_memory=_create_memory_factory(runtime_paths),
+        execution_identity=execution_identity,
+        target_agent_names=mem0_member_names,
+    )
+
+
+async def _resolve_mixed_team_memory_target_ids(
+    memory_id: str,
+    caller_context: list[str],
+    storage_path: Path,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None,
+    *,
+    file_member_names: list[str],
+    mem0_member_names: list[str],
+) -> _MixedTeamMemoryTargetIds:
+    file_memory_id: str | None = None
+    mem0_memory_id: str | None = None
+    file_result: MemoryResult | None = None
+    mem0_result: MemoryResult | None = None
+
+    if file_member_names:
+        file_memory_id = memory_id
+        file_result = get_file_agent_memory(
+            memory_id,
+            caller_context,
+            storage_path,
+            config,
+            runtime_paths,
+            execution_identity=execution_identity,
+            target_agent_names=file_member_names,
+        )
+    if mem0_member_names:
+        mem0_memory_id = memory_id
+        mem0_result = await get_mem0_agent_memory(
+            memory_id,
+            caller_context,
+            storage_path,
+            config,
+            runtime_paths,
+            create_memory=_create_memory_factory(runtime_paths),
+            execution_identity=execution_identity,
+            target_agent_names=mem0_member_names,
+        )
+
+    if file_result is None:
+        if (replica_key := _mem0_replica_key(mem0_result)) is not None:
+            file_memory_id = replica_key
+            file_result = get_file_agent_memory(
+                file_memory_id,
+                caller_context,
+                storage_path,
+                config,
+                runtime_paths,
+                execution_identity=execution_identity,
+                target_agent_names=file_member_names,
+            )
+        else:
+            file_memory_id = None
+    if mem0_member_names and mem0_result is None:
+        mem0_memory_id = file_memory_id
+        if mem0_memory_id is not None:
+            mem0_result = await get_mem0_agent_memory(
+                mem0_memory_id,
+                caller_context,
+                storage_path,
+                config,
+                runtime_paths,
+                create_memory=_create_memory_factory(runtime_paths),
+                execution_identity=execution_identity,
+                target_agent_names=mem0_member_names,
+            )
+        if mem0_result is None:
+            mem0_memory_id = None
+
+    return _MixedTeamMemoryTargetIds(
+        file=file_memory_id if file_result is not None else None,
+        mem0=mem0_memory_id if mem0_result is not None else None,
+    )
+
+
+async def _partitioned_team_memory_context_for_single_caller(
+    memory_id: str,
+    caller_context: str,
+    storage_path: Path,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None,
+) -> _PartitionedTeamMemoryContext | None:
+    memory = await get_agent_memory(
+        memory_id,
+        caller_context,
+        storage_path,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
+    )
+    if memory is None:
+        return None
+    user_id = memory.get("user_id")
+    if not isinstance(user_id, str):
+        return None
+    team_members = team_members_from_scope_user_id(user_id, config)
+    if team_members is None:
+        return None
+    members_by_backend = team_members_by_memory_backend(config, team_members)
+    if not _requires_partitioned_team_memory_backend(members_by_backend):
+        return None
+    return _PartitionedTeamMemoryContext(
+        team_members=team_members,
+        members_by_backend=members_by_backend,
+    )
+
+
+async def _update_partitioned_team_memory(
+    memory_id: str,
+    content: str,
+    team_members: list[str],
+    members_by_backend: dict[str, list[str]],
+    storage_path: Path,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None,
+) -> None:
+    target_ids = await _resolve_mixed_team_memory_target_ids(
+        memory_id,
+        team_members,
+        storage_path,
+        config,
+        runtime_paths,
+        execution_identity,
+        file_member_names=members_by_backend["file"],
+        mem0_member_names=members_by_backend["mem0"],
+    )
+    if target_ids.file is not None:
+        update_file_agent_memory(
+            target_ids.file,
+            content,
+            team_members,
+            storage_path,
+            config,
+            runtime_paths,
+            execution_identity=execution_identity,
+            target_agent_names=members_by_backend["file"],
+        )
+    if target_ids.mem0 is not None:
+        await update_mem0_agent_memory(
+            target_ids.mem0,
+            content,
+            team_members,
+            storage_path,
+            config,
+            runtime_paths,
+            create_memory=_create_memory_factory(runtime_paths),
+            execution_identity=execution_identity,
+            target_agent_names=members_by_backend["mem0"],
+        )
+    if target_ids.file is None and target_ids.mem0 is None:
+        raise MemoryNotFoundError(memory_id)
+
+
+async def _delete_partitioned_team_memory(
+    memory_id: str,
+    team_members: list[str],
+    members_by_backend: dict[str, list[str]],
+    storage_path: Path,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None,
+) -> None:
+    target_ids = await _resolve_mixed_team_memory_target_ids(
+        memory_id,
+        team_members,
+        storage_path,
+        config,
+        runtime_paths,
+        execution_identity,
+        file_member_names=members_by_backend["file"],
+        mem0_member_names=members_by_backend["mem0"],
+    )
+    if target_ids.file is not None:
+        delete_file_agent_memory(
+            target_ids.file,
+            team_members,
+            storage_path,
+            config,
+            runtime_paths,
+            execution_identity=execution_identity,
+            target_agent_names=members_by_backend["file"],
+        )
+    if target_ids.mem0 is not None:
+        await delete_mem0_agent_memory(
+            target_ids.mem0,
+            team_members,
+            storage_path,
+            config,
+            runtime_paths,
+            create_memory=_create_memory_factory(runtime_paths),
+            execution_identity=execution_identity,
+            target_agent_names=members_by_backend["mem0"],
+        )
+    if target_ids.file is None and target_ids.mem0 is None:
+        raise MemoryNotFoundError(memory_id)
+
+
 async def get_agent_memory(
     memory_id: str,
     caller_context: str | list[str],
@@ -280,6 +547,20 @@ async def get_agent_memory(
     """Get a single memory by ID."""
     if caller_uses_disabled_memory_backend(config, caller_context):
         return None
+    if isinstance(caller_context, list):
+        members_by_backend = team_members_by_memory_backend(config, caller_context)
+        if _requires_partitioned_team_memory_backend(members_by_backend):
+            return await _get_mixed_team_agent_memory(
+                memory_id,
+                caller_context,
+                storage_path,
+                config,
+                runtime_paths,
+                execution_identity,
+                file_member_names=members_by_backend["file"],
+                mem0_member_names=members_by_backend["mem0"],
+            )
+
     if caller_uses_file_memory_backend(config, caller_context):
         return get_file_agent_memory(
             memory_id,
@@ -312,6 +593,43 @@ async def update_agent_memory(
     """Update a single memory by ID."""
     if caller_uses_disabled_memory_backend(config, caller_context):
         return
+    if isinstance(caller_context, list):
+        members_by_backend = team_members_by_memory_backend(config, caller_context)
+        if _requires_partitioned_team_memory_backend(members_by_backend):
+            await _update_partitioned_team_memory(
+                memory_id,
+                content,
+                caller_context,
+                members_by_backend,
+                storage_path,
+                config,
+                runtime_paths,
+                execution_identity,
+            )
+            return
+
+    else:
+        partitioned_context = await _partitioned_team_memory_context_for_single_caller(
+            memory_id,
+            caller_context,
+            storage_path,
+            config,
+            runtime_paths,
+            execution_identity,
+        )
+        if partitioned_context is not None:
+            await _update_partitioned_team_memory(
+                memory_id,
+                content,
+                partitioned_context.team_members,
+                partitioned_context.members_by_backend,
+                storage_path,
+                config,
+                runtime_paths,
+                execution_identity,
+            )
+            return
+
     if caller_uses_file_memory_backend(config, caller_context):
         update_file_agent_memory(
             memory_id,
@@ -346,6 +664,41 @@ async def delete_agent_memory(
     """Delete a single memory by ID."""
     if caller_uses_disabled_memory_backend(config, caller_context):
         return
+    if isinstance(caller_context, list):
+        members_by_backend = team_members_by_memory_backend(config, caller_context)
+        if _requires_partitioned_team_memory_backend(members_by_backend):
+            await _delete_partitioned_team_memory(
+                memory_id,
+                caller_context,
+                members_by_backend,
+                storage_path,
+                config,
+                runtime_paths,
+                execution_identity,
+            )
+            return
+
+    else:
+        partitioned_context = await _partitioned_team_memory_context_for_single_caller(
+            memory_id,
+            caller_context,
+            storage_path,
+            config,
+            runtime_paths,
+            execution_identity,
+        )
+        if partitioned_context is not None:
+            await _delete_partitioned_team_memory(
+                memory_id,
+                partitioned_context.team_members,
+                partitioned_context.members_by_backend,
+                storage_path,
+                config,
+                runtime_paths,
+                execution_identity,
+            )
+            return
+
     if caller_uses_file_memory_backend(config, caller_context):
         delete_file_agent_memory(
             memory_id,
@@ -448,6 +801,51 @@ async def build_memory_enhanced_prompt(
     return "\n\n".join(prompt_chunks)
 
 
+async def _store_team_conversation_memory(
+    prompt: str,
+    agent_name: list[str],
+    storage_path: Path,
+    session_id: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    thread_history: Sequence[ResolvedVisibleMessage] | None,
+    user_id: str | None,
+    execution_identity: ToolExecutionIdentity | None,
+) -> None:
+    members_by_backend = team_members_by_memory_backend(config, agent_name)
+    file_member_names = members_by_backend["file"]
+    mem0_member_names = members_by_backend["mem0"]
+    team_replica_key = new_memory_id() if _has_mixed_team_memory_backends(members_by_backend) else None
+    if file_member_names:
+        store_file_conversation_memory(
+            prompt,
+            agent_name,
+            storage_path,
+            config,
+            runtime_paths,
+            execution_identity=execution_identity,
+            target_agent_names=None if file_member_names == agent_name else file_member_names,
+            memory_id=team_replica_key,
+        )
+    if not mem0_member_names:
+        return
+    messages = build_memory_messages(prompt, thread_history, user_id)
+    if not messages:
+        return
+    await store_mem0_conversation_memory(
+        messages,
+        agent_name,
+        storage_path,
+        session_id,
+        config,
+        runtime_paths,
+        replica_key=team_replica_key or new_memory_id(),
+        create_memory=_create_memory_factory(runtime_paths),
+        execution_identity=execution_identity,
+        target_agent_names=None if mem0_member_names == agent_name else mem0_member_names,
+    )
+
+
 async def store_conversation_memory(
     prompt: str,
     agent_name: str | list[str],
@@ -463,18 +861,23 @@ async def store_conversation_memory(
     if not prompt:
         return
 
-    if isinstance(agent_name, str):
-        if use_disabled_memory_backend(config, agent_name=agent_name):
-            return
-    elif team_uses_disabled_memory_backend(config, agent_name):
+    if isinstance(agent_name, list):
+        await _store_team_conversation_memory(
+            prompt,
+            agent_name,
+            storage_path,
+            session_id,
+            config,
+            runtime_paths,
+            thread_history,
+            user_id,
+            execution_identity,
+        )
         return
 
-    use_file_backend = (
-        use_file_memory_backend(config, agent_name=agent_name)
-        if isinstance(agent_name, str)
-        else team_uses_file_memory_backend(config, agent_name)
-    )
-    if use_file_backend:
+    if use_disabled_memory_backend(config, agent_name=agent_name):
+        return
+    if use_file_memory_backend(config, agent_name=agent_name):
         store_file_conversation_memory(
             prompt,
             agent_name,
@@ -495,7 +898,7 @@ async def store_conversation_memory(
         session_id,
         config,
         runtime_paths,
-        replica_key=new_memory_id() if isinstance(agent_name, list) else None,
+        replica_key=None,
         create_memory=_create_memory_factory(runtime_paths),
         execution_identity=execution_identity,
     )

--- a/src/mindroom/memory/functions.py
+++ b/src/mindroom/memory/functions.py
@@ -81,7 +81,7 @@ class _MixedTeamMemoryTargetIds:
     mem0: str | None
 
 
-@dataclass(frozen=True)
+@dataclass
 class _PartitionedTeamMemoryContext:
     team_members: list[str]
     members_by_backend: dict[str, list[str]]
@@ -376,7 +376,7 @@ async def _resolve_mixed_team_memory_target_ids(
             target_agent_names=mem0_member_names,
         )
 
-    if file_result is None:
+    if file_member_names and file_result is None:
         if (replica_key := _mem0_replica_key(mem0_result)) is not None:
             file_memory_id = replica_key
             file_result = get_file_agent_memory(

--- a/tests/test_memory_facade.py
+++ b/tests/test_memory_facade.py
@@ -21,12 +21,14 @@ from mindroom.memory import search_agent_memories as public_search_agent_memorie
 from mindroom.memory import store_conversation_memory as public_store_conversation_memory
 from mindroom.memory import update_agent_memory as public_update_agent_memory
 from mindroom.memory._prompting import format_memories_as_context
+from mindroom.memory._shared import MemoryNotFoundError
 from mindroom.prompts import MEMORY_CONTEXT_PROMPT_TEMPLATE
 from mindroom.tool_system.worker_routing import agent_state_root_path, agent_workspace_root_path
 from tests.conftest import bind_runtime_paths, make_visible_message, runtime_paths_for
-from tests.memory_test_support import MockTeamConfig
+from tests.memory_test_support import FakeMem0ScopedMemory, MockTeamConfig
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
     from pathlib import Path
 
     from mindroom.memory._shared import MemoryResult
@@ -188,6 +190,28 @@ def _test_config(storage_path: Path) -> Config:
         ),
         runtime_paths,
     )
+
+
+def _fake_mem0_factory(
+    mem0_stores: dict[Path, FakeMem0ScopedMemory],
+) -> Callable[..., Awaitable[FakeMem0ScopedMemory]]:
+    async def create_fake_memory_instance(
+        scope_storage_path: Path,
+        _config: Config,
+        *,
+        runtime_paths: object,
+        timing_scope: str | None = None,
+    ) -> FakeMem0ScopedMemory:
+        del runtime_paths, timing_scope
+        if scope_storage_path not in mem0_stores:
+            mem0_stores[scope_storage_path] = FakeMem0ScopedMemory()
+        return mem0_stores[scope_storage_path]
+
+    return create_fake_memory_instance
+
+
+def _team_file_memory_path(storage_path: Path, agent_name: str, team_id: str) -> Path:
+    return agent_state_root_path(storage_path, agent_name) / "memory_files" / team_id / "MEMORY.md"
 
 
 class TestMemoryFacade:
@@ -629,14 +653,13 @@ class TestMemoryFacade:
         mock_memory.add.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_store_conversation_memory_team_uses_mem0_when_any_member_overrides(
+    async def test_store_conversation_memory_team_writes_each_members_effective_backend(
         self,
         mock_memory: AsyncMock,
         storage_path: Path,
         config: Config,
     ) -> None:
         config.memory.backend = "file"
-        config.memory.file.path = str(storage_path / "memory-files")
         config.agents["calculator"].memory_backend = "mem0"
 
         with patch("mindroom.memory.functions.create_memory_instance", return_value=mock_memory) as mock_create:
@@ -648,21 +671,119 @@ class TestMemoryFacade:
                 config,
             )
 
-        assert mock_create.call_count == 2
         expected_runtime_paths = runtime_paths_for(config)
-        assert [(call.args, call.kwargs) for call in mock_create.call_args_list] == [
-            (
-                (agent_state_root_path(storage_path, "calculator"), config),
-                {"runtime_paths": expected_runtime_paths},
-            ),
-            (
-                (agent_state_root_path(storage_path, "finance"), config),
-                {"runtime_paths": expected_runtime_paths},
-            ),
-        ]
-        assert mock_memory.add.call_count == 2
-        team_memory_file = storage_path / "memory-files" / "team_calculator+finance" / "MEMORY.md"
-        assert not team_memory_file.exists()
+        mock_create.assert_called_once_with(
+            agent_state_root_path(storage_path, "calculator"),
+            config,
+            runtime_paths=expected_runtime_paths,
+        )
+        mock_memory.add.assert_called_once()
+        mem0_call = mock_memory.add.call_args
+        assert mem0_call[1]["user_id"] == "team_calculator+finance"
+        assert mem0_call[1]["metadata"]["team_members"] == ["calculator", "finance"]
+
+        file_team_memory = (
+            agent_state_root_path(storage_path, "finance") / "memory_files" / "team_calculator+finance" / "MEMORY.md"
+        )
+        assert file_team_memory.exists()
+        assert "Analyze our quarterly metrics" in file_team_memory.read_text(encoding="utf-8")
+        mem0_team_memory_file = (
+            agent_state_root_path(storage_path, "calculator") / "memory_files" / "team_calculator+finance" / "MEMORY.md"
+        )
+        assert not mem0_team_memory_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_mixed_team_memory_reads_through_each_members_effective_backend(
+        self,
+        storage_path: Path,
+        config: Config,
+    ) -> None:
+        config.memory.backend = "file"
+        config.agents["calculator"].memory_backend = "mem0"
+        config.teams = {"mixed_team": MockTeamConfig(agents=["calculator", "finance"])}
+        mem0_stores: dict[Path, FakeMem0ScopedMemory] = {}
+
+        with patch("mindroom.memory.functions.create_memory_instance", side_effect=_fake_mem0_factory(mem0_stores)):
+            await store_conversation_memory(
+                "Mixed backend team insight",
+                ["calculator", "finance"],
+                storage_path,
+                "session-team",
+                config,
+            )
+            calculator_results = await search_agent_memories(
+                "Mixed backend team",
+                "calculator",
+                storage_path,
+                config,
+                limit=5,
+            )
+
+        finance_results = await search_agent_memories("Mixed backend team", "finance", storage_path, config, limit=5)
+
+        assert any(
+            result.get("memory") == "Mixed backend team insight" and result.get("user_id") == "team_calculator+finance"
+            for result in calculator_results
+        )
+        assert any(
+            result.get("memory") == "Mixed backend team insight" and result.get("user_id") == "team_calculator+finance"
+            for result in finance_results
+        )
+        assert set(mem0_stores) == {agent_state_root_path(storage_path, "calculator")}
+
+    @pytest.mark.asyncio
+    async def test_file_search_ignores_stale_team_memory_in_mem0_member_root(
+        self,
+        storage_path: Path,
+        config: Config,
+    ) -> None:
+        config.memory.backend = "file"
+        config.agents["calculator"].memory_backend = "mem0"
+        config.teams = {"mixed_team": MockTeamConfig(agents=["calculator", "finance"])}
+
+        stale_team_file = _team_file_memory_path(storage_path, "calculator", "team_calculator+finance")
+        stale_team_file.parent.mkdir(parents=True)
+        stale_team_file.write_text("# Memory\n\n- [id=stale-file-id] stale migrated team memory\n", encoding="utf-8")
+
+        results = await search_agent_memories(
+            "stale migrated",
+            "finance",
+            storage_path,
+            config,
+            limit=5,
+        )
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_mem0_single_agent_crud_ignores_stale_team_memory_in_file_member_root(
+        self,
+        storage_path: Path,
+        config: Config,
+    ) -> None:
+        config.memory.backend = "file"
+        config.agents["calculator"].memory_backend = "mem0"
+        config.teams = {"mixed_team": MockTeamConfig(agents=["calculator", "finance"])}
+        mem0_stores: dict[Path, FakeMem0ScopedMemory] = {
+            agent_state_root_path(storage_path, "finance"): FakeMem0ScopedMemory(),
+        }
+        finance_store = mem0_stores[agent_state_root_path(storage_path, "finance")]
+        await finance_store.add(
+            [{"role": "user", "content": "stale mem0 team copy"}],
+            user_id="team_calculator+finance",
+            metadata={"type": "conversation", "is_team": True, "team_members": ["calculator", "finance"]},
+        )
+
+        with patch("mindroom.memory.functions.create_memory_instance", side_effect=_fake_mem0_factory(mem0_stores)):
+            stale_result = await get_agent_memory("mem-1", "calculator", storage_path, config)
+            with pytest.raises(MemoryNotFoundError):
+                await update_agent_memory("mem-1", "fresh mem0 team copy", "calculator", storage_path, config)
+            with pytest.raises(MemoryNotFoundError):
+                await delete_agent_memory("mem-1", "calculator", storage_path, config)
+
+        stale_entries = await finance_store.get_all(filters={"user_id": "team_calculator+finance"})
+        assert stale_result is None
+        assert stale_entries["results"][0]["memory"] == "stale mem0 team copy"
 
     @pytest.mark.asyncio
     async def test_disabled_backend_crud_facade_does_not_fall_through_to_mem0(
@@ -688,6 +809,182 @@ class TestMemoryFacade:
         assert get_result is None
         mock_create.assert_not_called()
         assert not any(storage_path.rglob("MEMORY.md"))
+
+    @pytest.mark.asyncio
+    async def test_mixed_team_context_crud_keeps_backend_copies_in_sync(
+        self,
+        storage_path: Path,
+        config: Config,
+    ) -> None:
+        config.memory.backend = "file"
+        config.agents["calculator"].memory_backend = "mem0"
+        config.teams = {"mixed_team": MockTeamConfig(agents=["calculator", "finance"])}
+        team_agents = ["calculator", "finance"]
+        mem0_stores: dict[Path, FakeMem0ScopedMemory] = {}
+
+        with patch("mindroom.memory.functions.create_memory_instance", side_effect=_fake_mem0_factory(mem0_stores)):
+            await store_conversation_memory(
+                "Mixed team stale-sensitive memory",
+                team_agents,
+                storage_path,
+                "session-team",
+                config,
+            )
+            calculator_results = await search_agent_memories(
+                "stale-sensitive",
+                "calculator",
+                storage_path,
+                config,
+                limit=5,
+            )
+            finance_results = await search_agent_memories(
+                "stale-sensitive",
+                "finance",
+                storage_path,
+                config,
+                limit=5,
+            )
+            assert len(calculator_results) == 1
+            assert len(finance_results) == 1
+
+            loaded_file_copy = await get_agent_memory(
+                finance_results[0]["id"],
+                team_agents,
+                storage_path,
+                config,
+            )
+            assert loaded_file_copy is not None
+            assert loaded_file_copy["memory"] == "Mixed team stale-sensitive memory"
+
+            await update_agent_memory(
+                calculator_results[0]["id"],
+                "Updated mixed team memory",
+                team_agents,
+                storage_path,
+                config,
+            )
+
+            calculator_updated = await search_agent_memories(
+                "updated mixed",
+                "calculator",
+                storage_path,
+                config,
+                limit=5,
+            )
+            finance_updated = await search_agent_memories(
+                "updated mixed",
+                "finance",
+                storage_path,
+                config,
+                limit=5,
+            )
+            assert any(result.get("memory") == "Updated mixed team memory" for result in calculator_updated)
+            assert any(result.get("memory") == "Updated mixed team memory" for result in finance_updated)
+            assert not await search_agent_memories("stale-sensitive", "finance", storage_path, config, limit=5)
+
+            await delete_agent_memory(
+                calculator_results[0]["id"],
+                team_agents,
+                storage_path,
+                config,
+            )
+
+            assert not await search_agent_memories("updated mixed", "calculator", storage_path, config, limit=5)
+            assert not await search_agent_memories("updated mixed", "finance", storage_path, config, limit=5)
+
+    @pytest.mark.asyncio
+    async def test_single_agent_update_of_mixed_team_memory_syncs_backend_copies(
+        self,
+        storage_path: Path,
+        config: Config,
+    ) -> None:
+        config.memory.backend = "file"
+        config.agents["calculator"].memory_backend = "mem0"
+        config.teams = {"mixed_team": MockTeamConfig(agents=["calculator", "finance"])}
+        team_agents = ["calculator", "finance"]
+        mem0_stores: dict[Path, FakeMem0ScopedMemory] = {}
+
+        with patch("mindroom.memory.functions.create_memory_instance", side_effect=_fake_mem0_factory(mem0_stores)):
+            await store_conversation_memory(
+                "Retired alpha source",
+                team_agents,
+                storage_path,
+                "session-team",
+                config,
+            )
+            calculator_results = await search_agent_memories(
+                "Retired alpha",
+                "calculator",
+                storage_path,
+                config,
+                limit=5,
+            )
+            assert len(calculator_results) == 1
+
+            await update_agent_memory(
+                calculator_results[0]["id"],
+                "Fresh beta team memory",
+                "calculator",
+                storage_path,
+                config,
+            )
+
+            calculator_updated = await search_agent_memories(
+                "Fresh beta",
+                "calculator",
+                storage_path,
+                config,
+                limit=5,
+            )
+            finance_updated = await search_agent_memories(
+                "Fresh beta",
+                "finance",
+                storage_path,
+                config,
+                limit=5,
+            )
+            assert any(result.get("memory") == "Fresh beta team memory" for result in calculator_updated)
+            assert any(result.get("memory") == "Fresh beta team memory" for result in finance_updated)
+            assert not await search_agent_memories("Retired alpha", "finance", storage_path, config, limit=5)
+
+    @pytest.mark.asyncio
+    async def test_single_agent_delete_of_mixed_team_memory_syncs_backend_copies(
+        self,
+        storage_path: Path,
+        config: Config,
+    ) -> None:
+        config.memory.backend = "file"
+        config.agents["calculator"].memory_backend = "mem0"
+        config.teams = {"mixed_team": MockTeamConfig(agents=["calculator", "finance"])}
+        team_agents = ["calculator", "finance"]
+        mem0_stores: dict[Path, FakeMem0ScopedMemory] = {}
+
+        with patch("mindroom.memory.functions.create_memory_instance", side_effect=_fake_mem0_factory(mem0_stores)):
+            await store_conversation_memory(
+                "Explicit tool delete source",
+                team_agents,
+                storage_path,
+                "session-team",
+                config,
+            )
+            finance_results = await search_agent_memories(
+                "Explicit tool",
+                "finance",
+                storage_path,
+                config,
+                limit=5,
+            )
+            assert len(finance_results) == 1
+
+            await delete_agent_memory(
+                finance_results[0]["id"],
+                "finance",
+                storage_path,
+                config,
+            )
+
+            assert not await search_agent_memories("delete source", "calculator", storage_path, config, limit=5)
+            assert not await search_agent_memories("delete source", "finance", storage_path, config, limit=5)
 
     @pytest.mark.asyncio
     async def test_search_agent_memories_with_teams(

--- a/tests/test_memory_facade.py
+++ b/tests/test_memory_facade.py
@@ -20,6 +20,8 @@ from mindroom.memory import list_all_agent_memories as public_list_all_agent_mem
 from mindroom.memory import search_agent_memories as public_search_agent_memories
 from mindroom.memory import store_conversation_memory as public_store_conversation_memory
 from mindroom.memory import update_agent_memory as public_update_agent_memory
+from mindroom.memory._mem0_backend import _mem0_storage_paths_for_scope_user_id
+from mindroom.memory._policy import agent_scope_user_id
 from mindroom.memory._prompting import format_memories_as_context
 from mindroom.memory._shared import MemoryNotFoundError
 from mindroom.prompts import MEMORY_CONTEXT_PROMPT_TEMPLATE
@@ -784,6 +786,25 @@ class TestMemoryFacade:
         stale_entries = await finance_store.get_all(filters={"user_id": "team_calculator+finance"})
         assert stale_result is None
         assert stale_entries["results"][0]["memory"] == "stale mem0 team copy"
+
+    def test_mem0_targeted_team_lookup_skips_single_agent_roots(
+        self,
+        storage_path: Path,
+        config: Config,
+    ) -> None:
+        config.memory.backend = "file"
+        config.agents["calculator"].memory_backend = "mem0"
+        config.teams = {"mixed_team": MockTeamConfig(agents=["calculator", "finance"])}
+
+        paths = _mem0_storage_paths_for_scope_user_id(
+            agent_scope_user_id("finance"),
+            storage_path,
+            config,
+            runtime_paths_for(config),
+            target_agent_names=["calculator"],
+        )
+
+        assert paths == []
 
     @pytest.mark.asyncio
     async def test_disabled_backend_crud_facade_does_not_fall_through_to_mem0(

--- a/tests/test_memory_policy.py
+++ b/tests/test_memory_policy.py
@@ -11,7 +11,6 @@ from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
 from mindroom.memory._policy import (
     agent_scope_user_id,
-    allowed_scope_storage_paths,
     effective_storage_paths_for_context,
     get_allowed_memory_user_ids,
     get_team_ids_for_agent,
@@ -80,24 +79,6 @@ def test_get_allowed_memory_user_ids_for_team_context(config: Config) -> None:
         "agent_general",
         "team_calculator+general",
     }
-
-
-def test_allowed_scope_storage_paths_orders_scopes_and_expands_storage_roots(
-    tmp_path: Path,
-    config: Config,
-) -> None:
-    """Allowed scope traversal is sorted and expands each scope to its storage roots."""
-    config.agents = {
-        "general": AgentConfig(display_name="General"),
-        "calculator": AgentConfig(display_name="Calculator"),
-    }
-    config.teams = {"pair": MockTeamConfig(agents=["general", "calculator"])}
-
-    assert list(allowed_scope_storage_paths("general", tmp_path, config, runtime_paths_for(config))) == [
-        ("agent_general", agent_state_root_path(tmp_path, "general")),
-        ("team_calculator+general", agent_state_root_path(tmp_path, "general")),
-        ("team_calculator+general", agent_state_root_path(tmp_path, "calculator")),
-    ]
 
 
 def test_effective_storage_paths_for_mixed_private_team_is_rejected(tmp_path: Path, config: Config) -> None:


### PR DESCRIPTION
## Summary
- Group team members by effective memory backend for team memory writes.
- Keep full team scope IDs while targeting only backend-specific member storage roots.
- Keep mixed-backend team reads and explicit memory-tool mutations synchronized across backend copies.

## Test Plan
- [x] `uv run pytest tests/test_memory_facade.py tests/test_memory_file_backend.py tests/test_memory_mem0_backend.py tests/test_memory_policy.py -x -n auto --no-cov -v`
- [x] `uv run pytest -x -n auto --no-cov`
- [x] `SKIP=generate-skill-references uv run pre-commit run --all-files`

Note: `uv run pre-commit run --all-files` was also run without skips and only failed because `generate-skill-references` modified unrelated Kubernetes docs skill-reference files from the rebased base. Those generated docs changes are intentionally not included in this scoped memory PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team memory now supports mixed-backend teams: writes and searches target each member’s effective backend and can be restricted to specific agent targets.
* **Documentation**
  * Clarified team memory persistence and file-backed team layout for mixed and all-file teams across docs and reference pages.
* **Tests**
  * Expanded tests for mixed-backend reads/writes, search behavior, targeted lookups, and synchronization across backends.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/798)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->