### PR TITLE
Allow adopting Postgres cache PVC templates without labels

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -85,6 +85,7 @@ jobs:
             --set eventCache.postgres.nameOverride=existing-event-cache-postgres \
             --set eventCache.postgres.selectorLabels.app=existing-event-cache-postgres \
             --set eventCache.postgres.persistence.volumeName=existing-event-cache-postgres-data \
+            --set eventCache.postgres.persistence.includeChartLabels=false \
             --set eventCache.postgres.auth.existingSecret=existing-event-cache-secrets \
             --set eventCache.postgres.auth.passwordKey=POSTGRES_PASSWORD \
             --set eventCache.databaseUrl.existingSecret=existing-event-cache-secrets \

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -147,6 +147,7 @@ workers:
 - Use `nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`, and `podDisruptionBudget` for cluster-specific scheduling and availability policy.
 - Set `selectorLabels` when adopting an existing Deployment with an immutable selector.
 - Set `storage.volumeName`, `eventCache.postgres.selectorLabels`, `eventCache.postgres.persistence.volumeName`, or `workers.kubernetes.networkPolicy.name` when adopting existing resources with established names.
+- Set `eventCache.postgres.persistence.includeChartLabels: false` when adopting an existing PostgreSQL StatefulSet whose volume claim template has no chart labels.
 - Override `probes.*.custom` when a deployment needs custom Kubernetes startup, readiness, or liveness probes.
 
 ## Adopting Existing Resources
@@ -180,6 +181,7 @@ eventCache:
       passwordKey: POSTGRES_PASSWORD
     persistence:
       volumeName: existing-event-cache-postgres-data
+      includeChartLabels: false
   databaseUrl:
     existingSecret: existing-event-cache-secrets
     key: DATABASE_URL

--- a/cluster/k8s/runtime/templates/event-cache-postgres.yaml
+++ b/cluster/k8s/runtime/templates/event-cache-postgres.yaml
@@ -121,8 +121,15 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: {{ include "mindroom-runtime.eventCachePostgresVolumeName" . }}
+        {{- if or .Values.eventCache.postgres.persistence.includeChartLabels .Values.eventCache.postgres.persistence.labels }}
         labels:
+          {{- if .Values.eventCache.postgres.persistence.includeChartLabels }}
           {{- include "mindroom-runtime.labels" . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.eventCache.postgres.persistence.labels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- end }}
       spec:
         accessModes:
           {{- toYaml .Values.eventCache.postgres.persistence.accessModes | nindent 10 }}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -109,6 +109,11 @@ eventCache:
     persistence:
       enabled: true
       volumeName: data
+      # Leave true for chart-created StatefulSets and upgrades.
+      # Set false when adopting an existing StatefulSet whose volumeClaimTemplate has no chart labels.
+      includeChartLabels: true
+      # Extra labels for the StatefulSet volumeClaimTemplates metadata.
+      labels: {}
       accessModes:
         - ReadWriteOnce
       storageClassName: ""


### PR DESCRIPTION
## Summary
- add an eventCache.postgres.persistence.includeChartLabels flag for adopting existing Postgres StatefulSets whose volumeClaimTemplate has no chart labels
- add optional eventCache.postgres.persistence.labels for explicit PVC template labels
- update runtime chart adoption docs and render validation

## Validation
- helm lint cluster/k8s/runtime
- helm template default runtime chart keeps PVC template chart labels
- helm template adoption values with includeChartLabels=false omits PVC template labels
- helm template with the current gcp-infra values plus includeChartLabels=false renders the existing Postgres PVC template metadata with only the stable name
