### PR TITLE
Publish runtime Helm chart on release

### DIFF
--- a/.github/workflows/calver-auto-release.yml
+++ b/.github/workflows/calver-auto-release.yml
@@ -27,4 +27,5 @@ jobs:
         run: |
           gh workflow run build-mindroom.yml --ref "$PUBLISH_WORKFLOW_REF" --field release_ref="$RELEASE_REF"
           gh workflow run build-platform.yml --ref "$PUBLISH_WORKFLOW_REF" --field release_ref="$RELEASE_REF"
+          gh workflow run publish-helm-charts.yml --ref "$PUBLISH_WORKFLOW_REF" --field release_ref="$RELEASE_REF"
           gh workflow run release.yml --ref "$PUBLISH_WORKFLOW_REF" --field release_ref="$RELEASE_REF"

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -1,0 +1,90 @@
+name: Publish Helm Charts
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "cluster/k8s/runtime/**"
+      - ".github/workflows/publish-helm-charts.yml"
+  workflow_dispatch:
+    inputs:
+      release_ref:
+        description: "Release tag to publish, for example v2026.4.304"
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+  RUNTIME_CHART_DIR: cluster/k8s/runtime
+
+jobs:
+  runtime-chart:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set chart version
+        id: vars
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            release_ref="${{ inputs.release_ref }}"
+            if [[ "$release_ref" != v* ]]; then
+              echo "release_ref must be a tag starting with 'v', got '$release_ref'" >&2
+              exit 1
+            fi
+            chart_version="${release_ref#v}"
+            app_version="$release_ref"
+            publish="true"
+          else
+            chart_version="0.0.0-pr.${{ github.event.pull_request.number }}"
+            app_version="pr-${{ github.event.pull_request.number }}"
+            publish="false"
+          fi
+
+          {
+            echo "chart_version=$chart_version"
+            echo "app_version=$app_version"
+            echo "publish=$publish"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Lint runtime chart
+        run: helm lint "$RUNTIME_CHART_DIR"
+
+      - name: Render runtime chart
+        run: helm template mindroom-runtime "$RUNTIME_CHART_DIR" --namespace mindroom
+
+      - name: Package runtime chart
+        run: |
+          mkdir -p dist
+          helm package "$RUNTIME_CHART_DIR" \
+            --version "${{ steps.vars.outputs.chart_version }}" \
+            --app-version "${{ steps.vars.outputs.app_version }}" \
+            --destination dist
+
+      - name: Login to GitHub Container Registry
+        if: steps.vars.outputs.publish == 'true'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login "$REGISTRY" \
+                --username "${{ github.actor }}" \
+                --password-stdin
+
+      - name: Push runtime chart
+        if: steps.vars.outputs.publish == 'true'
+        run: |
+          helm push \
+            "dist/mindroom-runtime-${{ steps.vars.outputs.chart_version }}.tgz" \
+            "oci://$REGISTRY/$OWNER/charts"


### PR DESCRIPTION
## Summary
- add a release-dispatched workflow that lints, renders, packages, and publishes the runtime Helm chart to GHCR as an OCI chart
- validate runtime chart changes on PRs without publishing packages
- dispatch Helm chart publishing from the existing CalVer release workflow

Published releases will be available as:

```sh
oci://ghcr.io/mindroom-ai/charts/mindroom-runtime --version <calver without v>
```

For example, release `v2026.4.304` publishes chart version `2026.4.304`.

## Validation
- `actionlint .github/workflows/publish-helm-charts.yml .github/workflows/calver-auto-release.yml`
- `helm lint cluster/k8s/runtime`
- `helm template mindroom-runtime cluster/k8s/runtime --namespace mindroom`
- `helm package cluster/k8s/runtime --version 2026.4.304 --app-version v2026.4.304`
