### PR TITLE
Scrub sandbox runner token from startup environment

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -126,7 +126,8 @@ def _startup_runtime_paths_from_env() -> RuntimePaths:
 
 
 def _startup_runner_token_from_env() -> str | None:
-    raw_token = os.environ.get(_RUNNER_TOKEN_ENV, "").strip()
+    """Read and remove the runner auth token from process env after startup."""
+    raw_token = os.environ.pop(_RUNNER_TOKEN_ENV, "").strip()
     return raw_token or None
 
 

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -329,6 +329,16 @@ def test_startup_runtime_keeps_runner_token_outside_runtime_paths(
     assert sandbox_runner_module._app_runner_token(sandbox_runner_app) == "from-env"
 
 
+def test_startup_runner_token_is_removed_from_process_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Startup auth token loading should not leave runner auth in process env."""
+    monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", "from-env")
+
+    assert sandbox_runner_module._startup_runner_token_from_env() == "from-env"
+
+    assert "MINDROOM_SANDBOX_PROXY_TOKEN" not in os.environ
+    assert sandbox_runner_module._startup_runner_token_from_env() is None
+
+
 def test_lifespan_reuses_initialized_runner_context_without_reloading_disk_config(tmp_path: Path) -> None:
     """Existing sandbox-runner state should survive lifespan startup without reparsing config.yaml."""
     config_path = tmp_path / "config.yaml"


### PR DESCRIPTION
## Summary
- read the sandbox runner auth token once during startup and remove it from the process environment
- keep the loaded token in FastAPI app state for request authentication
- add regression coverage that startup token loading scrubs the process env

## Testing
- uv run pytest tests/api/test_sandbox_runner_api.py -k startup_runner_token_is_removed_from_process_env
- uv run pytest tests/api/test_sandbox_runner_api.py -k "startup_runtime or startup_runner_token or dedicated_worker_inprocess_shell_does_not_see_runner_local_env or authenticates_worker_specific_token"
- uv run pytest tests/api/test_sandbox_runner_api.py
- uv run ruff check src/mindroom/api/sandbox_runner.py tests/api/test_sandbox_runner_api.py