### PR TITLE
chore: narrow overexposed Tach interfaces

### DIFF
--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -123,10 +123,10 @@ async def _send_prepared_room_message(
 
 def cached_room(client: nio.AsyncClient, room_id: str) -> nio.MatrixRoom | None:
     """Return one room from nio's in-memory room cache if present."""
-    return cached_rooms(client).get(room_id)
+    return _cached_rooms(client).get(room_id)
 
 
-def cached_rooms(client: nio.AsyncClient) -> Mapping[str, nio.MatrixRoom]:
+def _cached_rooms(client: nio.AsyncClient) -> Mapping[str, nio.MatrixRoom]:
     """Return the client room cache when nio has initialized it."""
     rooms = client.rooms
     return rooms if isinstance(rooms, Mapping) else {}

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -312,7 +312,7 @@ def oauth_connect_url(
     )
 
 
-def _build_oauth_connect_instruction(
+def build_oauth_connect_instruction(
     provider: OAuthProvider,
     runtime_paths: RuntimePaths,
     *,

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -140,7 +140,7 @@ class LiveToolDispatchContext(ToolDispatchContext):
     def from_runtime_context(cls, runtime_context: ToolRuntimeContext) -> LiveToolDispatchContext:
         """Build the live dispatch contract represented by one tool runtime context."""
         return cls(
-            execution_identity=_build_execution_identity_from_runtime_context(runtime_context),
+            execution_identity=build_execution_identity_from_runtime_context(runtime_context),
             runtime_context=runtime_context,
         )
 
@@ -429,7 +429,7 @@ def resolve_current_session_id(
     return None
 
 
-def _build_execution_identity_from_runtime_context(context: ToolRuntimeContext) -> ToolExecutionIdentity:
+def build_execution_identity_from_runtime_context(context: ToolRuntimeContext) -> ToolExecutionIdentity:
     """Build the canonical execution identity represented by one live runtime context."""
     target = MessageTarget.from_runtime_context(context)
     return build_tool_execution_identity(

--- a/src/mindroom/tool_system/sandbox_proxy.py
+++ b/src/mindroom/tool_system/sandbox_proxy.py
@@ -56,7 +56,7 @@ _MAX_CREDENTIAL_LEASE_TTL_SECONDS = 3600
 _EXECUTION_ENV_TOOL_NAMES = frozenset({"python", "shell"})
 _SANDBOX_PROXY_SAVE_ATTACHMENT_PATH = "/api/sandbox-runner/save-attachment"
 _INLINE_ATTACHMENT_BYTES_ENV = "MINDROOM_ATTACHMENT_INLINE_SAVE_MAX_BYTES"
-DEFAULT_INLINE_ATTACHMENT_BYTES = 16 * 1024 * 1024
+_DEFAULT_INLINE_ATTACHMENT_BYTES = 16 * 1024 * 1024
 _ATTACHMENT_SAVE_WORKSPACE_CONSUMER_TOOLS = frozenset({"file", "coding", "python", "shell"})
 
 
@@ -113,14 +113,14 @@ def inline_attachment_byte_limit(runtime_paths: RuntimePaths) -> int:
     raw_value = (
         runtime_paths.env_value(_INLINE_ATTACHMENT_BYTES_ENV)
         or os.environ.get(_INLINE_ATTACHMENT_BYTES_ENV)
-        or str(DEFAULT_INLINE_ATTACHMENT_BYTES)
+        or str(_DEFAULT_INLINE_ATTACHMENT_BYTES)
     )
     try:
         limit = int(raw_value)
     except ValueError:
-        return DEFAULT_INLINE_ATTACHMENT_BYTES
+        return _DEFAULT_INLINE_ATTACHMENT_BYTES
     if limit <= 0:
-        return DEFAULT_INLINE_ATTACHMENT_BYTES
+        return _DEFAULT_INLINE_ATTACHMENT_BYTES
     return limit
 
 

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -308,7 +308,7 @@ def worker_scope_allows_shared_only_integrations(worker_scope: WorkerScope | Non
     return worker_scope in (None, "shared")
 
 
-def requires_shared_only_integration_scope(
+def _requires_shared_only_integration_scope(
     name: str,
     *,
     configured_mcp_server_ids: Collection[str] | None = None,
@@ -328,7 +328,7 @@ def requires_shared_only_integration_scope(
 
 def supports_tool_name_for_worker_scope(name: str, worker_scope: WorkerScope | None) -> bool:
     """Return whether one tool/integration name is supported for the effective execution scope."""
-    return not requires_shared_only_integration_scope(name) or worker_scope_allows_shared_only_integrations(
+    return not _requires_shared_only_integration_scope(name) or worker_scope_allows_shared_only_integrations(
         worker_scope,
     )
 
@@ -345,7 +345,7 @@ def unsupported_shared_only_integration_names(
     return [
         name
         for name in names
-        if requires_shared_only_integration_scope(
+        if _requires_shared_only_integration_scope(
             name,
             configured_mcp_server_ids=configured_mcp_server_ids,
         )

--- a/tach.toml
+++ b/tach.toml
@@ -2317,7 +2317,6 @@ expose = [
     "build_threaded_edit_content",
     "can_send_to_encrypted_room",
     "cached_room",
-    "cached_rooms",
     "edit_message_result",
     "send_file_message",
     "send_message_result",
@@ -2566,7 +2565,6 @@ expose = [
     "resolve_worker_key",
     "resolve_worker_target",
     "resolved_worker_key_scope",
-    "requires_shared_only_integration_scope",
     "run_with_tool_execution_identity",
     "shared_storage_root",
     "stream_with_tool_execution_identity",
@@ -2774,7 +2772,6 @@ from = ["mindroom.sync_bridge_state"]
 
 [[interfaces]]
 expose = [
-    "DEFAULT_INLINE_ATTACHMENT_BYTES",
     "WorkerAttachmentSaveReceipt",
     "attachment_save_uses_worker",
     "inline_attachment_byte_limit",

--- a/tach.toml
+++ b/tach.toml
@@ -2524,6 +2524,7 @@ expose = [
     "ToolRuntimeSupport",
     "append_tool_runtime_attachment_id",
     "attachment_id_available_in_tool_runtime_context",
+    "build_execution_identity_from_runtime_context",
     "build_scheduling_runtime_from_tool_runtime_context",
     "emit_custom_event",
     "execution_identity_matches_tool_runtime_context",
@@ -2702,6 +2703,12 @@ expose = [
     "validate_event_name",
 ]
 from = ["mindroom.hooks"]
+
+[[interfaces]]
+expose = [
+    "build_oauth_connect_instruction",
+]
+from = ["mindroom.oauth.service"]
 
 [[interfaces]]
 expose = [

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -19,7 +19,7 @@ from mindroom.mcp.registry import (
 )
 from mindroom.mcp.toolkit import bind_mcp_server_manager
 from mindroom.tool_system.metadata import _TOOL_REGISTRY, TOOL_METADATA, get_tool_by_name
-from mindroom.tool_system.worker_routing import requires_shared_only_integration_scope
+from mindroom.tool_system.worker_routing import supports_tool_name_for_worker_scope
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -186,7 +186,7 @@ def test_mcp_server_id_from_tool_name_ignores_non_mcp_prefixed_plugin_tools() ->
     TOOL_METADATA["mcp_custom_plugin"] = replace(TOOL_METADATA["shell"], name="mcp_custom_plugin")
 
     assert mcp_server_id_from_tool_name("mcp_custom_plugin") is None
-    assert requires_shared_only_integration_scope("mcp_custom_plugin") is False
+    assert supports_tool_name_for_worker_scope("mcp_custom_plugin", "user") is True
 
 
 def test_config_validation_rejects_runtime_mcp_name_collisions(tmp_path: Path) -> None:
@@ -299,4 +299,4 @@ def test_mcp_tool_names_are_shared_only(tmp_path: Path) -> None:
     sync_mcp_tool_registry(_config(tmp_path))
 
     assert mcp_server_id_from_tool_name("mcp_demo") == "demo"
-    assert requires_shared_only_integration_scope("mcp_demo") is True
+    assert supports_tool_name_for_worker_scope("mcp_demo", "user") is False


### PR DESCRIPTION
## Summary
- make `cached_rooms` private now that only `cached_room` is part of the matrix delivery surface
- make the inline attachment byte default private while keeping `inline_attachment_byte_limit` public
- make the shared-only integration classifier private and keep the public behavior helper `supports_tool_name_for_worker_scope`
- restore `build_execution_identity_from_runtime_context` and `build_oauth_connect_instruction` as real plugin-facing public APIs and expose them in `tach.toml`
- remove the corresponding overexposed names from `tach.toml`

## Plugin API Audit
Searched sibling plugin repositories under `/Users/bas.nijholt/Work/dev/*plugin` for the suspect API names.
The plugins use `ToolRuntimeHookBindings`, `get_plugin_state_root`, `build_execution_identity_from_runtime_context`, and `build_oauth_connect_instruction`, which remain public.
No sibling plugin uses the names this PR makes private: `cached_rooms`, `DEFAULT_INLINE_ATTACHMENT_BYTES`, or `requires_shared_only_integration_scope`.

## Verification
- `env -u VIRTUAL_ENV uv run privata .` ✅
- `env -u VIRTUAL_ENV uv run tach check --dependencies --interfaces` ✅
- `uv run pytest tests/test_mcp_registry.py tests/test_sandbox_proxy.py::test_save_attachment_to_worker_posts_with_worker_token_and_size_cap tests/test_matrix_room_access.py::test_is_user_online_scans_cached_rooms_when_room_id_is_none -n 0 --no-cov -q` ✅
- `uv run python - <<'PY' ...` import smoke for `build_oauth_connect_instruction` and `build_execution_identity_from_runtime_context` ✅
- `uv run pre-commit run --all-files` ✅
- `uv run pytest --tach` selected 0 tests and exited with pytest code 5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal logic across several modules and adjusted which helpers are public vs private.
  * Updated exposed API surface to reflect renamed/reshuffled symbols (no behavioral changes).
  * Converted a previously public constant to private to improve encapsulation.

* **Tests**
  * Updated test suite to align with the revised API surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->