### PR TITLE
Fix timing log test expectations

### DIFF
--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -4893,7 +4893,7 @@ class TestThreadingBehavior:
             and call.kwargs["coalesced_update_count"] == 2
             and call.kwargs["predecessor_wait_ms"] >= 0.0
             and call.kwargs["update_run_ms"] >= 0.0
-            for call in timing_logger.info.call_args_list
+            for call in timing_logger.debug.call_args_list
         )
 
     @pytest.mark.asyncio
@@ -5062,7 +5062,7 @@ class TestThreadingBehavior:
             await coordinator.close()
 
         timing_calls = [
-            call for call in timing_logger.info.call_args_list if call.args == ("Event cache update timing",)
+            call for call in timing_logger.debug.call_args_list if call.args == ("Event cache update timing",)
         ]
         assert any(
             call.kwargs["barrier_kind"] == "room"
@@ -5109,7 +5109,7 @@ class TestThreadingBehavior:
 
         timing_call = next(
             call
-            for call in timing_logger.info.call_args_list
+            for call in timing_logger.debug.call_args_list
             if call.args == ("Event cache update timing",) and call.kwargs["operation"] == "matrix_cache_single_update"
         )
         assert timing_call.kwargs["predecessor_wait_ms"] == 0.0
@@ -5176,7 +5176,7 @@ class TestThreadingBehavior:
 
         timing_call = next(
             call
-            for call in timing_logger.info.call_args_list
+            for call in timing_logger.debug.call_args_list
             if call.args == ("Event cache update timing",) and call.kwargs["operation"] == "matrix_cache_third_update"
         )
         assert timing_call.kwargs["predecessor_count"] == 2
@@ -5218,7 +5218,7 @@ class TestThreadingBehavior:
             await coordinator.close()
 
         idle_wait_calls = [
-            call for call in timing_logger.info.call_args_list if call.args == ("Event cache idle wait timing",)
+            call for call in timing_logger.debug.call_args_list if call.args == ("Event cache idle wait timing",)
         ]
         assert any(
             call.kwargs["barrier_kind"] == "room"
@@ -5277,7 +5277,7 @@ class TestThreadingBehavior:
             await coordinator.close()
 
         timing_call = next(
-            call for call in timing_logger.info.call_args_list if call.args == ("Event cache idle wait timing",)
+            call for call in timing_logger.debug.call_args_list if call.args == ("Event cache idle wait timing",)
         )
         assert timing_call.kwargs["pending_task_count"] == 2
 
@@ -5332,7 +5332,7 @@ class TestThreadingBehavior:
             await coordinator.close()
 
         timing_call = next(
-            call for call in timing_logger.info.call_args_list if call.args == ("Event cache idle wait timing",)
+            call for call in timing_logger.debug.call_args_list if call.args == ("Event cache idle wait timing",)
         )
         assert timing_call.kwargs["pending_task_count"] == 2
 
@@ -5415,7 +5415,7 @@ class TestThreadingBehavior:
             await coordinator.close()
 
         timing_call = next(
-            call for call in timing_logger.info.call_args_list if call.args == ("Event cache idle wait timing",)
+            call for call in timing_logger.debug.call_args_list if call.args == ("Event cache idle wait timing",)
         )
         assert timing_call.kwargs["pending_task_count"] == 4
 
@@ -5488,7 +5488,7 @@ class TestThreadingBehavior:
         )
 
         append_calls = [
-            call for call in timing_logger.info.call_args_list if call.args == ("Live event cache append timing",)
+            call for call in timing_logger.debug.call_args_list if call.args == ("Live event cache append timing",)
         ]
         assert any(
             call.kwargs["thread_id"] == "$thread:localhost"
@@ -5542,7 +5542,7 @@ class TestThreadingBehavior:
         )
 
         timing_call = next(
-            call for call in timing_logger.info.call_args_list if call.args == ("Live event cache append timing",)
+            call for call in timing_logger.debug.call_args_list if call.args == ("Live event cache append timing",)
         )
         assert timing_call.kwargs["thread_id"] == "$thread:localhost"
         assert timing_call.kwargs["appended"] is False


### PR DESCRIPTION
## Summary
- Update threading timing tests to assert the new debug-level `emit_timing_event` calls.
- Keeps the test expectations aligned with #808, which demoted `MINDROOM_TIMING` events from info to debug.

## Verification
- `UV_PYTHON=3.13 uv sync --all-extras`
- `UV_PYTHON=3.13 uv run pytest tests/test_threading_error.py::TestThreadingBehavior::test_outbound_nonterminal_streaming_edits_coalesce_pending_cache_updates tests/test_threading_error.py::TestThreadingBehavior::test_queue_room_update_logs_timing_breakdown_when_enabled tests/test_threading_error.py::TestThreadingBehavior::test_queue_room_update_logs_wait_from_raw_interval_when_enabled tests/test_threading_error.py::TestThreadingBehavior::test_queue_room_update_logs_full_predecessor_chain_when_enabled tests/test_threading_error.py::TestThreadingBehavior::test_wait_for_room_idle_logs_timing_when_enabled tests/test_threading_error.py::TestThreadingBehavior::test_wait_for_room_idle_logs_full_pending_chain_when_enabled tests/test_threading_error.py::TestThreadingBehavior::test_wait_for_room_idle_counts_tasks_queued_after_wait_starts tests/test_threading_error.py::TestThreadingBehavior::test_wait_for_room_idle_counts_full_backlog_when_queue_grows_mid_wait tests/test_threading_error.py::TestThreadingBehavior::test_append_live_event_logs_phase_breakdown_when_enabled tests/test_threading_error.py::TestThreadingBehavior::test_append_live_event_logs_append_failure_outcome_when_enabled -n 0 --no-cov -q`
- `UV_PYTHON=3.13 uv run pytest -m "not requires_matrix"`
- `UV_PYTHON=3.13 uv run pre-commit run --all-files`

CI failure investigated: https://github.com/mindroom-ai/mindroom/actions/runs/25131344007/job/73658112864