### PR TITLE
Optimize pre-commit all-files runtime

### DIFF
--- a/.github/scripts/generate_skill_references.py
+++ b/.github/scripts/generate_skill_references.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import shutil
 import subprocess
 import tempfile
@@ -17,6 +18,7 @@ DOCS_DIR = REPO_ROOT / "docs"
 ZENSICAL_CONFIG = REPO_ROOT / "zensical.toml"
 SKILL_DIR = REPO_ROOT / "skills" / "mindroom-docs"
 REFERENCES_DIR = SKILL_DIR / "references"
+CACHE_PATH = REPO_ROOT / ".cache" / "mindroom-docs-skill-references.sha256"
 
 
 @dataclass(frozen=True)
@@ -65,6 +67,23 @@ def _load_project_and_nav() -> tuple[dict[str, Any], list[NavPage]]:
     pages: list[NavPage] = []
     _collect_nav_pages(nav, pages)
     return project, pages
+
+
+def _digest_paths(paths: list[Path]) -> str:
+    digest = hashlib.sha256()
+    for path in paths:
+        relative_path = path.relative_to(REPO_ROOT).as_posix()
+        digest.update(relative_path.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _cache_key() -> str:
+    inputs = sorted([Path(__file__).resolve(), ZENSICAL_CONFIG, *DOCS_DIR.rglob("*.md")])
+    references = sorted(path for path in REFERENCES_DIR.rglob("*") if path.is_file()) if REFERENCES_DIR.exists() else []
+    return f"{_digest_paths(inputs)}\n{_digest_paths(references)}"
 
 
 def _mkdocs_config(project: dict[str, Any], nav_pages: list[NavPage], site_dir: Path) -> dict[str, Any]:
@@ -173,6 +192,10 @@ def _write_reference_index(nav_pages: list[NavPage], built_to_reference: dict[st
 
 def main() -> None:
     """Build and sync generated docs references into the mindroom-docs skill."""
+    if CACHE_PATH.exists() and CACHE_PATH.read_text(encoding="utf-8") == _cache_key():
+        print(f"Generated references already up to date in {REFERENCES_DIR}")
+        return
+
     project, nav_pages = _load_project_and_nav()
     assert nav_pages, "No docs pages found in zensical.toml navigation"
     with tempfile.TemporaryDirectory(prefix="mindroom-docs-skill-") as tmp:
@@ -186,6 +209,8 @@ def main() -> None:
         built_to_reference = _flatten_page_references(generated_site_dir)
         _write_reference_index(nav_pages, built_to_reference)
 
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CACHE_PATH.write_text(_cache_key(), encoding="utf-8")
     print(f"Generated {len(list(REFERENCES_DIR.glob('*')))} files in {REFERENCES_DIR}")
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,6 @@ repos:
       - id: check-docstring-first
       - id: check-yaml
         exclude: (cluster/k8s/.*/templates/.*\.yaml$|cluster/k8s/.*\.yaml$|cluster/k8s/.*/templates/.*\.yaml$|cluster/k8s/.*\.yaml$)
-      - id: debug-statements
-      - id: check-ast
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.15.11"
@@ -50,7 +48,7 @@ repos:
         entry: .venv/bin/python .github/scripts/generate_skill_references.py
         language: system
         pass_filenames: false
-        files: ^(docs/.*\.md|zensical\.toml)$
+        files: ^(docs/.*\.md|zensical\.toml|\.github/scripts/generate_skill_references\.py)$
 
       - id: check-tool-extras-sync
         name: Check tool extras stay in sync with pyproject.toml
@@ -78,6 +76,8 @@ repos:
       - id: prettier
         files: ^frontend/.*\.(js|jsx|ts|tsx|json|css|scss|md)$
         exclude: ^(frontend/package-lock\.json|frontend/tsconfig.*\.json|.*\.min\.(js|css))$
+        args: ["--cache", "--cache-location", ".cache/prettier-precommit.json"]
+        require_serial: true
 
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v10.2.1


### PR DESCRIPTION
## Summary
- remove duplicate Python syntax/debug hooks now covered by Ruff
- enable serial Prettier caching for frontend files
- skip regenerating mindroom-docs skill references when docs inputs and generated outputs are unchanged

## Timings
- baseline full `pre-commit --all-files`: ~28.5s
- hot-cache full `pre-commit --all-files`: ~8s
- `generate-skill-references`: ~3-5s cold, ~0.06-0.3s hot
- Prettier: ~8.4s baseline, ~0.3-1.0s hot

## Verification
- `uv run pre-commit run --all-files --verbose`
- `uv run pytest` (5696 passed, 50 skipped)