### PR TITLE
Clarify queued user message notice

### DIFF
--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -45,14 +45,13 @@ type ModelRunInput = str | Sequence[Message]
 _QUEUED_MESSAGE_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
 _QUEUED_MESSAGE_NOTICE_HOOK_ATTR = "_mindroom_queued_message_notice_hook_installed"
 QUEUED_MESSAGE_NOTICE_TEXT = (
-    "[SYSTEM NOTICE - NEWER USER MESSAGE WAITING] The user sent another message in this thread while "
-    "you were still working. Treat this as a turn boundary: finish the current response promptly "
-    "instead of continuing an open-ended plan. Do not answer the newer message in this turn because "
-    "it will be handled next. Avoid new tool calls unless they are needed to make your current answer "
-    "coherent, safely close an already-started action, or report a useful handoff state. Your final "
-    "text should briefly summarize where you stopped or what you completed, and acknowledge that the "
-    "newer message will be handled next; the next turn may continue, adjust, or redirect this same "
-    "work based on that newer message."
+    "[SYSTEM NOTICE - NEWER USER MESSAGE WAITING] The user posted another message in this thread "
+    "while you were mid-turn. Treat that message as the start of the next turn, not part of this "
+    "one. Finish now with a final text response based on what you have already done — do not "
+    "address the newer message; the next turn will, and may continue, adjust, or redirect this "
+    "work. Do not start new tool calls. Only complete a tool call already in flight this turn if "
+    "stopping would leave broken or unsafe state. Write your final text as a normal response to "
+    "the original request; do not mention this notice or the queued message."
 )
 
 

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -45,10 +45,14 @@ type ModelRunInput = str | Sequence[Message]
 _QUEUED_MESSAGE_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
 _QUEUED_MESSAGE_NOTICE_HOOK_ATTR = "_mindroom_queued_message_notice_hook_installed"
 QUEUED_MESSAGE_NOTICE_TEXT = (
-    "[SYSTEM NOTICE] A new message from the user has arrived in this thread while you were working. "
-    "You should wrap up your current work and produce a final text response now. "
-    "Avoid further tool calls unless strictly necessary. "
-    "The new message will be handled in your next turn."
+    "[SYSTEM NOTICE - NEWER USER MESSAGE WAITING] The user sent another message in this thread while "
+    "you were still working. Treat this as a turn boundary: finish the current response promptly "
+    "instead of continuing an open-ended plan. Do not answer the newer message in this turn because "
+    "it will be handled next. Avoid new tool calls unless they are needed to make your current answer "
+    "coherent, safely close an already-started action, or report a useful handoff state. Your final "
+    "text should briefly summarize where you stopped or what you completed, and acknowledge that the "
+    "newer message will be handled next; the next turn may continue, adjust, or redirect this same "
+    "work based on that newer message."
 )
 
 

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -1642,6 +1642,16 @@ def test_notice_reinjects_at_end_across_multiple_tool_rounds() -> None:
             assert messages[-1].content == QUEUED_MESSAGE_NOTICE_TEXT
 
 
+def test_queued_notice_uses_interrupting_language() -> None:
+    """The hidden notice should make queued user messages an explicit turn-ending interruption."""
+    assert "[SYSTEM NOTICE - NEWER USER MESSAGE WAITING]" in QUEUED_MESSAGE_NOTICE_TEXT
+    assert "Treat this as a turn boundary" in QUEUED_MESSAGE_NOTICE_TEXT
+    assert "finish the current response promptly" in QUEUED_MESSAGE_NOTICE_TEXT
+    assert "Do not answer the newer message in this turn" in QUEUED_MESSAGE_NOTICE_TEXT
+    assert "Avoid new tool calls unless they are needed" in QUEUED_MESSAGE_NOTICE_TEXT
+    assert "the next turn may continue, adjust, or redirect this same work" in QUEUED_MESSAGE_NOTICE_TEXT
+
+
 def test_stop_after_tool_call_strips_stale_notice_without_readding() -> None:
     """A stop-after-tool-call round should remove any stale queued notice and not append a new one."""
     model = _FakeModel()

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -1642,16 +1642,6 @@ def test_notice_reinjects_at_end_across_multiple_tool_rounds() -> None:
             assert messages[-1].content == QUEUED_MESSAGE_NOTICE_TEXT
 
 
-def test_queued_notice_uses_interrupting_language() -> None:
-    """The hidden notice should make queued user messages an explicit turn-ending interruption."""
-    assert "[SYSTEM NOTICE - NEWER USER MESSAGE WAITING]" in QUEUED_MESSAGE_NOTICE_TEXT
-    assert "Treat this as a turn boundary" in QUEUED_MESSAGE_NOTICE_TEXT
-    assert "finish the current response promptly" in QUEUED_MESSAGE_NOTICE_TEXT
-    assert "Do not answer the newer message in this turn" in QUEUED_MESSAGE_NOTICE_TEXT
-    assert "Avoid new tool calls unless they are needed" in QUEUED_MESSAGE_NOTICE_TEXT
-    assert "the next turn may continue, adjust, or redirect this same work" in QUEUED_MESSAGE_NOTICE_TEXT
-
-
 def test_stop_after_tool_call_strips_stale_notice_without_readding() -> None:
     """A stop-after-tool-call round should remove any stale queued notice and not append a new one."""
     model = _FakeModel()


### PR DESCRIPTION
## Summary
- Reword the hidden queued-user-message notice so active agent turns treat newer user input as a turn boundary.
- Keep the instruction compatible with follow-ups by asking the agent to finish promptly, summarize/handoff state, and let the next turn handle the newer message.
- Add a regression assertion for the stronger-but-not-discarding notice language.

## Tests
- uv run pytest tests/test_queued_message_notify.py -q