### PR TITLE
Preserve workspace env hook overlays

### DIFF
--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -185,6 +185,7 @@ def runtime_paths_with_execution_env(
     env_file_values = dict(runtime_paths.env_file_values)
     if trusted_env_overlay:
         env_file_values.update(trusted_env_overlay)
+        process_env.update(trusted_env_overlay)
     return constants.RuntimePaths(
         config_path=runtime_paths.config_path,
         config_dir=runtime_paths.config_dir,

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -853,8 +853,9 @@ def _execute_request_subprocess_sync(
         execution_env,
         trusted_env_overlay=overlay,
     )
+    subprocess_request = request.model_copy(update={"execution_env": execution_env})
     envelope = sandbox_protocol.serialize_subprocess_envelope(
-        request=request.model_dump(mode="json"),
+        request=subprocess_request.model_dump(mode="json"),
         runtime_paths=constants.serialize_runtime_paths(effective_runtime_paths),
         committed_config=base64.b64encode(pickle.dumps(config)).decode("ascii"),
     )

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import os
 import re
+import shlex
 import signal
 import time
 import uuid
@@ -143,6 +144,59 @@ def _shell_subprocess_env(
     else:
         env["PATH"] = path_value
     return env
+
+
+def _login_bash_command_index(args: list[str]) -> int | None:
+    """Return the command index for `bash -lc ...` style invocations."""
+    if not args or Path(args[0]).name != "bash":
+        return None
+
+    login_shell = False
+    command_index: int | None = None
+    for index, arg in enumerate(args[1:], start=1):
+        if arg == "--":
+            break
+        if not arg.startswith("-"):
+            break
+        if arg in {"-l", "--login"}:
+            login_shell = True
+            continue
+        if arg.startswith("--"):
+            continue
+        if "l" in arg:
+            login_shell = True
+        if "c" in arg:
+            command_index = index + 1
+            break
+
+    if not login_shell or command_index is None or command_index >= len(args):
+        return None
+    return command_index
+
+
+def _restore_env_exports_for_login_shell(env: dict[str, str]) -> str:
+    """Return shell exports that restore env values commonly reset by login startup."""
+    path_value = env.get("PATH")
+    if path_value is None:
+        return ""
+    return f"export PATH={shlex.quote(path_value)}; "
+
+
+def _shell_subprocess_args(args: list[str], env: dict[str, str]) -> list[str]:
+    """Return argv adjusted for shell startup files that rewrite env overlays."""
+    command_index = _login_bash_command_index(args)
+    if command_index is None:
+        return args
+
+    env_restore = _restore_env_exports_for_login_shell(env)
+    if not env_restore:
+        return args
+
+    adjusted_args = list(args)
+    # Login bash can reset PATH in /etc/profile after subprocess env is applied.
+    # Restore MindRoom's captured execution PATH without re-sourcing workspace hooks.
+    adjusted_args[command_index] = env_restore + adjusted_args[command_index]
+    return adjusted_args
 
 
 def _handle_namespace(*, runtime_paths: RuntimePaths, base_dir: Path | None) -> str:
@@ -320,16 +374,17 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
             self._sweep_stale_records()
 
             try:
+                subprocess_env = _shell_subprocess_env(
+                    self._runtime_env,
+                    base_process_env=self._base_process_env,
+                    shell_path_prepend=self._shell_path_prepend,
+                )
                 process = await asyncio.create_subprocess_exec(
-                    *args,
+                    *_shell_subprocess_args(args, subprocess_env),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     cwd=str(self.base_dir) if self.base_dir else None,
-                    env=_shell_subprocess_env(
-                        self._runtime_env,
-                        base_process_env=self._base_process_env,
-                        shell_path_prepend=self._shell_path_prepend,
-                    ),
+                    env=subprocess_env,
                     start_new_session=True,
                 )
             except Exception as exc:

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -3478,6 +3478,99 @@ def test_workspace_env_hook_uses_routed_agent_workspace_without_base_dir(tmp_pat
     assert overlay["PATH"].startswith(f"{workspace.resolve()}/.local/bin:")
 
 
+def test_workspace_env_hook_subprocess_serializes_overlay_execution_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The subprocess child should receive the post-hook env, not the stale original request env."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(config_path=config_path, storage_path=tmp_path / "storage", process_env={})
+    config = Config.validate_with_runtime({}, runtime_paths)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_workspace_env_hook(workspace, "export PATH=/hook/bin:$PATH\n")
+    captured_envelope: dict[str, object] = {}
+
+    def fake_subprocess_run(
+        _command: list[str],
+        *,
+        input: str,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+        check: bool,
+        env: dict[str, str] | None,
+        cwd: str | None,
+    ) -> subprocess.CompletedProcess[str]:
+        captured_envelope["payload"] = sandbox_protocol_module.parse_subprocess_envelope(input)
+        captured_envelope["env"] = env
+        captured_envelope["cwd"] = cwd
+        assert capture_output is True
+        assert text is True
+        assert timeout >= 1.0
+        assert check is False
+        response = sandbox_runner_module.SandboxRunnerExecuteResponse(ok=True, result="ok")
+        return subprocess.CompletedProcess(
+            args=_command,
+            returncode=0,
+            stdout="",
+            stderr=sandbox_protocol_module.response_marker_payload(response.model_dump_json()),
+        )
+
+    monkeypatch.setattr(sandbox_runner_module.subprocess, "run", fake_subprocess_run)
+
+    request = sandbox_runner_module.SandboxRunnerExecuteRequest(
+        tool_name="shell",
+        function_name="run_shell_command",
+        args=[["bash", "-lc", "echo ok"]],
+        kwargs={},
+        execution_env={"PATH": "/usr/bin:/bin"},
+        tool_init_overrides={"base_dir": str(workspace)},
+    )
+    response = sandbox_runner_module._execute_request_subprocess_sync(request, runtime_paths, config)
+
+    assert response.ok is True
+    envelope = captured_envelope["payload"]
+    assert isinstance(envelope, sandbox_protocol_module.SandboxSubprocessEnvelope)
+    assert envelope.request["execution_env"]["PATH"] == "/hook/bin:/usr/bin:/bin"
+    env = captured_envelope["env"]
+    assert isinstance(env, dict)
+    assert env["PATH"] == "/hook/bin:/usr/bin:/bin"
+
+
+def test_workspace_env_hook_shell_side_effects_do_not_reach_command(tmp_path: Path) -> None:
+    """Hook shell state such as `cd` should not leak into the command process."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(config_path=config_path, storage_path=tmp_path / "storage", process_env={})
+    config = Config.validate_with_runtime({}, runtime_paths)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_workspace_env_hook(workspace, "export WORKSPACE_HOOK_TOKEN=hooked\ncd /\n")
+
+    request = sandbox_runner_module.SandboxRunnerExecuteRequest(
+        tool_name="shell",
+        function_name="run_shell_command",
+        args=[["bash", "-c", 'printf "%s|%s" "$WORKSPACE_HOOK_TOKEN" "$PWD"']],
+        kwargs={},
+        execution_env={"PATH": os.environ["PATH"]},
+        tool_init_overrides={"base_dir": str(workspace)},
+    )
+    response = sandbox_runner_module._execute_request_subprocess_sync(request, runtime_paths, config)
+
+    assert response.ok is True, response
+    token, pwd = str(response.result).split("|", 1)
+    assert token == "hooked"  # noqa: S105
+    assert pwd == str(workspace)
+
+
 def test_workspace_env_hook_skips_non_execution_tools_for_routed_agent(tmp_path: Path) -> None:
     """Routed non-execution tools should not be blocked by a shell env hook."""
     config_path = tmp_path / "config.yaml"

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -624,6 +624,42 @@ async def test_env_passthrough_preserved(tmp_path: Path) -> None:
     assert result == "async-shell-works"
 
 
+@pytest.mark.asyncio
+async def test_login_bash_preserves_runtime_path_after_profile_reset(tmp_path: Path) -> None:
+    """MindRoom shell calls should keep runtime PATH even when login startup rewrites it."""
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_bash = fake_bin / "bash"
+    fake_bash.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"-lc\" ]; then\n"
+        "  export PATH=/profile/default\n"
+        "  exec /bin/sh -c \"$2\"\n"
+        "fi\n"
+        "exec /bin/sh \"$@\"\n",
+        encoding="utf-8",
+    )
+    fake_bash.chmod(0o755)
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "storage",
+        process_env={"PATH": "/worker-env/bin:/usr/bin:/bin"},
+    )
+    tool = get_tool_by_name("shell", runtime_paths, disable_sandbox_proxy=True, worker_target=None)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+
+    result = await entrypoint([str(fake_bash), "-lc", "printf '%s' \"$PATH\""])
+
+    assert result == "/worker-env/bin:/usr/bin:/bin"
+
+
 # ---------------------------------------------------------------------------
 # Handle persistence across toolkit instances (sandbox runner path)
 # ---------------------------------------------------------------------------

--- a/tests/test_workspace_env_hook.py
+++ b/tests/test_workspace_env_hook.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from mindroom.constants import resolve_runtime_paths, shell_execution_runtime_env_values
 from mindroom.api import sandbox_exec
 from mindroom.api.sandbox_exec import (
     WORKSPACE_ENV_HOOK_RELATIVE_PATH,
@@ -31,6 +32,24 @@ def _write_hook(workspace: Path, body: str) -> Path:
     hook_path = hook_dir / "worker-env.sh"
     hook_path.write_text(body, encoding="utf-8")
     return hook_path
+
+
+def test_trusted_workspace_env_overlay_wins_over_execution_env_path(tmp_path: Path) -> None:
+    """Hook-exported PATH should not be overwritten by the runner's base PATH."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={"PATH": "/usr/bin:/bin"},
+    )
+
+    overlaid_paths = sandbox_exec.runtime_paths_with_execution_env(
+        runtime_paths,
+        {"PATH": "/usr/bin:/bin"},
+        trusted_env_overlay={"PATH": "/workspace/.local/bin:/usr/bin:/bin"},
+    )
+    shell_env = shell_execution_runtime_env_values(overlaid_paths)
+
+    assert shell_env["PATH"].startswith("/workspace/.local/bin:")
 
 
 def test_resolve_workspace_env_hook_path_returns_none_when_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- apply trusted .mindroom/worker-env.sh overlays to both env-file and process env runtime snapshots
- serialize the post-hook execution env into sandbox worker subprocess envelopes
- preserve worker-env PATH for normal MindRoom shell tool calls that invoke login bash, without patching /etc/profile and without re-sourcing agent-editable hooks

## Verification
- uv run pytest tests/test_shell_async.py tests/test_workspace_env_hook.py tests/api/test_sandbox_runner_api.py -k 'workspace_env_hook or login_bash_preserves_runtime_path_after_profile_reset' -q
- docker build -t mindroom-worker-env-shell-fix-check -f local/instances/deploy/Dockerfile.mindroom --build-arg VERSION=0.0.0 .
- live sandbox-runner Docker repro: confirmed /etc/profile is unmodified, then edited agents/general/workspace/.mindroom/worker-env.sh and verified next shell bash -lc call, python call, and failing-hook behavior through /api/sandbox-runner/execute

## Notes
- Compared with ~/Work/dev/mindroom-worktrees/worker-env.
- Kept the subprocess env serialization part.
- Did not use BASH_ENV because it would re-source the agent-editable hook inside command shells; instead the shell tool restores the captured PATH value for login bash commands.