### PR TITLE
Clarify AI run context cache metadata

### DIFF
--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -769,7 +769,7 @@ MindRoom can connect to external Model Context Protocol servers through the top-
 
 Use the top-level `tool_approval` block to gate tool calls behind human approval in Matrix conversations. Rules are evaluated in order and the first matching rule wins. Each rule must set exactly one of `action` or `script`. Use `action: require_approval` to always pause the tool call and send a Matrix approval card. Use `script: ./approval_scripts/review.py` to run `check(tool_name, arguments, agent_name) -> bool` and require approval only when it returns `True`. `timeout_days` sets the default approval expiry window and can be overridden per rule. React to the approval card with `✅` to approve the tool call. Reply to the approval card with a message to deny the tool call and record that text as the denial reason. Only the original human requester can approve or deny their pending tool call. Approval responses only resolve the live Matrix approval card in the same room; approval IDs are used only as a live client hint. If MindRoom restarts before a tool call is approved, the live tool call is cancelled. On startup, MindRoom attempts to mark recent unresolved approval cards sent by the current router as expired. Agent-authored, system-authored, and configured bridge-bot-authored tool calls are denied instead of entering the approval flow. OpenAI-compatible `/v1/chat/completions` has no approval transport, so any tool function that matches a required-approval rule, including script-based rules, is hidden from the `/v1` tool schema instead of being exposed and blocked later.
 
-```yaml
+```
 tool_approval:
   default: auto_approve
   timeout_days: 7

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -39,7 +39,7 @@ On startup, MindRoom attempts to mark recent unresolved approval cards sent by t
 Agent-authored, system-authored, and configured bridge-bot-authored tool calls are denied instead of entering the approval flow.
 OpenAI-compatible `/v1/chat/completions` has no approval transport, so any tool function that matches a required-approval rule, including script-based rules, is hidden from the `/v1` tool schema instead of being exposed and blocked later.
 
-```yaml
+```
 tool_approval:
   default: auto_approve
   timeout_days: 7

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -224,7 +224,9 @@ class _StreamingAttemptState:
     completed_tools: list[ToolTraceEntry] = field(default_factory=list)
     latest_model_id: str | None = None
     latest_model_provider: str | None = None
-    latest_request_input_tokens: int | None = None
+    latest_request_context_input_tokens: int | None = None
+    latest_request_cache_read_tokens: int | None = None
+    latest_request_cache_write_tokens: int | None = None
     cancelled_run_event: RunCancelledEvent | None = None
     completed_run_event: RunCompletedEvent | None = None
     canonical_final_body_candidate: str | None = None
@@ -417,6 +419,8 @@ def _build_model_request_metrics_fallback(
 def _build_context_payload(
     *,
     context_input_tokens: int | None,
+    cache_read_tokens: int | None,
+    cache_write_tokens: int | None,
     model_config: ModelConfig | None,
 ) -> dict[str, Any] | None:
     if context_input_tokens is None or model_config is None or model_config.context_window is None:
@@ -424,10 +428,64 @@ def _build_context_payload(
     context_window = model_config.context_window
     if context_window <= 0:
         return None
-    return {
+    payload = {
         "input_tokens": context_input_tokens,
         "window_tokens": context_window,
     }
+    if cache_read_tokens is not None and cache_read_tokens > 0:
+        payload["cache_read_input_tokens"] = cache_read_tokens
+    if cache_write_tokens is not None and cache_write_tokens > 0:
+        payload["cache_write_input_tokens"] = cache_write_tokens
+    if cache_read_tokens is not None or cache_write_tokens is not None:
+        uncached_input_tokens = context_input_tokens - (cache_read_tokens or 0)
+        if uncached_input_tokens >= 0:
+            payload["uncached_input_tokens"] = uncached_input_tokens
+    return payload
+
+
+def _provider_reports_cache_tokens_outside_input(
+    *,
+    provider: str | None,
+    configured_provider: str | None,
+    model_id: str | None,
+) -> bool:
+    """Return whether cache tokens must be added to input tokens for context occupancy."""
+    provider_key = (provider or configured_provider or "").lower()
+    configured_provider_key = (configured_provider or "").lower()
+    model_key = (model_id or "").lower()
+    if "anthropic" in provider_key or "bedrock" in provider_key:
+        return True
+    if configured_provider_key == "vertexai_claude":
+        return True
+    return "vertex" in provider_key and "claude" in model_key
+
+
+def _context_input_tokens_from_counts(
+    *,
+    input_tokens: int | None,
+    cache_read_tokens: int | None,
+    cache_write_tokens: int | None,
+    provider: str | None,
+    configured_provider: str | None,
+    model_id: str | None,
+) -> int | None:
+    """Return full request-context tokens from provider usage counters."""
+    if input_tokens is None:
+        return None
+    if not _provider_reports_cache_tokens_outside_input(
+        provider=provider,
+        configured_provider=configured_provider,
+        model_id=model_id,
+    ):
+        return input_tokens
+    return input_tokens + (cache_read_tokens or 0) + (cache_write_tokens or 0)
+
+
+def _int_usage_value(usage_payload: dict[str, Any] | None, key: str) -> int | None:
+    if usage_payload is None:
+        return None
+    value = usage_payload.get(key)
+    return value if isinstance(value, int) else None
 
 
 def _build_ai_run_metadata_content(  # noqa: C901, PLR0912
@@ -444,6 +502,8 @@ def _build_ai_run_metadata_content(  # noqa: C901, PLR0912
     metrics: Metrics | dict[str, Any] | None = None,
     metrics_fallback: dict[str, Any] | None = None,
     context_input_tokens: int | None = None,
+    context_cache_read_tokens: int | None = None,
+    context_cache_write_tokens: int | None = None,
     tool_count: int | None = None,
 ) -> dict[str, Any] | None:
     model_name, model_config = _get_model_config(
@@ -462,6 +522,22 @@ def _build_ai_run_metadata_content(  # noqa: C901, PLR0912
     usage_input_tokens = usage_payload.get("input_tokens") if usage_payload else None
     if not isinstance(usage_input_tokens, int):
         usage_input_tokens = None
+    resolved_context_input_tokens = context_input_tokens
+    if resolved_context_input_tokens is None:
+        resolved_context_input_tokens = _context_input_tokens_from_counts(
+            input_tokens=usage_input_tokens,
+            cache_read_tokens=_int_usage_value(usage_payload, "cache_read_tokens"),
+            cache_write_tokens=_int_usage_value(usage_payload, "cache_write_tokens"),
+            provider=provider,
+            configured_provider=model_config.provider if model_config is not None else None,
+            model_id=model_id,
+        )
+    resolved_context_cache_read_tokens = context_cache_read_tokens
+    if resolved_context_cache_read_tokens is None:
+        resolved_context_cache_read_tokens = _int_usage_value(usage_payload, "cache_read_tokens")
+    resolved_context_cache_write_tokens = context_cache_write_tokens
+    if resolved_context_cache_write_tokens is None:
+        resolved_context_cache_write_tokens = _int_usage_value(usage_payload, "cache_write_tokens")
 
     payload: dict[str, Any] = {"version": _AI_RUN_METADATA_VERSION}
     if run_id is not None:
@@ -484,7 +560,9 @@ def _build_ai_run_metadata_content(  # noqa: C901, PLR0912
     if usage_payload:
         payload["usage"] = usage_payload
     context_payload = _build_context_payload(
-        context_input_tokens=context_input_tokens if context_input_tokens is not None else usage_input_tokens,
+        context_input_tokens=resolved_context_input_tokens,
+        cache_read_tokens=resolved_context_cache_read_tokens,
+        cache_write_tokens=resolved_context_cache_write_tokens,
         model_config=model_config,
     )
     if context_payload:
@@ -631,9 +709,9 @@ def _track_model_request_metrics(
         state.latest_model_id = event.model
     if event.model_provider:
         state.latest_model_provider = event.model_provider
-    if isinstance(event.input_tokens, int):
-        state.latest_request_input_tokens = event.input_tokens
-        state.request_metric_totals["input_tokens"] += event.input_tokens
+    request_input_tokens = event.input_tokens if isinstance(event.input_tokens, int) else None
+    if request_input_tokens is not None:
+        state.request_metric_totals["input_tokens"] += request_input_tokens
     if isinstance(event.output_tokens, int):
         state.request_metric_totals["output_tokens"] += event.output_tokens
     if isinstance(event.total_tokens, int):
@@ -644,6 +722,20 @@ def _track_model_request_metrics(
         state.request_metric_totals["cache_read_tokens"] += event.cache_read_tokens
     if isinstance(event.cache_write_tokens, int):
         state.request_metric_totals["cache_write_tokens"] += event.cache_write_tokens
+    state.latest_request_cache_read_tokens = (
+        event.cache_read_tokens if isinstance(event.cache_read_tokens, int) else None
+    )
+    state.latest_request_cache_write_tokens = (
+        event.cache_write_tokens if isinstance(event.cache_write_tokens, int) else None
+    )
+    state.latest_request_context_input_tokens = _context_input_tokens_from_counts(
+        input_tokens=request_input_tokens,
+        cache_read_tokens=state.latest_request_cache_read_tokens,
+        cache_write_tokens=state.latest_request_cache_write_tokens,
+        provider=event.model_provider,
+        configured_provider=None,
+        model_id=event.model,
+    )
     if state.first_token_latency is None and isinstance(event.time_to_first_token, (int, float)):
         state.first_token_latency = float(event.time_to_first_token)
 
@@ -1630,7 +1722,9 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                                 model_provider=state.latest_model_provider,
                                 room_id=room_id,
                                 metrics=fallback_metrics,
-                                context_input_tokens=state.latest_request_input_tokens,
+                                context_input_tokens=state.latest_request_context_input_tokens,
+                                context_cache_read_tokens=state.latest_request_cache_read_tokens,
+                                context_cache_write_tokens=state.latest_request_cache_write_tokens,
                                 tool_count=state.observed_tool_calls,
                             )
                             if cancelled_metadata:
@@ -1674,7 +1768,9 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         room_id=room_id,
                         metrics=state.completed_run_event.metrics if state.completed_run_event is not None else None,
                         metrics_fallback=fallback_metrics,
-                        context_input_tokens=state.latest_request_input_tokens,
+                        context_input_tokens=state.latest_request_context_input_tokens,
+                        context_cache_read_tokens=state.latest_request_cache_read_tokens,
+                        context_cache_write_tokens=state.latest_request_cache_write_tokens,
                         tool_count=(
                             len(state.completed_run_event.tools)
                             if state.completed_run_event is not None and state.completed_run_event.tools is not None

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 
 from agno.db.base import SessionType
 from agno.models.message import Message
-from agno.models.metrics import Metrics
 from agno.run.agent import (
     ModelRequestCompletedEvent,
     RunCancelledEvent,
@@ -24,14 +23,17 @@ from agno.run.base import RunStatus
 
 from mindroom import ai_runtime
 from mindroom.agents import create_agent
+from mindroom.ai_run_metadata import (
+    build_ai_run_metadata_content,
+    build_model_request_metrics_fallback,
+    empty_request_metric_totals,
+)
 from mindroom.cancellation import build_cancelled_error
 from mindroom.constants import (
-    AI_RUN_METADATA_KEY,
     MATRIX_EVENT_ID_METADATA_KEY,
     MATRIX_SEEN_EVENT_IDS_METADATA_KEY,
     MATRIX_SOURCE_EVENT_IDS_METADATA_KEY,
     MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY,
-    ROUTER_AGENT_NAME,
     RuntimePaths,
 )
 from mindroom.error_handling import get_user_friendly_error_message
@@ -74,7 +76,6 @@ if TYPE_CHECKING:
     from agno.models.response import ToolExecution
 
     from mindroom.config.main import Config
-    from mindroom.config.models import ModelConfig
     from mindroom.history import CompactionLifecycle, PostResponseCompactionCheck
     from mindroom.history.turn_recorder import TurnRecorder
     from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
@@ -91,7 +92,6 @@ __all__ = [
     "stream_agent_response",
 ]
 AIStreamChunk = str | RunContentEvent | RunCompletedEvent | ToolCallStartedEvent | ToolCallCompletedEvent
-_AI_RUN_METADATA_VERSION = 1
 
 
 def _append_additional_context(agent: Agent, context_chunk: str) -> None:
@@ -153,17 +153,6 @@ class _PreparedAgentRun:
     def run_input(self) -> list[Message]:
         """Return a deep-copied mutable message list for one provider call."""
         return ai_runtime.copy_run_input(self.messages)
-
-
-def _empty_request_metric_totals() -> dict[str, int]:
-    return {
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "total_tokens": 0,
-        "reasoning_tokens": 0,
-        "cache_read_tokens": 0,
-        "cache_write_tokens": 0,
-    }
 
 
 def _next_retry_run_id(run_id: str | None) -> str | None:
@@ -230,7 +219,7 @@ class _StreamingAttemptState:
     cancelled_run_event: RunCancelledEvent | None = None
     completed_run_event: RunCompletedEvent | None = None
     canonical_final_body_candidate: str | None = None
-    request_metric_totals: dict[str, int] = field(default_factory=_empty_request_metric_totals)
+    request_metric_totals: dict[str, int] = field(default_factory=empty_request_metric_totals)
     first_token_latency: float | None = None
     first_token_logged: bool = False
     retry_requested: bool = False
@@ -359,239 +348,6 @@ def _extract_interrupted_partial_text(
 def _raise_agent_run_cancelled(reason: str | None) -> NoReturn:
     """Raise the canonical agent cancellation error."""
     raise build_cancelled_error(reason)
-
-
-def _get_model_config(
-    config: Config,
-    agent_name: str,
-    *,
-    runtime_paths: RuntimePaths,
-    room_id: str | None = None,
-) -> tuple[str | None, ModelConfig | None]:
-    """Return configured model name/config for an agent when available."""
-    if agent_name not in config.agents and agent_name not in config.teams and agent_name != ROUTER_AGENT_NAME:
-        return None, None
-    model_name = config.resolve_runtime_model(
-        entity_name=agent_name,
-        room_id=room_id,
-        runtime_paths=runtime_paths,
-    ).model_name
-    return model_name, config.models.get(model_name)
-
-
-def _serialize_metrics(metrics: Metrics | dict[str, Any] | None) -> dict[str, Any] | None:
-    def _sanitize_metrics_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
-        sanitized: dict[str, Any] = {}
-        for key, value in payload.items():
-            if isinstance(value, (str, int)) or value is None or isinstance(value, bool):
-                sanitized[key] = value
-            elif isinstance(value, float):
-                sanitized[key] = format(value, ".12g")
-        return sanitized or None
-
-    if metrics is None:
-        return None
-    if isinstance(metrics, Metrics):
-        metrics_dict = metrics.to_dict()
-        if not isinstance(metrics_dict, dict):
-            return None
-        return _sanitize_metrics_payload(metrics_dict)
-    if isinstance(metrics, dict):
-        return _sanitize_metrics_payload(metrics)
-    return None
-
-
-def _build_model_request_metrics_fallback(
-    totals: dict[str, int],
-    first_token_latency: float | None,
-) -> dict[str, Any] | None:
-    payload: dict[str, Any] = {key: value for key, value in totals.items() if value > 0}
-    if payload.get("total_tokens") is None:
-        input_tokens = payload.get("input_tokens")
-        output_tokens = payload.get("output_tokens")
-        if isinstance(input_tokens, int) and isinstance(output_tokens, int):
-            payload["total_tokens"] = input_tokens + output_tokens
-    if first_token_latency is not None:
-        payload["time_to_first_token"] = format(first_token_latency, ".12g")
-    return payload or None
-
-
-def _build_context_payload(
-    *,
-    context_input_tokens: int | None,
-    cache_read_tokens: int | None,
-    cache_write_tokens: int | None,
-    model_config: ModelConfig | None,
-) -> dict[str, Any] | None:
-    if context_input_tokens is None or model_config is None or model_config.context_window is None:
-        return None
-    context_window = model_config.context_window
-    if context_window <= 0:
-        return None
-    payload = {
-        "input_tokens": context_input_tokens,
-        "window_tokens": context_window,
-    }
-    if cache_read_tokens is not None and cache_read_tokens > 0:
-        payload["cache_read_input_tokens"] = cache_read_tokens
-    if cache_write_tokens is not None and cache_write_tokens > 0:
-        payload["cache_write_input_tokens"] = cache_write_tokens
-    if cache_read_tokens is not None or cache_write_tokens is not None:
-        # Cache writes were not read from cache, so they remain in the non-cache-read bucket.
-        uncached_input_tokens = context_input_tokens - (cache_read_tokens or 0)
-        if uncached_input_tokens >= 0:
-            payload["uncached_input_tokens"] = uncached_input_tokens
-    return payload
-
-
-def _provider_reports_cache_tokens_outside_input(
-    *,
-    provider: str | None,
-    configured_provider: str | None,
-    model_id: str | None,
-) -> bool:
-    """Return whether cache tokens must be added to input tokens for context occupancy."""
-    provider_key = (provider or configured_provider or "").lower()
-    configured_provider_key = (configured_provider or "").lower()
-    model_key = (model_id or "").lower()
-    if "anthropic" in provider_key or "bedrock" in provider_key:
-        return True
-    if configured_provider_key == "vertexai_claude":
-        return True
-    return "vertex" in provider_key and "claude" in model_key
-
-
-def _context_input_tokens_from_counts(
-    *,
-    input_tokens: int | None,
-    cache_read_tokens: int | None,
-    cache_write_tokens: int | None,
-    provider: str | None,
-    configured_provider: str | None,
-    model_id: str | None,
-) -> int | None:
-    """Return full request-context tokens from provider usage counters."""
-    if input_tokens is None:
-        return None
-    if not _provider_reports_cache_tokens_outside_input(
-        provider=provider,
-        configured_provider=configured_provider,
-        model_id=model_id,
-    ):
-        return input_tokens
-    return input_tokens + (cache_read_tokens or 0) + (cache_write_tokens or 0)
-
-
-def _int_usage_value(usage_payload: dict[str, Any] | None, key: str) -> int | None:
-    if usage_payload is None:
-        return None
-    value = usage_payload.get(key)
-    return value if isinstance(value, int) else None
-
-
-def _build_ai_run_metadata_content(  # noqa: C901, PLR0912
-    *,
-    agent_name: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    run_id: str | None,
-    session_id: str | None,
-    status: RunStatus | str | None,
-    model: str | None,
-    model_provider: str | None,
-    room_id: str | None = None,
-    metrics: Metrics | dict[str, Any] | None = None,
-    metrics_fallback: dict[str, Any] | None = None,
-    context_raw_input_tokens: int | None = None,
-    context_input_tokens: int | None = None,
-    context_cache_read_tokens: int | None = None,
-    context_cache_write_tokens: int | None = None,
-    tool_count: int | None = None,
-) -> dict[str, Any] | None:
-    model_name, model_config = _get_model_config(
-        config,
-        agent_name,
-        runtime_paths=runtime_paths,
-        room_id=room_id,
-    )
-    model_id = model or (model_config.id if model_config is not None else None)
-    provider = model_provider or (model_config.provider if model_config is not None else None)
-
-    usage_payload = _serialize_metrics(metrics)
-    if usage_payload is None and metrics_fallback:
-        usage_payload = dict(metrics_fallback)
-
-    usage_input_tokens = usage_payload.get("input_tokens") if usage_payload else None
-    if not isinstance(usage_input_tokens, int):
-        usage_input_tokens = None
-    explicit_context_scope = any(
-        value is not None
-        for value in (
-            context_raw_input_tokens,
-            context_input_tokens,
-            context_cache_read_tokens,
-            context_cache_write_tokens,
-        )
-    )
-    resolved_context_input_tokens = context_input_tokens
-    if resolved_context_input_tokens is None:
-        resolved_context_input_tokens = _context_input_tokens_from_counts(
-            input_tokens=context_raw_input_tokens if explicit_context_scope else usage_input_tokens,
-            cache_read_tokens=(
-                context_cache_read_tokens
-                if explicit_context_scope
-                else _int_usage_value(usage_payload, "cache_read_tokens")
-            ),
-            cache_write_tokens=(
-                context_cache_write_tokens
-                if explicit_context_scope
-                else _int_usage_value(usage_payload, "cache_write_tokens")
-            ),
-            provider=provider,
-            configured_provider=model_config.provider if model_config is not None else None,
-            model_id=model_id,
-        )
-    resolved_context_cache_read_tokens = context_cache_read_tokens
-    if resolved_context_cache_read_tokens is None and not explicit_context_scope:
-        resolved_context_cache_read_tokens = _int_usage_value(usage_payload, "cache_read_tokens")
-    resolved_context_cache_write_tokens = context_cache_write_tokens
-    if resolved_context_cache_write_tokens is None and not explicit_context_scope:
-        resolved_context_cache_write_tokens = _int_usage_value(usage_payload, "cache_write_tokens")
-
-    payload: dict[str, Any] = {"version": _AI_RUN_METADATA_VERSION}
-    if run_id is not None:
-        payload["run_id"] = run_id
-    if session_id is not None:
-        payload["session_id"] = session_id
-    if status is not None:
-        raw_status = status.value if isinstance(status, RunStatus) else str(status)
-        payload["status"] = raw_status.lower()
-    if model_name is not None or model_id is not None or provider is not None:
-        model_payload: dict[str, Any] = {}
-        if model_name is not None:
-            model_payload["config"] = model_name
-        if model_id is not None:
-            model_payload["id"] = model_id
-        if provider is not None:
-            model_payload["provider"] = provider
-        if model_payload:
-            payload["model"] = model_payload
-    if usage_payload:
-        payload["usage"] = usage_payload
-    context_payload = _build_context_payload(
-        context_input_tokens=resolved_context_input_tokens,
-        cache_read_tokens=resolved_context_cache_read_tokens,
-        cache_write_tokens=resolved_context_cache_write_tokens,
-        model_config=model_config,
-    )
-    if context_payload:
-        payload["context"] = context_payload
-    if tool_count is not None:
-        payload["tools"] = {"count": tool_count}
-
-    if len(payload) == 1:
-        return None
-    return {AI_RUN_METADATA_KEY: payload}
 
 
 def _normalized_string_list(values: object) -> list[str]:
@@ -1242,7 +998,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
             if tool_trace_collector is not None:
                 tool_trace_collector.extend(_extract_tool_trace(response))
             if run_metadata_collector is not None:
-                run_metadata = _build_ai_run_metadata_content(
+                run_metadata = build_ai_run_metadata_content(
                     agent_name=agent_name,
                     config=config,
                     runtime_paths=runtime_paths,
@@ -1719,11 +1475,11 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                                 interrupted_tools=[pending.trace_entry for pending in state.pending_tools],
                             )
                         if run_metadata_collector is not None:
-                            fallback_metrics = _build_model_request_metrics_fallback(
+                            fallback_metrics = build_model_request_metrics_fallback(
                                 state.request_metric_totals,
                                 state.first_token_latency,
                             )
-                            cancelled_metadata = _build_ai_run_metadata_content(
+                            cancelled_metadata = build_ai_run_metadata_content(
                                 agent_name=agent_name,
                                 config=config,
                                 runtime_paths=runtime_paths,
@@ -1759,11 +1515,11 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     break
 
                 if run_metadata_collector is not None:
-                    fallback_metrics = _build_model_request_metrics_fallback(
+                    fallback_metrics = build_model_request_metrics_fallback(
                         state.request_metric_totals,
                         state.first_token_latency,
                     )
-                    run_metadata = _build_ai_run_metadata_content(
+                    run_metadata = build_ai_run_metadata_content(
                         agent_name=agent_name,
                         config=config,
                         runtime_paths=runtime_paths,

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -224,7 +224,7 @@ class _StreamingAttemptState:
     completed_tools: list[ToolTraceEntry] = field(default_factory=list)
     latest_model_id: str | None = None
     latest_model_provider: str | None = None
-    latest_request_context_input_tokens: int | None = None
+    latest_request_input_tokens: int | None = None
     latest_request_cache_read_tokens: int | None = None
     latest_request_cache_write_tokens: int | None = None
     cancelled_run_event: RunCancelledEvent | None = None
@@ -437,6 +437,7 @@ def _build_context_payload(
     if cache_write_tokens is not None and cache_write_tokens > 0:
         payload["cache_write_input_tokens"] = cache_write_tokens
     if cache_read_tokens is not None or cache_write_tokens is not None:
+        # Cache writes were not read from cache, so they remain in the non-cache-read bucket.
         uncached_input_tokens = context_input_tokens - (cache_read_tokens or 0)
         if uncached_input_tokens >= 0:
             payload["uncached_input_tokens"] = uncached_input_tokens
@@ -501,6 +502,7 @@ def _build_ai_run_metadata_content(  # noqa: C901, PLR0912
     room_id: str | None = None,
     metrics: Metrics | dict[str, Any] | None = None,
     metrics_fallback: dict[str, Any] | None = None,
+    context_raw_input_tokens: int | None = None,
     context_input_tokens: int | None = None,
     context_cache_read_tokens: int | None = None,
     context_cache_write_tokens: int | None = None,
@@ -522,21 +524,38 @@ def _build_ai_run_metadata_content(  # noqa: C901, PLR0912
     usage_input_tokens = usage_payload.get("input_tokens") if usage_payload else None
     if not isinstance(usage_input_tokens, int):
         usage_input_tokens = None
+    explicit_context_scope = any(
+        value is not None
+        for value in (
+            context_raw_input_tokens,
+            context_input_tokens,
+            context_cache_read_tokens,
+            context_cache_write_tokens,
+        )
+    )
     resolved_context_input_tokens = context_input_tokens
     if resolved_context_input_tokens is None:
         resolved_context_input_tokens = _context_input_tokens_from_counts(
-            input_tokens=usage_input_tokens,
-            cache_read_tokens=_int_usage_value(usage_payload, "cache_read_tokens"),
-            cache_write_tokens=_int_usage_value(usage_payload, "cache_write_tokens"),
+            input_tokens=context_raw_input_tokens if explicit_context_scope else usage_input_tokens,
+            cache_read_tokens=(
+                context_cache_read_tokens
+                if explicit_context_scope
+                else _int_usage_value(usage_payload, "cache_read_tokens")
+            ),
+            cache_write_tokens=(
+                context_cache_write_tokens
+                if explicit_context_scope
+                else _int_usage_value(usage_payload, "cache_write_tokens")
+            ),
             provider=provider,
             configured_provider=model_config.provider if model_config is not None else None,
             model_id=model_id,
         )
     resolved_context_cache_read_tokens = context_cache_read_tokens
-    if resolved_context_cache_read_tokens is None:
+    if resolved_context_cache_read_tokens is None and not explicit_context_scope:
         resolved_context_cache_read_tokens = _int_usage_value(usage_payload, "cache_read_tokens")
     resolved_context_cache_write_tokens = context_cache_write_tokens
-    if resolved_context_cache_write_tokens is None:
+    if resolved_context_cache_write_tokens is None and not explicit_context_scope:
         resolved_context_cache_write_tokens = _int_usage_value(usage_payload, "cache_write_tokens")
 
     payload: dict[str, Any] = {"version": _AI_RUN_METADATA_VERSION}
@@ -711,6 +730,7 @@ def _track_model_request_metrics(
         state.latest_model_provider = event.model_provider
     request_input_tokens = event.input_tokens if isinstance(event.input_tokens, int) else None
     if request_input_tokens is not None:
+        state.latest_request_input_tokens = request_input_tokens
         state.request_metric_totals["input_tokens"] += request_input_tokens
     if isinstance(event.output_tokens, int):
         state.request_metric_totals["output_tokens"] += event.output_tokens
@@ -727,14 +747,6 @@ def _track_model_request_metrics(
     )
     state.latest_request_cache_write_tokens = (
         event.cache_write_tokens if isinstance(event.cache_write_tokens, int) else None
-    )
-    state.latest_request_context_input_tokens = _context_input_tokens_from_counts(
-        input_tokens=request_input_tokens,
-        cache_read_tokens=state.latest_request_cache_read_tokens,
-        cache_write_tokens=state.latest_request_cache_write_tokens,
-        provider=event.model_provider,
-        configured_provider=None,
-        model_id=event.model,
     )
     if state.first_token_latency is None and isinstance(event.time_to_first_token, (int, float)):
         state.first_token_latency = float(event.time_to_first_token)
@@ -1722,7 +1734,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                                 model_provider=state.latest_model_provider,
                                 room_id=room_id,
                                 metrics=fallback_metrics,
-                                context_input_tokens=state.latest_request_context_input_tokens,
+                                context_raw_input_tokens=state.latest_request_input_tokens,
                                 context_cache_read_tokens=state.latest_request_cache_read_tokens,
                                 context_cache_write_tokens=state.latest_request_cache_write_tokens,
                                 tool_count=state.observed_tool_calls,
@@ -1768,7 +1780,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         room_id=room_id,
                         metrics=state.completed_run_event.metrics if state.completed_run_event is not None else None,
                         metrics_fallback=fallback_metrics,
-                        context_input_tokens=state.latest_request_context_input_tokens,
+                        context_raw_input_tokens=state.latest_request_input_tokens,
                         context_cache_read_tokens=state.latest_request_cache_read_tokens,
                         context_cache_write_tokens=state.latest_request_cache_write_tokens,
                         tool_count=(

--- a/src/mindroom/ai_run_metadata.py
+++ b/src/mindroom/ai_run_metadata.py
@@ -1,0 +1,263 @@
+"""Build Matrix-visible AI run metadata from model usage counters."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agno.models.metrics import Metrics
+from agno.run.base import RunStatus
+
+from mindroom.constants import AI_RUN_METADATA_KEY, ROUTER_AGENT_NAME, RuntimePaths
+
+if TYPE_CHECKING:
+    from mindroom.config.main import Config
+    from mindroom.config.models import ModelConfig
+
+AI_RUN_METADATA_VERSION = 1
+
+
+def empty_request_metric_totals() -> dict[str, int]:
+    """Return zeroed cumulative model-request counters for one streamed run."""
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "reasoning_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+
+
+def _get_model_config(
+    config: Config,
+    agent_name: str,
+    *,
+    runtime_paths: RuntimePaths,
+    room_id: str | None = None,
+) -> tuple[str | None, ModelConfig | None]:
+    """Return configured model name/config for an agent when available."""
+    if agent_name not in config.agents and agent_name not in config.teams and agent_name != ROUTER_AGENT_NAME:
+        return None, None
+    model_name = config.resolve_runtime_model(
+        entity_name=agent_name,
+        room_id=room_id,
+        runtime_paths=runtime_paths,
+    ).model_name
+    return model_name, config.models.get(model_name)
+
+
+def _serialize_metrics(metrics: Metrics | dict[str, Any] | None) -> dict[str, Any] | None:
+    def _sanitize_metrics_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+        sanitized: dict[str, Any] = {}
+        for key, value in payload.items():
+            if isinstance(value, (str, int)) or value is None or isinstance(value, bool):
+                sanitized[key] = value
+            elif isinstance(value, float):
+                sanitized[key] = format(value, ".12g")
+        return sanitized or None
+
+    if metrics is None:
+        return None
+    if isinstance(metrics, Metrics):
+        metrics_dict = metrics.to_dict()
+        if not isinstance(metrics_dict, dict):
+            return None
+        return _sanitize_metrics_payload(metrics_dict)
+    if isinstance(metrics, dict):
+        return _sanitize_metrics_payload(metrics)
+    return None
+
+
+def build_model_request_metrics_fallback(
+    totals: dict[str, int],
+    first_token_latency: float | None,
+) -> dict[str, Any] | None:
+    """Build aggregate usage metadata from streamed request events."""
+    payload: dict[str, Any] = {key: value for key, value in totals.items() if value > 0}
+    if payload.get("total_tokens") is None:
+        input_tokens = payload.get("input_tokens")
+        output_tokens = payload.get("output_tokens")
+        if isinstance(input_tokens, int) and isinstance(output_tokens, int):
+            payload["total_tokens"] = input_tokens + output_tokens
+    if first_token_latency is not None:
+        payload["time_to_first_token"] = format(first_token_latency, ".12g")
+    return payload or None
+
+
+def _build_context_payload(
+    *,
+    context_input_tokens: int | None,
+    cache_read_tokens: int | None,
+    cache_write_tokens: int | None,
+    model_config: ModelConfig | None,
+) -> dict[str, Any] | None:
+    if context_input_tokens is None or model_config is None or model_config.context_window is None:
+        return None
+    context_window = model_config.context_window
+    if context_window <= 0:
+        return None
+    payload = {
+        "input_tokens": context_input_tokens,
+        "window_tokens": context_window,
+    }
+    if cache_read_tokens is not None and cache_read_tokens > 0:
+        payload["cache_read_input_tokens"] = cache_read_tokens
+    if cache_write_tokens is not None and cache_write_tokens > 0:
+        payload["cache_write_input_tokens"] = cache_write_tokens
+    if cache_read_tokens is not None or cache_write_tokens is not None:
+        # Cache writes were not read from cache, so they remain in the non-cache-read bucket.
+        uncached_input_tokens = context_input_tokens - (cache_read_tokens or 0)
+        if uncached_input_tokens >= 0:
+            payload["uncached_input_tokens"] = uncached_input_tokens
+    return payload
+
+
+def _provider_reports_cache_tokens_outside_input(
+    *,
+    provider: str | None,
+    configured_provider: str | None,
+    model_id: str | None,
+) -> bool:
+    """Return whether cache tokens must be added to input tokens for context occupancy."""
+    provider_key = (provider or configured_provider or "").lower()
+    configured_provider_key = (configured_provider or "").lower()
+    model_key = (model_id or "").lower()
+    if "anthropic" in provider_key or "bedrock" in provider_key:
+        return True
+    if configured_provider_key == "vertexai_claude":
+        return True
+    return "vertex" in provider_key and "claude" in model_key
+
+
+def _context_input_tokens_from_counts(
+    *,
+    input_tokens: int | None,
+    cache_read_tokens: int | None,
+    cache_write_tokens: int | None,
+    provider: str | None,
+    configured_provider: str | None,
+    model_id: str | None,
+) -> int | None:
+    """Return full request-context tokens from provider usage counters."""
+    if input_tokens is None:
+        return None
+    if not _provider_reports_cache_tokens_outside_input(
+        provider=provider,
+        configured_provider=configured_provider,
+        model_id=model_id,
+    ):
+        return input_tokens
+    return input_tokens + (cache_read_tokens or 0) + (cache_write_tokens or 0)
+
+
+def _int_usage_value(usage_payload: dict[str, Any] | None, key: str) -> int | None:
+    if usage_payload is None:
+        return None
+    value = usage_payload.get(key)
+    return value if isinstance(value, int) else None
+
+
+def build_ai_run_metadata_content(  # noqa: C901, PLR0912
+    *,
+    agent_name: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    run_id: str | None,
+    session_id: str | None,
+    status: RunStatus | str | None,
+    model: str | None,
+    model_provider: str | None,
+    room_id: str | None = None,
+    metrics: Metrics | dict[str, Any] | None = None,
+    metrics_fallback: dict[str, Any] | None = None,
+    context_raw_input_tokens: int | None = None,
+    context_input_tokens: int | None = None,
+    context_cache_read_tokens: int | None = None,
+    context_cache_write_tokens: int | None = None,
+    tool_count: int | None = None,
+) -> dict[str, Any] | None:
+    """Build the Matrix event content fragment for one AI run."""
+    model_name, model_config = _get_model_config(
+        config,
+        agent_name,
+        runtime_paths=runtime_paths,
+        room_id=room_id,
+    )
+    model_id = model or (model_config.id if model_config is not None else None)
+    provider = model_provider or (model_config.provider if model_config is not None else None)
+
+    usage_payload = _serialize_metrics(metrics)
+    if usage_payload is None and metrics_fallback:
+        usage_payload = dict(metrics_fallback)
+
+    usage_input_tokens = usage_payload.get("input_tokens") if usage_payload else None
+    if not isinstance(usage_input_tokens, int):
+        usage_input_tokens = None
+    explicit_context_scope = any(
+        value is not None
+        for value in (
+            context_raw_input_tokens,
+            context_input_tokens,
+            context_cache_read_tokens,
+            context_cache_write_tokens,
+        )
+    )
+    resolved_context_input_tokens = context_input_tokens
+    if resolved_context_input_tokens is None:
+        resolved_context_input_tokens = _context_input_tokens_from_counts(
+            input_tokens=context_raw_input_tokens if explicit_context_scope else usage_input_tokens,
+            cache_read_tokens=(
+                context_cache_read_tokens
+                if explicit_context_scope
+                else _int_usage_value(usage_payload, "cache_read_tokens")
+            ),
+            cache_write_tokens=(
+                context_cache_write_tokens
+                if explicit_context_scope
+                else _int_usage_value(usage_payload, "cache_write_tokens")
+            ),
+            provider=provider,
+            configured_provider=model_config.provider if model_config is not None else None,
+            model_id=model_id,
+        )
+    resolved_context_cache_read_tokens = context_cache_read_tokens
+    if resolved_context_cache_read_tokens is None and not explicit_context_scope:
+        resolved_context_cache_read_tokens = _int_usage_value(usage_payload, "cache_read_tokens")
+    resolved_context_cache_write_tokens = context_cache_write_tokens
+    if resolved_context_cache_write_tokens is None and not explicit_context_scope:
+        resolved_context_cache_write_tokens = _int_usage_value(usage_payload, "cache_write_tokens")
+
+    payload: dict[str, Any] = {"version": AI_RUN_METADATA_VERSION}
+    if run_id is not None:
+        payload["run_id"] = run_id
+    if session_id is not None:
+        payload["session_id"] = session_id
+    if status is not None:
+        raw_status = status.value if isinstance(status, RunStatus) else str(status)
+        payload["status"] = raw_status.lower()
+    if model_name is not None or model_id is not None or provider is not None:
+        model_payload: dict[str, Any] = {}
+        if model_name is not None:
+            model_payload["config"] = model_name
+        if model_id is not None:
+            model_payload["id"] = model_id
+        if provider is not None:
+            model_payload["provider"] = provider
+        if model_payload:
+            payload["model"] = model_payload
+    if usage_payload:
+        payload["usage"] = usage_payload
+    context_payload = _build_context_payload(
+        context_input_tokens=resolved_context_input_tokens,
+        cache_read_tokens=resolved_context_cache_read_tokens,
+        cache_write_tokens=resolved_context_cache_write_tokens,
+        model_config=model_config,
+    )
+    if context_payload:
+        payload["context"] = context_payload
+    if tool_count is not None:
+        payload["tools"] = {"count": tool_count}
+
+    if len(payload) == 1:
+        return None
+    return {AI_RUN_METADATA_KEY: payload}

--- a/tach.toml
+++ b/tach.toml
@@ -29,6 +29,7 @@ source_roots = ["src"]
 path = "mindroom.ai"
 depends_on = [
     "mindroom.agents",
+    "mindroom.ai_run_metadata",
     "mindroom.ai_runtime",
     "mindroom.cancellation",
     "mindroom.constants",
@@ -46,6 +47,12 @@ depends_on = [
     "mindroom.memory",
     "mindroom.timing",
     "mindroom.tool_system.events",
+]
+
+[[modules]]
+path = "mindroom.ai_run_metadata"
+depends_on = [
+    "mindroom.constants",
 ]
 
 [[modules]]

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -37,12 +37,12 @@ from agno.session.team import TeamSession
 from mindroom.ai import (
     _prepare_agent_and_prompt,
     _PreparedAgentRun,
-    _serialize_metrics,
     ai_response,
     build_matrix_run_metadata,
     should_retry_without_inline_media,
     stream_agent_response,
 )
+from mindroom.ai_run_metadata import _serialize_metrics
 from mindroom.bot import AgentBot
 from mindroom.cancellation import USER_STOP_CANCEL_MSG
 from mindroom.config.agent import AgentConfig, TeamConfig

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -6088,6 +6088,66 @@ class TestUserIdPassthrough:
         assert payload["context"]["window_tokens"] == 1000
 
     @pytest.mark.asyncio
+    async def test_stream_agent_response_does_not_backfill_latest_context_cache_from_usage(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Missing latest-request cache counters should stay unknown, not use cumulative totals."""
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "OpenAIChat"
+        mock_agent.model.id = "test-model"
+        mock_agent.name = "GeneralAgent"
+        mock_agent.add_history_to_context = False
+
+        async def fake_arun_stream(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+            yield RunContentEvent(content="step one")
+            yield ModelRequestCompletedEvent(
+                model="test-model",
+                model_provider="openai",
+                input_tokens=700,
+                output_tokens=50,
+                total_tokens=750,
+                cache_read_tokens=512,
+            )
+            yield RunContentEvent(content="step two")
+            yield ModelRequestCompletedEvent(
+                model="test-model",
+                model_provider="openai",
+                input_tokens=120,
+                output_tokens=20,
+                total_tokens=140,
+            )
+
+        mock_agent.arun = MagicMock(return_value=fake_arun_stream())
+
+        config = Config(
+            agents={"general": AgentConfig(display_name="General")},
+            models={"default": ModelConfig(provider="openai", id="test-model", context_window=1000)},
+        )
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            run_metadata: dict[str, object] = {}
+            async for _chunk in stream_agent_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=config,
+                run_metadata_collector=run_metadata,
+            ):
+                pass
+
+        payload = run_metadata["io.mindroom.ai_run"]
+        assert payload["usage"]["cache_read_tokens"] == 512
+        assert payload["context"]["input_tokens"] == 120
+        assert "cache_read_input_tokens" not in payload["context"]
+        assert "cache_write_input_tokens" not in payload["context"]
+        assert "uncached_input_tokens" not in payload["context"]
+        assert payload["context"]["window_tokens"] == 1000
+
+    @pytest.mark.asyncio
     async def test_stream_agent_response_context_counts_latest_anthropic_cache_tokens(self, tmp_path: Path) -> None:
         """Streaming context metadata should include cache tokens for the latest Claude request."""
         mock_agent = MagicMock()
@@ -6148,4 +6208,63 @@ class TestUserIdPassthrough:
         assert payload["context"]["cache_write_input_tokens"] == 10
         assert payload["context"]["uncached_input_tokens"] == 130
         assert "cached_input_tokens" not in payload["context"]
+        assert payload["context"]["window_tokens"] == 200_000
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_context_counts_vertex_claude_cache_tokens(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Streaming context should use configured provider when event provider is ambiguous."""
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "Claude"
+        mock_agent.model.id = "claude-sonnet-4-6"
+        mock_agent.name = "GeneralAgent"
+        mock_agent.add_history_to_context = False
+
+        async def fake_arun_stream(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+            yield RunContentEvent(content="step one")
+            yield ModelRequestCompletedEvent(
+                model="claude-sonnet-4-6",
+                model_provider="google",
+                input_tokens=120,
+                output_tokens=20,
+                total_tokens=140,
+                cache_read_tokens=9000,
+                cache_write_tokens=10,
+            )
+
+        mock_agent.arun = MagicMock(return_value=fake_arun_stream())
+
+        config = Config(
+            agents={"general": AgentConfig(display_name="General")},
+            models={
+                "default": ModelConfig(
+                    provider="vertexai_claude",
+                    id="claude-sonnet-4-6",
+                    context_window=200_000,
+                ),
+            },
+        )
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            run_metadata: dict[str, object] = {}
+            async for _chunk in stream_agent_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=config,
+                run_metadata_collector=run_metadata,
+            ):
+                pass
+
+        payload = run_metadata["io.mindroom.ai_run"]
+        assert payload["model"]["provider"] == "google"
+        assert payload["context"]["input_tokens"] == 9130
+        assert payload["context"]["cache_read_input_tokens"] == 9000
+        assert payload["context"]["cache_write_input_tokens"] == 10
+        assert payload["context"]["uncached_input_tokens"] == 130
         assert payload["context"]["window_tokens"] == 200_000

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -5285,6 +5285,61 @@ class TestUserIdPassthrough:
         assert "utilization_pct" not in payload["context"]
         assert payload["tools"]["count"] == 0
 
+    @pytest.mark.asyncio
+    async def test_ai_response_context_counts_anthropic_cache_tokens(self, tmp_path: Path) -> None:
+        """Claude-family cache tokens should count toward context occupancy."""
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "Claude"
+        mock_agent.model.id = "claude-sonnet-4-6"
+        mock_agent.name = "GeneralAgent"
+        mock_agent.add_history_to_context = False
+
+        mock_run_output = MagicMock()
+        mock_run_output.content = "Response"
+        mock_run_output.tools = []
+        mock_run_output.run_id = "run-1"
+        mock_run_output.session_id = "session1"
+        mock_run_output.status = RunStatus.completed
+        mock_run_output.model = "claude-sonnet-4-6"
+        mock_run_output.model_provider = "Anthropic"
+        mock_run_output.metrics = Metrics(
+            input_tokens=3000,
+            output_tokens=120,
+            total_tokens=3120,
+            cache_read_tokens=20_000,
+            cache_write_tokens=500,
+        )
+        mock_agent.arun = AsyncMock(return_value=mock_run_output)
+
+        config = Config(
+            agents={"general": AgentConfig(display_name="General")},
+            models={"default": ModelConfig(provider="anthropic", id="claude-sonnet-4-6", context_window=200_000)},
+        )
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            run_metadata: dict[str, object] = {}
+            await ai_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=config,
+                run_metadata_collector=run_metadata,
+            )
+
+        payload = run_metadata["io.mindroom.ai_run"]
+        assert payload["usage"]["input_tokens"] == 3000
+        assert payload["usage"]["cache_read_tokens"] == 20_000
+        assert payload["usage"]["cache_write_tokens"] == 500
+        assert payload["context"]["input_tokens"] == 23_500
+        assert payload["context"]["cache_read_input_tokens"] == 20_000
+        assert payload["context"]["cache_write_input_tokens"] == 500
+        assert payload["context"]["uncached_input_tokens"] == 3500
+        assert "cached_input_tokens" not in payload["context"]
+        assert payload["context"]["window_tokens"] == 200_000
+
     def test_build_matrix_run_metadata_merges_coalesced_source_event_ids(self) -> None:
         """Run metadata should mark every source event in a coalesced batch as seen."""
         metadata = build_matrix_run_metadata(
@@ -6027,4 +6082,70 @@ class TestUserIdPassthrough:
         assert payload["usage"]["cache_read_tokens"] == 576
         assert payload["usage"]["reasoning_tokens"] == 48
         assert payload["context"]["input_tokens"] == 120
+        assert payload["context"]["cache_read_input_tokens"] == 64
+        assert payload["context"]["uncached_input_tokens"] == 56
+        assert "cached_input_tokens" not in payload["context"]
         assert payload["context"]["window_tokens"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_context_counts_latest_anthropic_cache_tokens(self, tmp_path: Path) -> None:
+        """Streaming context metadata should include cache tokens for the latest Claude request."""
+        mock_agent = MagicMock()
+        mock_agent.model = MagicMock()
+        mock_agent.model.__class__.__name__ = "Claude"
+        mock_agent.model.id = "claude-sonnet-4-6"
+        mock_agent.name = "GeneralAgent"
+        mock_agent.add_history_to_context = False
+
+        async def fake_arun_stream(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+            yield RunContentEvent(content="step one")
+            yield ModelRequestCompletedEvent(
+                model="claude-sonnet-4-6",
+                model_provider="Anthropic",
+                input_tokens=3000,
+                output_tokens=50,
+                total_tokens=3050,
+                cache_read_tokens=20_000,
+                cache_write_tokens=500,
+            )
+            yield RunContentEvent(content="step two")
+            yield ModelRequestCompletedEvent(
+                model="claude-sonnet-4-6",
+                model_provider="Anthropic",
+                input_tokens=120,
+                output_tokens=20,
+                total_tokens=140,
+                cache_read_tokens=9000,
+                cache_write_tokens=10,
+            )
+
+        mock_agent.arun = MagicMock(return_value=fake_arun_stream())
+
+        config = Config(
+            agents={"general": AgentConfig(display_name="General")},
+            models={"default": ModelConfig(provider="anthropic", id="claude-sonnet-4-6", context_window=200_000)},
+        )
+
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.return_value = _prepared_prompt_result(mock_agent)
+            run_metadata: dict[str, object] = {}
+            async for _chunk in stream_agent_response(
+                agent_name="general",
+                prompt="test",
+                session_id="session1",
+                runtime_paths=_runtime_paths(tmp_path),
+                config=config,
+                run_metadata_collector=run_metadata,
+            ):
+                pass
+
+        payload = run_metadata["io.mindroom.ai_run"]
+        assert payload["usage"]["input_tokens"] == 3120
+        assert payload["usage"]["cache_read_tokens"] == 29_000
+        assert payload["usage"]["cache_write_tokens"] == 510
+        assert payload["context"]["input_tokens"] == 9130
+        assert payload["context"]["cache_read_input_tokens"] == 9000
+        assert payload["context"]["cache_write_input_tokens"] == 10
+        assert payload["context"]["uncached_input_tokens"] == 130
+        assert "cached_input_tokens" not in payload["context"]
+        assert payload["context"]["window_tokens"] == 200_000


### PR DESCRIPTION
## Summary
- Count provider-reported cache read/write tokens into `context.input_tokens` for Claude-family providers where cached prompt tokens are outside `input_tokens`.
- Add explicit `context.cache_read_input_tokens`, `context.cache_write_input_tokens`, and `context.uncached_input_tokens` fields to avoid ambiguous cached-token reporting.
- Keep streaming context metadata tied to the latest model request while preserving cumulative run usage totals.

## Test Plan
- `uv run pre-commit run --all-files`
- `uv run pytest -n auto --no-cov`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralizes AI run-metadata building and surfaces cache-aware context inputs; tracks per-request cache read/write token counts for more accurate context accounting in streaming and non-streaming responses.
* **Tests**
  * Adds tests covering cache read/write token reporting, ensuring latest-request counters are used and provider-specific behaviors are validated.
* **Documentation**
  * Fixes a Markdown code-fence in the tool-approval docs.
* **Chores**
  * Registers the new metadata helper module in runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->