### PR TITLE
Preserve streamed interactive metadata

### DIFF
--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -119,21 +119,21 @@ class MatrixMessageOperations:
             return
 
         response = parse_and_format_interactive(original_text, extract_mapping=True)
-        if not response.option_map or not response.options_list:
+        if response.interactive_metadata is None:
             return
 
         register_interactive_question(
             event_id,
             room_id,
             thread_id,
-            response.option_map,
+            response.interactive_metadata.option_map,
             context.agent_name,
         )
         await add_reaction_buttons(
             context.client,
             room_id,
             event_id,
-            response.options_list,
+            response.interactive_metadata.options_as_list(),
         )
 
     async def _message_send_or_reply(  # noqa: C901, PLR0911, PLR0912
@@ -659,19 +659,19 @@ class MatrixMessageOperations:
             delivered.content_sent,
         )
 
-        if interactive_response.option_map and interactive_response.options_list:
+        if interactive_response.interactive_metadata is not None:
             register_interactive_question(
                 target,
                 room_id,
                 thread_id,
-                interactive_response.option_map,
+                interactive_response.interactive_metadata.option_map,
                 context.agent_name,
             )
             await add_reaction_buttons(
                 context.client,
                 room_id,
                 target,
-                interactive_response.options_list,
+                interactive_response.interactive_metadata.options_as_list(),
             )
 
         return self._result(

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -354,8 +354,17 @@ class DeliveryGateway:
         visible_body: str,
         *,
         canonical_body_candidate: str | None,
+        stream_option_map: dict[str, str] | None = None,
+        stream_options_list: tuple[dict[str, str], ...] | None = None,
     ) -> interactive._InteractiveResponse:
         """Return interactive metadata only when it belongs to the visible body."""
+        if stream_option_map and stream_options_list:
+            return interactive._InteractiveResponse(
+                visible_body,
+                dict(stream_option_map),
+                [dict(item) for item in stream_options_list],
+            )
+
         visible_response = interactive.parse_and_format_interactive(visible_body, extract_mapping=True)
         if visible_response.option_map and visible_response.options_list:
             return visible_response
@@ -1444,6 +1453,8 @@ class DeliveryGateway:
             interactive_response = self._interactive_response_for_visible_body(
                 streamed_text,
                 canonical_body_candidate=final_body_candidate,
+                stream_option_map=stream_outcome.option_map,
+                stream_options_list=stream_outcome.options_list,
             )
             return FinalDeliveryOutcome(
                 terminal_status="completed",

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -354,19 +354,14 @@ class DeliveryGateway:
         visible_body: str,
         *,
         canonical_body_candidate: str | None,
-        stream_option_map: dict[str, str] | None = None,
-        stream_options_list: tuple[dict[str, str], ...] | None = None,
+        stream_interactive_metadata: interactive.InteractiveMetadata | None = None,
     ) -> interactive._InteractiveResponse:
         """Return interactive metadata only when it belongs to the visible body."""
-        if stream_option_map and stream_options_list:
-            return interactive._InteractiveResponse(
-                visible_body,
-                dict(stream_option_map),
-                [dict(item) for item in stream_options_list],
-            )
+        if stream_interactive_metadata is not None:
+            return interactive._InteractiveResponse(visible_body, stream_interactive_metadata)
 
         visible_response = interactive.parse_and_format_interactive(visible_body, extract_mapping=True)
-        if visible_response.option_map and visible_response.options_list:
+        if visible_response.interactive_metadata is not None:
             return visible_response
 
         if canonical_body_candidate is None or canonical_body_candidate == visible_body:
@@ -376,11 +371,7 @@ class DeliveryGateway:
             canonical_body_candidate,
             extract_mapping=True,
         )
-        if (
-            canonical_response.option_map
-            and canonical_response.options_list
-            and canonical_response.formatted_text == visible_body
-        ):
+        if canonical_response.interactive_metadata is not None and canonical_response.formatted_text == visible_body:
             return canonical_response
 
         return visible_response
@@ -785,12 +776,7 @@ class DeliveryGateway:
                     delivery_kind="edited",
                     tool_trace=tuple(draft.tool_trace or ()),
                     extra_content=draft.extra_content,
-                    option_map=interactive_response.option_map,
-                    options_list=(
-                        tuple(interactive_response.options_list)
-                        if interactive_response.options_list is not None
-                        else None
-                    ),
+                    interactive_metadata=interactive_response.interactive_metadata,
                 )
 
             if request.existing_event_is_placeholder:
@@ -839,10 +825,7 @@ class DeliveryGateway:
             delivery_kind="sent",
             tool_trace=tuple(draft.tool_trace or ()),
             extra_content=draft.extra_content,
-            option_map=interactive_response.option_map,
-            options_list=tuple(interactive_response.options_list)
-            if interactive_response.options_list is not None
-            else None,
+            interactive_metadata=interactive_response.interactive_metadata,
         )
 
     async def deliver_cancelled_visible_note(
@@ -1105,10 +1088,7 @@ class DeliveryGateway:
             failure_reason=failure_reason,
             tool_trace=tuple(tool_trace or ()),
             extra_content=extra_content,
-            option_map=interactive_response.option_map,
-            options_list=tuple(interactive_response.options_list)
-            if interactive_response.options_list is not None
-            else None,
+            interactive_metadata=interactive_response.interactive_metadata,
         )
 
     async def _finalize_placeholder_only_stream_error(
@@ -1453,8 +1433,7 @@ class DeliveryGateway:
             interactive_response = self._interactive_response_for_visible_body(
                 streamed_text,
                 canonical_body_candidate=final_body_candidate,
-                stream_option_map=stream_outcome.option_map,
-                stream_options_list=stream_outcome.options_list,
+                stream_interactive_metadata=stream_outcome.interactive_metadata,
             )
             return FinalDeliveryOutcome(
                 terminal_status="completed",
@@ -1465,10 +1444,7 @@ class DeliveryGateway:
                 failure_reason=stream_outcome.failure_reason,
                 tool_trace=tuple(request.tool_trace or ()),
                 extra_content=request.extra_content,
-                option_map=interactive_response.option_map,
-                options_list=tuple(interactive_response.options_list)
-                if interactive_response.options_list is not None
-                else None,
+                interactive_metadata=interactive_response.interactive_metadata,
             )
         except asyncio.CancelledError:
             visible_event_id = self._visible_stream_event_id(stream_outcome)

--- a/src/mindroom/final_delivery.py
+++ b/src/mindroom/final_delivery.py
@@ -29,6 +29,8 @@ class StreamTransportOutcome:  # noqa: D101
     visible_body_state: VisibleBodyState
     canonical_final_body_candidate: str | None = None
     failure_reason: str | None = None
+    option_map: dict[str, str] | None = None
+    options_list: tuple[dict[str, str], ...] | None = None
 
     @property
     def has_any_physical_stream_event(self) -> bool:  # noqa: D102

--- a/src/mindroom/final_delivery.py
+++ b/src/mindroom/final_delivery.py
@@ -6,19 +6,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    from mindroom.interactive import InteractiveMetadata
     from mindroom.tool_system.events import ToolTraceEntry
 
 TerminalStatus = Literal["completed", "cancelled", "error"]
 VisibleBodyState = Literal["none", "placeholder_only", "visible_body"]
 VisibleDeliveryKind = Literal["sent", "edited"]
-
-
-def _copy_dict(value: dict[str, str] | dict[str, Any] | None) -> dict[str, Any] | None:
-    return dict(value) if value else None
-
-
-def _copy_options(value: tuple[dict[str, str], ...] | list[dict[str, str]] | None) -> tuple[dict[str, str], ...] | None:
-    return tuple(dict(item) for item in value) if value is not None else None
 
 
 @dataclass(frozen=True)
@@ -29,8 +22,7 @@ class StreamTransportOutcome:  # noqa: D101
     visible_body_state: VisibleBodyState
     canonical_final_body_candidate: str | None = None
     failure_reason: str | None = None
-    option_map: dict[str, str] | None = None
-    options_list: tuple[dict[str, str], ...] | None = None
+    interactive_metadata: InteractiveMetadata | None = None
 
     @property
     def has_any_physical_stream_event(self) -> bool:  # noqa: D102
@@ -52,14 +44,11 @@ class FinalDeliveryOutcome:  # noqa: D101
     suppressed: bool = False
     tool_trace: tuple[ToolTraceEntry, ...] = ()
     extra_content: dict[str, Any] | None = None
-    option_map: dict[str, str] | None = None
-    options_list: tuple[dict[str, str], ...] | None = None
+    interactive_metadata: InteractiveMetadata | None = None
 
     def __post_init__(self) -> None:  # noqa: D105
         object.__setattr__(self, "tool_trace", tuple(self.tool_trace or ()))
         object.__setattr__(self, "extra_content", dict(self.extra_content or {}))
-        object.__setattr__(self, "option_map", _copy_dict(self.option_map))
-        object.__setattr__(self, "options_list", _copy_options(self.options_list))
 
     @property
     def final_visible_event_id(self) -> str | None:  # noqa: D102
@@ -72,6 +61,18 @@ class FinalDeliveryOutcome:  # noqa: D101
     @property
     def response_text(self) -> str:  # noqa: D102
         return self.final_visible_body or ""
+
+    @property
+    def option_map(self) -> dict[str, str] | None:  # noqa: D102
+        if self.interactive_metadata is None:
+            return None
+        return dict(self.interactive_metadata.option_map)
+
+    @property
+    def options_list(self) -> tuple[dict[str, str], ...] | None:  # noqa: D102
+        if self.interactive_metadata is None:
+            return None
+        return tuple(dict(item) for item in self.interactive_metadata.options_list)
 
     @classmethod
     def cancelled_for_empty_prompt(cls) -> FinalDeliveryOutcome:

--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -12,7 +12,7 @@ import time
 from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import nio
 
@@ -20,6 +20,8 @@ from mindroom.logging_config import bound_log_context, get_logger
 from mindroom.matrix.identity import is_agent_id
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
 
@@ -45,12 +47,52 @@ class _InteractiveQuestion:
     created_at: float = field(default_factory=time.time)
 
 
-class _InteractiveResponse(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class InteractiveMetadata:
+    """Registration metadata extracted from one interactive response."""
+
+    option_map: dict[str, str]
+    options_list: tuple[dict[str, str], ...]
+
+    @classmethod
+    def from_parts(
+        cls,
+        option_map: dict[str, str] | None,
+        options_list: Sequence[dict[str, str]] | None,
+    ) -> InteractiveMetadata | None:
+        """Return copied metadata when both interactive registration parts exist."""
+        if not option_map or not options_list:
+            return None
+        return cls(
+            option_map=dict(option_map),
+            options_list=tuple(dict(item) for item in options_list),
+        )
+
+    def options_as_list(self) -> list[dict[str, str]]:
+        """Return a mutable copy for Matrix reaction-button registration."""
+        return [dict(item) for item in self.options_list]
+
+
+@dataclass(frozen=True, slots=True)
+class _InteractiveResponse:
     """Result of parsing and formatting an interactive response."""
 
     formatted_text: str
-    option_map: dict[str, str] | None
-    options_list: list[dict[str, str]] | None
+    interactive_metadata: InteractiveMetadata | None = None
+
+    @property
+    def option_map(self) -> dict[str, str] | None:
+        """Return the emoji/number mapping when this response is interactive."""
+        if self.interactive_metadata is None:
+            return None
+        return dict(self.interactive_metadata.option_map)
+
+    @property
+    def options_list(self) -> list[dict[str, str]] | None:
+        """Return the button option list when this response is interactive."""
+        if self.interactive_metadata is None:
+            return None
+        return self.interactive_metadata.options_as_list()
 
 
 @dataclass(frozen=True, slots=True)
@@ -560,7 +602,7 @@ def parse_and_format_interactive(response_text: str, extract_mapping: bool = Fal
                 "Interactive block not parsed",
                 preview=_preview_text(response_text),
             )
-        return _InteractiveResponse(response_text, None, None)
+        return _InteractiveResponse(response_text)
 
     try:
         interactive_data = json.loads(first_match.group(1))
@@ -570,7 +612,7 @@ def parse_and_format_interactive(response_text: str, extract_mapping: bool = Fal
             error=str(exc),
             preview=_preview_text(first_match.group(1)),
         )
-        return _InteractiveResponse(response_text, None, None)
+        return _InteractiveResponse(response_text)
 
     if not isinstance(interactive_data, dict):
         logger.warning(
@@ -578,14 +620,14 @@ def parse_and_format_interactive(response_text: str, extract_mapping: bool = Fal
             payload_type=type(interactive_data).__name__,
             preview=_preview_text(first_match.group(1)),
         )
-        return _InteractiveResponse(response_text, None, None)
+        return _InteractiveResponse(response_text)
 
     interactive_payload = cast("dict[str, object]", interactive_data)
     question = interactive_payload.get("question", _DEFAULT_QUESTION)
     options = cast("list[dict[str, str]]", interactive_payload.get("options", []))
 
     if not options:
-        return _InteractiveResponse(response_text, None, None)
+        return _InteractiveResponse(response_text)
 
     options = options[:_MAX_OPTIONS]
     clean_response = response_text.replace(first_match.group(0), "").strip()
@@ -616,7 +658,10 @@ def parse_and_format_interactive(response_text: str, extract_mapping: bool = Fal
 
     final_text = "\n".join(message_parts)
 
-    return _InteractiveResponse(final_text, option_map, options if extract_mapping else None)
+    return _InteractiveResponse(
+        final_text,
+        InteractiveMetadata.from_parts(option_map, options if extract_mapping else None),
+    )
 
 
 def register_interactive_question(

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -74,7 +74,7 @@ class PostResponseEffectsDeps:
     logger: structlog.stdlib.BoundLogger
     register_interactive: (
         Callable[
-            [str, MessageTarget, dict[str, str], list[dict[str, str]]],
+            [str, MessageTarget, interactive.InteractiveMetadata],
             Awaitable[None],
         ]
         | None
@@ -133,8 +133,7 @@ class PostResponseEffectsSupport:
         event_id: str,
         room_id: str,
         target: MessageTarget,
-        option_map: dict[str, str],
-        options_list: list[dict[str, str]],
+        interactive_metadata: interactive.InteractiveMetadata,
         agent_name: str,
     ) -> None:
         """Persist one interactive response and add its reaction buttons."""
@@ -142,14 +141,14 @@ class PostResponseEffectsSupport:
             event_id,
             room_id,
             target.resolved_thread_id,
-            option_map,
+            interactive_metadata.option_map,
             agent_name,
         )
         await interactive.add_reaction_buttons(
             self._client(),
             room_id,
             event_id,
-            options_list,
+            interactive_metadata.options_as_list(),
         )
 
     def queue_thread_summary(
@@ -216,15 +215,13 @@ class PostResponseEffectsSupport:
         async def register_interactive(
             event_id: str,
             target: MessageTarget,
-            option_map: dict[str, str],
-            options_list: list[dict[str, str]],
+            interactive_metadata: interactive.InteractiveMetadata,
         ) -> None:
             await self._register_interactive_delivery(
                 event_id=event_id,
                 room_id=room_id,
                 target=target,
-                option_map=option_map,
-                options_list=options_list,
+                interactive_metadata=interactive_metadata,
                 agent_name=interactive_agent_name,
             )
 
@@ -268,23 +265,20 @@ async def apply_post_response_effects(
         and final_delivery_outcome.terminal_status == "completed"
         and final_delivery_outcome.final_visible_body is not None
         and not final_delivery_outcome.suppressed
-        and final_delivery_outcome.option_map
-        and final_delivery_outcome.options_list
+        and final_delivery_outcome.interactive_metadata is not None
         and outcome.interactive_target is not None
     ):
         await deps.register_interactive(
             response_event_id,
             outcome.interactive_target,
-            dict(final_delivery_outcome.option_map),
-            [dict(item) for item in final_delivery_outcome.options_list],
+            final_delivery_outcome.interactive_metadata,
         )
     else:  # noqa: PLR5501, RUF100
         if response_event_id is not None and (
             (final_delivery_outcome.final_visible_body or "")
             .rstrip()
             .endswith("React with an emoji or type the number to respond.")
-            or final_delivery_outcome.option_map
-            or final_delivery_outcome.options_list
+            or final_delivery_outcome.interactive_metadata is not None
         ):
             deps.logger.warning(
                 "Interactive question registration skipped",
@@ -293,8 +287,8 @@ async def apply_post_response_effects(
                 terminal_status=final_delivery_outcome.terminal_status,
                 final_visible_body_is_none=final_delivery_outcome.final_visible_body is None,
                 suppressed=final_delivery_outcome.suppressed,
-                option_map_empty=not bool(final_delivery_outcome.option_map),
-                options_list_empty=not bool(final_delivery_outcome.options_list),
+                option_map_empty=not bool(final_delivery_outcome.interactive_metadata),
+                options_list_empty=not bool(final_delivery_outcome.interactive_metadata),
                 interactive_target_is_none=outcome.interactive_target is None,
             )
 

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -126,8 +126,7 @@ def _build_streaming_delivery_error(
             visible_body_state=visible_body_state,
             canonical_final_body_candidate=canonical_final_body_candidate,
             failure_reason=failure_reason,
-            option_map=streaming._last_committed_option_map,
-            options_list=streaming._last_committed_options_list,
+            interactive_metadata=streaming._last_committed_interactive_metadata,
         ),
     )
 
@@ -208,8 +207,7 @@ class _CommittedDeliveryState:
     placeholder_progress_sent: bool
     rendered_body: str
     visible_body_state: Literal["placeholder_only", "visible_body"]
-    option_map: dict[str, str] | None
-    options_list: tuple[dict[str, str], ...] | None
+    interactive_metadata: interactive.InteractiveMetadata | None
 
 
 def _normalize_stream_accumulated_text(text: str) -> str:
@@ -307,8 +305,11 @@ class StreamingResponse:
     _last_delivered_tool_trace: list[ToolTraceEntry] = field(default_factory=list, init=False, repr=False)
     _last_placeholder_progress_sent: bool = field(default=False, init=False, repr=False)
     _last_committed_rendered_body: str | None = field(default=None, init=False, repr=False)
-    _last_committed_option_map: dict[str, str] | None = field(default=None, init=False, repr=False)
-    _last_committed_options_list: tuple[dict[str, str], ...] | None = field(default=None, init=False, repr=False)
+    _last_committed_interactive_metadata: interactive.InteractiveMetadata | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
     _last_committed_visible_body_state: Literal["none", "placeholder_only", "visible_body"] = field(
         default="none",
         init=False,
@@ -550,8 +551,7 @@ class StreamingResponse:
                 visible_body_state=committed_visible_body_state,
                 canonical_final_body_candidate=canonical_final_body_candidate,
                 failure_reason=cancellation_failure_reason,
-                option_map=self._last_committed_option_map,
-                options_list=self._last_committed_options_list,
+                interactive_metadata=self._last_committed_interactive_metadata,
             )
         if not text_to_send.strip() and final_stream_status == STREAM_STATUS_COMPLETED:
             text_to_send = canonical_final_body_candidate or ""
@@ -636,8 +636,7 @@ class StreamingResponse:
                 visible_body_state=committed_visible_body_state,
                 canonical_final_body_candidate=canonical_final_body_candidate,
                 failure_reason=cancellation_failure_reason or "terminal_update_cancelled",
-                option_map=self._last_committed_option_map,
-                options_list=self._last_committed_options_list,
+                interactive_metadata=self._last_committed_interactive_metadata,
             )
         except Exception as exc:
             logger.warning(
@@ -659,8 +658,7 @@ class StreamingResponse:
                 visible_body_state=committed_visible_body_state,
                 canonical_final_body_candidate=canonical_final_body_candidate,
                 failure_reason=cancellation_failure_reason or f"terminal_update_exception:{exc.__class__.__name__}",
-                option_map=self._last_committed_option_map,
-                options_list=self._last_committed_options_list,
+                interactive_metadata=self._last_committed_interactive_metadata,
             )
         if not send_succeeded:
             logger.warning(
@@ -680,8 +678,7 @@ class StreamingResponse:
                 visible_body_state=committed_visible_body_state,
                 canonical_final_body_candidate=canonical_final_body_candidate,
                 failure_reason=cancellation_failure_reason or "terminal_update_failed",
-                option_map=self._last_committed_option_map,
-                options_list=self._last_committed_options_list,
+                interactive_metadata=self._last_committed_interactive_metadata,
             )
         return StreamTransportOutcome(
             last_physical_stream_event_id=self.event_id,
@@ -690,8 +687,7 @@ class StreamingResponse:
             visible_body_state=attempted_visible_body_state,
             canonical_final_body_candidate=canonical_final_body_candidate,
             failure_reason=cancellation_failure_reason,
-            option_map=response.option_map,
-            options_list=tuple(response.options_list) if response.options_list is not None else None,
+            interactive_metadata=response.interactive_metadata,
         )
 
     async def _send_or_edit_message(
@@ -856,8 +852,7 @@ class StreamingResponse:
                 visible_body_state=(
                     "placeholder_only" if canonical_visible_body == _PROGRESS_PLACEHOLDER else "visible_body"
                 ),
-                option_map=response.option_map,
-                options_list=tuple(response.options_list) if response.options_list is not None else None,
+                interactive_metadata=response.interactive_metadata,
             ),
             had_warmup_suffix=bool(warmup_suffix_lines),
         )
@@ -869,12 +864,7 @@ class StreamingResponse:
         self._last_placeholder_progress_sent = committed_state.placeholder_progress_sent
         self._last_committed_rendered_body = committed_state.rendered_body
         self._last_committed_visible_body_state = committed_state.visible_body_state
-        self._last_committed_option_map = dict(committed_state.option_map) if committed_state.option_map else None
-        self._last_committed_options_list = (
-            tuple(dict(item) for item in committed_state.options_list)
-            if committed_state.options_list is not None
-            else None
-        )
+        self._last_committed_interactive_metadata = committed_state.interactive_metadata
         self.placeholder_progress_sent = committed_state.placeholder_progress_sent
 
     def _committed_terminal_snapshot(

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -126,6 +126,8 @@ def _build_streaming_delivery_error(
             visible_body_state=visible_body_state,
             canonical_final_body_candidate=canonical_final_body_candidate,
             failure_reason=failure_reason,
+            option_map=streaming._last_committed_option_map,
+            options_list=streaming._last_committed_options_list,
         ),
     )
 
@@ -206,6 +208,8 @@ class _CommittedDeliveryState:
     placeholder_progress_sent: bool
     rendered_body: str
     visible_body_state: Literal["placeholder_only", "visible_body"]
+    option_map: dict[str, str] | None
+    options_list: tuple[dict[str, str], ...] | None
 
 
 def _normalize_stream_accumulated_text(text: str) -> str:
@@ -303,6 +307,8 @@ class StreamingResponse:
     _last_delivered_tool_trace: list[ToolTraceEntry] = field(default_factory=list, init=False, repr=False)
     _last_placeholder_progress_sent: bool = field(default=False, init=False, repr=False)
     _last_committed_rendered_body: str | None = field(default=None, init=False, repr=False)
+    _last_committed_option_map: dict[str, str] | None = field(default=None, init=False, repr=False)
+    _last_committed_options_list: tuple[dict[str, str], ...] | None = field(default=None, init=False, repr=False)
     _last_committed_visible_body_state: Literal["none", "placeholder_only", "visible_body"] = field(
         default="none",
         init=False,
@@ -544,6 +550,8 @@ class StreamingResponse:
                 visible_body_state=committed_visible_body_state,
                 canonical_final_body_candidate=canonical_final_body_candidate,
                 failure_reason=cancellation_failure_reason,
+                option_map=self._last_committed_option_map,
+                options_list=self._last_committed_options_list,
             )
         if not text_to_send.strip() and final_stream_status == STREAM_STATUS_COMPLETED:
             text_to_send = canonical_final_body_candidate or ""
@@ -628,6 +636,8 @@ class StreamingResponse:
                 visible_body_state=committed_visible_body_state,
                 canonical_final_body_candidate=canonical_final_body_candidate,
                 failure_reason=cancellation_failure_reason or "terminal_update_cancelled",
+                option_map=self._last_committed_option_map,
+                options_list=self._last_committed_options_list,
             )
         except Exception as exc:
             logger.warning(
@@ -649,6 +659,8 @@ class StreamingResponse:
                 visible_body_state=committed_visible_body_state,
                 canonical_final_body_candidate=canonical_final_body_candidate,
                 failure_reason=cancellation_failure_reason or f"terminal_update_exception:{exc.__class__.__name__}",
+                option_map=self._last_committed_option_map,
+                options_list=self._last_committed_options_list,
             )
         if not send_succeeded:
             logger.warning(
@@ -668,6 +680,8 @@ class StreamingResponse:
                 visible_body_state=committed_visible_body_state,
                 canonical_final_body_candidate=canonical_final_body_candidate,
                 failure_reason=cancellation_failure_reason or "terminal_update_failed",
+                option_map=self._last_committed_option_map,
+                options_list=self._last_committed_options_list,
             )
         return StreamTransportOutcome(
             last_physical_stream_event_id=self.event_id,
@@ -676,6 +690,8 @@ class StreamingResponse:
             visible_body_state=attempted_visible_body_state,
             canonical_final_body_candidate=canonical_final_body_candidate,
             failure_reason=cancellation_failure_reason,
+            option_map=response.option_map,
+            options_list=tuple(response.options_list) if response.options_list is not None else None,
         )
 
     async def _send_or_edit_message(
@@ -840,6 +856,8 @@ class StreamingResponse:
                 visible_body_state=(
                     "placeholder_only" if canonical_visible_body == _PROGRESS_PLACEHOLDER else "visible_body"
                 ),
+                option_map=response.option_map,
+                options_list=tuple(response.options_list) if response.options_list is not None else None,
             ),
             had_warmup_suffix=bool(warmup_suffix_lines),
         )
@@ -851,6 +869,12 @@ class StreamingResponse:
         self._last_placeholder_progress_sent = committed_state.placeholder_progress_sent
         self._last_committed_rendered_body = committed_state.rendered_body
         self._last_committed_visible_body_state = committed_state.visible_body_state
+        self._last_committed_option_map = dict(committed_state.option_map) if committed_state.option_map else None
+        self._last_committed_options_list = (
+            tuple(dict(item) for item in committed_state.options_list)
+            if committed_state.options_list is not None
+            else None
+        )
         self.placeholder_progress_sent = committed_state.placeholder_progress_sent
 
     def _committed_terminal_snapshot(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.delivery_gateway import DeliveryGateway, EditTextRequest, FinalDeliveryRequest, SendTextRequest
 from mindroom.edit_regenerator import EditRegenerator
 from mindroom.final_delivery import FinalDeliveryOutcome
+from mindroom.interactive import InteractiveMetadata
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
@@ -280,8 +281,7 @@ def _outcome(
         suppressed=resolved_suppressed,
         tool_trace=tool_trace,
         extra_content=dict(extra_content or {}),
-        option_map=option_map,
-        options_list=options_list,
+        interactive_metadata=InteractiveMetadata.from_parts(option_map, options_list),
     )
 
 

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -41,6 +41,7 @@ from mindroom.dispatch_handoff import PendingDispatchMetadata, PreparedTextEvent
 from mindroom.final_delivery import FinalDeliveryOutcome
 from mindroom.hooks import MessageEnvelope
 from mindroom.inbound_turn_normalizer import DispatchPayload
+from mindroom.interactive import InteractiveMetadata
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
@@ -367,6 +368,11 @@ async def test_post_response_effects_register_interactive_follow_up_for_preserve
         thread_id="$thread",
         reply_to_event_id="$event",
     )
+    interactive_metadata = InteractiveMetadata.from_parts(
+        {"1": "yes"},
+        ({"emoji": "1", "label": "Yes", "value": "yes"},),
+    )
+    assert interactive_metadata is not None
 
     await apply_post_response_effects(
         FinalDeliveryOutcome(
@@ -375,8 +381,7 @@ async def test_post_response_effects_register_interactive_follow_up_for_preserve
             is_visible_response=True,
             final_visible_body="Choose",
             delivery_kind="sent",
-            option_map={"1": "yes"},
-            options_list=({"emoji": "1", "label": "Yes", "value": "yes"},),
+            interactive_metadata=interactive_metadata,
         ),
         ResponseOutcome(
             interactive_target=target,
@@ -390,8 +395,7 @@ async def test_post_response_effects_register_interactive_follow_up_for_preserve
     register_interactive.assert_awaited_once_with(
         "$stream",
         target,
-        {"1": "yes"},
-        [{"emoji": "1", "label": "Yes", "value": "yes"}],
+        interactive_metadata,
     )
 
 
@@ -404,6 +408,11 @@ async def test_post_response_effects_skip_interactive_follow_up_for_preserved_st
         thread_id="$thread",
         reply_to_event_id="$event",
     )
+    interactive_metadata = InteractiveMetadata.from_parts(
+        {"1": "yes"},
+        ({"emoji": "1", "label": "Yes", "value": "yes"},),
+    )
+    assert interactive_metadata is not None
 
     await apply_post_response_effects(
         FinalDeliveryOutcome(
@@ -411,8 +420,7 @@ async def test_post_response_effects_skip_interactive_follow_up_for_preserved_st
             event_id="$stream",
             is_visible_response=True,
             final_visible_body="Choose",
-            option_map={"1": "yes"},
-            options_list=({"emoji": "1", "label": "Yes", "value": "yes"},),
+            interactive_metadata=interactive_metadata,
         ),
         ResponseOutcome(
             interactive_target=target,

--- a/tests/test_streaming_finalize.py
+++ b/tests/test_streaming_finalize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -719,6 +720,97 @@ async def test_streamed_interactive_final_reply_registers_reactions_on_root_even
         assert reaction_keys == ["✅", "❌", "🧪"]
     finally:
         interactive._cleanup()
+
+
+@pytest.mark.asyncio
+async def test_streamed_interactive_metadata_survives_unparseable_canonical_final_body(tmp_path: Path) -> None:
+    """Registration should use the same interactive parse that rendered the visible streamed body."""
+    config = _config(tmp_path)
+    target = MessageTarget.resolve("!room:localhost", "$thread-root", "$reply")
+    client = _client()
+    raw_interactive = (
+        "```interactive\n"
+        "{\n"
+        '  "question": "What next?",\n'
+        '  "options": [\n'
+        '    {"emoji": "🎙️", "label": "Transcribe audio", "value": "transcribe"},\n'
+        '    {"emoji": "📂", "label": "Inspect incoming", "value": "inspect"}\n'
+        "  ]\n"
+        "}\n"
+        "```"
+    )
+    formatted_interactive = interactive.parse_and_format_interactive(raw_interactive, extract_mapping=True)
+
+    async def interactive_stream() -> AsyncIterator[str]:
+        yield raw_interactive
+
+    with patch("mindroom.streaming.edit_message_result", new=AsyncMock(return_value=DeliveredMatrixEvent("$edit", {}))):
+        stream_outcome = await send_streaming_response(
+            client=client,
+            room_id=target.room_id,
+            reply_to_event_id=target.reply_to_event_id,
+            thread_id=target.resolved_thread_id,
+            sender_domain="localhost",
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            response_stream=interactive_stream(),
+            existing_event_id="$displayed-root",
+            adopt_existing_placeholder=True,
+            target=target,
+            room_mode=target.is_room_mode,
+        )
+
+    assert stream_outcome.rendered_body == formatted_interactive.formatted_text
+    stream_outcome = replace(
+        stream_outcome,
+        canonical_final_body_candidate='```interactive\n{"question": "What next?", "options": [',
+    )
+
+    response_hooks = SimpleNamespace(
+        apply_before_response=AsyncMock(),
+        apply_final_response_transform=AsyncMock(
+            return_value=SimpleNamespace(
+                response_text=stream_outcome.canonical_final_body_candidate,
+                response_kind="ai",
+                envelope=_envelope(),
+            ),
+        ),
+        emit_after_response=AsyncMock(),
+        emit_cancelled_response=AsyncMock(),
+    )
+    gateway = DeliveryGateway(
+        DeliveryGatewayDeps(
+            runtime=SimpleNamespace(client=client, orchestrator=None, config=config, runtime_started_at=0.0),
+            runtime_paths=runtime_paths_for(config),
+            agent_name="code",
+            logger=get_logger("tests.delivery"),
+            redact_message_event=AsyncMock(return_value=True),
+            sender_domain="localhost",
+            resolver=Mock(),
+            response_hooks=response_hooks,
+        ),
+    )
+
+    final_outcome = await gateway.finalize_streamed_response(
+        FinalizeStreamedResponseRequest(
+            target=target,
+            stream_transport_outcome=stream_outcome,
+            initial_delivery_kind="sent",
+            response_kind="ai",
+            response_envelope=_envelope(),
+            correlation_id="corr-streamed-interactive-unparseable-canonical",
+            tool_trace=None,
+            extra_content=None,
+        ),
+    )
+
+    assert final_outcome.final_visible_body == formatted_interactive.formatted_text
+    assert dict(final_outcome.option_map or {}) == {
+        "🎙️": "transcribe",
+        "1": "transcribe",
+        "📂": "inspect",
+        "2": "inspect",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_streaming_finalize.py
+++ b/tests/test_streaming_finalize.py
@@ -805,6 +805,7 @@ async def test_streamed_interactive_metadata_survives_unparseable_canonical_fina
     )
 
     assert final_outcome.final_visible_body == formatted_interactive.formatted_text
+    assert final_outcome.interactive_metadata is not None
     assert dict(final_outcome.option_map or {}) == {
         "🎙️": "transcribe",
         "1": "transcribe",


### PR DESCRIPTION
## Summary
- Carry interactive option metadata from the stream render path into the terminal delivery outcome.
- Use streamed metadata for final reaction registration instead of reparsing already-rendered visible text.
- Add a regression test for rendered interactive replies whose canonical final body can no longer be parsed.

## Test Plan
- uv run pytest tests/test_streaming_finalize.py -q
- uv run ruff check src/mindroom/final_delivery.py src/mindroom/streaming.py src/mindroom/delivery_gateway.py tests/test_streaming_finalize.py
- uv run ruff format --check src/mindroom/final_delivery.py src/mindroom/streaming.py src/mindroom/delivery_gateway.py tests/test_streaming_finalize.py