### PR TITLE
Expire pending approvals before MCP shutdown

### DIFF
--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1649,6 +1649,7 @@ class MultiAgentOrchestrator:
         self.running = False
         if self._runtime_shutdown_event is not None:
             self._runtime_shutdown_event.set()
+        await shutdown_approval_runtime()
         await self._cancel_config_reload_task()
         await self._stop_memory_auto_flush_worker()
         await self._knowledge_source_watcher.shutdown()
@@ -1659,8 +1660,6 @@ class MultiAgentOrchestrator:
         # Cancel sync tasks first so shutdown does not race with active sync loops.
         for entity_name in list(self._sync_tasks.keys()):
             await cancel_sync_task(entity_name, self._sync_tasks)
-
-        await shutdown_approval_runtime()
 
         for bot in self.agent_bots.values():
             bot.running = False

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -12656,6 +12656,43 @@ class TestMultiAgentOrchestrator:
             await shutdown_approval_store()
 
     @pytest.mark.asyncio
+    async def test_orchestrator_stop_shuts_down_approvals_before_mcp_manager(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Pending approvals should expire even if MCP shutdown fails."""
+        orchestrator = MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        calls: list[str] = []
+
+        async def _shutdown_approvals() -> None:
+            calls.append("approvals")
+
+        async def _stop_mcp_manager() -> None:
+            calls.append("mcp")
+            msg = "mcp shutdown failed"
+            raise RuntimeError(msg)
+
+        orchestrator._knowledge_refresh_scheduler = MagicMock()
+        orchestrator._knowledge_refresh_scheduler.shutdown = AsyncMock()
+
+        with (
+            patch(
+                "mindroom.orchestrator.shutdown_approval_runtime",
+                new=AsyncMock(side_effect=_shutdown_approvals),
+            ) as mock_shutdown_approvals,
+            patch.object(orchestrator, "_cancel_config_reload_task", new=AsyncMock()),
+            patch.object(orchestrator, "_stop_memory_auto_flush_worker", new=AsyncMock()),
+            patch.object(orchestrator._knowledge_source_watcher, "shutdown", new=AsyncMock()),
+            patch.object(orchestrator, "_cancel_bot_start_tasks", new=AsyncMock()),
+            patch.object(orchestrator, "_stop_mcp_manager", new=AsyncMock(side_effect=_stop_mcp_manager)),
+            pytest.raises(RuntimeError, match="mcp shutdown failed"),
+        ):
+            await orchestrator.stop()
+
+        assert calls == ["approvals", "mcp"]
+        mock_shutdown_approvals.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_run_auxiliary_task_forever_restarts_after_failure(self) -> None:
         """Auxiliary supervisors should restart tasks that crash."""
         started = asyncio.Event()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orchestrator shutdown sequence to ensure approvals are properly shut down before additional shutdown steps.

* **Tests**
  * Added test to verify correct shutdown ordering during orchestrator termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->