### PR TITLE
Cache resolved module file paths in plugin validation

### DIFF
--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -841,15 +841,22 @@ def register_tool_with_metadata(
     return decorator
 
 
+@functools.lru_cache(maxsize=8192)
+def _resolved_module_file(module_file: str) -> Path | None:
+    """Return the resolved on-disk path for one module file, cached across calls."""
+    try:
+        return Path(module_file).resolve()
+    except OSError:
+        return None
+
+
 def _module_origin_within_root(module: ModuleType, root: Path) -> bool:
     """Return whether one loaded module originates from within one plugin root."""
     module_file = getattr(module, "__file__", None)
     if not isinstance(module_file, str):
         return False
-    try:
-        return Path(module_file).resolve().is_relative_to(root)
-    except OSError:
-        return False
+    resolved = _resolved_module_file(module_file)
+    return resolved is not None and resolved.is_relative_to(root)
 
 
 def _execute_validation_plugin_module(

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -146,6 +146,37 @@ def test_plugin_validation_uses_sys_modules_snapshot(tmp_path: Path, monkeypatch
     assert "__validation__" in module_name
 
 
+def test_module_origin_within_root_caches_path_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated origin checks for one module file should not re-resolve the path."""
+    plugin_root = tmp_path / "plugins" / "demo"
+    plugin_root.mkdir(parents=True)
+    module_path = plugin_root / "helper.py"
+    module_path.write_text("VALUE = 1\n", encoding="utf-8")
+    module = ModuleType("demo.helper")
+    module.__file__ = str(module_path)
+    resolve_calls = 0
+    original_resolve = Path.resolve
+
+    def counted_resolve(self: Path, *args: object, **kwargs: object) -> Path:
+        nonlocal resolve_calls
+        if self == Path(str(module_path)):
+            resolve_calls += 1
+        return original_resolve(self, *args, **kwargs)
+
+    metadata_module._resolved_module_file.cache_clear()
+    monkeypatch.setattr(metadata_module.Path, "resolve", counted_resolve)
+    try:
+        assert metadata_module._module_origin_within_root(module, plugin_root)
+        assert metadata_module._module_origin_within_root(module, plugin_root)
+    finally:
+        metadata_module._resolved_module_file.cache_clear()
+
+    assert resolve_calls == 1
+
+
 def test_restore_tool_registry_snapshot_uses_sys_modules_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

py-spy showed `_module_origin_within_root` as the hot path during `resolved_tool_validation_snapshot_for_runtime`, with `Path.resolve()` called repeatedly while iterating `sys.modules` per plugin validation. Wrap the resolve in `functools.lru_cache(maxsize=8192)` so the same module file is resolved once across calls.

## Changes

- `src/mindroom/tool_system/metadata.py`: extract `_resolved_module_file(module_file: str) -> Path | None` as an LRU-cached helper; `_module_origin_within_root` now calls it and only the cheap `is_relative_to` runs per check.
- `tests/test_tools_metadata.py`: one regression test asserting `Path.resolve` is invoked once across repeated origin checks for the same module file.

No invalidation hook is needed — the cache value (resolved on-disk path of a module file) is stable for the lifetime of the file at that path, and the LRU bound caps memory.

## Test plan

- [x] `uv run pytest tests/test_tools_metadata.py tests/test_plugins.py -x -n 0 --no-cov` (76 passed)
- [x] `uv run pre-commit run --files src/mindroom/tool_system/metadata.py tests/test_tools_metadata.py`