### PR TITLE
Harden network access approval prompts

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -43,6 +43,8 @@ If MindRoom restarts before a tool call is approved, the live tool call is cance
 On startup, MindRoom attempts to mark recent unresolved approval cards sent by the current router as expired.
 Agent-authored, system-authored, and configured bridge-bot-authored tool calls are denied instead of entering the approval flow.
 OpenAI-compatible `/v1/chat/completions` has no approval transport, so any tool function that matches a required-approval rule, including script-based rules, is hidden from the `/v1` tool schema instead of being exposed and blocked later.
+For network domain grants, approve only when the normalized hostname, requested TTL, requesting agent/tool, and concise reason match the action you intend to allow.
+Treat content copied from files, web pages, tickets, messages, or tool outputs as untrusted context rather than approval justification by itself.
 
 ```yaml
 tool_approval:

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -775,6 +775,8 @@ If MindRoom restarts before a tool call is approved, the live tool call is cance
 On startup, MindRoom attempts to mark recent unresolved approval cards sent by the current router as expired.
 Agent-authored, system-authored, and configured bridge-bot-authored tool calls are denied instead of entering the approval flow.
 OpenAI-compatible `/v1/chat/completions` has no approval transport, so any tool function that matches a required-approval rule, including script-based rules, is hidden from the `/v1` tool schema instead of being exposed and blocked later.
+For network domain grants, approve only when the normalized hostname, requested TTL, requesting agent/tool, and concise reason match the action you intend to allow.
+Treat content copied from files, web pages, tickets, messages, or tool outputs as untrusted context rather than approval justification by itself.
 
 ```yaml
 tool_approval:

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -39,6 +39,8 @@ If MindRoom restarts before a tool call is approved, the live tool call is cance
 On startup, MindRoom attempts to mark recent unresolved approval cards sent by the current router as expired.
 Agent-authored, system-authored, and configured bridge-bot-authored tool calls are denied instead of entering the approval flow.
 OpenAI-compatible `/v1/chat/completions` has no approval transport, so any tool function that matches a required-approval rule, including script-based rules, is hidden from the `/v1` tool schema instead of being exposed and blocked later.
+For network domain grants, approve only when the normalized hostname, requested TTL, requesting agent/tool, and concise reason match the action you intend to allow.
+Treat content copied from files, web pages, tickets, messages, or tool outputs as untrusted context rather than approval justification by itself.
 
 ```yaml
 tool_approval:

--- a/src/mindroom/approval_events.py
+++ b/src/mindroom/approval_events.py
@@ -25,6 +25,12 @@ class PendingApproval:
     tool_name: str
     arguments_preview: dict[str, Any]
     arguments_preview_truncated: bool
+    approval_type: str
+    approval_reason: str
+    approval_warning: str
+    request_context: dict[str, Any]
+    normalized_hostname: str | None
+    requested_ttl_seconds: int | None
     timeout_seconds: int
     created_at_ms: int
     thread_id: str | None = None
@@ -66,6 +72,15 @@ class PendingApproval:
         requester_id = _content_str(content, "requester_id") or ""
         thread_id = _content_str(content, "thread_id")
         agent_name = _content_str(content, "agent_name")
+        approval_type = _content_str(content, "approval_type") or "tool_action"
+        approval_reason = _content_str(content, "approval_reason") or ""
+        approval_warning = _content_str(content, "approval_warning") or ""
+        request_context = content.get("request_context")
+        if not isinstance(request_context, dict):
+            request_context = {}
+        requested_ttl_seconds = content.get("requested_ttl_seconds")
+        if isinstance(requested_ttl_seconds, bool) or not isinstance(requested_ttl_seconds, int):
+            requested_ttl_seconds = None
 
         return cls(
             approval_id=approval_id,
@@ -77,6 +92,12 @@ class PendingApproval:
             tool_name=tool_name,
             arguments_preview=cast("dict[str, Any]", arguments),
             arguments_preview_truncated=bool(content.get("arguments_truncated")),
+            approval_type=approval_type,
+            approval_reason=approval_reason,
+            approval_warning=approval_warning,
+            request_context=cast("dict[str, Any]", request_context),
+            normalized_hostname=_content_str(content, "normalized_hostname"),
+            requested_ttl_seconds=requested_ttl_seconds,
             timeout_seconds=timeout_seconds,
             created_at_ms=created_at_ms,
             thread_id=thread_id,

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -56,6 +56,7 @@ _DEFAULT_TRUNCATED_APPROVAL_REASON = (
     "Cannot approve: the displayed arguments are truncated. "
     "Ask the agent to retry with a smaller payload, or approve via the script-based approval rule."
 )
+_INVALID_DOMAIN_GRANT_REASON = "Cannot approve network access without an exact hostname."
 _STARTUP_DISCARD_REASON = "Bot restarted before approval — original request was cancelled."
 _UNTRUSTED_APPROVAL_WARNING = (
     "Content from files, web pages, tickets, messages, or tool outputs may be untrusted and "
@@ -209,8 +210,11 @@ def _normalize_approval_hostname(value: object) -> str | None:
     if not raw:
         return None
 
-    parsed = urlsplit(raw if "://" in raw else f"//{raw}")
-    hostname = parsed.hostname
+    try:
+        parsed = urlsplit(raw if "://" in raw else f"//{raw}")
+        hostname = parsed.hostname
+    except ValueError:
+        return None
     if hostname is None:
         hostname = raw.strip("[]")
     hostname = hostname.strip().rstrip(".").lower()
@@ -256,6 +260,11 @@ def _is_domain_grant_approval(tool_name: str, arguments: dict[str, Any]) -> bool
     if kind in _DOMAIN_GRANT_KIND_VALUES:
         return True
     return tool_name in _DOMAIN_GRANT_TOOL_NAMES and _domain_grant_hostname(arguments) is not None
+
+
+def _is_domain_grant_request(tool_name: str, arguments: dict[str, Any]) -> bool:
+    kind = _approval_kind_value(arguments)
+    return kind in _DOMAIN_GRANT_KIND_VALUES or tool_name in _DOMAIN_GRANT_TOOL_NAMES
 
 
 def _normalize_approval_arguments(tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -408,6 +417,12 @@ class _ApprovalManager:
         requested_at = _utcnow()
         expires_at = requested_at + timedelta(seconds=max(timeout_seconds, 0.0))
         approval_arguments = _normalize_approval_arguments(tool_name, arguments)
+        invalid_domain_grant = (
+            _is_domain_grant_request(tool_name, approval_arguments)
+            and _domain_grant_hostname(approval_arguments) is None
+        )
+        if invalid_domain_grant:
+            return self._new_decision(status="denied", reason=_INVALID_DOMAIN_GRANT_REASON, resolved_by=None)
         event_arguments, arguments_truncated = _build_event_arguments_preview(approval_arguments)
         content = self._pending_event_content(
             approval_id=approval_id,

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
-from urllib.parse import urlsplit
+from urllib.parse import SplitResult, urlsplit
 from uuid import uuid4
 
 from mindroom.approval_events import (
@@ -202,6 +202,31 @@ def _build_event_arguments_preview(arguments: dict[str, Any]) -> tuple[dict[str,
     return preview, True
 
 
+def _split_approval_hostname_value(raw: str) -> SplitResult | None:
+    if "://" in raw or raw.startswith("//"):
+        parsed = urlsplit(raw)
+        return parsed if parsed.netloc else None
+    if any(character in raw for character in "/\\?#@"):
+        return None
+    return urlsplit(f"//{raw}")
+
+
+def _normalized_hostname_text(hostname: str) -> str | None:
+    normalized = hostname.strip().rstrip(".").lower()
+    if (
+        not normalized
+        or "*" in normalized
+        or any(character.isspace() or character in "/\\?#@" for character in normalized)
+    ):
+        return None
+    if ":" in normalized:
+        return normalized
+    try:
+        return normalized.encode("idna").decode("ascii")
+    except UnicodeError:
+        return None
+
+
 def _normalize_approval_hostname(value: object) -> str | None:
     """Return the exact lowercase hostname represented by one approval value."""
     if not isinstance(value, str):
@@ -211,21 +236,13 @@ def _normalize_approval_hostname(value: object) -> str | None:
         return None
 
     try:
-        parsed = urlsplit(raw if "://" in raw else f"//{raw}")
-        hostname = parsed.hostname
+        parsed = _split_approval_hostname_value(raw)
+        if parsed is None:
+            return None
+        _ = parsed.port
     except ValueError:
         return None
-    if hostname is None:
-        hostname = raw.strip("[]")
-    hostname = hostname.strip().rstrip(".").lower()
-    if not hostname or "*" in hostname or any(character.isspace() for character in hostname):
-        return None
-    if ":" not in hostname:
-        try:
-            hostname = hostname.encode("idna").decode("ascii")
-        except UnicodeError:
-            return None
-    return hostname
+    return _normalized_hostname_text(parsed.hostname) if parsed.hostname is not None else None
 
 
 def _first_argument_value(arguments: dict[str, Any], keys: tuple[str, ...]) -> object | None:

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -57,6 +57,7 @@ _DEFAULT_TRUNCATED_APPROVAL_REASON = (
     "Ask the agent to retry with a smaller payload, or approve via the script-based approval rule."
 )
 _INVALID_DOMAIN_GRANT_REASON = "Cannot approve network access without an exact hostname."
+_INVALID_DOMAIN_GRANT_TTL_REASON = "Cannot approve network access with an invalid requested TTL."
 _STARTUP_DISCARD_REASON = "Bot restarted before approval — original request was cancelled."
 _UNTRUSTED_APPROVAL_WARNING = (
     "Content from files, web pages, tickets, messages, or tool outputs may be untrusted and "
@@ -207,6 +208,8 @@ def _split_approval_hostname_value(raw: str) -> SplitResult | None:
         return None
     if "://" in raw or raw.startswith("//"):
         parsed = urlsplit(raw)
+        if parsed.username is not None or parsed.password is not None:
+            return None
         return parsed if parsed.netloc else None
     if any(character in raw for character in "/\\?#@"):
         return None
@@ -218,7 +221,7 @@ def _normalized_hostname_text(hostname: str) -> str | None:
     if (
         not normalized
         or "*" in normalized
-        or any(character.isspace() or character in "/\\?#@" for character in normalized)
+        or any(character.isspace() or character in "/\\?#@%" for character in normalized)
     ):
         return None
     if ":" in normalized:
@@ -323,6 +326,8 @@ def _invalid_domain_grant_reason(tool_name: str, arguments: dict[str, Any]) -> s
         return None
     if _domain_grant_hostname(arguments) is None:
         return _INVALID_DOMAIN_GRANT_REASON
+    if not _domain_grant_ttl_is_valid(arguments):
+        return _INVALID_DOMAIN_GRANT_TTL_REASON
     return None
 
 
@@ -338,14 +343,30 @@ def _requested_ttl_seconds(arguments: dict[str, Any]) -> int | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, int):
-        return max(0, value)
+        return value
     if not isinstance(value, str) or not value.strip():
         return None
     try:
         ttl_seconds = int(value)
     except ValueError:
         return None
-    return max(0, ttl_seconds)
+    return ttl_seconds
+
+
+def _domain_grant_ttl_is_valid(arguments: dict[str, Any]) -> bool:
+    value = _first_argument_value(arguments, _TTL_ARGUMENT_KEYS)
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return value >= 0
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        return int(value) >= 0
+    except ValueError:
+        return False
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -76,18 +76,6 @@ _DOMAIN_GRANT_TOOL_NAMES = frozenset(
         "request_network_access",
     },
 )
-_DOMAIN_GRANT_KIND_VALUES = frozenset(
-    {
-        "domain",
-        "domain_grant",
-        "dynamic_egress",
-        "dynamic_network_access",
-        "egress_domain_grant",
-        "network_access",
-        "network_domain_grant",
-    },
-)
-_APPROVAL_KIND_KEYS = ("approval_kind", "approval_type", "grant_kind", "grant_type")
 _HOSTNAME_ARGUMENT_KEYS = ("hostname", "host", "domain", "requested_hostname", "target_host")
 _URL_ARGUMENT_KEYS = ("url", "uri", "endpoint")
 _TTL_ARGUMENT_KEYS = ("requested_ttl_seconds", "ttl_seconds", "ttl")
@@ -216,6 +204,10 @@ def _split_approval_hostname_value(raw: str) -> SplitResult | None:
     return urlsplit(f"//{raw}")
 
 
+def _has_control_character(value: str) -> bool:
+    return any(ord(character) < 32 or ord(character) == 127 for character in value)
+
+
 def _normalized_hostname_text(hostname: str) -> str | None:
     normalized = hostname.strip().rstrip(".").lower()
     if (
@@ -235,6 +227,8 @@ def _normalized_hostname_text(hostname: str) -> str | None:
 def _normalize_approval_hostname(value: object) -> str | None:
     """Return the exact lowercase hostname represented by one approval value."""
     if not isinstance(value, str):
+        return None
+    if _has_control_character(value):
         return None
     raw = value.strip()
     if not raw:
@@ -265,11 +259,6 @@ def _first_argument_key(arguments: dict[str, Any], keys: tuple[str, ...]) -> str
     return None
 
 
-def _approval_kind_value(arguments: dict[str, Any]) -> str | None:
-    value = _first_argument_value(arguments, _APPROVAL_KIND_KEYS)
-    return value.strip().lower() if isinstance(value, str) and value.strip() else None
-
-
 def _domain_grant_argument_hostnames(arguments: dict[str, Any]) -> tuple[str, ...] | None:
     hostnames: list[str] = []
     for key in (*_HOSTNAME_ARGUMENT_KEYS, *_URL_ARGUMENT_KEYS):
@@ -294,15 +283,11 @@ def _domain_grant_hostname(arguments: dict[str, Any]) -> str | None:
 
 
 def _is_domain_grant_approval(tool_name: str, arguments: dict[str, Any]) -> bool:
-    kind = _approval_kind_value(arguments)
-    if kind in _DOMAIN_GRANT_KIND_VALUES:
-        return True
     return tool_name in _DOMAIN_GRANT_TOOL_NAMES and _domain_grant_hostname(arguments) is not None
 
 
-def _is_domain_grant_request(tool_name: str, arguments: dict[str, Any]) -> bool:
-    kind = _approval_kind_value(arguments)
-    return kind in _DOMAIN_GRANT_KIND_VALUES or tool_name in _DOMAIN_GRANT_TOOL_NAMES
+def _is_domain_grant_request(tool_name: str, _arguments: dict[str, Any]) -> bool:
+    return tool_name in _DOMAIN_GRANT_TOOL_NAMES
 
 
 def _normalize_approval_arguments(tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -367,6 +352,19 @@ def _domain_grant_ttl_is_valid(arguments: dict[str, Any]) -> bool:
         return int(value) >= 0
     except ValueError:
         return False
+
+
+def _domain_grant_event_subject(
+    *,
+    hostname: str | None,
+    requested_ttl_seconds: int | None,
+    agent_name: str | None,
+    tool_name: str,
+    reason: str,
+) -> str:
+    ttl = "unspecified" if requested_ttl_seconds is None else f"{requested_ttl_seconds}s"
+    agent = agent_name or "unknown"
+    return f"hostname={hostname or 'unknown'}; ttl={ttl}; agent={agent}; tool={tool_name}; reason={reason}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -1287,6 +1285,8 @@ class _ApprovalManager:
             else None
         )
         approval_type = "domain_grant" if normalized_hostname is not None else "tool_action"
+        approval_reason = _approval_reason(normalized_arguments)
+        requested_ttl_seconds = _requested_ttl_seconds(normalized_arguments)
         content: dict[str, Any] = {
             "msgtype": "io.mindroom.tool_approval",
             "body": _ApprovalManager._event_body(
@@ -1294,6 +1294,9 @@ class _ApprovalManager:
                 status,
                 approval_type=approval_type,
                 subject=normalized_hostname,
+                requested_ttl_seconds=requested_ttl_seconds,
+                agent_name=agent_name,
+                approval_reason=approval_reason,
             ),
             "tool_name": tool_name,
             "tool_call_id": approval_id,
@@ -1301,7 +1304,7 @@ class _ApprovalManager:
             "status": status,
             "approval_id": approval_id,
             "approval_type": approval_type,
-            "approval_reason": _approval_reason(normalized_arguments),
+            "approval_reason": approval_reason,
             "approval_warning": _UNTRUSTED_APPROVAL_WARNING,
             "request_context": {
                 "agent_name": agent_name,
@@ -1315,7 +1318,7 @@ class _ApprovalManager:
         }
         if normalized_hostname is not None:
             content["normalized_hostname"] = normalized_hostname
-            content["requested_ttl_seconds"] = _requested_ttl_seconds(normalized_arguments)
+            content["requested_ttl_seconds"] = requested_ttl_seconds
         if agent_name is not None:
             content["agent_name"] = agent_name
         if arguments_truncated:
@@ -1347,6 +1350,9 @@ class _ApprovalManager:
                 status,
                 approval_type=pending.approval_type,
                 subject=pending.normalized_hostname,
+                requested_ttl_seconds=pending.requested_ttl_seconds,
+                agent_name=pending.agent_name,
+                approval_reason=pending.approval_reason,
             ),
             "tool_name": pending.tool_name,
             "tool_call_id": pending.approval_id,
@@ -1384,9 +1390,21 @@ class _ApprovalManager:
         *,
         approval_type: str = "tool_action",
         subject: str | None = None,
+        requested_ttl_seconds: int | None = None,
+        agent_name: str | None = None,
+        approval_reason: str | None = None,
     ) -> str:
         label = "Domain grant" if approval_type == "domain_grant" else "Tool/action"
-        target = subject or tool_name
+        if approval_type == "domain_grant":
+            target = _domain_grant_event_subject(
+                hostname=subject,
+                requested_ttl_seconds=requested_ttl_seconds,
+                agent_name=agent_name,
+                tool_name=tool_name,
+                reason=approval_reason or "Tool call requires human approval.",
+            )
+        else:
+            target = tool_name
         if status == "approved":
             return f"{label} approved: {target}"
         if status == "denied":

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -275,12 +275,16 @@ def _domain_grant_hostname(arguments: dict[str, Any]) -> str | None:
     return hostname
 
 
+def _is_explicit_domain_grant_request(tool_name: str, arguments: dict[str, Any]) -> bool:
+    return tool_name in _DOMAIN_GRANT_TOOL_NAMES and arguments.get("approval_kind") == "domain_grant"
+
+
 def _is_domain_grant_approval(tool_name: str, arguments: dict[str, Any]) -> bool:
-    return tool_name in _DOMAIN_GRANT_TOOL_NAMES and _domain_grant_hostname(arguments) is not None
+    return _is_explicit_domain_grant_request(tool_name, arguments) and _domain_grant_hostname(arguments) is not None
 
 
-def _is_domain_grant_request(tool_name: str, _arguments: dict[str, Any]) -> bool:
-    return tool_name in _DOMAIN_GRANT_TOOL_NAMES
+def _is_domain_grant_request(tool_name: str, arguments: dict[str, Any]) -> bool:
+    return _is_explicit_domain_grant_request(tool_name, arguments)
 
 
 def _normalize_approval_arguments(tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -213,7 +213,7 @@ def _normalized_hostname_text(hostname: str) -> str | None:
     if (
         not normalized
         or "*" in normalized
-        or any(character.isspace() or character in "/\\?#@%" for character in normalized)
+        or any(character.isspace() or character in "/\\?#@%;" for character in normalized)
     ):
         return None
     if ":" in normalized:

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -203,6 +203,8 @@ def _build_event_arguments_preview(arguments: dict[str, Any]) -> tuple[dict[str,
 
 
 def _split_approval_hostname_value(raw: str) -> SplitResult | None:
+    if "\\" in raw:
+        return None
     if "://" in raw or raw.startswith("//"):
         parsed = urlsplit(raw)
         return parsed if parsed.netloc else None
@@ -285,7 +287,7 @@ def _is_domain_grant_request(tool_name: str, arguments: dict[str, Any]) -> bool:
 
 
 def _normalize_approval_arguments(tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
-    """Normalize domain-grant arguments before rendering or granting policy."""
+    """Normalize only existing runtime arguments before granting policy."""
     normalized_arguments = dict(arguments)
     if not _is_domain_grant_approval(tool_name, normalized_arguments):
         return normalized_arguments
@@ -297,8 +299,19 @@ def _normalize_approval_arguments(tool_name: str, arguments: dict[str, Any]) -> 
     host_key = _first_argument_key(normalized_arguments, _HOSTNAME_ARGUMENT_KEYS)
     if host_key is not None:
         normalized_arguments[host_key] = normalized_hostname
-    normalized_arguments["normalized_hostname"] = normalized_hostname
     return normalized_arguments
+
+
+def _invalid_domain_grant_reason(tool_name: str, arguments: dict[str, Any]) -> str | None:
+    if not _is_domain_grant_request(tool_name, arguments):
+        return None
+    if _domain_grant_hostname(arguments) is None:
+        return _INVALID_DOMAIN_GRANT_REASON
+    for key in (*_HOSTNAME_ARGUMENT_KEYS, *_URL_ARGUMENT_KEYS):
+        value = arguments.get(key)
+        if value is not None and _normalize_approval_hostname(value) is None:
+            return _INVALID_DOMAIN_GRANT_REASON
+    return None
 
 
 def _approval_reason(arguments: dict[str, Any]) -> str:
@@ -434,12 +447,9 @@ class _ApprovalManager:
         requested_at = _utcnow()
         expires_at = requested_at + timedelta(seconds=max(timeout_seconds, 0.0))
         approval_arguments = _normalize_approval_arguments(tool_name, arguments)
-        invalid_domain_grant = (
-            _is_domain_grant_request(tool_name, approval_arguments)
-            and _domain_grant_hostname(approval_arguments) is None
-        )
-        if invalid_domain_grant:
-            return self._new_decision(status="denied", reason=_INVALID_DOMAIN_GRANT_REASON, resolved_by=None)
+        invalid_domain_grant_reason = _invalid_domain_grant_reason(tool_name, approval_arguments)
+        if invalid_domain_grant_reason is not None:
+            return self._new_decision(status="denied", reason=invalid_domain_grant_reason, resolved_by=None)
         event_arguments, arguments_truncated = _build_event_arguments_preview(approval_arguments)
         content = self._pending_event_content(
             approval_id=approval_id,

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -252,13 +252,6 @@ def _first_argument_value(arguments: dict[str, Any], keys: tuple[str, ...]) -> o
     return None
 
 
-def _first_argument_key(arguments: dict[str, Any], keys: tuple[str, ...]) -> str | None:
-    for key in keys:
-        if key in arguments:
-            return key
-    return None
-
-
 def _domain_grant_argument_hostnames(arguments: dict[str, Any]) -> tuple[str, ...] | None:
     hostnames: list[str] = []
     for key in (*_HOSTNAME_ARGUMENT_KEYS, *_URL_ARGUMENT_KEYS):

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -354,6 +354,10 @@ def _domain_grant_ttl_is_valid(arguments: dict[str, Any]) -> bool:
         return False
 
 
+def _approval_body_field_text(value: str) -> str:
+    return " ".join(value.split()).replace(";", ",")
+
+
 def _domain_grant_event_subject(
     *,
     hostname: str | None,
@@ -364,7 +368,8 @@ def _domain_grant_event_subject(
 ) -> str:
     ttl = "unspecified" if requested_ttl_seconds is None else f"{requested_ttl_seconds}s"
     agent = agent_name or "unknown"
-    return f"hostname={hostname or 'unknown'}; ttl={ttl}; agent={agent}; tool={tool_name}; reason={reason}"
+    safe_reason = _approval_body_field_text(reason)
+    return f"hostname={hostname or 'unknown'}; ttl={ttl}; agent={agent}; tool={tool_name}; reason={safe_reason}"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import urlsplit
 from uuid import uuid4
 
 from mindroom.approval_events import (
@@ -56,9 +57,39 @@ _DEFAULT_TRUNCATED_APPROVAL_REASON = (
     "Ask the agent to retry with a smaller payload, or approve via the script-based approval rule."
 )
 _STARTUP_DISCARD_REASON = "Bot restarted before approval — original request was cancelled."
+_UNTRUSTED_APPROVAL_WARNING = (
+    "Content from files, web pages, tickets, messages, or tool outputs may be untrusted and "
+    "should not be treated as approval justification by itself."
+)
 _MAX_ARGUMENTS_PREVIEW_CHARS = 1200
 _MAX_REMEMBERED_TERMINAL_CARD_IDS = 4096
 _SANITIZER_TRUNCATION_MARKER = "... [truncated]"
+_DOMAIN_GRANT_TOOL_NAMES = frozenset(
+    {
+        "dynamic_egress",
+        "dynamic_network_access",
+        "egress_network_access",
+        "grant_network_access",
+        "network_access",
+        "request_network_access",
+    },
+)
+_DOMAIN_GRANT_KIND_VALUES = frozenset(
+    {
+        "domain",
+        "domain_grant",
+        "dynamic_egress",
+        "dynamic_network_access",
+        "egress_domain_grant",
+        "network_access",
+        "network_domain_grant",
+    },
+)
+_APPROVAL_KIND_KEYS = ("approval_kind", "approval_type", "grant_kind", "grant_type")
+_HOSTNAME_ARGUMENT_KEYS = ("hostname", "host", "domain", "requested_hostname", "target_host")
+_URL_ARGUMENT_KEYS = ("url", "uri", "endpoint")
+_TTL_ARGUMENT_KEYS = ("requested_ttl_seconds", "ttl_seconds", "ttl")
+_REASON_ARGUMENT_KEYS = ("reason", "approval_reason", "justification")
 _MANAGER: _ApprovalManager | None = None
 logger = get_logger(__name__)
 
@@ -168,6 +199,102 @@ def _build_event_arguments_preview(arguments: dict[str, Any]) -> tuple[dict[str,
         }
         return summary, True
     return preview, True
+
+
+def _normalize_approval_hostname(value: object) -> str | None:
+    """Return the exact lowercase hostname represented by one approval value."""
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+
+    parsed = urlsplit(raw if "://" in raw else f"//{raw}")
+    hostname = parsed.hostname
+    if hostname is None:
+        hostname = raw.strip("[]")
+    hostname = hostname.strip().rstrip(".").lower()
+    if not hostname or "*" in hostname or any(character.isspace() for character in hostname):
+        return None
+    if ":" not in hostname:
+        try:
+            hostname = hostname.encode("idna").decode("ascii")
+        except UnicodeError:
+            return None
+    return hostname
+
+
+def _first_argument_value(arguments: dict[str, Any], keys: tuple[str, ...]) -> object | None:
+    for key in keys:
+        value = arguments.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _first_argument_key(arguments: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        if key in arguments:
+            return key
+    return None
+
+
+def _approval_kind_value(arguments: dict[str, Any]) -> str | None:
+    value = _first_argument_value(arguments, _APPROVAL_KIND_KEYS)
+    return value.strip().lower() if isinstance(value, str) and value.strip() else None
+
+
+def _domain_grant_hostname(arguments: dict[str, Any]) -> str | None:
+    hostname = _normalize_approval_hostname(_first_argument_value(arguments, _HOSTNAME_ARGUMENT_KEYS))
+    if hostname is not None:
+        return hostname
+    return _normalize_approval_hostname(_first_argument_value(arguments, _URL_ARGUMENT_KEYS))
+
+
+def _is_domain_grant_approval(tool_name: str, arguments: dict[str, Any]) -> bool:
+    kind = _approval_kind_value(arguments)
+    if kind in _DOMAIN_GRANT_KIND_VALUES:
+        return True
+    return tool_name in _DOMAIN_GRANT_TOOL_NAMES and _domain_grant_hostname(arguments) is not None
+
+
+def _normalize_approval_arguments(tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Normalize domain-grant arguments before rendering or granting policy."""
+    normalized_arguments = dict(arguments)
+    if not _is_domain_grant_approval(tool_name, normalized_arguments):
+        return normalized_arguments
+
+    normalized_hostname = _domain_grant_hostname(normalized_arguments)
+    if normalized_hostname is None:
+        return normalized_arguments
+
+    host_key = _first_argument_key(normalized_arguments, _HOSTNAME_ARGUMENT_KEYS)
+    if host_key is not None:
+        normalized_arguments[host_key] = normalized_hostname
+    normalized_arguments["normalized_hostname"] = normalized_hostname
+    return normalized_arguments
+
+
+def _approval_reason(arguments: dict[str, Any]) -> str:
+    reason = _first_argument_value(arguments, _REASON_ARGUMENT_KEYS)
+    if isinstance(reason, str) and reason.strip():
+        return sanitize_failure_text(reason.strip(), max_length=240)
+    return "Tool call requires human approval."
+
+
+def _requested_ttl_seconds(arguments: dict[str, Any]) -> int | None:
+    value = _first_argument_value(arguments, _TTL_ARGUMENT_KEYS)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return max(0, value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        ttl_seconds = int(value)
+    except ValueError:
+        return None
+    return max(0, ttl_seconds)
 
 
 @dataclass(frozen=True, slots=True)
@@ -280,7 +407,8 @@ class _ApprovalManager:
         approval_id = uuid4().hex
         requested_at = _utcnow()
         expires_at = requested_at + timedelta(seconds=max(timeout_seconds, 0.0))
-        event_arguments, arguments_truncated = _build_event_arguments_preview(arguments)
+        approval_arguments = _normalize_approval_arguments(tool_name, arguments)
+        event_arguments, arguments_truncated = _build_event_arguments_preview(approval_arguments)
         content = self._pending_event_content(
             approval_id=approval_id,
             tool_name=tool_name,
@@ -1077,19 +1205,42 @@ class _ApprovalManager:
         expires_at: datetime,
         status: PendingApprovalStatus,
     ) -> dict[str, Any]:
+        normalized_arguments = _normalize_approval_arguments(tool_name, arguments)
+        normalized_hostname = (
+            _domain_grant_hostname(normalized_arguments)
+            if _is_domain_grant_approval(tool_name, normalized_arguments)
+            else None
+        )
+        approval_type = "domain_grant" if normalized_hostname is not None else "tool_action"
         content: dict[str, Any] = {
             "msgtype": "io.mindroom.tool_approval",
-            "body": _ApprovalManager._event_body(tool_name, status),
+            "body": _ApprovalManager._event_body(
+                tool_name,
+                status,
+                approval_type=approval_type,
+                subject=normalized_hostname,
+            ),
             "tool_name": tool_name,
             "tool_call_id": approval_id,
-            "arguments": arguments,
+            "arguments": normalized_arguments,
             "status": status,
             "approval_id": approval_id,
+            "approval_type": approval_type,
+            "approval_reason": _approval_reason(normalized_arguments),
+            "approval_warning": _UNTRUSTED_APPROVAL_WARNING,
+            "request_context": {
+                "agent_name": agent_name,
+                "tool_name": tool_name,
+                "requester_id": requester_id,
+            },
             "approver_user_id": approver_user_id,
             "requested_at": requested_at.isoformat(),
             "expires_at": expires_at.isoformat(),
             "thread_id": thread_id,
         }
+        if normalized_hostname is not None:
+            content["normalized_hostname"] = normalized_hostname
+            content["requested_ttl_seconds"] = _requested_ttl_seconds(normalized_arguments)
         if agent_name is not None:
             content["agent_name"] = agent_name
         if arguments_truncated:
@@ -1116,12 +1267,21 @@ class _ApprovalManager:
         )
         content: dict[str, Any] = {
             "msgtype": "io.mindroom.tool_approval",
-            "body": _ApprovalManager._event_body(pending.tool_name, status),
+            "body": _ApprovalManager._event_body(
+                pending.tool_name,
+                status,
+                approval_type=pending.approval_type,
+                subject=pending.normalized_hostname,
+            ),
             "tool_name": pending.tool_name,
             "tool_call_id": pending.approval_id,
             "arguments": pending.arguments_preview,
             "status": status,
             "approval_id": pending.approval_id,
+            "approval_type": pending.approval_type,
+            "approval_reason": pending.approval_reason,
+            "approval_warning": pending.approval_warning,
+            "request_context": pending.request_context,
             "approver_user_id": pending.approver_user_id,
             "requested_at": requested_at.isoformat(),
             "expires_at": expires_at.isoformat(),
@@ -1129,6 +1289,9 @@ class _ApprovalManager:
             "resolved_at": resolved_at.isoformat(),
             "resolved_by": resolved_by,
         }
+        if pending.normalized_hostname is not None:
+            content["normalized_hostname"] = pending.normalized_hostname
+            content["requested_ttl_seconds"] = pending.requested_ttl_seconds
         if pending.agent_name is not None:
             content["agent_name"] = pending.agent_name
         if pending.arguments_preview_truncated:
@@ -1140,14 +1303,22 @@ class _ApprovalManager:
         return content
 
     @staticmethod
-    def _event_body(tool_name: str, status: PendingApprovalStatus) -> str:
+    def _event_body(
+        tool_name: str,
+        status: PendingApprovalStatus,
+        *,
+        approval_type: str = "tool_action",
+        subject: str | None = None,
+    ) -> str:
+        label = "Domain grant" if approval_type == "domain_grant" else "Tool/action"
+        target = subject or tool_name
         if status == "approved":
-            return f"Approved: {tool_name}"
+            return f"{label} approved: {target}"
         if status == "denied":
-            return f"Denied: {tool_name}"
+            return f"{label} denied: {target}"
         if status == "expired":
-            return f"Expired: {tool_name}"
-        return f"🔒 Approval required: {tool_name}"
+            return f"{label} approval expired: {target}"
+        return f"{label} approval required: {target}"
 
     @classmethod
     def _normalized_resolution_request(

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -300,9 +300,9 @@ def _normalize_approval_arguments(tool_name: str, arguments: dict[str, Any]) -> 
     if normalized_hostname is None:
         return normalized_arguments
 
-    host_key = _first_argument_key(normalized_arguments, _HOSTNAME_ARGUMENT_KEYS)
-    if host_key is not None:
-        normalized_arguments[host_key] = normalized_hostname
+    for host_key in _HOSTNAME_ARGUMENT_KEYS:
+        if host_key in normalized_arguments and normalized_arguments[host_key] is not None:
+            normalized_arguments[host_key] = normalized_hostname
     return normalized_arguments
 
 
@@ -491,6 +491,7 @@ class _ApprovalManager:
             approval_id=approval_id,
             tool_name=tool_name,
             arguments=event_arguments,
+            approval_metadata_arguments=approval_arguments,
             arguments_truncated=arguments_truncated,
             agent_name=agent_name,
             thread_id=thread_id,
@@ -1274,6 +1275,7 @@ class _ApprovalManager:
         approval_id: str,
         tool_name: str,
         arguments: dict[str, Any],
+        approval_metadata_arguments: dict[str, Any] | None = None,
         arguments_truncated: bool,
         agent_name: str | None,
         thread_id: str | None,
@@ -1283,15 +1285,23 @@ class _ApprovalManager:
         expires_at: datetime,
         status: PendingApprovalStatus,
     ) -> dict[str, Any]:
-        normalized_arguments = _normalize_approval_arguments(tool_name, arguments)
+        metadata_arguments = _normalize_approval_arguments(
+            tool_name,
+            approval_metadata_arguments if approval_metadata_arguments is not None else arguments,
+        )
+        event_arguments = (
+            dict(arguments)
+            if approval_metadata_arguments is not None
+            else _normalize_approval_arguments(tool_name, arguments)
+        )
         normalized_hostname = (
-            _domain_grant_hostname(normalized_arguments)
-            if _is_domain_grant_approval(tool_name, normalized_arguments)
+            _domain_grant_hostname(metadata_arguments)
+            if _is_domain_grant_approval(tool_name, metadata_arguments)
             else None
         )
         approval_type = "domain_grant" if normalized_hostname is not None else "tool_action"
-        approval_reason = _approval_reason(normalized_arguments)
-        requested_ttl_seconds = _requested_ttl_seconds(normalized_arguments)
+        approval_reason = _approval_reason(metadata_arguments)
+        requested_ttl_seconds = _requested_ttl_seconds(metadata_arguments)
         content: dict[str, Any] = {
             "msgtype": "io.mindroom.tool_approval",
             "body": _ApprovalManager._event_body(
@@ -1305,7 +1315,7 @@ class _ApprovalManager:
             ),
             "tool_name": tool_name,
             "tool_call_id": approval_id,
-            "arguments": normalized_arguments,
+            "arguments": event_arguments,
             "status": status,
             "approval_id": approval_id,
             "approval_type": approval_type,

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -267,11 +267,27 @@ def _approval_kind_value(arguments: dict[str, Any]) -> str | None:
     return value.strip().lower() if isinstance(value, str) and value.strip() else None
 
 
+def _domain_grant_argument_hostnames(arguments: dict[str, Any]) -> tuple[str, ...] | None:
+    hostnames: list[str] = []
+    for key in (*_HOSTNAME_ARGUMENT_KEYS, *_URL_ARGUMENT_KEYS):
+        value = arguments.get(key)
+        if value is None:
+            continue
+        hostname = _normalize_approval_hostname(value)
+        if hostname is None:
+            return None
+        hostnames.append(hostname)
+    return tuple(hostnames)
+
+
 def _domain_grant_hostname(arguments: dict[str, Any]) -> str | None:
-    hostname = _normalize_approval_hostname(_first_argument_value(arguments, _HOSTNAME_ARGUMENT_KEYS))
-    if hostname is not None:
-        return hostname
-    return _normalize_approval_hostname(_first_argument_value(arguments, _URL_ARGUMENT_KEYS))
+    hostnames = _domain_grant_argument_hostnames(arguments)
+    if not hostnames:
+        return None
+    hostname = hostnames[0]
+    if any(candidate != hostname for candidate in hostnames):
+        return None
+    return hostname
 
 
 def _is_domain_grant_approval(tool_name: str, arguments: dict[str, Any]) -> bool:
@@ -307,10 +323,6 @@ def _invalid_domain_grant_reason(tool_name: str, arguments: dict[str, Any]) -> s
         return None
     if _domain_grant_hostname(arguments) is None:
         return _INVALID_DOMAIN_GRANT_REASON
-    for key in (*_HOSTNAME_ARGUMENT_KEYS, *_URL_ARGUMENT_KEYS):
-        value = arguments.get(key)
-        if value is not None and _normalize_approval_hostname(value) is None:
-            return _INVALID_DOMAIN_GRANT_REASON
     return None
 
 

--- a/src/mindroom/tool_approval.py
+++ b/src/mindroom/tool_approval.py
@@ -240,6 +240,9 @@ async def request_tool_approval_for_call(call: ToolApprovalCall) -> ApprovalDeci
     if normalized_arguments != call.arguments:
         call.arguments.clear()
         call.arguments.update(normalized_arguments)
+    invalid_domain_grant_reason = approval_manager._invalid_domain_grant_reason(call.tool_name, call.arguments)
+    if invalid_domain_grant_reason is not None:
+        return _terminal_decision("denied", invalid_domain_grant_reason)
     policy_arguments = deepcopy(call.arguments)
     requires_approval, timeout_seconds = await evaluate_tool_approval(
         call.config,

--- a/src/mindroom/tool_approval.py
+++ b/src/mindroom/tool_approval.py
@@ -70,7 +70,12 @@ class ToolApprovalScriptError(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class ToolApprovalCall:
-    """One tool call that may require a Matrix approval card."""
+    """One tool call that may require a Matrix approval card.
+
+    ``arguments`` is the live tool-call argument mapping.
+    Domain-grant normalization updates it in place so the approved tool executes
+    with the same hostname shown in the approval card.
+    """
 
     config: Config
     runtime_paths: RuntimePaths

--- a/src/mindroom/tool_approval.py
+++ b/src/mindroom/tool_approval.py
@@ -236,6 +236,10 @@ async def evaluate_tool_approval(
 
 async def request_tool_approval_for_call(call: ToolApprovalCall) -> ApprovalDecision | None:
     """Return a terminal decision when one tool call is denied, or None when it may proceed."""
+    normalized_arguments = approval_manager._normalize_approval_arguments(call.tool_name, call.arguments)
+    if normalized_arguments != call.arguments:
+        call.arguments.clear()
+        call.arguments.update(normalized_arguments)
     policy_arguments = deepcopy(call.arguments)
     requires_approval, timeout_seconds = await evaluate_tool_approval(
         call.config,

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -491,7 +491,13 @@ async def _maybe_block_for_tool_approval(
                 requester_id=resolved_context.requester_id,
             ),
         )
+        if hook_arguments is not None:
+            hook_arguments.clear()
+            hook_arguments.update(deepcopy(args))
     except ToolApprovalScriptError:
+        if hook_arguments is not None:
+            hook_arguments.clear()
+            hook_arguments.update(deepcopy(args))
         logger.warning("Tool approval policy failed", exc_info=True)
         return await _blocked_tool_result(
             hook_registry=hook_registry,

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2609,6 +2609,35 @@ def test_tool_action_approval_payload_is_distinct_from_domain_grant() -> None:
 
 
 @pytest.mark.asyncio
+async def test_network_access_tool_action_does_not_require_domain_grant_payload(tmp_path: Path) -> None:
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    store = initialize_approval_store(test_runtime_paths(tmp_path), sender=sender)
+
+    task = asyncio.create_task(
+        store.request_approval(
+            tool_name="network_access",
+            arguments={"remote": "https://example.com/path"},
+            room_id="!room:localhost",
+            agent_name="code",
+            requester_id="@user:localhost",
+            approver_user_id="@user:localhost",
+            timeout_seconds=30,
+        ),
+    )
+    try:
+        await _wait_for_pending(store, sender=sender)
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    card = sender.await_args.args[2]
+    assert card["approval_type"] == "tool_action"
+    assert card["body"] == "Tool/action approval required: network_access"
+    assert "normalized_hostname" not in card
+
+
+@pytest.mark.asyncio
 async def test_domain_grant_arguments_are_normalized_before_tool_continues(tmp_path: Path) -> None:
     arguments = {
         "approval_kind": "domain_grant",

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2225,6 +2225,7 @@ def test_approval_hostname_normalization_uses_exact_display_host(value: str, exp
         "[bad",
         "http:///path",
         "file:///etc/passwd",
+        "http://evil.com\\@good.com/path",
         "/path/to/socket",
     ],
 )
@@ -2249,6 +2250,55 @@ async def test_invalid_domain_grant_is_denied_without_matrix_card(tmp_path: Path
     assert decision.status == "denied"
     assert decision.reason == "Cannot approve network access without an exact hostname."
     sender.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_invalid_domain_grant_is_denied_before_auto_approved_tool_continues(tmp_path: Path) -> None:
+    arguments = {"approval_kind": "domain_grant", "hostname": "http:///path", "ttl_seconds": 60}
+
+    decision = await request_tool_approval_for_call(
+        ToolApprovalCall(
+            config=_config(tmp_path),
+            runtime_paths=test_runtime_paths(tmp_path),
+            tool_name="network_access",
+            arguments=arguments,
+            agent_name="code",
+            room_id="!room:localhost",
+            thread_id="$thread",
+            requester_id="@user:localhost",
+        ),
+    )
+
+    assert decision is not None
+    assert decision.status == "denied"
+    assert decision.reason == "Cannot approve network access without an exact hostname."
+
+
+@pytest.mark.asyncio
+async def test_domain_grant_rejects_malformed_url_even_with_exact_hostname(tmp_path: Path) -> None:
+    arguments = {
+        "approval_kind": "domain_grant",
+        "hostname": "good.com",
+        "url": "http://evil.com\\@good.com/path",
+        "ttl_seconds": 60,
+    }
+
+    decision = await request_tool_approval_for_call(
+        ToolApprovalCall(
+            config=_config(tmp_path),
+            runtime_paths=test_runtime_paths(tmp_path),
+            tool_name="network_access",
+            arguments=arguments,
+            agent_name="code",
+            room_id="!room:localhost",
+            thread_id="$thread",
+            requester_id="@user:localhost",
+        ),
+    )
+
+    assert decision is not None
+    assert decision.status == "denied"
+    assert decision.reason == "Cannot approve network access without an exact hostname."
 
 
 def test_domain_grant_approval_payload_uses_normalized_hostname_and_warning() -> None:
@@ -2330,7 +2380,7 @@ async def test_domain_grant_arguments_are_normalized_before_tool_continues(tmp_p
 
     assert decision is None
     assert arguments["hostname"] == "sub.example.com"
-    assert arguments["normalized_hostname"] == "sub.example.com"
+    assert "normalized_hostname" not in arguments
 
 
 def test_approval_arguments_preview_marks_nested_sanitizer_truncation() -> None:

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2226,6 +2226,8 @@ def test_approval_hostname_normalization_uses_exact_display_host(value: str, exp
         "http:///path",
         "file:///etc/passwd",
         "http://evil.com\\@good.com/path",
+        "https://evil.com@good.com/path",
+        "https://good.com%2f.evil.com/path",
         "/path/to/socket",
     ],
 )
@@ -2326,6 +2328,47 @@ async def test_domain_grant_rejects_mismatched_hostname_and_url(tmp_path: Path) 
     assert decision is not None
     assert decision.status == "denied"
     assert decision.reason == "Cannot approve network access without an exact hostname."
+
+
+@pytest.mark.asyncio
+async def test_domain_grant_rejects_negative_ttl_without_matrix_card(tmp_path: Path) -> None:
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    store = initialize_approval_store(test_runtime_paths(tmp_path), sender=sender)
+
+    decision = await store.request_approval(
+        tool_name="network_access",
+        arguments={"approval_kind": "domain_grant", "hostname": "example.com", "ttl_seconds": -1},
+        room_id="!room:localhost",
+        requester_id="@user:localhost",
+        approver_user_id="@user:localhost",
+        timeout_seconds=30,
+    )
+
+    assert decision.status == "denied"
+    assert decision.reason == "Cannot approve network access with an invalid requested TTL."
+    sender.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_domain_grant_rejects_negative_ttl_before_auto_approved_tool_continues(tmp_path: Path) -> None:
+    arguments = {"approval_kind": "domain_grant", "hostname": "example.com", "ttl_seconds": "-1"}
+
+    decision = await request_tool_approval_for_call(
+        ToolApprovalCall(
+            config=_config(tmp_path),
+            runtime_paths=test_runtime_paths(tmp_path),
+            tool_name="network_access",
+            arguments=arguments,
+            agent_name="code",
+            room_id="!room:localhost",
+            thread_id="$thread",
+            requester_id="@user:localhost",
+        ),
+    )
+
+    assert decision is not None
+    assert decision.status == "denied"
+    assert decision.reason == "Cannot approve network access with an invalid requested TTL."
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2307,6 +2307,32 @@ async def test_domain_grant_rejects_malformed_url_even_with_exact_hostname(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_domain_grant_rejects_hostname_with_body_delimiter(tmp_path: Path) -> None:
+    arguments = {
+        "approval_kind": "domain_grant",
+        "hostname": "2001:db8::1;agent=evil_agent;tool=delete_file",
+        "ttl_seconds": 60,
+    }
+
+    decision = await request_tool_approval_for_call(
+        ToolApprovalCall(
+            config=_config(tmp_path),
+            runtime_paths=test_runtime_paths(tmp_path),
+            tool_name="network_access",
+            arguments=arguments,
+            agent_name="code",
+            room_id="!room:localhost",
+            thread_id="$thread",
+            requester_id="@user:localhost",
+        ),
+    )
+
+    assert decision is not None
+    assert decision.status == "denied"
+    assert decision.reason == "Cannot approve network access without an exact hostname."
+
+
+@pytest.mark.asyncio
 async def test_domain_grant_rejects_mismatched_hostname_and_url(tmp_path: Path) -> None:
     arguments = {
         "approval_kind": "domain_grant",

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2228,6 +2228,8 @@ def test_approval_hostname_normalization_uses_exact_display_host(value: str, exp
         "http://evil.com\\@good.com/path",
         "https://evil.com@good.com/path",
         "https://good.com%2f.evil.com/path",
+        "good.com\x00.evil.com",
+        "good.com\n.evil.com",
         "/path/to/socket",
     ],
 )
@@ -2371,6 +2373,31 @@ async def test_domain_grant_rejects_negative_ttl_before_auto_approved_tool_conti
     assert decision.reason == "Cannot approve network access with an invalid requested TTL."
 
 
+def test_non_network_tool_cannot_claim_domain_grant_approval_type() -> None:
+    card = _ApprovalManager._pending_event_content(
+        approval_id="approval-1",
+        tool_name="delete_file",
+        arguments={
+            "approval_kind": "domain_grant",
+            "hostname": "example.com",
+            "ttl_seconds": 60,
+            "reason": "Fetch public documentation.",
+        },
+        arguments_truncated=False,
+        agent_name="code",
+        thread_id="$thread",
+        requester_id="@user:localhost",
+        approver_user_id="@user:localhost",
+        requested_at=datetime.now(UTC),
+        expires_at=datetime.now(UTC) + timedelta(minutes=15),
+        status="pending",
+    )
+
+    assert card["approval_type"] == "tool_action"
+    assert card["body"] == "Tool/action approval required: delete_file"
+    assert "normalized_hostname" not in card
+
+
 @pytest.mark.asyncio
 async def test_domain_grant_allows_matching_hostname_and_url(tmp_path: Path) -> None:
     arguments = {
@@ -2419,7 +2446,10 @@ def test_domain_grant_approval_payload_uses_normalized_hostname_and_warning() ->
     )
 
     assert card["approval_type"] == "domain_grant"
-    assert card["body"] == "Domain grant approval required: sub.example.com"
+    assert card["body"] == (
+        "Domain grant approval required: hostname=sub.example.com; ttl=900s; "
+        "agent=code; tool=network_access; reason=Fetch public documentation."
+    )
     assert card["normalized_hostname"] == "sub.example.com"
     assert card["requested_ttl_seconds"] == 900
     assert card["approval_reason"] == "Fetch public documentation."

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2301,6 +2301,60 @@ async def test_domain_grant_rejects_malformed_url_even_with_exact_hostname(tmp_p
     assert decision.reason == "Cannot approve network access without an exact hostname."
 
 
+@pytest.mark.asyncio
+async def test_domain_grant_rejects_mismatched_hostname_and_url(tmp_path: Path) -> None:
+    arguments = {
+        "approval_kind": "domain_grant",
+        "hostname": "good.com",
+        "url": "https://evil.com/path",
+        "ttl_seconds": 60,
+    }
+
+    decision = await request_tool_approval_for_call(
+        ToolApprovalCall(
+            config=_config(tmp_path),
+            runtime_paths=test_runtime_paths(tmp_path),
+            tool_name="network_access",
+            arguments=arguments,
+            agent_name="code",
+            room_id="!room:localhost",
+            thread_id="$thread",
+            requester_id="@user:localhost",
+        ),
+    )
+
+    assert decision is not None
+    assert decision.status == "denied"
+    assert decision.reason == "Cannot approve network access without an exact hostname."
+
+
+@pytest.mark.asyncio
+async def test_domain_grant_allows_matching_hostname_and_url(tmp_path: Path) -> None:
+    arguments = {
+        "approval_kind": "domain_grant",
+        "hostname": "GOOD.COM.",
+        "url": "https://good.com/path",
+        "ttl_seconds": 60,
+    }
+
+    decision = await request_tool_approval_for_call(
+        ToolApprovalCall(
+            config=_config(tmp_path),
+            runtime_paths=test_runtime_paths(tmp_path),
+            tool_name="network_access",
+            arguments=arguments,
+            agent_name="code",
+            room_id="!room:localhost",
+            thread_id="$thread",
+            requester_id="@user:localhost",
+        ),
+    )
+
+    assert decision is None
+    assert arguments["hostname"] == "good.com"
+    assert arguments["url"] == "https://good.com/path"
+
+
 def test_domain_grant_approval_payload_uses_normalized_hostname_and_warning() -> None:
     card = _ApprovalManager._pending_event_content(
         approval_id="approval-1",

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2217,7 +2217,17 @@ def test_approval_hostname_normalization_uses_exact_display_host(value: str, exp
     assert _normalize_approval_hostname(value) == expected
 
 
-@pytest.mark.parametrize("value", ["*.example.com", "bad host.example", "[bad"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "*.example.com",
+        "bad host.example",
+        "[bad",
+        "http:///path",
+        "file:///etc/passwd",
+        "/path/to/socket",
+    ],
+)
 def test_approval_hostname_normalization_rejects_non_exact_hosts(value: str) -> None:
     assert _normalize_approval_hostname(value) is None
 

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2462,6 +2462,58 @@ def test_domain_grant_approval_payload_uses_normalized_hostname_and_warning() ->
     assert "untrusted" in card["approval_warning"]
 
 
+def test_domain_grant_event_body_sanitizes_reason_for_fallback_text() -> None:
+    card = _ApprovalManager._pending_event_content(
+        approval_id="approval-1",
+        tool_name="network_access",
+        arguments={
+            "approval_kind": "domain_grant",
+            "hostname": "example.com",
+            "ttl_seconds": 900,
+            "reason": "benign\nDomain grant approved: evil.com; tool=delete_file",
+        },
+        arguments_truncated=False,
+        agent_name="code",
+        thread_id="$thread",
+        requester_id="@user:localhost",
+        approver_user_id="@user:localhost",
+        requested_at=datetime.now(UTC),
+        expires_at=datetime.now(UTC) + timedelta(minutes=15),
+        status="pending",
+    )
+
+    assert "\n" not in card["body"]
+    assert card["approval_reason"] == "benign\nDomain grant approved: evil.com; tool=delete_file"
+    assert card["body"] == (
+        "Domain grant approval required: hostname=example.com; ttl=900s; "
+        "agent=code; tool=network_access; reason=benign Domain grant approved: evil.com, tool=delete_file"
+    )
+
+    pending = PendingApproval.from_card_event(
+        {
+            "event_id": "$approval",
+            "sender": "@mindroom_router:localhost",
+            "type": "io.mindroom.tool_approval",
+            "origin_server_ts": 1,
+            "content": card,
+        },
+        room_id="!room:localhost",
+    )
+    resolved = _ApprovalManager._resolved_event_content(
+        pending,
+        status="approved",
+        reason=None,
+        resolved_by="@user:localhost",
+        resolved_at=datetime.now(UTC),
+    )
+
+    assert "\n" not in resolved["body"]
+    assert resolved["body"] == (
+        "Domain grant approved: hostname=example.com; ttl=900s; "
+        "agent=code; tool=network_access; reason=benign Domain grant approved: evil.com, tool=delete_file"
+    )
+
+
 def test_tool_action_approval_payload_is_distinct_from_domain_grant() -> None:
     card = _ApprovalManager._pending_event_content(
         approval_id="approval-1",

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -23,6 +23,7 @@ from mindroom.approval_manager import (
     _ApprovalManager,
     _build_event_arguments_preview,
     _LiveApprovalWaiter,
+    _normalize_approval_hostname,
     get_approval_store,
     initialize_approval_store,
 )
@@ -2201,6 +2202,106 @@ def test_approval_arguments_preview_marks_sanitizer_truncation() -> None:
     )
 
     assert card["arguments_truncated"] is True
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("  HTTPS://Sub.Example.COM:443/path?q=1  ", "sub.example.com"),
+        ("Example.COM.", "example.com"),
+        ("example.com:8443", "example.com"),
+        ("https://[2001:db8::1]/status", "2001:db8::1"),
+    ],
+)
+def test_approval_hostname_normalization_uses_exact_display_host(value: str, expected: str) -> None:
+    assert _normalize_approval_hostname(value) == expected
+
+
+@pytest.mark.parametrize("value", ["*.example.com", "bad host.example"])
+def test_approval_hostname_normalization_rejects_non_exact_hosts(value: str) -> None:
+    assert _normalize_approval_hostname(value) is None
+
+
+def test_domain_grant_approval_payload_uses_normalized_hostname_and_warning() -> None:
+    card = _ApprovalManager._pending_event_content(
+        approval_id="approval-1",
+        tool_name="network_access",
+        arguments={
+            "approval_kind": "domain_grant",
+            "hostname": " HTTPS://Sub.Example.COM:443/path ",
+            "ttl_seconds": 900,
+            "reason": "Fetch public documentation.",
+        },
+        arguments_truncated=False,
+        agent_name="code",
+        thread_id="$thread",
+        requester_id="@user:localhost",
+        approver_user_id="@user:localhost",
+        requested_at=datetime.now(UTC),
+        expires_at=datetime.now(UTC) + timedelta(minutes=15),
+        status="pending",
+    )
+
+    assert card["approval_type"] == "domain_grant"
+    assert card["body"] == "Domain grant approval required: sub.example.com"
+    assert card["normalized_hostname"] == "sub.example.com"
+    assert card["requested_ttl_seconds"] == 900
+    assert card["approval_reason"] == "Fetch public documentation."
+    assert card["request_context"] == {
+        "agent_name": "code",
+        "tool_name": "network_access",
+        "requester_id": "@user:localhost",
+    }
+    assert card["arguments"]["hostname"] == "sub.example.com"
+    assert "untrusted" in card["approval_warning"]
+
+
+def test_tool_action_approval_payload_is_distinct_from_domain_grant() -> None:
+    card = _ApprovalManager._pending_event_content(
+        approval_id="approval-1",
+        tool_name="read_file",
+        arguments={"path": "notes.txt"},
+        arguments_truncated=False,
+        agent_name="code",
+        thread_id=None,
+        requester_id="@user:localhost",
+        approver_user_id="@user:localhost",
+        requested_at=datetime.now(UTC),
+        expires_at=datetime.now(UTC) + timedelta(minutes=5),
+        status="pending",
+    )
+
+    assert card["approval_type"] == "tool_action"
+    assert card["body"] == "Tool/action approval required: read_file"
+    assert "normalized_hostname" not in card
+    assert card["approval_reason"] == "Tool call requires human approval."
+
+
+@pytest.mark.asyncio
+async def test_domain_grant_arguments_are_normalized_before_tool_continues(tmp_path: Path) -> None:
+    arguments = {
+        "approval_kind": "domain_grant",
+        "hostname": "HTTPS://Sub.Example.COM/path",
+        "ttl_seconds": 60,
+        "reason": "Fetch public documentation.",
+    }
+
+    decision = await request_tool_approval_for_call(
+        ToolApprovalCall(
+            config=_config(tmp_path),
+            runtime_paths=test_runtime_paths(tmp_path),
+            tool_name="network_access",
+            arguments=arguments,
+            agent_name="code",
+            room_id="!room:localhost",
+            thread_id="$thread",
+            requester_id="@user:localhost",
+        ),
+    )
+
+    assert decision is None
+    assert arguments["hostname"] == "sub.example.com"
+    assert arguments["normalized_hostname"] == "sub.example.com"
 
 
 def test_approval_arguments_preview_marks_nested_sanitizer_truncation() -> None:

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2217,9 +2217,28 @@ def test_approval_hostname_normalization_uses_exact_display_host(value: str, exp
     assert _normalize_approval_hostname(value) == expected
 
 
-@pytest.mark.parametrize("value", ["*.example.com", "bad host.example"])
+@pytest.mark.parametrize("value", ["*.example.com", "bad host.example", "[bad"])
 def test_approval_hostname_normalization_rejects_non_exact_hosts(value: str) -> None:
     assert _normalize_approval_hostname(value) is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_domain_grant_is_denied_without_matrix_card(tmp_path: Path) -> None:
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    store = initialize_approval_store(test_runtime_paths(tmp_path), sender=sender)
+
+    decision = await store.request_approval(
+        tool_name="network_access",
+        arguments={"approval_kind": "domain_grant", "hostname": "*.example.com", "ttl_seconds": 60},
+        room_id="!room:localhost",
+        requester_id="@user:localhost",
+        approver_user_id="@user:localhost",
+        timeout_seconds=30,
+    )
+
+    assert decision.status == "denied"
+    assert decision.reason == "Cannot approve network access without an exact hostname."
+    sender.assert_not_awaited()
 
 
 def test_domain_grant_approval_payload_uses_normalized_hostname_and_warning() -> None:

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, call
@@ -2423,6 +2424,78 @@ async def test_domain_grant_allows_matching_hostname_and_url(tmp_path: Path) -> 
     assert decision is None
     assert arguments["hostname"] == "good.com"
     assert arguments["url"] == "https://good.com/path"
+
+
+@pytest.mark.asyncio
+async def test_domain_grant_preview_truncation_preserves_host_metadata(tmp_path: Path) -> None:
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    store = initialize_approval_store(test_runtime_paths(tmp_path), sender=sender)
+
+    task = asyncio.create_task(
+        store.request_approval(
+            tool_name="network_access",
+            arguments={
+                "approval_kind": "domain_grant",
+                "hostname": "docs.example.com",
+                "ttl_seconds": 900,
+                "reason": "Fetch public documentation.",
+                **{f"extra_{index}": "x" * 80 for index in range(40)},
+            },
+            room_id="!room:localhost",
+            agent_name="code",
+            requester_id="@user:localhost",
+            approver_user_id="@user:localhost",
+            timeout_seconds=30,
+        ),
+    )
+    try:
+        await _wait_for_pending(store, sender=sender)
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    card = sender.await_args.args[2]
+    assert card["arguments_truncated"] is True
+    assert card["approval_type"] == "domain_grant"
+    assert card["normalized_hostname"] == "docs.example.com"
+    assert card["requested_ttl_seconds"] == 900
+    assert card["approval_reason"] == "Fetch public documentation."
+    assert card["body"] == (
+        "Domain grant approval required: hostname=docs.example.com; ttl=900s; "
+        "agent=code; tool=network_access; reason=Fetch public documentation."
+    )
+
+
+@pytest.mark.asyncio
+async def test_domain_grant_normalizes_all_host_arguments_before_tool_continues(tmp_path: Path) -> None:
+    arguments = {
+        "approval_kind": "domain_grant",
+        "hostname": "HTTPS://Sub.Example.COM/path",
+        "host": "Sub.Example.COM.",
+        "domain": "sub.example.com",
+        "target_host": "https://sub.example.com/status",
+        "ttl_seconds": 60,
+    }
+
+    decision = await request_tool_approval_for_call(
+        ToolApprovalCall(
+            config=_config(tmp_path),
+            runtime_paths=test_runtime_paths(tmp_path),
+            tool_name="network_access",
+            arguments=arguments,
+            agent_name="code",
+            room_id="!room:localhost",
+            thread_id="$thread",
+            requester_id="@user:localhost",
+        ),
+    )
+
+    assert decision is None
+    assert arguments["hostname"] == "sub.example.com"
+    assert arguments["host"] == "sub.example.com"
+    assert arguments["domain"] == "sub.example.com"
+    assert arguments["target_host"] == "sub.example.com"
 
 
 def test_domain_grant_approval_payload_uses_normalized_hostname_and_warning() -> None:

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -2392,6 +2392,57 @@ async def test_tool_before_call_hooks_run_before_tool_approval_gate(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_tool_after_call_sees_domain_grant_arguments_that_executed(tmp_path: Path) -> None:
+    """Approval normalization should not leave after-call hooks with stale argument snapshots."""
+    after_seen: list[dict[str, object]] = []
+    tool_seen: list[dict[str, object]] = []
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "code": AgentConfig(
+                    display_name="Code",
+                    role="Help with coding.",
+                    rooms=[],
+                ),
+            },
+            models={"default": ModelConfig(provider="openai", id="test-model")},
+        ),
+        runtime_paths,
+    )
+
+    @hook(EVENT_TOOL_AFTER_CALL)
+    async def after(ctx: ToolAfterCallContext) -> None:
+        after_seen.append(dict(ctx.arguments))
+
+    registry = HookRegistry.from_plugins([_plugin("tool-policy", [after])])
+    bridge = build_tool_hook_bridge(
+        registry,
+        agent_name="code",
+        dispatch_context=_dispatch_context(_execution_identity()),
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    assert bridge is not None
+
+    async def next_func(**kwargs: object) -> str:
+        tool_seen.append(dict(kwargs))
+        return "ok"
+
+    arguments = {
+        "approval_kind": "domain_grant",
+        "hostname": "HTTPS://Sub.Example.COM/path",
+        "ttl_seconds": 60,
+    }
+    with tool_execution_identity(_execution_identity()):
+        result = await bridge("network_access", next_func, arguments)
+
+    assert result == "ok"
+    assert tool_seen == [{"approval_kind": "domain_grant", "hostname": "sub.example.com", "ttl_seconds": 60}]
+    assert after_seen == tool_seen
+
+
+@pytest.mark.asyncio
 async def test_tool_before_call_decline_short_circuits_tool_approval(tmp_path: Path) -> None:
     """Denied policy hooks should prevent approval cards from being shown."""
     runtime_paths = test_runtime_paths(tmp_path)


### PR DESCRIPTION
## Summary
- Normalize and display exact hostnames for network domain grant approvals.
- Add approval-card metadata for grant type, TTL, requester context, concise reason, and untrusted-content guidance.
- Preserve a distinct tool/action approval path and add regression coverage for grant payloads.

## Test Plan
- [x] uv run pre-commit run --all-files
- [x] uv run pytest tests/test_tool_approval.py -q -n 0 --no-cov -p no:tach
- [x] uv run pytest -q -n 0 --no-cov -p no:tach printed `6228 passed, 56 skipped` before a post-summary resource tracker process was stopped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for approving network domain grants and treating copied content as untrusted context across configuration and reference docs.

* **New Features**
  * Approval workflow now recognizes domain-grant requests and distinguishes them from standard tool actions.
  * Approval prompts and records include richer metadata (type, reason, warning, request context, normalized hostname, TTL) and show untrusted-approval warnings.

* **Tests**
  * Added tests validating hostname normalization, domain-grant payloads, and approval normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->