### PR TITLE
refactor(cli): share config search-location rendering

### DIFF
--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -262,6 +262,20 @@ def _config_discovery_env(path: Path | None = None) -> dict[str, str]:
     return process_env
 
 
+def _format_config_search_locations(process_env: Mapping[str, str]) -> list[str]:
+    """Return rendered config search locations with existence labels."""
+    return [
+        f"  {i}. {loc} ({'[green]exists[/green]' if loc.exists() else '[dim]not found[/dim]'})"
+        for i, loc in enumerate(config_search_locations(process_env), 1)
+    ]
+
+
+def _print_config_search_locations(process_env: Mapping[str, str], *, title: str) -> None:
+    console.print(title)
+    for line in _format_config_search_locations(process_env):
+        console.print(line)
+
+
 def _resolve_config_path(
     path: Path | None,
     *,
@@ -447,10 +461,7 @@ def config_show(
     if not config_file.exists():
         console.print(f"[yellow]No config file found at:[/yellow] {config_file}")
         console.print("\nRun [cyan]mindroom config init[/cyan] to create one.")
-        console.print("\nSearch locations (first match wins):")
-        for i, loc in enumerate(config_search_locations(process_env), 1):
-            status = "[green]exists[/green]" if loc.exists() else "[dim]not found[/dim]"
-            console.print(f"  {i}. {loc} ({status})")
+        _print_config_search_locations(process_env, title="\nSearch locations (first match wins):")
         raise typer.Exit(1)
 
     try:
@@ -558,10 +569,7 @@ def config_path_cmd(
     status = "[green]exists[/green]" if exists else "[red]not found[/red]"
     console.print(f"Resolved config path: {resolved} ({status})")
 
-    console.print("\nSearch locations (first match wins):")
-    for i, loc in enumerate(config_search_locations(process_env), 1):
-        loc_status = "[green]exists[/green]" if loc.exists() else "[dim]not found[/dim]"
-        console.print(f"  {i}. {loc} ({loc_status})")
+    _print_config_search_locations(process_env, title="\nSearch locations (first match wins):")
 
 
 # ---------------------------------------------------------------------------

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -14,7 +14,7 @@ import typer
 
 import mindroom.cli.connect as cli_connect
 from mindroom import __version__, constants
-from mindroom.constants import config_search_locations, ensure_writable_config_path
+from mindroom.constants import ensure_writable_config_path
 from mindroom.error_handling import AvatarGenerationError, AvatarSyncError
 from mindroom.frontend_assets import ensure_frontend_dist_dir
 
@@ -24,6 +24,7 @@ from .config import (
     _check_env_keys,
     _format_validation_errors,
     _load_config_quiet,
+    _print_config_search_locations,
     config_app,
     console,
 )
@@ -387,10 +388,7 @@ def _print_missing_config_error(process_env: Mapping[str, str]) -> None:
     console.print("Quick start:")
     console.print("  [cyan]mindroom config init[/cyan]    Create a starter config")
     console.print("  [cyan]mindroom config edit[/cyan]    Edit your config\n")
-    console.print("Config search locations (first match wins):")
-    for i, loc in enumerate(config_search_locations(process_env), 1):
-        status = "[green]exists[/green]" if loc.exists() else "[dim]not found[/dim]"
-        console.print(f"  {i}. {loc} ({status})")
+    _print_config_search_locations(process_env, title="Config search locations (first match wins):")
     console.print("\nLearn more: https://github.com/mindroom-ai/mindroom")
 
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -20,7 +20,7 @@ from typer.testing import CliRunner
 
 import mindroom.constants as constants_module
 from mindroom.agents import ensure_default_agent_workspaces
-from mindroom.cli.config import _activate_cli_runtime
+from mindroom.cli.config import _activate_cli_runtime, _format_config_search_locations
 from mindroom.cli.main import _load_active_config_or_exit, app
 from mindroom.config.main import Config
 from mindroom.constants import OWNER_MATRIX_USER_ID_ENV, OWNER_MATRIX_USER_ID_PLACEHOLDER
@@ -57,6 +57,22 @@ def _invoke_with_runtime(
     if env:
         command_env.update(env)
     return cast("object", runner.invoke(app, args, env=command_env, **kwargs))
+
+
+def test_format_config_search_locations_numbers_paths_and_statuses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Config search-location rendering should include numbers and existence status."""
+    monkeypatch.chdir(tmp_path)
+    existing = tmp_path / "config.yaml"
+    existing.write_text("agents: {}\n", encoding="utf-8")
+    missing = tmp_path / "missing.yaml"
+
+    lines = _format_config_search_locations({"MINDROOM_CONFIG_PATH": str(missing)})
+
+    assert lines[0] == f"  1. {missing.resolve()} ([dim]not found[/dim])"
+    assert lines[1] == f"  2. {existing.resolve()} ([green]exists[/green])"
 
 
 def test_activate_cli_runtime_explicit_path_keeps_exported_storage_override(


### PR DESCRIPTION
## Summary
- add a shared config search-location renderer for numbered paths and existence labels
- reuse it from config show, config path, and top-level missing-config output
- cover the renderer with a focused CLI config test

## Verification
- uv run pytest tests/test_cli_config.py::test_format_config_search_locations_numbers_paths_and_statuses tests/test_cli_config.py::TestConfigShow tests/test_cli_config.py::TestConfigPath tests/test_cli_config.py::TestRunErrorHandling -q
- uv run pre-commit run --files src/mindroom/cli/config.py src/mindroom/cli/main.py tests/test_cli_config.py

## Line-count gate
- git diff --numstat origin/main...HEAD: production net +6 lines (config.py +8, main.py -2); test net +16 lines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized formatting and coloring of configuration path display across the CLI interface.

* **Tests**
  * Added test coverage for configuration search location formatting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->