### PR TITLE
Disable third-party telemetry by default

### DIFF
--- a/cluster/k8s/platform/templates/all.yaml
+++ b/cluster/k8s/platform/templates/all.yaml
@@ -22,6 +22,9 @@ data:
   INSTANCE_MINDROOM_IMAGE_PULL_POLICY: {{ .Values.provisioner.instanceMindroomImagePullPolicy | default "" | quote }}
   INSTANCE_SYNAPSE_IMAGE: {{ .Values.provisioner.instanceSynapseImage | default "" | quote }}
   INSTANCE_SYNAPSE_IMAGE_PULL_POLICY: {{ .Values.provisioner.instanceSynapseImagePullPolicy | default "" | quote }}
+  DO_NOT_TRACK: "1"
+  NEXT_TELEMETRY_DISABLED: "1"
+  TURBO_TELEMETRY_DISABLED: "1"
   SUPABASE_URL: {{ .Values.supabase.url | default "" | quote }}
   SUPABASE_ANON_KEY: {{ .Values.supabase.anonKey | default "" | quote }}
   STRIPE_PUBLISHABLE_KEY: {{ .Values.stripe.publishableKey | default "" | quote }}

--- a/saas-platform/Dockerfile.platform-frontend
+++ b/saas-platform/Dockerfile.platform-frontend
@@ -4,6 +4,9 @@ FROM oven/bun:1 AS base
 
 # Dependencies stage
 FROM base AS deps
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    TURBO_TELEMETRY_DISABLED=1 \
+    DO_NOT_TRACK=1
 WORKDIR /app
 COPY saas-platform/platform-frontend/package.json saas-platform/platform-frontend/bun.lock ./platform-frontend/
 # Use cache mount for bun cache to speed up builds
@@ -20,6 +23,9 @@ RUN cd platform-frontend && bun run build
 
 # Production stage - optimized for Next.js standalone
 FROM public.ecr.aws/docker/library/node:20-alpine AS final
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    TURBO_TELEMETRY_DISABLED=1 \
+    DO_NOT_TRACK=1
 WORKDIR /app
 
 # Add non-root user for security

--- a/saas-platform/docker-compose.yml
+++ b/saas-platform/docker-compose.yml
@@ -17,6 +17,9 @@ services:
     env_file:
       - .env
     environment:
+      - DO_NOT_TRACK=1
+      - NEXT_TELEMETRY_DISABLED=1
+      - TURBO_TELEMETRY_DISABLED=1
       - SUPABASE_URL=${SUPABASE_URL}
       - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
       - PLATFORM_DOMAIN=${PLATFORM_DOMAIN}

--- a/saas-platform/platform-frontend/package.json
+++ b/saas-platform/platform-frontend/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "license": "BUSL-1.1",
   "scripts": {
-    "dev": "NEXT_PUBLIC_DEV_AUTH=true next dev --turbopack -H 0.0.0.0",
-    "build": "next build",
-    "start": "next start",
+    "dev": "NEXT_TELEMETRY_DISABLED=1 TURBO_TELEMETRY_DISABLED=1 DO_NOT_TRACK=1 NEXT_PUBLIC_DEV_AUTH=true next dev --turbopack -H 0.0.0.0",
+    "build": "NEXT_TELEMETRY_DISABLED=1 TURBO_TELEMETRY_DISABLED=1 DO_NOT_TRACK=1 next build",
+    "start": "NEXT_TELEMETRY_DISABLED=1 TURBO_TELEMETRY_DISABLED=1 DO_NOT_TRACK=1 next start",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/src/mindroom/__init__.py
+++ b/src/mindroom/__init__.py
@@ -1,14 +1,11 @@
 """MindRoom: A universal interface for AI agents with persistent memory."""
 
-import os
 from importlib.metadata import version
 
 from mindroom.constants import patch_chromadb_for_python314
+from mindroom.vendor_telemetry import disable_vendor_telemetry
 
-# MindRoom should never emit vendor network telemetry, even if a user .env enables it.
-os.environ["AGNO_TELEMETRY"] = "false"
-os.environ["ANONYMIZED_TELEMETRY"] = "false"
-os.environ["MEM0_TELEMETRY"] = "false"
+disable_vendor_telemetry()
 
 patch_chromadb_for_python314()
 

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -1200,6 +1200,7 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         enable_agentic_culture=enable_agentic_culture,
         compress_tool_results=compress_tool_results,
         max_tool_calls_from_history=max_tool_calls_from_history,
+        telemetry=False,
     )
     if include_all_history:
         _enable_all_history_replay(agent)

--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -281,6 +281,7 @@ def subprocess_env_for_request(
 
     env = dict(base_env)
     env.update(execution_env)
+    env.update(vendor_telemetry_env_values())
     return env
 
 

--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from mindroom import constants
 from mindroom.tool_system.worker_routing import worker_dir_name
+from mindroom.vendor_telemetry import vendor_telemetry_env_values
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -225,6 +226,7 @@ def subprocess_passthrough_env() -> dict[str, str]:
 def generic_subprocess_env() -> dict[str, str]:
     """Build the baseline subprocess env for non-worker execution."""
     env = subprocess_passthrough_env()
+    env.update(vendor_telemetry_env_values())
     for key in ("HOME", "PATH", "PYTHONPATH", "VIRTUAL_ENV"):
         value = os.environ.get(key)
         if value:

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -1135,6 +1135,10 @@ async def save_attachment_to_worker(  # noqa: C901, PLR0911
     if raw_path_error is not None:
         return SandboxRunnerSaveAttachmentResponse(ok=False, error=raw_path_error, failure_kind="tool")
 
+    decoded_bytes = _decode_attachment_save_bytes(payload)
+    if isinstance(decoded_bytes, str):
+        return SandboxRunnerSaveAttachmentResponse(ok=False, error=decoded_bytes, failure_kind="tool")
+
     prepared_worker: sandbox_worker_prep.PreparedWorkerRequest | None = None
     if payload.worker_key is not None:
         try:
@@ -1174,10 +1178,6 @@ async def save_attachment_to_worker(  # noqa: C901, PLR0911
     path_error = validate_output_path(policy, output_path)
     if path_error is not None:
         return SandboxRunnerSaveAttachmentResponse(ok=False, error=path_error, failure_kind="tool")
-
-    decoded_bytes = _decode_attachment_save_bytes(payload)
-    if isinstance(decoded_bytes, str):
-        return SandboxRunnerSaveAttachmentResponse(ok=False, error=decoded_bytes, failure_kind="tool")
 
     write_result = write_bytes_to_output_path(policy, output_path, decoded_bytes, file_mode=0o600)
     if isinstance(write_result, str):

--- a/src/mindroom/cli/__init__.py
+++ b/src/mindroom/cli/__init__.py
@@ -1,1 +1,5 @@
 """MindRoom CLI package."""
+
+from mindroom.vendor_telemetry import disable_vendor_telemetry
+
+disable_vendor_telemetry()

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -31,6 +31,31 @@ SANDBOX_STARTUP_MANIFEST_PATH_ENV = "MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH"
 SANDBOX_STARTUP_MANIFEST_RELATIVE_PATH = Path(".runtime") / "startup_manifest.json"
 _CONFIG_PATH_PLACEHOLDER_PATTERN = re.compile(r"\$(?:\{(?P<braced>[A-Z0-9_]+)\}|(?P<bare>[A-Z0-9_]+))")
 _RUNTIME_STARTUP_ENV_PREFIXES = ("MINDROOM_", "MATRIX_", "BROWSER_")
+# Evidence sources: installed package code in .venv; vendor docs only for
+# frontend/W&B controls. Python runtime envs are centralized here so
+# deployments do not repeat them.
+VENDOR_TELEMETRY_ENV_VALUES: Mapping[str, str] = MappingProxyType(
+    {
+        "AGNO_TELEMETRY": "false",
+        "ANONYMIZED_TELEMETRY": "false",
+        "CHROMA_OTEL_COLLECTION_ENDPOINT": "",
+        "CHROMA_OTEL_GRANULARITY": "none",
+        "COMPOSIO_DISABLE_SENTRY": "true",
+        "COMPOSIO_DISABLE_VERSION_CHECK": "true",
+        "DISABLE_TELEMETRY": "1",
+        "DO_NOT_TRACK": "1",
+        "HF_HUB_DISABLE_TELEMETRY": "1",
+        "LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS": "true",
+        "LITELLM_LOCAL_MODEL_COST_MAP": "true",
+        "MEM0_TELEMETRY": "false",
+        "MEM0_TELEMETRY_SAMPLE_RATE": "0",
+        "NEXT_TELEMETRY_DISABLED": "1",
+        "OTEL_SDK_DISABLED": "true",
+        "TURBO_TELEMETRY_DISABLED": "1",
+        "WANDB_MODE": "disabled",
+    },
+)
+_VENDOR_TELEMETRY_ENV_NAMES = frozenset(VENDOR_TELEMETRY_ENV_VALUES)
 _RUNTIME_STARTUP_ENV_EXTRA_KEYS = frozenset(
     {
         "ACCOUNT_ID",
@@ -44,9 +69,17 @@ _RUNTIME_STARTUP_ENV_EXTRA_KEYS = frozenset(
         "OLLAMA_HOST",
         "OPENAI_BASE_URL",
         "POD_NAMESPACE",
+        *_VENDOR_TELEMETRY_ENV_NAMES,
     },
 )
-_ISOLATED_RUNTIME_ENV_EXTRA_KEYS = frozenset({"ACCOUNT_ID", "CUSTOMER_ID", "POD_NAMESPACE"})
+_ISOLATED_RUNTIME_ENV_EXTRA_KEYS = frozenset(
+    {
+        "ACCOUNT_ID",
+        "CUSTOMER_ID",
+        "POD_NAMESPACE",
+        *_VENDOR_TELEMETRY_ENV_NAMES,
+    },
+)
 _RUNTIME_STARTUP_EXCLUDED_NAMES = frozenset(
     {
         "MINDROOM_EVENT_CACHE_DATABASE_URL",

--- a/src/mindroom/memory/auto_flush.py
+++ b/src/mindroom/memory/auto_flush.py
@@ -537,6 +537,7 @@ async def _extract_memory_summary(
         name="MemoryAutoFlushExtractor",
         role="Extract durable memory statements for long-term memory storage.",
         model=model,
+        telemetry=False,
     )
     response = await extractor_agent.arun(prompt, session_id=f"memory_auto_flush_extract:{agent_name}:{session_id}")
     content = response.content

--- a/src/mindroom/routing.py
+++ b/src/mindroom/routing.py
@@ -95,6 +95,7 @@ Choose the most appropriate agent based on their role, tools, and instructions."
             role="Route messages to appropriate agents",
             model=model,
             output_schema=_AgentSuggestion,
+            telemetry=False,
         )
 
         response = await agent.arun(prompt, session_id="routing")

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -692,6 +692,7 @@ Examples of event/condition phrasing to include in the message (do not include t
         role="Parse scheduling requests into structured workflows",
         model=model,
         output_schema=ScheduledWorkflow,
+        telemetry=False,
     )
 
     try:

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -566,6 +566,7 @@ Return the mode and a one-sentence reason why."""
         role="Determine team mode",
         model=model,
         output_schema=_TeamModeDecision,
+        telemetry=False,
     )
 
     try:
@@ -1311,6 +1312,7 @@ def _create_team_instance(
         store_history_messages=False,
         show_members_responses=True,
         debug_mode=False,
+        telemetry=False,
         # Agno will automatically list members with their names, roles, and tools
     )
     if history_settings.policy.mode == "all":

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -336,6 +336,7 @@ async def _generate_summary(
         instructions=list(_SUMMARY_INSTRUCTIONS),
         model=model,
         output_schema=_ThreadSummary,
+        telemetry=False,
     )
     response = await cached_agent_run(
         agent=agent,

--- a/src/mindroom/tool_system/dependencies.py
+++ b/src/mindroom/tool_system/dependencies.py
@@ -14,6 +14,8 @@ from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from mindroom.vendor_telemetry import vendor_telemetry_env_values
+
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
 
@@ -142,7 +144,9 @@ def _install_via_uv_tool(extras: list[str], *, quiet: bool) -> bool:
     cmd = ["uv", "tool", "install", package_spec, "--force", "--python", python_version]
     if quiet:
         cmd.append("-q")
-    result = subprocess.run(cmd, check=False)
+    env = os.environ.copy()
+    env.update(vendor_telemetry_env_values())
+    result = subprocess.run(cmd, check=False, env=env)
     return result.returncode == 0
 
 
@@ -172,6 +176,7 @@ def _install_via_uv_sync(extras: list[str], *, quiet: bool) -> bool:
     """Install extras using ``uv sync --locked --inexact`` for pinned versions from uv.lock."""
     cmd = ["uv", "sync", "--locked", "--inexact", "--no-dev"]
     env = os.environ.copy()
+    env.update(vendor_telemetry_env_values())
     if _in_virtualenv():
         # Ensure uv targets the interpreter that is currently running MindRoom.
         cmd.append("--active")
@@ -188,7 +193,9 @@ def _install_in_environment(extras: list[str], *, quiet: bool) -> bool:
     extras_str = ",".join(extras)
     package_spec = f"{_PACKAGE_NAME}[{extras_str}]"
     cmd = [*install_command_for_current_python(), package_spec]
-    result = subprocess.run(cmd, check=False, capture_output=quiet)
+    env = os.environ.copy()
+    env.update(vendor_telemetry_env_values())
+    result = subprocess.run(cmd, check=False, capture_output=quiet, env=env)
     return result.returncode == 0
 
 

--- a/src/mindroom/tools/composio.py
+++ b/src/mindroom/tools/composio.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.vendor_telemetry import disable_vendor_telemetry
 
 if TYPE_CHECKING:
     from composio_agno import ComposioToolSet
@@ -195,4 +196,5 @@ def composio_tools() -> type[ComposioToolSet]:
     """Return Composio tools for accessing 1000+ integrations."""
     from composio_agno import ComposioToolSet
 
+    disable_vendor_telemetry()
     return ComposioToolSet

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -30,6 +30,7 @@ from mindroom.tool_system.metadata import (
     ToolStatus,
     register_tool_with_metadata,
 )
+from mindroom.vendor_telemetry import vendor_telemetry_env_values
 
 _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS = frozenset(
     {
@@ -131,6 +132,7 @@ def _shell_subprocess_env(
 ) -> dict[str, str]:
     """Build the env passed to shell subprocesses."""
     env = {key: value for key, value in os.environ.items() if key in _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS}
+    env.update(vendor_telemetry_env_values())
     if base_process_env is not None:
         env.update({key: value for key, value in base_process_env.items() if key in _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS})
     env.update(runtime_env)

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -132,7 +132,6 @@ def _shell_subprocess_env(
 ) -> dict[str, str]:
     """Build the env passed to shell subprocesses."""
     env = {key: value for key, value in os.environ.items() if key in _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS}
-    env.update(vendor_telemetry_env_values())
     if base_process_env is not None:
         env.update({key: value for key, value in base_process_env.items() if key in _LOCAL_SHELL_PASSTHROUGH_ENV_KEYS})
     env.update(runtime_env)
@@ -145,6 +144,7 @@ def _shell_subprocess_env(
         env.pop("PATH", None)
     else:
         env["PATH"] = path_value
+    env.update(vendor_telemetry_env_values())
     return env
 
 

--- a/src/mindroom/topic_generator.py
+++ b/src/mindroom/topic_generator.py
@@ -93,6 +93,7 @@ Generate the topic:"""
         role="Generate contextual room topics",
         model=model,
         output_schema=_RoomTopic,
+        telemetry=False,
     )
 
     session_id = f"topic_{room_key}"

--- a/src/mindroom/vendor_telemetry.py
+++ b/src/mindroom/vendor_telemetry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import atexit
 import os
 import sys
 from typing import TYPE_CHECKING
@@ -45,3 +46,8 @@ def _disable_loaded_vendor_modules() -> None:
 
     if hf_constants_module := sys.modules.get("huggingface_hub.constants"):
         vars(hf_constants_module)["HF_HUB_DISABLE_TELEMETRY"] = True
+
+    if composio_sentry_module := sys.modules.get("composio.utils.sentry"):
+        update_dsn = vars(composio_sentry_module).get("update_dsn")
+        if callable(update_dsn):
+            atexit.unregister(update_dsn)

--- a/src/mindroom/vendor_telemetry.py
+++ b/src/mindroom/vendor_telemetry.py
@@ -1,0 +1,47 @@
+"""Disable third-party telemetry and vendor phone-home defaults."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TYPE_CHECKING
+
+from mindroom.constants import VENDOR_TELEMETRY_ENV_VALUES
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
+
+def disable_vendor_telemetry(environ: MutableMapping[str, str] | None = None) -> None:
+    """Force known third-party telemetry and vendor update checks off."""
+    target_env = os.environ if environ is None else environ
+    target_env.update(VENDOR_TELEMETRY_ENV_VALUES)
+    if target_env is os.environ:
+        _disable_loaded_vendor_modules()
+
+
+def vendor_telemetry_env_values() -> dict[str, str]:
+    """Return a mutable copy of the vendor telemetry opt-out env."""
+    return dict(VENDOR_TELEMETRY_ENV_VALUES)
+
+
+def _disable_loaded_vendor_modules() -> None:
+    """Apply best-effort guards for vendor modules imported before MindRoom."""
+    if posthog_module := sys.modules.get("posthog"):
+        posthog_vars = vars(posthog_module)
+        posthog_vars["disabled"] = True
+        posthog_vars["send"] = False
+        if default_client := posthog_vars.get("default_client"):
+            client_vars = vars(default_client)
+            client_vars["disabled"] = True
+            client_vars["send"] = False
+
+    if mem0_telemetry_module := sys.modules.get("mem0.memory.telemetry"):
+        mem0_telemetry_vars = vars(mem0_telemetry_module)
+        mem0_telemetry_vars["MEM0_TELEMETRY"] = False
+
+    if litellm_module := sys.modules.get("litellm"):
+        vars(litellm_module)["telemetry"] = False
+
+    if hf_constants_module := sys.modules.get("huggingface_hub.constants"):
+        vars(hf_constants_module)["HF_HUB_DISABLE_TELEMETRY"] = True

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -467,6 +467,7 @@ Output the formatted message only, no explanation:"""
             name="VoiceTranscriptionNormalizer",
             role="Normalize voice transcriptions while preserving natural language and mention intent",
             model=model,
+            telemetry=False,
         )
 
         # Process the transcription with the agent

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -657,6 +657,10 @@ class KubernetesResourceManager:
             raise WorkerBackendError(msg)
 
         for name, value in sorted(self.config.extra_env.items()):
+            if name in constants.VENDOR_TELEMETRY_ENV_VALUES:
+                continue
+            env.append({"name": name, "value": value})
+        for name, value in sorted(constants.VENDOR_TELEMETRY_ENV_VALUES.items()):
             env.append({"name": name, "value": value})
         return env
 
@@ -713,6 +717,7 @@ class KubernetesResourceManager:
             },
         )
         process_env.update(self.config.extra_env)
+        process_env.update(constants.VENDOR_TELEMETRY_ENV_VALUES)
         return constants.isolated_runtime_paths(
             RuntimePaths(
                 config_path=config_path,

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -52,6 +52,7 @@ from mindroom.tool_system.worker_routing import (
 )
 from mindroom.workers.backends import local as local_workers_module
 from mindroom.workers.models import WorkerSpec
+from tests.conftest import requires_linux
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -60,10 +61,8 @@ if TYPE_CHECKING:
 
 SANDBOX_TOKEN = "secret-token"  # noqa: S105
 SANDBOX_HEADERS = {"x-mindroom-sandbox-token": SANDBOX_TOKEN}
-REQUIRES_LINUX_LOCAL_WORKER = pytest.mark.skipif(
-    sys.platform != "linux",
-    reason="local worker venv bootstrap is validated on Linux",
-)
+LINUX_LOCAL_WORKER_REASON = "local worker venv bootstrap is validated on Linux"
+LINUX_LOCAL_WORKER_TIMEOUT_SECONDS = 180
 
 
 def _fake_local_worker_venv_create(_self: object, venv_dir: Path) -> None:
@@ -2130,7 +2129,7 @@ def test_sandbox_runner_rejects_unknown_worker_key_base_dir(
     assert "visible state roots" in response.json()["detail"]
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_sandbox_runner_worker_request_does_not_inject_base_dir_into_unrelated_tools(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -2182,7 +2181,7 @@ def test_sandbox_runner_worker_request_rejects_invalid_base_dir_type_for_unknown
     assert "base_dir" in response.json()["detail"]
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_sandbox_runner_prepares_worker_once_before_subprocess_dispatch(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -2381,7 +2380,7 @@ def test_sandbox_runner_forwards_worker_context_to_tool_rebuild(
     assert worker_target.routing_agent_name == "general"
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_sandbox_runner_worker_file_state_persists_and_is_isolated(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -2447,7 +2446,7 @@ def test_sandbox_runner_worker_file_state_persists_and_is_isolated(
     assert worker_file.read_text(encoding="utf-8") == "hello from worker A"
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_sandbox_runner_worker_request_preserves_forwarded_base_dir(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -2483,7 +2482,7 @@ def test_sandbox_runner_worker_request_preserves_forwarded_base_dir(
     assert not (worker_root / worker_dir_name(worker_key) / "workspace" / "note.txt").exists()
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_sandbox_runner_worker_request_uses_default_storage_root_when_env_is_unset(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -2677,7 +2676,7 @@ def test_prepare_worker_request_requires_explicit_private_visibility_for_user_ag
         )
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_dedicated_worker_mode_resolves_relative_agent_base_dir_from_shared_storage(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -2836,7 +2835,7 @@ def test_dedicated_worker_mode_allows_private_template_dir_missing_from_worker_f
     assert (private_base_dir / "note.txt").read_text(encoding="utf-8") == "hello from private worker"
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_dedicated_worker_mode_resolves_relative_agent_base_dir_from_nested_worker_prefix(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -2875,7 +2874,7 @@ def test_dedicated_worker_mode_resolves_relative_agent_base_dir_from_nested_work
     assert not (worker_root / "workspace" / "note.txt").exists()
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_sandbox_runner_worker_python_uses_persistent_virtualenv(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -2906,7 +2905,7 @@ def test_sandbox_runner_worker_python_uses_persistent_virtualenv(
     assert str(expected_prefix) in data["result"]
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_sandbox_runner_worker_python_supports_matrix_scoped_worker_keys(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -2954,7 +2953,7 @@ def test_sandbox_runner_worker_python_supports_matrix_scoped_worker_keys(
     assert str(expected_prefix) in data["result"]
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_sandbox_runner_worker_shell_uses_worker_home_and_venv(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -2986,7 +2985,7 @@ def test_sandbox_runner_worker_shell_uses_worker_home_and_venv(
     assert data["result"] == expected_result
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_sandbox_runner_lists_known_workers(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -3020,7 +3019,7 @@ def test_sandbox_runner_lists_known_workers(
     assert worker["debug_metadata"]["state_root"] == str((worker_root / worker_dir_name("worker-a")).resolve())
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_sandbox_runner_cleanup_marks_idle_workers_without_deleting_state(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -3614,7 +3613,7 @@ def test_workspace_env_hook_skips_non_execution_tools_for_routed_agent(tmp_path:
     assert failure is None
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_workspace_env_hook_overlays_shell_execution(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -3654,7 +3653,7 @@ def test_workspace_env_hook_overlays_shell_execution(
     assert path_value.startswith(f"{workspace.resolve()}/.local/bin:")
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_workspace_env_hook_edits_take_effect_on_next_call(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -3707,7 +3706,7 @@ def test_workspace_env_hook_edits_take_effect_on_next_call(
     assert second.json()["result"] == "second"
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_workspace_env_hook_keeps_user_credentials_and_filters_runner_control(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -3768,7 +3767,7 @@ def test_workspace_env_hook_keeps_user_credentials_and_filters_runner_control(
     assert sandbox_value == ""
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_workspace_env_hook_failure_returns_tool_failure(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -3805,7 +3804,7 @@ def test_workspace_env_hook_failure_returns_tool_failure(
     assert "exited with code 5" in payload["error"]
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_workspace_env_hook_overlays_worker_routed_python_default_mode(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -3853,7 +3852,7 @@ def test_workspace_env_hook_overlays_worker_routed_python_default_mode(
     assert "visible-to-python" in str(payload["result"])
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_workspace_env_hook_skips_worker_routed_coding_default_mode(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -3893,7 +3892,7 @@ def test_workspace_env_hook_skips_worker_routed_coding_default_mode(
     assert payload["result"] == "note.txt:1:needle"
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_workspace_env_hook_failure_does_not_block_worker_routed_file_default_mode(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -3929,7 +3928,7 @@ def test_workspace_env_hook_failure_does_not_block_worker_routed_file_default_mo
     assert (workspace / "note.txt").read_text(encoding="utf-8") == "should not be written"
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_workspace_env_hook_overlays_python_subprocess(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -3973,7 +3972,7 @@ def test_workspace_env_hook_overlays_python_subprocess(
     assert "https://wheels.example/simple" in str(payload["result"])
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_workspace_env_hook_unkeyed_proxy_uses_init_override_base_dir(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -4003,7 +4002,7 @@ def test_workspace_env_hook_unkeyed_proxy_uses_init_override_base_dir(
     assert payload["result"] == "visible"
 
 
-@REQUIRES_LINUX_LOCAL_WORKER
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_workspace_env_hook_rejects_symlink_escape(
     runner_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import time
 import uuid
 from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Iterator, Mapping, MutableMapping
@@ -74,6 +75,7 @@ __all__ = [
     "replace_turn_controller_deps",
     "replace_turn_policy_deps",
     "replace_turn_store_deps",
+    "requires_linux",
     "resolve_response_thread_root_for_test",
     "runtime_paths_for",
     "sync_bot_runtime_state",
@@ -87,6 +89,23 @@ _VISIBLE_MESSAGE_IDS = count(1)
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 _SOFT_WRAP_RE = re.compile(r"(?<=\S)\n(?=\S)")
 RuntimeBot = AgentBot | TeamBot
+TestFunction = Callable[..., object]
+
+
+def requires_linux(
+    *,
+    reason: str = "requires Linux",
+    timeout: float | None = None,
+) -> Callable[[TestFunction], TestFunction]:
+    """Return a decorator for tests that only run on Linux."""
+
+    def decorator(test_func: TestFunction) -> TestFunction:
+        marked = pytest.mark.skipif(sys.platform != "linux", reason=reason)(test_func)
+        if timeout is not None:
+            marked = pytest.mark.timeout(timeout)(marked)
+        return marked
+
+    return decorator
 
 
 async def drain_coalescing(*bots: RuntimeBot) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,21 +1,83 @@
 """Tests for package-level import side effects."""
 
 import importlib
+import json
 import os
+import subprocess
+import sys
 
 import pytest
 
 import mindroom
+from mindroom.constants import VENDOR_TELEMETRY_ENV_VALUES
+from mindroom.vendor_telemetry import disable_vendor_telemetry
 
 
 def test_package_init_disables_vendor_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
     """MindRoom should force vendor telemetry off at import time."""
-    monkeypatch.setenv("AGNO_TELEMETRY", "true")
-    monkeypatch.setenv("ANONYMIZED_TELEMETRY", "true")
-    monkeypatch.setenv("MEM0_TELEMETRY", "true")
+    for name in VENDOR_TELEMETRY_ENV_VALUES:
+        monkeypatch.setenv(name, "enabled")
 
     importlib.reload(mindroom)
 
-    assert os.environ["AGNO_TELEMETRY"] == "false"
-    assert os.environ["ANONYMIZED_TELEMETRY"] == "false"
-    assert os.environ["MEM0_TELEMETRY"] == "false"
+    for name, value in VENDOR_TELEMETRY_ENV_VALUES.items():
+        assert os.environ[name] == value
+
+
+def test_disable_vendor_telemetry_updates_supplied_env() -> None:
+    """Telemetry opt-outs should be reusable for subprocess env construction."""
+    env = {"AGNO_TELEMETRY": "true"}
+
+    disable_vendor_telemetry(env)
+
+    assert env == dict(VENDOR_TELEMETRY_ENV_VALUES)
+
+
+def test_cli_import_disables_vendor_telemetry_before_cli_dependencies() -> None:
+    """The ``mindroom run`` import path should disable telemetry before CLI dependencies."""
+    expected_json = json.dumps(dict(VENDOR_TELEMETRY_ENV_VALUES))
+    script = f"""
+import importlib.machinery
+import json
+import os
+import sys
+
+expected = json.loads({expected_json!r})
+targets = {{"httpx", "typer"}}
+seen = set()
+
+
+class GuardFinder:
+    def find_spec(self, fullname, path=None, target=None):
+        root = fullname.split(".", 1)[0]
+        if root in targets and root not in seen:
+            seen.add(root)
+            bad = {{name: os.environ.get(name) for name, value in expected.items() if os.environ.get(name) != value}}
+            if bad:
+                raise RuntimeError(f"{{root}} imported before telemetry opt-outs were applied: {{bad}}")
+        return importlib.machinery.PathFinder.find_spec(fullname, path)
+
+
+for target in targets:
+    if target in sys.modules:
+        raise RuntimeError(f"{{target}} was imported before the guard was installed")
+
+sys.meta_path.insert(0, GuardFinder())
+import mindroom.cli.main
+
+missing = targets - seen
+if missing:
+    raise RuntimeError(f"Guard did not observe expected CLI dependency imports: {{sorted(missing)}}")
+"""
+    env = os.environ.copy()
+    env.update(dict.fromkeys(VENDOR_TELEMETRY_ENV_VALUES, "enabled"))
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,11 +5,14 @@ import json
 import os
 import subprocess
 import sys
+import types
 
 import pytest
 
 import mindroom
+from mindroom import vendor_telemetry
 from mindroom.constants import VENDOR_TELEMETRY_ENV_VALUES
+from mindroom.tools.composio import composio_tools
 from mindroom.vendor_telemetry import disable_vendor_telemetry
 
 
@@ -31,6 +34,50 @@ def test_disable_vendor_telemetry_updates_supplied_env() -> None:
     disable_vendor_telemetry(env)
 
     assert env == dict(VENDOR_TELEMETRY_ENV_VALUES)
+
+
+def test_disable_vendor_telemetry_unregisters_loaded_composio_atexit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Composio's Sentry DSN fetch should be removed when the module is already loaded."""
+    sentry_module = types.ModuleType("composio.utils.sentry")
+
+    def update_dsn() -> None:
+        pass
+
+    sentry_module.update_dsn = update_dsn
+    unregistered: list[object] = []
+    monkeypatch.setitem(sys.modules, "composio.utils.sentry", sentry_module)
+    monkeypatch.setattr(vendor_telemetry.atexit, "unregister", unregistered.append)
+
+    disable_vendor_telemetry()
+
+    assert unregistered == [update_dsn]
+
+
+def test_composio_tools_reapplies_vendor_telemetry_after_lazy_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lazy Composio toolkit imports should still unregister import-time atexit callbacks."""
+
+    class FakeComposioToolSet:
+        pass
+
+    composio_agno_module = types.ModuleType("composio_agno")
+    composio_agno_module.ComposioToolSet = FakeComposioToolSet
+    sentry_module = types.ModuleType("composio.utils.sentry")
+
+    def update_dsn() -> None:
+        pass
+
+    sentry_module.update_dsn = update_dsn
+    unregistered: list[object] = []
+    monkeypatch.setitem(sys.modules, "composio_agno", composio_agno_module)
+    monkeypatch.setitem(sys.modules, "composio.utils.sentry", sentry_module)
+    monkeypatch.setattr(vendor_telemetry.atexit, "unregister", unregistered.append)
+
+    assert composio_tools() is FakeComposioToolSet
+    assert unregistered == [update_dsn]
 
 
 def test_cli_import_disables_vendor_telemetry_before_cli_dependencies() -> None:

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -69,7 +69,7 @@ from mindroom.workers.backend import WorkerBackendError
 from mindroom.workers.backends.local import local_worker_state_paths_for_root
 from mindroom.workers.backends.static_runner import StaticSandboxRunnerBackend
 from mindroom.workers.models import WorkerHandle, WorkerReadyProgress, WorkerSpec
-from tests.conftest import FakeCredentialsManager, make_conversation_cache_mock, make_event_cache_mock
+from tests.conftest import FakeCredentialsManager, make_conversation_cache_mock, make_event_cache_mock, requires_linux
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Iterator
@@ -438,6 +438,7 @@ def test_sandbox_runner_executes_wrapper_before_to_json_compatible(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+@requires_linux(reason="local worker venv bootstrap is validated on Linux", timeout=180)
 async def test_sandbox_runner_save_attachment_writes_worker_workspace(tmp_path: Path) -> None:
     """The runner save endpoint should validate and atomically write bytes under the worker workspace."""
     runtime_paths = resolve_runtime_paths(

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -26,6 +26,7 @@ from agno.models.response import ModelResponse
 from agno.tools import Toolkit
 from agno.tools.function import Function, FunctionCall
 
+import mindroom.api.sandbox_exec as sandbox_exec_module
 import mindroom.api.sandbox_runner as sandbox_runner_module
 import mindroom.tool_system.sandbox_proxy as sandbox_proxy_module
 import mindroom.tools  # noqa: F401
@@ -33,6 +34,7 @@ import mindroom.tools.shell as shell_tool_module
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig
 from mindroom.config.main import Config, load_config
 from mindroom.constants import (
+    VENDOR_TELEMETRY_ENV_VALUES,
     RuntimePaths,
     resolve_runtime_paths,
     shell_execution_runtime_env_values,
@@ -1410,6 +1412,30 @@ def test_shell_subprocess_env_prefers_explicit_base_process_env(monkeypatch: pyt
 
     assert env["PATH"] == "/request/bin"
     assert env["HOME"] == "/request-home"
+
+
+def test_shell_subprocess_env_forces_vendor_telemetry_over_runtime_env() -> None:
+    """Shell subprocesses should not let request-scoped env re-enable vendor telemetry."""
+    runtime_env = dict.fromkeys(VENDOR_TELEMETRY_ENV_VALUES, "enabled")
+
+    env = shell_tool_module._shell_subprocess_env(runtime_env)
+
+    for name, value in VENDOR_TELEMETRY_ENV_VALUES.items():
+        assert env[name] == value
+
+
+def test_subprocess_env_for_request_forces_vendor_telemetry_over_execution_env() -> None:
+    """Sandbox subprocess env should not let execution overlays re-enable vendor telemetry."""
+    base_env = dict.fromkeys(VENDOR_TELEMETRY_ENV_VALUES, "base-enabled")
+    execution_env = dict.fromkeys(VENDOR_TELEMETRY_ENV_VALUES, "request-enabled")
+    execution_env["MINDROOM_KEEP"] = "from-request"
+
+    env = sandbox_exec_module.subprocess_env_for_request(base_env, execution_env)
+
+    assert env is not None
+    assert env["MINDROOM_KEEP"] == "from-request"
+    for name, value in VENDOR_TELEMETRY_ENV_VALUES.items():
+        assert env[name] == value
 
 
 def test_execution_env_payload_denies_provider_env_by_default_in_isolated_runtime(


### PR DESCRIPTION
## Summary
- centralize third-party telemetry opt-out env values in MindRoom source and apply them at package/CLI import time
- pass telemetry opt-outs into shell, dependency install, sandbox, and Kubernetes worker environments
- disable Agno object telemetry explicitly and keep frontend-only Next/Turbo opt-outs at Node deployment boundaries
- add import-order coverage for the `mindroom run` CLI path

## Validation
- `uv run pre-commit run --all-files`
- `uv run pytest` (5715 passed, 50 skipped)
- import-time no-network smoke test for composio/litellm/mem0
- Helm and compose render checks for deployment env deduplication