### PR TITLE
Fix approval transport CI tests

### DIFF
--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -12650,6 +12650,7 @@ class TestMultiAgentOrchestrator:
         """Shutdown should settle approval sends that receive a card id during shutdown."""
         runtime_paths = TestAgentBot._runtime_paths(tmp_path)
         orchestrator = MultiAgentOrchestrator(runtime_paths=runtime_paths)
+        orchestrator.config = bind_runtime_paths(Config(), runtime_paths)
         orchestrator._capture_runtime_loop()
 
         send_started = asyncio.Event()
@@ -13181,6 +13182,7 @@ class TestMultiAgentOrchestrator:
             ),
             tmp_path,
         )
+        orchestrator.config = old_config
 
         event_order: list[str] = []
         approval_ids: list[str] = []

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -1103,6 +1103,7 @@ async def test_shutdown_bounds_cancelled_send_cleanup_wait(tmp_path: Path, monke
 async def test_request_approval_cleans_up_when_cache_write_is_cancelled_after_room_send(tmp_path: Path) -> None:
     runtime_paths = test_runtime_paths(tmp_path)
     orchestrator = MultiAgentOrchestrator(runtime_paths=runtime_paths)
+    orchestrator.config = bind_runtime_paths(Config(), runtime_paths)
     orchestrator._capture_runtime_loop()
     cache_started = asyncio.Event()
     release_cache = asyncio.Event()
@@ -1155,6 +1156,7 @@ async def test_request_approval_cleans_up_when_cache_write_is_cancelled_after_ro
 async def test_approval_transport_returns_event_after_successful_send_without_sender_user_id(tmp_path: Path) -> None:
     runtime_paths = test_runtime_paths(tmp_path)
     orchestrator = MultiAgentOrchestrator(runtime_paths=runtime_paths)
+    orchestrator.config = bind_runtime_paths(Config(), runtime_paths)
     orchestrator._capture_runtime_loop()
 
     client = MagicMock()
@@ -1183,6 +1185,7 @@ async def test_approval_transport_returns_event_after_successful_send_without_se
 async def test_approval_notice_replies_to_room_mode_card(tmp_path: Path) -> None:
     runtime_paths = test_runtime_paths(tmp_path)
     orchestrator = MultiAgentOrchestrator(runtime_paths=runtime_paths)
+    orchestrator.config = bind_runtime_paths(Config(), runtime_paths)
     orchestrator._capture_runtime_loop()
 
     client = MagicMock()
@@ -1209,6 +1212,7 @@ async def test_approval_notice_replies_to_room_mode_card(tmp_path: Path) -> None
 async def test_approval_thread_relation_uses_requesting_agent_cache(tmp_path: Path) -> None:
     runtime_paths = test_runtime_paths(tmp_path)
     orchestrator = MultiAgentOrchestrator(runtime_paths=runtime_paths)
+    orchestrator.config = bind_runtime_paths(Config(), runtime_paths)
     orchestrator._capture_runtime_loop()
     sent_contents: list[dict[str, Any]] = []
 
@@ -1284,6 +1288,7 @@ async def test_approval_transport_refuses_encrypted_room_without_e2ee(
 ) -> None:
     runtime_paths = test_runtime_paths(tmp_path)
     orchestrator = MultiAgentOrchestrator(runtime_paths=runtime_paths)
+    orchestrator.config = bind_runtime_paths(Config(), runtime_paths)
     orchestrator._capture_runtime_loop()
     monkeypatch.setattr("mindroom.matrix.client_delivery.crypto.ENCRYPTION_ENABLED", False)
 

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -163,6 +163,7 @@ def _initialize_router_approval_store(
     editor: AsyncMock | None = None,
 ) -> tuple[MagicMock, AsyncMock]:
     orchestrator = MultiAgentOrchestrator(runtime_paths=runtime_paths)
+    orchestrator.config = bind_runtime_paths(Config(), runtime_paths)
     orchestrator._capture_runtime_loop()
 
     client = MagicMock()


### PR DESCRIPTION
## Summary
- bind runtime configs in approval transport tests that instantiate MultiAgentOrchestrator directly
- keep Matrix delivery policy lookup on the production transport path while fixing the CI test setup

## Verification
- uv run pre-commit run --all-files
- uv run --python 3.13 pytest tests/test_tool_approval.py::test_request_approval_cleans_up_when_cache_write_is_cancelled_after_room_send tests/test_tool_approval.py::test_approval_transport_returns_event_after_successful_send_without_sender_user_id tests/test_tool_approval.py::test_approval_notice_replies_to_room_mode_card tests/test_tool_approval.py::test_approval_thread_relation_uses_requesting_agent_cache tests/test_tool_hooks.py::test_sync_tool_approval_send_uses_runtime_loop tests/test_tool_hooks.py::test_sync_execute_async_tool_entrypoint_still_runs_approval_gate tests/test_tool_hooks.py::test_sync_tool_approval_resumes_after_cross_loop_resolution tests/test_tool_hooks.py::test_sync_tool_approval_aexecute_resumes_on_runtime_loop tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_shutdown_expires_in_flight_approval_send_after_event_id_arrives tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_requesting_bot_room_reconcile_keeps_router_owned_approval_pending -q
- uv run --python 3.13 pytest tests/test_tool_approval.py tests/test_tool_hooks.py tests/test_multi_agent_bot.py -q
- uv run --python 3.13 pytest -q --ignore=tests/test_generate_skill_references.py

Note: a plain uv run --python 3.13 pytest -q also collected the pre-existing untracked local file tests/test_generate_skill_references.py and failed there; that file is not included in this PR or in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configurations to ensure proper initialization of orchestrator settings during test execution, improving test reliability and consistency across approval and routing verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->