### PR TITLE
Keep tmux servers alive in worker images

### DIFF
--- a/local/instances/deploy/Dockerfile.mindroom
+++ b/local/instances/deploy/Dockerfile.mindroom
@@ -51,6 +51,7 @@ WORKDIR /app
 # - bash and tmux for shell tooling and detached interactive CLI flows
 # - common small CLI utilities used by headless auth/install workflows
 RUN apt-get update && apt-get install -y bash bzip2 curl git git-lfs jq nano procps ripgrep tmux unzip \
+    && printf 'set-option -g exit-empty off\n' > /etc/tmux.conf \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user before copying files

--- a/local/instances/deploy/Dockerfile.mindroom-minimal
+++ b/local/instances/deploy/Dockerfile.mindroom-minimal
@@ -51,6 +51,7 @@ WORKDIR /app
 # - bash and tmux for shell tooling and detached interactive CLI flows
 # - common small CLI utilities used by headless auth/install workflows
 RUN apt-get update && apt-get install -y bash bzip2 curl git git-lfs jq nano procps ripgrep tmux unzip \
+    && printf 'set-option -g exit-empty off\n' > /etc/tmux.conf \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user before copying files

--- a/tests/test_tool_dependencies.py
+++ b/tests/test_tool_dependencies.py
@@ -178,6 +178,20 @@ def test_runtime_images_include_headless_cli_utilities(dockerfile_path: Path) ->
         assert package_name in dockerfile
 
 
+@pytest.mark.parametrize(
+    "dockerfile_path",
+    [
+        Path("local/instances/deploy/Dockerfile.mindroom"),
+        Path("local/instances/deploy/Dockerfile.mindroom-minimal"),
+    ],
+)
+def test_runtime_images_keep_tmux_server_alive_without_sessions(dockerfile_path: Path) -> None:
+    """Worker tmux servers should survive short-lived single-session auth/setup flows."""
+    dockerfile = dockerfile_path.read_text(encoding="utf-8")
+
+    assert "set-option -g exit-empty off" in dockerfile
+
+
 def test_tools_requiring_config_metadata() -> None:
     """Test that tools marked REQUIRES_CONFIG have config_fields or auth_provider."""
     inconsistent = []


### PR DESCRIPTION
## Summary
- Configure tmux in both MindRoom runtime images with `exit-empty off` so worker tmux servers stay alive after short-lived single-session commands exit.
- Add a regression check that both runtime Dockerfiles keep this tmux option.

## Reproduction
- Reproduced with plain Docker using separate `docker exec` calls: `tmux new-session -d -s only 'sleep 1'`, wait, then `tmux ls` reports no server with default tmux behavior.
- Verified `exit-empty off` keeps the tmux server alive with zero sessions; `tmux ls` returns rc=0 with empty output and `tmux info` returns `no current client`.

## Validation
- `uv run pytest tests/test_tool_dependencies.py -q` passed: 47 passed.
- Rebuilt `local/instances/deploy/Dockerfile.mindroom` locally as `mindroom-tmux-fix-check:latest` and verified `/etc/tmux.conf` contains `set-option -g exit-empty off`.
- In the rebuilt image, a short-lived tmux session exited, then `tmux ls` returned rc=0 and `tmux info` returned `no current client`, confirming the baked config works.