### PR TITLE
Fix Google Drive tool function collisions

### DIFF
--- a/docs/tools/data-and-databases.md
+++ b/docs/tools/data-and-databases.md
@@ -445,10 +445,10 @@ run_sql_query("SELECT event_name, COUNT(*) AS total FROM events GROUP BY 1 ORDER
 
 ### What It Does
 
-MindRoom exposes `list_files()`, `search_files()`, and `read_file()` through the Google Drive OAuth provider.
-`list_files()` returns recent Drive files visible to the connected account.
-`search_files()` searches Drive metadata.
-`read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`.
+MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, and `google_drive_read_file()` through the Google Drive OAuth provider.
+`google_drive_list_files()` returns recent Drive files visible to the connected account.
+`google_drive_search_files()` searches Drive metadata.
+`google_drive_read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to a local token flow.
 
 ### Configuration
@@ -471,9 +471,9 @@ agents:
 ```
 
 ```python
-list_files()
-search_files("name contains 'budget'")
-read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
+google_drive_list_files()
+google_drive_search_files("name contains 'budget'")
+google_drive_read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
 ```
 
 ### Notes

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -3241,7 +3241,7 @@ run_sql_query("SELECT event_name, COUNT(*) AS total FROM events GROUP BY 1 ORDER
 
 ### What It Does
 
-MindRoom exposes `list_files()`, `search_files()`, and `read_file()` through the Google Drive OAuth provider. `list_files()` returns recent Drive files visible to the connected account. `search_files()` searches Drive metadata. `read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`. When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to a local token flow.
+MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, and `google_drive_read_file()` through the Google Drive OAuth provider. `google_drive_list_files()` returns recent Drive files visible to the connected account. `google_drive_search_files()` searches Drive metadata. `google_drive_read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`. When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to a local token flow.
 
 ### Configuration
 
@@ -3263,9 +3263,9 @@ agents:
 ```
 
 ```
-list_files()
-search_files("name contains 'budget'")
-read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
+google_drive_list_files()
+google_drive_search_files("name contains 'budget'")
+google_drive_read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
 ```
 
 ### Notes

--- a/skills/mindroom-docs/references/page__tools__data-and-databases__index.md
+++ b/skills/mindroom-docs/references/page__tools__data-and-databases__index.md
@@ -441,10 +441,10 @@ run_sql_query("SELECT event_name, COUNT(*) AS total FROM events GROUP BY 1 ORDER
 
 ### What It Does
 
-MindRoom exposes `list_files()`, `search_files()`, and `read_file()` through the Google Drive OAuth provider.
-`list_files()` returns recent Drive files visible to the connected account.
-`search_files()` searches Drive metadata.
-`read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`.
+MindRoom exposes `google_drive_list_files()`, `google_drive_search_files()`, and `google_drive_read_file()` through the Google Drive OAuth provider.
+`google_drive_list_files()` returns recent Drive files visible to the connected account.
+`google_drive_search_files()` searches Drive metadata.
+`google_drive_read_file()` reads Google Workspace files and non-Google files up to the configured `max_read_size`.
 When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnectionRequired` instead of falling back to a local token flow.
 
 ### Configuration
@@ -467,9 +467,9 @@ agents:
 ```
 
 ```
-list_files()
-search_files("name contains 'budget'")
-read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
+google_drive_list_files()
+google_drive_search_files("name contains 'budget'")
+google_drive_read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
 ```
 
 ### Notes

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -396,6 +396,28 @@ def _build_registered_agent_tool(
     )
 
 
+def _log_toolkits_without_unique_model_functions(
+    toolkits: list[Toolkit],
+    *,
+    agent_name: str,
+) -> None:
+    """Warn when Agno would drop every function from a configured toolkit."""
+    for parse_mode in ("sync", "async"):
+        seen_function_names: set[str] = set()
+        for toolkit in toolkits:
+            functions = toolkit.get_async_functions() if parse_mode == "async" else toolkit.get_functions()
+            function_names = set(functions)
+            if function_names and function_names <= seen_function_names:
+                logger.warning(
+                    "Configured toolkit exposes no unique model functions because function names collide",
+                    agent=agent_name,
+                    toolkit=toolkit.name,
+                    parse_mode=parse_mode,
+                    function_names=sorted(function_names),
+                )
+            seen_function_names.update(function_names)
+
+
 def _wrap_direct_agent_toolkit_for_output_files(
     toolkit: Toolkit,
     *,
@@ -1110,6 +1132,8 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
 
     if include_interactive_questions:
         instructions.append(agent_prompts.INTERACTIVE_QUESTION_PROMPT)
+
+    _log_toolkits_without_unique_model_functions(tools, agent_name=agent_name)
 
     knowledge_enabled = bool(config.get_agent_knowledge_base_ids(agent_name)) and knowledge is not None
     culture_storage_root = resolved_storage_path

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_MODEL_FUNCTION_NAME_ALIASES = {
+    "list_files": "google_drive_list_files",
+    "search_files": "google_drive_search_files",
+    "read_file": "google_drive_read_file",
+}
+
 
 class GoogleDriveTools(ScopedOAuthClientMixin, AgnoGoogleDriveTools):
     """Google Drive toolkit that reads OAuth tokens from MindRoom's credential scopes."""
@@ -55,6 +61,7 @@ class GoogleDriveTools(ScopedOAuthClientMixin, AgnoGoogleDriveTools):
         super().__init__(creds=creds, **kwargs)
         self._set_original_auth(AgnoGoogleDriveTools._auth)
         self._wrap_oauth_function_entrypoints()
+        self._rename_model_functions()
 
     def _coerce_max_read_size(self, value: object) -> int | float | None:
         if value is None:
@@ -86,3 +93,18 @@ class GoogleDriveTools(ScopedOAuthClientMixin, AgnoGoogleDriveTools):
     def _should_fallback_to_original_auth(self) -> bool:
         """Prefer the upstream auth path when a service account is configured."""
         return bool(self.service_account_path or self._runtime_paths.env_value("GOOGLE_SERVICE_ACCOUNT_FILE"))
+
+    def _rename_model_functions(self) -> None:
+        """Expose Drive-specific function names while preserving upstream methods."""
+        self.functions = self._renamed_functions(self.functions, expose_attributes=True)
+        self.async_functions = self._renamed_functions(self.async_functions, expose_attributes=False)
+
+    def _renamed_functions(self, functions: dict[str, Any], *, expose_attributes: bool) -> dict[str, Any]:
+        renamed_functions: dict[str, Any] = type(functions)()
+        for function_name, function in functions.items():
+            renamed_name = _MODEL_FUNCTION_NAME_ALIASES.get(function_name, function_name)
+            function.name = renamed_name
+            renamed_functions[renamed_name] = function
+            if expose_attributes and renamed_name != function_name:
+                setattr(self, renamed_name, function.entrypoint)
+        return renamed_functions

--- a/src/mindroom/tools/google_drive.py
+++ b/src/mindroom/tools/google_drive.py
@@ -74,9 +74,9 @@ if TYPE_CHECKING:
     ],
     docs_url="https://docs.agno.com/tools/toolkits/others/google_drive",
     function_names=(
-        "list_files",
-        "search_files",
-        "read_file",
+        "google_drive_list_files",
+        "google_drive_search_files",
+        "google_drive_read_file",
     ),
 )
 def google_drive_tools() -> type[GoogleDriveTools]:

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -7332,9 +7332,9 @@
       "display_name": "Google Drive",
       "docs_url": "https://docs.agno.com/tools/toolkits/others/google_drive",
       "function_names": [
-        "list_files",
-        "search_files",
-        "read_file"
+        "google_drive_list_files",
+        "google_drive_search_files",
+        "google_drive_read_file"
       ],
       "helper_text": null,
       "icon": "SiGoogledrive",

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -646,7 +646,7 @@ async def test_execute_request_inprocess_serializes_oauth_connection_required(
     response = await sandbox_runner_module._execute_request_inprocess(
         sandbox_runner_module.SandboxRunnerExecuteRequest(
             tool_name="google_drive",
-            function_name="search_files",
+            function_name="google_drive_search_files",
             args=[],
             kwargs={},
         ),
@@ -687,7 +687,7 @@ async def test_execute_request_inprocess_serializes_oauth_connection_required_fr
     response = await sandbox_runner_module._execute_request_inprocess(
         sandbox_runner_module.SandboxRunnerExecuteRequest(
             tool_name="google_drive",
-            function_name="search_files",
+            function_name="google_drive_search_files",
             args=[],
             kwargs={},
         ),

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -1,12 +1,19 @@
 """Tests for the Google Drive OAuth-backed tool."""
 
-# ruff: noqa: D103, TC003
+# ruff: noqa: D102, D103, TC003
 
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
+
+from agno.agent import Agent
+from agno.agent._tools import parse_tools
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+from agno.tools.function import Function
 
 from mindroom import constants
 from mindroom import tools as _mindroom_tools  # noqa: F401  # registers built-in tool metadata
@@ -15,6 +22,33 @@ from mindroom.custom_tools.google_drive import GoogleDriveTools
 from mindroom.oauth.google_drive import GOOGLE_DRIVE_OAUTH_SCOPES
 from mindroom.tool_system.metadata import get_tool_by_name
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
+
+
+class MinimalModel(Model):
+    """Minimal model surface for Agno tool parsing tests."""
+
+    def invoke(self, *_args: object, **_kwargs: object) -> ModelResponse:
+        return ModelResponse(content="ok")
+
+    async def ainvoke(self, *_args: object, **_kwargs: object) -> ModelResponse:
+        return ModelResponse(content="ok")
+
+    def invoke_stream(self, *_args: object, **_kwargs: object) -> Iterator[ModelResponse]:
+        yield ModelResponse(content="ok")
+
+    async def ainvoke_stream(self, *_args: object, **_kwargs: object) -> AsyncIterator[ModelResponse]:
+        yield ModelResponse(content="ok")
+
+    def _parse_provider_response(self, response: ModelResponse, *_args: object, **_kwargs: object) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(
+        self,
+        response: ModelResponse,
+        *_args: object,
+        **_kwargs: object,
+    ) -> ModelResponse:
+        return response
 
 
 def test_google_drive_missing_credentials_returns_connect_instruction(tmp_path: Path) -> None:
@@ -44,10 +78,45 @@ def test_google_drive_missing_credentials_returns_connect_instruction(tmp_path: 
     )
 
     result = json.loads(tool.search_files(query="name contains 'plan'", max_results=1))
+    model_entrypoint = tool.functions["google_drive_search_files"].entrypoint
+    assert model_entrypoint is not None
+    model_result = json.loads(model_entrypoint(query="name contains 'plan'", max_results=1))
 
     assert "Google Drive is not connected for this agent" in result["error"]
     assert "https://mindroom.example.test/api/oauth/google_drive/authorize?connect_token=" in result["error"]
     assert "@alice:example.org" not in result["error"]
+    assert model_result["oauth_connection_required"] is True
+    assert model_result["provider"] == "google_drive"
+
+
+def test_google_drive_model_functions_do_not_collide_with_local_file_tools(tmp_path: Path) -> None:
+    runtime_paths = constants.resolve_runtime_paths(
+        storage_path=tmp_path / "mindroom_data",
+        process_env={"MINDROOM_PUBLIC_URL": "https://mindroom.example.test"},
+    )
+    credentials_manager = CredentialsManager(tmp_path / "credentials")
+    toolkits = [
+        get_tool_by_name(
+            tool_name,
+            runtime_paths,
+            credentials_manager=credentials_manager,
+            worker_target=None,
+            disable_sandbox_proxy=True,
+        )
+        for tool_name in ("file", "coding", "google_drive")
+    ]
+    model = MinimalModel(id="fake-model", provider="fake")
+    agent = Agent(id="code", model=model)
+
+    parsed_tools = parse_tools(agent, toolkits, model, async_mode=True)
+    function_names = {function.name for function in parsed_tools if isinstance(function, Function)}
+
+    assert {"read_file", "list_files", "search_files"} <= function_names
+    assert {
+        "google_drive_list_files",
+        "google_drive_search_files",
+        "google_drive_read_file",
+    } <= function_names
 
 
 def test_google_drive_connect_instruction_uses_redirect_uri_public_origin(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Rename Google Drive model-visible functions to `google_drive_list_files`, `google_drive_search_files`, and `google_drive_read_file` so Agno cannot de-duplicate them behind local file/coding tools.
- Preserve the existing Google Drive OAuth credential flow while keeping upstream method names available on the toolkit.
- Add collision visibility logging for configured toolkits that would otherwise lose all callable functions, plus regression coverage for file/coding + Google Drive tool parsing.

## Test Plan
- [x] `uv run ruff check src/mindroom/agents.py src/mindroom/custom_tools/google_drive.py src/mindroom/tools/google_drive.py tests/test_google_drive_oauth_tool.py tests/api/test_sandbox_runner_api.py`
- [x] `uv run pytest tests/test_google_drive_oauth_tool.py tests/test_google_tool_wrappers.py tests/test_tools_metadata.py tests/api/test_sandbox_runner_api.py::test_execute_request_inprocess_serializes_oauth_connection_required tests/api/test_sandbox_runner_api.py::test_execute_request_inprocess_serializes_oauth_connection_required_from_tool_construction -q`
- [x] `uv run pytest -q` (`6002 passed, 29 skipped`)