### PR TITLE
Fix Python subprocess workspace cwd creation

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -1059,6 +1059,7 @@ def _execute_request_subprocess_sync(
     subprocess_env = sandbox_exec.subprocess_env_for_request(subprocess_env, execution_env)
     # python's subprocess inherits this cwd as Path.cwd(); shell sets its own cwd via base_dir.
     if workspace_home is not None and request.tool_name == "python":
+        workspace_home.mkdir(parents=True, exist_ok=True)
         cwd = str(workspace_home)
     effective_runtime_paths = sandbox_exec.runtime_paths_with_execution_env(
         runtime_paths,

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -3928,6 +3928,69 @@ def test_worker_routed_python_subprocess_cwd_is_agent_workspace(
     assert envelope.request["execution_env"]["MINDROOM_AGENT_WORKSPACE"] == str(workspace.resolve())
 
 
+def test_worker_routed_python_subprocess_creates_missing_workspace_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A resolved worker base_dir must exist before it is used as subprocess cwd."""
+    config_path = tmp_path / "config.yaml"
+    _write_general_agent_config(config_path)
+    storage_root = tmp_path / "storage"
+    runtime_paths = resolve_runtime_paths(config_path=config_path, storage_path=storage_root, process_env={})
+    config = sandbox_runner_module._runtime_config_or_empty(runtime_paths)
+    worker_key = "worker-a"
+    worker_paths = local_workers_module.local_worker_state_paths_for_root(tmp_path / "worker-root")
+    workspace = worker_paths.root / "custom-workspace"
+    prepared = sandbox_runner_module.sandbox_worker_prep.PreparedWorkerRequest(
+        handle=WorkerHandle(
+            worker_id="worker-1",
+            worker_key=worker_key,
+            endpoint="/api/sandbox-runner/execute",
+            auth_token=SANDBOX_TOKEN,
+            status="ready",
+            backend_name="local",
+            last_used_at=0.0,
+            created_at=0.0,
+        ),
+        paths=worker_paths,
+        runtime_overrides={"base_dir": workspace},
+    )
+
+    def fake_subprocess_run(
+        _command: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        cwd = kwargs["cwd"]
+        assert isinstance(cwd, str)
+        if not Path(cwd).is_dir():
+            raise FileNotFoundError(2, "No such file or directory", cwd)
+        response = sandbox_runner_module.SandboxRunnerExecuteResponse(ok=True, result="ok")
+        return subprocess.CompletedProcess(
+            args=_command,
+            returncode=0,
+            stdout="",
+            stderr=sandbox_protocol_module.response_marker_payload(response.model_dump_json()),
+        )
+
+    monkeypatch.setattr(sandbox_runner_module.subprocess, "run", fake_subprocess_run)
+
+    request = sandbox_runner_module.SandboxRunnerExecuteRequest(
+        tool_name="python",
+        function_name="run_python_code",
+        worker_key=worker_key,
+        tool_init_overrides={"base_dir": str(workspace)},
+    )
+    response = sandbox_runner_module._execute_request_subprocess_sync(
+        request,
+        runtime_paths,
+        config,
+        prepared_worker=prepared,
+    )
+
+    assert response.ok is True
+    assert workspace.is_dir()
+
+
 @requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
 def test_worker_routed_shell_uses_agent_workspace_as_home(
     runner_client: TestClient,


### PR DESCRIPTION
## Summary
- Create the resolved workspace before using it as the parent cwd for worker-routed Python subprocess execution.
- Add a regression test for a prepared worker base_dir that does not exist yet.

## Testing
- `uv run pytest tests/api/test_sandbox_runner_api.py::test_worker_routed_python_subprocess_creates_missing_workspace_cwd -q` (red before fix, green after fix)
- `uv run pytest tests/api/test_sandbox_runner_api.py::test_worker_routed_python_subprocess_cwd_is_agent_workspace tests/api/test_sandbox_runner_api.py::test_worker_routed_python_subprocess_creates_missing_workspace_cwd -q`
- `uv run ruff check src/mindroom/api/sandbox_runner.py tests/api/test_sandbox_runner_api.py`
- `git diff --check`
- `uv sync --all-extras`
- `uv run pytest`
- `uv run pre-commit run --all-files`