### PR TITLE
docs: keep sentences on single lines

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -434,9 +434,7 @@ mindroom connect \
 
 Start local Synapse and the MindRoom Cinny client container for development.
 
-By default this command also writes `MATRIX_HOMESERVER`, `MATRIX_SERVER_NAME`, and
-`MATRIX_SSL_VERIFY=false` into `.env` next to your active `config.yaml` so
-`mindroom run` works without inline env exports.
+By default this command also writes `MATRIX_HOMESERVER`, `MATRIX_SERVER_NAME`, and `MATRIX_SSL_VERIFY=false` into `.env` next to your active `config.yaml` so `mindroom run` works without inline env exports.
 
 <!-- CODE:START -->
 <!-- from mindroom.cli.main import app -->

--- a/docs/deployment/bridges/telegram.md
+++ b/docs/deployment/bridges/telegram.md
@@ -78,9 +78,8 @@ docker compose ps synapse
 docker compose up -d telegram-bridge
 ```
 
-> **Note:** `docker compose restart synapse` will NOT work here because the
-> `registration.yaml` volume mount is new in `compose.yaml`. A restart reuses the
-> existing container; `up -d` recreates it with the updated mounts.
+> **Note:** `docker compose restart synapse` will NOT work here because the `registration.yaml` volume mount is new in `compose.yaml`.
+> A restart reuses the existing container; `up -d` recreates it with the updated mounts.
 
 ### 3. Verify
 
@@ -125,11 +124,9 @@ Once linked:
 
 Repeat for any other Matrix rooms you want accessible from Telegram.
 
-> **Why can't I just invite the bot directly?** The bridge bot
-> (`@telegrambot`) is Matrix-side infrastructure -- it manages the bridge
-> but isn't a Telegram chat. To use Telegram as your client, there must be
-> a Telegram group for the Telegram app to display. The bridge connects
-> that group to the Matrix room bidirectionally.
+> **Why can't I just invite the bot directly?** The bridge bot (`@telegrambot`) is Matrix-side infrastructure -- it manages the bridge but isn't a Telegram chat.
+> To use Telegram as your client, there must be a Telegram group for the Telegram app to display.
+> The bridge connects that group to the Matrix room bidirectionally.
 
 ### Accessing Telegram chats from Matrix
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -117,9 +117,7 @@ The local Matrix stack includes:
 - **PostgreSQL**: Database backend
 - **Redis**: Caching layer
 
-If you're running the backend on the host (not in Docker), you can use
-`mindroom local-stack-setup` to start Synapse + MindRoom Cinny and persist local Matrix
-env vars automatically:
+If you're running the backend on the host (not in Docker), you can use `mindroom local-stack-setup` to start Synapse + MindRoom Cinny and persist local Matrix env vars automatically:
 
 ```bash
 mindroom local-stack-setup --synapse-dir /path/to/mindroom-stack/local/matrix

--- a/docs/dev/archive/skills-planning.md
+++ b/docs/dev/archive/skills-planning.md
@@ -2,17 +2,14 @@
 
 Last updated: 2026-02-03
 
-This document is the entry point for all work on the "skills + plugins" feature. It is a
-living plan: update it as we learn, revise assumptions, or change direction.
+This document is the entry point for all work on the "skills + plugins" feature. It is a living plan: update it as we learn, revise assumptions, or change direction.
 
-Update rule: if any implementation choice changes or a new constraint is discovered, add a
-short note to the Change Log at the end and update the relevant section.
+Update rule: if any implementation choice changes or a new constraint is discovered, add a short note to the Change Log at the end and update the relevant section.
 
 ## 1) Background
 
-Mindroom currently has tools registered in code (`src/mindroom/tools/*` and
-`src/mindroom/tools_metadata.py`) and agents select tools directly in `config.yaml`. We want
-an OpenClaw-style model:
+Mindroom currently has tools registered in code (`src/mindroom/tools/*` and `src/mindroom/tools_metadata.py`) and agents select tools directly in `config.yaml`.
+We want an OpenClaw-style model:
 
 - Skills are instruction packs (`SKILL.md`) and do not add capabilities.
 - Plugins provide tools and optionally ship skills.
@@ -47,8 +44,7 @@ an OpenClaw-style model:
 - Skill orchestration uses Agno's `Skills` (prompt snippet + get_skill_* tools).
 - Skills are loaded via Agno `LocalSkills(validate=False)` and normalized to preserve OpenClaw metadata.
 - Plugin manifest filename: `mindroom.plugin.json`.
-- Tool metadata delivery: API builds from the in-memory registry at runtime; `tools_metadata.json`
-  remains for frontend/icon build scripts.
+- Tool metadata delivery: API builds from the in-memory registry at runtime; `tools_metadata.json` remains for frontend/icon build scripts.
 
 ## 5) Open Questions (Track Here)
 
@@ -128,8 +124,7 @@ Behavior:
 ### 6.3 Tool registry changes
 
 Current:
-- Tools are registered in `src/mindroom/tools/*` and imported by
-  `src/mindroom/tools/__init__.py`.
+- Tools are registered in `src/mindroom/tools/*` and imported by `src/mindroom/tools/__init__.py`.
 
 Target:
 - Keep core tools as-is for now.
@@ -210,8 +205,7 @@ Prompt rule:
 - `skills` (array of relative paths, optional; defaults to none)
 
 Behavior:
-- If `tools_module` is present, import it and expect tool registration via
-  `register_tool_with_metadata(...)`.
+- If `tools_module` is present, import it and expect tool registration via `register_tool_with_metadata(...)`.
 - If `skills` is present, add those directories to the skills search path.
 
 ## 8) Implementation Plan (Phased)
@@ -243,8 +237,7 @@ Status: complete (2026-02-02)
 ### Phase 4: Skill command / dispatch (OpenClaw-style)
 Status: complete (2026-02-03)
 
-- [x] Parse command dispatch fields from `SKILL.md` (e.g., `command-dispatch`, `command-tool`,
-  `command-arg-mode`, `user-invocable`).
+- [x] Parse command dispatch fields from `SKILL.md` (e.g., `command-dispatch`, `command-tool`, `command-arg-mode`, `user-invocable`).
 - [x] Add a chat command handler (`!skill <name> [args]`) that:
   - Resolves the skill by name (same precedence as normal skill discovery).
   - Optionally maps to a tool call (`command-tool`) or uses model-driven skill execution.

--- a/docs/dev/general-agent-guides/README.md
+++ b/docs/dev/general-agent-guides/README.md
@@ -1,4 +1,4 @@
 # General Agent Guides
 
-Condensed, project-agnostic copies of `CLAUDE.md` and `.claude/**`. Use them when
-the original notes would leak repo specifics.
+Condensed, project-agnostic copies of `CLAUDE.md` and `.claude/**`.
+Use them when the original notes would leak repo specifics.

--- a/docs/dev/general-agent-guides/agents/configfield-specialist.md
+++ b/docs/dev/general-agent-guides/agents/configfield-specialist.md
@@ -2,22 +2,17 @@
 
 ## Mission
 
-Recreate the `.claude/agents/configfield-generator.md` flow without
-project-specific paths.
+Recreate the `.claude/agents/configfield-generator.md` flow without project-specific paths.
 
 ## Required Workflow
 
 1. Read project instructions first.
 2. Copy the standard tool-module template.
-3. Fetch the upstream docs list, then the target tool doc (drop `.md` when
-   storing `docs_url`).
+3. Fetch the upstream docs list, then the target tool doc (drop `.md` when storing `docs_url`).
 4. Inspect the tool constructor for parameter names, types, defaults.
-5. Map Python types to field types (`bool→boolean`, `str→text/password/url`,
-   etc.) and write concise descriptions.
-6. Create `tools/<tool>.py` (or equivalent) that registers via the official
-   decorator.
+5. Map Python types to field types (`bool→boolean`, `str→text/password/url`, etc.) and write concise descriptions.
+6. Create `tools/<tool>.py` (or equivalent) that registers via the official decorator.
 7. Expose the module in the registry `__init__`.
 8. Add required dependencies with comments explaining which tool needs them.
-9. Run the verification helper (e.g.,
-   `verify_tool_configfields('<tool>', ToolClass)`).
+9. Run the verification helper (e.g., `verify_tool_configfields('<tool>', ToolClass)`).
 10. Report the command and result.

--- a/docs/dev/general-agent-guides/coding-agent-playbook.md
+++ b/docs/dev/general-agent-guides/coding-agent-playbook.md
@@ -13,13 +13,11 @@ Project-neutral version of `CLAUDE.md`.
 
 1. Read the request, main docs, and relevant source (including libs in `.venv`).
 2. Look up official docs before guessing.
-3. Install deps with the project tool (e.g., `uv sync --all-extras`), then
-   activate the venv.
+3. Install deps with the project tool (e.g., `uv sync --all-extras`), then activate the venv.
 4. Add packages via the approved command (e.g., `uv add`, `uv add --dev`).
 5. Inspect `git diff origin/main | cat` to understand recent work.
 6. Stage files individually; commits stay atomic and imperative.
-7. **CRITICAL**: run tests (e.g., `pytest`) and `pre-commit run --all-files`
-   before claiming the task is done.
+7. **CRITICAL**: run tests (e.g., `pytest`) and `pre-commit run --all-files` before claiming the task is done.
 
 ## CRITICAL Don’ts
 

--- a/docs/dev/general-agent-guides/commands/commit.md
+++ b/docs/dev/general-agent-guides/commands/commit.md
@@ -6,16 +6,13 @@
 - `git diff`
 
 ## CRITICAL Rules
-1. Never run `git add .`; stage files individually (or rely on `git commit -a`
-   when intentional).
-2. Run tests and hooks (e.g., `pytest`, `pre-commit run --all-files`) before
-   committing.
+1. Never run `git add .`; stage files individually (or rely on `git commit -a` when intentional).
+2. Run tests and hooks (e.g., `pytest`, `pre-commit run --all-files`) before committing.
 3. Check for secrets or temporary files before staging.
 
 ## Commit Message
 - Prefer conventional commits `type(scope): summary`.
-- Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`,
-  `build`, `perf`, `revert`.
+- Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`, `revert`.
 - Subject ≤72 chars, imperative tone; blank line before body.
 
 ## Final Gate

--- a/docs/dev/general-agent-guides/commands/init.md
+++ b/docs/dev/general-agent-guides/commands/init.md
@@ -12,8 +12,7 @@
 ## Working Agreements
 - Expect speech-to-text typos; clarify rather than guess.
 - Look for existing helpers before writing new ones.
-- Sync deps with the project tool (e.g., `uv`, `pip`, `pnpm`, `cargo`) and
-  activate the venv.
+- Sync deps with the project tool (e.g., `uv`, `pip`, `pnpm`, `cargo`) and activate the venv.
 - Follow the coding playbook (simplicity, tidy imports, remove unused code).
 
 ## Next

--- a/docs/dev/ops/README.md
+++ b/docs/dev/ops/README.md
@@ -45,8 +45,7 @@ Use the `just` commands from the repo root to drive everything. Below is a quick
 Use kind to spin up a throwaway local K8s cluster and install the platform chart for smoke testing and development.
 
 - Prereqs: `kind`, `kubectl`, `helm`, and Docker.
-- With Nix: use the root dev shell (`nix-shell`) which now includes `kind`,
-  or the focused one at `nix-shell cluster/k8s/kind/shell.nix`.
+- With Nix: use the root dev shell (`nix-shell`) which now includes `kind`, or the focused one at `nix-shell cluster/k8s/kind/shell.nix`.
 - Quickstart:
   - `just cluster-kind-up`
   - `just cluster-kind-build-load` (builds platform + MindRoom images and loads them into kind)

--- a/docs/dev/security/SECURITY_REVIEW_08_DEPENDENCIES.md
+++ b/docs/dev/security/SECURITY_REVIEW_08_DEPENDENCIES.md
@@ -211,11 +211,11 @@ sdist = { hash = "sha256:e80b3f02a047421be8939e278a168503576a612f6c9e75eb1984598
 
 ### Protection Mechanisms:
 
-✅ **Strong**: Lock files with hashes
-✅ **Strong**: Official source verification
-✅ **Strong**: Multi-stage Docker builds
-⚠️ **Moderate**: Base image security
-❌ **Weak**: Automated monitoring
+- ✅ **Strong**: Lock files with hashes
+- ✅ **Strong**: Official source verification
+- ✅ **Strong**: Multi-stage Docker builds
+- ⚠️ **Moderate**: Base image security
+- ❌ **Weak**: Automated monitoring
 
 ## Remediation Plan
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -222,8 +222,7 @@ OPENAI_API_KEY=your_openai_key
 
 #### Optional: Bootstrap local Synapse + Cinny with Docker (Linux/macOS)
 
-If you want a local Matrix + client setup without running the full `mindroom-stack` app,
-use the helper command:
+If you want a local Matrix + client setup without running the full `mindroom-stack` app, use the helper command:
 
 ```bash
 mindroom local-stack-setup --synapse-dir /path/to/mindroom-stack/local/matrix
@@ -235,9 +234,7 @@ If you're running from source in this repo, use:
 uv run mindroom local-stack-setup --synapse-dir /path/to/mindroom-stack/local/matrix
 ```
 
-This starts Synapse from the `mindroom-stack` compose files, starts a MindRoom Cinny
-container, waits for both services to be healthy, and by default writes local Matrix
-settings to `.env` next to your active `config.yaml`.
+This starts Synapse from the `mindroom-stack` compose files, starts a MindRoom Cinny container, waits for both services to be healthy, and by default writes local Matrix settings to `.env` next to your active `config.yaml`.
 
 > [!NOTE]
 > MindRoom automatically creates Matrix user accounts for each agent. Your Matrix homeserver must allow open registration, or you need to configure it to allow registration from localhost. If registration fails, check your homeserver's registration settings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,8 +98,7 @@ OPENAI_API_KEY=your_api_key
 mindroom run
 ```
 
-For local development with a host-installed backend plus Dockerized Synapse + Cinny
-(Linux/macOS), you can bootstrap the local stack with:
+For local development with a host-installed backend plus Dockerized Synapse + Cinny (Linux/macOS), you can bootstrap the local stack with:
 
 ```bash
 mindroom local-stack-setup --synapse-dir /path/to/mindroom-stack/local/matrix

--- a/saas-platform/platform-backend/README.md
+++ b/saas-platform/platform-backend/README.md
@@ -13,8 +13,7 @@ Provides APIs for:
 
 ## Architecture
 
-Modular FastAPI application with a thin entrypoint (`main.py`) that includes
-routers defined under `backend/`:
+Modular FastAPI application with a thin entrypoint (`main.py`) that includes routers defined under `backend/`:
 
 - `backend/config.py` – env, clients, and settings
 - `backend/deps.py` – shared auth dependencies

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -406,8 +406,7 @@ OPENAI_API_KEY=your_openai_key
 
 #### Optional: Bootstrap local Synapse + Cinny with Docker (Linux/macOS)
 
-If you want a local Matrix + client setup without running the full `mindroom-stack` app,
-use the helper command:
+If you want a local Matrix + client setup without running the full `mindroom-stack` app, use the helper command:
 
 ```
 
@@ -423,9 +422,7 @@ uv run mindroom local-stack-setup --synapse-dir /path/to/mindroom-stack/local/ma
 
 ```
 
-This starts Synapse from the `mindroom-stack` compose files, starts a MindRoom Cinny
-container, waits for both services to be healthy, and by default writes local Matrix
-settings to `.env` next to your active `config.yaml`.
+This starts Synapse from the `mindroom-stack` compose files, starts a MindRoom Cinny container, waits for both services to be healthy, and by default writes local Matrix settings to `.env` next to your active `config.yaml`.
 
 > [!NOTE]
 > MindRoom automatically creates Matrix user accounts for each agent. Your Matrix homeserver must allow open registration, or you need to configure it to allow registration from localhost. If registration fails, check your homeserver's registration settings.

--- a/skills/mindroom-docs/references/page__getting-started__index.md
+++ b/skills/mindroom-docs/references/page__getting-started__index.md
@@ -220,8 +220,7 @@ OPENAI_API_KEY=your_openai_key
 
 #### Optional: Bootstrap local Synapse + Cinny with Docker (Linux/macOS)
 
-If you want a local Matrix + client setup without running the full `mindroom-stack` app,
-use the helper command:
+If you want a local Matrix + client setup without running the full `mindroom-stack` app, use the helper command:
 
 ```
 
@@ -237,9 +236,7 @@ uv run mindroom local-stack-setup --synapse-dir /path/to/mindroom-stack/local/ma
 
 ```
 
-This starts Synapse from the `mindroom-stack` compose files, starts a MindRoom Cinny
-container, waits for both services to be healthy, and by default writes local Matrix
-settings to `.env` next to your active `config.yaml`.
+This starts Synapse from the `mindroom-stack` compose files, starts a MindRoom Cinny container, waits for both services to be healthy, and by default writes local Matrix settings to `.env` next to your active `config.yaml`.
 
 > [!NOTE]
 > MindRoom automatically creates Matrix user accounts for each agent. Your Matrix homeserver must allow open registration, or you need to configure it to allow registration from localhost. If registration fails, check your homeserver's registration settings.


### PR DESCRIPTION
## Summary
- Join manually wrapped prose lines in docs so each sentence stays on one physical line.
- Keep generated mindroom-docs skill references in sync with the getting started docs.

## Verification
- uv run pre-commit run --all-files
- uv run pytest (fails in existing sandbox worker attachment tests because temporary worker venv creation aborts during ensurepip with SIGABRT)