### PR TITLE
Drop tautological tests across the suite

### DIFF
--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -25,7 +25,6 @@ from mindroom.hooks import (
     HookRegistry,
     hook,
 )
-from mindroom.hooks.types import BUILTIN_EVENT_NAMES, DEFAULT_EVENT_TIMEOUT_MS, RESERVED_EVENT_NAMESPACES
 from mindroom.matrix.cache import ThreadHistoryResult, thread_history_result
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.orchestrator import MultiAgentOrchestrator
@@ -122,22 +121,6 @@ def _plugin(name: str, callbacks: list[object]) -> object:
             "plugin_order": 0,
         },
     )()
-
-
-def test_bot_ready_is_a_builtin_event() -> None:
-    """EVENT_BOT_READY should be registered as a built-in event."""
-    assert EVENT_BOT_READY == "bot:ready"
-    assert EVENT_BOT_READY in BUILTIN_EVENT_NAMES
-
-
-def test_bot_ready_has_default_timeout() -> None:
-    """bot:ready should have a default timeout of 5000ms."""
-    assert DEFAULT_EVENT_TIMEOUT_MS[EVENT_BOT_READY] == 5000
-
-
-def test_bot_namespace_is_reserved() -> None:
-    """The 'bot' namespace should be reserved to prevent custom event collisions."""
-    assert "bot" in RESERVED_EVENT_NAMESPACES
 
 
 @pytest.mark.asyncio

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -51,16 +51,6 @@ def test_hooks_package_reexports_hook_matrix_admin_api() -> None:
     assert hasattr(hooks, "build_hook_matrix_admin")
 
 
-def test_hook_context_declares_matrix_admin_field() -> None:
-    """HookContext should expose a bound matrix admin helper."""
-    assert "matrix_admin" in HookContext.__dataclass_fields__
-
-
-def test_hook_context_declares_agent_message_snapshot_reader_field() -> None:
-    """HookContext should expose a bound agent-message snapshot reader."""
-    assert "agent_message_snapshot_reader" in HookContext.__dataclass_fields__
-
-
 @pytest.mark.asyncio
 async def test_hook_context_delegates_latest_agent_message_snapshot_reads(tmp_path: Path) -> None:
     """HookContext should route latest-agent-message snapshot reads through the bound helper."""

--- a/tests/test_local_instance_deploy.py
+++ b/tests/test_local_instance_deploy.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-import yaml
 from rich.console import Console
 
 from tests.conftest import normalize_console_output
@@ -242,16 +241,6 @@ def test_restart_only_matrix_recreates_matrix_services_without_project_down(
     assert "docker compose -p alpha down" not in commands[0]
     assert "up -d --force-recreate tuwunel wellknown" in commands[0]
     assert registry.instances["alpha"].status == deploy.InstanceStatus.PARTIAL
-
-
-def test_compose_loads_shared_env_before_instance_env() -> None:
-    """Per-instance env values should override the shared repo defaults."""
-    compose = yaml.safe_load(Path("local/instances/deploy/docker-compose.yml").read_text())
-
-    assert compose["services"]["mindroom"]["env_file"] == [
-        {"path": "../../../.env", "required": False},
-        {"path": "${INSTANCE_ENV_FILE}", "required": True},
-    ]
 
 
 def test_remove_instance_preserves_state_when_teardown_fails(

--- a/tests/test_scheduler_tool.py
+++ b/tests/test_scheduler_tool.py
@@ -14,7 +14,6 @@ from mindroom.config.main import Config
 from mindroom.custom_tools.scheduler import SchedulerTools
 from mindroom.matrix.identity import MatrixID
 from mindroom.scheduling import SchedulingRuntime, _extract_mentioned_agents_from_text
-from mindroom.tool_system.metadata import TOOL_METADATA
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 from tests.conftest import bind_runtime_paths, make_event_cache_mock, runtime_paths_for, test_runtime_paths
 
@@ -223,8 +222,3 @@ async def test_cancel_schedule_tool_calls_backend() -> None:
         room_id=context.room_id,
         task_id="task123",
     )
-
-
-def test_scheduler_tool_registered_in_metadata() -> None:
-    """Scheduler tool should be visible in tool metadata."""
-    assert "scheduler" in TOOL_METADATA

--- a/tests/test_tool_dependencies.py
+++ b/tests/test_tool_dependencies.py
@@ -143,55 +143,6 @@ def test_vertexai_claude_google_auth_is_declared_as_base_dependency() -> None:
     )
 
 
-def test_full_runtime_image_keeps_sentence_transformers_runtime_only() -> None:
-    """The full image should not preinstall the runtime-only sentence_transformers extra."""
-    dockerfile = Path("local/instances/deploy/Dockerfile.mindroom").read_text(encoding="utf-8")
-    assert "--all-extras --no-extra sentence_transformers" in dockerfile
-
-
-@pytest.mark.parametrize(
-    "dockerfile_path",
-    [
-        Path("local/instances/deploy/Dockerfile.mindroom"),
-        Path("local/instances/deploy/Dockerfile.mindroom-minimal"),
-    ],
-)
-def test_runtime_images_copy_workspace_avatars(dockerfile_path: Path) -> None:
-    """Runtime images should still ship workspace avatar assets under /app/avatars."""
-    dockerfile = dockerfile_path.read_text(encoding="utf-8")
-
-    assert "COPY avatars /app/avatars" in dockerfile
-
-
-@pytest.mark.parametrize(
-    "dockerfile_path",
-    [
-        Path("local/instances/deploy/Dockerfile.mindroom"),
-        Path("local/instances/deploy/Dockerfile.mindroom-minimal"),
-    ],
-)
-def test_runtime_images_include_headless_cli_utilities(dockerfile_path: Path) -> None:
-    """Worker images should include baseline utilities for detached interactive CLI auth flows."""
-    dockerfile = dockerfile_path.read_text(encoding="utf-8")
-
-    for package_name in ("tmux", "nano", "procps", "jq", "unzip", "bzip2", "ripgrep"):
-        assert package_name in dockerfile
-
-
-@pytest.mark.parametrize(
-    "dockerfile_path",
-    [
-        Path("local/instances/deploy/Dockerfile.mindroom"),
-        Path("local/instances/deploy/Dockerfile.mindroom-minimal"),
-    ],
-)
-def test_runtime_images_keep_tmux_server_alive_without_sessions(dockerfile_path: Path) -> None:
-    """Worker tmux servers should survive short-lived single-session auth/setup flows."""
-    dockerfile = dockerfile_path.read_text(encoding="utf-8")
-
-    assert "set-option -g exit-empty off" in dockerfile
-
-
 def test_tools_requiring_config_metadata() -> None:
     """Test that tools marked REQUIRES_CONFIG have config_fields or auth_provider."""
     inconsistent = []


### PR DESCRIPTION
## Summary
- Remove tests that only assert literal substrings or keys appear in a constant or checked-in static file. They cannot fail in any way that catches a real bug — a wording or filename change just gets mirrored in the test in the same edit, and they lock copy/structure rather than behavior.
- Follow-up to #825, which removed one such test alongside the queued-message-notice rewording. This pass sweeps the rest of the suite.

## Removed
- `tests/test_bot_ready_hook.py` — three assertions over \`BUILTIN_EVENT_NAMES\`, \`DEFAULT_EVENT_TIMEOUT_MS\`, and \`RESERVED_EVENT_NAMESPACES\`.
- `tests/test_hook_matrix_admin.py` — two \`HookContext.__dataclass_fields__\` membership tests; behavior is already covered by the delegation/integration tests in the same file.
- `tests/test_scheduler_tool.py` — \`TOOL_METADATA\` membership-only test; real registration is exercised by the behavioral tests.
- `tests/test_local_instance_deploy.py` — \`docker-compose.yml\` env_file shape assertion against the checked-in compose file.
- `tests/test_tool_dependencies.py` — four Dockerfile substring tests (sentence_transformers extra, avatars copy line, headless CLI packages, tmux exit-empty option).

## Test plan
- [x] \`uv run pytest tests/test_bot_ready_hook.py tests/test_scheduler_tool.py tests/test_hook_matrix_admin.py tests/test_local_instance_deploy.py tests/test_tool_dependencies.py -x -n 0 --no-cov -q\` — 102 passed.
- [x] \`uv run ruff check\` on touched files — clean.