### PR TITLE
Demote MINDROOM_TIMING events to debug level

### DIFF
--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -122,7 +122,7 @@ class DispatchPipelineTiming:
             elapsed = self.elapsed_ms(start_label, end_label)
             if elapsed is not None:
                 summary[key] = elapsed
-        logger.info("Dispatch pipeline timing", **summary)
+        logger.debug("Dispatch pipeline timing", **summary)
 
 
 def create_dispatch_pipeline_timing(*, event_id: str, room_id: str) -> DispatchPipelineTiming | None:
@@ -163,7 +163,14 @@ def event_timing_scope(event_id: str | None) -> str:
 
 
 def emit_timing_event(event_name: str, **event_data: object) -> None:
-    """Emit one structured timing event when timing instrumentation is enabled."""
+    """Emit one structured timing event when timing instrumentation is enabled.
+
+    Emitted at ``debug`` level so callers can keep ``MINDROOM_TIMING=1`` enabled
+    in long-running processes and still flip emission off cheaply via the global
+    log level. With ``MINDROOM_TIMING=1`` and log level at INFO or above, the
+    stdlib ``isEnabledFor(DEBUG)`` check short-circuits before formatting and
+    handler dispatch.
+    """
     if not _is_enabled():
         return
     scope = event_data.pop("timing_scope", None)
@@ -172,7 +179,7 @@ def emit_timing_event(event_name: str, **event_data: object) -> None:
     filtered_event_data = {key: value for key, value in event_data.items() if value is not None}
     if scope:
         filtered_event_data["timing_scope"] = scope
-    logger.info(event_name, **filtered_event_data)
+    logger.debug(event_name, **filtered_event_data)
 
 
 def emit_elapsed_timing(label: str, start: float, **event_data: object) -> None:

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -27,15 +27,15 @@ def _mock_timing_logger(monkeypatch: pytest.MonkeyPatch) -> Mock:
 
 
 def _assert_timing_logged(logger: Mock, label: str, *, scope: str | None = None) -> None:
-    logger.info.assert_called_once()
-    assert logger.info.call_args.args == ("timing_elapsed",)
-    assert logger.info.call_args.kwargs["label"] == label
-    assert isinstance(logger.info.call_args.kwargs["duration_ms"], float)
-    assert logger.info.call_args.kwargs["duration_ms"] >= 0
+    logger.debug.assert_called_once()
+    assert logger.debug.call_args.args == ("timing_elapsed",)
+    assert logger.debug.call_args.kwargs["label"] == label
+    assert isinstance(logger.debug.call_args.kwargs["duration_ms"], float)
+    assert logger.debug.call_args.kwargs["duration_ms"] >= 0
     if scope is None:
-        assert "timing_scope" not in logger.info.call_args.kwargs
+        assert "timing_scope" not in logger.debug.call_args.kwargs
     else:
-        assert logger.info.call_args.kwargs["timing_scope"] == scope
+        assert logger.debug.call_args.kwargs["timing_scope"] == scope
 
 
 def test_timed_sync_logs_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -242,7 +242,7 @@ def test_emit_timing_event_logs_when_enabled(monkeypatch: pytest.MonkeyPatch) ->
     finally:
         timing_scope.reset(token)
 
-    logger.info.assert_called_once_with(
+    logger.debug.assert_called_once_with(
         "custom_timing_event",
         value=42,
         ok=True,
@@ -276,7 +276,7 @@ def test_timed_routes_elapsed_logging_through_shared_helper(monkeypatch: pytest.
     assert emit_elapsed_timing.call_args.args[0] == "delegated_label"
     assert isinstance(emit_elapsed_timing.call_args.args[1], float)
     assert emit_elapsed_timing.call_args.kwargs["timing_scope"] == "scope-123"
-    logger.info.assert_not_called()
+    logger.debug.assert_not_called()
 
 
 def _timing_probe_labels(
@@ -304,7 +304,7 @@ def _timing_probe_labels(
 
         labels = [
             call.kwargs["label"]
-            for call in timing_module.logger.info.call_args_list
+            for call in timing_module.logger.debug.call_args_list
             if call.args == ("timing_elapsed",)
         ]
         print(json.dumps(labels))
@@ -377,9 +377,9 @@ def test_dispatch_pipeline_summary_emits_additive_segments_and_diagnostics() -> 
 
     timing.emit_summary(logger, outcome="edited")
 
-    logger.info.assert_called_once()
-    assert logger.info.call_args.args == ("Dispatch pipeline timing",)
-    summary = logger.info.call_args.kwargs
+    logger.debug.assert_called_once()
+    assert logger.debug.call_args.args == ("Dispatch pipeline timing",)
+    summary = logger.debug.call_args.kwargs
     assert summary["first_visible_kind"] == "stream_update"
     assert summary["seg_ingress_ms"] == 1000.0
     assert summary["seg_coalescing_ms"] == 2000.0


### PR DESCRIPTION
## Summary
- `emit_timing_event` and `DispatchPipelineTiming.emit_summary` are gated on the `MINDROOM_TIMING` env var, but when enabled they unconditionally emit at info, so they cannot be filtered without disabling the env-var gate entirely.
- py-spy on a long-running process with `MINDROOM_TIMING=1` shows the per-chunk \`Dispatch tool delivery timing\` event accounting for a measurable share of asyncio main-loop work via the structlog → stdlib logger chain (`isEnabledFor`, `_proxy_to_logger`, `info`).
- Demoting both call sites to debug keeps the same diagnostics visible when `MINDROOM_TIMING=1` and the runtime log level is debug, but lets operators flip the cost off cheaply by raising the global log level to info — stdlib logging short-circuits at \`isEnabledFor(DEBUG)\` before formatting and handler dispatch.
- Update test_timing.py assertions to match the new level.

## Tests
- \`uv run pytest tests/test_timing.py tests/test_dispatch_timing_instrumentation.py tests/test_streaming_behavior.py tests/test_streaming_finalize.py tests/test_live_message_coalescing.py -nauto --no-cov -q\` → 242 passed
- \`uv run ruff check src/mindroom/timing.py tests/test_timing.py\`
- \`uv run ty check src/mindroom/timing.py tests/test_timing.py\`
- \`uv run tach check --dependencies --interfaces\`

## Test plan
- [x] timing-related unit tests pass against the new debug level
- [x] structured kwargs preserved (no behaviour change beyond level)
- [x] env-var gate (`MINDROOM_TIMING`) remains the operational on/off switch