### PR TITLE
Preserve model prompts in persisted history for cache reuse

### DIFF
--- a/src/mindroom/history/__init__.py
+++ b/src/mindroom/history/__init__.py
@@ -7,7 +7,11 @@ from mindroom.history.compaction import (
     team_tool_definition_payloads_for_logging,
 )
 from mindroom.history.manual import request_compaction_before_next_reply
-from mindroom.history.policy import context_budget_after_reserve
+from mindroom.history.policy import (
+    context_budget_after_reserve,
+    manual_compaction_unavailable_message,
+    resolve_history_execution_plan,
+)
 from mindroom.history.runtime import (
     PreparedScopeHistory,
     ScopeSessionContext,
@@ -21,15 +25,18 @@ from mindroom.history.runtime import (
     note_prepared_history_timing,
     open_bound_scope_session_context,
     open_resolved_scope_session_context,
+    open_scope_session_context,
     prepare_bound_scope_history,
     prepare_history_for_run,
     prepare_scope_history,
     resolve_bound_team_scope_context,
 )
 from mindroom.history.storage import (
+    add_pending_force_compaction_scope,
     read_scope_seen_event_ids,
-    strip_transient_enrichment_from_session,
+    read_scope_state,
     update_scope_seen_event_ids,
+    write_scope_state,
 )
 from mindroom.history.types import (
     CompactionDecision,
@@ -40,8 +47,12 @@ from mindroom.history.types import (
     CompactionLifecycleSuccess,
     CompactionOutcome,
     CompactionReplyOutcome,
+    HistoryPolicy,
     HistoryScope,
+    HistoryScopeState,
     PreparedHistoryState,
+    ResolvedHistoryExecutionPlan,
+    ResolvedHistorySettings,
     ResolvedReplayPlan,
 )
 
@@ -54,11 +65,16 @@ __all__ = [
     "CompactionLifecycleSuccess",
     "CompactionOutcome",
     "CompactionReplyOutcome",
+    "HistoryPolicy",
     "HistoryScope",
+    "HistoryScopeState",
     "PreparedHistoryState",
     "PreparedScopeHistory",
+    "ResolvedHistoryExecutionPlan",
+    "ResolvedHistorySettings",
     "ResolvedReplayPlan",
     "ScopeSessionContext",
+    "add_pending_force_compaction_scope",
     "agent_tool_definition_payloads_for_logging",
     "apply_replay_plan",
     "close_agent_runtime_state_dbs",
@@ -69,17 +85,21 @@ __all__ = [
     "estimate_preparation_static_tokens",
     "estimate_preparation_static_tokens_for_team",
     "finalize_history_preparation",
+    "manual_compaction_unavailable_message",
     "normalize_compaction_budget_tokens",
     "note_prepared_history_timing",
     "open_bound_scope_session_context",
     "open_resolved_scope_session_context",
+    "open_scope_session_context",
     "prepare_bound_scope_history",
     "prepare_history_for_run",
     "prepare_scope_history",
     "read_scope_seen_event_ids",
+    "read_scope_state",
     "request_compaction_before_next_reply",
     "resolve_bound_team_scope_context",
-    "strip_transient_enrichment_from_session",
+    "resolve_history_execution_plan",
     "team_tool_definition_payloads_for_logging",
     "update_scope_seen_event_ids",
+    "write_scope_state",
 ]

--- a/src/mindroom/history/storage.py
+++ b/src/mindroom/history/storage.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from agno.run.agent import RunOutput
 from agno.run.team import TeamRunOutput
-from agno.session.agent import AgentSession
-from agno.session.team import TeamSession
 
 from mindroom.constants import (
     MATRIX_RESPONSE_EVENT_ID_METADATA_KEY,
@@ -21,7 +19,8 @@ from mindroom.history.types import HistoryScope, HistoryScopeState
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from agno.db.base import BaseDb, SessionType
+    from agno.session.agent import AgentSession
+    from agno.session.team import TeamSession
 
 _COMPACTION_METADATA_VERSION = 2
 _MATRIX_HISTORY_METADATA_VERSION = 1
@@ -153,110 +152,6 @@ def consume_pending_force_compaction_scope(
 
     session.session_data = next_session_data or None
     return True
-
-
-def strip_transient_enrichment_from_session(
-    storage: BaseDb,
-    *,
-    session_id: str,
-    session_type: SessionType,
-    response_run_id: str | None = None,
-    memory_prompt: str,
-    transient_system_context: str | None = None,
-) -> bool:
-    """Restore the persisted current user turn after transient model context was used."""
-    session = storage.get_session(session_id, session_type)
-    if not isinstance(session, AgentSession | TeamSession) or not session.runs:
-        return False
-
-    runs = list(reversed(session.runs))
-    has_run_ids = any(isinstance(run, RunOutput | TeamRunOutput) and run.run_id for run in runs)
-    for run in runs:
-        if not isinstance(run, RunOutput | TeamRunOutput):
-            continue
-        if not run.messages and not (isinstance(run, TeamRunOutput) and run.member_responses):
-            continue
-        if response_run_id is not None and has_run_ids and run.run_id != response_run_id:
-            continue
-        changed = _strip_transient_system_context_from_run(run, transient_system_context)
-        for message in reversed(run.messages or []):
-            if message.role != "user":
-                continue
-            if message.content != memory_prompt:
-                message.content = memory_prompt
-                changed = True
-            break
-        if changed:
-            storage.upsert_session(session)
-        return changed
-    return False
-
-
-def _strip_transient_system_context_from_run(
-    run: RunOutput | TeamRunOutput,
-    transient_system_context: str | None,
-) -> bool:
-    if not transient_system_context:
-        return False
-
-    changed = _strip_transient_system_context_from_messages(run.messages, transient_system_context)
-    if isinstance(run, TeamRunOutput):
-        for member_response in run.member_responses or []:
-            if isinstance(member_response, RunOutput | TeamRunOutput):
-                changed = (
-                    _strip_transient_system_context_from_run(
-                        member_response,
-                        transient_system_context,
-                    )
-                    or changed
-                )
-    return changed
-
-
-def _strip_transient_system_context_from_messages(
-    messages: list[Any] | None,
-    transient_system_context: str,
-) -> bool:
-    if not messages:
-        return False
-
-    changed = False
-    next_messages: list[Any] = []
-    for message in messages:
-        if message.role != "system" or not isinstance(message.content, str):
-            next_messages.append(message)
-            continue
-        stripped_content = _remove_transient_system_context(message.content, transient_system_context)
-        if stripped_content == message.content:
-            next_messages.append(message)
-            continue
-        changed = True
-        if stripped_content:
-            message.content = stripped_content
-            next_messages.append(message)
-    if changed:
-        messages[:] = next_messages
-    return changed
-
-
-def _remove_transient_system_context(content: str, transient_system_context: str) -> str:
-    stripped_block = transient_system_context.strip()
-    if not stripped_block:
-        return content
-
-    stripped_content = content.strip()
-    if stripped_content == stripped_block:
-        return ""
-
-    replacements = (
-        f"\n\n{stripped_block}",
-        f"{stripped_block}\n\n",
-        stripped_block,
-    )
-    next_content = content
-    for replacement in replacements:
-        next_content = next_content.replace(replacement, "")
-    return next_content.strip()
 
 
 def read_scope_seen_event_ids(session: AgentSession | TeamSession, scope: HistoryScope) -> set[str]:

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -32,18 +32,17 @@ if TYPE_CHECKING:
 class ResponseOutcome:
     """Terminal response facts needed for post-delivery side effects."""
 
-    strip_transient_enrichment_after_run: bool = False
     response_run_id: str | None = None
     session_id: str | None = None
     session_type: SessionType | None = None
     execution_identity: ToolExecutionIdentity | None = None
+    run_succeeded: bool = True
     interactive_target: MessageTarget | None = None
     thread_summary_room_id: str | None = None
     thread_summary_thread_id: str | None = None
     thread_summary_message_count_hint: int | None = None
     memory_prompt: str | None = None
     memory_thread_history: Sequence[ResolvedVisibleMessage] | None = None
-    transient_system_context: str | None = None
 
 
 @dataclass(frozen=True)
@@ -60,7 +59,6 @@ class PostResponseEffectsDeps:
     ) = None
     queue_memory_persistence: Callable[[], None] | None = None
     persist_response_event_id: Callable[[str, str], None] | None = None
-    strip_transient_enrichment: Callable[[ResponseOutcome], None] | None = None
     should_queue_thread_summary: Callable[[str, str, int | None], bool] | None = None
     queue_thread_summary: Callable[[str, str, int | None], None] | None = None
 
@@ -162,7 +160,6 @@ class PostResponseEffectsSupport:
         interactive_agent_name: str,
         queue_memory_persistence: Callable[[], None] | None = None,
         persist_response_event_id: Callable[[str, str], None] | None = None,
-        strip_transient_enrichment: Callable[[ResponseOutcome], None] | None = None,
     ) -> PostResponseEffectsDeps:
         """Build the per-response post-effect dependency surface."""
 
@@ -184,7 +181,6 @@ class PostResponseEffectsSupport:
             register_interactive=register_interactive,
             queue_memory_persistence=queue_memory_persistence,
             persist_response_event_id=persist_response_event_id,
-            strip_transient_enrichment=strip_transient_enrichment,
             should_queue_thread_summary=self.should_queue_thread_summary,
             queue_thread_summary=self.queue_thread_summary,
         )
@@ -243,17 +239,6 @@ async def apply_post_response_effects(
                 session_id=outcome.session_id,
                 run_id=outcome.response_run_id,
                 response_event_id=response_event_id,
-            )
-
-    if outcome.strip_transient_enrichment_after_run and deps.strip_transient_enrichment is not None:
-        try:
-            deps.strip_transient_enrichment(outcome)
-        except Exception:
-            deps.logger.exception(
-                "Failed to strip transient enrichment from session history",
-                session_id=outcome.session_id,
-                session_type=outcome.session_type.value if outcome.session_type is not None else None,
-                run_id=outcome.response_run_id,
             )
 
     if deps.queue_memory_persistence is not None:

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -241,7 +241,7 @@ async def apply_post_response_effects(
                 response_event_id=response_event_id,
             )
 
-    if deps.queue_memory_persistence is not None:
+    if outcome.run_succeeded and deps.queue_memory_persistence is not None:
         try:
             deps.queue_memory_persistence()
         except Exception:

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -2297,7 +2297,7 @@ class ResponseRunner:
             session_id=session_id,
             session_type=self.deps.state_writer.session_type_for_scope(self.deps.state_writer.history_scope()),
             execution_identity=execution_identity,
-            run_succeeded=run_successes[-1] if run_successes else False,
+            run_succeeded=run_successes[-1] if run_successes else final_delivery_outcome.terminal_status == "completed",
             interactive_target=resolved_target,
             thread_summary_room_id=(request.room_id if resolved_target.resolved_thread_id is not None else None),
             thread_summary_thread_id=resolved_target.resolved_thread_id,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -20,10 +20,9 @@ from mindroom.background_tasks import create_background_task
 from mindroom.constants import ATTACHMENT_IDS_KEY, ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
-from mindroom.history import HistoryScope, strip_transient_enrichment_from_session
 from mindroom.history.interrupted_replay import persist_interrupted_replay_snapshot
 from mindroom.history.turn_recorder import TurnRecorder
-from mindroom.hooks import EnrichmentItem, MessageEnvelope, render_system_enrichment_block
+from mindroom.hooks import EnrichmentItem, MessageEnvelope
 from mindroom.matrix.client_visible_messages import replace_visible_message
 from mindroom.matrix.presence import should_use_streaming
 from mindroom.matrix.typing import typing_indicator
@@ -89,7 +88,7 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.conversation_resolver import ConversationResolver
     from mindroom.conversation_state_writer import ConversationStateWriter
-    from mindroom.history import CompactionOutcome
+    from mindroom.history import CompactionOutcome, HistoryScope
     from mindroom.knowledge import KnowledgeAccessSupport
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.identity import MatrixID
@@ -278,26 +277,6 @@ def prepare_memory_and_model_context(
         runtime_paths=runtime_paths,
     )
     return prompt, thread_history, model_prompt_text, model_thread_history
-
-
-def _should_strip_transient_enrichment(request: ResponseRequest) -> bool:
-    """Return whether per-turn model context should be scrubbed after delivery."""
-    return bool(request.system_enrichment_items) or (
-        request.model_prompt is not None
-        and _model_prompt_has_transient_tail(
-            memory_prompt=request.prompt,
-            model_prompt=request.model_prompt,
-        )
-    )
-
-
-def _model_prompt_has_transient_tail(*, memory_prompt: str, model_prompt: str | None) -> bool:
-    """Return whether the actual model prompt adds per-turn context beyond raw user text."""
-    if model_prompt is None:
-        return False
-    normalized_memory_prompt = memory_prompt.strip()
-    normalized_model_prompt = strip_user_turn_time_prefix(model_prompt.strip()).strip()
-    return normalized_model_prompt != normalized_memory_prompt
 
 
 @dataclass(frozen=True)
@@ -498,28 +477,6 @@ class ResponseRunner:
             is_team=is_team,
             response_event_id=response_event_id,
         )
-
-    def _strip_transient_enrichment_from_session(
-        self,
-        outcome: ResponseOutcome,
-        *,
-        session_scope: HistoryScope,
-        execution_identity: ToolExecutionIdentity | None,
-    ) -> None:
-        if outcome.session_id is None or outcome.session_type is None or outcome.memory_prompt is None:
-            return
-        storage = self.deps.state_writer.create_storage(execution_identity, scope=session_scope)
-        try:
-            strip_transient_enrichment_from_session(
-                storage,
-                session_id=outcome.session_id,
-                session_type=outcome.session_type,
-                response_run_id=outcome.response_run_id,
-                memory_prompt=outcome.memory_prompt,
-                transient_system_context=outcome.transient_system_context,
-            )
-        finally:
-            storage.close()
 
     def _record_stream_delivery_error(
         self,
@@ -1011,7 +968,6 @@ class ResponseRunner:
         delivery_cancelled = False
         matrix_run_metadata = _materialize_matrix_run_metadata(request.matrix_run_metadata)
         active_event_ids = self._active_response_event_ids(request.room_id)
-        transient_system_contexts: list[str] = []
         team_turn_recorder = self._build_turn_recorder(
             user_message=request.prompt,
             reply_to_event_id=request.reply_to_event_id,
@@ -1079,7 +1035,6 @@ class ResponseRunner:
                             if self.deps.agent_name in self.deps.runtime.config.teams
                             else None,
                             system_enrichment_items=request.system_enrichment_items,
-                            transient_system_context_collector=transient_system_contexts,
                             reason_prefix=team_request.reason_prefix,
                             matrix_run_metadata=matrix_run_metadata,
                             pipeline_timing=request.pipeline_timing,
@@ -1176,7 +1131,6 @@ class ResponseRunner:
                                     if self.deps.agent_name in self.deps.runtime.config.teams
                                     else None,
                                     system_enrichment_items=request.system_enrichment_items,
-                                    transient_system_context_collector=transient_system_contexts,
                                     reason_prefix=team_request.reason_prefix,
                                     matrix_run_metadata=matrix_run_metadata,
                                     pipeline_timing=request.pipeline_timing,
@@ -1375,17 +1329,9 @@ class ResponseRunner:
                 ),
             )
         assert final_delivery_outcome is not None
-        transient_system_context = (
-            transient_system_contexts[-1]
-            if transient_system_contexts
-            else render_system_enrichment_block(request.system_enrichment_items)
-        )
         final_outcome = await lifecycle.finalize(
             final_delivery_outcome,
             build_post_response_outcome=lambda _final_outcome: ResponseOutcome(
-                strip_transient_enrichment_after_run=_should_strip_transient_enrichment(request)
-                or _model_prompt_has_transient_tail(memory_prompt=_memory_prompt, model_prompt=model_message)
-                or bool(transient_system_context),
                 response_run_id=team_turn_recorder.run_id or response_run_id,
                 session_id=session_id,
                 session_type=SessionType.TEAM,
@@ -1396,17 +1342,11 @@ class ResponseRunner:
                 thread_summary_message_count_hint=thread_summary_message_count_hint(request.thread_history),
                 memory_prompt=_memory_prompt,
                 memory_thread_history=_memory_thread_history,
-                transient_system_context=transient_system_context,
             ),
             post_response_deps=lambda: self.deps.post_response_effects.build_deps(
                 room_id=request.room_id,
                 interactive_agent_name=self.deps.agent_name,
                 persist_response_event_id=persist_response_event_id,
-                strip_transient_enrichment=lambda outcome: self._strip_transient_enrichment_from_session(
-                    outcome,
-                    session_scope=session_scope,
-                    execution_identity=tool_dispatch.execution_identity,
-                ),
             ),
         )
         return final_outcome.final_visible_event_id if final_outcome.mark_handled else None
@@ -1552,7 +1492,6 @@ class ResponseRunner:
         tool_trace: list[Any],
         run_metadata_content: dict[str, Any],
         compaction_outcomes: list[CompactionOutcome],
-        transient_system_context_collector: list[str],
         attempt_run_id_collector: list[str],
         pipeline_timing: DispatchPipelineTiming | None = None,
     ) -> str:
@@ -1576,7 +1515,6 @@ class ResponseRunner:
                 request.system_enrichment_items,
                 knowledge_resolution.unavailable,
             )
-            transient_system_context_collector.append(render_system_enrichment_block(system_enrichment_items))
             matrix_run_metadata = _materialize_matrix_run_metadata(request.matrix_run_metadata)
             return await ai_response(
                 agent_name=self.deps.agent_name,
@@ -1643,7 +1581,6 @@ class ResponseRunner:
         tool_trace: list[Any],
         run_metadata_content: dict[str, Any],
         compaction_outcomes: list[CompactionOutcome],
-        transient_system_context_collector: list[str],
         attempt_run_id_collector: list[str],
         pipeline_timing: DispatchPipelineTiming | None = None,
     ) -> StreamTransportOutcome:
@@ -1669,7 +1606,6 @@ class ResponseRunner:
             request.system_enrichment_items,
             knowledge_resolution.unavailable,
         )
-        transient_system_context_collector.append(render_system_enrichment_block(system_enrichment_items))
         matrix_run_metadata = _materialize_matrix_run_metadata(request.matrix_run_metadata)
         response_stream = stream_agent_response(
             agent_name=self.deps.agent_name,
@@ -1752,8 +1688,7 @@ class ResponseRunner:
         run_id: str | None = None,
         response_kind: str = "ai",
         compaction_outcomes_collector: list[CompactionOutcome] | None = None,
-        transient_system_context_collector: list[str] | None = None,
-        model_prompt_collector: list[str] | None = None,
+        run_success_collector: list[bool] | None = None,
         attempt_run_id_collector: list[str] | None = None,
         on_delivery_started: Callable[[str | None], None] | None = None,
     ) -> FinalDeliveryOutcome:
@@ -1761,8 +1696,6 @@ class ResponseRunner:
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_start")
         runtime = await self.prepare_non_streaming_runtime(request)
-        if model_prompt_collector is not None:
-            model_prompt_collector.append(runtime.model_prompt)
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_ready")
         response_envelope = self._response_envelope_for_request(
@@ -1812,9 +1745,6 @@ class ResponseRunner:
                     tool_trace=tool_trace,
                     run_metadata_content=run_metadata_content,
                     compaction_outcomes=compaction_outcomes,
-                    transient_system_context_collector=(
-                        transient_system_context_collector if transient_system_context_collector is not None else []
-                    ),
                     attempt_run_id_collector=attempt_run_id_collector if attempt_run_id_collector is not None else [],
                     pipeline_timing=request.pipeline_timing,
                 )
@@ -1886,6 +1816,8 @@ class ResponseRunner:
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark_first_visible_reply("final")
             request.pipeline_timing.mark("response_complete")
+        if run_success_collector is not None:
+            run_success_collector.append(turn_recorder.outcome == "completed")
         if compaction_outcomes_collector is not None:
             compaction_outcomes_collector.extend(compaction_outcomes)
         return delivery
@@ -1897,8 +1829,7 @@ class ResponseRunner:
         run_id: str | None = None,
         response_kind: str = "ai",
         compaction_outcomes_collector: list[CompactionOutcome] | None = None,
-        transient_system_context_collector: list[str] | None = None,
-        model_prompt_collector: list[str] | None = None,
+        run_success_collector: list[bool] | None = None,
         attempt_run_id_collector: list[str] | None = None,
         on_delivery_started: Callable[[str | None], None] | None = None,
         tool_trace_collector: list[Any] | None = None,
@@ -1908,8 +1839,6 @@ class ResponseRunner:
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_start")
         runtime = await self.prepare_streaming_runtime(request)
-        if model_prompt_collector is not None:
-            model_prompt_collector.append(runtime.model_prompt)
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_ready")
         response_envelope = self._response_envelope_for_request(
@@ -1960,9 +1889,6 @@ class ResponseRunner:
                     tool_trace=tool_trace,
                     run_metadata_content=run_metadata_content,
                     compaction_outcomes=compaction_outcomes,
-                    transient_system_context_collector=(
-                        transient_system_context_collector if transient_system_context_collector is not None else []
-                    ),
                     attempt_run_id_collector=attempt_run_id_collector if attempt_run_id_collector is not None else [],
                     pipeline_timing=request.pipeline_timing,
                 )
@@ -1997,6 +1923,8 @@ class ResponseRunner:
                     is_team=False,
                     response_event_id=error.event_id,
                 )
+            if run_success_collector is not None:
+                run_success_collector.append(turn_recorder.outcome == "completed")
             if compaction_outcomes_collector is not None:
                 compaction_outcomes_collector.extend(compaction_outcomes)
             response_extra_content = _merge_response_extra_content(
@@ -2081,6 +2009,8 @@ class ResponseRunner:
             request.pipeline_timing.mark_first_visible_reply("final")
             request.pipeline_timing.mark("response_complete")
 
+        if run_success_collector is not None:
+            run_success_collector.append(turn_recorder.outcome == "completed")
         if compaction_outcomes_collector is not None:
             compaction_outcomes_collector.extend(compaction_outcomes)
         return delivery
@@ -2155,6 +2085,7 @@ class ResponseRunner:
         self._note_pipeline_metadata(request, response_kind="agent", used_streaming=use_streaming)
         final_delivery_outcome: FinalDeliveryOutcome | None = None
         compaction_outcomes: list[CompactionOutcome] = []
+        run_successes: list[bool] = []
         response_run_id = str(uuid4())
         tracked_event_id: str | None = request.existing_event_id
         delivery_stage_started = False
@@ -2163,8 +2094,6 @@ class ResponseRunner:
         early_delivery_error: BaseException | None = None
         tool_trace: list[Any] = []
         run_metadata_content: dict[str, Any] = {}
-        transient_system_contexts: list[str] = []
-        model_prompts: list[str] = []
         attempt_run_ids: list[str] = []
         resolved_correlation_id = self._correlation_id_for_request(request)
         resolved_response_envelope = self._response_envelope_for_request(
@@ -2257,8 +2186,7 @@ class ResponseRunner:
                     delivery_request,
                     run_id=response_run_id,
                     compaction_outcomes_collector=compaction_outcomes,
-                    transient_system_context_collector=transient_system_contexts,
-                    model_prompt_collector=model_prompts,
+                    run_success_collector=run_successes,
                     attempt_run_id_collector=attempt_run_ids,
                     on_delivery_started=note_delivery_started,
                     tool_trace_collector=tool_trace,
@@ -2269,8 +2197,7 @@ class ResponseRunner:
                     delivery_request,
                     run_id=response_run_id,
                     compaction_outcomes_collector=compaction_outcomes,
-                    transient_system_context_collector=transient_system_contexts,
-                    model_prompt_collector=model_prompts,
+                    run_success_collector=run_successes,
                     attempt_run_id_collector=attempt_run_ids,
                     on_delivery_started=note_delivery_started,
                 )
@@ -2365,40 +2292,24 @@ class ResponseRunner:
                     failure_reason=delivery_failure_reason or "interrupted",
                 )
         assert final_delivery_outcome is not None
-        transient_system_context = (
-            transient_system_contexts[-1]
-            if transient_system_contexts
-            else render_system_enrichment_block(request.system_enrichment_items)
-        )
         post_response_outcome = ResponseOutcome(
-            strip_transient_enrichment_after_run=_should_strip_transient_enrichment(request)
-            or any(
-                _model_prompt_has_transient_tail(memory_prompt=memory_prompt, model_prompt=model_prompt)
-                for model_prompt in model_prompts
-            )
-            or bool(transient_system_context),
             response_run_id=attempt_run_ids[-1] if attempt_run_ids else response_run_id,
             session_id=session_id,
             session_type=self.deps.state_writer.session_type_for_scope(self.deps.state_writer.history_scope()),
             execution_identity=execution_identity,
+            run_succeeded=run_successes[-1] if run_successes else False,
             interactive_target=resolved_target,
             thread_summary_room_id=(request.room_id if resolved_target.resolved_thread_id is not None else None),
             thread_summary_thread_id=resolved_target.resolved_thread_id,
             thread_summary_message_count_hint=thread_summary_message_count_hint(request.thread_history),
             memory_prompt=memory_prompt,
             memory_thread_history=memory_thread_history,
-            transient_system_context=transient_system_context,
         )
         post_response_deps = self.deps.post_response_effects.build_deps(
             room_id=request.room_id,
             interactive_agent_name=self.deps.agent_name,
             queue_memory_persistence=queue_memory_persistence,
             persist_response_event_id=persist_response_event_id,
-            strip_transient_enrichment=lambda outcome: self._strip_transient_enrichment_from_session(
-                outcome,
-                session_scope=self.deps.state_writer.history_scope(),
-                execution_identity=execution_identity,
-            ),
         )
         try:
             final_outcome = await lifecycle.finalize(

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1518,7 +1518,6 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
     configured_team_name: str | None = None,
     matrix_run_metadata: dict[str, Any] | None = None,
     system_enrichment_items: Sequence[EnrichmentItem] = (),
-    transient_system_context_collector: list[str] | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
     *,
     turn_recorder: TurnRecorder,
@@ -1556,8 +1555,6 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
         system_enrichment_items,
         unavailable_bases,
     )
-    if transient_system_context_collector is not None:
-        transient_system_context_collector.append(render_system_enrichment_block(system_enrichment_items))
     agents = team_members.agents
 
     agent_list = ", ".join(str(a.name) for a in agents if a.name)
@@ -1912,7 +1909,6 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
     configured_team_name: str | None = None,
     matrix_run_metadata: dict[str, Any] | None = None,
     system_enrichment_items: Sequence[EnrichmentItem] = (),
-    transient_system_context_collector: list[str] | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
     *,
     turn_recorder: TurnRecorder,
@@ -1958,8 +1954,6 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
         system_enrichment_items,
         unavailable_bases,
     )
-    if transient_system_context_collector is not None:
-        transient_system_context_collector.append(render_system_enrichment_block(system_enrichment_items))
     agent_names = team_members.display_names
     display_names = team_members.display_names
     team: Team | None = None

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1463,7 +1463,6 @@ class TurnController:
                         prepared_payload = type(prepared_payload)(
                             payload=prepared_payload.payload,
                             envelope=prepared_payload.envelope,
-                            strip_transient_enrichment_after_run=prepared_payload.strip_transient_enrichment_after_run,
                             system_enrichment_items=tuple(system_enrichment_items),
                         )
                     payload_ready_monotonic = time.monotonic()

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -115,7 +115,6 @@ class _PreparedHookedPayload:
 
     payload: DispatchPayload
     envelope: MessageEnvelope
-    strip_transient_enrichment_after_run: bool
     system_enrichment_items: tuple[EnrichmentItem, ...]
 
 
@@ -179,7 +178,6 @@ class IngressHookRunner:
             dispatch_policy_source_kind=dispatch.envelope.dispatch_policy_source_kind,
         )
         model_prompt = payload.model_prompt
-        strip_transient_enrichment_after_run = False
         if hook_registered:
             context = MessageEnrichContext(
                 **self.hook_context.base_kwargs(EVENT_MESSAGE_ENRICH, dispatch.correlation_id),
@@ -193,7 +191,6 @@ class IngressHookRunner:
                 enrichment_block = render_enrichment_block(items)
                 base_model_prompt = payload.model_prompt if payload.model_prompt is not None else payload.prompt
                 model_prompt = f"{base_model_prompt.rstrip()}\n\n{enrichment_block}"
-                strip_transient_enrichment_after_run = True
 
         emit_elapsed_timing(
             "response_payload.apply_message_enrichment",
@@ -211,7 +208,6 @@ class IngressHookRunner:
                 attachment_ids=payload.attachment_ids,
             ),
             envelope=envelope,
-            strip_transient_enrichment_after_run=strip_transient_enrichment_after_run,
             system_enrichment_items=(),
         )
 

--- a/tach.toml
+++ b/tach.toml
@@ -2859,7 +2859,6 @@ expose = [
     "read_scope_state",
     "resolve_bound_team_scope_context",
     "resolve_history_execution_plan",
-    "strip_transient_enrichment_from_session",
     "team_tool_definition_payloads_for_logging",
     "update_scope_seen_event_ids",
     "write_scope_state",

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -615,6 +615,7 @@ def _response_request(
     thread_id: str | None = None,
     prompt: str = "Hello",
     model_prompt: str | None = None,
+    media: MediaInputs | None = None,
     user_id: str | None = None,
     correlation_id: str | None = None,
 ) -> ResponseRequest:
@@ -626,6 +627,7 @@ def _response_request(
         thread_history=(),
         prompt=prompt,
         model_prompt=model_prompt,
+        media=media,
         user_id=user_id,
         correlation_id=correlation_id,
     )
@@ -2398,9 +2400,50 @@ async def test_generate_response_preserves_model_prompt_in_persisted_session(
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
     storage = _SessionStorage()
 
+    async def fake_prepare_agent_and_prompt(
+        _agent_name: str,
+        prompt: str,
+        *_args: object,
+        model_prompt: str | None = None,
+        **_kwargs: object,
+    ) -> _PreparedAgentRun:
+        model_facing_prompt = model_prompt if model_prompt is not None else prompt
+        return _PreparedAgentRun(
+            agent=MagicMock(),
+            messages=(
+                Message(role="user", content="Earlier context"),
+                Message(role="assistant", content="Earlier answer"),
+                Message(role="user", content=model_facing_prompt),
+            ),
+            unseen_event_ids=[],
+            prepared_history=PreparedHistoryState(),
+        )
+
+    async def fake_cached_agent_run(
+        _agent: object,
+        run_input: tuple[Message, ...],
+        session_id: str,
+        **kwargs: object,
+    ) -> RunOutput:
+        run = RunOutput(
+            run_id=cast("str | None", kwargs.get("run_id")),
+            content="Hello",
+            status=RunStatus.completed,
+            messages=[*run_input, Message(role="assistant", content="Hello")],
+        )
+        storage.session = AgentSession(
+            session_id=session_id,
+            agent_id="general",
+            created_at=1,
+            updated_at=1,
+            runs=[run],
+        )
+        return run
+
     with (
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
-        patch("mindroom.response_runner.ai_response", new=AsyncMock(return_value="Hello")),
+        patch("mindroom.ai._prepare_agent_and_prompt", new=AsyncMock(side_effect=fake_prepare_agent_and_prompt)),
+        patch("mindroom.ai_runtime.cached_agent_run", new=AsyncMock(side_effect=fake_cached_agent_run)),
     ):
         coordinator = _build_response_runner(
             bot,
@@ -2412,33 +2455,7 @@ async def test_generate_response_preserves_model_prompt_in_persisted_session(
             message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
         )
 
-        async def fake_send_text(*_args: object, **_kwargs: object) -> str:
-            storage.session = AgentSession(
-                session_id="!test:localhost:$thread-root",
-                agent_id="general",
-                created_at=1,
-                updated_at=1,
-                runs=[
-                    RunOutput(
-                        content="Hello",
-                        messages=[
-                            Message(role="user", content="Earlier context"),
-                            Message(role="assistant", content="Earlier answer"),
-                            Message(
-                                role="user",
-                                content=(
-                                    "Describe this image\n\n"
-                                    "Available attachment IDs: att_1. Use tool calls to inspect or process them."
-                                ),
-                            ),
-                            Message(role="assistant", content="Hello"),
-                        ],
-                    ),
-                ],
-            )
-            return "$msg"
-
-        coordinator.deps.delivery_gateway.send_text.side_effect = fake_send_text
+        coordinator.deps.delivery_gateway.send_text.return_value = "$msg"
 
         await coordinator.generate_response(
             replace(
@@ -2452,9 +2469,8 @@ async def test_generate_response_preserves_model_prompt_in_persisted_session(
     persisted_run = cast("RunOutput", persisted_session.runs[0])
     assert persisted_run.messages is not None
     assert persisted_run.messages[0].content == "Earlier context"
-    assert persisted_run.messages[2].content == (
-        "Describe this image\n\nAvailable attachment IDs: att_1. Use tool calls to inspect or process them."
-    )
+    assert "Describe this image" in cast("str", persisted_run.messages[2].content)
+    assert "Available attachment IDs: att_1" in cast("str", persisted_run.messages[2].content)
 
 
 @pytest.mark.asyncio
@@ -2538,15 +2554,48 @@ async def test_generate_response_preserves_retry_model_prompt(tmp_path: Path) ->
     config = bind_runtime_paths(_config(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
     storage = _SessionStorage()
+    seen_run_ids: list[str | None] = []
 
-    async def fake_ai_response(*_args: object, **kwargs: object) -> str:
-        run_id_callback = cast("Callable[[str], None]", kwargs["run_id_callback"])
-        run_id_callback("retry-run")
-        return "Hello"
+    async def fake_prepare_agent_and_prompt(
+        _agent_name: str,
+        prompt: str,
+        *_args: object,
+        model_prompt: str | None = None,
+        **_kwargs: object,
+    ) -> _PreparedAgentRun:
+        model_facing_prompt = model_prompt if model_prompt is not None else prompt
+        return _prepared_prompt_result(MagicMock(), prompt=model_facing_prompt)
+
+    async def fake_cached_agent_run(
+        _agent: object,
+        run_input: tuple[Message, ...],
+        session_id: str,
+        **kwargs: object,
+    ) -> RunOutput:
+        run_id = cast("str | None", kwargs.get("run_id"))
+        seen_run_ids.append(run_id)
+        if len(seen_run_ids) == 1:
+            error_message = "audio input is not supported"
+            raise ValueError(error_message)
+        run = RunOutput(
+            run_id=run_id,
+            content="Hello",
+            status=RunStatus.completed,
+            messages=[*run_input, Message(role="assistant", content="Hello")],
+        )
+        storage.session = AgentSession(
+            session_id=session_id,
+            agent_id="general",
+            created_at=1,
+            updated_at=1,
+            runs=[run],
+        )
+        return run
 
     with (
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
-        patch("mindroom.response_runner.ai_response", new=AsyncMock(side_effect=fake_ai_response)),
+        patch("mindroom.ai._prepare_agent_and_prompt", new=AsyncMock(side_effect=fake_prepare_agent_and_prompt)),
+        patch("mindroom.ai_runtime.cached_agent_run", new=AsyncMock(side_effect=fake_cached_agent_run)),
     ):
         coordinator = _build_response_runner(
             bot,
@@ -2558,36 +2607,16 @@ async def test_generate_response_preserves_retry_model_prompt(tmp_path: Path) ->
             message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
         )
 
-        async def fake_send_text(*_args: object, **_kwargs: object) -> str:
-            storage.session = AgentSession(
-                session_id="!test:localhost:$thread-root",
-                agent_id="general",
-                created_at=1,
-                updated_at=1,
-                runs=[
-                    RunOutput(
-                        run_id="retry-run",
-                        content="Hello",
-                        messages=[
-                            Message(
-                                role="user",
-                                content=(
-                                    "Describe this image\n\n"
-                                    "Available attachment IDs: att_1. Use tool calls to inspect or process them."
-                                ),
-                            ),
-                            Message(role="assistant", content="Hello"),
-                        ],
-                    ),
-                ],
-            )
-            return "$msg"
-
-        coordinator.deps.delivery_gateway.send_text.side_effect = fake_send_text
+        coordinator.deps.delivery_gateway.send_text.return_value = "$msg"
 
         await coordinator.generate_response(
             replace(
-                _response_request(prompt="Describe this image", user_id="@alice:localhost", thread_id="$thread-root"),
+                _response_request(
+                    prompt="Describe this image",
+                    user_id="@alice:localhost",
+                    thread_id="$thread-root",
+                    media=MediaInputs(audio=[MagicMock(name="audio_input")]),
+                ),
                 model_prompt="Available attachment IDs: att_1. Use tool calls to inspect or process them.",
             ),
         )
@@ -2595,11 +2624,14 @@ async def test_generate_response_preserves_retry_model_prompt(tmp_path: Path) ->
     persisted_session = cast("AgentSession", storage.session)
     assert persisted_session.runs is not None
     persisted_run = cast("RunOutput", persisted_session.runs[0])
-    assert persisted_run.run_id == "retry-run"
+    assert len(seen_run_ids) == 2
+    assert seen_run_ids[0] is not None
+    assert seen_run_ids[1] is not None
+    assert seen_run_ids[1] != seen_run_ids[0]
+    assert persisted_run.run_id == seen_run_ids[1]
     assert persisted_run.messages is not None
-    assert persisted_run.messages[0].content == (
-        "Describe this image\n\nAvailable attachment IDs: att_1. Use tool calls to inspect or process them."
-    )
+    assert "Describe this image" in cast("str", persisted_run.messages[0].content)
+    assert "Available attachment IDs: att_1" in cast("str", persisted_run.messages[0].content)
 
 
 @pytest.mark.asyncio
@@ -2692,7 +2724,9 @@ async def test_generate_team_response_preserves_model_prompt_in_persisted_sessio
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name="ultimate")
     storage = _SessionStorage()
 
-    async def fake_team_response(*_args: object, **_kwargs: object) -> str:
+    async def fake_team_response(*_args: object, **kwargs: object) -> str:
+        model_message = cast("str", kwargs["message"])
+        run_id = cast("str | None", kwargs.get("run_id"))
         storage.session = TeamSession(
             session_id="!test:localhost:$thread-root",
             team_id="ultimate",
@@ -2700,17 +2734,12 @@ async def test_generate_team_response_preserves_model_prompt_in_persisted_sessio
             updated_at=1,
             runs=[
                 TeamRunOutput(
+                    run_id=run_id,
                     content="Team answer",
                     messages=[
                         Message(role="user", content="Earlier context"),
                         Message(role="assistant", content="Earlier answer"),
-                        Message(
-                            role="user",
-                            content=(
-                                "Describe this image\n\n"
-                                "Available attachment IDs: att_1. Use tool calls to inspect or process them."
-                            ),
-                        ),
+                        Message(role="user", content=model_message),
                         Message(role="assistant", content="Team answer"),
                     ],
                 ),
@@ -2747,9 +2776,8 @@ async def test_generate_team_response_preserves_model_prompt_in_persisted_sessio
     persisted_run = cast("TeamRunOutput", persisted_session.runs[0])
     assert persisted_run.messages is not None
     assert persisted_run.messages[0].content == "Earlier context"
-    assert persisted_run.messages[2].content == (
-        "Describe this image\n\nAvailable attachment IDs: att_1. Use tool calls to inspect or process them."
-    )
+    assert "Describe this image" in cast("str", persisted_run.messages[2].content)
+    assert "Available attachment IDs: att_1" in cast("str", persisted_run.messages[2].content)
 
 
 @pytest.mark.asyncio
@@ -2759,10 +2787,31 @@ async def test_generate_team_response_preserves_retry_model_prompt(tmp_path: Pat
     config = bind_runtime_paths(_config_with_team(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name="ultimate")
     storage = _SessionStorage()
+    seen_run_ids: list[str | None] = []
 
     async def fake_team_response(*_args: object, **kwargs: object) -> str:
+        model_message = cast("str", kwargs["message"])
+        run_id = cast("str | None", kwargs.get("run_id"))
+        seen_run_ids.append(run_id)
         run_id_callback = cast("Callable[[str], None]", kwargs["run_id_callback"])
-        run_id_callback("team-retry-run")
+        if run_id is not None:
+            run_id_callback(run_id)
+        storage.session = TeamSession(
+            session_id="!test:localhost:$thread-root",
+            team_id="ultimate",
+            created_at=1,
+            updated_at=1,
+            runs=[
+                TeamRunOutput(
+                    run_id=run_id,
+                    content="Team answer",
+                    messages=[
+                        Message(role="user", content=model_message),
+                        Message(role="assistant", content="Team answer"),
+                    ],
+                ),
+            ],
+        )
         return "Team answer"
 
     with (
@@ -2784,32 +2833,7 @@ async def test_generate_team_response_preserves_retry_model_prompt(tmp_path: Pat
             orchestrator=_team_orchestrator(config, runtime_paths),
         )
 
-        async def fake_send_text(*_args: object, **_kwargs: object) -> str:
-            storage.session = TeamSession(
-                session_id="!test:localhost:$thread-root",
-                team_id="ultimate",
-                created_at=1,
-                updated_at=1,
-                runs=[
-                    TeamRunOutput(
-                        run_id="team-retry-run",
-                        content="Team answer",
-                        messages=[
-                            Message(
-                                role="user",
-                                content=(
-                                    "Describe this image\n\n"
-                                    "Available attachment IDs: att_1. Use tool calls to inspect or process them."
-                                ),
-                            ),
-                            Message(role="assistant", content="Team answer"),
-                        ],
-                    ),
-                ],
-            )
-            return "$msg"
-
-        coordinator.deps.delivery_gateway.send_text.side_effect = fake_send_text
+        coordinator.deps.delivery_gateway.send_text.return_value = "$msg"
 
         await coordinator.generate_team_response_helper(
             replace(
@@ -2823,11 +2847,11 @@ async def test_generate_team_response_preserves_retry_model_prompt(tmp_path: Pat
     persisted_session = cast("TeamSession", storage.session)
     assert persisted_session.runs is not None
     persisted_run = cast("TeamRunOutput", persisted_session.runs[0])
-    assert persisted_run.run_id == "team-retry-run"
+    assert seen_run_ids == [persisted_run.run_id]
+    assert persisted_run.run_id is not None
     assert persisted_run.messages is not None
-    assert persisted_run.messages[0].content == (
-        "Describe this image\n\nAvailable attachment IDs: att_1. Use tool calls to inspect or process them."
-    )
+    assert "Describe this image" in cast("str", persisted_run.messages[0].content)
+    assert "Available attachment IDs: att_1" in cast("str", persisted_run.messages[0].content)
 
 
 def test_append_knowledge_availability_notice_rendering() -> None:

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -67,7 +67,7 @@ from mindroom.delivery_gateway import DeliveryGateway, DeliveryGatewayDeps, Resp
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.execution_preparation import _PreparedExecutionContext
 from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
-from mindroom.history import PreparedHistoryState, strip_transient_enrichment_from_session
+from mindroom.history import PreparedHistoryState
 from mindroom.history.runtime import ScopeSessionContext
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.history.types import HistoryScope
@@ -2389,44 +2389,10 @@ async def test_generate_team_response_helper_preserves_raw_prompt_when_model_pro
 
 
 @pytest.mark.asyncio
-async def test_generate_response_marks_transient_model_prompt_for_cleanup(
+async def test_generate_response_preserves_model_prompt_in_persisted_session(
     tmp_path: Path,
 ) -> None:
-    """Agent responses should scrub transient per-turn model tails after the run."""
-    runtime_paths = _runtime_paths(tmp_path)
-    config = bind_runtime_paths(_config(), runtime_paths)
-    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
-
-    with (
-        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
-        patch("mindroom.response_runner.ai_response", new=AsyncMock(return_value="Hello")),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)) as mock_post,
-    ):
-        coordinator = _build_response_runner(
-            bot,
-            config=config,
-            runtime_paths=runtime_paths,
-            storage_path=tmp_path,
-            requester_id="@alice:localhost",
-            message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
-        )
-
-        await coordinator.generate_response(
-            replace(
-                _response_request(prompt="Describe this image", user_id="@alice:localhost", thread_id="$thread-root"),
-                model_prompt="Available attachment IDs: att_1. Use tool calls to inspect or process them.",
-            ),
-        )
-
-    outcome = mock_post.await_args.args[1]
-    assert outcome.strip_transient_enrichment_after_run is True
-
-
-@pytest.mark.asyncio
-async def test_generate_response_strips_transient_model_prompt_from_persisted_session(
-    tmp_path: Path,
-) -> None:
-    """Post-response cleanup should restore persisted user text to the raw turn."""
+    """Persisted model prompts should stay intact so later turns can reuse provider cache prefixes."""
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
@@ -2486,12 +2452,14 @@ async def test_generate_response_strips_transient_model_prompt_from_persisted_se
     persisted_run = cast("RunOutput", persisted_session.runs[0])
     assert persisted_run.messages is not None
     assert persisted_run.messages[0].content == "Earlier context"
-    assert persisted_run.messages[2].content == "Describe this image"
+    assert persisted_run.messages[2].content == (
+        "Describe this image\n\nAvailable attachment IDs: att_1. Use tool calls to inspect or process them."
+    )
 
 
 @pytest.mark.asyncio
-async def test_generate_response_marks_matrix_tool_prompt_context_for_cleanup(tmp_path: Path) -> None:
-    """Matrix tool metadata appended during runtime preparation should be scrubbed after the run."""
+async def test_generate_response_appends_matrix_tool_prompt_context(tmp_path: Path) -> None:
+    """Matrix tool metadata appended during runtime preparation should reach the model."""
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config_with_matrix_message(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
@@ -2504,7 +2472,7 @@ async def test_generate_response_marks_matrix_tool_prompt_context_for_cleanup(tm
     with (
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
         patch("mindroom.response_runner.ai_response", new=AsyncMock(side_effect=fake_ai_response)),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)) as mock_post,
+        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
     ):
         coordinator = _build_response_runner(
             bot,
@@ -2521,9 +2489,6 @@ async def test_generate_response_marks_matrix_tool_prompt_context_for_cleanup(tm
 
     assert model_prompts
     assert "[Matrix metadata for tool calls]" in model_prompts[0]
-    outcome = mock_post.await_args.args[1]
-    assert outcome.strip_transient_enrichment_after_run is True
-    assert outcome.memory_prompt == "Hello"
 
 
 @pytest.mark.asyncio
@@ -2567,8 +2532,8 @@ async def test_generate_response_passes_resolved_correlation_id_to_ai_response(t
 
 
 @pytest.mark.asyncio
-async def test_generate_response_cleanup_targets_retry_run_id(tmp_path: Path) -> None:
-    """Cleanup should target the persisted retry run instead of the abandoned first run id."""
+async def test_generate_response_preserves_retry_model_prompt(tmp_path: Path) -> None:
+    """Retry runs should keep the model-facing prompt that Agno persisted."""
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
@@ -2632,50 +2597,14 @@ async def test_generate_response_cleanup_targets_retry_run_id(tmp_path: Path) ->
     persisted_run = cast("RunOutput", persisted_session.runs[0])
     assert persisted_run.run_id == "retry-run"
     assert persisted_run.messages is not None
-    assert persisted_run.messages[0].content == "Describe this image"
+    assert persisted_run.messages[0].content == (
+        "Describe this image\n\nAvailable attachment IDs: att_1. Use tool calls to inspect or process them."
+    )
 
 
 @pytest.mark.asyncio
-async def test_generate_team_response_marks_transient_model_prompt_for_cleanup(
-    tmp_path: Path,
-) -> None:
-    """Team responses should scrub transient per-turn model tails after the run."""
-    runtime_paths = _runtime_paths(tmp_path)
-    config = bind_runtime_paths(_config_with_team(), runtime_paths)
-    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name="ultimate")
-
-    with (
-        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
-        patch("mindroom.response_runner.team_response", new=AsyncMock(return_value="Team answer")),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)) as mock_post,
-    ):
-        coordinator = _build_response_runner(
-            bot,
-            config=config,
-            runtime_paths=runtime_paths,
-            storage_path=tmp_path,
-            requester_id="@alice:localhost",
-            message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
-            orchestrator=_team_orchestrator(config, runtime_paths),
-        )
-
-        await coordinator.generate_team_response_helper(
-            replace(
-                _response_request(prompt="Describe this image", user_id="@alice:localhost", thread_id="$thread-root"),
-                model_prompt="Available attachment IDs: att_1. Use tool calls to inspect or process them.",
-            ),
-            team_agents=[fixture_entity_matrix_id("general", "localhost", runtime_paths)],
-            team_mode="coordinate",
-        )
-
-    outcome = mock_post.await_args.args[1]
-    assert outcome.strip_transient_enrichment_after_run is True
-    assert outcome.memory_prompt == "Describe this image"
-
-
-@pytest.mark.asyncio
-async def test_generate_team_response_marks_matrix_tool_prompt_context_for_cleanup(tmp_path: Path) -> None:
-    """Team Matrix tool metadata appended during runtime preparation should be scrubbed after the run."""
+async def test_generate_team_response_appends_matrix_tool_prompt_context(tmp_path: Path) -> None:
+    """Team Matrix tool metadata appended during runtime preparation should reach the model."""
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config_with_team_matrix_message(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name="ultimate")
@@ -2688,7 +2617,7 @@ async def test_generate_team_response_marks_matrix_tool_prompt_context_for_clean
     with (
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
         patch("mindroom.response_runner.team_response", new=AsyncMock(side_effect=fake_team_response)),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)) as mock_post,
+        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)),
     ):
         coordinator = _build_response_runner(
             bot,
@@ -2708,9 +2637,6 @@ async def test_generate_team_response_marks_matrix_tool_prompt_context_for_clean
 
     assert model_messages
     assert "[Matrix metadata for tool calls]" in model_messages[0]
-    outcome = mock_post.await_args.args[1]
-    assert outcome.strip_transient_enrichment_after_run is True
-    assert outcome.memory_prompt == "Hello"
 
 
 @pytest.mark.asyncio
@@ -2757,10 +2683,10 @@ async def test_generate_team_response_passes_resolved_correlation_id_to_team_res
 
 
 @pytest.mark.asyncio
-async def test_generate_team_response_strips_transient_model_prompt_from_persisted_session(
+async def test_generate_team_response_preserves_model_prompt_in_persisted_session(
     tmp_path: Path,
 ) -> None:
-    """Team cleanup should restore the current user turn, not earlier context."""
+    """Team persisted model prompts should stay intact for later provider cache reuse."""
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config_with_team(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name="ultimate")
@@ -2821,12 +2747,14 @@ async def test_generate_team_response_strips_transient_model_prompt_from_persist
     persisted_run = cast("TeamRunOutput", persisted_session.runs[0])
     assert persisted_run.messages is not None
     assert persisted_run.messages[0].content == "Earlier context"
-    assert persisted_run.messages[2].content == "Describe this image"
+    assert persisted_run.messages[2].content == (
+        "Describe this image\n\nAvailable attachment IDs: att_1. Use tool calls to inspect or process them."
+    )
 
 
 @pytest.mark.asyncio
-async def test_generate_team_response_cleanup_targets_retry_run_id(tmp_path: Path) -> None:
-    """Team cleanup should target the persisted retry run instead of the abandoned first run id."""
+async def test_generate_team_response_preserves_retry_model_prompt(tmp_path: Path) -> None:
+    """Team retry runs should keep the model-facing prompt that Agno persisted."""
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(_config_with_team(), runtime_paths)
     bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name="ultimate")
@@ -2897,208 +2825,9 @@ async def test_generate_team_response_cleanup_targets_retry_run_id(tmp_path: Pat
     persisted_run = cast("TeamRunOutput", persisted_session.runs[0])
     assert persisted_run.run_id == "team-retry-run"
     assert persisted_run.messages is not None
-    assert persisted_run.messages[0].content == "Describe this image"
-
-
-def test_strip_transient_enrichment_targets_response_run_id() -> None:
-    """Cleanup should not rewrite a newer or older run when the finished run id is known."""
-    transient_system_context = render_system_enrichment_block(
-        (EnrichmentItem(key="weather", text="72F and sunny", cache_policy="volatile"),),
+    assert persisted_run.messages[0].content == (
+        "Describe this image\n\nAvailable attachment IDs: att_1. Use tool calls to inspect or process them."
     )
-    storage = _SessionStorage(
-        AgentSession(
-            session_id="session-1",
-            agent_id="general",
-            runs=[
-                RunOutput(
-                    run_id="older-run",
-                    messages=[Message(role="user", content="older enriched prompt")],
-                ),
-                RunOutput(
-                    run_id="target-run",
-                    messages=[
-                        Message(role="system", content=f"durable system context\n\n{transient_system_context}"),
-                        Message(role="user", content="current enriched prompt"),
-                    ],
-                ),
-                RunOutput(
-                    run_id="newer-run",
-                    messages=[Message(role="user", content="newer enriched prompt")],
-                ),
-            ],
-        ),
-    )
-    storage_view = storage.open()
-
-    changed = strip_transient_enrichment_from_session(
-        storage_view,
-        session_id="session-1",
-        session_type=SessionType.AGENT,
-        response_run_id="target-run",
-        memory_prompt="current raw prompt",
-        transient_system_context=transient_system_context,
-    )
-
-    persisted_session = cast("AgentSession", storage.session)
-    assert changed is True
-    assert persisted_session.runs is not None
-    assert cast("RunOutput", persisted_session.runs[0]).messages[0].content == "older enriched prompt"
-    target_messages = cast("RunOutput", persisted_session.runs[1]).messages
-    assert target_messages is not None
-    assert target_messages[0].content == "durable system context"
-    assert target_messages[1].content == "current raw prompt"
-    assert cast("RunOutput", persisted_session.runs[2]).messages[0].content == "newer enriched prompt"
-
-
-def test_strip_transient_enrichment_strips_nested_team_member_system_context() -> None:
-    """Team cleanup should recurse into persisted member responses."""
-    transient_system_context = render_system_enrichment_block(
-        (EnrichmentItem(key="weather", text="72F and sunny", cache_policy="volatile"),),
-    )
-    storage = _SessionStorage(
-        TeamSession(
-            session_id="session-1",
-            team_id="ultimate",
-            runs=[
-                TeamRunOutput(
-                    run_id="target-run",
-                    messages=[
-                        Message(role="system", content=f"durable team context\n\n{transient_system_context}"),
-                        Message(role="user", content="current enriched prompt"),
-                    ],
-                    member_responses=[
-                        RunOutput(
-                            run_id="member-run",
-                            messages=[
-                                Message(
-                                    role="system",
-                                    content=f"durable member context\n\n{transient_system_context}",
-                                ),
-                                Message(role="assistant", content="member answer"),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-        ),
-    )
-    storage_view = storage.open()
-
-    changed = strip_transient_enrichment_from_session(
-        storage_view,
-        session_id="session-1",
-        session_type=SessionType.TEAM,
-        response_run_id="target-run",
-        memory_prompt="current raw prompt",
-        transient_system_context=transient_system_context,
-    )
-
-    persisted_session = cast("TeamSession", storage.session)
-    assert changed is True
-    assert persisted_session.runs is not None
-    target_run = cast("TeamRunOutput", persisted_session.runs[0])
-    assert target_run.messages is not None
-    assert target_run.messages[0].content == "durable team context"
-    assert target_run.messages[1].content == "current raw prompt"
-    assert target_run.member_responses is not None
-    member_run = cast("RunOutput", target_run.member_responses[0])
-    assert member_run.messages is not None
-    assert member_run.messages[0].content == "durable member context"
-
-
-@pytest.mark.asyncio
-async def test_generate_response_cleanup_uses_model_time_knowledge_notice(tmp_path: Path) -> None:
-    """Cleanup should use the exact knowledge notice appended before the model run."""
-    runtime_paths = _runtime_paths(tmp_path)
-    config = bind_runtime_paths(_config(), runtime_paths)
-    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
-    knowledge_access_support = _knowledge_access_support()
-    knowledge_access_support.resolve_for_agent.side_effect = [
-        _KnowledgeResolution(
-            knowledge=None,
-            unavailable={
-                "docs": KnowledgeAvailabilityDetail(
-                    availability=KnowledgeAvailability.INITIALIZING,
-                    search_available=False,
-                ),
-            },
-        ),
-        _KnowledgeResolution(knowledge=None, unavailable={}),
-    ]
-
-    with (
-        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
-        patch("mindroom.response_runner.ai_response", new=AsyncMock(return_value="Hello")),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)) as mock_post,
-    ):
-        coordinator = _build_response_runner(
-            bot,
-            config=config,
-            runtime_paths=runtime_paths,
-            storage_path=tmp_path,
-            requester_id="@alice:localhost",
-            knowledge_access_support=knowledge_access_support,
-            message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
-        )
-
-        await coordinator.generate_response(
-            _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
-        )
-
-    outcome = mock_post.await_args.args[1]
-    assert outcome.strip_transient_enrichment_after_run is True
-    assert "knowledge_availability" in outcome.transient_system_context
-    assert "Knowledge base `docs` is initializing" in outcome.transient_system_context
-    assert knowledge_access_support.resolve_for_agent.call_count == 1
-
-
-@pytest.mark.asyncio
-async def test_generate_response_streaming_cleanup_uses_model_time_knowledge_notice(tmp_path: Path) -> None:
-    """Streaming cleanup should use the exact knowledge notice appended before the model run."""
-    runtime_paths = _runtime_paths(tmp_path)
-    config = bind_runtime_paths(_config(), runtime_paths)
-    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
-    knowledge_access_support = _knowledge_access_support()
-    knowledge_access_support.resolve_for_agent.side_effect = [
-        _KnowledgeResolution(
-            knowledge=None,
-            unavailable={
-                "docs": KnowledgeAvailabilityDetail(
-                    availability=KnowledgeAvailability.INITIALIZING,
-                    search_available=False,
-                ),
-            },
-        ),
-        _KnowledgeResolution(knowledge=None, unavailable={}),
-    ]
-
-    async def fake_stream_agent_response(*_args: object, **_kwargs: object) -> AsyncGenerator[str, None]:
-        yield "Hello"
-
-    with (
-        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=True)),
-        patch("mindroom.response_runner.stream_agent_response", new=fake_stream_agent_response),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)) as mock_post,
-    ):
-        coordinator = _build_response_runner(
-            bot,
-            config=config,
-            runtime_paths=runtime_paths,
-            storage_path=tmp_path,
-            requester_id="@alice:localhost",
-            knowledge_access_support=knowledge_access_support,
-            message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
-        )
-
-        await coordinator.generate_response(
-            _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
-        )
-
-    outcome = mock_post.await_args.args[1]
-    assert outcome.strip_transient_enrichment_after_run is True
-    assert "knowledge_availability" in outcome.transient_system_context
-    assert "Knowledge base `docs` is initializing" in outcome.transient_system_context
-    assert knowledge_access_support.resolve_for_agent.call_count == 1
 
 
 def test_append_knowledge_availability_notice_rendering() -> None:
@@ -3138,77 +2867,6 @@ async def test_stream_with_request_log_context_closes_wrapped_stream_on_early_cl
     await stream.aclose()
 
     assert closed is True
-
-
-@pytest.mark.asyncio
-async def test_generate_response_marks_system_enrichment_for_cleanup(
-    tmp_path: Path,
-) -> None:
-    """Agent responses should scrub transient system enrichment after the run."""
-    runtime_paths = _runtime_paths(tmp_path)
-    config = bind_runtime_paths(_config(), runtime_paths)
-    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths)
-
-    with (
-        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
-        patch("mindroom.response_runner.ai_response", new=AsyncMock(return_value="Hello")),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)) as mock_post,
-    ):
-        coordinator = _build_response_runner(
-            bot,
-            config=config,
-            runtime_paths=runtime_paths,
-            storage_path=tmp_path,
-            requester_id="@alice:localhost",
-            message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
-        )
-
-        await coordinator.generate_response(
-            replace(
-                _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
-                system_enrichment_items=(EnrichmentItem(key="weather", text="72F and sunny"),),
-            ),
-        )
-
-    outcome = mock_post.await_args.args[1]
-    assert outcome.strip_transient_enrichment_after_run is True
-
-
-@pytest.mark.asyncio
-async def test_generate_team_response_marks_system_enrichment_for_cleanup(
-    tmp_path: Path,
-) -> None:
-    """Team responses should scrub transient system enrichment after the run."""
-    runtime_paths = _runtime_paths(tmp_path)
-    config = bind_runtime_paths(_config_with_team(), runtime_paths)
-    bot = _make_bot(tmp_path, config=config, runtime_paths=runtime_paths, agent_name="ultimate")
-
-    with (
-        patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
-        patch("mindroom.response_runner.team_response", new=AsyncMock(return_value="Team answer")),
-        patch("mindroom.response_lifecycle.apply_post_response_effects", new=AsyncMock(return_value=None)) as mock_post,
-    ):
-        coordinator = _build_response_runner(
-            bot,
-            config=config,
-            runtime_paths=runtime_paths,
-            storage_path=tmp_path,
-            requester_id="@alice:localhost",
-            message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
-            orchestrator=_team_orchestrator(config, runtime_paths),
-        )
-
-        await coordinator.generate_team_response_helper(
-            replace(
-                _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
-                system_enrichment_items=(EnrichmentItem(key="weather", text="72F and sunny"),),
-            ),
-            team_agents=[fixture_entity_matrix_id("general", "localhost", runtime_paths)],
-            team_mode="coordinate",
-        )
-
-    outcome = mock_post.await_args.args[1]
-    assert outcome.strip_transient_enrichment_after_run is True
 
 
 def test_compose_current_turn_prompt_uses_normalized_tail_comparison() -> None:

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -482,34 +482,6 @@ async def test_post_response_effects_skip_interactive_follow_up_for_preserved_st
 
 
 @pytest.mark.asyncio
-async def test_post_response_effects_strips_transient_enrichment_when_flagged() -> None:
-    """Transient model/system enrichment cleanup should run after delivery effects."""
-    cleanup = MagicMock()
-    outcome = ResponseOutcome(
-        strip_transient_enrichment_after_run=True,
-        session_id="session-1",
-        session_type=SessionType.AGENT,
-    )
-
-    await apply_post_response_effects(
-        FinalDeliveryOutcome(
-            terminal_status="completed",
-            event_id="$response",
-            is_visible_response=True,
-            final_visible_body="response",
-            delivery_kind="sent",
-        ),
-        outcome,
-        PostResponseEffectsDeps(
-            logger=MagicMock(),
-            strip_transient_enrichment=cleanup,
-        ),
-    )
-
-    cleanup.assert_called_once_with(outcome)
-
-
-@pytest.mark.asyncio
 async def test_post_response_effects_queues_summary_with_stale_hint_inside_margin(tmp_path: Path) -> None:
     """A stale hint just below threshold should still reach the live summary check."""
     config = _config(tmp_path)

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -407,6 +407,28 @@ async def test_post_response_effects_skip_thread_summary_for_suppressed_delivery
 
 
 @pytest.mark.asyncio
+async def test_post_response_effects_skip_memory_persistence_for_failed_run() -> None:
+    """Failed runs should not enqueue memory persistence for incomplete content."""
+    queue_memory_persistence = MagicMock()
+
+    await apply_post_response_effects(
+        FinalDeliveryOutcome(
+            terminal_status="error",
+            event_id="$response",
+            is_visible_response=True,
+            final_visible_body="Provider failed",
+        ),
+        ResponseOutcome(run_succeeded=False),
+        PostResponseEffectsDeps(
+            logger=MagicMock(),
+            queue_memory_persistence=queue_memory_persistence,
+        ),
+    )
+
+    queue_memory_persistence.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_post_response_effects_register_interactive_follow_up_for_preserved_stream_failure() -> None:
     """Preserved visible streamed replies should still register interactive follow-up."""
     register_interactive = AsyncMock()


### PR DESCRIPTION
## Summary
- remove the post-response transient enrichment scrubber added in PR #665
- stop threading cleanup flags/collectors through agent and team response flows
- update tests to assert model-facing prompts remain persisted for later provider prompt-cache reuse

## Rationale
Prompt caching matters more here than sanitizing Agno session history after the fact. Keeping the model-facing prompt exactly as persisted avoids rewriting the prompt prefix that future turns may reuse.

## Verification
- `uv run pytest tests/test_ai_user_id.py tests/test_queued_message_notify.py -q -n auto --no-cov` -> 170 passed
- `uv run pre-commit run --all-files` -> passed
- `uv run pytest -q -n auto --no-cov` -> 6184 passed, 69 skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed automatic transient enrichment stripping from post-response and session flows. Model-facing prompts and system enrichment are now preserved in persisted sessions and across retries. Response and team flows simplified; new delivery/attempt hooks added for clearer run handling.

* **Tests**
  * Updated tests to assert preserved model prompts and tool-context in persisted sessions/retries; removed tests expecting transient cleanup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/859)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->