### PR TITLE
Use elapsed timing context manager

### DIFF
--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -7,6 +7,7 @@ import functools
 import inspect
 import os
 import time
+from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
@@ -14,7 +15,7 @@ from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+    from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
 
     from structlog.stdlib import BoundLogger
 
@@ -192,6 +193,16 @@ def emit_elapsed_timing(label: str, start: float, **event_data: object) -> None:
         duration_ms=round((time.monotonic() - start) * 1000, 1),
         **event_data,
     )
+
+
+@contextmanager
+def elapsed_timing(label: str, **event_data: object) -> Iterator[dict[str, object]]:
+    """Emit one elapsed timing event for the enclosed synchronous block."""
+    start = time.monotonic()
+    try:
+        yield event_data
+    finally:
+        emit_elapsed_timing(label, start, **event_data)
 
 
 def timed(label: str) -> Callable[[Callable[P, R]], Callable[P, R]]:

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -85,6 +85,7 @@ from mindroom.timing import (
     DispatchPipelineTiming,
     attach_dispatch_pipeline_timing,
     create_dispatch_pipeline_timing,
+    elapsed_timing,
     emit_elapsed_timing,
     event_timing_scope,
     get_dispatch_pipeline_timing,
@@ -1278,19 +1279,14 @@ class TurnController:
                 dispatch.context.thread_history = request.thread_history
                 dispatch.context.thread_id = request.thread_id
                 dispatch.context.requires_full_thread_history = False
-                payload_builder_started = time.monotonic()
-                payload_builder_outcome = "failed"
-                try:
+                with elapsed_timing(
+                    "response_payload.builder",
+                    room_id=request.room_id,
+                    thread_id=request.thread_id,
+                    outcome="failed",
+                ) as payload_builder_timing:
                     payload = await payload_builder(dispatch.context)
-                    payload_builder_outcome = "success"
-                finally:
-                    emit_elapsed_timing(
-                        "response_payload.builder",
-                        payload_builder_started,
-                        room_id=request.room_id,
-                        thread_id=request.thread_id,
-                        outcome=payload_builder_outcome,
-                    )
+                    payload_builder_timing["outcome"] = "success"
                 prepared_payload = await self.deps.ingress_hook_runner.apply_message_enrichment(
                     dispatch,
                     payload,
@@ -1409,44 +1405,40 @@ class TurnController:
             dispatch_timing = get_dispatch_pipeline_timing(handoff.event.source)
             if dispatch_timing is not None:
                 dispatch_timing.mark("gate_exit")
-            retarget_start = time.monotonic()
-            batch_coalescing_key = await self._coalescing_key_for_event(
-                batch.room,
-                batch.primary_event,
-                batch.requester_user_id,
-            )
-            canonical_key = (
-                batch.room.room_id,
-                self.deps.resolver.build_message_target(
-                    room_id=batch.room.room_id,
-                    thread_id=batch_coalescing_key[1],
-                    reply_to_event_id=handoff.event.event_id,
-                    event_source=handoff.event.source,
-                ).resolved_thread_id,
-                batch.requester_user_id,
-            )
-            self.deps.coalescing_gate.retarget(batch_coalescing_key, canonical_key)
-            emit_elapsed_timing(
+            with elapsed_timing(
                 "coalescing.handle_batch.retarget",
-                retarget_start,
-                original_thread_id=batch_coalescing_key[1],
-                resolved_thread_id=canonical_key[1],
                 timing_scope=timing_scope,
-            )
-            async with self.deps.resolver.turn_thread_cache_scope():
-                dispatch_start = time.monotonic()
-                handled_turn = HandledTurnState.create(
-                    handoff.source_event_ids,
-                    source_event_prompts=dict(handoff.source_event_prompts),
+            ) as retarget_timing:
+                batch_coalescing_key = await self._coalescing_key_for_event(
+                    batch.room,
+                    batch.primary_event,
+                    batch.requester_user_id,
                 )
-                await self._dispatch_handoff(handoff, handled_turn=handled_turn)
-                reservation = None
-                emit_elapsed_timing(
+                canonical_key = (
+                    batch.room.room_id,
+                    self.deps.resolver.build_message_target(
+                        room_id=batch.room.room_id,
+                        thread_id=batch_coalescing_key[1],
+                        reply_to_event_id=handoff.event.event_id,
+                        event_source=handoff.event.source,
+                    ).resolved_thread_id,
+                    batch.requester_user_id,
+                )
+                self.deps.coalescing_gate.retarget(batch_coalescing_key, canonical_key)
+                retarget_timing["original_thread_id"] = batch_coalescing_key[1]
+                retarget_timing["resolved_thread_id"] = canonical_key[1]
+            async with self.deps.resolver.turn_thread_cache_scope():
+                with elapsed_timing(
                     "coalescing.handle_batch.dispatch_text_message",
-                    dispatch_start,
                     source_event_count=len(batch.source_event_ids),
                     timing_scope=timing_scope,
-                )
+                ):
+                    handled_turn = HandledTurnState.create(
+                        handoff.source_event_ids,
+                        source_event_prompts=dict(handoff.source_event_prompts),
+                    )
+                    await self._dispatch_handoff(handoff, handled_turn=handled_turn)
+                    reservation = None
         finally:
             if reservation is not None:
                 reservation.cancel()

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -2223,7 +2223,7 @@ async def test_handle_coalesced_batch_timing_events_include_dispatch_scope(tmp_p
 
     with (
         patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock()),
-        patch("mindroom.turn_controller.emit_elapsed_timing") as mock_emit,
+        patch("mindroom.timing.emit_elapsed_timing") as mock_emit,
     ):
         await bot._turn_controller.handle_coalesced_batch(batch)
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -10538,7 +10538,7 @@ class TestAgentBot:
         async def payload_builder(_context: MessageContext) -> DispatchPayload:
             return DispatchPayload(prompt="help me")
 
-        with patch("mindroom.turn_controller.emit_elapsed_timing") as mock_emit:
+        with patch("mindroom.timing.emit_elapsed_timing") as mock_emit:
             await bot._turn_controller._execute_response_action(
                 room,
                 event,
@@ -10612,7 +10612,7 @@ class TestAgentBot:
 
         with (
             patch.object(bot._turn_controller, "_finalize_dispatch_failure", new=AsyncMock(return_value="$error")),
-            patch("mindroom.turn_controller.emit_elapsed_timing") as mock_emit,
+            patch("mindroom.timing.emit_elapsed_timing") as mock_emit,
         ):
             await bot._turn_controller._execute_response_action(
                 room,

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -14,7 +14,14 @@ from unittest.mock import Mock
 import pytest
 
 import mindroom.timing as timing_module
-from mindroom.timing import DispatchPipelineTiming, emit_timing_event, timed, timing_enabled, timing_scope
+from mindroom.timing import (
+    DispatchPipelineTiming,
+    elapsed_timing,
+    emit_timing_event,
+    timed,
+    timing_enabled,
+    timing_scope,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -248,6 +255,50 @@ def test_emit_timing_event_logs_when_enabled(monkeypatch: pytest.MonkeyPatch) ->
         ok=True,
         timing_scope="scope-123",
     )
+
+
+def test_elapsed_timing_logs_block_duration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The block context manager should emit one elapsed timing log."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+
+    with elapsed_timing("block_label", extra="value"):
+        pass
+
+    logger.debug.assert_called_once()
+    assert logger.debug.call_args.args == ("timing_elapsed",)
+    assert logger.debug.call_args.kwargs["label"] == "block_label"
+    assert logger.debug.call_args.kwargs["extra"] == "value"
+    assert logger.debug.call_args.kwargs["duration_ms"] >= 0
+
+
+def test_elapsed_timing_allows_block_metadata_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The block can update metadata before the elapsed timing log is emitted."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+
+    with elapsed_timing("block_label", outcome="failed") as timing_data:
+        timing_data["outcome"] = "completed"
+
+    logger.debug.assert_called_once()
+    assert logger.debug.call_args.kwargs["label"] == "block_label"
+    assert logger.debug.call_args.kwargs["outcome"] == "completed"
+
+
+def test_elapsed_timing_logs_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The block context manager should still emit when the block raises."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+
+    def fail() -> None:
+        with elapsed_timing("block_error_label"):
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        fail()
+
+    _assert_timing_logged(logger, "block_error_label")
 
 
 def test_timing_enabled_reflects_env(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Add an `elapsed_timing(...)` context manager for block-scoped timing instrumentation.
- Convert selected turn-controller timing spans to the context manager where it removes timing-only boilerplate.
- Update tests to cover mutable timing metadata and converted timing call sites.

## Tests
- `uv run ruff check src/mindroom/timing.py src/mindroom/coalescing.py src/mindroom/turn_controller.py tests/test_timing.py tests/test_live_message_coalescing.py tests/test_multi_agent_bot.py`
- `uv run pytest tests/test_timing.py tests/test_live_message_coalescing.py -q -n 0 --no-cov`
- `uv run pytest tests/test_multi_agent_bot.py -k 'payload_builder_timing' -q -n 0 --no-cov`
- `git diff --check`

Note: the coalescing flush span was intentionally left on explicit `try/finally` because that code coordinates timing, final logging, mutable diagnostics, and gate cleanup; the context manager made that path harder to read.