### PR TITLE
Refactor worker API response serializers

### DIFF
--- a/justfile
+++ b/justfile
@@ -204,6 +204,7 @@ test-front:
 # Core backend tests (pytest in repo)
 # Run core backend tests (pytest) with optional arguments
 test-backend *args:
+    uv sync --all-extras
     uv run pytest {{args}}
 
 # Check for public symbols that should be private

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -28,13 +28,9 @@ from pydantic import BaseModel, Field, ValidationError
 from mindroom import constants
 from mindroom.api import sandbox_exec, sandbox_protocol, sandbox_worker_prep
 from mindroom.api.worker_responses import (
-    WorkerCleanupResponse as SandboxWorkerCleanupResponse,
-)
-from mindroom.api.worker_responses import (
-    WorkerListResponse as SandboxWorkerListResponse,
-)
-from mindroom.api.worker_responses import (
-    serialize_worker_response as _serialize_worker,
+    SandboxWorkerCleanupResponse,
+    SandboxWorkerListResponse,
+    serialize_sandbox_worker_response,
 )
 from mindroom.attachments import _normalize_attachment_id
 from mindroom.config.main import Config, _normalized_config_data, load_config
@@ -1252,7 +1248,7 @@ async def list_workers(request: Request, include_idle: bool = True) -> SandboxWo
     """List known workers and their current lifecycle status."""
     runtime_paths = _sandbox_runner_runtime_paths(request)
     workers = [
-        _serialize_worker(worker)
+        serialize_sandbox_worker_response(worker)
         for worker in get_local_worker_manager(runtime_paths).list_workers(include_idle=include_idle)
     ]
     return SandboxWorkerListResponse(workers=workers)
@@ -1263,7 +1259,7 @@ async def cleanup_idle_workers(request: Request) -> SandboxWorkerCleanupResponse
     """Mark idle workers inactive while retaining their persisted state."""
     runtime_paths = _sandbox_runner_runtime_paths(request)
     worker_manager = get_local_worker_manager(runtime_paths)
-    cleaned_workers = [_serialize_worker(worker) for worker in worker_manager.cleanup_idle_workers()]
+    cleaned_workers = [serialize_sandbox_worker_response(worker) for worker in worker_manager.cleanup_idle_workers()]
     return SandboxWorkerCleanupResponse(
         idle_timeout_seconds=worker_manager.idle_timeout_seconds,
         cleaned_workers=cleaned_workers,

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -27,6 +27,15 @@ from pydantic import BaseModel, Field, ValidationError
 
 from mindroom import constants
 from mindroom.api import sandbox_exec, sandbox_protocol, sandbox_worker_prep
+from mindroom.api.worker_responses import (
+    WorkerCleanupResponse as SandboxWorkerCleanupResponse,
+)
+from mindroom.api.worker_responses import (
+    WorkerListResponse as SandboxWorkerListResponse,
+)
+from mindroom.api.worker_responses import (
+    serialize_worker_response as _serialize_worker,
+)
 from mindroom.attachments import _normalize_attachment_id
 from mindroom.config.main import Config, _normalized_config_data, load_config
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager
@@ -68,7 +77,6 @@ if TYPE_CHECKING:
 
     from mindroom.constants import RuntimePaths
     from mindroom.tool_system.catalog import ToolValidationInfo
-    from mindroom.workers.models import WorkerHandle
 
 logger = get_logger(__name__)
 
@@ -365,37 +373,6 @@ class SandboxRunnerSaveAttachmentResponse(BaseModel):
     failure_kind: Literal["tool", "worker"] | None = None
 
 
-class SandboxWorkerResponse(BaseModel):
-    """Serialized worker metadata for sandbox-runner observability."""
-
-    worker_id: str
-    worker_key: str
-    endpoint: str
-    status: str
-    backend_name: str
-    last_used_at: float
-    created_at: float
-    last_started_at: float | None = None
-    expires_at: float | None = None
-    startup_count: int = 0
-    failure_count: int = 0
-    failure_reason: str | None = None
-    debug_metadata: dict[str, str] = Field(default_factory=dict)
-
-
-class SandboxWorkerListResponse(BaseModel):
-    """List of known sandbox workers."""
-
-    workers: list[SandboxWorkerResponse]
-
-
-class SandboxWorkerCleanupResponse(BaseModel):
-    """Result of one idle-worker cleanup pass."""
-
-    idle_timeout_seconds: float
-    cleaned_workers: list[SandboxWorkerResponse]
-
-
 @dataclass(frozen=True)
 class _SandboxRunnerContext:
     runtime_paths: RuntimePaths
@@ -573,24 +550,6 @@ def _resolve_entrypoint(
     if function is None or function.entrypoint is None:
         raise HTTPException(status_code=404, detail=f"Tool '{tool_name}' does not expose '{function_name}'.")
     return toolkit, function.entrypoint
-
-
-def _serialize_worker(worker: WorkerHandle) -> SandboxWorkerResponse:
-    return SandboxWorkerResponse(
-        worker_id=worker.worker_id,
-        worker_key=worker.worker_key,
-        endpoint=worker.endpoint,
-        status=worker.status,
-        backend_name=worker.backend_name,
-        last_used_at=worker.last_used_at,
-        created_at=worker.created_at,
-        last_started_at=worker.last_started_at,
-        expires_at=worker.expires_at,
-        startup_count=worker.startup_count,
-        failure_count=worker.failure_count,
-        failure_reason=worker.failure_reason,
-        debug_metadata=worker.debug_metadata,
-    )
 
 
 def _workspace_env_overlay_for_request(

--- a/src/mindroom/api/worker_responses.py
+++ b/src/mindroom/api/worker_responses.py
@@ -11,14 +11,14 @@ if TYPE_CHECKING:
 
 
 __all__ = [
-    "WorkerCleanupResponse",
-    "WorkerListResponse",
-    "WorkerResponse",
-    "serialize_worker_response",
+    "SandboxWorkerCleanupResponse",
+    "SandboxWorkerListResponse",
+    "SandboxWorkerResponse",
+    "serialize_sandbox_worker_response",
 ]
 
 
-class WorkerResponse(BaseModel):
+class SandboxWorkerResponse(BaseModel):
     """Serialized worker metadata for API responses."""
 
     worker_id: str
@@ -36,22 +36,22 @@ class WorkerResponse(BaseModel):
     debug_metadata: dict[str, str] = Field(default_factory=dict)
 
 
-class WorkerListResponse(BaseModel):
+class SandboxWorkerListResponse(BaseModel):
     """List of known workers."""
 
-    workers: list[WorkerResponse]
+    workers: list[SandboxWorkerResponse]
 
 
-class WorkerCleanupResponse(BaseModel):
+class SandboxWorkerCleanupResponse(BaseModel):
     """Result of one cleanup pass."""
 
     idle_timeout_seconds: float
-    cleaned_workers: list[WorkerResponse]
+    cleaned_workers: list[SandboxWorkerResponse]
 
 
-def serialize_worker_response(worker: WorkerHandle) -> WorkerResponse:
+def serialize_sandbox_worker_response(worker: WorkerHandle) -> SandboxWorkerResponse:
     """Serialize a WorkerHandle without exposing its auth token."""
-    return WorkerResponse(
+    return SandboxWorkerResponse(
         worker_id=worker.worker_id,
         worker_key=worker.worker_key,
         endpoint=worker.endpoint,

--- a/src/mindroom/api/worker_responses.py
+++ b/src/mindroom/api/worker_responses.py
@@ -1,0 +1,68 @@
+"""Shared worker observability response models."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from mindroom.workers.models import WorkerHandle
+
+
+__all__ = [
+    "WorkerCleanupResponse",
+    "WorkerListResponse",
+    "WorkerResponse",
+    "serialize_worker_response",
+]
+
+
+class WorkerResponse(BaseModel):
+    """Serialized worker metadata for API responses."""
+
+    worker_id: str
+    worker_key: str
+    endpoint: str
+    status: str
+    backend_name: str
+    last_used_at: float
+    created_at: float
+    last_started_at: float | None = None
+    expires_at: float | None = None
+    startup_count: int = 0
+    failure_count: int = 0
+    failure_reason: str | None = None
+    debug_metadata: dict[str, str] = Field(default_factory=dict)
+
+
+class WorkerListResponse(BaseModel):
+    """List of known workers."""
+
+    workers: list[WorkerResponse]
+
+
+class WorkerCleanupResponse(BaseModel):
+    """Result of one cleanup pass."""
+
+    idle_timeout_seconds: float
+    cleaned_workers: list[WorkerResponse]
+
+
+def serialize_worker_response(worker: WorkerHandle) -> WorkerResponse:
+    """Serialize a WorkerHandle without exposing its auth token."""
+    return WorkerResponse(
+        worker_id=worker.worker_id,
+        worker_key=worker.worker_key,
+        endpoint=worker.endpoint,
+        status=worker.status,
+        backend_name=worker.backend_name,
+        last_used_at=worker.last_used_at,
+        created_at=worker.created_at,
+        last_started_at=worker.last_started_at,
+        expires_at=worker.expires_at,
+        startup_count=worker.startup_count,
+        failure_count=worker.failure_count,
+        failure_reason=worker.failure_reason,
+        debug_metadata=worker.debug_metadata,
+    )

--- a/src/mindroom/api/workers.py
+++ b/src/mindroom/api/workers.py
@@ -5,9 +5,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
 
 from mindroom.api import config_lifecycle
+from mindroom.api.worker_responses import (
+    WorkerCleanupResponse,
+    WorkerListResponse,
+    WorkerResponse,
+)
+from mindroom.api.worker_responses import (
+    serialize_worker_response as _serialize_worker,
+)
 from mindroom.tool_system.sandbox_proxy import sandbox_proxy_config
 from mindroom.workers.runtime import (
     get_primary_worker_manager,
@@ -18,59 +25,18 @@ from mindroom.workers.runtime import (
 
 if TYPE_CHECKING:
     from mindroom.workers.manager import WorkerManager
-    from mindroom.workers.models import WorkerHandle
 
 
-class WorkerResponse(BaseModel):
-    """Serialized worker metadata for API responses."""
-
-    worker_id: str
-    worker_key: str
-    endpoint: str
-    status: str
-    backend_name: str
-    last_used_at: float
-    created_at: float
-    last_started_at: float | None = None
-    expires_at: float | None = None
-    startup_count: int = 0
-    failure_count: int = 0
-    failure_reason: str | None = None
-    debug_metadata: dict[str, str] = Field(default_factory=dict)
-
-
-class WorkerListResponse(BaseModel):
-    """List of known workers."""
-
-    workers: list[WorkerResponse]
-
-
-class WorkerCleanupResponse(BaseModel):
-    """Result of one cleanup pass."""
-
-    idle_timeout_seconds: float
-    cleaned_workers: list[WorkerResponse]
-
+__all__ = [
+    "WorkerCleanupResponse",
+    "WorkerListResponse",
+    "WorkerResponse",
+    "cleanup_idle_workers",
+    "list_workers",
+    "router",
+]
 
 router = APIRouter(prefix="/api/workers", tags=["workers"])
-
-
-def _serialize_worker(worker: WorkerHandle) -> WorkerResponse:
-    return WorkerResponse(
-        worker_id=worker.worker_id,
-        worker_key=worker.worker_key,
-        endpoint=worker.endpoint,
-        status=worker.status,
-        backend_name=worker.backend_name,
-        last_used_at=worker.last_used_at,
-        created_at=worker.created_at,
-        last_started_at=worker.last_started_at,
-        expires_at=worker.expires_at,
-        startup_count=worker.startup_count,
-        failure_count=worker.failure_count,
-        failure_reason=worker.failure_reason,
-        debug_metadata=worker.debug_metadata,
-    )
 
 
 def _worker_manager(request: Request) -> WorkerManager:

--- a/src/mindroom/api/workers.py
+++ b/src/mindroom/api/workers.py
@@ -8,12 +8,10 @@ from fastapi import APIRouter, HTTPException, Request
 
 from mindroom.api import config_lifecycle
 from mindroom.api.worker_responses import (
-    WorkerCleanupResponse,
-    WorkerListResponse,
-    WorkerResponse,
-)
-from mindroom.api.worker_responses import (
-    serialize_worker_response as _serialize_worker,
+    SandboxWorkerCleanupResponse,
+    SandboxWorkerListResponse,
+    SandboxWorkerResponse,
+    serialize_sandbox_worker_response,
 )
 from mindroom.tool_system.sandbox_proxy import sandbox_proxy_config
 from mindroom.workers.runtime import (
@@ -28,9 +26,9 @@ if TYPE_CHECKING:
 
 
 __all__ = [
-    "WorkerCleanupResponse",
-    "WorkerListResponse",
-    "WorkerResponse",
+    "SandboxWorkerCleanupResponse",
+    "SandboxWorkerListResponse",
+    "SandboxWorkerResponse",
     "cleanup_idle_workers",
     "list_workers",
     "router",
@@ -64,20 +62,22 @@ def _worker_manager(request: Request) -> WorkerManager:
     )
 
 
-@router.get("", response_model=WorkerListResponse)
-async def list_workers(request: Request, include_idle: bool = True) -> WorkerListResponse:
+@router.get("", response_model=SandboxWorkerListResponse)
+async def list_workers(request: Request, include_idle: bool = True) -> SandboxWorkerListResponse:
     """List known workers from the configured primary-runtime backend."""
     worker_manager = _worker_manager(request)
-    workers = [_serialize_worker(worker) for worker in worker_manager.list_workers(include_idle=include_idle)]
-    return WorkerListResponse(workers=workers)
+    workers = [
+        serialize_sandbox_worker_response(worker) for worker in worker_manager.list_workers(include_idle=include_idle)
+    ]
+    return SandboxWorkerListResponse(workers=workers)
 
 
-@router.post("/cleanup", response_model=WorkerCleanupResponse)
-async def cleanup_idle_workers(request: Request) -> WorkerCleanupResponse:
+@router.post("/cleanup", response_model=SandboxWorkerCleanupResponse)
+async def cleanup_idle_workers(request: Request) -> SandboxWorkerCleanupResponse:
     """Run one idle-worker cleanup pass on the configured backend."""
     worker_manager = _worker_manager(request)
-    cleaned_workers = [_serialize_worker(worker) for worker in worker_manager.cleanup_idle_workers()]
-    return WorkerCleanupResponse(
+    cleaned_workers = [serialize_sandbox_worker_response(worker) for worker in worker_manager.cleanup_idle_workers()]
+    return SandboxWorkerCleanupResponse(
         idle_timeout_seconds=worker_manager.idle_timeout_seconds,
         cleaned_workers=cleaned_workers,
     )

--- a/tach.toml
+++ b/tach.toml
@@ -459,6 +459,10 @@ depends_on = [
 path = "mindroom.api.sandbox_protocol"
 depends_on = []
 
+[[modules]]
+path = "mindroom.api.worker_responses"
+depends_on = []
+
 # NOTE (arch-b-7): sandbox modules currently depend on the concrete
 # workers.backends.local backend. Honest definition-site encoding for
 # now; ARCH-B-9 will lift the shared sandbox-relevant types into a
@@ -469,6 +473,7 @@ depends_on = [
     "mindroom.api.sandbox_exec",
     "mindroom.api.sandbox_protocol",
     "mindroom.api.sandbox_worker_prep",
+    "mindroom.api.worker_responses",
     "mindroom.config.main",
     "mindroom.constants",
     "mindroom.credentials",
@@ -521,6 +526,7 @@ depends_on = [
 path = "mindroom.api.workers"
 depends_on = [
     "mindroom.api.config_lifecycle",
+    "mindroom.api.worker_responses",
     "mindroom.tool_system.sandbox_proxy",
     "mindroom.workers.runtime",
 ]

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -36,11 +36,11 @@ TEST_WORKER_AUTH = "token"
 
 def test_worker_api_modules_share_response_dtos_and_serializer() -> None:
     """Primary and sandbox worker APIs should share the worker response contract."""
-    assert workers_api.WorkerListResponse is sandbox_runner_api.SandboxWorkerListResponse
-    assert workers_api.WorkerCleanupResponse is sandbox_runner_api.SandboxWorkerCleanupResponse
-    assert workers_api._serialize_worker is sandbox_runner_api._serialize_worker
+    assert workers_api.SandboxWorkerListResponse is sandbox_runner_api.SandboxWorkerListResponse
+    assert workers_api.SandboxWorkerCleanupResponse is sandbox_runner_api.SandboxWorkerCleanupResponse
+    assert workers_api.serialize_sandbox_worker_response is sandbox_runner_api.serialize_sandbox_worker_response
 
-    serialized_worker = workers_api._serialize_worker(
+    serialized_worker = workers_api.serialize_sandbox_worker_response(
         WorkerHandle(
             worker_id="worker-1",
             worker_key="worker-key",

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -20,6 +20,7 @@ from fastapi.testclient import TestClient
 
 from mindroom import constants, frontend_assets
 from mindroom.api import auth, config_lifecycle, frontend, main, runtime_reload
+from mindroom.api import sandbox_runner as sandbox_runner_api
 from mindroom.api import tools as tools_api
 from mindroom.api import workers as workers_api
 from mindroom.commands.config_commands import apply_config_change
@@ -31,6 +32,38 @@ from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_w
 from mindroom.workers.models import WorkerHandle
 
 TEST_WORKER_AUTH = "token"
+
+
+def test_worker_api_modules_share_response_dtos_and_serializer() -> None:
+    """Primary and sandbox worker APIs should share the worker response contract."""
+    assert workers_api.WorkerListResponse is sandbox_runner_api.SandboxWorkerListResponse
+    assert workers_api.WorkerCleanupResponse is sandbox_runner_api.SandboxWorkerCleanupResponse
+    assert workers_api._serialize_worker is sandbox_runner_api._serialize_worker
+
+    serialized_worker = workers_api._serialize_worker(
+        WorkerHandle(
+            worker_id="worker-1",
+            worker_key="worker-key",
+            endpoint="http://worker/api/sandbox-runner/execute",
+            auth_token=TEST_WORKER_AUTH,
+            status="failed",
+            backend_name="kubernetes",
+            last_used_at=12.0,
+            created_at=1.0,
+            last_started_at=2.0,
+            expires_at=30.0,
+            startup_count=3,
+            failure_count=2,
+            failure_reason="startup failed",
+            debug_metadata={"namespace": "mindroom-instances"},
+        ),
+    ).model_dump()
+
+    assert "auth_token" not in serialized_worker
+    assert serialized_worker["failure_reason"] == "startup failed"
+    assert serialized_worker["debug_metadata"] == {"namespace": "mindroom-instances"}
+    assert serialized_worker["last_started_at"] == 2.0
+    assert serialized_worker["expires_at"] == 30.0
 
 
 def _runtime_paths(tmp_path: Path, *, process_env: dict[str, str] | None = None) -> constants.RuntimePaths:


### PR DESCRIPTION
## Summary
- Extract shared worker observability response DTOs and WorkerHandle serialization into `mindroom.api.worker_responses`.
- Reuse the shared DTOs/serializer from primary worker and sandbox-runner worker endpoints.
- Update Tach boundaries for the new shared API module.

## Verification
- `uv sync --all-extras`
- `uv run pytest tests/api/test_api.py::test_worker_api_modules_share_response_dtos_and_serializer tests/api/test_api.py::test_list_workers_endpoint tests/api/test_api.py::test_cleanup_workers_endpoint -q -n 0 --no-cov`
- `uv run pytest tests/api/test_sandbox_runner_api.py::test_sandbox_runner_lists_known_workers tests/api/test_sandbox_runner_api.py::test_sandbox_runner_cleanup_marks_idle_workers_without_deleting_state tests/api/test_sandbox_runner_api.py::test_sandbox_runner_records_worker_initialization_failures -q -n 0 --no-cov` (2 Linux-only tests skipped on macOS)
- `uv run pre-commit run --files src/mindroom/api/workers.py src/mindroom/api/sandbox_runner.py src/mindroom/api/worker_responses.py tests/api/test_api.py tach.toml`

## Line-count gate
- `git diff --numstat origin/main...HEAD`: production files `+93/-100`, net `-7` production lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Worker API response models consolidated into a centralized module for consistent handling across endpoints.

* **Tests**
  * Added tests to verify worker response data consistency and serialization behavior across API endpoints.

* **Chores**
  * Updated module dependencies and test execution configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->