### PR TITLE
fix(matrix-cache): label thread-history refresh diagnostics

### DIFF
--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -41,7 +41,13 @@ class _ApprovalTransportBot(Protocol):
     client: nio.AsyncClient | None
     event_cache: ConversationEventCache
 
-    async def latest_thread_event_id_if_needed(self, room_id: str, thread_id: str) -> str | None:
+    async def latest_thread_event_id_if_needed(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        caller_label: str = "agent_bot_latest_thread_event_lookup",
+    ) -> str | None:
         """Return the latest event id for one Matrix thread when known."""
         ...
 
@@ -134,6 +140,7 @@ class ApprovalMatrixTransport:
             resolved_latest_event_id = await bot.latest_thread_event_id_if_needed(
                 room_id,
                 thread_id,
+                caller_label="approval_transport_thread_relation",
             )
             if resolved_latest_event_id is not None:
                 latest_thread_event_id = resolved_latest_event_id

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -723,6 +723,7 @@ class AgentBot:
                     access=self._conversation_resolver.thread_membership_access(
                         full_history=False,
                         dispatch_safe=True,
+                        caller_label="reaction_hook_context",
                     ),
                 )
             except Exception as exc:

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -588,9 +588,19 @@ class AgentBot:
         """Return when this bot runtime started."""
         return self._runtime_view.runtime_started_at
 
-    async def latest_thread_event_id_if_needed(self, room_id: str, thread_id: str) -> str | None:
+    async def latest_thread_event_id_if_needed(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        caller_label: str = "agent_bot_latest_thread_event_lookup",
+    ) -> str | None:
         """Return the latest event id for one Matrix thread when the cache knows it."""
-        return await self._conversation_cache.get_latest_thread_event_id_if_needed(room_id, thread_id)
+        return await self._conversation_cache.get_latest_thread_event_id_if_needed(
+            room_id,
+            thread_id,
+            caller_label=caller_label,
+        )
 
     @property
     def hook_registry(self) -> HookRegistry:

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -69,6 +69,7 @@ class DeriveConversationContext(Protocol):
         event_info: EventInfo,
         *,
         event_id: str | None = None,
+        caller_label: str = "unknown",
     ) -> tuple[bool, str | None, Sequence[ResolvedVisibleMessage]]:
         """Return whether one event is threaded plus its thread id and history."""
 
@@ -201,6 +202,7 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
         room.room_id,
         event_info,
         event_id=event.event_id,
+        caller_label="command_context",
     )
 
     # Commands/tools that persist conversation context should use the same

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -364,7 +364,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
-        caller_label: str = "unknown",
+        caller_label: str,
     ) -> str | None:
         """Resolve canonical thread membership for one event."""
         return await resolve_event_thread_id(
@@ -397,7 +397,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
-        caller_label: str = "unknown",
+        caller_label: str,
     ) -> ThreadMembershipAccess:
         """Return the shared thread-membership accessors for this resolver."""
         return thread_messages_thread_membership_access(
@@ -419,7 +419,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
-        caller_label: str = "unknown",
+        caller_label: str,
     ) -> ThreadReadResult:
         """Resolve one thread read through the shared cache entrypoint."""
         return await self.deps.conversation_cache.get_thread_messages(
@@ -475,7 +475,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
-        caller_label: str = "unknown",
+        caller_label: str,
     ) -> tuple[bool, str | None, Sequence[ResolvedVisibleMessage], bool]:
         """Resolve one thread context using either snapshot or full history."""
         thread_id = await self._explicit_thread_id_for_event(
@@ -596,7 +596,7 @@ class ConversationResolver:
         full_history: bool,
         dispatch_safe: bool,
         payload_metadata: DispatchPayloadMetadata | None = None,
-        caller_label: str = "unknown",
+        caller_label: str,
     ) -> MessageContext:
         """Resolve event metadata, mentions, and thread history for one inbound turn."""
         resolved_event_source = await resolve_event_source_content(event.source, self._client())

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -506,6 +506,7 @@ class ConversationResolver:
         event: DispatchEvent,
         *,
         payload_metadata: DispatchPayloadMetadata | None = None,
+        caller_label: str = "dispatch_context",
     ) -> MessageContext:
         """Extract lightweight routing context without hydrating full thread history."""
         return await self.extract_message_context_impl(
@@ -514,6 +515,7 @@ class ConversationResolver:
             full_history=False,
             dispatch_safe=True,
             payload_metadata=payload_metadata,
+            caller_label=caller_label,
         )
 
     async def extract_trusted_router_relay_context(
@@ -573,6 +575,7 @@ class ConversationResolver:
         *,
         full_history: bool = True,
         payload_metadata: DispatchPayloadMetadata | None = None,
+        caller_label: str = "message_context",
     ) -> MessageContext:
         """Extract message context, optionally using a lightweight thread snapshot."""
         return await self.extract_message_context_impl(
@@ -581,6 +584,7 @@ class ConversationResolver:
             full_history=full_history,
             dispatch_safe=False,
             payload_metadata=payload_metadata,
+            caller_label=caller_label,
         )
 
     async def extract_message_context_impl(

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -363,6 +363,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> str | None:
         """Resolve canonical thread membership for one event."""
         return await resolve_event_thread_id(
@@ -372,6 +373,7 @@ class ConversationResolver:
             access=self.thread_membership_access(
                 full_history=full_history,
                 dispatch_safe=dispatch_safe,
+                caller_label=caller_label,
             ),
         )
 
@@ -394,6 +396,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> ThreadMembershipAccess:
         """Return the shared thread-membership accessors for this resolver."""
         return thread_messages_thread_membership_access(
@@ -404,6 +407,7 @@ class ConversationResolver:
                 thread_id,
                 full_history=full_history,
                 dispatch_safe=dispatch_safe,
+                caller_label=caller_label,
             ),
         )
 
@@ -414,6 +418,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve one thread read through the shared cache entrypoint."""
         return await self.deps.conversation_cache.get_thread_messages(
@@ -421,6 +426,7 @@ class ConversationResolver:
             thread_id,
             full_history=full_history,
             dispatch_safe=dispatch_safe,
+            caller_label=caller_label,
         )
 
     async def _event_info_for_event_id(
@@ -447,6 +453,7 @@ class ConversationResolver:
         event_info: EventInfo,
         *,
         event_id: str | None = None,
+        caller_label: str = "unknown",
     ) -> tuple[bool, str | None, Sequence[ResolvedVisibleMessage]]:
         """Derive conversation context from canonical Matrix thread membership."""
         is_thread, thread_id, thread_history, _requires_full_thread_history = await self._resolve_thread_context(
@@ -455,6 +462,7 @@ class ConversationResolver:
             event_info,
             full_history=True,
             dispatch_safe=False,
+            caller_label=caller_label,
         )
         return is_thread, thread_id, thread_history
 
@@ -466,6 +474,7 @@ class ConversationResolver:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> tuple[bool, str | None, Sequence[ResolvedVisibleMessage], bool]:
         """Resolve one thread context using either snapshot or full history."""
         thread_id = await self._explicit_thread_id_for_event(
@@ -474,6 +483,7 @@ class ConversationResolver:
             event_info,
             full_history=full_history,
             dispatch_safe=dispatch_safe,
+            caller_label=caller_label,
         )
         if thread_id is None:
             return False, None, [], False
@@ -483,6 +493,7 @@ class ConversationResolver:
             thread_id,
             full_history=full_history,
             dispatch_safe=dispatch_safe,
+            caller_label=caller_label,
         )
         if full_history:
             return True, thread_id, thread_messages, False
@@ -580,6 +591,7 @@ class ConversationResolver:
         full_history: bool,
         dispatch_safe: bool,
         payload_metadata: DispatchPayloadMetadata | None = None,
+        caller_label: str = "unknown",
     ) -> MessageContext:
         """Resolve event metadata, mentions, and thread history for one inbound turn."""
         resolved_event_source = await resolve_event_source_content(event.source, self._client())
@@ -626,6 +638,7 @@ class ConversationResolver:
                 event_info,
                 full_history=full_history,
                 dispatch_safe=dispatch_safe,
+                caller_label=caller_label,
             )
 
         return MessageContext(
@@ -657,6 +670,7 @@ class ConversationResolver:
             full_history=True,
             dispatch_safe=True,
             payload_metadata=payload_metadata,
+            caller_label="dispatch_hydration",
         )
         context.thread_history = full_context.thread_history
         context.is_thread = full_context.is_thread
@@ -681,6 +695,8 @@ class ConversationResolver:
         _client: nio.AsyncClient,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Fetch strict post-lock thread history through the shared conversation-cache policy."""
         return await self._read_thread_messages(
@@ -688,4 +704,5 @@ class ConversationResolver:
             thread_id,
             full_history=True,
             dispatch_safe=True,
+            caller_label=caller_label,
         )

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -344,6 +344,7 @@ class ConversationResolver:
                 access=self.thread_membership_access(
                     full_history=False,
                     dispatch_safe=True,
+                    caller_label="coalescing_thread_id",
                 ),
             )
         except Exception as exc:

--- a/src/mindroom/custom_tools/attachments.py
+++ b/src/mindroom/custom_tools/attachments.py
@@ -258,6 +258,7 @@ async def _send_attachment_paths(
     latest_thread_event_id = await context.conversation_cache.get_latest_thread_event_id_if_needed(
         room_id,
         thread_id,
+        caller_label="attachment_tool_send",
     )
     for attachment_path in attachment_paths:
         attachment_event_id = await send_file_message(

--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -74,6 +74,7 @@ class MatrixMessageOperations:
         latest_thread_event_id = await context.conversation_cache.get_latest_thread_event_id_if_needed(
             room_id,
             thread_id,
+            caller_label="matrix_message_tool_send",
         )
         extra_content: dict[str, Any] = {}
         if ignore_mentions:
@@ -217,6 +218,7 @@ class MatrixMessageOperations:
                 latest_thread_event_id = await context.conversation_cache.get_latest_thread_event_id_if_needed(
                     room_id,
                     effective_thread_id,
+                    caller_label="matrix_message_tool_attachment",
                 )
                 first_attachment_event_id = await send_file_message(
                     context.client,
@@ -628,6 +630,7 @@ class MatrixMessageOperations:
             latest_thread_event_id = await context.conversation_cache.get_latest_thread_event_id_if_needed(
                 room_id,
                 thread_id,
+                caller_label="matrix_message_tool_edit",
             )
             if latest_thread_event_id is None:
                 latest_thread_event_id = target

--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -567,7 +567,13 @@ class MatrixMessageOperations:
         thread_id: str,
         read_limit: int,
     ) -> MatrixMessageOperationResult:
-        thread_messages = await context.conversation_cache.get_thread_history(room_id, thread_id)
+        thread_messages = await context.conversation_cache.get_thread_messages(
+            room_id,
+            thread_id,
+            full_history=True,
+            dispatch_safe=False,
+            caller_label="matrix_message_tool",
+        )
         recent_messages = thread_messages[-read_limit:]
         return self._result(
             "ok",

--- a/src/mindroom/custom_tools/subagents.py
+++ b/src/mindroom/custom_tools/subagents.py
@@ -260,6 +260,7 @@ async def _send_matrix_text(
         latest_thread_event_id = await context.conversation_cache.get_latest_thread_event_id_if_needed(
             room_id,
             thread_id,
+            caller_label="subagent_tool_send",
         )
     content = format_message_with_mentions(
         context.config,

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -545,6 +545,7 @@ class DeliveryGateway:
                     resolved_target.room_id,
                     effective_thread_id,
                     resolved_target.reply_to_event_id,
+                    caller_label="delivery_send_text",
                 )
             )
             content = format_message_with_mentions(
@@ -599,6 +600,7 @@ class DeliveryGateway:
                 await self.deps.resolver.deps.conversation_cache.get_latest_thread_event_id_if_needed(
                     target.room_id,
                     target.resolved_thread_id,
+                    caller_label="delivery_edit_text",
                 )
             )
             content = build_threaded_edit_content(
@@ -1013,6 +1015,7 @@ class DeliveryGateway:
             target.resolved_thread_id,
             target.reply_to_event_id,
             event_id,
+            caller_label="delivery_compaction_lifecycle_edit",
         )
         content = build_message_content(
             body,
@@ -1049,6 +1052,7 @@ class DeliveryGateway:
             request.target.resolved_thread_id,
             request.target.reply_to_event_id,
             request.existing_event_id,
+            caller_label="delivery_stream",
         )
         return await send_streaming_response(
             client,

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -136,6 +136,7 @@ class EditRegenerator:
         context = await self.deps.resolver.extract_message_context(
             room,
             event,
+            caller_label="edit_regeneration_context",
         )
         loaded_turn = self.deps.turn_store.load_turn(
             room=room,

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -102,6 +102,7 @@ class EditRegenerator:
             self._client(),
             room.room_id,
             conversation_target.resolved_thread_id,
+            caller_label="edit_regeneration_context",
         )
         return MessageContext(
             am_i_mentioned=context.am_i_mentioned,
@@ -132,7 +133,10 @@ class EditRegenerator:
             self._logger().debug("ignoring_edit_from_other_agent", agent=sender_agent_name)
             return
 
-        context = await self.deps.resolver.extract_message_context(room, event)
+        context = await self.deps.resolver.extract_message_context(
+            room,
+            event,
+        )
         loaded_turn = self.deps.turn_store.load_turn(
             room=room,
             thread_id=context.thread_id or event_info.thread_id or event_info.thread_id_from_edit,

--- a/src/mindroom/hooks/sender.py
+++ b/src/mindroom/hooks/sender.py
@@ -74,6 +74,7 @@ async def send_hook_message(
     latest_thread_event_id = await conversation_cache.get_latest_thread_event_id_if_needed(
         room_id,
         thread_id,
+        caller_label="hook_sender",
     )
     content = format_message_with_mentions(
         config,

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -156,6 +156,7 @@ class InboundTurnNormalizer:
             request.room.room_id,
             event_info,
             event_id=request.event.event_id,
+            caller_label="voice_normalization",
         )
         effective_thread_id = self.deps.conversation_resolver.build_message_target(
             room_id=request.room.room_id,

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -24,6 +24,20 @@ if TYPE_CHECKING:
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 
 
+class ThreadHistoryFetcher(typing.Protocol):
+    """Client-backed thread-history fetcher with refresh diagnostics metadata."""
+
+    def __call__(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
+    ) -> typing.Awaitable[ThreadHistoryResult]:
+        """Fetch one thread from cache/source and attach refresh diagnostics."""
+
+
 class ThreadReadPolicy:
     """Own thread-history reads for one cache facade."""
 
@@ -32,10 +46,10 @@ class ThreadReadPolicy:
         *,
         logger_getter: typing.Callable[[], structlog.stdlib.BoundLogger],
         runtime: BotRuntimeView,
-        fetch_thread_history_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
-        fetch_thread_snapshot_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
-        fetch_dispatch_thread_history_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
-        fetch_dispatch_thread_snapshot_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
+        fetch_thread_history_from_client: ThreadHistoryFetcher,
+        fetch_thread_snapshot_from_client: ThreadHistoryFetcher,
+        fetch_dispatch_thread_history_from_client: ThreadHistoryFetcher,
+        fetch_dispatch_thread_snapshot_from_client: ThreadHistoryFetcher,
     ) -> None:
         self._logger_getter = logger_getter
         self.runtime = runtime
@@ -79,13 +93,14 @@ class ThreadReadPolicy:
         room_id: str,
         thread_id: str,
         *,
-        fetcher: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
+        fetcher: ThreadHistoryFetcher,
         name: str,
         full_history: bool,
         caller_label: str,
-        coordinator_queue_wait_ms: float,
+        queue_wait_started: float,
     ) -> ThreadHistoryResult:
         async def load() -> ThreadHistoryResult:
+            coordinator_queue_wait_ms = round((time.perf_counter() - queue_wait_started) * 1000, 1)
             thread_history = await fetcher(
                 room_id,
                 thread_id,
@@ -122,7 +137,6 @@ class ThreadReadPolicy:
         """Resolve one thread read through the same-thread barrier and fetch selection path."""
         queue_wait_started = time.perf_counter()
         await self._wait_for_pending_thread_cache_updates(room_id, thread_id)
-        coordinator_queue_wait_ms = round((time.perf_counter() - queue_wait_started) * 1000, 1)
         if full_history and dispatch_safe:
             return await self._run_thread_read(
                 room_id,
@@ -131,7 +145,7 @@ class ThreadReadPolicy:
                 name="matrix_cache_refresh_dispatch_thread_history",
                 full_history=True,
                 caller_label=caller_label,
-                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+                queue_wait_started=queue_wait_started,
             )
         if full_history:
             return await self._run_thread_read(
@@ -141,7 +155,7 @@ class ThreadReadPolicy:
                 name="matrix_cache_refresh_thread_history",
                 full_history=True,
                 caller_label=caller_label,
-                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+                queue_wait_started=queue_wait_started,
             )
         if dispatch_safe:
             return await self._run_thread_read(
@@ -151,7 +165,7 @@ class ThreadReadPolicy:
                 name="matrix_cache_refresh_dispatch_thread_snapshot",
                 full_history=False,
                 caller_label=caller_label,
-                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+                queue_wait_started=queue_wait_started,
             )
         return await self._run_thread_read(
             room_id,
@@ -160,7 +174,7 @@ class ThreadReadPolicy:
             name="matrix_cache_refresh_thread_snapshot",
             full_history=False,
             caller_label=caller_label,
-            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+            queue_wait_started=queue_wait_started,
         )
 
     async def get_latest_thread_event_id_if_needed(
@@ -169,6 +183,8 @@ class ThreadReadPolicy:
         thread_id: str | None,
         reply_to_event_id: str | None = None,
         existing_event_id: str | None = None,
+        *,
+        caller_label: str = "latest_thread_event_lookup",
     ) -> str | None:
         """Resolve the latest visible thread event when MSC3440 fallback needs it."""
         if thread_id is None or existing_event_id is not None or reply_to_event_id is not None:
@@ -179,7 +195,7 @@ class ThreadReadPolicy:
                 thread_id,
                 full_history=True,
                 dispatch_safe=False,
-                caller_label="unknown",
+                caller_label=caller_label,
             )
         except Exception as exc:
             self.logger.warning(

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import typing
 from typing import TYPE_CHECKING
 
@@ -31,10 +32,10 @@ class ThreadReadPolicy:
         *,
         logger_getter: typing.Callable[[], structlog.stdlib.BoundLogger],
         runtime: BotRuntimeView,
-        fetch_thread_history_from_client: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
-        fetch_thread_snapshot_from_client: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
-        fetch_dispatch_thread_history_from_client: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
-        fetch_dispatch_thread_snapshot_from_client: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
+        fetch_thread_history_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
+        fetch_thread_snapshot_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
+        fetch_dispatch_thread_history_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
+        fetch_dispatch_thread_snapshot_from_client: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
     ) -> None:
         self._logger_getter = logger_getter
         self.runtime = runtime
@@ -78,12 +79,19 @@ class ThreadReadPolicy:
         room_id: str,
         thread_id: str,
         *,
-        fetcher: typing.Callable[[str, str], typing.Awaitable[ThreadHistoryResult]],
+        fetcher: typing.Callable[..., typing.Awaitable[ThreadHistoryResult]],
         name: str,
         full_history: bool,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
     ) -> ThreadHistoryResult:
         async def load() -> ThreadHistoryResult:
-            thread_history = await fetcher(room_id, thread_id)
+            thread_history = await fetcher(
+                room_id,
+                thread_id,
+                caller_label=caller_label,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+            )
             if full_history:
                 return self._full_history_result(thread_history)
             return thread_history
@@ -109,9 +117,12 @@ class ThreadReadPolicy:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str,
     ) -> ThreadHistoryResult:
         """Resolve one thread read through the same-thread barrier and fetch selection path."""
+        queue_wait_started = time.perf_counter()
         await self._wait_for_pending_thread_cache_updates(room_id, thread_id)
+        coordinator_queue_wait_ms = round((time.perf_counter() - queue_wait_started) * 1000, 1)
         if full_history and dispatch_safe:
             return await self._run_thread_read(
                 room_id,
@@ -119,6 +130,8 @@ class ThreadReadPolicy:
                 fetcher=self.fetch_dispatch_thread_history_from_client,
                 name="matrix_cache_refresh_dispatch_thread_history",
                 full_history=True,
+                caller_label=caller_label,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
             )
         if full_history:
             return await self._run_thread_read(
@@ -127,6 +140,8 @@ class ThreadReadPolicy:
                 fetcher=self.fetch_thread_history_from_client,
                 name="matrix_cache_refresh_thread_history",
                 full_history=True,
+                caller_label=caller_label,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
             )
         if dispatch_safe:
             return await self._run_thread_read(
@@ -135,6 +150,8 @@ class ThreadReadPolicy:
                 fetcher=self.fetch_dispatch_thread_snapshot_from_client,
                 name="matrix_cache_refresh_dispatch_thread_snapshot",
                 full_history=False,
+                caller_label=caller_label,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
             )
         return await self._run_thread_read(
             room_id,
@@ -142,6 +159,8 @@ class ThreadReadPolicy:
             fetcher=self.fetch_thread_snapshot_from_client,
             name="matrix_cache_refresh_thread_snapshot",
             full_history=False,
+            caller_label=caller_label,
+            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         )
 
     async def get_latest_thread_event_id_if_needed(
@@ -160,6 +179,7 @@ class ThreadReadPolicy:
                 thread_id,
                 full_history=True,
                 dispatch_safe=False,
+                caller_label="unknown",
             )
         except Exception as exc:
             self.logger.warning(

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
 from mindroom.background_tasks import create_background_task, wait_for_background_tasks
+from mindroom.logging_config import bound_log_context
 from mindroom.timing import emit_timing_event, timing_enabled
 
 if TYPE_CHECKING:
@@ -495,29 +496,18 @@ class _EventCacheWriteCoordinator:
         predecessor_count = self._pending_chain_length(self._pending_entry_tasks(room_state.entries))
         loop = asyncio.get_running_loop()
         start_signal: asyncio.Future[None] = loop.create_future()
+        queued_at = time.perf_counter() if instrument_timing else 0.0
 
-        if not instrument_timing:
-
-            async def run_when_scheduled() -> object:
-                await start_signal
-                self._log_coalesced_update_if_needed(
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    kind=kind,
-                    name=name,
-                    update_state=update_state,
-                )
-                return await update_state.update_coro_factory()
-
-        else:
-            queued_at = time.perf_counter()
-
-            async def run_when_scheduled() -> object:
-                outcome = "ok"
-                update_started: float | None = None
-                try:
+        async def run_when_scheduled() -> object:
+            outcome = "ok"
+            update_started: float | None = None
+            try:
+                current_task = asyncio.current_task()
+                task_name = current_task.get_name() if current_task is not None else name
+                with bound_log_context(task_name=task_name):
                     await start_signal
-                    update_started = time.perf_counter()
+                    if instrument_timing:
+                        update_started = time.perf_counter()
                     self._log_coalesced_update_if_needed(
                         room_id=room_id,
                         thread_id=thread_id,
@@ -526,13 +516,14 @@ class _EventCacheWriteCoordinator:
                         update_state=update_state,
                     )
                     return await update_state.update_coro_factory()
-                except asyncio.CancelledError:
-                    outcome = "cancelled"
-                    raise
-                except Exception:
-                    outcome = "error"
-                    raise
-                finally:
+            except asyncio.CancelledError:
+                outcome = "cancelled"
+                raise
+            except Exception:
+                outcome = "error"
+                raise
+            finally:
+                if instrument_timing:
                     finished = time.perf_counter()
                     total_ms = round((finished - queued_at) * 1000, 1)
                     if update_started is None:

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -496,34 +496,43 @@ class _EventCacheWriteCoordinator:
         predecessor_count = self._pending_chain_length(self._pending_entry_tasks(room_state.entries))
         loop = asyncio.get_running_loop()
         start_signal: asyncio.Future[None] = loop.create_future()
-        queued_at = time.perf_counter() if instrument_timing else 0.0
 
-        async def run_when_scheduled() -> object:
-            outcome = "ok"
-            update_started: float | None = None
-            try:
-                current_task = asyncio.current_task()
-                task_name = current_task.get_name() if current_task is not None else name
-                with bound_log_context(task_name=task_name):
+        async def run_update() -> object:
+            current_task = asyncio.current_task()
+            assert current_task is not None
+            with bound_log_context(task_name=current_task.get_name()):
+                self._log_coalesced_update_if_needed(
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    kind=kind,
+                    name=name,
+                    update_state=update_state,
+                )
+                return await update_state.update_coro_factory()
+
+        if not instrument_timing:
+
+            async def run_when_scheduled() -> object:
+                await start_signal
+                return await run_update()
+
+        else:
+            queued_at = time.perf_counter()
+
+            async def run_when_scheduled() -> object:
+                outcome = "ok"
+                update_started: float | None = None
+                try:
                     await start_signal
-                    if instrument_timing:
-                        update_started = time.perf_counter()
-                    self._log_coalesced_update_if_needed(
-                        room_id=room_id,
-                        thread_id=thread_id,
-                        kind=kind,
-                        name=name,
-                        update_state=update_state,
-                    )
-                    return await update_state.update_coro_factory()
-            except asyncio.CancelledError:
-                outcome = "cancelled"
-                raise
-            except Exception:
-                outcome = "error"
-                raise
-            finally:
-                if instrument_timing:
+                    update_started = time.perf_counter()
+                    return await run_update()
+                except asyncio.CancelledError:
+                    outcome = "cancelled"
+                    raise
+                except Exception:
+                    outcome = "error"
+                    raise
+                finally:
                     finished = time.perf_counter()
                     total_ms = round((finished - queued_at) * 1000, 1)
                     if update_started is None:

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -106,6 +106,9 @@ def _log_thread_history_refresh(
         sidecar_hydration_ms=diagnostics.get("sidecar_hydration_ms", 0.0),
         coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         cache_reject_reason=diagnostics.get(THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC),
+        thread_read_source=diagnostics.get(THREAD_HISTORY_SOURCE_DIAGNOSTIC),
+        thread_read_degraded=diagnostics.get(THREAD_HISTORY_DEGRADED_DIAGNOSTIC, False),
+        thread_read_error=diagnostics.get(THREAD_HISTORY_ERROR_DIAGNOSTIC),
     )
 
 

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -81,6 +81,34 @@ def _thread_history_result(
     return thread_history_result(history, is_full_history=is_full_history, diagnostics=diagnostics)
 
 
+def _log_thread_history_refresh(
+    *,
+    room_id: str,
+    thread_id: str,
+    caller_label: str,
+    mode: str,
+    diagnostics: Mapping[str, str | int | float | bool],
+    coordinator_queue_wait_ms: float,
+) -> None:
+    """Emit one structured INFO line for a completed thread read."""
+    logger.info(
+        "matrix_cache_thread_history_refreshed",
+        room_id=room_id,
+        thread_id=thread_id,
+        caller_label=caller_label,
+        mode=mode,
+        cache_read_ms=diagnostics.get("cache_read_ms", 0.0),
+        homeserver_fetch_ms=diagnostics.get("homeserver_fetch_ms", 0.0),
+        homeserver_scan_pages=diagnostics.get("homeserver_scan_pages", 0),
+        homeserver_scanned_event_count=diagnostics.get("homeserver_scanned_event_count", 0),
+        homeserver_thread_event_count=diagnostics.get("homeserver_thread_event_count", 0),
+        resolution_ms=diagnostics.get("resolution_ms", 0.0),
+        sidecar_hydration_ms=diagnostics.get("sidecar_hydration_ms", 0.0),
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+        cache_reject_reason=diagnostics.get(THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC),
+    )
+
+
 class RoomThreadsPageError(ValueError):
     """Raised when a single /threads page request fails."""
 
@@ -546,6 +574,8 @@ async def refresh_thread_history_from_source(
     cache_write_guard_started_at: float | None = None,
     cache_reject_diagnostics: Mapping[str, str | int | float | bool] | None = None,
     trusted_sender_ids: Collection[str] = (),
+    caller_label: str = "unknown",
+    coordinator_queue_wait_ms: float = 0.0,
 ) -> ThreadHistoryResult:
     """Fetch fresh thread history from Matrix and repopulate the advisory cache."""
     fetch_started_at = time.time() if cache_write_guard_started_at is None else cache_write_guard_started_at
@@ -571,6 +601,14 @@ async def refresh_thread_history_from_source(
                 trusted_sender_ids=trusted_sender_ids,
             )
             if stale_history is not None:
+                _log_thread_history_refresh(
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    caller_label=caller_label,
+                    mode="full_scan",
+                    diagnostics=stale_history.diagnostics,
+                    coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+                )
                 return stale_history
         raise
     if _thread_history_fetch_is_cacheable(fetch_result.event_sources, thread_id=thread_id):
@@ -617,11 +655,20 @@ async def refresh_thread_history_from_source(
     }
     if cache_reject_diagnostics is not None:
         diagnostics.update(cache_reject_diagnostics)
-    return _thread_history_result(
+    result = _thread_history_result(
         fetch_result.history,
         is_full_history=hydrate_sidecars,
         diagnostics=diagnostics,
     )
+    _log_thread_history_refresh(
+        room_id=room_id,
+        thread_id=thread_id,
+        caller_label=caller_label,
+        mode="full_scan",
+        diagnostics=result.diagnostics,
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+    )
+    return result
 
 
 async def _store_thread_history_cache(
@@ -719,6 +766,8 @@ async def fetch_thread_history(
     *,
     cache_write_guard_started_at: float | None = None,
     trusted_sender_ids: Collection[str] = (),
+    caller_label: str = "unknown",
+    coordinator_queue_wait_ms: float = 0.0,
 ) -> ThreadHistoryResult:
     """Fetch all messages in a thread."""
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
@@ -750,6 +799,8 @@ async def fetch_thread_history(
         cache_write_guard_started_at=cache_write_guard_started_at,
         cache_reject_diagnostics=cache_reject_diagnostics,
         trusted_sender_ids=trusted_sender_ids,
+        caller_label=caller_label,
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
     )
 
 
@@ -761,6 +812,8 @@ async def fetch_thread_snapshot(
     *,
     cache_write_guard_started_at: float | None = None,
     trusted_sender_ids: Collection[str] = (),
+    caller_label: str = "unknown",
+    coordinator_queue_wait_ms: float = 0.0,
 ) -> ThreadHistoryResult:
     """Fetch lightweight thread context without hydrating sidecars when a fresh cache hit is unavailable."""
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
@@ -793,6 +846,8 @@ async def fetch_thread_snapshot(
         cache_write_guard_started_at=cache_write_guard_started_at,
         cache_reject_diagnostics=cache_reject_diagnostics,
         trusted_sender_ids=trusted_sender_ids,
+        caller_label=caller_label,
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
     )
 
 
@@ -804,6 +859,8 @@ async def fetch_dispatch_thread_history(
     *,
     cache_write_guard_started_at: float | None = None,
     trusted_sender_ids: Collection[str] = (),
+    caller_label: str = "unknown",
+    coordinator_queue_wait_ms: float = 0.0,
 ) -> ThreadHistoryResult:
     """Fetch strict full thread history for dispatch using only fresh cache data or a homeserver refill."""
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
@@ -836,6 +893,8 @@ async def fetch_dispatch_thread_history(
         cache_write_guard_started_at=cache_write_guard_started_at,
         cache_reject_diagnostics=cache_reject_diagnostics,
         trusted_sender_ids=trusted_sender_ids,
+        caller_label=caller_label,
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
     )
 
 
@@ -847,6 +906,8 @@ async def fetch_dispatch_thread_snapshot(
     *,
     cache_write_guard_started_at: float | None = None,
     trusted_sender_ids: Collection[str] = (),
+    caller_label: str = "unknown",
+    coordinator_queue_wait_ms: float = 0.0,
 ) -> ThreadHistoryResult:
     """Fetch strict lightweight dispatch context using only fresh cache data or a homeserver refill."""
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
@@ -879,6 +940,8 @@ async def fetch_dispatch_thread_snapshot(
         cache_write_guard_started_at=cache_write_guard_started_at,
         cache_reject_diagnostics=cache_reject_diagnostics,
         trusted_sender_ids=trusted_sender_ids,
+        caller_label=caller_label,
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
     )
 
 

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -112,6 +112,25 @@ def _log_thread_history_refresh(
     )
 
 
+def _log_cached_thread_history_refresh(
+    *,
+    room_id: str,
+    thread_id: str,
+    caller_label: str,
+    cached_history: ThreadHistoryResult,
+    coordinator_queue_wait_ms: float,
+) -> None:
+    """Emit refresh diagnostics for a usable durable-cache hit."""
+    _log_thread_history_refresh(
+        room_id=room_id,
+        thread_id=thread_id,
+        caller_label=caller_label,
+        mode="cache_hit",
+        diagnostics=cached_history.diagnostics,
+        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+    )
+
+
 class RoomThreadsPageError(ValueError):
     """Raised when a single /threads page request fails."""
 
@@ -792,6 +811,13 @@ async def fetch_thread_history(
         )
     else:
         if cached_history is not None:
+            _log_cached_thread_history_refresh(
+                room_id=room_id,
+                thread_id=thread_id,
+                caller_label=caller_label,
+                cached_history=cached_history,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+            )
             return cached_history
     return await refresh_thread_history_from_source(
         client,
@@ -838,6 +864,13 @@ async def fetch_thread_snapshot(
         )
     else:
         if cached_history is not None:
+            _log_cached_thread_history_refresh(
+                room_id=room_id,
+                thread_id=thread_id,
+                caller_label=caller_label,
+                cached_history=cached_history,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+            )
             return cached_history
     return await refresh_thread_history_from_source(
         client,
@@ -885,6 +918,13 @@ async def fetch_dispatch_thread_history(
         )
     else:
         if cached_history is not None:
+            _log_cached_thread_history_refresh(
+                room_id=room_id,
+                thread_id=thread_id,
+                caller_label=caller_label,
+                cached_history=cached_history,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+            )
             return cached_history
     return await refresh_thread_history_from_source(
         client,
@@ -932,6 +972,13 @@ async def fetch_dispatch_thread_snapshot(
         )
     else:
         if cached_history is not None:
+            _log_cached_thread_history_refresh(
+                room_id=room_id,
+                thread_id=thread_id,
+                caller_label=caller_label,
+                cached_history=cached_history,
+                coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+            )
             return cached_history
     return await refresh_thread_history_from_source(
         client,

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 _VISIBLE_ROOM_MESSAGE_EVENT_TYPES = (nio.RoomMessageText, nio.RoomMessageNotice)
+type ThreadHistoryDiagnosticValue = str | int | float | bool | None
 
 
 @dataclass(slots=True)
@@ -87,7 +88,7 @@ def _log_thread_history_refresh(
     thread_id: str,
     caller_label: str,
     mode: str,
-    diagnostics: Mapping[str, str | int | float | bool],
+    diagnostics: Mapping[str, ThreadHistoryDiagnosticValue],
     coordinator_queue_wait_ms: float,
 ) -> None:
     """Emit one structured INFO line for a completed thread read."""
@@ -109,25 +110,6 @@ def _log_thread_history_refresh(
         thread_read_source=diagnostics.get(THREAD_HISTORY_SOURCE_DIAGNOSTIC),
         thread_read_degraded=diagnostics.get(THREAD_HISTORY_DEGRADED_DIAGNOSTIC, False),
         thread_read_error=diagnostics.get(THREAD_HISTORY_ERROR_DIAGNOSTIC),
-    )
-
-
-def _log_cached_thread_history_refresh(
-    *,
-    room_id: str,
-    thread_id: str,
-    caller_label: str,
-    cached_history: ThreadHistoryResult,
-    coordinator_queue_wait_ms: float,
-) -> None:
-    """Emit refresh diagnostics for a usable durable-cache hit."""
-    _log_thread_history_refresh(
-        room_id=room_id,
-        thread_id=thread_id,
-        caller_label=caller_label,
-        mode="cache_hit",
-        diagnostics=cached_history.diagnostics,
-        coordinator_queue_wait_ms=coordinator_queue_wait_ms,
     )
 
 
@@ -811,11 +793,12 @@ async def fetch_thread_history(
         )
     else:
         if cached_history is not None:
-            _log_cached_thread_history_refresh(
+            _log_thread_history_refresh(
                 room_id=room_id,
                 thread_id=thread_id,
                 caller_label=caller_label,
-                cached_history=cached_history,
+                mode="cache_hit",
+                diagnostics=cached_history.diagnostics,
                 coordinator_queue_wait_ms=coordinator_queue_wait_ms,
             )
             return cached_history
@@ -864,11 +847,12 @@ async def fetch_thread_snapshot(
         )
     else:
         if cached_history is not None:
-            _log_cached_thread_history_refresh(
+            _log_thread_history_refresh(
                 room_id=room_id,
                 thread_id=thread_id,
                 caller_label=caller_label,
-                cached_history=cached_history,
+                mode="cache_hit",
+                diagnostics=cached_history.diagnostics,
                 coordinator_queue_wait_ms=coordinator_queue_wait_ms,
             )
             return cached_history
@@ -918,11 +902,12 @@ async def fetch_dispatch_thread_history(
         )
     else:
         if cached_history is not None:
-            _log_cached_thread_history_refresh(
+            _log_thread_history_refresh(
                 room_id=room_id,
                 thread_id=thread_id,
                 caller_label=caller_label,
-                cached_history=cached_history,
+                mode="cache_hit",
+                diagnostics=cached_history.diagnostics,
                 coordinator_queue_wait_ms=coordinator_queue_wait_ms,
             )
             return cached_history
@@ -972,11 +957,12 @@ async def fetch_dispatch_thread_snapshot(
         )
     else:
         if cached_history is not None:
-            _log_cached_thread_history_refresh(
+            _log_thread_history_refresh(
                 room_id=room_id,
                 thread_id=thread_id,
                 caller_label=caller_label,
-                cached_history=cached_history,
+                mode="cache_hit",
+                diagnostics=cached_history.diagnostics,
                 coordinator_queue_wait_ms=coordinator_queue_wait_ms,
             )
             return cached_history

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -651,6 +651,8 @@ class MatrixConversationCache(ConversationCacheProtocol):
             event_cache=self.runtime.event_cache,
             cache_write_guard_started_at=fetch_started_at,
             trusted_sender_ids=self._trusted_sender_ids(),
+            caller_label="startup_thread_prewarm",
+            coordinator_queue_wait_ms=0.0,
         )
 
     async def _startup_thread_prewarm_ids(

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -140,6 +140,7 @@ class ConversationCacheProtocol(Protocol):
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve thread context using explicit history and dispatch-safety flags."""
 
@@ -154,6 +155,8 @@ class ConversationCacheProtocol(Protocol):
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve advisory full thread history for one conversation root."""
 
@@ -168,6 +171,8 @@ class ConversationCacheProtocol(Protocol):
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve strict full dispatch thread history using only fresh cache data or a homeserver refill."""
 
@@ -438,6 +443,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str,
     ) -> ThreadReadResult:
         """Resolve one thread read through per-turn memoization."""
         cache_key: ThreadReadCacheKey = (room_id, thread_id, full_history, dispatch_safe)
@@ -450,6 +456,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=full_history,
             dispatch_safe=dispatch_safe,
+            caller_label=caller_label,
         )
         if turn_cache is not None:
             turn_cache[cache_key] = self._copy_thread_read_result(result)
@@ -554,6 +561,9 @@ class MatrixConversationCache(ConversationCacheProtocol):
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
     ) -> ThreadHistoryResult:
         fetch_started_at = time.time()
         return await fetch_thread_history(
@@ -563,12 +573,17 @@ class MatrixConversationCache(ConversationCacheProtocol):
             event_cache=self.runtime.event_cache,
             cache_write_guard_started_at=fetch_started_at,
             trusted_sender_ids=self._trusted_sender_ids(),
+            caller_label=caller_label,
+            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         )
 
     async def _fetch_thread_snapshot_from_client(
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
     ) -> ThreadHistoryResult:
         fetch_started_at = time.time()
         return await fetch_thread_snapshot(
@@ -578,12 +593,17 @@ class MatrixConversationCache(ConversationCacheProtocol):
             event_cache=self.runtime.event_cache,
             cache_write_guard_started_at=fetch_started_at,
             trusted_sender_ids=self._trusted_sender_ids(),
+            caller_label=caller_label,
+            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         )
 
     async def _fetch_dispatch_thread_history_from_client(
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
     ) -> ThreadHistoryResult:
         fetch_started_at = time.time()
         return await fetch_dispatch_thread_history(
@@ -593,12 +613,17 @@ class MatrixConversationCache(ConversationCacheProtocol):
             event_cache=self.runtime.event_cache,
             cache_write_guard_started_at=fetch_started_at,
             trusted_sender_ids=self._trusted_sender_ids(),
+            caller_label=caller_label,
+            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         )
 
     async def _fetch_dispatch_thread_snapshot_from_client(
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
     ) -> ThreadHistoryResult:
         fetch_started_at = time.time()
         return await fetch_dispatch_thread_snapshot(
@@ -608,6 +633,8 @@ class MatrixConversationCache(ConversationCacheProtocol):
             event_cache=self.runtime.event_cache,
             cache_write_guard_started_at=fetch_started_at,
             trusted_sender_ids=self._trusted_sender_ids(),
+            caller_label=caller_label,
+            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         )
 
     async def _refresh_dispatch_thread_snapshot_for_startup_prewarm(
@@ -766,12 +793,15 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=False,
             dispatch_safe=False,
+            caller_label="unknown",
         )
 
     async def get_thread_history(
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve advisory full thread history for one conversation root."""
         return await self._read_thread_memoized(
@@ -779,6 +809,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=True,
             dispatch_safe=False,
+            caller_label=caller_label,
         )
 
     async def get_thread_messages(
@@ -788,14 +819,23 @@ class MatrixConversationCache(ConversationCacheProtocol):
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve thread context using one explicit read-mode entrypoint."""
         if dispatch_safe:
             if full_history:
-                return await self.get_dispatch_thread_history(room_id, thread_id)
+                return await self.get_dispatch_thread_history(
+                    room_id,
+                    thread_id,
+                    caller_label=caller_label,
+                )
             return await self.get_dispatch_thread_snapshot(room_id, thread_id)
         if full_history:
-            return await self.get_thread_history(room_id, thread_id)
+            return await self.get_thread_history(
+                room_id,
+                thread_id,
+                caller_label=caller_label,
+            )
         return await self.get_thread_snapshot(room_id, thread_id)
 
     async def get_dispatch_thread_snapshot(
@@ -809,12 +849,15 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=False,
             dispatch_safe=True,
+            caller_label="unknown",
         )
 
     async def get_dispatch_thread_history(
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve strict full dispatch thread history using only fresh cache data or a homeserver refill."""
         return await self._read_thread_memoized(
@@ -822,6 +865,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=True,
             dispatch_safe=True,
+            caller_label=caller_label,
         )
 
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -148,6 +148,8 @@ class ConversationCacheProtocol(Protocol):
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve advisory thread context for non-dispatch callers."""
 
@@ -164,6 +166,8 @@ class ConversationCacheProtocol(Protocol):
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve strict dispatch thread context using only fresh cache data or a homeserver refill."""
 
@@ -185,6 +189,8 @@ class ConversationCacheProtocol(Protocol):
         thread_id: str | None,
         reply_to_event_id: str | None = None,
         existing_event_id: str | None = None,
+        *,
+        caller_label: str = "latest_thread_event_lookup",
     ) -> str | None:
         """Resolve the latest visible thread event when MSC3440 fallback needs it."""
 
@@ -788,6 +794,8 @@ class MatrixConversationCache(ConversationCacheProtocol):
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve advisory thread context for non-dispatch callers."""
         return await self._read_thread_memoized(
@@ -795,7 +803,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=False,
             dispatch_safe=False,
-            caller_label="unknown",
+            caller_label=caller_label,
         )
 
     async def get_thread_history(
@@ -831,19 +839,25 @@ class MatrixConversationCache(ConversationCacheProtocol):
                     thread_id,
                     caller_label=caller_label,
                 )
-            return await self.get_dispatch_thread_snapshot(room_id, thread_id)
+            return await self.get_dispatch_thread_snapshot(
+                room_id,
+                thread_id,
+                caller_label=caller_label,
+            )
         if full_history:
             return await self.get_thread_history(
                 room_id,
                 thread_id,
                 caller_label=caller_label,
             )
-        return await self.get_thread_snapshot(room_id, thread_id)
+        return await self.get_thread_snapshot(room_id, thread_id, caller_label=caller_label)
 
     async def get_dispatch_thread_snapshot(
         self,
         room_id: str,
         thread_id: str,
+        *,
+        caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve strict dispatch thread context using only fresh cache data or a homeserver refill."""
         return await self._read_thread_memoized(
@@ -851,7 +865,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             full_history=False,
             dispatch_safe=True,
-            caller_label="unknown",
+            caller_label=caller_label,
         )
 
     async def get_dispatch_thread_history(
@@ -889,6 +903,8 @@ class MatrixConversationCache(ConversationCacheProtocol):
         thread_id: str | None,
         reply_to_event_id: str | None = None,
         existing_event_id: str | None = None,
+        *,
+        caller_label: str = "latest_thread_event_lookup",
     ) -> str | None:
         """Resolve the latest visible thread event when MSC3440 fallback needs it."""
         return await self._reads.get_latest_thread_event_id_if_needed(
@@ -896,6 +912,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             thread_id,
             reply_to_event_id=reply_to_event_id,
             existing_event_id=existing_event_id,
+            caller_label=caller_label,
         )
 
     def notify_outbound_message(

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -658,6 +658,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             cache_write_guard_started_at=fetch_started_at,
             trusted_sender_ids=self._trusted_sender_ids(),
             caller_label="startup_thread_prewarm",
+            # Startup prewarm bypasses the read coordinator; 0.0 means no coordinator queue was used.
             coordinator_queue_wait_ms=0.0,
         )
 

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -696,6 +696,7 @@ class ResponseRunner:
                 self._client(),
                 request.room_id,
                 request.thread_id,
+                caller_label="dispatch_post_lock_refresh",
             )
         except Exception as exc:
             if request.requires_full_thread_history:

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -1277,11 +1277,9 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
     else:
         if thread_id:
             thread_history = list(
-                await conversation_cache.get_thread_messages(
+                await conversation_cache.get_thread_history(
                     room_id,
                     thread_id,
-                    full_history=True,
-                    dispatch_safe=False,
                     caller_label="schedule_existing_thread",
                 ),
             )

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -753,6 +753,7 @@ async def _build_workflow_message_content(
         latest_thread_event_id = await conversation_cache.get_latest_thread_event_id_if_needed(
             workflow.room_id,
             target.resolved_thread_id,
+            caller_label="scheduled_workflow_message",
         )
     return format_message_with_mentions(
         config,
@@ -777,6 +778,7 @@ async def _build_scheduled_failure_content(
         latest_thread_event_id = await conversation_cache.get_latest_thread_event_id_if_needed(
             workflow.room_id,
             target.resolved_thread_id,
+            caller_label="scheduled_workflow_failure",
         )
     return build_message_content(
         body=error_message,

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -1274,7 +1274,15 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
         available_agents = list(sender_visible_room_agents)
     else:
         if thread_id:
-            thread_history = list(await conversation_cache.get_thread_history(room_id, thread_id))
+            thread_history = list(
+                await conversation_cache.get_thread_messages(
+                    room_id,
+                    thread_id,
+                    full_history=True,
+                    dispatch_safe=False,
+                    caller_label="schedule_existing_thread",
+                ),
+            )
             thread_agents = get_agents_in_thread(thread_history, config, runtime_paths)
             available_agents = [agent for agent in thread_agents if agent in sender_visible_room_agents]
 

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -202,11 +202,9 @@ async def _load_thread_history(
 ) -> list[ResolvedVisibleMessage]:
     """Load thread history through the explicit conversation-cache seam."""
     return list(
-        await conversation_cache.get_thread_messages(
+        await conversation_cache.get_thread_history(
             room_id,
             thread_id,
-            full_history=True,
-            dispatch_safe=False,
             caller_label="thread_summary_background",
         ),
     )

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -201,7 +201,15 @@ async def _load_thread_history(
     thread_id: str,
 ) -> list[ResolvedVisibleMessage]:
     """Load thread history through the explicit conversation-cache seam."""
-    return list(await conversation_cache.get_thread_history(room_id, thread_id))
+    return list(
+        await conversation_cache.get_thread_messages(
+            room_id,
+            thread_id,
+            full_history=True,
+            dispatch_safe=False,
+            caller_label="thread_summary_background",
+        ),
+    )
 
 
 async def _recover_last_summary_count(

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -396,6 +396,7 @@ async def send_thread_summary_event(
         latest_thread_event_id = await conversation_cache.get_latest_thread_event_id_if_needed(
             room_id,
             thread_id,
+            caller_label="thread_summary_send",
         )
     except Exception as exc:
         logger.warning(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -930,7 +930,12 @@ class TurnController:
     ) -> None:
         """Execute one validated interactive selection through the normal response path."""
         thread_history = (
-            await self.deps.resolver.fetch_thread_history(self._client(), room.room_id, selection.thread_id)
+            await self.deps.resolver.fetch_thread_history(
+                self._client(),
+                room.room_id,
+                selection.thread_id,
+                caller_label="interactive_selection",
+            )
             if selection.thread_id
             else []
         )

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -762,11 +762,10 @@ class TurnController:
             ingress_metadata=ingress_metadata,
             payload_metadata=payload_metadata,
         ):
-            context_kwargs = {"payload_metadata": payload_metadata} if payload_metadata is not None else {}
             context = await self.deps.resolver.extract_trusted_router_relay_context(
                 room,
                 event,
-                **context_kwargs,
+                payload_metadata=payload_metadata,
             )
             emit_elapsed_timing(
                 "dispatch_handoff.prepare_dispatch.extract_context",
@@ -774,11 +773,10 @@ class TurnController:
                 path="trusted_router_relay",
             )
         else:
-            context_kwargs = {"payload_metadata": payload_metadata} if payload_metadata is not None else {}
             context = await self.deps.resolver.extract_dispatch_context(
                 room,
                 event,
-                **context_kwargs,
+                payload_metadata=payload_metadata,
             )
             emit_elapsed_timing(
                 "dispatch_handoff.prepare_dispatch.extract_context",

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -585,6 +585,7 @@ class TurnController:
         thread_history = await self.deps.conversation_cache.get_dispatch_thread_snapshot(
             room.room_id,
             thread_id,
+            caller_label="router_pre_ingress_skip",
         )
         return thread_requires_explicit_agent_targeting(
             thread_history,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -426,7 +426,9 @@ def make_conversation_cache_mock() -> AsyncMock:
         *,
         full_history: bool,
         dispatch_safe: bool,
+        caller_label: str = "unknown",
     ) -> object:
+        _ = caller_label
         if dispatch_safe:
             if full_history:
                 return await conversation_cache.get_dispatch_thread_history(room_id, thread_id)

--- a/tests/test_attachments_tool.py
+++ b/tests/test_attachments_tool.py
@@ -619,6 +619,7 @@ async def test_send_context_attachments_reuses_latest_thread_event_id_for_multip
     context.conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
         context.room_id,
         context.thread_id,
+        caller_label="attachment_tool_send",
     )
     first_call = mock_send.await_args_list[0]
     second_call = mock_send.await_args_list[1]
@@ -779,6 +780,7 @@ async def test_send_context_attachments_inherits_resolved_thread_scope(tmp_path:
     ctx.conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
         ctx.room_id,
         "$thread-root:localhost",
+        caller_label="attachment_tool_send",
     )
     assert mocked.await_args.kwargs["thread_id"] == "$thread-root:localhost"
 

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -735,6 +735,8 @@ async def test_startup_thread_prewarm_refresh_waits_for_background_warm(tmp_path
 
     assert result.messages == []
     fetch_dispatch_thread_snapshot.assert_awaited_once()
+    assert fetch_dispatch_thread_snapshot.await_args.kwargs["caller_label"] == "startup_thread_prewarm"
+    assert fetch_dispatch_thread_snapshot.await_args.kwargs["coordinator_queue_wait_ms"] == 0.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -1509,6 +1509,7 @@ class TestRouterSkipsSingleAgent:
         bot._conversation_cache.get_dispatch_thread_snapshot.assert_awaited_once_with(
             "!test:server",
             "$thread_root",
+            caller_label="router_pre_ingress_skip",
         )
         bot._turn_controller._append_live_event_with_timing.assert_not_awaited()
         bot._turn_controller._enqueue_for_dispatch.assert_not_awaited()

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -732,7 +732,12 @@ async def test_handle_message_edit_reuses_persisted_target_and_thread_scope(
             requester_user_id="@user:example.com",
         )
 
-    mock_fetch_history.assert_awaited_once_with(bot.client, room.room_id, stored_target.resolved_thread_id)
+    mock_fetch_history.assert_awaited_once_with(
+        bot.client,
+        room.room_id,
+        stored_target.resolved_thread_id,
+        caller_label="edit_regeneration_context",
+    )
     mock_remove_stale_runs.assert_called_once()
     call_kwargs = mock_generate_response.call_args.kwargs
     assert call_kwargs["reply_to_event_id"] == "$original:example.com"

--- a/tests/test_hook_schedule.py
+++ b/tests/test_hook_schedule.py
@@ -304,7 +304,10 @@ async def test_schedule_hook_send_message_inherits_context_thread_id(tmp_path: P
             conversation_cache,
         )
 
-    conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with("!room:localhost", "$thread")
+    conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+        "!room:localhost",
+        "$thread",
+    )
     mock_schedule_send.assert_not_called()
     content = mock_hook_send.await_args.args[2]
     assert content["body"] == "resume"
@@ -344,7 +347,10 @@ async def test_schedule_hook_send_message_allows_explicit_room_level_opt_out(tmp
             conversation_cache,
         )
 
-    conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with("!room:localhost", None)
+    conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+        "!room:localhost",
+        None,
+    )
     mock_schedule_send.assert_not_called()
     content = mock_hook_send.await_args.args[2]
     assert content["body"] == "room-level"

--- a/tests/test_hook_schedule.py
+++ b/tests/test_hook_schedule.py
@@ -307,6 +307,7 @@ async def test_schedule_hook_send_message_inherits_context_thread_id(tmp_path: P
     conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
         "!room:localhost",
         "$thread",
+        caller_label="hook_sender",
     )
     mock_schedule_send.assert_not_called()
     content = mock_hook_send.await_args.args[2]
@@ -350,6 +351,7 @@ async def test_schedule_hook_send_message_allows_explicit_room_level_opt_out(tmp
     conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
         "!room:localhost",
         None,
+        caller_label="hook_sender",
     )
     mock_schedule_send.assert_not_called()
     content = mock_hook_send.await_args.args[2]

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -541,6 +541,7 @@ async def test_agent_bot_hook_send_message_tags_source_and_threads(tmp_path: Pat
     bot._conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
         "!room:localhost",
         "$thread",
+        caller_label="hook_sender",
     )
 
 

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -723,7 +723,11 @@ async def test_prepare_dispatch_uses_trusted_router_context_for_router_relays(tm
 
     assert dispatch is not None
     assert dispatch.context is trusted_context
-    bot._conversation_resolver.extract_trusted_router_relay_context.assert_awaited_once_with(room, event)
+    bot._conversation_resolver.extract_trusted_router_relay_context.assert_awaited_once_with(
+        room,
+        event,
+        payload_metadata=None,
+    )
     bot._conversation_resolver.extract_dispatch_context.assert_not_called()
 
 
@@ -788,6 +792,7 @@ async def test_prepare_dispatch_keeps_standard_context_for_non_router_internal_r
     bot._conversation_resolver.extract_dispatch_context.assert_awaited_once_with(
         room,
         event,
+        payload_metadata=None,
     )
     bot._conversation_resolver.extract_trusted_router_relay_context.assert_not_called()
 

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -784,7 +784,10 @@ async def test_prepare_dispatch_keeps_standard_context_for_non_router_internal_r
 
     assert dispatch is not None
     assert dispatch.context is standard_context
-    bot._conversation_resolver.extract_dispatch_context.assert_awaited_once_with(room, event)
+    bot._conversation_resolver.extract_dispatch_context.assert_awaited_once_with(
+        room,
+        event,
+    )
     bot._conversation_resolver.extract_trusted_router_relay_context.assert_not_called()
 
 

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -4591,3 +4591,41 @@ async def test_router_early_skip_keeps_sidecar_preview_for_hydration(tmp_path: P
     )
 
     assert should_skip is False
+
+
+@pytest.mark.asyncio
+async def test_router_early_skip_labels_thread_snapshot_refresh(tmp_path: Path) -> None:
+    """Router skip checks should attribute dispatch-safe snapshot refreshes."""
+    bot = _make_bot(tmp_path, agent_name="router")
+    room = _make_room()
+    event = cast(
+        "nio.RoomMessageText",
+        nio.RoomMessageText.from_dict(
+            {
+                "event_id": "$event",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1000,
+                "room_id": room.room_id,
+                "type": "m.room.message",
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "plain follow-up",
+                },
+            },
+        ),
+    )
+    bot._conversation_cache.get_dispatch_thread_snapshot = AsyncMock(return_value=[])
+
+    should_skip = await bot._turn_controller._should_skip_router_before_shared_ingress_work(
+        room,
+        event,
+        requester_user_id="@user:localhost",
+        thread_id="$thread",
+    )
+
+    assert should_skip is False
+    bot._conversation_cache.get_dispatch_thread_snapshot.assert_awaited_once_with(
+        room.room_id,
+        "$thread",
+        caller_label="router_pre_ingress_skip",
+    )

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -7,7 +7,7 @@ import json
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
-from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, patch
 
 import nio
 import pytest
@@ -274,6 +274,7 @@ async def test_matrix_message_send_room_sentinel_stays_room_level() -> None:
     ctx.conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
         ctx.room_id,
         None,
+        caller_label="matrix_message_tool_send",
     )
     sent_content = mock_send.await_args.args[2]
     assert sent_content["body"] == "hello"
@@ -415,6 +416,12 @@ async def test_matrix_message_send_supports_context_attachments(tmp_path: Path) 
     assert payload["attachment_thread_id"] == "$evt"
     assert payload["attachment_event_ids"] == ["$file_evt"]
     assert payload["resolved_attachment_ids"] == ["att_upload"]
+    ctx.conversation_cache.get_latest_thread_event_id_if_needed.assert_has_awaits(
+        [
+            call(ctx.room_id, None, caller_label="matrix_message_tool_send"),
+            call(ctx.room_id, "$evt", caller_label="attachment_tool_send"),
+        ],
+    )
     mock_send.assert_awaited_once()
     mock_send_file.assert_awaited_once_with(
         ctx.client,
@@ -697,6 +704,11 @@ async def test_matrix_message_send_multiple_attachments_only_auto_threads_under_
         thread_id=None,
         latest_thread_event_id=None,
         conversation_cache=ctx.conversation_cache,
+    )
+    ctx.conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+        ctx.room_id,
+        None,
+        caller_label="matrix_message_tool_attachment",
     )
     mock_send_attachment_paths.assert_awaited_once()
     assert mock_send_attachment_paths.await_args.args == (ctx,)
@@ -2368,6 +2380,7 @@ async def test_matrix_message_edit_happy_path() -> None:
     ctx.conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
         ctx.room_id,
         "$ctx-thread:localhost",
+        caller_label="matrix_message_tool_edit",
     )
     ctx.conversation_cache.get_thread_history.assert_not_awaited()
 

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -1264,7 +1264,13 @@ async def test_matrix_message_read_thread_enforces_max_limit() -> None:
     assert payload["limit"] == MatrixMessageTools._MAX_READ_LIMIT
     assert len(payload["messages"]) == MatrixMessageTools._MAX_READ_LIMIT
     assert "edit_options" in payload
-    ctx.conversation_cache.get_thread_history.assert_awaited_once_with(ctx.room_id, ctx.thread_id)
+    ctx.conversation_cache.get_thread_messages.assert_awaited_once_with(
+        ctx.room_id,
+        ctx.thread_id,
+        full_history=True,
+        dispatch_safe=False,
+        caller_label="matrix_message_tool",
+    )
 
 
 @pytest.mark.asyncio
@@ -1338,7 +1344,13 @@ async def test_matrix_message_thread_list_returns_thread_messages() -> None:
     assert payload["thread_id"] == "$thread-other:localhost"
     assert payload["messages"] == [thread_messages[-1].to_dict()]
     assert payload["edit_options"][0]["event_id"] == "$two"
-    ctx.conversation_cache.get_thread_history.assert_awaited_once_with(ctx.room_id, "$thread-other:localhost")
+    ctx.conversation_cache.get_thread_messages.assert_awaited_once_with(
+        ctx.room_id,
+        "$thread-other:localhost",
+        full_history=True,
+        dispatch_safe=False,
+        caller_label="matrix_message_tool",
+    )
 
 
 @pytest.mark.asyncio
@@ -1370,7 +1382,13 @@ async def test_matrix_message_thread_list_preserves_notice_messages() -> None:
     assert payload["status"] == "ok"
     assert payload["messages"] == [message.to_dict() for message in thread_messages]
     assert payload["messages"][1]["msgtype"] == "m.notice"
-    ctx.conversation_cache.get_thread_history.assert_awaited_once_with(ctx.room_id, "$thread-other:localhost")
+    ctx.conversation_cache.get_thread_messages.assert_awaited_once_with(
+        ctx.room_id,
+        "$thread-other:localhost",
+        full_history=True,
+        dispatch_safe=False,
+        caller_label="matrix_message_tool",
+    )
 
 
 @pytest.mark.asyncio
@@ -2306,7 +2324,13 @@ async def test_matrix_message_read_explicit_thread_id_still_reads_that_thread() 
     assert payload["action"] == "read"
     assert payload["thread_id"] == "$thread-other:localhost"
     assert payload["messages"] == [thread_messages[-1].to_dict()]
-    ctx.conversation_cache.get_thread_history.assert_awaited_once_with(ctx.room_id, "$thread-other:localhost")
+    ctx.conversation_cache.get_thread_messages.assert_awaited_once_with(
+        ctx.room_id,
+        "$thread-other:localhost",
+        full_history=True,
+        dispatch_safe=False,
+        caller_label="matrix_message_tool",
+    )
     ctx.client.room_messages.assert_not_awaited()
 
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -5017,7 +5017,17 @@ class TestAgentBot:
         bot.client = AsyncMock()
         _install_runtime_cache_support(bot)
 
-        async def cached_history_refresh(_room_id: str, _thread_id: str) -> list[ResolvedVisibleMessage]:
+        async def cached_history_refresh(
+            _room_id: str,
+            _thread_id: str,
+            *,
+            full_history: bool,
+            dispatch_safe: bool,
+            caller_label: str,
+        ) -> list[ResolvedVisibleMessage]:
+            assert full_history is True
+            assert dispatch_safe is True
+            assert caller_label == "dispatch_post_lock_refresh"
             return fresh_history
 
         with (
@@ -5040,7 +5050,7 @@ class TestAgentBot:
             ),
             patch.object(
                 bot._conversation_cache,
-                "get_dispatch_thread_history",
+                "get_thread_messages",
                 new=AsyncMock(side_effect=cached_history_refresh),
             ) as mock_get_thread_history,
             patch_response_runner_module(
@@ -5061,7 +5071,13 @@ class TestAgentBot:
                 )
 
         assert _handled_response_event_id(resolution) == "$response"
-        mock_get_thread_history.assert_awaited_once_with("!test:localhost", "$thread")
+        mock_get_thread_history.assert_awaited_once_with(
+            "!test:localhost",
+            "$thread",
+            full_history=True,
+            dispatch_safe=True,
+            caller_label="dispatch_post_lock_refresh",
+        )
         request = mock_process.await_args.args[0]
         assert list(request.thread_history) == fresh_history
         assert request.thread_history[0].stream_status == STREAM_STATUS_COMPLETED
@@ -9098,6 +9114,8 @@ class TestAgentBot:
             event_cache=bot.event_cache,
             cache_write_guard_started_at=ANY,
             trusted_sender_ids=trusted_sender_ids,
+            caller_label="unknown",
+            coordinator_queue_wait_ms=ANY,
         )
 
     @pytest.mark.asyncio

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -9044,6 +9044,7 @@ class TestAgentBot:
         mock_snapshot.assert_awaited_once_with(
             room.room_id,
             "$thread_root",
+            caller_label="dispatch_context",
         )
         mock_history.assert_not_awaited()
 
@@ -9114,7 +9115,7 @@ class TestAgentBot:
             event_cache=bot.event_cache,
             cache_write_guard_started_at=ANY,
             trusted_sender_ids=trusted_sender_ids,
-            caller_label="unknown",
+            caller_label="dispatch_context",
             coordinator_queue_wait_ms=ANY,
         )
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -4508,6 +4508,47 @@ class TestAgentBot:
         assert seen == [("$plain-reply", "$thread-root")]
 
     @pytest.mark.asyncio
+    async def test_reaction_hooks_label_thread_membership_reads(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """reaction:received hooks should attribute thread proof refreshes."""
+        seen: list[tuple[str, str | None]] = []
+
+        @hook(EVENT_REACTION_RECEIVED)
+        async def record_reaction(ctx: ReactionReceivedContext) -> None:
+            seen.append((ctx.target_event_id, ctx.thread_id))
+
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = make_matrix_client_mock()
+        access = MagicMock()
+        bot._conversation_resolver.thread_membership_access = MagicMock(return_value=access)
+        bot._conversation_resolver.resolve_related_event_thread_id_best_effort = AsyncMock(return_value="$thread-root")
+        bot.hook_registry = HookRegistry.from_plugins([_hook_plugin("hooked", [record_reaction])])
+        room = MagicMock()
+        room.room_id = "!test:localhost"
+        room.canonical_alias = None
+        event = self._make_handler_event("reaction", sender="@user:localhost", event_id="$reaction")
+        event.reacts_to = "$plain-reply"
+
+        with patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=False)):
+            await bot._on_reaction(room, event)
+
+        bot._conversation_resolver.thread_membership_access.assert_called_once_with(
+            full_history=False,
+            dispatch_safe=True,
+            caller_label="reaction_hook_context",
+        )
+        bot._conversation_resolver.resolve_related_event_thread_id_best_effort.assert_awaited_once_with(
+            room.room_id,
+            "$plain-reply",
+            access=access,
+        )
+        assert seen == [("$plain-reply", "$thread-root")]
+
+    @pytest.mark.asyncio
     async def test_reaction_hooks_inherit_thread_transitively_through_plain_reply_chain(
         self,
         mock_agent_user: AgentMatrixUser,

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -776,7 +776,12 @@ async def test_refresh_thread_history_after_lock_refreshes_empty_thread_history(
             ),
         )
 
-    mock_fetch_thread_history.assert_awaited_once_with(bot.client, "!room:localhost", "$thread")
+    mock_fetch_thread_history.assert_awaited_once_with(
+        bot.client,
+        "!room:localhost",
+        "$thread",
+        caller_label="dispatch_post_lock_refresh",
+    )
     assert request.thread_history == fresh_history
 
 

--- a/tests/test_schedule_agent_validation.py
+++ b/tests/test_schedule_agent_validation.py
@@ -39,7 +39,6 @@ def create_mock_room(room_id: str, user_ids: list[str] | None = None) -> nio.Mat
 def _conversation_cache(thread_history: list[object] | None = None) -> MagicMock:
     access = MagicMock()
     access.get_thread_history = AsyncMock(return_value=list(thread_history or []))
-    access.get_thread_messages = AsyncMock(return_value=list(thread_history or []))
     return access
 
 
@@ -385,7 +384,7 @@ async def test_schedule_with_no_agent_mentions() -> None:
     assert task_id is not None
     assert "✅ Scheduled" in response
     assert "New room-level thread root" in response
-    conversation_cache.get_thread_messages.assert_not_called()
+    conversation_cache.get_thread_history.assert_not_called()
     available_agents = mock_parse.await_args.args[3]
     expected_agents = [
         config.get_ids(runtime_paths_for(config))["assistant"],

--- a/tests/test_schedule_agent_validation.py
+++ b/tests/test_schedule_agent_validation.py
@@ -39,6 +39,7 @@ def create_mock_room(room_id: str, user_ids: list[str] | None = None) -> nio.Mat
 def _conversation_cache(thread_history: list[object] | None = None) -> MagicMock:
     access = MagicMock()
     access.get_thread_history = AsyncMock(return_value=list(thread_history or []))
+    access.get_thread_messages = AsyncMock(return_value=list(thread_history or []))
     return access
 
 
@@ -384,7 +385,7 @@ async def test_schedule_with_no_agent_mentions() -> None:
     assert task_id is not None
     assert "✅ Scheduled" in response
     assert "New room-level thread root" in response
-    conversation_cache.get_thread_history.assert_not_called()
+    conversation_cache.get_thread_messages.assert_not_called()
     available_agents = mock_parse.await_args.args[3]
     expected_agents = [
         config.get_ids(runtime_paths_for(config))["assistant"],

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -54,6 +54,7 @@ def _conversation_cache(
 ) -> AsyncMock:
     access = AsyncMock()
     access.get_thread_history = AsyncMock(return_value=list(thread_history or []))
+    access.get_thread_messages = AsyncMock(return_value=list(thread_history or []))
     access.get_latest_thread_event_id_if_needed = AsyncMock(return_value=latest_thread_event_id)
     access.notify_outbound_message = Mock()
     return access

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -54,7 +54,6 @@ def _conversation_cache(
 ) -> AsyncMock:
     access = AsyncMock()
     access.get_thread_history = AsyncMock(return_value=list(thread_history or []))
-    access.get_thread_messages = AsyncMock(return_value=list(thread_history or []))
     access.get_latest_thread_event_id_if_needed = AsyncMock(return_value=latest_thread_event_id)
     access.notify_outbound_message = Mock()
     return access

--- a/tests/test_skip_mentions.py
+++ b/tests/test_skip_mentions.py
@@ -187,6 +187,7 @@ async def test_extract_context_with_skip_mentions(tmp_path: Path) -> None:
         event_with_skip,
         full_history=True,
         dispatch_safe=False,
+        caller_label="skip_mentions_test",
     )
 
     # Verify mentions were ignored
@@ -219,6 +220,7 @@ async def test_extract_context_with_skip_mentions(tmp_path: Path) -> None:
             event_without_skip,
             full_history=True,
             dispatch_safe=False,
+            caller_label="skip_mentions_test",
         )
 
         # Verify mentions were detected
@@ -259,6 +261,7 @@ async def test_extract_context_without_skip_metadata_detects_tool_mentions(tmp_p
         event,
         full_history=True,
         dispatch_safe=False,
+        caller_label="skip_mentions_test",
     )
 
     assert context.am_i_mentioned is True

--- a/tests/test_skip_mentions.py
+++ b/tests/test_skip_mentions.py
@@ -21,6 +21,7 @@ from mindroom.delivery_gateway import (
     EditTextRequest,
     FinalDeliveryRequest,
     SendTextRequest,
+    StreamingDeliveryRequest,
 )
 from mindroom.hooks import MessageEnvelope, ResponseDraft
 from mindroom.logging_config import get_logger, setup_logging
@@ -38,6 +39,7 @@ from tests.conftest import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from pathlib import Path
 
 
@@ -355,6 +357,12 @@ async def test_delivery_gateway_send_text_logs_target_thread_context(
     assert payload["event"] == "Sent response"
     assert payload["room_id"] == "!test:server"
     assert payload["thread_id"] == "$thread"
+    gateway.deps.resolver.deps.conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+        "!test:server",
+        "$thread",
+        "$event123",
+        caller_label="delivery_send_text",
+    )
 
 
 @pytest.mark.asyncio
@@ -384,6 +392,12 @@ async def test_delivery_gateway_send_text_records_threaded_outbound_message(tmp_
     assert record_args[1] == "$response"
     assert record_args[2]["m.relates_to"]["event_id"] == "$thread"
     assert record_args[2]["m.relates_to"]["m.in_reply_to"]["event_id"] == "$latest"
+    gateway.deps.resolver.deps.conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+        "!test:server",
+        "$thread",
+        None,
+        caller_label="delivery_send_text",
+    )
 
 
 @pytest.mark.asyncio
@@ -415,6 +429,44 @@ async def test_delivery_gateway_edit_text_records_threaded_outbound_edit(tmp_pat
     assert record_args[2]["m.relates_to"]["rel_type"] == "m.replace"
     assert record_args[2]["m.relates_to"]["event_id"] == "$original"
     assert "m.relates_to" not in record_args[2]["m.new_content"]
+    gateway.deps.resolver.deps.conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+        "!test:server",
+        "$thread",
+        caller_label="delivery_edit_text",
+    )
+
+
+@pytest.mark.asyncio
+async def test_delivery_gateway_deliver_stream_labels_latest_thread_lookup(tmp_path: Path) -> None:
+    """Streaming delivery should attribute its latest-thread lookup."""
+    gateway, _, _ = _gateway_with_mocks(tmp_path)
+    target = MessageTarget.resolve("!test:server", "$thread", "$root")
+    gateway.deps.resolver.deps.conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(
+        return_value="$latest",
+    )
+
+    async def stream() -> AsyncIterator[str]:
+        yield "hello"
+
+    with patch(
+        "mindroom.delivery_gateway.send_streaming_response",
+        new=AsyncMock(return_value=SimpleNamespace(event_id="$stream", final_visible_body="hello")),
+    ):
+        await gateway.deliver_stream(
+            StreamingDeliveryRequest(
+                target=target,
+                response_stream=stream(),
+                existing_event_id="$existing",
+            ),
+        )
+
+    gateway.deps.resolver.deps.conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+        "!test:server",
+        "$thread",
+        "$root",
+        "$existing",
+        caller_label="delivery_stream",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -249,6 +249,7 @@ async def test_send_matrix_text_uses_latest_thread_event_id_for_fallback(
     ctx.conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
         ctx.room_id,
         ctx.thread_id,
+        caller_label="subagent_tool_send",
     )
     content = send_mock.await_args.args[2]
     assert content["m.relates_to"]["event_id"] == ctx.thread_id

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -3305,6 +3305,88 @@ class TestThreadHistoryCache:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("fetcher_name", "is_full_history"),
+        [
+            ("fetch_thread_history", True),
+            ("fetch_thread_snapshot", False),
+            ("fetch_dispatch_thread_history", True),
+            ("fetch_dispatch_thread_snapshot", False),
+        ],
+    )
+    async def test_thread_fetchers_log_refresh_diagnostics_for_cache_hit(
+        self,
+        fetcher_name: str,
+        is_full_history: bool,
+    ) -> None:
+        """Usable cache hits should emit the same structured refresh diagnostics."""
+        logger = MagicMock()
+        cached_history = ThreadHistoryResult(
+            [
+                ResolvedVisibleMessage.synthetic(
+                    sender="@user:localhost",
+                    body="cached",
+                    event_id="$thread_root",
+                    content={"body": "cached"},
+                ),
+            ],
+            is_full_history=is_full_history,
+            diagnostics={
+                "cache_read_ms": 5.5,
+                "resolution_ms": 3.2,
+                "sidecar_hydration_ms": 1.4,
+                THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_CACHE,
+            },
+        )
+        homeserver_fetch = AsyncMock()
+
+        with (
+            patch.object(matrix_client_module, "logger", logger),
+            patch(
+                "mindroom.matrix.client_thread_history._load_cached_thread_history_if_usable",
+                new=AsyncMock(return_value=(cached_history, None)),
+            ),
+            patch(
+                "mindroom.matrix.client_thread_history._fetch_thread_history_with_events",
+                new=homeserver_fetch,
+            ),
+        ):
+            history = await getattr(matrix_client_module, fetcher_name)(
+                AsyncMock(),
+                "!room:localhost",
+                "$thread_root",
+                event_cache=_event_cache(),
+                caller_label="cache_hit_test",
+                coordinator_queue_wait_ms=34.5,
+            )
+
+        assert history == cached_history
+        homeserver_fetch.assert_not_awaited()
+        refreshed_log = next(
+            call
+            for call in logger.info.call_args_list
+            if call.args and call.args[0] == "matrix_cache_thread_history_refreshed"
+        )
+        assert refreshed_log.kwargs == {
+            "room_id": "!room:localhost",
+            "thread_id": "$thread_root",
+            "caller_label": "cache_hit_test",
+            "mode": "cache_hit",
+            "cache_read_ms": 5.5,
+            "homeserver_fetch_ms": 0.0,
+            "homeserver_scan_pages": 0,
+            "homeserver_scanned_event_count": 0,
+            "homeserver_thread_event_count": 0,
+            "resolution_ms": 3.2,
+            "sidecar_hydration_ms": 1.4,
+            "coordinator_queue_wait_ms": 34.5,
+            "cache_reject_reason": None,
+            "thread_read_source": THREAD_HISTORY_SOURCE_CACHE,
+            "thread_read_degraded": False,
+            "thread_read_error": None,
+        }
+
+    @pytest.mark.asyncio
     async def test_fetch_thread_history_logs_stale_fallback_diagnostics(self) -> None:
         """Stale fallbacks should be visible in the structured refresh diagnostics."""
         logger = MagicMock()

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -741,6 +741,8 @@ class TestThreadHistory:
                 THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "no_cache_state",
             },
             trusted_sender_ids=(),
+            caller_label="unknown",
+            coordinator_queue_wait_ms=0.0,
         )
 
     @pytest.mark.asyncio
@@ -790,6 +792,8 @@ class TestThreadHistory:
                 THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "no_cache_state",
             },
             trusted_sender_ids=(),
+            caller_label="unknown",
+            coordinator_queue_wait_ms=0.0,
         )
 
     @pytest.mark.asyncio
@@ -3223,3 +3227,76 @@ class TestThreadHistoryCache:
         assert room_stale_revalidated is False
         assert [message.event_id for message in history] == ["$thread_root", "$reply1", "$reply2"]
         assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_HOMESERVER
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_history_logs_refresh_diagnostics_for_cache_miss(self) -> None:
+        """Homeserver refills should emit the phase-1 diagnostics line with miss metadata."""
+        logger = MagicMock()
+        refreshed_history = [
+            ResolvedVisibleMessage.synthetic(
+                sender="@user:localhost",
+                body="refreshed",
+                event_id="$thread_root",
+                content={"body": "refreshed"},
+            ),
+        ]
+
+        with (
+            patch.object(matrix_client_module, "logger", logger),
+            patch(
+                "mindroom.matrix.client_thread_history._load_cached_thread_history_if_usable",
+                new=AsyncMock(
+                    return_value=(
+                        None,
+                        {
+                            THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC: "no_cache_state",
+                        },
+                    ),
+                ),
+            ),
+            patch(
+                "mindroom.matrix.client_thread_history._fetch_thread_history_with_events",
+                new=AsyncMock(
+                    return_value=MagicMock(
+                        history=refreshed_history,
+                        event_sources=[{"event_id": "$thread_root"}],
+                        fetch_ms=91.2,
+                        room_scan_pages=7,
+                        scanned_event_count=42,
+                        resolution_ms=8.6,
+                        sidecar_hydration_ms=4.4,
+                    ),
+                ),
+            ),
+            patch("mindroom.matrix.client_thread_history._store_thread_history_cache", new=AsyncMock()),
+        ):
+            history = await matrix_client_module.fetch_thread_history(
+                AsyncMock(),
+                "!room:localhost",
+                "$thread_root",
+                event_cache=_event_cache(),
+                caller_label="cache_miss_test",
+                coordinator_queue_wait_ms=45.6,
+            )
+
+        assert [message.event_id for message in history] == ["$thread_root"]
+        refreshed_log = next(
+            call
+            for call in logger.info.call_args_list
+            if call.args and call.args[0] == "matrix_cache_thread_history_refreshed"
+        )
+        assert refreshed_log.kwargs == {
+            "room_id": "!room:localhost",
+            "thread_id": "$thread_root",
+            "caller_label": "cache_miss_test",
+            "mode": "full_scan",
+            "cache_read_ms": 0.0,
+            "homeserver_fetch_ms": 91.2,
+            "homeserver_scan_pages": 7,
+            "homeserver_scanned_event_count": 42,
+            "homeserver_thread_event_count": 1,
+            "resolution_ms": 8.6,
+            "sidecar_hydration_ms": 4.4,
+            "coordinator_queue_wait_ms": 45.6,
+            "cache_reject_reason": "no_cache_state",
+        }

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -3299,4 +3299,60 @@ class TestThreadHistoryCache:
             "sidecar_hydration_ms": 4.4,
             "coordinator_queue_wait_ms": 45.6,
             "cache_reject_reason": "no_cache_state",
+            "thread_read_source": THREAD_HISTORY_SOURCE_HOMESERVER,
+            "thread_read_degraded": False,
+            "thread_read_error": None,
         }
+
+    @pytest.mark.asyncio
+    async def test_fetch_thread_history_logs_stale_fallback_diagnostics(self) -> None:
+        """Stale fallbacks should be visible in the structured refresh diagnostics."""
+        logger = MagicMock()
+        stale_history = ThreadHistoryResult(
+            [
+                ResolvedVisibleMessage.synthetic(
+                    sender="@user:localhost",
+                    body="stale",
+                    event_id="$thread_root",
+                    content={"body": "stale"},
+                ),
+            ],
+            is_full_history=True,
+            diagnostics={
+                THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_STALE_CACHE,
+                THREAD_HISTORY_DEGRADED_DIAGNOSTIC: True,
+                THREAD_HISTORY_ERROR_DIAGNOSTIC: "homeserver unavailable",
+            },
+        )
+
+        with (
+            patch.object(matrix_client_module, "logger", logger),
+            patch(
+                "mindroom.matrix.client_thread_history._fetch_thread_history_with_events",
+                new=AsyncMock(side_effect=RuntimeError("homeserver unavailable")),
+            ),
+            patch(
+                "mindroom.matrix.client_thread_history._load_stale_cached_thread_history",
+                new=AsyncMock(return_value=stale_history),
+            ),
+        ):
+            history = await matrix_client_module.refresh_thread_history_from_source(
+                AsyncMock(),
+                "!room:localhost",
+                "$thread_root",
+                event_cache=_event_cache(),
+                caller_label="stale_fallback_test",
+                coordinator_queue_wait_ms=12.3,
+            )
+
+        assert history == stale_history
+        refreshed_log = next(
+            call
+            for call in logger.info.call_args_list
+            if call.args and call.args[0] == "matrix_cache_thread_history_refreshed"
+        )
+        assert refreshed_log.kwargs["caller_label"] == "stale_fallback_test"
+        assert refreshed_log.kwargs["coordinator_queue_wait_ms"] == 12.3
+        assert refreshed_log.kwargs["thread_read_source"] == THREAD_HISTORY_SOURCE_STALE_CACHE
+        assert refreshed_log.kwargs["thread_read_degraded"] is True
+        assert refreshed_log.kwargs["thread_read_error"] == "homeserver unavailable"

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -1365,7 +1365,11 @@ class TestExtractedModuleLoggerRebinding:
             ),
         )
 
-        bot._conversation_cache.get_dispatch_thread_history.assert_awaited_once_with("!room:localhost", "$threadroot")
+        bot._conversation_cache.get_dispatch_thread_history.assert_awaited_once()
+        assert bot._conversation_cache.get_dispatch_thread_history.await_args.args == (
+            "!room:localhost",
+            "$threadroot",
+        )
 
     @pytest.mark.asyncio
     async def test_conversation_cache_fetch_path_passes_explicit_event_cache(

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -761,6 +761,7 @@ class TestExtractMessageContextRoomMode:
                 event,
                 full_history=True,
                 dispatch_safe=False,
+                caller_label="thread_mode_test",
             )
             is context
         )
@@ -776,6 +777,7 @@ class TestExtractMessageContextRoomMode:
             event,
             full_history=True,
             dispatch_safe=False,
+            caller_label="thread_mode_test",
         )
 
     def test_hot_reloaded_bot_uses_updated_thread_mode_without_restart(
@@ -1551,6 +1553,7 @@ class TestExtractedModuleLoggerRebinding:
             EventInfo.from_event(event.source),
             full_history=False,
             dispatch_safe=True,
+            caller_label="thread_mode_test",
         )
 
         assert thread_id == "$threadroot"

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -1631,6 +1631,7 @@ class TestExtractedModuleLoggerRebinding:
         bot._conversation_cache.get_dispatch_thread_snapshot.assert_awaited_once_with(
             room.room_id,
             "$thread-root:localhost",
+            caller_label="dispatch_context",
         )
 
 

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -1165,7 +1165,10 @@ class TestSendSummaryEvent:
         assert meta["message_count"] == 15
         assert meta["model"] == "haiku"
         assert "generated_at" in meta
-        conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with("!room:x", "$root1")
+        conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+            "!room:x",
+            "$root1",
+        )
         conversation_cache.notify_outbound_message.assert_called_once_with("!room:x", "$s1", content)
 
     async def test_event_content_truncates_overlong_summary(self) -> None:
@@ -1248,7 +1251,7 @@ class TestSetManualThreadSummary:
         """Manual summary writes should normalize text, count non-summary messages, and update the cache."""
         client = _mock_client()
         conversation_cache = AsyncMock()
-        conversation_cache.get_thread_history.return_value = [
+        conversation_cache.get_thread_messages.return_value = [
             *_make_thread_history(3),
             _make_summary_notice_message("$root1", message_count=2),
         ]
@@ -1267,7 +1270,7 @@ class TestSetManualThreadSummary:
 
         assert result.event_id == "$summary1"
         assert result.summary == "Fix ISSUE-116"
-        assert result.message_count == _count_non_summary_messages(conversation_cache.get_thread_history.return_value)
+        assert result.message_count == _count_non_summary_messages(conversation_cache.get_thread_messages.return_value)
         mock_send.assert_awaited_once_with(
             client,
             "!room:x",
@@ -1283,7 +1286,7 @@ class TestSetManualThreadSummary:
         """A failed manual summary send should not advance the cached threshold baseline."""
         client = _mock_client()
         conversation_cache = AsyncMock()
-        conversation_cache.get_thread_history.return_value = _make_thread_history(5)
+        conversation_cache.get_thread_messages.return_value = _make_thread_history(5)
         update_last_summary_count("!room:x", "$root1", 2)
 
         with (
@@ -1307,7 +1310,7 @@ class TestSetManualThreadSummary:
         """A failed history fetch should raise the shared manual-summary fetch error."""
         client = _mock_client()
         conversation_cache = AsyncMock()
-        conversation_cache.get_thread_history.side_effect = TimeoutError("timed out")
+        conversation_cache.get_thread_messages.side_effect = TimeoutError("timed out")
 
         with pytest.raises(ThreadSummaryWriteError, match=r"Failed to fetch thread history for the target thread\."):
             await set_manual_thread_summary(

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -1252,7 +1252,7 @@ class TestSetManualThreadSummary:
         """Manual summary writes should normalize text, count non-summary messages, and update the cache."""
         client = _mock_client()
         conversation_cache = AsyncMock()
-        conversation_cache.get_thread_messages.return_value = [
+        conversation_cache.get_thread_history.return_value = [
             *_make_thread_history(3),
             _make_summary_notice_message("$root1", message_count=2),
         ]
@@ -1271,7 +1271,7 @@ class TestSetManualThreadSummary:
 
         assert result.event_id == "$summary1"
         assert result.summary == "Fix ISSUE-116"
-        assert result.message_count == _count_non_summary_messages(conversation_cache.get_thread_messages.return_value)
+        assert result.message_count == _count_non_summary_messages(conversation_cache.get_thread_history.return_value)
         mock_send.assert_awaited_once_with(
             client,
             "!room:x",
@@ -1287,7 +1287,7 @@ class TestSetManualThreadSummary:
         """A failed manual summary send should not advance the cached threshold baseline."""
         client = _mock_client()
         conversation_cache = AsyncMock()
-        conversation_cache.get_thread_messages.return_value = _make_thread_history(5)
+        conversation_cache.get_thread_history.return_value = _make_thread_history(5)
         update_last_summary_count("!room:x", "$root1", 2)
 
         with (
@@ -1311,7 +1311,7 @@ class TestSetManualThreadSummary:
         """A failed history fetch should raise the shared manual-summary fetch error."""
         client = _mock_client()
         conversation_cache = AsyncMock()
-        conversation_cache.get_thread_messages.side_effect = TimeoutError("timed out")
+        conversation_cache.get_thread_history.side_effect = TimeoutError("timed out")
 
         with pytest.raises(ThreadSummaryWriteError, match=r"Failed to fetch thread history for the target thread\."):
             await set_manual_thread_summary(

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -1168,6 +1168,7 @@ class TestSendSummaryEvent:
         conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
             "!room:x",
             "$root1",
+            caller_label="thread_summary_send",
         )
         conversation_cache.notify_outbound_message.assert_called_once_with("!room:x", "$s1", content)
 

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -8758,6 +8758,7 @@ class TestThreadingBehavior:
             event_info,
             full_history=False,
             dispatch_safe=False,
+            caller_label="threading_error_test",
         )
 
         assert thread_id is None
@@ -9026,6 +9027,7 @@ class TestThreadingBehavior:
                 event_info,
                 full_history=True,
                 dispatch_safe=False,
+                caller_label="threading_error_test",
             )
 
         assert is_thread is True

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -1446,7 +1446,7 @@ class TestMatrixConversationCacheThreadReads:
         access._reads.fetch_thread_history_from_client.assert_awaited_once_with(
             "!room:localhost",
             "$thread-root:localhost",
-            caller_label="unknown",
+            caller_label="latest_thread_event_lookup",
             coordinator_queue_wait_ms=0.0,
         )
 
@@ -6752,6 +6752,27 @@ class TestThreadingBehavior:
             caller_label="test_label",
         )
 
+        expected_snapshot = thread_history_result(
+            [_message(event_id="$thread:localhost", body="Root")],
+            is_full_history=False,
+        )
+        access.get_dispatch_thread_snapshot = AsyncMock(return_value=expected_snapshot)
+
+        snapshot_result = await access.get_thread_messages(
+            "!test:localhost",
+            "$thread:localhost",
+            full_history=False,
+            dispatch_safe=True,
+            caller_label="snapshot_label",
+        )
+
+        assert snapshot_result == expected_snapshot
+        access.get_dispatch_thread_snapshot.assert_awaited_once_with(
+            "!test:localhost",
+            "$thread:localhost",
+            caller_label="snapshot_label",
+        )
+
     @pytest.mark.asyncio
     async def test_live_event_cache_update_recovers_after_same_room_failure(self) -> None:
         """A failed same-room cache update should not block the next queued write."""
@@ -8877,7 +8898,7 @@ class TestThreadingBehavior:
             "$thread_root:localhost",
             full_history=False,
             dispatch_safe=True,
-            caller_label="unknown",
+            caller_label="dispatch_context",
         )
 
     @pytest.mark.asyncio

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -8902,6 +8902,54 @@ class TestThreadingBehavior:
         )
 
     @pytest.mark.asyncio
+    async def test_coalescing_thread_id_labels_thread_membership_reads(self, bot: AgentBot) -> None:
+        """Ingress coalescing should attribute any thread proof refreshes it triggers."""
+        room = MagicMock(spec=nio.MatrixRoom)
+        room.room_id = "!test:localhost"
+        event = nio.RoomMessageText.from_dict(
+            {
+                "content": {
+                    "body": "plain reply",
+                    "msgtype": "m.text",
+                    "m.relates_to": {"m.in_reply_to": {"event_id": "$plain1:localhost"}},
+                },
+                "event_id": "$event:localhost",
+                "sender": "@user:localhost",
+                "origin_server_ts": 1234567890,
+                "room_id": room.room_id,
+                "type": "m.room.message",
+            },
+        )
+        access = MagicMock()
+        resolver = unwrap_extracted_collaborator(bot._conversation_resolver)
+
+        with (
+            patch.object(
+                resolver,
+                "thread_membership_access",
+                MagicMock(return_value=access),
+            ) as mock_access,
+            patch(
+                "mindroom.conversation_resolver.resolve_event_thread_id_best_effort",
+                new=AsyncMock(return_value="$thread_root:localhost"),
+            ) as mock_resolve,
+        ):
+            thread_id = await resolver.coalescing_thread_id(room, event)
+
+        assert thread_id == "$thread_root:localhost"
+        mock_access.assert_called_once_with(
+            full_history=False,
+            dispatch_safe=True,
+            caller_label="coalescing_thread_id",
+        )
+        mock_resolve.assert_awaited_once_with(
+            room.room_id,
+            EventInfo.from_event(event.source),
+            event_id=event.event_id,
+            access=access,
+        )
+
+    @pytest.mark.asyncio
     async def test_full_history_thread_resolution_uses_full_history_to_prove_root(
         self,
         bot: AgentBot,

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -1381,6 +1381,7 @@ class TestMatrixConversationCacheThreadReads:
             "$thread_root",
             full_history=True,
             dispatch_safe=True,
+            caller_label="unknown",
         )
 
     def test_collect_sync_timeline_cache_updates_treats_reference_as_thread_candidate(self) -> None:
@@ -1445,6 +1446,8 @@ class TestMatrixConversationCacheThreadReads:
         access._reads.fetch_thread_history_from_client.assert_awaited_once_with(
             "!room:localhost",
             "$thread-root:localhost",
+            caller_label="unknown",
+            coordinator_queue_wait_ms=0.0,
         )
 
     @pytest.mark.asyncio
@@ -3370,7 +3373,11 @@ class TestThreadingBehavior:
             await allow_resolve.wait()
             return MutationThreadImpact.threaded("$mutated-thread:localhost")
 
-        async def quick_snapshot(_room_id: str, _thread_id: str) -> ThreadHistoryResult:
+        async def quick_snapshot(
+            _room_id: str,
+            _thread_id: str,
+            **_kwargs: object,
+        ) -> ThreadHistoryResult:
             read_finished.set()
             return thread_history_result(
                 [_message(event_id="$other-thread:localhost", body="Root")],
@@ -3435,7 +3442,11 @@ class TestThreadingBehavior:
             await allow_resolve.wait()
             return MutationThreadImpact.room_level()
 
-        async def quick_snapshot(_room_id: str, _thread_id: str) -> ThreadHistoryResult:
+        async def quick_snapshot(
+            _room_id: str,
+            _thread_id: str,
+            **_kwargs: object,
+        ) -> ThreadHistoryResult:
             read_finished.set()
             return thread_history_result(
                 [_message(event_id="$other-thread:localhost", body="Root")],
@@ -6100,6 +6111,7 @@ class TestThreadingBehavior:
         async def slow_refresh(
             _room_id: str,
             _thread_id: str,
+            **_kwargs: object,
         ) -> ThreadHistoryResult:
             refresh_started.set()
             await allow_refresh.wait()
@@ -6145,6 +6157,7 @@ class TestThreadingBehavior:
         async def slow_refresh(
             _room_id: str,
             _thread_id: str,
+            **_kwargs: object,
         ) -> ThreadHistoryResult:
             refresh_started.set()
             await allow_refresh.wait()
@@ -6226,6 +6239,7 @@ class TestThreadingBehavior:
         async def fetch_fresh_history(
             _room_id: str,
             _thread_id: str,
+            **_kwargs: object,
         ) -> ThreadHistoryResult:
             thread_state["value"] = ThreadCacheState(
                 validated_at=time.time(),
@@ -6280,10 +6294,13 @@ class TestThreadingBehavior:
         await write_task
 
         assert [message.body for message in history] == ["Root", "Old reply", "New reply"]
-        access._reads.fetch_thread_history_from_client.assert_awaited_once_with(
+        access._reads.fetch_thread_history_from_client.assert_awaited_once()
+        assert access._reads.fetch_thread_history_from_client.await_args.args == (
             "!room:localhost",
             "$thread:localhost",
         )
+        assert access._reads.fetch_thread_history_from_client.await_args.kwargs["caller_label"] == "unknown"
+        assert access._reads.fetch_thread_history_from_client.await_args.kwargs["coordinator_queue_wait_ms"] > 0
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("timing_enabled_for_test", [False, True], ids=["timing_disabled", "timing_enabled"])
@@ -6718,21 +6735,21 @@ class TestThreadingBehavior:
             is_full_history=True,
         )
 
-        access._reads.read_thread = AsyncMock(return_value=expected)
+        access.get_dispatch_thread_history = AsyncMock(return_value=expected)
 
         result = await access.get_thread_messages(
             "!test:localhost",
             "$thread:localhost",
             full_history=True,
             dispatch_safe=True,
+            caller_label="test_label",
         )
 
         assert result == expected
-        access._reads.read_thread.assert_awaited_once_with(
+        access.get_dispatch_thread_history.assert_awaited_once_with(
             "!test:localhost",
             "$thread:localhost",
-            full_history=True,
-            dispatch_safe=True,
+            caller_label="test_label",
         )
 
     @pytest.mark.asyncio
@@ -6990,7 +7007,12 @@ class TestThreadingBehavior:
         async def fetch_history(
             _room_id: str,
             _thread_id: str,
+            *,
+            caller_label: str,
+            coordinator_queue_wait_ms: float,
         ) -> ThreadHistoryResult:
+            assert caller_label == "unknown"
+            assert coordinator_queue_wait_ms >= 0.0
             fetch_started.set()
             return thread_history_result(
                 [_message(event_id="$thread-a:localhost", body="Root")],
@@ -7251,10 +7273,12 @@ class TestThreadingBehavior:
             )
 
             assert [message.body for message in history] == ["Root"]
-            access._reads.fetch_thread_history_from_client.assert_awaited_once_with(
-                "!test:localhost",
-                "$thread-c:localhost",
-            )
+            access._reads.fetch_thread_history_from_client.assert_awaited_once()
+            fetch_args = access._reads.fetch_thread_history_from_client.await_args
+            assert fetch_args is not None
+            assert fetch_args.args == ("!test:localhost", "$thread-c:localhost")
+            assert fetch_args.kwargs["caller_label"] == "unknown"
+            assert fetch_args.kwargs["coordinator_queue_wait_ms"] >= 0.0
             assert first_thread_task.done() is False
             assert second_thread_task.done() is False
         finally:
@@ -7714,7 +7738,11 @@ class TestThreadingBehavior:
                 "get_dispatch_thread_snapshot",
                 AsyncMock(return_value=thread_history_result([], is_full_history=False)),
             ),
-            patch.object(bot._conversation_cache, "get_dispatch_thread_history", AsyncMock(return_value=[])),
+            patch.object(
+                bot._conversation_cache,
+                "get_thread_messages",
+                AsyncMock(return_value=thread_history_result([], is_full_history=True)),
+            ),
         ):
             # Process the message
             await bot._on_message(room, event)
@@ -7772,10 +7800,8 @@ class TestThreadingBehavior:
         assert context.is_thread is True
         assert context.thread_id == "$thread_root:localhost"
         assert context.thread_history == expected_history
-        mock_fetch.assert_awaited_once_with(
-            room.room_id,
-            "$thread_root:localhost",
-        )
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_edit_resolves_thread_from_original_event(self, bot: AgentBot) -> None:
@@ -7835,10 +7861,8 @@ class TestThreadingBehavior:
         assert context.thread_id == "$thread_root:localhost"
         assert context.thread_history == expected_history
         bot.client.room_get_event.assert_awaited_once_with(room.room_id, "$thread_msg:localhost")
-        mock_fetch.assert_awaited_once_with(
-            room.room_id,
-            "$thread_root:localhost",
-        )
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_edit_of_plain_root_message_stays_room_level(self, bot: AgentBot) -> None:
@@ -7900,7 +7924,8 @@ class TestThreadingBehavior:
         assert context.thread_id is None
         assert context.thread_history == []
         bot.client.room_get_event.assert_awaited_once_with(room.room_id, "$room_message:localhost")
-        mock_fetch.assert_awaited_once_with(room.room_id, "$room_message:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$room_message:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_plain_reply_to_thread_reply_inherits_existing_thread(
@@ -7949,7 +7974,8 @@ class TestThreadingBehavior:
         assert context.thread_id == "$thread_root:localhost"
         assert context.thread_history == expected_history
         mock_lookup.assert_awaited_once_with(room.room_id, "$thread_msg:localhost")
-        mock_fetch.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_plain_reply_to_thread_root_inherits_existing_thread(
@@ -8115,7 +8141,8 @@ class TestThreadingBehavior:
             call(room.room_id, "$plain_reply_1:localhost"),
             call(room.room_id, "$thread_msg:localhost"),
         ]
-        mock_fetch.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_plain_reply_to_promoted_plain_reply_stays_threaded(
@@ -8177,7 +8204,8 @@ class TestThreadingBehavior:
         assert context.thread_id == "$thread_root:localhost"
         assert context.thread_history == [_message(event_id="$thread_root:localhost", body="root")]
         mock_lookup.assert_awaited_once_with(room.room_id, "$plain_reply_1:localhost")
-        mock_fetch.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
         bot.client.room_get_event.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -8258,7 +8286,8 @@ class TestThreadingBehavior:
             assert context.thread_id == "$thread_root:localhost"
             assert context.thread_history == expected_history
             bot.client.room_get_event.assert_not_awaited()
-            mock_fetch.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+            mock_fetch.assert_awaited_once()
+            assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
         finally:
             await real_event_cache.close()
 
@@ -8417,7 +8446,8 @@ class TestThreadingBehavior:
         assert context.thread_history == expected_history
         assert bot.client.room_get_event.await_args_list[0].args == (room.room_id, "$plain-reply:localhost")
         assert bot.client.room_get_event.await_args_list[1].args == (room.room_id, "$thread-reply:localhost")
-        mock_fetch.assert_awaited_once_with(room.room_id, "$thread-root:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread-root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_edit_of_plain_root_message_stays_room_level_when_snapshot_has_only_root(
@@ -8482,7 +8512,8 @@ class TestThreadingBehavior:
         assert context.thread_history == []
         bot.client.room_get_event.assert_awaited_once_with(room.room_id, "$room_root:localhost")
         bot.event_cache.get_thread_id_for_event.assert_awaited_once_with(room.room_id, "$room_root:localhost")
-        mock_snapshot.assert_awaited_once_with(room.room_id, "$room_root:localhost")
+        mock_snapshot.assert_awaited_once()
+        assert mock_snapshot.await_args.args == (room.room_id, "$room_root:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_edit_of_plain_root_message_degrades_when_thread_lookup_fails(
@@ -8552,7 +8583,8 @@ class TestThreadingBehavior:
         assert context.thread_history == []
         bot.client.room_get_event.assert_awaited_once_with(room.room_id, "$room_message:localhost")
         bot.event_cache.get_thread_id_for_event.assert_awaited_once_with(room.room_id, "$room_message:localhost")
-        mock_fetch.assert_awaited_once_with(room.room_id, "$room_message:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$room_message:localhost")
 
     @pytest.mark.asyncio
     async def test_extract_context_plain_reply_to_threaded_message_stays_threaded_transitively(
@@ -8642,7 +8674,8 @@ class TestThreadingBehavior:
         assert context.is_thread is True
         assert context.thread_id == "$thread_root:localhost"
         assert context.thread_history == expected_history
-        mock_fetch.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args == (room.room_id, "$thread_root:localhost")
 
     @pytest.mark.asyncio
     async def test_explicit_thread_id_returns_none_for_cyclic_edit_chain(self, bot: AgentBot) -> None:
@@ -8786,7 +8819,8 @@ class TestThreadingBehavior:
             bot.client.download.assert_not_awaited()
             bot.client.room_get_event.assert_not_awaited()
             mock_lookup.assert_awaited_once_with(room.room_id, "$plain1:localhost")
-            mock_snapshot.assert_awaited_once_with(room.room_id, "$thread_root:localhost")
+            mock_snapshot.assert_awaited_once()
+            assert mock_snapshot.await_args.args == (room.room_id, "$thread_root:localhost")
             mock_fetch.assert_not_called()
 
     @pytest.mark.asyncio
@@ -8843,6 +8877,7 @@ class TestThreadingBehavior:
             "$thread_root:localhost",
             full_history=False,
             dispatch_safe=True,
+            caller_label="unknown",
         )
 
     @pytest.mark.asyncio
@@ -9025,12 +9060,8 @@ class TestThreadingBehavior:
                     AsyncMock(return_value=thread_history_result([], is_full_history=False)),
                 ),
                 patch(
-                    "mindroom.matrix.conversation_cache.MatrixConversationCache.get_dispatch_thread_history",
-                    AsyncMock(return_value=[]),
-                ),
-                patch(
-                    "mindroom.matrix.conversation_cache.MatrixConversationCache.get_thread_history",
-                    AsyncMock(return_value=[]),
+                    "mindroom.matrix.conversation_cache.MatrixConversationCache.get_thread_messages",
+                    AsyncMock(return_value=thread_history_result([], is_full_history=True)),
                 ),
             ):
                 # Process the command

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import nio
 import pytest
@@ -1266,6 +1266,12 @@ async def test_approval_thread_relation_uses_requesting_agent_cache(tmp_path: Pa
     assert sent_contents[0]["m.relates_to"]["m.in_reply_to"]["event_id"] == "$code-latest"
     assert sent_contents[1]["m.new_content"]["m.relates_to"]["m.in_reply_to"]["event_id"] == "$code-latest"
     assert code_bot.latest_thread_event_id_if_needed.await_count == 2
+    code_bot.latest_thread_event_id_if_needed.assert_has_awaits(
+        [
+            call("!room:localhost", "$thread", caller_label="approval_transport_thread_relation"),
+            call("!room:localhost", "$thread", caller_label="approval_transport_thread_relation"),
+        ],
+    )
     router_bot.latest_thread_event_id_if_needed.assert_not_awaited()
 
 

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -48,6 +48,7 @@ def _conversation_cache(
 ) -> AsyncMock:
     access = AsyncMock()
     access.get_thread_history = AsyncMock(return_value=list(thread_history or []))
+    access.get_thread_messages = AsyncMock(return_value=list(thread_history or []))
     access.get_latest_thread_event_id_if_needed = AsyncMock(return_value=latest_thread_event_id)
     access.notify_outbound_message = Mock()
     return access

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -23,6 +23,7 @@ from mindroom.scheduling import (
     CronSchedule,
     ScheduledWorkflow,
     SchedulingRuntime,
+    _build_scheduled_failure_content,
     _execute_scheduled_workflow,
     _parse_workflow_schedule,
     _validate_conditional_workflow,
@@ -436,6 +437,7 @@ class TestExecuteScheduledWorkflow:
         conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
             "!room:server",
             "$thread123",
+            caller_label="scheduled_workflow_message",
         )
         mock_send.assert_awaited_once()
         call_args = mock_send.await_args
@@ -497,6 +499,34 @@ class TestExecuteScheduledWorkflow:
         assert config.get_ids(runtime_paths_for(config))["analyst"].full_id in content["body"]
         assert "m.relates_to" not in content
         assert content[ORIGINAL_SENDER_KEY] == "@user:server"
+
+    async def test_scheduled_failure_content_labels_latest_thread_lookup(self) -> None:
+        """Scheduled failure replies should attribute latest-thread lookups."""
+        workflow = ScheduledWorkflow(
+            schedule_type="once",
+            execute_at=datetime.now(UTC),
+            message="Run report",
+            description="report",
+            thread_id="$thread123",
+            room_id="!room:server",
+            created_by="@user:server",
+        )
+        target = MessageTarget.resolve("!room:server", "$thread123", None)
+        conversation_cache = _conversation_cache(latest_thread_event_id="$latest456")
+
+        content = await _build_scheduled_failure_content(
+            workflow,
+            target,
+            "Workflow failed",
+            conversation_cache,
+        )
+
+        assert content["m.relates_to"]["m.in_reply_to"]["event_id"] == "$latest456"
+        conversation_cache.get_latest_thread_event_id_if_needed.assert_awaited_once_with(
+            "!room:server",
+            "$thread123",
+            caller_label="scheduled_workflow_failure",
+        )
 
     async def test_execute_workflow_simple_reminder(self) -> None:
         """Test executing a simple reminder without agents."""

--- a/tests/test_workloop_thread_scope.py
+++ b/tests/test_workloop_thread_scope.py
@@ -111,6 +111,10 @@ def _copy_plugin_root(tmp_path: Path) -> Path:
             "from . import commands, formatting, poke, state, todos, types as workloop_types",
             f"from {package_prefix} import commands, formatting, poke, state, todos, types as workloop_types",
         )
+        module_text = module_text.replace(
+            "from . import commands, formatting, poke, runtime as workloop_runtime, state, todos",
+            f"from {package_prefix} import commands, formatting, poke, runtime as workloop_runtime, state, todos",
+        )
         module_text = module_text.replace("from .formatting import ", f"from {package_prefix}.formatting import ")
         module_text = module_text.replace("from .poke import ", f"from {package_prefix}.poke import ")
         module_text = module_text.replace("from .runtime import ", f"from {package_prefix}.runtime import ")


### PR DESCRIPTION
## Summary
- Adds caller labels to Matrix thread-history refresh paths so ISSUE-176 stalls can be attributed by entry point.
- Emits structured refresh diagnostics with cache rejection reason, homeserver scan cost, and queue wait metadata.
- Labels startup thread prewarm refreshes as `startup_thread_prewarm` instead of falling back to `unknown`.

## Notes
This is observability-only and does not reduce refresh latency yet.
It is intended to identify the next optimization target for ISSUE-176.

## Test Plan
- `uv run pytest tests/test_bot_ready_hook.py::test_startup_thread_prewarm_refresh_waits_for_background_warm tests/test_thread_history.py::TestThreadHistoryCache::test_fetch_thread_history_logs_refresh_diagnostics_for_cache_miss tests/test_threading_error.py::TestMatrixConversationCacheThreadReads tests/test_threading_error.py::TestThreadingBehavior::test_get_thread_messages_routes_through_collapsed_read_primitive tests/test_issue_176_real_thread_parallelism.py -n 0 --no-cov -q`
- `uv run pytest -q`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved diagnostics and structured logging for thread-history refreshes, cache reads, and queue-wait timing.
  * Added per-operation caller labels across thread-read and conversation-cache flows to improve observability and traceability for messaging, dispatching, scheduling, hooks, attachments, and reactions.
* **Tests**
  * Updated and added tests to validate new call shapes, caller labels, and emitted diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->