### PR TITLE
Resolve worker env hooks from routed agent workspaces

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -344,7 +344,7 @@ Isolation depends on the worker backend:
 
 Use `user_agent` if you need per-agent filesystem isolation.
 
-For per-workspace env that an agent can edit (PATH, npm/pip cache locations, etc.), drop a `.mindroom/worker-env.sh` script in the agent workspace; MindRoom sources it before each worker-routed `shell`, `python`, `coding`, or `file` request.
+For per-workspace env that an agent can edit (PATH, npm/pip cache locations, etc.), drop a `.mindroom/worker-env.sh` script in the agent workspace; MindRoom sources it before each worker-routed `shell` or `python` request.
 With `worker_scope: user`, the same runtime can move between several agent workspaces, and the hook is discovered from the current request's workspace — different agents get different overlays automatically.
 See [Workspace env hook](../deployment/sandbox-proxy.md#workspace-env-hook-mindroomworker-envsh) for filename, filtering, and failure semantics.
 

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -265,7 +265,7 @@ The runner sources this script with `bash` before each worker-routed `shell`, `p
 
 **Discovery:**
 
-- The hook lives at `<base_dir>/.mindroom/worker-env.sh` where `<base_dir>` is the resolved tool workspace.
+- For agent-routed worker requests, the hook lives at the resolved agent workspace root as `.mindroom/worker-env.sh`.
 - For shared and unscoped agents that means `agents/<agent>/workspace/.mindroom/worker-env.sh`.
 - For private agents that means `private_instances/<scope>/<agent>/workspace/.mindroom/worker-env.sh`.
 - For `worker_scope: user`, the hook follows the per-request workspace, so one shared user runtime can pick up different hooks as it works in different agent workspaces.

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -261,7 +261,7 @@ To make that work, shell background-handle requests stay owned by the long-lived
 
 Agents can drop a shell script at `<workspace>/.mindroom/worker-env.sh` to set custom env for worker-routed tool calls without changing config or redeploying.
 
-The runner sources this script with `bash` before each worker-routed `shell`, `python`, `coding`, or `file` request, then merges its exported env into the tool's execution environment.
+The runner sources this script with `bash` before each worker-routed `shell` or `python` request, then merges its exported env into the tool's execution environment.
 
 **Discovery:**
 

--- a/docs/tools/execution-and-coding.md
+++ b/docs/tools/execution-and-coding.md
@@ -237,7 +237,7 @@ list_files()
 - `restrict_to_base_dir` only constrains the file helper paths, not what arbitrary Python code can do once executed.
 - `safe_globals` and `safe_locals` are exposed directly from the upstream constructor and are mainly useful for advanced programmatic wiring, not typical hand-written YAML.
 - If you need runtime-scoped environment isolation, rely on worker-routed execution instead of assuming in-process Python emulation is a security boundary.
-- Worker-routed `python` execution also receives `.mindroom/worker-env.sh` overlay env via `os.environ` (e.g., `PIP_INDEX_URL`, `UV_CACHE_DIR`). Worker-routed `coding` and `file` subprocesses receive the same overlay as process env, though their documented behavior is file operations rather than env inspection. See "Workspace env hook" in `docs/deployment/sandbox-proxy.md`.
+- Worker-routed `python` execution also receives `.mindroom/worker-env.sh` overlay env via `os.environ` (e.g., `PIP_INDEX_URL`, `UV_CACHE_DIR`). See "Workspace env hook" in `docs/deployment/sandbox-proxy.md`.
 
 ## [`coding`]
 

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -542,6 +542,8 @@ def _workspace_env_overlay_for_request(
     request: SandboxRunnerExecuteRequest,
     prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
     execution_env: dict[str, str],
+    runtime_paths: RuntimePaths,
+    config: Config,
     *,
     subprocess_env: dict[str, str] | None = None,
     apply: bool,
@@ -562,17 +564,12 @@ def _workspace_env_overlay_for_request(
     if not apply:
         return {}, None
 
-    workspace: Path | None = None
-    if prepared is not None:
-        base_dir = prepared.runtime_overrides.get("base_dir")
-        if isinstance(base_dir, Path):
-            workspace = base_dir
-        elif isinstance(base_dir, str):
-            workspace = Path(base_dir)
-    elif isinstance(raw_base_dir := request.tool_init_overrides.get("base_dir"), str):
-        candidate = Path(raw_base_dir).expanduser()
-        if candidate.is_absolute():
-            workspace = candidate
+    workspace = _workspace_env_hook_workspace_for_request(
+        request,
+        prepared,
+        runtime_paths=runtime_paths,
+        config=config,
+    )
     if workspace is None:
         return {}, None
 
@@ -595,6 +592,48 @@ def _workspace_env_overlay_for_request(
             ),
         )
     return overlay, None
+
+
+def _workspace_env_hook_workspace_for_request(
+    request: SandboxRunnerExecuteRequest,
+    prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
+    *,
+    runtime_paths: RuntimePaths,
+    config: Config,
+) -> Path | None:
+    """Return the workspace root whose `.mindroom/worker-env.sh` applies.
+
+    Agent-routed requests use the canonical resolved agent workspace instead of
+    treating a tool's `base_dir` override as the source of truth.  Static
+    sidecar calls without an agent routing context still use an explicit
+    absolute `base_dir` when provided.
+    """
+    if request.routing_agent_name is not None:
+        execution_identity: ToolExecutionIdentity | None = None
+        if request.execution_identity:
+            execution_identity = ToolExecutionIdentity(**request.execution_identity)
+        agent_runtime = resolve_agent_runtime(
+            request.routing_agent_name,
+            config,
+            _runtime_paths_for_runner_agent_paths(runtime_paths),
+            execution_identity=execution_identity,
+            create=True,
+        )
+        return agent_runtime.tool_base_dir
+
+    if prepared is not None:
+        base_dir = prepared.runtime_overrides.get("base_dir")
+        if isinstance(base_dir, Path):
+            return base_dir
+        if isinstance(base_dir, str):
+            return Path(base_dir)
+        return None
+
+    if isinstance(raw_base_dir := request.tool_init_overrides.get("base_dir"), str):
+        candidate = Path(raw_base_dir).expanduser()
+        if candidate.is_absolute():
+            return candidate
+    return None
 
 
 def _workspace_env_overlay_base_env(
@@ -651,6 +690,8 @@ async def _execute_request_inprocess(
         request,
         prepared,
         execution_env,
+        runtime_paths,
+        config,
         apply=apply_workspace_env_hook,
     )
     if overlay_failure is not None:
@@ -794,6 +835,8 @@ def _execute_request_subprocess_sync(
         request,
         prepared,
         execution_env,
+        runtime_paths,
+        config,
         subprocess_env=subprocess_env,
         apply=apply_workspace_env_hook,
     )

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -65,6 +65,7 @@ logger = get_logger(__name__)
 
 _SUBPROCESS_WORKER_ARG = "--sandbox-subprocess-worker"
 _RUNNER_TOKEN_ENV = "MINDROOM_SANDBOX_PROXY_TOKEN"  # noqa: S105
+_WORKSPACE_ENV_HOOK_TOOL_NAMES = frozenset({"shell", "python"})
 
 
 def _startup_manifest_path_from_env() -> Path:
@@ -562,6 +563,8 @@ def _workspace_env_overlay_for_request(
         subprocess_env=subprocess_env,
     )
     if not apply:
+        return {}, None
+    if request.tool_name not in _WORKSPACE_ENV_HOOK_TOOL_NAMES:
         return {}, None
 
     workspace = _workspace_env_hook_workspace_for_request(

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -3434,6 +3434,50 @@ def _write_workspace_env_hook(workspace: Path, body: str) -> Path:
     return hook_path
 
 
+def test_workspace_env_hook_uses_routed_agent_workspace_without_base_dir(tmp_path: Path) -> None:
+    """Agent-routed requests should not depend on a tool base_dir to source the hook."""
+    config_path = tmp_path / "config.yaml"
+    storage_root = tmp_path / "storage"
+    runtime_paths = resolve_runtime_paths(config_path=config_path, storage_path=storage_root, process_env={})
+    config = Config.validate_with_runtime(
+        {
+            "models": {"default": {"provider": "openai", "id": "gpt-5.4"}},
+            "agents": {
+                "general": {
+                    "display_name": "General",
+                    "memory_backend": "file",
+                },
+            },
+            "router": {"model": "default"},
+        },
+        runtime_paths,
+    )
+    workspace = agent_workspace_root_path(storage_root, "general")
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_workspace_env_hook(
+        workspace,
+        'export WORKSPACE_HOOK_TOKEN=from-agent-workspace\nexport PATH="$PWD/.local/bin:$PATH"\n',
+    )
+
+    request = sandbox_runner_module.SandboxRunnerExecuteRequest(
+        tool_name="shell",
+        function_name="run_shell_command",
+        routing_agent_name="general",
+    )
+    overlay, failure = sandbox_runner_module._workspace_env_overlay_for_request(
+        request,
+        prepared=None,
+        execution_env={"PATH": "/usr/bin:/bin"},
+        runtime_paths=runtime_paths,
+        config=config,
+        apply=True,
+    )
+
+    assert failure is None
+    assert overlay["WORKSPACE_HOOK_TOKEN"] == "from-agent-workspace"  # noqa: S105
+    assert overlay["PATH"].startswith(f"{workspace.resolve()}/.local/bin:")
+
+
 @REQUIRES_LINUX_LOCAL_WORKER
 def test_workspace_env_hook_overlays_shell_execution(
     runner_client: TestClient,

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -3758,12 +3758,12 @@ def test_workspace_env_hook_overlays_worker_routed_python_default_mode(
 
 
 @REQUIRES_LINUX_LOCAL_WORKER
-def test_workspace_env_hook_overlays_worker_routed_coding_default_mode(
+def test_workspace_env_hook_skips_worker_routed_coding_default_mode(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Worker-keyed coding sees hook PATH changes in the default inprocess runner mode."""
+    """Worker-keyed coding should not source the workspace env hook."""
     _set_sandbox_token(monkeypatch)
     storage_root = tmp_path / "storage"
     workspace = storage_root / "agents" / "general" / "workspace"
@@ -3794,16 +3794,16 @@ def test_workspace_env_hook_overlays_worker_routed_coding_default_mode(
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True, payload
-    assert payload["result"] == "Error running grep: hook-rg"
+    assert payload["result"] == "note.txt:1:needle"
 
 
 @REQUIRES_LINUX_LOCAL_WORKER
-def test_workspace_env_hook_failure_blocks_worker_routed_file_default_mode(
+def test_workspace_env_hook_failure_does_not_block_worker_routed_file_default_mode(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Worker-keyed file requests source the hook before running."""
+    """Worker-keyed file requests should not source the workspace env hook."""
     _set_sandbox_token(monkeypatch)
     storage_root = tmp_path / "storage"
     workspace = storage_root / "agents" / "general" / "workspace"
@@ -3828,10 +3828,9 @@ def test_workspace_env_hook_failure_blocks_worker_routed_file_default_mode(
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["ok"] is False, payload
-    assert payload["failure_kind"] == "tool"
-    assert "exited with code 6" in payload["error"]
-    assert not (workspace / "note.txt").exists()
+    assert payload["ok"] is True, payload
+    assert payload["result"] == "note.txt"
+    assert (workspace / "note.txt").read_text(encoding="utf-8") == "should not be written"
 
 
 @REQUIRES_LINUX_LOCAL_WORKER

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -3478,6 +3478,46 @@ def test_workspace_env_hook_uses_routed_agent_workspace_without_base_dir(tmp_pat
     assert overlay["PATH"].startswith(f"{workspace.resolve()}/.local/bin:")
 
 
+def test_workspace_env_hook_skips_non_execution_tools_for_routed_agent(tmp_path: Path) -> None:
+    """Routed non-execution tools should not be blocked by a shell env hook."""
+    config_path = tmp_path / "config.yaml"
+    storage_root = tmp_path / "storage"
+    runtime_paths = resolve_runtime_paths(config_path=config_path, storage_path=storage_root, process_env={})
+    config = Config.validate_with_runtime(
+        {
+            "models": {"default": {"provider": "openai", "id": "gpt-5.4"}},
+            "agents": {
+                "general": {
+                    "display_name": "General",
+                    "memory_backend": "file",
+                },
+            },
+            "router": {"model": "default"},
+        },
+        runtime_paths,
+    )
+    workspace = agent_workspace_root_path(storage_root, "general")
+    workspace.mkdir(parents=True, exist_ok=True)
+    _write_workspace_env_hook(workspace, 'echo "bad hook" >&2\nexit 5\n')
+
+    request = sandbox_runner_module.SandboxRunnerExecuteRequest(
+        tool_name="file",
+        function_name="read_file",
+        routing_agent_name="general",
+    )
+    overlay, failure = sandbox_runner_module._workspace_env_overlay_for_request(
+        request,
+        prepared=None,
+        execution_env={"PATH": "/usr/bin:/bin"},
+        runtime_paths=runtime_paths,
+        config=config,
+        apply=True,
+    )
+
+    assert overlay == {}
+    assert failure is None
+
+
 @REQUIRES_LINUX_LOCAL_WORKER
 def test_workspace_env_hook_overlays_shell_execution(
     runner_client: TestClient,


### PR DESCRIPTION
## Summary
- source .mindroom/worker-env.sh from the resolved routed agent workspace instead of coupling discovery to a tool base_dir override
- keep absolute base_dir discovery for unkeyed static-sidecar calls that have no agent routing context
- document the agent-workspace discovery contract and add a regression test for routed requests without base_dir

## Tests
- uv run pytest tests/api/test_sandbox_runner_api.py::test_workspace_env_hook_uses_routed_agent_workspace_without_base_dir -q
- uv run pytest tests/test_workspace_env_hook.py tests/api/test_sandbox_runner_api.py::test_workspace_env_hook_unkeyed_proxy_uses_init_override_base_dir tests/api/test_sandbox_runner_api.py::test_workspace_env_hook_uses_routed_agent_workspace_without_base_dir -q
- uv run ruff check src/mindroom/api/sandbox_runner.py tests/api/test_sandbox_runner_api.py
- git diff --check