### PR TITLE
Remove credential policy wrapper

### DIFF
--- a/src/mindroom/api/credentials.py
+++ b/src/mindroom/api/credentials.py
@@ -38,7 +38,6 @@ from mindroom.oauth.state import consume_opaque_oauth_state, issue_opaque_oauth_
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
     WorkerScope,
-    local_shared_credential_allowlist,
     require_worker_key_for_scope,
     resolve_worker_target,
     unsupported_shared_only_integration_message,
@@ -532,8 +531,10 @@ def load_credentials_for_target(service: str, target: RequestCredentialsTarget) 
         )
 
     shared_manager = target.base_manager.shared_manager()
-    local_allowlist = local_shared_credential_allowlist(service, target.worker_scope)
-    allowed_shared_services = local_allowlist or target.allowed_shared_services or frozenset()
+    policy = credential_service_policy(service, target.worker_scope)
+    allowed_shared_services = (
+        frozenset({service}) if policy.uses_local_shared_credentials else target.allowed_shared_services or frozenset()
+    )
     shared_credentials = load_worker_grantable_shared_credentials(
         service,
         shared_manager=shared_manager,

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -11,8 +11,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol, cast, runtime_checkable
 
-from mindroom.credential_policy import credential_service_policy
-
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Collection, Iterator
 
@@ -354,16 +352,6 @@ def unsupported_shared_only_integration_names(
 def tool_stays_local(name: str) -> bool:
     """Return whether one integration tool always stays in the primary runtime."""
     return name in LOCAL_ONLY_SHARED_INTEGRATION_TOOL_NAMES
-
-
-def local_shared_credential_allowlist(
-    service: str,
-    worker_scope: WorkerScope | None,
-) -> frozenset[str] | None:
-    """Return the explicit shared-service allowlist for one local-only scoped integration."""
-    if credential_service_policy(service, worker_scope).uses_local_shared_credentials:
-        return frozenset({service})
-    return None
 
 
 def unsupported_shared_only_integration_message(

--- a/tach.toml
+++ b/tach.toml
@@ -1614,7 +1614,6 @@ depends_on = ["mindroom.tool_system.plugin_imports"]
 [[modules]]
 path = "mindroom.tool_system.worker_routing"
 depends_on = [
-    "mindroom.credential_policy",
     "mindroom.mcp.registry",
 ]
 
@@ -2445,7 +2444,6 @@ expose = [
     "build_tool_execution_identity",
     "build_worker_target_from_runtime_env",
     "get_tool_execution_identity",
-    "local_shared_credential_allowlist",
     "private_instance_scope_root_path",
     "require_worker_key_for_scope",
     "resolve_agent_owned_path",


### PR DESCRIPTION
## Summary
- remove the remaining local_shared_credential_allowlist compatibility wrapper
- route the api/credentials shared-service allowlist decision through credential_service_policy directly
- remove the stale Tach public interface export and dependency edge

## Verification
- uv run pytest tests/test_credential_policy.py tests/test_credentials.py tests/api/test_credentials_api.py tests/api/test_oauth_api.py tests/api/test_api.py tests/test_config_manager_consolidated.py tests/test_sandbox_proxy.py tests/test_kubernetes_worker_backend.py -x -n auto --no-cov -v
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --all-files