### PR TITLE
Trim unused bundled avatar assets

### DIFF
--- a/avatars/agents/calculator.png
+++ b/avatars/agents/calculator.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f98332a3b3cf126922d6205f5a403b2f9fef15985ea25fc263f361ce50992849
-size 1373602

--- a/avatars/agents/callagent.png
+++ b/avatars/agents/callagent.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a9e6406ea1b5e4c94392e1da5a1a78d65048c266fcae5c9b6b083233196b63fa
-size 1372639

--- a/avatars/agents/data_analyst.png
+++ b/avatars/agents/data_analyst.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e9a7f351382eb17458098eedd1f4f0486e6921663da7539475d73b5c954012a
-size 1386843

--- a/avatars/agents/email_assistant.png
+++ b/avatars/agents/email_assistant.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5132e051d6b7a60da444f6aeea4f93e5207e2470baf08c5e7aedba96a93366fa
-size 1385766

--- a/avatars/agents/finance.png
+++ b/avatars/agents/finance.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:492f4957fc1b9e22c40c2df6502c05269ae32f1a2bfaaea52f891c4198bdd434
-size 1360649

--- a/avatars/agents/home.png
+++ b/avatars/agents/home.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:244a96b92df7926b1ef9d86441070e942b05c4cba7709379095c4d3e9518e3df
-size 1376595

--- a/avatars/agents/news.png
+++ b/avatars/agents/news.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b54a71161da100adcac4409afe924bd245fb48c37b8cc33a992d1bf1d68eb44
-size 1381640

--- a/avatars/agents/router.png
+++ b/avatars/agents/router.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a5fec72ed24c7390ecc652922edf05b40d2c0260a67c3cbb0dda2450602004c9
-size 1365933

--- a/avatars/agents/security.png
+++ b/avatars/agents/security.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e2c3578d0eb626a2ddea35a809e429a1de4099abb858671c3b1875aa3160781
-size 1389019

--- a/avatars/agents/shell.png
+++ b/avatars/agents/shell.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a2460f5c3e946c9d82b064f815ec3151a40c4c3a1f547aed18b169ef79c13cc
-size 1317823

--- a/avatars/rooms/analysis.png
+++ b/avatars/rooms/analysis.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:44dbd2f70213d7a554de17877d14d9c0b283e2845e007982ff7f57fce6c52eb5
-size 1293632

--- a/avatars/rooms/automation.png
+++ b/avatars/rooms/automation.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1540a0b8bee1bdfb59b5c788dad6c139cb8293a98e7dfc34364c8acecd7649fb
-size 1355334

--- a/avatars/rooms/business.png
+++ b/avatars/rooms/business.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2d96046fae8d959f1eb2b6c44bf06529107689f0082e5c378fd4e6aa4945510
-size 828135

--- a/avatars/rooms/communication.png
+++ b/avatars/rooms/communication.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f03f849fc9bf77d70ab9a2c6fcff525ab884c0dceb08f7a74eb1f0ffe0e646cd
-size 1317935

--- a/avatars/rooms/dev.png
+++ b/avatars/rooms/dev.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e8d96dfb7531ffc39f9751740cb3ebcddbcd3e4c26c305a08734c944c3b0bd5
-size 1323255

--- a/avatars/rooms/docs.png
+++ b/avatars/rooms/docs.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f4c6a7f28751d488691756d50cb75c2557935c8e48872a670b31354d696dc34
-size 857145

--- a/avatars/rooms/finance.png
+++ b/avatars/rooms/finance.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d41e62785283987b21dcf55e4c4994d3c0516750d582081f8b00d75f70427cb6
-size 1351595

--- a/avatars/rooms/help.png
+++ b/avatars/rooms/help.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7be45c0089346bf2e19bb50ed15be5cef13786584231061f71c1b848fce9bb0
-size 944637

--- a/avatars/rooms/home.png
+++ b/avatars/rooms/home.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b9836585a2403255111d25a00cf6616a2dd341f98956d26c717c70d743b5125
-size 1038242

--- a/avatars/rooms/lobby.png
+++ b/avatars/rooms/lobby.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:25d8a4731bcfd671368669c06c5fb460a7a386d3966f3f579c5237575d6f341e
-size 1078556

--- a/avatars/rooms/news.png
+++ b/avatars/rooms/news.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3678a5bb00cd808639de72b930ce5fbd3e35869534ee0642b964923f1781c9ae
-size 1324530

--- a/avatars/rooms/ops.png
+++ b/avatars/rooms/ops.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3a174e1134feeaa2439f053d2852b179de15a64620e69083490fd07c23869070
-size 839199

--- a/avatars/rooms/productivity.png
+++ b/avatars/rooms/productivity.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a9b951daaeaa69f20e4445bc2db47f1d2f84a4c9db660c744d01eb9ce04c4df4
-size 823226

--- a/avatars/rooms/research.png
+++ b/avatars/rooms/research.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f4e8b87b1b53abf6259cd9f07c96f96db9622684b9c90c10a1ae4ef7972c02a1
-size 1341981

--- a/avatars/rooms/science.png
+++ b/avatars/rooms/science.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a19eea199fb0fdf3ad0530de678038c4a07148475bf500f2fc55c8e88fbd252e
-size 913054

--- a/avatars/teams/code_team.png
+++ b/avatars/teams/code_team.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c8a67a0d8e3a9516d7b532dee216dab5a11bb157bfbbfeb747b157c7ebb80f4
-size 1373121

--- a/avatars/teams/super_team.png
+++ b/avatars/teams/super_team.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c7871360e3f447843bfbaf487f6de0d9a5194a4fc246a4965c541826ac20aae
-size 1350414


### PR DESCRIPTION
## Summary
- remove bundled avatar PNGs that no longer have direct consumers
- keep the mockup agent avatars: general, code, research, analyst, and summary
- keep the bundled root Space avatar used by Matrix root Space setup
- leave bundled avatar fallback and Docker image avatar copying intact

## Tests
- uv run pre-commit run --all-files
- uv run pytest -n auto --no-cov