### PR TITLE
Harden Kubernetes worker runner isolation

### DIFF
--- a/cluster/k8s/instance/templates/_helpers.tpl
+++ b/cluster/k8s/instance/templates/_helpers.tpl
@@ -36,16 +36,14 @@
 - name: MINDROOM_KUBERNETES_WORKER_NODE_NAME
   value: {{ $controlPlaneNodeName | quote }}
 {{- end }}
-- name: MINDROOM_KUBERNETES_WORKER_TOKEN_SECRET_NAME
-  value: "mindroom-api-keys-{{ $values.customer }}"
-- name: MINDROOM_KUBERNETES_WORKER_TOKEN_SECRET_KEY
-  value: "sandbox_proxy_token"
 - name: MINDROOM_KUBERNETES_WORKER_IDLE_TIMEOUT_SECONDS
   value: {{ $values.kubernetesWorkerIdleTimeoutSeconds | quote }}
 - name: MINDROOM_KUBERNETES_WORKER_READY_TIMEOUT_SECONDS
   value: {{ $values.kubernetesWorkerReadyTimeoutSeconds | quote }}
 - name: MINDROOM_KUBERNETES_WORKER_NAME_PREFIX
   value: {{ $values.kubernetesWorkerNamePrefix | quote }}
+- name: MINDROOM_KUBERNETES_WORKER_ENABLE_SERVICE_LINKS
+  value: {{ $values.kubernetesWorkerEnableServiceLinks | quote }}
 - name: MINDROOM_KUBERNETES_WORKER_LABELS_JSON
   value: {{ dict "customer" $values.customer | toJson | quote }}
 - name: MINDROOM_KUBERNETES_WORKER_OWNER_DEPLOYMENT_NAME

--- a/cluster/k8s/instance/templates/networkpolicy.yaml
+++ b/cluster/k8s/instance/templates/networkpolicy.yaml
@@ -27,6 +27,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
+          app: mindroom
           customer: {{ .Values.customer | quote }}
     ports:
     - port: {{ $workerPort }}

--- a/cluster/k8s/instance/values.yaml
+++ b/cluster/k8s/instance/values.yaml
@@ -24,6 +24,7 @@ kubernetesWorkerStorageSubpathPrefix: "workers"
 kubernetesWorkerPort: 8766
 kubernetesWorkerReadyTimeoutSeconds: 60
 kubernetesWorkerIdleTimeoutSeconds: 1800
+kubernetesWorkerEnableServiceLinks: false
 
 # API keys and secrets (referenced via Secret in deployment)
 # Provide values here or inject via a separate Secret overwrite.

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -141,8 +141,7 @@ workers:
   The chart can create the worker-manager RBAC and a worker NetworkPolicy for the same namespace.
 - If workers run in a different namespace, provide storage, service accounts, and network policy behavior that are valid for that namespace.
   Kubernetes owner references are only set by default for same-namespace workers.
-  When using an existing sandbox proxy token secret, create it in both the runtime namespace and the worker namespace.
-  When using `workers.sandbox.proxyToken.value`, the chart creates both copies.
+  The sandbox proxy token secret is only needed by the primary runtime; dedicated worker pods receive per-worker derived runner tokens.
 - Mount arbitrary platform-specific files, projected secrets, ConfigMaps, init containers, and sidecars through `extraVolumes`, `extraVolumeMounts`, `initContainers`, and `extraContainers`.
 - Use `nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`, and `podDisruptionBudget` for cluster-specific scheduling and availability policy.
 - Set `selectorLabels` when adopting an existing Deployment with an immutable selector.

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -152,6 +152,8 @@ spec:
               value: {{ .Values.workers.kubernetes.readyTimeoutSeconds | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_NAME_PREFIX
               value: {{ .Values.workers.kubernetes.namePrefix | quote }}
+            - name: MINDROOM_KUBERNETES_WORKER_ENABLE_SERVICE_LINKS
+              value: {{ .Values.workers.kubernetes.enableServiceLinks | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_LABELS_JSON
               value: {{ toJson .Values.workers.kubernetes.extraLabels | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_ANNOTATIONS_JSON
@@ -164,12 +166,6 @@ spec:
               value: {{ .Values.workers.kubernetes.resources.requests.cpu | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_CPU_LIMIT
               value: {{ .Values.workers.kubernetes.resources.limits.cpu | quote }}
-            {{- if $proxyTokenSecretName }}
-            - name: MINDROOM_KUBERNETES_WORKER_TOKEN_SECRET_NAME
-              value: {{ $proxyTokenSecretName | quote }}
-            - name: MINDROOM_KUBERNETES_WORKER_TOKEN_SECRET_KEY
-              value: {{ .Values.workers.sandbox.proxyToken.key | quote }}
-            {{- end }}
             {{- if .Values.workers.kubernetes.nodeName }}
             - name: MINDROOM_KUBERNETES_WORKER_NODE_NAME
               value: {{ .Values.workers.kubernetes.nodeName | quote }}

--- a/cluster/k8s/runtime/templates/networkpolicy.yaml
+++ b/cluster/k8s/runtime/templates/networkpolicy.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/component: worker
+      mindroom.ai/component: worker
       app.kubernetes.io/managed-by: mindroom
       app.kubernetes.io/name: mindroom-worker
       {{- with .Values.workers.kubernetes.extraLabels }}

--- a/cluster/k8s/runtime/templates/secret.yaml
+++ b/cluster/k8s/runtime/templates/secret.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.workers.sandbox.proxyToken.value }}
 {{- $proxyTokenSecretName := include "mindroom-runtime.proxyTokenSecretName" . -}}
-{{- $workerNamespace := include "mindroom-runtime.workerNamespace" . -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/cluster/k8s/runtime/templates/secret.yaml
+++ b/cluster/k8s/runtime/templates/secret.yaml
@@ -10,19 +10,6 @@ metadata:
 type: Opaque
 stringData:
   {{ .Values.workers.sandbox.proxyToken.key }}: {{ .Values.workers.sandbox.proxyToken.value | quote }}
-{{- if and (eq .Values.workers.backend "kubernetes") (ne $workerNamespace .Release.Namespace) }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ $proxyTokenSecretName }}
-  namespace: {{ $workerNamespace }}
-  labels:
-    {{- include "mindroom-runtime.labels" . | nindent 4 }}
-type: Opaque
-stringData:
-  {{ .Values.workers.sandbox.proxyToken.key }}: {{ .Values.workers.sandbox.proxyToken.value | quote }}
-{{- end }}
 {{- end }}
 {{- if and (eq .Values.eventCache.backend "postgres") .Values.eventCache.postgres.create (not .Values.eventCache.postgres.auth.existingSecret) }}
 {{- $secretName := include "mindroom-runtime.eventCachePostgresSecretName" . -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -237,6 +237,7 @@ workers:
     idleTimeoutSeconds: 1800
     namePrefix: mindroom-worker
     storageSubpathPrefix: workers
+    enableServiceLinks: false
     configMapName: ""
     configKey: ""
     configPath: ""

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -189,7 +189,7 @@ When `workerBackend: kubernetes` is enabled, the chart creates:
 ### Operations
 
 The authenticated dashboard API exposes `/api/workers` to list active or idle workers and `/api/workers/cleanup` to trigger cleanup manually.
-Dedicated workers are internal-only cluster Services and are authenticated with the shared `sandbox_proxy_token`.
+Dedicated workers are internal-only cluster Services and are authenticated with per-worker runner tokens derived from the primary runtime's `sandbox_proxy_token`.
 See [Sandbox Proxy Isolation](sandbox-proxy.md) for the execution model, credential leases, and non-Kubernetes deployment modes.
 
 ## Secrets Management

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -184,7 +184,7 @@ When `workerBackend: kubernetes` is enabled, the chart creates:
 
 - A worker-manager ServiceAccount for the primary runtime.
 - A Role and RoleBinding that allow managing worker Deployments and Services in the instance namespace.
-- NetworkPolicy rules that allow the primary runtime to reach the internal worker port and allow worker traffic within the instance namespace.
+- NetworkPolicy rules that allow the primary runtime to reach the internal worker port while denying worker-to-worker runner ingress.
 
 ### Operations
 

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -25,7 +25,9 @@ This page describes the current sandboxed execution model.
 4. The worker executes the tool against the agent's storage directory plus any worker-local caches and returns the result.
 5. All other tools such as API tools or Matrix-bound tools execute in the primary MindRoom runtime as usual.
 
-The worker runtime authenticates requests with a shared token (`MINDROOM_SANDBOX_PROXY_TOKEN`).
+The static worker runtime authenticates requests with `MINDROOM_SANDBOX_PROXY_TOKEN`.
+Kubernetes dedicated workers derive a separate runner token for each worker from that control-plane token and the worker key.
+Compromising one dedicated worker token does not authorize requests to another dedicated worker runner.
 For tools that need credentials, such as a shell tool that calls an authenticated API, the primary MindRoom runtime can create a short-lived **credential lease** that the worker consumes once.
 Credentials never become part of the normal tool arguments or the model prompt.
 
@@ -143,7 +145,13 @@ Important notes for this mode:
 - `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
 - The chart creates the worker-manager ServiceAccount, Role, RoleBinding, and worker-specific NetworkPolicy rules automatically when this backend is enabled.
 - The primary runtime does not need `MINDROOM_SANDBOX_PROXY_URL` in this mode because worker endpoints come from the Kubernetes worker handles.
+- Dynamic worker pods default to `enableServiceLinks: false` so Kubernetes does not inject sibling Service names into the runner environment.
+- Runner ingress defaults to allowing the MindRoom control-plane pod to reach worker runner ports, while worker-to-worker ingress is denied by NetworkPolicy.
 - The authenticated `/api/workers` and `/api/workers/cleanup` endpoints on the primary runtime expose backend-neutral worker lifecycle information.
+
+Untrusted code-execution tools may still share the runner container's process namespace and may be able to inspect the runner process environment through `/proc` on some container runtimes.
+For dedicated Kubernetes workers, the exposed environment contains only that worker's derived runner token, not the shared control-plane token.
+This leaves same-worker token exposure as a local containment risk, while per-worker credentials and NetworkPolicy limit cross-worker blast radius.
 
 For the full Helm-side deployment guidance, see [Kubernetes Deployment](kubernetes.md).
 
@@ -207,7 +215,7 @@ This gives you the convenience of running MindRoom natively while keeping code-e
 |----------|-------------|---------|
 | `MINDROOM_WORKER_BACKEND` | Worker backend name: `static_runner` or `kubernetes` | `static_runner` |
 | `MINDROOM_SANDBOX_PROXY_URL` | URL of the shared sandbox runner when using `static_runner` | _(none — proxy disabled for `static_runner`)_ |
-| `MINDROOM_SANDBOX_PROXY_TOKEN` | Shared auth token used by the worker runtime | _(required for worker-routed execution)_ |
+| `MINDROOM_SANDBOX_PROXY_TOKEN` | Static-runner bearer token and Kubernetes control-plane secret used to derive per-worker runner tokens | _(required for worker-routed execution)_ |
 | `MINDROOM_SANDBOX_EXECUTION_MODE` | `selective`, `all`, `off` | _(unset — uses proxy tools list)_ |
 | `MINDROOM_SANDBOX_PROXY_TOOLS` | Comma-separated tool names to proxy | `*` (all, unless mode is `selective`) |
 | `MINDROOM_SANDBOX_PROXY_TIMEOUT_SECONDS` | HTTP timeout for proxy calls | `120` |
@@ -225,7 +233,7 @@ If you deploy that mode without Helm, see [Kubernetes Deployment](kubernetes.md)
 |----------|-------------|---------|
 | `MINDROOM_SANDBOX_RUNNER_PORT` | Port the sandbox runner listens on | `8766` |
 | `MINDROOM_SANDBOX_RUNNER_MODE` | Set to `true` to indicate runner mode | `false` |
-| `MINDROOM_SANDBOX_PROXY_TOKEN` | Shared auth token (must match primary) | _(required)_ |
+| `MINDROOM_SANDBOX_PROXY_TOKEN` | Runner bearer token. Static runners use the shared primary token; Kubernetes dedicated workers receive a per-worker derived token. | _(required)_ |
 | `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE` | `inprocess` or `subprocess` | `inprocess` |
 | `MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS` | Subprocess timeout | `120` |
 | `MINDROOM_STORAGE_PATH` | Writable directory for tool registry init and worker-local caches (e.g., `/app/workspace/.mindroom`) | `mindroom_data` next to config _(will fail if not writable)_ |
@@ -314,7 +322,7 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 ## Security considerations
 
 - The worker runtime never gets the primary runtime API key files, Matrix client state, or orchestrator authority.
-- The shared token authenticates all proxy traffic, so use a strong random value.
+- The sandbox token authenticates proxy traffic, so use a strong random value. Kubernetes dedicated workers derive per-worker runner tokens from the control-plane token.
 - Credential leases are single-use by default and expire after 60 seconds.
 - The worker container `securityContext` drops all capabilities and disables privilege escalation.
 - With `workerBackend: static_runner`, the Kubernetes sidecar uses `emptyDir` scratch space and shares access to the same agent storage directories as the main process.
@@ -324,7 +332,7 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 ### Sandbox-runner API endpoints
 
 These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime.
-All requests require the `MINDROOM_SANDBOX_PROXY_TOKEN` as a Bearer token.
+All requests require the runner's `MINDROOM_SANDBOX_PROXY_TOKEN` as a Bearer token.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -332,7 +332,7 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 ### Sandbox-runner API endpoints
 
 These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime.
-All requests require the runner's `MINDROOM_SANDBOX_PROXY_TOKEN` as a Bearer token.
+All requests require the runner's `MINDROOM_SANDBOX_PROXY_TOKEN` in the `x-mindroom-sandbox-token` header.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12169,7 +12169,7 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 
 ### Sandbox-runner API endpoints
 
-These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime. All requests require the runner's `MINDROOM_SANDBOX_PROXY_TOKEN` as a Bearer token.
+These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime. All requests require the runner's `MINDROOM_SANDBOX_PROXY_TOKEN` in the `x-mindroom-sandbox-token` header.
 
 | Method | Endpoint                              | Description                                                     |
 | ------ | ------------------------------------- | --------------------------------------------------------------- |

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -11922,7 +11922,7 @@ When agents have code-execution tools (`shell`, `file`, `python`), they can read
 1. The worker executes the tool against the agent's storage directory plus any worker-local caches and returns the result.
 1. All other tools such as API tools or Matrix-bound tools execute in the primary MindRoom runtime as usual.
 
-The worker runtime authenticates requests with a shared token (`MINDROOM_SANDBOX_PROXY_TOKEN`). For tools that need credentials, such as a shell tool that calls an authenticated API, the primary MindRoom runtime can create a short-lived **credential lease** that the worker consumes once. Credentials never become part of the normal tool arguments or the model prompt.
+The static worker runtime authenticates requests with `MINDROOM_SANDBOX_PROXY_TOKEN`. Kubernetes dedicated workers derive a separate runner token for each worker from that control-plane token and the worker key. Compromising one dedicated worker token does not authorize requests to another dedicated worker runner. For tools that need credentials, such as a shell tool that calls an authenticated API, the primary MindRoom runtime can create a short-lived **credential lease** that the worker consumes once. Credentials never become part of the normal tool arguments or the model prompt.
 
 MindRoom currently ships two worker backend shapes:
 
@@ -12016,7 +12016,11 @@ Important notes for this mode:
 - `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
 - The chart creates the worker-manager ServiceAccount, Role, RoleBinding, and worker-specific NetworkPolicy rules automatically when this backend is enabled.
 - The primary runtime does not need `MINDROOM_SANDBOX_PROXY_URL` in this mode because worker endpoints come from the Kubernetes worker handles.
+- Dynamic worker pods default to `enableServiceLinks: false` so Kubernetes does not inject sibling Service names into the runner environment.
+- Runner ingress defaults to allowing the MindRoom control-plane pod to reach worker runner ports, while worker-to-worker ingress is denied by NetworkPolicy.
 - The authenticated `/api/workers` and `/api/workers/cleanup` endpoints on the primary runtime expose backend-neutral worker lifecycle information.
+
+Untrusted code-execution tools may still share the runner container's process namespace and may be able to inspect the runner process environment through `/proc` on some container runtimes. For dedicated Kubernetes workers, the exposed environment contains only that worker's derived runner token, not the shared control-plane token. This leaves same-worker token exposure as a local containment risk, while per-worker credentials and NetworkPolicy limit cross-worker blast radius.
 
 For the full Helm-side deployment guidance, see [Kubernetes Deployment](https://docs.mindroom.chat/deployment/kubernetes/index.md).
 
@@ -12067,7 +12071,7 @@ This gives you the convenience of running MindRoom natively while keeping code-e
 | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
 | `MINDROOM_WORKER_BACKEND`                       | Worker backend name: `static_runner` or `kubernetes`                                                                                                                  | `static_runner`                               |
 | `MINDROOM_SANDBOX_PROXY_URL`                    | URL of the shared sandbox runner when using `static_runner`                                                                                                           | *(none — proxy disabled for `static_runner`)* |
-| `MINDROOM_SANDBOX_PROXY_TOKEN`                  | Shared auth token used by the worker runtime                                                                                                                          | *(required for worker-routed execution)*      |
+| `MINDROOM_SANDBOX_PROXY_TOKEN`                  | Static-runner bearer token and Kubernetes control-plane secret used to derive per-worker runner tokens                                                                | *(required for worker-routed execution)*      |
 | `MINDROOM_SANDBOX_EXECUTION_MODE`               | `selective`, `all`, `off`                                                                                                                                             | *(unset — uses proxy tools list)*             |
 | `MINDROOM_SANDBOX_PROXY_TOOLS`                  | Comma-separated tool names to proxy                                                                                                                                   | `*` (all, unless mode is `selective`)         |
 | `MINDROOM_SANDBOX_PROXY_TIMEOUT_SECONDS`        | HTTP timeout for proxy calls                                                                                                                                          | `120`                                         |
@@ -12079,15 +12083,15 @@ When `MINDROOM_WORKER_BACKEND=kubernetes`, the primary runtime resolves worker e
 
 ### Sandbox runner
 
-| Variable                                             | Description                                                                                          | Default                                                      |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `MINDROOM_SANDBOX_RUNNER_PORT`                       | Port the sandbox runner listens on                                                                   | `8766`                                                       |
-| `MINDROOM_SANDBOX_RUNNER_MODE`                       | Set to `true` to indicate runner mode                                                                | `false`                                                      |
-| `MINDROOM_SANDBOX_PROXY_TOKEN`                       | Shared auth token (must match primary)                                                               | *(required)*                                                 |
-| `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE`             | `inprocess` or `subprocess`                                                                          | `inprocess`                                                  |
-| `MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS` | Subprocess timeout                                                                                   | `120`                                                        |
-| `MINDROOM_STORAGE_PATH`                              | Writable directory for tool registry init and worker-local caches (e.g., `/app/workspace/.mindroom`) | `mindroom_data` next to config *(will fail if not writable)* |
-| `MINDROOM_CONFIG_PATH`                               | Path to config.yaml (for plugin tool registration)                                                   | *(optional)*                                                 |
+| Variable                                             | Description                                                                                                                        | Default                                                      |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `MINDROOM_SANDBOX_RUNNER_PORT`                       | Port the sandbox runner listens on                                                                                                 | `8766`                                                       |
+| `MINDROOM_SANDBOX_RUNNER_MODE`                       | Set to `true` to indicate runner mode                                                                                              | `false`                                                      |
+| `MINDROOM_SANDBOX_PROXY_TOKEN`                       | Runner bearer token. Static runners use the shared primary token; Kubernetes dedicated workers receive a per-worker derived token. | *(required)*                                                 |
+| `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE`             | `inprocess` or `subprocess`                                                                                                        | `inprocess`                                                  |
+| `MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS` | Subprocess timeout                                                                                                                 | `120`                                                        |
+| `MINDROOM_STORAGE_PATH`                              | Writable directory for tool registry init and worker-local caches (e.g., `/app/workspace/.mindroom`)                               | `mindroom_data` next to config *(will fail if not writable)* |
+| `MINDROOM_CONFIG_PATH`                               | Path to config.yaml (for plugin tool registration)                                                                                 | *(optional)*                                                 |
 
 ## Execution modes
 
@@ -12156,7 +12160,7 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 ## Security considerations
 
 - The worker runtime never gets the primary runtime API key files, Matrix client state, or orchestrator authority.
-- The shared token authenticates all proxy traffic, so use a strong random value.
+- The sandbox token authenticates proxy traffic, so use a strong random value. Kubernetes dedicated workers derive per-worker runner tokens from the control-plane token.
 - Credential leases are single-use by default and expire after 60 seconds.
 - The worker container `securityContext` drops all capabilities and disables privilege escalation.
 - With `workerBackend: static_runner`, the Kubernetes sidecar uses `emptyDir` scratch space and shares access to the same agent storage directories as the main process.
@@ -12165,7 +12169,7 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 
 ### Sandbox-runner API endpoints
 
-These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime. All requests require the `MINDROOM_SANDBOX_PROXY_TOKEN` as a Bearer token.
+These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime. All requests require the runner's `MINDROOM_SANDBOX_PROXY_TOKEN` as a Bearer token.
 
 | Method | Endpoint                              | Description                                                     |
 | ------ | ------------------------------------- | --------------------------------------------------------------- |
@@ -12423,7 +12427,7 @@ When `workerBackend: kubernetes` is enabled, the chart creates:
 
 - A worker-manager ServiceAccount for the primary runtime.
 - A Role and RoleBinding that allow managing worker Deployments and Services in the instance namespace.
-- NetworkPolicy rules that allow the primary runtime to reach the internal worker port and allow worker traffic within the instance namespace.
+- NetworkPolicy rules that allow the primary runtime to reach the internal worker port while denying worker-to-worker runner ingress.
 
 ### Operations
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12431,7 +12431,7 @@ When `workerBackend: kubernetes` is enabled, the chart creates:
 
 ### Operations
 
-The authenticated dashboard API exposes `/api/workers` to list active or idle workers and `/api/workers/cleanup` to trigger cleanup manually. Dedicated workers are internal-only cluster Services and are authenticated with the shared `sandbox_proxy_token`. See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for the execution model, credential leases, and non-Kubernetes deployment modes.
+The authenticated dashboard API exposes `/api/workers` to list active or idle workers and `/api/workers/cleanup` to trigger cleanup manually. Dedicated workers are internal-only cluster Services and are authenticated with per-worker runner tokens derived from the primary runtime's `sandbox_proxy_token`. See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for the execution model, credential leases, and non-Kubernetes deployment modes.
 
 ## Secrets Management
 

--- a/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
+++ b/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
@@ -166,7 +166,7 @@ When `workerBackend: kubernetes` is enabled, the chart creates:
 
 - A worker-manager ServiceAccount for the primary runtime.
 - A Role and RoleBinding that allow managing worker Deployments and Services in the instance namespace.
-- NetworkPolicy rules that allow the primary runtime to reach the internal worker port and allow worker traffic within the instance namespace.
+- NetworkPolicy rules that allow the primary runtime to reach the internal worker port while denying worker-to-worker runner ingress.
 
 ### Operations
 

--- a/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
+++ b/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
@@ -170,7 +170,7 @@ When `workerBackend: kubernetes` is enabled, the chart creates:
 
 ### Operations
 
-The authenticated dashboard API exposes `/api/workers` to list active or idle workers and `/api/workers/cleanup` to trigger cleanup manually. Dedicated workers are internal-only cluster Services and are authenticated with the shared `sandbox_proxy_token`. See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for the execution model, credential leases, and non-Kubernetes deployment modes.
+The authenticated dashboard API exposes `/api/workers` to list active or idle workers and `/api/workers/cleanup` to trigger cleanup manually. Dedicated workers are internal-only cluster Services and are authenticated with per-worker runner tokens derived from the primary runtime's `sandbox_proxy_token`. See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for the execution model, credential leases, and non-Kubernetes deployment modes.
 
 ## Secrets Management
 

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -266,7 +266,7 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 
 ### Sandbox-runner API endpoints
 
-These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime. All requests require the runner's `MINDROOM_SANDBOX_PROXY_TOKEN` as a Bearer token.
+These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime. All requests require the runner's `MINDROOM_SANDBOX_PROXY_TOKEN` in the `x-mindroom-sandbox-token` header.
 
 | Method | Endpoint                              | Description                                                     |
 | ------ | ------------------------------------- | --------------------------------------------------------------- |

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -19,7 +19,7 @@ When agents have code-execution tools (`shell`, `file`, `python`), they can read
 1. The worker executes the tool against the agent's storage directory plus any worker-local caches and returns the result.
 1. All other tools such as API tools or Matrix-bound tools execute in the primary MindRoom runtime as usual.
 
-The worker runtime authenticates requests with a shared token (`MINDROOM_SANDBOX_PROXY_TOKEN`). For tools that need credentials, such as a shell tool that calls an authenticated API, the primary MindRoom runtime can create a short-lived **credential lease** that the worker consumes once. Credentials never become part of the normal tool arguments or the model prompt.
+The static worker runtime authenticates requests with `MINDROOM_SANDBOX_PROXY_TOKEN`. Kubernetes dedicated workers derive a separate runner token for each worker from that control-plane token and the worker key. Compromising one dedicated worker token does not authorize requests to another dedicated worker runner. For tools that need credentials, such as a shell tool that calls an authenticated API, the primary MindRoom runtime can create a short-lived **credential lease** that the worker consumes once. Credentials never become part of the normal tool arguments or the model prompt.
 
 MindRoom currently ships two worker backend shapes:
 
@@ -113,7 +113,11 @@ Important notes for this mode:
 - `kubernetesWorkerImage` and `kubernetesWorkerImagePullPolicy` default to the main MindRoom image settings when left empty.
 - The chart creates the worker-manager ServiceAccount, Role, RoleBinding, and worker-specific NetworkPolicy rules automatically when this backend is enabled.
 - The primary runtime does not need `MINDROOM_SANDBOX_PROXY_URL` in this mode because worker endpoints come from the Kubernetes worker handles.
+- Dynamic worker pods default to `enableServiceLinks: false` so Kubernetes does not inject sibling Service names into the runner environment.
+- Runner ingress defaults to allowing the MindRoom control-plane pod to reach worker runner ports, while worker-to-worker ingress is denied by NetworkPolicy.
 - The authenticated `/api/workers` and `/api/workers/cleanup` endpoints on the primary runtime expose backend-neutral worker lifecycle information.
+
+Untrusted code-execution tools may still share the runner container's process namespace and may be able to inspect the runner process environment through `/proc` on some container runtimes. For dedicated Kubernetes workers, the exposed environment contains only that worker's derived runner token, not the shared control-plane token. This leaves same-worker token exposure as a local containment risk, while per-worker credentials and NetworkPolicy limit cross-worker blast radius.
 
 For the full Helm-side deployment guidance, see [Kubernetes Deployment](https://docs.mindroom.chat/deployment/kubernetes/index.md).
 
@@ -164,7 +168,7 @@ This gives you the convenience of running MindRoom natively while keeping code-e
 | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
 | `MINDROOM_WORKER_BACKEND`                       | Worker backend name: `static_runner` or `kubernetes`                                                                                                                  | `static_runner`                               |
 | `MINDROOM_SANDBOX_PROXY_URL`                    | URL of the shared sandbox runner when using `static_runner`                                                                                                           | *(none — proxy disabled for `static_runner`)* |
-| `MINDROOM_SANDBOX_PROXY_TOKEN`                  | Shared auth token used by the worker runtime                                                                                                                          | *(required for worker-routed execution)*      |
+| `MINDROOM_SANDBOX_PROXY_TOKEN`                  | Static-runner bearer token and Kubernetes control-plane secret used to derive per-worker runner tokens                                                                | *(required for worker-routed execution)*      |
 | `MINDROOM_SANDBOX_EXECUTION_MODE`               | `selective`, `all`, `off`                                                                                                                                             | *(unset — uses proxy tools list)*             |
 | `MINDROOM_SANDBOX_PROXY_TOOLS`                  | Comma-separated tool names to proxy                                                                                                                                   | `*` (all, unless mode is `selective`)         |
 | `MINDROOM_SANDBOX_PROXY_TIMEOUT_SECONDS`        | HTTP timeout for proxy calls                                                                                                                                          | `120`                                         |
@@ -176,15 +180,15 @@ When `MINDROOM_WORKER_BACKEND=kubernetes`, the primary runtime resolves worker e
 
 ### Sandbox runner
 
-| Variable                                             | Description                                                                                          | Default                                                      |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `MINDROOM_SANDBOX_RUNNER_PORT`                       | Port the sandbox runner listens on                                                                   | `8766`                                                       |
-| `MINDROOM_SANDBOX_RUNNER_MODE`                       | Set to `true` to indicate runner mode                                                                | `false`                                                      |
-| `MINDROOM_SANDBOX_PROXY_TOKEN`                       | Shared auth token (must match primary)                                                               | *(required)*                                                 |
-| `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE`             | `inprocess` or `subprocess`                                                                          | `inprocess`                                                  |
-| `MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS` | Subprocess timeout                                                                                   | `120`                                                        |
-| `MINDROOM_STORAGE_PATH`                              | Writable directory for tool registry init and worker-local caches (e.g., `/app/workspace/.mindroom`) | `mindroom_data` next to config *(will fail if not writable)* |
-| `MINDROOM_CONFIG_PATH`                               | Path to config.yaml (for plugin tool registration)                                                   | *(optional)*                                                 |
+| Variable                                             | Description                                                                                                                        | Default                                                      |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `MINDROOM_SANDBOX_RUNNER_PORT`                       | Port the sandbox runner listens on                                                                                                 | `8766`                                                       |
+| `MINDROOM_SANDBOX_RUNNER_MODE`                       | Set to `true` to indicate runner mode                                                                                              | `false`                                                      |
+| `MINDROOM_SANDBOX_PROXY_TOKEN`                       | Runner bearer token. Static runners use the shared primary token; Kubernetes dedicated workers receive a per-worker derived token. | *(required)*                                                 |
+| `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE`             | `inprocess` or `subprocess`                                                                                                        | `inprocess`                                                  |
+| `MINDROOM_SANDBOX_RUNNER_SUBPROCESS_TIMEOUT_SECONDS` | Subprocess timeout                                                                                                                 | `120`                                                        |
+| `MINDROOM_STORAGE_PATH`                              | Writable directory for tool registry init and worker-local caches (e.g., `/app/workspace/.mindroom`)                               | `mindroom_data` next to config *(will fail if not writable)* |
+| `MINDROOM_CONFIG_PATH`                               | Path to config.yaml (for plugin tool registration)                                                                                 | *(optional)*                                                 |
 
 ## Execution modes
 
@@ -253,7 +257,7 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 ## Security considerations
 
 - The worker runtime never gets the primary runtime API key files, Matrix client state, or orchestrator authority.
-- The shared token authenticates all proxy traffic, so use a strong random value.
+- The sandbox token authenticates proxy traffic, so use a strong random value. Kubernetes dedicated workers derive per-worker runner tokens from the control-plane token.
 - Credential leases are single-use by default and expire after 60 seconds.
 - The worker container `securityContext` drops all capabilities and disables privilege escalation.
 - With `workerBackend: static_runner`, the Kubernetes sidecar uses `emptyDir` scratch space and shares access to the same agent storage directories as the main process.
@@ -262,7 +266,7 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 
 ### Sandbox-runner API endpoints
 
-These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime. All requests require the `MINDROOM_SANDBOX_PROXY_TOKEN` as a Bearer token.
+These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime. All requests require the runner's `MINDROOM_SANDBOX_PROXY_TOKEN` as a Bearer token.
 
 | Method | Endpoint                              | Description                                                     |
 | ------ | ------------------------------------- | --------------------------------------------------------------- |

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -609,7 +609,7 @@ class KubernetesWorkerBackend:
             worker_id=worker_id,
             worker_key=worker_key,
             endpoint=f"{endpoint_root}/api/sandbox-runner/execute",
-            auth_token=self.auth_token,
+            auth_token=resources.worker_auth_token(self.auth_token, worker_key),
             status=status,
             backend_name=self.backend_name,
             last_used_at=last_used_at,

--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -42,8 +42,6 @@ _STORAGE_SUBPATH_PREFIX_ENV = "MINDROOM_KUBERNETES_WORKER_STORAGE_SUBPATH_PREFIX
 _CONFIG_MAP_NAME_ENV = "MINDROOM_KUBERNETES_WORKER_CONFIG_MAP_NAME"
 _CONFIG_KEY_ENV = "MINDROOM_KUBERNETES_WORKER_CONFIG_KEY"
 _CONFIG_PATH_ENV = "MINDROOM_KUBERNETES_WORKER_CONFIG_PATH"
-_TOKEN_SECRET_NAME_ENV = "MINDROOM_KUBERNETES_WORKER_TOKEN_SECRET_NAME"  # noqa: S105
-_TOKEN_SECRET_KEY_ENV = "MINDROOM_KUBERNETES_WORKER_TOKEN_SECRET_KEY"  # noqa: S105
 _IDLE_TIMEOUT_ENV = "MINDROOM_KUBERNETES_WORKER_IDLE_TIMEOUT_SECONDS"
 _READY_TIMEOUT_ENV = "MINDROOM_KUBERNETES_WORKER_READY_TIMEOUT_SECONDS"
 _NAME_PREFIX_ENV = "MINDROOM_KUBERNETES_WORKER_NAME_PREFIX"
@@ -57,6 +55,7 @@ _MEMORY_REQUEST_ENV = "MINDROOM_KUBERNETES_WORKER_MEMORY_REQUEST"
 _MEMORY_LIMIT_ENV = "MINDROOM_KUBERNETES_WORKER_MEMORY_LIMIT"
 _CPU_REQUEST_ENV = "MINDROOM_KUBERNETES_WORKER_CPU_REQUEST"
 _CPU_LIMIT_ENV = "MINDROOM_KUBERNETES_WORKER_CPU_LIMIT"
+_ENABLE_SERVICE_LINKS_ENV = "MINDROOM_KUBERNETES_WORKER_ENABLE_SERVICE_LINKS"
 _POD_NAMESPACE_ENV = "POD_NAMESPACE"
 
 
@@ -125,8 +124,6 @@ class _KubernetesWorkerBackendConfig:
     config_map_name: str | None
     config_key: str
     config_path: str
-    token_secret_name: str | None
-    token_secret_key: str
     idle_timeout_seconds: float
     ready_timeout_seconds: float
     name_prefix: str
@@ -138,6 +135,7 @@ class _KubernetesWorkerBackendConfig:
     owner_deployment_name: str | None
     resource_requests: dict[str, str]
     resource_limits: dict[str, str]
+    enable_service_links: bool
 
     @classmethod
     def from_runtime(cls, runtime_paths: RuntimePaths) -> _KubernetesWorkerBackendConfig:
@@ -155,7 +153,6 @@ class _KubernetesWorkerBackendConfig:
             raise WorkerBackendError(msg)
 
         config_map_name = _read_env(env, _CONFIG_MAP_NAME_ENV) or None
-        token_secret_name = _read_env(env, _TOKEN_SECRET_NAME_ENV) or None
         resource_requests = {
             "memory": _read_env(env, _MEMORY_REQUEST_ENV, _DEFAULT_MEMORY_REQUEST) or _DEFAULT_MEMORY_REQUEST,
             "cpu": _read_env(env, _CPU_REQUEST_ENV, _DEFAULT_CPU_REQUEST) or _DEFAULT_CPU_REQUEST,
@@ -180,8 +177,6 @@ class _KubernetesWorkerBackendConfig:
             config_map_name=config_map_name,
             config_key=_read_env(env, _CONFIG_KEY_ENV, _DEFAULT_CONFIG_KEY) or _DEFAULT_CONFIG_KEY,
             config_path=_read_env(env, _CONFIG_PATH_ENV, _DEFAULT_CONFIG_PATH) or _DEFAULT_CONFIG_PATH,
-            token_secret_name=token_secret_name,
-            token_secret_key=_read_env(env, _TOKEN_SECRET_KEY_ENV, "sandbox_proxy_token") or "sandbox_proxy_token",
             idle_timeout_seconds=_read_float_env(env, _IDLE_TIMEOUT_ENV, _DEFAULT_IDLE_TIMEOUT_SECONDS),
             ready_timeout_seconds=_read_float_env(env, _READY_TIMEOUT_ENV, _DEFAULT_READY_TIMEOUT_SECONDS),
             name_prefix=_read_env(env, _NAME_PREFIX_ENV, _DEFAULT_NAME_PREFIX) or _DEFAULT_NAME_PREFIX,
@@ -193,6 +188,7 @@ class _KubernetesWorkerBackendConfig:
             owner_deployment_name=_read_env(env, _OWNER_DEPLOYMENT_NAME_ENV) or None,
             resource_requests=resource_requests,
             resource_limits=resource_limits,
+            enable_service_links=_read_bool_env(env, _ENABLE_SERVICE_LINKS_ENV, default=False),
         )
 
 
@@ -222,8 +218,6 @@ def kubernetes_backend_config_signature(
         config.config_map_name or "",
         config.config_key,
         config.config_path,
-        config.token_secret_name or "",
-        config.token_secret_key,
         str(config.idle_timeout_seconds),
         str(config.ready_timeout_seconds),
         config.name_prefix,
@@ -235,6 +229,7 @@ def kubernetes_backend_config_signature(
         config.owner_deployment_name or "",
         resource_requests_json,
         resource_limits_json,
+        str(config.enable_service_links),
         auth_token or "",
         str(storage_root.expanduser().resolve()) if storage_root is not None else "",
     )

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -545,6 +545,7 @@ class KubernetesResourceManager:
         }
         template_spec: dict[str, object] = {
             "serviceAccountName": self.config.service_account_name,
+            "automountServiceAccountToken": False,
             "enableServiceLinks": self.config.enable_service_links,
             "securityContext": {
                 "runAsUser": 1000,

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import importlib
 import json
 import os
@@ -60,6 +61,7 @@ _DEDICATED_WORKER_KEY_ENV = "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY"
 _DEDICATED_WORKER_ROOT_ENV = "MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT"
 _SHARED_STORAGE_ROOT_ENV = "MINDROOM_SANDBOX_SHARED_STORAGE_ROOT"
 _DEFAULT_CONTAINER_PATH = "/app/.venv/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
+_WORKER_TOKEN_PURPOSE = b"mindroom-kubernetes-worker-token-v1"
 
 
 @dataclass(frozen=True, slots=True)
@@ -153,6 +155,15 @@ def worker_id_for_key(worker_key: str, *, prefix: str) -> str:
 def service_host(service_name: str, namespace: str, port: int) -> str:
     """Return the cluster-local HTTP root for one worker Service."""
     return f"http://{service_name}.{namespace}.svc.cluster.local:{port}"
+
+
+def worker_auth_token(shared_token: str | None, worker_key: str) -> str | None:
+    """Derive the bearer token accepted by one dedicated worker runner."""
+    if shared_token is None:
+        return None
+    key = shared_token.encode("utf-8")
+    payload = _WORKER_TOKEN_PURPOSE + b"\0" + worker_key.encode("utf-8")
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()
 
 
 def parse_annotation_float(annotations: dict[str, str], key: str, default: float) -> float:
@@ -534,6 +545,7 @@ class KubernetesResourceManager:
         }
         template_spec: dict[str, object] = {
             "serviceAccountName": self.config.service_account_name,
+            "enableServiceLinks": self.config.enable_service_links,
             "securityContext": {
                 "runAsUser": 1000,
                 "runAsGroup": 1000,
@@ -638,23 +650,11 @@ class KubernetesResourceManager:
             {"name": _DEDICATED_WORKER_ROOT_ENV, "value": dedicated_root},
             {"name": "HOME", "value": dedicated_root},
         ]
-        if self.config.token_secret_name is not None:
-            env.append(
-                {
-                    "name": _TOKEN_ENV_NAME,
-                    "valueFrom": {
-                        "secretKeyRef": {
-                            "name": self.config.token_secret_name,
-                            "key": self.config.token_secret_key,
-                        },
-                    },
-                },
-            )
-        elif self.auth_token is not None:
-            env.append({"name": _TOKEN_ENV_NAME, "value": self.auth_token})
-        else:
+        worker_token = worker_auth_token(self.auth_token, worker_key)
+        if worker_token is None:
             msg = "A worker auth token is required for Kubernetes workers."
             raise WorkerBackendError(msg)
+        env.append({"name": _TOKEN_ENV_NAME, "value": worker_token})
 
         for name, value in sorted(self.config.extra_env.items()):
             if name in constants.VENDOR_TELEMETRY_ENV_VALUES:

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -51,6 +51,7 @@ from mindroom.tool_system.worker_routing import (
     worker_dir_name,
 )
 from mindroom.workers.backends import local as local_workers_module
+from mindroom.workers.backends.kubernetes_resources import worker_auth_token
 from mindroom.workers.models import WorkerSpec
 from tests.conftest import requires_linux
 
@@ -3248,6 +3249,40 @@ def test_dedicated_worker_mode_rejects_mismatched_worker_key(
     )
     assert response.status_code == 400
     assert "Dedicated sandbox worker is pinned" in response.json()["detail"]
+
+
+def test_dedicated_worker_runner_rejects_sibling_worker_token(
+    runner_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """One worker's derived bearer token must not authorize another worker's runner."""
+    shared_control_plane_token = "shared-control-plane-token"  # noqa: S105
+    worker_a_token = worker_auth_token(shared_control_plane_token, "worker-a")
+    worker_b_token = worker_auth_token(shared_control_plane_token, "worker-b")
+    assert worker_a_token is not None
+    assert worker_b_token is not None
+    assert worker_a_token != worker_b_token
+
+    monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", worker_b_token)
+    monkeypatch.setenv("MINDROOM_SANDBOX_DEDICATED_WORKER_KEY", "worker-b")
+    monkeypatch.setenv("MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT", str(tmp_path / "worker-b"))
+    _refresh_runner_app_from_env()
+
+    response = runner_client.post(
+        "/api/sandbox-runner/execute",
+        headers={"x-mindroom-sandbox-token": worker_a_token},
+        json={
+            "tool_name": "file",
+            "function_name": "read_file",
+            "args": ["note.txt"],
+            "kwargs": {},
+            "worker_key": "worker-b",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Unauthorized sandbox runner request"
 
 
 def test_prepare_worker_uses_explicit_runtime_storage_root_for_local_workers(

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1,0 +1,127 @@
+"""Rendered Helm manifest checks for Kubernetes worker isolation defaults."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+
+def _render_chart(chart_dir: Path, *set_args: str, release_name: str = "mindroom-demo") -> list[dict[str, Any]]:
+    helm = shutil.which("helm")
+    if helm is None:
+        pytest.skip("helm is required for rendered chart checks")
+    completed = subprocess.run(
+        [
+            helm,
+            "template",
+            release_name,
+            str(chart_dir),
+            *(arg for value in set_args for arg in ("--set", value)),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [doc for doc in yaml.safe_load_all(completed.stdout) if isinstance(doc, dict)]
+
+
+def _render_instance_chart() -> list[dict[str, Any]]:
+    return _render_chart(
+        Path("cluster/k8s/instance"),
+        "workerBackend=kubernetes",
+        "storageAccessMode=ReadWriteMany",
+    )
+
+
+def _render_runtime_chart() -> list[dict[str, Any]]:
+    return _render_chart(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "eventCache.postgres.auth.password=test-password",
+        release_name="mindroom-runtime",
+    )
+
+
+def _render_runtime_chart_with_separate_worker_namespace() -> list[dict[str, Any]]:
+    return _render_chart(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.kubernetes.namespace=mindroom-workers",
+        "workers.sandbox.proxyToken.value=test-token",
+        "eventCache.postgres.auth.password=test-password",
+        release_name="mindroom-runtime",
+    )
+
+
+def _resource(docs: list[dict[str, Any]], kind: str, name: str) -> dict[str, Any]:
+    for doc in docs:
+        metadata = doc.get("metadata")
+        if doc.get("kind") == kind and isinstance(metadata, dict) and metadata.get("name") == name:
+            return doc
+    msg = f"{kind}/{name} was not rendered"
+    raise AssertionError(msg)
+
+
+def test_instance_chart_worker_network_policy_allows_runner_ingress_only_from_control_plane() -> None:
+    """Worker runner ingress should not allow every pod carrying the instance label."""
+    docs = _render_instance_chart()
+    policy = _resource(docs, "NetworkPolicy", "instance-traffic-controls-demo")
+    worker_rule = next(
+        rule for rule in policy["spec"]["ingress"] if any(port.get("port") == 8766 for port in rule.get("ports", []))
+    )
+
+    assert worker_rule["from"] == [{"podSelector": {"matchLabels": {"app": "mindroom", "customer": "demo"}}}]
+
+
+def test_instance_chart_disables_service_links_for_dynamic_worker_pods_by_default() -> None:
+    """The control plane should configure generated worker pod specs with service links disabled."""
+    docs = _render_instance_chart()
+    deployment = _resource(docs, "Deployment", "mindroom-demo")
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    env_values = {env["name"]: env.get("value") for env in container["env"]}
+
+    assert env_values["MINDROOM_KUBERNETES_WORKER_ENABLE_SERVICE_LINKS"] == "false"
+
+
+def test_runtime_chart_worker_network_policy_selects_dynamic_worker_labels() -> None:
+    """The runtime chart worker NetworkPolicy selector should match generated worker pod labels."""
+    docs = _render_runtime_chart()
+    policy = _resource(docs, "NetworkPolicy", "mindroom-runtime-workers")
+
+    assert policy["spec"]["podSelector"]["matchLabels"] == {
+        "mindroom.ai/component": "worker",
+        "app.kubernetes.io/managed-by": "mindroom",
+        "app.kubernetes.io/name": "mindroom-worker",
+    }
+
+
+def test_runtime_chart_disables_service_links_for_dynamic_worker_pods_by_default() -> None:
+    """The runtime chart should pass the default service-link setting to generated workers."""
+    docs = _render_runtime_chart()
+    deployment = _resource(docs, "Deployment", "mindroom-runtime")
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    env_values = {env["name"]: env.get("value") for env in container["env"]}
+
+    assert env_values["MINDROOM_KUBERNETES_WORKER_ENABLE_SERVICE_LINKS"] == "false"
+
+
+def test_runtime_chart_does_not_copy_shared_proxy_token_to_worker_namespace() -> None:
+    """Dedicated workers receive derived tokens, so their namespace should not get the shared token Secret."""
+    docs = _render_runtime_chart_with_separate_worker_namespace()
+
+    runtime_secret = _resource(docs, "Secret", "mindroom-runtime-sandbox-proxy")
+    assert runtime_secret["stringData"] == {"MINDROOM_SANDBOX_PROXY_TOKEN": "test-token"}
+
+    worker_namespace_secrets = [
+        doc
+        for doc in docs
+        if doc.get("kind") == "Secret" and doc.get("metadata", {}).get("namespace") == "mindroom-workers"
+    ]
+
+    assert worker_namespace_secrets == []

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -489,6 +489,7 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment(tmp_path: Path
     }
     assert container["resources"]["requests"] == {"memory": "256Mi", "cpu": "100m"}
     assert container["resources"]["limits"] == {"memory": "1Gi", "cpu": "500m"}
+    assert deployment["spec"]["template"]["spec"]["automountServiceAccountToken"] is False
     assert deployment["spec"]["template"]["spec"]["enableServiceLinks"] is False
     assert container["startupProbe"] == {
         "httpGet": {"path": "/healthz", "port": "api"},

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -32,7 +32,7 @@ from mindroom.workers.backend import WorkerBackendError
 from mindroom.workers.backends import kubernetes as kubernetes_backend_module
 from mindroom.workers.backends import kubernetes_resources as kubernetes_resources_module
 from mindroom.workers.backends.kubernetes import KubernetesWorkerBackend, _KubernetesWorkerBackendConfig
-from mindroom.workers.backends.kubernetes_resources import ANNOTATION_STARTUP_MANIFEST_HASH
+from mindroom.workers.backends.kubernetes_resources import ANNOTATION_STARTUP_MANIFEST_HASH, worker_auth_token
 from mindroom.workers.models import WorkerReadyProgress, WorkerSpec
 from mindroom.workers.runtime import primary_worker_backend_available, primary_worker_backend_name
 
@@ -41,8 +41,6 @@ if TYPE_CHECKING:
 
     from mindroom.constants import RuntimePaths
 
-_TEST_TOKEN_SECRET_NAME = "mindroom-secrets"  # noqa: S105
-_TEST_TOKEN_SECRET_KEY = "sandbox_proxy_token"  # noqa: S105
 _TEST_AUTH_TOKEN = "test-token"  # noqa: S105
 _TEST_SCOPED_WORKER_KEY_A = "v1:tenant-123:shared:code"
 _TEST_SCOPED_WORKER_KEY_B = "v1:tenant-123:shared:research"
@@ -285,6 +283,7 @@ def _backend(
     resource_requests: dict[str, str] | None = None,
     resource_limits: dict[str, str] | None = None,
     extra_annotations: dict[str, str] | None = None,
+    enable_service_links: bool = False,
 ) -> tuple[KubernetesWorkerBackend, _FakeAppsApi, _FakeCoreApi]:
     config = _KubernetesWorkerBackendConfig(
         namespace="chat",
@@ -298,8 +297,6 @@ def _backend(
         config_map_name=config_map_name,
         config_key="config.yaml",
         config_path="/app/config.yaml",
-        token_secret_name=_TEST_TOKEN_SECRET_NAME,
-        token_secret_key=_TEST_TOKEN_SECRET_KEY,
         idle_timeout_seconds=idle_timeout_seconds,
         ready_timeout_seconds=5.0,
         name_prefix=name_prefix,
@@ -311,6 +308,7 @@ def _backend(
         owner_deployment_name=owner_deployment_name,
         resource_requests=resource_requests if resource_requests is not None else {"memory": "256Mi", "cpu": "100m"},
         resource_limits=resource_limits if resource_limits is not None else {"memory": "1Gi", "cpu": "500m"},
+        enable_service_links=enable_service_links,
     )
     resolved_runtime_paths = runtime_paths or resolve_primary_runtime_paths(
         config_path=Path("config.yaml"),
@@ -402,6 +400,8 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment(tmp_path: Path
     handle = backend.ensure_worker(WorkerSpec(worker_key), now=10.0)
 
     assert handle.worker_key == worker_key
+    assert handle.auth_token == worker_auth_token(_TEST_AUTH_TOKEN, worker_key)
+    assert handle.auth_token != _TEST_AUTH_TOKEN
     assert handle.backend_name == "kubernetes"
     assert handle.endpoint.endswith("/api/sandbox-runner/execute")
     assert handle.debug_metadata["namespace"] == "chat"
@@ -424,7 +424,7 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment(tmp_path: Path
     assert "VIRTUAL_ENV" in env_names
     assert "PATH" in env_names
     assert "MINDROOM_SHARED_CREDENTIALS_PATH" in env_names
-    assert "MINDROOM_SANDBOX_PROXY_TOKEN" in env_names
+    assert env_values["MINDROOM_SANDBOX_PROXY_TOKEN"] == handle.auth_token
     assert env_values["MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE"] == "subprocess"
     assert env_values["MINDROOM_SANDBOX_RUNNER_PORT"] == "8766"
     manifest_path = env_values["MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH"]
@@ -489,6 +489,7 @@ def test_kubernetes_backend_ensures_worker_service_and_deployment(tmp_path: Path
     }
     assert container["resources"]["requests"] == {"memory": "256Mi", "cpu": "100m"}
     assert container["resources"]["limits"] == {"memory": "1Gi", "cpu": "500m"}
+    assert deployment["spec"]["template"]["spec"]["enableServiceLinks"] is False
     assert container["startupProbe"] == {
         "httpGet": {"path": "/healthz", "port": "api"},
         "periodSeconds": 5,
@@ -799,6 +800,32 @@ def test_kubernetes_backend_config_resources_default_when_env_unset(tmp_path: Pa
 
     assert config.resource_requests == {"memory": "256Mi", "cpu": "100m"}
     assert config.resource_limits == {"memory": "1Gi", "cpu": "500m"}
+    assert config.enable_service_links is False
+
+
+def test_kubernetes_backend_config_allows_service_links_override(tmp_path: Path) -> None:
+    """Worker service-link env injection remains opt-in."""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "config.yaml"
+    config_path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: gpt-5.4\nagents: {}\nrouter:\n  model: default\n",
+        encoding="utf-8",
+    )
+    (config_dir / ".env").write_text(
+        (
+            "MINDROOM_WORKER_BACKEND=kubernetes\n"
+            "MINDROOM_KUBERNETES_WORKER_IMAGE=test-image\n"
+            "MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME=test-pvc\n"
+            "MINDROOM_KUBERNETES_WORKER_ENABLE_SERVICE_LINKS=true\n"
+        ),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_primary_runtime_paths(config_path=config_path)
+
+    config = _KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
+
+    assert config.enable_service_links is True
 
 
 def test_kubernetes_backend_renders_configured_resources_on_worker_container(tmp_path: Path) -> None:
@@ -818,6 +845,16 @@ def test_kubernetes_backend_renders_configured_resources_on_worker_container(tmp
     container = apps_api.created_bodies[0]["spec"]["template"]["spec"]["containers"][0]
     assert container["resources"]["requests"] == {"memory": "2Gi", "cpu": "500m"}
     assert container["resources"]["limits"] == {"memory": "8Gi", "cpu": "2"}
+
+
+def test_kubernetes_backend_renders_service_links_override_in_worker_template() -> None:
+    """Generated worker pod templates should carry the configured service-link setting."""
+    backend, apps_api, _core_api = _backend(enable_service_links=True)
+
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A), now=10.0)
+
+    deployment = apps_api.created_bodies[0]
+    assert deployment["spec"]["template"]["spec"]["enableServiceLinks"] is True
 
 
 def test_kubernetes_backend_config_reads_worker_annotations_from_env(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- derive per-worker sandbox-runner bearer tokens for Kubernetes dedicated workers instead of passing the shared control-plane token into worker pods
- tighten worker NetworkPolicy defaults so runner ingress comes from the control-plane pod, and fix runtime chart selectors to match dynamic worker labels
- default dynamic worker pods to enableServiceLinks=false and render Helm checks for those isolation defaults
- document the remaining same-worker /proc environment exposure risk and the reduced cross-worker blast radius

## Tests
- uv run pytest tests/test_kubernetes_worker_backend.py tests/api/test_sandbox_runner_api.py::test_dedicated_worker_runner_rejects_sibling_worker_token tests/test_helm_instance_worker_isolation.py -q
- uv run pre-commit run --all-files
- uv run pytest tests/test_tool_dependencies.py::test_all_tools_can_be_imported -q

Note: a full uv run pytest pass initially hit a 60s import timeout in tests/test_tool_dependencies.py::test_all_tools_can_be_imported while importing optional dependency code. The same test passed on isolated rerun.