### PR TITLE
Preserve doc line breaks in skill references

### DIFF
--- a/.github/scripts/generate_skill_references.py
+++ b/.github/scripts/generate_skill_references.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 import tomllib
 from dataclasses import dataclass
+from itertools import pairwise
 from pathlib import Path
 from typing import Any
 
@@ -153,13 +154,66 @@ def _copy_main_outputs(site_dir: Path) -> None:
         shutil.copyfile(source, REFERENCES_DIR / filename)
 
 
-def _flatten_page_references(site_dir: Path) -> dict[str, str]:
+def _strip_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return text
+
+    _, separator, rest = text[4:].partition("\n---\n")
+    return rest if separator else text
+
+
+def _source_paragraph_lines(source_text: str) -> list[list[str]]:
+    paragraphs: list[list[str]] = []
+    current: list[str] = []
+    in_code = False
+
+    for line in _strip_frontmatter(source_text).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code = not in_code
+
+        starts_block = (
+            in_code
+            or not stripped
+            or line.startswith((" ", "\t"))
+            or stripped.startswith(("#", "-", "*", "|", ">", "```", "===", "!!!"))
+            or stripped[0].isdigit()
+        )
+        if starts_block:
+            if current:
+                paragraphs.append(current)
+                current = []
+            continue
+
+        current.append(stripped)
+
+    if current:
+        paragraphs.append(current)
+
+    return paragraphs
+
+
+def _restore_source_line_breaks(rendered_text: str, source_text: str) -> str:
+    for paragraph in _source_paragraph_lines(source_text):
+        for left, right in pairwise(paragraph):
+            rendered_text = rendered_text.replace(f"{left} {right}", f"{left}\n{right}")
+
+    return rendered_text
+
+
+def _flatten_page_references(site_dir: Path, nav_pages: list[NavPage]) -> dict[str, str]:
     built_to_reference: dict[str, str] = {}
-    for source in sorted(site_dir.rglob("*.md")):
-        relative = source.relative_to(site_dir).as_posix()
-        reference_name = f"page__{relative.replace('/', '__')}"
-        shutil.copyfile(source, REFERENCES_DIR / reference_name)
-        built_to_reference[relative] = reference_name
+    for page in nav_pages:
+        generated = site_dir / page.built_path
+        assert generated.exists(), f"Expected generated page: {generated}"
+        source_path = DOCS_DIR / page.source_path
+        assert source_path.exists(), f"Expected docs source page: {source_path}"
+        reference_name = f"page__{page.built_path.replace('/', '__')}"
+        rendered_text = generated.read_text(encoding="utf-8")
+        source_text = source_path.read_text(encoding="utf-8")
+        restored_text = _restore_source_line_breaks(rendered_text, source_text)
+        (REFERENCES_DIR / reference_name).write_text(restored_text, encoding="utf-8")
+        built_to_reference[page.built_path] = reference_name
     return built_to_reference
 
 
@@ -206,7 +260,7 @@ def main() -> None:
 
         _clear_reference_dir()
         _copy_main_outputs(generated_site_dir)
-        built_to_reference = _flatten_page_references(generated_site_dir)
+        built_to_reference = _flatten_page_references(generated_site_dir, nav_pages)
         _write_reference_index(nav_pages, built_to_reference)
 
     CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -44,7 +44,10 @@ Rooms are auto-created via `_ensure_room_exists()` (private) and `ensure_all_roo
 
 MindRoom emits thread replies following [MSC3440](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3440-threading-via-relations.md), using `m.relates_to` with `rel_type: m.thread`.
 
-Explicit `m.thread` metadata remains the primary source of thread conversation context. For clients or bridges that send plain replies without thread metadata (`m.in_reply_to` but no `rel_type: m.thread`), MindRoom applies a transitive compatibility rule. If a reply chain eventually reaches explicit thread `T` or a proven thread root, MindRoom treats the new reply as part of `T`. Replies that never reach threaded context stay room-level.
+Explicit `m.thread` metadata remains the primary source of thread conversation context.
+For clients or bridges that send plain replies without thread metadata (`m.in_reply_to` but no `rel_type: m.thread`), MindRoom applies a transitive compatibility rule.
+If a reply chain eventually reaches explicit thread `T` or a proven thread root, MindRoom treats the new reply as part of `T`.
+Replies that never reach threaded context stay room-level.
 
 ### Resolution Rules
 
@@ -129,11 +132,16 @@ Messages exceeding the 64KB Matrix event limit are automatically handled by `pre
 
 ## Response Tracking
 
-MindRoom prevents duplicate responses using a `ResponseTracker` that records which events have already been processed. When a sync reconnection or retry delivers the same event twice, the tracker suppresses the duplicate so only one agent response is sent per triggering message. Tracking state is persisted under `mindroom_data/tracking/` and survives restarts.
+MindRoom prevents duplicate responses using a `ResponseTracker` that records which events have already been processed.
+When a sync reconnection or retry delivers the same event twice, the tracker suppresses the duplicate so only one agent response is sent per triggering message.
+Tracking state is persisted under `mindroom_data/tracking/` and survives restarts.
 
 ## Room Cleanup
 
-On startup, MindRoom detects orphaned bot memberships left over from a previous configuration. When an agent is removed from `config.yaml`, its Matrix bot account may still be a member of rooms it previously joined. The cleanup process leaves those rooms safely without ejecting currently configured entities from their required rooms. This runs automatically — no manual intervention is needed.
+On startup, MindRoom detects orphaned bot memberships left over from a previous configuration.
+When an agent is removed from `config.yaml`, its Matrix bot account may still be a member of rooms it previously joined.
+The cleanup process leaves those rooms safely without ejecting currently configured entities from their required rooms.
+This runs automatically — no manual intervention is needed.
 
 ## Identity Management
 
@@ -162,7 +170,8 @@ matrix_space:
   name: MindRoom       # Display name for the Space
 ```
 
-When enabled, `ensure_root_space()` creates the Space on first boot (or resolves an existing one by alias), links all managed rooms as children, and sets the Space avatar from workspace or bundled assets. The Space name is reconciled on each startup to match the configured value.
+When enabled, `ensure_root_space()` creates the Space on first boot (or resolves an existing one by alias), links all managed rooms as children, and sets the Space avatar from workspace or bundled assets.
+The Space name is reconciled on each startup to match the configured value.
 
 ## Configuration
 

--- a/skills/mindroom-docs/references/page__architecture__orchestration__index.md
+++ b/skills/mindroom-docs/references/page__architecture__orchestration__index.md
@@ -119,7 +119,8 @@ Event callbacks are wrapped in `_create_task_wrapper()` to run as background tas
 1. Check for team formation or individual response
 1. Generate response and store memory
 
-**Message edits**: When a user edits a message that already received an agent response, the agent regenerates its response for the updated content. The agent edits its own previous reply in place rather than sending a new message. Edits from other agents are ignored, and the feature requires that the original response event ID is tracked by the `ResponseTracker`.
+**Message edits**: When a user edits a message that already received an agent response, the agent regenerates its response for the updated content. The agent edits its own previous reply in place rather than sending a new message.
+Edits from other agents are ignored, and the feature requires that the original response event ID is tracked by the `ResponseTracker`.
 
 **`_on_media_message`**: Handles media events (images, videos, files, and audio). Downloads and decrypts media data, then processes it through the agent. When no agent is mentioned, AI routing is used to select the appropriate agent, similar to text messages.
 

--- a/skills/mindroom-docs/references/page__attachments__index.md
+++ b/skills/mindroom-docs/references/page__attachments__index.md
@@ -1,6 +1,7 @@
 # Attachments
 
-MindRoom can process files, images, audio, and videos sent to Matrix rooms, passing them to agents for analysis or action. Supported attachment kinds: `audio`, `file`, `image`, `video`.
+MindRoom can process files, images, audio, and videos sent to Matrix rooms, passing them to agents for analysis or action.
+Supported attachment kinds: `audio`, `file`, `image`, `video`.
 
 ## Overview
 
@@ -41,13 +42,15 @@ Attachments work in both direct messages and threads, and with both individual a
 
 ## Attachment IDs
 
-Each uploaded file or video is assigned a stable attachment ID (e.g., `att_abc123`). The agent's prompt is augmented with the available IDs:
+Each uploaded file or video is assigned a stable attachment ID (e.g., `att_abc123`).
+The agent's prompt is augmented with the available IDs:
 
 ```
 Available attachment IDs: att_abc123. Use tool calls to inspect or process them.
 ```
 
-Attachment IDs are **context-scoped** -- an attachment registered in one room or thread is not accessible from another. This prevents cross-room data leakage for ID-based access. Voice raw-audio fallback uses the same attachment ID mechanism; see [Voice Fallback](https://docs.mindroom.chat/voice/#voice-fallback-no-stt-available).
+Attachment IDs are **context-scoped** -- an attachment registered in one room or thread is not accessible from another.
+This prevents cross-room data leakage for ID-based access. Voice raw-audio fallback uses the same attachment ID mechanism; see [Voice Fallback](https://docs.mindroom.chat/voice/#voice-fallback-no-stt-available).
 
 ## The `attachments` Tool
 
@@ -72,17 +75,25 @@ agents:
 | `get_attachment(attachment_id, mindroom_output_path?)` | Return one context attachment record, or save its bytes to a workspace-relative path and return a save receipt                                 |
 | `register_attachment(file_path)`                       | Register a local file path as a context attachment ID (`att_*`)                                                                                |
 
-When `mindroom_output_path` is omitted, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`. For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path="incoming/file.ext")` before processing an attachment with `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace. `mindroom_output_path` must be a file path relative to the agent workspace. It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion. When the save succeeds, the response includes `mindroom_tool_output` with `status: "saved_to_file"`, `path`, byte count, `format: "binary"`, and `sha256`.
+When `mindroom_output_path` is omitted, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
+For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path="incoming/file.ext")` before processing an attachment with `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
+`mindroom_output_path` must be a file path relative to the agent workspace.
+It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
+When the save succeeds, the response includes `mindroom_tool_output` with `status: "saved_to_file"`, `path`, byte count, `format: "binary"`, and `sha256`.
 
-`attachment_ids` accepts only context attachment IDs (`att_*`). `attachment_file_paths` accepts local file paths and auto-registers them in the current context before sending. Use `matrix_message(action="send"|"reply"|"thread-reply", attachment_ids=..., attachment_file_paths=...)` to send attachments.
+`attachment_ids` accepts only context attachment IDs (`att_*`).
+`attachment_file_paths` accepts local file paths and auto-registers them in the current context before sending.
+Use `matrix_message(action="send"|"reply"|"thread-reply", attachment_ids=..., attachment_file_paths=...)` to send attachments.
 
 ### Why use this tool?
 
-Not all AI models support direct file inputs. The `attachments` tool lets any model work with files by calling tools that operate on attachment IDs, even if the model itself cannot ingest the raw bytes.
+Not all AI models support direct file inputs.
+The `attachments` tool lets any model work with files by calling tools that operate on attachment IDs, even if the model itself cannot ingest the raw bytes.
 
 ## Encryption
 
-Both unencrypted and E2E encrypted files and videos are supported. Encrypted media is decrypted transparently using the key material from the Matrix event.
+Both unencrypted and E2E encrypted files and videos are supported.
+Encrypted media is decrypted transparently using the key material from the Matrix event.
 
 ## Caching
 
@@ -90,7 +101,8 @@ AI response caching is automatically skipped when files, images, audio, or video
 
 ## Retention
 
-MindRoom automatically prunes attachment metadata and managed `incoming_media/` files older than 30 days. Pruning runs opportunistically during new attachment registration.
+MindRoom automatically prunes attachment metadata and managed `incoming_media/` files older than 30 days.
+Pruning runs opportunistically during new attachment registration.
 
 ## Limitations
 

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -1,6 +1,7 @@
 # Chat Commands
 
-MindRoom provides chat commands that users can type in any Matrix room where MindRoom agents are present. Commands start with `!` and are handled by the router agent.
+MindRoom provides chat commands that users can type in any Matrix room where MindRoom agents are present.
+Commands start with `!` and are handled by the router agent.
 
 ## Quick Reference
 
@@ -17,15 +18,19 @@ MindRoom provides chat commands that users can type in any Matrix room where Min
 
 ## Who Handles Commands
 
-The **router** handles all commands exclusively. Even in single-agent rooms, commands are always processed by the router, not the agent. Commands work in both main room messages and within threads.
+The **router** handles all commands exclusively.
+Even in single-agent rooms, commands are always processed by the router, not the agent.
+Commands work in both main room messages and within threads.
 
 Voice messages that contain commands (e.g., spoken `!schedule`) are recognized after transcription and processed the same way.
 
 ## Permission Behavior
 
-Commands are subject to the same authorization rules as normal messages. The sender must be authorized to interact with agents in the room (via `global_users`, `room_permissions`, or `default_room_access`). See [Authorization](https://docs.mindroom.chat/authorization/index.md) for details.
+Commands are subject to the same authorization rules as normal messages.
+The sender must be authorized to interact with agents in the room (via `global_users`, `room_permissions`, or `default_room_access`). See [Authorization](https://docs.mindroom.chat/authorization/index.md) for details.
 
-For `!config set`, only the user who requested the change can confirm or cancel it via reactions. Pending config changes expire after 24 hours.
+For `!config set`, only the user who requested the change can confirm or cancel it via reactions.
+Pending config changes expire after 24 hours.
 
 ## Commands
 
@@ -53,7 +58,8 @@ Show the welcome message for the current room, listing available agents, their r
 
 ### `!schedule`
 
-Schedule a one-time or recurring task using natural language. Tasks run in the thread where they were created.
+Schedule a one-time or recurring task using natural language.
+Tasks run in the thread where they were created.
 
 ```
 !schedule <natural-language-request>
@@ -76,14 +82,16 @@ Schedule a one-time or recurring task using natural language. Tasks run in the t
 
 **Conditional workflows (polling-based):**
 
-Conditional requests are converted to recurring cron-based polling schedules. These are periodic checks, not real event subscriptions.
+Conditional requests are converted to recurring cron-based polling schedules.
+These are periodic checks, not real event subscriptions.
 
 ```
 !schedule If I get an email about "urgent", @phone_agent call me
 !schedule When Bitcoin drops below $40k, @crypto_agent notify me
 ```
 
-Include `@agent_name` in your schedule to target specific agents. The scheduler validates that mentioned agents are available in the room before creating the task.
+Include `@agent_name` in your schedule to target specific agents.
+The scheduler validates that mentioned agents are available in the room before creating the task.
 
 Schedules use the timezone from `config.yaml` (defaults to UTC). See [Scheduling](https://docs.mindroom.chat/scheduling/index.md) for full details.
 
@@ -118,13 +126,15 @@ Replace an existing scheduled task with new timing and content.
 !edit_schedule <task-id> <new-task-description>
 ```
 
-The task description is re-parsed to update timing and content. Schedule type cannot be changed (one-time to recurring or vice versa) -- cancel and recreate instead.
+The task description is re-parsed to update timing and content.
+Schedule type cannot be changed (one-time to recurring or vice versa) -- cancel and recreate instead.
 
 **Aliases:** `!editschedule`, `!edit-schedule`
 
 ### `!config`
 
-View and modify MindRoom configuration from chat. Changes are validated against the Pydantic config schema before applying.
+View and modify MindRoom configuration from chat.
+Changes are validated against the Pydantic config schema before applying.
 
 **View configuration:**
 
@@ -159,7 +169,9 @@ When you use `!config set`, MindRoom:
 1. Adds reaction buttons to the preview message
 1. Waits for the requester to react with ✅ (confirm) or ❌ (cancel)
 
-Only the user who requested the change can confirm or cancel it. Pending changes are persisted in Matrix room state and survive restarts. Unconfirmed changes expire after 24 hours.
+Only the user who requested the change can confirm or cancel it.
+Pending changes are persisted in Matrix room state and survive restarts.
+Unconfirmed changes expire after 24 hours.
 
 Changes are saved to `config.yaml` immediately on confirmation and take effect for new agent interactions.
 
@@ -185,9 +197,12 @@ Plugins are also auto-reloaded on file save, typically about 1-2 seconds after s
 
 MindRoom supports cancelling in-progress responses via a reaction-based stop button, not a chat command.
 
-When `defaults.show_stop_button` is `true` (the default), MindRoom adds a 🛑 reaction to the agent's message while it is generating. React with 🛑 on the message to cancel the response. The agent finalizes the partial text with `**[Response cancelled by user]**`.
+When `defaults.show_stop_button` is `true` (the default), MindRoom adds a 🛑 reaction to the agent's message while it is generating.
+React with 🛑 on the message to cancel the response.
+The agent finalizes the partial text with `**[Response cancelled by user]**`.
 
-The stop button only works on messages currently being generated. Only non-agent users can trigger cancellation — agent reactions are ignored.
+The stop button only works on messages currently being generated.
+Only non-agent users can trigger cancellation — agent reactions are ignored.
 
 See [Streaming — Cancellation](https://docs.mindroom.chat/streaming/#cancellation-and-errors) for details on how cancelled responses are finalized.
 

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -105,7 +105,11 @@ Generate and sync managed avatar assets.
 
 ## avatars generate
 
-Generate missing managed avatar files in the workspace. In a source checkout, generated files are written under `./avatars/`. In containerized deployments, generated overrides are written under the persistent MindRoom storage path. Existing managed files are skipped by default. Use `--force` to overwrite them after changing avatar prompts or styles.
+Generate missing managed avatar files in the workspace.
+In a source checkout, generated files are written under `./avatars/`.
+In containerized deployments, generated overrides are written under the persistent MindRoom storage path.
+Existing managed files are skipped by default.
+Use `--force` to overwrite them after changing avatar prompts or styles.
 
 ```
  Usage: root avatars generate [OPTIONS]
@@ -120,7 +124,9 @@ Generate missing managed avatar files in the workspace. In a source checkout, ge
 
 ## avatars sync
 
-Sync configured room and root-space avatars to Matrix using the initialized router account. Existing Matrix avatars are skipped by default. Use `--force` to replace them.
+Sync configured room and root-space avatars to Matrix using the initialized router account.
+Existing Matrix avatars are skipped by default.
+Use `--force` to replace them.
 
 ```
  Usage: root avatars sync [OPTIONS]
@@ -161,7 +167,8 @@ Runs a series of checks in one pass:
 
 ## config
 
-Manage MindRoom configuration files. The `config` subgroup contains commands for creating, viewing, editing, and validating your `config.yaml`.
+Manage MindRoom configuration files.
+The `config` subgroup contains commands for creating, viewing, editing, and validating your `config.yaml`.
 
 ```
  Usage: root config [OPTIONS] COMMAND [ARGS]...
@@ -211,7 +218,10 @@ mindroom config init --profile public-vertexai-anthropic
 mindroom config init --force
 ```
 
-The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5` and `context_window: 258000`. They set `extra_kwargs.reasoning_effort: medium`. Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key. Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
+The `public-codex` profile and `--provider codex` preset generate `provider: codex` with `id: gpt-5.5` and `context_window: 258000`.
+They set `extra_kwargs.reasoning_effort: medium`.
+Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key.
+Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
 
 ### config show
 
@@ -230,7 +240,8 @@ mindroom config show --path /custom/path/config.yaml
 
 ### config edit
 
-Open `config.yaml` in your default editor. Editor preference: `$EDITOR` → `$VISUAL` → `nano` → `vim` → `vi`.
+Open `config.yaml` in your default editor.
+Editor preference: `$EDITOR` → `$VISUAL` → `nano` → `vim` → `vi`.
 
 ```
 mindroom config edit
@@ -238,7 +249,9 @@ mindroom config edit
 
 ### config validate
 
-Validate `config.yaml` and check for common issues. Parses the YAML config using Pydantic and reports errors in a friendly format. Also checks whether required API keys are set as environment variables.
+Validate `config.yaml` and check for common issues.
+Parses the YAML config using Pydantic and reports errors in a friendly format.
+Also checks whether required API keys are set as environment variables.
 
 ```
 mindroom config validate

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -160,17 +160,35 @@ agents:
 
 Each entry in `knowledge_bases` must match a key under `knowledge_bases` in `config.yaml`.
 
-Per-agent fields with a `null` default inherit from the `defaults` section at runtime. Per-agent values override them. `memory.backend` is the global memory default, and `agents.<name>.memory_backend` overrides it per agent. Use `memory_backend: none` for stateless agents that should skip prompt memory lookup, automatic memory persistence, and the explicit `memory` tool. `show_stop_button` and `enable_streaming` are global-only settings in `defaults` and cannot be overridden per-agent. The dashboard Agents tab exposes this as the **Memory Backend** selector for each agent.
+Per-agent fields with a `null` default inherit from the `defaults` section at runtime.
+Per-agent values override them.
+`memory.backend` is the global memory default, and `agents.<name>.memory_backend` overrides it per agent.
+Use `memory_backend: none` for stateless agents that should skip prompt memory lookup, automatic memory persistence, and the explicit `memory` tool.
+`show_stop_button` and `enable_streaming` are global-only settings in `defaults` and cannot be overridden per-agent.
+The dashboard Agents tab exposes this as the **Memory Backend** selector for each agent.
 
-Startup thread prewarm is a background, best-effort cache warmup for rooms already joined when first sync completes. Agents use `agents.<name>.accept_invites`, while the router uses its own `router.accept_invites` option with the same durable invite semantics. Teams do not currently expose a separate `accept_invites` option, but accepted team invites are still persisted as durable desired membership. Invite acceptance still respects your normal authorization rules, so unauthorized senders cannot force an entity to join and persist a room.
+Startup thread prewarm is a background, best-effort cache warmup for rooms already joined when first sync completes.
+Agents use `agents.<name>.accept_invites`, while the router uses its own `router.accept_invites` option with the same durable invite semantics.
+Teams do not currently expose a separate `accept_invites` option, but accepted team invites are still persisted as durable desired membership.
+Invite acceptance still respects your normal authorization rules, so unauthorized senders cannot force an entity to join and persist a room.
 
-MindRoom compacts in one visible lifecycle. If the current reply needs compaction to preserve usable history, MindRoom sends `Compacting history...`, compacts before the model call, and edits that same notice with the result. After a successful visible reply, MindRoom re-checks the updated persisted session and immediately compacts if the next reply would cross the compaction threshold. It always plans the replay that is safe for the current model call when the active runtime model has a known `context_window`. That replay planner can keep configured replay, reduce raw replay, fall back to summary-only replay, or disable persisted replay for the run. Compaction rewrites the persisted Agno session in SQLite. Older compacted runs are removed from `session.runs` and replaced by the merged `session.summary`, so raw pre-compaction runs are not retained for later audit or debugging.
+MindRoom compacts in one visible lifecycle.
+If the current reply needs compaction to preserve usable history, MindRoom sends `Compacting history...`, compacts before the model call, and edits that same notice with the result.
+After a successful visible reply, MindRoom re-checks the updated persisted session and immediately compacts if the next reply would cross the compaction threshold.
+It always plans the replay that is safe for the current model call when the active runtime model has a known `context_window`.
+That replay planner can keep configured replay, reduce raw replay, fall back to summary-only replay, or disable persisted replay for the run.
+Compaction rewrites the persisted Agno session in SQLite.
+Older compacted runs are removed from `session.runs` and replaced by the merged `session.summary`, so raw pre-compaction runs are not retained for later audit or debugging.
 
-Learning data is persisted under `agents/<name>/learning/<agent>.db`, so it survives container restarts when the storage directory is mounted. `context_files` are resolved relative to the agent's workspace directory (`agents/<name>/workspace/`). When the effective memory backend is `file`, the agent's canonical file memory root is that same workspace directory. Absolute paths and `..` traversal are rejected.
+Learning data is persisted under `agents/<name>/learning/<agent>.db`, so it survives container restarts when the storage directory is mounted.
+`context_files` are resolved relative to the agent's workspace directory (`agents/<name>/workspace/`).
+When the effective memory backend is `file`, the agent's canonical file memory root is that same workspace directory.
+Absolute paths and `..` traversal are rejected.
 
 ## Per-Agent Tool Configuration
 
-Tools can be plain strings or single-key dicts with inline config overrides. This lets you customize tool behavior per agent without affecting other agents that use the same tool.
+Tools can be plain strings or single-key dicts with inline config overrides.
+This lets you customize tool behavior per agent without affecting other agents that use the same tool.
 
 ```
 agents:
@@ -202,7 +220,8 @@ Within the authored layers (`defaults.tools` and `agents.<name>.tools`), each fi
 - Concrete value: override the next lower layer with that value.
 - `__MINDROOM_INHERIT__`: clear an inherited authored override and fall back to the next lower layer.
 
-When the same tool appears in both `defaults.tools` and `agents.<name>.tools`, MindRoom merges them field-by-field. Per-agent values win for overlapping keys, non-overlapping keys are kept from both, and `__MINDROOM_INHERIT__` removes the inherited authored value instead of passing the literal string to the tool.
+When the same tool appears in both `defaults.tools` and `agents.<name>.tools`, MindRoom merges them field-by-field.
+Per-agent values win for overlapping keys, non-overlapping keys are kept from both, and `__MINDROOM_INHERIT__` removes the inherited authored value instead of passing the literal string to the tool.
 
 ### Defaults with Overrides
 
@@ -253,7 +272,8 @@ agents:
           master_space_id: __MINDROOM_INHERIT__
 ```
 
-`ops` still uses the `clickup` tool, but `master_space_id` no longer inherits `"space-default"`. MindRoom falls back to the next lower layer, which is usually the stored tool config from the dashboard or credential store.
+`ops` still uses the `clickup` tool, but `master_space_id` no longer inherits `"space-default"`.
+MindRoom falls back to the next lower layer, which is usually the stored tool config from the dashboard or credential store.
 
 ### `include_default_tools` vs `__MINDROOM_INHERIT__`
 
@@ -280,11 +300,18 @@ tools: [shell, file, duckduckgo]   # still valid
 
 ### Config Manager
 
-The `!config` chat command and the `config_manager` tool preserve inline overrides when updating tool lists. Adding or removing tools via chat does not discard existing per-agent overrides on other tools.
+The `!config` chat command and the `config_manager` tool preserve inline overrides when updating tool lists.
+Adding or removing tools via chat does not discard existing per-agent overrides on other tools.
 
 ## Worker Routing
 
-`worker_tools` decides which tools run in the sandbox proxy instead of the main MindRoom process. When omitted, MindRoom routes `coding`, `file`, `python`, and `shell` through the proxy by default. `worker_scope` controls how those sandbox runtimes are reused between calls. The shared-only integrations require `worker_scope` unset or `shared`. That list includes `google`, `spotify`, `gmail`, `google_calendar`, `google_sheets`, `homeassistant`, and all configured `mcp_<server_id>` tools. Of those, `gmail`, `google_calendar`, `google_sheets`, and `homeassistant` also always stay local regardless of `worker_tools` (they are never proxied to the sandbox). `google` and `spotify` can still be proxied through the sandbox.
+`worker_tools` decides which tools run in the sandbox proxy instead of the main MindRoom process.
+When omitted, MindRoom routes `coding`, `file`, `python`, and `shell` through the proxy by default.
+`worker_scope` controls how those sandbox runtimes are reused between calls.
+The shared-only integrations require `worker_scope` unset or `shared`.
+That list includes `google`, `spotify`, `gmail`, `google_calendar`, `google_sheets`, `homeassistant`, and all configured `mcp_<server_id>` tools.
+Of those, `gmail`, `google_calendar`, `google_sheets`, and `homeassistant` also always stay local regardless of `worker_tools` (they are never proxied to the sandbox).
+`google` and `spotify` can still be proxied through the sandbox.
 
 The supported `worker_scope` values are:
 
@@ -292,11 +319,15 @@ The supported `worker_scope` values are:
 - `user`: one runtime per user, shared across that user's agents.
 - `user_agent`: one runtime per user+agent pair.
 
-Leave `worker_scope` unset for unscoped execution — calls still run in the sandbox, but each call gets a fresh runtime instead of a persistent one. `worker_scope` also affects dashboard credential support and OpenAI-compatible agent eligibility.
+Leave `worker_scope` unset for unscoped execution — calls still run in the sandbox, but each call gets a fresh runtime instead of a persistent one.
+`worker_scope` also affects dashboard credential support and OpenAI-compatible agent eligibility.
 
 ### Filesystem Isolation
 
-`worker_scope` controls runtime reuse, not filesystem security. When the effective memory backend is `file`, tools like `shell`, `file`, `python`, and `coding` get a default working directory (`base_dir`) at the agent's canonical workspace root. Without file-backed workspace state, those tools keep their normal defaults such as the current directory. Even when set, `base_dir` is a convenience, not a hard boundary.
+`worker_scope` controls runtime reuse, not filesystem security.
+When the effective memory backend is `file`, tools like `shell`, `file`, `python`, and `coding` get a default working directory (`base_dir`) at the agent's canonical workspace root.
+Without file-backed workspace state, those tools keep their normal defaults such as the current directory.
+Even when set, `base_dir` is a convenience, not a hard boundary.
 
 Isolation depends on the worker backend:
 
@@ -306,21 +337,37 @@ Isolation depends on the worker backend:
 
 Use `user_agent` if you need per-agent filesystem isolation.
 
-For per-workspace env that an agent can edit (PATH, npm/pip cache locations, etc.), drop a `.mindroom/worker-env.sh` script in the agent workspace; MindRoom sources it before each worker-routed `shell` or `python` request. With `worker_scope: user`, the same runtime can move between several agent workspaces, and the hook is discovered from the current request's workspace — different agents get different overlays automatically. See [Workspace env hook](https://docs.mindroom.chat/deployment/sandbox-proxy/#workspace-env-hook-mindroomworker-envsh) for filename, filtering, and failure semantics.
+For per-workspace env that an agent can edit (PATH, npm/pip cache locations, etc.), drop a `.mindroom/worker-env.sh` script in the agent workspace; MindRoom sources it before each worker-routed `shell` or `python` request.
+With `worker_scope: user`, the same runtime can move between several agent workspaces, and the hook is discovered from the current request's workspace — different agents get different overlays automatically. See [Workspace env hook](https://docs.mindroom.chat/deployment/sandbox-proxy/#workspace-env-hook-mindroomworker-envsh) for filename, filtering, and failure semantics.
 
 ### Where Agent Data Lives
 
-Agents without `private` store all their data in one canonical directory: `agents/<name>/` (context files, workspace, memory, sessions, learning). Changing `worker_scope` changes how tool runtimes are isolated. It does **not** change where that non-private agent's data lives. All runtimes for the same non-private agent read and write the same storage directory. If multiple runtimes run concurrently, files and databases in that directory must tolerate concurrent access. Agents that use `private` are different. They materialize one canonical state root per requester-scoped private instance under `private_instances/<scope-key>/<agent>/`. Workers mount those canonical private-instance roots. They do not own them.
+Agents without `private` store all their data in one canonical directory: `agents/<name>/` (context files, workspace, memory, sessions, learning).
+Changing `worker_scope` changes how tool runtimes are isolated.
+It does **not** change where that non-private agent's data lives.
+All runtimes for the same non-private agent read and write the same storage directory.
+If multiple runtimes run concurrently, files and databases in that directory must tolerate concurrent access.
+Agents that use `private` are different.
+They materialize one canonical state root per requester-scoped private instance under `private_instances/<scope-key>/<agent>/`.
+Workers mount those canonical private-instance roots.
+They do not own them.
 
-The dashboard credential UI only works for unscoped agents and agents with `worker_scope=shared`. Agents using `user` or `user_agent` manage credentials through their worker runtime instead.
+The dashboard credential UI only works for unscoped agents and agents with `worker_scope=shared`.
+Agents using `user` or `user_agent` manage credentials through their worker runtime instead.
 
 For more details on storage layout and isolation, see [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md).
 
 ## Private Instances
 
-Use `private` when one shared agent definition should behave like a template that materializes a separate requester-local instance at runtime. The YAML definition stays shared. The private root, copied files, file-memory workspace, and private knowledge path do not. Private agents cannot participate in teams yet. That restriction also applies transitively: a shared team member that reaches a private agent through `delegate_to` is rejected.
+Use `private` when one shared agent definition should behave like a template that materializes a separate requester-local instance at runtime.
+The YAML definition stays shared.
+The private root, copied files, file-memory workspace, and private knowledge path do not.
+Private agents cannot participate in teams yet.
+That restriction also applies transitively: a shared team member that reaches a private agent through `delegate_to` is rejected.
 
-`private.per` is not a second spelling of `worker_scope`. `private.per` chooses who gets a separate private instance of the agent's state. MindRoom then uses that same requester partition for worker execution, but that is an internal consequence of private execution, not the public meaning of `worker_scope`.
+`private.per` is not a second spelling of `worker_scope`.
+`private.per` chooses who gets a separate private instance of the agent's state.
+MindRoom then uses that same requester partition for worker execution, but that is an internal consequence of private execution, not the public meaning of `worker_scope`.
 
 ```
 knowledge_bases:
@@ -368,7 +415,11 @@ mind_template/
 └── memory/
 ```
 
-In the example above, each requester gets their own effective `mind_data/` root under a canonical private-instance state root in shared storage. That private root is not created next to `config.yaml`. It is not stored under `workers/<worker>/`. Workers mount the same canonical private-instance root when they execute that requester scope. For a `mind` agent with `private.per: user`, different users get different private `mind_data/` trees even though the agent definition is shared.
+In the example above, each requester gets their own effective `mind_data/` root under a canonical private-instance state root in shared storage.
+That private root is not created next to `config.yaml`.
+It is not stored under `workers/<worker>/`.
+Workers mount the same canonical private-instance root when they execute that requester scope.
+For a `mind` agent with `private.per: user`, different users get different private `mind_data/` trees even though the agent definition is shared.
 
 ### Private Fields
 
@@ -419,11 +470,21 @@ In the example above, each requester gets their own effective `mind_data/` root 
 
 ## Thread Mode Resolution
 
-Thread mode is resolved per message using the current room ID. For an agent, MindRoom checks `room_thread_modes` in this order. First, it checks an exact room ID key. Second, it checks the managed room key/alias associated with that room ID. Third, it resolves each configured `room_thread_modes` key to a room ID and matches that against the current room. If none match, it falls back to `thread_mode`.
+Thread mode is resolved per message using the current room ID.
+For an agent, MindRoom checks `room_thread_modes` in this order.
+First, it checks an exact room ID key.
+Second, it checks the managed room key/alias associated with that room ID.
+Third, it resolves each configured `room_thread_modes` key to a room ID and matches that against the current room.
+If none match, it falls back to `thread_mode`.
 
-For a team, MindRoom resolves mode per member agent for that room. If all member agents resolve to the same mode, the team uses that mode. If member modes differ, the team defaults to `thread`.
+For a team, MindRoom resolves mode per member agent for that room.
+If all member agents resolve to the same mode, the team uses that mode.
+If member modes differ, the team defaults to `thread`.
 
-For the router, MindRoom resolves mode using agents relevant to the active room. This includes agents directly configured for the room and agents included via `teams.<name>.rooms`. If all relevant agents resolve to the same mode, the router uses that mode. If modes are mixed, the router defaults to `thread`.
+For the router, MindRoom resolves mode using agents relevant to the active room.
+This includes agents directly configured for the room and agents included via `teams.<name>.rooms`.
+If all relevant agents resolve to the same mode, the router uses that mode.
+If modes are mixed, the router defaults to `thread`.
 
 ## File-Based Context Loading
 
@@ -436,7 +497,8 @@ You can inject file content directly into an agent's role context without using 
 - Existing files are loaded in list order and added under `Personality Context`
 - Missing files are skipped with a warning in logs
 
-MindRoom loads the files when it builds an agent instance. The normal Matrix and OpenAI-compatible reply paths build fresh agent instances per reply/request, so editing a context file affects the next reply without restarting the process.
+MindRoom loads the files when it builds an agent instance.
+The normal Matrix and OpenAI-compatible reply paths build fresh agent instances per reply/request, so editing a context file affects the next reply without restarting the process.
 
 ## Agent Delegation
 
@@ -477,7 +539,8 @@ agents:
 
 ## Naming Rules
 
-Agent and team YAML keys must contain only alphanumeric characters and underscores (matching `^[a-zA-Z0-9_]+$`). Agent and team names must be distinct — the same key cannot appear in both `agents:` and `teams:`.
+Agent and team YAML keys must contain only alphanumeric characters and underscores (matching `^[a-zA-Z0-9_]+$`).
+Agent and team names must be distinct — the same key cannot appear in both `agents:` and `teams:`.
 
 ## Rich Prompt Agents
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -61,7 +61,9 @@ All API key variables also support a `_FILE` suffix for file-based secrets (e.g.
 
 ### Codex CLI Subscription Auth
 
-The `codex` provider does not use an API key environment variable. Run `codex login` so `~/.codex/auth.json` contains ChatGPT OAuth tokens. Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
+The `codex` provider does not use an API key environment variable.
+Run `codex login` so `~/.codex/auth.json` contains ChatGPT OAuth tokens.
+Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
 
 ### Operational
 
@@ -409,7 +411,9 @@ timezone: America/Los_Angeles      # Default: UTC
 
 ## Managed Avatars
 
-MindRoom can generate managed avatars for agents, teams, rooms, and the optional root Matrix Space. Use the optional `avatars.prompts` block to override the built-in prompt styles without editing Python code. Every field is optional and falls back to MindRoom's built-in defaults when omitted.
+MindRoom can generate managed avatars for agents, teams, rooms, and the optional root Matrix Space.
+Use the optional `avatars.prompts` block to override the built-in prompt styles without editing Python code.
+Every field is optional and falls back to MindRoom's built-in defaults when omitted.
 
 ```
 avatars:
@@ -421,7 +425,10 @@ avatars:
     room_system_prompt: "You are creating a refined, minimalist icon design for a room avatar."
 ```
 
-`mindroom avatars generate` only creates missing local avatar files by default. Run `mindroom avatars generate --force` to overwrite existing managed workspace avatar files after changing prompts or styles. `mindroom avatars sync` only fills missing Matrix avatars by default. Run `mindroom avatars sync --force` to replace existing Matrix room or root-space avatars.
+`mindroom avatars generate` only creates missing local avatar files by default.
+Run `mindroom avatars generate --force` to overwrite existing managed workspace avatar files after changing prompts or styles.
+`mindroom avatars sync` only fills missing Matrix avatars by default.
+Run `mindroom avatars sync --force` to replace existing Matrix room or root-space avatars.
 
 ## Internal User Username
 

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -102,7 +102,12 @@ models:
 
 ## Codex Subscription Models
 
-Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API. Run `codex login` first so `~/.codex/auth.json` contains ChatGPT OAuth tokens. MindRoom refreshes the access token when needed and sends requests to the Codex Responses endpoint. The model ID may be either the bare Codex slug, such as `gpt-5.5`, or the LLM-plugin-style form `openai-codex/gpt-5.5`. If you keep Codex state outside `~/.codex`, pass `extra_kwargs.codex_home`. For starter config generation, use `mindroom config init --profile public-codex` or `mindroom config init --provider codex`.
+Use `provider: codex` when you want MindRoom to call models exposed through an authenticated local Codex CLI session instead of the regular OpenAI API.
+Run `codex login` first so `~/.codex/auth.json` contains ChatGPT OAuth tokens.
+MindRoom refreshes the access token when needed and sends requests to the Codex Responses endpoint.
+The model ID may be either the bare Codex slug, such as `gpt-5.5`, or the LLM-plugin-style form `openai-codex/gpt-5.5`.
+If you keep Codex state outside `~/.codex`, pass `extra_kwargs.codex_home`.
+For starter config generation, use `mindroom config init --profile public-codex` or `mindroom config init --provider codex`.
 
 ```
 models:
@@ -115,11 +120,33 @@ models:
       reasoning_effort: medium
 ```
 
-Set Codex reasoning effort through `extra_kwargs.reasoning_effort`. Agno maps this to the Responses API `reasoning.effort` field. Supported effort values are `minimal`, `low`, `medium`, and `high`. The starter Codex profile uses `medium`. MindRoom sends a Codex prompt-cache key plus the Codex CLI session headers for each active agent session. By default, that key is derived from the current execution identity, so separate Matrix threads can run concurrently without sharing one global cache key. You can set `extra_kwargs.prompt_cache_key` to override that derived key for a model, but avoid a single low-cardinality value for many busy threads unless you intentionally want those requests routed together. Live testing against the Codex subscription endpoint reported `cached_tokens` only when the request included Codex CLI-style session headers tied to the prompt-cache key. Repeated long requests then reported cache hits, while requests without those headers stayed at `cached_tokens: 0`, and `prompt_cache_retention` was rejected. Treat Codex prompt caching as best-effort rather than guaranteed.
+Set Codex reasoning effort through `extra_kwargs.reasoning_effort`.
+Agno maps this to the Responses API `reasoning.effort` field.
+Supported effort values are `minimal`, `low`, `medium`, and `high`.
+The starter Codex profile uses `medium`.
+MindRoom sends a Codex prompt-cache key plus the Codex CLI session headers for each active agent session.
+By default, that key is derived from the current execution identity, so separate Matrix threads can run concurrently without sharing one global cache key.
+You can set `extra_kwargs.prompt_cache_key` to override that derived key for a model, but avoid a single low-cardinality value for many busy threads unless you intentionally want those requests routed together.
+Live testing against the Codex subscription endpoint reported `cached_tokens` only when the request included Codex CLI-style session headers tied to the prompt-cache key.
+Repeated long requests then reported cache hits, while requests without those headers stayed at `cached_tokens: 0`, and `prompt_cache_retention` was rejected.
+Treat Codex prompt caching as best-effort rather than guaranteed.
 
 ## Context Window
 
-When `context_window` is set, MindRoom uses it to budget persisted replay and destructive auto-compaction. MindRoom always applies a final replay-fit step when the active runtime model has a known `context_window`. That replay-fit step reduces or disables persisted replay for the current run when needed. Authoring `defaults.compaction`, or a non-empty per-agent/per-team `compaction` override, enables destructive compaction and lets you customize the thresholds, reserve, and summary model, or disable destructive auto-compaction entirely. A bare per-entity `compaction: {}` is only a no-op override that inherits authored defaults. `threshold_tokens` and `threshold_percent` use the active runtime model window for replay budgeting. Manual `compact_context` still uses that active runtime window for the final replay-fit step on the next run, but destructive compaction itself can be available whenever an explicit `compaction.model` has its own `context_window`. If you set `compaction.model`, that summary model must also define its own `context_window` for the durable summary-generation pass. Required compaction runs before the reply with a Matrix lifecycle notice that is edited in place. Otherwise MindRoom re-checks the updated session after a successful visible reply and compacts immediately if the next reply would cross the threshold. The budget uses a chars/4 approximation and reserves headroom for the current prompt and output. MindRoom does not mutate configured `num_history_runs` to fit the window. Instead, it computes the replay plan that actually fits the current call and uses compaction to keep future replay healthy. If needed, that replay plan can reduce raw replay, fall back to summary-only replay, or disable persisted replay entirely for the run.
+When `context_window` is set, MindRoom uses it to budget persisted replay and destructive auto-compaction.
+MindRoom always applies a final replay-fit step when the active runtime model has a known `context_window`.
+That replay-fit step reduces or disables persisted replay for the current run when needed.
+Authoring `defaults.compaction`, or a non-empty per-agent/per-team `compaction` override, enables destructive compaction and lets you customize the thresholds, reserve, and summary model, or disable destructive auto-compaction entirely.
+A bare per-entity `compaction: {}` is only a no-op override that inherits authored defaults.
+`threshold_tokens` and `threshold_percent` use the active runtime model window for replay budgeting.
+Manual `compact_context` still uses that active runtime window for the final replay-fit step on the next run, but destructive compaction itself can be available whenever an explicit `compaction.model` has its own `context_window`.
+If you set `compaction.model`, that summary model must also define its own `context_window` for the durable summary-generation pass.
+Required compaction runs before the reply with a Matrix lifecycle notice that is edited in place.
+Otherwise MindRoom re-checks the updated session after a successful visible reply and compacts immediately if the next reply would cross the threshold.
+The budget uses a chars/4 approximation and reserves headroom for the current prompt and output.
+MindRoom does not mutate configured `num_history_runs` to fit the window.
+Instead, it computes the replay plan that actually fits the current call and uses compaction to keep future replay healthy.
+If needed, that replay plan can reduce raw replay, fall back to summary-only replay, or disable persisted replay entirely for the run.
 
 ```
 models:

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -78,11 +78,16 @@ The router creates and manages rooms:
 - Has admin privileges to manage room membership
 - Cleans up orphaned bots on startup
 
-By default (`matrix_room_access.mode: single_user_private`), rooms remain invite-only and private in the room directory. In `multi_user` mode, the router can set join rules (`public`/`knock`) and optionally publish rooms to the server directory. That same reconciliation path also updates `m.room.power_levels` for managed rooms, so the router must be joined and able to edit room power levels when thread tags are enabled.
+By default (`matrix_room_access.mode: single_user_private`), rooms remain invite-only and private in the room directory.
+In `multi_user` mode, the router can set join rules (`public`/`knock`) and optionally publish rooms to the server directory.
+That same reconciliation path also updates `m.room.power_levels` for managed rooms, so the router must be joined and able to edit room power levels when thread tags are enabled.
 
 ### Voice Message Processing
 
-Audio events are handled through the shared media pipeline on all bots. The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a multi-agent room. When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message. Set `voice.visible_router_echo: true` if you also want the router to post the normalized voice text as a display-only message when it is allowed to reply. See [Voice Messages](https://docs.mindroom.chat/voice/index.md) for the detailed dispatch behavior.
+Audio events are handled through the shared media pipeline on all bots.
+The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a multi-agent room.
+When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
+Set `voice.visible_router_echo: true` if you also want the router to post the normalized voice text as a display-only message when it is allowed to reply. See [Voice Messages](https://docs.mindroom.chat/voice/index.md) for the detailed dispatch behavior.
 
 ### Configuration Confirmations
 

--- a/skills/mindroom-docs/references/page__configuration__teams__index.md
+++ b/skills/mindroom-docs/references/page__configuration__teams__index.md
@@ -94,7 +94,8 @@ teams:
 
 Team YAML keys follow the same naming rules as agents: alphanumeric characters and underscores only, and no overlap with agent names.
 
-`num_history_runs` and `num_history_messages` are mutually exclusive, just like the agent-level settings. When a named team sets these fields, the team scope uses the team-owned policy instead of inheriting one member's history policy.
+`num_history_runs` and `num_history_messages` are mutually exclusive, just like the agent-level settings.
+When a named team sets these fields, the team scope uses the team-owned policy instead of inheriting one member's history policy.
 
 Startup thread prewarm is a background, best-effort cache warmup for rooms already joined when first sync completes.
 
@@ -107,7 +108,9 @@ Startup thread prewarm is a background, best-effort cache warmup for rooms alrea
 
 ## Dynamic Team Formation
 
-When multiple agents are mentioned in a message (e.g., `@code @research analyze this`), MindRoom automatically forms an ad-hoc team. Dynamic teams form in these scenarios: In threads with multiple human participants, stale thread context does not auto-form a team. A fresh explicit `@mention` in the current message is required before agents respond.
+When multiple agents are mentioned in a message (e.g., `@code @research analyze this`), MindRoom automatically forms an ad-hoc team. Dynamic teams form in these scenarios:
+In threads with multiple human participants, stale thread context does not auto-form a team.
+A fresh explicit `@mention` in the current message is required before agents respond.
 
 1. **Multiple agents explicitly tagged** - e.g., `@code @research analyze this`
 1. **Thread with previously mentioned agents** - Follow-up messages in a thread where multiple agents were mentioned earlier, as long as the thread has not become a multi-human conversation that now requires a fresh explicit mention

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -10,7 +10,8 @@ MindRoom includes a web dashboard for configuring agents, teams, rooms, and inte
 mindroom run
 ```
 
-The dashboard will be available at `http://localhost:8765`. When running from a source checkout, MindRoom will build the dashboard assets on first start if Bun is available.
+The dashboard will be available at `http://localhost:8765`.
+When running from a source checkout, MindRoom will build the dashboard assets on first start if Bun is available.
 
 **SaaS Platform:** Access your dashboard at `https://<instance-id>.mindroom.chat`
 

--- a/skills/mindroom-docs/references/page__deployment__docker__index.md
+++ b/skills/mindroom-docs/references/page__deployment__docker__index.md
@@ -73,7 +73,8 @@ Key environment variables (set in `.env` or pass directly):
 | `MINDROOM_PORT`         | Port used by Google OAuth callback URL construction and deployment tooling. Does **not** change the API server bind port — use `mindroom run --api-port` for that | `8765`                                          |
 | `MINDROOM_API_KEY`      | API key for dashboard auth (standalone)                                                                                                                           | - (open access)                                 |
 
-To change the API server port or bind address, pass `--api-port` or `--api-host` to the `mindroom run` command. For example, add `command: ["mindroom", "run", "--api-port", "9000"]` to the Docker Compose service.
+To change the API server port or bind address, pass `--api-port` or `--api-host` to the `mindroom run` command.
+For example, add `command: ["mindroom", "run", "--api-port", "9000"]` to the Docker Compose service.
 
 Streaming responses are configured in `config.yaml` via `defaults.enable_streaming` (default: `true`).
 

--- a/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
@@ -1,6 +1,7 @@
 # Google Services OAuth (Admin Setup)
 
-This is the one-time setup for a shared Google OAuth app in MindRoom. After you finish these steps, users only click **Login with Google** in the frontend.
+This is the one-time setup for a shared Google OAuth app in MindRoom.
+After you finish these steps, users only click **Login with Google** in the frontend.
 
 ## Who This Is For
 

--- a/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
+++ b/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
@@ -27,7 +27,8 @@ This guide covers the simplest production-like setup:
 uvx mindroom config init --profile public
 ```
 
-This creates `~/.mindroom/config.yaml` and `~/.mindroom/.env` with hosted defaults. Use `uvx mindroom config init --profile public-codex` if you want the starter config to use `provider: codex`.
+This creates `~/.mindroom/config.yaml` and `~/.mindroom/.env` with hosted defaults.
+Use `uvx mindroom config init --profile public-codex` if you want the starter config to use `provider: codex`.
 
 ## 2. Add AI Provider Key
 
@@ -38,7 +39,8 @@ OPENAI_API_KEY=...
 # or OPENROUTER_API_KEY=...
 ```
 
-For Codex CLI subscription auth, run `codex login` instead of adding an API key. MindRoom reads `~/.codex/auth.json` by default.
+For Codex CLI subscription auth, run `codex login` instead of adding an API key.
+MindRoom reads `~/.codex/auth.json` by default.
 
 ## 3. Pair This Install
 
@@ -79,9 +81,11 @@ MindRoom then:
 - `MINDROOM_LOCAL_CLIENT_SECRET`
 - `MINDROOM_NAMESPACE`
 
-`MINDROOM_LOCAL_CLIENT_ID` and `MINDROOM_LOCAL_CLIENT_SECRET` are **not Matrix user access tokens**. `MINDROOM_NAMESPACE` is appended to managed agent usernames and room aliases to avoid collisions on shared homeservers.
+`MINDROOM_LOCAL_CLIENT_ID` and `MINDROOM_LOCAL_CLIENT_SECRET` are **not Matrix user access tokens**.
+`MINDROOM_NAMESPACE` is appended to managed agent usernames and room aliases to avoid collisions on shared homeservers.
 
-They can only call provisioning-service endpoints that accept local client credentials (for example agent registration flows). Revoke them from `Settings -> Local MindRoom` in the chat UI.
+They can only call provisioning-service endpoints that accept local client credentials (for example agent registration flows).
+Revoke them from `Settings -> Local MindRoom` in the chat UI.
 
 ## Trust Model (Hosted Server vs Message Privacy)
 

--- a/skills/mindroom-docs/references/page__deployment__index.md
+++ b/skills/mindroom-docs/references/page__deployment__index.md
@@ -38,7 +38,8 @@ uvx mindroom connect --pair-code ABCD-EFGH
 uvx mindroom run
 ```
 
-Generate the pair code in `https://chat.mindroom.chat` under: `Settings -> Local MindRoom`.
+Generate the pair code in `https://chat.mindroom.chat` under:
+`Settings -> Local MindRoom`.
 
 See [Hosted Matrix deployment](https://docs.mindroom.chat/deployment/hosted-matrix/index.md) for the full walkthrough.
 
@@ -53,7 +54,9 @@ $EDITOR .env  # add at least one AI provider key
 docker compose up -d
 ```
 
-The stack exposes MindRoom at `http://localhost:8765`, the MindRoom client at `http://localhost:8080`, and Matrix at `http://localhost:8008`. The stack uses published `mindroom`, `mindroom-cinny`, and `mindroom-tuwunel` images by default. If you access it from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
+The stack exposes MindRoom at `http://localhost:8765`, the MindRoom client at `http://localhost:8080`, and Matrix at `http://localhost:8008`.
+The stack uses published `mindroom`, `mindroom-cinny`, and `mindroom-tuwunel` images by default.
+If you access it from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip>:8008` in `.env` before starting it.
 
 ### Direct (Development)
 

--- a/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
+++ b/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
@@ -110,11 +110,18 @@ Both modes store agent data in the same per-agent directory structure.
 
 ### Shared Sidecar Mode
 
-`workerBackend: static_runner` is the default. The primary runtime talks to a shared sidecar over `localhost`. This keeps the deployment simple, but all proxied tool calls share the same runner process. The runner reads and writes the same agent storage directories as the main process.
+`workerBackend: static_runner` is the default.
+The primary runtime talks to a shared sidecar over `localhost`.
+This keeps the deployment simple, but all proxied tool calls share the same runner process.
+The runner reads and writes the same agent storage directories as the main process.
 
 ### Dedicated Worker Mode
 
-`workerBackend: kubernetes` enables the built-in Kubernetes worker backend. The primary runtime creates worker Deployments and Services on demand and routes tool calls to the matching worker. Each worker pod runs the sandbox-runner app and accesses the same agent storage directory as every other runtime for that agent. Worker-local files (caches, virtualenvs, metadata) are kept separate per worker. When a worker is idle, its Deployment scales to zero, but agent data and worker caches are preserved.
+`workerBackend: kubernetes` enables the built-in Kubernetes worker backend.
+The primary runtime creates worker Deployments and Services on demand and routes tool calls to the matching worker.
+Each worker pod runs the sandbox-runner app and accesses the same agent storage directory as every other runtime for that agent.
+Worker-local files (caches, virtualenvs, metadata) are kept separate per worker.
+When a worker is idle, its Deployment scales to zero, but agent data and worker caches are preserved.
 
 > [!WARNING] **Filesystem isolation depends on `worker_scope`.** With `shared`, `user_agent`, or unscoped execution, each worker can only see its own agent's storage directory — this is the strongest isolation available. With `user`, the worker can see all agents' storage because it shares one runtime across multiple agents for a single user. Use `user_agent` for per-agent filesystem isolation.
 
@@ -158,7 +165,10 @@ Important behavior and constraints:
 
 ### Storage Requirements
 
-Dedicated workers need access to the same PVC as the primary runtime. Set `storageAccessMode: ReadWriteMany` so multiple workers can access agent storage concurrently. If your storage class only supports `ReadWriteOnce`, set `controlPlaneNodeName` so the control plane and dedicated workers stay on the same node. The chart enforces this constraint during template rendering.
+Dedicated workers need access to the same PVC as the primary runtime.
+Set `storageAccessMode: ReadWriteMany` so multiple workers can access agent storage concurrently.
+If your storage class only supports `ReadWriteOnce`, set `controlPlaneNodeName` so the control plane and dedicated workers stay on the same node.
+The chart enforces this constraint during template rendering.
 
 ### RBAC And Network Policy
 
@@ -170,7 +180,8 @@ When `workerBackend: kubernetes` is enabled, the chart creates:
 
 ### Operations
 
-The authenticated dashboard API exposes `/api/workers` to list active or idle workers and `/api/workers/cleanup` to trigger cleanup manually. Dedicated workers are internal-only cluster Services and are authenticated with per-worker runner tokens derived from the primary runtime's `sandbox_proxy_token`. See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for the execution model, credential leases, and non-Kubernetes deployment modes.
+The authenticated dashboard API exposes `/api/workers` to list active or idle workers and `/api/workers/cleanup` to trigger cleanup manually.
+Dedicated workers are internal-only cluster Services and are authenticated with per-worker runner tokens derived from the primary runtime's `sandbox_proxy_token`. See [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for the execution model, credential leases, and non-Kubernetes deployment modes.
 
 ## Secrets Management
 

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -1,6 +1,8 @@
 # Sandbox Proxy Isolation
 
-When agents have code-execution tools (`shell`, `file`, `python`), they can read and modify anything on the filesystem, including config files, credentials, and application code. The **sandbox proxy** isolates these tools by forwarding their calls to a separate worker runtime that has no direct access to the primary process secrets. This page describes the current sandboxed execution model.
+When agents have code-execution tools (`shell`, `file`, `python`), they can read and modify anything on the filesystem, including config files, credentials, and application code.
+The **sandbox proxy** isolates these tools by forwarding their calls to a separate worker runtime that has no direct access to the primary process secrets.
+This page describes the current sandboxed execution model.
 
 ## How it works
 
@@ -19,7 +21,11 @@ When agents have code-execution tools (`shell`, `file`, `python`), they can read
 1. The worker executes the tool against the agent's storage directory plus any worker-local caches and returns the result.
 1. All other tools such as API tools or Matrix-bound tools execute in the primary MindRoom runtime as usual.
 
-The static worker runtime authenticates requests with `MINDROOM_SANDBOX_PROXY_TOKEN`. Kubernetes dedicated workers derive a separate runner token for each worker from that control-plane token and the worker key. Compromising one dedicated worker token does not authorize requests to another dedicated worker runner. For tools that need credentials, such as a shell tool that calls an authenticated API, the primary MindRoom runtime can create a short-lived **credential lease** that the worker consumes once. Credentials never become part of the normal tool arguments or the model prompt.
+The static worker runtime authenticates requests with `MINDROOM_SANDBOX_PROXY_TOKEN`.
+Kubernetes dedicated workers derive a separate runner token for each worker from that control-plane token and the worker key.
+Compromising one dedicated worker token does not authorize requests to another dedicated worker runner.
+For tools that need credentials, such as a shell tool that calls an authenticated API, the primary MindRoom runtime can create a short-lived **credential lease** that the worker consumes once.
+Credentials never become part of the normal tool arguments or the model prompt.
 
 MindRoom currently ships two worker backend shapes:
 
@@ -28,13 +34,18 @@ MindRoom currently ships two worker backend shapes:
 
 ## Where Agent Data Lives
 
-Each agent stores all its persistent data (context files, workspace files, memory, sessions, learning) in one directory: `agents/<name>/`. This directory is shared across all worker scopes — switching `worker_scope` changes how tool runtimes are isolated, not where agent data lives. Worker runtimes may keep their own virtualenvs, caches, and scratch files, but those are not agent data. Multiple runtimes may access the same agent directory concurrently, so files and databases there must tolerate concurrent access.
+Each agent stores all its persistent data (context files, workspace files, memory, sessions, learning) in one directory: `agents/<name>/`.
+This directory is shared across all worker scopes — switching `worker_scope` changes how tool runtimes are isolated, not where agent data lives.
+Worker runtimes may keep their own virtualenvs, caches, and scratch files, but those are not agent data.
+Multiple runtimes may access the same agent directory concurrently, so files and databases there must tolerate concurrent access.
 
 ## Deployment modes
 
 ### Docker Compose (`static_runner`)
 
-Add a `sandbox-runner` service alongside MindRoom. Both use the same image. The runner just has a different entrypoint and no access to `.env` or the primary data volume.
+Add a `sandbox-runner` service alongside MindRoom.
+Both use the same image.
+The runner just has a different entrypoint and no access to `.env` or the primary data volume.
 
 ```
 services:
@@ -68,7 +79,8 @@ volumes:
   sandbox-workspace:
 ```
 
-Add a shared volume or bind mount for agent storage that both the main process and the runner can access. Keep secrets and other main-process-only files on separate mounts that are not exposed to the runner.
+Add a shared volume or bind mount for agent storage that both the main process and the runner can access.
+Keep secrets and other main-process-only files on separate mounts that are not exposed to the runner.
 
 > [!IMPORTANT] The `sandbox-workspace` Docker volume is created as root by default. The runner runs as UID 1000, so you must fix ownership after first creating the volume: `bash docker run --rm -v sandbox-workspace:/workspace busybox chown -R 1000:1000 /workspace` Alternatively, omit the `user:` directive to run as root (less secure).
 
@@ -83,7 +95,10 @@ Key differences from the primary MindRoom runtime:
 
 ### Kubernetes shared sidecar (`workerBackend: static_runner`)
 
-In Kubernetes the shared runner can still run as a second container in the same pod, sharing `localhost` networking. This is the `workerBackend: static_runner` Helm mode. See `cluster/k8s/instance/templates/deployment-mindroom.yaml` for the full manifest. The sidecar gets:
+In Kubernetes the shared runner can still run as a second container in the same pod, sharing `localhost` networking.
+This is the `workerBackend: static_runner` Helm mode.
+See `cluster/k8s/instance/templates/deployment-mindroom.yaml` for the full manifest.
+The sidecar gets:
 
 - An `emptyDir` volume for worker-local scratch files and caches.
 - Access to the same shared storage that holds agent data directories.
@@ -92,7 +107,11 @@ In Kubernetes the shared runner can still run as a second container in the same 
 
 ### Kubernetes dedicated workers (`workerBackend: kubernetes`)
 
-In dedicated-worker mode the primary MindRoom runtime creates worker Deployments and Services on demand. Each worker pod runs the sandbox-runner app and is addressed through an internal cluster Service. Each dedicated worker needs access to its agent's storage directory. Worker-local files (caches, virtualenvs, metadata) are kept separate per worker. When a worker is idle, its Deployment scales to zero, but agent data and worker caches are preserved.
+In dedicated-worker mode the primary MindRoom runtime creates worker Deployments and Services on demand.
+Each worker pod runs the sandbox-runner app and is addressed through an internal cluster Service.
+Each dedicated worker needs access to its agent's storage directory.
+Worker-local files (caches, virtualenvs, metadata) are kept separate per worker.
+When a worker is idle, its Deployment scales to zero, but agent data and worker caches are preserved.
 
 Use the instance Helm chart with values like:
 
@@ -117,7 +136,9 @@ Important notes for this mode:
 - Runner ingress defaults to allowing the MindRoom control-plane pod to reach worker runner ports, while worker-to-worker ingress is denied by NetworkPolicy.
 - The authenticated `/api/workers` and `/api/workers/cleanup` endpoints on the primary runtime expose backend-neutral worker lifecycle information.
 
-Untrusted code-execution tools may still share the runner container's process namespace and may be able to inspect the runner process environment through `/proc` on some container runtimes. For dedicated Kubernetes workers, the exposed environment contains only that worker's derived runner token, not the shared control-plane token. This leaves same-worker token exposure as a local containment risk, while per-worker credentials and NetworkPolicy limit cross-worker blast radius.
+Untrusted code-execution tools may still share the runner container's process namespace and may be able to inspect the runner process environment through `/proc` on some container runtimes.
+For dedicated Kubernetes workers, the exposed environment contains only that worker's derived runner token, not the shared control-plane token.
+This leaves same-worker token exposure as a local containment risk, while per-worker credentials and NetworkPolicy limit cross-worker blast radius.
 
 For the full Helm-side deployment guidance, see [Kubernetes Deployment](https://docs.mindroom.chat/deployment/kubernetes/index.md).
 
@@ -176,7 +197,8 @@ This gives you the convenience of running MindRoom natively while keeping code-e
 | `MINDROOM_SANDBOX_CREDENTIAL_LEASE_TTL_SECONDS` | Credential lease lifetime                                                                                                                                             | `60`                                          |
 | `MINDROOM_SANDBOX_CREDENTIAL_POLICY_JSON`       | JSON mapping tool selectors to credential services                                                                                                                    | `{}`                                          |
 
-When `MINDROOM_WORKER_BACKEND=kubernetes`, the primary runtime resolves worker endpoints through the Kubernetes backend and does not use `MINDROOM_SANDBOX_PROXY_URL`. The Helm chart sets the Kubernetes backend environment variables automatically. If you deploy that mode without Helm, see [Kubernetes Deployment](https://docs.mindroom.chat/deployment/kubernetes/index.md) and `src/mindroom/workers/backends/kubernetes_config.py` for the required environment surface.
+When `MINDROOM_WORKER_BACKEND=kubernetes`, the primary runtime resolves worker endpoints through the Kubernetes backend and does not use `MINDROOM_SANDBOX_PROXY_URL`.
+The Helm chart sets the Kubernetes backend environment variables automatically. If you deploy that mode without Helm, see [Kubernetes Deployment](https://docs.mindroom.chat/deployment/kubernetes/index.md) and `src/mindroom/workers/backends/kubernetes_config.py` for the required environment surface.
 
 ### Sandbox runner
 
@@ -201,11 +223,21 @@ When `MINDROOM_WORKER_BACKEND=kubernetes`, the primary runtime resolves worker e
 
 ## Shell env and PATH
 
-When `shell` runs through the sandbox proxy, it receives the stricter sandbox runtime env rather than the main process's ordinary committed runtime `.env`. Additional env is not forwarded implicitly: configure `extra_env_passthrough` with exact names or glob patterns for exported process env variables you want shell execution to inherit. `extra_env_passthrough` matches exported process env, not config-adjacent `.env` entries. To prevent the runner from leaking its own control-plane credentials to tools, shell passthrough drops names in a small explicit denylist (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`. Everything else that matches your configured names or globs passes through, including service tokens and provider credentials. If you don't want a value to reach shell commands, don't match it with `extra_env_passthrough`.
+When `shell` runs through the sandbox proxy, it receives the stricter sandbox runtime env rather than the main process's ordinary committed runtime `.env`.
+Additional env is not forwarded implicitly: configure `extra_env_passthrough` with exact names or glob patterns for exported process env variables you want shell execution to inherit.
+`extra_env_passthrough` matches exported process env, not config-adjacent `.env` entries.
+To prevent the runner from leaking its own control-plane credentials to tools, shell passthrough drops names in a small explicit denylist (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`.
+Everything else that matches your configured names or globs passes through, including service tokens and provider credentials.
+If you don't want a value to reach shell commands, don't match it with `extra_env_passthrough`.
 
-If proxied shell commands need extra PATH entries such as wrapper directories, configure `shell_path_prepend`. This prepends the configured entries ahead of the runtime PATH while preserving the existing PATH order and removing duplicates. That keeps PATH handling deployment-specific instead of baking host-specific directories into the shell tool itself.
+If proxied shell commands need extra PATH entries such as wrapper directories, configure `shell_path_prepend`.
+This prepends the configured entries ahead of the runtime PATH while preserving the existing PATH order and removing duplicates.
+That keeps PATH handling deployment-specific instead of baking host-specific directories into the shell tool itself.
 
-Shell commands that exceed their timeout return a background handle. Use `check_shell_command(handle)` to poll and `kill_shell_command(handle)` to stop the process. These handles are process-local to the sandbox runner: they survive multiple requests to the same runner process, but not runner restarts. To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE=subprocess`.
+Shell commands that exceed their timeout return a background handle.
+Use `check_shell_command(handle)` to poll and `kill_shell_command(handle)` to stop the process.
+These handles are process-local to the sandbox runner: they survive multiple requests to the same runner process, but not runner restarts.
+To make that work, shell background-handle requests stay owned by the long-lived runner process even when `MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE=subprocess`.
 
 ## Workspace env hook (`.mindroom/worker-env.sh`)
 
@@ -230,7 +262,11 @@ The runner sources this script with `bash` before each worker-routed `shell` or 
 
 **Filtering:**
 
-`.mindroom/worker-env.sh` is sourced by bash that inherits the runner's process env, which contains tokens the runner needs to function (sandbox proxy auth, etc.). To prevent the runner from leaking its own control-plane credentials to tools, the overlay drops names in a small explicit denylist (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`. Bash bookkeeping vars (`PWD`, `OLDPWD`, `SHLVL`, `_`, `PIPESTATUS`) are also dropped because they're noise, not values the script meant to export. Everything else passes through, including service tokens and provider credentials you intentionally export from the hook. If you don't want a value to reach tools, don't export it.
+`.mindroom/worker-env.sh` is sourced by bash that inherits the runner's process env, which contains tokens the runner needs to function (sandbox proxy auth, etc.).
+To prevent the runner from leaking its own control-plane credentials to tools, the overlay drops names in a small explicit denylist (`MINDROOM_API_KEY`, `MINDROOM_LOCAL_CLIENT_SECRET`, `MINDROOM_SANDBOX_PROXY_TOKEN`, `MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH`) and any name starting with `MINDROOM_SANDBOX_`.
+Bash bookkeeping vars (`PWD`, `OLDPWD`, `SHLVL`, `_`, `PIPESTATUS`) are also dropped because they're noise, not values the script meant to export.
+Everything else passes through, including service tokens and provider credentials you intentionally export from the hook.
+If you don't want a value to reach tools, don't export it.
 
 **Limits and failure handling:**
 
@@ -240,7 +276,9 @@ The runner sources this script with `bash` before each worker-routed `shell` or 
 - Any failure (non-zero exit, timeout, escape, missing `bash`) returns the tool call as `ok: false` with `failure_kind: "tool"` and an error mentioning `.mindroom/worker-env.sh`.
 - Hook failures do not poison the worker; only the requesting tool call fails.
 
-This hook works identically for the static sidecar and dedicated Kubernetes worker backends because it runs inside the sandbox runner per request. It is not a true container startup hook — it does not change pod templates, recreate Deployments, or alter Helm values. For an example, see `docs/tools/execution-and-coding.md`.
+This hook works identically for the static sidecar and dedicated Kubernetes worker backends because it runs inside the sandbox runner per request.
+It is not a true container startup hook — it does not change pod templates, recreate Deployments, or alter Helm values.
+For an example, see `docs/tools/execution-and-coding.md`.
 
 ## Credential leases
 
@@ -266,7 +304,8 @@ This shares the `github` credential service with `shell` tool calls and `openai`
 
 ### Sandbox-runner API endpoints
 
-These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime. All requests require the runner's `MINDROOM_SANDBOX_PROXY_TOKEN` in the `x-mindroom-sandbox-token` header.
+These endpoints are served by the sandbox-runner process, not the primary MindRoom runtime.
+All requests require the runner's `MINDROOM_SANDBOX_PROXY_TOKEN` in the `x-mindroom-sandbox-token` header.
 
 | Method | Endpoint                              | Description                                                     |
 | ------ | ------------------------------------- | --------------------------------------------------------------- |
@@ -309,11 +348,16 @@ The `worker_tools` field has three states:
 | `[]` (empty list)   | Explicitly disable sandbox proxying for this agent                                                                                                        |
 | `["shell", "file"]` | Proxy exactly these tools for this agent                                                                                                                  |
 
-Agent-level `worker_tools` overrides `defaults.worker_tools`. With `MINDROOM_WORKER_BACKEND=static_runner`, a sandbox proxy URL (`MINDROOM_SANDBOX_PROXY_URL`) must still be configured for proxying to take effect. With `MINDROOM_WORKER_BACKEND=kubernetes`, worker endpoints are resolved dynamically and `MINDROOM_SANDBOX_PROXY_URL` is not used.
+Agent-level `worker_tools` overrides `defaults.worker_tools`.
+With `MINDROOM_WORKER_BACKEND=static_runner`, a sandbox proxy URL (`MINDROOM_SANDBOX_PROXY_URL`) must still be configured for proxying to take effect.
+With `MINDROOM_WORKER_BACKEND=kubernetes`, worker endpoints are resolved dynamically and `MINDROOM_SANDBOX_PROXY_URL` is not used.
 
 ## Worker Scope
 
-`worker_tools` controls which tools run in the sandbox proxy. `worker_scope` controls how those sandbox runtimes are shared between calls. Some credential-backed tools always stay local regardless of `worker_tools`: `gmail`, `google_calendar`, `google_sheets`, and `homeassistant`. Additionally, `google` and `spotify` are shared-only integrations that require `worker_scope` unset or `shared` but can still be proxied through the sandbox.
+`worker_tools` controls which tools run in the sandbox proxy.
+`worker_scope` controls how those sandbox runtimes are shared between calls.
+Some credential-backed tools always stay local regardless of `worker_tools`: `gmail`, `google_calendar`, `google_sheets`, and `homeassistant`.
+Additionally, `google` and `spotify` are shared-only integrations that require `worker_scope` unset or `shared` but can still be proxied through the sandbox.
 
 You can set `worker_scope` per agent or in `defaults`:
 
@@ -354,4 +398,6 @@ If `worker_scope` is unset, proxied tools still run in the sandbox, but each cal
 
 ## Without configured worker routing
 
-With `MINDROOM_WORKER_BACKEND=static_runner` and no `MINDROOM_SANDBOX_PROXY_URL`, tool calls execute directly in the primary MindRoom runtime process. This is fine for development but not recommended for production deployments where agents run untrusted code. With `MINDROOM_WORKER_BACKEND=kubernetes`, worker-routed tool calls fail closed when the backend is misconfigured instead of silently running locally.
+With `MINDROOM_WORKER_BACKEND=static_runner` and no `MINDROOM_SANDBOX_PROXY_URL`, tool calls execute directly in the primary MindRoom runtime process.
+This is fine for development but not recommended for production deployments where agents run untrusted code.
+With `MINDROOM_WORKER_BACKEND=kubernetes`, worker-routed tool calls fail closed when the backend is misconfigured instead of silently running locally.

--- a/skills/mindroom-docs/references/page__getting-started__index.md
+++ b/skills/mindroom-docs/references/page__getting-started__index.md
@@ -4,7 +4,8 @@ This guide will help you set up MindRoom and create your first AI agent.
 
 ## Recommended: Hosted Matrix + Local MindRoom (`uv` only)
 
-If you do not want to self-host Matrix yet, this is the simplest setup. You only run MindRoom locally.
+If you do not want to self-host Matrix yet, this is the simplest setup.
+You only run MindRoom locally.
 
 **Prerequisite:** Install [uv](https://docs.astral.sh/uv/getting-started/installation/).
 
@@ -19,7 +20,8 @@ This creates:
 - `~/.mindroom/config.yaml`
 - `~/.mindroom/.env` prefilled with `MATRIX_HOMESERVER=https://mindroom.chat`
 
-The `--profile public` template defaults to the `openai` provider. Use `--provider` to select a different provider preset:
+The `--profile public` template defaults to the `openai` provider.
+Use `--provider` to select a different provider preset:
 
 ```
 # Use Anthropic Claude
@@ -32,9 +34,12 @@ uvx mindroom config init --profile public-codex
 uvx mindroom config init --profile public-vertexai-anthropic
 ```
 
-`public-codex` is the canonical profile name for hosted Matrix with Codex CLI subscription auth. The shorter `codex` profile alias is also accepted. Run `codex login` before starting MindRoom when using this profile.
+`public-codex` is the canonical profile name for hosted Matrix with Codex CLI subscription auth.
+The shorter `codex` profile alias is also accepted.
+Run `codex login` before starting MindRoom when using this profile.
 
-`public-vertexai-anthropic` is the canonical profile name for Vertex AI Claude on hosted Matrix. Aliases `public-vertexai-claude`, `vertexai-anthropic`, and `vertexai-claude` are also accepted.
+`public-vertexai-anthropic` is the canonical profile name for Vertex AI Claude on hosted Matrix.
+Aliases `public-vertexai-claude`, `vertexai-anthropic`, and `vertexai-claude` are also accepted.
 
 Other profiles:
 

--- a/skills/mindroom-docs/references/page__images__index.md
+++ b/skills/mindroom-docs/references/page__images__index.md
@@ -53,11 +53,13 @@ Images work in both direct messages and threads, and with both individual agents
 
 ## Captions (MSC2530)
 
-If the Matrix event's `filename` field differs from `body`, the `body` is used as a user caption. This follows [MSC2530](https://github.com/matrix-org/matrix-spec-proposals/pull/2530) semantics and works with clients that set the caption in the body.
+If the Matrix event's `filename` field differs from `body`, the `body` is used as a user caption.
+This follows [MSC2530](https://github.com/matrix-org/matrix-spec-proposals/pull/2530) semantics and works with clients that set the caption in the body.
 
 ## Image Persistence
 
-Images are saved under `mindroom_data/attachments/` and `mindroom_data/incoming_media/` and registered as attachment records with 30-day retention. In addition to being passed to the AI model as vision input, each image is also registered as an `att_*` attachment ID so agents can reference it via tool calls. See [Attachments](https://docs.mindroom.chat/attachments/index.md) for details on retention and context scoping.
+Images are saved under `mindroom_data/attachments/` and `mindroom_data/incoming_media/` and registered as attachment records with 30-day retention.
+In addition to being passed to the AI model as vision input, each image is also registered as an `att_*` attachment ID so agents can reference it via tool calls. See [Attachments](https://docs.mindroom.chat/attachments/index.md) for details on retention and context scoping.
 
 ## Encryption
 
@@ -69,9 +71,12 @@ AI response caching is automatically skipped when images are present, since imag
 
 ## Media Fallback
 
-If a model rejects inline media (images, audio, video, or documents), MindRoom automatically retries the request without the inline media. The retried prompt includes `[Inline media unavailable for this model]` to inform the agent that attachments were dropped. Agents can still reference the files via attachment IDs and tools.
+If a model rejects inline media (images, audio, video, or documents), MindRoom automatically retries the request without the inline media.
+The retried prompt includes `[Inline media unavailable for this model]` to inform the agent that attachments were dropped.
+Agents can still reference the files via attachment IDs and tools.
 
-This fallback is transparent — no user action is required. It detects provider-specific error patterns such as unsupported media type, base64 field validation failures, and capability rejections.
+This fallback is transparent — no user action is required.
+It detects provider-specific error patterns such as unsupported media type, base64 field validation failures, and capability rejections.
 
 ## Limitations
 

--- a/skills/mindroom-docs/references/page__interactive__index.md
+++ b/skills/mindroom-docs/references/page__interactive__index.md
@@ -1,6 +1,7 @@
 # Interactive Q&A
 
-MindRoom agents can present clickable multiple-choice questions to users using Matrix reactions. When an agent's response contains a specially formatted JSON block, MindRoom automatically renders it as a numbered list with emoji reactions that users can click to respond.
+MindRoom agents can present clickable multiple-choice questions to users using Matrix reactions.
+When an agent's response contains a specially formatted JSON block, MindRoom automatically renders it as a numbered list with emoji reactions that users can click to respond.
 
 ## How It Works
 

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -1,6 +1,7 @@
 # Knowledge Bases
 
-Knowledge bases give your agents access to your own documents through RAG (Retrieval-Augmented Generation). Drop files into a folder, point a knowledge base at it, and agents can search the indexed content when answering questions.
+Knowledge bases give your agents access to your own documents through RAG (Retrieval-Augmented Generation).
+Drop files into a folder, point a knowledge base at it, and agents can search the indexed content when answering questions.
 
 ## How It Works
 
@@ -46,7 +47,12 @@ agents:
     knowledge_bases: [docs]
 ```
 
-Place files in `./knowledge_docs/`, then trigger a reindex from the dashboard/API or let MindRoom watch shared local bases with `watch: true`. Chat uses the last successfully published index and continues without blocking when a base is missing, stale, or failed. When a watched file changes, MindRoom marks the published index stale, refreshes in the background, and atomically publishes the replacement when it succeeds. When `watch: false`, direct external file edits require explicit reindex, while dashboard/API upload and delete actions still schedule refresh after a successful mutation. Knowledge base IDs are the keys under `knowledge_bases`. Use a non-empty single path component such as `docs` or `company_docs`, not `""`, `.`, `..`, or names containing `/` or `\`.
+Place files in `./knowledge_docs/`, then trigger a reindex from the dashboard/API or let MindRoom watch shared local bases with `watch: true`.
+Chat uses the last successfully published index and continues without blocking when a base is missing, stale, or failed.
+When a watched file changes, MindRoom marks the published index stale, refreshes in the background, and atomically publishes the replacement when it succeeds.
+When `watch: false`, direct external file edits require explicit reindex, while dashboard/API upload and delete actions still schedule refresh after a successful mutation.
+Knowledge base IDs are the keys under `knowledge_bases`.
+Use a non-empty single path component such as `docs` or `company_docs`, not `""`, `.`, `..`, or names containing `/` or `\`.
 
 ## Configuration
 
@@ -69,7 +75,8 @@ knowledge_bases:
 | `chunk_overlap` | int    | `0`                | Overlap characters between adjacent chunks (must be `< chunk_size`)                                                                                                                                                                                         |
 | `git`           | object | `null`             | Optional Git repository sync settings                                                                                                                                                                                                                       |
 
-Use smaller `chunk_size` values when your embedding server has lower token or batch limits. If chunking is too large, indexing retries will fail with embedder 500 errors.
+Use smaller `chunk_size` values when your embedding server has lower token or batch limits.
+If chunking is too large, indexing retries will fail with embedder 500 errors.
 
 ### Private Agent Knowledge
 
@@ -96,7 +103,19 @@ agents:
     knowledge_bases: [company_docs]
 ```
 
-With this configuration, each requester's private knowledge path becomes `<their private root>/memory`. The template source is explicit, so you can see and edit the files being copied into each requester's private root. `private.template_dir` only copies files. PrivateAgentKnowledge is enabled only when you explicitly configure `private.knowledge.path`. `private.knowledge.path` must be relative to the private root and cannot be absolute or escape with `..`. `private.knowledge.path` can point to any folder inside the private root, including `.` for the private root itself. MindRoom keeps a separate index per effective private root, so one requester's indexed data is not shared with another requester's runtime. For isolating scopes such as `user` and `user_agent`, MindRoom refreshes the private index on access instead of keeping a background watcher alive for every requester root. Git-backed knowledge syncs during scheduled or explicit refreshes. Top-level `knowledge_bases` remain the shared/global mechanism, so the same agent can combine PrivateAgentKnowledge with shared company knowledge. PrivateAgentKnowledge applies to the normal agent runtime path, not the OpenAI-compatible `/v1` API. If you enable `private.knowledge.git`, use a dedicated subtree such as `kb_repo`. Do not point Git-backed private knowledge at `.` or `memory/`, and do not use a Git checkout path that your template or private file memory also writes into.
+With this configuration, each requester's private knowledge path becomes `<their private root>/memory`.
+The template source is explicit, so you can see and edit the files being copied into each requester's private root.
+`private.template_dir` only copies files.
+PrivateAgentKnowledge is enabled only when you explicitly configure `private.knowledge.path`.
+`private.knowledge.path` must be relative to the private root and cannot be absolute or escape with `..`.
+`private.knowledge.path` can point to any folder inside the private root, including `.` for the private root itself.
+MindRoom keeps a separate index per effective private root, so one requester's indexed data is not shared with another requester's runtime.
+For isolating scopes such as `user` and `user_agent`, MindRoom refreshes the private index on access instead of keeping a background watcher alive for every requester root.
+Git-backed knowledge syncs during scheduled or explicit refreshes.
+Top-level `knowledge_bases` remain the shared/global mechanism, so the same agent can combine PrivateAgentKnowledge with shared company knowledge.
+PrivateAgentKnowledge applies to the normal agent runtime path, not the OpenAI-compatible `/v1` API.
+If you enable `private.knowledge.git`, use a dedicated subtree such as `kb_repo`.
+Do not point Git-backed private knowledge at `.` or `memory/`, and do not use a Git checkout path that your template or private file memory also writes into.
 
 | Field                             | Type   | Default | Description                                                                                                                                                             |
 | --------------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -107,7 +126,8 @@ With this configuration, each requester's private knowledge path becomes `<their
 | `private.knowledge.chunk_overlap` | int    | `0`     | Overlap characters between adjacent chunks. Must be smaller than `chunk_size`                                                                                           |
 | `private.knowledge.git`           | object | `null`  | Optional Git sync configuration for PrivateAgentKnowledge. Git-backed private knowledge must use a dedicated subtree outside requester-writable memory/template content |
 
-Use `private.knowledge` when the data itself should be private to that requester's private instance. Use top-level `knowledge_bases` when the same documents should stay shared across agents or users.
+Use `private.knowledge` when the data itself should be private to that requester's private instance.
+Use top-level `knowledge_bases` when the same documents should stay shared across agents or users.
 
 ### Multiple Knowledge Bases
 
@@ -152,7 +172,10 @@ When an agent has multiple knowledge bases, results are interleaved fairly so no
 
 ## Git-Backed Knowledge Bases
 
-Knowledge bases can sync from a Git repository. MindRoom starts a background refresh for configured shared Git knowledge bases when runtime support starts. After that, it schedules another background refresh every `poll_interval_seconds`. Reads keep using the last published index while a refresh is running.
+Knowledge bases can sync from a Git repository.
+MindRoom starts a background refresh for configured shared Git knowledge bases when runtime support starts.
+After that, it schedules another background refresh every `poll_interval_seconds`.
+Reads keep using the last published index while a refresh is running.
 
 ```
 knowledge_bases:
@@ -185,7 +208,8 @@ knowledge_bases:
 | `include_patterns`      | list   | `[]`       | Root-anchored glob patterns to include                                                                         |
 | `exclude_patterns`      | list   | `[]`       | Root-anchored glob patterns to exclude                                                                         |
 
-When `lfs: true`, install `git-lfs` on the runtime host for `uv run` or `uvx` flows. Bundled container images already include it.
+When `lfs: true`, install `git-lfs` on the runtime host for `uv run` or `uvx` flows.
+Bundled container images already include it.
 
 ### Sync Behavior
 
@@ -219,7 +243,8 @@ knowledge_bases:
 - If `include_patterns` is set, a file must match at least one pattern
 - `exclude_patterns` are applied last and remove matching files
 
-Multiple knowledge bases may point at the same root when they use the same source ownership settings. This is the preferred way to expose separate views of a large repository without cloning it more than once.
+Multiple knowledge bases may point at the same root when they use the same source ownership settings.
+This is the preferred way to expose separate views of a large repository without cloning it more than once.
 
 ```
 knowledge_bases:
@@ -290,7 +315,10 @@ memory:
 
 ## Storage
 
-Knowledge data is stored under `<storage_path>/knowledge_db/<sanitized_base_id>_<hash>/`. Each successful refresh publishes a generation-specific ChromaDB collection whose name begins with `mindroom_knowledge_<sanitized_base_id>_<hash>`. The base ID is sanitized to alphanumerics, hyphens, and underscores only, and the hash is a digest of the resolved knowledge path. For PrivateAgentKnowledge, the effective private-root path is part of that hash, so each requester-local root gets an isolated index.
+Knowledge data is stored under `<storage_path>/knowledge_db/<sanitized_base_id>_<hash>/`.
+Each successful refresh publishes a generation-specific ChromaDB collection whose name begins with `mindroom_knowledge_<sanitized_base_id>_<hash>`.
+The base ID is sanitized to alphanumerics, hyphens, and underscores only, and the hash is a digest of the resolved knowledge path.
+For PrivateAgentKnowledge, the effective private-root path is part of that hash, so each requester-local root gets an isolated index.
 
 The storage path defaults to `mindroom_data/` next to your `config.yaml`, or can be set with `MINDROOM_STORAGE_PATH`.
 
@@ -312,4 +340,7 @@ See the [Dashboard API reference](https://docs.mindroom.chat/dashboard/#knowledg
 
 ## Hot Reload
 
-Knowledge base configuration supports hot reload. Changing `config.yaml` does not initialize every configured knowledge base. Agents keep using last successfully published indexes until a refresh for their resolved binding succeeds. Changed settings make existing published indexes stale or unavailable depending on query compatibility, and scheduled refresh rebuilds the affected binding in the background.
+Knowledge base configuration supports hot reload.
+Changing `config.yaml` does not initialize every configured knowledge base.
+Agents keep using last successfully published indexes until a refresh for their resolved binding succeeds.
+Changed settings make existing published indexes stale or unavailable depending on query compatibility, and scheduled refresh rebuilds the affected binding in the background.

--- a/skills/mindroom-docs/references/page__matrix-space__index.md
+++ b/skills/mindroom-docs/references/page__matrix-space__index.md
@@ -1,6 +1,7 @@
 # Matrix Space
 
-MindRoom can create and maintain a root Matrix Space that groups all managed rooms together. This makes it easy for users to discover and navigate MindRoom rooms in their Matrix client.
+MindRoom can create and maintain a root Matrix Space that groups all managed rooms together.
+This makes it easy for users to discover and navigate MindRoom rooms in their Matrix client.
 
 ## Configuration
 
@@ -17,6 +18,8 @@ matrix_space:
 
 ## Behavior
 
-When `enabled` is `true`, MindRoom creates a Space on startup and adds all managed rooms as children. Rooms created later (by agents joining new rooms or config changes) are automatically added to the Space.
+When `enabled` is `true`, MindRoom creates a Space on startup and adds all managed rooms as children.
+Rooms created later (by agents joining new rooms or config changes) are automatically added to the Space.
 
-Set `enabled: false` to disable Space creation entirely. The `name` field controls the Space's display name and can be changed at any time.
+Set `enabled: false` to disable Space creation entirely.
+The `name` field controls the Space's display name and can be changed at any time.

--- a/skills/mindroom-docs/references/page__memory__index.md
+++ b/skills/mindroom-docs/references/page__memory__index.md
@@ -6,7 +6,13 @@ MindRoom supports three memory backends:
 - `file`: markdown memory files (`MEMORY.md` plus optional dated notes)
 - `none`: disabled memory for stateless agents
 
-Set the global default backend with `memory.backend`. Override the backend per agent with `agents.<name>.memory_backend`. When an agent uses `memory_backend: file`, its file memory lives in its canonical workspace root. When an agent uses `memory_backend: none`, MindRoom skips prompt memory lookup, automatic memory persistence, and the explicit `memory` tool for that agent. Use `agents.<name>.private` when one shared agent definition should keep file memory inside a requester-local private root. `private` changes where private files live. It does not switch the memory backend by itself.
+Set the global default backend with `memory.backend`.
+Override the backend per agent with `agents.<name>.memory_backend`.
+When an agent uses `memory_backend: file`, its file memory lives in its canonical workspace root.
+When an agent uses `memory_backend: none`, MindRoom skips prompt memory lookup, automatic memory persistence, and the explicit `memory` tool for that agent.
+Use `agents.<name>.private` when one shared agent definition should keep file memory inside a requester-local private root.
+`private` changes where private files live.
+It does not switch the memory backend by itself.
 
 OpenClaw compatibility uses this same backend selection; there is no separate OpenClaw-only memory engine.
 
@@ -116,7 +122,8 @@ agents:
     memory_backend: none
 ```
 
-Disabled memory does not disable Agno Learning. Set `learning: false` separately if you also want to disable learning.
+Disabled memory does not disable Agno Learning.
+Set `learning: false` separately if you also want to disable learning.
 
 ## Backend: `file`
 
@@ -131,7 +138,9 @@ memory:
     max_entrypoint_lines: 200
 ```
 
-`memory.file.path` is an optional fallback root for file-memory paths. It does not relocate canonical agent file memory (which always lives under the agent's workspace root). It can affect team file memory when the resolution determines the configured path should be used.
+`memory.file.path` is an optional fallback root for file-memory paths.
+It does not relocate canonical agent file memory (which always lives under the agent's workspace root).
+It can affect team file memory when the resolution determines the configured path should be used.
 
 Per-agent override example:
 
@@ -146,7 +155,9 @@ agents:
     memory_backend: file
 ```
 
-For shared agents, file memory now lives directly under `agents/<name>/workspace/`. For requester-private agents, file memory lives directly under the effective private root. Use `private` when you need per-requester file-memory isolation.
+For shared agents, file memory now lives directly under `agents/<name>/workspace/`.
+For requester-private agents, file memory lives directly under the effective private root.
+Use `private` when you need per-requester file-memory isolation.
 
 Private instance example:
 
@@ -162,7 +173,14 @@ agents:
       template_dir: ./mind_template
 ```
 
-In this setup, each requester gets their own private `mind_data/` root inside a canonical private-instance state root in shared storage. When `memory_backend: file` is enabled, that private root becomes the agent's effective file-memory root. If `./mind_template/` contains `MEMORY.md` and `memory/`, those files are copied into each private root on first use and then remain editable per requester. Later runs backfill newly added scaffold files without overwriting requester edits. MindRoom does not invent `MEMORY.md` or `memory/` for private agents. Put those files in your template directory if you want them scaffolded into each private root. If `memory_backend` is not `file`, `private` still creates private files and directories, but it does not make file memory active. Use `private` for requester-isolated workspaces.
+In this setup, each requester gets their own private `mind_data/` root inside a canonical private-instance state root in shared storage.
+When `memory_backend: file` is enabled, that private root becomes the agent's effective file-memory root.
+If `./mind_template/` contains `MEMORY.md` and `memory/`, those files are copied into each private root on first use and then remain editable per requester.
+Later runs backfill newly added scaffold files without overwriting requester edits.
+MindRoom does not invent `MEMORY.md` or `memory/` for private agents.
+Put those files in your template directory if you want them scaffolded into each private root.
+If `memory_backend` is not `file`, `private` still creates private files and directories, but it does not make file memory active.
+Use `private` for requester-isolated workspaces.
 
 ### File layout
 
@@ -225,7 +243,8 @@ The Dashboard **Memory** page supports:
 - batch sizing
 - extractor settings (`no_reply_token`, message/char/time limits, `include_memory_context` dedupe bounds)
 
-Save from the Memory page to persist changes to `config.yaml`. Use the Dashboard **Agents** page to set an agent-specific **Memory Backend** override.
+Save from the Memory page to persist changes to `config.yaml`.
+Use the Dashboard **Agents** page to set an agent-specific **Memory Backend** override.
 
 ## Optional Memory Tool
 
@@ -241,7 +260,8 @@ This exposes `add_memory`, `search_memories`, `list_memories`, `get_memory`, `up
 
 ## Agno Learning
 
-MindRoom integrates Agno's built-in Learning system, which lets agents learn and adapt from conversations. Learning is separate from the memory backends above — it uses Agno's own SQLite-backed storage in each agent's state root (`learning/`).
+MindRoom integrates Agno's built-in Learning system, which lets agents learn and adapt from conversations.
+Learning is separate from the memory backends above — it uses Agno's own SQLite-backed storage in each agent's state root (`learning/`).
 
 ### Configuration
 
@@ -266,4 +286,6 @@ agents:
 | `learning`      | bool   | `true`   | Enable Agno Learning for the agent                                                               |
 | `learning_mode` | string | `always` | `always`: automatic extraction after every turn. `agentic`: agent decides via tool when to learn |
 
-Agents inherit `learning` and `learning_mode` from `defaults` unless explicitly overridden. Disabled agents do not create or update learning state. Learning data persists in `agents/<name>/learning/<agent>.db` within the agent's state root.
+Agents inherit `learning` and `learning_mode` from `defaults` unless explicitly overridden.
+Disabled agents do not create or update learning state.
+Learning data persists in `agents/<name>/learning/<agent>.db` within the agent's state root.

--- a/skills/mindroom-docs/references/page__openai-api__index.md
+++ b/skills/mindroom-docs/references/page__openai-api__index.md
@@ -95,7 +95,9 @@ endpoints:
         X-LibreChat-Conversation-Id: "{{LIBRECHAT_BODY_CONVERSATIONID}}"
 ```
 
-`X-Session-Id` is recommended when you want deterministic MindRoom session continuity. This is especially important for tools that keep long-lived sessions inside the MindRoom runtime. `X-LibreChat-Conversation-Id` alone is still enough to keep continuity if you already use it.
+`X-Session-Id` is recommended when you want deterministic MindRoom session continuity.
+This is especially important for tools that keep long-lived sessions inside the MindRoom runtime.
+`X-LibreChat-Conversation-Id` alone is still enough to keep continuity if you already use it.
 
 ### Open WebUI
 
@@ -112,11 +114,14 @@ Point the base URL at `http://localhost:8765/v1` and set the API key. MindRoom i
 
 ### Model selection
 
-Each agent in `config.yaml` appears as a selectable model. The model ID is the agent's internal name (e.g., `code`, `research`), and the display name comes from `display_name`. Only shared agents that are either unscoped or explicitly configured with `worker_scope=shared` appear in `/v1/models`. Agents that use `agents.<name>.private` are not listed there, because `private.per` creates requester-private instances and therefore an isolating execution scope.
+Each agent in `config.yaml` appears as a selectable model. The model ID is the agent's internal name (e.g., `code`, `research`), and the display name comes from `display_name`.
+Only shared agents that are either unscoped or explicitly configured with `worker_scope=shared` appear in `/v1/models`.
+Agents that use `agents.<name>.private` are not listed there, because `private.per` creates requester-private instances and therefore an isolating execution scope.
 
 ### Auto-routing
 
-Select the `auto` model to let MindRoom's router pick the best agent for each message, the same routing logic used in Matrix rooms. Once routing resolves a specific agent, session continuity and streamed identity bind to that resolved agent name, not the literal `auto` label.
+Select the `auto` model to let MindRoom's router pick the best agent for each message, the same routing logic used in Matrix rooms.
+Once routing resolves a specific agent, session continuity and streamed identity bind to that resolved agent name, not the literal `auto` label.
 
 ### Teams
 
@@ -126,11 +131,14 @@ Teams are exposed as `team/<team_name>` models. Selecting `team/super_team` runs
 
 `stream: true` returns Server-Sent Events in the standard OpenAI format: role chunk, content chunks, finish chunk, `[DONE]`.
 
-Tool calls appear inline as text in the stream (not as native OpenAI `tool_calls` deltas). MindRoom currently emits tool events in stream chunks as inline `<tool id="N" state="start|done">...</tool>` content.
+Tool calls appear inline as text in the stream (not as native OpenAI `tool_calls` deltas).
+MindRoom currently emits tool events in stream chunks as inline `<tool id="N" state="start|done">...</tool>` content.
 
 ### Multimodal messages
 
-When a message's `content` is an array of content parts (the OpenAI multimodal format), MindRoom extracts only the `text` parts and concatenates them as the prompt. Non-text parts such as `image_url` are silently ignored by the current implementation. Agents still process the text normally with all their configured tools and instructions.
+When a message's `content` is an array of content parts (the OpenAI multimodal format), MindRoom extracts only the `text` parts and concatenates them as the prompt.
+Non-text parts such as `image_url` are silently ignored by the current implementation.
+Agents still process the text normally with all their configured tools and instructions.
 
 ### Session continuity
 
@@ -140,13 +148,16 @@ Session IDs are derived from request headers:
 1. `X-LibreChat-Conversation-Id` header (automatic with LibreChat)
 1. Random UUID fallback
 
-Agent memory and conversation history persist across requests with the same session ID. For persistent MindRoom tool sessions (for example a long-running coding session), prefer `X-Session-Id`.
+Agent memory and conversation history persist across requests with the same session ID.
+For persistent MindRoom tool sessions (for example a long-running coding session), prefer `X-Session-Id`.
 
-Session IDs are namespaced internally with a hash of the API key to prevent cross-key session collision. Two different API keys using the same `X-Session-Id` value will not share a session.
+Session IDs are namespaced internally with a hash of the API key to prevent cross-key session collision.
+Two different API keys using the same `X-Session-Id` value will not share a session.
 
 ### Claude Agent tool sessions
 
-If an agent enables the `claude_agent` tool, the same `X-Session-Id` keeps the Claude session alive across turns. This lets a user continue one long coding flow instead of starting a fresh Claude process on every request. See the `claude_agent` section in [Agent Orchestration](https://docs.mindroom.chat/tools/agent-orchestration/index.md) for configuration details.
+If an agent enables the `claude_agent` tool, the same `X-Session-Id` keeps the Claude session alive across turns.
+This lets a user continue one long coding flow instead of starting a fresh Claude process on every request. See the `claude_agent` section in [Agent Orchestration](https://docs.mindroom.chat/tools/agent-orchestration/index.md) for configuration details.
 
 Parallel Claude sub-sessions are supported by using different `session_label` values in tool calls:
 
@@ -155,7 +166,9 @@ Parallel Claude sub-sessions are supported by using different `session_label` va
 
 ### Knowledge bases
 
-Agents with configured `knowledge_bases` in `config.yaml` get RAG support automatically. No additional API configuration needed. For Git-backed knowledge bases, missing or stale published indexes schedule the same per-binding refresh flow used by the Matrix runtime. Explicit dashboard/API reindex runs Git sync first and then rebuilds a candidate index.
+Agents with configured `knowledge_bases` in `config.yaml` get RAG support automatically. No additional API configuration needed.
+For Git-backed knowledge bases, missing or stale published indexes schedule the same per-binding refresh flow used by the Matrix runtime.
+Explicit dashboard/API reindex runs Git sync first and then rebuilds a candidate index.
 
 ## What's ignored
 

--- a/skills/mindroom-docs/references/page__openclaw__index.md
+++ b/skills/mindroom-docs/references/page__openclaw__index.md
@@ -29,7 +29,8 @@ Not included:
 
 ## The `openclaw_compat` preset
 
-`openclaw_compat` is a config macro, not a runtime toolkit. `Config.get_agent_tools` expands it into native MindRoom tools and dedupes while preserving order.
+`openclaw_compat` is a config macro, not a runtime toolkit.
+`Config.get_agent_tools` expands it into native MindRoom tools and dedupes while preserving order.
 
 Preset expansion:
 
@@ -43,7 +44,8 @@ Preset expansion:
 - `matrix_message`
 - `attachments` (auto-implied by `matrix_message` via `IMPLIED_TOOLS`, not listed in the preset directly)
 
-Memory is not a separate OpenClaw subsystem in MindRoom. It uses the normal MindRoom memory backend.
+Memory is not a separate OpenClaw subsystem in MindRoom.
+It uses the normal MindRoom memory backend.
 
 ## Drop-in config
 
@@ -96,7 +98,13 @@ memory:
     enabled: true
 ```
 
-When using `memory_backend: file`, the file backend automatically loads `MEMORY.md` from the canonical workspace root, so there is no need to add it to `context_files`. If you switch to `mem0`, add `MEMORY.md` back to `context_files` if you still want it preloaded. The `openclaw_compat` preset already expands to native shell, coding, duckduckgo, website, browser, scheduler, sub-agent orchestration, and `matrix_message` tools (`attachments` is auto-implied by `matrix_message`), so listing those tools individually is not necessary. Copy or sync your OpenClaw files into `agents/openclaw/workspace/` before using this config so `context_files`, file memory, and `openclaw_memory` read the same canonical workspace. This example sets `watch: false`, so direct external file edits require explicit reindex, while dashboard/API mutations still schedule refresh after a successful mutation. For shared local non-Git knowledge bases, `watch: true` still starts a live filesystem watcher. If `openclaw_memory` is Git-backed, update the repository and reindex instead of using dashboard upload or delete actions.
+When using `memory_backend: file`, the file backend automatically loads `MEMORY.md` from the canonical workspace root, so there is no need to add it to `context_files`.
+If you switch to `mem0`, add `MEMORY.md` back to `context_files` if you still want it preloaded.
+The `openclaw_compat` preset already expands to native shell, coding, duckduckgo, website, browser, scheduler, sub-agent orchestration, and `matrix_message` tools (`attachments` is auto-implied by `matrix_message`), so listing those tools individually is not necessary.
+Copy or sync your OpenClaw files into `agents/openclaw/workspace/` before using this config so `context_files`, file memory, and `openclaw_memory` read the same canonical workspace.
+This example sets `watch: false`, so direct external file edits require explicit reindex, while dashboard/API mutations still schedule refresh after a successful mutation.
+For shared local non-Git knowledge bases, `watch: true` still starts a live filesystem watcher.
+If `openclaw_memory` is Git-backed, update the repository and reindex instead of using dashboard upload or delete actions.
 
 ## Recommended workspace layout
 

--- a/skills/mindroom-docs/references/page__plugins__index.md
+++ b/skills/mindroom-docs/references/page__plugins__index.md
@@ -2,7 +2,8 @@
 
 > [!WARNING] **Plugins execute arbitrary Python code in the same process as MindRoom.** A malicious plugin has full access to your credentials, Matrix sessions, file system, and network. Only install plugins you trust and have reviewed.
 
-MindRoom plugins extend agents with custom tools, [hooks](https://docs.mindroom.chat/hooks/index.md), and skills. A plugin is a directory with a `mindroom.plugin.json` manifest, one or more Python modules, and optionally skill directories. Plugins are loaded from paths listed under `plugins:` in `config.yaml`.
+MindRoom plugins extend agents with custom tools, [hooks](https://docs.mindroom.chat/hooks/index.md), and skills. A plugin is a directory with a `mindroom.plugin.json` manifest, one or more Python modules, and optionally skill directories.
+Plugins are loaded from paths listed under `plugins:` in `config.yaml`.
 
 ## Plugin structure
 
@@ -18,7 +19,10 @@ my-plugin/
         └── SKILL.md
 ```
 
-A plugin must have at least one of `tools_module`, `hooks_module`, or `skills`. A tools-only plugin exposes callable functions to agents. A hooks-only plugin observes or transforms events without adding agent-facing tools. Many plugins combine both.
+A plugin must have at least one of `tools_module`, `hooks_module`, or `skills`.
+A tools-only plugin exposes callable functions to agents.
+A hooks-only plugin observes or transforms events without adding agent-facing tools.
+Many plugins combine both.
 
 ## Manifest format
 
@@ -40,9 +44,12 @@ The manifest is a JSON file named `mindroom.plugin.json` at the plugin root:
 | `hooks_module` | string          | no       | Relative path to the Python module containing `@hook`-decorated functions. Must exist on disk if declared.                                                                                                        |
 | `skills`       | list of strings | no       | Relative directories containing skill subdirectories (each with a `SKILL.md`). Each directory must exist on disk.                                                                                                 |
 
-Unknown fields are silently ignored. Invalid, duplicate, or malformed manifests are configuration errors and stop all plugin loading. All declared module files and skill directories must exist on disk.
+Unknown fields are silently ignored.
+Invalid, duplicate, or malformed manifests are configuration errors and stop all plugin loading.
+All declared module files and skill directories must exist on disk.
 
-If `hooks_module` is omitted, MindRoom auto-scans `tools_module` for `@hook`-decorated functions. If both fields point at the same file, MindRoom imports it once and reuses it for both tool registration and hook discovery.
+If `hooks_module` is omitted, MindRoom auto-scans `tools_module` for `@hook`-decorated functions.
+If both fields point at the same file, MindRoom imports it once and reuses it for both tool registration and hook discovery.
 
 ## Configure plugins
 
@@ -66,7 +73,8 @@ plugins:
 
 ### Entry formats
 
-Plugin entries can be **strings** (path only) or **objects** (with options). Both forms can be mixed in the same list.
+Plugin entries can be **strings** (path only) or **objects** (with options).
+Both forms can be mixed in the same list.
 
 **String entry** — just the path:
 
@@ -133,7 +141,9 @@ MindRoom resolves the package location via `importlib` and looks for `mindroom.p
 
 ## Tools module
 
-A tools module is a Python file that registers one or more tool factories using the `@register_tool_with_metadata` decorator. Each factory function returns a **Toolkit class** (not an instance). MindRoom instantiates the class when building agents.
+A tools module is a Python file that registers one or more tool factories using the `@register_tool_with_metadata` decorator.
+Each factory function returns a **Toolkit class** (not an instance).
+MindRoom instantiates the class when building agents.
 
 ### Minimal example
 
@@ -220,11 +230,13 @@ All `@register_tool_with_metadata` arguments are keyword-only.
 
 ### Dependencies
 
-The `dependencies` field lists Python packages that the tool requires at runtime. MindRoom checks whether each package is importable before the tool is instantiated.
+The `dependencies` field lists Python packages that the tool requires at runtime.
+MindRoom checks whether each package is importable before the tool is instantiated.
 
 **For built-in tools** (those shipped inside `src/mindroom/tools/`), missing dependencies trigger automatic installation via `uv sync` or `pip install` using the matching optional extra from MindRoom's `pyproject.toml`.
 
-**For plugin tools**, automatic installation does **not** apply — there is no matching optional extra in MindRoom's package metadata. If the listed dependencies are not already installed in the environment, MindRoom raises an `ImportError` with a message listing the missing packages. Plugin authors should document their dependencies in their README so users can install them manually:
+**For plugin tools**, automatic installation does **not** apply — there is no matching optional extra in MindRoom's package metadata. If the listed dependencies are not already installed in the environment, MindRoom raises an `ImportError` with a message listing the missing packages.
+Plugin authors should document their dependencies in their README so users can install them manually:
 
 ```
 pip install openviking-client aiohttp
@@ -289,7 +301,8 @@ def weather_tools() -> type[Toolkit]:
 
 ### Managed init args
 
-If your toolkit constructor needs MindRoom-managed runtime values, declare them with `managed_init_args`. MindRoom does **not** auto-detect constructor parameter names — undeclared managed args are not passed through.
+If your toolkit constructor needs MindRoom-managed runtime values, declare them with `managed_init_args`.
+MindRoom does **not** auto-detect constructor parameter names — undeclared managed args are not passed through.
 
 | Value                 | Constructor kwarg     | Description                                                             |
 | --------------------- | --------------------- | ----------------------------------------------------------------------- |
@@ -366,11 +379,14 @@ agents:
       - mcp_filesystem
 ```
 
-The factory function must return the toolkit class, not an instance. MCP toolkits are async; Agno's async agent runs (`arun`, `aprint_response`) handle MCP connect and disconnect automatically.
+The factory function must return the toolkit class, not an instance.
+MCP toolkits are async; Agno's async agent runs (`arun`, `aprint_response`) handle MCP connect and disconnect automatically.
 
 ## Plugin skills
 
-List skill directories in the manifest `skills` array. Each listed directory is added to MindRoom's skill search roots. Skill subdirectories must contain a `SKILL.md` file with YAML frontmatter (name, description, requirements).
+List skill directories in the manifest `skills` array.
+Each listed directory is added to MindRoom's skill search roots.
+Skill subdirectories must contain a `SKILL.md` file with YAML frontmatter (name, description, requirements).
 
 ## Hooks
 
@@ -385,7 +401,10 @@ Plugins can ship typed event hooks for message enrichment, response transformati
 
 ## Live development (hot reload)
 
-Plugins hot-reload automatically. When you edit any file inside a configured plugin directory, MindRoom notices the change on the next poll, waits out the debounce window, re-imports the plugin's modules in place, swaps the new hooks and tools into the live registry, and the next event invokes your new code. In practice the new code is usually live about 1-2 seconds after a save. No service restart and no agent session disruption.
+Plugins hot-reload automatically.
+When you edit any file inside a configured plugin directory, MindRoom notices the change on the next poll, waits out the debounce window, re-imports the plugin's modules in place, swaps the new hooks and tools into the live registry, and the next event invokes your new code.
+In practice the new code is usually live about 1-2 seconds after a save.
+No service restart and no agent session disruption.
 
 ### How it works
 
@@ -407,7 +426,11 @@ journalctl -u mindroom.service -f | grep -E 'Reloading plugins|Plugin reload com
 #    The new code path is live.
 ```
 
-You can break and fix a plugin freely. A broken save that prevents reload, such as an import error or plugin validation error, can deactivate the affected plugin set, and the next valid save reloads it successfully. A hook that only raises at runtime is different: that failure is logged for that event, and the hook is tried again on the next matching event. There is no quarantine, failure threshold, or cooldown. Each save just reloads.
+You can break and fix a plugin freely.
+A broken save that prevents reload, such as an import error or plugin validation error, can deactivate the affected plugin set, and the next valid save reloads it successfully.
+A hook that only raises at runtime is different: that failure is logged for that event, and the hook is tried again on the next matching event.
+There is no quarantine, failure threshold, or cooldown.
+Each save just reloads.
 
 ### Manual reload
 
@@ -417,7 +440,8 @@ If you need to force a reload, for example because the watcher missed something 
 !reload-plugins
 ```
 
-The bot replies with the active plugin set and the count of cancelled background tasks. Admin gating uses `authorization.global_users` from `config.yaml`.
+The bot replies with the active plugin set and the count of cancelled background tasks.
+Admin gating uses `authorization.global_users` from `config.yaml`.
 
 ### Caveats and tradeoffs
 
@@ -431,11 +455,14 @@ The hot-reload path is intentionally best-effort, not transactional.
 
 ### Production tip
 
-Hot reload is enabled by default in production. Edit any configured plugin directory directly while `mindroom.service` is running. `~/.mindroom/plugins/<name>/` is the common local layout, and active agent sessions, in-flight conversations, and streaming responses continue untouched.
+Hot reload is enabled by default in production.
+Edit any configured plugin directory directly while `mindroom.service` is running.
+`~/.mindroom/plugins/<name>/` is the common local layout, and active agent sessions, in-flight conversations, and streaming responses continue untouched.
 
 ## Community plugins
 
-The [mindroom-ai](https://github.com/mindroom-ai) organization maintains a collection of open-source plugins. Clone any of them into your plugins directory and add the path to `config.yaml`:
+The [mindroom-ai](https://github.com/mindroom-ai) organization maintains a collection of open-source plugins.
+Clone any of them into your plugins directory and add the path to `config.yaml`:
 
 ```
 git clone https://github.com/mindroom-ai/ping-hook-plugin.git ~/.mindroom/plugins/ping-hook

--- a/skills/mindroom-docs/references/page__scheduling__index.md
+++ b/skills/mindroom-docs/references/page__scheduling__index.md
@@ -27,7 +27,9 @@ Schedule agents to perform tasks at specific times or intervals using natural la
 
 **Conditional Workflows (polling-based):**
 
-Conditional or event-like requests are converted to recurring cron-based polling schedules. The AI picks an appropriate polling frequency based on urgency, and the condition is embedded in the task message so the agent checks it on each poll cycle. These are **not** real event subscriptions — they are periodic checks.
+Conditional or event-like requests are converted to recurring cron-based polling schedules.
+The AI picks an appropriate polling frequency based on urgency, and the condition is embedded in the task message so the agent checks it on each poll cycle.
+These are **not** real event subscriptions — they are periodic checks.
 
 ```
 !schedule If I get an email about "urgent", @phone_agent call me
@@ -73,4 +75,10 @@ timezone: America/Los_Angeles
 
 ## Persistence
 
-Schedules are stored in Matrix room state and persist across restarts. New schedules use the live runtime to start their in-memory runners immediately. Edits are state-only Matrix writes. Running tasks pick up edited state on their next poll instead of relying on caller-supplied cache or restart hooks. Past one-time tasks are automatically skipped during restoration. Only the router restores persisted schedules after startup — individual agents do not restore their own. On shutdown, the router cancels its in-memory scheduled tasks before exiting.
+Schedules are stored in Matrix room state and persist across restarts.
+New schedules use the live runtime to start their in-memory runners immediately.
+Edits are state-only Matrix writes.
+Running tasks pick up edited state on their next poll instead of relying on caller-supplied cache or restart hooks.
+Past one-time tasks are automatically skipped during restoration.
+Only the router restores persisted schedules after startup — individual agents do not restore their own.
+On shutdown, the router cancels its in-memory scheduled tasks before exiting.

--- a/skills/mindroom-docs/references/page__skills__index.md
+++ b/skills/mindroom-docs/references/page__skills__index.md
@@ -91,9 +91,13 @@ agents:
       - code-review
 ```
 
-The `skills:` list is an allowlist for bundled, plugin, and user skills. If `skills` is empty or unset, the agent gets no bundled, plugin, or user skills. Workspace skills under `<storage>/agents/<agent>/workspace/skills/` are still auto-loaded for that agent. This lets an agent create or receive skills in its own workspace without editing `config.yaml`.
+The `skills:` list is an allowlist for bundled, plugin, and user skills.
+If `skills` is empty or unset, the agent gets no bundled, plugin, or user skills.
+Workspace skills under `<storage>/agents/<agent>/workspace/skills/` are still auto-loaded for that agent.
+This lets an agent create or receive skills in its own workspace without editing `config.yaml`.
 
-Workspace auto-loading is a runtime capability, not a proactive behavior policy. If you want agents to create skills on their own when they notice reusable workflows, add that guidance to the agent's prompt or instructions.
+Workspace auto-loading is a runtime capability, not a proactive behavior policy.
+If you want agents to create skills on their own when they notice reusable workflows, add that guidance to the agent's prompt or instructions.
 
 ## Using skills at runtime
 
@@ -103,7 +107,9 @@ Agents see available skills in the system prompt and can load details using thes
 - `get_skill_reference(skill_name, reference_path)` - Access reference documentation
 - `get_skill_script(skill_name, script_path, execute=False, args=None, timeout=30)` - Read or execute scripts
 
-Workspace skill scripts can be read with `get_skill_script(..., execute=False)`. Workspace skill scripts cannot be executed through `get_skill_script(..., execute=True)`. Agents that have shell or file execution permissions can still read and execute workspace files through their normal authorized tools.
+Workspace skill scripts can be read with `get_skill_script(..., execute=False)`.
+Workspace skill scripts cannot be executed through `get_skill_script(..., execute=True)`.
+Agents that have shell or file execution permissions can still read and execute workspace files through their normal authorized tools.
 
 ## Skill vs tool
 
@@ -117,7 +123,8 @@ Workspace skill scripts can be read with `get_skill_script(..., execute=False)`.
 
 ## Hot reloading
 
-MindRoom polls skill directories every second. When a `SKILL.md` file is added, removed, or modified, the skill cache is automatically cleared so agents pick up the new instructions on their next request. For workspace skills created during an agent turn, assume they become available on the next agent run rather than in the same response.
+MindRoom polls skill directories every second. When a `SKILL.md` file is added, removed, or modified, the skill cache is automatically cleared so agents pick up the new instructions on their next request.
+For workspace skills created during an agent turn, assume they become available on the next agent run rather than in the same response.
 
 ## Best practices
 

--- a/skills/mindroom-docs/references/page__streaming__index.md
+++ b/skills/mindroom-docs/references/page__streaming__index.md
@@ -1,6 +1,7 @@
 # Streaming Responses
 
-MindRoom streams agent responses to Matrix by progressively editing a single message. Instead of waiting for the full response, users see text appear in real time as the model generates it.
+MindRoom streams agent responses to Matrix by progressively editing a single message.
+Instead of waiting for the full response, users see text appear in real time as the model generates it.
 
 ## How It Works
 
@@ -30,7 +31,8 @@ User sends message
 
 ## Configuration
 
-Streaming is enabled by default. Disable it globally in `config.yaml`:
+Streaming is enabled by default.
+Disable it globally in `config.yaml`:
 
 ```
 defaults:
@@ -55,7 +57,8 @@ These timing settings are global-only. Agents inherit them from `defaults` and c
 
 ## Presence-Based Streaming
 
-Even when streaming is enabled, MindRoom only streams to users who are currently online. This is checked via `should_use_streaming()` which queries the Matrix presence API.
+Even when streaming is enabled, MindRoom only streams to users who are currently online.
+This is checked via `should_use_streaming()` which queries the Matrix presence API.
 
 | Presence State | Streaming Used?                        |
 | -------------- | -------------------------------------- |
@@ -63,7 +66,8 @@ Even when streaming is enabled, MindRoom only streams to users who are currently
 | `unavailable`  | Yes                                    |
 | `offline`      | No (single message sent when complete) |
 
-If the presence check fails, MindRoom defaults to non-streaming (safer, fewer API calls). When no requester user ID is available, MindRoom defaults to streaming.
+If the presence check fails, MindRoom defaults to non-streaming (safer, fewer API calls).
+When no requester user ID is available, MindRoom defaults to streaming.
 
 ## In-Progress Marker
 
@@ -76,7 +80,8 @@ Hello! I can help you with that ⋯..
 Hello! I can help you with that ⋯
 ```
 
-If no text has arrived yet, a `Thinking...` placeholder is shown with the marker. The marker is removed on the final edit.
+If no text has arrived yet, a `Thinking...` placeholder is shown with the marker.
+The marker is removed on the final edit.
 
 ## Throttling
 
@@ -99,9 +104,12 @@ When an agent calls tools during a streamed response, MindRoom shows inline mark
 🔧 `web_search` [1]          ← tool call completed
 ```
 
-The number in brackets (`[N]`) is a 1-indexed counter per message. Each marker maps to `io.mindroom.tool_trace.events[N-1]` in the message metadata.
+The number in brackets (`[N]`) is a 1-indexed counter per message.
+Each marker maps to `io.mindroom.tool_trace.events[N-1]` in the message metadata.
 
-When `show_tool_calls` is disabled for an entity, tool markers are omitted from the message text and tool-trace metadata is not attached. If a routed tool needs an isolated worker, streaming may still show a generic worker warmup line such as `Preparing isolated worker...`. That hidden-tool warmup copy never includes tool names or tool-trace metadata.
+When `show_tool_calls` is disabled for an entity, tool markers are omitted from the message text and tool-trace metadata is not attached.
+If a routed tool needs an isolated worker, streaming may still show a generic worker warmup line such as `Preparing isolated worker...`.
+That hidden-tool warmup copy never includes tool names or tool-trace metadata.
 
 ## Cancellation and Errors
 
@@ -149,9 +157,15 @@ defaults:
   show_stop_button: true    # Default: true — add 🛑 reaction for cancellation
 ```
 
-When `show_tool_calls` is `false`, inline tool markers (`🔧 tool_name [N]`) are omitted from the message text and `io.mindroom.tool_trace` metadata is not attached. The agent still shows typing activity during hidden tool calls. If a routed tool needs an isolated worker, users may still see generic worker progress copy such as `Preparing isolated worker...` or `Preparing isolated worker... 17s elapsed.`. Hidden-tool mode never includes tool identifiers or tool-trace metadata in that worker progress text. `show_tool_calls` can also be overridden per agent in the agent config.
+When `show_tool_calls` is `false`, inline tool markers (`🔧 tool_name [N]`) are omitted from the message text and `io.mindroom.tool_trace` metadata is not attached.
+The agent still shows typing activity during hidden tool calls.
+If a routed tool needs an isolated worker, users may still see generic worker progress copy such as `Preparing isolated worker...` or `Preparing isolated worker... 17s elapsed.`.
+Hidden-tool mode never includes tool identifiers or tool-trace metadata in that worker progress text.
+`show_tool_calls` can also be overridden per agent in the agent config.
 
-When `show_stop_button` is `false`, the 🛑 reaction is not added to in-progress messages. Streaming itself still works — only the cancellation affordance is removed. `show_stop_button` is a global-only setting under `defaults`.
+When `show_stop_button` is `false`, the 🛑 reaction is not added to in-progress messages.
+Streaming itself still works — only the cancellation affordance is removed.
+`show_stop_button` is a global-only setting under `defaults`.
 
 `enable_streaming` is also global-only and cannot be overridden per agent.
 
@@ -161,4 +175,5 @@ When an agent operates in `thread_mode: room` (see [Thread Mode Resolution](http
 
 ## Replacement Streaming
 
-MindRoom also supports a `ReplacementStreamingResponse` variant where each chunk replaces the entire message content instead of appending to it. This is used for structured live rendering where the full document is rebuilt on each tick.
+MindRoom also supports a `ReplacementStreamingResponse` variant where each chunk replaces the entire message content instead of appending to it.
+This is used for structured live rendering where the full document is rebuilt on each tick.

--- a/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
+++ b/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
@@ -4,7 +4,8 @@ Use these tools and presets to coordinate other agents, change runtime configura
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `agent-orchestration` group. Use these tools when you need multi-agent coordination, runtime config changes, config-only presets, or persistent Claude Agent SDK sessions.
+This page documents the built-in tools in the `agent-orchestration` group.
+Use these tools when you need multi-agent coordination, runtime config changes, config-only presets, or persistent Claude Agent SDK sessions.
 
 ## Tools On This Page
 
@@ -25,7 +26,22 @@ All six entries on this page are MindRoom-native orchestration features rather t
 
 ### What It Does
 
-`subagents` exposes `agents_list()`, `sessions_spawn()`, `sessions_send()`, and `list_sessions()`. All four calls return JSON strings with a `status` field, a `tool` field, and operation-specific payload data. `agents_list()` returns the configured agent IDs and the current agent name. `sessions_spawn(task, summary, tag, label=None, agent_id=None)` requires a non-empty task plus a normalized summary and tag. `sessions_spawn()` posts a fresh room-level Matrix message that mentions the target agent, then treats the resulting event ID as the root of a new isolated session thread. After the spawn succeeds, it writes the requested thread summary and tag through the lower-level thread summary and thread tag APIs. If you pass a `label` and the current `(agent_name, room_id, requester_id)` scope already has a matching tracked session, `sessions_spawn()` reuses that session instead of creating a new one and still applies the requested summary and tag to the existing thread. If the post-spawn summary or tag write fails, the spawn still succeeds and the response includes a `warnings` list describing the follow-up failure. `sessions_send()` sends a follow-up message into an existing tracked session. If you omit `session_key`, `sessions_send()` defaults to the current room or thread session key from `create_session_id(room_id, thread_id)`. If you pass `label` without `session_key`, `sessions_send()` resolves the most recent in-scope session with that label. If you pass `agent_id`, `sessions_send()` prefixes the outgoing message with `@mindroom_<agent_id>` before sending it. Tracked sessions are persisted in `subagents/session_registry.json` under the current runtime storage root. `list_sessions()` paginates those tracked sessions with a default `limit` of 50 and a maximum of 200. Isolated spawned sessions require thread-capable agents. If the target agent uses `thread_mode=room`, `sessions_spawn()` fails and threaded `sessions_send()` calls to that session also fail.
+`subagents` exposes `agents_list()`, `sessions_spawn()`, `sessions_send()`, and `list_sessions()`.
+All four calls return JSON strings with a `status` field, a `tool` field, and operation-specific payload data.
+`agents_list()` returns the configured agent IDs and the current agent name.
+`sessions_spawn(task, summary, tag, label=None, agent_id=None)` requires a non-empty task plus a normalized summary and tag.
+`sessions_spawn()` posts a fresh room-level Matrix message that mentions the target agent, then treats the resulting event ID as the root of a new isolated session thread.
+After the spawn succeeds, it writes the requested thread summary and tag through the lower-level thread summary and thread tag APIs.
+If you pass a `label` and the current `(agent_name, room_id, requester_id)` scope already has a matching tracked session, `sessions_spawn()` reuses that session instead of creating a new one and still applies the requested summary and tag to the existing thread.
+If the post-spawn summary or tag write fails, the spawn still succeeds and the response includes a `warnings` list describing the follow-up failure.
+`sessions_send()` sends a follow-up message into an existing tracked session.
+If you omit `session_key`, `sessions_send()` defaults to the current room or thread session key from `create_session_id(room_id, thread_id)`.
+If you pass `label` without `session_key`, `sessions_send()` resolves the most recent in-scope session with that label.
+If you pass `agent_id`, `sessions_send()` prefixes the outgoing message with `@mindroom_<agent_id>` before sending it.
+Tracked sessions are persisted in `subagents/session_registry.json` under the current runtime storage root.
+`list_sessions()` paginates those tracked sessions with a default `limit` of 50 and a maximum of 200.
+Isolated spawned sessions require thread-capable agents.
+If the target agent uses `thread_mode=room`, `sessions_spawn()` fails and threaded `sessions_send()` calls to that session also fail.
 
 ### Configuration
 
@@ -72,11 +88,18 @@ list_sessions(limit=20)
 
 ### What It Does
 
-`delegate` exposes one tool call, `delegate_task(agent_name, task)`. The delegated agent is created with `create_agent()` and runs independently with no shared session or chat history from the caller. The caller waits for the delegated agent to finish, and the delegated agent's `response.content` becomes the tool result. MindRoom gives the delegated agent any already-published last-good knowledge indexes and schedules missing or stale refresh work in the background. Interactive questions are disabled for delegated runs. Unlike \[`subagents`\], \[`delegate`\] does not create a Matrix thread, does not write to the room timeline, and does not keep a reusable session handle. If `agent_name` is not in the caller's allowed `delegate_to` list, the tool returns an error string. Empty tasks are rejected.
+`delegate` exposes one tool call, `delegate_task(agent_name, task)`.
+The delegated agent is created with `create_agent()` and runs independently with no shared session or chat history from the caller.
+The caller waits for the delegated agent to finish, and the delegated agent's `response.content` becomes the tool result.
+MindRoom gives the delegated agent any already-published last-good knowledge indexes and schedules missing or stale refresh work in the background.
+Interactive questions are disabled for delegated runs. Unlike \[`subagents`\], \[`delegate`\] does not create a Matrix thread, does not write to the room timeline, and does not keep a reusable session handle. If `agent_name` is not in the caller's allowed `delegate_to` list, the tool returns an error string.
+Empty tasks are rejected.
 
 ### Configuration
 
-This tool has no tool-specific inline configuration fields. Enable it by setting `delegate_to` on the agent config. MindRoom adds the tool automatically when `delegate_to` is non-empty, so listing `delegate` in `tools:` is usually unnecessary.
+This tool has no tool-specific inline configuration fields.
+Enable it by setting `delegate_to` on the agent config.
+MindRoom adds the tool automatically when `delegate_to` is non-empty, so listing `delegate` in `tools:` is usually unnecessary.
 
 ### Example
 
@@ -126,7 +149,17 @@ delegate_task(
 
 ### What It Does
 
-`config_manager` exposes `get_info()`, `manage_agent()`, and `manage_team()`. `get_info(info_type, name=None)` supports `mindroom_docs`, `config_schema`, `available_models`, `agents`, `teams`, `available_tools`, `tool_details`, `agent_config`, and `agent_template`. `tool_details` requires `name` and reads from live `TOOL_METADATA`, so it includes real config fields and statuses from the current worktree. `agent_config` returns the authored YAML for a specific agent. `agent_template` generates starter YAML for one of the built-in template types: `researcher`, `developer`, `social`, `communicator`, `analyst`, or `productivity`. `manage_agent()` supports `create`, `update`, and `validate`. Agent creates and updates validate tool names against the live registry and validate knowledge base IDs against the current config. When a plain string tool list replaces an existing tool list, `config_manager` preserves inline overrides for retained tools instead of flattening them away. On create, `include_default_tools` falls back to `true` when you omit it. `manage_team()` creates a new team with `coordinate` or `collaborate` mode and rejects unknown member agents or duplicate team names. All writes go through full runtime config validation before `config.yaml` is saved.
+`config_manager` exposes `get_info()`, `manage_agent()`, and `manage_team()`.
+`get_info(info_type, name=None)` supports `mindroom_docs`, `config_schema`, `available_models`, `agents`, `teams`, `available_tools`, `tool_details`, `agent_config`, and `agent_template`.
+`tool_details` requires `name` and reads from live `TOOL_METADATA`, so it includes real config fields and statuses from the current worktree.
+`agent_config` returns the authored YAML for a specific agent.
+`agent_template` generates starter YAML for one of the built-in template types: `researcher`, `developer`, `social`, `communicator`, `analyst`, or `productivity`.
+`manage_agent()` supports `create`, `update`, and `validate`.
+Agent creates and updates validate tool names against the live registry and validate knowledge base IDs against the current config.
+When a plain string tool list replaces an existing tool list, `config_manager` preserves inline overrides for retained tools instead of flattening them away.
+On create, `include_default_tools` falls back to `true` when you omit it.
+`manage_team()` creates a new team with `coordinate` or `collaborate` mode and rejects unknown member agents or duplicate team names.
+All writes go through full runtime config validation before `config.yaml` is saved.
 
 ### Configuration
 
@@ -177,11 +210,20 @@ manage_team(
 
 ### What It Does
 
-`self_config` exposes `get_own_config()` and `update_own_config()`. `get_own_config()` returns the current agent's authored YAML block. `update_own_config()` only changes fields that you pass explicitly. On this branch, `update_own_config()` can modify `display_name`, `role`, `instructions`, `tools`, `model`, `rooms`, `markdown`, `learning`, `learning_mode`, `knowledge_bases`, `skills`, `include_default_tools`, `show_tool_calls`, `thread_mode`, `num_history_runs`, `num_history_messages`, `compress_tool_results`, `max_tool_calls_from_history`, and `context_files`. The update path validates tool names against the live registry and validates knowledge base IDs against the current config. It also preserves inline tool overrides for retained tools when a string-only tool list is provided. Updates are validated through `AgentConfig.model_validate()` before the file is saved. Only the current agent can be changed. There is no path to modify other agents or teams through this tool.
+`self_config` exposes `get_own_config()` and `update_own_config()`.
+`get_own_config()` returns the current agent's authored YAML block.
+`update_own_config()` only changes fields that you pass explicitly.
+On this branch, `update_own_config()` can modify `display_name`, `role`, `instructions`, `tools`, `model`, `rooms`, `markdown`, `learning`, `learning_mode`, `knowledge_bases`, `skills`, `include_default_tools`, `show_tool_calls`, `thread_mode`, `num_history_runs`, `num_history_messages`, `compress_tool_results`, `max_tool_calls_from_history`, and `context_files`.
+The update path validates tool names against the live registry and validates knowledge base IDs against the current config.
+It also preserves inline tool overrides for retained tools when a string-only tool list is provided.
+Updates are validated through `AgentConfig.model_validate()` before the file is saved.
+Only the current agent can be changed.
+There is no path to modify other agents or teams through this tool.
 
 ### Configuration
 
-This tool has no tool-specific inline configuration fields. The normal way to enable it is `agents.<name>.allow_self_config: true` or `defaults.allow_self_config: true`.
+This tool has no tool-specific inline configuration fields.
+The normal way to enable it is `agents.<name>.allow_self_config: true` or `defaults.allow_self_config: true`.
 
 ### Example
 
@@ -225,7 +267,12 @@ update_own_config(
 
 ### What It Does
 
-`openclaw_compat` is not a runtime toolkit. The registered factory returns an empty `Toolkit`, and the real behavior comes from `Config.TOOL_PRESETS`. `Config.expand_tool_names()` expands `openclaw_compat` into `shell`, `coding`, `duckduckgo`, `website`, `browser`, `scheduler`, `subagents`, and `matrix_message`. `matrix_message` then implies `attachments`, so the effective enabled set also includes `attachments` even though the preset does not list it directly. Preset expansion dedupes while preserving order, so adding `openclaw_compat` alongside one of its member tools does not create duplicates. This preset is meant for OpenClaw-compatible workspace behavior inside MindRoom rather than for cloning the full OpenClaw gateway control plane.
+`openclaw_compat` is not a runtime toolkit.
+The registered factory returns an empty `Toolkit`, and the real behavior comes from `Config.TOOL_PRESETS`.
+`Config.expand_tool_names()` expands `openclaw_compat` into `shell`, `coding`, `duckduckgo`, `website`, `browser`, `scheduler`, `subagents`, and `matrix_message`.
+`matrix_message` then implies `attachments`, so the effective enabled set also includes `attachments` even though the preset does not list it directly.
+Preset expansion dedupes while preserving order, so adding `openclaw_compat` alongside one of its member tools does not create duplicates.
+This preset is meant for OpenClaw-compatible workspace behavior inside MindRoom rather than for cloning the full OpenClaw gateway control plane.
 
 ### Configuration
 
@@ -266,7 +313,18 @@ agents:
 
 ### What It Does
 
-`claude_agent` exposes `claude_start_session()`, `claude_send()`, `claude_session_status()`, `claude_interrupt()`, and `claude_end_session()`. `claude_send()` automatically creates the session if it does not already exist, so `claude_start_session()` is optional. Session keys are namespaced by agent identity and Agno run session ID, with optional `session_label` suffixes for parallel sub-sessions. The same session key is serialized by an `asyncio.Lock`, so concurrent calls to one label run one after the other. Different `session_label` values create distinct Claude sessions that can proceed independently. Idle sessions expire after `session_ttl_minutes`, which defaults to 60 minutes. The process-wide session manager keeps at most `max_sessions` active sessions per agent namespace, defaulting to 200. `resume` and `fork_session` only apply when creating a new session. `fork_session=True` requires a non-empty `resume` session ID. If a session already exists for the computed key, passing `resume` or `fork_session` returns an error instead of silently changing the live session. `claude_session_status()` reports age, idle time, and the underlying Claude session ID once Claude has returned a result. On SDK failures, the tool includes recent Claude CLI stderr lines in its error output to help debug gateway or CLI issues.
+`claude_agent` exposes `claude_start_session()`, `claude_send()`, `claude_session_status()`, `claude_interrupt()`, and `claude_end_session()`.
+`claude_send()` automatically creates the session if it does not already exist, so `claude_start_session()` is optional.
+Session keys are namespaced by agent identity and Agno run session ID, with optional `session_label` suffixes for parallel sub-sessions.
+The same session key is serialized by an `asyncio.Lock`, so concurrent calls to one label run one after the other.
+Different `session_label` values create distinct Claude sessions that can proceed independently.
+Idle sessions expire after `session_ttl_minutes`, which defaults to 60 minutes.
+The process-wide session manager keeps at most `max_sessions` active sessions per agent namespace, defaulting to 200.
+`resume` and `fork_session` only apply when creating a new session.
+`fork_session=True` requires a non-empty `resume` session ID.
+If a session already exists for the computed key, passing `resume` or `fork_session` returns an error instead of silently changing the live session.
+`claude_session_status()` reports age, idle time, and the underlying Claude session ID once Claude has returned a result.
+On SDK failures, the tool includes recent Claude CLI stderr lines in its error output to help debug gateway or CLI issues.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__ai-and-generation__index.md
+++ b/skills/mindroom-docs/references/page__tools__ai-and-generation__index.md
@@ -4,7 +4,8 @@ Use these tools to transcribe audio, generate images and videos, synthesize spee
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `ai-and-generation` group. Use these tools when you need OpenAI- or Google-style multimodal generation, provider-specific media APIs, or text-to-speech and audio workflows.
+This page documents the built-in tools in the `ai-and-generation` group.
+Use these tools when you need OpenAI- or Google-style multimodal generation, provider-specific media APIs, or text-to-speech and audio workflows.
 
 ## Tools On This Page
 
@@ -22,7 +23,14 @@ This page documents the built-in tools in the `ai-and-generation` group. Use the
 
 ## Common Setup Notes
 
-Every tool on this page is `status=requires_config` in the live registry and is meant to be configured with provider credentials. These tools do not use an `auth_provider`, and `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes, so setup is done through stored tool credentials or provider SDK environment variables rather than a dedicated dashboard OAuth flow. Password fields such as `api_key` should be stored through the dashboard or credential store instead of inline YAML. Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set. Most generation calls on this page return `ToolResult` media attachments rather than only raw text, so they are best suited to agents that can pass generated images, videos, or audio back to the user. `openai` and `dalle` both use the OpenAI Python SDK and the same `OPENAI_API_KEY`, but they expose different tool surfaces. `gemini` uses `GOOGLE_API_KEY` in Gemini API mode, and MindRoom also maps provider name `gemini` to shared Google credentials in its provider credential helpers. The current upstream SDK implementations also honor provider env vars such as `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`, `REPLICATE_API_KEY`, `FAL_API_KEY`, `CARTESIA_API_KEY`, `ELEVEN_LABS_API_KEY`, `DESI_VOCAL_API_KEY`, `LUMAAI_API_KEY`, and `MODELS_LAB_API_KEY`.
+Every tool on this page is `status=requires_config` in the live registry and is meant to be configured with provider credentials.
+These tools do not use an `auth_provider`, and `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes, so setup is done through stored tool credentials or provider SDK environment variables rather than a dedicated dashboard OAuth flow.
+Password fields such as `api_key` should be stored through the dashboard or credential store instead of inline YAML.
+Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
+Most generation calls on this page return `ToolResult` media attachments rather than only raw text, so they are best suited to agents that can pass generated images, videos, or audio back to the user.
+`openai` and `dalle` both use the OpenAI Python SDK and the same `OPENAI_API_KEY`, but they expose different tool surfaces.
+`gemini` uses `GOOGLE_API_KEY` in Gemini API mode, and MindRoom also maps provider name `gemini` to shared Google credentials in its provider credential helpers.
+The current upstream SDK implementations also honor provider env vars such as `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`, `REPLICATE_API_KEY`, `FAL_API_KEY`, `CARTESIA_API_KEY`, `ELEVEN_LABS_API_KEY`, `DESI_VOCAL_API_KEY`, `LUMAAI_API_KEY`, and `MODELS_LAB_API_KEY`.
 
 ## \[`openai`\]
 
@@ -30,7 +38,11 @@ Every tool on this page is `status=requires_config` in the live registry and is 
 
 ### What It Does
 
-`openai` exposes `transcribe_audio(audio_path)`, `generate_image(prompt)`, and `generate_speech(text_input)`. `transcribe_audio()` expects a local file path and sends it to the configured transcription model, which defaults to `whisper-1`. `generate_image()` uses the configured `image_model`, defaults to `dall-e-3`, and returns attached image bytes rather than only a remote URL. The current implementation handles both `gpt-image-*` style models and older DALL-E response formats internally. `generate_speech()` uses the configured OpenAI TTS model, voice, and output format and returns an attached audio artifact.
+`openai` exposes `transcribe_audio(audio_path)`, `generate_image(prompt)`, and `generate_speech(text_input)`.
+`transcribe_audio()` expects a local file path and sends it to the configured transcription model, which defaults to `whisper-1`.
+`generate_image()` uses the configured `image_model`, defaults to `dall-e-3`, and returns attached image bytes rather than only a remote URL.
+The current implementation handles both `gpt-image-*` style models and older DALL-E response formats internally.
+`generate_speech()` uses the configured OpenAI TTS model, voice, and output format and returns an attached audio artifact.
 
 ### Configuration
 
@@ -80,7 +92,11 @@ generate_speech("Status update complete.")
 
 ### What It Does
 
-`gemini` exposes `generate_image(prompt)` and `generate_video(prompt)`. `generate_image()` uses the configured `image_generation_model`, which defaults to `imagen-3.0-generate-002`, and returns attached image bytes. `generate_video()` uses the configured `video_generation_model`, which defaults to `veo-2.0-generate-001`, polls until the long-running operation completes, and returns attached video artifacts. The current implementation requires Vertex AI mode for video generation and returns an error if `vertexai` is not enabled. In non-Vertex mode, the tool uses the Gemini API through `GOOGLE_API_KEY`.
+`gemini` exposes `generate_image(prompt)` and `generate_video(prompt)`.
+`generate_image()` uses the configured `image_generation_model`, which defaults to `imagen-3.0-generate-002`, and returns attached image bytes.
+`generate_video()` uses the configured `video_generation_model`, which defaults to `veo-2.0-generate-001`, polls until the long-running operation completes, and returns attached video artifacts.
+The current implementation requires Vertex AI mode for video generation and returns an error if `vertexai` is not enabled.
+In non-Vertex mode, the tool uses the Gemini API through `GOOGLE_API_KEY`.
 
 ### Configuration
 
@@ -127,7 +143,11 @@ generate_video("A slow cinematic flythrough of a neon data center.")
 
 ### What It Does
 
-`groq` exposes `transcribe_audio(audio_source)`, `translate_audio(audio_source)`, and `generate_speech(text_input)`. `transcribe_audio()` and `translate_audio()` accept either a local file path or a public URL. `translate_audio()` translates the source audio to English using the configured translation model. `generate_speech()` uses the configured Groq TTS model and voice and returns an attached WAV artifact. All three functions use the Groq SDK directly and require a Groq API key.
+`groq` exposes `transcribe_audio(audio_source)`, `translate_audio(audio_source)`, and `generate_speech(text_input)`.
+`transcribe_audio()` and `translate_audio()` accept either a local file path or a public URL.
+`translate_audio()` translates the source audio to English using the configured translation model.
+`generate_speech()` uses the configured Groq TTS model and voice and returns an attached WAV artifact.
+All three functions use the Groq SDK directly and require a Groq API key.
 
 ### Configuration
 
@@ -173,7 +193,10 @@ generate_speech("Your transcript is ready.")
 
 ### What It Does
 
-`replicate` exposes one call, `generate_media(prompt)`. It runs the configured Replicate model with `input={"prompt": prompt}` and expects one `FileOutput` or an iterable of `FileOutput` objects. The current implementation infers whether each output is an image or a video from the returned file URL extension. Generated artifacts are attached by remote URL rather than downloaded into MindRoom-managed bytes.
+`replicate` exposes one call, `generate_media(prompt)`.
+It runs the configured Replicate model with `input={"prompt": prompt}` and expects one `FileOutput` or an iterable of `FileOutput` objects.
+The current implementation infers whether each output is an image or a video from the returned file URL extension.
+Generated artifacts are attached by remote URL rather than downloaded into MindRoom-managed bytes.
 
 ### Configuration
 
@@ -210,7 +233,10 @@ generate_media("A short looping animation of code flowing across a terminal.")
 
 ### What It Does
 
-`fal` exposes `generate_media(prompt)` and, when enabled, `image_to_image(prompt, image_url=None)`. `generate_media()` calls `fal_client.subscribe()` with the configured `model` and a single `prompt` argument and returns the first `image` or `video` URL from the provider result. `image_to_image()` is a separate fixed workflow that always uses `fal-ai/flux/dev/image-to-image` rather than the configured `model`. The current implementation streams queue log messages to the MindRoom process logs while the job is running.
+`fal` exposes `generate_media(prompt)` and, when enabled, `image_to_image(prompt, image_url=None)`.
+`generate_media()` calls `fal_client.subscribe()` with the configured `model` and a single `prompt` argument and returns the first `image` or `video` URL from the provider result.
+`image_to_image()` is a separate fixed workflow that always uses `fal-ai/flux/dev/image-to-image` rather than the configured `model`.
+The current implementation streams queue log messages to the MindRoom process logs while the job is running.
 
 ### Configuration
 
@@ -253,7 +279,8 @@ image_to_image(
 
 ### What It Does
 
-`dalle` exposes one call, `create_image(prompt)`. It uses the OpenAI image API directly with the configured `model`, `n`, `size`, `quality`, and `style`. Unlike \[`openai`\], this wrapper is image-only and exposes DALL-E-specific request options directly in the tool config. Generated images are returned as provider-hosted URLs with optional revised prompts when the API supplies them.
+`dalle` exposes one call, `create_image(prompt)`.
+It uses the OpenAI image API directly with the configured `model`, `n`, `size`, `quality`, and `style`. Unlike \[`openai`\], this wrapper is image-only and exposes DALL-E-specific request options directly in the tool config. Generated images are returned as provider-hosted URLs with optional revised prompts when the API supplies them.
 
 ### Configuration
 
@@ -297,7 +324,11 @@ create_image("A cover illustration for a Matrix automation handbook.")
 
 ### What It Does
 
-`cartesia` exposes `list_voices()`, `localize_voice(name, description, language, original_speaker_gender, voice_id=None)`, and `text_to_speech(transcript, voice_id=None)`. `list_voices()` returns a filtered JSON list of voice IDs, names, descriptions, and languages. `localize_voice()` creates a localized derivative of an existing voice, using `default_voice_id` unless you pass a different `voice_id`. `text_to_speech()` uses the configured `model_id` and voice ID and returns attached MP3 audio bytes. The current implementation hardcodes MP3 output at 44.1 kHz and 128 kbps.
+`cartesia` exposes `list_voices()`, `localize_voice(name, description, language, original_speaker_gender, voice_id=None)`, and `text_to_speech(transcript, voice_id=None)`.
+`list_voices()` returns a filtered JSON list of voice IDs, names, descriptions, and languages.
+`localize_voice()` creates a localized derivative of an existing voice, using `default_voice_id` unless you pass a different `voice_id`.
+`text_to_speech()` uses the configured `model_id` and voice ID and returns attached MP3 audio bytes.
+The current implementation hardcodes MP3 output at 44.1 kHz and 128 kbps.
 
 ### Configuration
 
@@ -345,7 +376,11 @@ text_to_speech("Deployment complete.")
 
 ### What It Does
 
-`eleven_labs` exposes `get_voices()`, `generate_sound_effect(prompt, duration_seconds=None)`, and `text_to_speech(prompt)`. `get_voices()` returns voice IDs, names, and descriptions from the ElevenLabs account. `generate_sound_effect()` turns a text description into an attached audio artifact. `text_to_speech()` uses the configured `voice_id`, `model_id`, and `output_format` and returns attached audio bytes. If `target_directory` is set, the current implementation also saves generated audio files to disk in that directory.
+`eleven_labs` exposes `get_voices()`, `generate_sound_effect(prompt, duration_seconds=None)`, and `text_to_speech(prompt)`.
+`get_voices()` returns voice IDs, names, and descriptions from the ElevenLabs account.
+`generate_sound_effect()` turns a text description into an attached audio artifact.
+`text_to_speech()` uses the configured `voice_id`, `model_id`, and `output_format` and returns attached audio bytes.
+If `target_directory` is set, the current implementation also saves generated audio files to disk in that directory.
 
 ### Configuration
 
@@ -391,7 +426,10 @@ text_to_speech("The build succeeded.")
 
 ### What It Does
 
-`desi_vocal` exposes `get_voices()` and `text_to_speech(prompt, voice_id=None)`. `get_voices()` returns a provider voice list with ID, name, gender, voice type, supported languages, and preview URL. `text_to_speech()` posts the prompt to DesiVocal's generation API and returns the resulting audio as a remote URL attachment. The default `voice_id` can be overridden per call.
+`desi_vocal` exposes `get_voices()` and `text_to_speech(prompt, voice_id=None)`.
+`get_voices()` returns a provider voice list with ID, name, gender, voice type, supported languages, and preview URL.
+`text_to_speech()` posts the prompt to DesiVocal's generation API and returns the resulting audio as a remote URL attachment.
+The default `voice_id` can be overridden per call.
 
 ### Configuration
 
@@ -430,7 +468,11 @@ text_to_speech("नमस्ते, आपकी रिपोर्ट तैय
 
 ### What It Does
 
-`lumalabs` exposes `generate_video(prompt, loop=False, aspect_ratio="16:9", keyframes=None)` and `image_to_video(prompt, start_image_url, end_image_url=None, loop=False, aspect_ratio="16:9")`. Both calls create a Luma generation job and poll until it completes or times out. `generate_video()` optionally accepts provider-style keyframes, while `image_to_video()` builds the required keyframe structure from one or two image URLs. Completed jobs return remote video URL attachments. If `wait_for_completion` is false, the current implementation returns `Async generation unsupported`.
+`lumalabs` exposes `generate_video(prompt, loop=False, aspect_ratio="16:9", keyframes=None)` and `image_to_video(prompt, start_image_url, end_image_url=None, loop=False, aspect_ratio="16:9")`.
+Both calls create a Luma generation job and poll until it completes or times out.
+`generate_video()` optionally accepts provider-style keyframes, while `image_to_video()` builds the required keyframe structure from one or two image URLs.
+Completed jobs return remote video URL attachments.
+If `wait_for_completion` is false, the current implementation returns `Async generation unsupported`.
 
 ### Configuration
 
@@ -476,7 +518,11 @@ image_to_video(
 
 ### What It Does
 
-`modelslabs` exposes one call, `generate_media(prompt)`. The current wrapper chooses one of several provider endpoints based on `file_type` and sends a fixed payload template for that media class. For MP4 and GIF generation, it currently uses the provider's text-to-video endpoint and returns future-link URLs with an ETA. For MP3 and WAV generation, it uses provider voice endpoints and returns audio URLs. If `wait_for_completion` is enabled, the tool polls the provider fetch endpoint until the media is ready or the timeout is reached.
+`modelslabs` exposes one call, `generate_media(prompt)`.
+The current wrapper chooses one of several provider endpoints based on `file_type` and sends a fixed payload template for that media class.
+For MP4 and GIF generation, it currently uses the provider's text-to-video endpoint and returns future-link URLs with an ETA.
+For MP3 and WAV generation, it uses provider voice endpoints and returns audio URLs.
+If `wait_for_completion` is enabled, the tool polls the provider fetch endpoint until the media is ready or the timeout is reached.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__automation-and-platforms__index.md
+++ b/skills/mindroom-docs/references/page__tools__automation-and-platforms__index.md
@@ -4,7 +4,8 @@ Use these tools to manage AWS-backed automation, edit Airflow DAG files, run cod
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `automation-and-platforms` group. Use these tools when you need infrastructure automation, generic API access, remote execution environments, or platform-level integration brokers.
+This page documents the built-in tools in the `automation-and-platforms` group.
+Use these tools when you need infrastructure automation, generic API access, remote execution environments, or platform-level integration brokers.
 
 ## Tools On This Page
 
@@ -18,7 +19,17 @@ This page documents the built-in tools in the `automation-and-platforms` group. 
 
 ## Common Setup Notes
 
-All seven tools on this page default to the primary agent runtime instead of MindRoom's worker-routed execution set. `aws_lambda`, `airflow`, and `custom_api` are registered as `setup_type: none`, while `aws_ses`, `e2b`, `daytona`, and `composio` are marked `requires_config`. `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes on this branch, so none of the tools on this page have a dedicated MindRoom OAuth flow. Password fields such as `api_key` and `password` must be stored through the dashboard or credential store instead of inline YAML. `aws_lambda` and `aws_ses` both rely on standard boto3 credential resolution, so normal AWS environment variables, shared config files, or instance-role credentials are the real authentication path. That matters especially for `aws_ses`, because the current registry marks it as `setup_type: api_key` even though the tool itself does not expose an API-key field. `e2b` accepts `api_key` inline from stored credentials or falls back to `E2B_API_KEY`. `daytona` accepts stored credentials or environment fallback through `DAYTONA_API_KEY`, and `api_url` can also fall back to `DAYTONA_API_URL`. `composio` can fall back to cached Composio user data or `COMPOSIO_API_KEY` when `api_key` is not stored directly. Several fields on this page are advanced raw constructor inputs rather than friendly hand-authored YAML values, including `sandbox_options`, `sandbox_env_vars`, `sandbox_labels`, `workspace_config`, `connected_account_ids`, `metadata`, `processors`, and `headers`. Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
+All seven tools on this page default to the primary agent runtime instead of MindRoom's worker-routed execution set.
+`aws_lambda`, `airflow`, and `custom_api` are registered as `setup_type: none`, while `aws_ses`, `e2b`, `daytona`, and `composio` are marked `requires_config`.
+`src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes on this branch, so none of the tools on this page have a dedicated MindRoom OAuth flow.
+Password fields such as `api_key` and `password` must be stored through the dashboard or credential store instead of inline YAML.
+`aws_lambda` and `aws_ses` both rely on standard boto3 credential resolution, so normal AWS environment variables, shared config files, or instance-role credentials are the real authentication path.
+That matters especially for `aws_ses`, because the current registry marks it as `setup_type: api_key` even though the tool itself does not expose an API-key field.
+`e2b` accepts `api_key` inline from stored credentials or falls back to `E2B_API_KEY`.
+`daytona` accepts stored credentials or environment fallback through `DAYTONA_API_KEY`, and `api_url` can also fall back to `DAYTONA_API_URL`.
+`composio` can fall back to cached Composio user data or `COMPOSIO_API_KEY` when `api_key` is not stored directly.
+Several fields on this page are advanced raw constructor inputs rather than friendly hand-authored YAML values, including `sandbox_options`, `sandbox_env_vars`, `sandbox_labels`, `workspace_config`, `connected_account_ids`, `metadata`, `processors`, and `headers`.
+Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
 
 ## \[`aws_lambda`\]
 
@@ -26,7 +37,10 @@ All seven tools on this page default to the primary agent runtime instead of Min
 
 ### What It Does
 
-`aws_lambda` exposes `list_functions()` and `invoke_function(function_name, payload="{}")`. The toolkit constructs a boto3 Lambda client at init time with `region_name`. `invoke_function()` passes the payload through to boto3 as a string and returns the Lambda status code plus the decoded response payload. `list_functions()` currently makes one direct `list_functions()` call rather than using a paginator, so very large accounts may need a richer AWS-specific path than this thin wrapper.
+`aws_lambda` exposes `list_functions()` and `invoke_function(function_name, payload="{}")`.
+The toolkit constructs a boto3 Lambda client at init time with `region_name`.
+`invoke_function()` passes the payload through to boto3 as a string and returns the Lambda status code plus the decoded response payload.
+`list_functions()` currently makes one direct `list_functions()` call rather than using a paginator, so very large accounts may need a richer AWS-specific path than this thin wrapper.
 
 ### Configuration
 
@@ -64,7 +78,10 @@ invoke_function("daily-report", payload='{"date": "2026-03-31"}')
 
 ### What It Does
 
-`aws_ses` exposes `send_email(subject, body, receiver_email)`. The toolkit builds a boto3 SES client with `region_name` and then sends a plain-text message from `"{sender_name} <{sender_email}>"`. It validates that `subject` and `body` are non-empty before sending. The current wrapper does not add HTML email support, templates, attachments, or richer SES delivery controls on top of the basic send call.
+`aws_ses` exposes `send_email(subject, body, receiver_email)`.
+The toolkit builds a boto3 SES client with `region_name` and then sends a plain-text message from `"{sender_name} <{sender_email}>"`.
+It validates that `subject` and `body` are non-empty before sending.
+The current wrapper does not add HTML email support, templates, attachments, or richer SES delivery controls on top of the basic send call.
 
 ### Configuration
 
@@ -108,7 +125,11 @@ send_email(
 
 ### What It Does
 
-`airflow` exposes `save_dag_file(contents, dag_file)` and `read_dag_file(dag_file)`. If `dags_dir` is a string, the upstream toolkit resolves it relative to the current working directory at tool initialization time. `save_dag_file()` creates missing parent directories before writing the target DAG file. This tool manages DAG source files only. It does not talk to the Airflow scheduler, trigger DAG runs, inspect task state, or call the Airflow REST API.
+`airflow` exposes `save_dag_file(contents, dag_file)` and `read_dag_file(dag_file)`.
+If `dags_dir` is a string, the upstream toolkit resolves it relative to the current working directory at tool initialization time.
+`save_dag_file()` creates missing parent directories before writing the target DAG file.
+This tool manages DAG source files only.
+It does not talk to the Airflow scheduler, trigger DAG runs, inspect task state, or call the Airflow REST API.
 
 ### Configuration
 
@@ -146,7 +167,11 @@ save_dag_file("from airflow import DAG\n", "generated/new_job.py")
 
 ### What It Does
 
-`e2b` requires an API key from stored credentials or `E2B_API_KEY`. The toolkit creates one E2B sandbox at initialization time and reuses it for subsequent tool calls from that toolkit instance. It exposes `run_python_code()`, `upload_file()`, `download_png_result()`, `download_chart_data()`, `download_file_from_sandbox()`, `run_command()`, `stream_command()`, `run_background_command()`, `kill_background_command()`, `list_files()`, `read_file_content()`, `write_file_content()`, `watch_directory()`, `get_public_url()`, `run_server()`, `set_sandbox_timeout()`, `get_sandbox_status()`, `shutdown_sandbox()`, and `list_running_sandboxes()`. The media helpers operate on the most recent `run_python_code()` result, which is why chart and PNG download flows are companion actions instead of standalone reads. `timeout` is passed into `Sandbox.create(...)`, and `sandbox_options` is splatted directly into that constructor.
+`e2b` requires an API key from stored credentials or `E2B_API_KEY`.
+The toolkit creates one E2B sandbox at initialization time and reuses it for subsequent tool calls from that toolkit instance.
+It exposes `run_python_code()`, `upload_file()`, `download_png_result()`, `download_chart_data()`, `download_file_from_sandbox()`, `run_command()`, `stream_command()`, `run_background_command()`, `kill_background_command()`, `list_files()`, `read_file_content()`, `write_file_content()`, `watch_directory()`, `get_public_url()`, `run_server()`, `set_sandbox_timeout()`, `get_sandbox_status()`, `shutdown_sandbox()`, and `list_running_sandboxes()`.
+The media helpers operate on the most recent `run_python_code()` result, which is why chart and PNG download flows are companion actions instead of standalone reads.
+`timeout` is passed into `Sandbox.create(...)`, and `sandbox_options` is splatted directly into that constructor.
 
 ### Configuration
 
@@ -184,7 +209,13 @@ run_server("python -m http.server 8000", port=8000)
 
 ### What It Does
 
-`daytona` requires an API key from stored credentials or `DAYTONA_API_KEY`. `api_url` can also fall back to `DAYTONA_API_URL`. The toolkit exposes `run_code()`, `run_shell_command()`, `create_file()`, `read_file()`, `list_files()`, `delete_file()`, and `change_directory()`. When `persistent` is true, the tool stores the active sandbox ID in `agent.session_state` and tries to reuse that sandbox on later calls. It also tracks a working directory in `agent.session_state`, and `run_shell_command()` treats `cd ...` specially so later relative-path commands and file operations stay in that directory. If no reusable sandbox exists, the toolkit creates one automatically unless `auto_create_sandbox` is disabled. The bundled default instructions describe a code-write, execute, and show-results workflow, but those instructions are only added to the agent prompt when `add_instructions: true`.
+`daytona` requires an API key from stored credentials or `DAYTONA_API_KEY`.
+`api_url` can also fall back to `DAYTONA_API_URL`.
+The toolkit exposes `run_code()`, `run_shell_command()`, `create_file()`, `read_file()`, `list_files()`, `delete_file()`, and `change_directory()`.
+When `persistent` is true, the tool stores the active sandbox ID in `agent.session_state` and tries to reuse that sandbox on later calls.
+It also tracks a working directory in `agent.session_state`, and `run_shell_command()` treats `cd ...` specially so later relative-path commands and file operations stay in that directory.
+If no reusable sandbox exists, the toolkit creates one automatically unless `auto_create_sandbox` is disabled.
+The bundled default instructions describe a code-write, execute, and show-results workflow, but those instructions are only added to the agent prompt when `add_instructions: true`.
 
 ### Configuration
 
@@ -242,7 +273,11 @@ create_file("main.py", "print('ok')")
 
 ### What It Does
 
-The registered MindRoom tool instantiates `composio_agno.ComposioToolSet`. That upstream object does not expose a stable fixed method list like `aws_lambda` or `custom_api`. Instead, its main surface is `get_tools(actions=..., apps=..., tags=...)`, which wraps selected Composio actions into Agno `Toolkit` objects at runtime. The resulting callable tools therefore depend on your Composio workspace, connected accounts, and action selection rather than a static MindRoom-defined function list. MindRoom's current registry metadata on this branch documents the connection and workspace fields, but it does not expose separate per-agent app or action filter fields in `config.yaml`.
+The registered MindRoom tool instantiates `composio_agno.ComposioToolSet`.
+That upstream object does not expose a stable fixed method list like `aws_lambda` or `custom_api`.
+Instead, its main surface is `get_tools(actions=..., apps=..., tags=...)`, which wraps selected Composio actions into Agno `Toolkit` objects at runtime.
+The resulting callable tools therefore depend on your Composio workspace, connected accounts, and action selection rather than a static MindRoom-defined function list.
+MindRoom's current registry metadata on this branch documents the connection and workspace fields, but it does not expose separate per-agent app or action filter fields in `config.yaml`.
 
 ### Configuration
 
@@ -289,7 +324,13 @@ agents:
 
 ### What It Does
 
-`custom_api` exposes `make_request(endpoint, method="GET", params=None, data=None, headers=None, json_data=None)`. If `base_url` is set, the tool joins it with the passed endpoint. If `username` and `password` are configured, the request uses HTTP Basic Auth. If `api_key` is configured, the tool adds `Authorization: Bearer <api_key>` to the default headers. Per-call headers are merged on top of configured default headers. The response body is parsed as JSON when possible and otherwise returned as plain text inside a JSON envelope with `status_code`, response `headers`, and `data`. Non-2xx responses still return a structured result object, with an added `"error": "Request failed"` field.
+`custom_api` exposes `make_request(endpoint, method="GET", params=None, data=None, headers=None, json_data=None)`.
+If `base_url` is set, the tool joins it with the passed endpoint.
+If `username` and `password` are configured, the request uses HTTP Basic Auth.
+If `api_key` is configured, the tool adds `Authorization: Bearer <api_key>` to the default headers.
+Per-call headers are merged on top of configured default headers.
+The response body is parsed as JSON when possible and otherwise returned as plain text inside a JSON envelope with `status_code`, response `headers`, and `data`.
+Non-2xx responses still return a structured result object, with an added `"error": "Request failed"` field.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__calendar-and-scheduling__index.md
+++ b/skills/mindroom-docs/references/page__tools__calendar-and-scheduling__index.md
@@ -4,7 +4,8 @@ Use these tools to read external calendars, manage bookings, and schedule future
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `calendar-and-scheduling` group. Use these tools when you need Google Calendar access, Cal.com booking APIs, or Matrix-native scheduled tasks that post back into MindRoom later.
+This page documents the built-in tools in the `calendar-and-scheduling` group.
+Use these tools when you need Google Calendar access, Cal.com booking APIs, or Matrix-native scheduled tasks that post back into MindRoom later.
 
 ## Tools On This Page
 
@@ -14,7 +15,12 @@ This page documents the built-in tools in the `calendar-and-scheduling` group. U
 
 ## Common Setup Notes
 
-`google_calendar` is a Google-backed shared-only integration. It uses the shared Google Services OAuth connection instead of its own API key form. Agents can only use it when `worker_scope` is unset or `shared`, and MindRoom keeps it local even when other tools are routed through the sandbox proxy. Use [Google Services OAuth (Admin Setup)](https://docs.mindroom.chat/deployment/google-services-oauth/index.md) or [Google Services OAuth (Individual Setup)](https://docs.mindroom.chat/deployment/google-services-user-oauth/index.md) to connect Google before enabling `google_calendar`. `cal_com` is a standard credential-backed tool with its own config fields and no shared-only restriction. `scheduler` is MindRoom's built-in scheduling system, so it does not need dashboard OAuth setup or API keys. Unlike the two calendar API tools, `scheduler` depends on the active Matrix `ToolRuntimeContext`, so it only works from a live room or thread. MindRoom also includes `scheduler` in `defaults.tools` by default on this branch.
+`google_calendar` is a Google-backed shared-only integration.
+It uses the shared Google Services OAuth connection instead of its own API key form.
+Agents can only use it when `worker_scope` is unset or `shared`, and MindRoom keeps it local even when other tools are routed through the sandbox proxy. Use [Google Services OAuth (Admin Setup)](https://docs.mindroom.chat/deployment/google-services-oauth/index.md) or [Google Services OAuth (Individual Setup)](https://docs.mindroom.chat/deployment/google-services-user-oauth/index.md) to connect Google before enabling `google_calendar`. `cal_com` is a standard credential-backed tool with its own config fields and no shared-only restriction.
+`scheduler` is MindRoom's built-in scheduling system, so it does not need dashboard OAuth setup or API keys.
+Unlike the two calendar API tools, `scheduler` depends on the active Matrix `ToolRuntimeContext`, so it only works from a live room or thread.
+MindRoom also includes `scheduler` in `defaults.tools` by default on this branch.
 
 ## \[`google_calendar`\]
 
@@ -22,7 +28,11 @@ This page documents the built-in tools in the `calendar-and-scheduling` group. U
 
 ### What It Does
 
-`google_calendar` exposes `list_events()`, `fetch_all_events()`, `find_available_slots()`, `list_calendars()`, `create_event()`, `update_event()`, and `delete_event()`. MindRoom loads the connected Google account from its unified credential store instead of relying on a per-process `token.json`. Read-oriented calls work with calendar read scopes. Write calls are still part of the tool surface, but they only succeed when `allow_update: true` is configured and the connected Google account has granted calendar write scope. `find_available_slots()` derives openings from the user's current calendar events plus working-hours settings inferred from Google Calendar settings and locale.
+`google_calendar` exposes `list_events()`, `fetch_all_events()`, `find_available_slots()`, `list_calendars()`, `create_event()`, `update_event()`, and `delete_event()`.
+MindRoom loads the connected Google account from its unified credential store instead of relying on a per-process `token.json`.
+Read-oriented calls work with calendar read scopes.
+Write calls are still part of the tool surface, but they only succeed when `allow_update: true` is configured and the connected Google account has granted calendar write scope.
+`find_available_slots()` derives openings from the user's current calendar events plus working-hours settings inferred from Google Calendar settings and locale.
 
 ### Configuration
 
@@ -68,7 +78,10 @@ create_event(
 
 ### What It Does
 
-`cal_com` exposes `get_available_slots()`, `create_booking()`, `get_upcoming_bookings()`, `reschedule_booking()`, and `cancel_booking()`. The toolkit uses one configured `event_type_id` as the default booking type for slot lookup and booking creation. Responses are converted from UTC into `user_timezone` before they are returned. The per-method enable flags let you narrow the exposed call surface when an agent should only inspect availability or only manage existing bookings.
+`cal_com` exposes `get_available_slots()`, `create_booking()`, `get_upcoming_bookings()`, `reschedule_booking()`, and `cancel_booking()`.
+The toolkit uses one configured `event_type_id` as the default booking type for slot lookup and booking creation.
+Responses are converted from UTC into `user_timezone` before they are returned.
+The per-method enable flags let you narrow the exposed call surface when an agent should only inspect availability or only manage existing bookings.
 
 ### Configuration
 
@@ -119,7 +132,12 @@ get_upcoming_bookings(email="alex@example.com")
 
 ### What It Does
 
-`scheduler` exposes `schedule()`, `edit_schedule()`, `list_schedules()`, and `cancel_schedule()`. It reuses the same backend as `!schedule`, `!edit_schedule`, `!list_schedules`, and `!cancel_schedule`. By default `schedule()` posts back into the current room or thread scope, while `new_thread=True` schedules a future room-level root message. Scheduled tasks are stored in Matrix room state and persist across restarts. The scheduler validates mentioned agents against the current room or thread before it saves a task. If no Matrix room context is available, the tool returns an unavailable error instead of creating a task.
+`scheduler` exposes `schedule()`, `edit_schedule()`, `list_schedules()`, and `cancel_schedule()`.
+It reuses the same backend as `!schedule`, `!edit_schedule`, `!list_schedules`, and `!cancel_schedule`.
+By default `schedule()` posts back into the current room or thread scope, while `new_thread=True` schedules a future room-level root message.
+Scheduled tasks are stored in Matrix room state and persist across restarts.
+The scheduler validates mentioned agents against the current room or thread before it saves a task.
+If no Matrix room context is available, the tool returns an unavailable error instead of creating a task.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__data-and-databases__index.md
+++ b/skills/mindroom-docs/references/page__tools__data-and-databases__index.md
@@ -4,7 +4,8 @@ Use these tools to query SQL and graph databases, analyze tabular files, work wi
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `data-and-databases` group. Use these tools when you need database access, dataframe-style analysis, spreadsheet automation, or market and company data.
+This page documents the built-in tools in the `data-and-databases` group.
+Use these tools when you need database access, dataframe-style analysis, spreadsheet automation, or market and company data.
 
 ## Tools On This Page
 
@@ -23,7 +24,15 @@ This page documents the built-in tools in the `data-and-databases` group. Use th
 
 ## Common Setup Notes
 
-`sql`, `postgres`, `redshift`, `neo4j`, `google_bigquery`, `google_sheets`, and `financial_datasets_api` are registered as `requires_config`, so they stay unavailable in the dashboard until their required config or auth is present. `duckdb`, `csv`, `pandas`, `openbb`, and `yfinance` are `setup_type: none`, so they can be enabled immediately once their optional Python dependencies are installed. MindRoom validates inline tool overrides against the declared `config_fields`, and `type="password"` fields such as `password`, `secret_access_key`, and `api_key` must go through the dashboard or credential store instead of inline YAML. Several fields on this page are advanced constructor inputs rather than normal `config.yaml` values, including `db_engine`, `connection`, `credentials`, `duckdb_connection`, `duckdb_kwargs`, `obb`, and `session`. Token-like fields such as `openbb_pat` are better kept in stored credentials even when the current metadata does not mark them as password fields. `src/mindroom/api/integrations.py` currently contains Spotify-specific OAuth endpoints only, so the tools on this page are configured through standard tool credentials, environment-backed SDK auth, or the shared Google Services OAuth flow instead of dedicated per-tool integration routes. `google_sheets` is special because it declares `auth_provider="google"`, checks for Google Sheets OAuth scopes, is restricted to unscoped agents or `worker_scope=shared`, and always stays local instead of being proxied through worker sandbox routing. `csv` queries use DuckDB under the hood, and `duckdb` is the better fit when you need to create tables from files, export results, or load local and S3 data repeatedly. Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
+`sql`, `postgres`, `redshift`, `neo4j`, `google_bigquery`, `google_sheets`, and `financial_datasets_api` are registered as `requires_config`, so they stay unavailable in the dashboard until their required config or auth is present.
+`duckdb`, `csv`, `pandas`, `openbb`, and `yfinance` are `setup_type: none`, so they can be enabled immediately once their optional Python dependencies are installed.
+MindRoom validates inline tool overrides against the declared `config_fields`, and `type="password"` fields such as `password`, `secret_access_key`, and `api_key` must go through the dashboard or credential store instead of inline YAML.
+Several fields on this page are advanced constructor inputs rather than normal `config.yaml` values, including `db_engine`, `connection`, `credentials`, `duckdb_connection`, `duckdb_kwargs`, `obb`, and `session`.
+Token-like fields such as `openbb_pat` are better kept in stored credentials even when the current metadata does not mark them as password fields.
+`src/mindroom/api/integrations.py` currently contains Spotify-specific OAuth endpoints only, so the tools on this page are configured through standard tool credentials, environment-backed SDK auth, or the shared Google Services OAuth flow instead of dedicated per-tool integration routes.
+`google_sheets` is special because it declares `auth_provider="google"`, checks for Google Sheets OAuth scopes, is restricted to unscoped agents or `worker_scope=shared`, and always stays local instead of being proxied through worker sandbox routing.
+`csv` queries use DuckDB under the hood, and `duckdb` is the better fit when you need to create tables from files, export results, or load local and S3 data repeatedly.
+Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
 
 ## \[`sql`\]
 
@@ -31,7 +40,11 @@ This page documents the built-in tools in the `data-and-databases` group. Use th
 
 ### What It Does
 
-`sql` exposes `list_tables()`, `describe_table()`, and `run_sql_query()`. The toolkit can connect through `db_url`, an existing `db_engine`, or a URL assembled from `user`, `password`, `host`, `port`, `schema`, and `dialect`. `list_tables()` and `describe_table()` use SQLAlchemy inspection, and `run_sql_query()` returns JSON rows with a default limit of 10 unless you pass `limit=None`. If you pass a `tables` mapping, `list_tables()` returns that mapping directly instead of live database introspection. For dialects where database name and schema are distinct concepts, `db_url` is the safest authored configuration because the generic `schema` field is used both in the constructed URL path and in later table inspection calls.
+`sql` exposes `list_tables()`, `describe_table()`, and `run_sql_query()`.
+The toolkit can connect through `db_url`, an existing `db_engine`, or a URL assembled from `user`, `password`, `host`, `port`, `schema`, and `dialect`.
+`list_tables()` and `describe_table()` use SQLAlchemy inspection, and `run_sql_query()` returns JSON rows with a default limit of 10 unless you pass `limit=None`.
+If you pass a `tables` mapping, `list_tables()` returns that mapping directly instead of live database introspection.
+For dialects where database name and schema are distinct concepts, `db_url` is the safest authored configuration because the generic `schema` field is used both in the constructed URL path and in later table inspection calls.
 
 ### Configuration
 
@@ -80,7 +93,10 @@ run_sql_query("SELECT * FROM events ORDER BY created_at DESC", limit=20)
 
 ### What It Does
 
-`postgres` exposes `show_tables()`, `describe_table()`, `summarize_table()`, `inspect_query()`, `run_query()`, and `export_table_to_path()`. The toolkit opens a Psycopg connection, sets `search_path` to `table_schema`, and marks the connection read-only. `inspect_query()` runs `EXPLAIN`, which makes it the safe first step before a larger `run_query()`. `export_table_to_path()` writes queryable table output to a local file path from the running process.
+`postgres` exposes `show_tables()`, `describe_table()`, `summarize_table()`, `inspect_query()`, `run_query()`, and `export_table_to_path()`.
+The toolkit opens a Psycopg connection, sets `search_path` to `table_schema`, and marks the connection read-only.
+`inspect_query()` runs `EXPLAIN`, which makes it the safe first step before a larger `run_query()`.
+`export_table_to_path()` writes queryable table output to a local file path from the running process.
 
 ### Configuration
 
@@ -128,7 +144,10 @@ export_table_to_path("daily_revenue", "/tmp/daily_revenue.csv")
 
 ### What It Does
 
-`redshift` exposes `show_tables()`, `describe_table()`, `summarize_table()`, `inspect_query()`, `run_query()`, and `export_table_to_path()`. The upstream connector supports standard `user` and `password` authentication, IAM authentication through `profile`, and IAM authentication through explicit AWS credentials. When IAM auth is enabled, the toolkit can fall back to environment variables such as `REDSHIFT_HOST`, `REDSHIFT_DATABASE`, `REDSHIFT_CLUSTER_IDENTIFIER`, `AWS_REGION`, and `AWS_PROFILE`. `table_schema` defaults to `public`, and `ssl` defaults to `true`.
+`redshift` exposes `show_tables()`, `describe_table()`, `summarize_table()`, `inspect_query()`, `run_query()`, and `export_table_to_path()`.
+The upstream connector supports standard `user` and `password` authentication, IAM authentication through `profile`, and IAM authentication through explicit AWS credentials.
+When IAM auth is enabled, the toolkit can fall back to environment variables such as `REDSHIFT_HOST`, `REDSHIFT_DATABASE`, `REDSHIFT_CLUSTER_IDENTIFIER`, `AWS_REGION`, and `AWS_PROFILE`.
+`table_schema` defaults to `public`, and `ssl` defaults to `true`.
 
 ### Configuration
 
@@ -185,7 +204,9 @@ export_table_to_path("fact_orders", "/tmp/fact_orders.csv")
 
 ### What It Does
 
-`neo4j` exposes `list_labels()`, `list_relationship_types()`, `get_schema()`, and `run_cypher_query()`. It uses the Neo4j Python driver and can target a specific database when `database` is set. The individual enable flags let you expose schema discovery without allowing arbitrary Cypher execution.
+`neo4j` exposes `list_labels()`, `list_relationship_types()`, `get_schema()`, and `run_cypher_query()`.
+It uses the Neo4j Python driver and can target a specific database when `database` is set.
+The individual enable flags let you expose schema discovery without allowing arbitrary Cypher execution.
 
 ### Configuration
 
@@ -233,7 +254,10 @@ run_cypher_query("MATCH (u:User)-[:PLACED]->(o:Order) RETURN u.id, count(o) AS o
 
 ### What It Does
 
-`duckdb` exposes `show_tables()`, `describe_table()`, `inspect_query()`, `run_query()`, `summarize_table()`, `create_table_from_path()`, `export_table_to_path()`, `load_local_path_to_table()`, `load_local_csv_to_table()`, `load_s3_path_to_table()`, `load_s3_csv_to_table()`, `create_fts_index()`, and `full_text_search()`. If `db_path` is unset, DuckDB runs in memory. `create_table_from_path()` can load CSV or other file formats directly into a table, and `export_table_to_path()` defaults to `PARQUET`. `init_commands`, `connection`, and `config` are advanced constructor inputs that are passed directly to the upstream toolkit.
+`duckdb` exposes `show_tables()`, `describe_table()`, `inspect_query()`, `run_query()`, `summarize_table()`, `create_table_from_path()`, `export_table_to_path()`, `load_local_path_to_table()`, `load_local_csv_to_table()`, `load_s3_path_to_table()`, `load_s3_csv_to_table()`, `create_fts_index()`, and `full_text_search()`.
+If `db_path` is unset, DuckDB runs in memory.
+`create_table_from_path()` can load CSV or other file formats directly into a table, and `export_table_to_path()` defaults to `PARQUET`.
+`init_commands`, `connection`, and `config` are advanced constructor inputs that are passed directly to the upstream toolkit.
 
 ### Configuration
 
@@ -276,7 +300,10 @@ export_table_to_path("orders", format="CSV", path="/tmp")
 
 ### What It Does
 
-`csv` exposes `list_csv_files()`, `read_csv_file()`, `get_columns()`, and `query_csv_file()`. The toolkit works with a preconfigured list of CSV paths and exposes each one by its filename stem. `read_csv_file()` returns JSON rows and respects either the per-call `row_limit` or the configured default `row_limit`. `query_csv_file()` loads the target CSV into DuckDB and runs one SQL statement against it.
+`csv` exposes `list_csv_files()`, `read_csv_file()`, `get_columns()`, and `query_csv_file()`.
+The toolkit works with a preconfigured list of CSV paths and exposes each one by its filename stem.
+`read_csv_file()` returns JSON rows and respects either the per-call `row_limit` or the configured default `row_limit`.
+`query_csv_file()` loads the target CSV into DuckDB and runs one SQL statement against it.
 
 ### Configuration
 
@@ -321,7 +348,10 @@ query_csv_file("sales_2025", 'SELECT "region", COUNT(*) FROM sales_2025 GROUP BY
 
 ### What It Does
 
-`pandas` exposes `create_pandas_dataframe()` and `run_dataframe_operation()`. `create_pandas_dataframe()` calls a top-level Pandas constructor such as `read_csv` or `read_json` and stores the resulting dataframe under a caller-chosen name. `run_dataframe_operation()` then calls a dataframe method such as `head`, `tail`, `describe`, or `groupby` on that stored dataframe. Stored dataframes live in the current process memory only and are not persisted to disk.
+`pandas` exposes `create_pandas_dataframe()` and `run_dataframe_operation()`.
+`create_pandas_dataframe()` calls a top-level Pandas constructor such as `read_csv` or `read_json` and stores the resulting dataframe under a caller-chosen name.
+`run_dataframe_operation()` then calls a dataframe method such as `head`, `tail`, `describe`, or `groupby` on that stored dataframe.
+Stored dataframes live in the current process memory only and are not persisted to disk.
 
 ### Configuration
 
@@ -362,7 +392,10 @@ run_dataframe_operation("sales", "describe", {})
 
 ### What It Does
 
-`google_bigquery` exposes `list_tables()`, `describe_table()`, and `run_sql_query()`. The toolkit builds a `bigquery.Client` at initialization and scopes query jobs to `project.dataset` through the default query job configuration. MindRoom's metadata marks `dataset`, `project`, and `location` as required, even though the upstream toolkit can fall back to `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` if those values are omitted. `credentials` is an advanced programmatic Google credentials object for cases where the process should not rely on default application credentials.
+`google_bigquery` exposes `list_tables()`, `describe_table()`, and `run_sql_query()`.
+The toolkit builds a `bigquery.Client` at initialization and scopes query jobs to `project.dataset` through the default query job configuration.
+MindRoom's metadata marks `dataset`, `project`, and `location` as required, even though the upstream toolkit can fall back to `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` if those values are omitted.
+`credentials` is an advanced programmatic Google credentials object for cases where the process should not rely on default application credentials.
 
 ### Configuration
 
@@ -407,7 +440,13 @@ run_sql_query("SELECT event_name, COUNT(*) AS total FROM events GROUP BY 1 ORDER
 
 ### What It Does
 
-The underlying Agno toolkit supports `read_sheet()`, `create_sheet()`, `update_sheet()`, and `create_duplicate_sheet()`. MindRoom wraps Agno's Google Sheets toolkit with `ScopedGoogleOAuthMixin`, so it loads stored Google credentials from MindRoom's credential store instead of relying only on local token files. The upstream toolkit selects read-only Sheets scope when only reads are enabled, and it selects write scope when create, update, or duplicate operations are enabled. `create_duplicate_sheet()` uses the Google Drive copy API under the hood, so duplication depends on Google Drive scope in addition to Sheets access. If `spreadsheet_id` or `spreadsheet_range` is unset, you can still pass them per call. On this branch, the declared MindRoom config fields are `read`, `create`, `update`, and `duplicate`, while the upstream constructor consumes `enable_read_sheet`, `enable_create_sheet`, `enable_update_sheet`, and `enable_create_duplicate_sheet`. That means the read path is the verified default behavior here, while the write toggles should be treated as intended metadata until the field names are aligned with the upstream constructor.
+The underlying Agno toolkit supports `read_sheet()`, `create_sheet()`, `update_sheet()`, and `create_duplicate_sheet()`.
+MindRoom wraps Agno's Google Sheets toolkit with `ScopedGoogleOAuthMixin`, so it loads stored Google credentials from MindRoom's credential store instead of relying only on local token files.
+The upstream toolkit selects read-only Sheets scope when only reads are enabled, and it selects write scope when create, update, or duplicate operations are enabled.
+`create_duplicate_sheet()` uses the Google Drive copy API under the hood, so duplication depends on Google Drive scope in addition to Sheets access.
+If `spreadsheet_id` or `spreadsheet_range` is unset, you can still pass them per call.
+On this branch, the declared MindRoom config fields are `read`, `create`, `update`, and `duplicate`, while the upstream constructor consumes `enable_read_sheet`, `enable_create_sheet`, `enable_update_sheet`, and `enable_create_duplicate_sheet`.
+That means the read path is the verified default behavior here, while the write toggles should be treated as intended metadata until the field names are aligned with the upstream constructor.
 
 ### Configuration
 
@@ -454,7 +493,10 @@ read_sheet(
 
 ### What It Does
 
-`openbb` exposes `get_stock_price()`, `search_company_symbol()`, `get_company_news()`, `get_company_profile()`, and `get_price_targets()`. The toolkit logs into OpenBB when `openbb_pat` or `OPENBB_PAT` is available, but it still works without a PAT when the selected provider supports unauthenticated access. The default provider is `yfinance`, which makes the tool usable without premium OpenBB credentials for many common quote lookups. You can selectively enable additional research functions without exposing the full OpenBB surface.
+`openbb` exposes `get_stock_price()`, `search_company_symbol()`, `get_company_news()`, `get_company_profile()`, and `get_price_targets()`.
+The toolkit logs into OpenBB when `openbb_pat` or `OPENBB_PAT` is available, but it still works without a PAT when the selected provider supports unauthenticated access.
+The default provider is `yfinance`, which makes the tool usable without premium OpenBB credentials for many common quote lookups.
+You can selectively enable additional research functions without exposing the full OpenBB surface.
 
 ### Configuration
 
@@ -502,7 +544,9 @@ get_price_targets("NVDA")
 
 ### What It Does
 
-`yfinance` exposes `get_current_stock_price()`, `get_company_info()`, `get_historical_stock_prices()`, `get_stock_fundamentals()`, `get_income_statements()`, `get_key_financial_ratios()`, `get_analyst_recommendations()`, `get_company_news()`, and `get_technical_indicators()`. Unlike `openbb`, it does not require a PAT or provider selection. The optional `session` field is an advanced programmatic HTTP session hook for callers that need custom transport behavior.
+`yfinance` exposes `get_current_stock_price()`, `get_company_info()`, `get_historical_stock_prices()`, `get_stock_fundamentals()`, `get_income_statements()`, `get_key_financial_ratios()`, `get_analyst_recommendations()`, `get_company_news()`, and `get_technical_indicators()`.
+Unlike `openbb`, it does not require a PAT or provider selection.
+The optional `session` field is an advanced programmatic HTTP session hook for callers that need custom transport behavior.
 
 ### Configuration
 
@@ -538,7 +582,9 @@ get_company_news("TSLA", num_stories=5)
 
 ### What It Does
 
-`financial_datasets_api` exposes methods such as `get_income_statements()`, `get_balance_sheets()`, `get_cash_flow_statements()`, `get_segmented_financials()`, `get_financial_metrics()`, `get_company_info()`, `get_stock_prices()`, `get_earnings()`, `get_insider_trades()`, `get_institutional_ownership()`, `get_news()`, `get_sec_filings()`, `get_crypto_prices()`, and `search_tickers()`. The toolkit sends authenticated HTTP requests to `https://api.financialdatasets.ai` with `X-API-KEY`. If `api_key` is unset, it falls back to `FINANCIAL_DATASETS_API_KEY`, and otherwise the tool returns an API-key-not-set error instead of working partially.
+`financial_datasets_api` exposes methods such as `get_income_statements()`, `get_balance_sheets()`, `get_cash_flow_statements()`, `get_segmented_financials()`, `get_financial_metrics()`, `get_company_info()`, `get_stock_prices()`, `get_earnings()`, `get_insider_trades()`, `get_institutional_ownership()`, `get_news()`, `get_sec_filings()`, `get_crypto_prices()`, and `search_tickers()`.
+The toolkit sends authenticated HTTP requests to `https://api.financialdatasets.ai` with `X-API-KEY`.
+If `api_key` is unset, it falls back to `FINANCIAL_DATASETS_API_KEY`, and otherwise the tool returns an API-key-not-set error instead of working partially.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
+++ b/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
@@ -4,7 +4,8 @@ Use these tools to inspect and edit local files, run shell commands or Python, w
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `execution-and-coding` group. Use these tools when you need local execution, coding-oriented file access, lightweight computation, or artifact generation inside the agent runtime.
+This page documents the built-in tools in the `execution-and-coding` group.
+Use these tools when you need local execution, coding-oriented file access, lightweight computation, or artifact generation inside the agent runtime.
 
 ## Tools On This Page
 
@@ -21,7 +22,20 @@ This page documents the built-in tools in the `execution-and-coding` group. Use 
 
 ## Common Setup Notes
 
-All ten tools on this page are exposed as `setup_type: none` in the live tool registry, so they do not require dashboard OAuth setup or credential forms before they appear as available. `src/mindroom/api/integrations.py` currently has no dedicated integration endpoints for them because they are local-runtime tools rather than OAuth-backed services. MindRoom's built-in default worker-routed set is `coding`, `file`, `python`, and `shell`. You can override the effective routed set with `defaults.worker_tools` or `agents.<name>.worker_tools`. When `worker_scope` is unset, worker-routed calls still execute in the sandbox, but they use a fresh runtime per call instead of a persistent scoped worker. `worker_scope: shared` reuses one runtime per agent, `worker_scope: user` reuses one runtime per requester across that requester's agents, and `worker_scope: user_agent` reuses one runtime per requester-agent pair. `worker_scope` controls runtime reuse, not filesystem security. Use [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for the deployment model, storage visibility rules, and scope tradeoffs. When an agent has a canonical workspace root, MindRoom injects that workspace as `base_dir` for tools that expose a `base_dir` constructor field. In normal `config.yaml` authoring, `base_dir` is therefore usually runtime-managed instead of something you set inline. Those workspace-backed agents also receive the optional `mindroom_output_path` argument on eligible tools. Set it to a workspace-relative file path to save the full supported tool output to that file and return a compact receipt to the model. Agents without a resolved workspace do not receive this argument. No extra configuration is required beyond that workspace root, and `MINDROOM_TOOL_OUTPUT_REDIRECT_MAX_BYTES` only overrides the default 64 MiB per-output write cap. Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set. That matters most here for `docker`, `file_generation`, and `visualization`, which depend on Docker access, `reportlab`, and `matplotlib`.
+All ten tools on this page are exposed as `setup_type: none` in the live tool registry, so they do not require dashboard OAuth setup or credential forms before they appear as available.
+`src/mindroom/api/integrations.py` currently has no dedicated integration endpoints for them because they are local-runtime tools rather than OAuth-backed services.
+MindRoom's built-in default worker-routed set is `coding`, `file`, `python`, and `shell`.
+You can override the effective routed set with `defaults.worker_tools` or `agents.<name>.worker_tools`.
+When `worker_scope` is unset, worker-routed calls still execute in the sandbox, but they use a fresh runtime per call instead of a persistent scoped worker.
+`worker_scope: shared` reuses one runtime per agent, `worker_scope: user` reuses one runtime per requester across that requester's agents, and `worker_scope: user_agent` reuses one runtime per requester-agent pair.
+`worker_scope` controls runtime reuse, not filesystem security. Use [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for the deployment model, storage visibility rules, and scope tradeoffs. When an agent has a canonical workspace root, MindRoom injects that workspace as `base_dir` for tools that expose a `base_dir` constructor field.
+In normal `config.yaml` authoring, `base_dir` is therefore usually runtime-managed instead of something you set inline.
+Those workspace-backed agents also receive the optional `mindroom_output_path` argument on eligible tools.
+Set it to a workspace-relative file path to save the full supported tool output to that file and return a compact receipt to the model.
+Agents without a resolved workspace do not receive this argument.
+No extra configuration is required beyond that workspace root, and `MINDROOM_TOOL_OUTPUT_REDIRECT_MAX_BYTES` only overrides the default 64 MiB per-output write cap.
+Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
+That matters most here for `docker`, `file_generation`, and `visualization`, which depend on Docker access, `reportlab`, and `matplotlib`.
 
 ```
 defaults:
@@ -57,7 +71,11 @@ agents:
 
 ### What It Does
 
-`file` exposes `save_file()`, `read_file()`, `delete_file()`, `list_files()`, `search_files()`, `read_file_chunk()`, and `replace_file_chunk()`. The underlying Agno toolkit resolves paths against `base_dir` and rejects paths that escape that root. `read_file()` enforces `max_file_length` and `max_file_lines`, and it tells the caller to use chunk reads when a file is too large. `search_files()` uses glob patterns relative to `base_dir` rather than full-text search. MindRoom marks `file` as worker-routed by default, so it usually executes in the sandboxed worker runtime unless you override `worker_tools`.
+`file` exposes `save_file()`, `read_file()`, `delete_file()`, `list_files()`, `search_files()`, `read_file_chunk()`, and `replace_file_chunk()`.
+The underlying Agno toolkit resolves paths against `base_dir` and rejects paths that escape that root.
+`read_file()` enforces `max_file_length` and `max_file_lines`, and it tells the caller to use chunk reads when a file is too large.
+`search_files()` uses glob patterns relative to `base_dir` rather than full-text search.
+MindRoom marks `file` as worker-routed by default, so it usually executes in the sandboxed worker runtime unless you override `worker_tools`.
 
 ### Configuration
 
@@ -109,7 +127,14 @@ save_file("temporary notes\n", "scratch/notes.txt")
 
 ### What It Does
 
-`shell` exposes `run_shell_command()`, `check_shell_command()`, and `kill_shell_command()`. `run_shell_command()` expects a list of arguments, not a shell-parsed string. If the command exits within `timeout`, the tool returns the last `tail` lines of stdout, or stderr on non-zero exit. If the timeout is exceeded, the process keeps running in the background and the tool returns a `shell:...` handle. Use `check_shell_command(handle)` to poll a backgrounded command and `kill_shell_command(handle)` to stop it. MindRoom keeps up to 16 backgrounded shell processes per runner and automatically sweeps finished handle records after roughly 10 minutes. Unlike upstream Agno's simple shell wrapper, MindRoom injects the stricter sandbox runtime env for proxied execution, supports explicit exported-process-env passthrough patterns, and supports PATH prepends. MindRoom marks `shell` as worker-routed by default, so it usually executes in the sandboxed worker runtime.
+`shell` exposes `run_shell_command()`, `check_shell_command()`, and `kill_shell_command()`.
+`run_shell_command()` expects a list of arguments, not a shell-parsed string.
+If the command exits within `timeout`, the tool returns the last `tail` lines of stdout, or stderr on non-zero exit.
+If the timeout is exceeded, the process keeps running in the background and the tool returns a `shell:...` handle.
+Use `check_shell_command(handle)` to poll a backgrounded command and `kill_shell_command(handle)` to stop it.
+MindRoom keeps up to 16 backgrounded shell processes per runner and automatically sweeps finished handle records after roughly 10 minutes.
+Unlike upstream Agno's simple shell wrapper, MindRoom injects the stricter sandbox runtime env for proxied execution, supports explicit exported-process-env passthrough patterns, and supports PATH prepends.
+MindRoom marks `shell` as worker-routed by default, so it usually executes in the sandboxed worker runtime.
 
 ### Configuration
 
@@ -167,7 +192,11 @@ EOF
 
 ### What It Does
 
-`python` exposes `save_to_file_and_run()`, `run_python_code()`, `pip_install_package()`, `uv_pip_install_package()`, `run_python_file_return_variable()`, `read_file()`, and `list_files()`. The upstream toolkit can execute arbitrary Python code and warns that it should be used with human supervision. MindRoom wraps the installer functions so both `pip_install_package()` and `uv_pip_install_package()` install into the current interpreter environment through MindRoom's shared installer path. When `python` is worker-routed, that means package installs land in the active worker environment rather than the primary agent process. MindRoom marks `python` as worker-routed by default, so sandbox execution is the normal path when a sandbox backend is configured.
+`python` exposes `save_to_file_and_run()`, `run_python_code()`, `pip_install_package()`, `uv_pip_install_package()`, `run_python_file_return_variable()`, `read_file()`, and `list_files()`.
+The upstream toolkit can execute arbitrary Python code and warns that it should be used with human supervision.
+MindRoom wraps the installer functions so both `pip_install_package()` and `uv_pip_install_package()` install into the current interpreter environment through MindRoom's shared installer path.
+When `python` is worker-routed, that means package installs land in the active worker environment rather than the primary agent process.
+MindRoom marks `python` as worker-routed by default, so sandbox execution is the normal path when a sandbox backend is configured.
 
 ### Configuration
 
@@ -210,7 +239,14 @@ list_files()
 
 ### What It Does
 
-`coding` exposes `read_file()`, `edit_file()`, `write_file()`, `grep()`, `find_files()`, and `ls()`. `read_file()` adds line numbers and pagination hints when output is truncated. `edit_file()` requires the old text to match exactly one location and returns a unified diff after the edit. If exact matching fails, `edit_file()` falls back to whitespace-and-Unicode-normalized fuzzy matching. `grep()` prefers `rg` when available and falls back to Python regex search otherwise. `find_files()` filters hidden and gitignored paths, and `ls()` keeps dotfiles visible while adding `/` markers to directories. All path resolution stays inside `base_dir`. MindRoom marks `coding` as worker-routed by default.
+`coding` exposes `read_file()`, `edit_file()`, `write_file()`, `grep()`, `find_files()`, and `ls()`.
+`read_file()` adds line numbers and pagination hints when output is truncated.
+`edit_file()` requires the old text to match exactly one location and returns a unified diff after the edit.
+If exact matching fails, `edit_file()` falls back to whitespace-and-Unicode-normalized fuzzy matching.
+`grep()` prefers `rg` when available and falls back to Python regex search otherwise.
+`find_files()` filters hidden and gitignored paths, and `ls()` keeps dotfiles visible while adding `/` markers to directories.
+All path resolution stays inside `base_dir`.
+MindRoom marks `coding` as worker-routed by default.
 
 ### Configuration
 
@@ -248,7 +284,10 @@ ls("src/mindroom")
 
 ### What It Does
 
-`docker` exposes container operations such as `list_containers()`, `run_container()`, `exec_in_container()`, `start_container()`, `stop_container()`, `remove_container()`, `get_container_logs()`, and `inspect_container()`. It also exposes image, volume, and network operations including `pull_image()`, `build_image()`, `tag_image()`, `list_volumes()`, `create_volume()`, `list_networks()`, and `connect_container_to_network()`. On startup, the toolkit checks common Docker socket locations and pings the Docker daemon. `docker` defaults to primary execution, so it normally runs beside the main agent process rather than in the worker sandbox.
+`docker` exposes container operations such as `list_containers()`, `run_container()`, `exec_in_container()`, `start_container()`, `stop_container()`, `remove_container()`, `get_container_logs()`, and `inspect_container()`.
+It also exposes image, volume, and network operations including `pull_image()`, `build_image()`, `tag_image()`, `list_volumes()`, `create_volume()`, `list_networks()`, and `connect_container_to_network()`.
+On startup, the toolkit checks common Docker socket locations and pings the Docker daemon.
+`docker` defaults to primary execution, so it normally runs beside the main agent process rather than in the worker sandbox.
 
 ### Configuration
 
@@ -283,7 +322,9 @@ list_networks()
 
 ### What It Does
 
-`calculator` exposes `add()`, `subtract()`, `multiply()`, `divide()`, `exponentiate()`, `factorial()`, `is_prime()`, and `square_root()`. Each function returns a small JSON payload describing the operation and result. `calculator` defaults to primary execution.
+`calculator` exposes `add()`, `subtract()`, `multiply()`, `divide()`, `exponentiate()`, `factorial()`, `is_prime()`, and `square_root()`.
+Each function returns a small JSON payload describing the operation and result.
+`calculator` defaults to primary execution.
 
 ### Configuration
 
@@ -317,7 +358,12 @@ square_root(144)
 
 ### What It Does
 
-`reasoning` exposes `think()` and `analyze()`. Both functions write reasoning steps into run-scoped session state keyed by the current Agno `run_id`. `think()` records an intermediate thought plus an optional next action. `analyze()` records the result of a prior step and maps `next_action` onto `continue`, `validate`, or `final_answer`. These steps are intended for the agent's internal reasoning flow rather than user-visible output. `reasoning` defaults to primary execution.
+`reasoning` exposes `think()` and `analyze()`.
+Both functions write reasoning steps into run-scoped session state keyed by the current Agno `run_id`.
+`think()` records an intermediate thought plus an optional next action.
+`analyze()` records the result of a prior step and maps `next_action` onto `continue`, `validate`, or `final_answer`.
+These steps are intended for the agent's internal reasoning flow rather than user-visible output.
+`reasoning` defaults to primary execution.
 
 ### Configuration
 
@@ -368,7 +414,12 @@ analyze(
 
 ### What It Does
 
-`file_generation` exposes `generate_json_file()`, `generate_csv_file()`, `generate_pdf_file()`, and `generate_text_file()`. Each function returns a `ToolResult` with a generated file artifact attached. If `output_directory` is set, the generated file is also written to disk and the result message includes that file path. If `output_directory` is unset, the file still exists in the tool result payload but is not persisted to disk by the toolkit itself. PDF generation is automatically disabled when `reportlab` is unavailable, even if `enable_pdf_generation` is left on. `file_generation` defaults to primary execution.
+`file_generation` exposes `generate_json_file()`, `generate_csv_file()`, `generate_pdf_file()`, and `generate_text_file()`.
+Each function returns a `ToolResult` with a generated file artifact attached.
+If `output_directory` is set, the generated file is also written to disk and the result message includes that file path.
+If `output_directory` is unset, the file still exists in the tool result payload but is not persisted to disk by the toolkit itself.
+PDF generation is automatically disabled when `reportlab` is unavailable, even if `enable_pdf_generation` is left on.
+`file_generation` defaults to primary execution.
 
 ### Configuration
 
@@ -411,7 +462,10 @@ generate_text_file("Plain text export", filename="notes.txt")
 
 ### What It Does
 
-`visualization` exposes `create_bar_chart()`, `create_line_chart()`, `create_pie_chart()`, `create_scatter_plot()`, and `create_histogram()`. The upstream toolkit switches matplotlib to the non-interactive `Agg` backend and auto-creates `output_dir` if it does not exist. Each chart function accepts dict-like data, list-based data, or JSON strings, normalizes the data, saves a PNG image, and returns a JSON payload with the file path and status. `visualization` defaults to primary execution.
+`visualization` exposes `create_bar_chart()`, `create_line_chart()`, `create_pie_chart()`, `create_scatter_plot()`, and `create_histogram()`.
+The upstream toolkit switches matplotlib to the non-interactive `Agg` backend and auto-creates `output_dir` if it does not exist.
+Each chart function accepts dict-like data, list-based data, or JSON strings, normalizes the data, saves a PNG image, and returns a JSON payload with the file path and status.
+`visualization` defaults to primary execution.
 
 ### Configuration
 
@@ -459,7 +513,8 @@ create_histogram([1, 1, 2, 3, 5, 8, 13], title="Value distribution")
 
 ### What It Does
 
-`sleep` exposes a single `sleep()` function that blocks for the requested number of seconds and then returns a confirmation string. `sleep` defaults to primary execution.
+`sleep` exposes a single `sleep()` function that blocks for the requested number of seconds and then returns a confirmation string.
+`sleep` defaults to primary execution.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__index.md
@@ -4,7 +4,8 @@ MindRoom includes 100+ built-in tools and presets that agents can use to work wi
 
 ## Enabling Tools
 
-Tools are enabled per-agent in the configuration. Each tool entry can be a plain string or a single-key dict with inline config overrides:
+Tools are enabled per-agent in the configuration.
+Each tool entry can be a plain string or a single-key dict with inline config overrides:
 
 ```
 agents:
@@ -28,7 +29,9 @@ defaults:
     - scheduler
 ```
 
-`defaults.tools` are merged into each agent's own `tools` list with duplicates removed. Set `defaults.tools: []` to disable global default tools, or set `agents.<name>.include_default_tools: false` to opt out a specific agent. When the same tool appears in both `defaults.tools` and an agent's `tools` with inline overrides, the per-agent overrides take priority, with non-overlapping keys merged from both. See [Per-Agent Tool Configuration](https://docs.mindroom.chat/configuration/agents/#per-agent-tool-configuration) for the full override syntax and merge order. Configured MCP servers also appear here as dynamic tools named `mcp_<server_id>`. See [MCP](https://docs.mindroom.chat/mcp/index.md) for the `mcp_servers` config and naming rules.
+`defaults.tools` are merged into each agent's own `tools` list with duplicates removed.
+Set `defaults.tools: []` to disable global default tools, or set `agents.<name>.include_default_tools: false` to opt out a specific agent.
+When the same tool appears in both `defaults.tools` and an agent's `tools` with inline overrides, the per-agent overrides take priority, with non-overlapping keys merged from both. See [Per-Agent Tool Configuration](https://docs.mindroom.chat/configuration/agents/#per-agent-tool-configuration) for the full override syntax and merge order. Configured MCP servers also appear here as dynamic tools named `mcp_<server_id>`. See [MCP](https://docs.mindroom.chat/mcp/index.md) for the `mcp_servers` config and naming rules.
 
 ## Browse By Topic
 
@@ -50,23 +53,41 @@ defaults:
 
 ## Tool Presets And Implied Tools
 
-Some entries are config-only presets rather than runtime toolkits. `openclaw_compat` expands to a native bundle of MindRoom tools. Some tools also imply companion tools through `Config.IMPLIED_TOOLS`. Today `matrix_message` implies `attachments`, so the effective tool set includes both even when only `matrix_message` is configured explicitly.
+Some entries are config-only presets rather than runtime toolkits.
+`openclaw_compat` expands to a native bundle of MindRoom tools.
+Some tools also imply companion tools through `Config.IMPLIED_TOOLS`.
+Today `matrix_message` implies `attachments`, so the effective tool set includes both even when only `matrix_message` is configured explicitly.
 
 ## Tool Runtime Context
 
-When a tool runs inside a Matrix-connected agent, it receives a `ToolRuntimeContext` via a context variable. This context carries the current `room_id`, source `thread_id`, canonical `resolved_thread_id`, `requester_id`, `agent_name`, the Matrix client, the active config, and runtime paths. `thread_id` preserves the raw inbound thread provenance, while `resolved_thread_id` is the canonical thread scope after compatible plain replies and other transitive resolution are applied. Tools like `matrix_message`, `matrix_room`, `thread_tags`, and `matrix_api` use this context to act on the correct room and canonical thread without the caller passing explicit IDs. `thread_tags` can also target another authorized room, but it still checks the target room's canonical thread root and requester membership before writing the shared tag state. `thread_tags.tag_thread()` and `thread_tags.untag_thread()` still use the active thread when the caller explicitly repeats the current `room_id`. `thread_tags.list_thread_tags()` uses the active thread by default, but passing `room_id` without `thread_id` forces room-wide listing even from inside an active thread. `thread_tags.list_thread_tags(tag=...)` narrows both thread-specific and room-wide responses to the requested tag only. `thread_tags.list_thread_tags(include_tag=..., exclude_tag=...)` filters which threads are returned: `include_tag` keeps only threads with that tag, `exclude_tag` removes threads with that tag. Both can be combined. Unlike `tag` (which narrows the output payload), these filter which threads appear at all. `thread_tags` also validates and normalizes predefined payload schemas for `blocked.data.blocked_by`, `waiting.data.waiting_on`, `priority.data.level`, and `due.data.deadline`. `thread_tags` intentionally replaces the removed experimental `thread_resolution` tool and does not auto-read old `com.mindroom.thread.resolution` markers. `matrix_api` defaults `room_id` to the active room, supports authorized cross-room targeting, never infers event IDs or state keys from thread context, and now also supports room-scoped full-text search through `action="search"`.
+When a tool runs inside a Matrix-connected agent, it receives a `ToolRuntimeContext` via a context variable.
+This context carries the current `room_id`, source `thread_id`, canonical `resolved_thread_id`, `requester_id`, `agent_name`, the Matrix client, the active config, and runtime paths.
+`thread_id` preserves the raw inbound thread provenance, while `resolved_thread_id` is the canonical thread scope after compatible plain replies and other transitive resolution are applied.
+Tools like `matrix_message`, `matrix_room`, `thread_tags`, and `matrix_api` use this context to act on the correct room and canonical thread without the caller passing explicit IDs.
+`thread_tags` can also target another authorized room, but it still checks the target room's canonical thread root and requester membership before writing the shared tag state.
+`thread_tags.tag_thread()` and `thread_tags.untag_thread()` still use the active thread when the caller explicitly repeats the current `room_id`.
+`thread_tags.list_thread_tags()` uses the active thread by default, but passing `room_id` without `thread_id` forces room-wide listing even from inside an active thread.
+`thread_tags.list_thread_tags(tag=...)` narrows both thread-specific and room-wide responses to the requested tag only.
+`thread_tags.list_thread_tags(include_tag=..., exclude_tag=...)` filters which threads are returned: `include_tag` keeps only threads with that tag, `exclude_tag` removes threads with that tag. Both can be combined. Unlike `tag` (which narrows the output payload), these filter which threads appear at all.
+`thread_tags` also validates and normalizes predefined payload schemas for `blocked.data.blocked_by`, `waiting.data.waiting_on`, `priority.data.level`, and `due.data.deadline`.
+`thread_tags` intentionally replaces the removed experimental `thread_resolution` tool and does not auto-read old `com.mindroom.thread.resolution` markers.
+`matrix_api` defaults `room_id` to the active room, supports authorized cross-room targeting, never infers event IDs or state keys from thread context, and now also supports room-scoped full-text search through `action="search"`.
 
 ## Worker-Routed Execution
 
-Some tools default to running in a sandboxed worker container instead of the primary agent process. The current worker-routed defaults are `file`, `shell`, `python`, and `coding`. Use [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for deployment details and worker-scope behavior.
+Some tools default to running in a sandboxed worker container instead of the primary agent process.
+The current worker-routed defaults are `file`, `shell`, `python`, and `coding`. Use [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md) for deployment details and worker-scope behavior.
 
 ## Shared-Only Integrations
 
-Some dashboard integrations are restricted to shared or unscoped execution and cannot be used by agents with isolating worker scopes. The current shared-only integrations are `google`, `spotify`, `homeassistant`, `gmail`, `google_calendar`, `google_sheets`, and all configured `mcp_<server_id>` tools.
+Some dashboard integrations are restricted to shared or unscoped execution and cannot be used by agents with isolating worker scopes.
+The current shared-only integrations are `google`, `spotify`, `homeassistant`, `gmail`, `google_calendar`, `google_sheets`, and all configured `mcp_<server_id>` tools.
 
 ## Automatic Dependency Installation
 
-Each tool declares its optional Python dependencies in `pyproject.toml`. When a tool is enabled but its dependencies are missing, MindRoom can auto-install the required extra at runtime. Set `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` to disable that behavior.
+Each tool declares its optional Python dependencies in `pyproject.toml`.
+When a tool is enabled but its dependencies are missing, MindRoom can auto-install the required extra at runtime.
+Set `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` to disable that behavior.
 
 ## Related Docs
 

--- a/skills/mindroom-docs/references/page__tools__location-commerce-and-home__index.md
+++ b/skills/mindroom-docs/references/page__tools__location-commerce-and-home__index.md
@@ -4,7 +4,8 @@ Use these tools to search places, fetch weather data, analyze Shopify stores, an
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `location-commerce-and-home` group. Use these tools when you need physical-world lookup data, store analytics, or smart home control.
+This page documents the built-in tools in the `location-commerce-and-home` group.
+Use these tools when you need physical-world lookup data, store analytics, or smart home control.
 
 ## Tools On This Page
 
@@ -15,7 +16,14 @@ This page documents the built-in tools in the `location-commerce-and-home` group
 
 ## Common Setup Notes
 
-All four tools on this page are `requires_config`, so they only become available after the needed credentials or integration setup is present. MindRoom validates inline overrides against the declared `config_fields`, and `type="password"` fields such as `key`, `api_key`, `access_token`, and `HOMEASSISTANT_TOKEN` must be stored through the dashboard or credential store instead of inline YAML. `google_maps`, `openweather`, and `shopify` are standard credential-backed tools with no dedicated MindRoom integration routes in `src/mindroom/api/integrations.py`. Their upstream Agno toolkits also support environment fallbacks through `GOOGLE_MAPS_API_KEY`, `OPENWEATHER_API_KEY`, `SHOPIFY_SHOP_NAME`, and `SHOPIFY_ACCESS_TOKEN`. `homeassistant` is different because MindRoom ships a dedicated integration flow in `src/mindroom/api/homeassistant_integration.py` with both OAuth and long-lived-token setup paths. `homeassistant` is also a shared-only integration, so it requires `worker_scope` to be unset or `shared`. Unlike `google` and `spotify`, `homeassistant` always stays local and is never proxied through worker sandbox routing. Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
+All four tools on this page are `requires_config`, so they only become available after the needed credentials or integration setup is present.
+MindRoom validates inline overrides against the declared `config_fields`, and `type="password"` fields such as `key`, `api_key`, `access_token`, and `HOMEASSISTANT_TOKEN` must be stored through the dashboard or credential store instead of inline YAML.
+`google_maps`, `openweather`, and `shopify` are standard credential-backed tools with no dedicated MindRoom integration routes in `src/mindroom/api/integrations.py`.
+Their upstream Agno toolkits also support environment fallbacks through `GOOGLE_MAPS_API_KEY`, `OPENWEATHER_API_KEY`, `SHOPIFY_SHOP_NAME`, and `SHOPIFY_ACCESS_TOKEN`.
+`homeassistant` is different because MindRoom ships a dedicated integration flow in `src/mindroom/api/homeassistant_integration.py` with both OAuth and long-lived-token setup paths.
+`homeassistant` is also a shared-only integration, so it requires `worker_scope` to be unset or `shared`.
+Unlike `google` and `spotify`, `homeassistant` always stays local and is never proxied through worker sandbox routing.
+Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
 
 ## \[`google_maps`\]
 
@@ -23,7 +31,11 @@ All four tools on this page are `requires_config`, so they only become available
 
 ### What It Does
 
-`google_maps` exposes `search_places()`, `get_directions()`, `validate_address()`, `geocode_address()`, `reverse_geocode()`, `get_distance_matrix()`, `get_elevation()`, and `get_timezone()`. The upstream toolkit builds both a `googlemaps.Client` and a `google.maps.places_v1.PlacesClient`. `search_places()` returns rich place details including name, formatted address, rating, reviews, phone number, website, and opening hours. `validate_address()` uses Google's Address Validation API rather than normal geocoding. MindRoom does not add extra runtime behavior on top of the upstream toolkit beyond metadata, dependency management, and credential storage.
+`google_maps` exposes `search_places()`, `get_directions()`, `validate_address()`, `geocode_address()`, `reverse_geocode()`, `get_distance_matrix()`, `get_elevation()`, and `get_timezone()`.
+The upstream toolkit builds both a `googlemaps.Client` and a `google.maps.places_v1.PlacesClient`.
+`search_places()` returns rich place details including name, formatted address, rating, reviews, phone number, website, and opening hours.
+`validate_address()` uses Google's Address Validation API rather than normal geocoding.
+MindRoom does not add extra runtime behavior on top of the upstream toolkit beyond metadata, dependency management, and credential storage.
 
 ### Configuration
 
@@ -60,7 +72,11 @@ validate_address("1600 Amphitheatre Pkwy, Mountain View, CA", region_code="US")
 
 ### What It Does
 
-`openweather` exposes `get_current_weather()`, `get_forecast()`, `get_air_pollution()`, and `geocode_location()`. The weather, forecast, and air pollution methods geocode the requested location first and then query OpenWeather by latitude and longitude. `units` controls whether the toolkit requests `standard`, `metric`, or `imperial` output from the API. `get_forecast()` uses the 5-day forecast endpoint and caps the response to 40 three-hour entries. MindRoom does not add custom behavior here beyond metadata, dependency management, and credential storage.
+`openweather` exposes `get_current_weather()`, `get_forecast()`, `get_air_pollution()`, and `geocode_location()`.
+The weather, forecast, and air pollution methods geocode the requested location first and then query OpenWeather by latitude and longitude.
+`units` controls whether the toolkit requests `standard`, `metric`, or `imperial` output from the API.
+`get_forecast()` uses the 5-day forecast endpoint and caps the response to 40 three-hour entries.
+MindRoom does not add custom behavior here beyond metadata, dependency management, and credential storage.
 
 ### Configuration
 
@@ -104,7 +120,11 @@ geocode_location("Reykjavik", limit=3)
 
 ### What It Does
 
-`shopify` exposes `get_shop_info()`, `get_products()`, `get_orders()`, `get_top_selling_products()`, `get_products_bought_together()`, `get_sales_by_date_range()`, `get_order_analytics()`, `get_product_sales_breakdown()`, `get_customer_order_history()`, `get_inventory_levels()`, `get_low_stock_products()`, `get_sales_trends()`, `get_average_order_value()`, and `get_repeat_customers()`. The toolkit talks to Shopify's Admin GraphQL endpoint at `https://<shop_name>.myshopify.com/admin/api/<api_version>/graphql.json`. Most list-style methods cap query size to Shopify's first-page limits, such as 250 products or orders. `get_orders()` supports `created_after`, `created_before`, and financial status filters, and the date filters expect `YYYY-MM-DD`. MindRoom does not wrap the Shopify API further, so behavior comes directly from the upstream Agno toolkit.
+`shopify` exposes `get_shop_info()`, `get_products()`, `get_orders()`, `get_top_selling_products()`, `get_products_bought_together()`, `get_sales_by_date_range()`, `get_order_analytics()`, `get_product_sales_breakdown()`, `get_customer_order_history()`, `get_inventory_levels()`, `get_low_stock_products()`, `get_sales_trends()`, `get_average_order_value()`, and `get_repeat_customers()`.
+The toolkit talks to Shopify's Admin GraphQL endpoint at `https://<shop_name>.myshopify.com/admin/api/<api_version>/graphql.json`.
+Most list-style methods cap query size to Shopify's first-page limits, such as 250 products or orders.
+`get_orders()` supports `created_after`, `created_before`, and financial status filters, and the date filters expect `YYYY-MM-DD`.
+MindRoom does not wrap the Shopify API further, so behavior comes directly from the upstream Agno toolkit.
 
 ### Configuration
 
@@ -147,7 +167,11 @@ get_average_order_value(days=30)
 
 ### What It Does
 
-`homeassistant` exposes `get_entity_state()`, `list_entities()`, `turn_on()`, `turn_off()`, `toggle()`, `set_brightness()`, `set_color()`, `set_temperature()`, `activate_scene()`, `trigger_automation()`, and `call_service()`. The toolkit calls Home Assistant's REST API through `/api/states` and `/api/services/...`. `list_entities()` returns a simplified response and limits the output to the first 50 entities to avoid huge payloads. `set_brightness()` validates a `0` to `255` range, `set_color()` validates each RGB channel in the same range, and `call_service()` expects extra service data as a JSON string. MindRoom adds important runtime behavior here by loading scoped credentials, enforcing shared-only integration rules, and returning a clear error when the agent's `worker_scope` does not allow the integration.
+`homeassistant` exposes `get_entity_state()`, `list_entities()`, `turn_on()`, `turn_off()`, `toggle()`, `set_brightness()`, `set_color()`, `set_temperature()`, `activate_scene()`, `trigger_automation()`, and `call_service()`.
+The toolkit calls Home Assistant's REST API through `/api/states` and `/api/services/...`.
+`list_entities()` returns a simplified response and limits the output to the first 50 entities to avoid huge payloads.
+`set_brightness()` validates a `0` to `255` range, `set_color()` validates each RGB channel in the same range, and `call_service()` expects extra service data as a JSON string.
+MindRoom adds important runtime behavior here by loading scoped credentials, enforcing shared-only integration rules, and returning a clear error when the agent's `worker_scope` does not allow the integration.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -4,7 +4,8 @@ Use these tools to work inside the active Matrix room and thread, send follow-up
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `matrix-and-attachments` group. Use these tools when you need to send or inspect Matrix messages, manage thread tags or summaries, or handle attachment IDs that are scoped to the current room and thread.
+This page documents the built-in tools in the `matrix-and-attachments` group.
+Use these tools when you need to send or inspect Matrix messages, manage thread tags or summaries, or handle attachment IDs that are scoped to the current room and thread.
 
 ## Tools On This Page
 
@@ -16,7 +17,10 @@ This page documents the built-in tools in the `matrix-and-attachments` group. Us
 
 ## Common Setup Notes
 
-These tools depend on the active `ToolRuntimeContext`, so they only work when an agent is running in a Matrix-connected conversation. `matrix_message` implies `attachments` through `Config.IMPLIED_TOOLS`, so enabling `matrix_message` makes the `attachments` toolkit available even when you do not list it separately. Attachment IDs are context-scoped `att_*` values, and the runtime only exposes IDs from the current conversation plus any IDs registered during the current tool run. Current source in this worktree exposes `matrix_message`, `thread_tags`, `thread_summary`, `matrix_api`, and `attachments` in this area.
+These tools depend on the active `ToolRuntimeContext`, so they only work when an agent is running in a Matrix-connected conversation.
+`matrix_message` implies `attachments` through `Config.IMPLIED_TOOLS`, so enabling `matrix_message` makes the `attachments` toolkit available even when you do not list it separately.
+Attachment IDs are context-scoped `att_*` values, and the runtime only exposes IDs from the current conversation plus any IDs registered during the current tool run.
+Current source in this worktree exposes `matrix_message`, `thread_tags`, `thread_summary`, `matrix_api`, and `attachments` in this area.
 
 ## \[`matrix_message`\]
 
@@ -24,7 +28,20 @@ These tools depend on the active `ToolRuntimeContext`, so they only work when an
 
 ### What It Does
 
-`matrix_message` supports `send`, `reply`, `thread-reply`, `react`, `read`, `thread-list`, `edit`, and `context`. `send` targets the room timeline by default, even when the current conversation is inside a thread. When a room-level `send` includes both text and attachments, the text is posted to the room timeline and the attachments are threaded under that new text event. When a room-level `send` includes multiple attachments and no text, the first attachment is posted to the room timeline and the remaining attachments are threaded under it. When `send` uses an explicit `thread_id`, both text and attachments stay in that existing thread instead of creating a new attachment thread. In `thread_mode: room`, room-level `send` stays plain room messaging and does not auto-thread attachments unless you pass an explicit `thread_id`. `reply` and `thread-reply` inherit the current thread when one can be resolved, and they return an error when no thread target is available. `read`, `edit`, and `context` also inherit the current thread when one can be resolved, while `thread_id="room"` forces room-level scope instead of thread inheritance. `thread-list` uses the current thread when one is active, and it requires an explicit `thread_id` when there is no active thread context. `react` requires `target` and uses `👍` when `message` is empty. `read` defaults to 20 messages and caps `limit` at 50. `thread-list` returns recent thread messages plus `edit_options` for messages that the current Matrix account can edit. Only `send`, `reply`, and `thread-reply` accept attachments, with a combined cap of five `attachment_ids` plus `attachment_file_paths` per call. The tool rate-limits each `(agent_name, requester_id, room_id)` combination to 12 weighted actions per 30 seconds, where each attachment increases the weight of a send or reply.
+`matrix_message` supports `send`, `reply`, `thread-reply`, `react`, `read`, `thread-list`, `edit`, and `context`.
+`send` targets the room timeline by default, even when the current conversation is inside a thread.
+When a room-level `send` includes both text and attachments, the text is posted to the room timeline and the attachments are threaded under that new text event.
+When a room-level `send` includes multiple attachments and no text, the first attachment is posted to the room timeline and the remaining attachments are threaded under it.
+When `send` uses an explicit `thread_id`, both text and attachments stay in that existing thread instead of creating a new attachment thread.
+In `thread_mode: room`, room-level `send` stays plain room messaging and does not auto-thread attachments unless you pass an explicit `thread_id`.
+`reply` and `thread-reply` inherit the current thread when one can be resolved, and they return an error when no thread target is available.
+`read`, `edit`, and `context` also inherit the current thread when one can be resolved, while `thread_id="room"` forces room-level scope instead of thread inheritance.
+`thread-list` uses the current thread when one is active, and it requires an explicit `thread_id` when there is no active thread context.
+`react` requires `target` and uses `👍` when `message` is empty.
+`read` defaults to 20 messages and caps `limit` at 50.
+`thread-list` returns recent thread messages plus `edit_options` for messages that the current Matrix account can edit.
+Only `send`, `reply`, and `thread-reply` accept attachments, with a combined cap of five `attachment_ids` plus `attachment_file_paths` per call.
+The tool rate-limits each `(agent_name, requester_id, room_id)` combination to 12 weighted actions per 30 seconds, where each attachment increases the weight of a send or reply.
 
 ### Configuration
 
@@ -64,7 +81,14 @@ matrix_message(action="react", target="$event123", message="✅")
 
 ### What It Does
 
-`thread_tags` exposes `tag_thread()`, `untag_thread()`, and `list_thread_tags()`. All three operations default to the current room and active resolved thread context. When there is no active resolved thread context, pass `thread_id` explicitly. The tool normalizes the supplied event into the canonical thread root before reading or writing state. Tags are stored as `com.mindroom.thread.tags` room state. Each `(thread_root_id, tag)` pair uses its own state event, and the state key is the JSON array `[thread_root_id, tag]`. Writes fail unless both the running Matrix client and the human requester have enough power to send that state event in the target room. When the requester differs from the bot account, the requester must also be joined to the target room.
+`thread_tags` exposes `tag_thread()`, `untag_thread()`, and `list_thread_tags()`.
+All three operations default to the current room and active resolved thread context.
+When there is no active resolved thread context, pass `thread_id` explicitly.
+The tool normalizes the supplied event into the canonical thread root before reading or writing state.
+Tags are stored as `com.mindroom.thread.tags` room state.
+Each `(thread_root_id, tag)` pair uses its own state event, and the state key is the JSON array `[thread_root_id, tag]`.
+Writes fail unless both the running Matrix client and the human requester have enough power to send that state event in the target room.
+When the requester differs from the bot account, the requester must also be joined to the target room.
 
 ### Configuration
 
@@ -97,7 +121,12 @@ list_thread_tags(thread_id="$threadRootEvent")
 
 ### What It Does
 
-`thread_summary` exposes `set_thread_summary(summary, thread_id=None, room_id=None)`. The tool defaults to the active room and current resolved thread from `ToolRuntimeContext`. When there is no active resolved thread context, pass `thread_id` explicitly. The tool normalizes the target to the canonical thread root before sending a new `m.notice` summary event with `io.mindroom.thread_summary` metadata. Manual summaries are marked with `model_name="manual"` and update the cached last-summary count so later automatic summaries continue from the new baseline. A per-thread async lock prevents concurrent duplicate manual summaries from racing each other.
+`thread_summary` exposes `set_thread_summary(summary, thread_id=None, room_id=None)`.
+The tool defaults to the active room and current resolved thread from `ToolRuntimeContext`.
+When there is no active resolved thread context, pass `thread_id` explicitly.
+The tool normalizes the target to the canonical thread root before sending a new `m.notice` summary event with `io.mindroom.thread_summary` metadata.
+Manual summaries are marked with `model_name="manual"` and update the cached last-summary count so later automatic summaries continue from the new baseline.
+A per-thread async lock prevents concurrent duplicate manual summaries from racing each other.
 
 ### Configuration
 
@@ -133,7 +162,15 @@ set_thread_summary(
 
 ### What It Does
 
-`matrix_api` supports `send_event`, `get_state`, `put_state`, `redact`, `get_event`, and `search`. It defaults `room_id` to the active room, but it also supports authorized cross-room access when the requester is allowed to act there. It never infers thread IDs, event IDs, or state keys from thread context, so callers must pass those identifiers explicitly for low-level operations. `send_event`, `put_state`, and `redact` are rate-limited per `(agent_name, requester_id, room_id)` and audited in logs. Dangerous state event types like `m.room.power_levels` and `m.room.encryption` are blocked by default. Pass `allow_dangerous=true` only when you intentionally want to change critical room state. Hard-blocked state event types like `m.room.create` remain blocked. `search` is read-only, scopes results to one room via `room_id`, uses the top-level `limit` parameter, and rejects `filter.limit`. When `event_context={"include_profile": true}` is requested, returned context preserves `profile_info` for matching senders.
+`matrix_api` supports `send_event`, `get_state`, `put_state`, `redact`, `get_event`, and `search`.
+It defaults `room_id` to the active room, but it also supports authorized cross-room access when the requester is allowed to act there.
+It never infers thread IDs, event IDs, or state keys from thread context, so callers must pass those identifiers explicitly for low-level operations.
+`send_event`, `put_state`, and `redact` are rate-limited per `(agent_name, requester_id, room_id)` and audited in logs.
+Dangerous state event types like `m.room.power_levels` and `m.room.encryption` are blocked by default.
+Pass `allow_dangerous=true` only when you intentionally want to change critical room state.
+Hard-blocked state event types like `m.room.create` remain blocked.
+`search` is read-only, scopes results to one room via `room_id`, uses the top-level `limit` parameter, and rejects `filter.limit`.
+When `event_context={"include_profile": true}` is requested, returned context preserves `profile_info` for matching senders.
 
 ### Configuration
 
@@ -179,7 +216,15 @@ matrix_api(
 
 ### What It Does
 
-`attachments` exposes `list_attachments()`, `get_attachment()`, and `register_attachment()`. `list_attachments()` returns the attachment IDs currently available in tool runtime context, the resolved metadata payloads, and any `missing_attachment_ids`. `get_attachment()` returns a single attachment record, including the runtime-local path, when called with only an attachment ID. `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest. Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace. The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion. `register_attachment()` turns a local file path into a new context-scoped `att_*` ID and appends that ID to the current runtime context so later tool calls in the same run can reuse it. Attachment records include kind, filename, MIME type, room ID, thread ID, sender, creation time, and an `available` flag that reports whether the local file still exists. This tool does not send files by itself, but its IDs can be passed to `matrix_message` for `send`, `reply`, or `thread-reply`.
+`attachments` exposes `list_attachments()`, `get_attachment()`, and `register_attachment()`.
+`list_attachments()` returns the attachment IDs currently available in tool runtime context, the resolved metadata payloads, and any `missing_attachment_ids`.
+`get_attachment()` returns a single attachment record, including the runtime-local path, when called with only an attachment ID.
+`get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
+Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
+The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
+`register_attachment()` turns a local file path into a new context-scoped `att_*` ID and appends that ID to the current runtime context so later tool calls in the same run can reuse it.
+Attachment records include kind, filename, MIME type, room ID, thread ID, sender, creation time, and an `available` flag that reports whether the local file still exists.
+This tool does not send files by itself, but its IDs can be passed to `matrix_message` for `send`, `reply`, or `thread-reply`.
 
 ### Configuration
 
@@ -210,7 +255,10 @@ matrix_message(action="reply", message="Sharing the plan here.", attachment_ids=
 
 ## Related Matrix Runtime Features
 
-Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior. The summarizer posts one `m.notice` summary after a thread reaches the configured first threshold (one message by default), and then again every ten additional messages by default, using `defaults.thread_summary_model` or `default`. MindRoom uses `defaults.thread_summary_temperature` for automatic summaries when the provider supports runtime temperature overrides, and always omits temperature for Vertex Claude summaries. The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
+Automatic thread summaries are still implemented in `src/mindroom/thread_summary.py` as bot runtime behavior.
+The summarizer posts one `m.notice` summary after a thread reaches the configured first threshold (one message by default), and then again every ten additional messages by default, using `defaults.thread_summary_model` or `default`.
+MindRoom uses `defaults.thread_summary_temperature` for automatic summaries when the provider supports runtime temperature overrides, and always omits temperature for Vertex Claude summaries.
+The `thread_summary` tool complements that automatic behavior by letting an agent publish a manual summary immediately and advance the stored summary baseline.
 
 ## Related Docs
 

--- a/skills/mindroom-docs/references/page__tools__media-and-content__index.md
+++ b/skills/mindroom-docs/references/page__tools__media-and-content__index.md
@@ -4,7 +4,8 @@ Use these tools to process local video files, search GIFs and stock images, insp
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `media-and-content` group. Use these tools when you need local video processing, media lookup, brand asset retrieval, or Spotify-backed search and playlist workflows.
+This page documents the built-in tools in the `media-and-content` group.
+Use these tools when you need local video processing, media lookup, brand asset retrieval, or Spotify-backed search and playlist workflows.
 
 ## Tools On This Page
 
@@ -17,7 +18,15 @@ This page documents the built-in tools in the `media-and-content` group. Use the
 
 ## Common Setup Notes
 
-`moviepy_video_tools` and `youtube` are `setup_type: none`, so they do not need dashboard OAuth or stored API credentials. `giphy`, `unsplash`, `brandfetch`, and `spotify` all use stored credentials, and password-type fields such as `api_key`, `access_key`, and `access_token` should be managed through the dashboard or credential store instead of inline YAML. The upstream toolkits for `giphy`, `unsplash`, and `brandfetch` also fall back to provider-specific environment variables such as `GIPHY_API_KEY`, `UNSPLASH_ACCESS_KEY`, `BRANDFETCH_API_KEY`, and `BRANDFETCH_CLIENT_ID`. These tools operate on external URLs or local file paths rather than Matrix attachment IDs directly. When you pass local files, the paths must exist inside the runtime that executes the tool. Missing optional Python dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set. That matters most on this page for `moviepy_video_tools`, `giphy`, `brandfetch`, `spotify`, and `youtube`. `spotify` is the only tool on this page with dedicated integration routes in `src/mindroom/api/integrations.py`. MindRoom treats `spotify` as a shared-only integration, so dashboard credential management and tool support require `worker_scope` unset or `shared`, not `user` or `user_agent`.
+`moviepy_video_tools` and `youtube` are `setup_type: none`, so they do not need dashboard OAuth or stored API credentials.
+`giphy`, `unsplash`, `brandfetch`, and `spotify` all use stored credentials, and password-type fields such as `api_key`, `access_key`, and `access_token` should be managed through the dashboard or credential store instead of inline YAML.
+The upstream toolkits for `giphy`, `unsplash`, and `brandfetch` also fall back to provider-specific environment variables such as `GIPHY_API_KEY`, `UNSPLASH_ACCESS_KEY`, `BRANDFETCH_API_KEY`, and `BRANDFETCH_CLIENT_ID`.
+These tools operate on external URLs or local file paths rather than Matrix attachment IDs directly.
+When you pass local files, the paths must exist inside the runtime that executes the tool.
+Missing optional Python dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
+That matters most on this page for `moviepy_video_tools`, `giphy`, `brandfetch`, `spotify`, and `youtube`.
+`spotify` is the only tool on this page with dedicated integration routes in `src/mindroom/api/integrations.py`.
+MindRoom treats `spotify` as a shared-only integration, so dashboard credential management and tool support require `worker_scope` unset or `shared`, not `user` or `user_agent`.
 
 ## \[`moviepy_video_tools`\]
 
@@ -25,7 +34,11 @@ This page documents the built-in tools in the `media-and-content` group. Use the
 
 ### What It Does
 
-`moviepy_video_tools` exposes `extract_audio(video_path, output_path)`, `create_srt(transcription, output_path)`, and `embed_captions(video_path, srt_path, output_path=None, font_size=24, font_color="white", stroke_color="black", stroke_width=1)`. Despite the `enable_process_video` config name, the current upstream method it enables is specifically `extract_audio()`, not a general-purpose video editing surface. `create_srt()` writes the provided transcription text directly to disk, so it expects the caller to already have SRT-formatted content. `embed_captions()` reads an SRT file, converts it to word timings, and renders word-highlighted captions onto a new MP4 output. This tool works entirely on local files, so it is only useful when the agent runtime can read the source media and write the output paths.
+`moviepy_video_tools` exposes `extract_audio(video_path, output_path)`, `create_srt(transcription, output_path)`, and `embed_captions(video_path, srt_path, output_path=None, font_size=24, font_color="white", stroke_color="black", stroke_width=1)`.
+Despite the `enable_process_video` config name, the current upstream method it enables is specifically `extract_audio()`, not a general-purpose video editing surface.
+`create_srt()` writes the provided transcription text directly to disk, so it expects the caller to already have SRT-formatted content.
+`embed_captions()` reads an SRT file, converts it to word timings, and renders word-highlighted captions onto a new MP4 output.
+This tool works entirely on local files, so it is only useful when the agent runtime can read the source media and write the output paths.
 
 ### Configuration
 
@@ -64,7 +77,10 @@ embed_captions("clips/demo.mp4", "clips/demo.srt", output_path="clips/demo_capti
 
 ### What It Does
 
-`giphy` exposes `search_gifs(query)`. The upstream method signature includes the active agent or team object, but MindRoom callers only provide the search query because the runtime injects the current tool context. Successful calls return a `ToolResult` with both plain-text URLs and attached image artifacts for each GIF. `limit` is fixed at toolkit construction time, so callers do not set result count per request.
+`giphy` exposes `search_gifs(query)`.
+The upstream method signature includes the active agent or team object, but MindRoom callers only provide the search query because the runtime injects the current tool context.
+Successful calls return a `ToolResult` with both plain-text URLs and attached image artifacts for each GIF.
+`limit` is fixed at toolkit construction time, so callers do not set result count per request.
 
 ### Configuration
 
@@ -101,7 +117,11 @@ search_gifs("matrix code review celebration")
 
 ### What It Does
 
-`youtube` exposes `get_youtube_video_data(url)`, `get_youtube_video_captions(url)`, and `get_video_timestamps(url)`. `get_youtube_video_data()` uses YouTube's oEmbed endpoint and returns metadata such as title, author, thumbnail, size, and provider fields. `get_youtube_video_captions()` and `get_video_timestamps()` use `youtube_transcript_api` against the parsed video ID. The current tool does not perform keyword-based YouTube search. It expects a specific YouTube URL and then fetches metadata or transcript-derived output for that video.
+`youtube` exposes `get_youtube_video_data(url)`, `get_youtube_video_captions(url)`, and `get_video_timestamps(url)`.
+`get_youtube_video_data()` uses YouTube's oEmbed endpoint and returns metadata such as title, author, thumbnail, size, and provider fields.
+`get_youtube_video_captions()` and `get_video_timestamps()` use `youtube_transcript_api` against the parsed video ID.
+The current tool does not perform keyword-based YouTube search.
+It expects a specific YouTube URL and then fetches metadata or transcript-derived output for that video.
 
 ### Configuration
 
@@ -142,7 +162,12 @@ get_video_timestamps("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
 
 ### What It Does
 
-`unsplash` exposes `search_photos(query, per_page=10, page=1, orientation=None, color=None)`, `get_photo(photo_id)`, `get_random_photo(query=None, orientation=None, count=1)`, and optionally `download_photo(photo_id)`. `search_photos()` returns a JSON payload with total counts plus a simplified list of photo metadata, author info, and image URLs. `get_photo()` adds extra fields such as EXIF data, views, downloads, and location when the API returns them. `get_random_photo()` supports an optional query filter and returns one or more formatted photo records. `download_photo()` does not fetch the image binary. It triggers Unsplash's required download-tracking endpoint and returns the download URL that the caller can fetch separately.
+`unsplash` exposes `search_photos(query, per_page=10, page=1, orientation=None, color=None)`, `get_photo(photo_id)`, `get_random_photo(query=None, orientation=None, count=1)`, and optionally `download_photo(photo_id)`.
+`search_photos()` returns a JSON payload with total counts plus a simplified list of photo metadata, author info, and image URLs.
+`get_photo()` adds extra fields such as EXIF data, views, downloads, and location when the API returns them.
+`get_random_photo()` supports an optional query filter and returns one or more formatted photo records.
+`download_photo()` does not fetch the image binary.
+It triggers Unsplash's required download-tracking endpoint and returns the download URL that the caller can fetch separately.
 
 ### Configuration
 
@@ -183,7 +208,11 @@ get_photo("abcd1234")
 
 ### What It Does
 
-`brandfetch` exposes `search_by_identifier(identifier)` and optionally `search_by_brand(name)`. `search_by_identifier()` uses the Brand API and accepts domains, Brandfetch brand IDs, ISINs, or stock tickers. `search_by_brand()` uses the Brand Search API and is useful when you only know the brand name and need to discover the canonical brand entry first. The two methods use different credentials. `search_by_identifier()` requires `api_key`, while `search_by_brand()` requires `client_id`.
+`brandfetch` exposes `search_by_identifier(identifier)` and optionally `search_by_brand(name)`.
+`search_by_identifier()` uses the Brand API and accepts domains, Brandfetch brand IDs, ISINs, or stock tickers.
+`search_by_brand()` uses the Brand Search API and is useful when you only know the brand name and need to discover the canonical brand entry first.
+The two methods use different credentials.
+`search_by_identifier()` requires `api_key`, while `search_by_brand()` requires `client_id`.
 
 ### Configuration
 
@@ -226,7 +255,11 @@ search_by_brand("OpenAI")
 
 ### What It Does
 
-`spotify` exposes a broad toolkit including `search_tracks()`, `search_playlists()`, `search_artists()`, `search_albums()`, `get_user_playlists()`, `get_track_recommendations()`, `get_artist_top_tracks()`, `get_album_tracks()`, `get_my_top_tracks()`, `get_my_top_artists()`, `create_playlist()`, `add_tracks_to_playlist()`, `get_playlist()`, `update_playlist_details()`, `remove_tracks_from_playlist()`, `get_current_user()`, `play_track()`, and `get_currently_playing()`. The tool itself consumes an `access_token`, but MindRoom also provides a dedicated dashboard OAuth flow in `src/mindroom/api/integrations.py` via `/api/integrations/spotify/connect`, `/spotify/status`, `/spotify/callback`, and `/spotify/disconnect`. That OAuth flow stores `access_token` plus extra metadata such as `refresh_token`, `expires_at`, and `username`. By default the connect flow requests the scopes `user-read-private`, `user-read-email`, `user-read-playback-state`, `user-read-currently-playing`, and `user-top-read`. The upstream playlist and playback methods need additional Spotify scopes beyond that base dashboard flow, so manual token provisioning or a broadened OAuth scope set is still required if you want playlist modification or playback control to succeed.
+`spotify` exposes a broad toolkit including `search_tracks()`, `search_playlists()`, `search_artists()`, `search_albums()`, `get_user_playlists()`, `get_track_recommendations()`, `get_artist_top_tracks()`, `get_album_tracks()`, `get_my_top_tracks()`, `get_my_top_artists()`, `create_playlist()`, `add_tracks_to_playlist()`, `get_playlist()`, `update_playlist_details()`, `remove_tracks_from_playlist()`, `get_current_user()`, `play_track()`, and `get_currently_playing()`.
+The tool itself consumes an `access_token`, but MindRoom also provides a dedicated dashboard OAuth flow in `src/mindroom/api/integrations.py` via `/api/integrations/spotify/connect`, `/spotify/status`, `/spotify/callback`, and `/spotify/disconnect`.
+That OAuth flow stores `access_token` plus extra metadata such as `refresh_token`, `expires_at`, and `username`.
+By default the connect flow requests the scopes `user-read-private`, `user-read-email`, `user-read-playback-state`, `user-read-currently-playing`, and `user-top-read`.
+The upstream playlist and playback methods need additional Spotify scopes beyond that base dashboard flow, so manual token provisioning or a broadened OAuth scope set is still required if you want playlist modification or playback control to succeed.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__memory-and-storage__index.md
+++ b/skills/mindroom-docs/references/page__tools__memory-and-storage__index.md
@@ -4,7 +4,8 @@ Use these tools to explicitly manage MindRoom memory or connect an agent to exte
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `memory-and-storage` group. Use these tools when you need explicit memory CRUD operations, direct provider-specific memory access, or a clear separation between MindRoom memory and third-party memory services.
+This page documents the built-in tools in the `memory-and-storage` group.
+Use these tools when you need explicit memory CRUD operations, direct provider-specific memory access, or a clear separation between MindRoom memory and third-party memory services.
 
 ## Tools On This Page
 
@@ -14,7 +15,14 @@ This page documents the built-in tools in the `memory-and-storage` group. Use th
 
 ## Common Setup Notes
 
-`memory` is MindRoom-native and has no tool-specific configuration fields. It operates on the same MindRoom memory backend configured through `memory.backend` or `agents.<name>.memory_backend`, so it follows the effective `mem0`, `file`, or `none` backend for that agent. If the effective backend is `none`, MindRoom does not attach the `memory` tool to that agent. Use [Memory System](https://docs.mindroom.chat/memory/index.md) for the canonical docs on backend selection, automatic extraction, file-backed memory, Agno Learning, and storage layout. `mem0` and `zep` are separate upstream Agno toolkits that talk to external memory providers directly. Enabling `mem0` or `zep` does not change MindRoom's own memory backend, automatic memory extraction, or the behavior of the `memory` tool. `mem0` can work with a hosted Mem0 API key or with local/default upstream Mem0 configuration. `zep` requires a Zep API key, either through stored credentials or the `ZEP_API_KEY` environment variable. If optional dependencies for these tools are missing, MindRoom can auto-install them at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set. This page does not document conversation-scoped file attachments even though they are storage-like. Use [Matrix & Attachments](https://docs.mindroom.chat/tools/matrix-and-attachments/index.md) and [Attachments](https://docs.mindroom.chat/attachments/index.md) for attachment IDs, retention, and Matrix media flow.
+`memory` is MindRoom-native and has no tool-specific configuration fields.
+It operates on the same MindRoom memory backend configured through `memory.backend` or `agents.<name>.memory_backend`, so it follows the effective `mem0`, `file`, or `none` backend for that agent.
+If the effective backend is `none`, MindRoom does not attach the `memory` tool to that agent. Use [Memory System](https://docs.mindroom.chat/memory/index.md) for the canonical docs on backend selection, automatic extraction, file-backed memory, Agno Learning, and storage layout. `mem0` and `zep` are separate upstream Agno toolkits that talk to external memory providers directly.
+Enabling `mem0` or `zep` does not change MindRoom's own memory backend, automatic memory extraction, or the behavior of the `memory` tool.
+`mem0` can work with a hosted Mem0 API key or with local/default upstream Mem0 configuration.
+`zep` requires a Zep API key, either through stored credentials or the `ZEP_API_KEY` environment variable.
+If optional dependencies for these tools are missing, MindRoom can auto-install them at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
+This page does not document conversation-scoped file attachments even though they are storage-like. Use [Matrix & Attachments](https://docs.mindroom.chat/tools/matrix-and-attachments/index.md) and [Attachments](https://docs.mindroom.chat/attachments/index.md) for attachment IDs, retention, and Matrix media flow.
 
 ## \[`memory`\]
 
@@ -22,7 +30,12 @@ This page documents the built-in tools in the `memory-and-storage` group. Use th
 
 ### What It Does
 
-`memory` exposes `add_memory()`, `search_memories()`, `list_memories()`, `get_memory()`, `update_memory()`, and `delete_memory()`. It complements MindRoom's automatic post-response memory extraction by letting the agent deliberately remember or inspect something on demand. The tool always uses the current agent's configured MindRoom memory backend, so the same calls work whether that agent uses built-in `mem0` storage or file-backed memory. Agents with `memory_backend: none` do not receive this tool. Search and list results include memory IDs, and those IDs are then used with `get_memory()`, `update_memory()`, and `delete_memory()`. The tool is bound to the current agent's MindRoom scope and can reach any agent or team memories that MindRoom makes visible to that agent.
+`memory` exposes `add_memory()`, `search_memories()`, `list_memories()`, `get_memory()`, `update_memory()`, and `delete_memory()`.
+It complements MindRoom's automatic post-response memory extraction by letting the agent deliberately remember or inspect something on demand.
+The tool always uses the current agent's configured MindRoom memory backend, so the same calls work whether that agent uses built-in `mem0` storage or file-backed memory.
+Agents with `memory_backend: none` do not receive this tool.
+Search and list results include memory IDs, and those IDs are then used with `get_memory()`, `update_memory()`, and `delete_memory()`.
+The tool is bound to the current agent's MindRoom scope and can reach any agent or team memories that MindRoom makes visible to that agent.
 
 ### Configuration
 
@@ -61,7 +74,12 @@ delete_memory("abc123")
 
 ### What It Does
 
-`mem0` exposes `add_memory()`, `search_memory()`, `get_all_memories()`, and `delete_all_memories()`. It uses the upstream `mem0ai` client directly rather than MindRoom's built-in memory API. If `api_key` is set, or `MEM0_API_KEY` is present in the environment, the toolkit connects to Mem0's hosted platform client. If no API key is present but `config` is supplied, the toolkit initializes upstream Mem0 from that local config object. If neither `api_key` nor `config` is supplied, the toolkit falls back to upstream Mem0 defaults. Operations need a `user_id`, either from tool config or from the run context, and they return an error string when no user ID can be resolved.
+`mem0` exposes `add_memory()`, `search_memory()`, `get_all_memories()`, and `delete_all_memories()`.
+It uses the upstream `mem0ai` client directly rather than MindRoom's built-in memory API.
+If `api_key` is set, or `MEM0_API_KEY` is present in the environment, the toolkit connects to Mem0's hosted platform client.
+If no API key is present but `config` is supplied, the toolkit initializes upstream Mem0 from that local config object.
+If neither `api_key` nor `config` is supplied, the toolkit falls back to upstream Mem0 defaults.
+Operations need a `user_id`, either from tool config or from the run context, and they return an error string when no user ID can be resolved.
 
 ### Configuration
 
@@ -110,7 +128,14 @@ delete_all_memories()
 
 ### What It Does
 
-`zep` exposes `add_zep_message()`, `get_zep_memory()`, and `search_zep_memory()`. The toolkit requires a Zep API key at initialization time and raises an error when neither `api_key` nor `ZEP_API_KEY` is available. If `session_id` is omitted, the toolkit generates a new session ID automatically. If `user_id` is omitted, the toolkit generates a new Zep user and creates it in the remote account. If `user_id` is provided but the user does not exist yet, the toolkit attempts to create it before use. `get_zep_memory(memory_type="context")` returns either session context or raw message history. `search_zep_memory(query, search_scope="edges")` searches the Zep user graph by facts or nodes. `ignore_assistant_messages` skips assistant-role content when messages are added to Zep.
+`zep` exposes `add_zep_message()`, `get_zep_memory()`, and `search_zep_memory()`.
+The toolkit requires a Zep API key at initialization time and raises an error when neither `api_key` nor `ZEP_API_KEY` is available.
+If `session_id` is omitted, the toolkit generates a new session ID automatically.
+If `user_id` is omitted, the toolkit generates a new Zep user and creates it in the remote account.
+If `user_id` is provided but the user does not exist yet, the toolkit attempts to create it before use.
+`get_zep_memory(memory_type="context")` returns either session context or raw message history.
+`search_zep_memory(query, search_scope="edges")` searches the Zep user graph by facts or nodes.
+`ignore_assistant_messages` skips assistant-role content when messages are added to Zep.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__messaging-and-social__index.md
+++ b/skills/mindroom-docs/references/page__tools__messaging-and-social__index.md
@@ -4,7 +4,8 @@ Use these tools to read and send email, post into chat systems, deliver SMS or W
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `messaging-and-social` group. Use these tools when you need outbound communication, mailbox access, team-chat delivery, social/community lookups, or Zoom meeting management.
+This page documents the built-in tools in the `messaging-and-social` group.
+Use these tools when you need outbound communication, mailbox access, team-chat delivery, social/community lookups, or Zoom meeting management.
 
 ## Tools On This Page
 
@@ -23,7 +24,17 @@ This page documents the built-in tools in the `messaging-and-social` group. Use 
 
 ## Common Setup Notes
 
-`gmail` is the only tool on this page with `auth_provider="google"`. It uses the shared Google Services integration instead of standalone per-tool credentials. `gmail` is also a shared-only integration, so it is supported only for unscoped agents or agents with `worker_scope: shared`. Like `google_calendar`, `google_sheets`, and `homeassistant`, `gmail` stays local even when other tools are routed through the sandbox proxy. MindRoom enforces that restriction both at config-validation time and again during tool construction. On this branch, `src/mindroom/api/integrations.py` only exposes Spotify routes, while Google OAuth lives in `src/mindroom/api/google_integration.py`, so the rest of the tools on this page rely on ordinary stored tool credentials or SDK environment variables rather than a dedicated MindRoom OAuth flow. Password fields should be stored through the dashboard or credential store instead of inline YAML. Several metadata fields on this page are marked `required: false`, but the installed SDKs still need the corresponding token or secret in practice. Useful environment fallbacks on this page include `SLACK_TOKEN`, `DISCORD_BOT_TOKEN`, `TELEGRAM_TOKEN`, `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `WEBEX_ACCESS_TOKEN`, `RESEND_API_KEY`, `X_BEARER_TOKEN`, `X_CONSUMER_KEY`, `X_CONSUMER_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`, `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USERNAME`, `REDDIT_PASSWORD`, `ZOOM_ACCOUNT_ID`, `ZOOM_CLIENT_ID`, and `ZOOM_CLIENT_SECRET`. The generic-looking `email` tool is not a fully configurable SMTP client on this branch. Its installed upstream implementation is hard-wired to Gmail SMTP over `smtp.gmail.com:465` and does not expose SMTP host, port, or TLS configuration fields.
+`gmail` is the only tool on this page with `auth_provider="google"`.
+It uses the shared Google Services integration instead of standalone per-tool credentials.
+`gmail` is also a shared-only integration, so it is supported only for unscoped agents or agents with `worker_scope: shared`.
+Like `google_calendar`, `google_sheets`, and `homeassistant`, `gmail` stays local even when other tools are routed through the sandbox proxy.
+MindRoom enforces that restriction both at config-validation time and again during tool construction.
+On this branch, `src/mindroom/api/integrations.py` only exposes Spotify routes, while Google OAuth lives in `src/mindroom/api/google_integration.py`, so the rest of the tools on this page rely on ordinary stored tool credentials or SDK environment variables rather than a dedicated MindRoom OAuth flow.
+Password fields should be stored through the dashboard or credential store instead of inline YAML.
+Several metadata fields on this page are marked `required: false`, but the installed SDKs still need the corresponding token or secret in practice.
+Useful environment fallbacks on this page include `SLACK_TOKEN`, `DISCORD_BOT_TOKEN`, `TELEGRAM_TOKEN`, `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `WEBEX_ACCESS_TOKEN`, `RESEND_API_KEY`, `X_BEARER_TOKEN`, `X_CONSUMER_KEY`, `X_CONSUMER_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`, `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USERNAME`, `REDDIT_PASSWORD`, `ZOOM_ACCOUNT_ID`, `ZOOM_CLIENT_ID`, and `ZOOM_CLIENT_SECRET`.
+The generic-looking `email` tool is not a fully configurable SMTP client on this branch.
+Its installed upstream implementation is hard-wired to Gmail SMTP over `smtp.gmail.com:465` and does not expose SMTP host, port, or TLS configuration fields.
 
 ## \[`gmail`\]
 
@@ -31,7 +42,10 @@ This page documents the built-in tools in the `messaging-and-social` group. Use 
 
 ### What It Does
 
-MindRoom wraps Agno's `GmailTools` with `ScopedGoogleOAuthMixin`, so Gmail credentials are loaded from MindRoom's unified Google credential store instead of a local `token.json` file. The wrapper refreshes stored Google tokens when needed and falls back to the upstream auth flow only when no stored credentials are available. The current installed Gmail toolkit exposes `get_latest_emails()`, `get_emails_from_user()`, `get_unread_emails()`, `get_starred_emails()`, `get_emails_by_context()`, `get_emails_by_date()`, `get_emails_by_thread()`, `search_emails()`, `create_draft_email()`, `send_email()`, `send_email_reply()`, `mark_email_as_read()`, `mark_email_as_unread()`, `list_custom_labels()`, `apply_label()`, `remove_label()`, and `delete_custom_label()`. Draft and send operations accept local file-system paths for attachments.
+MindRoom wraps Agno's `GmailTools` with `ScopedGoogleOAuthMixin`, so Gmail credentials are loaded from MindRoom's unified Google credential store instead of a local `token.json` file.
+The wrapper refreshes stored Google tokens when needed and falls back to the upstream auth flow only when no stored credentials are available.
+The current installed Gmail toolkit exposes `get_latest_emails()`, `get_emails_from_user()`, `get_unread_emails()`, `get_starred_emails()`, `get_emails_by_context()`, `get_emails_by_date()`, `get_emails_by_thread()`, `search_emails()`, `create_draft_email()`, `send_email()`, `send_email_reply()`, `mark_email_as_read()`, `mark_email_as_unread()`, `list_custom_labels()`, `apply_label()`, `remove_label()`, and `delete_custom_label()`.
+Draft and send operations accept local file-system paths for attachments.
 
 ### Configuration
 
@@ -78,7 +92,10 @@ apply_label("is:unread category:promotions", "Needs Review", count=10)
 
 ### What It Does
 
-The installed upstream tool exposes `send_message()`, `send_message_thread()`, `list_channels()`, and `get_channel_history()`. It uses Slack's `WebClient` from `slack_sdk`. `markdown` maps to the `mrkdwn` flag on `chat_postMessage()`. Channel-history responses are normalized into a smaller JSON structure instead of returning the full Slack API payload.
+The installed upstream tool exposes `send_message()`, `send_message_thread()`, `list_channels()`, and `get_channel_history()`.
+It uses Slack's `WebClient` from `slack_sdk`.
+`markdown` maps to the `mrkdwn` flag on `chat_postMessage()`.
+Channel-history responses are normalized into a smaller JSON structure instead of returning the full Slack API payload.
 
 ### Configuration
 
@@ -122,7 +139,10 @@ get_channel_history("C0123456789", limit=25)
 
 ### What It Does
 
-The installed upstream tool exposes `send_message()`, `get_channel_messages()`, `get_channel_info()`, `list_channels()`, and `delete_message()`. It talks directly to `https://discord.com/api/v10` with a bot token in the `Authorization` header. This is a raw REST wrapper rather than a gateway-connected real-time bot runtime. Most functions expect Discord IDs such as `channel_id`, `guild_id`, and `message_id`, not display names.
+The installed upstream tool exposes `send_message()`, `get_channel_messages()`, `get_channel_info()`, `list_channels()`, and `delete_message()`.
+It talks directly to `https://discord.com/api/v10` with a bot token in the `Authorization` header.
+This is a raw REST wrapper rather than a gateway-connected real-time bot runtime.
+Most functions expect Discord IDs such as `channel_id`, `guild_id`, and `message_id`, not display names.
 
 ### Configuration
 
@@ -165,7 +185,10 @@ send_message("123456789012345678", "Hello from MindRoom.")
 
 ### What It Does
 
-The installed upstream tool exposes only `send_message()`. It posts to Telegram Bot API `sendMessage` for the configured `chat_id`. The tool instance is bound to one chat destination, so callers do not pass a chat ID per request. Responses are returned as the raw Telegram API response text.
+The installed upstream tool exposes only `send_message()`.
+It posts to Telegram Bot API `sendMessage` for the configured `chat_id`.
+The tool instance is bound to one chat destination, so callers do not pass a chat ID per request.
+Responses are returned as the raw Telegram API response text.
 
 ### Configuration
 
@@ -202,7 +225,10 @@ send_message("Nightly backup completed.")
 
 ### What It Does
 
-The installed upstream tool can expose either `send_text_message_sync()` and `send_template_message_sync()` or their async variants, depending on `async_mode`. It posts to `https://graph.facebook.com/<version>/<phone_number_id>/messages`. `recipient_waid` sets a default recipient so callers can omit the `recipient` argument. If no default recipient is configured, every send call must provide one.
+The installed upstream tool can expose either `send_text_message_sync()` and `send_template_message_sync()` or their async variants, depending on `async_mode`.
+It posts to `https://graph.facebook.com/<version>/<phone_number_id>/messages`.
+`recipient_waid` sets a default recipient so callers can omit the `recipient` argument.
+If no default recipient is configured, every send call must provide one.
 
 ### Configuration
 
@@ -243,7 +269,10 @@ send_template_message_sync(template_name="deployment_notice", language_code="en_
 
 ### What It Does
 
-The installed upstream tool exposes `send_sms()`, `get_call_details()`, and `list_messages()`. It supports two auth modes: `account_sid` plus `auth_token`, or `account_sid` plus `api_key` and `api_secret`. Optional `region` and `edge` are passed into the Twilio client for regional routing. `send_sms()` validates that both `to` and `from_` are in E.164 format before sending.
+The installed upstream tool exposes `send_sms()`, `get_call_details()`, and `list_messages()`.
+It supports two auth modes: `account_sid` plus `auth_token`, or `account_sid` plus `api_key` and `api_secret`.
+Optional `region` and `edge` are passed into the Twilio client for regional routing.
+`send_sms()` validates that both `to` and `from_` are in E.164 format before sending.
 
 ### Configuration
 
@@ -291,7 +320,10 @@ list_messages(limit=10)
 
 ### What It Does
 
-The installed upstream tool exposes `send_message()` and `list_rooms()`. It authenticates with `webexpythonsdk.WebexAPI` using one access token. Despite the broader description in the registry, the current tool surface is messaging-centric and does not manage meetings. Responses are returned as JSON strings built from the SDK result objects.
+The installed upstream tool exposes `send_message()` and `list_rooms()`.
+It authenticates with `webexpythonsdk.WebexAPI` using one access token.
+Despite the broader description in the registry, the current tool surface is messaging-centric and does not manage meetings.
+Responses are returned as JSON strings built from the SDK result objects.
 
 ### Configuration
 
@@ -329,7 +361,10 @@ send_message("Y2lzY29zcGFyazovL3VzL1JPT00v...", "Agenda is ready.")
 
 ### What It Does
 
-The installed upstream tool exposes one function, `send_email()`. It sets `resend.api_key` on each call and sends email through `resend.Emails.send()`. The current implementation passes the message body as HTML, not plain text. `from_email` is stored on the tool instance and reused for every call.
+The installed upstream tool exposes one function, `send_email()`.
+It sets `resend.api_key` on each call and sends email through `resend.Emails.send()`.
+The current implementation passes the message body as HTML, not plain text.
+`from_email` is stored on the tool instance and reused for every call.
 
 ### Configuration
 
@@ -366,7 +401,10 @@ send_email("alice@example.com", "Welcome", "<p>Your account is ready.</p>")
 
 ### What It Does
 
-The installed upstream tool exposes one function, `email_user()`. It builds an `EmailMessage`, then logs in with `smtplib.SMTP_SSL("smtp.gmail.com", 465)`. That means the sender account must be a Gmail account or a Google Workspace account compatible with Gmail SMTP. The current implementation sends plain-text bodies only.
+The installed upstream tool exposes one function, `email_user()`.
+It builds an `EmailMessage`, then logs in with `smtplib.SMTP_SSL("smtp.gmail.com", 465)`.
+That means the sender account must be a Gmail account or a Google Workspace account compatible with Gmail SMTP.
+The current implementation sends plain-text bodies only.
 
 ### Configuration
 
@@ -408,7 +446,10 @@ email_user("Nightly report", "The report finished successfully.")
 
 ### What It Does
 
-The installed upstream tool exposes `create_post()`, `reply_to_post()`, `send_dm()`, `get_user_info()`, `get_home_timeline()`, and `search_posts()`. It uses `tweepy.Client` and passes through `wait_on_rate_limit`. `search_posts()` calls `search_recent_tweets()` and, when `include_post_metrics` is enabled, augments each returned post with reply, retweet, like, and quote counts. The implementation clamps `max_results` for search to the Twitter API's supported `10` to `100` range.
+The installed upstream tool exposes `create_post()`, `reply_to_post()`, `send_dm()`, `get_user_info()`, `get_home_timeline()`, and `search_posts()`.
+It uses `tweepy.Client` and passes through `wait_on_rate_limit`.
+`search_posts()` calls `search_recent_tweets()` and, when `include_post_metrics` is enabled, augments each returned post with reply, retweet, like, and quote counts.
+The implementation clamps `max_results` for search to the Twitter API's supported `10` to `100` range.
 
 ### Configuration
 
@@ -452,7 +493,10 @@ reply_to_post("1890123456789012345", "Thanks for the feedback.")
 
 ### What It Does
 
-The installed upstream tool exposes `get_user_info()`, `get_top_posts()`, `get_subreddit_info()`, `get_trending_subreddits()`, `get_subreddit_stats()`, `create_post()`, `reply_to_post()`, and `reply_to_comment()`. With only `client_id` and `client_secret`, the tool initializes a read-only `praw.Reddit` client. If `username` and `password` are also configured, the tool enables posting and replying with authenticated user actions. `reddit_instance` is an advanced programmatic injection point for an existing `praw.Reddit` object rather than a normal YAML value.
+The installed upstream tool exposes `get_user_info()`, `get_top_posts()`, `get_subreddit_info()`, `get_trending_subreddits()`, `get_subreddit_stats()`, `create_post()`, `reply_to_post()`, and `reply_to_comment()`.
+With only `client_id` and `client_secret`, the tool initializes a read-only `praw.Reddit` client.
+If `username` and `password` are also configured, the tool enables posting and replying with authenticated user actions.
+`reddit_instance` is an advanced programmatic injection point for an existing `praw.Reddit` object rather than a normal YAML value.
 
 ### Configuration
 
@@ -494,7 +538,10 @@ get_user_info("spez")
 
 ### What It Does
 
-The installed upstream tool exposes `get_access_token()`, `schedule_meeting()`, `get_upcoming_meetings()`, `list_meetings()`, `get_meeting_recordings()`, `delete_meeting()`, and `get_meeting()`. It exchanges `account_id`, `client_id`, and `client_secret` against `https://zoom.us/oauth/token` with `grant_type=account_credentials`. The generated access token is cached in process until shortly before expiry. Meeting creation always targets `users/me/meetings` and applies a fixed set of default meeting settings in the upstream implementation.
+The installed upstream tool exposes `get_access_token()`, `schedule_meeting()`, `get_upcoming_meetings()`, `list_meetings()`, `get_meeting_recordings()`, `delete_meeting()`, and `get_meeting()`.
+It exchanges `account_id`, `client_id`, and `client_secret` against `https://zoom.us/oauth/token` with `grant_type=account_credentials`.
+The generated access token is cached in process until shortly before expiry.
+Meeting creation always targets `users/me/meetings` and applies a fixed set of default meeting settings in the upstream implementation.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__project-management__index.md
+++ b/skills/mindroom-docs/references/page__tools__project-management__index.md
@@ -4,7 +4,8 @@ Use these tools to work with source hosts, issue trackers, knowledge bases, kanb
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `project-management` group. Use these tools when you need repository context, issue tracking, documentation updates, board workflows, personal task management, or support article search.
+This page documents the built-in tools in the `project-management` group.
+Use these tools when you need repository context, issue tracking, documentation updates, board workflows, personal task management, or support article search.
 
 ## Tools On This Page
 
@@ -21,7 +22,12 @@ This page documents the built-in tools in the `project-management` group. Use th
 
 ## Common Setup Notes
 
-All tools on this page are registered as `status=requires_config`, so they stay unavailable in the dashboard until their required credentials or connection fields are present. None of these tools declare an `auth_provider`, and `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes, so project-management tools are configured through stored tool credentials or environment variables rather than a dedicated dashboard OAuth flow. Password and token fields should be stored through the dashboard or credential store instead of inline YAML. Most upstream SDKs also read environment variables, including `GITHUB_ACCESS_TOKEN`, `BITBUCKET_USERNAME`, `BITBUCKET_PASSWORD`, `BITBUCKET_TOKEN`, `JIRA_SERVER_URL`, `JIRA_USERNAME`, `JIRA_PASSWORD`, `JIRA_TOKEN`, `LINEAR_API_KEY`, `CLICKUP_API_KEY`, `MASTER_SPACE_ID`, `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, `CONFLUENCE_API_KEY`, `CONFLUENCE_PASSWORD`, `NOTION_API_KEY`, `NOTION_DATABASE_ID`, `TRELLO_API_KEY`, `TRELLO_API_SECRET`, `TRELLO_TOKEN`, `TODOIST_API_TOKEN`, `ZENDESK_USERNAME`, `ZENDESK_PASSWORD`, and `ZENDESK_COMPANY_NAME`. Several registry fields on this page are marked optional in metadata even though the upstream tool effectively requires them at runtime, so the notes below call out the practical requirement level for each tool. Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
+All tools on this page are registered as `status=requires_config`, so they stay unavailable in the dashboard until their required credentials or connection fields are present.
+None of these tools declare an `auth_provider`, and `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes, so project-management tools are configured through stored tool credentials or environment variables rather than a dedicated dashboard OAuth flow.
+Password and token fields should be stored through the dashboard or credential store instead of inline YAML.
+Most upstream SDKs also read environment variables, including `GITHUB_ACCESS_TOKEN`, `BITBUCKET_USERNAME`, `BITBUCKET_PASSWORD`, `BITBUCKET_TOKEN`, `JIRA_SERVER_URL`, `JIRA_USERNAME`, `JIRA_PASSWORD`, `JIRA_TOKEN`, `LINEAR_API_KEY`, `CLICKUP_API_KEY`, `MASTER_SPACE_ID`, `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, `CONFLUENCE_API_KEY`, `CONFLUENCE_PASSWORD`, `NOTION_API_KEY`, `NOTION_DATABASE_ID`, `TRELLO_API_KEY`, `TRELLO_API_SECRET`, `TRELLO_TOKEN`, `TODOIST_API_TOKEN`, `ZENDESK_USERNAME`, `ZENDESK_PASSWORD`, and `ZENDESK_COMPANY_NAME`.
+Several registry fields on this page are marked optional in metadata even though the upstream tool effectively requires them at runtime, so the notes below call out the practical requirement level for each tool.
+Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
 
 ## \[`github`\]
 
@@ -29,7 +35,10 @@ All tools on this page are registered as `status=requires_config`, so they stay 
 
 ### What It Does
 
-`github` exposes repository discovery methods such as `search_repositories()`, `list_repositories()`, `get_repository()`, `get_repository_with_stats()`, `list_branches()`, `get_repository_languages()`, and `get_repository_stars()`. It also exposes issue and pull request workflows such as `list_issues()`, `get_issue()`, `comment_on_issue()`, `edit_issue()`, `get_pull_request()`, `get_pull_request_comments()`, `create_pull_request()`, `create_pull_request_comment()`, and `create_review_request()`. The file-management surface includes `create_file()`, `get_file_content()`, `update_file()`, `delete_file()`, `get_directory_content()`, and `get_branch_content()`. `base_url` lets the same tool talk to GitHub Enterprise, but it must point at the API root rather than the normal web UI root.
+`github` exposes repository discovery methods such as `search_repositories()`, `list_repositories()`, `get_repository()`, `get_repository_with_stats()`, `list_branches()`, `get_repository_languages()`, and `get_repository_stars()`.
+It also exposes issue and pull request workflows such as `list_issues()`, `get_issue()`, `comment_on_issue()`, `edit_issue()`, `get_pull_request()`, `get_pull_request_comments()`, `create_pull_request()`, `create_pull_request_comment()`, and `create_review_request()`.
+The file-management surface includes `create_file()`, `get_file_content()`, `update_file()`, `delete_file()`, `get_directory_content()`, and `get_branch_content()`.
+`base_url` lets the same tool talk to GitHub Enterprise, but it must point at the API root rather than the normal web UI root.
 
 ### Configuration
 
@@ -66,7 +75,9 @@ get_pull_request("mindroom-ai/mindroom", 123)
 
 ### What It Does
 
-`bitbucket` exposes `list_repositories()`, `get_repository_details()`, `create_repository()`, `list_repository_commits()`, `list_all_pull_requests()`, `get_pull_request_details()`, `get_pull_request_changes()`, and `list_issues()`. The tool always authenticates with a configured `username` plus either `password` or `token`, and it scopes most operations to the configured `workspace` and `repo_slug`. If `server_url` has no scheme, the upstream tool normalizes it to `https://<server_url>/<api_version>`.
+`bitbucket` exposes `list_repositories()`, `get_repository_details()`, `create_repository()`, `list_repository_commits()`, `list_all_pull_requests()`, `get_pull_request_details()`, `get_pull_request_changes()`, and `list_issues()`.
+The tool always authenticates with a configured `username` plus either `password` or `token`, and it scopes most operations to the configured `workspace` and `repo_slug`.
+If `server_url` has no scheme, the upstream tool normalizes it to `https://<server_url>/<api_version>`.
 
 ### Configuration
 
@@ -110,7 +121,9 @@ list_repository_commits(count=10)
 
 ### What It Does
 
-`jira` can expose `get_issue()`, `create_issue()`, `search_issues()`, `add_comment()`, and `add_worklog()` through individual enable flags. `server_url` is required at runtime, and the upstream client authenticates with `username` plus `token` when both are present, falls back to `username` plus `password`, and otherwise attempts anonymous access. `search_issues()` uses plain JQL, which makes it the main entry point for filtered issue lists and backlog queries.
+`jira` can expose `get_issue()`, `create_issue()`, `search_issues()`, `add_comment()`, and `add_worklog()` through individual enable flags.
+`server_url` is required at runtime, and the upstream client authenticates with `username` plus `token` when both are present, falls back to `username` plus `password`, and otherwise attempts anonymous access.
+`search_issues()` uses plain JQL, which makes it the main entry point for filtered issue lists and backlog queries.
 
 ### Configuration
 
@@ -157,7 +170,9 @@ add_comment("PROJ-123", "Reviewed and ready for testing.")
 
 ### What It Does
 
-`linear` exposes `get_user_details()`, `get_teams_details()`, `get_issue_details()`, `create_issue()`, `update_issue()`, `get_user_assigned_issues()`, `get_workflow_issues()`, and `get_high_priority_issues()`. All calls go to `https://api.linear.app/graphql`, and the tool expects a Linear API key in either `api_key` or `LINEAR_API_KEY`. The read methods are useful for discovering the IDs you need before calling `create_issue()` or `update_issue()`.
+`linear` exposes `get_user_details()`, `get_teams_details()`, `get_issue_details()`, `create_issue()`, `update_issue()`, `get_user_assigned_issues()`, `get_workflow_issues()`, and `get_high_priority_issues()`.
+All calls go to `https://api.linear.app/graphql`, and the tool expects a Linear API key in either `api_key` or `LINEAR_API_KEY`.
+The read methods are useful for discovering the IDs you need before calling `create_issue()` or `update_issue()`.
 
 ### Configuration
 
@@ -192,7 +207,10 @@ get_high_priority_issues()
 
 ### What It Does
 
-`clickup` exposes `list_tasks()`, `create_task()`, `get_task()`, `update_task()`, `delete_task()`, `list_spaces()`, and `list_lists()`. The tool uses `master_space_id` to call ClickUp's `team/{id}/space` endpoints, so this field is effectively the team or workspace identifier used to discover spaces. Name-based space and list lookup is case-insensitive and also supports regex-style matching in the current upstream implementation. `list_tasks()` aggregates tasks across all lists in a space, while `create_task()` creates into the first list returned for the matched space.
+`clickup` exposes `list_tasks()`, `create_task()`, `get_task()`, `update_task()`, `delete_task()`, `list_spaces()`, and `list_lists()`.
+The tool uses `master_space_id` to call ClickUp's `team/{id}/space` endpoints, so this field is effectively the team or workspace identifier used to discover spaces.
+Name-based space and list lookup is case-insensitive and also supports regex-style matching in the current upstream implementation.
+`list_tasks()` aggregates tasks across all lists in a space, while `create_task()` creates into the first list returned for the matched space.
 
 ### Configuration
 
@@ -229,7 +247,10 @@ create_task("Engineering", "ISSUE-075", "Draft the project-management tool page"
 
 ### What It Does
 
-`confluence` exposes `get_page_content()`, `get_space_key()`, `create_page()`, `update_page()`, `get_all_space_detail()`, and `get_all_page_from_space()`. The tool resolves a space by human-readable name or by key, and other space-scoped methods depend on that resolution step. `get_page_content()` defaults to `expand="body.storage"`, and `create_page()` and `update_page()` pass raw body content to the Confluence API. At runtime the tool accepts either `api_key` or `password`, with the current implementation preferring `api_key` or `CONFLUENCE_API_KEY` when both are present.
+`confluence` exposes `get_page_content()`, `get_space_key()`, `create_page()`, `update_page()`, `get_all_space_detail()`, and `get_all_page_from_space()`.
+The tool resolves a space by human-readable name or by key, and other space-scoped methods depend on that resolution step.
+`get_page_content()` defaults to `expand="body.storage"`, and `create_page()` and `update_page()` pass raw body content to the Confluence API.
+At runtime the tool accepts either `api_key` or `password`, with the current implementation preferring `api_key` or `CONFLUENCE_API_KEY` when both are present.
 
 ### Configuration
 
@@ -270,7 +291,11 @@ create_page("Engineering", "Release Notes", "<p>Initial draft</p>")
 
 ### What It Does
 
-`notion` can expose `create_page()`, `update_page()`, and `search_pages()` through individual enable flags. The current upstream implementation assumes the target database has a title property named `Name` and a select property named `Tag`. `create_page()` creates a page with a title, a tag, and one initial paragraph block. `update_page()` appends a paragraph block to an existing page instead of rewriting the whole page. `search_pages()` queries the database directly over HTTP and filters by the `Tag` select value.
+`notion` can expose `create_page()`, `update_page()`, and `search_pages()` through individual enable flags.
+The current upstream implementation assumes the target database has a title property named `Name` and a select property named `Tag`.
+`create_page()` creates a page with a title, a tag, and one initial paragraph block.
+`update_page()` appends a paragraph block to an existing page instead of rewriting the whole page.
+`search_pages()` queries the database directly over HTTP and filters by the `Tag` select value.
 
 ### Configuration
 
@@ -312,7 +337,10 @@ update_page("PAGE_ID", "Added rollout notes")
 
 ### What It Does
 
-`trello` exposes `create_card()`, `get_board_lists()`, `move_card()`, `get_cards()`, `create_board()`, `create_list()`, and `list_boards()`. `create_card()` looks up the target list by case-insensitive `list_name` within a board and then creates the card there. `move_card()` works by card ID and destination list ID, which makes `get_board_lists()` and `get_cards()` the normal discovery helpers before edits. If the Trello client cannot initialize, the current upstream methods return `"Trello client not initialized"` instead of structured JSON.
+`trello` exposes `create_card()`, `get_board_lists()`, `move_card()`, `get_cards()`, `create_board()`, `create_list()`, and `list_boards()`.
+`create_card()` looks up the target list by case-insensitive `list_name` within a board and then creates the card there.
+`move_card()` works by card ID and destination list ID, which makes `get_board_lists()` and `get_cards()` the normal discovery helpers before edits.
+If the Trello client cannot initialize, the current upstream methods return `"Trello client not initialized"` instead of structured JSON.
 
 ### Configuration
 
@@ -349,7 +377,10 @@ create_card("BOARD_ID", "To Do", "Write docs", "Draft the new tool page")
 
 ### What It Does
 
-`todoist` exposes `create_task()`, `get_task()`, `update_task()`, `close_task()`, `delete_task()`, `get_active_tasks()`, and `get_projects()`. `create_task()` supports optional `project_id`, natural-language `due_string`, `priority`, and `labels`. `update_task()` is the richest write method, with support for content, description, labels, priority, `due_string`, `due_date`, `due_datetime`, `due_lang`, `assignee_id`, and `section_id`. `close_task()` marks a task complete, while `delete_task()` permanently removes it.
+`todoist` exposes `create_task()`, `get_task()`, `update_task()`, `close_task()`, `delete_task()`, `get_active_tasks()`, and `get_projects()`.
+`create_task()` supports optional `project_id`, natural-language `due_string`, `priority`, and `labels`.
+`update_task()` is the richest write method, with support for content, description, labels, priority, `due_string`, `due_date`, `due_datetime`, `due_lang`, `assignee_id`, and `section_id`.
+`close_task()` marks a task complete, while `delete_task()` permanently removes it.
 
 ### Configuration
 
@@ -384,7 +415,10 @@ close_task("TASK_ID")
 
 ### What It Does
 
-`zendesk` can expose `search_zendesk()` through the `enable_search_zendesk` flag. The current upstream implementation calls the Zendesk Help Center articles search endpoint at `https://<company_name>.zendesk.com/api/v2/help_center/articles/search.json`. Search results are reduced to cleaned article body text with HTML tags removed. This tool does not expose ticket lookup or ticket updates on this branch.
+`zendesk` can expose `search_zendesk()` through the `enable_search_zendesk` flag.
+The current upstream implementation calls the Zendesk Help Center articles search endpoint at `https://<company_name>.zendesk.com/api/v2/help_center/articles/search.json`.
+Search results are reduced to cleaned article body text with HTML tags removed.
+This tool does not expose ticket lookup or ticket updates on this branch.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__research-sources__index.md
+++ b/skills/mindroom-docs/references/page__tools__research-sources__index.md
@@ -4,7 +4,8 @@ Use these tools to query source-specific knowledge bases such as ArXiv, Wikipedi
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `research-sources` group. Use these tools when you want paper-only search, encyclopedia summaries, biomedical literature lookup, or Hacker News story and user data.
+This page documents the built-in tools in the `research-sources` group.
+Use these tools when you want paper-only search, encyclopedia summaries, biomedical literature lookup, or Hacker News story and user data.
 
 ## Tools On This Page
 
@@ -15,7 +16,10 @@ This page documents the built-in tools in the `research-sources` group. Use thes
 
 ## Common Setup Notes
 
-All four tools are `setup_type: none`, so they work out of the box and do not require API keys or OAuth. `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes on this branch, so these tools have no dedicated dashboard auth flow. Missing optional Python dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set. MindRoom does not add Matrix runtime-context behavior or worker-routing overrides for these tools. Use [Web Search](https://docs.mindroom.chat/tools/web-search/index.md) instead when you need broader web discovery, news search, or provider-backed search APIs.
+All four tools are `setup_type: none`, so they work out of the box and do not require API keys or OAuth.
+`src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes on this branch, so these tools have no dedicated dashboard auth flow.
+Missing optional Python dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
+MindRoom does not add Matrix runtime-context behavior or worker-routing overrides for these tools. Use [Web Search](https://docs.mindroom.chat/tools/web-search/index.md) instead when you need broader web discovery, news search, or provider-backed search APIs.
 
 ## \[`arxiv`\]
 
@@ -23,7 +27,9 @@ All four tools are `setup_type: none`, so they work out of the box and do not re
 
 ### What It Does
 
-By default `arxiv` exposes `search_arxiv_and_return_articles(query, num_articles=10)` and `read_arxiv_papers(id_list, pages_to_read=None)`. Search results are returned as JSON with title, short ID, entry URL, authors, categories, publish timestamp, PDF URL, links, summary, and comment. Reading papers downloads each PDF locally, parses it with `pypdf`, and returns the same metadata plus per-page extracted text.
+By default `arxiv` exposes `search_arxiv_and_return_articles(query, num_articles=10)` and `read_arxiv_papers(id_list, pages_to_read=None)`.
+Search results are returned as JSON with title, short ID, entry URL, authors, categories, publish timestamp, PDF URL, links, summary, and comment.
+Reading papers downloads each PDF locally, parses it with `pypdf`, and returns the same metadata plus per-page extracted text.
 
 ### Configuration
 
@@ -61,7 +67,9 @@ read_arxiv_papers(["2103.03404v1"], pages_to_read=3)
 
 ### What It Does
 
-In normal MindRoom usage `wikipedia` exposes `search_wikipedia(query)`, which returns one JSON document containing the queried title and `wikipedia.summary(query)` content. If an upstream `Knowledge` object is injected, the toolkit instead exposes `search_wikipedia_and_update_knowledge_base(topic)`, which inserts the topic into that knowledge base and returns relevant documents from it. This makes `wikipedia` a simple direct lookup tool by default, with an advanced knowledge-base update mode for custom integrations.
+In normal MindRoom usage `wikipedia` exposes `search_wikipedia(query)`, which returns one JSON document containing the queried title and `wikipedia.summary(query)` content.
+If an upstream `Knowledge` object is injected, the toolkit instead exposes `search_wikipedia_and_update_knowledge_base(topic)`, which inserts the topic into that knowledge base and returns relevant documents from it.
+This makes `wikipedia` a simple direct lookup tool by default, with an advanced knowledge-base update mode for custom integrations.
 
 ### Configuration
 
@@ -95,7 +103,10 @@ search_wikipedia("Matrix protocol")
 
 ### What It Does
 
-`pubmed` exposes `search_pubmed(query, max_results=10)`. It first looks up PubMed IDs through `esearch`, then fetches article XML through `efetch`, and finally returns a JSON list of formatted result strings. Default output includes title, publication year, and summary text. When `results_expanded` is enabled, each result also includes first author, journal, publication type, DOI, PubMed URL, full-text URL when available, keywords, and MeSH terms.
+`pubmed` exposes `search_pubmed(query, max_results=10)`.
+It first looks up PubMed IDs through `esearch`, then fetches article XML through `efetch`, and finally returns a JSON list of formatted result strings.
+Default output includes title, publication year, and summary text.
+When `results_expanded` is enabled, each result also includes first author, journal, publication type, DOI, PubMed URL, full-text URL when available, keywords, and MeSH terms.
 
 ### Configuration
 
@@ -135,7 +146,9 @@ search_pubmed("CRISPR therapy", max_results=5)
 
 ### What It Does
 
-By default `hackernews` exposes `get_top_hackernews_stories(num_stories=10)` and `get_user_details(username)`. Top-story lookups return the raw story objects from the Hacker News item endpoint, with an extra `username` field copied from `by`. User lookups return a smaller JSON object with karma, about text, and total submitted item count.
+By default `hackernews` exposes `get_top_hackernews_stories(num_stories=10)` and `get_user_details(username)`.
+Top-story lookups return the raw story objects from the Hacker News item endpoint, with an extra `username` field copied from `by`.
+User lookups return a smaller JSON object with karma, about text, and total submitted item count.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__web-scraping-and-browser__index.md
+++ b/skills/mindroom-docs/references/page__tools__web-scraping-and-browser__index.md
@@ -4,7 +4,8 @@ Use these tools to read pages, extract article text, crawl websites, and drive e
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `web-scraping-and-browser` group. Use these tools when you need lightweight text extraction, structured scraping APIs, or browser automation against live websites.
+This page documents the built-in tools in the `web-scraping-and-browser` group.
+Use these tools when you need lightweight text extraction, structured scraping APIs, or browser automation against live websites.
 
 ## Tools On This Page
 
@@ -26,7 +27,15 @@ This page documents the built-in tools in the `web-scraping-and-browser` group. 
 
 ## Common Setup Notes
 
-`crawl4ai`, `website`, `trafilatura`, `newspaper`, and `web_browser_tools` are the lowest-friction no-config options on this page. `firecrawl`, `browserbase`, `agentql`, `scrapegraph`, `apify`, `brightdata`, and `oxylabs` are all credentialed tools that normally need stored credentials or SDK environment variables before they are useful. `spider` also needs credentials in practice even though the current MindRoom metadata marks it as `setup_type: none`, because the installed `spider-client` raises when `SPIDER_API_KEY` is missing. `jina` is the middle ground here, because the installed `JinaReaderTools` only adds an `Authorization` header when `api_key` is present, so public `read_url()` usage works without a key while authenticated plans can still set one. `browser` is local Playwright automation, `browserbase` is a hosted browser API that you connect to over CDP, and `web_browser_tools` simply asks the host operating system to open a browser tab or window. `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes on this branch, so none of the tools on this page have a dedicated MindRoom OAuth flow. Store password fields through the dashboard or credential store instead of inline YAML, and use environment variables such as `FIRECRAWL_API_KEY`, `SPIDER_API_KEY`, `BROWSERBASE_API_KEY`, `BROWSERBASE_PROJECT_ID`, `AGENTQL_API_KEY`, `SGAI_API_KEY`, `APIFY_API_TOKEN`, `BRIGHT_DATA_API_KEY`, `OXYLABS_USERNAME`, `OXYLABS_PASSWORD`, and `JINA_API_KEY` when you prefer SDK-native auth. `crawl4ai`, `agentql`, `browserbase`, and `browser` also depend on a working browser runtime, and `web_browser_tools` only makes sense on a host that can open a real desktop browser. Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
+`crawl4ai`, `website`, `trafilatura`, `newspaper`, and `web_browser_tools` are the lowest-friction no-config options on this page.
+`firecrawl`, `browserbase`, `agentql`, `scrapegraph`, `apify`, `brightdata`, and `oxylabs` are all credentialed tools that normally need stored credentials or SDK environment variables before they are useful.
+`spider` also needs credentials in practice even though the current MindRoom metadata marks it as `setup_type: none`, because the installed `spider-client` raises when `SPIDER_API_KEY` is missing.
+`jina` is the middle ground here, because the installed `JinaReaderTools` only adds an `Authorization` header when `api_key` is present, so public `read_url()` usage works without a key while authenticated plans can still set one.
+`browser` is local Playwright automation, `browserbase` is a hosted browser API that you connect to over CDP, and `web_browser_tools` simply asks the host operating system to open a browser tab or window.
+`src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes on this branch, so none of the tools on this page have a dedicated MindRoom OAuth flow.
+Store password fields through the dashboard or credential store instead of inline YAML, and use environment variables such as `FIRECRAWL_API_KEY`, `SPIDER_API_KEY`, `BROWSERBASE_API_KEY`, `BROWSERBASE_PROJECT_ID`, `AGENTQL_API_KEY`, `SGAI_API_KEY`, `APIFY_API_TOKEN`, `BRIGHT_DATA_API_KEY`, `OXYLABS_USERNAME`, `OXYLABS_PASSWORD`, and `JINA_API_KEY` when you prefer SDK-native auth.
+`crawl4ai`, `agentql`, `browserbase`, and `browser` also depend on a working browser runtime, and `web_browser_tools` only makes sense on a host that can open a real desktop browser.
+Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
 
 ## No-Config Scrapers
 
@@ -36,7 +45,12 @@ This page documents the built-in tools in the `web-scraping-and-browser` group. 
 
 #### What It Does
 
-`crawl4ai` exposes `crawl(url, search_query=None)`. It accepts either one URL string or a list of URLs and returns readable extracted content for each one. When you pass `search_query`, the tool enables BM25-based content filtering to keep the extracted text focused on that query. When `use_pruning` is enabled without a query, the tool uses Crawl4AI pruning to trim noisy page content. The current implementation bypasses Crawl4AI cache for fresher reads and truncates the result to `max_length` when needed. This is a local crawler rather than a hosted API, so it does not need an API key, but it still needs a working browser runtime.
+`crawl4ai` exposes `crawl(url, search_query=None)`.
+It accepts either one URL string or a list of URLs and returns readable extracted content for each one.
+When you pass `search_query`, the tool enables BM25-based content filtering to keep the extracted text focused on that query.
+When `use_pruning` is enabled without a query, the tool uses Crawl4AI pruning to trim noisy page content.
+The current implementation bypasses Crawl4AI cache for fresher reads and truncates the result to `max_length` when needed.
+This is a local crawler rather than a hosted API, so it does not need an API key, but it still needs a working browser runtime.
 
 #### Configuration
 
@@ -81,7 +95,10 @@ crawl("https://matrix.org/blog/", search_query="bridges and federation")
 
 #### What It Does
 
-With normal MindRoom YAML configuration, `website` exposes `read_url(url)` and returns JSON-serialized `Document` objects from Agno's `WebsiteReader`. If a `Knowledge` object is injected programmatically through the `knowledge` constructor argument, the tool exposes `add_website_to_knowledge(url)` instead of `read_url()`. That means the same registry entry can act either as a simple page reader or as a knowledge-base ingestion hook depending on how it is constructed. In normal hand-authored `config.yaml`, you should treat this as a quick page-reading tool.
+With normal MindRoom YAML configuration, `website` exposes `read_url(url)` and returns JSON-serialized `Document` objects from Agno's `WebsiteReader`.
+If a `Knowledge` object is injected programmatically through the `knowledge` constructor argument, the tool exposes `add_website_to_knowledge(url)` instead of `read_url()`.
+That means the same registry entry can act either as a simple page reader or as a knowledge-base ingestion hook depending on how it is constructed.
+In normal hand-authored `config.yaml`, you should treat this as a quick page-reading tool.
 
 #### Configuration
 
@@ -114,7 +131,12 @@ read_url("https://docs.mindroom.chat")
 
 #### What It Does
 
-`trafilatura` exposes `extract_text()`, `extract_metadata_only()`, `crawl_website()`, `html_to_text()`, and `extract_batch()`. It fetches pages locally through Trafilatura and can return plain text, Markdown, JSON, XML, CSV, or HTML output depending on `output_format`. `extract_metadata_only()` returns metadata without full article text. `extract_batch()` loops over multiple URLs and returns one JSON payload with successes and failures. `crawl_website()` uses Trafilatura's focused spider support when that module is importable in the runtime. If the spider module is missing, the tool skips crawler registration instead of exposing a broken crawl function.
+`trafilatura` exposes `extract_text()`, `extract_metadata_only()`, `crawl_website()`, `html_to_text()`, and `extract_batch()`.
+It fetches pages locally through Trafilatura and can return plain text, Markdown, JSON, XML, CSV, or HTML output depending on `output_format`.
+`extract_metadata_only()` returns metadata without full article text.
+`extract_batch()` loops over multiple URLs and returns one JSON payload with successes and failures.
+`crawl_website()` uses Trafilatura's focused spider support when that module is importable in the runtime.
+If the spider module is missing, the tool skips crawler registration instead of exposing a broken crawl function.
 
 #### Configuration
 
@@ -170,7 +192,11 @@ extract_metadata_only("https://matrix.org/blog/")
 
 #### What It Does
 
-`newspaper` exposes `read_article(url)`. It returns JSON with whichever article fields were extracted successfully, including title, authors, text, publish date, and optional summary. `article_length` truncates article text after extraction. The registry name is `newspaper`, but the underlying module and dependency still come from `newspaper4k`. That means old references to `newspaper4k` are stale for current MindRoom config.
+`newspaper` exposes `read_article(url)`.
+It returns JSON with whichever article fields were extracted successfully, including title, authors, text, publish date, and optional summary.
+`article_length` truncates article text after extraction.
+The registry name is `newspaper`, but the underlying module and dependency still come from `newspaper4k`.
+That means old references to `newspaper4k` are stale for current MindRoom config.
 
 #### Configuration
 
@@ -208,7 +234,12 @@ read_article("https://matrix.org/blog/")
 
 #### What It Does
 
-`jina` exposes `read_url(url)` and, when enabled, `search_query(query)`. `read_url()` prepends the target URL to `base_url`, which defaults to `https://r.jina.ai/`. `search_query()` posts the query to `search_url`, which defaults to `https://s.jina.ai/`. When `search_query_content` is false, the tool adds `X-Respond-With: no-content` to avoid returning full page text in search results. Returned content is truncated to `max_content_length`. The installed implementation only adds the `Authorization` header when an API key is present, so unauthenticated public-reader usage still works.
+`jina` exposes `read_url(url)` and, when enabled, `search_query(query)`.
+`read_url()` prepends the target URL to `base_url`, which defaults to `https://r.jina.ai/`.
+`search_query()` posts the query to `search_url`, which defaults to `https://s.jina.ai/`.
+When `search_query_content` is false, the tool adds `X-Respond-With: no-content` to avoid returning full page text in search results.
+Returned content is truncated to `max_content_length`.
+The installed implementation only adds the `Authorization` header when an API key is present, so unauthenticated public-reader usage still works.
 
 #### Configuration
 
@@ -254,7 +285,12 @@ search_query("latest Matrix bridge updates")
 
 #### What It Does
 
-`firecrawl` exposes `scrape_website()`, `crawl_website()`, `map_website()`, and `search_web()`. `formats` is applied to scrape, crawl, and search requests. `limit` acts as the default result cap for crawl and search operations. `poll_interval` controls how often crawl jobs are polled. `search_params` is passed through to Firecrawl search calls as raw provider-specific options. The upstream tool falls back to `FIRECRAWL_API_KEY` when `api_key` is not provided directly.
+`firecrawl` exposes `scrape_website()`, `crawl_website()`, `map_website()`, and `search_web()`.
+`formats` is applied to scrape, crawl, and search requests.
+`limit` acts as the default result cap for crawl and search operations.
+`poll_interval` controls how often crawl jobs are polled.
+`search_params` is passed through to Firecrawl search calls as raw provider-specific options.
+The upstream tool falls back to `FIRECRAWL_API_KEY` when `api_key` is not provided directly.
 
 #### Configuration
 
@@ -301,7 +337,11 @@ search_web("latest Matrix bridges")
 
 #### What It Does
 
-`spider` exposes `search_web(query, max_results=5)`, `scrape(url)`, and `crawl(url, limit=None)`. The current wrapper calls Spider search with `fetch_page_content: false`, so search is primarily discovery rather than full-content extraction. `scrape()` and `crawl()` request Markdown-style output from Spider. `optional_params` is merged into Spider API requests as a raw provider options object. The installed `spider-client` constructor raises when no API key is available, even though the current MindRoom metadata says this tool is available without setup.
+`spider` exposes `search_web(query, max_results=5)`, `scrape(url)`, and `crawl(url, limit=None)`.
+The current wrapper calls Spider search with `fetch_page_content: false`, so search is primarily discovery rather than full-content extraction.
+`scrape()` and `crawl()` request Markdown-style output from Spider.
+`optional_params` is merged into Spider API requests as a raw provider options object.
+The installed `spider-client` constructor raises when no API key is available, even though the current MindRoom metadata says this tool is available without setup.
 
 #### Configuration
 
@@ -343,7 +383,13 @@ scrape("https://matrix.org/blog/")
 
 #### What It Does
 
-`scrapegraph` exposes `smartscraper()`, `markdownify()`, `crawl()`, `agentic_crawler()`, `searchscraper()`, and `scrape()`. `smartscraper()` extracts structured data from one page based on a natural-language prompt. `markdownify()` returns a Markdown version of a page. `crawl()` applies a prompt plus JSON schema across a crawl. `agentic_crawler()` performs automated steps in the browser and can optionally run AI extraction over the resulting content. `searchscraper()` searches the web before extracting information. `render_heavy_js` only affects the low-level `scrape()` path.
+`scrapegraph` exposes `smartscraper()`, `markdownify()`, `crawl()`, `agentic_crawler()`, `searchscraper()`, and `scrape()`.
+`smartscraper()` extracts structured data from one page based on a natural-language prompt.
+`markdownify()` returns a Markdown version of a page.
+`crawl()` applies a prompt plus JSON schema across a crawl.
+`agentic_crawler()` performs automated steps in the browser and can optionally run AI extraction over the resulting content.
+`searchscraper()` searches the web before extracting information.
+`render_heavy_js` only affects the low-level `scrape()` path.
 
 #### Configuration
 
@@ -387,7 +433,11 @@ markdownify("https://matrix.org/blog/")
 
 #### What It Does
 
-`apify` does not expose one fixed method like the other tools on this page. Instead, it reads the configured Actor IDs and registers one tool function per Actor at startup. Each generated tool uses the Actor's input schema to build parameters and returns that Actor's dataset items as JSON. Without configured `actors`, there is no practical tool surface. This is best thought of as a hosted Actor adapter rather than a single scraper API.
+`apify` does not expose one fixed method like the other tools on this page.
+Instead, it reads the configured Actor IDs and registers one tool function per Actor at startup.
+Each generated tool uses the Actor's input schema to build parameters and returns that Actor's dataset items as JSON.
+Without configured `actors`, there is no practical tool surface.
+This is best thought of as a hosted Actor adapter rather than a single scraper API.
 
 #### Configuration
 
@@ -418,7 +468,12 @@ agents:
 
 #### What It Does
 
-`brightdata` exposes `scrape_as_markdown()`, `get_screenshot()`, `search_engine()`, and `web_data_feed()`. `scrape_as_markdown()` uses the configured web-unlocker zone and returns Markdown output. `get_screenshot()` returns a `ToolResult` with an image artifact instead of just raw text. `search_engine()` supports Google, Bing, and Yandex search through Bright Data's SERP infrastructure. `web_data_feed()` accesses Bright Data feed endpoints for supported source types. Zone selection is controlled by `serp_zone` and `web_unlocker_zone`, which can also be overridden by environment variables.
+`brightdata` exposes `scrape_as_markdown()`, `get_screenshot()`, `search_engine()`, and `web_data_feed()`.
+`scrape_as_markdown()` uses the configured web-unlocker zone and returns Markdown output.
+`get_screenshot()` returns a `ToolResult` with an image artifact instead of just raw text.
+`search_engine()` supports Google, Bing, and Yandex search through Bright Data's SERP infrastructure.
+`web_data_feed()` accesses Bright Data feed endpoints for supported source types.
+Zone selection is controlled by `serp_zone` and `web_unlocker_zone`, which can also be overridden by environment variables.
 
 #### Configuration
 
@@ -463,7 +518,12 @@ search_engine("Matrix hosting", engine="google", num_results=5)
 
 #### What It Does
 
-`oxylabs` exposes `search_google()`, `get_amazon_product()`, `search_amazon_products()`, and `scrape_website()`. It uses the Oxylabs realtime client for Google and Amazon scraping rather than a generic HTML fetch path. `search_google()` returns parsed organic results with title, URL, description, and position. The Amazon functions expose both product-detail and product-search workflows. `scrape_website()` is the generic fallback when you just want one URL scraped. This tool is credentialed with a username and password pair rather than one API key.
+`oxylabs` exposes `search_google()`, `get_amazon_product()`, `search_amazon_products()`, and `scrape_website()`.
+It uses the Oxylabs realtime client for Google and Amazon scraping rather than a generic HTML fetch path.
+`search_google()` returns parsed organic results with title, URL, description, and position.
+The Amazon functions expose both product-detail and product-search workflows.
+`scrape_website()` is the generic fallback when you just want one URL scraped.
+This tool is credentialed with a username and password pair rather than one API key.
 
 #### Configuration
 
@@ -500,7 +560,11 @@ search_amazon_products("ergonomic keyboard", domain_code="com")
 
 #### What It Does
 
-`agentql` exposes `scrape_website(url)` and, when enabled, `custom_scrape_website(url)`. `scrape_website()` uses a built-in query that extracts generic page text. `custom_scrape_website()` only becomes useful when `agentql_query` is non-empty. The installed upstream toolkit registers the custom scrape function automatically when `agentql_query` is set, even if `enable_custom_scrape_website` is false. The current upstream implementation launches Playwright with `headless=False`, which matters on headless-only runtimes.
+`agentql` exposes `scrape_website(url)` and, when enabled, `custom_scrape_website(url)`.
+`scrape_website()` uses a built-in query that extracts generic page text.
+`custom_scrape_website()` only becomes useful when `agentql_query` is non-empty.
+The installed upstream toolkit registers the custom scrape function automatically when `agentql_query` is set, even if `enable_custom_scrape_website` is false.
+The current upstream implementation launches Playwright with `headless=False`, which matters on headless-only runtimes.
 
 #### Configuration
 
@@ -543,7 +607,12 @@ custom_scrape_website("https://matrix.org/blog/")
 
 #### What It Does
 
-`browserbase` exposes `navigate_to()`, `screenshot()`, `get_page_content()`, and `close_session()`, plus async variants for async agent execution. The tool auto-creates a Browserbase session, stores its `connect_url`, and connects to it over Playwright CDP. `get_page_content()` returns visible cleaned text when `parse_html` is true and raw HTML when `parse_html` is false. Long page content is truncated to `max_content_length`. `base_url` configures the Browserbase API endpoint, not the website you want to visit. This is simpler than `browser` when you only need remote navigation, screenshots, and page reads.
+`browserbase` exposes `navigate_to()`, `screenshot()`, `get_page_content()`, and `close_session()`, plus async variants for async agent execution.
+The tool auto-creates a Browserbase session, stores its `connect_url`, and connects to it over Playwright CDP.
+`get_page_content()` returns visible cleaned text when `parse_html` is true and raw HTML when `parse_html` is false.
+Long page content is truncated to `max_content_length`.
+`base_url` configures the Browserbase API endpoint, not the website you want to visit.
+This is simpler than `browser` when you only need remote navigation, screenshots, and page reads.
 
 #### Configuration
 
@@ -588,7 +657,14 @@ get_page_content()
 
 #### What It Does
 
-`browser` exposes one callable, `browser(action=...)`, with actions such as `status`, `start`, `stop`, `profiles`, `tabs`, `open`, `focus`, `close`, `snapshot`, `screenshot`, `navigate`, `console`, `pdf`, `upload`, `dialog`, and `act`. It manages named browser profiles, with `mindroom` as the default profile name. It creates tabs, tracks the active tab, records console entries, and resolves temporary element refs from `snapshot()` into later `act()` and `screenshot()` calls. `snapshot()` can return either `ai` or `aria` format. `act()` currently supports `click`, `type`, `press`, `hover`, `drag`, `select`, `fill`, `resize`, `wait`, `evaluate`, and `close`. Only `target="host"` is supported on this branch, so sandbox or node targeting fields currently return an error. If `output_dir` is unset, screenshots and PDFs are written under `<storage>/browser`. The runtime picks Chromium from `BROWSER_EXECUTABLE_PATH`, `chromium`, or `google-chrome-stable` when available.
+`browser` exposes one callable, `browser(action=...)`, with actions such as `status`, `start`, `stop`, `profiles`, `tabs`, `open`, `focus`, `close`, `snapshot`, `screenshot`, `navigate`, `console`, `pdf`, `upload`, `dialog`, and `act`.
+It manages named browser profiles, with `mindroom` as the default profile name.
+It creates tabs, tracks the active tab, records console entries, and resolves temporary element refs from `snapshot()` into later `act()` and `screenshot()` calls.
+`snapshot()` can return either `ai` or `aria` format.
+`act()` currently supports `click`, `type`, `press`, `hover`, `drag`, `select`, `fill`, `resize`, `wait`, `evaluate`, and `close`.
+Only `target="host"` is supported on this branch, so sandbox or node targeting fields currently return an error.
+If `output_dir` is unset, screenshots and PDFs are written under `<storage>/browser`.
+The runtime picks Chromium from `BROWSER_EXECUTABLE_PATH`, `chromium`, or `google-chrome-stable` when available.
 
 #### Configuration
 
@@ -623,7 +699,10 @@ browser(action="screenshot", fullPage=True)
 
 #### What It Does
 
-`web_browser_tools` exposes `open_page(url, new_window=False)`. It uses Python's standard-library `webbrowser` module to open a tab or window on the host operating system. It does not return page content, DOM state, screenshots, or automation handles. This makes it useful for human handoff or local desktop workflows, but not for scraping.
+`web_browser_tools` exposes `open_page(url, new_window=False)`.
+It uses Python's standard-library `webbrowser` module to open a tab or window on the host operating system.
+It does not return page content, DOM state, screenshots, or automation handles.
+This makes it useful for human handoff or local desktop workflows, but not for scraping.
 
 #### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__web-search__index.md
+++ b/skills/mindroom-docs/references/page__tools__web-search__index.md
@@ -4,7 +4,8 @@ Use these tools to search the public web, query paid search APIs, access Google-
 
 ## What This Page Covers
 
-This page documents the built-in tools in the `web-search` group. Use these tools when you need general web discovery, current-events search, answer-style search APIs, Google or Baidu specific results, or a self-hosted metasearch backend.
+This page documents the built-in tools in the `web-search` group.
+Use these tools when you need general web discovery, current-events search, answer-style search APIs, Google or Baidu specific results, or a self-hosted metasearch backend.
 
 ## Tools On This Page
 
@@ -20,7 +21,19 @@ This page documents the built-in tools in the `web-search` group. Use these tool
 
 ## Common Setup Notes
 
-`duckduckgo`, `googlesearch`, and `baidusearch` are `setup_type: none`, so they work out of the box once their optional Python dependencies are available. `tavily`, `exa`, `serpapi`, `serper`, and `linkup` are `status=requires_config` and are intended to be configured with a stored `api_key`. `searxng` is also `status=requires_config`, but it needs a reachable `host` URL instead of an API key. None of the tools on this page declare an `auth_provider`, and `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes, so these tools use ordinary tool credentials or SDK environment variables rather than a dedicated dashboard OAuth flow. Password fields such as `api_key` should be stored through the dashboard or credential store instead of inline YAML. Current upstream SDKs also support environment variables such as `TAVILY_API_KEY`, `TAVILY_API_BASE_URL`, `EXA_API_KEY`, `SERP_API_KEY`, `SERPER_API_KEY`, and `LINKUP_API_KEY`. Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set. `duckduckgo` and `googlesearch` are the simplest no-key defaults for general search and basic news lookups. `baidusearch` is the better fit when you want Baidu indexing or Chinese-language defaults. `tavily` and `linkup` are useful when you want answer-oriented search output instead of only result lists. `exa` is the deepest research option on this page when you need domain filters, date filters, content fetches, find-similar, or a long-running research task. `serpapi` and `serper` are Google-focused paid APIs, with `serpapi` covering Google and YouTube verticals and `serper` covering Google web, news, scholar, and a scrape endpoint. `searxng` is the best fit when you control your own search stack or want SearXNG categories such as images, maps, music, science, and video.
+`duckduckgo`, `googlesearch`, and `baidusearch` are `setup_type: none`, so they work out of the box once their optional Python dependencies are available.
+`tavily`, `exa`, `serpapi`, `serper`, and `linkup` are `status=requires_config` and are intended to be configured with a stored `api_key`.
+`searxng` is also `status=requires_config`, but it needs a reachable `host` URL instead of an API key.
+None of the tools on this page declare an `auth_provider`, and `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes, so these tools use ordinary tool credentials or SDK environment variables rather than a dedicated dashboard OAuth flow.
+Password fields such as `api_key` should be stored through the dashboard or credential store instead of inline YAML.
+Current upstream SDKs also support environment variables such as `TAVILY_API_KEY`, `TAVILY_API_BASE_URL`, `EXA_API_KEY`, `SERP_API_KEY`, `SERPER_API_KEY`, and `LINKUP_API_KEY`.
+Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
+`duckduckgo` and `googlesearch` are the simplest no-key defaults for general search and basic news lookups.
+`baidusearch` is the better fit when you want Baidu indexing or Chinese-language defaults.
+`tavily` and `linkup` are useful when you want answer-oriented search output instead of only result lists.
+`exa` is the deepest research option on this page when you need domain filters, date filters, content fetches, find-similar, or a long-running research task.
+`serpapi` and `serper` are Google-focused paid APIs, with `serpapi` covering Google and YouTube verticals and `serper` covering Google web, news, scholar, and a scrape endpoint.
+`searxng` is the best fit when you control your own search stack or want SearXNG categories such as images, maps, music, science, and video.
 
 ## \[`duckduckgo`\]
 
@@ -28,7 +41,10 @@ This page documents the built-in tools in the `web-search` group. Use these tool
 
 ### What It Does
 
-`duckduckgo` wraps Agno's `DuckDuckGoTools`, which is a convenience layer over the shared `WebSearchTools` backend with `backend="duckduckgo"`. It exposes `web_search(query, max_results=5)` and `search_news(query, max_results=5)`. `modifier` prepends extra query text, `fixed_max_results` caps all calls, and `proxy`, `timeout`, and `verify_ssl` control the underlying DDGS client. The tool returns JSON strings from DDGS rather than a MindRoom-specific normalized response format.
+`duckduckgo` wraps Agno's `DuckDuckGoTools`, which is a convenience layer over the shared `WebSearchTools` backend with `backend="duckduckgo"`.
+It exposes `web_search(query, max_results=5)` and `search_news(query, max_results=5)`.
+`modifier` prepends extra query text, `fixed_max_results` caps all calls, and `proxy`, `timeout`, and `verify_ssl` control the underlying DDGS client.
+The tool returns JSON strings from DDGS rather than a MindRoom-specific normalized response format.
 
 ### Configuration
 
@@ -70,7 +86,10 @@ search_news("Matrix ecosystem", max_results=5)
 
 ### What It Does
 
-MindRoom registers `googlesearch` as a custom wrapper around Agno's `WebSearchTools` with `backend="google"`. It exposes `web_search(query, max_results=5)` and `search_news(query, max_results=5)`. Runtime behavior matches the `duckduckgo` tool surface, including `modifier`, `fixed_max_results`, `proxy`, `timeout`, and `verify_ssl`. This is still a DDGS-backed scraper-style search path rather than an official Google paid search API.
+MindRoom registers `googlesearch` as a custom wrapper around Agno's `WebSearchTools` with `backend="google"`.
+It exposes `web_search(query, max_results=5)` and `search_news(query, max_results=5)`.
+Runtime behavior matches the `duckduckgo` tool surface, including `modifier`, `fixed_max_results`, `proxy`, `timeout`, and `verify_ssl`.
+This is still a DDGS-backed scraper-style search path rather than an official Google paid search API.
 
 ### Configuration
 
@@ -112,7 +131,10 @@ search_news("open source Matrix news", max_results=5)
 
 ### What It Does
 
-`baidusearch` exposes one method, `baidu_search(query, max_results=5, language="zh")`. `fixed_language` overrides the per-call `language`, and non-two-letter language values are normalized through `pycountry` when possible. If language normalization fails, the upstream tool falls back to `zh`. The returned payload is a JSON array with `title`, `url`, `abstract`, and `rank`.
+`baidusearch` exposes one method, `baidu_search(query, max_results=5, language="zh")`.
+`fixed_language` overrides the per-call `language`, and non-two-letter language values are normalized through `pycountry` when possible.
+If language normalization fails, the upstream tool falls back to `zh`.
+The returned payload is a JSON array with `title`, `url`, `abstract`, and `rank`.
 
 ### Configuration
 
@@ -154,7 +176,10 @@ baidu_search("Matrix 协议 新闻", max_results=5, language="zh")
 
 ### What It Does
 
-`tavily` can expose `web_search_using_tavily(query, max_results=5)`, `web_search_with_tavily(query)`, and `extract_url_content(urls)`, depending on the enable flags. `enable_search_context` switches the search surface from the normal result-list call to the context-oriented call, so you get one search method or the other instead of both. `web_search_using_tavily()` can include an AI-generated answer and returns either JSON or Markdown depending on `format`. `extract_url_content()` accepts one URL or a comma-separated URL list and formats extracted page content as Markdown or plain text depending on `extract_format`.
+`tavily` can expose `web_search_using_tavily(query, max_results=5)`, `web_search_with_tavily(query)`, and `extract_url_content(urls)`, depending on the enable flags.
+`enable_search_context` switches the search surface from the normal result-list call to the context-oriented call, so you get one search method or the other instead of both.
+`web_search_using_tavily()` can include an AI-generated answer and returns either JSON or Markdown depending on `format`.
+`extract_url_content()` accepts one URL or a comma-separated URL list and formats extracted page content as Markdown or plain text depending on `extract_format`.
 
 ### Configuration
 
@@ -206,7 +231,10 @@ extract_url_content("https://matrix.org/blog/")
 
 ### What It Does
 
-`exa` can expose `search_exa(query, num_results=5, category=None)`, `get_contents(urls)`, `find_similar(url, num_results=5)`, `exa_answer(query, text=False)`, and `research(instructions, output_schema=None)`. Search results can include title, author, published date, URL, and truncated page text. The toolkit supports domain allowlists and denylists, crawl-date and publish-date filters, category and type filters, answer-model selection, and a separate `research_model` for long-running research tasks. `enable_research` is off by default, so deep research is opt-in even when the rest of the toolkit is enabled.
+`exa` can expose `search_exa(query, num_results=5, category=None)`, `get_contents(urls)`, `find_similar(url, num_results=5)`, `exa_answer(query, text=False)`, and `research(instructions, output_schema=None)`.
+Search results can include title, author, published date, URL, and truncated page text.
+The toolkit supports domain allowlists and denylists, crawl-date and publish-date filters, category and type filters, answer-model selection, and a separate `research_model` for long-running research tasks.
+`enable_research` is off by default, so deep research is opt-in even when the rest of the toolkit is enabled.
 
 ### Configuration
 
@@ -271,7 +299,10 @@ research("Compare hosted Matrix bridges for small teams.")
 
 ### What It Does
 
-`serpapi` exposes `search_google(query, num_results=10)` and `search_youtube(query)`. `search_google()` returns a JSON payload with `search_results`, `recipes_results`, `shopping_results`, `knowledge_graph`, and `related_questions`. `search_youtube()` returns `video_results`, `movie_results`, and `channel_results`. MindRoom does not add extra behavior here beyond registering the tool metadata and dependency set.
+`serpapi` exposes `search_google(query, num_results=10)` and `search_youtube(query)`.
+`search_google()` returns a JSON payload with `search_results`, `recipes_results`, `shopping_results`, `knowledge_graph`, and `related_questions`.
+`search_youtube()` returns `video_results`, `movie_results`, and `channel_results`.
+MindRoom does not add extra behavior here beyond registering the tool metadata and dependency set.
 
 ### Configuration
 
@@ -309,7 +340,10 @@ search_youtube("Matrix conference talks")
 
 ### What It Does
 
-`serper` exposes `search_web(query, num_results=None)`, `search_news(query, num_results=None)`, `search_scholar(query, num_results=None)`, and `scrape_webpage(url, markdown=False)`. `location`, `language`, and `date_range` become shared request parameters across the search endpoints. The search methods return raw JSON responses from Serper. `scrape_webpage()` hits Serper's scrape endpoint and can optionally request Markdown output.
+`serper` exposes `search_web(query, num_results=None)`, `search_news(query, num_results=None)`, `search_scholar(query, num_results=None)`, and `scrape_webpage(url, markdown=False)`.
+`location`, `language`, and `date_range` become shared request parameters across the search endpoints.
+The search methods return raw JSON responses from Serper.
+`scrape_webpage()` hits Serper's scrape endpoint and can optionally request Markdown output.
 
 ### Configuration
 
@@ -357,7 +391,10 @@ scrape_webpage("https://matrix.org/blog/", markdown=True)
 
 ### What It Does
 
-`searxng` exposes `search_web(query, max_results=5)`, `image_search(query, max_results=5)`, `it_search(query, max_results=5)`, `map_search(query, max_results=5)`, `music_search(query, max_results=5)`, `news_search(query, max_results=5)`, `science_search(query, max_results=5)`, and `video_search(query, max_results=5)`. All of those calls route through the same `/search?format=json` endpoint on the configured `host`. If `engines` is set, the tool appends those engine names to the SearXNG request. `fixed_max_results` truncates every category response to a consistent maximum.
+`searxng` exposes `search_web(query, max_results=5)`, `image_search(query, max_results=5)`, `it_search(query, max_results=5)`, `map_search(query, max_results=5)`, `music_search(query, max_results=5)`, `news_search(query, max_results=5)`, `science_search(query, max_results=5)`, and `video_search(query, max_results=5)`.
+All of those calls route through the same `/search?format=json` endpoint on the configured `host`.
+If `engines` is set, the tool appends those engine names to the SearXNG request.
+`fixed_max_results` truncates every category response to a consistent maximum.
 
 ### Configuration
 
@@ -400,7 +437,10 @@ image_search("Matrix logo", max_results=5)
 
 ### What It Does
 
-`linkup` exposes `web_search_with_linkup(query, depth=None, output_type=None)`. `depth` controls how aggressively Linkup searches, and `output_type` controls whether the response is a `searchResults` list or a `sourcedAnswer`. The configured defaults are applied when the call does not override them. The tool returns the raw response from the Linkup SDK rather than a MindRoom-specific normalized envelope.
+`linkup` exposes `web_search_with_linkup(query, depth=None, output_type=None)`.
+`depth` controls how aggressively Linkup searches, and `output_type` controls whether the response is a `searchResults` list or a `sourcedAnswer`.
+The configured defaults are applied when the call does not override them.
+The tool returns the raw response from the Linkup SDK rather than a MindRoom-specific normalized envelope.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/page__voice__index.md
+++ b/skills/mindroom-docs/references/page__voice__index.md
@@ -1,6 +1,8 @@
 # Voice Messages
 
-MindRoom can surface Matrix voice messages as attachment-aware prompts for agents. If STT is configured, MindRoom also transcribes the audio and routes it through the normal text pipeline. If STT is unavailable, disabled, or fails, the audio still remains available as an attachment and falls back to `🎤 [Attached voice message]`.
+MindRoom can surface Matrix voice messages as attachment-aware prompts for agents.
+If STT is configured, MindRoom also transcribes the audio and routes it through the normal text pipeline.
+If STT is unavailable, disabled, or fails, the audio still remains available as an attachment and falls back to `🎤 [Attached voice message]`.
 
 ## Overview
 
@@ -35,7 +37,9 @@ voice:
 
 Or use the dashboard's Voice tab.
 
-With `voice.enabled: false`, audio messages are still surfaced as attachments with the fallback prompt. Enabling voice adds STT and command-recognition on top of that attachment flow. With `voice.visible_router_echo: true`, the router also posts the normalized transcript or fallback text for inspection when it is present in the room and allowed to reply.
+With `voice.enabled: false`, audio messages are still surfaced as attachments with the fallback prompt.
+Enabling voice adds STT and command-recognition on top of that attachment flow.
+With `voice.visible_router_echo: true`, the router also posts the normalized transcript or fallback text for inspection when it is present in the room and allowed to reply.
 
 ## STT Providers
 
@@ -140,23 +144,40 @@ You can specify a different model for faster or more accurate command recognitio
 
 ### Single-agent rooms or explicitly targeted audio
 
-If only one eligible agent is visible, that agent responds directly to the normalized audio event. If the audio caption or transcript explicitly mentions an agent, that targeted agent responds directly as well. In these cases, the router does not post an extra visible routing handoff. The transcript or fallback text is used internally for dispatch, not echoed to the room as a separate message. If `voice.visible_router_echo` is enabled, the router still posts a display-only copy of the normalized voice text, but agents ignore that echo and continue responding to the original audio event.
+If only one eligible agent is visible, that agent responds directly to the normalized audio event.
+If the audio caption or transcript explicitly mentions an agent, that targeted agent responds directly as well.
+In these cases, the router does not post an extra visible routing handoff.
+The transcript or fallback text is used internally for dispatch, not echoed to the room as a separate message.
+If `voice.visible_router_echo` is enabled, the router still posts a display-only copy of the normalized voice text, but agents ignore that echo and continue responding to the original audio event.
 
 ### Multi-agent rooms where the router must choose
 
-If multiple agents are available and the audio does not already target one of them, the router uses the normalized text to do the usual routing step. The router then posts a normal handoff message such as `@home could you help with this?`. The selected agent responds to that router handoff, and the handoff carries the original audio attachment metadata forward. This is the case where a visible router message appears. If `voice.visible_router_echo` is also enabled, the router first posts the normalized voice text as a display-only echo and then posts the normal handoff.
+If multiple agents are available and the audio does not already target one of them, the router uses the normalized text to do the usual routing step.
+The router then posts a normal handoff message such as `@home could you help with this?`.
+The selected agent responds to that router handoff, and the handoff carries the original audio attachment metadata forward.
+This is the case where a visible router message appears.
+If `voice.visible_router_echo` is also enabled, the router first posts the normalized voice text as a display-only echo and then posts the normal handoff.
 
 ### No router, or router cannot reply
 
-Audio still works when the router is absent. In that case, agents handle the normalized audio directly using the same mention, thread, and permission rules as normal text messages. The same direct handling also applies when the router is present but is not allowed to reply to the original sender. In these cases, there is no visible router echo because the router does not handle the event. If multiple eligible agents remain and the audio does not already target one of them, there is no automatic handoff until the user mentions an agent.
+Audio still works when the router is absent.
+In that case, agents handle the normalized audio directly using the same mention, thread, and permission rules as normal text messages.
+The same direct handling also applies when the router is present but is not allowed to reply to the original sender.
+In these cases, there is no visible router echo because the router does not handle the event.
+If multiple eligible agents remain and the audio does not already target one of them, there is no automatic handoff until the user mentions an agent.
 
 ### Visibility rule
 
-MindRoom does not automatically post the transcript to the room. A visible router message appears only when the router must disambiguate between multiple eligible responders. If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent replies directly without an extra router message. Setting `voice.visible_router_echo: true` adds a visible router-authored echo of the normalized voice text when the router is actually allowed to process the event, without changing which event agents actually answer.
+MindRoom does not automatically post the transcript to the room.
+A visible router message appears only when the router must disambiguate between multiple eligible responders.
+If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent replies directly without an extra router message.
+Setting `voice.visible_router_echo: true` adds a visible router-authored echo of the normalized voice text when the router is actually allowed to process the event, without changing which event agents actually answer.
 
 ### Attachment access
 
-The original audio is always registered as a context-scoped attachment before dispatch continues. That means the responding agent can inspect the file directly, use audio-capable models, or fetch it later with the `attachments` tool. This is true whether the prompt came from a transcript, a fallback message, or a router handoff.
+The original audio is always registered as a context-scoped attachment before dispatch continues.
+That means the responding agent can inspect the file directly, use audio-capable models, or fetch it later with the `attachments` tool.
+This is true whether the prompt came from a transcript, a fallback message, or a router handoff.
 
 ## Matrix Integration
 
@@ -169,7 +190,9 @@ Voice messages in Matrix are:
 - Sent to the STT service via the OpenAI-compatible API when transcription is enabled
 - Normalized once per room and thread context, even though multiple bots may observe the event
 
-Audio callbacks are registered on all bots because audio now follows the shared media pipeline. Shared normalization prevents repeated download and STT work for the same event. Reply-permission checks still use the original human sender, not a later router relay.
+Audio callbacks are registered on all bots because audio now follows the shared media pipeline.
+Shared normalization prevents repeated download and STT work for the same event.
+Reply-permission checks still use the original human sender, not a later router relay.
 
 ## Environment Variables
 
@@ -197,7 +220,8 @@ When STT is unavailable, disabled, or transcription fails, MindRoom falls back t
 1. The raw audio is registered as an attachment ID available to agents in the room or thread context
 1. When an agent responds, it automatically receives the raw audio as an Agno `Audio` object
 
-This means voice messages still reach agents even without STT. Agents with audio-capable models can process the raw audio directly, and tool-using agents can retrieve the file by attachment ID. Attachment IDs in this fallback path use the same context-scoping rules described in [File & Video Attachments](https://docs.mindroom.chat/attachments/index.md).
+This means voice messages still reach agents even without STT.
+Agents with audio-capable models can process the raw audio directly, and tool-using agents can retrieve the file by attachment ID. Attachment IDs in this fallback path use the same context-scoping rules described in [File & Video Attachments](https://docs.mindroom.chat/attachments/index.md).
 
 ## Limitations
 


### PR DESCRIPTION
## Summary
- preserve authored paragraph line breaks when generating per-page mindroom-docs skill references
- keep MkDocs-rendered links, tables, lists, and llms outputs intact
- regenerate affected page references

## Tests
- uv run pre-commit run --all-files
- uv run pytest --no-cov -q