### PR TITLE
Fix Mem0 embedding dimension collection keys

### DIFF
--- a/src/mindroom/embeddings.py
+++ b/src/mindroom/embeddings.py
@@ -21,7 +21,6 @@ _OPENAI_EMBEDDING_DIMENSIONS = {
     "text-embedding-3-large": 3072,
     "text-embedding-3-small": 1536,
 }
-_MEM0_OPENAI_DEFAULT_DIMENSIONS = 1536
 DEFAULT_SENTENCE_TRANSFORMERS_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 _SENTENCE_TRANSFORMERS_DEPENDENCIES = ["sentence-transformers"]
 _SENTENCE_TRANSFORMERS_EXTRA = "sentence_transformers"
@@ -65,7 +64,7 @@ def effective_mem0_embedder_signature(
     effective_host = host if provider in {"openai", "ollama"} else ""
     effective_dimensions = dimensions
     if provider == "openai" and effective_dimensions is None:
-        effective_dimensions = _MEM0_OPENAI_DEFAULT_DIMENSIONS
+        effective_dimensions = _default_dimensions(model)
     elif provider in {"ollama", "sentence_transformers"}:
         effective_dimensions = None
     return (

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -125,17 +125,42 @@ def test_create_sentence_transformers_embedder_auto_installs_optional_runtime(
     }
 
 
-def test_mem0_and_knowledge_signatures_keep_their_own_openai_defaults() -> None:
-    """Memory and knowledge signatures should not conflate different OpenAI defaults."""
+def test_mem0_and_knowledge_signatures_use_openai_model_defaults() -> None:
+    """Memory and knowledge signatures should match known OpenAI model defaults."""
     assert effective_mem0_embedder_signature("openai", "text-embedding-3-large") == (
         "openai",
         "text-embedding-3-large",
         "",
-        "1536",
+        "3072",
     )
     assert effective_knowledge_embedder_signature("openai", "text-embedding-3-large") == (
         "openai",
         "text-embedding-3-large",
         "",
         "3072",
+    )
+
+
+def test_mem0_custom_openai_compatible_signature_keeps_implicit_dimensions_unset() -> None:
+    """Custom OpenAI-compatible models should not be keyed as explicit 1536-d vectors."""
+    assert effective_mem0_embedder_signature(
+        "openai",
+        "gemini-embedding-001",
+        host="http://example.com/v1",
+    ) == (
+        "openai",
+        "gemini-embedding-001",
+        "http://example.com/v1",
+        "",
+    )
+    assert effective_mem0_embedder_signature(
+        "openai",
+        "gemini-embedding-001",
+        host="http://example.com/v1",
+        dimensions=1536,
+    ) == (
+        "openai",
+        "gemini-embedding-001",
+        "http://example.com/v1",
+        "1536",
     )

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -245,7 +245,7 @@ class TestMemoryConfig:
         ("model", "effective_dimensions"),
         [
             ("text-embedding-3-small", 1536),
-            ("text-embedding-3-large", 1536),
+            ("text-embedding-3-large", 3072),
         ],
     )
     def test_memory_collection_name_ignores_equivalent_mem0_openai_default_dimensions(
@@ -272,6 +272,34 @@ class TestMemoryConfig:
         explicit_config = Config(memory=explicit_default, router=RouterConfig(model="default"))
 
         assert _memory_collection_name(implicit_config) == _memory_collection_name(explicit_config)
+
+    def test_custom_openai_compatible_memory_collection_name_tracks_explicit_dimensions(self) -> None:
+        """Custom OpenAI-compatible embedders must not treat omitted dimensions as explicit 1536."""
+        implicit_dimensions = MemoryConfig(
+            embedder=_MemoryEmbedderConfig(
+                provider="openai",
+                config=EmbedderConfig(
+                    model="gemini-embedding-001",
+                    host="http://example.com/v1",
+                ),
+            ),
+            llm=None,
+        )
+        explicit_dimensions = MemoryConfig(
+            embedder=_MemoryEmbedderConfig(
+                provider="openai",
+                config=EmbedderConfig(
+                    model="gemini-embedding-001",
+                    host="http://example.com/v1",
+                    dimensions=1536,
+                ),
+            ),
+            llm=None,
+        )
+        implicit_config = Config(memory=implicit_dimensions, router=RouterConfig(model="default"))
+        explicit_config = Config(memory=explicit_dimensions, router=RouterConfig(model="default"))
+
+        assert _memory_collection_name(implicit_config) != _memory_collection_name(explicit_config)
 
     @patch("mindroom.memory.config.get_runtime_shared_credentials_manager")
     @patch.dict("os.environ", {}, clear=True)


### PR DESCRIPTION
## Summary
- make Mem0 collection keys use known OpenAI embedding model defaults instead of a hard-coded 1536 fallback
- keep implicit dimensions unset for OpenAI-compatible non-OpenAI models so they do not collide with explicitly dimensioned collections
- add regression coverage for custom OpenAI-compatible embedders and updated OpenAI model defaults

## Testing
- uv run pytest tests/test_embeddings.py tests/test_memory_config.py