### PR TITLE
Extract Matrix reaction content builder

### DIFF
--- a/src/mindroom/commands/config_confirmation.py
+++ b/src/mindroom/commands/config_confirmation.py
@@ -10,6 +10,7 @@ import nio
 
 from mindroom.config.matrix import ignore_unverified_devices_for_config
 from mindroom.logging_config import get_logger
+from mindroom.matrix.message_builder import build_reaction_content
 
 if TYPE_CHECKING:
     from mindroom.bot import AgentBot
@@ -314,37 +315,15 @@ async def add_confirmation_reactions(
 
     """
     ignore_unverified_devices = ignore_unverified_devices_for_config(config)
-    # Add ✅ reaction
-    confirm_response = await client.room_send(
-        room_id=room_id,
-        message_type="m.reaction",
-        content={
-            "m.relates_to": {
-                "rel_type": "m.annotation",
-                "event_id": event_id,
-                "key": "✅",
-            },
-        },
-        ignore_unverified_devices=ignore_unverified_devices,
-    )
-    if not isinstance(confirm_response, nio.RoomSendResponse):
-        logger.warning("Failed to add confirm reaction", error=str(confirm_response))
-
-    # Add ❌ reaction
-    cancel_response = await client.room_send(
-        room_id=room_id,
-        message_type="m.reaction",
-        content={
-            "m.relates_to": {
-                "rel_type": "m.annotation",
-                "event_id": event_id,
-                "key": "❌",
-            },
-        },
-        ignore_unverified_devices=ignore_unverified_devices,
-    )
-    if not isinstance(cancel_response, nio.RoomSendResponse):
-        logger.warning("Failed to add cancel reaction", error=str(cancel_response))
+    for reaction_name, reaction_key in (("confirm", "✅"), ("cancel", "❌")):
+        response = await client.room_send(
+            room_id=room_id,
+            message_type="m.reaction",
+            content=build_reaction_content(event_id, reaction_key),
+            ignore_unverified_devices=ignore_unverified_devices,
+        )
+        if not isinstance(response, nio.RoomSendResponse):
+            logger.warning("Failed to add %s reaction", reaction_name, error=str(response))
 
 
 async def handle_confirmation_reaction(

--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -36,6 +36,7 @@ from mindroom.matrix.client_visible_messages import (
     trusted_visible_sender_ids,
 )
 from mindroom.matrix.mentions import format_message_with_mentions
+from mindroom.matrix.message_builder import build_reaction_content
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -339,17 +340,10 @@ class MatrixMessageOperations:
             return self._result("error", action="react", message="target event_id is required.")
 
         reaction = message.strip() if message and message.strip() else "👍"
-        content = {
-            "m.relates_to": {
-                "rel_type": "m.annotation",
-                "event_id": target,
-                "key": reaction,
-            },
-        }
         response = await context.client.room_send(
             room_id=room_id,
             message_type="m.reaction",
-            content=content,
+            content=build_reaction_content(target, reaction),
             ignore_unverified_devices=ignore_unverified_devices_for_config(context.config),
         )
         if isinstance(response, nio.RoomSendResponse):

--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -19,6 +19,7 @@ import nio
 from mindroom.config.matrix import ignore_unverified_devices_for_config
 from mindroom.logging_config import bound_log_context, get_logger
 from mindroom.matrix.identity import is_agent_id
+from mindroom.matrix.message_builder import build_reaction_content
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -734,13 +735,7 @@ async def add_reaction_buttons(
         reaction_response = await client.room_send(
             room_id=room_id,
             message_type="m.reaction",
-            content={
-                "m.relates_to": {
-                    "rel_type": "m.annotation",
-                    "event_id": event_id,
-                    "key": emoji_char,
-                },
-            },
+            content=build_reaction_content(event_id, emoji_char),
             ignore_unverified_devices=ignore_unverified_devices_for_config(config),
         )
         if not isinstance(reaction_response, nio.RoomSendResponse):

--- a/src/mindroom/matrix/message_builder.py
+++ b/src/mindroom/matrix/message_builder.py
@@ -505,6 +505,17 @@ def build_matrix_edit_content(event_id: str, new_content: Mapping[str, Any]) -> 
     }
 
 
+def build_reaction_content(event_id: str, key: str) -> dict[str, Any]:
+    """Build a Matrix ``m.reaction`` annotation content payload."""
+    return {
+        "m.relates_to": {
+            "rel_type": "m.annotation",
+            "event_id": event_id,
+            "key": key,
+        },
+    }
+
+
 def build_message_content(
     body: str,
     formatted_body: str | None = None,

--- a/src/mindroom/stop.py
+++ b/src/mindroom/stop.py
@@ -13,6 +13,7 @@ from agno.run.cancel import acancel_run
 from mindroom.cancellation import USER_STOP_CANCEL_MSG, request_task_cancel
 from mindroom.config.matrix import ignore_unverified_devices_for_config
 from mindroom.logging_config import get_logger
+from mindroom.matrix.message_builder import build_reaction_content
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -367,16 +368,11 @@ class StopManager:
             **self._log_target(tracked.target),
         )
         try:
+            reaction_content = build_reaction_content(message_id, "🛑")
             response = await client.room_send(
                 room_id=tracked.target.room_id,
                 message_type="m.reaction",
-                content={
-                    "m.relates_to": {
-                        "rel_type": "m.annotation",
-                        "event_id": message_id,
-                        "key": "🛑",
-                    },
-                },
+                content=reaction_content,
                 ignore_unverified_devices=ignore_unverified_devices_for_config(config),
             )
             if isinstance(response, nio.RoomSendResponse):
@@ -396,13 +392,7 @@ class StopManager:
                             "room_id": tracked.target.room_id,
                             "event_id": event_id,
                             "sender": client.user_id if isinstance(client.user_id, str) else None,
-                            "content": {
-                                "m.relates_to": {
-                                    "rel_type": "m.annotation",
-                                    "event_id": message_id,
-                                    "key": "🛑",
-                                },
-                            },
+                            "content": reaction_content,
                         },
                     )
                 return event_id

--- a/tests/test_config_commands.py
+++ b/tests/test_config_commands.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import nio
 import pytest
 import yaml
 
@@ -21,6 +22,7 @@ from mindroom.commands.config_commands import (
     apply_config_change,
     handle_config_command,
 )
+from mindroom.commands.config_confirmation import add_confirmation_reactions
 from mindroom.commands.handler import CommandHandlerContext, handle_command
 from mindroom.commands.parsing import Command, CommandType, _CommandParser
 from mindroom.config.auth import AuthorizationConfig
@@ -34,6 +36,34 @@ from tests.conftest import make_event_cache_mock
 
 def _runtime_paths_for_config(config_path: Path) -> constants_mod.RuntimePaths:
     return resolve_runtime_paths(config_path=config_path)
+
+
+@pytest.mark.asyncio
+async def test_add_confirmation_reactions_sends_confirm_and_cancel_annotations() -> None:
+    """Config confirmation should add canonical Matrix annotation reactions."""
+    client = AsyncMock()
+    response = MagicMock(spec=nio.RoomSendResponse)
+    client.room_send.return_value = response
+    config = SimpleNamespace(matrix_delivery=SimpleNamespace(ignore_unverified_devices=False))
+
+    await add_confirmation_reactions(client, "!room:example.org", "$preview", config=config)
+
+    assert [call.kwargs["content"] for call in client.room_send.await_args_list] == [
+        {
+            "m.relates_to": {
+                "rel_type": "m.annotation",
+                "event_id": "$preview",
+                "key": "✅",
+            },
+        },
+        {
+            "m.relates_to": {
+                "rel_type": "m.annotation",
+                "event_id": "$preview",
+                "key": "❌",
+            },
+        },
+    ]
 
 
 class TestCommandParser:

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -305,6 +305,22 @@ Based on your choice, I'll proceed accordingly."""
 
         # Should have added reactions
         assert mock_client.room_send.call_count == 2
+        assert [call.kwargs["content"] for call in mock_client.room_send.await_args_list] == [
+            {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": event_id,
+                    "key": "🚀",
+                },
+            },
+            {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": event_id,
+                    "key": "🔍",
+                },
+            },
+        ]
 
     @pytest.mark.asyncio
     async def test_handle_interactive_response_invalid_json(self, mock_client: AsyncMock) -> None:  # noqa: ARG002

--- a/tests/test_message_builder.py
+++ b/tests/test_message_builder.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from mindroom.matrix.message_builder import build_matrix_edit_content, build_thread_relation, markdown_to_html
+from mindroom.matrix.message_builder import (
+    build_matrix_edit_content,
+    build_reaction_content,
+    build_thread_relation,
+    markdown_to_html,
+)
 
 
 def test_build_thread_relation_returns_fallback_reply_relation() -> None:
@@ -32,6 +37,17 @@ def test_build_matrix_edit_content_wraps_replacement_content() -> None:
             "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread"},
         },
         "m.relates_to": {"rel_type": "m.replace", "event_id": "$approval"},
+    }
+
+
+def test_build_reaction_content_returns_annotation_relation() -> None:
+    """Reaction content construction should be shared at send sites."""
+    assert build_reaction_content("$event", "✅") == {
+        "m.relates_to": {
+            "rel_type": "m.annotation",
+            "event_id": "$event",
+            "key": "✅",
+        },
     }
 
 


### PR DESCRIPTION
## Summary
- Add `build_reaction_content(event_id, key)` to centralize Matrix `m.reaction` annotation payload construction.
- Reuse the helper in interactive buttons, config confirmations, stop buttons, and matrix_message react handling without changing send behavior.
- Tighten focused tests around the shared payload shape and changed reaction send paths.

## Verification
- `uv run pytest tests/test_message_builder.py::test_build_reaction_content_returns_annotation_relation tests/test_interactive.py::TestInteractiveFunctions::test_handle_interactive_response_valid_json tests/test_config_commands.py::test_add_confirmation_reactions_sends_confirm_and_cancel_annotations tests/test_stop_emoji_reuse.py::test_stop_manager_add_and_remove_button_notifies_cache_bookkeeping tests/test_matrix_message_tool.py::test_matrix_message_react_happy_path -q -n 0 --no-cov`
- `uv run pre-commit run --files src/mindroom/matrix/message_builder.py src/mindroom/interactive.py src/mindroom/commands/config_confirmation.py src/mindroom/stop.py src/mindroom/custom_tools/matrix_conversation_operations.py tests/test_message_builder.py tests/test_interactive.py tests/test_config_commands.py` from clean detached worktree at commit `2ed8e941`

## Line-count gate
- `git diff --numstat origin/main...HEAD` production files: `+29/-60`, net `-31` lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined reaction annotation handling across the application for improved consistency.
  * Unified reaction payload generation mechanisms across multiple components.

* **Tests**
  * Added comprehensive test coverage for reaction creation and confirmation flows.
  * Verified annotation payload structure and delivery accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->