### PR TITLE
test: characterize credential policy boundaries

### DIFF
--- a/tests/test_config_manager_consolidated.py
+++ b/tests/test_config_manager_consolidated.py
@@ -15,7 +15,12 @@ from mindroom.config.knowledge import KnowledgeBaseConfig
 from mindroom.config.main import Config
 from mindroom.config.matrix import MindRoomUserConfig
 from mindroom.config.models import DefaultsConfig
-from mindroom.constants import DEFAULT_WORKER_GRANTABLE_CREDENTIALS, RuntimePaths, resolve_runtime_paths
+from mindroom.constants import (
+    DEFAULT_WORKER_GRANTABLE_CREDENTIALS,
+    UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS,
+    RuntimePaths,
+    resolve_runtime_paths,
+)
 from mindroom.custom_tools.config_manager import ConfigManagerTools, _InfoType
 from mindroom.tool_system.metadata import AUTHORED_OVERRIDE_INHERIT
 
@@ -1156,3 +1161,9 @@ class TestWorkerGrantableCredentials:
 
         with pytest.raises(ValidationError, match="google_oauth_client"):
             DefaultsConfig(worker_grantable_credentials=["google_oauth_client"])
+
+    @pytest.mark.parametrize("service", sorted(UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS))
+    def test_worker_grantable_credentials_reject_unsupported_services(self, service: str) -> None:
+        """Worker credential mirroring should reject every unsupported credential service."""
+        with pytest.raises(ValidationError, match=service):
+            DefaultsConfig(worker_grantable_credentials=[service])

--- a/tests/test_credential_policy.py
+++ b/tests/test_credential_policy.py
@@ -1,0 +1,57 @@
+"""Characterization tests for current credential placement policy."""
+
+from __future__ import annotations
+
+import pytest
+
+from mindroom.constants import UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS
+from mindroom.tool_system.worker_routing import (
+    service_uses_local_shared_credentials,
+    service_uses_primary_runtime_scoped_credentials,
+)
+
+
+@pytest.mark.parametrize(
+    ("service", "worker_scope", "expected"),
+    [
+        ("google_drive_oauth", "user", True),
+        ("google_drive_oauth", "user_agent", True),
+        ("google_drive_oauth", "shared", False),
+        ("openai", "user", False),
+        ("homeassistant", "user_agent", True),
+    ],
+)
+def test_primary_runtime_scoped_service_policy(service: str, worker_scope: str, expected: bool) -> None:
+    """Private worker scopes should read local-only services from primary-runtime scoped storage."""
+    assert service_uses_primary_runtime_scoped_credentials(service, worker_scope) is expected
+
+
+@pytest.mark.parametrize(
+    ("service", "worker_scope", "expected"),
+    [
+        ("google_drive", "shared", True),
+        ("google_drive_oauth", "shared", True),
+        ("gmail", "shared", True),
+        ("openai", "shared", False),
+        ("google_drive", "user", False),
+    ],
+)
+def test_local_shared_service_policy(service: str, worker_scope: str, expected: bool) -> None:
+    """Shared worker scope should read local-only service credentials from the primary runtime."""
+    assert service_uses_local_shared_credentials(service, worker_scope) is expected
+
+
+@pytest.mark.parametrize(
+    "service",
+    [
+        "google_oauth_client",
+        "google_calendar_oauth",
+        "google_drive_oauth",
+        "google_gmail_oauth",
+        "google_sheets_oauth",
+        "google_vertex_adc",
+    ],
+)
+def test_worker_grantable_policy_rejects_sensitive_google_services(service: str) -> None:
+    """Sensitive Google credential services should stay unsupported for worker mirroring."""
+    assert service in UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS


### PR DESCRIPTION
## Summary
- Add pure characterization tests for existing credential service scope predicates.
- Lock down the sensitive Google credential services that must remain unsupported for worker mirroring.
- Keep this first PR behavior-preserving before introducing the new credential policy module.

## Test Plan
- [x] uv run pytest tests/test_credential_policy.py tests/test_credentials.py tests/api/test_credentials_api.py tests/test_config_manager_consolidated.py tests/test_sandbox_proxy.py -x -n auto --no-cov -v
- [x] uv run pre-commit run --all-files
- [x] uv run pytest -x -n 0 --no-cov