### PR TITLE
Register thread-history media attachments

### DIFF
--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -115,6 +115,12 @@ def parse_attachment_ids_from_thread_history(thread_history: Sequence[ResolvedVi
     return attachment_ids
 
 
+def _thread_history_message_in_scope(message: ResolvedVisibleMessage, thread_id: str | None) -> bool:
+    if thread_id is None:
+        return message.thread_id is None
+    return thread_id in (message.thread_id, message.event_id)
+
+
 def merge_attachment_ids(*attachment_id_lists: list[str]) -> list[str]:
     """Merge attachment IDs preserving first-seen order."""
     merged: list[str] = []
@@ -649,6 +655,108 @@ def filter_attachments_for_context(
         else:
             rejected_attachment_ids.append(record.attachment_id)
     return allowed_records, rejected_attachment_ids
+
+
+def _media_event_from_thread_history_message(
+    room_id: str,
+    message: ResolvedVisibleMessage,
+) -> _FileOrVideoEvent | _ImageEvent | None:
+    msgtype = message.content.get("msgtype")
+    if msgtype not in {"m.file", "m.image", "m.video"}:
+        return None
+
+    content = {key: value for key, value in message.content.items() if isinstance(key, str)}
+    event_source = {
+        "content": content,
+        "event_id": message.event_id,
+        "origin_server_ts": message.timestamp,
+        "room_id": room_id,
+        "sender": message.sender,
+        "type": "m.room.message",
+    }
+    parsed_event = (
+        nio.RoomMessage.parse_decrypted_event(event_source)
+        if "file" in content
+        else nio.RoomMessage.parse_event(event_source)
+    )
+    if isinstance(
+        parsed_event,
+        nio.RoomMessageFile
+        | nio.RoomEncryptedFile
+        | nio.RoomMessageVideo
+        | nio.RoomEncryptedVideo
+        | nio.RoomMessageImage
+        | nio.RoomEncryptedImage,
+    ):
+        return parsed_event
+    return None
+
+
+async def _register_thread_history_media_attachment(
+    client: nio.AsyncClient,
+    storage_path: Path,
+    *,
+    room_id: str,
+    thread_id: str | None,
+    event: _FileOrVideoEvent | _ImageEvent,
+) -> AttachmentRecord | None:
+    attachment_id = _attachment_id_for_event(event.event_id)
+    existing_record = load_attachment(storage_path, attachment_id)
+    if (
+        existing_record is not None
+        and existing_record.room_id == room_id
+        and existing_record.thread_id == thread_id
+        and existing_record.local_path.is_file()
+    ):
+        return existing_record
+
+    if isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage):
+        return await register_image_attachment(
+            client,
+            storage_path,
+            room_id=room_id,
+            thread_id=thread_id,
+            event=event,
+        )
+
+    return await register_file_or_video_attachment(
+        client,
+        storage_path,
+        room_id=room_id,
+        thread_id=thread_id,
+        event=event,
+    )
+
+
+async def register_thread_history_media_attachments(
+    client: nio.AsyncClient,
+    storage_path: Path,
+    *,
+    room_id: str,
+    thread_id: str | None,
+    thread_history: Sequence[ResolvedVisibleMessage],
+) -> list[str]:
+    """Register unannotated image/file/video events visible in thread history."""
+    attachment_ids: list[str] = []
+    seen_attachment_ids: set[str] = set()
+    for message in thread_history:
+        if not _thread_history_message_in_scope(message, thread_id):
+            continue
+        event = _media_event_from_thread_history_message(room_id, message)
+        if event is None:
+            continue
+        attachment_record = await _register_thread_history_media_attachment(
+            client,
+            storage_path,
+            room_id=room_id,
+            thread_id=thread_id,
+            event=event,
+        )
+        if attachment_record is None or attachment_record.attachment_id in seen_attachment_ids:
+            continue
+        seen_attachment_ids.add(attachment_record.attachment_id)
+        attachment_ids.append(attachment_record.attachment_id)
+    return attachment_ids
 
 
 async def resolve_thread_attachment_ids(

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -19,7 +19,20 @@ import nio
 
 from .constants import ATTACHMENT_IDS_KEY
 from .logging_config import get_logger
-from .matrix.media import download_media_bytes, media_mime_type, resolve_image_mime_type
+from .matrix.media import (
+    AudioMessageEvent,
+    FileOrVideoMessageEvent,
+    ImageMessageEvent,
+    download_media_bytes,
+    is_audio_message_event,
+    is_file_or_video_message_event,
+    is_image_message_event,
+    is_matrix_media_dispatch_event,
+    is_video_message_event,
+    media_mime_type,
+    parse_matrix_media_dispatch_event_source,
+    resolve_image_mime_type,
+)
 from .timing import emit_elapsed_timing
 
 if TYPE_CHECKING:
@@ -30,9 +43,6 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _AttachmentKind = Literal["audio", "file", "image", "video"]
-_FileOrVideoEvent = nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo
-_ImageEvent = nio.RoomMessageImage | nio.RoomEncryptedImage
-_AudioEvent = nio.RoomMessageAudio | nio.RoomEncryptedAudio
 _ATTACHMENT_ID_PATTERN = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_-]{0,127}$")
 _ATTACHMENT_RETENTION_DAYS = 30
 _CLEANUP_INTERVAL = timedelta(hours=1)
@@ -442,7 +452,7 @@ def register_local_attachment(
     return record
 
 
-def _filename_for_media_event(event: _FileOrVideoEvent | _ImageEvent | _AudioEvent) -> str | None:
+def _filename_for_media_event(event: FileOrVideoMessageEvent | ImageMessageEvent | AudioMessageEvent) -> str | None:
     """Extract best-effort filename from Matrix media event content."""
     content = event.source.get("content", {})
     filename = content.get("filename")
@@ -492,11 +502,11 @@ async def register_file_or_video_attachment(
     *,
     room_id: str,
     thread_id: str | None,
-    event: _FileOrVideoEvent,
+    event: FileOrVideoMessageEvent,
 ) -> AttachmentRecord | None:
     """Persist a file/video event and register it as an attachment record."""
     media_bytes = await download_media_bytes(client, event)
-    kind: _AttachmentKind = "video" if isinstance(event, nio.RoomMessageVideo | nio.RoomEncryptedVideo) else "file"
+    kind: _AttachmentKind = "video" if is_video_message_event(event) else "file"
     return await _register_media_attachment(
         storage_path=storage_path,
         event_id=event.event_id,
@@ -516,7 +526,7 @@ async def register_image_attachment(
     *,
     room_id: str,
     thread_id: str | None,
-    event: _ImageEvent,
+    event: ImageMessageEvent,
     image_bytes: bytes | None = None,
 ) -> AttachmentRecord | None:
     """Persist an image event and register it as an attachment record."""
@@ -657,39 +667,70 @@ def filter_attachments_for_context(
     return allowed_records, rejected_attachment_ids
 
 
+def _load_existing_context_attachment(
+    storage_path: Path,
+    *,
+    room_id: str,
+    thread_id: str | None,
+    event_id: str,
+) -> AttachmentRecord | None:
+    existing_record = load_attachment(storage_path, _attachment_id_for_event(event_id))
+    if (
+        existing_record is not None
+        and existing_record.room_id == room_id
+        and existing_record.thread_id == thread_id
+        and existing_record.local_path.is_file()
+    ):
+        return existing_record
+    return None
+
+
 def _media_event_from_thread_history_message(
     room_id: str,
     message: ResolvedVisibleMessage,
-) -> _FileOrVideoEvent | _ImageEvent | None:
-    msgtype = message.content.get("msgtype")
-    if msgtype not in {"m.file", "m.image", "m.video"}:
-        return None
-
+) -> FileOrVideoMessageEvent | ImageMessageEvent | None:
     content = {key: value for key, value in message.content.items() if isinstance(key, str)}
-    event_source = {
-        "content": content,
-        "event_id": message.event_id,
-        "origin_server_ts": message.timestamp,
-        "room_id": room_id,
-        "sender": message.sender,
-        "type": "m.room.message",
-    }
-    parsed_event = (
-        nio.RoomMessage.parse_decrypted_event(event_source)
-        if "file" in content
-        else nio.RoomMessage.parse_event(event_source)
+    return parse_matrix_media_dispatch_event_source(
+        {
+            "content": content,
+            "event_id": message.event_id,
+            "origin_server_ts": message.timestamp,
+            "room_id": room_id,
+            "sender": message.sender,
+            "type": "m.room.message",
+        },
     )
-    if isinstance(
-        parsed_event,
-        nio.RoomMessageFile
-        | nio.RoomEncryptedFile
-        | nio.RoomMessageVideo
-        | nio.RoomEncryptedVideo
-        | nio.RoomMessageImage
-        | nio.RoomEncryptedImage,
-    ):
-        return parsed_event
-    return None
+
+
+async def register_matrix_media_attachment(
+    client: nio.AsyncClient,
+    storage_path: Path,
+    *,
+    room_id: str,
+    thread_id: str | None,
+    event: FileOrVideoMessageEvent | ImageMessageEvent,
+    image_bytes: bytes | None = None,
+) -> AttachmentRecord | None:
+    """Persist an image/file/video Matrix event and register an attachment record."""
+    if is_image_message_event(event):
+        return await register_image_attachment(
+            client,
+            storage_path,
+            room_id=room_id,
+            thread_id=thread_id,
+            event=event,
+            image_bytes=image_bytes,
+        )
+    if is_file_or_video_message_event(event):
+        return await register_file_or_video_attachment(
+            client,
+            storage_path,
+            room_id=room_id,
+            thread_id=thread_id,
+            event=event,
+        )
+    msg = f"Expected image, file, or video event, got {type(event).__name__}"
+    raise TypeError(msg)
 
 
 async def _register_thread_history_media_attachment(
@@ -698,28 +739,18 @@ async def _register_thread_history_media_attachment(
     *,
     room_id: str,
     thread_id: str | None,
-    event: _FileOrVideoEvent | _ImageEvent,
+    event: FileOrVideoMessageEvent | ImageMessageEvent,
 ) -> AttachmentRecord | None:
-    attachment_id = _attachment_id_for_event(event.event_id)
-    existing_record = load_attachment(storage_path, attachment_id)
-    if (
-        existing_record is not None
-        and existing_record.room_id == room_id
-        and existing_record.thread_id == thread_id
-        and existing_record.local_path.is_file()
-    ):
+    existing_record = _load_existing_context_attachment(
+        storage_path,
+        room_id=room_id,
+        thread_id=thread_id,
+        event_id=event.event_id,
+    )
+    if existing_record is not None:
         return existing_record
 
-    if isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage):
-        return await register_image_attachment(
-            client,
-            storage_path,
-            room_id=room_id,
-            thread_id=thread_id,
-            event=event,
-        )
-
-    return await register_file_or_video_attachment(
+    return await register_matrix_media_attachment(
         client,
         storage_path,
         room_id=room_id,
@@ -802,49 +833,31 @@ async def resolve_thread_attachment_ids(
     # Check for an existing attachment record for any media root (file, video,
     # image, or audio). Audio roots are registered by the voice handler and
     # can be looked up but not re-downloaded here.
-    is_file_or_video = isinstance(
-        event,
-        nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo,
-    )
-    is_image = isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
-    is_audio = isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio)
-    if not is_file_or_video and not is_image and not is_audio:
+    if not is_matrix_media_dispatch_event(event) and not is_audio_message_event(event):
         return finish([], "not_media_root")
 
-    existing_attachment_id = _attachment_id_for_event(event.event_id)
-    existing_record = load_attachment(storage_path, existing_attachment_id)
-    if (
-        existing_record is not None
-        and existing_record.room_id == room_id
-        and existing_record.thread_id == thread_id
-        and existing_record.local_path.is_file()
-    ):
+    existing_record = _load_existing_context_attachment(
+        storage_path,
+        room_id=room_id,
+        thread_id=thread_id,
+        event_id=event.event_id,
+    )
+    if existing_record is not None:
         return finish([existing_record.attachment_id], "existing_record")
 
-    record: AttachmentRecord | None = None
-    if is_file_or_video:
-        assert isinstance(
-            event,
-            nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo,
-        )
-        record = await register_file_or_video_attachment(
-            client,
-            storage_path,
-            room_id=room_id,
-            thread_id=thread_id,
-            event=event,
-        )
-    elif is_image:
-        assert isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
-        record = await register_image_attachment(
-            client,
-            storage_path,
-            room_id=room_id,
-            thread_id=thread_id,
-            event=event,
-        )
     # Audio roots cannot be re-registered here (the voice handler owns that
-    # lifecycle), so ``record`` stays ``None``.
+    # lifecycle), so only existing audio records are returned above.
+    record = (
+        await register_matrix_media_attachment(
+            client,
+            storage_path,
+            room_id=room_id,
+            thread_id=thread_id,
+            event=event,
+        )
+        if is_matrix_media_dispatch_event(event)
+        else None
+    )
     if record is None:
         return finish([], "no_record")
     return finish([record.attachment_id], "registered_record")

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -38,6 +38,7 @@ from mindroom.matrix.conversation_cache import MatrixConversationCache
 from mindroom.matrix.event_info import origin_server_ts_from_event_source
 from mindroom.matrix.health import clear_matrix_sync_state, mark_matrix_sync_loop_started, mark_matrix_sync_success
 from mindroom.matrix.identity import MatrixID, extract_agent_name, is_agent_id
+from mindroom.matrix.media import MATRIX_MEDIA_EVENT_TYPES
 from mindroom.matrix.presence import build_agent_status_message, set_presence_status
 from mindroom.matrix.room_cleanup import cleanup_all_orphaned_bots
 from mindroom.matrix.rooms import leave_non_dm_rooms, resolve_room_aliases
@@ -1136,16 +1137,7 @@ class AgentBot:
 
             # Register media callbacks on all agents (each agent handles its own routing)
             media_callback = _create_task_wrapper(self._on_media_message, owner=self._runtime_view)
-            for event_type in (
-                nio.RoomMessageImage,
-                nio.RoomEncryptedImage,
-                nio.RoomMessageFile,
-                nio.RoomEncryptedFile,
-                nio.RoomMessageVideo,
-                nio.RoomEncryptedVideo,
-                nio.RoomMessageAudio,
-                nio.RoomEncryptedAudio,
-            ):
+            for event_type in MATRIX_MEDIA_EVENT_TYPES:
                 client.add_event_callback(media_callback, event_type)
             client.add_event_callback(
                 _create_task_wrapper(self._on_unknown_event, owner=self._runtime_view),

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -109,6 +109,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.matrix.cache import AgentMessageSnapshot, ConversationEventCache, EventCacheWriteCoordinator
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
+    from mindroom.matrix.media import MatrixMediaDispatchEvent
     from mindroom.runtime_protocols import OrchestratorRuntime
     from mindroom.runtime_support import StartupThreadPrewarmRegistry
     from mindroom.tool_system.events import ToolTraceEntry
@@ -230,15 +231,6 @@ def create_bot_for_entity(
     msg = f"Entity '{entity_name}' not found in configuration."
     raise ValueError(msg)
 
-
-type _MediaDispatchEvent = (
-    nio.RoomMessageImage
-    | nio.RoomEncryptedImage
-    | nio.RoomMessageFile
-    | nio.RoomEncryptedFile
-    | nio.RoomMessageVideo
-    | nio.RoomEncryptedVideo
-)
 
 type _MessageContext = MessageContext
 
@@ -1353,7 +1345,7 @@ class AgentBot:
     def _log_matrix_event_callback_started(
         self,
         room: nio.MatrixRoom,
-        event: nio.RoomMessageText | _MediaDispatchEvent,
+        event: nio.RoomMessageText | MatrixMediaDispatchEvent,
         *,
         callback_name: str,
     ) -> None:
@@ -1501,7 +1493,7 @@ class AgentBot:
     async def _on_media_message(
         self,
         room: nio.MatrixRoom,
-        event: _MediaDispatchEvent,
+        event: MatrixMediaDispatchEvent,
     ) -> None:
         """Delegate one inbound media event to the turn engine."""
         self._log_matrix_event_callback_started(room, event, callback_name="media")

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -110,7 +110,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.matrix.cache import AgentMessageSnapshot, ConversationEventCache, EventCacheWriteCoordinator
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
-    from mindroom.matrix.media import MatrixMediaDispatchEvent
+    from mindroom.matrix.media import MatrixMediaEvent
     from mindroom.runtime_protocols import OrchestratorRuntime
     from mindroom.runtime_support import StartupThreadPrewarmRegistry
     from mindroom.tool_system.events import ToolTraceEntry
@@ -1337,7 +1337,7 @@ class AgentBot:
     def _log_matrix_event_callback_started(
         self,
         room: nio.MatrixRoom,
-        event: nio.RoomMessageText | MatrixMediaDispatchEvent,
+        event: nio.RoomMessageText | MatrixMediaEvent,
         *,
         callback_name: str,
     ) -> None:
@@ -1485,7 +1485,7 @@ class AgentBot:
     async def _on_media_message(
         self,
         room: nio.MatrixRoom,
-        event: MatrixMediaDispatchEvent,
+        event: MatrixMediaEvent,
     ) -> None:
         """Delegate one inbound media event to the turn engine."""
         self._log_matrix_event_callback_started(room, event, callback_name="media")

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -16,6 +16,7 @@ from mindroom.dispatch_handoff import DispatchEvent, DispatchPayloadMetadata, Pr
 from mindroom.matrix.client_delivery import cached_room as matrix_cached_room
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.identity import MatrixID, extract_agent_name
+from mindroom.matrix.media import is_audio_message_event, is_image_message_event
 from mindroom.matrix.message_content import resolve_event_source_content
 from mindroom.matrix.thread_membership import (
     ThreadMembershipAccess,
@@ -153,9 +154,9 @@ class ConversationResolver:
             if isinstance(source_kind_override, str) and source_kind_override and source_kind_sender_is_trusted:
                 resolved_source_kind = source_kind_override
         if resolved_source_kind is None:
-            if isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio):
+            if is_audio_message_event(event):
                 resolved_source_kind = "voice"
-            elif isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage):
+            elif is_image_message_event(event):
                 resolved_source_kind = "image"
             else:
                 resolved_source_kind = "message"

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -16,7 +16,7 @@ from mindroom.dispatch_handoff import DispatchEvent, DispatchPayloadMetadata, Pr
 from mindroom.matrix.client_delivery import cached_room as matrix_cached_room
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.identity import MatrixID, extract_agent_name
-from mindroom.matrix.media import is_audio_message_event, is_image_message_event
+from mindroom.matrix.media import MatrixMediaEvent, is_audio_message_event, is_image_message_event
 from mindroom.matrix.message_content import resolve_event_source_content
 from mindroom.matrix.thread_membership import (
     ThreadMembershipAccess,
@@ -324,7 +324,7 @@ class ConversationResolver:
     async def coalescing_thread_id(
         self,
         room: nio.MatrixRoom,
-        event: DispatchEvent,
+        event: DispatchEvent | MatrixMediaEvent,
     ) -> str | None:
         """Return the coalescing thread scope for one inbound event."""
         config = self.deps.runtime.config

--- a/src/mindroom/dispatch_handoff.py
+++ b/src/mindroom/dispatch_handoff.py
@@ -14,7 +14,15 @@ from mindroom.constants import (
     ORIGINAL_SENDER_KEY,
     VOICE_RAW_AUDIO_FALLBACK_KEY,
 )
-from mindroom.matrix.media import extract_media_caption
+from mindroom.matrix.media import (
+    MatrixMediaDispatchEvent,
+    extract_media_caption,
+    is_audio_message_event,
+    is_file_message_event,
+    is_image_message_event,
+    is_matrix_media_dispatch_event,
+    is_video_message_event,
+)
 from mindroom.matrix.message_content import is_v2_sidecar_text_preview
 
 if TYPE_CHECKING:
@@ -42,16 +50,9 @@ class PreparedTextEvent:
     source_kind_override: str | None = None
 
 
-type MediaDispatchEvent = (
-    # Voice messages are normalized into PreparedTextEvent before coalescing,
-    # so this contract only includes routed image/file/video events.
-    nio.RoomMessageImage
-    | nio.RoomEncryptedImage
-    | nio.RoomMessageFile
-    | nio.RoomEncryptedFile
-    | nio.RoomMessageVideo
-    | nio.RoomEncryptedVideo
-)
+# Voice messages are normalized into PreparedTextEvent before coalescing, so
+# this contract only includes routed image/file/video events.
+type MediaDispatchEvent = MatrixMediaDispatchEvent
 type TextDispatchEvent = nio.RoomMessageText | PreparedTextEvent
 type DispatchEvent = TextDispatchEvent | MediaDispatchEvent
 
@@ -115,27 +116,19 @@ def _event_content_dict(event: DispatchEvent) -> dict[str, object] | None:
 
 def is_media_dispatch_event(event: DispatchEvent) -> TypeGuard[MediaDispatchEvent]:
     """Return whether one dispatch event is image, file, or video media."""
-    return isinstance(
-        event,
-        nio.RoomMessageImage
-        | nio.RoomEncryptedImage
-        | nio.RoomMessageFile
-        | nio.RoomEncryptedFile
-        | nio.RoomMessageVideo
-        | nio.RoomEncryptedVideo,
-    )
+    return is_matrix_media_dispatch_event(event)
 
 
 def dispatch_prompt_for_event(event: DispatchEvent) -> str:
     """Return the prompt text contributed by one dispatch event."""
-    if isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio):
+    if is_audio_message_event(event):
         msg = "Raw audio must be normalized into PreparedTextEvent before coalescing"
         raise TypeError(msg)
-    if isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage):
+    if is_image_message_event(event):
         return extract_media_caption(event, default="[Attached image]")
-    if isinstance(event, nio.RoomMessageVideo | nio.RoomEncryptedVideo):
+    if is_video_message_event(event):
         return extract_media_caption(event, default="[Attached video]")
-    if isinstance(event, nio.RoomMessageFile | nio.RoomEncryptedFile):
+    if is_file_message_event(event):
         return extract_media_caption(event, default="[Attached file]")
     return event.body
 

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -7,14 +7,11 @@ from collections.abc import Sequence  # noqa: TC003
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-import nio
-
 from mindroom.attachment_media import resolve_attachment_media
 from mindroom.attachments import (
     merge_attachment_ids,
     parse_attachment_ids_from_thread_history,
-    register_file_or_video_attachment,
-    register_image_attachment,
+    register_matrix_media_attachment,
     register_thread_history_media_attachments,
     resolve_thread_attachment_ids,
 )
@@ -23,6 +20,14 @@ from mindroom.logging_config import bound_log_context
 from mindroom.matrix.client_visible_messages import resolve_visible_event_source
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.image_handler import download_image
+from mindroom.matrix.media import (
+    AudioMessageEvent,
+    FileMessageEvent,
+    FileOrVideoMessageEvent,
+    is_file_or_video_message_event,
+    is_image_message_event,
+    is_matrix_media_dispatch_event,
+)
 from mindroom.matrix.message_content import is_v2_sidecar_text_preview
 from mindroom.media_inputs import MediaInputs
 from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
@@ -32,6 +37,7 @@ from mindroom.voice_handler import prepare_voice_message
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import nio
     import structlog
     from agno.media import Image
 
@@ -52,7 +58,7 @@ class VoiceNormalizationRequest:
     """One inbound audio event to normalize into a text dispatch event."""
 
     room: nio.MatrixRoom
-    event: nio.RoomMessageAudio | nio.RoomEncryptedAudio
+    event: AudioMessageEvent
 
 
 @dataclass(frozen=True)
@@ -200,7 +206,7 @@ class InboundTurnNormalizer:
 
     async def prepare_file_sidecar_text_event(
         self,
-        event: nio.RoomMessageFile | nio.RoomEncryptedFile,
+        event: FileMessageEvent,
     ) -> PreparedTextEvent | None:
         """Return a prepared text event when a file event is really a long-text preview."""
         if not is_v2_sidecar_text_preview(event.source):
@@ -229,43 +235,22 @@ class InboundTurnNormalizer:
         event: nio.RoomMessageText | PreparedTextEvent | MediaDispatchEvent,
     ) -> str | None:
         """Register a routed media event and return its attachment ID when available."""
-        client = self._client()
-        if isinstance(
-            event,
-            nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo,
-        ):
-            attachment_record = await register_file_or_video_attachment(
-                client,
-                self.deps.storage_path,
-                room_id=room_id,
-                thread_id=thread_id,
-                event=event,
+        if not is_matrix_media_dispatch_event(event):
+            return None
+        attachment_record = await register_matrix_media_attachment(
+            self._client(),
+            self.deps.storage_path,
+            room_id=room_id,
+            thread_id=thread_id,
+            event=event,
+        )
+        if attachment_record is None:
+            self.deps.logger.error(
+                "Failed to register routed media attachment",
+                event_id=event.event_id,
             )
-            if attachment_record is None:
-                self.deps.logger.error(
-                    "Failed to register routed media attachment",
-                    event_id=event.event_id,
-                )
-                return None
-            return attachment_record.attachment_id
-
-        if isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage):
-            attachment_record = await register_image_attachment(
-                client,
-                self.deps.storage_path,
-                room_id=room_id,
-                thread_id=thread_id,
-                event=event,
-            )
-            if attachment_record is None:
-                self.deps.logger.error(
-                    "Failed to register routed image attachment",
-                    event_id=event.event_id,
-                )
-                return None
-            return attachment_record.attachment_id
-
-        return None
+            return None
+        return attachment_record.attachment_id
 
     async def register_batch_media_attachments(
         self,
@@ -301,13 +286,13 @@ class InboundTurnNormalizer:
 
             client = self._client()
             for media_event in request.media_events:
-                if isinstance(media_event, nio.RoomMessageImage | nio.RoomEncryptedImage):
+                if is_image_message_event(media_event):
                     image_event_count += 1
                     image = await download_image(client, media_event)
                     if image is None:
                         msg = "Failed to download image"
                         raise RuntimeError(msg)
-                    attachment_record = await register_image_attachment(
+                    attachment_record = await register_matrix_media_attachment(
                         client,
                         self.deps.storage_path,
                         room_id=request.room_id,
@@ -322,7 +307,7 @@ class InboundTurnNormalizer:
                     continue
 
                 file_or_video_event_count += 1
-                attachment_record = await register_file_or_video_attachment(
+                attachment_record = await register_matrix_media_attachment(
                     client,
                     self.deps.storage_path,
                     room_id=request.room_id,
@@ -406,12 +391,9 @@ class InboundTurnNormalizer:
     @staticmethod
     def _as_file_or_video_dispatch_event(
         event: MediaDispatchEvent,
-    ) -> nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo:
+    ) -> FileOrVideoMessageEvent:
         """Narrow a media dispatch event to the file/video subset used for attachment registration."""
-        if isinstance(
-            event,
-            nio.RoomMessageFile | nio.RoomEncryptedFile | nio.RoomMessageVideo | nio.RoomEncryptedVideo,
-        ):
+        if is_file_or_video_message_event(event):
             return event
         msg = f"Expected file or video event, got {type(event).__name__}"
         raise TypeError(msg)

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -15,6 +15,7 @@ from mindroom.attachments import (
     parse_attachment_ids_from_thread_history,
     register_file_or_video_attachment,
     register_image_attachment,
+    register_thread_history_media_attachments,
     resolve_thread_attachment_ids,
 )
 from mindroom.dispatch_handoff import MediaDispatchEvent, PreparedTextEvent
@@ -357,10 +358,18 @@ class InboundTurnNormalizer:
             else []
         )
         history_attachment_ids = parse_attachment_ids_from_thread_history(request.thread_history)
+        history_media_attachment_ids = await register_thread_history_media_attachments(
+            self._client(),
+            self.deps.storage_path,
+            room_id=request.room_id,
+            thread_id=request.media_thread_id,
+            thread_history=request.thread_history,
+        )
         attachment_ids = merge_attachment_ids(
             request.current_attachment_ids,
             thread_attachment_ids,
             history_attachment_ids,
+            history_media_attachment_ids,
         )
         resolved_attachment_ids, attachment_audio, attachment_images, attachment_files, attachment_videos = (
             resolve_attachment_media(

--- a/src/mindroom/matrix/image_handler.py
+++ b/src/mindroom/matrix/image_handler.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from agno.media import Image
 
 from mindroom.logging_config import get_logger
-from mindroom.matrix.media import download_media_bytes, media_mime_type, resolve_image_mime_type
+from mindroom.matrix.media import ImageMessageEvent, download_media_bytes, media_mime_type, resolve_image_mime_type
 
 if TYPE_CHECKING:
     import nio
@@ -17,7 +17,7 @@ logger = get_logger(__name__)
 
 async def download_image(
     client: nio.AsyncClient,
-    event: nio.RoomMessageImage | nio.RoomEncryptedImage,
+    event: ImageMessageEvent,
 ) -> Image | None:
     """Download image from Matrix, returning an agno Image or None.
 

--- a/src/mindroom/matrix/media.py
+++ b/src/mindroom/matrix/media.py
@@ -21,6 +21,14 @@ type FileOrVideoMessageEvent = FileMessageEvent | VideoMessageEvent
 type AudioMessageEvent = nio.RoomMessageAudio | nio.RoomEncryptedAudio
 type MatrixMediaDispatchEvent = ImageMessageEvent | FileOrVideoMessageEvent
 
+IMAGE_MESSAGE_EVENT_TYPES = (nio.RoomMessageImage, nio.RoomEncryptedImage)
+FILE_MESSAGE_EVENT_TYPES = (nio.RoomMessageFile, nio.RoomEncryptedFile)
+VIDEO_MESSAGE_EVENT_TYPES = (nio.RoomMessageVideo, nio.RoomEncryptedVideo)
+FILE_OR_VIDEO_MESSAGE_EVENT_TYPES = (*FILE_MESSAGE_EVENT_TYPES, *VIDEO_MESSAGE_EVENT_TYPES)
+AUDIO_MESSAGE_EVENT_TYPES = (nio.RoomMessageAudio, nio.RoomEncryptedAudio)
+MATRIX_MEDIA_DISPATCH_EVENT_TYPES = (*IMAGE_MESSAGE_EVENT_TYPES, *FILE_OR_VIDEO_MESSAGE_EVENT_TYPES)
+MATRIX_MEDIA_EVENT_TYPES = (*MATRIX_MEDIA_DISPATCH_EVENT_TYPES, *AUDIO_MESSAGE_EVENT_TYPES)
+
 
 @dataclass(frozen=True)
 class _ImageMimeResolution:
@@ -34,17 +42,17 @@ class _ImageMimeResolution:
 
 def is_image_message_event(event: object) -> TypeGuard[ImageMessageEvent]:
     """Return whether *event* is a Matrix image message."""
-    return isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
+    return isinstance(event, IMAGE_MESSAGE_EVENT_TYPES)
 
 
 def is_file_message_event(event: object) -> TypeGuard[FileMessageEvent]:
     """Return whether *event* is a Matrix file message."""
-    return isinstance(event, nio.RoomMessageFile | nio.RoomEncryptedFile)
+    return isinstance(event, FILE_MESSAGE_EVENT_TYPES)
 
 
 def is_video_message_event(event: object) -> TypeGuard[VideoMessageEvent]:
     """Return whether *event* is a Matrix video message."""
-    return isinstance(event, nio.RoomMessageVideo | nio.RoomEncryptedVideo)
+    return isinstance(event, VIDEO_MESSAGE_EVENT_TYPES)
 
 
 def is_file_or_video_message_event(event: object) -> TypeGuard[FileOrVideoMessageEvent]:
@@ -54,7 +62,7 @@ def is_file_or_video_message_event(event: object) -> TypeGuard[FileOrVideoMessag
 
 def is_audio_message_event(event: object) -> TypeGuard[AudioMessageEvent]:
     """Return whether *event* is a Matrix audio message."""
-    return isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio)
+    return isinstance(event, AUDIO_MESSAGE_EVENT_TYPES)
 
 
 def is_matrix_media_dispatch_event(event: object) -> TypeGuard[MatrixMediaDispatchEvent]:

--- a/src/mindroom/matrix/media.py
+++ b/src/mindroom/matrix/media.py
@@ -71,11 +71,6 @@ def is_matrix_media_dispatch_event(event: object) -> TypeGuard[MatrixMediaDispat
     return is_image_message_event(event) or is_file_or_video_message_event(event)
 
 
-def is_matrix_media_event(event: object) -> TypeGuard[MatrixMediaEvent]:
-    """Return whether *event* is image, file, video, or audio media."""
-    return isinstance(event, MATRIX_MEDIA_EVENT_TYPES)
-
-
 def parse_matrix_media_dispatch_event_source(
     event_source: Mapping[str, Any],
 ) -> MatrixMediaDispatchEvent | None:

--- a/src/mindroom/matrix/media.py
+++ b/src/mindroom/matrix/media.py
@@ -20,6 +20,7 @@ type VideoMessageEvent = nio.RoomMessageVideo | nio.RoomEncryptedVideo
 type FileOrVideoMessageEvent = FileMessageEvent | VideoMessageEvent
 type AudioMessageEvent = nio.RoomMessageAudio | nio.RoomEncryptedAudio
 type MatrixMediaDispatchEvent = ImageMessageEvent | FileOrVideoMessageEvent
+type MatrixMediaEvent = MatrixMediaDispatchEvent | AudioMessageEvent
 
 IMAGE_MESSAGE_EVENT_TYPES = (nio.RoomMessageImage, nio.RoomEncryptedImage)
 FILE_MESSAGE_EVENT_TYPES = (nio.RoomMessageFile, nio.RoomEncryptedFile)
@@ -68,6 +69,11 @@ def is_audio_message_event(event: object) -> TypeGuard[AudioMessageEvent]:
 def is_matrix_media_dispatch_event(event: object) -> TypeGuard[MatrixMediaDispatchEvent]:
     """Return whether *event* is image, file, or video media."""
     return is_image_message_event(event) or is_file_or_video_message_event(event)
+
+
+def is_matrix_media_event(event: object) -> TypeGuard[MatrixMediaEvent]:
+    """Return whether *event* is image, file, video, or audio media."""
+    return isinstance(event, MATRIX_MEDIA_EVENT_TYPES)
 
 
 def parse_matrix_media_dispatch_event_source(

--- a/src/mindroom/matrix/media.py
+++ b/src/mindroom/matrix/media.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Any, TypeGuard
 
 import nio
 from nio import crypto
@@ -10,6 +12,14 @@ from nio import crypto
 from mindroom.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+
+type ImageMessageEvent = nio.RoomMessageImage | nio.RoomEncryptedImage
+type FileMessageEvent = nio.RoomMessageFile | nio.RoomEncryptedFile
+type VideoMessageEvent = nio.RoomMessageVideo | nio.RoomEncryptedVideo
+type FileOrVideoMessageEvent = FileMessageEvent | VideoMessageEvent
+type AudioMessageEvent = nio.RoomMessageAudio | nio.RoomEncryptedAudio
+type MatrixMediaDispatchEvent = ImageMessageEvent | FileOrVideoMessageEvent
 
 
 @dataclass(frozen=True)
@@ -20,6 +30,53 @@ class _ImageMimeResolution:
     declared_mime_type: str | None
     detected_mime_type: str | None
     is_mismatch: bool
+
+
+def is_image_message_event(event: object) -> TypeGuard[ImageMessageEvent]:
+    """Return whether *event* is a Matrix image message."""
+    return isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage)
+
+
+def is_file_message_event(event: object) -> TypeGuard[FileMessageEvent]:
+    """Return whether *event* is a Matrix file message."""
+    return isinstance(event, nio.RoomMessageFile | nio.RoomEncryptedFile)
+
+
+def is_video_message_event(event: object) -> TypeGuard[VideoMessageEvent]:
+    """Return whether *event* is a Matrix video message."""
+    return isinstance(event, nio.RoomMessageVideo | nio.RoomEncryptedVideo)
+
+
+def is_file_or_video_message_event(event: object) -> TypeGuard[FileOrVideoMessageEvent]:
+    """Return whether *event* is a Matrix file or video message."""
+    return is_file_message_event(event) or is_video_message_event(event)
+
+
+def is_audio_message_event(event: object) -> TypeGuard[AudioMessageEvent]:
+    """Return whether *event* is a Matrix audio message."""
+    return isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio)
+
+
+def is_matrix_media_dispatch_event(event: object) -> TypeGuard[MatrixMediaDispatchEvent]:
+    """Return whether *event* is image, file, or video media."""
+    return is_image_message_event(event) or is_file_or_video_message_event(event)
+
+
+def parse_matrix_media_dispatch_event_source(
+    event_source: Mapping[str, Any],
+) -> MatrixMediaDispatchEvent | None:
+    """Parse one Matrix event source into image/file/video media when possible."""
+    normalized_source = {key: value for key, value in event_source.items() if isinstance(key, str)}
+    content = normalized_source.get("content")
+    try:
+        parsed_event = (
+            nio.RoomMessage.parse_decrypted_event(normalized_source)
+            if isinstance(content, Mapping) and "file" in content
+            else nio.RoomMessage.parse_event(normalized_source)
+        )
+    except Exception:
+        return None
+    return parsed_event if is_matrix_media_dispatch_event(parsed_event) else None
 
 
 def _event_id_for_log(event: nio.RoomMessageMedia | nio.RoomEncryptedMedia) -> str | None:

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -68,6 +68,7 @@ from mindroom.matrix.identity import extract_agent_name, is_agent_id
 from mindroom.matrix.media import (
     AudioMessageEvent,
     FileMessageEvent,
+    MatrixMediaEvent,
     is_audio_message_event,
     is_file_message_event,
     is_image_message_event,
@@ -116,7 +117,7 @@ if TYPE_CHECKING:
 type DispatchPayloadBuilder = Callable[[MessageContext], Awaitable[DispatchPayload]]
 
 type _MediaDispatchEvent = MediaDispatchEvent
-type _InboundMediaEvent = _MediaDispatchEvent | AudioMessageEvent
+type _InboundMediaEvent = MatrixMediaEvent
 type _TextDispatchEvent = TextDispatchEvent
 type _DispatchEvent = DispatchEvent
 
@@ -172,7 +173,7 @@ class _PrecheckedEvent[T]:
 
 
 type _PrecheckedTextDispatchEvent = _PrecheckedEvent[_TextDispatchEvent]
-type _PrecheckedMediaDispatchEvent = _PrecheckedEvent[_MediaDispatchEvent]
+type _PrecheckedInboundMediaEvent = _PrecheckedEvent[_InboundMediaEvent]
 
 
 @dataclass(frozen=True)
@@ -325,7 +326,7 @@ class TurnController:
 
         return requester_user_id
 
-    def _precheck_dispatch_event[T: _DispatchEvent](
+    def _precheck_dispatch_event[T: _DispatchEvent | _InboundMediaEvent](
         self,
         room: nio.MatrixRoom,
         event: T,
@@ -1842,7 +1843,7 @@ class TurnController:
     async def handle_media_event(
         self,
         room: nio.MatrixRoom,
-        event: _MediaDispatchEvent,
+        event: _InboundMediaEvent,
     ) -> None:
         """Handle one inbound media event."""
         async with self.deps.resolver.turn_thread_cache_scope():
@@ -1851,7 +1852,7 @@ class TurnController:
     async def _handle_media_message_inner(
         self,
         room: nio.MatrixRoom,
-        event: _MediaDispatchEvent,
+        event: _InboundMediaEvent,
     ) -> None:
         """Handle one media event inside the per-turn conversation lookup scope."""
         prechecked_event = self._precheck_dispatch_event(room, event)
@@ -1874,6 +1875,8 @@ class TurnController:
 
         if await self._dispatch_special_media_as_text(room, prechecked_event):
             return
+        if not is_matrix_media_dispatch_event(prechecked_event.event):
+            return
         await self._enqueue_media_for_dispatch(
             room=room,
             event=prechecked_event.event,
@@ -1885,7 +1888,7 @@ class TurnController:
     async def _dispatch_special_media_as_text(
         self,
         room: nio.MatrixRoom,
-        prechecked_event: _PrecheckedMediaDispatchEvent,
+        prechecked_event: _PrecheckedInboundMediaEvent,
     ) -> bool:
         """Handle media events that normalize into the text dispatch pipeline."""
         event = prechecked_event.event

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -65,6 +65,13 @@ from mindroom.logging_config import bound_log_context
 from mindroom.matrix.cache import ThreadHistoryResult
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.identity import extract_agent_name, is_agent_id
+from mindroom.matrix.media import (
+    AudioMessageEvent,
+    FileMessageEvent,
+    is_audio_message_event,
+    is_file_message_event,
+    is_image_message_event,
+)
 from mindroom.matrix.message_content import is_v2_sidecar_text_preview
 from mindroom.matrix.rooms import is_dm_room
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest
@@ -108,7 +115,7 @@ if TYPE_CHECKING:
 type DispatchPayloadBuilder = Callable[[MessageContext], Awaitable[DispatchPayload]]
 
 type _MediaDispatchEvent = MediaDispatchEvent
-type _InboundMediaEvent = _MediaDispatchEvent | nio.RoomMessageAudio | nio.RoomEncryptedAudio
+type _InboundMediaEvent = _MediaDispatchEvent | AudioMessageEvent
 type _TextDispatchEvent = TextDispatchEvent
 type _DispatchEvent = DispatchEvent
 
@@ -518,7 +525,7 @@ class TurnController:
         dispatch_timing: DispatchPipelineTiming | None,
     ) -> None:
         """Queue one media event with the same active-follow-up policy as text."""
-        source_kind = "image" if isinstance(event, nio.RoomMessageImage | nio.RoomEncryptedImage) else "media"
+        source_kind = "image" if is_image_message_event(event) else "media"
         target = self.deps.resolver.build_message_target(
             room_id=room.room_id,
             thread_id=coalescing_thread_id,
@@ -715,7 +722,7 @@ class TurnController:
     async def _maybe_send_visible_voice_echo(
         self,
         room: nio.MatrixRoom,
-        event: nio.RoomMessageAudio | nio.RoomEncryptedAudio,
+        event: AudioMessageEvent,
         *,
         text: str,
         thread_id: str | None,
@@ -1897,7 +1904,7 @@ class TurnController:
     ) -> bool:
         """Handle media events that normalize into the text dispatch pipeline."""
         event = prechecked_event.event
-        if isinstance(event, nio.RoomMessageAudio | nio.RoomEncryptedAudio):
+        if is_audio_message_event(event):
             await self._on_audio_media_message(
                 room,
                 _PrecheckedEvent(
@@ -1906,7 +1913,7 @@ class TurnController:
                 ),
             )
             return True
-        if isinstance(event, nio.RoomMessageFile | nio.RoomEncryptedFile):
+        if is_file_message_event(event):
             return await self._dispatch_file_sidecar_text_preview(
                 room,
                 _PrecheckedEvent(
@@ -1919,7 +1926,7 @@ class TurnController:
     async def _on_audio_media_message(
         self,
         room: nio.MatrixRoom,
-        prechecked_event: _PrecheckedEvent[nio.RoomMessageAudio | nio.RoomEncryptedAudio],
+        prechecked_event: _PrecheckedEvent[AudioMessageEvent],
     ) -> None:
         """Normalize audio into a synthetic text event and reuse text dispatch."""
         event = prechecked_event.event
@@ -1980,7 +1987,7 @@ class TurnController:
     async def _dispatch_file_sidecar_text_preview(
         self,
         room: nio.MatrixRoom,
-        prechecked_event: _PrecheckedEvent[nio.RoomMessageFile | nio.RoomEncryptedFile],
+        prechecked_event: _PrecheckedEvent[FileMessageEvent],
     ) -> bool:
         """Dispatch one sidecar-backed file preview through the normal text pipeline."""
         event = prechecked_event.event

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -116,11 +116,6 @@ if TYPE_CHECKING:
 
 type DispatchPayloadBuilder = Callable[[MessageContext], Awaitable[DispatchPayload]]
 
-type _MediaDispatchEvent = MediaDispatchEvent
-type _InboundMediaEvent = MatrixMediaEvent
-type _TextDispatchEvent = TextDispatchEvent
-type _DispatchEvent = DispatchEvent
-
 _QUEUED_NOTICE_METADATA_KIND = "queued_notice_reservation"
 
 
@@ -172,8 +167,8 @@ class _PrecheckedEvent[T]:
     requester_user_id: str
 
 
-type _PrecheckedTextDispatchEvent = _PrecheckedEvent[_TextDispatchEvent]
-type _PrecheckedInboundMediaEvent = _PrecheckedEvent[_InboundMediaEvent]
+type _PrecheckedTextDispatchEvent = _PrecheckedEvent[TextDispatchEvent]
+type _PrecheckedInboundMediaEvent = _PrecheckedEvent[MatrixMediaEvent]
 
 
 @dataclass(frozen=True)
@@ -237,11 +232,11 @@ class TurnController:
         """Return whether one sender may supply trusted ingress metadata overrides."""
         return extract_agent_name(sender_id, self.deps.runtime.config, self.deps.runtime_paths) is not None
 
-    def _should_trust_internal_payload_metadata(self, event: _DispatchEvent) -> bool:
+    def _should_trust_internal_payload_metadata(self, event: DispatchEvent) -> bool:
         """Return whether internal payload keys on one event should be treated as authoritative."""
         return self._sender_is_trusted_for_ingress_metadata(event.sender)
 
-    def _is_trusted_internal_relay_event(self, event: _DispatchEvent) -> bool:
+    def _is_trusted_internal_relay_event(self, event: DispatchEvent) -> bool:
         """Return whether one agent-authored relay should bypass user-turn coalescing."""
         if not isinstance(event, nio.RoomMessageText | PreparedTextEvent):
             return False
@@ -259,7 +254,7 @@ class TurnController:
         original_sender = content.get(ORIGINAL_SENDER_KEY)
         return isinstance(original_sender, str) and bool(original_sender)
 
-    def _is_trusted_router_relay_event(self, event: _DispatchEvent) -> bool:
+    def _is_trusted_router_relay_event(self, event: DispatchEvent) -> bool:
         """Return whether one trusted internal relay originated from the router."""
         if not self._is_trusted_internal_relay_event(event):
             return False
@@ -272,7 +267,7 @@ class TurnController:
 
     def _should_use_trusted_router_relay_context(
         self,
-        event: _DispatchEvent,
+        event: DispatchEvent,
         *,
         ingress_metadata: DispatchIngressMetadata | None,
         payload_metadata: DispatchPayloadMetadata | None,
@@ -292,7 +287,7 @@ class TurnController:
     def _precheck_event(
         self,
         room: nio.MatrixRoom,
-        event: _DispatchEvent | _InboundMediaEvent,
+        event: DispatchEvent | MatrixMediaEvent,
         *,
         is_edit: bool = False,
     ) -> str | None:
@@ -326,7 +321,7 @@ class TurnController:
 
         return requester_user_id
 
-    def _precheck_dispatch_event[T: _DispatchEvent | _InboundMediaEvent](
+    def _precheck_dispatch_event[T: DispatchEvent | MatrixMediaEvent](
         self,
         room: nio.MatrixRoom,
         event: T,
@@ -345,7 +340,7 @@ class TurnController:
 
     def _has_newer_unresponded_in_thread(
         self,
-        event: _TextDispatchEvent,
+        event: TextDispatchEvent,
         requester_user_id: str,
         thread_history: Sequence[ResolvedVisibleMessage],
         *,
@@ -430,7 +425,7 @@ class TurnController:
         self,
         *,
         room: nio.MatrixRoom,
-        event: _DispatchEvent,
+        event: DispatchEvent,
         target: MessageTarget,
         envelope: MessageEnvelope,
         coalescing_thread_id: str | None,
@@ -475,7 +470,7 @@ class TurnController:
         *,
         room: nio.MatrixRoom,
         prepared_event: PreparedTextEvent,
-        dispatch_event: _TextDispatchEvent,
+        dispatch_event: TextDispatchEvent,
         envelope: MessageEnvelope,
         coalescing_thread_id: str | None,
         requester_user_id: str,
@@ -521,7 +516,7 @@ class TurnController:
         self,
         *,
         room: nio.MatrixRoom,
-        event: _MediaDispatchEvent,
+        event: MediaDispatchEvent,
         coalescing_thread_id: str | None,
         requester_user_id: str,
         dispatch_timing: DispatchPipelineTiming | None,
@@ -606,7 +601,7 @@ class TurnController:
     async def _coalescing_key_for_event(
         self,
         room: nio.MatrixRoom,
-        event: _DispatchEvent,
+        event: DispatchEvent,
         requester_user_id: str,
     ) -> CoalescingKey:
         """Return the sender or thread scoped dispatch key for one event."""
@@ -650,7 +645,7 @@ class TurnController:
 
     async def _enqueue_for_dispatch(
         self,
-        event: _DispatchEvent,
+        event: DispatchEvent,
         room: nio.MatrixRoom,
         *,
         source_kind: str,
@@ -757,7 +752,7 @@ class TurnController:
     async def _prepare_dispatch(
         self,
         room: nio.MatrixRoom,
-        event: _TextDispatchEvent,
+        event: TextDispatchEvent,
         requester_user_id: str,
         *,
         event_label: str,
@@ -865,7 +860,7 @@ class TurnController:
     async def _execute_command(
         self,
         room: nio.MatrixRoom,
-        event: _TextDispatchEvent,
+        event: TextDispatchEvent,
         requester_user_id: str,
         command: Command,
     ) -> None:
@@ -1016,14 +1011,14 @@ class TurnController:
     async def _execute_router_relay(
         self,
         room: nio.MatrixRoom,
-        event: _DispatchEvent,
+        event: DispatchEvent,
         thread_history: Sequence[ResolvedVisibleMessage],
         thread_id: str | None = None,
         message: str | None = None,
         *,
         requester_user_id: str,
         extra_content: dict[str, Any] | None = None,
-        media_events: list[_MediaDispatchEvent] | None = None,
+        media_events: list[MediaDispatchEvent] | None = None,
         handled_turn: HandledTurnState | None = None,
     ) -> None:
         """Run one explicit router relay from the turn controller."""
@@ -1206,7 +1201,7 @@ class TurnController:
     async def _execute_response_action(  # noqa: C901, PLR0912, PLR0915
         self,
         room: nio.MatrixRoom,
-        event: _DispatchEvent,
+        event: DispatchEvent,
         dispatch: PreparedDispatch,
         action: ResponseAction,
         payload_builder: DispatchPayloadBuilder,
@@ -1594,10 +1589,10 @@ class TurnController:
     async def _dispatch_text_message(  # noqa: C901, PLR0912, PLR0915
         self,
         room: nio.MatrixRoom,
-        event: _TextDispatchEvent | _PrecheckedTextDispatchEvent,
+        event: TextDispatchEvent | _PrecheckedTextDispatchEvent,
         requester_user_id: str | None = None,
         *,
-        media_events: list[_MediaDispatchEvent] | None = None,
+        media_events: list[MediaDispatchEvent] | None = None,
         handled_turn: HandledTurnState | None = None,
         queued_notice_reservation: QueuedHumanNoticeReservation | None = None,
         ingress_metadata: DispatchIngressMetadata | None = None,
@@ -1605,16 +1600,16 @@ class TurnController:
         trust_hydrated_internal_metadata: bool | None = None,
     ) -> None:
         """Run the normal text or command dispatch pipeline for a prepared text event."""
-        raw_event: _TextDispatchEvent
+        raw_event: TextDispatchEvent
         if isinstance(event, _PrecheckedEvent):
             requester_user_id = event.requester_user_id
-            raw_event = cast("_TextDispatchEvent", event.event)
+            raw_event = cast("TextDispatchEvent", event.event)
         else:
             raw_event = event
         if requester_user_id is None:
             msg = "requester_user_id is required when dispatching a raw event"
             raise TypeError(msg)
-        router_event: _DispatchEvent = raw_event
+        router_event: DispatchEvent = raw_event
         reservation = queued_notice_reservation
         dispatch: PreparedDispatch | None = None
         timing_scope_token = None
@@ -1843,7 +1838,7 @@ class TurnController:
     async def handle_media_event(
         self,
         room: nio.MatrixRoom,
-        event: _InboundMediaEvent,
+        event: MatrixMediaEvent,
     ) -> None:
         """Handle one inbound media event."""
         async with self.deps.resolver.turn_thread_cache_scope():
@@ -1852,7 +1847,7 @@ class TurnController:
     async def _handle_media_message_inner(
         self,
         room: nio.MatrixRoom,
-        event: _InboundMediaEvent,
+        event: MatrixMediaEvent,
     ) -> None:
         """Handle one media event inside the per-turn conversation lookup scope."""
         prechecked_event = self._precheck_dispatch_event(room, event)

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -71,6 +71,7 @@ from mindroom.matrix.media import (
     is_audio_message_event,
     is_file_message_event,
     is_image_message_event,
+    is_matrix_media_dispatch_event,
 )
 from mindroom.matrix.message_content import is_v2_sidecar_text_preview
 from mindroom.matrix.rooms import is_dm_room
@@ -1087,15 +1088,7 @@ class TurnController:
         thread_event_id = resolved_target.resolved_thread_id
         routed_extra_content = dict(extra_content) if extra_content is not None else {}
         routed_media_events = list(media_events or [])
-        if not routed_media_events and isinstance(
-            event,
-            nio.RoomMessageFile
-            | nio.RoomEncryptedFile
-            | nio.RoomMessageVideo
-            | nio.RoomEncryptedVideo
-            | nio.RoomMessageImage
-            | nio.RoomEncryptedImage,
-        ):
+        if not routed_media_events and is_matrix_media_dispatch_event(event):
             routed_media_events.append(event)
         if routed_media_events:
             routed_attachment_ids = merge_attachment_ids(
@@ -1757,15 +1750,7 @@ class TurnController:
                     else None
                 )
                 single_direct_media_route = (
-                    isinstance(
-                        route_event,
-                        nio.RoomMessageFile
-                        | nio.RoomEncryptedFile
-                        | nio.RoomMessageVideo
-                        | nio.RoomEncryptedVideo
-                        | nio.RoomMessageImage
-                        | nio.RoomEncryptedImage,
-                    )
+                    is_matrix_media_dispatch_event(route_event)
                     and media_events == [route_event]
                     and handled_turn.source_event_ids == (event.event_id,)
                 )

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -19,7 +19,7 @@ from mindroom.authorization import get_available_agents_for_sender_authoritative
 from mindroom.constants import ATTACHMENT_IDS_KEY, ORIGINAL_SENDER_KEY, VOICE_PREFIX, VOICE_RAW_AUDIO_FALLBACK_KEY
 from mindroom.credentials_sync import get_secret_from_env
 from mindroom.logging_config import get_logger
-from mindroom.matrix.media import download_media_bytes, extract_media_caption, media_mime_type
+from mindroom.matrix.media import AudioMessageEvent, download_media_bytes, extract_media_caption, media_mime_type
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix_identifiers import agent_username_localpart
 
@@ -113,7 +113,7 @@ async def _compute_normalized_voice_message(
     client: nio.AsyncClient,
     storage_path: Path,
     room: nio.MatrixRoom,
-    event: nio.RoomMessageAudio | nio.RoomEncryptedAudio,
+    event: AudioMessageEvent,
     config: Config,
     runtime_paths: RuntimePaths,
     *,
@@ -157,7 +157,7 @@ async def _normalize_voice_message(
     client: nio.AsyncClient,
     storage_path: Path,
     room: nio.MatrixRoom,
-    event: nio.RoomMessageAudio | nio.RoomEncryptedAudio,
+    event: AudioMessageEvent,
     config: Config,
     runtime_paths: RuntimePaths,
     *,
@@ -192,7 +192,7 @@ async def prepare_voice_message(
     client: nio.AsyncClient,
     storage_path: Path,
     room: nio.MatrixRoom,
-    event: nio.RoomMessageAudio | nio.RoomEncryptedAudio,
+    event: AudioMessageEvent,
     config: Config,
     *,
     runtime_paths: RuntimePaths,
@@ -256,7 +256,7 @@ async def prepare_voice_message(
 async def _handle_voice_message(
     client: nio.AsyncClient,
     room: nio.MatrixRoom,
-    event: nio.RoomMessageAudio | nio.RoomEncryptedAudio,
+    event: AudioMessageEvent,
     config: Config,
     runtime_paths: RuntimePaths,
     audio: Audio | None = None,
@@ -323,7 +323,7 @@ async def _handle_voice_message(
 
 async def _download_audio(
     client: nio.AsyncClient,
-    event: nio.RoomMessageAudio | nio.RoomEncryptedAudio,
+    event: AudioMessageEvent,
 ) -> Audio | None:
     """Download Matrix audio and convert it to an agno Audio media object."""
     audio_data = await download_media_bytes(client, event)

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -12,6 +12,7 @@ import nio
 import pytest
 from pydantic import ValidationError
 
+from mindroom.attachments import _attachment_id_for_event, load_attachment
 from mindroom.bot import AgentBot
 from mindroom.coalescing import (
     COALESCING_BYPASS_ACTIVE_THREAD_FOLLOW_UP,
@@ -2298,6 +2299,50 @@ async def test_register_batch_media_attachments_emits_payload_timing_on_failure(
         "attachment_count": 0,
         "fallback_image_count": 0,
     }
+
+
+@pytest.mark.asyncio
+async def test_dispatch_payload_registers_unregistered_image_from_thread_history(tmp_path: Path) -> None:
+    """Prior thread images without MindRoom metadata should become context attachments."""
+    bot = _make_bot(tmp_path)
+    image_event = _image_event(event_id="$img-history", thread_id="$thread")
+    image_content = image_event.source["content"]
+    assert isinstance(image_content, dict)
+    history_image = ResolvedVisibleMessage(
+        sender=image_event.sender,
+        body=image_event.body,
+        timestamp=1000,
+        event_id=image_event.event_id,
+        content=image_content,
+        thread_id="$thread",
+        latest_event_id=image_event.event_id,
+    )
+    download_response = MagicMock(spec=nio.DownloadResponse)
+    download_response.body = b"\x89PNG\r\n\x1a\npayload"
+    bot.client.download = AsyncMock(return_value=download_response)
+
+    with patch("mindroom.inbound_turn_normalizer.resolve_thread_attachment_ids", new=AsyncMock(return_value=[])):
+        payload = await bot._inbound_turn_normalizer.build_dispatch_payload_with_attachments(
+            DispatchPayloadWithAttachmentsRequest(
+                room_id="!room:localhost",
+                prompt="@test_agent see above",
+                current_attachment_ids=[],
+                thread_id="$thread",
+                media_thread_id="$thread",
+                thread_history=[history_image],
+            ),
+        )
+
+    attachment_id = _attachment_id_for_event("$img-history")
+    assert payload.attachment_ids == [attachment_id]
+    assert payload.model_prompt == (
+        f"Available attachment IDs: {attachment_id}. Use tool calls to inspect or process them."
+    )
+    assert len(payload.media.images) == 1
+    record = load_attachment(tmp_path, attachment_id)
+    assert record is not None
+    assert record.source_event_id == "$img-history"
+    assert record.thread_id == "$thread"
 
 
 @pytest.mark.asyncio

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -6606,7 +6606,7 @@ class TestAgentBot:
             patch("mindroom.turn_policy.should_agent_respond", return_value=True),
             patch("mindroom.inbound_turn_normalizer.download_image", new_callable=AsyncMock, return_value=image),
             patch(
-                "mindroom.inbound_turn_normalizer.register_image_attachment",
+                "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
                 new_callable=AsyncMock,
                 return_value=attachment_record,
             ),
@@ -6782,7 +6782,7 @@ class TestAgentBot:
             patch("mindroom.turn_policy.should_agent_respond", return_value=True),
             patch("mindroom.inbound_turn_normalizer.download_image", new_callable=AsyncMock, return_value=image),
             patch(
-                "mindroom.inbound_turn_normalizer.register_image_attachment",
+                "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
                 new_callable=AsyncMock,
                 return_value=attachment_record,
             ),
@@ -7076,7 +7076,7 @@ class TestAgentBot:
             ),
             patch("mindroom.turn_policy.should_agent_respond", return_value=True),
             patch(
-                "mindroom.inbound_turn_normalizer.register_file_or_video_attachment",
+                "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
                 new_callable=AsyncMock,
                 return_value=attachment_record,
             ),
@@ -7167,7 +7167,7 @@ class TestAgentBot:
             ),
             patch("mindroom.turn_policy.should_agent_respond", return_value=True),
             patch(
-                "mindroom.inbound_turn_normalizer.register_file_or_video_attachment",
+                "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
                 new_callable=AsyncMock,
                 return_value=None,
             ),
@@ -7381,7 +7381,7 @@ class TestAgentBot:
             patch("mindroom.turn_policy.get_available_agents_for_sender_authoritative") as mock_get_available,
             patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
             patch(
-                "mindroom.inbound_turn_normalizer.register_file_or_video_attachment",
+                "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
                 new_callable=AsyncMock,
                 return_value=attachment_record,
             ) as mock_register_file,
@@ -7471,7 +7471,7 @@ class TestAgentBot:
                 return_value="general",
             ),
             patch(
-                "mindroom.inbound_turn_normalizer.register_file_or_video_attachment",
+                "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
                 new_callable=AsyncMock,
                 return_value=attachment_record,
             ) as mock_register_file,
@@ -7549,7 +7549,7 @@ class TestAgentBot:
                 return_value="general",
             ),
             patch(
-                "mindroom.inbound_turn_normalizer.register_image_attachment",
+                "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
                 new_callable=AsyncMock,
                 return_value=attachment_record,
             ) as mock_register_image,
@@ -7687,7 +7687,7 @@ class TestAgentBot:
                 return_value="general",
             ),
             patch(
-                "mindroom.inbound_turn_normalizer.register_file_or_video_attachment",
+                "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
                 new_callable=AsyncMock,
                 return_value=attachment_record,
             ) as mock_register,

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -1257,7 +1257,7 @@ class TestExtractedModuleLoggerRebinding:
         event.source = {"content": {"body": "photo.png", "msgtype": "m.image"}}
 
         with patch(
-            "mindroom.inbound_turn_normalizer.register_image_attachment",
+            "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
             new_callable=AsyncMock,
             return_value=None,
         ):
@@ -1269,7 +1269,7 @@ class TestExtractedModuleLoggerRebinding:
 
         assert attachment_id is None
         original_logger.error.assert_called_once_with(
-            "Failed to register routed image attachment",
+            "Failed to register routed media attachment",
             event_id="$img123",
         )
         rebound_logger.error.assert_not_called()


### PR DESCRIPTION
## Summary
- Register visible image, file, and video events from thread history as attachments during dispatch payload assembly.
- Centralize Matrix media event aliases, guards, and parsing helpers so dispatch and attachment code share one media surface.
- Reuse existing attachment lookup logic for event-scoped media records and update tests to mock the shared registration boundary.

## Test Plan
- [x] uv run ruff check src/mindroom/matrix/media.py src/mindroom/attachments.py src/mindroom/dispatch_handoff.py src/mindroom/inbound_turn_normalizer.py src/mindroom/bot.py src/mindroom/conversation_resolver.py src/mindroom/matrix/image_handler.py src/mindroom/turn_controller.py src/mindroom/voice_handler.py tests/test_multi_agent_bot.py tests/test_thread_mode.py
- [x] uv run ruff format --check src/mindroom/matrix/media.py src/mindroom/attachments.py src/mindroom/dispatch_handoff.py src/mindroom/inbound_turn_normalizer.py src/mindroom/bot.py src/mindroom/conversation_resolver.py src/mindroom/matrix/image_handler.py src/mindroom/turn_controller.py src/mindroom/voice_handler.py tests/test_multi_agent_bot.py tests/test_thread_mode.py
- [x] uv run ty check src/mindroom/matrix/media.py src/mindroom/attachments.py src/mindroom/dispatch_handoff.py src/mindroom/inbound_turn_normalizer.py src/mindroom/bot.py src/mindroom/conversation_resolver.py src/mindroom/matrix/image_handler.py src/mindroom/turn_controller.py src/mindroom/voice_handler.py tests/test_multi_agent_bot.py tests/test_thread_mode.py
- [x] uv run pytest tests/test_attachments.py tests/test_image_handler.py tests/test_voice_command_processing.py tests/test_live_message_coalescing.py::test_dispatch_payload_registers_unregistered_image_from_thread_history tests/test_live_message_coalescing.py::test_coalesced_attachment_ids_reach_envelope_and_model_payload tests/test_multi_agent_bot.py::TestAgentBot::test_agent_bot_on_image_message_forwards_image_to_generate_response tests/test_multi_agent_bot.py::TestAgentBot::test_media_message_merges_thread_history_attachment_ids tests/test_multi_agent_bot.py::TestAgentBot::test_agent_bot_on_file_message_forwards_local_path_to_generate_response tests/test_multi_agent_bot.py::TestAgentBot::test_agent_bot_on_file_message_leaves_event_retryable_when_terminal_error_cannot_be_sent tests/test_multi_agent_bot.py::TestAgentBot::test_router_routes_file_messages_with_sender_metadata tests/test_multi_agent_bot.py::TestAgentBot::test_router_routing_registers_file_with_effective_thread_scope tests/test_multi_agent_bot.py::TestAgentBot::test_router_routing_registers_image_with_effective_thread_scope tests/test_multi_agent_bot.py::TestAgentBot::test_multi_agent_file_event_registers_attachment_once tests/test_thread_mode.py::TestExtractedModuleLoggerRebinding::test_inbound_turn_normalizer_uses_rebound_bot_logger -q
- [x] uv run pre-commit run --all-files
- [x] uv run pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread-history media (images, files, videos) are auto-discovered, registered, de-duplicated, and included in dispatches.
  * Unified Matrix-based media registration for images, files, videos and audio improves attachment handling consistency.
  * Voice messages now produce normalized, mention-aware transcriptions for clearer, formatted text.

* **Tests**
  * Added tests for thread-history media registration and the unified media registration flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->