### PR TITLE
Harden invalid credential seed declarations

### DIFF
--- a/src/mindroom/credentials_sync.py
+++ b/src/mindroom/credentials_sync.py
@@ -166,7 +166,14 @@ def _decode_seed_entries(
             log_context["path"] = str(source_path)
         logger.warning("credential_seed_declaration_json_invalid", **log_context)
         return []
-    return _coerce_seed_entries(raw_value, source=source_env_var)
+    try:
+        return _coerce_seed_entries(raw_value, source=source_env_var)
+    except (TypeError, ValueError) as exc:
+        log_context = {"env_var": source_env_var, "error": str(exc)}
+        if source_path is not None:
+            log_context["path"] = str(source_path)
+        logger.warning("credential_seed_declaration_invalid", **log_context)
+        return []
 
 
 def _load_declared_credential_seeds(runtime_paths: RuntimePaths) -> list[_CredentialSeedDeclaration]:
@@ -269,10 +276,22 @@ def _sync_declared_credential_seeds(runtime_paths: RuntimePaths) -> int:
         seed = declaration.seed
         raw_service = seed.get("service")
         if not isinstance(raw_service, str):
-            msg = "Credential seed must include a string service name"
-            raise TypeError(msg)
-        service = validate_service_name(raw_service)
-        credentials = _resolve_seed_credentials(seed, service=service, runtime_paths=runtime_paths)
+            logger.warning(
+                "credential_seed_declaration_invalid",
+                env_var=declaration.source_env_var,
+                error="Credential seed must include a string service name",
+            )
+            continue
+        try:
+            service = validate_service_name(raw_service)
+            credentials = _resolve_seed_credentials(seed, service=service, runtime_paths=runtime_paths)
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "credential_seed_declaration_invalid",
+                env_var=declaration.source_env_var,
+                error=str(exc),
+            )
+            continue
         if credentials is None:
             continue
         if _sync_service_credentials(

--- a/tests/test_credentials_sync.py
+++ b/tests/test_credentials_sync.py
@@ -377,6 +377,66 @@ class TestCredentialsSync:
         cm = CredentialsManager(base_path=credentials_dir)
         assert cm.get_api_key("openai") == "sk-test-openai-key"
 
+    def test_invalid_declared_credential_seed_shape_does_not_block_builtin_sync(
+        self,
+        temp_credentials_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Decoded-but-invalid seed declarations should not abort provider env syncing."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-openai-key")
+        monkeypatch.setenv("MINDROOM_CREDENTIAL_SEEDS_JSON", json.dumps({"seeds": "not-a-list"}))
+
+        sync_env_to_credentials(
+            runtime_paths=_runtime_paths(
+                temp_credentials_dir.parent,
+                shared_credentials_dir=temp_credentials_dir,
+            ),
+        )
+
+        cm = CredentialsManager(base_path=temp_credentials_dir)
+        assert cm.get_api_key("openai") == "sk-test-openai-key"
+
+    def test_invalid_declared_credential_seed_entry_does_not_block_later_valid_seed(
+        self,
+        temp_credentials_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """One invalid optional seed should not prevent later valid seeds from syncing."""
+        monkeypatch.setenv("OAUTH_CLIENT_ID", "client-id")
+        monkeypatch.setenv("OAUTH_CLIENT_SECRET", "client-secret")
+        monkeypatch.setenv(
+            "MINDROOM_CREDENTIAL_SEEDS_JSON",
+            json.dumps(
+                [
+                    {
+                        "service": 123,
+                        "credentials": {"token": {"value": "bad"}},
+                    },
+                    {
+                        "service": "google_oauth_client",
+                        "credentials": {
+                            "client_id": {"env": "OAUTH_CLIENT_ID"},
+                            "client_secret": {"env": "OAUTH_CLIENT_SECRET"},
+                        },
+                    },
+                ],
+            ),
+        )
+
+        sync_env_to_credentials(
+            runtime_paths=_runtime_paths(
+                temp_credentials_dir.parent,
+                shared_credentials_dir=temp_credentials_dir,
+            ),
+        )
+
+        cm = CredentialsManager(base_path=temp_credentials_dir)
+        assert cm.load_credentials("google_oauth_client") == {
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "_source": "env",
+        }
+
     def test_declared_credential_seed_env_names_stay_out_of_runtime_env_views(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary
- skip decoded-but-invalid credential seed declaration payloads with a warning
- skip invalid individual seed entries so later valid seeds still apply
- add regressions for invalid seed shape and invalid entry before a valid seed

## Context
Follow-up to #855 after CodeRabbit noted that non-JSON validation failures could still abort credential seed sync.
The generated-reference fenced-code comments were not included here because the source docs already use language-tagged fences and the generated references strip fence languages broadly.

## Tests
- uv run pytest tests/test_credentials_sync.py -q
- uv run ruff check src/mindroom/credentials_sync.py tests/test_credentials_sync.py
- .venv/bin/ty check src/mindroom/credentials_sync.py tests/test_credentials_sync.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in credential synchronization: invalid or malformed credential declarations are now logged and safely skipped, allowing the sync process to continue successfully. Built-in provider synchronization (e.g., standard API keys) continues to work properly even when invalid declarations are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->