### PR TITLE
Add headless CLI utilities to runtime images

### DIFF
--- a/local/instances/deploy/Dockerfile.mindroom
+++ b/local/instances/deploy/Dockerfile.mindroom
@@ -48,8 +48,9 @@ WORKDIR /app
 # Install runtime dependencies:
 # - curl for health checks
 # - git and git-lfs for remote knowledge base cloning/sync
-# - bash for shell tooling
-RUN apt-get update && apt-get install -y bash curl git git-lfs \
+# - bash and tmux for shell tooling and detached interactive CLI flows
+# - common small CLI utilities used by headless auth/install workflows
+RUN apt-get update && apt-get install -y bash bzip2 curl git git-lfs jq nano procps ripgrep tmux unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user before copying files

--- a/local/instances/deploy/Dockerfile.mindroom-minimal
+++ b/local/instances/deploy/Dockerfile.mindroom-minimal
@@ -48,8 +48,9 @@ WORKDIR /app
 # Install runtime dependencies:
 # - curl for health checks
 # - git and git-lfs for remote knowledge base cloning/sync
-# - bash for shell tooling
-RUN apt-get update && apt-get install -y bash curl git git-lfs \
+# - bash and tmux for shell tooling and detached interactive CLI flows
+# - common small CLI utilities used by headless auth/install workflows
+RUN apt-get update && apt-get install -y bash bzip2 curl git git-lfs jq nano procps ripgrep tmux unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user before copying files

--- a/tests/test_tool_dependencies.py
+++ b/tests/test_tool_dependencies.py
@@ -163,6 +163,21 @@ def test_runtime_images_copy_workspace_avatars(dockerfile_path: Path) -> None:
     assert "COPY avatars /app/avatars" in dockerfile
 
 
+@pytest.mark.parametrize(
+    "dockerfile_path",
+    [
+        Path("local/instances/deploy/Dockerfile.mindroom"),
+        Path("local/instances/deploy/Dockerfile.mindroom-minimal"),
+    ],
+)
+def test_runtime_images_include_headless_cli_utilities(dockerfile_path: Path) -> None:
+    """Worker images should include baseline utilities for detached interactive CLI auth flows."""
+    dockerfile = dockerfile_path.read_text(encoding="utf-8")
+
+    for package_name in ("tmux", "nano", "procps", "jq", "unzip", "bzip2", "ripgrep"):
+        assert package_name in dockerfile
+
+
 def test_tools_requiring_config_metadata() -> None:
     """Test that tools marked REQUIRES_CONFIG have config_fields or auth_provider."""
     inconsistent = []


### PR DESCRIPTION
## Summary
- add tmux, ripgrep, procps, jq, nano, unzip, and bzip2 to the full and minimal runtime images
- cover the expected headless CLI utility package set with a Dockerfile regression test

## Why
Worker-routed shell workflows often need to run detached interactive CLIs, inspect processes, search files, and handle common archive formats. These utilities are small baseline tools and avoid per-workspace bootstrap workarounds.

## Validation
- `uv run pytest tests/test_tool_dependencies.py::test_runtime_images_include_headless_cli_utilities -q`
- `docker build -f local/instances/deploy/Dockerfile.mindroom-minimal -t mindroom-headless-cli-worker-env-test .`
- `docker run --rm mindroom-headless-cli-worker-env-test bash -lc 'which tmux && tmux -V && which rg && rg --version | head -n1 && which ps && which jq && which nano && which unzip && which bzip2'`