### PR TITLE
fix(history): preserve messages in oversized compaction excerpts

### DIFF
--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -55,6 +55,12 @@ logger = get_logger(__name__)
 
 _WRAPPER_OVERHEAD_TOKENS = 200
 _OVERSIZED_RUN_NOTE = "Run truncated to fit compaction budget."
+_EXCERPT_METADATA_OMIT_KEYS = frozenset(
+    {
+        "model_params",
+        "tools_schema",
+    },
+)
 _STANDARD_HISTORY_ROLES = frozenset({"user", "assistant", "tool"})
 _COMPACTION_CANCEL_DRAIN_TIMEOUT_SECONDS = 1.0
 type _ToolDefinition = dict[str, object]
@@ -968,13 +974,20 @@ def _serialize_run_excerpt(
 def _excerpt_blocks(run: RunOutput | TeamRunOutput) -> list[_ExcerptBlock]:
     blocks: list[_ExcerptBlock] = []
     if run.metadata:
-        blocks.append(_ExcerptBlock("<run_metadata>", stable_serialize(run.metadata), "</run_metadata>"))
+        blocks.append(
+            _ExcerptBlock("<run_metadata>", stable_serialize(_metadata_for_excerpt(run.metadata)), "</run_metadata>"),
+        )
     for message in run.messages or []:
         content = _render_message_content(message)
         if not content:
             continue
         blocks.append(_ExcerptBlock(_message_open_tag(message), content, "</message>"))
     return blocks
+
+
+def _metadata_for_excerpt(metadata: dict[str, object]) -> dict[str, object]:
+    """Keep compact identity metadata for oversized excerpts without tool schema bulk."""
+    return {key: value for key, value in metadata.items() if key not in _EXCERPT_METADATA_OMIT_KEYS}
 
 
 def _truncate_excerpt(text: str, max_chars: int) -> str:

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -2798,6 +2798,32 @@ def test_build_summary_input_advances_past_oversized_oldest_run() -> None:
     assert 'run_id="run-big"' in summary_input
 
 
+def test_build_summary_input_oversized_run_preserves_messages_before_tool_schema() -> None:
+    root_request = "Look into how the automatic memory flush in mindroom is supposed to work."
+    run = _completed_run(
+        "run-big-metadata",
+        messages=[
+            Message(role="user", content=root_request),
+            Message(role="assistant", content="I will investigate."),
+        ],
+    )
+    run.metadata = {
+        "matrix_event_id": "$root",
+        "thread_id": "$root",
+        "tools_schema": [{"name": f"tool_{index}", "description": "x" * 2000} for index in range(30)],
+    }
+
+    summary_input, included_runs = _build_summary_input(
+        previous_summary=None,
+        compacted_runs=[run],
+        max_input_tokens=280,
+    )
+
+    assert [included_run.run_id for included_run in included_runs] == ["run-big-metadata"]
+    assert root_request in summary_input
+    assert "tools_schema" not in summary_input
+
+
 def test_build_summary_input_skips_when_previous_summary_cannot_be_preserved() -> None:
     run = _completed_run("run-1")
 


### PR DESCRIPTION
Oversized compaction excerpts serialized run metadata before user and assistant messages. For tool-heavy agent runs that metadata can include large model_params and tools_schema payloads, consuming the summary budget before the actual conversation appears.

When the summary model only sees metadata, compaction can delete the raw run while leaving a durable summary that omits the root request. In Matrix threads this makes later replay appear to start at a later message even though the original first turn existed when the run was created.

Omit bulky provider/tool metadata from oversized excerpts so the summary input keeps compact identity fields and reaches the real conversation messages. Add a regression test for a huge tools_schema run that must still preserve the root user request before compaction can remove the raw run.