### PR TITLE
refactor: introduce credential policy helpers

### DIFF
--- a/src/mindroom/api/credentials.py
+++ b/src/mindroom/api/credentials.py
@@ -15,6 +15,12 @@ from mindroom.agent_policy import (
 )
 from mindroom.api import config_lifecycle
 from mindroom.config.main import Config
+from mindroom.credential_policy import (
+    OAUTH_CREDENTIAL_FIELDS,
+    credential_service_policy,
+    filter_oauth_credential_fields,
+    looks_like_oauth_credentials,
+)
 from mindroom.credentials import (
     CredentialsManager,
     delete_scoped_credentials,
@@ -27,7 +33,6 @@ from mindroom.credentials import (
 )
 from mindroom.oauth.providers import OAuthProviderError
 from mindroom.oauth.registry import load_oauth_providers_for_snapshot
-from mindroom.oauth.service import OAUTH_CREDENTIAL_FIELDS
 from mindroom.oauth.state import consume_opaque_oauth_state, issue_opaque_oauth_state, read_opaque_oauth_state
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
@@ -35,8 +40,6 @@ from mindroom.tool_system.worker_routing import (
     local_shared_credential_allowlist,
     require_worker_key_for_scope,
     resolve_worker_target,
-    service_uses_local_shared_credentials,
-    service_uses_primary_runtime_scoped_credentials,
     unsupported_shared_only_integration_message,
     unsupported_shared_only_integration_names,
 )
@@ -74,19 +77,9 @@ def _filter_internal_keys(credentials: dict[str, Any]) -> dict[str, Any]:
 def _filter_credentials_for_response(credentials: dict[str, Any], *, is_oauth_service: bool) -> dict[str, Any]:
     """Return credentials safe for dashboard config responses."""
     filtered = _filter_internal_keys(credentials)
-    if not is_oauth_service and not _looks_like_oauth_credentials(credentials):
+    if not is_oauth_service and not looks_like_oauth_credentials(credentials):
         return filtered
-    return {key: value for key, value in filtered.items() if key not in OAUTH_CREDENTIAL_FIELDS}
-
-
-def _looks_like_oauth_credentials(credentials: dict[str, Any]) -> bool:
-    """Return whether stored credentials carry MindRoom OAuth token metadata."""
-    return (
-        credentials.get("_source") == "oauth"
-        or isinstance(credentials.get("_oauth_provider"), str)
-        or isinstance(credentials.get("_id_token"), str)
-        or isinstance(credentials.get("_oauth_claims"), dict)
-    )
+    return filter_oauth_credential_fields(credentials)
 
 
 def _validated_service(service: str) -> str:
@@ -555,10 +548,8 @@ def load_credentials_for_target(service: str, target: RequestCredentialsTarget) 
 
 
 def _service_uses_primary_runtime_store(service: str, target: RequestCredentialsTarget) -> bool:
-    return service_uses_primary_runtime_scoped_credentials(
-        service,
-        target.worker_scope,
-    ) or service_uses_local_shared_credentials(service, target.worker_scope)
+    policy = credential_service_policy(service, target.worker_scope)
+    return policy.uses_primary_runtime_scoped_credentials or policy.uses_local_shared_credentials
 
 
 def _worker_target_for_credentials_target(target: RequestCredentialsTarget) -> ResolvedWorkerTarget | None:
@@ -596,7 +587,7 @@ def _primary_runtime_scoped_services_for_target(target: RequestCredentialsTarget
     return {
         service
         for service in scoped_manager.list_services()
-        if service_uses_primary_runtime_scoped_credentials(service, target.worker_scope)
+        if credential_service_policy(service, target.worker_scope).uses_primary_runtime_scoped_credentials
     }
 
 
@@ -639,7 +630,7 @@ def _reject_oauth_token_service(
 
 
 def _reject_oauth_credentials_document(credentials: dict[str, Any]) -> None:
-    if not _looks_like_oauth_credentials(credentials):
+    if not looks_like_oauth_credentials(credentials):
         return
     raise HTTPException(status_code=400, detail=_OAUTH_TOKEN_CREDENTIALS_ERROR)
 
@@ -666,11 +657,7 @@ def _dashboard_credentials_for_save(
 ) -> dict[str, Any]:
     credentials = dict(config_values)
     if strip_oauth_fields:
-        credentials = {
-            key: value
-            for key, value in credentials.items()
-            if key not in OAUTH_CREDENTIAL_FIELDS and not key.startswith("_")
-        }
+        credentials = filter_oauth_credential_fields(credentials)
     credentials["_source"] = "ui"
     return credentials
 
@@ -764,7 +751,7 @@ class DashboardCredentialAccess:
             shared_services |= {
                 service
                 for service in shared_manager.list_services()
-                if service_uses_local_shared_credentials(service, self.target.worker_scope)
+                if credential_service_policy(service, self.target.worker_scope).uses_local_shared_credentials
             }
         services = worker_services | primary_runtime_services | shared_services
         services -= set(unsupported_shared_only_integration_names(sorted(services), self.target.worker_scope))

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, Self, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_serializer, model_validator
 
-from mindroom.constants import UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS
+from mindroom.credential_policy import credential_service_policy
 from mindroom.credentials import validate_service_name
 from mindroom.tool_system.worker_routing import WorkerScope  # noqa: TC001
 
@@ -446,7 +446,13 @@ class DefaultsConfig(BaseModel):
         if services is None:
             return None
         normalized_services = [validate_service_name(service) for service in services]
-        unsupported_services = sorted(set(normalized_services) & UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS)
+        unsupported_services = sorted(
+            {
+                service
+                for service in normalized_services
+                if not credential_service_policy(service, None).worker_grantable_supported
+            },
+        )
         if unsupported_services:
             msg = (
                 "worker_grantable_credentials does not support "

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -1007,18 +1007,6 @@ PROVIDER_ENV_KEYS: dict[str, str] = {
 # Dedicated workers start with no mirrored/shared credentials by default.
 # Any service exposure into an isolated worker runtime must be explicitly authored.
 DEFAULT_WORKER_GRANTABLE_CREDENTIALS = frozenset()
-# Some credentials are intentionally unsupported in isolated workers because they rely on
-# host-local files or ambient env that the sandbox contract now denies by default.
-UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS = frozenset(
-    {
-        "google_vertex_adc",
-        "google_oauth_client",
-        "google_calendar_oauth",
-        "google_drive_oauth",
-        "google_gmail_oauth",
-        "google_sheets_oauth",
-    },
-)
 VERTEXAI_CLAUDE_ENV_KEYS: tuple[str, str] = ("ANTHROPIC_VERTEX_PROJECT_ID", "CLOUD_ML_REGION")
 
 _CHROMADB_PY314_PATCHED = False

--- a/src/mindroom/credential_policy.py
+++ b/src/mindroom/credential_policy.py
@@ -1,0 +1,100 @@
+"""Pure credential service classification and visibility policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+WorkerScope = Literal["shared", "user", "user_agent"]
+
+OAUTH_CREDENTIAL_FIELDS = frozenset(
+    {
+        "_id_token",
+        "_oauth_claims",
+        "_oauth_claims_verified",
+        "_oauth_provider",
+        "_source",
+        "access_token",
+        "client_id",
+        "client_secret",
+        "expires_at",
+        "expires_in",
+        "id_token",
+        "refresh_token",
+        "scope",
+        "scopes",
+        "token",
+        "token_type",
+        "token_uri",
+    },
+)
+
+LOCAL_ONLY_SHARED_CREDENTIAL_SERVICES = frozenset(
+    {
+        "google_calendar",
+        "google_calendar_oauth",
+        "google_drive",
+        "google_drive_oauth",
+        "google_gmail",
+        "google_gmail_oauth",
+        "google_sheets",
+        "google_sheets_oauth",
+        "gmail",
+        "homeassistant",
+    },
+)
+
+UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS = frozenset(
+    {
+        "google_vertex_adc",
+        "google_oauth_client",
+        "google_calendar_oauth",
+        "google_drive_oauth",
+        "google_gmail_oauth",
+        "google_sheets_oauth",
+    },
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialServicePolicy:
+    """Credential placement decisions for one service in one worker scope."""
+
+    service: str
+    worker_scope: WorkerScope | None
+    is_local_only_shared_service: bool
+    uses_local_shared_credentials: bool
+    uses_primary_runtime_scoped_credentials: bool
+    worker_grantable_supported: bool
+
+
+def credential_service_policy(service: str, worker_scope: WorkerScope | None) -> CredentialServicePolicy:
+    """Return credential placement policy for one service in one worker scope."""
+    is_local_only = service in LOCAL_ONLY_SHARED_CREDENTIAL_SERVICES
+    return CredentialServicePolicy(
+        service=service,
+        worker_scope=worker_scope,
+        is_local_only_shared_service=is_local_only,
+        uses_local_shared_credentials=worker_scope == "shared" and is_local_only,
+        uses_primary_runtime_scoped_credentials=worker_scope in {"user", "user_agent"} and is_local_only,
+        worker_grantable_supported=service not in UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS,
+    )
+
+
+def looks_like_oauth_credentials(credentials: dict[str, object]) -> bool:
+    """Return whether a credential document appears to contain OAuth token state."""
+    return (
+        credentials.get("_source") == "oauth"
+        or isinstance(credentials.get("_oauth_provider"), str)
+        or isinstance(credentials.get("_id_token"), str)
+        or isinstance(credentials.get("_oauth_claims"), dict)
+    )
+
+
+def filter_oauth_credential_fields(credentials: dict[str, object]) -> dict[str, object]:
+    """Return credentials with OAuth token material and internal fields removed."""
+    return {
+        key: value
+        for key, value in credentials.items()
+        if key not in OAUTH_CREDENTIAL_FIELDS and not key.startswith("_")
+    }

--- a/src/mindroom/credentials.py
+++ b/src/mindroom/credentials.py
@@ -13,12 +13,9 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from mindroom.credential_policy import credential_service_policy
 from mindroom.logging_config import get_logger
-from mindroom.tool_system.worker_routing import (
-    service_uses_local_shared_credentials,
-    service_uses_primary_runtime_scoped_credentials,
-    worker_root_path,
-)
+from mindroom.tool_system.worker_routing import worker_root_path
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
@@ -473,7 +470,8 @@ def _primary_runtime_scoped_credentials_manager(
     manager: CredentialsManager,
     worker_target: ResolvedWorkerTarget,
 ) -> CredentialsManager | None:
-    if not service_uses_primary_runtime_scoped_credentials(service, worker_target.worker_scope):
+    policy = credential_service_policy(service, worker_target.worker_scope)
+    if not policy.uses_primary_runtime_scoped_credentials:
         return None
     identity = worker_target.execution_identity
     if identity is None or identity.requester_id is None:
@@ -507,7 +505,10 @@ def load_scoped_credentials(
         manager=manager,
         worker_target=worker_target,
     )
-    uses_local_shared_credentials = service_uses_local_shared_credentials(service, worker_target.worker_scope)
+    uses_local_shared_credentials = credential_service_policy(
+        service,
+        worker_target.worker_scope,
+    ).uses_local_shared_credentials
     worker_manager = (
         _resolve_worker_credentials_manager(
             credentials_manager=manager,
@@ -552,7 +553,7 @@ def save_scoped_credentials(
         target_manager.save_credentials(service, credentials)
         return
 
-    if service_uses_local_shared_credentials(service, worker_target.worker_scope):
+    if credential_service_policy(service, worker_target.worker_scope).uses_local_shared_credentials:
         manager.shared_manager().save_credentials(service, credentials)
         return
 
@@ -586,7 +587,7 @@ def delete_scoped_credentials(
         target_manager.delete_credentials(service)
         return
 
-    if service_uses_local_shared_credentials(service, worker_target.worker_scope):
+    if credential_service_policy(service, worker_target.worker_scope).uses_local_shared_credentials:
         manager.shared_manager().delete_credentials(service)
         return
 

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -18,27 +18,6 @@ if TYPE_CHECKING:
 
 _OAUTH_CONNECT_TOKEN_TTL_SECONDS = 600
 _OAUTH_CONNECT_TOKEN_KIND = "conversation_oauth_connect"  # noqa: S105
-OAUTH_CREDENTIAL_FIELDS = frozenset(
-    {
-        "_id_token",
-        "_oauth_claims",
-        "_oauth_claims_verified",
-        "_oauth_provider",
-        "_source",
-        "access_token",
-        "client_id",
-        "client_secret",
-        "expires_at",
-        "expires_in",
-        "id_token",
-        "refresh_token",
-        "scope",
-        "scopes",
-        "token",
-        "token_type",
-        "token_uri",
-    },
-)
 _OAUTH_ACCESS_TOKEN_EXPIRY_SKEW_SECONDS = 60
 _GOOGLE_SERVICE_ACCOUNT_PROVIDER_IDS = frozenset(
     {

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol, cast, runtime_checkable
 
+from mindroom.credential_policy import credential_service_policy
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Collection, Iterator
 
@@ -36,20 +38,6 @@ LOCAL_ONLY_SHARED_INTEGRATION_TOOL_NAMES = frozenset(
         "google_calendar",
         "google_drive",
         "google_sheets",
-        "homeassistant",
-    },
-)
-LOCAL_ONLY_SHARED_CREDENTIAL_SERVICES = frozenset(
-    {
-        "google_calendar",
-        "google_calendar_oauth",
-        "google_drive",
-        "google_drive_oauth",
-        "google_gmail",
-        "google_gmail_oauth",
-        "google_sheets",
-        "google_sheets_oauth",
-        "gmail",
         "homeassistant",
     },
 )
@@ -368,22 +356,12 @@ def tool_stays_local(name: str) -> bool:
     return name in LOCAL_ONLY_SHARED_INTEGRATION_TOOL_NAMES
 
 
-def service_uses_local_shared_credentials(service: str, worker_scope: WorkerScope | None) -> bool:
-    """Return whether one scoped service reads shared credentials locally instead of worker mirrors."""
-    return worker_scope == "shared" and service in LOCAL_ONLY_SHARED_CREDENTIAL_SERVICES
-
-
-def service_uses_primary_runtime_scoped_credentials(service: str, worker_scope: WorkerScope | None) -> bool:
-    """Return whether one scoped service must stay outside worker-mounted storage."""
-    return worker_scope in {"user", "user_agent"} and service in LOCAL_ONLY_SHARED_CREDENTIAL_SERVICES
-
-
 def local_shared_credential_allowlist(
     service: str,
     worker_scope: WorkerScope | None,
 ) -> frozenset[str] | None:
     """Return the explicit shared-service allowlist for one local-only scoped integration."""
-    if service_uses_local_shared_credentials(service, worker_scope):
+    if credential_service_policy(service, worker_scope).uses_local_shared_credentials:
         return frozenset({service})
     return None
 

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -7,7 +7,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from mindroom.constants import UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS
+from mindroom.credential_policy import credential_service_policy
 from mindroom.credentials import get_runtime_credentials_manager, sync_shared_credentials_to_worker
 from mindroom.tool_system.worker_routing import worker_dir_name
 from mindroom.workers.backend import WorkerBackendError
@@ -258,7 +258,13 @@ class KubernetesWorkerBackend:
         tool_validation_snapshot: dict[str, dict[str, object]],
         worker_grantable_credentials: frozenset[str],
     ) -> None:
-        unsupported_services = sorted(worker_grantable_credentials & UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS)
+        unsupported_services = sorted(
+            {
+                service
+                for service in worker_grantable_credentials
+                if not credential_service_policy(service, None).worker_grantable_supported
+            },
+        )
         if unsupported_services:
             msg = (
                 "Dedicated workers do not support "

--- a/tach.toml
+++ b/tach.toml
@@ -163,6 +163,10 @@ path = "mindroom.agent_policy"
 depends_on = ["mindroom.config.agent"]
 
 [[modules]]
+path = "mindroom.credential_policy"
+depends_on = []
+
+[[modules]]
 path = "mindroom.runtime_resolution"
 depends_on = [
     "mindroom.agent_policy",
@@ -350,6 +354,7 @@ depends_on = [
     "mindroom.agent_policy",
     "mindroom.api.config_lifecycle",
     "mindroom.config.main",
+    "mindroom.credential_policy",
     "mindroom.credentials",
     "mindroom.oauth.registry",
     "mindroom.oauth.service",
@@ -1607,7 +1612,10 @@ depends_on = ["mindroom.tool_system.plugin_imports"]
 
 [[modules]]
 path = "mindroom.tool_system.worker_routing"
-depends_on = ["mindroom.mcp.registry"]
+depends_on = [
+    "mindroom.credential_policy",
+    "mindroom.mcp.registry",
+]
 
 [[modules]]
 path = "mindroom.tool_system.events"
@@ -2448,8 +2456,6 @@ expose = [
     "resolved_worker_key_scope",
     "requires_shared_only_integration_scope",
     "run_with_tool_execution_identity",
-    "service_uses_local_shared_credentials",
-    "service_uses_primary_runtime_scoped_credentials",
     "shared_storage_root",
     "stream_with_tool_execution_identity",
     "supports_tool_name_for_worker_scope",

--- a/tests/test_config_manager_consolidated.py
+++ b/tests/test_config_manager_consolidated.py
@@ -17,10 +17,10 @@ from mindroom.config.matrix import MindRoomUserConfig
 from mindroom.config.models import DefaultsConfig
 from mindroom.constants import (
     DEFAULT_WORKER_GRANTABLE_CREDENTIALS,
-    UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS,
     RuntimePaths,
     resolve_runtime_paths,
 )
+from mindroom.credential_policy import UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS
 from mindroom.custom_tools.config_manager import ConfigManagerTools, _InfoType
 from mindroom.tool_system.metadata import AUTHORED_OVERRIDE_INHERIT
 

--- a/tests/test_credential_policy.py
+++ b/tests/test_credential_policy.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from mindroom.constants import UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS
-from mindroom.tool_system.worker_routing import (
-    service_uses_local_shared_credentials,
-    service_uses_primary_runtime_scoped_credentials,
+from mindroom.credential_policy import (
+    OAUTH_CREDENTIAL_FIELDS,
+    UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS,
+    credential_service_policy,
+    filter_oauth_credential_fields,
+    looks_like_oauth_credentials,
 )
 
 
@@ -23,7 +25,7 @@ from mindroom.tool_system.worker_routing import (
 )
 def test_primary_runtime_scoped_service_policy(service: str, worker_scope: str, expected: bool) -> None:
     """Private worker scopes should read local-only services from primary-runtime scoped storage."""
-    assert service_uses_primary_runtime_scoped_credentials(service, worker_scope) is expected
+    assert credential_service_policy(service, worker_scope).uses_primary_runtime_scoped_credentials is expected
 
 
 @pytest.mark.parametrize(
@@ -38,7 +40,7 @@ def test_primary_runtime_scoped_service_policy(service: str, worker_scope: str, 
 )
 def test_local_shared_service_policy(service: str, worker_scope: str, expected: bool) -> None:
     """Shared worker scope should read local-only service credentials from the primary runtime."""
-    assert service_uses_local_shared_credentials(service, worker_scope) is expected
+    assert credential_service_policy(service, worker_scope).uses_local_shared_credentials is expected
 
 
 @pytest.mark.parametrize(
@@ -55,3 +57,63 @@ def test_local_shared_service_policy(service: str, worker_scope: str, expected: 
 def test_worker_grantable_policy_rejects_sensitive_google_services(service: str) -> None:
     """Sensitive Google credential services should stay unsupported for worker mirroring."""
     assert service in UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS
+
+
+def test_credential_service_policy_classifies_google_oauth_user_scope() -> None:
+    """Google OAuth token services should use private storage and reject worker grants."""
+    policy = credential_service_policy("google_drive_oauth", "user")
+
+    assert policy.service == "google_drive_oauth"
+    assert policy.worker_scope == "user"
+    assert policy.is_local_only_shared_service is True
+    assert policy.uses_primary_runtime_scoped_credentials is True
+    assert policy.uses_local_shared_credentials is False
+    assert policy.worker_grantable_supported is False
+
+
+def test_credential_service_policy_classifies_regular_shared_service() -> None:
+    """Regular services should remain worker-grantable and avoid local-only storage policy."""
+    policy = credential_service_policy("openai", "shared")
+
+    assert policy.service == "openai"
+    assert policy.worker_scope == "shared"
+    assert policy.is_local_only_shared_service is False
+    assert policy.uses_primary_runtime_scoped_credentials is False
+    assert policy.uses_local_shared_credentials is False
+    assert policy.worker_grantable_supported is True
+
+
+def test_looks_like_oauth_credentials_detects_oauth_documents() -> None:
+    """OAuth-looking credential documents should be identified without provider registry access."""
+    assert looks_like_oauth_credentials({"_source": "oauth"}) is True
+    assert looks_like_oauth_credentials({"_oauth_provider": "google_drive"}) is True
+    assert looks_like_oauth_credentials({"_id_token": "id-token"}) is True
+    assert looks_like_oauth_credentials({"_oauth_claims": {"email": "user@example.org"}}) is True
+    assert looks_like_oauth_credentials({"token": "ordinary-api-token"}) is False
+
+
+def test_filter_oauth_credential_fields_removes_token_material() -> None:
+    """OAuth field filtering should keep editable settings and remove token material."""
+    filtered = filter_oauth_credential_fields(
+        {
+            "token": "access-token",
+            "refresh_token": "refresh-token",
+            "client_secret": "client-secret",
+            "_oauth_provider": "google_drive",
+            "max_read_size": 10485760,
+        },
+    )
+
+    assert filtered == {"max_read_size": 10485760}
+
+
+def test_oauth_credential_fields_include_current_token_material() -> None:
+    """The policy module should own the current OAuth token field denylist."""
+    assert {
+        "access_token",
+        "client_id",
+        "client_secret",
+        "refresh_token",
+        "token",
+        "token_uri",
+    } <= OAUTH_CREDENTIAL_FIELDS


### PR DESCRIPTION
## Summary
- Add a pure `mindroom.credential_policy` module for credential service classification and OAuth token-field filtering.
- Route worker storage, dashboard credential APIs, config validation, and Kubernetes worker validation through the shared policy helpers.
- Remove duplicated OAuth field and worker-grantable credential policy constants from their old homes, and remove the now-redundant worker-routing predicate wrappers.
- Register the new policy module and changed import edges in `tach.toml`.

## Test Plan
- [x] uv run pytest tests/test_credential_policy.py tests/test_credentials.py tests/api/test_credentials_api.py tests/api/test_oauth_api.py tests/test_config_manager_consolidated.py tests/test_sandbox_proxy.py tests/test_kubernetes_worker_backend.py -x -n auto --no-cov -v
- [x] uv run tach check --dependencies --interfaces
- [x] uv run pre-commit run --all-files