### PR TITLE
Fix visible thread history dedupe for self-authored events

### DIFF
--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -283,6 +283,12 @@ def _message_speaker_label(message: ResolvedVisibleMessage) -> str:
     return message.sender
 
 
+def _is_relayed_user_message(message: ResolvedVisibleMessage) -> bool:
+    """Return whether an internal Matrix sender is relaying a user-authored message."""
+    original_sender = message.content.get(ORIGINAL_SENDER_KEY)
+    return isinstance(original_sender, str) and bool(original_sender)
+
+
 def _build_unseen_messages_header(partial_reply_kinds: set[_PartialReplyKind]) -> str:
     """Choose the unseen-context guidance for the partial-reply mix present."""
     if not partial_reply_kinds:
@@ -301,7 +307,11 @@ def _context_message_from_visible_message(
     missing_sender_label: str | None = None,
 ) -> Message:
     """Convert one visible Matrix message into a structured Agno message."""
-    if response_sender_id is not None and message.sender == response_sender_id:
+    if (
+        response_sender_id is not None
+        and message.sender == response_sender_id
+        and not _is_relayed_user_message(message)
+    ):
         return Message(role="assistant", content=message.body)
     speaker_label = _message_speaker_label(message)
     if not speaker_label:
@@ -474,29 +484,28 @@ def _get_unseen_messages_for_sender(
             continue
         if isinstance(content, dict) and COMPACTION_NOTICE_CONTENT_KEY in content:
             continue
-        if sender_id and sender == sender_id:
+        if sender_id and sender == sender_id and not _is_relayed_user_message(msg):
             partial_kind = _classify_partial_reply(
                 msg,
                 active_event_ids=active_event_ids,
             )
             if partial_kind is _PartialReplyKind.INTERRUPTED:
                 continue
-            if partial_kind is None:
+            if partial_kind is not None:
+                cleaned_body = _clean_partial_reply_body(msg.body)
+                if not cleaned_body:
+                    continue
+                partial_reply_kinds.add(partial_kind)
+                if partial_kind is _PartialReplyKind.IN_PROGRESS and event_id is not None:
+                    in_progress_event_ids.add(event_id)
+                unseen.append(
+                    replace_visible_message(
+                        msg,
+                        sender=_PARTIAL_REPLY_SENDER_LABELS.get(partial_kind.value, "You (partial reply)"),
+                        body=cleaned_body,
+                    ),
+                )
                 continue
-            cleaned_body = _clean_partial_reply_body(msg.body)
-            if not cleaned_body:
-                continue
-            partial_reply_kinds.add(partial_kind)
-            if partial_kind is _PartialReplyKind.IN_PROGRESS and event_id is not None:
-                in_progress_event_ids.add(event_id)
-            unseen.append(
-                replace_visible_message(
-                    msg,
-                    sender=_PARTIAL_REPLY_SENDER_LABELS.get(partial_kind.value, "You (partial reply)"),
-                    body=cleaned_body,
-                ),
-            )
-            continue
         unseen.append(msg)
     return unseen, partial_reply_kinds, in_progress_event_ids
 

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -1029,9 +1029,11 @@ def _seen_event_ids_for_runs(runs: Sequence[RunOutput | TeamRunOutput]) -> list[
         if not isinstance(metadata, dict):
             continue
         raw_seen_ids = metadata.get("matrix_seen_event_ids")
-        if not isinstance(raw_seen_ids, list):
-            continue
-        seen_event_ids.update(event_id for event_id in raw_seen_ids if isinstance(event_id, str) and event_id)
+        if isinstance(raw_seen_ids, list):
+            seen_event_ids.update(event_id for event_id in raw_seen_ids if isinstance(event_id, str) and event_id)
+        response_event_id = metadata.get("matrix_response_event_id")
+        if isinstance(response_event_id, str) and response_event_id:
+            seen_event_ids.add(response_event_id)
     return sorted(seen_event_ids)
 
 

--- a/src/mindroom/history/storage.py
+++ b/src/mindroom/history/storage.py
@@ -153,6 +153,9 @@ def read_scope_seen_event_ids(session: AgentSession | TeamSession, scope: Histor
         raw_seen_ids = metadata.get("matrix_seen_event_ids")
         if isinstance(raw_seen_ids, list):
             seen_event_ids.update(event_id for event_id in raw_seen_ids if isinstance(event_id, str) and event_id)
+        response_event_id = metadata.get("matrix_response_event_id")
+        if isinstance(response_event_id, str) and response_event_id:
+            seen_event_ids.add(response_event_id)
     return seen_event_ids
 
 

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -4720,6 +4720,19 @@ def test_scope_seen_event_ids_survive_scope_state_writes(tmp_path: Path) -> None
     assert read_scope_seen_event_ids(session, scope) == {"event-1"}
 
 
+def test_scope_seen_event_ids_include_persisted_response_event_ids(tmp_path: Path) -> None:
+    _config, _runtime_paths_value = _make_config(tmp_path)
+    scope = HistoryScope(kind="agent", scope_id="test_agent")
+    run = _completed_run("run-1")
+    run.metadata = {
+        "matrix_seen_event_ids": ["question-1"],
+        "matrix_response_event_id": "answer-1",
+    }
+    session = _session("session-1", runs=[run])
+
+    assert read_scope_seen_event_ids(session, scope) == {"question-1", "answer-1"}
+
+
 def test_scope_states_do_not_bleed_between_scopes(tmp_path: Path) -> None:
     _config, _runtime_paths_value = _make_config(tmp_path)
     agent_scope = HistoryScope(kind="agent", scope_id="test_agent")
@@ -4806,25 +4819,37 @@ async def test_prepare_history_for_run_compaction_preserves_seen_event_ids(tmp_p
                 run_id="run-1",
                 agent_id="test_agent",
                 status=RunStatus.completed,
-                metadata={"matrix_seen_event_ids": ["event-1", "event-2"]},
+                metadata={
+                    "matrix_seen_event_ids": ["event-1", "event-2"],
+                    "matrix_response_event_id": "response-1",
+                },
             ),
             RunOutput(
                 run_id="run-2",
                 agent_id="test_agent",
                 status=RunStatus.completed,
-                metadata={"matrix_seen_event_ids": ["event-3"]},
+                metadata={
+                    "matrix_seen_event_ids": ["event-3"],
+                    "matrix_response_event_id": "response-2",
+                },
             ),
             RunOutput(
                 run_id="run-3",
                 agent_id="test_agent",
                 status=RunStatus.completed,
-                metadata={"matrix_seen_event_ids": ["event-4"]},
+                metadata={
+                    "matrix_seen_event_ids": ["event-4"],
+                    "matrix_response_event_id": "response-3",
+                },
             ),
             RunOutput(
                 run_id="run-4",
                 agent_id="test_agent",
                 status=RunStatus.completed,
-                metadata={"matrix_seen_event_ids": ["event-5"]},
+                metadata={
+                    "matrix_seen_event_ids": ["event-5"],
+                    "matrix_response_event_id": "response-4",
+                },
             ),
         ],
     )
@@ -4864,6 +4889,10 @@ async def test_prepare_history_for_run_compaction_preserves_seen_event_ids(tmp_p
         "event-3",
         "event-4",
         "event-5",
+        "response-1",
+        "response-2",
+        "response-3",
+        "response-4",
     }
 
 

--- a/tests/test_execution_preparation.py
+++ b/tests/test_execution_preparation.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from defusedxml.ElementTree import fromstring
 
-from mindroom.execution_preparation import _collect_history_messages, build_matrix_prompt_with_thread_history
+from mindroom.constants import ORIGINAL_SENDER_KEY
+from mindroom.execution_preparation import (
+    _build_unseen_context_messages,
+    _collect_history_messages,
+    build_matrix_prompt_with_thread_history,
+)
 from tests.conftest import make_visible_message
 
 
@@ -112,3 +117,97 @@ def test_build_matrix_prompt_with_thread_history_truncates_visible_body_to_max_l
     assert message.text.startswith("okok")
     assert message.text.endswith("…")
     assert len(message.text) <= 200
+
+
+def test_unseen_context_keeps_self_sent_relayed_user_message() -> None:
+    """A tool-relayed user message from the agent account should remain user context."""
+    thread_history = [
+        make_visible_message(
+            sender="@mindroom_code:localhost",
+            body="@mindroom_missing_agent Please investigate this",
+            event_id="$spawn-root",
+            content={
+                "body": "@mindroom_missing_agent Please investigate this",
+                ORIGINAL_SENDER_KEY: "@alice:localhost",
+            },
+        ),
+        make_visible_message(
+            sender="@alice:localhost",
+            body="What happened?",
+            event_id="$question",
+        ),
+    ]
+
+    messages, unseen_event_ids = _build_unseen_context_messages(
+        "What happened?",
+        thread_history,
+        seen_event_ids=set(),
+        current_event_id="$question",
+        active_event_ids=(),
+        response_sender_id="@mindroom_code:localhost",
+        current_sender_id="@alice:localhost",
+    )
+
+    assert unseen_event_ids == ["$spawn-root"]
+    assert messages[0].role == "user"
+    assert messages[0].content == "@alice:localhost: @mindroom_missing_agent Please investigate this"
+
+
+def test_unseen_context_keeps_unpersisted_self_sent_message() -> None:
+    """A self-sent Matrix event not known to persisted history should remain visible context."""
+    thread_history = [
+        make_visible_message(
+            sender="@mindroom_code:localhost",
+            body="@mindroom_missing_agent Please investigate this",
+            event_id="$spawn-root",
+        ),
+        make_visible_message(
+            sender="@alice:localhost",
+            body="What happened?",
+            event_id="$question",
+        ),
+    ]
+
+    messages, unseen_event_ids = _build_unseen_context_messages(
+        "What happened?",
+        thread_history,
+        seen_event_ids=set(),
+        current_event_id="$question",
+        active_event_ids=(),
+        response_sender_id="@mindroom_code:localhost",
+        current_sender_id="@alice:localhost",
+    )
+
+    assert unseen_event_ids == ["$spawn-root"]
+    assert messages[0].role == "assistant"
+    assert messages[0].content == "@mindroom_missing_agent Please investigate this"
+
+
+def test_unseen_context_skips_persisted_self_sent_response_event() -> None:
+    """A self-sent Matrix event already represented in persisted history should not be duplicated."""
+    thread_history = [
+        make_visible_message(
+            sender="@mindroom_code:localhost",
+            body="Persisted assistant answer",
+            event_id="$answer",
+        ),
+        make_visible_message(
+            sender="@alice:localhost",
+            body="What next?",
+            event_id="$question",
+        ),
+    ]
+
+    messages, unseen_event_ids = _build_unseen_context_messages(
+        "What next?",
+        thread_history,
+        seen_event_ids={"$answer"},
+        current_event_id="$question",
+        active_event_ids=(),
+        response_sender_id="@mindroom_code:localhost",
+        current_sender_id="@alice:localhost",
+    )
+
+    assert unseen_event_ids == []
+    assert len(messages) == 1
+    assert messages[0].content == 'Current message:\n<msg from="@alice:localhost"><![CDATA[What next?]]></msg>'


### PR DESCRIPTION
## Problem

Before this change, threaded model input could omit visible Matrix messages when the message was sent by the responding agent's own Matrix account.
That happened in the `sessions_spawn` flow: an agent could create a new Matrix thread as itself while relaying the original human sender in metadata.
If the spawned thread mentioned an agent that was not actually in the room, no agent answered the root message.
Later, when a human asked a follow-up in that thread, the available agent built its model input from persisted Agno history plus "unseen" Matrix messages.
The unseen-message filter treated any completed message from the responding Matrix user as already represented by persisted history, so it dropped the self-authored thread root even though that root was only visible in Matrix.
The model then answered from a partial thread view and missed the first visible message.

There was a second edge case after the initial fix: persisted response event IDs were treated as represented history, but compaction only preserved `matrix_seen_event_ids`.
After compaction removed old runs, old assistant response event IDs could be lost from the preserved seen set and re-enter the unseen Matrix path alongside the compaction summary.

## What happens now

Self-authored Matrix messages are no longer dropped solely because `sender == response_sender_id`.
Tool-relayed user messages sent from an agent account still render as user context using the original sender metadata.
Completed self-authored Matrix events are included when they are not known to be represented in persisted history.
Persisted assistant response events are deduped by `matrix_response_event_id`, not by sender equality.
Compaction now preserves both `matrix_seen_event_ids` and `matrix_response_event_id`, so dedupe survives run compaction.

With this change, the model input for a threaded response preserves the visible thread transcript unless an event is explicitly known to already be represented by persisted history or is intentionally excluded by existing current-event, partial-reply, or compaction-notice rules.

## Tests

- `uv run --python 3.13 pytest tests/test_agno_history.py tests/test_execution_preparation.py tests/test_partial_reply_context.py -q -n 0 --no-cov`
- `uv run ruff check src/mindroom/execution_preparation.py src/mindroom/history/storage.py src/mindroom/history/compaction.py tests/test_execution_preparation.py tests/test_agno_history.py`
- `uv run --python 3.13 pytest -q --no-cov`
- `uv run pre-commit run --all-files`
