### PR TITLE
Refactor attachment output path schema

### DIFF
--- a/src/mindroom/custom_tools/attachments.py
+++ b/src/mindroom/custom_tools/attachments.py
@@ -22,8 +22,8 @@ from mindroom.attachments import (
 from mindroom.custom_tools.attachment_helpers import room_access_allowed
 from mindroom.matrix.client_delivery import send_file_message
 from mindroom.tool_system.output_files import (
-    OUTPUT_PATH_ARGUMENT_DESCRIPTION,
     ToolOutputFilePolicy,
+    ensure_output_path_schema_optional,
     validate_output_path,
     validate_output_path_syntax,
     write_bytes_to_output_path,
@@ -386,18 +386,13 @@ class AttachmentTools(Toolkit):
         function = self.async_functions.get("get_attachment")
         if function is None:
             return
+        ensure_output_path_schema_optional(function)
         parameters = dict(function.parameters)
         properties = dict(parameters.get("properties") or {})
         attachment_id_schema = dict(properties.get("attachment_id") or {})
         attachment_id_schema["description"] = "Context-scoped attachment ID returned by list_attachments."
         properties["attachment_id"] = attachment_id_schema
-        output_path_schema = dict(properties.get("mindroom_output_path") or {})
-        output_path_schema["description"] = OUTPUT_PATH_ARGUMENT_DESCRIPTION
-        properties["mindroom_output_path"] = output_path_schema
         parameters["properties"] = properties
-        required = parameters.get("required")
-        if isinstance(required, list):
-            parameters["required"] = [name for name in required if name != "mindroom_output_path"]
         function.parameters = parameters
 
     async def list_attachments(self, target: str | None = None) -> str:

--- a/src/mindroom/tool_system/output_files.py
+++ b/src/mindroom/tool_system/output_files.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 OUTPUT_PATH_ARGUMENT = "mindroom_output_path"
-OUTPUT_PATH_ARGUMENT_DESCRIPTION = (
+_OUTPUT_PATH_ARGUMENT_DESCRIPTION = (
     "Optional MindRoom-managed workspace-relative path. "
     "If set, the full supported tool output is written to this file in your workspace and the tool returns only a "
     "compact receipt. "
@@ -136,7 +136,7 @@ def _output_path_schema() -> dict[str, object]:
     return {
         "anyOf": [{"type": "string"}, {"type": "null"}],
         "default": None,
-        "description": OUTPUT_PATH_ARGUMENT_DESCRIPTION,
+        "description": _OUTPUT_PATH_ARGUMENT_DESCRIPTION,
     }
 
 
@@ -147,7 +147,7 @@ def _has_output_path_argument(function: Function) -> bool:
     return isinstance(properties, dict) and OUTPUT_PATH_ARGUMENT in properties
 
 
-def _ensure_output_path_schema_optional(function: Function) -> None:
+def ensure_output_path_schema_optional(function: Function) -> None:
     """Keep MindRoom's reserved output-path argument optional in one tool schema."""
     parameters = dict(function.parameters or _DEFAULT_PARAMETERS)
     properties = dict(parameters.get("properties") or {})
@@ -178,7 +178,7 @@ def normalize_output_path_argument(raw_path: object) -> object | None:
 def _process_entrypoint_with_output_path_schema(self: Function, strict: bool = False) -> None:
     effective_strict = False if self.strict is False else strict
     Function.process_entrypoint(self, strict=effective_strict)
-    _ensure_output_path_schema_optional(self)
+    ensure_output_path_schema_optional(self)
 
 
 def _copy_function_model(self: Function, *, update: Mapping[str, object] | None, deep: bool) -> Function:
@@ -538,7 +538,7 @@ def _copy_annotations_with_output_path(
 
 def _docstring_with_output_path(original_doc: str | None) -> str:
     base = (original_doc or "MindRoom wrapped tool entrypoint.").strip()
-    output_arg_doc = f"Args:\n    {OUTPUT_PATH_ARGUMENT}: {OUTPUT_PATH_ARGUMENT_DESCRIPTION}"
+    output_arg_doc = f"Args:\n    {OUTPUT_PATH_ARGUMENT}: {_OUTPUT_PATH_ARGUMENT_DESCRIPTION}"
     return f"{base}\n\n{output_arg_doc}"
 
 
@@ -600,7 +600,7 @@ def _wrap_function_for_output_files(function: Function, policy: ToolOutputFilePo
     function.strict = False
     _install_output_path_schema_postprocessor(function)
     if uses_custom_parameters:
-        _ensure_output_path_schema_optional(function)
+        ensure_output_path_schema_optional(function)
     return function
 
 

--- a/tests/test_attachments_tool.py
+++ b/tests/test_attachments_tool.py
@@ -220,9 +220,14 @@ async def test_attachments_tool_get_attachment_schema_describes_output_path(
     del tmp_path
     tool = AttachmentTools()
 
-    schema = tool.async_functions["get_attachment"].parameters["properties"]
+    parameters = tool.async_functions["get_attachment"].parameters
+    schema = parameters["properties"]
 
+    assert schema["attachment_id"]["description"] == "Context-scoped attachment ID returned by list_attachments."
+    assert schema["mindroom_output_path"]["anyOf"] == [{"type": "string"}, {"type": "null"}]
+    assert schema["mindroom_output_path"]["default"] is None
     assert "Use this for large output" in schema["mindroom_output_path"]["description"]
+    assert "mindroom_output_path" not in parameters["required"]
     assert "save_to_disk" not in schema
 
 

--- a/tests/test_tool_output_files.py
+++ b/tests/test_tool_output_files.py
@@ -30,6 +30,7 @@ from mindroom.tool_system.output_files import (
     OUTPUT_PATH_ARGUMENT,
     ToolOutputFilePolicy,
     _wrap_function_for_output_files,
+    ensure_output_path_schema_optional,
     wrap_toolkit_for_output_files,
 )
 from mindroom.tool_system.tool_hooks import build_tool_hook_bridge, prepend_tool_hook_bridge
@@ -82,6 +83,28 @@ def _receipt(result: object) -> dict[str, object]:
     envelope = result.get("mindroom_tool_output")
     assert isinstance(envelope, dict)
     return envelope
+
+
+def test_ensure_output_path_schema_optional_preserves_custom_schema_shape() -> None:
+    function = Function(
+        name="attachment_reader",
+        parameters={
+            "type": "object",
+            "properties": {"attachment_id": {"type": "string", "description": "Context attachment."}},
+            "required": ["attachment_id", OUTPUT_PATH_ARGUMENT],
+            "additionalProperties": False,
+        },
+        skip_entrypoint_processing=True,
+    )
+
+    ensure_output_path_schema_optional(function)
+
+    assert function.parameters["additionalProperties"] is False
+    assert function.parameters["properties"]["attachment_id"] == {
+        "type": "string",
+        "description": "Context attachment.",
+    }
+    _assert_output_path_schema_is_optional(function)
 
 
 def _plugin(*callbacks: object) -> object:


### PR DESCRIPTION
## Summary
- Promote the output-path schema sanitizer so bespoke tools can reuse the canonical `mindroom_output_path` schema.
- Have the attachment tool reuse that helper while preserving the attachment-specific `attachment_id` description.
- Expand focused schema coverage for output-files and attachments.

## Verification
- `uv run pytest tests/test_tool_output_files.py tests/test_attachments_tool.py -q --no-cov -n 0`
- `uv run pre-commit run --files src/mindroom/custom_tools/attachments.py src/mindroom/tool_system/output_files.py tests/test_attachments_tool.py tests/test_tool_output_files.py`

## Line-count gate
- `git diff --numstat origin/main...HEAD` production delta: `src/mindroom/custom_tools/attachments.py` +2/-7, `src/mindroom/tool_system/output_files.py` +6/-6, net -5 production lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed attachment tool schema to properly mark the output path parameter as optional, allowing attachments to be retrieved without requiring explicit path specification.

* **Tests**
  * Expanded test coverage for attachment tool schema validation and output path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->