### PR TITLE
Fix hosted public profile env defaults

### DIFF
--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12260,10 +12260,11 @@ Deploy MindRoom on Kubernetes for production multi-tenant deployments.
 
 ## Architecture
 
-MindRoom uses two Helm charts:
+MindRoom uses three Helm charts:
 
 - **Instance Chart** (`cluster/k8s/instance/`) - Individual MindRoom runtime with bundled dashboard/API plus Matrix/Synapse
 - **Platform Chart** (`cluster/k8s/platform/`) - SaaS control plane (API, frontend, provisioner)
+- **Runtime Chart** (`cluster/k8s/runtime/`) - MindRoom runtime only, for clusters that provide Matrix, storage, secrets, ingress, and platform services externally
 
 ## Prerequisites
 
@@ -12303,9 +12304,54 @@ helm upgrade --install instance-1 ./cluster/k8s/instance \
   --set supabaseServiceKey="your-service-key"
 ```
 
+## Runtime-Only Deployment
+
+Use the runtime chart when you already operate the surrounding platform and only want Kubernetes to run the MindRoom runtime. The chart intentionally does not create Matrix, ingress, a model gateway, or platform services.
+
+```
+helm upgrade --install mindroom-runtime ./cluster/k8s/runtime \
+  --namespace mindroom \
+  --create-namespace \
+  -f runtime-values.yaml
+```
+
+Typical production values point at existing resources:
+
+```
+config:
+  create: false
+  existingConfigMap: mindroom-config
+  key: config.yaml
+
+storage:
+  create: false
+  existingClaim: mindroom-data
+
+matrix:
+  homeserverUrl: http://matrix.example.svc.cluster.local:8008
+  serverName: example.com
+  registrationToken:
+    existingSecret: mindroom-secrets
+    key: MATRIX_REGISTRATION_TOKEN
+
+env:
+  envFrom:
+    - secretRef:
+        name: mindroom-secrets
+
+workers:
+  backend: kubernetes
+  sandbox:
+    proxyToken:
+      existingSecret: mindroom-sandbox-proxy
+      key: MINDROOM_SANDBOX_PROXY_TOKEN
+```
+
+See `cluster/k8s/runtime/README.md` and `cluster/k8s/runtime/values.yaml` for the full values surface.
+
 ## Worker Backends
 
-The instance chart supports two worker backend modes for worker-routed tools such as `shell`, `file`, and `python`. The dedicated-worker provisioning flow is implemented today. Both modes store agent data in the same per-agent directory structure.
+The instance and runtime charts support two worker backend modes for worker-routed tools such as `shell`, `file`, and `python`. The dedicated-worker provisioning flow is implemented today. Both modes store agent data in the same per-agent directory structure.
 
 | Helm value                     | Behavior                                                            | Best for                                                                              |
 | ------------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
@@ -12339,6 +12385,8 @@ kubernetesWorkerReadyTimeoutSeconds: 60
 kubernetesWorkerIdleTimeoutSeconds: 1800
 sandbox_proxy_token: "replace-me"
 ```
+
+The runtime chart exposes the same concepts under the nested `workers.*` values.
 
 Important behavior and constraints:
 

--- a/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
+++ b/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
@@ -4,10 +4,11 @@ Deploy MindRoom on Kubernetes for production multi-tenant deployments.
 
 ## Architecture
 
-MindRoom uses two Helm charts:
+MindRoom uses three Helm charts:
 
 - **Instance Chart** (`cluster/k8s/instance/`) - Individual MindRoom runtime with bundled dashboard/API plus Matrix/Synapse
 - **Platform Chart** (`cluster/k8s/platform/`) - SaaS control plane (API, frontend, provisioner)
+- **Runtime Chart** (`cluster/k8s/runtime/`) - MindRoom runtime only, for clusters that provide Matrix, storage, secrets, ingress, and platform services externally
 
 ## Prerequisites
 
@@ -47,9 +48,54 @@ helm upgrade --install instance-1 ./cluster/k8s/instance \
   --set supabaseServiceKey="your-service-key"
 ```
 
+## Runtime-Only Deployment
+
+Use the runtime chart when you already operate the surrounding platform and only want Kubernetes to run the MindRoom runtime. The chart intentionally does not create Matrix, ingress, a model gateway, or platform services.
+
+```
+helm upgrade --install mindroom-runtime ./cluster/k8s/runtime \
+  --namespace mindroom \
+  --create-namespace \
+  -f runtime-values.yaml
+```
+
+Typical production values point at existing resources:
+
+```
+config:
+  create: false
+  existingConfigMap: mindroom-config
+  key: config.yaml
+
+storage:
+  create: false
+  existingClaim: mindroom-data
+
+matrix:
+  homeserverUrl: http://matrix.example.svc.cluster.local:8008
+  serverName: example.com
+  registrationToken:
+    existingSecret: mindroom-secrets
+    key: MATRIX_REGISTRATION_TOKEN
+
+env:
+  envFrom:
+    - secretRef:
+        name: mindroom-secrets
+
+workers:
+  backend: kubernetes
+  sandbox:
+    proxyToken:
+      existingSecret: mindroom-sandbox-proxy
+      key: MINDROOM_SANDBOX_PROXY_TOKEN
+```
+
+See `cluster/k8s/runtime/README.md` and `cluster/k8s/runtime/values.yaml` for the full values surface.
+
 ## Worker Backends
 
-The instance chart supports two worker backend modes for worker-routed tools such as `shell`, `file`, and `python`. The dedicated-worker provisioning flow is implemented today. Both modes store agent data in the same per-agent directory structure.
+The instance and runtime charts support two worker backend modes for worker-routed tools such as `shell`, `file`, and `python`. The dedicated-worker provisioning flow is implemented today. Both modes store agent data in the same per-agent directory structure.
 
 | Helm value                     | Behavior                                                            | Best for                                                                              |
 | ------------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
@@ -83,6 +129,8 @@ kubernetesWorkerReadyTimeoutSeconds: 60
 kubernetesWorkerIdleTimeoutSeconds: 1800
 sandbox_proxy_token: "replace-me"
 ```
+
+The runtime chart exposes the same concepts under the nested `workers.*` values.
 
 Important behavior and constraints:
 

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -14,6 +14,7 @@ from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING, Literal
 
 import typer
+from dotenv import dotenv_values
 from rich.console import Console
 from rich.syntax import Syntax
 
@@ -79,6 +80,12 @@ _REQUIRED_ENV_KEYS: dict[_ProviderPreset, tuple[str, ...]] = {
     "openrouter": ("OPENROUTER_API_KEY",),
     "vertexai_claude": (),
 }
+_PUBLIC_HOSTED_ENV_DEFAULTS: tuple[tuple[str, str], ...] = (
+    ("MATRIX_HOMESERVER", "https://mindroom.chat"),
+    ("MATRIX_SERVER_NAME", "mindroom.chat"),
+    ("MINDROOM_PROVISIONING_URL", "https://mindroom.chat"),
+    ("MATRIX_REGISTRATION_TOKEN", ""),
+)
 _CANONICAL_INIT_PROFILES: tuple[str, ...] = (
     "full",
     "minimal",
@@ -150,10 +157,42 @@ def _write_env_file(
         return True
 
     if not replace_existing:
+        if selected_profile == "public":
+            return _append_missing_env_defaults(
+                env_path,
+                _PUBLIC_HOSTED_ENV_DEFAULTS,
+                title="Hosted Matrix defaults for public profiles",
+            )
         return False
 
     env_path.write_text(_env_template(selected_profile, selected_preset, storage_root), encoding="utf-8")
     console.print(f"[green]Env file overwritten:[/green] {env_path}")
+    return True
+
+
+def _append_missing_env_defaults(
+    env_path: Path,
+    defaults: tuple[tuple[str, str], ...],
+    *,
+    title: str,
+) -> bool:
+    """Append missing env defaults without changing existing user-owned values."""
+    existing_values = dotenv_values(env_path)
+    missing_defaults = [(key, value) for key, value in defaults if key not in existing_values]
+    if not missing_defaults:
+        return False
+
+    current_content = env_path.read_text(encoding="utf-8")
+    separator = ""
+    if current_content:
+        separator = "" if current_content.endswith("\n") else "\n"
+        if current_content.strip():
+            separator += "\n"
+
+    appended_lines = [f"# {title}", *(f"{key}={value}" for key, value in missing_defaults)]
+    appended_content = "\n".join(appended_lines)
+    env_path.write_text(f"{current_content}{separator}{appended_content}\n", encoding="utf-8")
+    console.print(f"[green]Env file updated:[/green] {env_path}")
     return True
 
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -344,6 +344,64 @@ class TestConfigInit:
         assert "Google" in output
         assert "auth" in output
 
+    def test_init_profile_public_vertexai_anthropic_updates_existing_env_with_hosted_defaults(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Hosted profiles should append Matrix defaults when preserving an existing `.env`."""
+        target = tmp_path / "config.yaml"
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "ANTHROPIC_VERTEX_PROJECT_ID=existing-project\nCLOUD_ML_REGION=europe-west4\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            ["config", "init", "--path", str(target), "--profile", "public-vertexai-anthropic"],
+            input="n\n",
+        )
+
+        assert result.exit_code == 0
+        env_content = env_path.read_text(encoding="utf-8")
+        assert "ANTHROPIC_VERTEX_PROJECT_ID=existing-project" in env_content
+        assert "CLOUD_ML_REGION=europe-west4" in env_content
+        assert "MATRIX_HOMESERVER=https://mindroom.chat" in env_content
+        assert "MATRIX_SERVER_NAME=mindroom.chat" in env_content
+        assert "MINDROOM_PROVISIONING_URL=https://mindroom.chat" in env_content
+        assert "MATRIX_REGISTRATION_TOKEN=" in env_content
+        assert "Env file updated" in normalize_console_output(result.output)
+
+    def test_init_profile_public_updates_connect_created_env_with_hosted_defaults(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Running `connect` before `config init` should not strand public Matrix defaults."""
+        target = tmp_path / "config.yaml"
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "MINDROOM_PROVISIONING_URL=https://mindroom.chat\n"
+            "MINDROOM_LOCAL_CLIENT_ID=client-123\n"
+            "MINDROOM_LOCAL_CLIENT_SECRET=secret-123\n"
+            "MINDROOM_NAMESPACE=a1b2c3d4\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            ["config", "init", "--path", str(target), "--profile", "public-vertexai-anthropic"],
+            input="n\n",
+        )
+
+        assert result.exit_code == 0
+        env_content = env_path.read_text(encoding="utf-8")
+        assert "MINDROOM_LOCAL_CLIENT_ID=client-123" in env_content
+        assert "MINDROOM_LOCAL_CLIENT_SECRET=secret-123" in env_content
+        assert env_content.count("MINDROOM_PROVISIONING_URL=") == 1
+        assert "MATRIX_HOMESERVER=https://mindroom.chat" in env_content
+        assert "MATRIX_SERVER_NAME=mindroom.chat" in env_content
+        assert "MATRIX_REGISTRATION_TOKEN=" in env_content
+
     def test_init_profile_public_codex_writes_hosted_codex_defaults(self, tmp_path: Path) -> None:
         """Hosted Codex profile should use Codex defaults and hosted Matrix settings."""
         target = tmp_path / "config.yaml"


### PR DESCRIPTION
## Summary
- Append missing hosted Matrix defaults when public config init preserves an existing .env
- Keep existing user-owned env values such as Vertex AI project and region unchanged
- Add regression coverage for public-vertexai-anthropic with an existing .env
- Include regenerated mindroom-docs skill references from pre-commit

## Tests
- uv run pytest -n auto --no-cov
- uv run pre-commit run --all-files