### PR TITLE
Centralize toolkit function aliasing

### DIFF
--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -10,6 +10,7 @@ from agno.tools.google.drive import GoogleDriveTools as AgnoGoogleDriveTools
 from mindroom.logging_config import get_logger
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.oauth.google_drive import google_drive_oauth_provider
+from mindroom.tool_system.toolkit_aliases import apply_toolkit_function_aliases
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
@@ -61,7 +62,7 @@ class GoogleDriveTools(ScopedOAuthClientMixin, AgnoGoogleDriveTools):
         super().__init__(creds=creds, **kwargs)
         self._set_original_auth(AgnoGoogleDriveTools._auth)
         self._wrap_oauth_function_entrypoints()
-        self._rename_model_functions()
+        apply_toolkit_function_aliases(self, _MODEL_FUNCTION_NAME_ALIASES)
 
     def _coerce_max_read_size(self, value: object) -> int | float | None:
         if value is None:
@@ -93,18 +94,3 @@ class GoogleDriveTools(ScopedOAuthClientMixin, AgnoGoogleDriveTools):
     def _should_fallback_to_original_auth(self) -> bool:
         """Prefer the upstream auth path when a service account is configured."""
         return bool(self.service_account_path or self._runtime_paths.env_value("GOOGLE_SERVICE_ACCOUNT_FILE"))
-
-    def _rename_model_functions(self) -> None:
-        """Expose Drive-specific function names while preserving upstream methods."""
-        self.functions = self._renamed_functions(self.functions, expose_attributes=True)
-        self.async_functions = self._renamed_functions(self.async_functions, expose_attributes=False)
-
-    def _renamed_functions(self, functions: dict[str, Any], *, expose_attributes: bool) -> dict[str, Any]:
-        renamed_functions: dict[str, Any] = type(functions)()
-        for function_name, function in functions.items():
-            renamed_name = _MODEL_FUNCTION_NAME_ALIASES.get(function_name, function_name)
-            function.name = renamed_name
-            renamed_functions[renamed_name] = function
-            if expose_attributes and renamed_name != function_name:
-                setattr(self, renamed_name, function.entrypoint)
-        return renamed_functions

--- a/src/mindroom/tool_system/toolkit_aliases.py
+++ b/src/mindroom/tool_system/toolkit_aliases.py
@@ -1,0 +1,37 @@
+"""Helpers for adapting Agno toolkit function names."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from agno.tools.function import Function
+    from agno.tools.toolkit import Toolkit
+
+
+def apply_toolkit_function_aliases(
+    toolkit: Toolkit,
+    aliases: Mapping[str, str],
+    *,
+    expose_attributes: bool = True,
+) -> Toolkit:
+    """Rename model-visible toolkit functions while preserving original methods."""
+    toolkit.functions = _aliased_functions(toolkit.functions, aliases)
+    toolkit.async_functions = _aliased_functions(toolkit.async_functions, aliases)
+    if expose_attributes:
+        for aliased_name in aliases.values():
+            function = toolkit.functions.get(aliased_name)
+            if function is not None and function.entrypoint is not None:
+                setattr(toolkit, aliased_name, function.entrypoint)
+    return toolkit
+
+
+def _aliased_functions(functions: Mapping[str, Function], aliases: Mapping[str, str]) -> dict[str, Function]:
+    aliased_functions: dict[str, Function] = {}
+    for function_name, function in functions.items():
+        aliased_name = aliases.get(function_name, function_name)
+        function.name = aliased_name
+        aliased_functions[aliased_name] = function
+    return aliased_functions

--- a/tests/test_toolkit_aliases.py
+++ b/tests/test_toolkit_aliases.py
@@ -1,0 +1,44 @@
+"""Tests for shared Agno toolkit alias helpers."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agno.tools.toolkit import Toolkit
+
+from mindroom.tool_system.toolkit_aliases import apply_toolkit_function_aliases
+
+
+class DemoTools(Toolkit):
+    """Small toolkit with matching sync and async model-facing function names."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="demo_tools",
+            tools=[self.search],
+            async_tools=[(self.asearch, "search")],
+        )
+
+    def search(self, query: str) -> str:
+        """Search synchronously."""
+        return f"sync:{query}"
+
+    async def asearch(self, query: str) -> str:
+        """Search asynchronously."""
+        return f"async:{query}"
+
+
+def test_apply_toolkit_function_aliases_renames_sync_and_async_functions() -> None:
+    """Alias helper updates sync and async functions without replacing original methods."""
+    toolkit = DemoTools()
+
+    apply_toolkit_function_aliases(toolkit, {"search": "demo_search"})
+
+    assert set(toolkit.functions) == {"demo_search"}
+    assert set(toolkit.async_functions) == {"demo_search"}
+    assert toolkit.functions["demo_search"].name == "demo_search"
+    assert toolkit.async_functions["demo_search"].name == "demo_search"
+    assert toolkit.functions["demo_search"].entrypoint("docs") == "sync:docs"
+    assert asyncio.run(toolkit.async_functions["demo_search"].entrypoint("docs")) == "async:docs"
+    assert toolkit.demo_search("docs") == "sync:docs"
+    assert toolkit.search("docs") == "sync:docs"


### PR DESCRIPTION
## Summary
- Add a shared MindRoom `apply_toolkit_function_aliases` helper for adapting Agno toolkit function names after toolkit construction
- Use the helper in the Google Drive OAuth toolkit instead of bespoke rename methods
- Cover sync and async aliasing behavior with a focused helper test

## Notes
Agno supports naming functions when they are registered, but built-in toolkits such as Google Drive do not expose a constructor-level alias map for already-registered functions. This PR keeps the current Google Drive behavior and centralizes MindRoom-owned explicit aliasing in one helper.

## Tests
- `uv run pytest tests/test_toolkit_aliases.py tests/test_google_drive_oauth_tool.py -q`
- `uv run ruff check src/mindroom/tool_system/toolkit_aliases.py src/mindroom/custom_tools/google_drive.py tests/test_toolkit_aliases.py tests/test_google_drive_oauth_tool.py`
- `uv run ty check src/mindroom/tool_system/toolkit_aliases.py src/mindroom/custom_tools/google_drive.py tests/test_toolkit_aliases.py`
- commit hooks: passed (`ruff`, `ty`, Tach, etc.)