### PR TITLE
Refactor approval datetime parsing

### DIFF
--- a/src/mindroom/approval_events.py
+++ b/src/mindroom/approval_events.py
@@ -129,7 +129,7 @@ def _content_str(content: dict[str, Any], key: str) -> str | None:
 
 
 def _created_at_ms(event: dict[str, Any], requested_at: str | None) -> int:
-    parsed = _parse_datetime(requested_at)
+    parsed = parse_approval_datetime(requested_at)
     if parsed is None:
         timestamp = event.get("origin_server_ts")
         return timestamp if isinstance(timestamp, int) and not isinstance(timestamp, bool) else 0
@@ -137,14 +137,15 @@ def _created_at_ms(event: dict[str, Any], requested_at: str | None) -> int:
 
 
 def _timeout_seconds(requested_at: str | None, expires_at: str | None) -> int:
-    requested = _parse_datetime(requested_at)
-    expires = _parse_datetime(expires_at)
+    requested = parse_approval_datetime(requested_at)
+    expires = parse_approval_datetime(expires_at)
     if requested is None or expires is None:
         return 0
     return max(0, int((expires - requested).total_seconds()))
 
 
-def _parse_datetime(value: str | None) -> datetime | None:
+def parse_approval_datetime(value: str | None) -> datetime | None:
+    """Parse an approval ISO timestamp, treating naive timestamps as UTC."""
     if value is None:
         return None
     parsed = datetime.fromisoformat(value)

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -19,6 +19,7 @@ from mindroom.approval_events import (
     PendingApproval,
     PendingApprovalStatus,
     is_original_approval_card,
+    parse_approval_datetime,
     terminal_edit_matches_card_sender,
 )
 from mindroom.logging_config import get_logger
@@ -94,13 +95,6 @@ class _BoundedCardEventIds:
 
 def _utcnow() -> datetime:
     return datetime.now(UTC)
-
-
-def _parse_datetime(value: str | None) -> datetime | None:
-    if value is None:
-        return None
-    parsed = datetime.fromisoformat(value)
-    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
 def _compact_preview_text(value: object) -> str:
@@ -1148,11 +1142,13 @@ class _ApprovalManager:
         resolved_by: str | None,
         resolved_at: datetime,
     ) -> dict[str, Any]:
-        requested_at = _parse_datetime(pending.requested_at) or datetime.fromtimestamp(
+        requested_at = parse_approval_datetime(pending.requested_at) or datetime.fromtimestamp(
             pending.created_at_ms / 1000,
             tz=UTC,
         )
-        expires_at = _parse_datetime(pending.expires_at) or requested_at + timedelta(seconds=pending.timeout_seconds)
+        expires_at = parse_approval_datetime(pending.expires_at) or requested_at + timedelta(
+            seconds=pending.timeout_seconds,
+        )
         content: dict[str, Any] = {
             "msgtype": "io.mindroom.tool_approval",
             "body": _ApprovalManager._event_body(pending.tool_name, status),

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -13,6 +13,7 @@ import pytest
 from pydantic import ValidationError
 
 import mindroom.tool_approval as approval_module
+from mindroom.approval_events import parse_approval_datetime
 from mindroom.approval_inbound import handle_tool_approval_action
 from mindroom.approval_manager import (
     _MAX_REMEMBERED_TERMINAL_CARD_IDS,
@@ -2141,6 +2142,17 @@ def test_pending_approval_preserves_distinct_requester_and_approver() -> None:
 
     assert pending.requester_id == "@requester:localhost"
     assert pending.approver_user_id == "@approver:localhost"
+
+
+def test_parse_approval_datetime_preserves_approval_timestamp_contract() -> None:
+    assert parse_approval_datetime(None) is None
+    assert parse_approval_datetime("2030-01-01T10:00:00+02:00") == datetime.fromisoformat(
+        "2030-01-01T10:00:00+02:00",
+    )
+    assert parse_approval_datetime("2030-01-01T10:00:00") == datetime(2030, 1, 1, 10, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match="Invalid isoformat string"):
+        parse_approval_datetime("not-a-datetime")
 
 
 def test_approval_arguments_preview_marks_sanitizer_truncation() -> None:


### PR DESCRIPTION
## Summary
- Move approval ISO datetime parsing into one approval-local helper in approval_events.py.
- Reuse the helper from approval_manager.py for resolved approval content.
- Add focused coverage for None, aware ISO, naive-as-UTC, and invalid timestamp behavior.

## Verification
- uv run pytest tests/test_tool_approval.py -n 0 --no-cov
- uv sync --all-extras
- uv run pre-commit run --files src/mindroom/approval_events.py src/mindroom/approval_manager.py tests/test_tool_approval.py

## Line-count gate
- git diff --numstat origin/main...HEAD
- Production net delta: -3 lines (approval_events.py +1, approval_manager.py -4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal date handling for approval processing.

* **Tests**
  * Added comprehensive test coverage for approval timestamp validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->