### PR TITLE
Wipe sandbox runner token from raw process environment

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import binascii
 import ctypes
-import hashlib
 import inspect
 import io
 import json

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
+import ctypes
+import hashlib
 import inspect
 import io
 import json
@@ -129,8 +132,38 @@ def _startup_runtime_paths_from_env() -> RuntimePaths:
 
 def startup_runner_token_from_env() -> str | None:
     """Read and remove the runner auth token from process env after startup."""
-    raw_token = os.environ.pop(_RUNNER_TOKEN_ENV, "").strip()
-    return raw_token or None
+    if _RUNNER_TOKEN_ENV not in os.environ:
+        return None
+    raw_token = os.environ.get(_RUNNER_TOKEN_ENV, "")
+    raw_process_entry = _process_environment_entry(_RUNNER_TOKEN_ENV)
+    if raw_process_entry is not None:
+        _wipe_process_environment_entry(*raw_process_entry)
+    os.environ.pop(_RUNNER_TOKEN_ENV, None)
+    return raw_token.strip() or None
+
+
+def _process_environment_entry(name: str) -> tuple[int, int] | None:
+    """Return the raw process environment entry address and size for an env var."""
+    prefix = os.fsencode(f"{name}=")
+    try:
+        envp = ctypes.POINTER(ctypes.c_void_p).in_dll(ctypes.CDLL(None), "environ")
+    except (AttributeError, OSError, ValueError):
+        return None
+
+    index = 0
+    while envp[index]:
+        address = int(envp[index])
+        entry = ctypes.string_at(address)
+        if entry.startswith(prefix):
+            return address, len(entry)
+        index += 1
+    return None
+
+
+def _wipe_process_environment_entry(address: int, size: int) -> None:
+    """Overwrite a raw process environment entry exposed by /proc/<pid>/environ."""
+    if size > 0:
+        ctypes.memset(address, 0, size)
 
 
 def _upstream_tool_validation_snapshot(runtime_paths: RuntimePaths) -> dict[str, ToolValidationInfo]:

--- a/src/mindroom/api/sandbox_runner_app.py
+++ b/src/mindroom/api/sandbox_runner_app.py
@@ -21,8 +21,8 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     try:
         runtime_paths = app_runtime_paths(app)
     except TypeError:
-        runtime_paths, config = load_config_from_startup_runtime()
         runner_token = startup_runner_token_from_env()
+        runtime_paths, config = load_config_from_startup_runtime()
     else:
         config = app_runtime_config(app)
         runner_token = app_runner_token(app)

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -16,11 +16,13 @@ from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 import mindroom.api.sandbox_exec as sandbox_exec_module
 import mindroom.api.sandbox_protocol as sandbox_protocol_module
 import mindroom.api.sandbox_runner as sandbox_runner_module
+import mindroom.api.sandbox_runner_app as sandbox_runner_app_module
 import mindroom.api.sandbox_worker_prep as sandbox_worker_prep_module
 import mindroom.constants as constants_module
 import mindroom.credentials as credentials_module
@@ -370,6 +372,55 @@ def test_startup_runner_token_is_removed_from_proc_environ() -> None:
     )
 
     assert result.stdout.splitlines() == ["from-subprocess", "False"]
+
+
+def test_lifespan_scrubs_runner_token_before_loading_plugins(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Plugin startup code should not observe the runner auth token in os.environ."""
+    plugin_root = tmp_path / "plugins" / "env-reader"
+    plugin_root.mkdir(parents=True)
+    capture_path = tmp_path / "plugin-captured-token.txt"
+    (plugin_root / "mindroom.plugin.json").write_text(
+        json.dumps({"name": "env_reader", "tools_module": "tools.py", "skills": []}),
+        encoding="utf-8",
+    )
+    (plugin_root / "tools.py").write_text(
+        "import os\n"
+        "from pathlib import Path\n"
+        f"Path({str(capture_path)!r}).write_text("
+        "os.environ.get('MINDROOM_SANDBOX_PROXY_TOKEN', ''), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "models:\n"
+        "  default:\n"
+        "    provider: openai\n"
+        "    id: gpt-5.4\n"
+        "agents: {}\n"
+        "router:\n"
+        "  model: default\n"
+        "plugins:\n"
+        "  - ./plugins/env-reader\n",
+        encoding="utf-8",
+    )
+    payload_runtime = resolve_primary_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "storage",
+        process_env={"MINDROOM_NAMESPACE": "alpha1234"},
+    )
+    manifest_path = _write_startup_manifest(runtime_paths=payload_runtime)
+    _set_startup_manifest(monkeypatch, manifest_path=manifest_path)
+    monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", "runner-secret")
+
+    app = FastAPI(lifespan=sandbox_runner_app_module._lifespan)
+    with TestClient(app):
+        pass
+
+    assert capture_path.read_text(encoding="utf-8") == ""
+    assert sandbox_runner_module.app_runner_token(app) == "runner-secret"
 
 
 def test_lifespan_reuses_initialized_runner_context_without_reloading_disk_config(tmp_path: Path) -> None:

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -331,12 +331,45 @@ def test_startup_runtime_keeps_runner_token_outside_runtime_paths(
 
 def test_startup_runner_token_is_removed_from_process_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Startup auth token loading should not leave runner auth in process env."""
+    wiped_entries: list[tuple[int, int]] = []
+    monkeypatch.setattr(sandbox_runner_module, "_process_environment_entry", lambda _name: (123, 45))
+    monkeypatch.setattr(
+        sandbox_runner_module,
+        "_wipe_process_environment_entry",
+        lambda address, size: wiped_entries.append((address, size)),
+    )
     monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", "from-env")
 
     assert sandbox_runner_module.startup_runner_token_from_env() == "from-env"
 
     assert "MINDROOM_SANDBOX_PROXY_TOKEN" not in os.environ
     assert sandbox_runner_module.startup_runner_token_from_env() is None
+    assert wiped_entries == [(123, 45)]
+
+
+def test_startup_runner_token_is_removed_from_proc_environ() -> None:
+    """Linux exposes the original startup env through /proc, so wipe that entry too."""
+    if not Path("/proc/self/environ").exists():
+        pytest.skip("/proc/self/environ is not available on this platform")
+    env = os.environ.copy()
+    env["MINDROOM_SANDBOX_PROXY_TOKEN"] = "from-subprocess"  # noqa: S105
+    script = (
+        "from mindroom.api import sandbox_runner as m\n"
+        "token = m.startup_runner_token_from_env()\n"
+        "raw_environ = open('/proc/self/environ', 'rb').read()\n"
+        "print(token)\n"
+        "print(b'MINDROOM_SANDBOX_PROXY_TOKEN=' in raw_environ)\n"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.stdout.splitlines() == ["from-subprocess", "False"]
 
 
 def test_lifespan_reuses_initialized_runner_context_without_reloading_disk_config(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- wipe the raw process environment entry for the sandbox runner auth token before removing it from Python's environment mapping
- keep startup token loading behavior unchanged for request authentication
- add regression coverage for both Python environment removal and Linux /proc/self/environ exposure

## Testing
- uv run pytest tests/api/test_sandbox_runner_api.py -k "startup_runner_token_is_removed_from_process_env or startup_runner_token_is_removed_from_proc_environ or sandbox_runner_worker_request_rejects_invalid_base_dir_type_for_unknown_tool"
- docker run --rm -e MINDROOM_SANDBOX_PROXY_TOKEN=from-env python:3.13-slim python -c '<raw environment wipe check>'
- uv run ruff check src/mindroom/api/sandbox_runner.py tests/api/test_sandbox_runner_api.py
- uv run pytest tests/api/test_sandbox_runner_api.py

Note: local commit hooks were run with ty skipped because optional test/runtime extras are not installed in this fresh worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup token handling hardened: sensitive startup credentials are now securely removed from process memory and cleared from the environment during application startup.

* **Tests**
  * Added tests validating startup token cleanup, including checks that tokens are eliminated from process memory and from the system environment on Linux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->