### PR TITLE
Add Postgres event cache to runtime chart

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -64,7 +64,32 @@ jobs:
         run: helm lint "$RUNTIME_CHART_DIR"
 
       - name: Render runtime chart
-        run: helm template mindroom-runtime "$RUNTIME_CHART_DIR" --namespace mindroom
+        run: |
+          render_dir="$(mktemp -d)"
+          helm template mindroom-runtime "$RUNTIME_CHART_DIR" \
+            --namespace mindroom \
+            > "$render_dir/default.yaml"
+          helm template mindroom-runtime "$RUNTIME_CHART_DIR" \
+            --namespace mindroom \
+            --set eventCache.backend=sqlite \
+            > "$render_dir/sqlite.yaml"
+          helm template mindroom-runtime "$RUNTIME_CHART_DIR" \
+            --namespace mindroom \
+            --set eventCache.postgres.create=false \
+            --set eventCache.databaseUrl.existingSecret=event-cache-database-url \
+            --set eventCache.databaseUrl.key=DATABASE_URL \
+            > "$render_dir/external-postgres.yaml"
+          helm template mindroom-runtime "$RUNTIME_CHART_DIR" \
+            --namespace mindroom \
+            --set selectorLabels.app=existing-runtime \
+            --set eventCache.postgres.nameOverride=existing-event-cache-postgres \
+            --set eventCache.postgres.selectorLabels.app=existing-event-cache-postgres \
+            --set eventCache.postgres.persistence.volumeName=existing-event-cache-postgres-data \
+            --set eventCache.postgres.auth.existingSecret=existing-event-cache-secrets \
+            --set eventCache.postgres.auth.passwordKey=POSTGRES_PASSWORD \
+            --set eventCache.databaseUrl.existingSecret=existing-event-cache-secrets \
+            --set eventCache.databaseUrl.key=DATABASE_URL \
+            > "$render_dir/adoption.yaml"
 
       - name: Package runtime chart
         run: |

--- a/cluster/k8s/runtime/Chart.yaml
+++ b/cluster/k8s/runtime/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: mindroom-runtime
-description: Runtime-only MindRoom chart for clusters that provide Matrix, storage, and platform services externally
+description: Runtime-only MindRoom chart for clusters that provide Matrix and platform services externally
 type: application
 version: 0.1.0
 appVersion: "0.0.0"

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -1,12 +1,10 @@
 # MindRoom Runtime Chart
 
-This chart deploys only the MindRoom runtime. It is for clusters that already
-provide the surrounding platform pieces such as Matrix, ingress, storage,
-secrets, model gateways, and optional backing services.
+This chart deploys only the MindRoom runtime and its own runtime support resources.
+It is for clusters that already provide surrounding platform pieces such as Matrix, ingress, deployment-specific secrets, model gateways, and optional external backing services.
 
-Use the instance chart in `cluster/k8s/instance` when you want a complete
-MindRoom instance with its own Matrix homeserver. Use this chart when MindRoom
-should run inside an existing platform.
+Use the instance chart in `cluster/k8s/instance` when you want a complete MindRoom instance with its own Matrix homeserver.
+Use this chart when MindRoom should run inside an existing platform.
 
 ## Minimal Install
 
@@ -16,8 +14,67 @@ helm upgrade --install mindroom-runtime ./cluster/k8s/runtime \
   --create-namespace
 ```
 
-The default values render a self-contained Deployment, Service, ConfigMap, and
-PVC. A real deployment should provide a useful config and Matrix settings.
+The default values render a self-contained Deployment, Service, ConfigMap, runtime PVC, and PostgreSQL event-cache StatefulSet.
+A real deployment should provide a useful config and Matrix settings.
+
+## Event Cache
+
+The runtime chart defaults to PostgreSQL for MindRoom's Matrix event cache, because Kubernetes deployments need a restart-safe cache backend.
+The chart can either create a small PostgreSQL StatefulSet for this cache or wire the runtime to an externally managed database.
+
+Use the chart-managed database for a simple cluster deployment:
+
+```yaml
+eventCache:
+  backend: postgres
+  postgres:
+    create: true
+    persistence:
+      size: 20Gi
+```
+
+For GitOps or `helm template` workflows, set `eventCache.postgres.auth.password` or provide existing Secrets so renders do not rotate generated credentials.
+When adopting an existing PostgreSQL StatefulSet, keep the service name and password source stable:
+
+```yaml
+eventCache:
+  backend: postgres
+  postgres:
+    create: true
+    nameOverride: existing-event-cache-postgres
+    selectorLabels:
+      app: existing-event-cache-postgres
+    auth:
+      existingSecret: existing-event-cache-secrets
+      passwordKey: POSTGRES_PASSWORD
+    persistence:
+      volumeName: existing-event-cache-postgres-data
+  databaseUrl:
+    existingSecret: existing-event-cache-secrets
+    key: DATABASE_URL
+```
+
+Use an external database by providing a Secret with a full PostgreSQL connection URL:
+
+```yaml
+eventCache:
+  backend: postgres
+  postgres:
+    create: false
+  databaseUrl:
+    existingSecret: event-cache-database-url
+    key: DATABASE_URL
+```
+
+Use SQLite only for lightweight or local-style installs:
+
+```yaml
+eventCache:
+  backend: sqlite
+```
+
+When `config.create` is enabled and `config.data` is empty, the chart renders a minimal config whose `cache` section follows `eventCache`.
+When using `config.existingConfigMap` or custom `config.data`, keep that config's cache settings aligned with the chart values.
 
 ## Existing Platform Example
 
@@ -50,6 +107,14 @@ env:
     - configMapRef:
         name: mindroom-env
 
+eventCache:
+  backend: postgres
+  postgres:
+    create: false
+  databaseUrl:
+    existingSecret: event-cache-database-url
+    key: DATABASE_URL
+
 workers:
   backend: kubernetes
   sandbox:
@@ -69,36 +134,24 @@ workers:
 ## Notes
 
 - The chart does not create ingress or a Matrix homeserver.
-- Set `workers.sandbox.proxyToken.existingSecret` or
-  `workers.sandbox.proxyToken.value` when sandbox proxying is enabled.
-- `workers.backend: static_runner` adds a sandbox-runner sidecar to the runtime
-  pod.
-- `workers.backend: kubernetes` lets the runtime create dedicated worker
-  Deployments and Services on demand. The chart can create the worker-manager
-  RBAC and a worker NetworkPolicy for the same namespace.
-- If workers run in a different namespace, provide storage, service accounts,
-  and network policy behavior that are valid for that namespace. Kubernetes
-  owner references are only set by default for same-namespace workers. When
-  using an existing sandbox proxy token secret, create it in both the runtime
-  namespace and the worker namespace. When using
-  `workers.sandbox.proxyToken.value`, the chart creates both copies.
-- Mount arbitrary platform-specific files, projected secrets, ConfigMaps, init
-  containers, and sidecars through `extraVolumes`, `extraVolumeMounts`,
-  `initContainers`, and `extraContainers`.
-- Use `nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`,
-  and `podDisruptionBudget` for cluster-specific scheduling and availability
-  policy.
-- Set `selectorLabels` when adopting an existing Deployment with an immutable
-  selector.
-- Set `storage.volumeName` or `workers.kubernetes.networkPolicy.name` when
-  adopting existing resources with established names.
-- Override `probes.*.custom` when a deployment needs custom Kubernetes
-  startup, readiness, or liveness probes.
+- The chart can create PostgreSQL for MindRoom's event cache, or use an external PostgreSQL URL from an existing Secret.
+- Set `workers.sandbox.proxyToken.existingSecret` or `workers.sandbox.proxyToken.value` when sandbox proxying is enabled.
+- `workers.backend: static_runner` adds a sandbox-runner sidecar to the runtime pod.
+- `workers.backend: kubernetes` lets the runtime create dedicated worker Deployments and Services on demand.
+  The chart can create the worker-manager RBAC and a worker NetworkPolicy for the same namespace.
+- If workers run in a different namespace, provide storage, service accounts, and network policy behavior that are valid for that namespace.
+  Kubernetes owner references are only set by default for same-namespace workers.
+  When using an existing sandbox proxy token secret, create it in both the runtime namespace and the worker namespace.
+  When using `workers.sandbox.proxyToken.value`, the chart creates both copies.
+- Mount arbitrary platform-specific files, projected secrets, ConfigMaps, init containers, and sidecars through `extraVolumes`, `extraVolumeMounts`, `initContainers`, and `extraContainers`.
+- Use `nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`, and `podDisruptionBudget` for cluster-specific scheduling and availability policy.
+- Set `selectorLabels` when adopting an existing Deployment with an immutable selector.
+- Set `storage.volumeName`, `eventCache.postgres.selectorLabels`, `eventCache.postgres.persistence.volumeName`, or `workers.kubernetes.networkPolicy.name` when adopting existing resources with established names.
+- Override `probes.*.custom` when a deployment needs custom Kubernetes startup, readiness, or liveness probes.
 
 ## Adopting Existing Resources
 
-When replacing hand-written manifests for an existing runtime, keep immutable
-and externally referenced names stable in values:
+When replacing hand-written manifests for an existing runtime, keep immutable and externally referenced names stable in values:
 
 ```yaml
 fullnameOverride: mindroom
@@ -115,6 +168,21 @@ storage:
   create: false
   existingClaim: mindroom-data
   volumeName: data
+
+eventCache:
+  backend: postgres
+  postgres:
+    nameOverride: existing-event-cache-postgres
+    selectorLabels:
+      app: existing-event-cache-postgres
+    auth:
+      existingSecret: existing-event-cache-secrets
+      passwordKey: POSTGRES_PASSWORD
+    persistence:
+      volumeName: existing-event-cache-postgres-data
+  databaseUrl:
+    existingSecret: existing-event-cache-secrets
+    key: DATABASE_URL
 
 workers:
   backend: kubernetes

--- a/cluster/k8s/runtime/templates/NOTES.txt
+++ b/cluster/k8s/runtime/templates/NOTES.txt
@@ -7,6 +7,7 @@ Configuration:
   ConfigMap: {{ include "mindroom-runtime.configMapName" . }}
   Storage PVC: {{ include "mindroom-runtime.storageClaimName" . }}
   Worker backend: {{ .Values.workers.backend }}
+  Event cache: {{ .Values.eventCache.backend }}{{- if and (eq .Values.eventCache.backend "postgres") .Values.eventCache.postgres.create }} (chart-managed PostgreSQL: {{ include "mindroom-runtime.eventCachePostgresName" . }}){{- end }}
 
-For production use, provide Matrix settings, runtime secrets, and either an
-existing config ConfigMap or a chart-managed config value.
+For production use, provide Matrix settings, runtime secrets, and either an existing config ConfigMap or a chart-managed config value.
+For externally managed PostgreSQL, set eventCache.databaseUrl.existingSecret.

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -126,3 +126,76 @@ app.kubernetes.io/component: runtime
 {{- define "mindroom-runtime.workerNetworkPolicyName" -}}
 {{- default (printf "%s-workers" (include "mindroom-runtime.fullname" .)) .Values.workers.kubernetes.networkPolicy.name -}}
 {{- end -}}
+
+{{- define "mindroom-runtime.eventCacheNamespace" -}}
+{{- default .Release.Namespace .Values.eventCache.namespace -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.eventCacheDatabaseUrlSecretKey" -}}
+{{- default .Values.eventCache.databaseUrlEnv .Values.eventCache.databaseUrl.key -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.eventCachePostgresName" -}}
+{{- default (printf "%s-event-cache-postgres" (include "mindroom-runtime.fullname" .)) .Values.eventCache.postgres.nameOverride -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.eventCachePostgresSecretName" -}}
+{{- printf "%s-auth" (include "mindroom-runtime.eventCachePostgresName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.eventCachePostgresPasswordSecretName" -}}
+{{- if .Values.eventCache.postgres.auth.existingSecret -}}
+{{- .Values.eventCache.postgres.auth.existingSecret -}}
+{{- else -}}
+{{- include "mindroom-runtime.eventCachePostgresSecretName" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.eventCacheDatabaseUrlSecretName" -}}
+{{- if .Values.eventCache.databaseUrl.existingSecret -}}
+{{- .Values.eventCache.databaseUrl.existingSecret -}}
+{{- else if and .Values.eventCache.postgres.create (not .Values.eventCache.postgres.auth.existingSecret) -}}
+{{- include "mindroom-runtime.eventCachePostgresSecretName" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.eventCachePostgresImage" -}}
+{{- printf "%s:%s" .Values.eventCache.postgres.image.repository .Values.eventCache.postgres.image.tag -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.eventCachePostgresSelectorLabels" -}}
+{{- if .Values.eventCache.postgres.selectorLabels -}}
+{{- toYaml .Values.eventCache.postgres.selectorLabels -}}
+{{- else -}}
+app.kubernetes.io/name: {{ include "mindroom-runtime.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/component: event-cache-postgres
+{{- end -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.eventCachePostgresVolumeName" -}}
+{{- default "data" .Values.eventCache.postgres.persistence.volumeName -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.eventCachePostgresNetworkPolicyName" -}}
+{{- default (include "mindroom-runtime.eventCachePostgresName" .) .Values.eventCache.postgres.networkPolicy.name -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.eventCachePostgresDatabaseUrl" -}}
+{{- $root := .root -}}
+{{- $password := .password -}}
+{{- printf "postgresql://%s:%s@%s:%v/%s" ($root.Values.eventCache.postgres.auth.username | urlquery) ($password | urlquery) (include "mindroom-runtime.eventCachePostgresName" $root) $root.Values.eventCache.postgres.service.port ($root.Values.eventCache.postgres.auth.database | urlquery) -}}
+{{- end -}}
+
+{{- define "mindroom-runtime.defaultConfig" -}}
+agents: {}
+models: {}
+cache:
+  backend: {{ .Values.eventCache.backend | quote }}
+{{- if eq .Values.eventCache.backend "postgres" }}
+  database_url_env: {{ .Values.eventCache.databaseUrlEnv | quote }}
+  namespace: {{ include "mindroom-runtime.eventCacheNamespace" . | quote }}
+{{- else if .Values.eventCache.sqlite.dbPath }}
+  db_path: {{ .Values.eventCache.sqlite.dbPath | quote }}
+{{- end }}
+{{- end -}}

--- a/cluster/k8s/runtime/templates/configmap.yaml
+++ b/cluster/k8s/runtime/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.config.create (not .Values.config.existingConfigMap) }}
+{{- $configData := default (include "mindroom-runtime.defaultConfig" .) .Values.config.data -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,5 +8,5 @@ metadata:
     {{- include "mindroom-runtime.labels" . | nindent 4 }}
 data:
   {{ .Values.config.key }}: |
-{{ .Values.config.data | indent 4 }}
+{{ $configData | indent 4 }}
 {{- end }}

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -1,6 +1,8 @@
 {{- $fullname := include "mindroom-runtime.fullname" . -}}
 {{- $proxyTokenSecretName := include "mindroom-runtime.proxyTokenSecretName" . -}}
 {{- $workerNamespace := include "mindroom-runtime.workerNamespace" . -}}
+{{- $eventCacheDatabaseUrlSecretName := include "mindroom-runtime.eventCacheDatabaseUrlSecretName" . -}}
+{{- $eventCacheDatabaseUrlSecretKey := include "mindroom-runtime.eventCacheDatabaseUrlSecretKey" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -95,6 +97,13 @@ spec:
             {{- if .Values.runtime.timing }}
             - name: MINDROOM_TIMING
               value: "1"
+            {{- end }}
+            {{- if and (eq .Values.eventCache.backend "postgres") $eventCacheDatabaseUrlSecretName }}
+            - name: {{ .Values.eventCache.databaseUrlEnv }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $eventCacheDatabaseUrlSecretName }}
+                  key: {{ $eventCacheDatabaseUrlSecretKey }}
             {{- end }}
             - name: MINDROOM_WORKER_BACKEND
               value: {{ .Values.workers.backend | quote }}

--- a/cluster/k8s/runtime/templates/event-cache-postgres.yaml
+++ b/cluster/k8s/runtime/templates/event-cache-postgres.yaml
@@ -1,0 +1,159 @@
+{{- if and (eq .Values.eventCache.backend "postgres") .Values.eventCache.postgres.create }}
+{{- $name := include "mindroom-runtime.eventCachePostgresName" . -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+  {{- with .Values.eventCache.postgres.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: postgres
+      port: {{ .Values.eventCache.postgres.service.port }}
+      targetPort: postgres
+      protocol: TCP
+  selector:
+    {{- include "mindroom-runtime.eventCachePostgresSelectorLabels" . | nindent 4 }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ $name }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "mindroom-runtime.eventCachePostgresSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mindroom-runtime.eventCachePostgresSelectorLabels" . | nindent 8 }}
+        {{- with .Values.eventCache.postgres.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.eventCache.postgres.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.eventCache.postgres.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.eventCache.postgres.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.eventCache.postgres.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.eventCache.postgres.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgres
+          image: {{ include "mindroom-runtime.eventCachePostgresImage" . | quote }}
+          imagePullPolicy: {{ .Values.eventCache.postgres.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.eventCache.postgres.service.port }}
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.eventCache.postgres.auth.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.eventCache.postgres.auth.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mindroom-runtime.eventCachePostgresPasswordSecretName" . }}
+                  key: {{ .Values.eventCache.postgres.auth.passwordKey }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.eventCache.postgres.auth.username | quote }}
+                - -d
+                - {{ .Values.eventCache.postgres.auth.database | quote }}
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.eventCache.postgres.auth.username | quote }}
+                - -d
+                - {{ .Values.eventCache.postgres.auth.database | quote }}
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.eventCache.postgres.resources | nindent 12 }}
+          {{- with .Values.eventCache.postgres.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: {{ include "mindroom-runtime.eventCachePostgresVolumeName" . }}
+              mountPath: /var/lib/postgresql/data
+      {{- if not .Values.eventCache.postgres.persistence.enabled }}
+      volumes:
+        - name: {{ include "mindroom-runtime.eventCachePostgresVolumeName" . }}
+          emptyDir: {}
+      {{- end }}
+  {{- if .Values.eventCache.postgres.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "mindroom-runtime.eventCachePostgresVolumeName" . }}
+        labels:
+          {{- include "mindroom-runtime.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.eventCache.postgres.persistence.accessModes | nindent 10 }}
+        {{- if .Values.eventCache.postgres.persistence.storageClassName }}
+        storageClassName: {{ .Values.eventCache.postgres.persistence.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.eventCache.postgres.persistence.size | quote }}
+  {{- end }}
+{{- if .Values.eventCache.postgres.networkPolicy.create }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mindroom-runtime.eventCachePostgresNetworkPolicyName" . }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mindroom-runtime.eventCachePostgresSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "mindroom-runtime.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.eventCache.postgres.service.port }}
+{{- end }}
+{{- end }}

--- a/cluster/k8s/runtime/templates/secret.yaml
+++ b/cluster/k8s/runtime/templates/secret.yaml
@@ -24,3 +24,32 @@ stringData:
   {{ .Values.workers.sandbox.proxyToken.key }}: {{ .Values.workers.sandbox.proxyToken.value | quote }}
 {{- end }}
 {{- end }}
+{{- if and (eq .Values.eventCache.backend "postgres") .Values.eventCache.postgres.create (not .Values.eventCache.postgres.auth.existingSecret) }}
+{{- $secretName := include "mindroom-runtime.eventCachePostgresSecretName" . -}}
+{{- $passwordKey := .Values.eventCache.postgres.auth.passwordKey -}}
+{{- $databaseUrlKey := include "mindroom-runtime.eventCacheDatabaseUrlSecretKey" . -}}
+{{- $password := .Values.eventCache.postgres.auth.password -}}
+{{- if not $password }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if and $existing (hasKey $existing.data $passwordKey) }}
+{{- $password = index $existing.data $passwordKey | b64dec -}}
+{{- else }}
+{{- $password = randAlphaNum 32 -}}
+{{- end }}
+{{- end }}
+{{- if .Values.workers.sandbox.proxyToken.value }}
+---
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "mindroom-runtime.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ $passwordKey }}: {{ $password | quote }}
+  {{- if not .Values.eventCache.databaseUrl.existingSecret }}
+  {{ $databaseUrlKey }}: {{ include "mindroom-runtime.eventCachePostgresDatabaseUrl" (dict "root" . "password" $password) | quote }}
+  {{- end }}
+{{- end }}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -1,0 +1,15 @@
+{{- if not (or (eq .Values.eventCache.backend "postgres") (eq .Values.eventCache.backend "sqlite")) -}}
+{{- fail "eventCache.backend must be either postgres or sqlite" -}}
+{{- end -}}
+{{- if and (eq .Values.eventCache.backend "postgres") (not .Values.eventCache.databaseUrlEnv) -}}
+{{- fail "eventCache.databaseUrlEnv is required when eventCache.backend=postgres" -}}
+{{- end -}}
+{{- if and (eq .Values.eventCache.backend "postgres") (not (regexMatch "(^DATABASE_URL$|_DATABASE_URL$)" .Values.eventCache.databaseUrlEnv)) -}}
+{{- fail "eventCache.databaseUrlEnv must be DATABASE_URL or end with _DATABASE_URL" -}}
+{{- end -}}
+{{- if and (eq .Values.eventCache.backend "postgres") .Values.eventCache.postgres.create .Values.eventCache.databaseUrl.existingSecret (not .Values.eventCache.postgres.auth.existingSecret) (not .Values.eventCache.postgres.auth.password) -}}
+{{- fail "eventCache.postgres.auth.password or eventCache.postgres.auth.existingSecret is required when chart-managed PostgreSQL uses an existing database URL Secret" -}}
+{{- end -}}
+{{- if and (eq .Values.eventCache.backend "postgres") .Values.eventCache.postgres.create (not .Values.eventCache.postgres.auth.existingSecret) (not .Values.eventCache.databaseUrl.existingSecret) (eq .Values.eventCache.postgres.auth.passwordKey (include "mindroom-runtime.eventCacheDatabaseUrlSecretKey" .)) -}}
+{{- fail "eventCache.postgres.auth.passwordKey must differ from the event-cache database URL secret key" -}}
+{{- end -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -1,6 +1,6 @@
 # Runtime-only MindRoom chart.
-# This chart intentionally avoids platform-specific defaults. Use existing
-# ConfigMaps, Secrets, PVCs, and service URLs from your own cluster.
+# This chart intentionally avoids platform-specific defaults.
+# It can create MindRoom runtime storage and event-cache resources, while Matrix, ingress, model gateways, and deployment-specific secrets come from your own cluster.
 
 nameOverride: ""
 fullnameOverride: ""
@@ -18,8 +18,8 @@ imagePullSecrets: []
 deploymentAnnotations: {}
 podAnnotations: {}
 podLabels: {}
-# Leave empty for the chart default. Set this when adopting an existing
-# Deployment whose selector is immutable.
+# Leave empty for the chart default.
+# Set this when adopting an existing Deployment whose selector is immutable.
 selectorLabels: {}
 priorityClassName: ""
 nodeSelector: {}
@@ -65,9 +65,70 @@ config:
   existingConfigMap: ""
   key: config.yaml
   mountPath: /app/config.yaml
-  data: |
-    agents: {}
-    models: {}
+  # Leave empty to render the chart's minimal default config, including the event-cache settings below.
+  # Set this when you want full control over the generated config file.
+  data: ""
+
+eventCache:
+  # The runtime chart defaults to PostgreSQL because Kubernetes deployments need a restart-safe cache backend.
+  # Set this to sqlite for lightweight installs.
+  backend: postgres
+  # Logical namespace for rows in a shared PostgreSQL event-cache database.
+  # Defaults to the Helm release namespace.
+  namespace: ""
+  databaseUrlEnv: MINDROOM_EVENT_CACHE_DATABASE_URL
+  databaseUrl:
+    # Use this for an externally managed PostgreSQL database, or when adopting an existing Secret for a chart-managed database.
+    # The secret should contain a full psycopg-compatible connection string.
+    existingSecret: ""
+    key: ""
+  sqlite:
+    dbPath: ""
+  postgres:
+    create: true
+    nameOverride: ""
+    # Leave empty for the chart default.
+    # Set this when adopting an existing StatefulSet whose selector is immutable.
+    selectorLabels: {}
+    image:
+      repository: postgres
+      tag: "17"
+      pullPolicy: IfNotPresent
+    service:
+      port: 5432
+      annotations: {}
+    auth:
+      database: mindroom_cache
+      username: mindroom_cache
+      # Existing password Secret for a chart-managed PostgreSQL database.
+      existingSecret: ""
+      # Leave empty to generate and preserve a random password during Helm upgrades.
+      # Set a value for deterministic helm template output.
+      password: ""
+      passwordKey: password
+    persistence:
+      enabled: true
+      volumeName: data
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: ""
+      size: 20Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    podAnnotations: {}
+    podLabels: {}
+    podSecurityContext: {}
+    securityContext: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    networkPolicy:
+      create: true
+      name: ""
 
 storage:
   create: true


### PR DESCRIPTION
## Summary
- add optional chart-managed PostgreSQL for the runtime event cache
- default runtime chart event cache config to PostgreSQL while keeping SQLite available
- support external database URL Secrets and adoption of existing StatefulSet names/selectors/password Secrets
- extend chart render validation for default, SQLite, external PostgreSQL, and adoption-style PostgreSQL values without printing rendered Secrets to logs

## Validation
- `helm lint cluster/k8s/runtime`
- `helm template` default PostgreSQL mode redirected to temp file
- `helm template` SQLite mode redirected to temp file
- `helm template` external PostgreSQL mode redirected to temp file
- `helm template` adoption-style PostgreSQL mode redirected to temp file
- `helm package cluster/k8s/runtime`
- `git diff --check`