### PR TITLE
Fix connect-first owner placeholder init

### DIFF
--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -18,6 +18,7 @@ from dotenv import dotenv_values
 from rich.console import Console
 from rich.syntax import Syntax
 
+from mindroom.cli.owner import parse_owner_matrix_user_id, replace_owner_placeholders_in_text
 from mindroom.config.main import (
     CONFIG_LOAD_USER_ERROR_TYPES,
     Config,
@@ -26,6 +27,7 @@ from mindroom.config.main import (
     load_config,
 )
 from mindroom.constants import (
+    OWNER_MATRIX_USER_ID_ENV,
     OWNER_MATRIX_USER_ID_PLACEHOLDER,
     VERTEXAI_CLAUDE_ENV_KEYS,
     RuntimePaths,
@@ -99,15 +101,21 @@ def _config_init_storage_plan(
     config_dir: Path,
     env_path: Path,
     *,
-    write_env_file: bool,
+    replace_env_file: bool,
 ) -> tuple[Path, bool]:
     """Return the storage root and whether the starter config can use the env placeholder."""
     runtime_paths = resolve_runtime_paths(config_path=config_dir / "config.yaml")
-    if write_env_file:
+    if replace_env_file:
         return runtime_paths.storage_root, True
     if "MINDROOM_STORAGE_PATH" in runtime_paths.env_file_values and env_path.is_file():
         return runtime_paths.storage_root, True
     return runtime_paths.storage_root, False
+
+
+def _config_init_owner_user_id(config_path: Path) -> str | None:
+    """Return the paired owner MXID available to config init, if one was persisted."""
+    runtime_paths = resolve_runtime_paths(config_path=config_path)
+    return parse_owner_matrix_user_id(runtime_paths.env_value(OWNER_MATRIX_USER_ID_ENV))
 
 
 def _default_mind_workspace(storage_root: Path) -> Path:
@@ -157,6 +165,9 @@ def _write_env_file(
         return True
 
     if not replace_existing:
+        # `connect` can create .env before `config init`; public profiles still
+        # need hosted Matrix defaults, so preserve user-owned values and append
+        # only the missing hosted keys.
         if selected_profile == "public":
             return _append_missing_env_defaults(
                 env_path,
@@ -196,8 +207,8 @@ def _append_missing_env_defaults(
     return True
 
 
-def _should_write_env_file(env_path: Path, *, force: bool) -> bool:
-    """Return whether config init should create or overwrite the env file."""
+def _should_replace_env_file(env_path: Path, *, force: bool) -> bool:
+    """Return whether config init should create or overwrite the full env template."""
     if not env_path.exists():
         return True
     return force or typer.confirm(f"Overwrite existing .env file ({env_path})?", default=False)
@@ -221,13 +232,13 @@ def _config_init_env_hint(selected_profile: _ConfigInitProfile, selected_preset:
 def _print_config_init_next_steps(
     env_path: Path,
     *,
-    env_created: bool,
+    env_changed: bool,
     selected_profile: _ConfigInitProfile,
     selected_preset: _ProviderPreset,
 ) -> None:
     """Print post-init guidance for the selected profile."""
     console.print("\nNext steps:")
-    if env_created:
+    if env_changed:
         env_hint = _config_init_env_hint(selected_profile, selected_preset)
         console.print(f"  [cyan]Edit {env_path}[/cyan]  {env_hint}")
     if selected_profile == "public":
@@ -368,11 +379,11 @@ def config_init(
         minimal=minimal,
         provider=provider,
     )
-    write_env_file = _should_write_env_file(env_path, force=force)
+    replace_env_file = _should_replace_env_file(env_path, force=force)
     storage_root, use_storage_env_placeholder = _config_init_storage_plan(
         target.parent,
         env_path,
-        write_env_file=write_env_file,
+        replace_env_file=replace_env_file,
     )
 
     if selected_profile == "minimal":
@@ -387,24 +398,30 @@ def config_init(
             profile=full_profile,
         )
 
+    # `connect` can run before `config init`, when no config exists to patch.
+    # In that order, connect persists the owner MXID in .env so init can render
+    # authorization defaults without leaving pairing placeholders behind.
+    if owner_user_id := _config_init_owner_user_id(target):
+        content = replace_owner_placeholders_in_text(content, owner_user_id)
+
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(content, encoding="utf-8")
 
     if selected_profile != "minimal":
         _ensure_mind_workspace(_default_mind_workspace(storage_root), force=force)
 
-    env_created = _write_env_file(
+    env_changed = _write_env_file(
         env_path,
         selected_profile,
         selected_preset,
         storage_root=storage_root,
-        replace_existing=write_env_file,
+        replace_existing=replace_env_file,
     )
 
     console.print(f"[green]Config created:[/green] {target}")
     _print_config_init_next_steps(
         env_path,
-        env_created=env_created,
+        env_changed=env_changed,
         selected_profile=selected_profile,
         selected_preset=selected_preset,
     )

--- a/src/mindroom/cli/connect.py
+++ b/src/mindroom/cli/connect.py
@@ -10,15 +10,16 @@ from typing import TYPE_CHECKING
 
 import httpx
 
-from mindroom.constants import OWNER_MATRIX_USER_ID_PLACEHOLDER
+from mindroom.cli.owner import parse_owner_matrix_user_id, replace_owner_placeholders_in_text
+from mindroom.constants import (
+    OWNER_MATRIX_USER_ID_ENV,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 _PAIR_CODE_RE = re.compile(r"^[A-Z0-9]{4}-[A-Z0-9]{4}$")
-_MATRIX_USER_ID_RE = re.compile(r"^@[^:\s]+:[^\s]+$")
 _NAMESPACE_RE = re.compile(r"^[a-z0-9]{4,32}$")
-_LEGACY_OWNER_PLACEHOLDER = "__PLACEHOLDER__"
 
 
 @dataclass(frozen=True)
@@ -76,7 +77,7 @@ def complete_local_pairing(
         raise TypeError(msg)
 
     raw_owner_user_id = data.get("owner_user_id")
-    parsed_owner_user_id = _parse_owner_user_id(raw_owner_user_id)
+    parsed_owner_user_id = parse_owner_matrix_user_id(raw_owner_user_id)
     owner_user_id_invalid = (
         isinstance(raw_owner_user_id, str) and bool(raw_owner_user_id.strip()) and parsed_owner_user_id is None
     )
@@ -103,6 +104,7 @@ def persist_local_provisioning_env(
     client_id: str,
     client_secret: str,
     namespace: str,
+    owner_user_id: str | None = None,
     config_path: str | Path,
 ) -> Path:
     """Write local provisioning credentials to .env next to the active config file."""
@@ -117,6 +119,8 @@ def persist_local_provisioning_env(
         "MINDROOM_LOCAL_CLIENT_SECRET": client_secret,
         "MINDROOM_NAMESPACE": namespace,
     }
+    if parsed_owner_user_id := parse_owner_matrix_user_id(owner_user_id):
+        updates[OWNER_MATRIX_USER_ID_ENV] = parsed_owner_user_id
     for key, value in updates.items():
         lines = _upsert_env_var(lines, key, value)
 
@@ -126,19 +130,13 @@ def persist_local_provisioning_env(
 
 def replace_owner_placeholders_in_config(*, config_path: Path, owner_user_id: str) -> bool:
     """Replace owner placeholder tokens in config.yaml if they are still present."""
-    if not _MATRIX_USER_ID_RE.fullmatch(owner_user_id):
+    if parse_owner_matrix_user_id(owner_user_id) is None:
         return False
     if not config_path.exists():
         return False
 
     content = config_path.read_text(encoding="utf-8")
-    # Quote the Matrix user ID so the leading '@' doesn't break YAML parsing
-    # (@ starts a YAML tag/anchor when unquoted).
-    quoted = f'"{owner_user_id}"'
-    replaced = content.replace(OWNER_MATRIX_USER_ID_PLACEHOLDER, quoted).replace(
-        _LEGACY_OWNER_PLACEHOLDER,
-        quoted,
-    )
+    replaced = replace_owner_placeholders_in_text(content, owner_user_id)
     if replaced == content:
         return False
 
@@ -155,18 +153,6 @@ def _required_non_empty_string(data: dict[str, object], key: str) -> str:
             return value
     msg = f"Provisioning response missing {key}."
     raise ValueError(msg)
-
-
-def _parse_owner_user_id(raw_value: object) -> str | None:
-    """Parse optional owner_user_id from pairing response."""
-    if not isinstance(raw_value, str):
-        return None
-    candidate_owner_user_id = raw_value.strip()
-    if not candidate_owner_user_id:
-        return None
-    if _MATRIX_USER_ID_RE.fullmatch(candidate_owner_user_id):
-        return candidate_owner_user_id
-    return None
 
 
 def _parse_namespace(raw_value: object) -> str | None:

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -318,6 +318,7 @@ def connect(
             client_id=credentials.client_id,
             client_secret=credentials.client_secret,
             namespace=credentials.namespace,
+            owner_user_id=credentials.owner_user_id,
             config_path=resolved_config_path,
         )
         console.print("[green]Paired successfully.[/green]")
@@ -359,6 +360,7 @@ def _print_pairing_success_with_exports(
     console.print(f"  export MINDROOM_LOCAL_CLIENT_SECRET={client_secret}")
     console.print(f"  export MINDROOM_NAMESPACE={namespace}")
     if owner_user_id:
+        console.print(f"  export MINDROOM_OWNER_USER_ID={owner_user_id}")
         console.print(
             f"\nOwner user ID from pairing: {owner_user_id} (not persisted in --no-persist-env mode).",
         )

--- a/src/mindroom/cli/owner.py
+++ b/src/mindroom/cli/owner.py
@@ -1,0 +1,33 @@
+"""Owner Matrix user ID helpers for CLI onboarding."""
+
+from __future__ import annotations
+
+import re
+
+from mindroom.constants import OWNER_MATRIX_USER_ID_PLACEHOLDER
+
+_LEGACY_OWNER_MATRIX_USER_ID_PLACEHOLDER = "__PLACEHOLDER__"
+_OWNER_MATRIX_USER_ID_RE = re.compile(r"^@[^:\s]+:[^\s]+$")
+
+
+def parse_owner_matrix_user_id(raw_value: object) -> str | None:
+    """Parse an optional owner Matrix user ID."""
+    if not isinstance(raw_value, str):
+        return None
+    candidate_owner_user_id = raw_value.strip()
+    if _OWNER_MATRIX_USER_ID_RE.fullmatch(candidate_owner_user_id):
+        return candidate_owner_user_id
+    return None
+
+
+def replace_owner_placeholders_in_text(content: str, owner_user_id: str) -> str:
+    """Return config text with owner placeholders replaced by a quoted Matrix user ID."""
+    if parse_owner_matrix_user_id(owner_user_id) is None:
+        return content
+    # Quote the Matrix user ID so the leading '@' doesn't break YAML parsing
+    # (@ starts a YAML tag/anchor when unquoted).
+    quoted = f'"{owner_user_id}"'
+    return content.replace(OWNER_MATRIX_USER_ID_PLACEHOLDER, quoted).replace(
+        _LEGACY_OWNER_MATRIX_USER_ID_PLACEHOLDER,
+        quoted,
+    )

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -873,6 +873,7 @@ STREAM_STATUS_ERROR = "error"
 # automatically replace this token with the owner Matrix user ID returned
 # by the provisioning service.
 OWNER_MATRIX_USER_ID_PLACEHOLDER = "__MINDROOM_OWNER_USER_ID_FROM_PAIRING__"
+OWNER_MATRIX_USER_ID_ENV = "MINDROOM_OWNER_USER_ID"
 
 
 # Canonical mapping from provider name to the environment variable it requires.

--- a/tach.toml
+++ b/tach.toml
@@ -1440,6 +1440,7 @@ depends_on = []
 [[modules]]
 path = "mindroom.cli.config"
 depends_on = [
+    "mindroom.cli.owner",
     "mindroom.config.main",
     "mindroom.constants",
     "mindroom.credentials_sync",
@@ -1449,7 +1450,18 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.cli.connect"
+depends_on = [
+    "mindroom.cli.owner",
+    "mindroom.constants",
+]
+
+[[modules]]
+path = "mindroom.cli.owner"
 depends_on = ["mindroom.constants"]
+visibility = [
+    "mindroom.cli.config",
+    "mindroom.cli.connect",
+]
 
 [[modules]]
 path = "mindroom.cli.doctor"

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -23,7 +23,7 @@ from mindroom.agents import ensure_default_agent_workspaces
 from mindroom.cli.config import _activate_cli_runtime
 from mindroom.cli.main import _load_active_config_or_exit, app
 from mindroom.config.main import Config
-from mindroom.constants import OWNER_MATRIX_USER_ID_PLACEHOLDER
+from mindroom.constants import OWNER_MATRIX_USER_ID_ENV, OWNER_MATRIX_USER_ID_PLACEHOLDER
 from mindroom.error_handling import AvatarGenerationError, AvatarSyncError
 from mindroom.handled_turns import HandledTurnLedger
 from mindroom.matrix.state import MatrixState
@@ -401,6 +401,35 @@ class TestConfigInit:
         assert "MATRIX_HOMESERVER=https://mindroom.chat" in env_content
         assert "MATRIX_SERVER_NAME=mindroom.chat" in env_content
         assert "MATRIX_REGISTRATION_TOKEN=" in env_content
+
+    def test_init_profile_public_uses_connect_created_owner_env(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Running `connect` before `config init` should still fill owner authorization."""
+        target = tmp_path / "config.yaml"
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "MINDROOM_PROVISIONING_URL=https://mindroom.chat\n"
+            "MINDROOM_LOCAL_CLIENT_ID=client-123\n"
+            "MINDROOM_LOCAL_CLIENT_SECRET=secret-123\n"
+            "MINDROOM_NAMESPACE=a1b2c3d4\n"
+            f"{OWNER_MATRIX_USER_ID_ENV}=@alice:mindroom.chat\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            app,
+            ["config", "init", "--path", str(target), "--profile", "public-vertexai-anthropic"],
+            input="n\n",
+        )
+
+        assert result.exit_code == 0
+        config_content = target.read_text(encoding="utf-8")
+        config = yaml.safe_load(config_content)
+        assert OWNER_MATRIX_USER_ID_PLACEHOLDER not in config_content
+        assert config["authorization"]["global_users"] == ["@alice:mindroom.chat"]
+        assert config["authorization"]["agent_reply_permissions"]["*"] == ["@alice:mindroom.chat"]
 
     def test_init_profile_public_codex_writes_hosted_codex_defaults(self, tmp_path: Path) -> None:
         """Hosted Codex profile should use Codex defaults and hosted Matrix settings."""
@@ -2097,7 +2126,7 @@ class TestConnect:
         assert "MINDROOM_LOCAL_CLIENT_ID=client-123" in env_content
         assert "MINDROOM_LOCAL_CLIENT_SECRET=secret-123" in env_content
         assert "MINDROOM_NAMESPACE=a1b2c3d4" in env_content
-        assert "MINDROOM_OWNER_USER_ID=" not in env_content
+        assert f"{OWNER_MATRIX_USER_ID_ENV}=@alice:mindroom.chat" in env_content
         updated_config = cfg.read_text()
         assert OWNER_MATRIX_USER_ID_PLACEHOLDER not in updated_config
         assert "@alice:mindroom.chat" in updated_config
@@ -2199,8 +2228,8 @@ class TestConnect:
         assert "export MINDROOM_LOCAL_CLIENT_ID=client-123" in result.output
         assert "export MINDROOM_LOCAL_CLIENT_SECRET=secret-123" in result.output
         assert "export MINDROOM_NAMESPACE=a1b2c3d4" in result.output
+        assert "export MINDROOM_OWNER_USER_ID=@alice:mindroom.chat" in result.output
         assert "Owner user ID from pairing: @alice:mindroom.chat" in result.output
-        assert "export MINDROOM_OWNER_USER_ID=" not in result.output
         assert not (tmp_path / ".env").exists()
 
     def test_connect_uses_runtime_env_default_provisioning_url(
@@ -2236,8 +2265,8 @@ class TestConnect:
         assert called["url"] == "https://env-provisioning.example/v1/local-mindroom/pair/complete"
         assert "export MINDROOM_PROVISIONING_URL=https://env-provisioning.example" in result.output
         assert "export MINDROOM_NAMESPACE=a1b2c3d4" in result.output
+        assert "export MINDROOM_OWNER_USER_ID=@alice:mindroom.chat" in result.output
         assert "Owner user ID from pairing: @alice:mindroom.chat" in result.output
-        assert "export MINDROOM_OWNER_USER_ID=" not in result.output
 
     def test_connect_warns_when_owner_user_id_is_malformed(
         self,
@@ -2273,6 +2302,8 @@ class TestConnect:
 
         assert result.exit_code == 0
         assert "malformed owner_user_id" in normalize_console_output(result.output)
+        env_content = (tmp_path / ".env").read_text(encoding="utf-8")
+        assert "MINDROOM_OWNER_USER_ID=" not in env_content
         updated_config = cfg.read_text()
         assert OWNER_MATRIX_USER_ID_PLACEHOLDER in updated_config
 

--- a/tests/test_cli_connect.py
+++ b/tests/test_cli_connect.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 
 import mindroom.cli.connect as cli_connect
-from mindroom.constants import OWNER_MATRIX_USER_ID_PLACEHOLDER
+from mindroom.constants import OWNER_MATRIX_USER_ID_ENV, OWNER_MATRIX_USER_ID_PLACEHOLDER
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +66,24 @@ def test_persist_local_provisioning_env_writes_credentials_only(tmp_path: Path) 
     assert "MINDROOM_LOCAL_CLIENT_SECRET=secret-123" in content
     assert "MINDROOM_NAMESPACE=a1b2c3d4" in content
     assert "MINDROOM_OWNER_USER_ID=" not in content
+
+
+def test_persist_local_provisioning_env_writes_owner_when_available(tmp_path: Path) -> None:
+    """Persisted owner MXID lets a later config init replace authorization placeholders."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("models: {}\nagents: {}\nrouter:\n  model: default\n")
+
+    env_path = cli_connect.persist_local_provisioning_env(
+        provisioning_url="https://provisioning.example",
+        client_id="client-123",
+        client_secret="secret-123",  # noqa: S106
+        namespace="a1b2c3d4",
+        owner_user_id="@alice:mindroom.chat",
+        config_path=config_path,
+    )
+
+    content = env_path.read_text()
+    assert f"{OWNER_MATRIX_USER_ID_ENV}=@alice:mindroom.chat" in content
 
 
 def test_replace_owner_placeholders_in_config_accepts_server_port(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- persist the paired owner Matrix user ID in the config-adjacent .env when connect succeeds
- let config init use MINDROOM_OWNER_USER_ID from runtime env/.env to replace starter authorization placeholders
- export MINDROOM_OWNER_USER_ID in --no-persist-env mode and cover the connect-first order with tests

## Tests
- uv run pytest tests/test_cli_connect.py tests/test_cli_config.py -x -n auto --no-cov -v
- uv run pytest -n auto --no-cov
- uv run pre-commit run --all-files