### PR TITLE
Use credential policy for tool availability

### DIFF
--- a/src/mindroom/api/tools.py
+++ b/src/mindroom/api/tools.py
@@ -17,6 +17,7 @@ from mindroom.api.credentials import (
     resolve_dashboard_execution_scope_override,
 )
 from mindroom.config.main import Config
+from mindroom.credential_policy import credential_service_policy
 from mindroom.credentials import (
     get_runtime_credentials_manager,
     load_scoped_credentials,
@@ -28,7 +29,6 @@ from mindroom.tool_system.catalog import export_tools_metadata, resolved_tool_me
 from mindroom.tool_system.worker_routing import (
     WorkerScope,
     build_worker_target_from_runtime_env,
-    local_shared_credential_allowlist,
     unsupported_shared_only_integration_names,
 )
 
@@ -68,9 +68,9 @@ def _effective_allowed_shared_services(
     context: _ResolvedToolAvailabilityContext,
 ) -> frozenset[str] | None:
     """Return the worker allowlist that applies to one dashboard credential lookup."""
-    local_allowlist = local_shared_credential_allowlist(service, context.execution_scope)
-    if local_allowlist is not None:
-        return local_allowlist
+    policy = credential_service_policy(service, context.execution_scope)
+    if policy.uses_local_shared_credentials:
+        return frozenset({service})
     return context.allowed_shared_services
 
 

--- a/tach.toml
+++ b/tach.toml
@@ -368,6 +368,7 @@ depends_on = [
     "mindroom.api.config_lifecycle",
     "mindroom.api.credentials",
     "mindroom.config.main",
+    "mindroom.credential_policy",
     "mindroom.credentials",
     "mindroom.tool_system.catalog",
     "mindroom.tool_system.worker_routing",

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1387,6 +1387,41 @@ def test_non_oauth_auth_provider_uses_required_credential_fields(tmp_path: Path)
     assert tools[0]["status"] == "available"
 
 
+@pytest.mark.parametrize(
+    ("service", "execution_scope", "expected_allowed_services"),
+    [
+        ("google_drive", "shared", frozenset({"google_drive"})),
+        ("google_calendar", "shared", frozenset({"google_calendar"})),
+        ("google_sheets", "shared", frozenset({"google_sheets"})),
+        ("gmail", "shared", frozenset({"gmail"})),
+        ("google_drive_oauth", "shared", frozenset({"google_drive_oauth"})),
+        ("weather", "shared", frozenset({"weather"})),
+        ("google_drive", "user", frozenset({"weather"})),
+        ("google_drive", "user_agent", frozenset({"weather"})),
+    ],
+)
+def test_effective_allowed_shared_services_uses_credential_policy(
+    tmp_path: Path,
+    service: str,
+    execution_scope: str,
+    expected_allowed_services: frozenset[str],
+) -> None:
+    """Tool availability should apply local-only credential policy before worker grants."""
+    context = tools_api._ResolvedToolAvailabilityContext(
+        execution_scope=execution_scope,
+        dashboard_configuration_supported=True,
+        status_authoritative=True,
+        credentials_manager=get_runtime_credentials_manager(_runtime_paths(tmp_path)),
+        worker_target=None,
+        allowed_shared_services=frozenset({"weather"}),
+        auth_provider_credential_services={},
+        oauth_providers={},
+        runtime_paths=_runtime_paths(tmp_path),
+    )
+
+    assert tools_api._effective_allowed_shared_services(service, context) == expected_allowed_services
+
+
 def test_get_tools_marks_shared_only_integrations_unsupported_for_isolating_worker_scope(
     test_client: TestClient,
 ) -> None:


### PR DESCRIPTION
## Summary
- Route `/api/tools` shared credential visibility through `credential_service_policy()`.
- Remove the tools API dependency on worker-routing local credential allowlist helpers.
- Add table-driven coverage for shared local-only services and private-scope allowlist behavior.
- Update Tach metadata for the new `mindroom.api.tools -> mindroom.credential_policy` dependency.

## Test Plan
- [x] uv run pytest tests/api/test_api.py::test_effective_allowed_shared_services_uses_credential_policy -x -n auto --no-cov -v
- [x] uv run pytest tests/api/test_api.py tests/api/test_credentials_api.py tests/test_credential_policy.py -x -n auto --no-cov -v
- [x] uv run tach check --dependencies --interfaces
- [x] uv run pre-commit run --all-files