### PR TITLE
Support Kubernetes worker pod annotations

### DIFF
--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -154,6 +154,8 @@ spec:
               value: {{ .Values.workers.kubernetes.namePrefix | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_LABELS_JSON
               value: {{ toJson .Values.workers.kubernetes.extraLabels | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_ANNOTATIONS_JSON
+              value: {{ toJson .Values.workers.kubernetes.extraAnnotations | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_MEMORY_REQUEST
               value: {{ .Values.workers.kubernetes.resources.requests.memory | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_MEMORY_LIMIT

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -245,6 +245,7 @@ workers:
     colocateWithControlPlaneNode: false
     extraEnv: {}
     extraLabels: {}
+    extraAnnotations: {}
     resources:
       requests:
         cpu: 100m

--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -51,6 +51,7 @@ _NODE_NAME_ENV = "MINDROOM_KUBERNETES_WORKER_NODE_NAME"
 _COLOCATE_WITH_CONTROL_PLANE_NODE_ENV = "MINDROOM_KUBERNETES_WORKER_COLOCATE_WITH_CONTROL_PLANE_NODE"
 _EXTRA_ENV_JSON_ENV = "MINDROOM_KUBERNETES_WORKER_ENV_JSON"
 _EXTRA_LABELS_JSON_ENV = "MINDROOM_KUBERNETES_WORKER_LABELS_JSON"
+_EXTRA_ANNOTATIONS_JSON_ENV = "MINDROOM_KUBERNETES_WORKER_ANNOTATIONS_JSON"
 _OWNER_DEPLOYMENT_NAME_ENV = "MINDROOM_KUBERNETES_WORKER_OWNER_DEPLOYMENT_NAME"
 _MEMORY_REQUEST_ENV = "MINDROOM_KUBERNETES_WORKER_MEMORY_REQUEST"
 _MEMORY_LIMIT_ENV = "MINDROOM_KUBERNETES_WORKER_MEMORY_LIMIT"
@@ -133,6 +134,7 @@ class _KubernetesWorkerBackendConfig:
     colocate_with_control_plane_node: bool
     extra_env: dict[str, str]
     extra_labels: dict[str, str]
+    extra_annotations: dict[str, str]
     owner_deployment_name: str | None
     resource_requests: dict[str, str]
     resource_limits: dict[str, str]
@@ -187,6 +189,7 @@ class _KubernetesWorkerBackendConfig:
             colocate_with_control_plane_node=_read_bool_env(env, _COLOCATE_WITH_CONTROL_PLANE_NODE_ENV, default=False),
             extra_env=_read_json_mapping_env(env, _EXTRA_ENV_JSON_ENV),
             extra_labels=_read_json_mapping_env(env, _EXTRA_LABELS_JSON_ENV),
+            extra_annotations=_read_json_mapping_env(env, _EXTRA_ANNOTATIONS_JSON_ENV),
             owner_deployment_name=_read_env(env, _OWNER_DEPLOYMENT_NAME_ENV) or None,
             resource_requests=resource_requests,
             resource_limits=resource_limits,
@@ -203,6 +206,7 @@ def kubernetes_backend_config_signature(
     config = _KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
     extra_env_json = json.dumps(config.extra_env, sort_keys=True, separators=(",", ":"))
     extra_labels_json = json.dumps(config.extra_labels, sort_keys=True, separators=(",", ":"))
+    extra_annotations_json = json.dumps(config.extra_annotations, sort_keys=True, separators=(",", ":"))
     resource_requests_json = json.dumps(config.resource_requests, sort_keys=True, separators=(",", ":"))
     resource_limits_json = json.dumps(config.resource_limits, sort_keys=True, separators=(",", ":"))
     return (
@@ -227,6 +231,7 @@ def kubernetes_backend_config_signature(
         str(config.colocate_with_control_plane_node),
         extra_env_json,
         extra_labels_json,
+        extra_annotations_json,
         config.owner_deployment_name or "",
         resource_requests_json,
         resource_limits_json,

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -526,9 +526,11 @@ class KubernetesResourceManager:
             dedicated_root=Path(f"{self.config.storage_mount_path}/{state_subpath}".rstrip("/")),
             local_dedicated_root=(self.storage_root / state_subpath).resolve(),
         )
+        template_annotations = dict(self.config.extra_annotations)
+        template_annotations[ANNOTATION_STARTUP_MANIFEST_HASH] = startup_manifest_hash
         template_metadata = {
             "labels": worker_labels,
-            "annotations": {ANNOTATION_STARTUP_MANIFEST_HASH: startup_manifest_hash},
+            "annotations": template_annotations,
         }
         template_spec: dict[str, object] = {
             "serviceAccountName": self.config.service_account_name,

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -284,6 +284,7 @@ def _backend(
     worker_grantable_credentials: frozenset[str] = DEFAULT_WORKER_GRANTABLE_CREDENTIALS,
     resource_requests: dict[str, str] | None = None,
     resource_limits: dict[str, str] | None = None,
+    extra_annotations: dict[str, str] | None = None,
 ) -> tuple[KubernetesWorkerBackend, _FakeAppsApi, _FakeCoreApi]:
     config = _KubernetesWorkerBackendConfig(
         namespace="chat",
@@ -306,6 +307,7 @@ def _backend(
         colocate_with_control_plane_node=colocate_with_control_plane_node,
         extra_env={},
         extra_labels={"mindroom.ai/tenant": "test"},
+        extra_annotations=extra_annotations or {},
         owner_deployment_name=owner_deployment_name,
         resource_requests=resource_requests if resource_requests is not None else {"memory": "256Mi", "cpu": "100m"},
         resource_limits=resource_limits if resource_limits is not None else {"memory": "1Gi", "cpu": "500m"},
@@ -812,6 +814,60 @@ def test_kubernetes_backend_renders_configured_resources_on_worker_container(tmp
     container = apps_api.created_bodies[0]["spec"]["template"]["spec"]["containers"][0]
     assert container["resources"]["requests"] == {"memory": "2Gi", "cpu": "500m"}
     assert container["resources"]["limits"] == {"memory": "8Gi", "cpu": "2"}
+
+
+def test_kubernetes_backend_config_reads_worker_annotations_from_env(tmp_path: Path) -> None:
+    """Worker pod annotations are configurable through runtime env."""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    (config_dir / ".env").write_text(
+        (
+            "MINDROOM_WORKER_BACKEND=kubernetes\n"
+            "MINDROOM_KUBERNETES_WORKER_IMAGE=test-image\n"
+            "MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME=test-pvc\n"
+            'MINDROOM_KUBERNETES_WORKER_ANNOTATIONS_JSON={"cluster-autoscaler.kubernetes.io/safe-to-evict":"false"}\n'
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_primary_runtime_paths(config_path=config_path)
+
+    config = _KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
+
+    assert config.extra_annotations == {
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+    }
+
+
+def test_kubernetes_backend_renders_configured_annotations_on_worker_pod_template(tmp_path: Path) -> None:
+    """Configured annotations land on the rendered worker pod template."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, _core_api = _backend(
+        runtime_paths=runtime_paths,
+        extra_annotations={
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+            ANNOTATION_STARTUP_MANIFEST_HASH: "user-supplied-value",
+        },
+    )
+
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
+
+    annotations = apps_api.created_bodies[0]["spec"]["template"]["metadata"]["annotations"]
+    startup_manifest = _load_startup_manifest(backend, worker_key=_TEST_SCOPED_WORKER_KEY_A)
+    committed_runtime = deserialize_runtime_paths(startup_manifest["runtime_paths"])
+    assert annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] == "false"
+    assert annotations[ANNOTATION_STARTUP_MANIFEST_HASH] == startup_manifest_sha256(
+        committed_runtime,
+        tool_validation_snapshot=_TEST_TOOL_VALIDATION_SNAPSHOT,
+    )
+    assert annotations[ANNOTATION_STARTUP_MANIFEST_HASH] != "user-supplied-value"
 
 
 def test_kubernetes_backend_rejects_unknown_worker_keys_for_scoped_mounts() -> None:


### PR DESCRIPTION
## Summary
- add a Kubernetes worker annotation map alongside existing extra labels
- pass worker annotations through the runtime chart as `workers.kubernetes.extraAnnotations`
- render annotations onto generated worker pod templates while preserving internal startup-manifest metadata

## Tests
- `uv run pytest tests/test_kubernetes_worker_backend.py -q -n 0 --no-cov`
- `uv run ruff check src/mindroom/workers/backends/kubernetes_config.py src/mindroom/workers/backends/kubernetes_resources.py tests/test_kubernetes_worker_backend.py`
- `uv run tach check --dependencies --interfaces`
- `ruby -e 'require "yaml"; YAML.load_file("cluster/k8s/runtime/values.yaml"); puts "values yaml ok"'`\n- `helm template test cluster/k8s/runtime --set workers.backend=kubernetes --set-string 'workers.kubernetes.extraAnnotations.cluster-autoscaler\\.kubernetes\\.io/safe-to-evict=false'`