### PR TITLE
Store OAuth client config in credentials

### DIFF
--- a/docs/deployment/google-services-oauth.md
+++ b/docs/deployment/google-services-oauth.md
@@ -5,17 +5,17 @@ icon: lucide/mail
 # Google Services OAuth
 
 MindRoom uses the generic OAuth framework for Google tools.
-Each Google service has its own provider ID, callback URL, token service, and editable tool settings service.
+Each Google service has its own provider ID, callback URL, token service, OAuth client config service, and editable tool settings service.
 There is no bundled `/api/google/*` OAuth flow.
 
 ## Providers
 
-| Tool | Provider ID | Callback path | Token service | Settings service | Scopes |
-| --- | --- | --- | --- | --- | --- |
-| Google Drive | `google_drive` | `/api/oauth/google_drive/callback` | `google_drive_oauth` | `google_drive` | Drive read-only plus OpenID email/profile |
-| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar` | Calendar read/write plus OpenID email/profile |
-| Google Sheets | `google_sheets` | `/api/oauth/google_sheets/callback` | `google_sheets_oauth` | `google_sheets` | Sheets read/write, plus OpenID email/profile |
-| Gmail | `google_gmail` | `/api/oauth/google_gmail/callback` | `google_gmail_oauth` | `gmail` | Gmail readonly, modify, compose plus OpenID email/profile |
+| Tool | Provider ID | Callback path | Token service | Client config service | Settings service | Scopes |
+| --- | --- | --- | --- | --- | --- | --- |
+| Google Drive | `google_drive` | `/api/oauth/google_drive/callback` | `google_drive_oauth` | `google_drive_oauth_client` | `google_drive` | Drive read-only plus OpenID email/profile |
+| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar read/write plus OpenID email/profile |
+| Google Sheets | `google_sheets` | `/api/oauth/google_sheets/callback` | `google_sheets_oauth` | `google_sheets_oauth_client` | `google_sheets` | Sheets read/write, plus OpenID email/profile |
+| Gmail | `google_gmail` | `/api/oauth/google_gmail/callback` | `google_gmail_oauth` | `google_gmail_oauth_client` | `gmail` | Gmail readonly, modify, compose plus OpenID email/profile |
 
 ## Google Cloud Setup
 
@@ -34,9 +34,31 @@ http://localhost:8765/api/oauth/google_gmail/callback
 
 For production, replace the origin with your public MindRoom origin.
 
+## Stored Client Config
+
+OAuth app client config is stored through normal credential storage, separate from user OAuth tokens and editable tool settings.
+Use one provider-specific service when one Google Cloud OAuth client should apply to only that provider.
+Use `google_oauth_client` when one shared Google Cloud OAuth client should apply to every Google provider.
+Provider-specific services win over `google_oauth_client`.
+Environment variables remain supported as bootstrap and fallback.
+
+Store these fields on the client config service:
+
+```json
+{
+  "client_id": "your-client-id.apps.googleusercontent.com",
+  "client_secret": "your-client-secret",
+  "redirect_uri": "https://mindroom.example.com/api/oauth/google_drive/callback"
+}
+```
+
+`redirect_uri` is optional when `MINDROOM_PUBLIC_URL` or the local default origin is correct.
+Dashboard credential responses redact `client_secret`.
+Client config services are not worker-grantable and are never mirrored into worker containers.
+
 ## Environment Variables
 
-You can configure each provider independently:
+You can still configure each provider independently through environment variables:
 
 ```bash
 GOOGLE_DRIVE_CLIENT_ID=...

--- a/docs/deployment/google-services-user-oauth.md
+++ b/docs/deployment/google-services-user-oauth.md
@@ -39,6 +39,20 @@ http://localhost:8765/api/oauth/google_gmail/callback
 
 ## Configure MindRoom
 
+For a single personal OAuth client, store shared Google OAuth app client config under `google_oauth_client` through the dashboard credentials API or UI:
+
+```json
+{
+  "client_id": "your-client-id.apps.googleusercontent.com",
+  "client_secret": "your-client-secret"
+}
+```
+
+For provider-specific client config, use `google_drive_oauth_client`, `google_calendar_oauth_client`, `google_sheets_oauth_client`, or `google_gmail_oauth_client`.
+Provider-specific client config wins over the shared `google_oauth_client` service.
+MindRoom stores OAuth app client config separately from user OAuth tokens and never mirrors it into worker containers.
+
+Environment variables remain available as bootstrap and fallback.
 For a single personal OAuth client, set the shared fallback client variables:
 
 ```bash
@@ -67,3 +81,4 @@ After the browser OAuth flow completes, retry the original request.
 
 OAuth tokens are stored under provider token services such as `google_drive_oauth`.
 Editable tool settings are stored separately under services such as `google_drive`, `google_calendar`, `google_sheets`, and `gmail`.
+OAuth app client config is stored separately under services such as `google_oauth_client` or `google_drive_oauth_client`.

--- a/docs/oauth-framework.md
+++ b/docs/oauth-framework.md
@@ -5,7 +5,7 @@ icon: lucide/key-round
 # OAuth Integration Framework
 
 MindRoom owns OAuth state, callback handling, credential scoping, and token persistence because those steps decide which human and agent scope receive access to an external account.
-Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client environment variables, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
+Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, client environment variables, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
 
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/status`, and `/api/oauth/{provider}/disconnect`.
 Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider.
@@ -28,6 +28,10 @@ Tools should declare `auth_provider` and, when credentials are missing, return a
 Google OAuth tools always execute in the primary MindRoom runtime so worker runtimes never need Google OAuth client config or user refresh tokens.
 OAuth token documents and editable tool setting documents should be separate services.
 The OAuth callback writes only the provider's `credential_service`, while dashboard configuration reads and writes the provider's `tool_config_service` when one is declared.
+OAuth app client config is stored separately from both of those services.
+Providers declare `client_config_services` in lookup order, and MindRoom reads `client_id`, `client_secret`, and optional `redirect_uri` from those services before falling back to environment variables.
+Client config services are local-only deployment configuration and cannot be mirrored into worker containers.
+Generic credential responses redact `client_secret` for client config services.
 Generic credentials endpoints do not return OAuth token fields and reject direct writes to OAuth token services.
 
 Identity restrictions are provider settings, not MindRoom policy.
@@ -36,3 +40,4 @@ If a configured restriction cannot be checked from verified provider claims, the
 
 Built-in Google providers use the generic framework for Drive, Calendar, Sheets, and Gmail.
 Each provider has minimal service-specific scopes, stores OAuth tokens under its own `*_oauth` service, stores editable tool settings separately, and uses `/api/oauth/*`.
+Each provider first checks its provider-specific client config service, then the shared `google_oauth_client` service, then the existing environment variables.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -8732,17 +8732,17 @@ plugins:
 
 # OAuth Integration Framework
 
-MindRoom owns OAuth state, callback handling, credential scoping, and token persistence because those steps decide which human and agent scope receive access to an external account. Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client environment variables, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
+MindRoom owns OAuth state, callback handling, credential scoping, and token persistence because those steps decide which human and agent scope receive access to an external account. Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, client environment variables, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
 
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/status`, and `/api/oauth/{provider}/disconnect`. Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider. Dashboard OAuth state is opaque, time-limited, single-use, and bound to the authenticated MindRoom user plus the persisted agent execution scope resolved by the existing credentials target machinery. Conversation OAuth links use an additional opaque, time-limited, single-use connect token that binds the browser flow to the requester that produced the missing-credentials tool result. That connect token also carries the requester identity from the tool runtime, and MindRoom rejects redemption unless the authenticated dashboard user resolves to the same requester for scoped credentials. Standalone deployments should set `MINDROOM_OWNER_USER_ID` through pairing so dashboard credential management and agent-issued OAuth links resolve to the owner Matrix user instead of the generic dashboard API-key principal.
 
 Plugins may declare an `oauth_module` in `mindroom.plugin.json`. That module exposes `register_oauth_providers(settings, runtime_paths)` and returns `OAuthProvider` objects. This keeps FastAPI routing and state handling in core while still letting plugin authors define provider IDs, scopes, token exchange details, optional claim validators, and tool metadata.
 
-OAuth token writes always go through `resolve_request_credentials_target()` and `save_scoped_credentials()`. For private agents, the target worker key is derived from the authenticated requester and the agent's saved `worker_scope`, so a user-owned OAuth token lands under the same scope normal tools will read at runtime. If MindRoom cannot resolve the authenticated dashboard user to the requester carried by a conversation-issued link, the link fails closed and no credential is saved. Credential placement and visibility policy is centralized in `src/mindroom/credential_policy.py`. That module owns service classification, OAuth token field filtering, local-only credential service names, and worker-grantable rejections. Storage, API routing, OAuth provider loading, and worker identity derivation stay in their existing modules. Tools should declare `auth_provider` and, when credentials are missing, return a concise connect instruction that points at the generic `authorize` route for the provider and agent. Google OAuth tools always execute in the primary MindRoom runtime so worker runtimes never need Google OAuth client config or user refresh tokens. OAuth token documents and editable tool setting documents should be separate services. The OAuth callback writes only the provider's `credential_service`, while dashboard configuration reads and writes the provider's `tool_config_service` when one is declared. Generic credentials endpoints do not return OAuth token fields and reject direct writes to OAuth token services.
+OAuth token writes always go through `resolve_request_credentials_target()` and `save_scoped_credentials()`. For private agents, the target worker key is derived from the authenticated requester and the agent's saved `worker_scope`, so a user-owned OAuth token lands under the same scope normal tools will read at runtime. If MindRoom cannot resolve the authenticated dashboard user to the requester carried by a conversation-issued link, the link fails closed and no credential is saved. Credential placement and visibility policy is centralized in `src/mindroom/credential_policy.py`. That module owns service classification, OAuth token field filtering, local-only credential service names, and worker-grantable rejections. Storage, API routing, OAuth provider loading, and worker identity derivation stay in their existing modules. Tools should declare `auth_provider` and, when credentials are missing, return a concise connect instruction that points at the generic `authorize` route for the provider and agent. Google OAuth tools always execute in the primary MindRoom runtime so worker runtimes never need Google OAuth client config or user refresh tokens. OAuth token documents and editable tool setting documents should be separate services. The OAuth callback writes only the provider's `credential_service`, while dashboard configuration reads and writes the provider's `tool_config_service` when one is declared. OAuth app client config is stored separately from both of those services. Providers declare `client_config_services` in lookup order, and MindRoom reads `client_id`, `client_secret`, and optional `redirect_uri` from those services before falling back to environment variables. Client config services are local-only deployment configuration and cannot be mirrored into worker containers. Generic credential responses redact `client_secret` for client config services. Generic credentials endpoints do not return OAuth token fields and reject direct writes to OAuth token services.
 
 Identity restrictions are provider settings, not MindRoom policy. Providers can enforce allowed email domains, allowed hosted-domain claims, and custom claim validators. If a configured restriction cannot be checked from verified provider claims, the callback fails closed and no credential is saved.
 
-Built-in Google providers use the generic framework for Drive, Calendar, Sheets, and Gmail. Each provider has minimal service-specific scopes, stores OAuth tokens under its own `*_oauth` service, stores editable tool settings separately, and uses `/api/oauth/*`.
+Built-in Google providers use the generic framework for Drive, Calendar, Sheets, and Gmail. Each provider has minimal service-specific scopes, stores OAuth tokens under its own `*_oauth` service, stores editable tool settings separately, and uses `/api/oauth/*`. Each provider first checks its provider-specific client config service, then the shared `google_oauth_client` service, then the existing environment variables.
 
 # Knowledge Bases
 
@@ -11567,16 +11567,16 @@ Important data locations:
 
 # Google Services OAuth
 
-MindRoom uses the generic OAuth framework for Google tools. Each Google service has its own provider ID, callback URL, token service, and editable tool settings service. There is no bundled `/api/google/*` OAuth flow.
+MindRoom uses the generic OAuth framework for Google tools. Each Google service has its own provider ID, callback URL, token service, OAuth client config service, and editable tool settings service. There is no bundled `/api/google/*` OAuth flow.
 
 ## Providers
 
-| Tool            | Provider ID       | Callback path                         | Token service           | Settings service  | Scopes                                                    |
-| --------------- | ----------------- | ------------------------------------- | ----------------------- | ----------------- | --------------------------------------------------------- |
-| Google Drive    | `google_drive`    | `/api/oauth/google_drive/callback`    | `google_drive_oauth`    | `google_drive`    | Drive read-only plus OpenID email/profile                 |
-| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar` | Calendar read/write plus OpenID email/profile             |
-| Google Sheets   | `google_sheets`   | `/api/oauth/google_sheets/callback`   | `google_sheets_oauth`   | `google_sheets`   | Sheets read/write, plus OpenID email/profile              |
-| Gmail           | `google_gmail`    | `/api/oauth/google_gmail/callback`    | `google_gmail_oauth`    | `gmail`           | Gmail readonly, modify, compose plus OpenID email/profile |
+| Tool            | Provider ID       | Callback path                         | Token service           | Client config service          | Settings service  | Scopes                                                    |
+| --------------- | ----------------- | ------------------------------------- | ----------------------- | ------------------------------ | ----------------- | --------------------------------------------------------- |
+| Google Drive    | `google_drive`    | `/api/oauth/google_drive/callback`    | `google_drive_oauth`    | `google_drive_oauth_client`    | `google_drive`    | Drive read-only plus OpenID email/profile                 |
+| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar read/write plus OpenID email/profile             |
+| Google Sheets   | `google_sheets`   | `/api/oauth/google_sheets/callback`   | `google_sheets_oauth`   | `google_sheets_oauth_client`   | `google_sheets`   | Sheets read/write, plus OpenID email/profile              |
+| Gmail           | `google_gmail`    | `/api/oauth/google_gmail/callback`    | `google_gmail_oauth`    | `google_gmail_oauth_client`    | `gmail`           | Gmail readonly, modify, compose plus OpenID email/profile |
 
 ## Google Cloud Setup
 
@@ -11593,9 +11593,25 @@ http://localhost:8765/api/oauth/google_gmail/callback
 
 For production, replace the origin with your public MindRoom origin.
 
+## Stored Client Config
+
+OAuth app client config is stored through normal credential storage, separate from user OAuth tokens and editable tool settings. Use one provider-specific service when one Google Cloud OAuth client should apply to only that provider. Use `google_oauth_client` when one shared Google Cloud OAuth client should apply to every Google provider. Provider-specific services win over `google_oauth_client`. Environment variables remain supported as bootstrap and fallback.
+
+Store these fields on the client config service:
+
+```
+{
+  "client_id": "your-client-id.apps.googleusercontent.com",
+  "client_secret": "your-client-secret",
+  "redirect_uri": "https://mindroom.example.com/api/oauth/google_drive/callback"
+}
+```
+
+`redirect_uri` is optional when `MINDROOM_PUBLIC_URL` or the local default origin is correct. Dashboard credential responses redact `client_secret`. Client config services are not worker-grantable and are never mirrored into worker containers.
+
 ## Environment Variables
 
-You can configure each provider independently:
+You can still configure each provider independently through environment variables:
 
 ```
 GOOGLE_DRIVE_CLIENT_ID=...
@@ -11664,7 +11680,18 @@ http://localhost:8765/api/oauth/google_gmail/callback
 
 ## Configure MindRoom
 
-For a single personal OAuth client, set the shared fallback client variables:
+For a single personal OAuth client, store shared Google OAuth app client config under `google_oauth_client` through the dashboard credentials API or UI:
+
+```
+{
+  "client_id": "your-client-id.apps.googleusercontent.com",
+  "client_secret": "your-client-secret"
+}
+```
+
+For provider-specific client config, use `google_drive_oauth_client`, `google_calendar_oauth_client`, `google_sheets_oauth_client`, or `google_gmail_oauth_client`. Provider-specific client config wins over the shared `google_oauth_client` service. MindRoom stores OAuth app client config separately from user OAuth tokens and never mirrors it into worker containers.
+
+Environment variables remain available as bootstrap and fallback. For a single personal OAuth client, set the shared fallback client variables:
 
 ```
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
@@ -11688,7 +11715,7 @@ You may instead set `GOOGLE_DRIVE_CLIENT_ID`, `GOOGLE_CALENDAR_CLIENT_ID`, `GOOG
 
 Open the MindRoom dashboard and connect the integration required by each tool. If an agent tries a Google tool before it is connected, the tool result includes a MindRoom connect URL for that exact provider and agent scope. After the browser OAuth flow completes, retry the original request.
 
-OAuth tokens are stored under provider token services such as `google_drive_oauth`. Editable tool settings are stored separately under services such as `google_drive`, `google_calendar`, `google_sheets`, and `gmail`.
+OAuth tokens are stored under provider token services such as `google_drive_oauth`. Editable tool settings are stored separately under services such as `google_drive`, `google_calendar`, `google_sheets`, and `gmail`. OAuth app client config is stored separately under services such as `google_oauth_client` or `google_drive_oauth_client`.
 
 # Docker Deployment
 

--- a/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
@@ -1,17 +1,17 @@
 # Google Services OAuth
 
 MindRoom uses the generic OAuth framework for Google tools.
-Each Google service has its own provider ID, callback URL, token service, and editable tool settings service.
+Each Google service has its own provider ID, callback URL, token service, OAuth client config service, and editable tool settings service.
 There is no bundled `/api/google/*` OAuth flow.
 
 ## Providers
 
-| Tool            | Provider ID       | Callback path                         | Token service           | Settings service  | Scopes                                                    |
-| --------------- | ----------------- | ------------------------------------- | ----------------------- | ----------------- | --------------------------------------------------------- |
-| Google Drive    | `google_drive`    | `/api/oauth/google_drive/callback`    | `google_drive_oauth`    | `google_drive`    | Drive read-only plus OpenID email/profile                 |
-| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar` | Calendar read/write plus OpenID email/profile             |
-| Google Sheets   | `google_sheets`   | `/api/oauth/google_sheets/callback`   | `google_sheets_oauth`   | `google_sheets`   | Sheets read/write, plus OpenID email/profile              |
-| Gmail           | `google_gmail`    | `/api/oauth/google_gmail/callback`    | `google_gmail_oauth`    | `gmail`           | Gmail readonly, modify, compose plus OpenID email/profile |
+| Tool            | Provider ID       | Callback path                         | Token service           | Client config service          | Settings service  | Scopes                                                    |
+| --------------- | ----------------- | ------------------------------------- | ----------------------- | ------------------------------ | ----------------- | --------------------------------------------------------- |
+| Google Drive    | `google_drive`    | `/api/oauth/google_drive/callback`    | `google_drive_oauth`    | `google_drive_oauth_client`    | `google_drive`    | Drive read-only plus OpenID email/profile                 |
+| Google Calendar | `google_calendar` | `/api/oauth/google_calendar/callback` | `google_calendar_oauth` | `google_calendar_oauth_client` | `google_calendar` | Calendar read/write plus OpenID email/profile             |
+| Google Sheets   | `google_sheets`   | `/api/oauth/google_sheets/callback`   | `google_sheets_oauth`   | `google_sheets_oauth_client`   | `google_sheets`   | Sheets read/write, plus OpenID email/profile              |
+| Gmail           | `google_gmail`    | `/api/oauth/google_gmail/callback`    | `google_gmail_oauth`    | `google_gmail_oauth_client`    | `gmail`           | Gmail readonly, modify, compose plus OpenID email/profile |
 
 ## Google Cloud Setup
 
@@ -30,9 +30,31 @@ http://localhost:8765/api/oauth/google_gmail/callback
 
 For production, replace the origin with your public MindRoom origin.
 
+## Stored Client Config
+
+OAuth app client config is stored through normal credential storage, separate from user OAuth tokens and editable tool settings.
+Use one provider-specific service when one Google Cloud OAuth client should apply to only that provider.
+Use `google_oauth_client` when one shared Google Cloud OAuth client should apply to every Google provider.
+Provider-specific services win over `google_oauth_client`.
+Environment variables remain supported as bootstrap and fallback.
+
+Store these fields on the client config service:
+
+```
+{
+  "client_id": "your-client-id.apps.googleusercontent.com",
+  "client_secret": "your-client-secret",
+  "redirect_uri": "https://mindroom.example.com/api/oauth/google_drive/callback"
+}
+```
+
+`redirect_uri` is optional when `MINDROOM_PUBLIC_URL` or the local default origin is correct.
+Dashboard credential responses redact `client_secret`.
+Client config services are not worker-grantable and are never mirrored into worker containers.
+
 ## Environment Variables
 
-You can configure each provider independently:
+You can still configure each provider independently through environment variables:
 
 ```
 GOOGLE_DRIVE_CLIENT_ID=...

--- a/skills/mindroom-docs/references/page__deployment__google-services-user-oauth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__google-services-user-oauth__index.md
@@ -35,6 +35,20 @@ http://localhost:8765/api/oauth/google_gmail/callback
 
 ## Configure MindRoom
 
+For a single personal OAuth client, store shared Google OAuth app client config under `google_oauth_client` through the dashboard credentials API or UI:
+
+```
+{
+  "client_id": "your-client-id.apps.googleusercontent.com",
+  "client_secret": "your-client-secret"
+}
+```
+
+For provider-specific client config, use `google_drive_oauth_client`, `google_calendar_oauth_client`, `google_sheets_oauth_client`, or `google_gmail_oauth_client`.
+Provider-specific client config wins over the shared `google_oauth_client` service.
+MindRoom stores OAuth app client config separately from user OAuth tokens and never mirrors it into worker containers.
+
+Environment variables remain available as bootstrap and fallback.
 For a single personal OAuth client, set the shared fallback client variables:
 
 ```
@@ -63,3 +77,4 @@ After the browser OAuth flow completes, retry the original request.
 
 OAuth tokens are stored under provider token services such as `google_drive_oauth`.
 Editable tool settings are stored separately under services such as `google_drive`, `google_calendar`, `google_sheets`, and `gmail`.
+OAuth app client config is stored separately under services such as `google_oauth_client` or `google_drive_oauth_client`.

--- a/skills/mindroom-docs/references/page__oauth-framework__index.md
+++ b/skills/mindroom-docs/references/page__oauth-framework__index.md
@@ -1,7 +1,7 @@
 # OAuth Integration Framework
 
 MindRoom owns OAuth state, callback handling, credential scoping, and token persistence because those steps decide which human and agent scope receive access to an external account.
-Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client environment variables, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
+Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, client environment variables, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
 
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/status`, and `/api/oauth/{provider}/disconnect`.
 Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider.
@@ -24,6 +24,10 @@ Tools should declare `auth_provider` and, when credentials are missing, return a
 Google OAuth tools always execute in the primary MindRoom runtime so worker runtimes never need Google OAuth client config or user refresh tokens.
 OAuth token documents and editable tool setting documents should be separate services.
 The OAuth callback writes only the provider's `credential_service`, while dashboard configuration reads and writes the provider's `tool_config_service` when one is declared.
+OAuth app client config is stored separately from both of those services.
+Providers declare `client_config_services` in lookup order, and MindRoom reads `client_id`, `client_secret`, and optional `redirect_uri` from those services before falling back to environment variables.
+Client config services are local-only deployment configuration and cannot be mirrored into worker containers.
+Generic credential responses redact `client_secret` for client config services.
 Generic credentials endpoints do not return OAuth token fields and reject direct writes to OAuth token services.
 
 Identity restrictions are provider settings, not MindRoom policy.
@@ -32,3 +36,4 @@ If a configured restriction cannot be checked from verified provider claims, the
 
 Built-in Google providers use the generic framework for Drive, Calendar, Sheets, and Gmail.
 Each provider has minimal service-specific scopes, stores OAuth tokens under its own `*_oauth` service, stores editable tool settings separately, and uses `/api/oauth/*`.
+Each provider first checks its provider-specific client config service, then the shared `google_oauth_client` service, then the existing environment variables.

--- a/src/mindroom/api/credentials.py
+++ b/src/mindroom/api/credentials.py
@@ -82,6 +82,13 @@ def _filter_credentials_for_response(credentials: dict[str, Any], *, is_oauth_se
     return filter_oauth_credential_fields(credentials)
 
 
+def _filter_oauth_client_config_for_response(credentials: dict[str, Any]) -> dict[str, Any]:
+    """Return OAuth app client config without client secret material."""
+    filtered = _filter_internal_keys(credentials)
+    filtered.pop("client_secret", None)
+    return filtered
+
+
 def _validated_service(service: str) -> str:
     try:
         return validate_service_name(service)
@@ -121,6 +128,7 @@ class OAuthCredentialServiceMatch:
     provider: OAuthProvider
     token_service: bool
     tool_config_service: bool
+    client_config_service: bool
 
 
 @dataclass(frozen=True)
@@ -134,11 +142,13 @@ class OAuthCredentialServices:
         for provider in self.providers.values():
             token_service = provider.credential_service == service
             tool_config_service = provider.tool_config_service == service
-            if token_service or tool_config_service:
+            client_config_service = service in provider.client_config_services
+            if token_service or tool_config_service or client_config_service:
                 return OAuthCredentialServiceMatch(
                     provider=provider,
                     token_service=token_service,
                     tool_config_service=tool_config_service,
+                    client_config_service=client_config_service,
                 )
         return None
 
@@ -150,7 +160,7 @@ class OAuthCredentialServices:
     def allows_private_scope_for(self, service: str) -> bool:
         """Return whether this OAuth tool config service can target a private scope."""
         match = self.match(service)
-        return _dashboard_may_edit_oauth_match(match)
+        return match is not None and match.tool_config_service and _dashboard_may_edit_oauth_match(match)
 
     def dashboard_may_show_service(self, service: str) -> bool:
         """Return whether a service may appear in dashboard credential listings."""
@@ -630,10 +640,16 @@ def _reject_oauth_token_service(
 def _dashboard_may_edit_oauth_match(oauth_service_match: OAuthCredentialServiceMatch | None) -> bool:
     if oauth_service_match is None:
         return False
+    if oauth_service_match.client_config_service:
+        return True
     return dashboard_may_edit_oauth_service(
         token_service=oauth_service_match.token_service,
         tool_config_service=oauth_service_match.tool_config_service,
     )
+
+
+def _is_oauth_client_config_match(oauth_service_match: OAuthCredentialServiceMatch | None) -> bool:
+    return oauth_service_match is not None and oauth_service_match.client_config_service
 
 
 def _reject_oauth_credentials_document(credentials: dict[str, Any]) -> None:
@@ -647,6 +663,11 @@ def _reject_oauth_api_key_field(
     *,
     key_name: str,
 ) -> None:
+    if _is_oauth_client_config_match(oauth_service_match) and key_name == "client_secret":
+        raise HTTPException(
+            status_code=400,
+            detail="OAuth client secret must be managed through the credentials document route.",
+        )
     if not _dashboard_may_edit_oauth_match(oauth_service_match):
         return
     if key_name not in OAUTH_CREDENTIAL_FIELDS:
@@ -728,6 +749,8 @@ class DashboardCredentialAccess:
 
     def response_credentials(self, service: str, credentials: dict[str, Any]) -> dict[str, Any]:
         """Return credentials filtered for dashboard responses."""
+        if _is_oauth_client_config_match(self.match(service)):
+            return _filter_oauth_client_config_for_response(credentials)
         return _filter_credentials_for_response(
             credentials,
             is_oauth_service=_dashboard_may_edit_oauth_match(self.match(service)),
@@ -737,7 +760,10 @@ class DashboardCredentialAccess:
         """Return user-submitted credentials normalized for storage."""
         return _dashboard_credentials_for_save(
             config_values,
-            strip_oauth_fields=_dashboard_may_edit_oauth_match(self.match(service)),
+            strip_oauth_fields=(
+                _dashboard_may_edit_oauth_match(self.match(service))
+                and not _is_oauth_client_config_match(self.match(service))
+            ),
         )
 
     def list_services(self) -> list[str]:

--- a/src/mindroom/credential_policy.py
+++ b/src/mindroom/credential_policy.py
@@ -48,9 +48,13 @@ UNSUPPORTED_WORKER_GRANTABLE_CREDENTIALS = frozenset(
     {
         "google_vertex_adc",
         "google_oauth_client",
+        "google_calendar_oauth_client",
         "google_calendar_oauth",
+        "google_drive_oauth_client",
         "google_drive_oauth",
+        "google_gmail_oauth_client",
         "google_gmail_oauth",
+        "google_sheets_oauth_client",
         "google_sheets_oauth",
     },
 )

--- a/src/mindroom/credentials.py
+++ b/src/mindroom/credentials.py
@@ -381,6 +381,8 @@ def load_worker_grantable_shared_credentials(
     """Return one shared credential only when the worker allowlist permits mirroring it."""
     if service not in allowed_services:
         return None
+    if not credential_service_policy(service, None).worker_grantable_supported:
+        return None
     shared_credentials = shared_manager.load_credentials(service)
     if not isinstance(shared_credentials, Mapping):
         return None

--- a/src/mindroom/oauth/google.py
+++ b/src/mindroom/oauth/google.py
@@ -119,6 +119,10 @@ def _google_redirect_env_names(provider_id: str) -> tuple[str, ...]:
     return (f"{prefix}_REDIRECT_URI", f"MINDROOM_OAUTH_{prefix}_REDIRECT_URI")
 
 
+def _google_client_config_services(provider_id: str) -> tuple[str, ...]:
+    return (f"{provider_id}_oauth_client", "google_oauth_client")
+
+
 def _google_domain_env_names(provider_id: str, suffix: str) -> tuple[str, ...]:
     prefix = provider_id.upper()
     return (f"{prefix}_{suffix}", f"MINDROOM_OAUTH_{prefix}_{suffix}")

--- a/src/mindroom/oauth/google_calendar.py
+++ b/src/mindroom/oauth/google_calendar.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from mindroom.oauth.google import (
     GOOGLE_IDENTITY_SCOPES,
+    _google_client_config_services,
     _google_domain_env_names,
     _google_provider_env_names,
     _google_redirect_env_names,
@@ -28,6 +29,7 @@ def google_calendar_oauth_provider() -> OAuthProvider:
         scopes=GOOGLE_CALENDAR_OAUTH_SCOPES,
         credential_service="google_calendar_oauth",
         tool_config_service="google_calendar",
+        client_config_services=_google_client_config_services("google_calendar"),
         client_id_env=client_id_env,
         client_secret_env=client_secret_env,
         redirect_uri_env=_google_redirect_env_names("google_calendar"),

--- a/src/mindroom/oauth/google_drive.py
+++ b/src/mindroom/oauth/google_drive.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from mindroom.oauth.google import (
     GOOGLE_IDENTITY_SCOPES,
+    _google_client_config_services,
     _google_domain_env_names,
     _google_provider_env_names,
     _google_redirect_env_names,
@@ -28,6 +29,7 @@ def google_drive_oauth_provider() -> OAuthProvider:
         scopes=GOOGLE_DRIVE_OAUTH_SCOPES,
         credential_service="google_drive_oauth",
         tool_config_service="google_drive",
+        client_config_services=_google_client_config_services("google_drive"),
         client_id_env=client_id_env,
         client_secret_env=client_secret_env,
         redirect_uri_env=_google_redirect_env_names("google_drive"),

--- a/src/mindroom/oauth/google_gmail.py
+++ b/src/mindroom/oauth/google_gmail.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from mindroom.oauth.google import (
     GOOGLE_IDENTITY_SCOPES,
+    _google_client_config_services,
     _google_domain_env_names,
     _google_provider_env_names,
     _google_redirect_env_names,
@@ -30,6 +31,7 @@ def google_gmail_oauth_provider() -> OAuthProvider:
         scopes=GOOGLE_GMAIL_OAUTH_SCOPES,
         credential_service="google_gmail_oauth",
         tool_config_service="gmail",
+        client_config_services=_google_client_config_services("google_gmail"),
         client_id_env=client_id_env,
         client_secret_env=client_secret_env,
         redirect_uri_env=_google_redirect_env_names("google_gmail"),

--- a/src/mindroom/oauth/google_sheets.py
+++ b/src/mindroom/oauth/google_sheets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from mindroom.oauth.google import (
     GOOGLE_IDENTITY_SCOPES,
+    _google_client_config_services,
     _google_domain_env_names,
     _google_provider_env_names,
     _google_redirect_env_names,
@@ -28,6 +29,7 @@ def google_sheets_oauth_provider() -> OAuthProvider:
         scopes=GOOGLE_SHEETS_OAUTH_SCOPES,
         credential_service="google_sheets_oauth",
         tool_config_service="google_sheets",
+        client_config_services=_google_client_config_services("google_sheets"),
         client_id_env=client_id_env,
         client_secret_env=client_secret_env,
         redirect_uri_env=_google_redirect_env_names("google_sheets"),

--- a/src/mindroom/oauth/providers.py
+++ b/src/mindroom/oauth/providers.py
@@ -14,7 +14,7 @@ from authlib.common.errors import AuthlibBaseError
 from authlib.deprecate import AuthlibDeprecationWarning
 from httpx import HTTPError
 
-from mindroom.credentials import validate_service_name
+from mindroom.credentials import get_runtime_credentials_manager, validate_service_name
 
 warnings.filterwarnings(
     "ignore",
@@ -230,6 +230,7 @@ class OAuthProvider:
     scopes: tuple[str, ...]
     credential_service: str
     tool_config_service: str | None = None
+    client_config_services: tuple[str, ...] = ()
     client_id_env: str | Sequence[str] | None = None
     client_secret_env: str | Sequence[str] | None = None
     redirect_uri_env: str | Sequence[str] | None = None
@@ -250,6 +251,8 @@ class OAuthProvider:
         validate_service_name(self.credential_service)
         if self.tool_config_service is not None:
             validate_service_name(self.tool_config_service)
+        for service in self.client_config_services:
+            validate_service_name(service)
         if not self.scopes:
             msg = f"OAuth provider '{self.id}' must declare at least one scope"
             raise ValueError(msg)
@@ -289,6 +292,9 @@ class OAuthProvider:
 
     def client_config(self, runtime_paths: RuntimePaths) -> OAuthClientConfig | None:
         """Return resolved client settings or None when the provider is not configured."""
+        stored_config = self._stored_client_config(runtime_paths)
+        if stored_config is not None:
+            return stored_config
         client_id = _runtime_env_value(runtime_paths, self.normalized_client_id_env)
         client_secret = _runtime_env_value(runtime_paths, self.normalized_client_secret_env)
         if not client_id or not client_secret:
@@ -299,6 +305,29 @@ class OAuthProvider:
             client_secret=client_secret,
             redirect_uri=redirect_uri or self.default_redirect_uri(runtime_paths),
         )
+
+    def _stored_client_config(self, runtime_paths: RuntimePaths) -> OAuthClientConfig | None:
+        """Return stored OAuth app client settings before falling back to env."""
+        manager = get_runtime_credentials_manager(runtime_paths)
+        for service in self.client_config_services:
+            credentials = manager.load_credentials(service)
+            if not credentials:
+                continue
+            client_id = credentials.get("client_id")
+            client_secret = credentials.get("client_secret")
+            if not isinstance(client_id, str) or not client_id.strip():
+                continue
+            if not isinstance(client_secret, str) or not client_secret.strip():
+                continue
+            redirect_uri = credentials.get("redirect_uri")
+            return OAuthClientConfig(
+                client_id=client_id.strip(),
+                client_secret=client_secret.strip(),
+                redirect_uri=redirect_uri.strip()
+                if isinstance(redirect_uri, str) and redirect_uri.strip()
+                else self.default_redirect_uri(runtime_paths),
+            )
+        return None
 
     def require_client_config(self, runtime_paths: RuntimePaths) -> OAuthClientConfig:
         """Return client settings or raise one safe user-facing configuration error."""

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -393,6 +393,45 @@ class TestCredentialsAPI:
         assert token_status_response.status_code == 400
         assert "OAuth token credentials" in token_status_response.json()["detail"]
 
+    def test_oauth_client_config_service_redacts_secret_fields(
+        self,
+        client: TestClient,
+    ) -> None:
+        """OAuth app client config services should be editable without echoing secrets."""
+        runtime_paths = main._app_runtime_paths(client.app)
+        manager = get_runtime_credentials_manager(runtime_paths)
+
+        response = client.post(
+            "/api/credentials/google_drive_oauth_client",
+            json={
+                "credentials": {
+                    "client_id": "stored-client-id",
+                    "client_secret": "stored-client-secret",
+                    "redirect_uri": "https://stored.example.test/callback",
+                },
+            },
+        )
+        get_response = client.get("/api/credentials/google_drive_oauth_client")
+        status_response = client.get("/api/credentials/google_drive_oauth_client/status")
+
+        assert response.status_code == 200
+        assert manager.load_credentials("google_drive_oauth_client") == {
+            "client_id": "stored-client-id",
+            "client_secret": "stored-client-secret",
+            "redirect_uri": "https://stored.example.test/callback",
+            "_source": "ui",
+        }
+        assert get_response.status_code == 200
+        assert get_response.json() == {
+            "service": "google_drive_oauth_client",
+            "credentials": {
+                "client_id": "stored-client-id",
+                "redirect_uri": "https://stored.example.test/callback",
+            },
+        }
+        assert status_response.status_code == 200
+        assert set(status_response.json()["key_names"]) == {"client_id", "redirect_uri"}
+
     def test_orphaned_oauth_credentials_reject_generic_routes(
         self,
         client: TestClient,

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -107,17 +107,20 @@ def _fake_provider(
     allowed_email_domains: tuple[str, ...] = (),
     allowed_hosted_domains: tuple[str, ...] = (),
     scopes: tuple[str, ...] = ("scope.read",),
+    client_config_services: tuple[str, ...] = (),
 ) -> OAuthProvider:
     async def _exchange(
         provider: OAuthProvider,
         code: str,
-        _client_config: object,
+        client_config: object,
         _runtime_paths: object,
     ) -> OAuthTokenResult:
         assert code == "test-code"
+        assert isinstance(client_config, OAuthClientConfig)
         token_data = {
             "token": f"{provider.id}-access-token",
             "token_uri": provider.token_url,
+            "client_id": client_config.client_id,
             "scopes": list(provider.scopes),
             "_source": "oauth",
             "_oauth_provider": provider.id,
@@ -143,6 +146,7 @@ def _fake_provider(
         scopes=scopes,
         credential_service=credential_service,
         tool_config_service=tool_config_service,
+        client_config_services=client_config_services,
         client_id_env="TEST_OAUTH_CLIENT_ID",
         client_secret_env="TEST_OAUTH_CLIENT_SECRET",
         allowed_email_domains=allowed_email_domains,
@@ -465,6 +469,33 @@ def test_connect_generates_authorization_url_with_opaque_state(tmp_path: Path) -
     assert params["state"][0] in state_store.read_text(encoding="utf-8")
 
 
+def test_connect_uses_stored_oauth_client_config(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {constants.OWNER_MATRIX_USER_ID_ENV: "@alice:example.org"},
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload())
+    provider = _fake_provider(client_config_services=("test_drive_oauth_client",))
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "test_drive_oauth_client",
+        {
+            "client_id": "stored-client-id",
+            "client_secret": "stored-client-secret",
+            "_source": "ui",
+        },
+    )
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            _login(client)
+            response = client.post(f"/api/oauth/{provider.id}/connect?agent_name=general")
+
+    assert response.status_code == 200
+    params = parse_qs(urlparse(response.json()["auth_url"]).query)
+    assert params["client_id"] == ["stored-client-id"]
+
+
 def test_provider_exchange_and_refresh_use_oauth_client(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -713,6 +744,85 @@ def test_google_drive_refresh_parser_accepts_existing_verified_claim_summary(tmp
     assert result.claims_verified is True
 
 
+def test_google_oauth_client_config_prefers_stored_provider_config(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "GOOGLE_DRIVE_CLIENT_ID": "env-client-id",
+            "GOOGLE_DRIVE_CLIENT_SECRET": "env-client-secret",
+            "GOOGLE_DRIVE_REDIRECT_URI": "https://env.example.test/callback",
+        },
+    )
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "google_drive_oauth_client",
+        {
+            "client_id": "stored-client-id",
+            "client_secret": "stored-client-secret",
+            "redirect_uri": "https://stored.example.test/callback",
+            "_source": "ui",
+        },
+    )
+
+    client_config = google_drive_oauth_provider().client_config(runtime_paths)
+
+    assert client_config == OAuthClientConfig(
+        client_id="stored-client-id",
+        client_secret="stored-client-secret",
+        redirect_uri="https://stored.example.test/callback",
+    )
+
+
+def test_google_oauth_client_config_falls_back_to_env(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "GOOGLE_CLIENT_ID": "env-client-id",
+            "GOOGLE_CLIENT_SECRET": "env-client-secret",
+            "MINDROOM_PUBLIC_URL": "https://mindroom.example.test",
+        },
+    )
+
+    client_config = google_drive_oauth_provider().client_config(runtime_paths)
+
+    assert client_config == OAuthClientConfig(
+        client_id="env-client-id",
+        client_secret="env-client-secret",
+        redirect_uri="https://mindroom.example.test/api/oauth/google_drive/callback",
+    )
+
+
+def test_google_provider_oauth_client_config_wins_over_shared_config(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "google_oauth_client",
+        {
+            "client_id": "shared-client-id",
+            "client_secret": "shared-client-secret",
+            "redirect_uri": "https://shared.example.test/callback",
+            "_source": "ui",
+        },
+    )
+    manager.save_credentials(
+        "google_drive_oauth_client",
+        {
+            "client_id": "drive-client-id",
+            "client_secret": "drive-client-secret",
+            "redirect_uri": "https://drive.example.test/callback",
+            "_source": "ui",
+        },
+    )
+
+    client_config = google_drive_oauth_provider().client_config(runtime_paths)
+
+    assert client_config == OAuthClientConfig(
+        client_id="drive-client-id",
+        client_secret="drive-client-secret",
+        redirect_uri="https://drive.example.test/callback",
+    )
+
+
 def test_google_drive_refresh_parser_rejects_unverified_existing_claim_summary(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(tmp_path)
     provider = google_drive_oauth_provider()
@@ -888,6 +998,46 @@ def test_callback_stores_credentials_in_scoped_target(tmp_path: Path) -> None:
     }
     assert manager.for_worker(owner_worker_key).load_credentials("google_drive") is None
     assert manager.for_worker(_worker_key_for_standalone_user()).load_credentials(provider.credential_service) is None
+
+
+def test_callback_uses_stored_oauth_client_config(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {constants.OWNER_MATRIX_USER_ID_ENV: "@alice:example.org"},
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
+    provider = _fake_provider(
+        provider_id="google_drive",
+        credential_service="google_drive_oauth",
+        tool_config_service="google_drive",
+        client_config_services=("google_drive_oauth_client",),
+    )
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "google_drive_oauth_client",
+        {
+            "client_id": "stored-client-id",
+            "client_secret": "stored-client-secret",
+            "_source": "ui",
+        },
+    )
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            _login(client)
+            connect_response = client.post(f"/api/oauth/{provider.id}/connect?agent_name=general")
+            state = _state_from_auth_url(connect_response.json()["auth_url"])
+            callback_response = client.get(
+                f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                follow_redirects=False,
+            )
+
+    assert callback_response.status_code == 307
+    scoped_manager = manager.for_primary_runtime_scope("@alice:example.org", "general")
+    scoped_credentials = scoped_manager.load_credentials(provider.credential_service)
+    assert scoped_credentials is not None
+    assert scoped_credentials["client_id"] == "stored-client-id"
+    assert scoped_credentials["token"] == "google_drive-access-token"
 
 
 def test_user_scope_oauth_token_not_in_worker_path(tmp_path: Path) -> None:
@@ -1632,6 +1782,42 @@ def test_status_requires_client_config_for_connected_true(tmp_path: Path) -> Non
     assert status_response.status_code == 200
     assert status_response.json()["has_client_config"] is False
     assert status_response.json()["connected"] is False
+
+
+def test_status_uses_stored_oauth_client_config(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {constants.OWNER_MATRIX_USER_ID_ENV: "@alice:example.org"},
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
+    provider = _fake_provider(client_config_services=("test_drive_oauth_client",))
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "test_drive_oauth_client",
+        {
+            "client_id": "stored-client-id",
+            "client_secret": "stored-client-secret",
+            "_source": "ui",
+        },
+    )
+    manager.for_worker(_worker_key_for_matrix_user("@alice:example.org")).save_credentials(
+        provider.credential_service,
+        {
+            "token": "stored-token",
+            "scopes": list(provider.scopes),
+            "_source": "oauth",
+            "_oauth_provider": provider.id,
+        },
+    )
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            _login(client)
+            status_response = client.get(f"/api/oauth/{provider.id}/status?agent_name=general")
+
+    assert status_response.status_code == 200
+    assert status_response.json()["has_client_config"] is True
+    assert status_response.json()["connected"] is True
 
 
 def test_google_status_reports_connected_with_service_account(tmp_path: Path) -> None:

--- a/tests/test_credential_policy.py
+++ b/tests/test_credential_policy.py
@@ -48,9 +48,13 @@ def test_local_shared_service_policy(service: str, worker_scope: str, expected: 
     "service",
     [
         "google_oauth_client",
+        "google_calendar_oauth_client",
         "google_calendar_oauth",
+        "google_drive_oauth_client",
         "google_drive_oauth",
+        "google_gmail_oauth_client",
         "google_gmail_oauth",
+        "google_sheets_oauth_client",
         "google_sheets_oauth",
         "google_vertex_adc",
     ],

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -580,6 +580,30 @@ class TestCredentialsManager:
         }
         assert worker_shared_manager.load_credentials("spotify") is None
 
+    def test_sync_shared_credentials_to_worker_never_mirrors_oauth_client_config(
+        self,
+        temp_credentials_dir: Path,
+    ) -> None:
+        """OAuth app client secrets should stay in the primary runtime even if allowlisted."""
+        manager = CredentialsManager(temp_credentials_dir)
+        manager.save_credentials(
+            "google_drive_oauth_client",
+            {
+                "client_id": "stored-client-id",
+                "client_secret": "stored-client-secret",
+                "_source": "ui",
+            },
+        )
+        worker_shared_manager = manager.for_worker("worker-a").shared_manager()
+
+        sync_shared_credentials_to_worker(
+            "worker-a",
+            allowed_services=frozenset({"google_drive_oauth_client"}),
+            credentials_manager=manager,
+        )
+
+        assert worker_shared_manager.load_credentials("google_drive_oauth_client") is None
+
     def test_sync_shared_credentials_to_worker_default_denies_all_services(
         self,
         temp_credentials_dir: Path,


### PR DESCRIPTION
## Summary
- add provider-declared OAuth client config credential services, with stored config resolved before env fallback
- add Google provider-specific services with shared `google_oauth_client` fallback
- keep OAuth app client secrets out of generic responses and worker credential mirroring
- update OAuth docs and generated skill references

## Verification
- `uv run pytest tests/api/test_oauth_api.py tests/api/test_credentials_api.py tests/test_credentials.py tests/test_config_manager_consolidated.py tests/test_credential_policy.py -x -n 0 --no-cov -v`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --all-files`