### PR TITLE
Fix Google API service reuse across threads

### DIFF
--- a/src/mindroom/custom_tools/gmail.py
+++ b/src/mindroom/custom_tools/gmail.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from agno.tools.gmail import GmailTools as AgnoGmailTools
 
+from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin
 from mindroom.logging_config import get_logger
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.oauth.google_gmail import google_gmail_oauth_provider
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-class GmailTools(ScopedOAuthClientMixin, AgnoGmailTools):
+class GmailTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, AgnoGmailTools):
     """Gmail tools wrapper that uses MindRoom's credential management."""
 
     _oauth_provider = google_gmail_oauth_provider()

--- a/src/mindroom/custom_tools/google_calendar.py
+++ b/src/mindroom/custom_tools/google_calendar.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from agno.tools.googlecalendar import GoogleCalendarTools as AgnoGoogleCalendarTools
 
+from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin
 from mindroom.logging_config import get_logger
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.oauth.google_calendar import google_calendar_oauth_provider
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-class GoogleCalendarTools(ScopedOAuthClientMixin, AgnoGoogleCalendarTools):
+class GoogleCalendarTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, AgnoGoogleCalendarTools):
     """Google Calendar tools wrapper that uses MindRoom's credential management."""
 
     _oauth_provider = google_calendar_oauth_provider()

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from agno.tools.google.drive import GoogleDriveTools as AgnoGoogleDriveTools
 
+from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin
 from mindroom.logging_config import get_logger
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.oauth.google_drive import google_drive_oauth_provider
@@ -26,7 +27,7 @@ _MODEL_FUNCTION_NAME_ALIASES = {
 }
 
 
-class GoogleDriveTools(ScopedOAuthClientMixin, AgnoGoogleDriveTools):
+class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, AgnoGoogleDriveTools):
     """Google Drive toolkit that reads OAuth tokens from MindRoom's credential scopes."""
 
     _oauth_provider = google_drive_oauth_provider()

--- a/src/mindroom/custom_tools/google_service.py
+++ b/src/mindroom/custom_tools/google_service.py
@@ -3,23 +3,25 @@
 from __future__ import annotations
 
 import threading
-from typing import Any
+from typing import Any, cast
+
+
+class _GoogleServiceThreadState(threading.local):
+    def __init__(self) -> None:
+        self.service: Any | None = None
 
 
 class ThreadLocalGoogleServiceMixin:
     """Cache googleapiclient service objects per worker thread."""
 
-    def _google_service_state(self) -> threading.local:
-        state = self.__dict__.get("_google_service_thread_state")
-        if state is None:
-            state = threading.local()
-            self.__dict__["_google_service_thread_state"] = state
-        return state
+    def _google_service_state(self) -> _GoogleServiceThreadState:
+        state = self.__dict__.setdefault("_google_service_thread_state", _GoogleServiceThreadState())
+        return cast("_GoogleServiceThreadState", state)
 
     @property
     def service(self) -> Any | None:  # noqa: ANN401
         """Return the Google API service cached for the current worker thread."""
-        return getattr(self._google_service_state(), "service", None)
+        return self._google_service_state().service
 
     @service.setter
     def service(self, value: Any | None) -> None:  # noqa: ANN401

--- a/src/mindroom/custom_tools/google_service.py
+++ b/src/mindroom/custom_tools/google_service.py
@@ -1,0 +1,26 @@
+"""Shared helpers for Google API-backed tools."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+
+class ThreadLocalGoogleServiceMixin:
+    """Cache googleapiclient service objects per worker thread."""
+
+    def _google_service_state(self) -> threading.local:
+        state = self.__dict__.get("_google_service_thread_state")
+        if state is None:
+            state = threading.local()
+            self.__dict__["_google_service_thread_state"] = state
+        return state
+
+    @property
+    def service(self) -> Any | None:  # noqa: ANN401
+        """Return the Google API service cached for the current worker thread."""
+        return getattr(self._google_service_state(), "service", None)
+
+    @service.setter
+    def service(self, value: Any | None) -> None:  # noqa: ANN401
+        self._google_service_state().service = value

--- a/src/mindroom/custom_tools/google_sheets.py
+++ b/src/mindroom/custom_tools/google_sheets.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from agno.tools.googlesheets import GoogleSheetsTools as AgnoGoogleSheetsTools
 
+from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin
 from mindroom.logging_config import get_logger
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.oauth.google_sheets import google_sheets_oauth_provider
@@ -28,7 +29,7 @@ _CONFIG_FIELD_INIT_ARG_ALIASES = {
 }
 
 
-class GoogleSheetsTools(ScopedOAuthClientMixin, AgnoGoogleSheetsTools):
+class GoogleSheetsTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, AgnoGoogleSheetsTools):
     """Google Sheets tools wrapper that uses MindRoom's credential management."""
 
     _oauth_provider = google_sheets_oauth_provider()

--- a/tests/test_google_tool_wrappers.py
+++ b/tests/test_google_tool_wrappers.py
@@ -11,9 +11,11 @@ import pytest
 
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager
+from mindroom.custom_tools import google_service
 from mindroom.custom_tools.gmail import GmailTools
 from mindroom.custom_tools.google_calendar import GoogleCalendarTools
 from mindroom.custom_tools.google_drive import GoogleDriveTools
+from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin
 from mindroom.custom_tools.google_sheets import GoogleSheetsTools
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.tool_system.metadata import get_tool_by_name
@@ -102,6 +104,37 @@ def test_google_service_cache_is_isolated_per_thread(
         thread_service = object()
         tool.service = thread_service
         barrier.wait(timeout=5)
+        return tool.service is thread_service
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: set_and_read_thread_service(), range(2)))
+
+    assert results == [True, True]
+
+
+def test_google_service_state_first_access_is_thread_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrent first access must not replace another thread's service state."""
+
+    class Tool(ThreadLocalGoogleServiceMixin):
+        pass
+
+    class RaceLocal:
+        service: Any | None = None
+
+    tool = Tool()
+    creation_barrier = threading.Barrier(2)
+    read_barrier = threading.Barrier(2)
+
+    def race_local_factory() -> RaceLocal:
+        creation_barrier.wait(timeout=5)
+        return RaceLocal()
+
+    monkeypatch.setattr(google_service.threading, "local", race_local_factory)
+
+    def set_and_read_thread_service() -> bool:
+        thread_service = object()
+        tool.service = thread_service
+        read_barrier.wait(timeout=5)
         return tool.service is thread_service
 
     with ThreadPoolExecutor(max_workers=2) as executor:

--- a/tests/test_google_tool_wrappers.py
+++ b/tests/test_google_tool_wrappers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
@@ -19,6 +21,12 @@ from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_w
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+class ValidCredentials:
+    """Minimal valid credential object for constructor tests."""
+
+    valid = True
 
 
 @pytest.fixture
@@ -73,6 +81,33 @@ def test_google_wrappers_allow_isolating_worker_scopes(
     )
 
     assert isinstance(tool, tool_class)
+
+
+@pytest.mark.parametrize("tool_class", [GmailTools, GoogleCalendarTools, GoogleDriveTools, GoogleSheetsTools])
+def test_google_service_cache_is_isolated_per_thread(
+    tool_class: type[Any],
+    runtime_paths: RuntimePaths,
+    tmp_path: Path,
+) -> None:
+    """Google API clients should not share httplib2-backed service objects across threads."""
+    tool = tool_class(
+        runtime_paths=runtime_paths,
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        worker_target=None,
+        creds=ValidCredentials(),
+    )
+    barrier = threading.Barrier(2)
+
+    def set_and_read_thread_service() -> bool:
+        thread_service = object()
+        tool.service = thread_service
+        barrier.wait(timeout=5)
+        return tool.service is thread_service
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: set_and_read_thread_service(), range(2)))
+
+    assert results == [True, True]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- cache Google API service objects per worker thread for Gmail, Calendar, Drive, and Sheets
- keep Agno's existing auth/service initialization flow while avoiding cross-thread reuse of googleapiclient/httplib2 state
- add a regression test that proves concurrent threads do not share the cached service for Google-backed wrappers

## Why
Google's Python client uses httplib2 underneath, and httplib2 clients are not thread-safe. MindRoom dispatches sync tool entrypoints through `asyncio.to_thread`; Agno's Drive toolkit also defines async methods that delegate sync calls through `asyncio.to_thread`. Without per-thread service caching, parallel Google tool calls can share one cached service object across threads.

## Tests
- `uv run --with google-api-python-client --with google-auth-httplib2 --with google-auth-oauthlib pytest tests/test_google_drive_oauth_tool.py tests/test_google_tool_wrappers.py tests/test_google_calendar_oauth_tool.py tests/test_google_sheets_oauth_tool.py -q`
- `uv run ruff check src/mindroom/custom_tools/gmail.py src/mindroom/custom_tools/google_calendar.py src/mindroom/custom_tools/google_drive.py src/mindroom/custom_tools/google_sheets.py src/mindroom/custom_tools/google_service.py tests/test_google_tool_wrappers.py tests/test_google_drive_oauth_tool.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety for Google integrations (Gmail, Drive, Calendar, Sheets) so service state is isolated per concurrent operation.

* **Tests**
  * Added concurrency tests to verify per-thread service isolation and thread-safe first-access behavior in multi-threaded scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->