### PR TITLE
Fail scheduler tool calls on rejected schedules

### DIFF
--- a/src/mindroom/custom_tools/scheduler.py
+++ b/src/mindroom/custom_tools/scheduler.py
@@ -10,6 +10,14 @@ from mindroom.tool_system.runtime_context import (
     get_tool_runtime_context,
 )
 
+_TOOL_ERROR_PREFIX = "❌"
+_LIST_SCHEDULES_ERROR = "Unable to retrieve scheduled tasks."
+
+
+def _raise_for_scheduler_error(response_text: str) -> None:
+    if response_text.startswith(_TOOL_ERROR_PREFIX) or response_text == _LIST_SCHEDULES_ERROR:
+        raise RuntimeError(response_text)
+
 
 class SchedulerTools(Toolkit):
     """Tools for scheduling tasks in the current Matrix room/thread."""
@@ -42,7 +50,7 @@ class SchedulerTools(Toolkit):
             return "❌ Scheduler tool is unavailable in this context."
 
         runtime = build_scheduling_runtime_from_tool_runtime_context(context)
-        _, response_text = await schedule_task(
+        task_id, response_text = await schedule_task(
             runtime=runtime,
             room_id=context.room_id,
             thread_id=context.resolved_thread_id,
@@ -50,6 +58,8 @@ class SchedulerTools(Toolkit):
             full_text=request,
             new_thread=new_thread,
         )
+        if task_id is None:
+            raise RuntimeError(response_text)
         return response_text
 
     async def edit_schedule(self, task_id: str, request: str) -> str:
@@ -68,7 +78,7 @@ class SchedulerTools(Toolkit):
             return "❌ Scheduler tool is unavailable in this context."
 
         runtime = build_scheduling_runtime_from_tool_runtime_context(context)
-        return await edit_scheduled_task(
+        response_text = await edit_scheduled_task(
             runtime=runtime,
             room_id=context.room_id,
             task_id=task_id,
@@ -76,6 +86,8 @@ class SchedulerTools(Toolkit):
             scheduled_by=context.requester_id,
             thread_id=context.resolved_thread_id,
         )
+        _raise_for_scheduler_error(response_text)
+        return response_text
 
     async def list_schedules(self) -> str:
         """List all pending scheduled tasks in the current room/thread.
@@ -88,12 +100,14 @@ class SchedulerTools(Toolkit):
         if context is None:
             return "❌ Scheduler tool is unavailable in this context."
 
-        return await list_scheduled_tasks(
+        response_text = await list_scheduled_tasks(
             client=context.client,
             room_id=context.room_id,
             thread_id=context.resolved_thread_id,
             config=context.config,
         )
+        _raise_for_scheduler_error(response_text)
+        return response_text
 
     async def cancel_schedule(self, task_id: str) -> str:
         """Cancel a scheduled task.
@@ -109,8 +123,10 @@ class SchedulerTools(Toolkit):
         if context is None:
             return "❌ Scheduler tool is unavailable in this context."
 
-        return await cancel_scheduled_task(
+        response_text = await cancel_scheduled_task(
             client=context.client,
             room_id=context.room_id,
             task_id=task_id,
         )
+        _raise_for_scheduler_error(response_text)
+        return response_text

--- a/tests/test_scheduler_tool.py
+++ b/tests/test_scheduler_tool.py
@@ -118,6 +118,24 @@ async def test_scheduler_tool_uses_shared_backend() -> None:
 
 
 @pytest.mark.asyncio
+async def test_scheduler_tool_raises_when_backend_rejects_request() -> None:
+    """Invalid schedule requests should fail the tool call instead of returning error text."""
+    tools = SchedulerTools()
+    config = _bind_runtime_paths(Config(agents={"general": AgentConfig(display_name="General Agent")}))
+    context = _make_context(config)
+
+    with (
+        patch(
+            "mindroom.custom_tools.scheduler.schedule_task",
+            new=AsyncMock(return_value=(None, "❌ Failed to schedule: schedule is not valid")),
+        ),
+        tool_runtime_context(context),
+        pytest.raises(RuntimeError, match="schedule is not valid"),
+    ):
+        await tools.schedule("next message")
+
+
+@pytest.mark.asyncio
 async def test_edit_schedule_tool_requires_context() -> None:
     """Edit tool should fail clearly when called outside Matrix response context."""
     tools = SchedulerTools()

--- a/tests/test_scheduler_tool.py
+++ b/tests/test_scheduler_tool.py
@@ -178,6 +178,24 @@ async def test_edit_schedule_tool_calls_backend() -> None:
 
 
 @pytest.mark.asyncio
+async def test_edit_schedule_tool_raises_when_backend_rejects_request() -> None:
+    """Edit failures should fail the tool call instead of returning error text."""
+    tools = SchedulerTools()
+    config = _bind_runtime_paths(Config(agents={"general": AgentConfig(display_name="General Agent")}))
+    context = _make_context(config)
+
+    with (
+        patch(
+            "mindroom.custom_tools.scheduler.edit_scheduled_task",
+            new=AsyncMock(return_value="❌ Failed to edit task `task123`."),
+        ),
+        tool_runtime_context(context),
+        pytest.raises(RuntimeError, match="Failed to edit task"),
+    ):
+        await tools.edit_schedule("task123", "tomorrow at 9am check deployment")
+
+
+@pytest.mark.asyncio
 async def test_list_schedules_tool_requires_context() -> None:
     """List tool should fail clearly when called outside Matrix response context."""
     tools = SchedulerTools()
@@ -211,6 +229,24 @@ async def test_list_schedules_tool_calls_backend() -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_schedules_tool_raises_when_backend_rejects_request() -> None:
+    """List failures should fail the tool call instead of returning error text."""
+    tools = SchedulerTools()
+    config = _bind_runtime_paths(Config(agents={"general": AgentConfig(display_name="General Agent")}))
+    context = _make_context(config)
+
+    with (
+        patch(
+            "mindroom.custom_tools.scheduler.list_scheduled_tasks",
+            new=AsyncMock(return_value="Unable to retrieve scheduled tasks."),
+        ),
+        tool_runtime_context(context),
+        pytest.raises(RuntimeError, match="Unable to retrieve scheduled tasks"),
+    ):
+        await tools.list_schedules()
+
+
+@pytest.mark.asyncio
 async def test_cancel_schedule_tool_requires_context() -> None:
     """Cancel tool should fail clearly when called outside Matrix response context."""
     tools = SchedulerTools()
@@ -240,3 +276,21 @@ async def test_cancel_schedule_tool_calls_backend() -> None:
         room_id=context.room_id,
         task_id="task123",
     )
+
+
+@pytest.mark.asyncio
+async def test_cancel_schedule_tool_raises_when_backend_rejects_request() -> None:
+    """Cancel failures should fail the tool call instead of returning error text."""
+    tools = SchedulerTools()
+    config = _bind_runtime_paths(Config(agents={"general": AgentConfig(display_name="General Agent")}))
+    context = _make_context(config)
+
+    with (
+        patch(
+            "mindroom.custom_tools.scheduler.cancel_scheduled_task",
+            new=AsyncMock(return_value="❌ Task `task123` not found."),
+        ),
+        tool_runtime_context(context),
+        pytest.raises(RuntimeError, match="not found"),
+    ):
+        await tools.cancel_schedule("task123")


### PR DESCRIPTION
## Summary
- Raise scheduler tool failures when the shared backend rejects a schedule request instead of returning error text as a successful tool result.
- Apply the same agent-facing failure handling to edit/list/cancel scheduler tool error responses.
- Add a regression test for rejected schedule requests.

## Test Plan
- [x] uv run pytest tests/test_scheduler_tool.py tests/test_workflow_scheduling.py tests/test_scheduling.py -q
- [x] uv run pytest -q
- [x] uv run pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduler now consistently raises errors when backend operations fail, instead of returning raw error text.

* **New Features**
  * Centralized scheduler error handling to surface backend failures as exceptions.

* **Tests**
  * Added tests covering scheduler error-handling for scheduling, editing, listing, and cancelling operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->