### PR TITLE
chore: fix privata __all__ findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -413,7 +413,7 @@ dev = [
   "markdown-gfm-admonition",
   "pre-commit>=4.2",
   "pre-commit-uv>=4.1.4",
-  "privata>=0.1.5",
+  "privata>=0.1.7",
   "pytest>=8.4.1",
   "pytest-asyncio>=1.1",
   "pytest-cov>=6.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -413,7 +413,7 @@ dev = [
   "markdown-gfm-admonition",
   "pre-commit>=4.2",
   "pre-commit-uv>=4.1.4",
-  "privata>=0.1.3",
+  "privata>=0.1.5",
   "pytest>=8.4.1",
   "pytest-asyncio>=1.1",
   "pytest-cov>=6.2.1",

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -119,7 +119,7 @@ type _MatrixEventId = str
 
 logger = get_logger(__name__)
 
-__all__ = ["AgentBot"]
+__all__ = ["AgentBot", "TeamBot", "create_bot_for_entity"]
 
 
 # Constants

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -27,7 +27,12 @@ from .event_normalization import normalize_event_source_for_cache, normalize_nio
 if TYPE_CHECKING:
     from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
 
-__all__ = ["_collect_sync_timeline_cache_updates"]
+__all__ = [
+    "ThreadLiveWritePolicy",
+    "ThreadOutboundWritePolicy",
+    "ThreadSyncWritePolicy",
+    "_collect_sync_timeline_cache_updates",
+]
 
 
 _NONTERMINAL_STREAM_STATUSES = frozenset({STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING})

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -31,7 +31,6 @@ __all__ = [
     "ThreadLiveWritePolicy",
     "ThreadOutboundWritePolicy",
     "ThreadSyncWritePolicy",
-    "_collect_sync_timeline_cache_updates",
 ]
 
 

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -496,6 +496,8 @@ __all__ = [
     "DeliveredMatrixEvent",
     "build_edit_event_content",
     "build_threaded_edit_content",
+    "cached_room",
+    "can_send_to_encrypted_room",
     "edit_message_result",
     "send_file_message",
     "send_message_result",

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -38,7 +38,7 @@ from mindroom.matrix.thread_membership import (
     lookup_thread_id_from_conversation_cache,
     resolve_event_thread_id,
 )
-from mindroom.matrix.thread_room_scan import _room_scan_membership_access_for_client
+from mindroom.matrix.thread_room_scan import room_scan_membership_access_for_client
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Collection
@@ -111,7 +111,7 @@ async def resolve_thread_root_event_id_for_client(
         event_info,
         event_id=normalized_event_id,
         allow_current_root=True,
-        access=_room_scan_membership_access_for_client(
+        access=room_scan_membership_access_for_client(
             client,
             conversation_cache=conversation_cache,
             fetch_event_info=lambda lookup_room_id, lookup_event_id: fetch_event_info_for_client(

--- a/src/mindroom/matrix/thread_bookkeeping.py
+++ b/src/mindroom/matrix/thread_bookkeeping.py
@@ -26,8 +26,8 @@ from mindroom.matrix.thread_membership import (
 from mindroom.matrix.thread_projection import resolve_thread_ids_for_event_infos
 from mindroom.matrix.thread_room_scan import (
     RoomScanConversationCache,
-    _fetch_event_info_from_conversation_cache,
-    _room_scan_membership_access_for_client,
+    fetch_event_info_from_conversation_cache,
+    room_scan_membership_access_for_client,
 )
 
 if TYPE_CHECKING:
@@ -123,7 +123,7 @@ async def resolve_event_thread_impact_for_client(
     resolution = await resolve_event_thread_membership(
         room_id,
         event_info,
-        access=_room_scan_membership_access_for_client(
+        access=room_scan_membership_access_for_client(
             client,
             conversation_cache=conversation_cache,
         ),
@@ -147,7 +147,7 @@ async def resolve_redaction_thread_impact_for_client(
             strict=True,
         )
     else:
-        target_event_info = await _fetch_event_info_from_conversation_cache(
+        target_event_info = await fetch_event_info_from_conversation_cache(
             conversation_cache,
             room_id,
             event_id,
@@ -158,7 +158,7 @@ async def resolve_redaction_thread_impact_for_client(
     resolution = await resolve_related_event_thread_membership(
         room_id,
         event_id,
-        access=_room_scan_membership_access_for_client(
+        access=room_scan_membership_access_for_client(
             client,
             conversation_cache=conversation_cache,
         ),

--- a/src/mindroom/matrix/thread_room_scan.py
+++ b/src/mindroom/matrix/thread_room_scan.py
@@ -66,7 +66,7 @@ async def _lookup_thread_id_from_conversation_cache(
     return await conversation_cache.get_thread_id_for_event(room_id, event_id)
 
 
-async def _fetch_event_info_from_conversation_cache(
+async def fetch_event_info_from_conversation_cache(
     conversation_cache: RoomScanConversationCache,
     room_id: str,
     event_id: str,
@@ -82,7 +82,7 @@ async def _fetch_event_info_from_conversation_cache(
     )
 
 
-def _room_scan_membership_access_for_client(
+def room_scan_membership_access_for_client(
     client: nio.AsyncClient,
     *,
     conversation_cache: RoomScanConversationCache | None,
@@ -102,7 +102,7 @@ def _room_scan_membership_access_for_client(
             return await fetch_event_info(lookup_room_id, lookup_event_id)
         if conversation_cache is None:
             return None
-        return await _fetch_event_info_from_conversation_cache(
+        return await fetch_event_info_from_conversation_cache(
             conversation_cache,
             lookup_room_id,
             lookup_event_id,
@@ -122,6 +122,6 @@ def _room_scan_membership_access_for_client(
 
 __all__ = [
     "RoomScanConversationCache",
-    "_fetch_event_info_from_conversation_cache",
-    "_room_scan_membership_access_for_client",
+    "fetch_event_info_from_conversation_cache",
+    "room_scan_membership_access_for_client",
 ]

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -49,14 +49,28 @@ _MATRIX_SYNC_WATCHDOG_POLL_INTERVAL_SECONDS = 5.0
 _MATRIX_SYNC_STARTUP_TIMEOUT_ENV = "MINDROOM_MATRIX_SYNC_STARTUP_TIMEOUT_SECONDS"
 
 __all__ = [
+    "STARTUP_RETRY_INITIAL_DELAY_SECONDS",
+    "STARTUP_RETRY_MAX_DELAY_SECONDS",
     "SYNC_RESTART_CANCEL_MSG",
     "USER_STOP_CANCEL_MSG",
     "CancelSource",
+    "EntityStartResults",
     "cancel_failure_reason",
+    "cancel_logged_task",
+    "cancel_sync_task",
+    "cancel_task",
     "classify_cancel_source",
+    "create_logged_task",
+    "create_temp_user",
+    "is_permanent_startup_error",
     "is_sync_restart_cancel",
     "matrix_sync_startup_timeout_seconds",
     "request_task_cancel",
+    "retry_delay_seconds",
+    "run_with_retry",
+    "stop_entities",
+    "sync_forever_with_restart",
+    "wait_for_matrix_homeserver",
 ]
 
 

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -62,10 +62,19 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 __all__ = [
+    "PROGRESS_PLACEHOLDER",
     "SYNC_RESTART_CANCEL_MSG",
     "USER_STOP_CANCEL_MSG",
     "CancelSource",
+    "ReplacementStreamingResponse",
+    "StreamingDeliveryError",
+    "StreamingResponse",
+    "build_cancelled_response_update",
+    "build_restart_interrupted_body",
     "cancel_failure_reason",
+    "clean_partial_reply_text",
+    "is_interrupted_partial_reply",
+    "send_streaming_response",
 ]
 
 _PROGRESS_PLACEHOLDER = "Thinking..."

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -21,7 +21,7 @@ from mindroom.workers.models import (
 )
 
 from . import kubernetes_resources as resources
-from .kubernetes_config import _KubernetesWorkerBackendConfig, kubernetes_backend_config_signature
+from .kubernetes_config import KubernetesWorkerBackendConfig, kubernetes_backend_config_signature
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "KubernetesWorkerBackend",
-    "_KubernetesWorkerBackendConfig",
+    "KubernetesWorkerBackendConfig",
     "kubernetes_backend_config_signature",
 ]
 
@@ -252,7 +252,7 @@ class KubernetesWorkerBackend:
         self,
         *,
         runtime_paths: RuntimePaths,
-        config: _KubernetesWorkerBackendConfig,
+        config: KubernetesWorkerBackendConfig,
         auth_token: str | None,
         storage_root: Path,
         tool_validation_snapshot: dict[str, dict[str, object]],
@@ -304,7 +304,7 @@ class KubernetesWorkerBackend:
         """Construct a backend instance from one explicit runtime context."""
         return cls(
             runtime_paths=runtime_paths,
-            config=_KubernetesWorkerBackendConfig.from_runtime(runtime_paths),
+            config=KubernetesWorkerBackendConfig.from_runtime(runtime_paths),
             auth_token=auth_token,
             storage_root=storage_root,
             tool_validation_snapshot=tool_validation_snapshot,

--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -111,7 +111,7 @@ def _read_json_mapping_env(env: Mapping[str, str], name: str) -> dict[str, str]:
 
 
 @dataclass(frozen=True, slots=True)
-class _KubernetesWorkerBackendConfig:
+class KubernetesWorkerBackendConfig:
     """Resolved environment-backed configuration for the Kubernetes provider."""
 
     namespace: str
@@ -140,7 +140,7 @@ class _KubernetesWorkerBackendConfig:
     auth_secret_name: str | None
 
     @classmethod
-    def from_runtime(cls, runtime_paths: RuntimePaths) -> _KubernetesWorkerBackendConfig:
+    def from_runtime(cls, runtime_paths: RuntimePaths) -> KubernetesWorkerBackendConfig:
         """Build Kubernetes worker configuration from one explicit runtime context."""
         env = runtime_env_values(runtime_paths)
         namespace = _read_env(env, _NAMESPACE_ENV) or _read_env(env, _POD_NAMESPACE_ENV) or "default"
@@ -202,7 +202,7 @@ def kubernetes_backend_config_signature(
     storage_root: Path | None = None,
 ) -> tuple[str, ...]:
     """Return a cache signature for one concrete Kubernetes backend config."""
-    config = _KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
+    config = KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
     extra_env_json = json.dumps(config.extra_env, sort_keys=True, separators=(",", ":"))
     extra_labels_json = json.dumps(config.extra_labels, sort_keys=True, separators=(",", ":"))
     extra_annotations_json = json.dumps(config.extra_annotations, sort_keys=True, separators=(",", ":"))

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
     from mindroom.workers.models import WorkerStatus
 
-    from .kubernetes_config import _KubernetesWorkerBackendConfig
+    from .kubernetes_config import KubernetesWorkerBackendConfig
 
 _DEFAULT_NAME_PREFIX = "mindroom-worker"
 _READY_POLL_INTERVAL_SECONDS = 1.0
@@ -293,7 +293,7 @@ class KubernetesResourceManager:
         self,
         *,
         runtime_paths: RuntimePaths,
-        config: _KubernetesWorkerBackendConfig,
+        config: KubernetesWorkerBackendConfig,
         auth_token: str | None,
         storage_root: Path,
         tool_validation_snapshot: dict[str, dict[str, object]],

--- a/tach.toml
+++ b/tach.toml
@@ -2369,8 +2369,8 @@ exclusive = true
 [[interfaces]]
 expose = [
     "RoomScanConversationCache",
-    "_fetch_event_info_from_conversation_cache",
-    "_room_scan_membership_access_for_client",
+    "fetch_event_info_from_conversation_cache",
+    "room_scan_membership_access_for_client",
 ]
 from = ["mindroom.matrix.thread_room_scan"]
 visibility = ["mindroom.matrix.conversation_cache", "mindroom.matrix.thread_bookkeeping"]

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -32,7 +32,7 @@ from mindroom.tool_system.worker_routing import (
 from mindroom.workers.backend import WorkerBackendError
 from mindroom.workers.backends import kubernetes as kubernetes_backend_module
 from mindroom.workers.backends import kubernetes_resources as kubernetes_resources_module
-from mindroom.workers.backends.kubernetes import KubernetesWorkerBackend, _KubernetesWorkerBackendConfig
+from mindroom.workers.backends.kubernetes import KubernetesWorkerBackend, KubernetesWorkerBackendConfig
 from mindroom.workers.backends.kubernetes_resources import (
     _ANNOTATION_RUNNER_TOKEN_HASH,
     _ANNOTATION_STARTUP_MANIFEST_HASH,
@@ -374,7 +374,7 @@ def _backend(
     enable_service_links: bool = False,
     auth_secret_name: str | None = None,
 ) -> tuple[KubernetesWorkerBackend, _FakeAppsApi, _FakeCoreApi]:
-    config = _KubernetesWorkerBackendConfig(
+    config = KubernetesWorkerBackendConfig(
         namespace="chat",
         image="ghcr.io/mindroom-ai/mindroom:latest",
         image_pull_policy="IfNotPresent",
@@ -1026,7 +1026,7 @@ def test_kubernetes_backend_config_resource_envs_override_defaults(tmp_path: Pat
     )
     runtime_paths = resolve_primary_runtime_paths(config_path=config_path)
 
-    config = _KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
+    config = KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
 
     assert config.resource_requests == {"memory": "2Gi", "cpu": "500m"}
     assert config.resource_limits == {"memory": "8Gi", "cpu": "2"}
@@ -1051,7 +1051,7 @@ def test_kubernetes_backend_config_resources_default_when_env_unset(tmp_path: Pa
     )
     runtime_paths = resolve_primary_runtime_paths(config_path=config_path)
 
-    config = _KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
+    config = KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
 
     assert config.resource_requests == {"memory": "256Mi", "cpu": "100m"}
     assert config.resource_limits == {"memory": "1Gi", "cpu": "500m"}
@@ -1078,7 +1078,7 @@ def test_kubernetes_backend_config_allows_service_links_override(tmp_path: Path)
     )
     runtime_paths = resolve_primary_runtime_paths(config_path=config_path)
 
-    config = _KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
+    config = KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
 
     assert config.enable_service_links is True
 
@@ -1132,7 +1132,7 @@ def test_kubernetes_backend_config_reads_worker_annotations_from_env(tmp_path: P
     )
     runtime_paths = resolve_primary_runtime_paths(config_path=config_path)
 
-    config = _KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
+    config = KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
 
     assert config.extra_annotations == {
         "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",

--- a/uv.lock
+++ b/uv.lock
@@ -4243,7 +4243,7 @@ dev = [
     { name = "markdown-gfm-admonition" },
     { name = "pre-commit", specifier = ">=4.2" },
     { name = "pre-commit-uv", specifier = ">=4.1.4" },
-    { name = "privata", specifier = ">=0.1.3" },
+    { name = "privata", specifier = ">=0.1.5" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
@@ -6039,11 +6039,11 @@ wheels = [
 
 [[package]]
 name = "privata"
-version = "0.1.3"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/12/b7/b156bfb0311edd85f93e5e820777de2b9e3dcf0d2aed70909eac670992a6/privata-0.1.3.tar.gz", hash = "sha256:ba043ee949a297e66ce822d0cca159f16e97e22fd1a1e5160cbf5f76d50a4ece", size = 59865, upload-time = "2026-05-05T23:08:09.889Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/d5/d5ca697a1985c5560fe781f95f5ec7acd74f885744c3555a46a120921452/privata-0.1.5.tar.gz", hash = "sha256:e0c844ba6417d05f790ef54815a2b1e50af06d0e6c8c0aff059d4c080c9751bd", size = 63191, upload-time = "2026-05-05T23:56:33.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/9e/844d97499d5f85a3f1239bb3391115f2f63e893d21cd98ff9ee3cab00833/privata-0.1.3-py3-none-any.whl", hash = "sha256:73720de12233e9f6b002ef44c3226bb4a7dbca265f1e0edc6100288be54afadf", size = 10607, upload-time = "2026-05-05T23:08:08.576Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ee/05d27aa9d9fa78217e7813563ff1328e2b57f37f5ed120b9cd5b77dbce9c/privata-0.1.5-py3-none-any.whl", hash = "sha256:f37b783112a13e55ba28fe748e6e83c36e19bc3e4a6f3c7387ec973c88273f91", size = 15482, upload-time = "2026-05-05T23:56:31.64Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4243,7 +4243,7 @@ dev = [
     { name = "markdown-gfm-admonition" },
     { name = "pre-commit", specifier = ">=4.2" },
     { name = "pre-commit-uv", specifier = ">=4.1.4" },
-    { name = "privata", specifier = ">=0.1.5" },
+    { name = "privata", specifier = ">=0.1.7" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
@@ -6039,11 +6039,11 @@ wheels = [
 
 [[package]]
 name = "privata"
-version = "0.1.5"
+version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/d5/d5ca697a1985c5560fe781f95f5ec7acd74f885744c3555a46a120921452/privata-0.1.5.tar.gz", hash = "sha256:e0c844ba6417d05f790ef54815a2b1e50af06d0e6c8c0aff059d4c080c9751bd", size = 63191, upload-time = "2026-05-05T23:56:33.236Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/47/0d8678f9691e676fbaaa849a2996407faebeb7c9e228d19cd6bade866b39/privata-0.1.7.tar.gz", hash = "sha256:4d0b6493f6f7827e025933a6b52ff6e353ddc0cbd39e98ea2edecdb94403863f", size = 63288, upload-time = "2026-05-06T01:10:48.881Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ee/05d27aa9d9fa78217e7813563ff1328e2b57f37f5ed120b9cd5b77dbce9c/privata-0.1.5-py3-none-any.whl", hash = "sha256:f37b783112a13e55ba28fe748e6e83c36e19bc3e4a6f3c7387ec973c88273f91", size = 15482, upload-time = "2026-05-05T23:56:31.64Z" },
+    { url = "https://files.pythonhosted.org/packages/51/de/ea7e4f3306487fc915b3cdffae1368fd64e7eabd7f6632c527f6eb5788da/privata-0.1.7-py3-none-any.whl", hash = "sha256:b4f83d3b2c107c663053228c124ea11fccabe1e3bdc7ae1932b55963aa8d375a", size = 15543, upload-time = "2026-05-06T01:10:47.255Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump `privata` to `>=0.1.5`, which fixes `__all__` validation treating dependency imports as mandatory exports
- add missing explicit `__all__` entries for MindRoom symbols that are imported by production modules
- keep `privata .` clean on current `main`

## Related
- `privata` fix PR: https://github.com/basnijholt/privata/pull/1
- published `privata` release used here: https://github.com/basnijholt/privata/releases/tag/v0.1.5

## Verification
- `env -u VIRTUAL_ENV uv run privata .` ✅
- `env -u VIRTUAL_ENV uv run tach check --dependencies --interfaces` ✅
- `uv run pytest tests/test_tach_split_matrix_client_boundaries.py tests/test_tool_system_facade_boundaries.py tests/test_streaming_behavior.py::TestStreamingBehavior::test_clean_partial_reply_text_strips_shared_markers -n 0 --no-cov -q` ✅
- `uv run pre-commit run --all-files` ✅
- `uv run pytest` ✅ (`6219 passed, 56 skipped`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped privata dependency to 0.1.7.

* **Refactor**
  * Broadened public API surface across multiple modules, exposing additional runtime utilities, bot components, streaming helpers, thread/room scan helpers, and client delivery helpers.
  * Migrated Kubernetes worker backend config from private to public types and updated backend and tests to use the public config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->