### PR TITLE
Handle expected Matrix delivery policy rejections compactly

### DIFF
--- a/.claude/REPORT.md
+++ b/.claude/REPORT.md
@@ -1,0 +1,44 @@
+# Matrix Delivery Policy Failure Handling
+
+## Summary of changes
+
+Added a typed `MatrixExpectedDeliveryPolicyError` for deterministic Matrix delivery policy rejections raised from nio trust checks.
+Kept Matrix delivery logs sanitized and compact while preserving traceback propagation for genuinely unexpected local delivery exceptions.
+Updated streaming delivery to stop retrying terminal updates when the failure is an expected Matrix delivery policy rejection.
+Updated response-level streaming logging to emit compact structured warnings for expected policy rejections without traceback rendering.
+Added focused tests covering typed policy failures, compact logging, and skipped terminal retry behavior.
+
+## Tests run and results
+
+`uv run ruff check src/mindroom/matrix/client_delivery.py src/mindroom/matrix/client.py src/mindroom/streaming.py src/mindroom/response_runner.py tests/test_send_file_message.py tests/test_streaming_behavior.py` passed.
+`uv run ruff format --check src/mindroom/matrix/client_delivery.py src/mindroom/matrix/client.py src/mindroom/streaming.py src/mindroom/response_runner.py tests/test_send_file_message.py tests/test_streaming_behavior.py` passed.
+`uv run --python 3.13 pytest tests/test_send_file_message.py tests/test_streaming_behavior.py tests/test_tach_split_matrix_client_boundaries.py::test_split_matrix_client_importers_have_explicit_tach_modules -q -n 0 --no-cov` passed with 126 tests.
+`uv run --python 3.13 pytest --no-cov` passed with 6248 tests passed and 56 skipped.
+An earlier full parallel pytest run exposed timing-sensitive approval and compaction failures plus a split-client Tach boundary failure.
+The Tach boundary issue was fixed in this patch, the timing-sensitive failures passed when rerun serially, and the final full parallel pytest run passed.
+
+## Remaining risks/questions
+
+The policy classification currently covers `MatrixExpectedDeliveryPolicyError` and nio `OlmTrustError` subclasses.
+If nio adds new deterministic trust-policy exception types outside that hierarchy, the classifier should be extended.
+Unexpected Matrix delivery exceptions now propagate after compact low-level logging so higher layers can preserve tracebacks.
+
+## Suggested PR title
+
+Handle expected Matrix delivery policy rejections compactly
+
+## Suggested PR body
+
+### Summary
+
+- Classify deterministic Matrix delivery policy rejections with a typed exception.
+- Log expected Matrix policy delivery failures without expensive traceback rendering at streaming and response boundaries.
+- Skip terminal streaming retries when the underlying failure is a deterministic policy rejection.
+- Preserve tracebacks for unexpected Matrix delivery exceptions.
+
+### Tests
+
+- `uv run ruff check src/mindroom/matrix/client_delivery.py src/mindroom/matrix/client.py src/mindroom/streaming.py src/mindroom/response_runner.py tests/test_send_file_message.py tests/test_streaming_behavior.py`
+- `uv run ruff format --check src/mindroom/matrix/client_delivery.py src/mindroom/matrix/client.py src/mindroom/streaming.py src/mindroom/response_runner.py tests/test_send_file_message.py tests/test_streaming_behavior.py`
+- `uv run --python 3.13 pytest tests/test_send_file_message.py tests/test_streaming_behavior.py tests/test_tach_split_matrix_client_boundaries.py::test_split_matrix_client_importers_have_explicit_tach_modules -q -n 0 --no-cov`
+- `uv run --python 3.13 pytest --no-cov`

--- a/src/mindroom/matrix/client.py
+++ b/src/mindroom/matrix/client.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from mindroom.matrix.client_delivery import (
     DeliveredMatrixEvent,
+    MatrixExpectedDeliveryPolicyError,
     cached_room,  # noqa: F401
     edit_message_result,
+    is_expected_matrix_delivery_policy_error,
     send_file_message,
     send_message_result,
 )
@@ -36,6 +38,7 @@ from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage, repl
 
 __all__ = [
     "DeliveredMatrixEvent",
+    "MatrixExpectedDeliveryPolicyError",
     "PermanentMatrixStartupError",
     "ResolvedVisibleMessage",
     "RoomThreadsPageError",
@@ -48,6 +51,7 @@ __all__ = [
     "get_room_name",
     "get_room_threads_page",
     "invite_to_room",
+    "is_expected_matrix_delivery_policy_error",
     "join_room",
     "leave_room",
     "login",

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -32,6 +32,7 @@ logger = get_logger(__name__)
 
 _MATRIX_TRUST_DELIVERY_ERROR_MESSAGE = "Matrix encrypted delivery rejected by local device trust policy."
 _MATRIX_GENERIC_DELIVERY_ERROR_MESSAGE = "Matrix delivery raised an unexpected local exception."
+_MATRIX_POLICY_FAILURE_KIND = "matrix_delivery_policy_rejection"
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,9 +43,33 @@ class DeliveredMatrixEvent:
     content_sent: dict[str, Any]
 
 
+class MatrixExpectedDeliveryPolicyError(Exception):
+    """Expected deterministic Matrix delivery rejection from local trust policy."""
+
+    def __init__(
+        self,
+        *,
+        room_id: str,
+        operation: str,
+        cache_bypass: bool,
+        exception_type: str,
+    ) -> None:
+        super().__init__(_MATRIX_TRUST_DELIVERY_ERROR_MESSAGE)
+        self.room_id = room_id
+        self.operation = operation
+        self.cache_bypass = cache_bypass
+        self.exception_type = exception_type
+        self.failure_kind = _MATRIX_POLICY_FAILURE_KIND
+
+
+def is_expected_matrix_delivery_policy_error(error: BaseException) -> bool:
+    """Return whether an exception is a deterministic Matrix policy rejection."""
+    return isinstance(error, MatrixExpectedDeliveryPolicyError | OlmTrustError)
+
+
 def _sanitized_delivery_error_message(error: Exception) -> str:
     """Return a log-safe Matrix delivery failure message."""
-    if isinstance(error, OlmTrustError):
+    if is_expected_matrix_delivery_policy_error(error):
         return _MATRIX_TRUST_DELIVERY_ERROR_MESSAGE
     return _MATRIX_GENERIC_DELIVERY_ERROR_MESSAGE
 
@@ -64,6 +89,22 @@ def _log_matrix_delivery_exception(
         cache_bypass=cache_bypass,
         exception_type=error.__class__.__name__,
         error_message=_sanitized_delivery_error_message(error),
+    )
+
+
+def _matrix_delivery_policy_error(
+    error: Exception,
+    *,
+    room_id: str,
+    operation: str,
+    cache_bypass: bool,
+) -> MatrixExpectedDeliveryPolicyError:
+    """Build one typed expected Matrix delivery policy rejection."""
+    return MatrixExpectedDeliveryPolicyError(
+        room_id=room_id,
+        operation=operation,
+        cache_bypass=cache_bypass,
+        exception_type=error.__class__.__name__,
     )
 
 
@@ -118,7 +159,14 @@ async def _send_prepared_room_message(
             operation=operation,
             cache_bypass=cache_bypass,
         )
-        return None
+        if is_expected_matrix_delivery_policy_error(error):
+            raise _matrix_delivery_policy_error(
+                error,
+                room_id=room_id,
+                operation=operation,
+                cache_bypass=cache_bypass,
+            ) from error
+        raise
 
 
 def cached_room(client: nio.AsyncClient, room_id: str) -> nio.MatrixRoom | None:
@@ -485,11 +533,13 @@ async def edit_message_result(
 
 __all__ = [
     "DeliveredMatrixEvent",
+    "MatrixExpectedDeliveryPolicyError",
     "build_edit_event_content",
     "build_threaded_edit_content",
     "cached_room",
     "can_send_to_encrypted_room",
     "edit_message_result",
+    "is_expected_matrix_delivery_policy_error",
     "send_file_message",
     "send_message_result",
 ]

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -53,6 +53,7 @@ from mindroom.streaming import (
     StreamingDeliveryError,
     StreamingResponse,
     clean_partial_reply_text,
+    is_expected_streaming_delivery_policy_error,
 )
 from mindroom.teams import TeamMode, select_model_for_team, team_response, team_response_stream
 from mindroom.thread_summary import thread_summary_message_count_hint
@@ -177,6 +178,39 @@ def _agent_has_matrix_messaging_tool(config: Config, agent_name: str) -> bool:
     except ValueError:
         return False
     return "matrix_message" in tool_names
+
+
+def _log_streaming_delivery_error(
+    logger: structlog.stdlib.BoundLogger,
+    *,
+    response_label: Literal["Bot", "Team"],
+    error: StreamingDeliveryError,
+) -> None:
+    """Log expected Matrix policy delivery failures without traceback rendering."""
+    stream_transport_outcome = error.transport_outcome
+    if stream_transport_outcome.terminal_status == "cancelled":
+        log_cancelled_response_source(
+            logger,
+            cancel_source=cancel_source_from_failure_reason(stream_transport_outcome.failure_reason),
+            message_id=error.event_id,
+            restart_message=f"{response_label} streaming response interrupted by sync restart",
+            user_stop_message=f"{response_label} streaming response cancelled by user",
+            interrupted_message=f"{response_label} streaming response interrupted — traceback for diagnosis",
+            exc_info=(type(error.error), error.error, error.error.__traceback__),
+        )
+        return
+    if is_expected_streaming_delivery_policy_error(error):
+        logger.warning(
+            f"{response_label} streaming response rejected by Matrix delivery policy",
+            message_id=error.event_id,
+            exception_type=error.error.__class__.__name__,
+            error=str(error.error),
+        )
+        return
+    unexpected_message = (
+        "Error in streaming response" if response_label == "Bot" else "Error in team streaming response"
+    )
+    logger.exception(unexpected_message, error=str(error.error))
 
 
 def _append_matrix_prompt_context(
@@ -887,7 +921,7 @@ class ResponseRunner:
             ),
         )
 
-    async def generate_team_response_helper_locked(  # noqa: C901, PLR0912, PLR0915
+    async def generate_team_response_helper_locked(  # noqa: C901, PLR0915
         self,
         team_request: _TeamResponseRequest,
         *,
@@ -1294,19 +1328,7 @@ class ResponseRunner:
             if tracked_event_id is None:
                 tracked_event_id = run_message_id
         except StreamingDeliveryError as error:
-            stream_transport_outcome = error.transport_outcome
-            if stream_transport_outcome.terminal_status == "cancelled":
-                log_cancelled_response_source(
-                    self.deps.logger,
-                    cancel_source=cancel_source_from_failure_reason(stream_transport_outcome.failure_reason),
-                    message_id=error.event_id,
-                    restart_message="Team streaming response interrupted by sync restart",
-                    user_stop_message="Team streaming response cancelled by user",
-                    interrupted_message="Team streaming response interrupted — traceback for diagnosis",
-                    exc_info=(type(error.error), error.error, error.error.__traceback__),
-                )
-            else:
-                self.deps.logger.exception("Error in team streaming response", error=str(error.error))
+            _log_streaming_delivery_error(self.deps.logger, response_label="Team", error=error)
             if error.event_id:
                 tracked_event_id = error.event_id
             if self._record_stream_delivery_error(
@@ -1969,19 +1991,7 @@ class ResponseRunner:
             finally:
                 await lifecycle.emit_session_started(session_started_watch)
         except StreamingDeliveryError as error:
-            stream_transport_outcome = error.transport_outcome
-            if stream_transport_outcome.terminal_status == "cancelled":
-                log_cancelled_response_source(
-                    self.deps.logger,
-                    cancel_source=cancel_source_from_failure_reason(stream_transport_outcome.failure_reason),
-                    message_id=error.event_id,
-                    restart_message="Bot streaming response interrupted by sync restart",
-                    user_stop_message="Bot streaming response cancelled by user",
-                    interrupted_message="Bot streaming response interrupted — traceback for diagnosis",
-                    exc_info=(type(error.error), error.error, error.error.__traceback__),
-                )
-            else:
-                self.deps.logger.exception("Error in streaming response", error=str(error.error))
+            _log_streaming_delivery_error(self.deps.logger, response_label="Bot", error=error)
             tool_trace[:] = error.tool_trace
             if self._record_stream_delivery_error(
                 recorder=turn_recorder,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -210,7 +210,11 @@ def _log_streaming_delivery_error(
     unexpected_message = (
         "Error in streaming response" if response_label == "Bot" else "Error in team streaming response"
     )
-    logger.exception(unexpected_message, error=str(error.error))
+    logger.exception(
+        unexpected_message,
+        message_id=error.event_id,
+        error=str(error.error),
+    )
 
 
 def _append_matrix_prompt_context(

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1333,6 +1333,7 @@ class ResponseRunner:
                 tracked_event_id = run_message_id
         except StreamingDeliveryError as error:
             _log_streaming_delivery_error(self.deps.logger, response_label="Team", error=error)
+            stream_transport_outcome = error.transport_outcome
             if error.event_id:
                 tracked_event_id = error.event_id
             if self._record_stream_delivery_error(
@@ -1916,7 +1917,7 @@ class ResponseRunner:
             compaction_outcomes_collector.extend(compaction_outcomes)
         return delivery
 
-    async def process_and_respond_streaming(  # noqa: C901, PLR0912, PLR0915
+    async def process_and_respond_streaming(  # noqa: C901, PLR0915
         self,
         request: ResponseRequest,
         *,
@@ -1996,6 +1997,7 @@ class ResponseRunner:
                 await lifecycle.emit_session_started(session_started_watch)
         except StreamingDeliveryError as error:
             _log_streaming_delivery_error(self.deps.logger, response_label="Bot", error=error)
+            stream_transport_outcome = error.transport_outcome
             tool_trace[:] = error.tool_trace
             if self._record_stream_delivery_error(
                 recorder=turn_recorder,

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -21,7 +21,13 @@ from mindroom.constants import (
 )
 from mindroom.final_delivery import StreamTransportOutcome
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client_delivery import build_edit_event_content, edit_message_result, send_message_result
+from mindroom.matrix.client_delivery import (
+    MatrixExpectedDeliveryPolicyError,
+    build_edit_event_content,
+    edit_message_result,
+    is_expected_matrix_delivery_policy_error,
+    send_message_result,
+)
 from mindroom.matrix.large_messages import should_send_oversized_nonterminal_streaming_edit
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.message_target import MessageTarget
@@ -75,6 +81,7 @@ __all__ = [
     "build_restart_interrupted_body",
     "cancel_failure_reason",
     "clean_partial_reply_text",
+    "is_expected_streaming_delivery_policy_error",
     "is_interrupted_partial_reply",
     "send_streaming_response",
 ]
@@ -106,6 +113,11 @@ class StreamingDeliveryError(Exception):
         self.accumulated_text = accumulated_text
         self.tool_trace = tool_trace.copy()
         self.transport_outcome = transport_outcome
+
+
+def is_expected_streaming_delivery_policy_error(error: StreamingDeliveryError) -> bool:
+    """Return whether a streaming failure was caused by Matrix delivery policy."""
+    return is_expected_matrix_delivery_policy_error(error.error)
 
 
 def _build_streaming_delivery_error(
@@ -592,11 +604,14 @@ class StreamingResponse:
             "placeholder_only" if attempted_rendered_body == _PROGRESS_PLACEHOLDER else "visible_body"
         )
         try:
-            retry_terminal_update = final_stream_status == STREAM_STATUS_COMPLETED
+            retry_terminal_update = final_stream_status == STREAM_STATUS_COMPLETED and not (
+                error is not None and is_expected_matrix_delivery_policy_error(error)
+            )
             retry_terminal_update_immediately = (
                 final_stream_status != STREAM_STATUS_COMPLETED
                 and not restart_interrupted
                 and cancel_source != "sync_restart"
+                and not (error is not None and is_expected_matrix_delivery_policy_error(error))
             )
             send_succeeded = await self._send_or_edit_message(
                 client,
@@ -628,14 +643,24 @@ class StreamingResponse:
                 interactive_metadata=self._last_committed_interactive_metadata,
             )
         except Exception as exc:
-            logger.warning(
-                "Terminal streaming update raised after retries",
-                event_id=self.event_id,
-                room_id=self.room_id,
-                stream_status=final_stream_status,
-                reason=str(exc),
-                exc_info=True,
-            )
+            if is_expected_matrix_delivery_policy_error(exc):
+                logger.warning(
+                    "Terminal streaming update rejected by Matrix delivery policy",
+                    event_id=self.event_id,
+                    room_id=self.room_id,
+                    stream_status=final_stream_status,
+                    exception_type=exc.__class__.__name__,
+                    error=str(exc),
+                )
+            else:
+                logger.warning(
+                    "Terminal streaming update raised after retries",
+                    event_id=self.event_id,
+                    room_id=self.room_id,
+                    stream_status=final_stream_status,
+                    reason=str(exc),
+                    exc_info=True,
+                )
             (
                 committed_rendered_body,
                 committed_visible_body_state,
@@ -966,7 +991,23 @@ class StreamingResponse:
                     if await self._edit_existing_content(client, content=content, display_text=display_text):
                         return True
                     logger.error("Failed to edit streaming message", attempt=attempt)
-            except Exception:
+            except Exception as exc:
+                if is_expected_matrix_delivery_policy_error(exc):
+                    log_fields: dict[str, object] = {"exception_type": exc.__class__.__name__}
+                    if isinstance(exc, MatrixExpectedDeliveryPolicyError):
+                        log_fields.update(
+                            operation=exc.operation,
+                            exception_type=exc.exception_type,
+                            failure_kind=exc.failure_kind,
+                        )
+                    logger.warning(
+                        "Streaming update rejected by Matrix delivery policy",
+                        attempt=attempt,
+                        event_id=self.event_id,
+                        room_id=self.room_id,
+                        **log_fields,
+                    )
+                    raise
                 logger.warning(
                     "Streaming update attempt raised an exception",
                     attempt=attempt,
@@ -1146,7 +1187,14 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
             ) from exc
         except Exception as exc:
             delivery_error = exc.error if isinstance(exc, NonTerminalDeliveryError) else exc
-            logger.exception("Streaming response failed", error=str(delivery_error))
+            if is_expected_matrix_delivery_policy_error(delivery_error):
+                logger.warning(
+                    "Streaming response failed due to Matrix delivery policy",
+                    error=str(delivery_error),
+                    exception_type=delivery_error.__class__.__name__,
+                )
+            else:
+                logger.exception("Streaming response failed", error=str(delivery_error))
             cleanup_error = await shutdown_worker_progress_drain(pump, progress_task)
             if cleanup_error is None:
                 progress_task = None

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -604,9 +604,7 @@ class StreamingResponse:
             "placeholder_only" if attempted_rendered_body == _PROGRESS_PLACEHOLDER else "visible_body"
         )
         try:
-            retry_terminal_update = final_stream_status == STREAM_STATUS_COMPLETED and not (
-                error is not None and is_expected_matrix_delivery_policy_error(error)
-            )
+            retry_terminal_update = final_stream_status == STREAM_STATUS_COMPLETED
             retry_terminal_update_immediately = (
                 final_stream_status != STREAM_STATUS_COMPLETED
                 and not restart_interrupted

--- a/tach.toml
+++ b/tach.toml
@@ -2551,11 +2551,13 @@ from = ["mindroom.matrix.client_session"]
 [[interfaces]]
 expose = [
     "DeliveredMatrixEvent",
+    "MatrixExpectedDeliveryPolicyError",
     "build_edit_event_content",
     "build_threaded_edit_content",
     "can_send_to_encrypted_room",
     "cached_room",
     "edit_message_result",
+    "is_expected_matrix_delivery_policy_error",
     "send_file_message",
     "send_message_result",
 ]

--- a/tach.toml
+++ b/tach.toml
@@ -2490,6 +2490,7 @@ from = ["mindroom.matrix.event_info"]
 [[interfaces]]
 expose = [
     "DeliveredMatrixEvent",
+    "MatrixExpectedDeliveryPolicyError",
     "PermanentMatrixStartupError",
     "ResolvedVisibleMessage",
     "RoomThreadsPageError",
@@ -2502,6 +2503,7 @@ expose = [
     "get_room_name",
     "get_room_threads_page",
     "invite_to_room",
+    "is_expected_matrix_delivery_policy_error",
     "join_room",
     "leave_room",
     "login",

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -11,6 +11,7 @@ import pytest
 from nio.exceptions import OlmUnverifiedDeviceError
 
 from mindroom.config.main import Config
+from mindroom.matrix import client_delivery as client_delivery_module
 from mindroom.matrix.client import DeliveredMatrixEvent, join_room
 from mindroom.matrix.client_delivery import (
     _msgtype_for_mimetype,
@@ -581,8 +582,8 @@ class TestSendMessageResult:
         client.room_send.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_room_send_raises_unverified_device_error(self) -> None:
-        """Local E2EE trust failures should not escape text send delivery."""
+    async def test_raises_policy_error_when_room_send_raises_unverified_device_error(self) -> None:
+        """Local E2EE trust failures should surface as typed policy rejections."""
         client = _mock_client()
         client.room_send.side_effect = OlmUnverifiedDeviceError(
             SimpleNamespace(user_id="@private:localhost", device_id="SECRETDEVICE"),
@@ -595,15 +596,17 @@ class TestSendMessageResult:
                 new=AsyncMock(side_effect=lambda *_: {"body": "hello", "msgtype": "m.text"}),
             ),
             patch("mindroom.matrix.client_delivery.logger.error") as mock_error,
+            pytest.raises(client_delivery_module.MatrixExpectedDeliveryPolicyError) as exc_info,
         ):
-            result = await send_message_result(
+            await send_message_result(
                 client,
                 "!room:localhost",
                 {"body": "hello", "msgtype": "m.text"},
                 config=Config(),
             )
 
-        assert result is None
+        assert exc_info.value.operation == "send_message"
+        assert exc_info.value.exception_type == "OlmUnverifiedDeviceError"
         mock_error.assert_called_once()
         assert mock_error.call_args.args == ("matrix_message_delivery_exception",)
         assert mock_error.call_args.kwargs["exception_type"] == "OlmUnverifiedDeviceError"
@@ -612,8 +615,8 @@ class TestSendMessageResult:
         )
 
     @pytest.mark.asyncio
-    async def test_edit_returns_none_when_room_send_raises_unverified_device_error(self) -> None:
-        """Local E2EE trust failures should not escape edit delivery."""
+    async def test_edit_raises_policy_error_when_room_send_raises_unverified_device_error(self) -> None:
+        """Local E2EE trust failures should surface as typed edit policy rejections."""
         client = _mock_client()
         client.room_send.side_effect = OlmUnverifiedDeviceError(
             SimpleNamespace(user_id="@private:localhost", device_id="SECRETDEVICE"),
@@ -626,8 +629,9 @@ class TestSendMessageResult:
                 new=AsyncMock(side_effect=lambda *_: {"body": "hello", "msgtype": "m.text"}),
             ),
             patch("mindroom.matrix.client_delivery.logger.error") as mock_error,
+            pytest.raises(client_delivery_module.MatrixExpectedDeliveryPolicyError) as exc_info,
         ):
-            result = await edit_message_result(
+            await edit_message_result(
                 client,
                 "!room:localhost",
                 "$placeholder",
@@ -636,14 +640,14 @@ class TestSendMessageResult:
                 config=Config(),
             )
 
-        assert result is None
+        assert exc_info.value.operation == "edit_message"
         assert mock_error.call_args.args == ("matrix_message_delivery_exception",)
         assert mock_error.call_args.kwargs["operation"] == "edit_message"
         assert mock_error.call_args.kwargs["exception_type"] == "OlmUnverifiedDeviceError"
 
     @pytest.mark.asyncio
-    async def test_unexpected_room_send_exception_logs_generic_sanitized_message(self) -> None:
-        """Unexpected local delivery exceptions should log type plus a safe generic message."""
+    async def test_unexpected_room_send_exception_propagates_with_sanitized_log(self) -> None:
+        """Unexpected local delivery exceptions should keep traceback ownership for callers."""
         client = _mock_client()
         client.room_send.side_effect = RuntimeError(
             "failed token=supersecret for @private:localhost via https://matrix.example/private",
@@ -655,15 +659,15 @@ class TestSendMessageResult:
                 new=AsyncMock(side_effect=lambda *_: {"body": "hello", "msgtype": "m.text"}),
             ),
             patch("mindroom.matrix.client_delivery.logger.error") as mock_error,
+            pytest.raises(RuntimeError, match="failed token=supersecret"),
         ):
-            result = await send_message_result(
+            await send_message_result(
                 client,
                 "!room:localhost",
                 {"body": "hello", "msgtype": "m.text"},
                 config=Config(),
             )
 
-        assert result is None
         assert mock_error.call_args.args == ("matrix_message_delivery_exception",)
         assert mock_error.call_args.kwargs["exception_type"] == "RuntimeError"
         assert mock_error.call_args.kwargs["error_message"] == "Matrix delivery raised an unexpected local exception."

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -41,14 +41,14 @@ from mindroom.history.interrupted_replay import (
 )
 from mindroom.hooks import MessageEnvelope
 from mindroom.matrix.client import DeliveredMatrixEvent
-from mindroom.matrix.client_delivery import build_edit_event_content
+from mindroom.matrix.client_delivery import MatrixExpectedDeliveryPolicyError, build_edit_event_content
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.large_messages import _oversized_nonterminal_streaming_edit_sent_at
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutcome
 from mindroom.response_lifecycle import ResponseLifecycle, ResponseLifecycleDeps
-from mindroom.response_runner import ResponseRequest
+from mindroom.response_runner import ResponseRequest, _log_streaming_delivery_error
 from mindroom.streaming import (
     _CANCELLED_RESPONSE_NOTE,
     _INTERRUPTED_RESPONSE_NOTE,
@@ -3150,6 +3150,84 @@ class TestStreamingBehavior:
 
         assert terminal_texts[-1].startswith("**[Response interrupted by an error:")
         assert "hello" not in exc_info.value.accumulated_text
+
+    @pytest.mark.asyncio
+    async def test_policy_delivery_failure_logs_compactly_and_skips_terminal_retry(self) -> None:
+        """Deterministic Matrix policy rejections should not emit traceback retries."""
+        mock_client = _make_matrix_client_mock()
+
+        class ImmediateStreamingResponse(StreamingResponse):
+            def __init__(self, **kwargs: object) -> None:
+                super().__init__(**kwargs)
+                self.update_interval = 0.0
+                self.min_update_interval = 0.0
+                self.progress_update_interval = 0.0
+                self.min_char_update_interval = 0.0
+                self.update_char_threshold = 1
+                self.min_update_char_threshold = 1
+
+        policy_error = MatrixExpectedDeliveryPolicyError(
+            room_id="!test:localhost",
+            operation="edit_message",
+            cache_bypass=False,
+            exception_type="OlmUnverifiedDeviceError",
+        )
+
+        async def stream() -> AsyncIterator[str]:
+            yield "hello"
+
+        with (
+            patch("mindroom.streaming.edit_message_result", new=AsyncMock(side_effect=policy_error)) as mock_edit,
+            patch("mindroom.streaming.logger.exception") as mock_streaming_exception,
+            pytest.raises(StreamingDeliveryError) as exc_info,
+        ):
+            await send_streaming_response(
+                client=mock_client,
+                room_id="!test:localhost",
+                reply_to_event_id="$original_123",
+                thread_id=None,
+                sender_domain="localhost",
+                config=self.config,
+                runtime_paths=runtime_paths_for(self.config),
+                response_stream=stream(),
+                existing_event_id="$thinking_123",
+                adopt_existing_placeholder=True,
+                room_mode=True,
+                streaming_cls=ImmediateStreamingResponse,
+            )
+
+        assert exc_info.value.error is policy_error
+        assert mock_edit.await_count == 2
+        mock_streaming_exception.assert_not_called()
+
+    def test_response_runner_logs_policy_delivery_failure_without_traceback(self) -> None:
+        """Response-level delivery logging should keep policy rejections compact."""
+        policy_error = MatrixExpectedDeliveryPolicyError(
+            room_id="!test:localhost",
+            operation="edit_message",
+            cache_bypass=False,
+            exception_type="OlmUnverifiedDeviceError",
+        )
+        delivery_error = StreamingDeliveryError(
+            policy_error,
+            event_id="$thinking_123",
+            accumulated_text="hello",
+            tool_trace=[],
+            transport_outcome=StreamTransportOutcome(
+                last_physical_stream_event_id="$thinking_123",
+                terminal_status="error",
+                rendered_body="hello",
+                visible_body_state="visible_body",
+            ),
+        )
+        logger = MagicMock()
+
+        _log_streaming_delivery_error(logger, response_label="Bot", error=delivery_error)
+
+        logger.exception.assert_not_called()
+        logger.warning.assert_called_once()
+        assert logger.warning.call_args.args == ("Bot streaming response rejected by Matrix delivery policy",)
+        assert "exc_info" not in logger.warning.call_args.kwargs
 
     @pytest.mark.asyncio
     async def test_send_or_edit_message_commits_frozen_preawait_snapshot(self) -> None:

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -3186,7 +3186,6 @@ class TestStreamingBehavior:
                 room_id="!test:localhost",
                 reply_to_event_id="$original_123",
                 thread_id=None,
-                sender_domain="localhost",
                 config=self.config,
                 runtime_paths=runtime_paths_for(self.config),
                 response_stream=stream(),


### PR DESCRIPTION
### Summary

- Classify deterministic Matrix delivery policy rejections with a typed exception.
- Log expected Matrix policy delivery failures without expensive traceback rendering at streaming and response boundaries.
- Skip terminal streaming retries when the underlying failure is a deterministic policy rejection.
- Preserve tracebacks for unexpected Matrix delivery exceptions.

### Tests

- `uv run ruff check src/mindroom/matrix/client_delivery.py src/mindroom/matrix/client.py src/mindroom/streaming.py src/mindroom/response_runner.py tests/test_send_file_message.py tests/test_streaming_behavior.py`
- `uv run ruff format --check src/mindroom/matrix/client_delivery.py src/mindroom/matrix/client.py src/mindroom/streaming.py src/mindroom/response_runner.py tests/test_send_file_message.py tests/test_streaming_behavior.py`
- `uv run --python 3.13 pytest tests/test_send_file_message.py tests/test_streaming_behavior.py tests/test_tach_split_matrix_client_boundaries.py::test_split_matrix_client_importers_have_explicit_tach_modules -q -n 0 --no-cov`
- `uv run --python 3.13 pytest --no-cov`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a typed delivery-policy error and helpers so Matrix delivery-policy rejections surface via the public API.

* **Bug Fixes**
  * Delivery failures due to local device trust policies are reported (not silently dropped) and no longer trigger terminal retry behavior.
  * Streaming and response flows now emit concise structured warnings for expected delivery rejections instead of full exception traces.

* **Documentation**
  * Added a report detailing policy-rejection handling and logging behavior.

* **Tests**
  * Added tests for typed policy failures, compact logging, and skipped terminal retries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/871)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->