### PR TITLE
Fix Postgres cache rollback on cancellation

### DIFF
--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -135,7 +135,7 @@ async def _close_postgres_connection_best_effort(
 async def initialize_postgres_event_cache_db(
     database_url: str,
     *,
-    namespace: str = "",
+    namespace: str,
 ) -> psycopg.AsyncConnection:
     """Open the PostgreSQL database and ensure the event-cache schema exists."""
     db = await psycopg.AsyncConnection.connect(database_url)

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -748,7 +748,7 @@ class PostgresEventCache:
                         result = await callback(db)
                         await db.commit()
                     except BaseException:
-                        await self._rollback_best_effort(db, operation=operation)
+                        await self._runtime._rollback_best_effort(db, operation=operation)
                         raise
             except EventCacheBackendUnavailableError as exc:
                 transient_error = exc
@@ -767,18 +767,6 @@ class PostgresEventCache:
                 self._forget_flushed_pending_invalidations(room_id, flushed_pending)
                 return result
         raise _cache_backend_unavailable(operation, transient_error or RuntimeError("operation did not run"))
-
-    async def _rollback_best_effort(self, db: psycopg.AsyncConnection, *, operation: str) -> None:
-        try:
-            await db.rollback()
-        except Exception as exc:
-            logger.debug(
-                "Ignoring Postgres event cache rollback failure",
-                namespace=self._runtime.namespace,
-                operation=operation,
-                error_type=type(exc).__name__,
-                error=str(exc),
-            )
 
     async def _flush_pending_invalidations(
         self,

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -393,6 +393,19 @@ class _PostgresEventCacheRuntime:
             diagnostics["cache_postgres_unavailable_reason"] = self._unavailable_reason
         return diagnostics
 
+    async def _rollback_best_effort(self, db: psycopg.AsyncConnection, *, operation: str) -> None:
+        """Roll back the shared connection without masking the original failure."""
+        try:
+            await db.rollback()
+        except Exception as exc:
+            logger.debug(
+                "Ignoring Postgres event cache rollback failure",
+                namespace=self._namespace,
+                operation=operation,
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+
     async def initialize(self) -> None:
         """Open the PostgreSQL database and create the cache schema."""
         async with self._db_lock:
@@ -591,10 +604,14 @@ class _PostgresEventCacheRuntime:
             await self.initialize()
         async with self._db_lock, self.acquire_room_lock(room_id, operation=operation):
             db = self.require_db()
-            await db.execute(
-                "SELECT pg_advisory_xact_lock(hashtext(%s), hashtext(%s))",
-                (self._namespace, room_id),
-            )
+            try:
+                await db.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext(%s), hashtext(%s))",
+                    (self._namespace, room_id),
+                )
+            except BaseException:
+                await self._rollback_best_effort(db, operation=operation)
+                raise
             yield db
 
     def require_db(self) -> psycopg.AsyncConnection:
@@ -730,7 +747,7 @@ class PostgresEventCache:
                         flushed_pending = await self._flush_pending_invalidations(db, room_id)
                         result = await callback(db)
                         await db.commit()
-                    except Exception:
+                    except BaseException:
                         await self._rollback_best_effort(db, operation=operation)
                         raise
             except EventCacheBackendUnavailableError as exc:

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -94,16 +94,58 @@ def _cache_backend_unavailable(operation: str, exc: BaseException) -> EventCache
     return EventCacheBackendUnavailableError(f"Postgres event cache unavailable during {operation}: {detail}")
 
 
-async def initialize_postgres_event_cache_db(database_url: str) -> psycopg.AsyncConnection:
+async def _rollback_postgres_connection_best_effort(
+    db: psycopg.AsyncConnection,
+    *,
+    namespace: str,
+    operation: str,
+) -> None:
+    """Roll back one shared connection without masking the original failure."""
+    try:
+        await db.rollback()
+    except Exception as exc:
+        logger.debug(
+            "Ignoring Postgres event cache rollback failure",
+            namespace=namespace,
+            operation=operation,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+
+
+async def _close_postgres_connection_best_effort(
+    db: psycopg.AsyncConnection,
+    *,
+    namespace: str,
+    operation: str,
+) -> None:
+    """Close one shared connection without masking the original failure."""
+    try:
+        await db.close()
+    except Exception as exc:
+        logger.debug(
+            "Ignoring error while closing Postgres event cache connection",
+            namespace=namespace,
+            operation=operation,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+
+
+async def initialize_postgres_event_cache_db(
+    database_url: str,
+    *,
+    namespace: str = "",
+) -> psycopg.AsyncConnection:
     """Open the PostgreSQL database and ensure the event-cache schema exists."""
     db = await psycopg.AsyncConnection.connect(database_url)
     try:
         await create_postgres_event_cache_schema(db)
         await validate_postgres_event_cache_schema(db)
         await db.commit()
-    except Exception:
-        await db.rollback()
-        await db.close()
+    except BaseException:
+        await _rollback_postgres_connection_best_effort(db, namespace=namespace, operation="initialize")
+        await _close_postgres_connection_best_effort(db, namespace=namespace, operation="initialize")
         raise
     return db
 
@@ -393,19 +435,6 @@ class _PostgresEventCacheRuntime:
             diagnostics["cache_postgres_unavailable_reason"] = self._unavailable_reason
         return diagnostics
 
-    async def _rollback_best_effort(self, db: psycopg.AsyncConnection, *, operation: str) -> None:
-        """Roll back the shared connection without masking the original failure."""
-        try:
-            await db.rollback()
-        except Exception as exc:
-            logger.debug(
-                "Ignoring Postgres event cache rollback failure",
-                namespace=self._namespace,
-                operation=operation,
-                error_type=type(exc).__name__,
-                error=str(exc),
-            )
-
     async def initialize(self) -> None:
         """Open the PostgreSQL database and create the cache schema."""
         async with self._db_lock:
@@ -417,7 +446,7 @@ class _PostgresEventCacheRuntime:
             had_previous_connection = self._db is not None
             await self._close_db_locked(operation="initialize")
             try:
-                self._db = await initialize_postgres_event_cache_db(self._database_url)
+                self._db = await initialize_postgres_event_cache_db(self._database_url, namespace=self._namespace)
             except Exception as exc:
                 if _is_transient_postgres_failure(exc):
                     self._transient_failure_count += 1
@@ -534,15 +563,7 @@ class _PostgresEventCacheRuntime:
         self._db = None
         if db is None:
             return
-        try:
-            await db.close()
-        except Exception as exc:
-            logger.debug(
-                "Ignoring error while closing Postgres event cache connection",
-                namespace=self._namespace,
-                operation=operation,
-                error=str(exc),
-            )
+        await _close_postgres_connection_best_effort(db, namespace=self._namespace, operation=operation)
 
     def connection_is_closed(self, db: psycopg.AsyncConnection) -> bool:
         """Return whether psycopg considers one connection closed."""
@@ -610,7 +631,7 @@ class _PostgresEventCacheRuntime:
                     (self._namespace, room_id),
                 )
             except BaseException:
-                await self._rollback_best_effort(db, operation=operation)
+                await _rollback_postgres_connection_best_effort(db, namespace=self._namespace, operation=operation)
                 raise
             yield db
 
@@ -748,7 +769,11 @@ class PostgresEventCache:
                         result = await callback(db)
                         await db.commit()
                     except BaseException:
-                        await self._runtime._rollback_best_effort(db, operation=operation)
+                        await _rollback_postgres_connection_best_effort(
+                            db,
+                            namespace=self._runtime.namespace,
+                            operation=operation,
+                        )
                         raise
             except EventCacheBackendUnavailableError as exc:
                 transient_error = exc

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -53,7 +53,7 @@ async def initialize_event_cache_db(db_path: Path) -> aiosqlite.Connection:
         await reset_stale_cache_if_needed(db, db_path=db_path)
         await create_event_cache_schema(db)
         await db.commit()
-    except Exception:
+    except BaseException:
         await db.close()
         raise
     return db
@@ -440,7 +440,7 @@ class SqliteEventCache:
             try:
                 result = await writer(db)
                 await db.commit()
-            except Exception:
+            except BaseException:
                 await db.rollback()
                 raise
         return result

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -43,6 +43,32 @@ T = TypeVar("T")
 logger = get_logger(__name__)
 
 
+async def _close_sqlite_connection_best_effort(db: aiosqlite.Connection, *, operation: str) -> None:
+    """Close one SQLite connection without masking the original failure."""
+    try:
+        await db.close()
+    except Exception as exc:
+        logger.debug(
+            "Ignoring error while closing SQLite event cache connection",
+            operation=operation,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+
+
+async def _rollback_sqlite_connection_best_effort(db: aiosqlite.Connection, *, operation: str) -> None:
+    """Roll back one SQLite connection without masking the original failure."""
+    try:
+        await db.rollback()
+    except Exception as exc:
+        logger.debug(
+            "Ignoring SQLite event cache rollback failure",
+            operation=operation,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+
+
 async def initialize_event_cache_db(db_path: Path) -> aiosqlite.Connection:
     """Open the SQLite database and ensure the event-cache schema exists."""
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -54,7 +80,7 @@ async def initialize_event_cache_db(db_path: Path) -> aiosqlite.Connection:
         await create_event_cache_schema(db)
         await db.commit()
     except BaseException:
-        await db.close()
+        await _close_sqlite_connection_best_effort(db, operation="initialize")
         raise
     return db
 
@@ -441,7 +467,7 @@ class SqliteEventCache:
                 result = await writer(db)
                 await db.commit()
             except BaseException:
-                await db.rollback()
+                await _rollback_sqlite_connection_best_effort(db, operation=operation)
                 raise
         return result
 

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -15,12 +15,13 @@ import pytest
 from mindroom.config.matrix import CacheConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.logging_config import get_logger
-from mindroom.matrix.cache import postgres_event_cache_threads
+from mindroom.matrix.cache import postgres_event_cache_threads, sqlite_event_cache
 from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailableError
 from mindroom.matrix.cache.postgres_event_cache import (
     PostgresEventCache,
     PostgresEventCacheRuntime,
     _is_transient_postgres_failure,
+    initialize_postgres_event_cache_db,
 )
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
@@ -37,12 +38,8 @@ from mindroom.runtime_support import (
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from pathlib import Path
-    from typing import Protocol
 
     from mindroom.matrix.cache import ConversationEventCache
-
-    class _RollbackDb(Protocol):
-        async def rollback(self) -> None: ...
 
 
 def _message_event(
@@ -245,6 +242,74 @@ def test_build_event_cache_defaults_to_sqlite(tmp_path: Path) -> None:
     assert cache.db_path == tmp_path / "mindroom_data" / "event_cache.db"
 
 
+@pytest.mark.asyncio
+async def test_sqlite_event_cache_write_operation_rolls_back_cancelled_writer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation inside a SQLite cache write must not leave the shared connection in a transaction."""
+    cache = SqliteEventCache(tmp_path / "event_cache.db")
+    cancel_reason = "stop requested"
+    db = SimpleNamespace(commit=AsyncMock(), rollback=AsyncMock())
+
+    @asynccontextmanager
+    async def acquire_db_operation(room_id: str, *, operation: str) -> AsyncIterator[object]:
+        assert room_id == "!room:example.test"
+        assert operation == "cancelled_writer"
+        yield db
+
+    monkeypatch.setattr(
+        cache,
+        "_runtime",
+        SimpleNamespace(
+            is_disabled=False,
+            acquire_db_operation=acquire_db_operation,
+        ),
+    )
+
+    async def cancelled_writer(_db: object) -> None:
+        raise asyncio.CancelledError(cancel_reason)
+
+    with pytest.raises(asyncio.CancelledError, match=cancel_reason):
+        await cache._write_operation(
+            "!room:example.test",
+            operation="cancelled_writer",
+            disabled_result=None,
+            writer=cancelled_writer,
+        )
+
+    db.rollback.assert_awaited_once()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_event_cache_initialize_closes_db_after_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation during SQLite cache initialization must close the half-initialized connection."""
+    cancel_reason = "init cancelled"
+    db = SimpleNamespace(
+        close=AsyncMock(),
+        execute=AsyncMock(),
+    )
+
+    async def connect(_db_path: Path) -> object:
+        return db
+
+    async def reset_stale_cache_if_needed(_db: object, *, db_path: Path) -> None:
+        _ = db_path
+        raise asyncio.CancelledError(cancel_reason)
+
+    monkeypatch.setattr(sqlite_event_cache.aiosqlite, "connect", connect)
+    monkeypatch.setattr(sqlite_event_cache, "reset_stale_cache_if_needed", reset_stale_cache_if_needed)
+
+    with pytest.raises(asyncio.CancelledError, match=cancel_reason):
+        await sqlite_event_cache.initialize_event_cache_db(tmp_path / "event_cache.db")
+
+    db.close.assert_awaited_once()
+
+
 def test_build_event_cache_uses_postgres_when_configured(tmp_path: Path) -> None:
     """The runtime factory should construct the Postgres cache backend only when requested."""
     runtime_paths = _runtime_paths(
@@ -262,6 +327,35 @@ def test_build_event_cache_uses_postgres_when_configured(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
+async def test_postgres_event_cache_initialize_attempts_cleanup_without_masking_cancelled_schema_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation during Postgres startup schema creation must not leak an open transaction."""
+    cancel_reason = "startup cancelled"
+    db = SimpleNamespace(
+        commit=AsyncMock(),
+        rollback=AsyncMock(side_effect=RuntimeError("rollback failed")),
+        close=AsyncMock(side_effect=RuntimeError("close failed")),
+    )
+
+    async def connect(_database_url: str) -> object:
+        return db
+
+    async def create_schema(_db: object) -> None:
+        raise asyncio.CancelledError(cancel_reason)
+
+    monkeypatch.setattr("mindroom.matrix.cache.postgres_event_cache.psycopg.AsyncConnection.connect", connect)
+    monkeypatch.setattr("mindroom.matrix.cache.postgres_event_cache.create_postgres_event_cache_schema", create_schema)
+
+    with pytest.raises(asyncio.CancelledError, match=cancel_reason):
+        await initialize_postgres_event_cache_db("postgresql://cache:test@localhost/mindroom")
+
+    db.rollback.assert_awaited_once()
+    db.close.assert_awaited_once()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_postgres_event_cache_operation_rolls_back_cancelled_callback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -276,10 +370,6 @@ async def test_postgres_event_cache_operation_rolls_back_cancelled_callback(
         assert operation == "cancelled_callback"
         yield db
 
-    async def rollback_best_effort(db_arg: _RollbackDb, *, operation: str) -> None:
-        assert operation == "cancelled_callback"
-        await db_arg.rollback()
-
     monkeypatch.setattr(
         cache,
         "_runtime",
@@ -287,7 +377,6 @@ async def test_postgres_event_cache_operation_rolls_back_cancelled_callback(
             is_disabled=False,
             namespace="tenant-a",
             acquire_db_operation=acquire_db_operation,
-            _rollback_best_effort=rollback_best_effort,
         ),
     )
     monkeypatch.setattr(cache, "_flush_pending_invalidations", AsyncMock(return_value=()))

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -250,7 +250,10 @@ async def test_sqlite_event_cache_write_operation_rolls_back_cancelled_writer(
     """Cancellation inside a SQLite cache write must not leave the shared connection in a transaction."""
     cache = SqliteEventCache(tmp_path / "event_cache.db")
     cancel_reason = "stop requested"
-    db = SimpleNamespace(commit=AsyncMock(), rollback=AsyncMock())
+    db = SimpleNamespace(
+        commit=AsyncMock(),
+        rollback=AsyncMock(side_effect=RuntimeError("rollback failed")),
+    )
 
     @asynccontextmanager
     async def acquire_db_operation(room_id: str, *, operation: str) -> AsyncIterator[object]:
@@ -290,7 +293,7 @@ async def test_sqlite_event_cache_initialize_closes_db_after_cancellation(
     """Cancellation during SQLite cache initialization must close the half-initialized connection."""
     cancel_reason = "init cancelled"
     db = SimpleNamespace(
-        close=AsyncMock(),
+        close=AsyncMock(side_effect=RuntimeError("close failed")),
         execute=AsyncMock(),
     )
 
@@ -348,7 +351,10 @@ async def test_postgres_event_cache_initialize_attempts_cleanup_without_masking_
     monkeypatch.setattr("mindroom.matrix.cache.postgres_event_cache.create_postgres_event_cache_schema", create_schema)
 
     with pytest.raises(asyncio.CancelledError, match=cancel_reason):
-        await initialize_postgres_event_cache_db("postgresql://cache:test@localhost/mindroom")
+        await initialize_postgres_event_cache_db(
+            "postgresql://cache:test@localhost/mindroom",
+            namespace="tenant-a",
+        )
 
     db.rollback.assert_awaited_once()
     db.close.assert_awaited_once()

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, Mock
@@ -33,6 +35,7 @@ from mindroom.runtime_support import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from pathlib import Path
 
     from mindroom.matrix.cache import ConversationEventCache
@@ -252,6 +255,67 @@ def test_build_event_cache_uses_postgres_when_configured(tmp_path: Path) -> None
     assert isinstance(cache, PostgresEventCache)
     assert cache.database_url == "postgresql://cache:test@localhost/mindroom"
     assert cache.namespace == "tenant-a"
+
+
+async def test_postgres_event_cache_operation_rolls_back_cancelled_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation inside a Postgres cache operation must not leave the shared connection in a transaction."""
+    cache = PostgresEventCache(database_url="postgresql://cache:test@localhost/mindroom", namespace="tenant-a")
+    cancel_reason = "stop requested"
+    db = SimpleNamespace(commit=AsyncMock(), rollback=AsyncMock())
+
+    @asynccontextmanager
+    async def acquire_db_operation(room_id: str, *, operation: str) -> AsyncIterator[object]:
+        assert room_id == "!room:example.test"
+        assert operation == "cancelled_callback"
+        yield db
+
+    monkeypatch.setattr(
+        cache,
+        "_runtime",
+        SimpleNamespace(
+            is_disabled=False,
+            namespace="tenant-a",
+            acquire_db_operation=acquire_db_operation,
+        ),
+    )
+    monkeypatch.setattr(cache, "_flush_pending_invalidations", AsyncMock(return_value=()))
+
+    async def cancelled_callback(_db: object) -> None:
+        raise asyncio.CancelledError(cancel_reason)
+
+    with pytest.raises(asyncio.CancelledError, match=cancel_reason):
+        await cache._operation(
+            "!room:example.test",
+            operation="cancelled_callback",
+            disabled_result=None,
+            callback=cancelled_callback,
+        )
+
+    db.rollback.assert_awaited_once()
+    db.commit.assert_not_awaited()
+
+
+async def test_postgres_runtime_rolls_back_cancelled_advisory_lock() -> None:
+    """Cancellation while acquiring the advisory lock must rollback the implicit transaction."""
+    cancel_reason = "lock wait cancelled"
+    runtime = PostgresEventCacheRuntime(
+        "postgresql://cache:test@localhost/mindroom",
+        namespace="tenant-a",
+    )
+    db = SimpleNamespace(
+        closed=False,
+        execute=AsyncMock(side_effect=asyncio.CancelledError(cancel_reason)),
+        rollback=AsyncMock(),
+    )
+    runtime._db = db
+
+    with pytest.raises(asyncio.CancelledError, match=cancel_reason):
+        async with runtime.acquire_db_operation("!room:example.test", operation="advisory_lock"):
+            pytest.fail("acquire_db_operation should not yield when advisory lock acquisition is cancelled")
+
+    db.rollback.assert_awaited_once()
 
 
 def test_build_event_cache_auto_installs_postgres_extra_before_import(

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -37,8 +37,12 @@ from mindroom.runtime_support import (
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from pathlib import Path
+    from typing import Protocol
 
     from mindroom.matrix.cache import ConversationEventCache
+
+    class _RollbackDb(Protocol):
+        async def rollback(self) -> None: ...
 
 
 def _message_event(
@@ -257,6 +261,7 @@ def test_build_event_cache_uses_postgres_when_configured(tmp_path: Path) -> None
     assert cache.namespace == "tenant-a"
 
 
+@pytest.mark.asyncio
 async def test_postgres_event_cache_operation_rolls_back_cancelled_callback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -271,6 +276,10 @@ async def test_postgres_event_cache_operation_rolls_back_cancelled_callback(
         assert operation == "cancelled_callback"
         yield db
 
+    async def rollback_best_effort(db_arg: _RollbackDb, *, operation: str) -> None:
+        assert operation == "cancelled_callback"
+        await db_arg.rollback()
+
     monkeypatch.setattr(
         cache,
         "_runtime",
@@ -278,6 +287,7 @@ async def test_postgres_event_cache_operation_rolls_back_cancelled_callback(
             is_disabled=False,
             namespace="tenant-a",
             acquire_db_operation=acquire_db_operation,
+            _rollback_best_effort=rollback_best_effort,
         ),
     )
     monkeypatch.setattr(cache, "_flush_pending_invalidations", AsyncMock(return_value=()))
@@ -297,6 +307,7 @@ async def test_postgres_event_cache_operation_rolls_back_cancelled_callback(
     db.commit.assert_not_awaited()
 
 
+@pytest.mark.asyncio
 async def test_postgres_runtime_rolls_back_cancelled_advisory_lock() -> None:
     """Cancellation while acquiring the advisory lock must rollback the implicit transaction."""
     cancel_reason = "lock wait cancelled"


### PR DESCRIPTION
## Summary
- rollback the shared Postgres event-cache connection when advisory-lock acquisition is cancelled
- rollback cache operations on `BaseException`, including `asyncio.CancelledError`, before re-raising
- add regression coverage for cancellation during advisory-lock acquisition and during a cache callback

## Why
Production showed MindRoom Postgres event-cache sessions left `idle in transaction` after cancellation/restart pressure. `CancelledError` can bypass `except Exception`, leaving the shared psycopg connection inside a transaction.

## Verification
- `uv run --extra postgres pytest tests/test_event_cache_backends.py -k 'rolls_back_cancelled' -o addopts=''` failed before the fix because rollback was awaited 0 times
- `uv run --extra postgres pytest tests/test_event_cache_backends.py -o addopts=''` -> 26 passed
- `uv run ruff check src/mindroom/matrix/cache/postgres_event_cache.py tests/test_event_cache_backends.py` -> All checks passed
- `uv run ruff format --check src/mindroom/matrix/cache/postgres_event_cache.py tests/test_event_cache_backends.py` -> 2 files already formatted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust transaction rollback and cleanup for database operations (startup, runtime operations, and advisory lock paths), ensuring cancellations and unexpected failures do not result in unintended commits and that connections are closed without masking the original error.
  * Added best-effort cleanup for both PostgreSQL and SQLite to log cleanup failures without obscuring root exceptions.

* **Tests**
  * Added cancellation-focused tests for SQLite and Postgres to verify rollbacks, no commits on cancellation, and proper connection cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->