### PR TITLE
Add review bot configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,95 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+enable_free_tier: true
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  review_details: true
+  poem: false
+  path_filters:
+    - "**/*"
+    - "!mindroom_data/**"
+    - "!tests/mindroom_data/**"
+    - "!.venv/**"
+    - "!**/node_modules/**"
+    - "!**/.next/**"
+    - "!frontend/dist/**"
+    - "!**/coverage/**"
+    - "!**/htmlcov/**"
+    - "!skills/mindroom-docs/references/llms-full.txt"
+  path_instructions:
+    - path: "**/*"
+      instructions: |
+        Review as a pragmatic blocker-focused reviewer for MindRoom.
+        Prioritize correctness, security, data privacy, Matrix protocol behavior, concurrency, config migration safety, deployment safety, and test coverage.
+        Prefer small direct fixes that match existing patterns.
+        Do not suggest backward-compatibility wrappers unless the changed surface is explicitly a compatibility contract.
+        Do not claim a model identifier is invalid just because it is unfamiliar; ask for source verification when current model names matter.
+    - path: "**/*.py"
+      instructions: |
+        Prefer typed dataclasses or Pydantic models over dictionaries for structured data.
+        Avoid getattr and hasattr probes that weaken typed interfaces.
+        Avoid broad try/except blocks unless the boundary genuinely needs user-facing failure handling.
+        Keep imports at module top unless avoiding a real circular import.
+        If tests or mocks fail, recommend fixing them to use proper typed objects or stricter mocks instead of adding production fallback branches.
+    - path: "frontend/**/*"
+      instructions: |
+        Match the existing Vite and React dashboard patterns.
+        Keep operational interfaces dense, scannable, responsive, and free of decorative landing-page treatment.
+        Verify user-facing layout changes across desktop and mobile viewports when possible.
+    - path: "saas-platform/platform-frontend/**/*"
+      instructions: |
+        Match the existing Next.js 15 portal patterns and centralized API client.
+        Treat auth, subscription state, and instance-management flows as high-risk user-facing behavior.
+        Verify user-facing layout changes across desktop and mobile viewports when possible.
+    - path: "saas-platform/platform-backend/**/*"
+      instructions: |
+        Treat SSO cookies, Supabase RLS assumptions, subscription state, and Kubernetes provisioning as high-risk behavior.
+        Prefer explicit typed request and response models over unstructured dictionaries.
+    - path: "cluster/**/*"
+      instructions: |
+        Treat Kubernetes, Helm, Terraform, and local-stack changes as deployment-sensitive.
+        Flag committed secrets, unsafe defaults, namespace mistakes, and drift from provisioner-owned deployment flows.
+    - path: "local/**/*"
+      instructions: |
+        Treat Kubernetes, Helm, Terraform, and local-stack changes as deployment-sensitive.
+        Flag committed secrets, unsafe defaults, namespace mistakes, and drift from provisioner-owned deployment flows.
+    - path: "docs/**/*.md"
+      instructions: |
+        Preserve the repository Markdown style of one sentence per line.
+        Do not recommend hand-editing generated CLI documentation sections; update the source or generator instead.
+    - path: "README.md"
+      instructions: |
+        Preserve the repository Markdown style of one sentence per line.
+        Do not recommend hand-editing generated CLI documentation sections; update the source or generator instead.
+    - path: "skills/**/*.md"
+      instructions: |
+        Preserve the repository Markdown style of one sentence per line.
+        Do not recommend hand-editing generated CLI documentation sections; update the source or generator instead.
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "renovate[bot]"
+
+chat:
+  auto_reply: false
+  allow_non_org_members: true
+
+knowledge_base:
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "CLAUDE.md"
+      - "**/AGENTS.md"

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,45 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "style"],
+  "triggerOnUpdates": true,
+  "statusCheck": false,
+  "ignorePatterns": "mindroom_data/\ntests/mindroom_data/\n.venv/\nnode_modules/\nfrontend/node_modules/\nfrontend/dist/\n**/.next/\n**/coverage/\n**/htmlcov/\nskills/mindroom-docs/references/llms-full.txt",
+  "instructions": "MindRoom is an Apache-2.0 repository for Matrix-based AI agent orchestration plus a SaaS control plane. Review with CLAUDE.md as the primary repository guidance. Prioritize correctness, security, privacy, Matrix protocol behavior, concurrency, config migration safety, deployment safety, and focused tests.",
+  "rules": [
+    {
+      "id": "verify-current-model-names",
+      "rule": "Do not flag AI model identifiers as invalid just because they are unfamiliar. When model names matter, ask for current provider documentation verification.",
+      "severity": "medium"
+    },
+    {
+      "id": "typed-interfaces-over-dynamic-probes",
+      "rule": "Do not recommend getattr or hasattr fallbacks that weaken a typed production interface. Prefer fixing the declared type, dataclass, Pydantic model, or test fixture.",
+      "scope": ["src/**", "tests/**", "saas-platform/platform-backend/**"],
+      "severity": "high"
+    },
+    {
+      "id": "no-test-only-production-branches",
+      "rule": "Do not recommend production wrappers, fallback branches, or compatibility shims whose only purpose is to preserve an old test expectation.",
+      "scope": ["src/**", "saas-platform/**"],
+      "severity": "high"
+    },
+    {
+      "id": "module-top-imports",
+      "rule": "Prefer module-level imports in Python. Only recommend function-local imports when they avoid a real circular import or expensive optional dependency boundary.",
+      "scope": ["**/*.py"],
+      "severity": "medium"
+    },
+    {
+      "id": "deployment-secret-safety",
+      "rule": "Flag committed secrets, plaintext deployment credentials, unsafe Helm values, and changes that bypass the provisioner-owned instance deployment flow.",
+      "scope": ["cluster/**", "local/**", "saas-platform/**"],
+      "severity": "high"
+    },
+    {
+      "id": "markdown-one-sentence-per-line",
+      "rule": "Markdown documentation should keep one sentence per line and should not split a single sentence across multiple lines.",
+      "scope": ["docs/**/*.md", "README.md", "skills/**/*.md"],
+      "severity": "low"
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,28 @@
+{
+  "files": [
+    {
+      "path": "CLAUDE.md",
+      "description": "Repository architecture map, project workflow, coding standards, testing guidance, and current model-name policy."
+    },
+    {
+      "path": "pyproject.toml",
+      "description": "Core Python package metadata, runtime dependencies, optional tool extras, and supported Python versions.",
+      "scope": ["src/**", "tests/**", "pyproject.toml"]
+    },
+    {
+      "path": "tach.toml",
+      "description": "Architecture boundary definitions for the core MindRoom package.",
+      "scope": ["src/**", "tach.toml"]
+    },
+    {
+      "path": ".github/workflows/pytest.yml",
+      "description": "Primary backend test workflow and expected CI test shape.",
+      "scope": [".github/**", "src/**", "tests/**"]
+    },
+    {
+      "path": "saas-platform/README.md",
+      "description": "SaaS platform development and deployment overview.",
+      "scope": ["saas-platform/**"]
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,33 @@
+# MindRoom Review Rules
+
+## Review Focus
+
+- Prioritize bugs, security risks, privacy leaks, Matrix protocol regressions, broken authorization, deployment mistakes, and missing tests.
+- Keep suggestions scoped to the changed code and the requested behavior.
+- Prefer direct fixes that match existing local patterns over speculative abstractions.
+- Treat `CLAUDE.md` as the source of truth for repository-specific architecture and workflow guidance.
+
+## Python
+
+- Prefer functional Python and typed dataclasses or Pydantic models over loose dictionaries for structured data.
+- Keep imports at module top unless a function-local import avoids a real circular dependency or optional dependency boundary.
+- Avoid broad try/except blocks unless the code is handling an expected external failure boundary.
+- Do not weaken typed production code with `getattr` or `hasattr` fallbacks.
+- If a test or mock breaks, prefer stricter fixtures or typed objects over production code branches that only satisfy the old test.
+
+## Frontend
+
+- Preserve the existing Vite React dashboard and Next.js SaaS portal conventions.
+- Operational UI should stay dense, scannable, and responsive.
+- Flag layout changes that are likely to overlap, truncate critical text, or fail on mobile.
+
+## Docs And Generated Files
+
+- Markdown docs should use one sentence per line.
+- Do not recommend hand-editing generated CLI documentation sections.
+- For generated documentation references, prefer updating the source documentation or generator.
+
+## Deployment And Secrets
+
+- Flag committed secrets, plaintext credentials, unsafe Helm values, and accidental use of manual Helm flows where the provisioner API is expected.
+- Treat SSO cookies, Supabase RLS, Kubernetes namespace boundaries, and Matrix credentials as high-risk review areas.


### PR DESCRIPTION
## Summary
- add repository-level CodeRabbit configuration for MindRoom review expectations and OSS/free-tier settings
- add Greptile configuration, context files, and review rules for the MindRoom codebase
- exclude generated/local-heavy paths from both review bots

## Setup notes
- CodeRabbit GitHub app is enabled for `mindroom-ai/mindroom`.
- Greptile GitHub app is enabled for `mindroom-ai/mindroom`.
- CodeRabbit advertises free usage for public repositories.
- Greptile showed a trial in the UI; its OSS discount/free access appears to require a separate application rather than being automatic.

## Validation
- `uv run python - <<'PY' ...` validated Greptile JSON syntax and `.coderabbit.yaml` against CodeRabbit's published schema.
- `uv sync --all-extras`
- `uv run pre-commit run --all-files`
- `uv run pytest` - 5947 passed, 99 skipped, 198 warnings in 145.71s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository configuration for automated code review and indexing tools to improve review consistency and safety.
  * Enables incremental/auto-review, targeted security/privacy and deployment checks, and focused test/format guidance.
  * Improves searchable documentation indexing and review scoping while ignoring drafts, build artifacts, and common vendor files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/851)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->