### PR TITLE
Preserve code fence languages in docs references

### DIFF
--- a/.github/scripts/generate_skill_references.py
+++ b/.github/scripts/generate_skill_references.py
@@ -193,12 +193,58 @@ def _source_paragraph_lines(source_text: str) -> list[list[str]]:
     return paragraphs
 
 
+def _source_fence_openings(source_text: str) -> list[str]:
+    openings: list[str] = []
+    in_code = False
+    for line in _strip_frontmatter(source_text).splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("```"):
+            continue
+        if not in_code:
+            openings.append(stripped)
+        in_code = not in_code
+    return openings
+
+
+def _restore_source_fence_languages(rendered_text: str, source_text: str) -> str:
+    source_openings = _source_fence_openings(source_text)
+    if not source_openings:
+        return rendered_text
+
+    restored_lines: list[str] = []
+    in_code = False
+    opening_index = 0
+    for line in rendered_text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("```"):
+            restored_lines.append(line)
+            continue
+
+        if in_code:
+            restored_lines.append(line)
+            in_code = False
+            continue
+
+        source_opening = source_openings[opening_index] if opening_index < len(source_openings) else stripped
+        opening_index += 1
+        in_code = True
+        if source_opening == stripped:
+            restored_lines.append(line)
+            continue
+
+        prefix = line[: len(line) - len(line.lstrip())]
+        restored_lines.append(f"{prefix}{source_opening}")
+
+    suffix = "\n" if rendered_text.endswith("\n") else ""
+    return "\n".join(restored_lines) + suffix
+
+
 def _restore_source_line_breaks(rendered_text: str, source_text: str) -> str:
     for paragraph in _source_paragraph_lines(source_text):
         for left, right in pairwise(paragraph):
             rendered_text = rendered_text.replace(f"{left} {right}", f"{left}\n{right}")
 
-    return rendered_text
+    return _restore_source_fence_languages(rendered_text, source_text)
 
 
 def _flatten_page_references(site_dir: Path, nav_pages: list[NavPage]) -> dict[str, str]:

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -88,7 +88,7 @@ Tool call telemetry is emitted as plain inline markers and mirrored in `io.mindr
 
 Marker format:
 
-```
+```text
 🔧 `tool_name` [N] ⏳     ← pending
 🔧 `tool_name` [N]        ← completed
 ```
@@ -147,7 +147,7 @@ This runs automatically — no manual intervention is needed.
 
 The `MatrixID` class handles Matrix user ID parsing and agent identification:
 
-```
+```python
 mid = MatrixID.parse("@mindroom_assistant:example.com")
 mid.username  # "mindroom_assistant"
 mid.domain    # "example.com"
@@ -164,7 +164,7 @@ agent_name = extract_agent_name("@mindroom_code:localhost", config, runtime_path
 
 MindRoom can create and maintain a root Matrix Space that groups all managed rooms.
 
-```
+```yaml
 matrix_space:
   enabled: true        # Default: true
   name: MindRoom       # Display name for the Space
@@ -177,7 +177,7 @@ The Space name is reconciled on each startup to match the configured value.
 
 Outgoing encrypted Matrix sends keep nio's device-trust checks enabled by default.
 
-```
+```yaml
 matrix_delivery:
   ignore_unverified_devices: false
 ```
@@ -189,7 +189,7 @@ This is a security tradeoff because Matrix may encrypt outgoing events for devic
 
 Matrix settings are derived from `config.yaml`:
 
-```
+```yaml
 agents:
   assistant:
     rooms: [lobby, dev]  # Room aliases (auto-created if needed)

--- a/skills/mindroom-docs/references/page__attachments__index.md
+++ b/skills/mindroom-docs/references/page__attachments__index.md
@@ -60,7 +60,7 @@ Agents can use the optional `attachments` tool to interact with context-scoped a
 
 Add `attachments` to the agent's tool list:
 
-```
+```yaml
 agents:
   assistant:
     tools:

--- a/skills/mindroom-docs/references/page__authorization__index.md
+++ b/skills/mindroom-docs/references/page__authorization__index.md
@@ -8,7 +8,7 @@ Room access (joinability/discoverability) is configured separately through `matr
 
 Configure authorization in `config.yaml`:
 
-```
+```yaml
 authorization:
   # Users with access to all rooms
   global_users:
@@ -132,7 +132,7 @@ Authorization checks are performed in order:
 
 When using Matrix bridges (e.g., mautrix-telegram, mautrix-signal), messages from the bridged platform arrive with a different Matrix user ID. Use `aliases` to map these bridge-created IDs to a canonical user so they inherit the same permissions:
 
-```
+```yaml
 authorization:
   global_users:
     - "@alice:example.com"
@@ -165,7 +165,7 @@ Use `authorization.agent_reply_permissions` to restrict which users each agent c
 - Keys that do not match any configured agent, team, `router`, or `*` are rejected at config load time.
 - For voice messages, the permission check uses the original human sender, not the router that posted the transcription.
 
-```
+```yaml
 authorization:
   global_users:
     - "@alice:example.com"
@@ -190,7 +190,7 @@ In this example, `*` restricts all entities to Alice by default, `research` over
 
 The `bot_accounts` field is a **top-level** config option (not under `authorization:`). It lists Matrix user IDs of non-MindRoom bots — such as bridge bots for Telegram, Slack, or other platforms — that should be treated like agents for response logic. Bots in this list won't trigger the multi-human-thread mention requirement.
 
-```
+```yaml
 # Top-level config, not under authorization:
 bot_accounts:
   - "@telegram_bot:example.com"

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -4,7 +4,7 @@ MindRoom provides a command-line interface for managing agents.
 
 ## Basic Usage
 
-```
+```bash
 mindroom [OPTIONS] COMMAND [ARGS]...
 ```
 
@@ -201,7 +201,7 @@ Profiles control the template style:
 
 Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `openai`, `openrouter`, or `vertexai_claude`.
 
-```
+```bash
 # Hosted Matrix quickstart (creates ~/.mindroom/config.yaml)
 mindroom config init --profile public
 
@@ -227,7 +227,7 @@ Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
 
 Display the current config file with syntax highlighting.
 
-```
+```bash
 # Show config with syntax highlighting
 mindroom config show
 
@@ -243,7 +243,7 @@ mindroom config show --path /custom/path/config.yaml
 Open `config.yaml` in your default editor.
 Editor preference: `$EDITOR` → `$VISUAL` → `nano` → `vim` → `vi`.
 
-```
+```bash
 mindroom config edit
 ```
 
@@ -253,7 +253,7 @@ Validate `config.yaml` and check for common issues.
 Parses the YAML config using Pydantic and reports errors in a friendly format.
 Also checks whether required API keys are set as environment variables.
 
-```
+```bash
 mindroom config validate
 ```
 
@@ -261,7 +261,7 @@ mindroom config validate
 
 Show the resolved config file path and all search locations.
 
-```
+```bash
 mindroom config path
 ```
 
@@ -271,7 +271,7 @@ Pair this local MindRoom install with a provisioning service.
 
 Default provisioning URL is `https://mindroom.chat` unless you override it with `--provisioning-url` or `MINDROOM_PROVISIONING_URL`.
 
-```
+```bash
 mindroom connect --pair-code ABCD-EFGH
 ```
 
@@ -286,13 +286,13 @@ If your config still contains the owner placeholder token `__MINDROOM_OWNER_USER
 
 Use `--no-persist-env` if you want to export variables only for the current shell session.
 
-```
+```bash
 mindroom connect --pair-code ABCD-EFGH --no-persist-env
 ```
 
 Use `--provisioning-url` for non-default deployments:
 
-```
+```bash
 mindroom connect \
   --pair-code ABCD-EFGH \
   --provisioning-url https://matrix.example.com
@@ -359,73 +359,73 @@ By default this command also writes `MATRIX_HOMESERVER`, `MATRIX_SERVER_NAME`, a
 
 ### Basic run
 
-```
+```bash
 mindroom run
 ```
 
 ### Debug logging
 
-```
+```bash
 mindroom run --log-level DEBUG
 ```
 
 To debug MindRoom internals without enabling debug logs from every dependency, keep the global level at `INFO` and set targeted logger overrides:
 
-```
+```bash
 LOG_LEVEL=INFO MINDROOM_LOGGER_LEVELS="mindroom:DEBUG,httpx:WARNING,httpcore:WARNING,anthropic:INFO,nio:WARNING" mindroom run
 ```
 
 Matrix crypto decrypt warnings from `nio.crypto` are quieted by default because missing Megolm sessions can produce bursts of diagnostically useful but high-volume logs.
 To inspect those warnings while debugging encryption state, explicitly restore that logger:
 
-```
+```bash
 LOG_LEVEL=INFO MINDROOM_LOGGER_LEVELS="nio.crypto:WARNING" mindroom run
 ```
 
 ### Custom storage path
 
-```
+```bash
 mindroom run --storage-path /data/mindroom
 ```
 
 ### Pair local install with hosted provisioning
 
-```
+```bash
 mindroom connect --pair-code ABCD-EFGH
 ```
 
 ### Start local Synapse + Cinny (default local setup)
 
-```
+```bash
 mindroom local-stack-setup --synapse-dir /path/to/mindroom-stack/local/matrix
 ```
 
 ### Start local stack without writing `.env`
 
-```
+```bash
 mindroom local-stack-setup --no-persist-env
 ```
 
 ### Show version
 
-```
+```bash
 mindroom version
 ```
 
 ### Preflight environment check
 
-```
+```bash
 mindroom doctor
 ```
 
 ### Initialize a config
 
-```
+```bash
 mindroom config init --profile public
 ```
 
 ### Validate your config
 
-```
+```bash
 mindroom config validate
 ```

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -4,7 +4,7 @@ Agents are the core building blocks of MindRoom. Each agent is a specialized AI 
 
 ## Basic Agent
 
-```
+```yaml
 agents:
   assistant:
     display_name: Assistant
@@ -15,7 +15,7 @@ agents:
 
 ## Full Configuration
 
-```
+```yaml
 agents:
   developer:
     # Display name shown in Matrix
@@ -202,7 +202,7 @@ Absolute paths and `..` traversal are rejected.
 Tools can be plain strings or single-key dicts with inline config overrides.
 This lets you customize tool behavior per agent without affecting other agents that use the same tool.
 
-```
+```yaml
 agents:
   code:
     tools:
@@ -239,7 +239,7 @@ Per-agent values win for overlapping keys, non-overlapping keys are kept from bo
 
 `defaults.tools` also accepts the single-key dict syntax for global overrides that apply to all agents:
 
-```
+```yaml
 defaults:
   tools:
     - scheduler
@@ -253,7 +253,7 @@ Use `__MINDROOM_INHERIT__` when an agent should keep the tool but stop inheritin
 
 Optional-field example:
 
-```
+```yaml
 defaults:
   tools:
     - shell:
@@ -273,7 +273,7 @@ Use `extra_env_passthrough` when a specific exported process env value must be v
 
 Required non-secret field example:
 
-```
+```yaml
 defaults:
   tools:
     - clickup:
@@ -308,7 +308,7 @@ MindRoom validates overrides at config load time and rejects unknown field names
 
 Existing configs with plain string tool lists work unchanged:
 
-```
+```yaml
 tools: [shell, file, duckduckgo]   # still valid
 ```
 
@@ -386,7 +386,7 @@ That restriction also applies transitively: a shared team member that reaches a 
 `private.per` chooses who gets a separate private instance of the agent's state.
 MindRoom then uses that same requester partition for worker execution, but that is an internal consequence of private execution, not the public meaning of `worker_scope`.
 
-```
+```yaml
 knowledge_bases:
   company_docs:
     path: ./company_docs
@@ -420,7 +420,7 @@ agents:
 
 Example template directory:
 
-```
+```text
 mind_template/
 ├── SOUL.md
 ├── AGENTS.md
@@ -523,7 +523,7 @@ Agents can delegate tasks to other agents using the `delegate_to` field. When co
 
 The delegated agent runs as a fresh, one-shot instance with no shared session or history. It executes the task and returns its response as the tool result.
 
-```
+```yaml
 agents:
   leader:
     display_name: Leader
@@ -571,7 +571,7 @@ When using these names, the built-in prompt replaces the `role` field and any cu
 
 The `defaults` section sets fallback values for all agents. Any agent that omits a setting inherits the value from here.
 
-```
+```yaml
 defaults:
   tools:                                # Tools added to every agent by default (set [] to disable)
     - scheduler
@@ -607,7 +607,7 @@ defaults:
 
 To opt out a specific agent:
 
-```
+```yaml
 agents:
   researcher:
     display_name: Researcher

--- a/skills/mindroom-docs/references/page__configuration__cultures__index.md
+++ b/skills/mindroom-docs/references/page__configuration__cultures__index.md
@@ -4,7 +4,7 @@ Cultures let a group of agents share evolving principles, practices, and convent
 
 ## Basic Culture
 
-```
+```yaml
 cultures:
   engineering:
     description: Follow clean code principles and write tests
@@ -13,7 +13,7 @@ cultures:
 
 ## Full Configuration
 
-```
+```yaml
 cultures:
   engineering:
     # Describes the shared principles this culture captures

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -14,7 +14,7 @@ Data storage (`mindroom_data/`) is placed next to the config file by default.
 
 You can also validate a specific file directly:
 
-```
+```bash
 mindroom config validate --path /path/to/config.yaml
 ```
 
@@ -39,7 +39,7 @@ On startup, MindRoom attempts to mark recent unresolved approval cards sent by t
 Agent-authored, system-authored, and configured bridge-bot-authored tool calls are denied instead of entering the approval flow.
 OpenAI-compatible `/v1/chat/completions` has no approval transport, so any tool function that matches a required-approval rule, including script-based rules, is hidden from the `/v1` tool schema instead of being exposed and blocked later.
 
-```
+```yaml
 tool_approval:
   default: auto_approve
   timeout_days: 7
@@ -165,7 +165,7 @@ See [Sandbox Proxy](https://docs.mindroom.chat/deployment/sandbox-proxy/index.md
 
 ## Basic Structure
 
-```
+```yaml
 # Agent definitions (at least one recommended)
 agents:
   assistant:
@@ -461,7 +461,7 @@ Set `MINDROOM_CREDENTIAL_SEEDS_FILE` to a JSON file path, or `MINDROOM_CREDENTIA
 Relative file paths resolve from the config directory.
 Credential fields can read from env vars, from files, or from literal values:
 
-```
+```json
 [
   {
     "service": "example_oauth_client",
@@ -491,7 +491,7 @@ MindRoom can generate managed avatars for agents, teams, rooms, and the optional
 Use the optional `avatars.prompts` block to override the built-in prompt styles without editing Python code.
 Every field is optional and falls back to MindRoom's built-in defaults when omitted.
 
-```
+```yaml
 avatars:
   prompts:
     character_style: "professional AI avatar portrait, abstract geometric silhouette"

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -30,7 +30,7 @@ Each model configuration supports the following fields:
 
 ## Configuration Examples
 
-```
+```yaml
 models:
   # Anthropic Claude
   sonnet:
@@ -109,7 +109,7 @@ The model ID may be either the bare Codex slug, such as `gpt-5.5`, or the LLM-pl
 If you keep Codex state outside `~/.codex`, pass `extra_kwargs.codex_home`.
 For starter config generation, use `mindroom config init --profile public-codex` or `mindroom config init --provider codex`.
 
-```
+```yaml
 models:
   default:
     provider: codex
@@ -153,7 +153,7 @@ MindRoom does not mutate configured `num_history_runs` to fit the window.
 Instead, it computes the replay plan that actually fits the current call and uses compaction to keep future replay healthy.
 If needed, that replay plan can reduce raw replay, fall back to summary-only replay, or disable persisted replay entirely for the run.
 
-```
+```yaml
 models:
   default:
     provider: anthropic
@@ -175,7 +175,7 @@ The `extra_kwargs` field passes additional parameters directly to the underlying
 
 API keys are read from environment variables:
 
-```
+```bash
 ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 GOOGLE_API_KEY=...
@@ -187,13 +187,13 @@ DEEPSEEK_API_KEY=...
 
 For Ollama, you can also set:
 
-```
+```bash
 OLLAMA_HOST=http://localhost:11434
 ```
 
 For Vertex AI Claude, set these instead of an API key:
 
-```
+```bash
 ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project
 CLOUD_ML_REGION=us-central1
 ```
@@ -204,7 +204,7 @@ Authenticate with `gcloud auth application-default login` or set `GOOGLE_APPLICA
 
 For container environments (Kubernetes, Docker Swarm), you can also use file-based secrets by appending `_FILE` to any environment variable name:
 
-```
+```bash
 # Instead of setting the key directly:
 ANTHROPIC_API_KEY=sk-ant-...
 

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -4,7 +4,7 @@ The router is a built-in system component that handles intelligent message routi
 
 ## Configuration
 
-```
+```yaml
 router:
   # Model for routing decisions (defaults to "default")
   model: haiku
@@ -121,7 +121,7 @@ By default, any Matrix user that is not a MindRoom agent counts as a "human" for
 
 To prevent this, list those accounts in `bot_accounts`:
 
-```
+```yaml
 bot_accounts:
   - "@telegram:example.com"
   - "@slackbot:example.com"

--- a/skills/mindroom-docs/references/page__configuration__teams__index.md
+++ b/skills/mindroom-docs/references/page__configuration__teams__index.md
@@ -8,7 +8,7 @@ Teams allow multiple agents to collaborate on tasks. MindRoom supports two colla
 
 The team coordinator analyzes the task and delegates different subtasks to specific team members:
 
-```
+```yaml
 teams:
   dev_team:
     display_name: Dev Team
@@ -23,7 +23,7 @@ In coordinate mode, the coordinator analyzes the task and selects which agents s
 
 All agents work on the same task simultaneously and their outputs are synthesized:
 
-```
+```yaml
 teams:
   research_team:
     display_name: Research Team
@@ -36,7 +36,7 @@ In collaborate mode, the task is delegated to all team members simultaneously. E
 
 ## Full Configuration
 
-```
+```yaml
 teams:
   super_team:
     # Display name shown in Matrix

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -6,7 +6,7 @@ MindRoom includes a web dashboard for configuring agents, teams, rooms, and inte
 
 **Standalone Mode:**
 
-```
+```bash
 mindroom run
 ```
 

--- a/skills/mindroom-docs/references/page__deployment__bridges__telegram__index.md
+++ b/skills/mindroom-docs/references/page__deployment__bridges__telegram__index.md
@@ -43,7 +43,7 @@ Telegram Cloud <--> mautrix-telegram <--> Synapse <--> Element
 
 Edit `telegram-bridge/config.yaml` and replace the placeholders in the `telegram:` section:
 
-```
+```yaml
 telegram:
     api_id: 12345678          # Your numeric api_id
     api_hash: abcdef123456    # Your api_hash string
@@ -52,7 +52,7 @@ telegram:
 
 Also update the same values in your `.env`:
 
-```
+```bash
 TELEGRAM_API_ID=12345678
 TELEGRAM_API_HASH=abcdef123456
 TELEGRAM_BOT_TOKEN=123456:ABC...
@@ -62,7 +62,7 @@ TELEGRAM_BOT_TOKEN=123456:ABC...
 
 Synapse needs a new volume mount for the bridge registration file, so it must be **recreated** (not just restarted):
 
-```
+```bash
 # Recreate Synapse to pick up the new volume mount and bridge registration
 docker compose up -d synapse
 
@@ -77,7 +77,7 @@ docker compose up -d telegram-bridge
 
 ### 3. Verify
 
-```
+```bash
 # Check bridge logs
 docker compose logs telegram-bridge --tail 20
 
@@ -200,7 +200,7 @@ To make your messages from Matrix appear as your real Telegram account (not the 
 
 The bridge uses SQLite stored in the `telegram-bridge` data volume. To reset:
 
-```
+```bash
 docker compose stop telegram-bridge
 rm <data-dir>/telegram-bridge/mautrix-telegram.db
 docker compose up -d telegram-bridge
@@ -212,7 +212,7 @@ Note: This will require re-logging into Telegram.
 
 If Synapse reports appservice errors, regenerate the registration:
 
-```
+```bash
 docker compose stop telegram-bridge
 rm telegram-bridge/registration.yaml
 # Temporarily set valid api_id in config.yaml, then:
@@ -227,7 +227,7 @@ docker compose up -d telegram-bridge
 
 ### Updating
 
-```
+```bash
 docker compose pull telegram-bridge
 docker compose up -d telegram-bridge
 ```

--- a/skills/mindroom-docs/references/page__deployment__docker__index.md
+++ b/skills/mindroom-docs/references/page__deployment__docker__index.md
@@ -13,7 +13,7 @@ MindRoom ships as a single runtime container that serves:
 
 Run it with:
 
-```
+```bash
 docker run -d \
   --name mindroom \
   -p 8765:8765 \
@@ -27,7 +27,7 @@ docker run -d \
 
 Create a `docker-compose.yml`:
 
-```
+```yaml
 services:
   mindroom:
     image: ghcr.io/mindroom-ai/mindroom:latest
@@ -52,7 +52,7 @@ services:
 
 Run with:
 
-```
+```bash
 docker compose up -d
 ```
 
@@ -85,7 +85,7 @@ If `MINDROOM_API_KEY` is set, the browser dashboard will prompt for the key via 
 
 Build from the repository root:
 
-```
+```bash
 docker build -t mindroom:dev -f local/instances/deploy/Dockerfile.mindroom .
 ```
 
@@ -97,7 +97,7 @@ A `Dockerfile.mindroom-minimal` variant is also available, which builds a smalle
 
 For development, run MindRoom alongside a local Matrix server:
 
-```
+```bash
 # Start Matrix (Synapse + Postgres + Redis)
 cd local/matrix && docker compose up -d
 
@@ -116,7 +116,7 @@ The local Matrix stack includes:
 
 If you're running the backend on the host (not in Docker), you can use `mindroom local-stack-setup` to start Synapse + MindRoom Cinny and persist local Matrix env vars automatically:
 
-```
+```bash
 mindroom local-stack-setup --synapse-dir /path/to/mindroom-stack/local/matrix
 mindroom run
 ```
@@ -125,7 +125,7 @@ mindroom run
 
 The container exposes a health endpoint on port 8765:
 
-```
+```bash
 curl http://localhost:8765/api/health
 ```
 

--- a/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__google-services-oauth__index.md
@@ -21,7 +21,7 @@ Add one authorized redirect URI for each provider you enable.
 
 For local development, the redirect URIs are:
 
-```
+```text
 http://localhost:8765/api/oauth/google_drive/callback
 http://localhost:8765/api/oauth/google_calendar/callback
 http://localhost:8765/api/oauth/google_sheets/callback
@@ -39,7 +39,7 @@ Provider-specific services win over `google_oauth_client`.
 
 Store these fields on the client config service:
 
-```
+```json
 {
   "client_id": "your-client-id.apps.googleusercontent.com",
   "client_secret": "your-client-secret",
@@ -59,7 +59,7 @@ Client config services cannot be copied into ordinary credential services.
 
 For non-interactive deployments, you can seed the shared client config service at startup with `MINDROOM_CREDENTIAL_SEEDS_FILE`:
 
-```
+```json
 [
   {
     "service": "google_oauth_client",
@@ -78,7 +78,7 @@ MindRoom updates env-sourced seeded credentials on restart, but it does not over
 
 Optional account restrictions are service-specific:
 
-```
+```bash
 GOOGLE_DRIVE_ALLOWED_EMAIL_DOMAINS=example.com
 GOOGLE_CALENDAR_ALLOWED_HOSTED_DOMAINS=example.com
 GOOGLE_SHEETS_ALLOWED_EMAIL_DOMAINS=example.com

--- a/skills/mindroom-docs/references/page__deployment__google-services-user-oauth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__google-services-user-oauth__index.md
@@ -8,7 +8,7 @@ MindRoom uses per-service generic OAuth providers instead of a legacy all-Google
 Enable only the APIs your agents need.
 Add the matching tool to the agent config.
 
-```
+```yaml
 agents:
   personal:
     display_name: Personal
@@ -26,7 +26,7 @@ agents:
 Open Google Cloud Console and create an OAuth client.
 Add one redirect URI per provider you use.
 
-```
+```text
 http://localhost:8765/api/oauth/google_drive/callback
 http://localhost:8765/api/oauth/google_calendar/callback
 http://localhost:8765/api/oauth/google_sheets/callback
@@ -37,7 +37,7 @@ http://localhost:8765/api/oauth/google_gmail/callback
 
 For a single personal OAuth client, store shared Google OAuth app client config under `google_oauth_client` through the dashboard credentials API or raw credentials editor:
 
-```
+```json
 {
   "client_id": "your-client-id.apps.googleusercontent.com",
   "client_secret": "your-client-secret"

--- a/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
+++ b/skills/mindroom-docs/references/page__deployment__hosted-matrix__index.md
@@ -23,7 +23,7 @@ This guide covers the simplest production-like setup:
 
 ## 1. Initialize Local Config
 
-```
+```bash
 uvx mindroom config init --profile public
 ```
 
@@ -34,7 +34,7 @@ Use `uvx mindroom config init --profile public-codex` if you want the starter co
 
 Edit `~/.mindroom/.env` and set at least one provider key:
 
-```
+```bash
 OPENAI_API_KEY=...
 # or OPENROUTER_API_KEY=...
 ```
@@ -49,7 +49,7 @@ MindRoom reads `~/.codex/auth.json` by default.
 1. Click `Generate Pair Code`.
 1. Run locally:
 
-```
+```bash
 uvx mindroom connect --pair-code ABCD-EFGH
 ```
 
@@ -62,7 +62,7 @@ After successful pairing, local provisioning credentials are written to `~/.mind
 
 ## 4. Start MindRoom
 
-```
+```bash
 uvx mindroom run
 ```
 

--- a/skills/mindroom-docs/references/page__deployment__index.md
+++ b/skills/mindroom-docs/references/page__deployment__index.md
@@ -33,7 +33,7 @@ For private personal-agent tools, use the generic [OAuth Framework](https://docs
 
 ### Hosted Matrix + local MindRoom (simplest)
 
-```
+```bash
 # Creates ~/.mindroom/config.yaml and ~/.mindroom/.env by default
 uvx mindroom config init --profile public
 $EDITOR ~/.mindroom/.env
@@ -48,7 +48,7 @@ See [Hosted Matrix deployment](https://docs.mindroom.chat/deployment/hosted-matr
 
 ### Full Stack (recommended)
 
-```
+```bash
 git clone https://github.com/mindroom-ai/mindroom-stack
 cd mindroom-stack
 cp .env.example .env
@@ -63,7 +63,7 @@ If you access it from another device, set `CLIENT_HOMESERVER_URL=http://<host-ip
 
 ### Direct (Development)
 
-```
+```bash
 mindroom run --storage-path ./mindroom_data
 ```
 
@@ -71,14 +71,14 @@ The config file path is set via `MINDROOM_CONFIG_PATH` and otherwise defaults to
 
 If you want local Matrix + Cinny with a host-installed MindRoom runtime (Linux/macOS), use:
 
-```
+```bash
 mindroom local-stack-setup --synapse-dir /path/to/mindroom-stack/local/matrix
 mindroom run --storage-path ./mindroom_data
 ```
 
 ### Docker (single container)
 
-```
+```bash
 docker run -d \
   --name mindroom \
   -p 8765:8765 \
@@ -98,7 +98,7 @@ See the [Kubernetes deployment guide](https://docs.mindroom.chat/deployment/kube
 
 Full stack:
 
-```
+```bash
 # .env in the full stack repo
 OPENAI_API_KEY=sk-...
 # Add other providers as needed

--- a/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
+++ b/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
@@ -21,7 +21,7 @@ MindRoom uses three Helm charts:
 
 ### Via Provisioner API (Recommended)
 
-```
+```bash
 export KUBECONFIG=./cluster/terraform/terraform-k8s/mindroom-k8s_kubeconfig.yaml
 
 # Provision, check status, view logs
@@ -34,7 +34,7 @@ export KUBECONFIG=./cluster/terraform/terraform-k8s/mindroom-k8s_kubeconfig.yaml
 
 For debugging only:
 
-```
+```bash
 helm upgrade --install instance-1 ./cluster/k8s/instance \
   --namespace mindroom-instances \
   --create-namespace \
@@ -50,7 +50,7 @@ helm upgrade --install instance-1 ./cluster/k8s/instance \
 
 Only enable trusted upstream auth when the instance is behind a verified access layer that strips client-supplied copies of those headers and injects authenticated values itself:
 
-```
+```bash
 helm upgrade --install instance-1 ./cluster/k8s/instance \
   --namespace mindroom-instances \
   --reuse-values \
@@ -71,7 +71,7 @@ Use the runtime chart when you already operate the surrounding platform and only
 
 The chart intentionally does not create Matrix, ingress, a model gateway, or platform services.
 
-```
+```bash
 helm upgrade --install mindroom-runtime ./cluster/k8s/runtime \
   --namespace mindroom \
   --create-namespace \
@@ -80,7 +80,7 @@ helm upgrade --install mindroom-runtime ./cluster/k8s/runtime \
 
 Typical production values point at existing resources:
 
-```
+```yaml
 config:
   create: false
   existingConfigMap: mindroom-config
@@ -148,7 +148,7 @@ The hosted instance worker-manager Role does not grant broad Secret API access i
 
 Typical Helm values look like:
 
-```
+```yaml
 workerBackend: kubernetes
 workerCleanupIntervalSeconds: 30
 storageAccessMode: ReadWriteMany
@@ -212,7 +212,7 @@ Dedicated workers are internal-only cluster Services and are authenticated with 
 
 API keys are mounted as files at `/etc/secrets/` (not environment variables). MindRoom reads paths from `*_API_KEY_FILE` environment variables:
 
-```
+```yaml
 env:
   - name: ANTHROPIC_API_KEY_FILE
     value: "/etc/secrets/anthropic_key"
@@ -230,7 +230,7 @@ Each instance gets three hosts:
 
 ## Platform Deployment
 
-```
+```bash
 # Create values file from example
 cp cluster/k8s/platform/values-staging.example.yaml cluster/k8s/platform/values-staging.yaml
 # Edit with your configuration
@@ -250,7 +250,7 @@ Platform ingress hosts:
 
 ## Local Development with Kind
 
-```
+```bash
 just cluster-kind-fresh              # Start cluster with everything
 just cluster-kind-port-frontend      # http://localhost:3000
 just cluster-kind-port-backend       # http://localhost:8000
@@ -261,7 +261,7 @@ See `cluster/k8s/kind/README.md` for details.
 
 ## CLI Helper
 
-```
+```bash
 ./cluster/scripts/mindroom-cli.sh list              # List instances
 ./cluster/scripts/mindroom-cli.sh status            # Overall status
 ./cluster/scripts/mindroom-cli.sh logs <id>         # View logs
@@ -287,7 +287,7 @@ All endpoints require bearer token (`PROVISIONER_API_KEY`).
 
 Example provision request:
 
-```
+```bash
 curl -X POST "https://api.mindroom.chat/system/provision" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $PROVISIONER_API_KEY" \
@@ -298,7 +298,7 @@ The provisioner creates the namespace, generates URLs, deploys via Helm, and upd
 
 ## Deployment Scripts
 
-```
+```bash
 cd saas-platform
 ./deploy.sh platform-frontend          # Deploy platform frontend
 ./deploy.sh platform-backend           # Deploy platform backend

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -47,7 +47,7 @@ Add a `sandbox-runner` service alongside MindRoom.
 Both use the same image.
 The runner just has a different entrypoint and no access to `.env` or the primary data volume.
 
-```
+```yaml
 services:
   mindroom:
     image: ghcr.io/mindroom-ai/mindroom:latest
@@ -116,7 +116,7 @@ The hosted instance worker-manager Role does not grant broad Secret API access i
 
 Use the instance Helm chart with values like:
 
-```
+```yaml
 workerBackend: kubernetes
 workerCleanupIntervalSeconds: 30
 storageAccessMode: ReadWriteMany
@@ -150,7 +150,7 @@ For the full Helm-side deployment guidance, see [Kubernetes Deployment](https://
 
 Run MindRoom directly on the host while isolating code-execution tools in a Docker container:
 
-```
+```bash
 # 1. Start the sandbox runner container
 docker run -d \
   --name mindroom-sandbox-runner \
@@ -173,7 +173,7 @@ mindroom run
 
 Or add the proxy variables to your `.env` file:
 
-```
+```bash
 MINDROOM_WORKER_BACKEND=static_runner
 MINDROOM_SANDBOX_PROXY_URL=http://localhost:8766
 MINDROOM_SANDBOX_PROXY_TOKEN=your-secret-token
@@ -305,7 +305,7 @@ Some proxied tools need credentials (e.g., a `shell` tool that runs `git push` a
 
 Configure which credentials are shared via `MINDROOM_SANDBOX_CREDENTIAL_POLICY_JSON`:
 
-```
+```bash
 export MINDROOM_SANDBOX_CREDENTIAL_POLICY_JSON='{"shell": ["github"], "python": ["openai"]}'
 ```
 
@@ -344,7 +344,7 @@ MindRoom owns the default local-versus-worker routing policy. You can override w
 
 Per-agent tool config overrides (inline `shell: {extra_env_passthrough: "DAWARICH_*"}` syntax in agent `tools` lists) are threaded through the sandbox proxy so workers receive the merged overrides alongside credentials and runtime overrides. See [Per-Agent Tool Configuration](https://docs.mindroom.chat/configuration/agents/#per-agent-tool-configuration) for the full syntax.
 
-```
+```yaml
 defaults:
   worker_tools: [shell, file]        # route shell+file through the sandbox proxy for all agents by default
 
@@ -383,7 +383,7 @@ Additionally, `spotify` is a shared-only integration that requires `worker_scope
 
 You can set `worker_scope` per agent or in `defaults`:
 
-```
+```yaml
 defaults:
   worker_tools: [shell, file]
   worker_scope: user_agent

--- a/skills/mindroom-docs/references/page__deployment__trusted-upstream-auth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__trusted-upstream-auth__index.md
@@ -16,7 +16,7 @@ It is not a hosted multi-user identity solution.
 
 Configure the header names that your access layer owns:
 
-```
+```bash
 MINDROOM_TRUSTED_UPSTREAM_AUTH_ENABLED=true
 MINDROOM_TRUSTED_UPSTREAM_USER_ID_HEADER=X-MindRoom-User-Id
 MINDROOM_TRUSTED_UPSTREAM_EMAIL_HEADER=X-MindRoom-User-Email
@@ -41,7 +41,7 @@ Derived Matrix IDs must pass MindRoom's Matrix user ID parser.
 
 For the hosted instance chart, configure the equivalent values:
 
-```
+```yaml
 trustedUpstreamAuth:
   enabled: "true"
   userIdHeader: X-MindRoom-User-Id
@@ -55,7 +55,7 @@ The instance chart fails rendering when `trustedUpstreamAuth.emailToMatrixUserId
 The template value must contain exactly one `{localpart}` placeholder.
 When using the platform provisioner, configure the platform chart with matching provisioner values:
 
-```
+```yaml
 provisioner:
   trustedUpstreamAuth:
     enabled: "true"

--- a/skills/mindroom-docs/references/page__getting-started__index.md
+++ b/skills/mindroom-docs/references/page__getting-started__index.md
@@ -11,7 +11,7 @@ You only run MindRoom locally.
 
 ### 1. Initialize local config
 
-```
+```bash
 uvx mindroom config init --profile public
 ```
 
@@ -23,7 +23,7 @@ This creates:
 The `--profile public` template defaults to the `openai` provider.
 Use `--provider` to select a different provider preset:
 
-```
+```bash
 # Use Anthropic Claude
 uvx mindroom config init --profile public --provider anthropic
 
@@ -48,7 +48,7 @@ Other profiles:
 
 ### 2. Add model API key(s)
 
-```
+```bash
 $EDITOR ~/.mindroom/.env
 ```
 
@@ -67,7 +67,7 @@ Set at least one key:
 1. Click `Generate Pair Code`.
 1. Run locally:
 
-```
+```bash
 uvx mindroom connect --pair-code ABCD-EFGH
 ```
 
@@ -79,7 +79,7 @@ Notes:
 
 ### 4. Run MindRoom
 
-```
+```bash
 uvx mindroom run
 ```
 
@@ -101,21 +101,21 @@ Use this when you want everything local: the bundled MindRoom dashboard, Matrix 
 
 ### 1. Clone the full stack repo
 
-```
+```bash
 git clone https://github.com/mindroom-ai/mindroom-stack
 cd mindroom-stack
 ```
 
 ### 2. Add your API keys
 
-```
+```bash
 cp .env.example .env
 $EDITOR .env  # add at least one AI provider key
 ```
 
 ### 3. Start everything
 
-```
+```bash
 docker compose up -d
 ```
 
@@ -143,33 +143,33 @@ Use this if you already have a Matrix homeserver and want to run MindRoom direct
 
 === "uv (recommended)"
 
-````
+```bash
 ```bash
 uv tool install mindroom
-````
+```bash
 
 ```
 
 === "pip"
 
-```
+```bash
 
 ```bash
 pip install mindroom
-```
+```yaml
 
 ```
 
 === "From source"
 
-```
+```bash
 
 ```bash
 git clone https://github.com/mindroom-ai/mindroom
 cd mindroom
 uv sync
 source .venv/bin/activate
-```
+```bash
 
 ```
 
@@ -179,7 +179,7 @@ source .venv/bin/activate
 
 Create a `config.yaml` in your working directory:
 
-```
+```bash
 
 agents: assistant: display_name: Assistant role: A helpful AI assistant that can answer questions model: default include_default_tools: true rooms: [lobby] # Optional: file-based context (OpenClaw-style) # context_files: [SOUL.md, USER.md]
 
@@ -195,7 +195,7 @@ timezone: America/Los_Angeles
 
 Create a `.env` file with your credentials:
 
-```
+```bash
 
 # Matrix homeserver (must allow open registration for agent accounts)
 

--- a/skills/mindroom-docs/references/page__index.md
+++ b/skills/mindroom-docs/references/page__index.md
@@ -24,7 +24,7 @@ MindRoom is an AI agent orchestration system with Matrix integration. It provide
 
 **Prereqs:** Docker + Docker Compose.
 
-```
+```bash
 git clone https://github.com/mindroom-ai/mindroom-stack
 cd mindroom-stack
 cp .env.example .env
@@ -47,7 +47,7 @@ If you access the stack from another device, set `CLIENT_HOMESERVER_URL=http://<
 
 Use this if you already have a Matrix homeserver and want to run MindRoom directly.
 
-```
+```bash
 # Using uv
 uv tool install mindroom
 
@@ -59,7 +59,7 @@ pip install mindroom
 
 1. Create a `config.yaml`:
 
-```
+```yaml
 agents:
   assistant:
     display_name: Assistant
@@ -79,7 +79,7 @@ defaults:
 
 1. Set up your environment in `.env`:
 
-```
+```bash
 # Matrix homeserver (must allow open registration)
 MATRIX_HOMESERVER=https://matrix.example.com
 
@@ -89,13 +89,13 @@ OPENAI_API_KEY=your_api_key
 
 1. Run MindRoom:
 
-```
+```bash
 mindroom run
 ```
 
 For local development with a host-installed backend plus Dockerized Synapse + Cinny (Linux/macOS), you can bootstrap the local stack with:
 
-```
+```bash
 mindroom local-stack-setup --synapse-dir /path/to/mindroom-stack/local/matrix
 mindroom run
 ```

--- a/skills/mindroom-docs/references/page__interactive__index.md
+++ b/skills/mindroom-docs/references/page__interactive__index.md
@@ -16,7 +16,7 @@ The entire flow happens within the thread where the original question was asked.
 
 Agents emit interactive questions by wrapping JSON in an `interactive` code block:
 
-````
+````markdown
 ```interactive
 {
     "question": "What approach would you prefer?",
@@ -25,7 +25,7 @@ Agents emit interactive questions by wrapping JSON in an `interactive` code bloc
         {"emoji": "🔍", "label": "Careful and manual", "value": "careful"}
     ]
 }
-````
+```
 
 ```
 
@@ -71,7 +71,7 @@ Agents don't need any special tools or configuration to use interactive question
 Any agent can include an `interactive` code block in its response text.
 You can guide agents to use this feature through their `instructions` or `role`:
 
-```
+```yaml
 
 agents: assistant: display_name: Assistant role: A helpful assistant instructions: - > When the user needs to choose between options, present them using an interactive code block with JSON containing question and options (each with emoji, label, and value fields).
 

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -32,7 +32,7 @@ Querying (agentic RAG):
 
 Add a knowledge base and assign it to an agent:
 
-```
+```yaml
 knowledge_bases:
   docs:
     path: ./knowledge_docs
@@ -58,7 +58,7 @@ Use a non-empty single path component such as `docs` or `company_docs`, not `""`
 
 ### Basic Knowledge Base
 
-```
+```yaml
 knowledge_bases:
   my_docs:
     path: ./knowledge_docs/my_docs   # Folder containing documents
@@ -82,7 +82,7 @@ If chunking is too large, indexing retries will fail with embedder 500 errors.
 
 Use `agents.<name>.private.knowledge` when one shared agent definition should index PrivateAgentKnowledge from that requester's private root.
 
-```
+```yaml
 knowledge_bases:
   company_docs:
     path: ./company_docs
@@ -133,7 +133,7 @@ Use top-level `knowledge_bases` when the same documents should stay shared acros
 
 You can define multiple knowledge bases and assign them to different agents:
 
-```
+```yaml
 knowledge_bases:
   engineering:
     path: ./knowledge_docs/engineering
@@ -177,7 +177,7 @@ MindRoom starts a background refresh for configured shared Git knowledge bases w
 After that, it schedules another background refresh every `poll_interval_seconds`.
 Reads keep using the last published index while a refresh is running.
 
-```
+```yaml
 knowledge_bases:
   pipefunc_docs:
     path: ./knowledge_docs/pipefunc
@@ -225,7 +225,7 @@ Bundled container images already include it.
 
 Patterns are matched from the repository root. `*` matches one path segment, `**` matches zero or more segments.
 
-```
+```yaml
 knowledge_bases:
   project_docs:
     path: ./knowledge_docs/project
@@ -246,7 +246,7 @@ knowledge_bases:
 Multiple knowledge bases may point at the same root when they use the same source ownership settings.
 This is the preferred way to expose separate views of a large repository without cloning it more than once.
 
-```
+```yaml
 knowledge_bases:
   project_docs:
     path: ./knowledge_docs/project
@@ -268,7 +268,7 @@ For private HTTPS repositories, store credentials and reference them in the conf
 
 **Step 1:** Store credentials via the API or Dashboard (Credentials tab):
 
-```
+```bash
 curl -X POST http://localhost:8765/api/credentials/github_private \
   -H "Content-Type: application/json" \
   -d '{"credentials":{"username":"x-access-token","token":"ghp_your_token_here"}}'
@@ -276,7 +276,7 @@ curl -X POST http://localhost:8765/api/credentials/github_private \
 
 **Step 2:** Reference the service name in your knowledge base config:
 
-```
+```yaml
 knowledge_bases:
   private_docs:
     path: ./knowledge_docs/private
@@ -297,7 +297,7 @@ Accepted credential fields:
 
 Knowledge bases use the same embedder configured in the `memory` section:
 
-```
+```yaml
 memory:
   embedder:
     provider: openai        # or "ollama", "huggingface", or "sentence_transformers"

--- a/skills/mindroom-docs/references/page__matrix-space__index.md
+++ b/skills/mindroom-docs/references/page__matrix-space__index.md
@@ -5,7 +5,7 @@ This makes it easy for users to discover and navigate MindRoom rooms in their Ma
 
 ## Configuration
 
-```
+```yaml
 matrix_space:
   enabled: true    # Default: true
   name: MindRoom   # Default: "MindRoom"

--- a/skills/mindroom-docs/references/page__memory__index.md
+++ b/skills/mindroom-docs/references/page__memory__index.md
@@ -41,7 +41,7 @@ Notes:
 
 Example:
 
-```
+```yaml
 memory:
   backend: mem0
   embedder:
@@ -53,7 +53,7 @@ memory:
 
 Fully local embedder example:
 
-```
+```yaml
 memory:
   backend: mem0
   embedder:
@@ -66,7 +66,7 @@ MindRoom auto-installs the optional `sentence_transformers` extra the first time
 
 Ollama embedder example:
 
-```
+```yaml
 memory:
   backend: mem0
   embedder:
@@ -82,7 +82,7 @@ Supported embedder providers: `openai`, `ollama`, `huggingface`, `sentence_trans
 
 The memory system uses an LLM for extraction. Configure it with `memory.llm`:
 
-```
+```yaml
 memory:
   llm:
     provider: ollama    # ollama, openai, or anthropic
@@ -98,20 +98,20 @@ Supported LLM providers: `ollama` (default), `openai`, `anthropic`.
 
 Global example:
 
-```
+```yaml
 memory:
   backend: none
 ```
 
 Shorthand example:
 
-```
+```yaml
 memory: none
 ```
 
 Per-agent stateless override:
 
-```
+```yaml
 memory:
   backend: mem0
 
@@ -131,7 +131,7 @@ Set `learning: false` separately if you also want to disable learning.
 
 Example:
 
-```
+```yaml
 memory:
   backend: file
   file:
@@ -144,7 +144,7 @@ It can affect team file memory when the resolution determines the configured pat
 
 Per-agent override example:
 
-```
+```yaml
 memory:
   backend: mem0
 
@@ -161,7 +161,7 @@ Use `private` when you need per-requester file-memory isolation.
 
 Private instance example:
 
-```
+```yaml
 agents:
   mind:
     display_name: Mind
@@ -198,7 +198,7 @@ Team file memory is mirrored under each participating agent's storage directory:
 
 When the effective backend is `file` for at least one agent, you can enable background auto-flush:
 
-```
+```yaml
 memory:
   backend: file
   auto_flush:
@@ -250,7 +250,7 @@ Use the Dashboard **Agents** page to set an agent-specific **Memory Backend** ov
 
 For explicit agent-controlled memory operations, add the `memory` tool:
 
-```
+```yaml
 agents:
   assistant:
     tools: [memory]
@@ -265,7 +265,7 @@ Learning is separate from the memory backends above — it uses Agno's own SQLit
 
 ### Configuration
 
-```
+```yaml
 defaults:
   learning: true          # Enable learning for all agents (default: true)
   learning_mode: always   # "always" (extract after every turn) or "agentic" (agent decides via tool)
@@ -273,7 +273,7 @@ defaults:
 
 Per-agent override:
 
-```
+```yaml
 agents:
   assistant:
     learning: false       # Disable learning for this agent

--- a/skills/mindroom-docs/references/page__openai-api__index.md
+++ b/skills/mindroom-docs/references/page__openai-api__index.md
@@ -25,7 +25,7 @@ No Matrix auth dependency. You can run the OpenAI-compatible API standalone or a
 
 Add to your `.env`:
 
-```
+```bash
 # Option A: Set API keys (recommended for production)
 OPENAI_COMPAT_API_KEYS=sk-my-secret-key-1,sk-my-secret-key-2
 
@@ -37,7 +37,7 @@ Without either of these, the API returns 401 on all requests.
 
 ### 2. Start MindRoom
 
-```
+```bash
 # Full MindRoom runtime (Matrix bot + API server + dashboard)
 uv run mindroom run
 
@@ -51,7 +51,7 @@ The API is available at `http://localhost:8765/v1/`.
 
 ### 3. Verify
 
-```
+```bash
 # List available agents
 curl -H "Authorization: Bearer sk-my-secret-key-1" \
   http://localhost:8765/v1/models
@@ -75,7 +75,7 @@ curl -N -H "Authorization: Bearer sk-my-secret-key-1" \
 
 Add to your `librechat.yaml`:
 
-```
+```yaml
 endpoints:
   custom:
     - name: "MindRoom"

--- a/skills/mindroom-docs/references/page__openclaw__index.md
+++ b/skills/mindroom-docs/references/page__openclaw__index.md
@@ -51,7 +51,7 @@ It uses the normal MindRoom memory backend.
 
 Use this as a starting point for importing an OpenClaw workspace into MindRoom's canonical agent workspace:
 
-```
+```yaml
 agents:
   openclaw:
     display_name: OpenClawAgent
@@ -108,7 +108,7 @@ If `openclaw_memory` is Git-backed, update the repository and reindex instead of
 
 ## Recommended workspace layout
 
-```
+```text
 mindroom_data/
 └── agents/
     └── openclaw/
@@ -165,7 +165,7 @@ For details on skill eligibility gating (`openclaw.os`, `openclaw.requires`, `op
 
 Skills are loaded from `~/.mindroom/skills/<name>/`. To use an OpenClaw skill like `transcribe`, copy the skill directory from your OpenClaw workspace:
 
-```
+```bash
 mkdir -p ~/.mindroom/skills
 cp -r /path/to/openclaw-workspace/skills/transcribe ~/.mindroom/skills/
 ```

--- a/skills/mindroom-docs/references/page__plugins__index.md
+++ b/skills/mindroom-docs/references/page__plugins__index.md
@@ -30,7 +30,7 @@ Many plugins combine both.
 
 The manifest is a JSON file named `mindroom.plugin.json` at the plugin root:
 
-```
+```json
 {
   "name": "my-plugin",
   "tools_module": "tools.py",
@@ -59,7 +59,7 @@ If both fields point at the same file, MindRoom imports it once and reuses it fo
 
 Add plugin paths under `plugins:` in `config.yaml`:
 
-```
+```yaml
 plugins:
   - ./plugins/my-plugin
   - python:my_skill_pack
@@ -82,14 +82,14 @@ Both forms can be mixed in the same list.
 
 **String entry** — just the path:
 
-```
+```yaml
 plugins:
   - ./plugins/my-plugin
 ```
 
 **Object entry** — path plus options:
 
-```
+```yaml
 plugins:
   - path: ./plugins/my-plugin
     enabled: true
@@ -127,7 +127,7 @@ Paths are resolved in this order:
 
 MindRoom can resolve plugins from installed Python packages:
 
-```
+```yaml
 plugins:
   - my_skill_pack
   - python:my_skill_pack
@@ -157,7 +157,7 @@ The provider module supplies only provider-specific details such as endpoint URL
 
 Declare the module in the manifest:
 
-```
+```json
 {
   "name": "drive-plugin",
   "tools_module": "tools.py",
@@ -167,7 +167,7 @@ Declare the module in the manifest:
 
 Then expose `register_oauth_providers(settings, runtime_paths)`:
 
-```
+```python
 from __future__ import annotations
 
 from mindroom.oauth import OAuthProvider
@@ -214,7 +214,7 @@ If a configured restriction cannot be checked from verified claims, MindRoom fai
 
 ### Minimal example
 
-```
+```python
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -254,7 +254,7 @@ def greeter_tools() -> type[Toolkit]:
 
 After registering the plugin, assign the tool to agents in `config.yaml`:
 
-```
+```yaml
 plugins:
   - ./plugins/my-greeter
 
@@ -305,7 +305,7 @@ MindRoom checks whether each package is importable before the tool is instantiat
 **For plugin tools**, automatic installation does **not** apply — there is no matching optional extra in MindRoom's package metadata. If the listed dependencies are not already installed in the environment, MindRoom raises an `ImportError` with a message listing the missing packages.
 Plugin authors should document their dependencies in their README so users can install them manually:
 
-```
+```bash
 pip install openviking-client aiohttp
 ```
 
@@ -331,7 +331,7 @@ Each `ConfigField` describes one constructor parameter that can be configured th
 
 Example — a tool that requires an API key:
 
-```
+```python
 from mindroom.tool_system.metadata import (
     ConfigField,
     SetupType,
@@ -379,7 +379,7 @@ MindRoom does **not** auto-detect constructor parameter names — undeclared man
 
 Example:
 
-```
+```python
 from agno.tools import Toolkit
 from mindroom.tool_system.metadata import ToolCategory, ToolManagedInitArg, register_tool_with_metadata
 
@@ -404,7 +404,7 @@ def needs_runtime_tools() -> type[Toolkit]:
 
 MindRoom supports native MCP servers in `config.yaml` — see [MCP](https://docs.mindroom.chat/mcp/index.md) for the normal setup path. This plugin pattern is still useful when you want a custom wrapper around Agno `MCPTools`:
 
-```
+```python
 from agno.tools.mcp import MCPTools
 from mindroom.tool_system.metadata import (
     SetupType,
@@ -436,7 +436,7 @@ def mcp_filesystem_tools():
 
 Reference the plugin and tool in `config.yaml`:
 
-```
+```yaml
 plugins:
   - ./plugins/mcp-filesystem
 
@@ -482,7 +482,7 @@ No service restart and no agent session disruption.
 
 ### Iterating on a plugin
 
-```
+```bash
 # 1. Edit any file under your plugin
 $EDITOR ~/.mindroom/plugins/my-plugin/hooks.py
 
@@ -531,11 +531,11 @@ Edit any configured plugin directory directly while `mindroom.service` is runnin
 The [mindroom-ai](https://github.com/mindroom-ai) organization maintains a collection of open-source plugins.
 Clone any of them into your plugins directory and add the path to `config.yaml`:
 
-```
+```bash
 git clone https://github.com/mindroom-ai/ping-hook-plugin.git ~/.mindroom/plugins/ping-hook
 ```
 
-```
+```yaml
 plugins:
   - ~/.mindroom/plugins/ping-hook
 ```

--- a/skills/mindroom-docs/references/page__scheduling__index.md
+++ b/skills/mindroom-docs/references/page__scheduling__index.md
@@ -64,7 +64,7 @@ Include `@agent_name` in your schedule to have specific agents respond. The sche
 
 Schedules use the timezone from `config.yaml` (defaults to UTC):
 
-```
+```yaml
 timezone: America/Los_Angeles
 ```
 

--- a/skills/mindroom-docs/references/page__skills__index.md
+++ b/skills/mindroom-docs/references/page__skills__index.md
@@ -19,7 +19,7 @@ Agents access skills via `get_skill_instructions()`, scripts via `get_skill_scri
 
 ## SKILL.md format (OpenClaw compatible)
 
-```
+```markdown
 ---
 name: repo-quick-audit
 description: Quick repository audit checklist
@@ -80,7 +80,7 @@ Agent workspace skills are only available to the owning agent at runtime. They d
 
 Add skills to an agent allowlist in `config.yaml`:
 
-```
+```yaml
 agents:
   developer:
     display_name: Developer

--- a/skills/mindroom-docs/references/page__streaming__index.md
+++ b/skills/mindroom-docs/references/page__streaming__index.md
@@ -34,7 +34,7 @@ User sends message
 Streaming is enabled by default.
 Disable it globally in `config.yaml`:
 
-```
+```yaml
 defaults:
   enable_streaming: false   # Default: true
 ```
@@ -43,7 +43,7 @@ defaults:
 
 Tune the streaming edit cadence globally under `defaults.streaming`:
 
-```
+```yaml
 defaults:
   enable_streaming: true
   streaming:
@@ -151,7 +151,7 @@ If a streamed response exceeds the Matrix event size limit (55KB for new message
 
 Two global defaults control what users see during streaming:
 
-```
+```yaml
 defaults:
   show_tool_calls: true     # Default: true — show inline tool markers and tool-trace metadata
   show_stop_button: true    # Default: true — add 🛑 reaction for cancellation

--- a/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
+++ b/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
@@ -49,7 +49,7 @@ This tool has no tool-specific inline configuration fields.
 
 ### Example
 
-```
+```yaml
 agents:
   coordinator:
     display_name: Coordinator
@@ -59,7 +59,7 @@ agents:
       - subagents
 ```
 
-```
+```python
 agents_list()
 sessions_spawn(
     task="Review the failing deployment and propose a rollback plan.",
@@ -103,7 +103,7 @@ MindRoom adds the tool automatically when `delegate_to` is non-empty, so listing
 
 ### Example
 
-```
+```yaml
 agents:
   lead:
     display_name: Lead
@@ -129,7 +129,7 @@ agents:
       - duckduckgo
 ```
 
-```
+```python
 delegate_task(
     agent_name="research",
     task="Summarize the three main risks in this proposal and cite supporting facts.",
@@ -167,7 +167,7 @@ This tool has no tool-specific inline configuration fields.
 
 ### Example
 
-```
+```yaml
 agents:
   builder:
     display_name: Builder
@@ -177,7 +177,7 @@ agents:
       - config_manager
 ```
 
-```
+```python
 get_info("available_tools")
 get_info("tool_details", name="claude_agent")
 manage_agent(
@@ -227,7 +227,7 @@ The normal way to enable it is `agents.<name>.allow_self_config: true` or `defau
 
 ### Example
 
-```
+```yaml
 defaults:
   allow_self_config: false
 
@@ -242,7 +242,7 @@ agents:
       - wikipedia
 ```
 
-```
+```python
 get_own_config()
 update_own_config(
     instructions=[
@@ -280,7 +280,7 @@ This preset has no inline configuration fields.
 
 ### Example
 
-```
+```yaml
 agents:
   openclaw:
     display_name: OpenClawAgent
@@ -348,7 +348,7 @@ On SDK failures, the tool includes recent Claude CLI stderr lines in its error o
 
 ### Example
 
-```
+```yaml
 agents:
   code:
     display_name: Code Agent
@@ -364,7 +364,7 @@ agents:
           max_sessions: 20
 ```
 
-```
+```json
 {
   "api_key": "sk-ant-or-proxy-key",
   "model": "claude-sonnet-4-6",
@@ -375,7 +375,7 @@ agents:
 }
 ```
 
-```
+```json
 {
   "api_key": "sk-dummy",
   "anthropic_base_url": "http://litellm.local",
@@ -384,7 +384,7 @@ agents:
 }
 ```
 
-```
+```python
 claude_send(
     prompt="Refactor the failing test and explain the diff.",
     session_label="bugfix",

--- a/skills/mindroom-docs/references/page__tools__ai-and-generation__index.md
+++ b/skills/mindroom-docs/references/page__tools__ai-and-generation__index.md
@@ -64,7 +64,7 @@ The current implementation handles both `gpt-image-*` style models and older DAL
 
 ### Example
 
-```
+```yaml
 agents:
   creator:
     tools:
@@ -74,7 +74,7 @@ agents:
           text_to_speech_voice: alloy
 ```
 
-```
+```python
 transcribe_audio("recordings/intro.wav")
 generate_image("A retro-futurist Matrix control room with warm lighting.")
 generate_speech("Status update complete.")
@@ -114,7 +114,7 @@ In non-Vertex mode, the tool uses the Gemini API through `GOOGLE_API_KEY`.
 
 ### Example
 
-```
+```yaml
 agents:
   studio:
     tools:
@@ -126,7 +126,7 @@ agents:
           video_generation_model: veo-2.0-generate-001
 ```
 
-```
+```python
 generate_image("A minimal poster for a Matrix developer conference.")
 generate_video("A slow cinematic flythrough of a neon data center.")
 ```
@@ -165,7 +165,7 @@ All three functions use the Groq SDK directly and require a Groq API key.
 
 ### Example
 
-```
+```yaml
 agents:
   audio:
     tools:
@@ -175,7 +175,7 @@ agents:
           tts_voice: Chip-PlayAI
 ```
 
-```
+```python
 transcribe_audio("samples/interview.mp3")
 translate_audio("https://example.com/spanish-briefing.mp3")
 generate_speech("Your transcript is ready.")
@@ -209,7 +209,7 @@ Generated artifacts are attached by remote URL rather than downloaded into MindR
 
 ### Example
 
-```
+```yaml
 agents:
   video:
     tools:
@@ -217,7 +217,7 @@ agents:
           model: minimax/video-01
 ```
 
-```
+```python
 generate_media("A short looping animation of code flowing across a terminal.")
 ```
 
@@ -250,7 +250,7 @@ The current implementation streams queue log messages to the MindRoom process lo
 
 ### Example
 
-```
+```yaml
 agents:
   visuals:
     tools:
@@ -259,7 +259,7 @@ agents:
           enable_image_to_image: true
 ```
 
-```
+```python
 generate_media("A cinematic drone shot over a rainy cyberpunk street.")
 image_to_image(
     "Turn this product photo into a watercolor illustration.",
@@ -297,7 +297,7 @@ It uses the OpenAI image API directly with the configured `model`, `n`, `size`, 
 
 ### Example
 
-```
+```yaml
 agents:
   illustrator:
     tools:
@@ -308,7 +308,7 @@ agents:
           style: vivid
 ```
 
-```
+```python
 create_image("A cover illustration for a Matrix automation handbook.")
 ```
 
@@ -344,7 +344,7 @@ The current implementation hardcodes MP3 output at 44.1 kHz and 128 kbps.
 
 ### Example
 
-```
+```yaml
 agents:
   voice:
     tools:
@@ -353,7 +353,7 @@ agents:
           enable_localize_voice: true
 ```
 
-```
+```python
 list_voices()
 localize_voice(
     name="French Support Voice",
@@ -398,7 +398,7 @@ If `target_directory` is set, the current implementation also saves generated au
 
 ### Example
 
-```
+```yaml
 agents:
   audio_fx:
     tools:
@@ -408,7 +408,7 @@ agents:
           target_directory: generated-audio
 ```
 
-```
+```python
 get_voices()
 generate_sound_effect("Mechanical keyboard typing in a quiet office.", duration_seconds=4)
 text_to_speech("The build succeeded.")
@@ -443,7 +443,7 @@ The default `voice_id` can be overridden per call.
 
 ### Example
 
-```
+```yaml
 agents:
   hindi_voice:
     tools:
@@ -451,7 +451,7 @@ agents:
           voice_id: f27d74e5-ea71-4697-be3e-f04bbd80c1a8
 ```
 
-```
+```python
 get_voices()
 text_to_speech("नमस्ते, आपकी रिपोर्ट तैयार है।")
 ```
@@ -488,7 +488,7 @@ If `wait_for_completion` is false, the current implementation returns `Async gen
 
 ### Example
 
-```
+```yaml
 agents:
   motion:
     tools:
@@ -497,7 +497,7 @@ agents:
           max_wait_time: 600
 ```
 
-```
+```python
 generate_video("A calm flythrough of a futuristic coworking space.", aspect_ratio="16:9")
 image_to_video(
     "Animate this concept art into a short reveal shot.",
@@ -536,7 +536,7 @@ If `wait_for_completion` is enabled, the tool polls the provider fetch endpoint 
 
 ### Example
 
-```
+```yaml
 agents:
   generator:
     tools:
@@ -546,7 +546,7 @@ agents:
           max_wait_time: 90
 ```
 
-```
+```python
 generate_media("A looping animation of messages flowing through a Matrix bridge.")
 ```
 

--- a/skills/mindroom-docs/references/page__tools__automation-and-platforms__index.md
+++ b/skills/mindroom-docs/references/page__tools__automation-and-platforms__index.md
@@ -53,7 +53,7 @@ The toolkit constructs a boto3 Lambda client at init time with `region_name`.
 
 ### Example
 
-```
+```yaml
 agents:
   automation:
     tools:
@@ -61,7 +61,7 @@ agents:
           region_name: us-west-2
 ```
 
-```
+```python
 list_functions()
 invoke_function("daily-report", payload='{"date": "2026-03-31"}')
 ```
@@ -95,7 +95,7 @@ The current wrapper does not add HTML email support, templates, attachments, or 
 
 ### Example
 
-```
+```yaml
 agents:
   notifications:
     tools:
@@ -105,7 +105,7 @@ agents:
           region_name: us-east-1
 ```
 
-```
+```python
 send_email(
     subject="Nightly sync complete",
     body="The nightly sync finished successfully.",
@@ -142,7 +142,7 @@ It does not talk to the Airflow scheduler, trigger DAG runs, inspect task state,
 
 ### Example
 
-```
+```yaml
 agents:
   airflow_editor:
     tools:
@@ -150,7 +150,7 @@ agents:
           dags_dir: dags
 ```
 
-```
+```python
 read_dag_file("daily_reporting.py")
 save_dag_file("from airflow import DAG\n", "generated/new_job.py")
 ```
@@ -183,7 +183,7 @@ The media helpers operate on the most recent `run_python_code()` result, which i
 
 ### Example
 
-```
+```yaml
 agents:
   remote_exec:
     tools:
@@ -191,7 +191,7 @@ agents:
           timeout: 600
 ```
 
-```
+```python
 run_python_code("print('hello from e2b')")
 upload_file("data/report.csv", "workspace/report.csv")
 run_server("python -m http.server 8000", port=8000)
@@ -242,7 +242,7 @@ The bundled default instructions describe a code-write, execute, and show-result
 
 ### Example
 
-```
+```yaml
 agents:
   remote_dev:
     tools:
@@ -254,7 +254,7 @@ agents:
           add_instructions: true
 ```
 
-```
+```python
 run_code("print('hello from daytona')")
 run_shell_command("pwd && ls -la")
 change_directory("project")
@@ -302,7 +302,7 @@ MindRoom's current registry metadata on this branch documents the connection and
 
 ### Example
 
-```
+```yaml
 agents:
   integrations:
     tools:
@@ -348,7 +348,7 @@ Non-2xx responses still return a structured result object, with an added `"error
 
 ### Example
 
-```
+```yaml
 agents:
   api_bridge:
     tools:
@@ -358,7 +358,7 @@ agents:
           timeout: 20
 ```
 
-```
+```python
 make_request("health")
 make_request("users/42", method="GET")
 make_request("reports", method="POST", json_data={"range": "7d"})

--- a/skills/mindroom-docs/references/page__tools__calendar-and-scheduling__index.md
+++ b/skills/mindroom-docs/references/page__tools__calendar-and-scheduling__index.md
@@ -44,7 +44,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 
 ### Example
 
-```
+```yaml
 agents:
   assistant:
     worker_scope: shared
@@ -54,7 +54,7 @@ agents:
           allow_update: true
 ```
 
-```
+```python
 list_events(limit=5)
 find_available_slots(start_date="2026-04-01", end_date="2026-04-03", duration_minutes=30)
 create_event(
@@ -99,7 +99,7 @@ The per-method enable flags let you narrow the exposed call surface when an agen
 
 ### Example
 
-```
+```yaml
 agents:
   scheduler_assistant:
     tools:
@@ -109,7 +109,7 @@ agents:
           enable_cancel_booking: false
 ```
 
-```
+```python
 get_available_slots(start_date="2026-04-01", end_date="2026-04-07")
 create_booking(
     start_time="2026-04-03T17:00:00+00:00",
@@ -145,14 +145,14 @@ This tool has no tool-specific inline configuration fields.
 
 ### Example
 
-```
+```yaml
 agents:
   assistant:
     tools:
       - scheduler
 ```
 
-```
+```python
 schedule("tomorrow at 9am @ops check the deployment")
 schedule("every weekday at 8am post the on-call handoff summary", new_thread=True)
 list_schedules()

--- a/skills/mindroom-docs/references/page__tools__data-and-databases__index.md
+++ b/skills/mindroom-docs/references/page__tools__data-and-databases__index.md
@@ -67,7 +67,7 @@ For dialects where database name and schema are distinct concepts, `db_url` is t
 
 ### Example
 
-```
+```yaml
 agents:
   analyst:
     tools:
@@ -76,7 +76,7 @@ agents:
           enable_run_sql_query: true
 ```
 
-```
+```python
 list_tables()
 describe_table("events")
 run_sql_query("SELECT * FROM events ORDER BY created_at DESC", limit=20)
@@ -113,7 +113,7 @@ The toolkit opens a Psycopg connection, sets `search_path` to `table_schema`, an
 
 ### Example
 
-```
+```yaml
 agents:
   warehouse:
     tools:
@@ -125,7 +125,7 @@ agents:
           table_schema: reporting
 ```
 
-```
+```python
 show_tables()
 describe_table("daily_revenue")
 inspect_query("SELECT * FROM daily_revenue WHERE day >= CURRENT_DATE - INTERVAL '7 days'")
@@ -172,7 +172,7 @@ When IAM auth is enabled, the toolkit can fall back to environment variables suc
 
 ### Example
 
-```
+```yaml
 agents:
   warehouse:
     tools:
@@ -185,7 +185,7 @@ agents:
           db_user: analyst
 ```
 
-```
+```python
 show_tables()
 describe_table("fact_orders")
 inspect_query("SELECT COUNT(*) FROM fact_orders WHERE created_at >= current_date - 30")
@@ -225,7 +225,7 @@ The individual enable flags let you expose schema discovery without allowing arb
 
 ### Example
 
-```
+```yaml
 agents:
   graph:
     tools:
@@ -236,7 +236,7 @@ agents:
           enable_run_cypher: true
 ```
 
-```
+```python
 list_labels()
 list_relationship_types()
 get_schema()
@@ -272,7 +272,7 @@ If `db_path` is unset, DuckDB runs in memory.
 
 ### Example
 
-```
+```yaml
 agents:
   analyst:
     tools:
@@ -281,7 +281,7 @@ agents:
           read_only: false
 ```
 
-```
+```python
 show_tables(True)
 create_table_from_path("/workspace/data/orders.parquet", table="orders", replace=True)
 inspect_query("SELECT customer_id, COUNT(*) FROM orders GROUP BY 1")
@@ -322,7 +322,7 @@ The toolkit works with a preconfigured list of CSV paths and exposes each one by
 
 ### Example
 
-```
+```yaml
 agents:
   analyst:
     tools:
@@ -330,7 +330,7 @@ agents:
           row_limit: 200
 ```
 
-```
+```python
 list_csv_files()
 read_csv_file("sales_2025", row_limit=50)
 get_columns("sales_2025")
@@ -364,14 +364,14 @@ Stored dataframes live in the current process memory only and are not persisted 
 
 ### Example
 
-```
+```yaml
 agents:
   analyst:
     tools:
       - pandas
 ```
 
-```
+```python
 create_pandas_dataframe(
     "sales",
     "read_csv",
@@ -413,7 +413,7 @@ MindRoom's metadata marks `dataset`, `project`, and `location` as required, even
 
 ### Example
 
-```
+```yaml
 agents:
   analyst:
     tools:
@@ -423,7 +423,7 @@ agents:
           location: US
 ```
 
-```
+```python
 list_tables()
 describe_table("events")
 run_sql_query("SELECT event_name, COUNT(*) AS total FROM events GROUP BY 1 ORDER BY total DESC LIMIT 20")
@@ -458,7 +458,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 
 ### Example
 
-```
+```yaml
 agents:
   assistant:
     tools:
@@ -466,7 +466,7 @@ agents:
           max_read_size: 10485760
 ```
 
-```
+```python
 google_drive_list_files()
 google_drive_search_files("name contains 'budget'")
 google_drive_read_file("1AbCdEfGhIjKlMnOpQrStUvWxYz")
@@ -503,7 +503,7 @@ When no usable MindRoom OAuth credentials exist, the wrapper raises `OAuthConnec
 
 ### Example
 
-```
+```yaml
 agents:
   ops:
     worker_scope: shared
@@ -513,7 +513,7 @@ agents:
           spreadsheet_range: Sheet1!A1:G200
 ```
 
-```
+```python
 read_sheet()
 read_sheet(
     spreadsheet_id="1AbCdEfGhIjKlMnOpQrStUvWxYz",
@@ -554,7 +554,7 @@ You can selectively enable additional research functions without exposing the fu
 
 ### Example
 
-```
+```yaml
 agents:
   market:
     tools:
@@ -564,7 +564,7 @@ agents:
           enable_get_company_news: true
 ```
 
-```
+```python
 get_stock_price("AAPL,MSFT")
 search_company_symbol("Nvidia")
 get_company_news("AAPL", num_stories=5)
@@ -596,14 +596,14 @@ The optional `session` field is an advanced programmatic HTTP session hook for c
 
 ### Example
 
-```
+```yaml
 agents:
   market:
     tools:
       - yfinance
 ```
 
-```
+```python
 get_current_stock_price("AAPL")
 get_company_info("MSFT")
 get_historical_stock_prices("NVDA", period="6mo", interval="1d")
@@ -634,14 +634,14 @@ If `api_key` is unset, it falls back to `FINANCIAL_DATASETS_API_KEY`, and otherw
 
 ### Example
 
-```
+```yaml
 agents:
   market:
     tools:
       - financial_datasets_api
 ```
 
-```
+```python
 search_tickers("cloud software", limit=5)
 get_company_info("MSFT")
 get_stock_prices("AAPL", interval="1d", limit=30)

--- a/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
+++ b/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
@@ -37,7 +37,7 @@ No extra configuration is required beyond that workspace root, and `MINDROOM_TOO
 Missing optional dependencies can auto-install at first use unless `MINDROOM_NO_AUTO_INSTALL_TOOLS=1` is set.
 That matters most here for `docker`, `file_generation`, and `visualization`, which depend on Docker access, `reportlab`, and `matplotlib`.
 
-```
+```yaml
 defaults:
   worker_scope: user_agent
 
@@ -97,7 +97,7 @@ MindRoom marks `file` as worker-routed by default, so it usually executes in the
 
 ### Example
 
-```
+```yaml
 agents:
   editor:
     tools:
@@ -106,7 +106,7 @@ agents:
           max_file_lines: 2000
 ```
 
-```
+```python
 read_file("README.md")
 read_file_chunk("src/mindroom/tools/file.py", 0, 80)
 replace_file_chunk("docs/notes.md", 10, 12, "Updated text")
@@ -148,7 +148,7 @@ MindRoom marks `shell` as worker-routed by default, so it usually executes in th
 
 ### Example
 
-```
+```yaml
 agents:
   ops:
     worker_scope: user_agent
@@ -162,7 +162,7 @@ agents:
             - /opt/custom/bin
 ```
 
-```
+```python
 run_shell_command(["git", "status", "--short"], tail=50)
 run_shell_command(["bash", "-lc", "sleep 300 && echo done"], timeout=2)
 check_shell_command("shell:abcd1234")
@@ -179,7 +179,7 @@ kill_shell_command("shell:abcd1234")
 - MindRoom-owned env names are reasserted after the hook and cannot be redirected from `.mindroom/worker-env.sh`: `HOME`, `MINDROOM_AGENT_WORKSPACE`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`, `PIP_CACHE_DIR`, `UV_CACHE_DIR`, `PYTHONPYCACHEPREFIX`, and `VIRTUAL_ENV`.
 - Example:
 
-```
+```bash
 mkdir -p .mindroom .local/bin .cache/npm
 cat > .mindroom/worker-env.sh <<'EOF'
 export NPM_CONFIG_PREFIX="$PWD/.local"
@@ -211,7 +211,7 @@ MindRoom marks `python` as worker-routed by default, so sandbox execution is the
 
 ### Example
 
-```
+```yaml
 agents:
   analyst:
     tools:
@@ -219,7 +219,7 @@ agents:
           restrict_to_base_dir: true
 ```
 
-```
+```python
 run_python_code("total = sum(i * i for i in range(10))", variable_to_return="total")
 save_to_file_and_run("scripts/demo.py", "result = 6 * 7", variable_to_return="result")
 run_python_file_return_variable("scripts/demo.py", variable_to_return="result")
@@ -259,14 +259,14 @@ MindRoom marks `coding` as worker-routed by default.
 
 ### Example
 
-```
+```yaml
 agents:
   code:
     tools:
       - coding
 ```
 
-```
+```python
 read_file("src/mindroom/tools/shell.py", offset=1, limit=120)
 grep("default_execution_target", path="src/mindroom/tools")
 find_files("**/*.md", path="docs")
@@ -298,14 +298,14 @@ This tool has no tool-specific inline configuration fields.
 
 ### Example
 
-```
+```yaml
 agents:
   platform:
     tools:
       - docker
 ```
 
-```
+```python
 list_containers()
 run_container("postgres:16", detach=True, environment={"POSTGRES_PASSWORD": "example"})
 get_container_logs("postgres", tail=50)
@@ -335,14 +335,14 @@ This tool has no tool-specific inline configuration fields.
 
 ### Example
 
-```
+```yaml
 agents:
   math:
     tools:
       - calculator
 ```
 
-```
+```python
 add(2, 3)
 divide(22, 7)
 factorial(6)
@@ -382,7 +382,7 @@ These steps are intended for the agent's internal reasoning flow rather than use
 
 ### Example
 
-```
+```yaml
 agents:
   researcher:
     tools:
@@ -391,7 +391,7 @@ agents:
           add_few_shot: true
 ```
 
-```
+```python
 think(
     title="Plan the investigation",
     thought="I should inspect the config and then compare it with the runtime behavior.",
@@ -437,7 +437,7 @@ PDF generation is automatically disabled when `reportlab` is unavailable, even i
 
 ### Example
 
-```
+```yaml
 agents:
   reporter:
     tools:
@@ -446,7 +446,7 @@ agents:
           enable_pdf_generation: true
 ```
 
-```
+```python
 generate_json_file({"status": "ok", "items": 3}, filename="summary.json")
 generate_csv_file([{"name": "alpha", "value": 1}, {"name": "beta", "value": 2}], filename="data.csv")
 generate_pdf_file("Quarterly summary", filename="report.pdf", title="Q1 Report")
@@ -484,7 +484,7 @@ Each chart function accepts dict-like data, list-based data, or JSON strings, no
 
 ### Example
 
-```
+```yaml
 agents:
   analyst:
     tools:
@@ -493,7 +493,7 @@ agents:
           enable_create_pie_chart: false
 ```
 
-```
+```python
 create_bar_chart({"Mon": 12, "Tue": 18, "Wed": 9}, title="Requests per day")
 create_line_chart({"Jan": 3, "Feb": 8, "Mar": 13}, title="Growth")
 create_scatter_plot(
@@ -528,14 +528,14 @@ create_histogram([1, 1, 2, 3, 5, 8, 13], title="Value distribution")
 
 ### Example
 
-```
+```yaml
 agents:
   scheduler_helper:
     tools:
       - sleep
 ```
 
-```
+```python
 sleep(5)
 ```
 

--- a/skills/mindroom-docs/references/page__tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__index.md
@@ -7,7 +7,7 @@ MindRoom includes 100+ built-in tools and presets that agents can use to work wi
 Tools are enabled per-agent in the configuration.
 Each tool entry can be a plain string or a single-key dict with inline config overrides:
 
-```
+```yaml
 agents:
   assistant:
     display_name: Assistant
@@ -23,7 +23,7 @@ agents:
 
 You can also assign tools to all agents globally:
 
-```
+```yaml
 defaults:
   tools:
     - scheduler

--- a/skills/mindroom-docs/references/page__tools__location-commerce-and-home__index.md
+++ b/skills/mindroom-docs/references/page__tools__location-commerce-and-home__index.md
@@ -45,14 +45,14 @@ MindRoom does not add extra runtime behavior on top of the upstream toolkit beyo
 
 ### Example
 
-```
+```yaml
 agents:
   local_guide:
     tools:
       - google_maps
 ```
 
-```
+```python
 search_places("coffee shops near Pike Place Market")
 get_directions("Seattle, WA", "Portland, OR", mode="driving")
 geocode_address("1600 Amphitheatre Parkway, Mountain View, CA")
@@ -92,7 +92,7 @@ MindRoom does not add custom behavior here beyond metadata, dependency managemen
 
 ### Example
 
-```
+```yaml
 agents:
   weather:
     tools:
@@ -101,7 +101,7 @@ agents:
           enable_air_pollution: false
 ```
 
-```
+```python
 get_current_weather("San Francisco")
 get_forecast("Chicago", days=3)
 get_air_pollution("Los Angeles")
@@ -137,7 +137,7 @@ MindRoom does not wrap the Shopify API further, so behavior comes directly from 
 
 ### Example
 
-```
+```yaml
 agents:
   store_analyst:
     tools:
@@ -147,7 +147,7 @@ agents:
           timeout: 45
 ```
 
-```
+```python
 get_shop_info()
 get_products(max_results=25, status="ACTIVE")
 get_orders(max_results=50, created_after="2026-03-01", created_before="2026-03-31")
@@ -182,7 +182,7 @@ MindRoom adds important runtime behavior here by loading scoped credentials, enf
 
 ### Example
 
-```
+```yaml
 agents:
   home:
     worker_scope: shared
@@ -190,7 +190,7 @@ agents:
       - homeassistant
 ```
 
-```
+```python
 list_entities("light")
 get_entity_state("climate.thermostat")
 turn_on("light.living_room")

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -49,14 +49,14 @@ This tool has no tool-specific inline configuration fields.
 
 ### Example
 
-```
+```yaml
 agents:
   assistant:
     tools:
       - matrix_message
 ```
 
-```
+```python
 matrix_message(action="context")
 matrix_message(action="send", message="Posting this to the room timeline.", thread_id="room")
 matrix_message(
@@ -96,14 +96,14 @@ This tool has no tool-specific inline configuration fields.
 
 ### Example
 
-```
+```yaml
 agents:
   assistant:
     tools:
       - thread_tags
 ```
 
-```
+```python
 tag_thread("blocked")
 untag_thread("blocked")
 list_thread_tags(thread_id="$threadRootEvent")
@@ -134,14 +134,14 @@ This tool has no tool-specific inline configuration fields.
 
 ### Example
 
-```
+```yaml
 agents:
   assistant:
     tools:
       - thread_summary
 ```
 
-```
+```python
 set_thread_summary("Decision: ship the current plan and revisit logs tomorrow.")
 set_thread_summary(
     "Summary for the import thread.",
@@ -178,14 +178,14 @@ This tool has no tool-specific inline configuration fields.
 
 ### Example
 
-```
+```yaml
 agents:
   assistant:
     tools:
       - matrix_api
 ```
 
-```
+```python
 matrix_api(action="get_event", event_id="$event123")
 matrix_api(action="get_state", event_type="m.room.topic")
 matrix_api(
@@ -233,14 +233,14 @@ This tool has no tool-specific inline configuration fields.
 
 ### Example
 
-```
+```yaml
 agents:
   assistant:
     tools:
       - attachments
 ```
 
-```
+```python
 list_attachments()
 get_attachment("att_abc123")
 get_attachment("att_abc123", mindroom_output_path="incoming/plan.pdf")

--- a/skills/mindroom-docs/references/page__tools__media-and-content__index.md
+++ b/skills/mindroom-docs/references/page__tools__media-and-content__index.md
@@ -51,7 +51,7 @@ This tool works entirely on local files, so it is only useful when the agent run
 
 ### Example
 
-```
+```yaml
 agents:
   editor:
     tools:
@@ -59,7 +59,7 @@ agents:
           enable_embed_captions: true
 ```
 
-```
+```python
 extract_audio("clips/demo.mp4", "clips/demo.wav")
 create_srt(transcription_srt, "clips/demo.srt")
 embed_captions("clips/demo.mp4", "clips/demo.srt", output_path="clips/demo_captioned.mp4")
@@ -93,7 +93,7 @@ Successful calls return a `ToolResult` with both plain-text URLs and attached im
 
 ### Example
 
-```
+```yaml
 agents:
   social:
     tools:
@@ -101,7 +101,7 @@ agents:
           limit: 3
 ```
 
-```
+```python
 search_gifs("matrix code review celebration")
 ```
 
@@ -136,7 +136,7 @@ It expects a specific YouTube URL and then fetches metadata or transcript-derive
 
 ### Example
 
-```
+```yaml
 agents:
   researcher:
     tools:
@@ -144,7 +144,7 @@ agents:
           languages: [en]
 ```
 
-```
+```python
 get_youtube_video_data("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
 get_youtube_video_captions("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
 get_video_timestamps("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
@@ -182,7 +182,7 @@ It triggers Unsplash's required download-tracking endpoint and returns the downl
 
 ### Example
 
-```
+```yaml
 agents:
   designer:
     tools:
@@ -190,7 +190,7 @@ agents:
           enable_download_photo: true
 ```
 
-```
+```python
 search_photos("conference stage lighting", per_page=5, orientation="landscape")
 get_random_photo(query="workspace desk", count=3)
 get_photo("abcd1234")
@@ -229,7 +229,7 @@ The two methods use different credentials.
 
 ### Example
 
-```
+```yaml
 agents:
   branding:
     tools:
@@ -238,7 +238,7 @@ agents:
           timeout: 10
 ```
 
-```
+```python
 search_by_identifier("openai.com")
 search_by_brand("OpenAI")
 ```
@@ -271,7 +271,7 @@ The upstream playlist and playback methods need additional Spotify scopes beyond
 
 ### Example
 
-```
+```yaml
 agents:
   dj:
     worker_scope: shared
@@ -280,7 +280,7 @@ agents:
           default_market: GB
 ```
 
-```
+```python
 search_tracks("ambient coding music", max_results=5)
 get_my_top_tracks(time_range="short_term", limit=10)
 create_playlist("MindRoom Picks", description="Tracks from this week's chat")

--- a/skills/mindroom-docs/references/page__tools__memory-and-storage__index.md
+++ b/skills/mindroom-docs/references/page__tools__memory-and-storage__index.md
@@ -43,7 +43,7 @@ This tool has no tool-specific inline configuration fields.
 
 ### Example
 
-```
+```yaml
 memory:
   backend: file
 
@@ -53,7 +53,7 @@ agents:
       - memory
 ```
 
-```
+```python
 add_memory("The user prefers terse release notes.")
 search_memories("release notes", limit=3)
 list_memories(limit=20)
@@ -99,7 +99,7 @@ Operations need a `user_id`, either from tool config or from the run context, an
 
 ### Example
 
-```
+```yaml
 agents:
   assistant:
     tools:
@@ -108,7 +108,7 @@ agents:
           infer: true
 ```
 
-```
+```python
 add_memory("The user prefers terse release notes.")
 search_memory("release notes")
 get_all_memories()
@@ -154,7 +154,7 @@ If `user_id` is provided but the user does not exist yet, the toolkit attempts t
 
 ### Example
 
-```
+```yaml
 agents:
   assistant:
     tools:
@@ -163,7 +163,7 @@ agents:
           session_id: release-review
 ```
 
-```
+```python
 add_zep_message(role="user", content="The user prefers terse release notes.")
 get_zep_memory(memory_type="context")
 search_zep_memory(query="release notes", search_scope="edges")

--- a/skills/mindroom-docs/references/page__tools__messaging-and-social__index.md
+++ b/skills/mindroom-docs/references/page__tools__messaging-and-social__index.md
@@ -62,7 +62,7 @@ Draft and send operations accept local file-system paths for attachments.
 
 ### Example
 
-```
+```yaml
 agents:
   assistant:
     worker_scope: shared
@@ -70,7 +70,7 @@ agents:
       - gmail
 ```
 
-```
+```python
 get_latest_emails(10)
 search_emails("label:unread from:billing@example.com", 10)
 send_email("alice@example.com", "Project update", "Here is the latest status.")
@@ -112,7 +112,7 @@ Channel-history responses are normalized into a smaller JSON structure instead o
 
 ### Example
 
-```
+```yaml
 agents:
   support:
     tools:
@@ -121,7 +121,7 @@ agents:
           enable_get_channel_history: true
 ```
 
-```
+```python
 list_channels()
 send_message("C0123456789", "Deployment finished.")
 send_message_thread("C0123456789", "Following up in the same thread.", "1743112345.678900")
@@ -159,7 +159,7 @@ Most functions expect Discord IDs such as `channel_id`, `guild_id`, and `message
 
 ### Example
 
-```
+```yaml
 agents:
   community:
     tools:
@@ -167,7 +167,7 @@ agents:
           enable_delete_message: false
 ```
 
-```
+```python
 list_channels("123456789012345678")
 get_channel_info("123456789012345678")
 get_channel_messages("123456789012345678", limit=25)
@@ -202,7 +202,7 @@ Responses are returned as the raw Telegram API response text.
 
 ### Example
 
-```
+```yaml
 agents:
   notifier:
     tools:
@@ -210,7 +210,7 @@ agents:
           chat_id: "-1001234567890"
 ```
 
-```
+```python
 send_message("Nightly backup completed.")
 ```
 
@@ -243,7 +243,7 @@ If no default recipient is configured, every send call must provide one.
 
 ### Example
 
-```
+```yaml
 agents:
   pager:
     tools:
@@ -253,7 +253,7 @@ agents:
           async_mode: false
 ```
 
-```
+```python
 send_text_message_sync("The deployment finished.")
 send_template_message_sync(template_name="deployment_notice", language_code="en_US")
 ```
@@ -293,7 +293,7 @@ Optional `region` and `edge` are passed into the Twilio client for regional rout
 
 ### Example
 
-```
+```yaml
 agents:
   phone_ops:
     tools:
@@ -303,7 +303,7 @@ agents:
           enable_list_messages: true
 ```
 
-```
+```python
 send_sms("+15551234567", "+15557654321", "Build passed.")
 get_call_details("CA1234567890abcdef")
 list_messages(limit=10)
@@ -337,7 +337,7 @@ Responses are returned as JSON strings built from the SDK result objects.
 
 ### Example
 
-```
+```yaml
 agents:
   meetings:
     tools:
@@ -345,7 +345,7 @@ agents:
           enable_list_rooms: true
 ```
 
-```
+```python
 list_rooms()
 send_message("Y2lzY29zcGFyazovL3VzL1JPT00v...", "Agenda is ready.")
 ```
@@ -378,7 +378,7 @@ The current implementation passes the message body as HTML, not plain text.
 
 ### Example
 
-```
+```yaml
 agents:
   mailer:
     tools:
@@ -386,7 +386,7 @@ agents:
           from_email: no-reply@example.com
 ```
 
-```
+```python
 send_email("alice@example.com", "Welcome", "<p>Your account is ready.</p>")
 ```
 
@@ -420,7 +420,7 @@ The current implementation sends plain-text bodies only.
 
 ### Example
 
-```
+```yaml
 agents:
   alerts:
     tools:
@@ -430,7 +430,7 @@ agents:
           sender_email: alerts@gmail.com
 ```
 
-```
+```python
 email_user("Nightly report", "The report finished successfully.")
 ```
 
@@ -466,7 +466,7 @@ The implementation clamps `max_results` for search to the Twitter API's supporte
 
 ### Example
 
-```
+```yaml
 agents:
   social:
     tools:
@@ -475,7 +475,7 @@ agents:
           wait_on_rate_limit: true
 ```
 
-```
+```python
 search_posts("mindroom matrix", max_results=10)
 get_user_info("mindroom_ai")
 create_post("MindRoom now supports another release.")
@@ -512,7 +512,7 @@ If `username` and `password` are also configured, the tool enables posting and r
 
 ### Example
 
-```
+```yaml
 agents:
   research:
     tools:
@@ -520,7 +520,7 @@ agents:
           user_agent: MindRoomResearchBot/1.0
 ```
 
-```
+```python
 get_top_posts("matrixdotorg", time_filter="week", limit=10)
 get_subreddit_info("python")
 get_trending_subreddits()
@@ -554,7 +554,7 @@ Meeting creation always targets `users/me/meetings` and applies a fixed set of d
 
 ### Example
 
-```
+```yaml
 agents:
   coordinator:
     tools:
@@ -563,7 +563,7 @@ agents:
           client_id: your_client_id
 ```
 
-```
+```python
 schedule_meeting("Weekly sync", "2026-04-02T16:00:00Z", 30, timezone="America/Los_Angeles")
 get_upcoming_meetings()
 list_meetings(type="scheduled")

--- a/skills/mindroom-docs/references/page__tools__project-management__index.md
+++ b/skills/mindroom-docs/references/page__tools__project-management__index.md
@@ -49,7 +49,7 @@ The file-management surface includes `create_file()`, `get_file_content()`, `upd
 
 ### Example
 
-```
+```yaml
 agents:
   maintainer:
     tools:
@@ -57,7 +57,7 @@ agents:
           base_url: https://github.example.com/api/v3
 ```
 
-```
+```python
 get_repository("mindroom-ai/mindroom")
 list_issues("mindroom-ai/mindroom", state="open", page=1, per_page=20)
 get_pull_request("mindroom-ai/mindroom", 123)
@@ -93,7 +93,7 @@ If `server_url` has no scheme, the upstream tool normalizes it to `https://<serv
 
 ### Example
 
-```
+```yaml
 agents:
   maintainer:
     tools:
@@ -103,7 +103,7 @@ agents:
           repo_slug: docs
 ```
 
-```
+```python
 get_repository_details()
 list_all_pull_requests(state="OPEN")
 list_repository_commits(count=10)
@@ -142,7 +142,7 @@ list_repository_commits(count=10)
 
 ### Example
 
-```
+```yaml
 agents:
   delivery:
     tools:
@@ -152,7 +152,7 @@ agents:
           enable_add_worklog: false
 ```
 
-```
+```python
 get_issue("PROJ-123")
 search_issues("project = PROJ AND status != Done", max_results=20)
 add_comment("PROJ-123", "Reviewed and ready for testing.")
@@ -182,14 +182,14 @@ The read methods are useful for discovering the IDs you need before calling `cre
 
 ### Example
 
-```
+```yaml
 agents:
   delivery:
     tools:
       - linear
 ```
 
-```
+```python
 get_user_details()
 get_teams_details()
 get_high_priority_issues()
@@ -221,7 +221,7 @@ Name-based space and list lookup is case-insensitive and also supports regex-sty
 
 ### Example
 
-```
+```yaml
 agents:
   delivery:
     tools:
@@ -229,7 +229,7 @@ agents:
           master_space_id: "90123456"
 ```
 
-```
+```python
 list_spaces()
 list_lists("Engineering")
 create_task("Engineering", "ISSUE-075", "Draft the project-management tool page")
@@ -264,7 +264,7 @@ At runtime the tool accepts either `api_key` or `password`, with the current imp
 
 ### Example
 
-```
+```yaml
 agents:
   docs:
     tools:
@@ -273,7 +273,7 @@ agents:
           username: docs@example.com
 ```
 
-```
+```python
 get_all_space_detail()
 get_page_content("Engineering", "Runbook")
 create_page("Engineering", "Release Notes", "<p>Initial draft</p>")
@@ -310,7 +310,7 @@ The current upstream implementation assumes the target database has a title prop
 
 ### Example
 
-```
+```yaml
 agents:
   docs:
     tools:
@@ -319,7 +319,7 @@ agents:
           enable_update_page: false
 ```
 
-```
+```python
 search_pages("docs")
 create_page("ISSUE-075", "docs", "Draft the project-management tool page")
 update_page("PAGE_ID", "Added rollout notes")
@@ -352,14 +352,14 @@ If the Trello client cannot initialize, the current upstream methods return `"Tr
 
 ### Example
 
-```
+```yaml
 agents:
   planner:
     tools:
       - trello
 ```
 
-```
+```python
 list_boards(board_filter="open")
 get_board_lists("BOARD_ID")
 create_card("BOARD_ID", "To Do", "Write docs", "Draft the new tool page")
@@ -390,14 +390,14 @@ create_card("BOARD_ID", "To Do", "Write docs", "Draft the new tool page")
 
 ### Example
 
-```
+```yaml
 agents:
   planner:
     tools:
       - todoist
 ```
 
-```
+```python
 create_task("Write project-management docs", due_string="tomorrow", priority=4)
 get_active_tasks()
 close_task("TASK_ID")
@@ -432,7 +432,7 @@ This tool does not expose ticket lookup or ticket updates on this branch.
 
 ### Example
 
-```
+```yaml
 agents:
   support:
     tools:
@@ -441,7 +441,7 @@ agents:
           company_name: acme
 ```
 
-```
+```python
 search_zendesk("Matrix onboarding")
 ```
 

--- a/skills/mindroom-docs/references/page__tools__research-sources__index.md
+++ b/skills/mindroom-docs/references/page__tools__research-sources__index.md
@@ -42,7 +42,7 @@ Reading papers downloads each PDF locally, parses it with `pypdf`, and returns t
 
 ### Example
 
-```
+```yaml
 agents:
   researcher:
     tools:
@@ -50,7 +50,7 @@ agents:
           download_dir: mindroom_data/arxiv
 ```
 
-```
+```python
 search_arxiv_and_return_articles("matrix protocol", num_articles=5)
 read_arxiv_papers(["2103.03404v1"], pages_to_read=3)
 ```
@@ -80,14 +80,14 @@ This makes `wikipedia` a simple direct lookup tool by default, with an advanced 
 
 ### Example
 
-```
+```yaml
 agents:
   researcher:
     tools:
       - wikipedia
 ```
 
-```
+```python
 search_wikipedia("Matrix protocol")
 ```
 
@@ -120,7 +120,7 @@ When `results_expanded` is enabled, each result also includes first author, jour
 
 ### Example
 
-```
+```yaml
 agents:
   clinician:
     tools:
@@ -130,7 +130,7 @@ agents:
           results_expanded: true
 ```
 
-```
+```python
 search_pubmed("CRISPR therapy", max_results=5)
 ```
 
@@ -160,14 +160,14 @@ User lookups return a smaller JSON object with karma, about text, and total subm
 
 ### Example
 
-```
+```yaml
 agents:
   tech_watch:
     tools:
       - hackernews
 ```
 
-```
+```python
 get_top_hackernews_stories(num_stories=5)
 get_user_details("pg")
 ```

--- a/skills/mindroom-docs/references/page__tools__web-scraping-and-browser__index.md
+++ b/skills/mindroom-docs/references/page__tools__web-scraping-and-browser__index.md
@@ -69,7 +69,7 @@ This is a local crawler rather than a hosted API, so it does not need an API key
 
 #### Example
 
-```
+```yaml
 agents:
   researcher:
     tools:
@@ -79,7 +79,7 @@ agents:
           wait_until: networkidle
 ```
 
-```
+```python
 crawl("https://matrix.org/blog/", search_query="bridges and federation")
 ```
 
@@ -108,14 +108,14 @@ In normal hand-authored `config.yaml`, you should treat this as a quick page-rea
 
 #### Example
 
-```
+```yaml
 agents:
   assistant:
     tools:
       - website
 ```
 
-```
+```python
 read_url("https://docs.mindroom.chat")
 ```
 
@@ -165,7 +165,7 @@ If the spider module is missing, the tool skips crawler registration instead of 
 
 #### Example
 
-```
+```yaml
 agents:
   analyst:
     tools:
@@ -175,7 +175,7 @@ agents:
           include_links: true
 ```
 
-```
+```python
 extract_text("https://matrix.org/blog/", output_format="markdown")
 extract_metadata_only("https://matrix.org/blog/")
 ```
@@ -209,7 +209,7 @@ That means old references to `newspaper4k` are stale for current MindRoom config
 
 #### Example
 
-```
+```yaml
 agents:
   newsdesk:
     tools:
@@ -218,7 +218,7 @@ agents:
           article_length: 6000
 ```
 
-```
+```python
 read_article("https://matrix.org/blog/")
 ```
 
@@ -257,7 +257,7 @@ The installed implementation only adds the `Authorization` header when an API ke
 
 #### Example
 
-```
+```yaml
 agents:
   researcher:
     tools:
@@ -266,7 +266,7 @@ agents:
           search_query_content: false
 ```
 
-```
+```python
 read_url("https://matrix.org/blog/")
 search_query("latest Matrix bridge updates")
 ```
@@ -310,7 +310,7 @@ The upstream tool falls back to `FIRECRAWL_API_KEY` when `api_key` is not provid
 
 #### Example
 
-```
+```yaml
 agents:
   research:
     tools:
@@ -320,7 +320,7 @@ agents:
           limit: 5
 ```
 
-```
+```python
 scrape_website("https://matrix.org/blog/")
 search_web("latest Matrix bridges")
 ```
@@ -357,7 +357,7 @@ The installed `spider-client` constructor raises when no API key is available, e
 
 #### Example
 
-```
+```yaml
 agents:
   crawler:
     tools:
@@ -366,7 +366,7 @@ agents:
           enable_crawl: true
 ```
 
-```
+```python
 search_web("MindRoom Matrix setup", max_results=5)
 scrape("https://matrix.org/blog/")
 ```
@@ -407,7 +407,7 @@ scrape("https://matrix.org/blog/")
 
 #### Example
 
-```
+```yaml
 agents:
   extractor:
     tools:
@@ -416,7 +416,7 @@ agents:
           enable_agentic_crawler: true
 ```
 
-```
+```python
 smartscraper("https://matrix.org/blog/", "Extract the title, date, and three main points.")
 markdownify("https://matrix.org/blog/")
 ```
@@ -448,7 +448,7 @@ This is best thought of as a hosted Actor adapter rather than a single scraper A
 
 #### Example
 
-```
+```yaml
 agents:
   extractor:
     tools:
@@ -492,7 +492,7 @@ Zone selection is controlled by `serp_zone` and `web_unlocker_zone`, which can a
 
 #### Example
 
-```
+```yaml
 agents:
   research:
     tools:
@@ -501,7 +501,7 @@ agents:
           timeout: 300
 ```
 
-```
+```python
 scrape_as_markdown("https://matrix.org/blog/")
 search_engine("Matrix hosting", engine="google", num_results=5)
 ```
@@ -534,14 +534,14 @@ This tool is credentialed with a username and password pair rather than one API 
 
 #### Example
 
-```
+```yaml
 agents:
   commerce:
     tools:
       - oxylabs
 ```
 
-```
+```python
 search_google("Matrix hosting", domain_code="com")
 search_amazon_products("ergonomic keyboard", domain_code="com")
 ```
@@ -578,7 +578,7 @@ The current upstream implementation launches Playwright with `headless=False`, w
 
 #### Example
 
-```
+```yaml
 agents:
   extractor:
     tools:
@@ -590,7 +590,7 @@ agents:
             }
 ```
 
-```
+```python
 scrape_website("https://matrix.org/blog/")
 custom_scrape_website("https://matrix.org/blog/")
 ```
@@ -631,7 +631,7 @@ This is simpler than `browser` when you only need remote navigation, screenshots
 
 #### Example
 
-```
+```yaml
 agents:
   browser_worker:
     tools:
@@ -640,7 +640,7 @@ agents:
           max_content_length: 20000
 ```
 
-```
+```python
 navigate_to("https://matrix.org/blog/")
 get_page_content()
 ```
@@ -674,7 +674,7 @@ The runtime picks Chromium from `BROWSER_EXECUTABLE_PATH`, `chromium`, or `googl
 
 #### Example
 
-```
+```yaml
 agents:
   browser_worker:
     tools:
@@ -682,7 +682,7 @@ agents:
           output_dir: browser-artifacts
 ```
 
-```
+```python
 browser(action="open", targetUrl="https://matrix.org/blog/")
 browser(action="snapshot", snapshotFormat="ai")
 browser(action="act", request={"kind": "click", "ref": "e1"})
@@ -713,14 +713,14 @@ This makes it useful for human handoff or local desktop workflows, but not for s
 
 #### Example
 
-```
+```yaml
 agents:
   assistant:
     tools:
       - web_browser_tools
 ```
 
-```
+```python
 open_page("https://docs.mindroom.chat")
 open_page("https://matrix.org/blog/", new_window=True)
 ```

--- a/skills/mindroom-docs/references/page__tools__web-search__index.md
+++ b/skills/mindroom-docs/references/page__tools__web-search__index.md
@@ -60,7 +60,7 @@ The tool returns JSON strings from DDGS rather than a MindRoom-specific normaliz
 
 ### Example
 
-```
+```yaml
 agents:
   researcher:
     tools:
@@ -69,7 +69,7 @@ agents:
           fixed_max_results: 8
 ```
 
-```
+```python
 web_search("latest Matrix client features", max_results=5)
 search_news("Matrix ecosystem", max_results=5)
 ```
@@ -105,7 +105,7 @@ This is still a DDGS-backed scraper-style search path rather than an official Go
 
 ### Example
 
-```
+```yaml
 agents:
   researcher:
     tools:
@@ -114,7 +114,7 @@ agents:
           fixed_max_results: 6
 ```
 
-```
+```python
 web_search("MindRoom Matrix threads", max_results=5)
 search_news("open source Matrix news", max_results=5)
 ```
@@ -151,7 +151,7 @@ The returned payload is a JSON array with `title`, `url`, `abstract`, and `rank`
 
 ### Example
 
-```
+```yaml
 agents:
   cn_research:
     tools:
@@ -160,7 +160,7 @@ agents:
           fixed_max_results: 8
 ```
 
-```
+```python
 baidu_search("Matrix 协议 新闻", max_results=5, language="zh")
 ```
 
@@ -203,7 +203,7 @@ baidu_search("Matrix 协议 新闻", max_results=5, language="zh")
 
 ### Example
 
-```
+```yaml
 agents:
   newsdesk:
     tools:
@@ -214,7 +214,7 @@ agents:
           format: markdown
 ```
 
-```
+```python
 web_search_using_tavily("latest Matrix bridge updates", max_results=5)
 extract_url_content("https://matrix.org/blog/")
 ```
@@ -267,7 +267,7 @@ The toolkit supports domain allowlists and denylists, crawl-date and publish-dat
 
 ### Example
 
-```
+```yaml
 agents:
   analyst:
     tools:
@@ -280,7 +280,7 @@ agents:
           research_model: exa-research
 ```
 
-```
+```python
 search_exa("Matrix sliding sync adoption", num_results=5)
 find_similar("https://matrix.org/blog/")
 exa_answer("What changed in the Matrix ecosystem this week?")
@@ -315,7 +315,7 @@ MindRoom does not add extra behavior here beyond registering the tool metadata a
 
 ### Example
 
-```
+```yaml
 agents:
   researcher:
     tools:
@@ -323,7 +323,7 @@ agents:
           enable_search_youtube: true
 ```
 
-```
+```python
 search_google("Matrix bridges", num_results=10)
 search_youtube("Matrix conference talks")
 ```
@@ -362,7 +362,7 @@ The search methods return raw JSON responses from Serper.
 
 ### Example
 
-```
+```yaml
 agents:
   analyst:
     tools:
@@ -372,7 +372,7 @@ agents:
           enable_search_scholar: true
 ```
 
-```
+```python
 search_web("latest Matrix rooms UX", num_results=5)
 search_news("Matrix foundation news", num_results=5)
 search_scholar("Matrix protocol paper", num_results=5)
@@ -406,7 +406,7 @@ If `engines` is set, the tool appends those engine names to the SearXNG request.
 
 ### Example
 
-```
+```yaml
 agents:
   privacy_research:
     tools:
@@ -418,7 +418,7 @@ agents:
           fixed_max_results: 6
 ```
 
-```
+```python
 search_web("Matrix federation guide", max_results=5)
 news_search("Matrix news", max_results=5)
 science_search("decentralized messaging protocol", max_results=5)
@@ -454,7 +454,7 @@ The tool returns the raw response from the Linkup SDK rather than a MindRoom-spe
 
 ### Example
 
-```
+```yaml
 agents:
   briefings:
     tools:
@@ -463,7 +463,7 @@ agents:
           output_type: sourcedAnswer
 ```
 
-```
+```python
 web_search_with_linkup(
     "Summarize the latest Matrix bridge announcements",
     depth="deep",

--- a/skills/mindroom-docs/references/page__voice__index.md
+++ b/skills/mindroom-docs/references/page__voice__index.md
@@ -22,7 +22,7 @@ When a voice message is received:
 
 Enable STT and voice-intelligence formatting in `config.yaml`:
 
-```
+```yaml
 voice:
   enabled: true
   visible_router_echo: false
@@ -47,7 +47,7 @@ MindRoom uses the OpenAI-compatible transcription API. Any service that implemen
 
 ### OpenAI Whisper (Cloud)
 
-```
+```yaml
 voice:
   enabled: true
   stt:
@@ -59,7 +59,7 @@ Requires `OPENAI_API_KEY` environment variable.
 
 ### Self-Hosted Whisper
 
-```
+```yaml
 voice:
   enabled: true
   stt:
@@ -76,7 +76,7 @@ Use with [faster-whisper-server](https://github.com/fedirz/faster-whisper-server
 
 For self-hosted solutions that require authentication:
 
-```
+```yaml
 voice:
   enabled: true
   stt:
@@ -102,7 +102,7 @@ The intelligence component uses an AI model to analyze transcriptions and format
 
 The intelligence model processes raw transcriptions to recognize commands and agent names:
 
-```
+```yaml
 voice:
   intelligence:
     model: default  # Uses the default model from your models config

--- a/tests/test_generate_skill_references.py
+++ b/tests/test_generate_skill_references.py
@@ -1,0 +1,45 @@
+"""Tests for the mindroom-docs skill reference generator."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def _load_generator() -> ModuleType:
+    script_path = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "generate_skill_references.py"
+    spec = importlib.util.spec_from_file_location("generate_skill_references", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_restore_source_line_breaks_preserves_fenced_code_language() -> None:
+    """Generated references should preserve language tags from source code fences."""
+    generator = _load_generator()
+    source_text = """\
+## Delivery Policy
+
+```yaml
+matrix_delivery:
+  ignore_unverified_devices: false
+```
+"""
+    rendered_text = """\
+## Delivery Policy
+
+```
+matrix_delivery:
+  ignore_unverified_devices: false
+```
+"""
+
+    assert generator._restore_source_line_breaks(rendered_text, source_text) == source_text


### PR DESCRIPTION
## Summary
- Preserve source code-fence opening lines when generating mindroom-docs skill references.
- Regenerate references so language tags like `yaml`, `python`, and `text` stay intact.
- Add a regression test for the Matrix delivery-policy fence case.

## Verification
- `uv run pytest tests/test_generate_skill_references.py -q -n 0 --no-cov`
- `uv run ruff check .github/scripts/generate_skill_references.py tests/test_generate_skill_references.py`
- `uv run pre-commit run generate-skill-references --files docs/architecture/matrix.md .github/scripts/generate_skill_references.py`
- `uv run pre-commit run --files <changed files>`
- Commit-time pre-commit hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized code block formatting across documentation with proper language identifiers (YAML, Python, Bash, JSON) for improved readability and syntax highlighting in all code examples.

* **Tests**
  * Added test validation for code fence language preservation in documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->