### PR TITLE
Update Privata to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -413,7 +413,7 @@ dev = [
   "markdown-gfm-admonition",
   "pre-commit>=4.2",
   "pre-commit-uv>=4.1.4",
-  "privata>=0.1.7",
+  "privata>=0.2",
   "pytest>=8.4.1",
   "pytest-asyncio>=1.1",
   "pytest-cov>=6.2.1",

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -32,8 +32,8 @@ from mindroom.api.worker_responses import (
     SandboxWorkerListResponse,
     serialize_sandbox_worker_response,
 )
-from mindroom.attachments import _normalize_attachment_id
-from mindroom.config.main import Config, _normalized_config_data, load_config
+from mindroom.attachments import normalize_attachment_id
+from mindroom.config.main import Config, load_config, normalized_config_data
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager
 from mindroom.logging_config import get_logger
 from mindroom.oauth.providers import OAuthConnectionRequired
@@ -129,7 +129,7 @@ def _startup_runtime_paths_from_env() -> RuntimePaths:
     )
 
 
-def _startup_runner_token_from_env() -> str | None:
+def startup_runner_token_from_env() -> str | None:
     """Read and remove the runner auth token from process env after startup."""
     raw_token = os.environ.pop(_RUNNER_TOKEN_ENV, "").strip()
     return raw_token or None
@@ -171,7 +171,7 @@ def _dedicated_worker_runtime_config_or_empty(runtime_paths: RuntimePaths) -> Co
     # runtime is authoritative for full authored tool validation; workers
     # validate the requested tool at execution time with their local registry.
     config = Config.model_validate(
-        _normalized_config_data(data),
+        normalized_config_data(data),
         context={"runtime_paths": runtime_paths},
     )
     return _config_with_available_plugins(config, runtime_paths)
@@ -212,7 +212,7 @@ def _config_with_available_plugins(config: Config, runtime_paths: RuntimePaths) 
     return config.model_copy(update={"plugins": available_plugins}, deep=True)
 
 
-def _load_config_from_startup_runtime() -> tuple[RuntimePaths, Config]:
+def load_config_from_startup_runtime() -> tuple[RuntimePaths, Config]:
     """Read the sandbox runner runtime context from explicit startup payload."""
     runtime_paths = _startup_runtime_paths_from_env()
     return runtime_paths, _runtime_config_or_empty(runtime_paths)
@@ -388,11 +388,13 @@ def _app_context(app: FastAPI) -> _SandboxRunnerContext:
     return context
 
 
-def _app_runtime_paths(app: FastAPI) -> RuntimePaths:
+def app_runtime_paths(app: FastAPI) -> RuntimePaths:
+    """Return sandbox runner runtime paths stored on the FastAPI app."""
     return _app_context(app).runtime_paths
 
 
-def _app_runtime_config(app: FastAPI) -> Config:
+def app_runtime_config(app: FastAPI) -> Config:
+    """Return sandbox runner config stored on the FastAPI app."""
     return _app_context(app).config
 
 
@@ -400,7 +402,8 @@ def _app_tool_metadata(app: FastAPI) -> dict[str, Any]:
     return _app_context(app).tool_metadata
 
 
-def _app_runner_token(app: FastAPI) -> str | None:
+def app_runner_token(app: FastAPI) -> str | None:
+    """Return the configured sandbox runner token for the FastAPI app."""
     runner_token = _app_context(app).runner_token
     if runner_token is None:
         return None
@@ -412,12 +415,12 @@ def _app_runner_token(app: FastAPI) -> str | None:
 
 def _sandbox_runner_runtime_paths(request: Request) -> RuntimePaths:
     """Return the committed runtime paths for one sandbox runner request."""
-    return _app_runtime_paths(request.app)
+    return app_runtime_paths(request.app)
 
 
 def _sandbox_runner_runtime_config(request: Request) -> Config:
     """Return the committed validated config for one sandbox runner request."""
-    return _app_runtime_config(request.app)
+    return app_runtime_config(request.app)
 
 
 def _sandbox_runner_tool_metadata(request: Request) -> dict[str, Any]:
@@ -429,7 +432,7 @@ async def _validate_runner_token(
     request: Request,
     x_mindroom_sandbox_token: Annotated[str | None, Header()] = None,
 ) -> None:
-    proxy_token = _app_runner_token(request.app)
+    proxy_token = app_runner_token(request.app)
     if proxy_token is None:
         raise HTTPException(status_code=503, detail="Sandbox runner token is not configured.")
     if not secrets.compare_digest(x_mindroom_sandbox_token or "", proxy_token):
@@ -1337,10 +1340,10 @@ async def save_attachment_to_worker(  # noqa: C901, PLR0911
     """Save one context-authorized attachment into the prepared worker workspace."""
     runtime_paths = _sandbox_runner_runtime_paths(request)
     config = _sandbox_runner_runtime_config(request)
-    runner_token = _app_runner_token(request.app)
+    runner_token = app_runner_token(request.app)
     payload.worker_key = sandbox_worker_prep.normalize_request_worker_key(payload.worker_key, runtime_paths)
 
-    attachment_id = _normalize_attachment_id(payload.attachment_id)
+    attachment_id = normalize_attachment_id(payload.attachment_id)
     if attachment_id is None:
         return SandboxRunnerSaveAttachmentResponse(
             ok=False,
@@ -1431,7 +1434,7 @@ async def execute_tool_call(
     runtime_paths = _sandbox_runner_runtime_paths(request)
     config = _sandbox_runner_runtime_config(request)
     tool_metadata = _sandbox_runner_tool_metadata(request)
-    runner_token = _app_runner_token(request.app)
+    runner_token = app_runner_token(request.app)
     payload.worker_key = sandbox_worker_prep.normalize_request_worker_key(payload.worker_key, runtime_paths)
     _validate_execute_request_payload(payload, tool_metadata=tool_metadata)
     credential_overrides: dict[str, object] = {}

--- a/src/mindroom/api/sandbox_runner_app.py
+++ b/src/mindroom/api/sandbox_runner_app.py
@@ -6,12 +6,12 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from mindroom.api.sandbox_runner import (
-    _app_runner_token,
-    _app_runtime_config,
-    _app_runtime_paths,
-    _load_config_from_startup_runtime,
-    _startup_runner_token_from_env,
+    app_runner_token,
+    app_runtime_config,
+    app_runtime_paths,
     initialize_sandbox_runner_app,
+    load_config_from_startup_runtime,
+    startup_runner_token_from_env,
 )
 from mindroom.api.sandbox_runner import router as sandbox_runner_router
 
@@ -19,13 +19,13 @@ from mindroom.api.sandbox_runner import router as sandbox_runner_router
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     try:
-        runtime_paths = _app_runtime_paths(app)
+        runtime_paths = app_runtime_paths(app)
     except TypeError:
-        runtime_paths, config = _load_config_from_startup_runtime()
-        runner_token = _startup_runner_token_from_env()
+        runtime_paths, config = load_config_from_startup_runtime()
+        runner_token = startup_runner_token_from_env()
     else:
-        config = _app_runtime_config(app)
-        runner_token = _app_runner_token(app)
+        config = app_runtime_config(app)
+        runner_token = app_runner_token(app)
     initialize_sandbox_runner_app(
         app,
         runtime_paths,

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -49,7 +49,7 @@ _CLEANUP_INTERVAL = timedelta(hours=1)
 _last_cleanup_time_by_storage_path: dict[Path, datetime] = {}
 
 
-def _normalize_attachment_id(raw_attachment_id: str) -> str | None:
+def normalize_attachment_id(raw_attachment_id: str) -> str | None:
     """Normalize attachment IDs and reject unsafe values."""
     attachment_id = raw_attachment_id.strip()
     if not attachment_id or not _ATTACHMENT_ID_PATTERN.fullmatch(attachment_id):
@@ -105,7 +105,7 @@ def parse_attachment_ids_from_event_source(event_source: dict[str, Any] | None) 
     for raw_attachment_id in raw_attachment_ids:
         if not isinstance(raw_attachment_id, str):
             continue
-        attachment_id = _normalize_attachment_id(raw_attachment_id)
+        attachment_id = normalize_attachment_id(raw_attachment_id)
         if attachment_id and attachment_id not in seen_attachment_ids:
             seen_attachment_ids.add(attachment_id)
             normalized.append(attachment_id)
@@ -416,7 +416,7 @@ def register_local_attachment(
         return None
 
     resolved_attachment_id = attachment_id or f"att_{uuid4().hex[:16]}"
-    normalized_attachment_id = _normalize_attachment_id(resolved_attachment_id)
+    normalized_attachment_id = normalize_attachment_id(resolved_attachment_id)
     if normalized_attachment_id is None:
         logger.warning("Invalid attachment ID", attachment_id=resolved_attachment_id)
         return None
@@ -579,7 +579,7 @@ async def register_audio_attachment(
 
 def load_attachment(storage_path: Path, attachment_id: str) -> AttachmentRecord | None:
     """Load attachment metadata by ID."""
-    normalized_attachment_id = _normalize_attachment_id(attachment_id)
+    normalized_attachment_id = normalize_attachment_id(attachment_id)
     if normalized_attachment_id is None:
         return None
     record_path = _attachment_record_path(storage_path, normalized_attachment_id)
@@ -629,7 +629,7 @@ def resolve_attachments(storage_path: Path, attachment_ids: list[str]) -> list[A
     resolved: list[AttachmentRecord] = []
     seen_ids: set[str] = set()
     for attachment_id in attachment_ids:
-        normalized_attachment_id = _normalize_attachment_id(attachment_id)
+        normalized_attachment_id = normalize_attachment_id(attachment_id)
         if normalized_attachment_id is None or normalized_attachment_id in seen_ids:
             continue
         seen_ids.add(normalized_attachment_id)

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import nio
 
 from mindroom.authorization import is_authorized_sender
-from mindroom.commands.handler import _generate_welcome_message
+from mindroom.commands.handler import generate_welcome_message
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.matrix.client_room_admin import get_joined_rooms, join_room
 from mindroom.matrix.invited_rooms_store import (
@@ -164,7 +164,7 @@ class BotRoomLifecycle:
 
         if not response.chunk:
             self._logger().info("Room is empty, sending welcome message", room_id=room_id)
-            welcome_msg = _generate_welcome_message(room_id, self._config(), self.deps.runtime_paths)
+            welcome_msg = generate_welcome_message(room_id, self._config(), self.deps.runtime_paths)
             await self.deps.send_response(
                 room_id=room_id,
                 reply_to_event_id=None,

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -270,7 +270,8 @@ def _format_config_search_locations(process_env: Mapping[str, str]) -> list[str]
     ]
 
 
-def _print_config_search_locations(process_env: Mapping[str, str], *, title: str) -> None:
+def print_config_search_locations(process_env: Mapping[str, str], *, title: str) -> None:
+    """Print the config search locations used by CLI commands."""
     console.print(title)
     for line in _format_config_search_locations(process_env):
         console.print(line)
@@ -288,7 +289,7 @@ def _resolve_config_path(
     return resolve_primary_runtime_paths(process_env=resolved_process_env).config_path.resolve()
 
 
-def _activate_cli_runtime(
+def activate_cli_runtime(
     path: Path | None = None,
     *,
     storage_path: Path | None = None,
@@ -327,7 +328,7 @@ def _get_editor() -> str:
     return "vi"
 
 
-def _format_validation_errors(
+def format_validation_errors(
     exc: ValidationError | ConfigRuntimeValidationError | yaml.YAMLError | OSError | UnicodeError,
     config_path: Path | None = None,
 ) -> None:
@@ -461,13 +462,13 @@ def config_show(
     if not config_file.exists():
         console.print(f"[yellow]No config file found at:[/yellow] {config_file}")
         console.print("\nRun [cyan]mindroom config init[/cyan] to create one.")
-        _print_config_search_locations(process_env, title="\nSearch locations (first match wins):")
+        print_config_search_locations(process_env, title="\nSearch locations (first match wins):")
         raise typer.Exit(1)
 
     try:
         content = config_file.read_text(encoding="utf-8")
     except CONFIG_LOAD_USER_ERROR_TYPES as exc:
-        _format_validation_errors(exc, config_path=config_file)
+        format_validation_errors(exc, config_path=config_file)
         raise typer.Exit(1) from None
 
     if raw:
@@ -532,7 +533,7 @@ def config_validate(
     Parses the YAML config using Pydantic and reports errors in a friendly format.
     Also checks whether required API keys are set as environment variables.
     """
-    runtime_paths = _activate_cli_runtime(path)
+    runtime_paths = activate_cli_runtime(path)
     config_path = runtime_paths.config_path
     console.print(f"Validating configuration: [bold]{config_path}[/bold]\n")
 
@@ -542,9 +543,9 @@ def config_validate(
         raise typer.Exit(1)
 
     try:
-        config = _load_config_quiet(runtime_paths=runtime_paths)
+        config = load_config_quiet(runtime_paths=runtime_paths)
     except CONFIG_LOAD_USER_ERROR_TYPES as exc:
-        _format_validation_errors(exc, config_path)
+        format_validation_errors(exc, config_path)
         raise typer.Exit(1) from None
 
     console.print("[green]Configuration is valid.[/green]\n")
@@ -555,7 +556,7 @@ def config_validate(
     console.print(f"  Rooms:  {len(rooms)} ({', '.join(sorted(rooms)) or 'none'})")
 
     # Check for missing API keys based on configured providers
-    _check_env_keys(config, runtime_paths=runtime_paths)
+    check_env_keys(config, runtime_paths=runtime_paths)
 
 
 @config_app.command("path")
@@ -569,7 +570,7 @@ def config_path_cmd(
     status = "[green]exists[/green]" if exists else "[red]not found[/red]"
     console.print(f"Resolved config path: {resolved} ({status})")
 
-    _print_config_search_locations(process_env, title="\nSearch locations (first match wins):")
+    print_config_search_locations(process_env, title="\nSearch locations (first match wins):")
 
 
 # ---------------------------------------------------------------------------
@@ -577,7 +578,7 @@ def config_path_cmd(
 # ---------------------------------------------------------------------------
 
 
-def _load_config_quiet(
+def load_config_quiet(
     runtime_paths: RuntimePaths,
     *,
     tolerate_plugin_load_errors: bool = False,
@@ -677,7 +678,7 @@ def _normalize_init_profile(profile: str) -> tuple[_ConfigInitProfile, _Provider
     return aliases.get(profile.strip().lower())
 
 
-def _check_env_keys(config: Config, runtime_paths: RuntimePaths) -> None:
+def check_env_keys(config: Config, runtime_paths: RuntimePaths) -> None:
     """Warn about missing environment variables for configured providers."""
     missing = _find_missing_env_keys(config, runtime_paths)
     if missing:

--- a/src/mindroom/cli/doctor.py
+++ b/src/mindroom/cli/doctor.py
@@ -20,7 +20,7 @@ from mindroom.constants import RuntimePaths, env_key_for_provider
 from mindroom.embeddings import create_sentence_transformers_embedder
 from mindroom.matrix.health import matrix_versions_url, response_has_matrix_versions
 
-from .config import _activate_cli_runtime, _load_config_quiet, console
+from .config import activate_cli_runtime, console, load_config_quiet
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -42,7 +42,7 @@ def doctor() -> None:
     failed = 0
     warnings = 0
 
-    runtime_paths = _activate_cli_runtime()
+    runtime_paths = activate_cli_runtime()
     config_path = runtime_paths.config_path
 
     # 1. Config file exists
@@ -118,7 +118,7 @@ def _check_config_exists(config_path: Path) -> tuple[int, int, int]:
 def _check_config_valid(runtime_paths: RuntimePaths) -> tuple[Config | None, int, int, int]:
     """Validate config file. Returns (config_or_none, passed, failed, warnings)."""
     try:
-        config = _load_config_quiet(runtime_paths=runtime_paths)
+        config = load_config_quiet(runtime_paths=runtime_paths)
     except CONFIG_LOAD_USER_ERROR_TYPES as exc:
         issues = "; ".join(f"{location}: {message}" for location, message in iter_config_validation_messages(exc))
         console.print(f"[red]✗[/red] Config invalid: {issues}")

--- a/src/mindroom/cli/local_stack.py
+++ b/src/mindroom/cli/local_stack.py
@@ -17,7 +17,7 @@ import typer
 
 from mindroom.matrix.health import matrix_versions_url, response_has_matrix_versions
 
-from .config import _activate_cli_runtime, console
+from .config import activate_cli_runtime, console
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -73,7 +73,7 @@ def local_stack_setup(
     ),
 ) -> None:
     """Start local Synapse + MindRoom Cinny using Docker only."""
-    runtime_paths = _activate_cli_runtime()
+    runtime_paths = activate_cli_runtime()
     _require_supported_platform()
     _require_binary("docker", "Docker is required but was not found in PATH.")
 

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -20,13 +20,13 @@ from mindroom.frontend_assets import ensure_frontend_dist_dir
 
 from .banner import make_banner
 from .config import (
-    _activate_cli_runtime,
-    _check_env_keys,
-    _format_validation_errors,
-    _load_config_quiet,
-    _print_config_search_locations,
+    activate_cli_runtime,
+    check_env_keys,
     config_app,
     console,
+    format_validation_errors,
+    load_config_quiet,
+    print_config_search_locations,
 )
 from .doctor import doctor
 from .local_stack import local_stack_setup
@@ -128,12 +128,12 @@ def _load_active_config_or_exit(runtime_paths: RuntimePaths) -> Config:
         raise typer.Exit(1)
 
     try:
-        config = _load_config_quiet(
+        config = load_config_quiet(
             runtime_paths=runtime_paths,
             tolerate_plugin_load_errors=True,
         )
     except CONFIG_LOAD_USER_ERROR_TYPES as exc:
-        _format_validation_errors(exc, config_path)
+        format_validation_errors(exc, config_path)
         raise typer.Exit(1) from None
 
     return config
@@ -148,11 +148,11 @@ async def _run(
     api_host: str,
 ) -> None:
     """Run the multi-agent system with friendly error handling."""
-    runtime_paths = _activate_cli_runtime(storage_path=storage_path)
+    runtime_paths = activate_cli_runtime(storage_path=storage_path)
     config = _load_active_config_or_exit(runtime_paths)
 
     # Check for missing API keys
-    _check_env_keys(config, runtime_paths=runtime_paths)
+    check_env_keys(config, runtime_paths=runtime_paths)
 
     console.print(make_banner())
     console.print()
@@ -202,7 +202,7 @@ def avatars_generate(
     ),
 ) -> None:
     """Generate missing managed avatar files in the workspace."""
-    runtime_paths = _activate_cli_runtime()
+    runtime_paths = activate_cli_runtime()
     _load_active_config_or_exit(runtime_paths)
 
     try:
@@ -223,7 +223,7 @@ def avatars_sync(
     ),
 ) -> None:
     """Sync configured room and root-space avatars to Matrix using the initialized router account."""
-    runtime_paths = _activate_cli_runtime()
+    runtime_paths = activate_cli_runtime()
     _load_active_config_or_exit(runtime_paths)
 
     try:
@@ -278,7 +278,7 @@ def connect(
         console.print("[red]Error:[/red] Invalid pair code format. Expected ABCD-EFGH.")
         raise typer.Exit(1)
 
-    runtime_paths = _activate_cli_runtime(path)
+    runtime_paths = activate_cli_runtime(path)
     resolved_provisioning_url = (
         provisioning_url or runtime_paths.env_value("MINDROOM_PROVISIONING_URL") or "https://mindroom.chat"
     ).strip()
@@ -388,7 +388,7 @@ def _print_missing_config_error(process_env: Mapping[str, str]) -> None:
     console.print("Quick start:")
     console.print("  [cyan]mindroom config init[/cyan]    Create a starter config")
     console.print("  [cyan]mindroom config edit[/cyan]    Edit your config\n")
-    _print_config_search_locations(process_env, title="Config search locations (first match wins):")
+    print_config_search_locations(process_env, title="Config search locations (first match wins):")
     console.print("\nLearn more: https://github.com/mindroom-ai/mindroom")
 
 

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -124,7 +124,7 @@ def _format_agent_description(agent_name: str, config: Config) -> str:
     return ""
 
 
-def _generate_welcome_message(room_id: str, config: Config, runtime_paths: RuntimePaths) -> str:
+def generate_welcome_message(room_id: str, config: Config, runtime_paths: RuntimePaths) -> str:
     """Generate the welcome message text for a room."""
     # Get list of configured agents for this room
     configured_agents = get_configured_agents_for_room(room_id, config, runtime_paths)
@@ -235,7 +235,7 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
 
     elif command.type == CommandType.HI:
         # Generate the welcome message for this room
-        response_text = _generate_welcome_message(room.room_id, context.config, context.runtime_paths)
+        response_text = generate_welcome_message(room.room_id, context.config, context.runtime_paths)
 
     elif command.type == CommandType.SCHEDULE:
         full_text = command.args["full_text"]

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -220,7 +220,7 @@ def _normalize_optional_config_sections(data: dict[str, object]) -> None:
         data["plugins"] = []
 
 
-def _normalized_config_data(data: object) -> object:
+def normalized_config_data(data: object) -> object:
     """Return config input with legacy optional sections normalized."""
     if not isinstance(data, dict):
         return data
@@ -424,7 +424,7 @@ class Config(BaseModel):
     @classmethod
     def validate_raw_root_config(cls, data: object) -> object:
         """Normalize optional root sections before nested model validation."""
-        return _normalized_config_data(data)
+        return normalized_config_data(data)
 
     @field_validator("plugins", mode="before")
     @classmethod
@@ -931,7 +931,7 @@ class Config(BaseModel):
         tolerate_plugin_load_errors: bool = False,
     ) -> Config:
         """Validate config data against one explicit runtime context."""
-        config = cls.model_validate(_normalized_config_data(data), context={"runtime_paths": runtime_paths})
+        config = cls.model_validate(normalized_config_data(data), context={"runtime_paths": runtime_paths})
         # why-lazy: module-top catalog import pulls runtime tool registry paths and loads agents+tools at config import.
         from mindroom.tool_system.catalog import ToolConfigOverrideError, ToolMetadataValidationError  # noqa: PLC0415
 

--- a/src/mindroom/custom_tools/attachments.py
+++ b/src/mindroom/custom_tools/attachments.py
@@ -219,7 +219,7 @@ def _resolve_attachment_file_paths(
     return resolved_paths, newly_registered_attachment_ids, None
 
 
-def _resolve_send_attachments(
+def resolve_send_attachments(
     context: ToolRuntimeContext,
     *,
     attachment_ids: list[str],
@@ -245,7 +245,7 @@ def _resolve_send_attachments(
     return attachment_paths, resolved_attachment_ids, newly_registered_attachment_ids, None
 
 
-async def _send_attachment_paths(
+async def send_attachment_paths(
     context: ToolRuntimeContext,
     *,
     room_id: str,
@@ -289,7 +289,7 @@ async def send_context_attachments(
 ) -> tuple[_AttachmentSendResult | None, str | None]:
     """Resolve and send context-scoped attachments to Matrix."""
     attachment_paths, resolved_attachment_ids, newly_registered_attachment_ids, resolve_error = (
-        _resolve_send_attachments(
+        resolve_send_attachments(
             context,
             attachment_ids=attachment_ids,
             attachment_file_paths=attachment_file_paths,
@@ -317,7 +317,7 @@ async def send_context_attachments(
             destination_error,
         )
 
-    attachment_event_ids, send_error = await _send_attachment_paths(
+    attachment_event_ids, send_error = await send_attachment_paths(
         context,
         room_id=effective_room_id,
         thread_id=effective_thread_id,

--- a/src/mindroom/custom_tools/config_manager.py
+++ b/src/mindroom/custom_tools/config_manager.py
@@ -41,7 +41,7 @@ def _is_known_tool_entry(tool_name: str, tool_metadata: dict[str, ToolMetadata])
     return tool_name in tool_metadata
 
 
-def _preserve_tool_overrides(
+def preserve_tool_overrides(
     existing_entries: list[ToolConfigEntry],
     updated_tool_names: list[str],
 ) -> list[ToolConfigEntry]:
@@ -80,7 +80,7 @@ def validate_knowledge_bases(
     return f"Error: Unknown knowledge bases: {invalid}. Available knowledge bases: {available}."
 
 
-def _save_runtime_validated_config(config: Config, runtime_paths: RuntimePaths) -> None:
+def save_runtime_validated_config(config: Config, runtime_paths: RuntimePaths) -> None:
     """Revalidate the full config against the active runtime before writing it."""
     validated = Config.validate_with_runtime(config.authored_model_dump(), runtime_paths)
     config_lifecycle.persist_runtime_validated_config(validated, runtime_paths)
@@ -644,7 +644,7 @@ class ConfigManagerTools(Toolkit):
             config.agents[agent_name] = new_agent
 
             # Save config
-            _save_runtime_validated_config(config, self.runtime_paths)
+            save_runtime_validated_config(config, self.runtime_paths)
 
             # Build success message
             tools_str = ", ".join(tools) if tools else "None"
@@ -717,7 +717,7 @@ class ConfigManagerTools(Toolkit):
                 changes.append(f"Role -> {role}")
 
             if tools is not None and tools != agent.tool_names:
-                agent.tools = _preserve_tool_overrides(agent.tools, tools)
+                agent.tools = preserve_tool_overrides(agent.tools, tools)
                 changes.append(f"Tools -> {', '.join(tools) if tools else '(empty)'}")
 
             if instructions is not None and instructions != agent.instructions:
@@ -759,7 +759,7 @@ class ConfigManagerTools(Toolkit):
                 return "No changes made. All provided values are the same as current configuration."
 
             # Save config
-            _save_runtime_validated_config(config, self.runtime_paths)
+            save_runtime_validated_config(config, self.runtime_paths)
 
             return f"✅ Successfully updated agent '{agent_name}'!\n\n**Changes:**\n" + "\n".join(
                 f"- {c}" for c in changes
@@ -808,7 +808,7 @@ class ConfigManagerTools(Toolkit):
             config.teams[team_name] = new_team
 
             # Save config
-            _save_runtime_validated_config(config, self.runtime_paths)
+            save_runtime_validated_config(config, self.runtime_paths)
 
             return (
                 f"✅ Successfully created team '{team_name}'!\n\n"

--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -11,8 +11,8 @@ from mindroom.config.matrix import ignore_unverified_devices_for_config
 from mindroom.constants import ORIGINAL_SENDER_KEY
 from mindroom.custom_tools.attachment_helpers import resolve_context_thread_id
 from mindroom.custom_tools.attachments import (
-    _resolve_send_attachments,
-    _send_attachment_paths,
+    resolve_send_attachments,
+    send_attachment_paths,
     send_context_attachments,
 )
 from mindroom.interactive import (
@@ -203,7 +203,7 @@ class MatrixMessageOperations:
             attachment_count = len(attachment_ids) + len(attachment_file_paths)
             if text is None and attachment_count > 1 and effective_thread_id is None and not room_mode:
                 attachment_paths, resolved_attachment_ids, newly_registered_attachment_ids, resolve_error = (
-                    _resolve_send_attachments(
+                    resolve_send_attachments(
                         context,
                         attachment_ids=attachment_ids,
                         attachment_file_paths=attachment_file_paths,
@@ -252,7 +252,7 @@ class MatrixMessageOperations:
 
                 attachment_event_ids = [first_attachment_event_id]
                 attachment_thread_id = first_attachment_event_id
-                remaining_attachment_event_ids, send_error = await _send_attachment_paths(
+                remaining_attachment_event_ids, send_error = await send_attachment_paths(
                     context,
                     room_id=room_id,
                     thread_id=attachment_thread_id,

--- a/src/mindroom/custom_tools/self_config.py
+++ b/src/mindroom/custom_tools/self_config.py
@@ -12,8 +12,8 @@ from mindroom.config.agent import AgentConfig
 from mindroom.config.main import ConfigRuntimeValidationError, format_invalid_config_message, load_config_or_user_error
 from mindroom.config.models import AgentLearningMode  # noqa: TC001
 from mindroom.custom_tools.config_manager import (
-    _preserve_tool_overrides,
-    _save_runtime_validated_config,
+    preserve_tool_overrides,
+    save_runtime_validated_config,
     validate_knowledge_bases,
 )
 from mindroom.logging_config import get_logger
@@ -157,7 +157,7 @@ class SelfConfigTools(Toolkit):
             ("display_name", display_name),
             ("role", role),
             ("instructions", instructions),
-            ("tools", _preserve_tool_overrides(agent.tools, tools) if tools is not None else None),
+            ("tools", preserve_tool_overrides(agent.tools, tools) if tools is not None else None),
             ("model", model),
             ("rooms", rooms),
             ("markdown", markdown),
@@ -208,7 +208,7 @@ class SelfConfigTools(Toolkit):
 
         config.agents[self.agent_name] = validated_agent
         try:
-            _save_runtime_validated_config(config, self.runtime_paths)
+            save_runtime_validated_config(config, self.runtime_paths)
         except (ValidationError, ConfigRuntimeValidationError) as exc:
             return format_invalid_config_message(exc, footer=_CONFIG_CHANGE_REJECTED_MESSAGE)
         except Exception as e:

--- a/src/mindroom/history/policy.py
+++ b/src/mindroom/history/policy.py
@@ -9,7 +9,7 @@ from mindroom.history.compaction import (
     resolve_compaction_runtime_settings,
     resolve_effective_compaction_threshold,
 )
-from mindroom.history.types import CompactionDecision, ResolvedHistoryExecutionPlan, _CompactionAvailabilityReason
+from mindroom.history.types import CompactionAvailabilityReason, CompactionDecision, ResolvedHistoryExecutionPlan
 from mindroom.token_budget import compute_compaction_input_budget
 
 if TYPE_CHECKING:
@@ -190,7 +190,7 @@ def _resolve_summary_input_budget(
     *,
     compaction_context_window: int | None,
     reserve_tokens: int,
-) -> tuple[int | None, _CompactionAvailabilityReason | None]:
+) -> tuple[int | None, CompactionAvailabilityReason | None]:
     if compaction_context_window is None:
         return None, "no_context_window"
 

--- a/src/mindroom/history/types.py
+++ b/src/mindroom/history/types.py
@@ -11,7 +11,7 @@ _CompactionMode = Literal["auto", "manual"]
 _CompactionDecisionMode = Literal["none", "required"]
 CompactionReplyOutcome = Literal["none", "success", "failed", "timeout"]
 _CompactionLifecycleStatus = Literal["success", "failed", "timeout"]
-_CompactionAvailabilityReason = Literal["no_context_window", "non_positive_summary_input_budget"]
+CompactionAvailabilityReason = Literal["no_context_window", "non_positive_summary_input_budget"]
 _ReplayPlanMode = Literal["configured", "limited", "disabled"]
 
 
@@ -72,7 +72,7 @@ class ResolvedHistoryExecutionPlan:
     static_prompt_tokens: int | None
     replay_budget_tokens: int | None
     summary_input_budget_tokens: int | None
-    unavailable_reason: _CompactionAvailabilityReason | None = None
+    unavailable_reason: CompactionAvailabilityReason | None = None
     hard_replay_budget_tokens: int | None = None
 
 

--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -13,7 +13,7 @@ Developer note:
 
 Package boundary:
 - `mindroom.matrix.cache` is the package-level import surface for cache-facing contracts and shared helpers used above the cache package.
-- `SqliteEventCache`, `PostgresEventCache`, and `_EventCacheWriteCoordinator` remain private concrete services used by `runtime_support.py` through their concrete owner modules.
+- `SqliteEventCache`, `PostgresEventCache`, and `EventCacheWriteCoordinator` remain private concrete services used by `runtime_support.py` through their concrete owner modules.
 - `MatrixConversationCache` remains the higher-level conversation read/write facade above the cache package and may use specific cache helper submodules through narrow Tach visibility.
 
 Main invariants:

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -6,7 +6,7 @@ import asyncio
 import time
 import typing
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 from mindroom.background_tasks import create_background_task, wait_for_background_tasks
 from mindroom.logging_config import bound_log_context
@@ -59,78 +59,8 @@ class _RoomSchedulerState:
     waiters: list[asyncio.Future[None]] = field(default_factory=list)
 
 
-class EventCacheWriteCoordinator(Protocol):
-    """Runtime-facing coordinator contract for ordered advisory cache writes."""
-
-    def queue_room_update(
-        self,
-        room_id: str,
-        update_coro_factory: _UpdateCoroFactory,
-        *,
-        name: str,
-        log_exceptions: bool = True,
-        emit_timing: bool = True,
-        coalesce_key: _CoalesceKey | None = None,
-        coalesce_log_context: dict[str, object] | None = None,
-    ) -> asyncio.Task[object]:
-        """Queue one room-scoped update behind any active predecessor."""
-
-    async def run_room_update(
-        self,
-        room_id: str,
-        update_coro_factory: _UpdateCoroFactory,
-        *,
-        name: str,
-    ) -> object:
-        """Run one room-scoped update through the same ordered barrier."""
-
-    def queue_thread_update(
-        self,
-        room_id: str,
-        thread_id: str,
-        update_coro_factory: _UpdateCoroFactory,
-        *,
-        name: str,
-        log_exceptions: bool = True,
-        emit_timing: bool = False,
-        coalesce_key: _CoalesceKey | None = None,
-        coalesce_log_context: dict[str, object] | None = None,
-    ) -> asyncio.Task[object]:
-        """Queue one thread-scoped update behind same-thread and room-wide predecessors."""
-
-    async def run_thread_update(
-        self,
-        room_id: str,
-        thread_id: str,
-        update_coro_factory: _UpdateCoroFactory,
-        *,
-        name: str,
-        ignore_cancelled_room_fences: bool = False,
-    ) -> object:
-        """Run one thread-scoped update through the ordered thread barrier."""
-
-    async def wait_for_room_idle(self, room_id: str) -> None:
-        """Wait for one room's queued updates to drain."""
-
-    async def wait_for_thread_idle(
-        self,
-        room_id: str,
-        thread_id: str,
-        *,
-        ignore_cancelled_room_fences: bool = False,
-    ) -> None:
-        """Wait for room-wide and same-thread queued updates to drain.
-
-        Set ``ignore_cancelled_room_fences`` only for read-style callers that can
-        safely bypass cancelled room fences preserving write ordering.
-        """
-
-    async def close(self) -> None:
-        """Drain and tear down the coordinator."""
-
-
 @dataclass
-class _EventCacheWriteCoordinator:
+class EventCacheWriteCoordinator:
     """Serialize same-room advisory cache writes across the whole runtime."""
 
     logger: structlog.stdlib.BoundLogger

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -28,8 +28,8 @@ from mindroom.matrix.cache import (
 )
 from mindroom.matrix.client_visible_messages import (
     ResolvedVisibleMessage,
-    _apply_latest_edits_to_messages,
-    _record_latest_thread_edit,
+    apply_latest_edits_to_messages,
+    record_latest_thread_edit,
 )
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.message_content import extract_and_resolve_message, resolve_event_source_content
@@ -287,12 +287,12 @@ async def _resolve_thread_history_from_event_sources_timed(
         if bundled_replacement_source is not None:
             bundled_replacement = nio.Event.parse_event(bundled_replacement_source)
             if isinstance(bundled_replacement, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES):
-                _record_latest_thread_edit(
+                record_latest_thread_edit(
                     bundled_replacement,
                     event_info=EventInfo.from_event(bundled_replacement.source),
                     latest_edits_by_original_event_id=latest_edits_by_original_event_id,
                 )
-        if isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES) and _record_latest_thread_edit(
+        if isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES) and record_latest_thread_edit(
             event,
             event_info=event_info,
             latest_edits_by_original_event_id=latest_edits_by_original_event_id,
@@ -312,7 +312,7 @@ async def _resolve_thread_history_from_event_sources_timed(
             else _snapshot_message_dict(event, trusted_sender_ids=trusted_sender_ids)
         )
 
-    await _apply_latest_edits_to_messages(
+    await apply_latest_edits_to_messages(
         client,
         messages_by_event_id=messages_by_event_id,
         latest_edits_by_original_event_id=latest_edits_by_original_event_id,
@@ -993,7 +993,7 @@ async def _fetch_thread_history_via_room_messages_with_events(
 ) -> _ThreadHistoryFetchResult:
     """Fetch all thread messages by scanning room history pages."""
     fetch_started = time.perf_counter()
-    scan_result = await _fetch_thread_event_sources_via_room_messages(client, room_id, thread_id)
+    scan_result = await fetch_thread_event_sources_via_room_messages(client, room_id, thread_id)
     resolution_started = time.perf_counter()
     history, sidecar_hydration_ms = await _resolve_thread_history_from_event_sources_timed(
         client,
@@ -1027,7 +1027,7 @@ def _record_scanned_room_message_source(
         return False
 
     event_info = EventInfo.from_event(event.source)
-    if isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES) and _record_latest_thread_edit(
+    if isinstance(event, _VISIBLE_ROOM_MESSAGE_EVENT_TYPES) and record_latest_thread_edit(
         event,
         event_info=event_info,
         latest_edits_by_original_event_id=latest_edits_by_original_event_id,
@@ -1078,7 +1078,7 @@ async def _resolve_scanned_thread_message_sources(
     }
 
 
-async def _fetch_thread_event_sources_via_room_messages(
+async def fetch_thread_event_sources_via_room_messages(
     client: nio.AsyncClient,
     room_id: str,
     thread_id: str,
@@ -1194,6 +1194,7 @@ __all__ = [
     "ThreadRoomScanRootNotFoundError",
     "fetch_dispatch_thread_history",
     "fetch_dispatch_thread_snapshot",
+    "fetch_thread_event_sources_via_room_messages",
     "fetch_thread_history",
     "fetch_thread_snapshot",
     "get_room_threads_page",

--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -377,7 +377,7 @@ def _stream_status_from_content(content: dict[str, Any] | None) -> str | None:
     return status if isinstance(status, str) else None
 
 
-def _record_latest_thread_edit(
+def record_latest_thread_edit(
     event: nio.RoomMessageText | nio.RoomMessageNotice,
     *,
     event_info: EventInfo,
@@ -398,7 +398,7 @@ def _record_latest_thread_edit(
     return True
 
 
-async def _apply_latest_edits_to_messages(
+async def apply_latest_edits_to_messages(
     client: nio.AsyncClient,
     *,
     messages_by_event_id: dict[str, ResolvedVisibleMessage],
@@ -466,7 +466,7 @@ async def resolve_latest_visible_messages(
             continue
 
         event_info = EventInfo.from_event(event.source)
-        if _record_latest_thread_edit(
+        if record_latest_thread_edit(
             event,
             event_info=event_info,
             latest_edits_by_original_event_id=latest_edits_by_original_event_id,
@@ -487,7 +487,7 @@ async def resolve_latest_visible_messages(
             latest_event_id=event.event_id,
         )
 
-    await _apply_latest_edits_to_messages(
+    await apply_latest_edits_to_messages(
         client,
         messages_by_event_id=messages_by_event_id,
         latest_edits_by_original_event_id=latest_edits_by_original_event_id,
@@ -498,10 +498,12 @@ async def resolve_latest_visible_messages(
 
 __all__ = [
     "ResolvedVisibleMessage",
+    "apply_latest_edits_to_messages",
     "bundled_replacement_body",
     "extract_visible_edit_body",
     "extract_visible_message",
     "message_preview",
+    "record_latest_thread_edit",
     "replace_visible_message",
     "resolve_latest_visible_messages",
     "resolve_visible_event_source",

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -38,7 +38,7 @@ from mindroom.matrix.thread_projection import (
     ordered_event_ids_from_scanned_event_sources,
     resolve_thread_ids_for_event_infos,
 )
-from mindroom.streaming import _RESTART_INTERRUPTED_RESPONSE_NOTE, build_restart_interrupted_body
+from mindroom.streaming import RESTART_INTERRUPTED_RESPONSE_NOTE, build_restart_interrupted_body
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable
@@ -1298,9 +1298,9 @@ async def _iter_reaction_relation_events(
 def _extract_partial_text(body: str) -> str:
     """Return partial text without the restart interruption note."""
     interrupted_body = build_restart_interrupted_body(body)
-    if interrupted_body == _RESTART_INTERRUPTED_RESPONSE_NOTE:
+    if interrupted_body == RESTART_INTERRUPTED_RESPONSE_NOTE:
         return ""
-    return interrupted_body.removesuffix(f"\n\n{_RESTART_INTERRUPTED_RESPONSE_NOTE}")
+    return interrupted_body.removesuffix(f"\n\n{RESTART_INTERRUPTED_RESPONSE_NOTE}")
 
 
 def _truncate_partial_text(text: str, *, limit: int = _INTERRUPTED_PARTIAL_TEXT_LIMIT) -> str:
@@ -1343,7 +1343,7 @@ def _select_threads_to_resume(
 
 def _has_restart_interrupted_note(body: str) -> bool:
     """Return whether the body already contains the restart interruption note."""
-    return body.rstrip().endswith(_RESTART_INTERRUPTED_RESPONSE_NOTE)
+    return body.rstrip().endswith(RESTART_INTERRUPTED_RESPONSE_NOTE)
 
 
 def _is_cleanup_candidate(state: _MessageState) -> bool:

--- a/src/mindroom/matrix/thread_room_scan.py
+++ b/src/mindroom/matrix/thread_room_scan.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Protocol
 import nio
 from nio.responses import RoomGetEventError
 
-from mindroom.matrix.client_thread_history import _fetch_thread_event_sources_via_room_messages
+from mindroom.matrix.client_thread_history import fetch_thread_event_sources_via_room_messages
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.thread_membership import ThreadMembershipAccess, room_scan_thread_membership_access
 
@@ -33,7 +33,7 @@ async def _scan_thread_event_sources(
     thread_root_id: str,
 ) -> tuple[Sequence[Mapping[str, object]], bool]:
     """Fetch authoritative room-scan event sources for one candidate thread root."""
-    scan_result = await _fetch_thread_event_sources_via_room_messages(client, room_id, thread_root_id)
+    scan_result = await fetch_thread_event_sources_via_room_messages(client, room_id, thread_root_id)
     return scan_result.event_sources, True
 
 

--- a/src/mindroom/mcp/registry.py
+++ b/src/mindroom/mcp/registry.py
@@ -15,7 +15,7 @@ from mindroom.tool_system.catalog import (
     ToolMetadata,
     ToolStatus,
 )
-from mindroom.tool_system.registry_state import _TOOL_REGISTRY
+from mindroom.tool_system.registry_state import TOOL_REGISTRY
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -39,7 +39,7 @@ def mcp_server_id_from_tool_name(tool_name: str) -> str | None:
     """Return the server id for an MCP registry tool name."""
     if not tool_name.startswith(_MCP_TOOL_PREFIX):
         return None
-    factory = _TOOL_REGISTRY.get(tool_name)
+    factory = TOOL_REGISTRY.get(tool_name)
     if tool_name not in _MCP_TOOL_NAMES and not getattr(factory, _MCP_TOOL_FACTORY_MARKER, False):
         return None
     server_id = tool_name.removeprefix(_MCP_TOOL_PREFIX)
@@ -57,7 +57,7 @@ def _registered_mcp_tool_names() -> set[str]:
         *_MCP_TOOL_NAMES,
         *(
             tool_name
-            for tool_name, factory in _TOOL_REGISTRY.items()
+            for tool_name, factory in TOOL_REGISTRY.items()
             if getattr(factory, _MCP_TOOL_FACTORY_MARKER, False)
         ),
     }
@@ -166,18 +166,18 @@ def _tool_factory(server_id: str) -> Callable[[], type[Toolkit]]:
 def _register_mcp_tool(server_id: str, server_config: MCPServerConfig) -> None:
     """Register one dynamic MCP tool entry."""
     tool_name = mcp_tool_name(server_id)
-    if tool_name not in _registered_mcp_tool_names() and (tool_name in TOOL_METADATA or tool_name in _TOOL_REGISTRY):
+    if tool_name not in _registered_mcp_tool_names() and (tool_name in TOOL_METADATA or tool_name in TOOL_REGISTRY):
         msg = f"MCP tool '{tool_name}' conflicts with an existing registered tool"
         raise ValueError(msg)
     TOOL_METADATA[tool_name] = _tool_metadata(server_id, server_config)
-    _TOOL_REGISTRY[tool_name] = _tool_factory(server_id)
+    TOOL_REGISTRY[tool_name] = _tool_factory(server_id)
     _MCP_TOOL_NAMES.add(tool_name)
 
 
 def _unregister_mcp_tool(tool_name: str) -> None:
     """Remove one dynamic MCP tool entry."""
     TOOL_METADATA.pop(tool_name, None)
-    _TOOL_REGISTRY.pop(tool_name, None)
+    TOOL_REGISTRY.pop(tool_name, None)
     _MCP_TOOL_NAMES.discard(tool_name)
 
 
@@ -194,7 +194,7 @@ def sync_mcp_tool_registry(config: Config | None) -> None:
     desired_registry, desired_metadata = resolved_mcp_tool_state(config)
     desired_tool_names = set(desired_registry)
     registered_mcp_tool_names = _registered_mcp_tool_names()
-    existing_non_mcp_tool_names = {*TOOL_METADATA, *_TOOL_REGISTRY} - registered_mcp_tool_names
+    existing_non_mcp_tool_names = {*TOOL_METADATA, *TOOL_REGISTRY} - registered_mcp_tool_names
     conflicting_tool_names = sorted(desired_tool_names & existing_non_mcp_tool_names)
     if conflicting_tool_names:
         msg = f"MCP tool '{conflicting_tool_names[0]}' conflicts with an existing registered tool"
@@ -205,7 +205,7 @@ def sync_mcp_tool_registry(config: Config | None) -> None:
 
     for tool_name in desired_tool_names:
         TOOL_METADATA[tool_name] = desired_metadata[tool_name]
-        _TOOL_REGISTRY[tool_name] = desired_registry[tool_name]
+        TOOL_REGISTRY[tool_name] = desired_registry[tool_name]
 
     _MCP_TOOL_NAMES.clear()
     _MCP_TOOL_NAMES.update(desired_tool_names)

--- a/src/mindroom/memory/_prompting.py
+++ b/src/mindroom/memory/_prompting.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 _USER_TURN_TIME_PREFIX_RE = re.compile(r"^\[(?:\d{4}-\d{2}-\d{2} )?\d{2}:\d{2} [^\]]+\]\s")
 
 
-def _format_memories_as_context(memories: list[MemoryResult], context_type: str = "agent") -> str:
+def format_memories_as_context(memories: list[MemoryResult], context_type: str = "agent") -> str:
     """Format memories into a context string."""
     if not memories:
         return ""

--- a/src/mindroom/memory/functions.py
+++ b/src/mindroom/memory/functions.py
@@ -40,7 +40,7 @@ from ._policy import (
     use_disabled_memory_backend,
     use_file_memory_backend,
 )
-from ._prompting import _format_memories_as_context, build_memory_messages
+from ._prompting import build_memory_messages, format_memories_as_context
 from ._shared import MemoryResult, new_memory_id
 
 if TYPE_CHECKING:
@@ -410,7 +410,7 @@ async def build_memory_prompt_parts(
             session_preamble = f"[File memory entrypoint (agent)]\n{agent_entrypoint}"
         context_type = "agent file"
 
-    turn_context = _format_memories_as_context(agent_memories, context_type) if agent_memories else ""
+    turn_context = format_memories_as_context(agent_memories, context_type) if agent_memories else ""
     return MemoryPromptParts(
         session_preamble=session_preamble,
         turn_context=turn_context,

--- a/src/mindroom/oauth/google.py
+++ b/src/mindroom/oauth/google.py
@@ -31,12 +31,13 @@ GOOGLE_IDENTITY_SCOPES = (
 )
 
 
-def _google_token_parser(
+def google_token_parser(
     provider: OAuthProvider,
     token_response: Mapping[str, Any],
     client_config: OAuthClientConfig,
     _runtime_paths: RuntimePaths,
 ) -> OAuthTokenResult:
+    """Parse a Google OAuth token response into shared token data."""
     access_token = token_response.get("access_token")
     refresh_token = token_response.get("refresh_token")
     id_token = token_response.get("id_token")
@@ -99,6 +100,7 @@ def _google_token_parser(
     return OAuthTokenResult(token_data=token_data, claims=claims, claims_verified=True)
 
 
-def _google_domain_env_names(provider_id: str, suffix: str) -> tuple[str, ...]:
+def google_domain_env_names(provider_id: str, suffix: str) -> tuple[str, ...]:
+    """Return provider-specific environment variable names for Google domain settings."""
     prefix = provider_id.upper()
     return (f"{prefix}_{suffix}", f"MINDROOM_OAUTH_{prefix}_{suffix}")

--- a/src/mindroom/oauth/google_calendar.py
+++ b/src/mindroom/oauth/google_calendar.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from mindroom.oauth.google import (
     GOOGLE_IDENTITY_SCOPES,
-    _google_domain_env_names,
-    _google_token_parser,
+    google_domain_env_names,
+    google_token_parser,
 )
 from mindroom.oauth.providers import OAuthProvider
 
@@ -27,13 +27,13 @@ def google_calendar_oauth_provider() -> OAuthProvider:
         tool_config_service="google_calendar",
         client_config_services=("google_calendar_oauth_client",),
         shared_client_config_services=("google_oauth_client",),
-        allowed_email_domains_env=_google_domain_env_names("google_calendar", "ALLOWED_EMAIL_DOMAINS"),
-        allowed_hosted_domains_env=_google_domain_env_names("google_calendar", "ALLOWED_HOSTED_DOMAINS"),
+        allowed_email_domains_env=google_domain_env_names("google_calendar", "ALLOWED_EMAIL_DOMAINS"),
+        allowed_hosted_domains_env=google_domain_env_names("google_calendar", "ALLOWED_HOSTED_DOMAINS"),
         extra_auth_params={
             "access_type": "offline",
             "include_granted_scopes": "true",
             "prompt": "consent",
         },
         status_capabilities=("Calendar event read/write",),
-        token_parser=_google_token_parser,
+        token_parser=google_token_parser,
     )

--- a/src/mindroom/oauth/google_drive.py
+++ b/src/mindroom/oauth/google_drive.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from mindroom.oauth.google import (
     GOOGLE_IDENTITY_SCOPES,
-    _google_domain_env_names,
-    _google_token_parser,
+    google_domain_env_names,
+    google_token_parser,
 )
 from mindroom.oauth.providers import OAuthProvider
 
@@ -27,8 +27,8 @@ def google_drive_oauth_provider() -> OAuthProvider:
         tool_config_service="google_drive",
         client_config_services=("google_drive_oauth_client",),
         shared_client_config_services=("google_oauth_client",),
-        allowed_email_domains_env=_google_domain_env_names("google_drive", "ALLOWED_EMAIL_DOMAINS"),
-        allowed_hosted_domains_env=_google_domain_env_names("google_drive", "ALLOWED_HOSTED_DOMAINS"),
+        allowed_email_domains_env=google_domain_env_names("google_drive", "ALLOWED_EMAIL_DOMAINS"),
+        allowed_hosted_domains_env=google_domain_env_names("google_drive", "ALLOWED_HOSTED_DOMAINS"),
         extra_auth_params={
             "access_type": "offline",
             "include_granted_scopes": "true",
@@ -38,5 +38,5 @@ def google_drive_oauth_provider() -> OAuthProvider:
             "Drive file search",
             "Drive file read",
         ),
-        token_parser=_google_token_parser,
+        token_parser=google_token_parser,
     )

--- a/src/mindroom/oauth/google_gmail.py
+++ b/src/mindroom/oauth/google_gmail.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from mindroom.oauth.google import (
     GOOGLE_IDENTITY_SCOPES,
-    _google_domain_env_names,
-    _google_token_parser,
+    google_domain_env_names,
+    google_token_parser,
 )
 from mindroom.oauth.providers import OAuthProvider
 
@@ -29,13 +29,13 @@ def google_gmail_oauth_provider() -> OAuthProvider:
         tool_config_service="gmail",
         client_config_services=("google_gmail_oauth_client",),
         shared_client_config_services=("google_oauth_client",),
-        allowed_email_domains_env=_google_domain_env_names("google_gmail", "ALLOWED_EMAIL_DOMAINS"),
-        allowed_hosted_domains_env=_google_domain_env_names("google_gmail", "ALLOWED_HOSTED_DOMAINS"),
+        allowed_email_domains_env=google_domain_env_names("google_gmail", "ALLOWED_EMAIL_DOMAINS"),
+        allowed_hosted_domains_env=google_domain_env_names("google_gmail", "ALLOWED_HOSTED_DOMAINS"),
         extra_auth_params={
             "access_type": "offline",
             "include_granted_scopes": "true",
             "prompt": "consent",
         },
         status_capabilities=("Gmail read/modify/compose",),
-        token_parser=_google_token_parser,
+        token_parser=google_token_parser,
     )

--- a/src/mindroom/oauth/google_sheets.py
+++ b/src/mindroom/oauth/google_sheets.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from mindroom.oauth.google import (
     GOOGLE_IDENTITY_SCOPES,
-    _google_domain_env_names,
-    _google_token_parser,
+    google_domain_env_names,
+    google_token_parser,
 )
 from mindroom.oauth.providers import OAuthProvider
 
@@ -27,13 +27,13 @@ def google_sheets_oauth_provider() -> OAuthProvider:
         tool_config_service="google_sheets",
         client_config_services=("google_sheets_oauth_client",),
         shared_client_config_services=("google_oauth_client",),
-        allowed_email_domains_env=_google_domain_env_names("google_sheets", "ALLOWED_EMAIL_DOMAINS"),
-        allowed_hosted_domains_env=_google_domain_env_names("google_sheets", "ALLOWED_HOSTED_DOMAINS"),
+        allowed_email_domains_env=google_domain_env_names("google_sheets", "ALLOWED_EMAIL_DOMAINS"),
+        allowed_hosted_domains_env=google_domain_env_names("google_sheets", "ALLOWED_HOSTED_DOMAINS"),
         extra_auth_params={
             "access_type": "offline",
             "include_granted_scopes": "true",
             "prompt": "consent",
         },
         status_capabilities=("Sheets read/write",),
-        token_parser=_google_token_parser,
+        token_parser=google_token_parser,
     )

--- a/src/mindroom/oauth/registry.py
+++ b/src/mindroom/oauth/registry.py
@@ -16,7 +16,7 @@ from mindroom.oauth.google_sheets import google_sheets_oauth_provider
 from mindroom.oauth.providers import OAuthProvider
 from mindroom.tool_system import plugin_imports
 from mindroom.tool_system.metadata import TOOL_METADATA
-from mindroom.tool_system.plugins import _load_plugin_module
+from mindroom.tool_system.plugins import load_plugin_module
 
 if TYPE_CHECKING:
     from mindroom.api.config_lifecycle import ApiSnapshot
@@ -91,7 +91,7 @@ def _load_plugin_oauth_providers(
         if plugin_base.oauth_module_path is None:
             continue
         try:
-            module = _load_plugin_module(
+            module = load_plugin_module(
                 plugin_base.name,
                 plugin_base.root,
                 plugin_base.oauth_module_path,

--- a/src/mindroom/runtime_support.py
+++ b/src/mindroom/runtime_support.py
@@ -12,7 +12,7 @@ from mindroom.constants import RuntimePaths
 from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailableError
 from mindroom.matrix.cache.postgres_redaction import redact_postgres_connection_info
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
-from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
+from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.tool_system.dependencies import ensure_optional_deps
 
 if TYPE_CHECKING:
@@ -66,7 +66,7 @@ class OwnedRuntimeSupport:
     """Concrete event-cache services owned by one runtime lifecycle."""
 
     event_cache: ConversationEventCache
-    event_cache_write_coordinator: _EventCacheWriteCoordinator
+    event_cache_write_coordinator: EventCacheWriteCoordinator
     startup_thread_prewarm_registry: StartupThreadPrewarmRegistry
     event_cache_identity: _EventCacheRuntimeIdentity
 
@@ -136,7 +136,7 @@ def build_owned_runtime_support(
     cache_identity = _event_cache_runtime_identity(cache_config, runtime_paths)
     return OwnedRuntimeSupport(
         event_cache=_build_event_cache(cache_config, runtime_paths),
-        event_cache_write_coordinator=_EventCacheWriteCoordinator(
+        event_cache_write_coordinator=EventCacheWriteCoordinator(
             logger=logger,
             background_task_owner=background_task_owner,
         ),

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -33,16 +33,16 @@ from mindroom.orchestration.runtime import (
     classify_cancel_source,
 )
 from mindroom.streaming_delivery import (
+    DeliveryRequest,
+    NonTerminalDeliveryError,
+    StreamDeliveryShutdownTimeoutError,
     StreamInputChunk,
-    _consume_stream_with_progress_supervision,
-    _DeliveryRequest,
-    _drain_worker_progress_events,
-    _drive_stream_delivery,
-    _NonTerminalDeliveryError,
-    _raise_progress_delivery_error,
-    _shutdown_stream_delivery,
-    _shutdown_worker_progress_drain,
-    _StreamDeliveryShutdownTimeoutError,
+    consume_stream_with_progress_supervision,
+    drain_worker_progress_events,
+    drive_stream_delivery,
+    raise_progress_delivery_error,
+    shutdown_stream_delivery,
+    shutdown_worker_progress_drain,
 )
 from mindroom.streaming_warmup import WorkerWarmupState
 from mindroom.tool_system.runtime_context import worker_progress_pump_scope
@@ -63,6 +63,7 @@ logger = get_logger(__name__)
 
 __all__ = [
     "PROGRESS_PLACEHOLDER",
+    "RESTART_INTERRUPTED_RESPONSE_NOTE",
     "SYNC_RESTART_CANCEL_MSG",
     "USER_STOP_CANCEL_MSG",
     "CancelSource",
@@ -81,7 +82,7 @@ _PROGRESS_PLACEHOLDER = "Thinking..."
 PROGRESS_PLACEHOLDER = _PROGRESS_PLACEHOLDER
 _CANCELLED_RESPONSE_NOTE = "**[Response cancelled by user]**"
 _INTERRUPTED_RESPONSE_NOTE = "**[Response interrupted]**"
-_RESTART_INTERRUPTED_RESPONSE_NOTE = "**[Response interrupted by service restart]**"
+RESTART_INTERRUPTED_RESPONSE_NOTE = "**[Response interrupted by service restart]**"
 _STREAM_ERROR_RESPONSE_NOTE = "**[Response interrupted by an error"
 _TerminalStreamStatus = Literal["completed", "cancelled", "error"]
 
@@ -140,7 +141,7 @@ def _build_streaming_delivery_error(
 
 def _raise_nonterminal_delivery_error(error: Exception) -> NoReturn:
     """Raise one wrapped non-terminal delivery error for unified rollback handling."""
-    raise _NonTerminalDeliveryError(error) from error
+    raise NonTerminalDeliveryError(error) from error
 
 
 def _complete_capture_completions(capture_completions: tuple[asyncio.Future[None], ...]) -> None:
@@ -168,7 +169,7 @@ def is_interrupted_partial_reply(text: object) -> bool:
         (
             _CANCELLED_RESPONSE_NOTE,
             _INTERRUPTED_RESPONSE_NOTE,
-            _RESTART_INTERRUPTED_RESPONSE_NOTE,
+            RESTART_INTERRUPTED_RESPONSE_NOTE,
             " [cancelled]",
             " [error]",
         ),
@@ -184,7 +185,7 @@ def clean_partial_reply_text(text: str) -> str:
         " [error]",
         _CANCELLED_RESPONSE_NOTE,
         _INTERRUPTED_RESPONSE_NOTE,
-        _RESTART_INTERRUPTED_RESPONSE_NOTE,
+        RESTART_INTERRUPTED_RESPONSE_NOTE,
     ):
         if cleaned.endswith(marker):
             cleaned = cleaned[: -len(marker)].rstrip()
@@ -201,8 +202,8 @@ def build_restart_interrupted_body(text: str) -> str:
     """Return restart-note text for a stale in-progress message body."""
     stripped_text = text.rstrip()
     if not stripped_text or stripped_text == _PROGRESS_PLACEHOLDER:
-        return _RESTART_INTERRUPTED_RESPONSE_NOTE
-    return f"{stripped_text}\n\n{_RESTART_INTERRUPTED_RESPONSE_NOTE}"
+        return RESTART_INTERRUPTED_RESPONSE_NOTE
+    return f"{stripped_text}\n\n{RESTART_INTERRUPTED_RESPONSE_NOTE}"
 
 
 @dataclass(frozen=True)
@@ -1098,40 +1099,40 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
         await streaming.update_content(header, client)
 
     worker_progress_queue: asyncio.Queue[WorkerProgressEvent] = asyncio.Queue()
-    delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
+    delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
     progress_task: asyncio.Task[None] | None = None
     delivery_task: asyncio.Task[None] | None = None
     loop = asyncio.get_running_loop()
     transport_outcome: StreamTransportOutcome | None = None
     with worker_progress_pump_scope(loop, worker_progress_queue) as pump:
-        delivery_task = asyncio.create_task(_drive_stream_delivery(client, streaming, delivery_queue))
+        delivery_task = asyncio.create_task(drive_stream_delivery(client, streaming, delivery_queue))
         progress_task = asyncio.create_task(
-            _drain_worker_progress_events(streaming, worker_progress_queue, pump, delivery_queue),
+            drain_worker_progress_events(streaming, worker_progress_queue, pump, delivery_queue),
         )
         try:
-            await _consume_stream_with_progress_supervision(
+            await consume_stream_with_progress_supervision(
                 response_stream,
                 streaming,
                 progress_task,
                 delivery_task,
                 delivery_queue,
             )
-            progress_error = await _shutdown_worker_progress_drain(pump, progress_task)
+            progress_error = await shutdown_worker_progress_drain(pump, progress_task)
             if progress_error is None:
                 progress_task = None
-            delivery_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            delivery_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
             if delivery_error is None:
                 delivery_task = None
             if progress_error is not None:
-                _raise_progress_delivery_error(progress_error)
+                raise_progress_delivery_error(progress_error)
             if delivery_error is not None:
                 _raise_nonterminal_delivery_error(delivery_error)
         except asyncio.CancelledError as exc:
             cancel_source = classify_cancel_source(exc)
-            cleanup_error = await _shutdown_worker_progress_drain(pump, progress_task)
+            cleanup_error = await shutdown_worker_progress_drain(pump, progress_task)
             if cleanup_error is None:
                 progress_task = None
-            delivery_cleanup_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            delivery_cleanup_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
             if delivery_cleanup_error is None:
                 delivery_task = None
             if cleanup_error is not None:
@@ -1144,7 +1145,7 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
                     "Stream delivery controller raised during cancellation cleanup",
                     error=str(delivery_cleanup_error),
                 )
-                if isinstance(delivery_cleanup_error, _StreamDeliveryShutdownTimeoutError):
+                if isinstance(delivery_cleanup_error, StreamDeliveryShutdownTimeoutError):
                     streaming.restore_last_delivered_state()
                     raise _build_streaming_delivery_error(
                         streaming,
@@ -1163,12 +1164,12 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
                 transport_outcome=transport_outcome,
             ) from exc
         except Exception as exc:
-            delivery_error = exc.error if isinstance(exc, _NonTerminalDeliveryError) else exc
+            delivery_error = exc.error if isinstance(exc, NonTerminalDeliveryError) else exc
             logger.exception("Streaming response failed", error=str(delivery_error))
-            cleanup_error = await _shutdown_worker_progress_drain(pump, progress_task)
+            cleanup_error = await shutdown_worker_progress_drain(pump, progress_task)
             if cleanup_error is None:
                 progress_task = None
-            delivery_cleanup_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            delivery_cleanup_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
             if delivery_cleanup_error is None:
                 delivery_task = None
             if cleanup_error is not None and cleanup_error is not delivery_error:
@@ -1182,9 +1183,9 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
                     error=str(delivery_cleanup_error),
                 )
             shutdown_timeout = None
-            if isinstance(delivery_error, _StreamDeliveryShutdownTimeoutError):
+            if isinstance(delivery_error, StreamDeliveryShutdownTimeoutError):
                 shutdown_timeout = delivery_error
-            elif isinstance(delivery_cleanup_error, _StreamDeliveryShutdownTimeoutError):
+            elif isinstance(delivery_cleanup_error, StreamDeliveryShutdownTimeoutError):
                 shutdown_timeout = delivery_cleanup_error
             if shutdown_timeout is not None:
                 streaming.restore_last_delivered_state()
@@ -1195,7 +1196,7 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
                     terminal_status="error",
                     tool_trace_collector=tool_trace_collector,
                 ) from shutdown_timeout
-            if isinstance(exc, _NonTerminalDeliveryError):
+            if isinstance(exc, NonTerminalDeliveryError):
                 streaming.restore_last_delivered_state()
             transport_outcome = await streaming.finalize(client, error=delivery_error)
             raise StreamingDeliveryError(
@@ -1208,13 +1209,13 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
         else:
             transport_outcome = await streaming.finalize(client)
         finally:
-            cleanup_error = await _shutdown_worker_progress_drain(pump, progress_task)
+            cleanup_error = await shutdown_worker_progress_drain(pump, progress_task)
             if cleanup_error is not None:
                 logger.warning(
                     "Worker progress drain raised during final cleanup",
                     error=str(cleanup_error),
                 )
-            delivery_cleanup_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            delivery_cleanup_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
             if delivery_cleanup_error is not None:
                 logger.warning(
                     "Stream delivery controller raised during final cleanup",

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -38,7 +38,7 @@ _STREAM_DELIVERY_DRAIN_TIMEOUT_SECONDS = 5.0
 _STREAM_DELIVERY_CANCEL_TIMEOUT_SECONDS = 5.0
 
 
-class _NonTerminalDeliveryError(Exception):
+class NonTerminalDeliveryError(Exception):
     """Internal wrapper for non-terminal delivery failures."""
 
     def __init__(self, error: Exception) -> None:
@@ -46,7 +46,7 @@ class _NonTerminalDeliveryError(Exception):
         self.error = error
 
 
-class _StreamDeliveryShutdownTimeoutError(TimeoutError):
+class StreamDeliveryShutdownTimeoutError(TimeoutError):
     """Raised when the single non-terminal delivery owner refuses to stop."""
 
 
@@ -86,7 +86,7 @@ def _merge_prior_delta_at(existing: float | None, incoming: float | None) -> flo
 
 
 @dataclass(frozen=True, slots=True)
-class _DeliveryRequest:
+class DeliveryRequest:
     """One non-terminal stream delivery request for the single delivery owner."""
 
     progress_hint: bool = False
@@ -99,13 +99,13 @@ class _DeliveryRequest:
     capture_completion: asyncio.Future[None] | None = None
 
 
-def _raise_progress_delivery_error(error: Exception) -> NoReturn:
+def raise_progress_delivery_error(error: Exception) -> NoReturn:
     """Raise a stored worker-progress delivery error from a helper."""
     raise error
 
 
 def _queue_delivery_request(
-    delivery_queue: asyncio.Queue[_DeliveryRequest | None],
+    delivery_queue: asyncio.Queue[DeliveryRequest | None],
     *,
     progress_hint: bool = False,
     force_refresh: bool = False,
@@ -119,7 +119,7 @@ def _queue_delivery_request(
     """Queue one non-terminal delivery request for the single delivery owner."""
     capture_completion = asyncio.get_running_loop().create_future() if wait_for_capture else None
     delivery_queue.put_nowait(
-        _DeliveryRequest(
+        DeliveryRequest(
             progress_hint=progress_hint,
             force_refresh=force_refresh,
             boundary_refresh=boundary_refresh,
@@ -150,7 +150,7 @@ def _queue_delivery_request(
 
 async def _flush_phase_boundary_if_needed(
     streaming: StreamingResponse,
-    delivery_queue: asyncio.Queue[_DeliveryRequest | None],
+    delivery_queue: asyncio.Queue[DeliveryRequest | None],
 ) -> None:
     """Flush any buffered visible text before mutating the next phase."""
     if streaming.chars_since_last_update == 0:
@@ -170,7 +170,7 @@ async def _flush_phase_boundary_if_needed(
 
 async def _apply_visible_text_chunk(
     streaming: StreamingResponse,
-    delivery_queue: asyncio.Queue[_DeliveryRequest | None],
+    delivery_queue: asyncio.Queue[DeliveryRequest | None],
     text_chunk: str,
     *,
     apply_chunk: Callable[[str], None],
@@ -205,7 +205,7 @@ async def _apply_visible_text_chunk(
 async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
     response_stream: AsyncIterator[StreamInputChunk],
     streaming: StreamingResponse,
-    delivery_queue: asyncio.Queue[_DeliveryRequest | None],
+    delivery_queue: asyncio.Queue[DeliveryRequest | None],
 ) -> None:
     """Consume stream chunks and apply incremental message updates."""
     pending_tools: list[tuple[str, int, str]] = []
@@ -329,11 +329,11 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
         )
 
 
-async def _drain_worker_progress_events(
+async def drain_worker_progress_events(
     streaming: StreamingResponse,
     queue: asyncio.Queue[WorkerProgressEvent],
     pump: WorkerProgressPump,
-    delivery_queue: asyncio.Queue[_DeliveryRequest | None],
+    delivery_queue: asyncio.Queue[DeliveryRequest | None],
 ) -> None:
     """Apply worker progress events to side-band state and refresh the current stream body."""
     while True:
@@ -362,7 +362,7 @@ async def _drain_worker_progress_events(
             _queue_delivery_request(delivery_queue, progress_hint=True)
 
 
-async def _shutdown_worker_progress_drain(
+async def shutdown_worker_progress_drain(
     pump: WorkerProgressPump,
     progress_task: asyncio.Task[None] | None,
 ) -> Exception | None:
@@ -381,10 +381,10 @@ async def _shutdown_worker_progress_drain(
     return None
 
 
-async def _drive_stream_delivery(  # noqa: C901, PLR0912
+async def drive_stream_delivery(  # noqa: C901, PLR0912
     client: nio.AsyncClient,
     streaming: StreamingResponse,
-    delivery_queue: asyncio.Queue[_DeliveryRequest | None],
+    delivery_queue: asyncio.Queue[DeliveryRequest | None],
 ) -> None:
     """Own all non-terminal stream sends and edits from one supervised task."""
     stop_after_current = False
@@ -415,7 +415,7 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
                 phase_boundary_capture_completions.append(next_request.capture_completion)
             if next_request.boundary_refresh and next_request.capture_completion is not None:
                 boundary_refresh_capture_completions.append(next_request.capture_completion)
-            merged_request = _DeliveryRequest(
+            merged_request = DeliveryRequest(
                 progress_hint=merged_request.progress_hint or next_request.progress_hint,
                 force_refresh=merged_request.force_refresh or next_request.force_refresh,
                 boundary_refresh=merged_request.boundary_refresh or next_request.boundary_refresh,
@@ -506,8 +506,8 @@ async def _drive_stream_delivery(  # noqa: C901, PLR0912
             return
 
 
-async def _shutdown_stream_delivery(
-    delivery_queue: asyncio.Queue[_DeliveryRequest | None],
+async def shutdown_stream_delivery(
+    delivery_queue: asyncio.Queue[DeliveryRequest | None],
     delivery_task: asyncio.Task[None] | None,
     *,
     drain_timeout_seconds: float = _STREAM_DELIVERY_DRAIN_TIMEOUT_SECONDS,
@@ -523,7 +523,7 @@ async def _shutdown_stream_delivery(
         delivery_task.cancel()
         done, _pending = await asyncio.wait({delivery_task}, timeout=cancel_timeout_seconds)
         if delivery_task not in done:
-            return _StreamDeliveryShutdownTimeoutError("Timed out shutting down stream delivery controller")
+            return StreamDeliveryShutdownTimeoutError("Timed out shutting down stream delivery controller")
     if delivery_task.cancelled():
         return None
     task_error = delivery_task.exception()
@@ -567,19 +567,19 @@ async def _handle_auxiliary_task_completion(
         if not isinstance(task_error, Exception):
             raise task_error
         if task is delivery_task:
-            raise _NonTerminalDeliveryError(task_error) from task_error
-        _raise_progress_delivery_error(task_error)
+            raise NonTerminalDeliveryError(task_error) from task_error
+        raise_progress_delivery_error(task_error)
 
     monitored_tasks.discard(task)
     return True
 
 
-async def _consume_stream_with_progress_supervision(
+async def consume_stream_with_progress_supervision(
     response_stream: AsyncIterator[StreamInputChunk],
     streaming: StreamingResponse,
     progress_task: asyncio.Task[None] | None,
     delivery_task: asyncio.Task[None] | None,
-    delivery_queue: asyncio.Queue[_DeliveryRequest | None],
+    delivery_queue: asyncio.Queue[DeliveryRequest | None],
 ) -> None:
     """Abort chunk consumption as soon as the worker-progress drain fails."""
     stream_task = asyncio.create_task(_consume_streaming_chunks(response_stream, streaming, delivery_queue))

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -19,18 +19,18 @@ from mindroom.logging_config import get_logger
 from mindroom.tool_system.dependencies import auto_install_tool_extra, check_deps_installed
 from mindroom.tool_system.output_files import ToolOutputFilePolicy, wrap_toolkit_for_output_files
 from mindroom.tool_system.registry_state import (
-    _BUILTIN_TOOL_METADATA,
-    _BUILTIN_TOOL_REGISTRY,
-    _PLUGIN_MODULE_PREFIX,
-    _PLUGIN_REGISTRATION_SCOPE,
-    _TOOL_REGISTRY,
+    BUILTIN_TOOL_METADATA,
+    BUILTIN_TOOL_REGISTRY,
+    PLUGIN_MODULE_PREFIX,
+    PLUGIN_REGISTRATION_SCOPE,
     TOOL_METADATA,
+    TOOL_REGISTRY,
     ToolMetadataValidationError,
-    _register_plugin_tool_metadata,
-    _resolved_tool_state,
-    _scoped_plugin_registration_owner,
-    _scoped_plugin_registration_store,
     register_builtin_tool_metadata,
+    register_plugin_tool_metadata,
+    resolved_tool_state,
+    scoped_plugin_registration_owner,
+    scoped_plugin_registration_store,
 )
 from mindroom.tool_system.sandbox_proxy import maybe_wrap_toolkit_for_sandbox_proxy
 from mindroom.tool_system.worker_routing import (
@@ -507,7 +507,7 @@ def _build_tool_instance(
         raise ToolMetadataValidationError(msg)
 
     metadata = TOOL_METADATA[tool_name]
-    tool_class = _TOOL_REGISTRY[tool_name]()
+    tool_class = TOOL_REGISTRY[tool_name]()
     resolved_credentials_manager = _resolve_tool_credentials_manager(
         metadata,
         runtime_paths,
@@ -591,8 +591,8 @@ def get_tool_by_name(
     worker_target: ResolvedWorkerTarget | None,
 ) -> Toolkit:
     """Get a tool instance by its registered name."""
-    if tool_name not in _TOOL_REGISTRY:
-        available = ", ".join(sorted(_TOOL_REGISTRY.keys()))
+    if tool_name not in TOOL_REGISTRY:
+        available = ", ".join(sorted(TOOL_REGISTRY.keys()))
         msg = f"Unknown tool: {tool_name}. Available tools: {available}"
         raise ToolMetadataValidationError(msg)
 
@@ -822,16 +822,16 @@ def register_tool_with_metadata(
         )
 
         validation_owner_module_name = getattr(
-            _PLUGIN_REGISTRATION_SCOPE,
+            PLUGIN_REGISTRATION_SCOPE,
             "owner_module_name",
             None,
         )
         if validation_owner_module_name is not None:
-            _register_plugin_tool_metadata(validation_owner_module_name, metadata)
+            register_plugin_tool_metadata(validation_owner_module_name, metadata)
             return func
 
-        if func.__module__.startswith(_PLUGIN_MODULE_PREFIX):
-            _register_plugin_tool_metadata(func.__module__, metadata)
+        if func.__module__.startswith(PLUGIN_MODULE_PREFIX):
+            register_plugin_tool_metadata(func.__module__, metadata)
             return func
 
         register_builtin_tool_metadata(metadata)
@@ -887,8 +887,8 @@ def _execute_validation_plugin_module(
     sys.modules[validation_module_name] = module
     try:
         with (
-            _scoped_plugin_registration_store(registrations_by_module),
-            _scoped_plugin_registration_owner(validation_module_name),
+            scoped_plugin_registration_store(registrations_by_module),
+            scoped_plugin_registration_owner(validation_module_name),
         ):
             spec.loader.exec_module(module)
     except Exception as exc:
@@ -924,8 +924,8 @@ def _resolved_tool_state_for_runtime(
 
     plugin_entries = config.plugins
     if not plugin_entries:
-        builtin_registry = _BUILTIN_TOOL_REGISTRY.copy()
-        builtin_metadata = _BUILTIN_TOOL_METADATA.copy()
+        builtin_registry = BUILTIN_TOOL_REGISTRY.copy()
+        builtin_metadata = BUILTIN_TOOL_METADATA.copy()
         mcp_registry, mcp_metadata = resolved_mcp_tool_state(config)
         _merge_mcp_tool_state(
             builtin_registry,
@@ -988,7 +988,7 @@ def _resolved_tool_state_for_runtime(
         validation_registrations.update(candidate_registrations)
         active_plugins.extend(candidate_active_plugins)
 
-    desired_registry, desired_metadata = _resolved_tool_state(active_plugins, validation_registrations)
+    desired_registry, desired_metadata = resolved_tool_state(active_plugins, validation_registrations)
     mcp_registry, mcp_metadata = resolved_mcp_tool_state(config)
     _merge_mcp_tool_state(
         desired_registry,

--- a/src/mindroom/tool_system/plugins.py
+++ b/src/mindroom/tool_system/plugins.py
@@ -14,14 +14,14 @@ from mindroom.hooks import HookRegistry, iter_module_hooks
 from mindroom.logging_config import get_logger
 from mindroom.tool_system import plugin_imports
 from mindroom.tool_system.registry_state import (
-    _capture_tool_registry_snapshot,
-    _clear_plugin_tool_registrations,
-    _locked_tool_registry_state,
-    _restore_plugin_tool_registrations,
-    _restore_tool_registry_snapshot,
-    _scoped_plugin_registration_owner,
-    _snapshot_plugin_tool_registrations,
-    _synchronize_plugin_tools,
+    capture_tool_registry_snapshot,
+    clear_plugin_tool_registrations,
+    locked_tool_registry_state,
+    restore_plugin_tool_registrations,
+    restore_tool_registry_snapshot,
+    scoped_plugin_registration_owner,
+    snapshot_plugin_tool_registrations,
+    synchronize_plugin_tools,
 )
 from mindroom.tool_system.skills import get_plugin_skill_roots, set_plugin_skill_roots
 
@@ -96,12 +96,12 @@ def _sync_loaded_plugin_tools(plugins: list[_Plugin]) -> None:
         for plugin in plugins
         if plugin.tools_module_path is not None
     ]
-    _synchronize_plugin_tools(active_tool_modules)
+    synchronize_plugin_tools(active_tool_modules)
 
 
 def deactivate_plugins() -> PluginReloadResult:
     """Clear live plugin-derived tools, skills, and hooks."""
-    with _locked_tool_registry_state():
+    with locked_tool_registry_state():
         _sync_loaded_plugin_tools([])
         set_plugin_skill_roots([])
         _clear_oauth_provider_cache_after_plugin_change()
@@ -122,7 +122,7 @@ def load_plugins(
     """Load plugins from config and register their tools and skills."""
     import mindroom.tools  # noqa: F401, PLC0415
 
-    with _locked_tool_registry_state():
+    with locked_tool_registry_state():
         plugin_entries = config.plugins
         if not plugin_entries:
             _sync_loaded_plugin_tools([])
@@ -136,16 +136,16 @@ def load_plugins(
             runtime_paths,
             skip_broken_plugins=skip_broken_plugins,
         )
-        snapshot = _capture_tool_registry_snapshot()
+        snapshot = capture_tool_registry_snapshot()
         try:
             plugin_imports._reject_duplicate_plugin_manifest_names(plugin_bases)
 
             for plugin_base, plugin_entry, plugin_order in plugin_bases:
-                plugin_snapshot = _capture_tool_registry_snapshot()
+                plugin_snapshot = capture_tool_registry_snapshot()
                 try:
                     plugin = _materialize_plugin(plugin_base, plugin_entry, plugin_order)
                 except Exception as exc:
-                    _restore_tool_registry_snapshot(plugin_snapshot)
+                    restore_tool_registry_snapshot(plugin_snapshot)
                     if not skip_broken_plugins:
                         raise
                     plugin_imports._log_skipped_plugin_entry(plugin_entry.path, plugin_base.root, exc)
@@ -161,7 +161,7 @@ def load_plugins(
             if set_skill_roots:
                 set_plugin_skill_roots(skill_roots)
         except Exception:
-            _restore_tool_registry_snapshot(snapshot)
+            restore_tool_registry_snapshot(snapshot)
             raise
 
         return plugins
@@ -224,9 +224,9 @@ def prepare_plugin_reload(
     skip_broken_plugins: bool = False,
 ) -> _PreparedPluginReload:
     """Build one fresh plugin snapshot without mutating the live runtime."""
-    with _locked_tool_registry_state():
+    with locked_tool_registry_state():
         package_roots = {cached.module_name.split(".", 1)[0] for cached in plugin_imports._MODULE_IMPORT_CACHE.values()}
-        previous_snapshot = _capture_tool_registry_snapshot()
+        previous_snapshot = capture_tool_registry_snapshot()
         previous_plugin_skill_roots = tuple(get_plugin_skill_roots())
         try:
             _clear_plugin_reload_caches()
@@ -235,11 +235,11 @@ def prepare_plugin_reload(
             return _PreparedPluginReload(
                 hook_registry=HookRegistry.from_plugins(plugins),
                 active_plugin_names=tuple(plugin.name for plugin in plugins),
-                tool_registry_snapshot=_capture_tool_registry_snapshot(),
+                tool_registry_snapshot=capture_tool_registry_snapshot(),
                 plugin_skill_roots=tuple(get_plugin_skill_roots()),
             )
         finally:
-            _restore_tool_registry_snapshot(previous_snapshot)
+            restore_tool_registry_snapshot(previous_snapshot)
             set_plugin_skill_roots(previous_plugin_skill_roots)
 
 
@@ -250,13 +250,13 @@ def apply_prepared_plugin_reload(
     cancel_existing_tasks: bool = False,
 ) -> PluginReloadResult:
     """Commit one previously prepared plugin runtime snapshot."""
-    with _locked_tool_registry_state():
+    with locked_tool_registry_state():
         if cancel_existing_tasks:
             package_roots = {
                 cached.module_name.split(".", 1)[0] for cached in plugin_imports._MODULE_IMPORT_CACHE.values()
             }
             cancelled_task_count = _cancel_plugin_module_tasks(package_roots)
-        _restore_tool_registry_snapshot(prepared_reload.tool_registry_snapshot)
+        restore_tool_registry_snapshot(prepared_reload.tool_registry_snapshot)
         set_plugin_skill_roots(prepared_reload.plugin_skill_roots)
     return PluginReloadResult(
         hook_registry=prepared_reload.hook_registry,
@@ -338,10 +338,10 @@ def _materialize_plugin(
     entry_config: PluginEntryConfig,
     plugin_order: int,
 ) -> _Plugin:
-    tools_module = _load_plugin_module(plugin.name, plugin.root, plugin.tools_module_path, kind="tools")
+    tools_module = load_plugin_module(plugin.name, plugin.root, plugin.tools_module_path, kind="tools")
     hooks_module_path = plugin.hooks_module_path or plugin.tools_module_path
     hooks_module = (
-        _load_plugin_module(plugin.name, plugin.root, hooks_module_path, kind="hooks") if hooks_module_path else None
+        load_plugin_module(plugin.name, plugin.root, hooks_module_path, kind="hooks") if hooks_module_path else None
     )
     if hooks_module is None and plugin.hooks_module_path is None:
         hooks_module = tools_module
@@ -374,10 +374,10 @@ def _prepare_plugin_tool_module_reload(
     for candidate_module_name in {module_name, cached.module_name if cached is not None else None}:
         if candidate_module_name is None:
             continue
-        previous_registrations_by_module_name[candidate_module_name] = _snapshot_plugin_tool_registrations(
+        previous_registrations_by_module_name[candidate_module_name] = snapshot_plugin_tool_registrations(
             candidate_module_name,
         )
-        _clear_plugin_tool_registrations(candidate_module_name)
+        clear_plugin_tool_registrations(candidate_module_name)
     return previous_registrations_by_module_name
 
 
@@ -390,7 +390,7 @@ def _restore_failed_plugin_tool_module_reload(
     """Restore cached tool registrations and module imports after one failed reload."""
     sys.modules.pop(module_name, None)
     for restored_module_name, registrations in previous_registrations_by_module_name.items():
-        _restore_plugin_tool_registrations(restored_module_name, registrations)
+        restore_plugin_tool_registrations(restored_module_name, registrations)
     if cached is not None:
         plugin_imports._MODULE_IMPORT_CACHE[module_path] = cached
         sys.modules[cached.module_name] = cached.module
@@ -398,13 +398,14 @@ def _restore_failed_plugin_tool_module_reload(
         plugin_imports._MODULE_IMPORT_CACHE.pop(module_path, None)
 
 
-def _load_plugin_module(
+def load_plugin_module(
     plugin_name: str,
     plugin_root: Path,
     module_path: Path | None,
     *,
     kind: str,
 ) -> ModuleType | None:
+    """Load a plugin module from a configured plugin root."""
     if module_path is None:
         return None
     try:
@@ -439,7 +440,7 @@ def _load_plugin_module(
     sys.modules[module_name] = module
     try:
         if kind == "tools":
-            with _scoped_plugin_registration_owner(module_name):
+            with scoped_plugin_registration_owner(module_name):
                 _exec_plugin_source(module_path, module)
         else:
             _exec_plugin_source(module_path, module)

--- a/src/mindroom/tool_system/registry_state.py
+++ b/src/mindroom/tool_system/registry_state.py
@@ -20,13 +20,13 @@ if TYPE_CHECKING:
     from mindroom.tool_system.metadata import ToolMetadata
 
 TOOL_METADATA: dict[str, ToolMetadata] = {}
-_TOOL_REGISTRY: dict[str, Callable[[], type[Toolkit]]] = {}
-_BUILTIN_TOOL_REGISTRY: dict[str, Callable[[], type[Toolkit]]] = {}
+TOOL_REGISTRY: dict[str, Callable[[], type[Toolkit]]] = {}
+BUILTIN_TOOL_REGISTRY: dict[str, Callable[[], type[Toolkit]]] = {}
 _PLUGIN_TOOL_METADATA_BY_MODULE: dict[str, dict[str, ToolMetadata]] = {}
-_BUILTIN_TOOL_METADATA: dict[str, ToolMetadata] = {}
-_PLUGIN_MODULE_PREFIX = "mindroom_plugin_"
+BUILTIN_TOOL_METADATA: dict[str, ToolMetadata] = {}
+PLUGIN_MODULE_PREFIX = "mindroom_plugin_"
 _TOOL_REGISTRY_STATE_LOCK = threading.RLock()
-_PLUGIN_REGISTRATION_SCOPE = threading.local()
+PLUGIN_REGISTRATION_SCOPE = threading.local()
 
 
 class ToolMetadataValidationError(ValueError):
@@ -44,17 +44,17 @@ class _ToolRegistrySnapshot:
     plugin_modules: dict[str, ModuleType]
 
 
-def _clear_plugin_tool_registrations(module_name: str) -> None:
+def clear_plugin_tool_registrations(module_name: str) -> None:
     """Forget cached tool registrations for one plugin module before it is re-executed."""
     _PLUGIN_TOOL_METADATA_BY_MODULE.pop(module_name, None)
 
 
-def _snapshot_plugin_tool_registrations(module_name: str) -> dict[str, ToolMetadata]:
+def snapshot_plugin_tool_registrations(module_name: str) -> dict[str, ToolMetadata]:
     """Return a copy of one plugin module's cached tool registrations."""
     return _PLUGIN_TOOL_METADATA_BY_MODULE.get(module_name, {}).copy()
 
 
-def _restore_plugin_tool_registrations(
+def restore_plugin_tool_registrations(
     module_name: str,
     registrations: dict[str, ToolMetadata],
 ) -> None:
@@ -66,59 +66,59 @@ def _restore_plugin_tool_registrations(
 
 
 @contextmanager
-def _scoped_plugin_registration_store(
+def scoped_plugin_registration_store(
     registrations_by_module: dict[str, dict[str, ToolMetadata]],
 ) -> Iterator[None]:
     """Route plugin registration decorators into one temporary module->metadata store."""
     sentinel = object()
-    previous = getattr(_PLUGIN_REGISTRATION_SCOPE, "registrations_by_module", sentinel)
-    _PLUGIN_REGISTRATION_SCOPE.registrations_by_module = registrations_by_module
+    previous = getattr(PLUGIN_REGISTRATION_SCOPE, "registrations_by_module", sentinel)
+    PLUGIN_REGISTRATION_SCOPE.registrations_by_module = registrations_by_module
     try:
         yield
     finally:
         if previous is sentinel:
-            delattr(_PLUGIN_REGISTRATION_SCOPE, "registrations_by_module")
+            delattr(PLUGIN_REGISTRATION_SCOPE, "registrations_by_module")
         else:
-            _PLUGIN_REGISTRATION_SCOPE.registrations_by_module = previous
+            PLUGIN_REGISTRATION_SCOPE.registrations_by_module = previous
 
 
 @contextmanager
-def _scoped_plugin_registration_owner(module_name: str) -> Iterator[None]:
+def scoped_plugin_registration_owner(module_name: str) -> Iterator[None]:
     """Attribute scoped validation registrations to one synthetic plugin module."""
     sentinel = object()
-    previous = getattr(_PLUGIN_REGISTRATION_SCOPE, "owner_module_name", sentinel)
-    _PLUGIN_REGISTRATION_SCOPE.owner_module_name = module_name
+    previous = getattr(PLUGIN_REGISTRATION_SCOPE, "owner_module_name", sentinel)
+    PLUGIN_REGISTRATION_SCOPE.owner_module_name = module_name
     try:
         yield
     finally:
         if previous is sentinel:
-            delattr(_PLUGIN_REGISTRATION_SCOPE, "owner_module_name")
+            delattr(PLUGIN_REGISTRATION_SCOPE, "owner_module_name")
         else:
-            _PLUGIN_REGISTRATION_SCOPE.owner_module_name = previous
+            PLUGIN_REGISTRATION_SCOPE.owner_module_name = previous
 
 
 def _plugin_registration_store() -> dict[str, dict[str, ToolMetadata]]:
     """Return the active plugin registration sink for this thread."""
-    registrations = getattr(_PLUGIN_REGISTRATION_SCOPE, "registrations_by_module", None)
+    registrations = getattr(PLUGIN_REGISTRATION_SCOPE, "registrations_by_module", None)
     if registrations is None:
         return _PLUGIN_TOOL_METADATA_BY_MODULE
     return registrations
 
 
 @contextmanager
-def _locked_tool_registry_state() -> Iterator[None]:
+def locked_tool_registry_state() -> Iterator[None]:
     """Serialize mutations of the process-global tool and plugin registries."""
     with _TOOL_REGISTRY_STATE_LOCK:
         yield
 
 
-def _resolved_tool_state(
+def resolved_tool_state(
     active_plugins: list[tuple[str, str]],
     plugin_metadata_by_module: dict[str, dict[str, ToolMetadata]],
 ) -> tuple[dict[str, Callable[[], type[Toolkit]]], dict[str, ToolMetadata]]:
     """Build one complete tool registry state from built-ins plus active plugin overlays."""
-    desired_metadata = _BUILTIN_TOOL_METADATA.copy()
-    desired_registry = _BUILTIN_TOOL_REGISTRY.copy()
+    desired_metadata = BUILTIN_TOOL_METADATA.copy()
+    desired_registry = BUILTIN_TOOL_REGISTRY.copy()
     plugin_owner_by_tool_name: dict[str, str] = {}
 
     for plugin_name, module_name in active_plugins:
@@ -138,21 +138,21 @@ def _resolved_tool_state(
     return desired_registry, desired_metadata
 
 
-def _synchronize_plugin_tools(active_plugins: list[tuple[str, str]]) -> None:
+def synchronize_plugin_tools(active_plugins: list[tuple[str, str]]) -> None:
     """Rebuild the active plugin tool overlay from cached per-module registrations."""
-    desired_registry, desired_metadata = _resolved_tool_state(
+    desired_registry, desired_metadata = resolved_tool_state(
         active_plugins,
         _PLUGIN_TOOL_METADATA_BY_MODULE,
     )
-    _TOOL_REGISTRY.clear()
-    _TOOL_REGISTRY.update(desired_registry)
+    TOOL_REGISTRY.clear()
+    TOOL_REGISTRY.update(desired_registry)
     TOOL_METADATA.clear()
     TOOL_METADATA.update(desired_metadata)
 
 
 def _reject_plugin_builtin_tool_collision(tool_name: str) -> None:
     """Fail plugin registration when it reuses a built-in tool name."""
-    if tool_name in _BUILTIN_TOOL_METADATA:
+    if tool_name in BUILTIN_TOOL_METADATA:
         msg = f"Plugin tool '{tool_name}' conflicts with built-in tool '{tool_name}'."
         raise ToolMetadataValidationError(msg)
 
@@ -160,17 +160,17 @@ def _reject_plugin_builtin_tool_collision(tool_name: str) -> None:
 def register_builtin_tool_metadata(metadata: ToolMetadata) -> None:
     """Store one built-in tool or metadata-only built-in entry in the durable registry."""
     factory = cast("Callable[[], type[Toolkit]] | None", getattr(metadata, "factory", None))
-    _BUILTIN_TOOL_METADATA[metadata.name] = metadata
+    BUILTIN_TOOL_METADATA[metadata.name] = metadata
     TOOL_METADATA[metadata.name] = metadata
     if factory is None:
-        _BUILTIN_TOOL_REGISTRY.pop(metadata.name, None)
-        _TOOL_REGISTRY.pop(metadata.name, None)
+        BUILTIN_TOOL_REGISTRY.pop(metadata.name, None)
+        TOOL_REGISTRY.pop(metadata.name, None)
     else:
-        _BUILTIN_TOOL_REGISTRY[metadata.name] = factory
-        _TOOL_REGISTRY[metadata.name] = factory
+        BUILTIN_TOOL_REGISTRY[metadata.name] = factory
+        TOOL_REGISTRY[metadata.name] = factory
 
 
-def _register_plugin_tool_metadata(module_name: str, metadata: ToolMetadata) -> None:
+def register_plugin_tool_metadata(module_name: str, metadata: ToolMetadata) -> None:
     """Store one plugin tool in the per-module overlay cache."""
     _reject_plugin_builtin_tool_collision(metadata.name)
     module_registrations = _plugin_registration_store().setdefault(module_name, {})
@@ -180,14 +180,14 @@ def _register_plugin_tool_metadata(module_name: str, metadata: ToolMetadata) -> 
     module_registrations[metadata.name] = metadata
 
 
-def _capture_tool_registry_snapshot() -> _ToolRegistrySnapshot:
+def capture_tool_registry_snapshot() -> _ToolRegistrySnapshot:
     """Capture the mutable tool/plugin registry state for transactional restoration."""
     loaded_modules = sys.modules.copy()
     return _ToolRegistrySnapshot(
-        registry=_TOOL_REGISTRY.copy(),
+        registry=TOOL_REGISTRY.copy(),
         metadata=TOOL_METADATA.copy(),
-        builtin_registry=_BUILTIN_TOOL_REGISTRY.copy(),
-        builtin_metadata=_BUILTIN_TOOL_METADATA.copy(),
+        builtin_registry=BUILTIN_TOOL_REGISTRY.copy(),
+        builtin_metadata=BUILTIN_TOOL_METADATA.copy(),
         module_import_cache=plugin_imports._MODULE_IMPORT_CACHE.copy(),
         plugin_tool_metadata_by_module={
             module_name: registrations.copy() for module_name, registrations in _PLUGIN_TOOL_METADATA_BY_MODULE.items()
@@ -195,21 +195,21 @@ def _capture_tool_registry_snapshot() -> _ToolRegistrySnapshot:
         plugin_modules={
             module_name: module
             for module_name, module in loaded_modules.items()
-            if module_name.startswith(_PLUGIN_MODULE_PREFIX)
+            if module_name.startswith(PLUGIN_MODULE_PREFIX)
         },
     )
 
 
-def _restore_tool_registry_snapshot(snapshot: _ToolRegistrySnapshot) -> None:
+def restore_tool_registry_snapshot(snapshot: _ToolRegistrySnapshot) -> None:
     """Restore one previously captured tool/plugin registry snapshot."""
-    _TOOL_REGISTRY.clear()
-    _TOOL_REGISTRY.update(snapshot.registry)
+    TOOL_REGISTRY.clear()
+    TOOL_REGISTRY.update(snapshot.registry)
     TOOL_METADATA.clear()
     TOOL_METADATA.update(snapshot.metadata)
-    _BUILTIN_TOOL_REGISTRY.clear()
-    _BUILTIN_TOOL_REGISTRY.update(snapshot.builtin_registry)
-    _BUILTIN_TOOL_METADATA.clear()
-    _BUILTIN_TOOL_METADATA.update(snapshot.builtin_metadata)
+    BUILTIN_TOOL_REGISTRY.clear()
+    BUILTIN_TOOL_REGISTRY.update(snapshot.builtin_registry)
+    BUILTIN_TOOL_METADATA.clear()
+    BUILTIN_TOOL_METADATA.update(snapshot.builtin_metadata)
     plugin_imports._MODULE_IMPORT_CACHE.clear()
     plugin_imports._MODULE_IMPORT_CACHE.update(snapshot.module_import_cache)
     _PLUGIN_TOOL_METADATA_BY_MODULE.clear()
@@ -220,6 +220,6 @@ def _restore_tool_registry_snapshot(snapshot: _ToolRegistrySnapshot) -> None:
         },
     )
     for module_name in tuple(sys.modules.copy()):
-        if module_name.startswith(_PLUGIN_MODULE_PREFIX) and module_name not in snapshot.plugin_modules:
+        if module_name.startswith(PLUGIN_MODULE_PREFIX) and module_name not in snapshot.plugin_modules:
             sys.modules.pop(module_name, None)
     sys.modules.update(snapshot.plugin_modules)

--- a/tach.toml
+++ b/tach.toml
@@ -2198,13 +2198,7 @@ exclusive = true
 [[interfaces]]
 expose = ["EventCacheWriteCoordinator"]
 from = ["mindroom.matrix.cache.write_coordinator"]
-visibility = ["mindroom.matrix.cache"]
-exclusive = true
-
-[[interfaces]]
-expose = ["_EventCacheWriteCoordinator"]
-from = ["mindroom.matrix.cache.write_coordinator"]
-visibility = ["mindroom.runtime_support"]
+visibility = ["mindroom.matrix.cache", "mindroom.runtime_support"]
 exclusive = true
 
 [[interfaces]]
@@ -2332,11 +2326,11 @@ from = ["mindroom.matrix.client_delivery"]
 [[interfaces]]
 expose = [
     "ResolvedVisibleMessage",
-    "_apply_latest_edits_to_messages",
-    "_record_latest_thread_edit",
+    "apply_latest_edits_to_messages",
     "extract_visible_edit_body",
     "extract_visible_message",
     "message_preview",
+    "record_latest_thread_edit",
     "replace_visible_message",
     "resolve_visible_event_source",
     "resolve_latest_visible_messages",
@@ -2347,7 +2341,7 @@ from = ["mindroom.matrix.client_visible_messages"]
 
 [[interfaces]]
 expose = [
-    "_fetch_thread_event_sources_via_room_messages",
+    "fetch_thread_event_sources_via_room_messages",
     "RoomThreadsPageError",
     "ThreadRoomScanRootNotFoundError",
     "fetch_dispatch_thread_history",
@@ -2460,22 +2454,22 @@ from = ["mindroom.tool_system.catalog"]
 expose = [
     "TOOL_METADATA",
     "ToolMetadataValidationError",
-    "_BUILTIN_TOOL_METADATA",
-    "_BUILTIN_TOOL_REGISTRY",
-    "_PLUGIN_MODULE_PREFIX",
-    "_PLUGIN_REGISTRATION_SCOPE",
-    "_TOOL_REGISTRY",
-    "_capture_tool_registry_snapshot",
-    "_clear_plugin_tool_registrations",
-    "_locked_tool_registry_state",
-    "_register_plugin_tool_metadata",
-    "_resolved_tool_state",
-    "_restore_plugin_tool_registrations",
-    "_restore_tool_registry_snapshot",
-    "_scoped_plugin_registration_store",
-    "_scoped_plugin_registration_owner",
-    "_snapshot_plugin_tool_registrations",
-    "_synchronize_plugin_tools",
+    "BUILTIN_TOOL_METADATA",
+    "BUILTIN_TOOL_REGISTRY",
+    "PLUGIN_MODULE_PREFIX",
+    "PLUGIN_REGISTRATION_SCOPE",
+    "TOOL_REGISTRY",
+    "capture_tool_registry_snapshot",
+    "clear_plugin_tool_registrations",
+    "locked_tool_registry_state",
+    "register_plugin_tool_metadata",
+    "resolved_tool_state",
+    "restore_plugin_tool_registrations",
+    "restore_tool_registry_snapshot",
+    "scoped_plugin_registration_store",
+    "scoped_plugin_registration_owner",
+    "snapshot_plugin_tool_registrations",
+    "synchronize_plugin_tools",
     "register_builtin_tool_metadata",
 ]
 from = ["mindroom.tool_system.registry_state"]

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -322,21 +322,21 @@ def test_startup_runtime_keeps_runner_token_outside_runtime_paths(
     sandbox_runner_module.initialize_sandbox_runner_app(
         sandbox_runner_app,
         startup_runtime,
-        runner_token=sandbox_runner_module._startup_runner_token_from_env(),
+        runner_token=sandbox_runner_module.startup_runner_token_from_env(),
     )
 
     assert startup_runtime.env_value("MINDROOM_SANDBOX_PROXY_TOKEN") is None
-    assert sandbox_runner_module._app_runner_token(sandbox_runner_app) == "from-env"
+    assert sandbox_runner_module.app_runner_token(sandbox_runner_app) == "from-env"
 
 
 def test_startup_runner_token_is_removed_from_process_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Startup auth token loading should not leave runner auth in process env."""
     monkeypatch.setenv("MINDROOM_SANDBOX_PROXY_TOKEN", "from-env")
 
-    assert sandbox_runner_module._startup_runner_token_from_env() == "from-env"
+    assert sandbox_runner_module.startup_runner_token_from_env() == "from-env"
 
     assert "MINDROOM_SANDBOX_PROXY_TOKEN" not in os.environ
-    assert sandbox_runner_module._startup_runner_token_from_env() is None
+    assert sandbox_runner_module.startup_runner_token_from_env() is None
 
 
 def test_lifespan_reuses_initialized_runner_context_without_reloading_disk_config(tmp_path: Path) -> None:
@@ -365,8 +365,8 @@ def test_lifespan_reuses_initialized_runner_context_without_reloading_disk_confi
         response = client.get("/healthz")
 
     assert response.status_code == 200
-    assert sandbox_runner_module._app_runner_token(sandbox_runner_app) == preserved_runner_token
-    assert sandbox_runner_module._app_runtime_config(sandbox_runner_app) == config
+    assert sandbox_runner_module.app_runner_token(sandbox_runner_app) == preserved_runner_token
+    assert sandbox_runner_module.app_runtime_config(sandbox_runner_app) == config
 
 
 def test_startup_runtime_rehydrates_runtime_env_from_process_env_and_dotenv(
@@ -1421,7 +1421,7 @@ def test_sandbox_runner_execute_uses_committed_startup_config_until_explicit_ref
 ) -> None:
     """Execute requests should keep using the runner's committed startup config after later disk drift."""
     _set_sandbox_token(monkeypatch)
-    runtime_paths = sandbox_runner_module._app_runtime_paths(sandbox_runner_app)
+    runtime_paths = sandbox_runner_module.app_runtime_paths(sandbox_runner_app)
     runtime_paths.config_path.write_text("models: [\n", encoding="utf-8")
 
     response = runner_client.post(
@@ -1520,10 +1520,10 @@ def test_resolve_entrypoint_loads_persisted_tool_credentials(
 
     tool_name = "dummy_cred_tool"
     stored_value = "value123"
-    original_registry = metadata_module._TOOL_REGISTRY.copy()
+    original_registry = metadata_module.TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
-    original_builtin_registry = metadata_module._BUILTIN_TOOL_REGISTRY.copy()
-    original_builtin_metadata = metadata_module._BUILTIN_TOOL_METADATA.copy()
+    original_builtin_registry = metadata_module.BUILTIN_TOOL_REGISTRY.copy()
+    original_builtin_metadata = metadata_module.BUILTIN_TOOL_METADATA.copy()
     original_manager = credentials_module._credentials_manager
     original_signature = credentials_module._credentials_manager_signature
     shared_storage = tmp_path / "shared-storage"
@@ -1565,14 +1565,14 @@ def test_resolve_entrypoint_loads_persisted_tool_credentials(
 
         assert toolkit.token == stored_value
     finally:
-        metadata_module._TOOL_REGISTRY.clear()
-        metadata_module._TOOL_REGISTRY.update(original_registry)
-        metadata_module._BUILTIN_TOOL_REGISTRY.clear()
-        metadata_module._BUILTIN_TOOL_REGISTRY.update(original_builtin_registry)
+        metadata_module.TOOL_REGISTRY.clear()
+        metadata_module.TOOL_REGISTRY.update(original_registry)
+        metadata_module.BUILTIN_TOOL_REGISTRY.clear()
+        metadata_module.BUILTIN_TOOL_REGISTRY.update(original_builtin_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
-        metadata_module._BUILTIN_TOOL_METADATA.clear()
-        metadata_module._BUILTIN_TOOL_METADATA.update(original_builtin_metadata)
+        metadata_module.BUILTIN_TOOL_METADATA.clear()
+        metadata_module.BUILTIN_TOOL_METADATA.update(original_builtin_metadata)
         credentials_module._credentials_manager = original_manager
         credentials_module._credentials_manager_signature = original_signature
 
@@ -1593,10 +1593,10 @@ def test_get_tool_by_name_loads_persisted_tool_credentials_without_explicit_mana
 
     tool_name = "dummy_runtime_cred_tool"
     stored_value = "value123"
-    original_registry = metadata_module._TOOL_REGISTRY.copy()
+    original_registry = metadata_module.TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
-    original_builtin_registry = metadata_module._BUILTIN_TOOL_REGISTRY.copy()
-    original_builtin_metadata = metadata_module._BUILTIN_TOOL_METADATA.copy()
+    original_builtin_registry = metadata_module.BUILTIN_TOOL_REGISTRY.copy()
+    original_builtin_metadata = metadata_module.BUILTIN_TOOL_METADATA.copy()
     original_manager = credentials_module._credentials_manager
     original_signature = credentials_module._credentials_manager_signature
     storage_root = tmp_path / "runtime-storage"
@@ -1630,14 +1630,14 @@ def test_get_tool_by_name_loads_persisted_tool_credentials_without_explicit_mana
 
         assert toolkit.token == stored_value
     finally:
-        metadata_module._TOOL_REGISTRY.clear()
-        metadata_module._TOOL_REGISTRY.update(original_registry)
-        metadata_module._BUILTIN_TOOL_REGISTRY.clear()
-        metadata_module._BUILTIN_TOOL_REGISTRY.update(original_builtin_registry)
+        metadata_module.TOOL_REGISTRY.clear()
+        metadata_module.TOOL_REGISTRY.update(original_registry)
+        metadata_module.BUILTIN_TOOL_REGISTRY.clear()
+        metadata_module.BUILTIN_TOOL_REGISTRY.update(original_builtin_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
-        metadata_module._BUILTIN_TOOL_METADATA.clear()
-        metadata_module._BUILTIN_TOOL_METADATA.update(original_builtin_metadata)
+        metadata_module.BUILTIN_TOOL_METADATA.clear()
+        metadata_module.BUILTIN_TOOL_METADATA.update(original_builtin_metadata)
         credentials_module._credentials_manager = original_manager
         credentials_module._credentials_manager_signature = original_signature
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ from mindroom.final_delivery import FinalDeliveryOutcome
 from mindroom.interactive import InteractiveMetadata
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_history_result import thread_history_result
-from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
+from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.client import DeliveredMatrixEvent, ResolvedVisibleMessage
 from mindroom.matrix.client_delivery import build_edit_event_content
 from mindroom.matrix.conversation_cache import ConversationCacheProtocol
@@ -447,9 +447,9 @@ def make_conversation_cache_mock() -> AsyncMock:
     return conversation_cache
 
 
-def make_event_cache_write_coordinator_mock(*, owner: object | None = None) -> _EventCacheWriteCoordinator:
+def make_event_cache_write_coordinator_mock(*, owner: object | None = None) -> EventCacheWriteCoordinator:
     """Return a coordinator-shaped runtime helper with the real synchronous queue contract."""
-    return _EventCacheWriteCoordinator(
+    return EventCacheWriteCoordinator(
         logger=MagicMock(),
         background_task_owner=object() if owner is None else owner,
     )

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -20,7 +20,7 @@ from typer.testing import CliRunner
 
 import mindroom.constants as constants_module
 from mindroom.agents import ensure_default_agent_workspaces
-from mindroom.cli.config import _activate_cli_runtime, _format_config_search_locations
+from mindroom.cli.config import _format_config_search_locations, activate_cli_runtime
 from mindroom.cli.main import _load_active_config_or_exit, app
 from mindroom.config.main import Config
 from mindroom.constants import OWNER_MATRIX_USER_ID_ENV, OWNER_MATRIX_USER_ID_PLACEHOLDER
@@ -88,7 +88,7 @@ def test_activate_cli_runtime_explicit_path_keeps_exported_storage_override(
     )
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_path))
 
-    runtime_paths = _activate_cli_runtime(config_path)
+    runtime_paths = activate_cli_runtime(config_path)
 
     assert runtime_paths.storage_root == storage_path.resolve()
 

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -24,7 +24,7 @@ from mindroom.matrix.cache.postgres_event_cache import (
     _PostgresEventCacheRuntime,
 )
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
-from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
+from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.runtime_support import (
     OwnedRuntimeSupport,
     StartupThreadPrewarmRegistry,
@@ -940,7 +940,7 @@ async def test_event_cache_startup_backend_unavailable_retries_without_disabling
     logger = get_logger("tests.event_cache_backends")
     support = OwnedRuntimeSupport(
         event_cache=cast("ConversationEventCache", cache),
-        event_cache_write_coordinator=_EventCacheWriteCoordinator(logger=logger),
+        event_cache_write_coordinator=EventCacheWriteCoordinator(logger=logger),
         startup_thread_prewarm_registry=StartupThreadPrewarmRegistry(),
         event_cache_identity=_event_cache_runtime_identity(cache_config, runtime_paths),
     )

--- a/tests/test_issue_176_real_thread_parallelism.py
+++ b/tests/test_issue_176_real_thread_parallelism.py
@@ -7,14 +7,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
+from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 
 ROOM_ID = "!issue-176:localhost"
 THREAD_A_ID = "$thread-a:localhost"
 THREAD_B_ID = "$thread-b:localhost"
 
 
-async def _assert_sibling_threads_start_concurrently(coord: _EventCacheWriteCoordinator) -> None:
+async def _assert_sibling_threads_start_concurrently(coord: EventCacheWriteCoordinator) -> None:
     started_a = asyncio.Event()
     started_b = asyncio.Event()
     release_a = asyncio.Event()
@@ -62,7 +62,7 @@ async def _assert_sibling_threads_start_concurrently(coord: _EventCacheWriteCoor
         await asyncio.gather(first, second, return_exceptions=True)
 
 
-async def _assert_room_update_blocks_later_thread(coord: _EventCacheWriteCoordinator) -> None:
+async def _assert_room_update_blocks_later_thread(coord: EventCacheWriteCoordinator) -> None:
     started_a = asyncio.Event()
     started_b = asyncio.Event()
     release_a = asyncio.Event()
@@ -113,7 +113,7 @@ async def _assert_room_update_blocks_later_thread(coord: _EventCacheWriteCoordin
 @pytest.mark.asyncio
 async def test_issue_176_network_bound_sibling_thread_updates_run_in_parallel() -> None:
     """Different-thread updates should overlap when the slow work is outside SQLite."""
-    coord = _EventCacheWriteCoordinator(
+    coord = EventCacheWriteCoordinator(
         logger=MagicMock(),
         background_task_owner=object(),
     )

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -685,7 +685,7 @@ async def test_matrix_message_send_multiple_attachments_only_auto_threads_under_
             new=AsyncMock(return_value="$file_root"),
         ) as mock_send_file,
         patch(
-            "mindroom.custom_tools.matrix_conversation_operations._send_attachment_paths",
+            "mindroom.custom_tools.matrix_conversation_operations.send_attachment_paths",
             new=AsyncMock(return_value=(["$file_child"], None)),
         ) as mock_send_attachment_paths,
         tool_runtime_context(ctx),
@@ -925,7 +925,7 @@ async def test_matrix_message_send_multiple_attachments_only_returns_error_when_
             new=AsyncMock(return_value=None),
         ) as mock_send_file,
         patch(
-            "mindroom.custom_tools.matrix_conversation_operations._send_attachment_paths",
+            "mindroom.custom_tools.matrix_conversation_operations.send_attachment_paths",
             new=AsyncMock(return_value=([], None)),
         ) as mock_send_attachment_paths,
         tool_runtime_context(ctx),

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -18,7 +18,7 @@ from mindroom.mcp.registry import (
     sync_mcp_tool_registry,
 )
 from mindroom.mcp.toolkit import bind_mcp_server_manager
-from mindroom.tool_system.metadata import _TOOL_REGISTRY, TOOL_METADATA, get_tool_by_name
+from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, get_tool_by_name
 from mindroom.tool_system.worker_routing import supports_tool_name_for_worker_scope
 
 if TYPE_CHECKING:
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
 
 _BASE_TOOL_REGISTRY = {
-    tool_name: factory for tool_name, factory in _TOOL_REGISTRY.items() if not tool_name.startswith("mcp_")
+    tool_name: factory for tool_name, factory in TOOL_REGISTRY.items() if not tool_name.startswith("mcp_")
 }
 _BASE_TOOL_METADATA = {
     tool_name: metadata for tool_name, metadata in TOOL_METADATA.items() if not tool_name.startswith("mcp_")
@@ -38,16 +38,16 @@ _BASE_TOOL_METADATA = {
 @pytest.fixture(autouse=True)
 def _restore_tool_registry() -> Iterator[None]:
     _MCP_TOOL_NAMES.clear()
-    _TOOL_REGISTRY.clear()
-    _TOOL_REGISTRY.update(_BASE_TOOL_REGISTRY)
+    TOOL_REGISTRY.clear()
+    TOOL_REGISTRY.update(_BASE_TOOL_REGISTRY)
     TOOL_METADATA.clear()
     TOOL_METADATA.update(_BASE_TOOL_METADATA)
     bind_mcp_server_manager(None)
     sync_mcp_tool_registry(None)
     yield
     _MCP_TOOL_NAMES.clear()
-    _TOOL_REGISTRY.clear()
-    _TOOL_REGISTRY.update(_BASE_TOOL_REGISTRY)
+    TOOL_REGISTRY.clear()
+    TOOL_REGISTRY.update(_BASE_TOOL_REGISTRY)
     TOOL_METADATA.clear()
     TOOL_METADATA.update(_BASE_TOOL_METADATA)
     bind_mcp_server_manager(None)
@@ -85,7 +85,7 @@ def test_sync_mcp_tool_registry_registers_dynamic_tool(tmp_path: Path) -> None:
     sync_mcp_tool_registry(config)
     tool_name = mcp_tool_name("demo")
     assert tool_name in TOOL_METADATA
-    assert tool_name in _TOOL_REGISTRY
+    assert tool_name in TOOL_REGISTRY
     assert TOOL_METADATA[tool_name].agent_override_fields is not None
 
 
@@ -136,7 +136,7 @@ def test_sync_mcp_tool_registry_removes_deleted_servers(tmp_path: Path) -> None:
         ),
     )
     assert "mcp_demo" not in TOOL_METADATA
-    assert "mcp_demo" not in _TOOL_REGISTRY
+    assert "mcp_demo" not in TOOL_REGISTRY
 
 
 def test_sync_mcp_tool_registry_removes_untracked_dynamic_entries(tmp_path: Path) -> None:
@@ -158,12 +158,12 @@ def test_sync_mcp_tool_registry_removes_untracked_dynamic_entries(tmp_path: Path
         ),
     )
     assert "mcp_demo" not in TOOL_METADATA
-    assert "mcp_demo" not in _TOOL_REGISTRY
+    assert "mcp_demo" not in TOOL_REGISTRY
 
 
 def test_sync_mcp_tool_registry_rejects_name_collisions(tmp_path: Path) -> None:
     """Fail fast instead of silently overwriting an existing built-in tool entry."""
-    _TOOL_REGISTRY["mcp_demo"] = _TOOL_REGISTRY["shell"]
+    TOOL_REGISTRY["mcp_demo"] = TOOL_REGISTRY["shell"]
     TOOL_METADATA["mcp_demo"] = TOOL_METADATA["shell"]
     with pytest.raises(ValueError, match="conflicts with an existing registered tool"):
         sync_mcp_tool_registry(_config(tmp_path))
@@ -171,18 +171,18 @@ def test_sync_mcp_tool_registry_rejects_name_collisions(tmp_path: Path) -> None:
 
 def test_sync_mcp_tool_registry_keeps_non_mcp_prefixed_plugin_tools() -> None:
     """Do not unregister unrelated tools just because their names start with mcp_."""
-    _TOOL_REGISTRY["mcp_custom_plugin"] = _TOOL_REGISTRY["shell"]
+    TOOL_REGISTRY["mcp_custom_plugin"] = TOOL_REGISTRY["shell"]
     TOOL_METADATA["mcp_custom_plugin"] = replace(TOOL_METADATA["shell"], name="mcp_custom_plugin")
 
     sync_mcp_tool_registry(None)
 
     assert "mcp_custom_plugin" in TOOL_METADATA
-    assert "mcp_custom_plugin" in _TOOL_REGISTRY
+    assert "mcp_custom_plugin" in TOOL_REGISTRY
 
 
 def test_mcp_server_id_from_tool_name_ignores_non_mcp_prefixed_plugin_tools() -> None:
     """Only registry-owned MCP tools should be classified as MCP integrations."""
-    _TOOL_REGISTRY["mcp_custom_plugin"] = _TOOL_REGISTRY["shell"]
+    TOOL_REGISTRY["mcp_custom_plugin"] = TOOL_REGISTRY["shell"]
     TOOL_METADATA["mcp_custom_plugin"] = replace(TOOL_METADATA["shell"], name="mcp_custom_plugin")
 
     assert mcp_server_id_from_tool_name("mcp_custom_plugin") is None

--- a/tests/test_memory_facade.py
+++ b/tests/test_memory_facade.py
@@ -20,7 +20,7 @@ from mindroom.memory import list_all_agent_memories as public_list_all_agent_mem
 from mindroom.memory import search_agent_memories as public_search_agent_memories
 from mindroom.memory import store_conversation_memory as public_store_conversation_memory
 from mindroom.memory import update_agent_memory as public_update_agent_memory
-from mindroom.memory._prompting import _format_memories_as_context
+from mindroom.memory._prompting import format_memories_as_context
 from mindroom.tool_system.worker_routing import agent_state_root_path, agent_workspace_root_path
 from tests.conftest import bind_runtime_paths, make_visible_message, runtime_paths_for
 from tests.memory_test_support import MockTeamConfig
@@ -411,7 +411,7 @@ class TestMemoryFacade:
             {"memory": "Second memory", "id": "2"},
         ]
 
-        context = _format_memories_as_context(memories, "agent")
+        context = format_memories_as_context(memories, "agent")
         expected = (
             "[Automatically extracted agent memories - may not be relevant to current context]\n"
             "Previous agent memories that might be related:\n"
@@ -421,7 +421,7 @@ class TestMemoryFacade:
         assert context == expected
 
     def test_format_memories_as_context_empty(self) -> None:
-        assert _format_memories_as_context([], "agent") == ""
+        assert format_memories_as_context([], "agent") == ""
 
     @pytest.mark.asyncio
     async def test_build_memory_prompt_parts(

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -7293,7 +7293,7 @@ class TestAgentBot:
 
         bot._send_response = AsyncMock(side_effect=fake_send_response)
         with (
-            patch("mindroom.bot_room_lifecycle._generate_welcome_message", return_value="Welcome"),
+            patch("mindroom.bot_room_lifecycle.generate_welcome_message", return_value="Welcome"),
             patch("mindroom.bot_room_lifecycle.get_joined_rooms", new=AsyncMock(return_value=[])),
             patch("mindroom.bot.restore_scheduled_tasks", new=AsyncMock(return_value=0)),
             patch("mindroom.bot.config_confirmation.restore_pending_changes", new=AsyncMock(return_value=0)),

--- a/tests/test_partial_reply_context.py
+++ b/tests/test_partial_reply_context.py
@@ -42,7 +42,7 @@ from mindroom.streaming import (
     _CANCELLED_RESPONSE_NOTE,
     _INTERRUPTED_RESPONSE_NOTE,
     _PROGRESS_PLACEHOLDER,
-    _RESTART_INTERRUPTED_RESPONSE_NOTE,
+    RESTART_INTERRUPTED_RESPONSE_NOTE,
     StreamingResponse,
 )
 from tests.conftest import (
@@ -274,7 +274,7 @@ class TestClassifyPartialReply:
         [
             f"Legacy partial\n\n{_CANCELLED_RESPONSE_NOTE}",
             f"Legacy partial\n\n{_INTERRUPTED_RESPONSE_NOTE}",
-            f"Legacy partial\n\n{_RESTART_INTERRUPTED_RESPONSE_NOTE}",
+            f"Legacy partial\n\n{RESTART_INTERRUPTED_RESPONSE_NOTE}",
             "Legacy partial\n\n**[Response interrupted by an error: boom]**",
             "Legacy partial [cancelled]",
             "Legacy partial [error]",
@@ -309,7 +309,7 @@ class TestCleanPartialReplyBody:
         [
             (f"Partial answer\n\n{_CANCELLED_RESPONSE_NOTE}", "Partial answer"),
             (f"Partial answer\n\n{_INTERRUPTED_RESPONSE_NOTE}", "Partial answer"),
-            (f"Partial answer\n\n{_RESTART_INTERRUPTED_RESPONSE_NOTE}", "Partial answer"),
+            (f"Partial answer\n\n{RESTART_INTERRUPTED_RESPONSE_NOTE}", "Partial answer"),
             ("Partial answer [cancelled]", "Partial answer"),
             ("Partial answer [error]", "Partial answer"),
             ("Partial answer\n\n**[Response interrupted by an error: boom]**", "Partial answer"),
@@ -331,7 +331,7 @@ class TestCleanPartialReplyBody:
             _render_normalized_interrupted_replay(f"Partial answer\n\n{_CANCELLED_RESPONSE_NOTE}").encode("utf-8"),
             _render_normalized_interrupted_replay(f"Partial answer\n\n{_INTERRUPTED_RESPONSE_NOTE}").encode("utf-8"),
             _render_normalized_interrupted_replay(
-                f"Partial answer\n\n{_RESTART_INTERRUPTED_RESPONSE_NOTE}",
+                f"Partial answer\n\n{RESTART_INTERRUPTED_RESPONSE_NOTE}",
             ).encode("utf-8"),
         ]
 
@@ -509,7 +509,7 @@ class TestUnseenMessagesPartialReplies:
                 _make_visible_message(
                     event_id="e1",
                     sender=agent_id,
-                    body=f"Partial reply\n\n{_RESTART_INTERRUPTED_RESPONSE_NOTE}",
+                    body=f"Partial reply\n\n{RESTART_INTERRUPTED_RESPONSE_NOTE}",
                     stream_status=STREAM_STATUS_STREAMING,
                     timestamp=599_000,
                 ),

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -19,7 +19,7 @@ from mindroom.config.main import Config, ConfigRuntimeValidationError, load_conf
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.hooks import EVENT_MESSAGE_RECEIVED, HookRegistry
 from mindroom.oauth.registry import clear_oauth_provider_cache, load_oauth_providers
-from mindroom.tool_system.metadata import _TOOL_REGISTRY, TOOL_METADATA, get_tool_by_name
+from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, get_tool_by_name
 from mindroom.tool_system.plugins import get_configured_plugin_roots, load_plugins, reload_plugins
 from mindroom.tool_system.skills import _get_plugin_skill_roots, set_plugin_skill_roots
 from tests.conftest import bind_runtime_paths, runtime_paths_for
@@ -141,7 +141,7 @@ def test_load_plugins_registers_tools_and_skills(tmp_path: Path) -> None:
     config_path.write_text("agents: {}", encoding="utf-8")
     config = _bind_runtime_paths(Config(plugins=["./plugins/demo"]), config_path)
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_plugin_roots = _get_plugin_skill_roots()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
@@ -150,13 +150,13 @@ def test_load_plugins_registers_tools_and_skills(tmp_path: Path) -> None:
     try:
         plugins = load_plugins(config, runtime_paths_for(config))
         assert [plugin.name for plugin in plugins] == ["demo-plugin"]
-        assert "demo_plugin" in _TOOL_REGISTRY
+        assert "demo_plugin" in TOOL_REGISTRY
         tool = get_tool_by_name("demo_plugin", runtime_paths_for(config), worker_target=None)
         assert tool.name == "demo"
         assert (plugin_root / "skills").resolve() in _get_plugin_skill_roots()
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
@@ -197,7 +197,7 @@ def test_resolved_tool_metadata_for_runtime_does_not_mutate_live_registry(tmp_pa
     config_path.write_text("agents: {}", encoding="utf-8")
     config_with_plugin = _bind_runtime_paths(Config(plugins=["./plugins/demo"]), config_path)
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
@@ -210,12 +210,12 @@ def test_resolved_tool_metadata_for_runtime_does_not_mutate_live_registry(tmp_pa
         )
         assert "demo_plugin" in resolved_metadata
         assert "demo_plugin" not in TOOL_METADATA
-        assert original_registry == _TOOL_REGISTRY
+        assert original_registry == TOOL_REGISTRY
         assert original_metadata == TOOL_METADATA
         assert original_module_cache == plugin_module._MODULE_IMPORT_CACHE
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
@@ -272,7 +272,7 @@ def test_load_plugins_from_python_package(tmp_path: Path, monkeypatch: pytest.Mo
     config_path.write_text("agents: {}", encoding="utf-8")
     config = _bind_runtime_paths(Config(plugins=["demo_pkg"]), config_path)
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_plugin_roots = _get_plugin_skill_roots()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
@@ -282,13 +282,13 @@ def test_load_plugins_from_python_package(tmp_path: Path, monkeypatch: pytest.Mo
         plugins = load_plugins(config, runtime_paths_for(config))
         assert [plugin.name for plugin in plugins] == ["demo-pkg"]
         assert plugins[0].root == plugin_root.resolve()
-        assert "demo_pkg_tool" in _TOOL_REGISTRY
+        assert "demo_pkg_tool" in TOOL_REGISTRY
         tool = get_tool_by_name("demo_pkg_tool", runtime_paths_for(config), worker_target=None)
         assert tool.name == "demo_pkg"
         assert (plugin_root / "skills").resolve() in _get_plugin_skill_roots()
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
@@ -535,7 +535,7 @@ def test_load_plugins_skips_missing_plugin_directory_with_warning(
     mock_logger = MagicMock()
     missing_root = (tmp_path / "plugins" / "missing").resolve()
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
@@ -547,8 +547,8 @@ def test_load_plugins_skips_missing_plugin_directory_with_warning(
         assert load_plugins(Config(plugins=["./plugins/missing"]), runtime_paths) == []
         mock_logger.warning.assert_any_call("Plugin path does not exist, skipping", path=str(missing_root))
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
@@ -667,7 +667,7 @@ def test_load_plugins_warns_once_for_repeated_non_bundled_plugin_loads(
     config = Config(plugins=["./plugins/demo"])
 
     mock_logger = MagicMock()
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_plugin_roots = _get_plugin_skill_roots()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
@@ -686,8 +686,8 @@ def test_load_plugins_warns_once_for_repeated_non_bundled_plugin_loads(
         ]
         assert len(matching_calls) == 1
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
@@ -757,7 +757,7 @@ def test_validate_with_runtime_does_not_leak_plugin_tools_after_failure(tmp_path
     config_path = tmp_path / "config.yaml"
     config_path.write_text("agents: {}", encoding="utf-8")
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
 
@@ -774,7 +774,7 @@ def test_validate_with_runtime_does_not_leak_plugin_tools_after_failure(tmp_path
         with pytest.raises(ValueError, match="Unknown tool 'missing_tool'"):
             _bind_runtime_paths(bad_config, config_path)
 
-        assert "leaked_plugin_tool" not in _TOOL_REGISTRY
+        assert "leaked_plugin_tool" not in TOOL_REGISTRY
         assert "leaked_plugin_tool" not in TOOL_METADATA
 
         follow_up_config = Config.model_validate(
@@ -794,8 +794,8 @@ def test_validate_with_runtime_does_not_leak_plugin_tools_after_failure(tmp_path
         with pytest.raises(ValueError, match="Unknown tool 'leaked_plugin_tool'"):
             _bind_runtime_paths(follow_up_config, config_path)
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._MODULE_IMPORT_CACHE.clear()
@@ -852,19 +852,19 @@ def test_validate_with_runtime_does_not_mutate_live_tool_registry_on_success(tmp
         "plugins": ["./plugins/demo"],
     }
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
 
     try:
         validated = Config.validate_with_runtime(authored_config, runtime_paths)
         assert validated.get_agent("assistant").tool_names == ["validated_plugin_tool"]
-        assert "validated_plugin_tool" not in _TOOL_REGISTRY
+        assert "validated_plugin_tool" not in TOOL_REGISTRY
         assert "validated_plugin_tool" not in TOOL_METADATA
         assert original_module_cache == plugin_module._MODULE_IMPORT_CACHE
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._MODULE_IMPORT_CACHE.clear()
@@ -958,7 +958,7 @@ def test_validate_with_runtime_does_not_mutate_live_registry_for_package_helper_
         },
     )
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
 
@@ -979,14 +979,14 @@ def test_validate_with_runtime_does_not_mutate_live_registry_for_package_helper_
             runtime_paths,
         )
         assert validated.get_agent("assistant").tool_names == ["helper_tool"]
-        assert "helper_tool" not in _TOOL_REGISTRY
+        assert "helper_tool" not in TOOL_REGISTRY
         assert "helper_tool" not in TOOL_METADATA
-        assert original_registry == _TOOL_REGISTRY
+        assert original_registry == TOOL_REGISTRY
         assert original_metadata == TOOL_METADATA
         assert original_module_cache == plugin_module._MODULE_IMPORT_CACHE
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._MODULE_IMPORT_CACHE.clear()
@@ -1025,7 +1025,7 @@ def test_load_plugins_removes_tools_for_successfully_removed_plugins(tmp_path: P
     config_with_plugin = _bind_runtime_paths(Config(plugins=["./plugins/demo"]), config_path)
     config_without_plugin = _bind_runtime_paths(Config(plugins=[]), config_path)
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
@@ -1035,11 +1035,11 @@ def test_load_plugins_removes_tools_for_successfully_removed_plugins(tmp_path: P
         assert [plugin.name for plugin in load_plugins(config_with_plugin, runtime_paths_for(config_with_plugin))] == [
             "demo_plugin",
         ]
-        assert "removed_plugin_tool" in _TOOL_REGISTRY
+        assert "removed_plugin_tool" in TOOL_REGISTRY
         assert "removed_plugin_tool" in TOOL_METADATA
 
         assert load_plugins(config_without_plugin, runtime_paths_for(config_without_plugin)) == []
-        assert "removed_plugin_tool" not in _TOOL_REGISTRY
+        assert "removed_plugin_tool" not in TOOL_REGISTRY
         assert "removed_plugin_tool" not in TOOL_METADATA
 
         follow_up_config = Config.model_validate(
@@ -1059,8 +1059,8 @@ def test_load_plugins_removes_tools_for_successfully_removed_plugins(tmp_path: P
         with pytest.raises(ValueError, match="Unknown tool 'removed_plugin_tool'"):
             _bind_runtime_paths(follow_up_config, config_path)
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
@@ -1102,7 +1102,7 @@ def test_load_plugins_re_registers_tools_when_plugin_is_re_enabled(tmp_path: Pat
     config_with_plugin = _bind_runtime_paths(Config(plugins=["./plugins/demo"]), config_path)
     config_without_plugin = _bind_runtime_paths(Config(plugins=[]), config_path)
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
@@ -1112,15 +1112,15 @@ def test_load_plugins_re_registers_tools_when_plugin_is_re_enabled(tmp_path: Pat
         assert [plugin.name for plugin in load_plugins(config_with_plugin, runtime_paths_for(config_with_plugin))] == [
             "demo_plugin",
         ]
-        assert "toggled_plugin_tool" in _TOOL_REGISTRY
+        assert "toggled_plugin_tool" in TOOL_REGISTRY
 
         assert load_plugins(config_without_plugin, runtime_paths_for(config_without_plugin)) == []
-        assert "toggled_plugin_tool" not in _TOOL_REGISTRY
+        assert "toggled_plugin_tool" not in TOOL_REGISTRY
 
         assert [plugin.name for plugin in load_plugins(config_with_plugin, runtime_paths_for(config_with_plugin))] == [
             "demo_plugin",
         ]
-        assert "toggled_plugin_tool" in _TOOL_REGISTRY
+        assert "toggled_plugin_tool" in TOOL_REGISTRY
 
         follow_up_config = Config.model_validate(
             {
@@ -1139,8 +1139,8 @@ def test_load_plugins_re_registers_tools_when_plugin_is_re_enabled(tmp_path: Pat
         bound = _bind_runtime_paths(follow_up_config, config_path)
         assert bound.get_agent("assistant").tool_names == ["toggled_plugin_tool"]
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
@@ -1156,7 +1156,7 @@ def test_load_plugins_preserves_metadata_only_built_in_tools(tmp_path: Path) -> 
     config_path.write_text("agents: {}", encoding="utf-8")
     config_without_plugins = _bind_runtime_paths(Config(plugins=[]), config_path)
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
@@ -1167,8 +1167,8 @@ def test_load_plugins_preserves_metadata_only_built_in_tools(tmp_path: Path) -> 
         for tool_name in ("memory", "delegate", "self_config", "compact_context"):
             assert tool_name in TOOL_METADATA
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
@@ -1210,7 +1210,7 @@ def test_load_plugins_removes_stale_tools_when_enabled_plugin_changes_exports(tm
     config_path.write_text("agents: {}", encoding="utf-8")
     config = _bind_runtime_paths(Config(plugins=["./plugins/demo"]), config_path)
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
@@ -1218,7 +1218,7 @@ def test_load_plugins_removes_stale_tools_when_enabled_plugin_changes_exports(tm
 
     try:
         assert [plugin.name for plugin in load_plugins(config, runtime_paths_for(config))] == ["demo_plugin"]
-        assert "old_tool" in _TOOL_REGISTRY
+        assert "old_tool" in TOOL_REGISTRY
 
         tools_path.write_text(
             "from agno.tools import Toolkit\n"
@@ -1242,12 +1242,12 @@ def test_load_plugins_removes_stale_tools_when_enabled_plugin_changes_exports(tm
         os.utime(tools_path, (stat_result.st_atime, stat_result.st_mtime + 1))
 
         assert [plugin.name for plugin in load_plugins(config, runtime_paths_for(config))] == ["demo_plugin"]
-        assert "old_tool" not in _TOOL_REGISTRY
+        assert "old_tool" not in TOOL_REGISTRY
         assert "old_tool" not in TOOL_METADATA
-        assert "new_tool" in _TOOL_REGISTRY
+        assert "new_tool" in TOOL_REGISTRY
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
@@ -1417,7 +1417,7 @@ def test_load_plugins_preserves_tools_when_manifest_name_changes(tmp_path: Path)
     config_path.write_text("agents: {}", encoding="utf-8")
     config = _bind_runtime_paths(Config(plugins=["./plugins/demo"]), config_path)
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
@@ -1425,7 +1425,7 @@ def test_load_plugins_preserves_tools_when_manifest_name_changes(tmp_path: Path)
 
     try:
         assert [plugin.name for plugin in load_plugins(config, runtime_paths_for(config))] == ["demo_plugin"]
-        assert "renamed_tool" in _TOOL_REGISTRY
+        assert "renamed_tool" in TOOL_REGISTRY
 
         manifest_path.write_text(
             json.dumps({"name": "renamed_plugin", "tools_module": "tools.py", "skills": []}),
@@ -1435,7 +1435,7 @@ def test_load_plugins_preserves_tools_when_manifest_name_changes(tmp_path: Path)
         os.utime(manifest_path, (stat_result.st_atime, stat_result.st_mtime + 1))
 
         assert [plugin.name for plugin in load_plugins(config, runtime_paths_for(config))] == ["renamed_plugin"]
-        assert "renamed_tool" in _TOOL_REGISTRY
+        assert "renamed_tool" in TOOL_REGISTRY
 
         follow_up_config = Config.model_validate(
             {
@@ -1454,8 +1454,8 @@ def test_load_plugins_preserves_tools_when_manifest_name_changes(tmp_path: Path)
         bound = _bind_runtime_paths(follow_up_config, config_path)
         assert bound.get_agent("assistant").tool_names == ["renamed_tool"]
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
@@ -1532,7 +1532,7 @@ def test_load_config_tolerates_missing_and_broken_plugins_on_startup(
             "MINDROOM_NAMESPACE": "",
         },
     )
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
@@ -1555,8 +1555,8 @@ def test_load_config_tolerates_missing_and_broken_plugins_on_startup(
             for call in mock_logger.warning.call_args_list
         )
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()
@@ -1615,7 +1615,7 @@ def test_load_plugins_skips_later_broken_plugin_and_keeps_earlier_tools(
     )
     config = Config(plugins=["./plugins/good", "./plugins/bad"])
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_module_cache = plugin_module._MODULE_IMPORT_CACHE.copy()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
@@ -1627,7 +1627,7 @@ def test_load_plugins_skips_later_broken_plugin_and_keeps_earlier_tools(
     try:
         plugins = load_plugins(config, runtime_paths)
         assert [plugin.name for plugin in plugins] == ["good_plugin"]
-        assert "good_plugin_tool" in _TOOL_REGISTRY
+        assert "good_plugin_tool" in TOOL_REGISTRY
         assert "good_plugin_tool" in TOOL_METADATA
         assert any(
             call.args == ("Failed to load plugin, skipping",)
@@ -1636,8 +1636,8 @@ def test_load_plugins_skips_later_broken_plugin_and_keeps_earlier_tools(
             for call in mock_logger.warning.call_args_list
         )
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -45,8 +45,8 @@ from mindroom.constants import (
 from mindroom.credentials import get_runtime_credentials_manager, save_scoped_credentials
 from mindroom.hooks import HookRegistry
 from mindroom.tool_system.metadata import (
-    _TOOL_REGISTRY,
     TOOL_METADATA,
+    TOOL_REGISTRY,
     ConfigField,
     ToolCategory,
     ToolInitOverrideError,
@@ -435,7 +435,7 @@ def test_sandbox_runner_executes_wrapper_before_to_json_compatible(tmp_path: Pat
         assert marker not in str(proxy_result)
         assert proxy_result["mindroom_tool_output"]["status"] == "saved_to_file"
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 
@@ -665,7 +665,7 @@ async def test_static_runner_redirect_resolves_agent_workspace_without_prepared_
         assert marker not in str(response.result)
         assert response.result["mindroom_tool_output"]["status"] == "saved_to_file"
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 
@@ -751,7 +751,7 @@ async def test_worker_redirect_uses_agent_workspace_not_worker_scratch(tmp_path:
         assert not (worker_paths.workspace / "tool-results/worker.json").exists()
         assert response.result["mindroom_tool_output"]["path"] == "tool-results/worker.json"
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 
@@ -806,7 +806,7 @@ def test_proxy_payload_includes_tool_config_overrides(monkeypatch: pytest.Monkey
         assert captured["json"]["tool_config_overrides"] == {"label": "from-config"}
         assert "tool_init_overrides" not in captured["json"]
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -61,14 +61,14 @@ from mindroom.streaming import (
     is_interrupted_partial_reply,
     send_streaming_response,
 )
-from mindroom.streaming_delivery import _consume_streaming_chunks as _consume_streaming_chunks_impl
 from mindroom.streaming_delivery import (
-    _DeliveryRequest,
-    _drive_stream_delivery,
+    DeliveryRequest,
+    StreamDeliveryShutdownTimeoutError,
     _flush_phase_boundary_if_needed,
-    _shutdown_stream_delivery,
-    _StreamDeliveryShutdownTimeoutError,
+    drive_stream_delivery,
+    shutdown_stream_delivery,
 )
+from mindroom.streaming_delivery import _consume_streaming_chunks as _consume_streaming_chunks_impl
 from mindroom.timing import DispatchPipelineTiming
 from mindroom.tool_system.runtime_context import WorkerProgressEvent, get_worker_progress_pump
 from mindroom.workers.models import WorkerReadyProgress
@@ -164,17 +164,17 @@ async def _consume_streaming_chunks_for_test(
     response_stream: AsyncIterator[object],
     streaming: StreamingResponse,
 ) -> None:
-    delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-    delivery_task = asyncio.create_task(_drive_stream_delivery(client, streaming, delivery_queue))
+    delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+    delivery_task = asyncio.create_task(drive_stream_delivery(client, streaming, delivery_queue))
     try:
         await _consume_streaming_chunks_impl(response_stream, streaming, delivery_queue)
-        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
         delivery_task = None
         if shutdown_error is not None:
             raise shutdown_error
     finally:
         if delivery_task is not None:
-            cleanup_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            cleanup_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
             if cleanup_error is not None:
                 raise cleanup_error
 
@@ -937,8 +937,8 @@ class TestStreamingBehavior:
             second_yield_started.set()
             yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
 
-        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(drive_stream_delivery(mock_client, streaming, delivery_queue))
         consume_task = asyncio.create_task(_consume_streaming_chunks_impl(response_stream(), streaming, delivery_queue))
 
         await first_send_started.wait()
@@ -948,7 +948,7 @@ class TestStreamingBehavior:
 
         allow_send_to_finish.set()
         await consume_task
-        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
         assert shutdown_error is None
 
     @pytest.mark.asyncio
@@ -990,8 +990,8 @@ class TestStreamingBehavior:
             yield ToolCallStartedEvent(tool=ToolExecution(tool_name="search_web", tool_args={"q": "mindroom"}))
             yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
 
-        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(drive_stream_delivery(mock_client, streaming, delivery_queue))
         consume_task = asyncio.create_task(_consume_streaming_chunks_impl(response_stream(), streaming, delivery_queue))
 
         await first_send_started.wait()
@@ -999,7 +999,7 @@ class TestStreamingBehavior:
         await asyncio.sleep(0)
         allow_send_to_finish.set()
         await consume_task
-        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
         assert shutdown_error is None
 
         assert mock_client.room_send.call_count == 1
@@ -1053,15 +1053,15 @@ class TestStreamingBehavior:
             await first_send_started.wait()
             yield ToolCallStartedEvent(tool=ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}))
 
-        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(drive_stream_delivery(mock_client, streaming, delivery_queue))
         consume_task = asyncio.create_task(_consume_streaming_chunks_impl(response_stream(), streaming, delivery_queue))
 
         await first_send_started.wait()
         await asyncio.sleep(0)
         allow_first_send_to_finish.set()
         await consume_task
-        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
         assert shutdown_error is None
 
         assert mock_client.room_send.call_count == 2
@@ -1239,8 +1239,8 @@ class TestStreamingBehavior:
             second_yield_started.set()
             yield "after"
 
-        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(drive_stream_delivery(mock_client, streaming, delivery_queue))
         consume_task = asyncio.create_task(_consume_streaming_chunks_impl(response_stream(), streaming, delivery_queue))
 
         await first_send_started.wait()
@@ -1250,7 +1250,7 @@ class TestStreamingBehavior:
 
         allow_send_to_finish.set()
         await consume_task
-        shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+        shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
         assert shutdown_error is None
 
     @pytest.mark.asyncio
@@ -1286,10 +1286,10 @@ class TestStreamingBehavior:
         streaming.accumulated_text = "\n\n🔧 `search_web` [1] ⏳\nx\n\n🔧 `save_file` [2] ⏳\n"
         streaming.chars_since_last_update = len(streaming.accumulated_text)
 
-        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(drive_stream_delivery(mock_client, streaming, delivery_queue))
         delivery_queue.put_nowait(
-            _DeliveryRequest(
+            DeliveryRequest(
                 boundary_refresh=True,
                 prior_delta_at=100.0,
                 boundary_refresh_prior_delta_at=100.0,
@@ -1300,7 +1300,7 @@ class TestStreamingBehavior:
             patch("mindroom.streaming.time.time", return_value=100.0),
             patch("mindroom.streaming_delivery.time.time", return_value=100.0),
         ):
-            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
 
         assert shutdown_error is None
         assert mock_client.room_send.call_count == 1
@@ -1429,15 +1429,15 @@ class TestStreamingBehavior:
         with patch("mindroom.streaming.time.time", return_value=100.0):
             streaming._update("\n")
 
-        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(drive_stream_delivery(mock_client, streaming, delivery_queue))
         await _flush_phase_boundary_if_needed(streaming, delivery_queue)
 
         with (
             patch("mindroom.streaming.time.time", return_value=101.0),
             patch("mindroom.streaming_delivery.time.time", return_value=101.0),
         ):
-            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
 
         assert shutdown_error is None
         assert mock_client.room_send.call_count == 0
@@ -1491,8 +1491,8 @@ class TestStreamingBehavior:
             second_yield_started.set()
             yield "B"
 
-        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(drive_stream_delivery(mock_client, streaming, delivery_queue))
         streaming_times = iter([100.0, 100.0, 100.1, 100.2, 100.2, 100.2])
 
         with patch("mindroom.streaming.time.time", side_effect=lambda: next(streaming_times, 100.2)):
@@ -1505,7 +1505,7 @@ class TestStreamingBehavior:
             assert second_yield_started.is_set()
             allow_first_send_to_finish.set()
             await consume_task
-            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
 
         assert shutdown_error is None
         assert mock_client.room_send.call_count == 2
@@ -1535,9 +1535,9 @@ class TestStreamingBehavior:
         streaming.accumulated_text = "hello"
         streaming.chars_since_last_update = len(streaming.accumulated_text)
 
-        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
-        delivery_queue.put_nowait(_DeliveryRequest(boundary_refresh=True))
+        delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue.put_nowait(DeliveryRequest(boundary_refresh=True))
 
         with (
             patch("mindroom.streaming.time.time", return_value=101.0),
@@ -1546,7 +1546,7 @@ class TestStreamingBehavior:
                 return_value=101.0,
             ),
         ):
-            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
 
         assert shutdown_error is None
         assert streaming.stream_started_at == 101.0
@@ -2989,7 +2989,7 @@ class TestStreamingBehavior:
                 "mindroom.streaming.edit_message_result",
                 new=AsyncMock(return_value=DeliveredMatrixEvent(event_id="$edit123", content_sent={})),
             ),
-            patch("mindroom.streaming._drain_worker_progress_events", new=lingering_drain),
+            patch("mindroom.streaming.drain_worker_progress_events", new=lingering_drain),
         ):
             outcome = await send_streaming_response(
                 client=mock_client,
@@ -3272,7 +3272,7 @@ class TestStreamingBehavior:
         delivery_task = asyncio.create_task(stuck_delivery())
         await task_started.wait()
 
-        shutdown_error = await _shutdown_stream_delivery(
+        shutdown_error = await shutdown_stream_delivery(
             delivery_queue,
             delivery_task,
             drain_timeout_seconds=0.01,
@@ -3302,7 +3302,7 @@ class TestStreamingBehavior:
         await task_started.wait()
         asyncio.get_running_loop().call_later(0.05, release_task.set)
 
-        shutdown_error = await _shutdown_stream_delivery(
+        shutdown_error = await shutdown_stream_delivery(
             delivery_queue,
             delivery_task,
             drain_timeout_seconds=0.1,
@@ -3339,13 +3339,13 @@ class TestStreamingBehavior:
         streaming.chars_since_last_update = len(streaming.accumulated_text)
         streaming._send_content = AsyncMock(return_value=True)
 
-        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
-        delivery_queue.put_nowait(_DeliveryRequest(prior_delta_at=100.0))
-        delivery_queue.put_nowait(_DeliveryRequest(prior_delta_at=105.0))
+        delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue.put_nowait(DeliveryRequest(prior_delta_at=100.0))
+        delivery_queue.put_nowait(DeliveryRequest(prior_delta_at=105.0))
 
         with patch("mindroom.streaming.time.time", return_value=105.02):
-            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
 
         assert shutdown_error is None
         assert streaming._send_content.await_count == 1
@@ -3372,15 +3372,15 @@ class TestStreamingBehavior:
         streaming.chars_since_last_update = len(streaming.accumulated_text)
 
         capture_completion = asyncio.get_running_loop().create_future()
-        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
-        delivery_queue.put_nowait(_DeliveryRequest(force_refresh=True))
+        delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue.put_nowait(DeliveryRequest(force_refresh=True))
         delivery_queue.put_nowait(
-            _DeliveryRequest(boundary_refresh=True, capture_completion=capture_completion),
+            DeliveryRequest(boundary_refresh=True, capture_completion=capture_completion),
         )
 
         with patch("mindroom.streaming.time.time", return_value=101.0):
-            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
 
         assert shutdown_error is None
         assert capture_completion.done()
@@ -3432,11 +3432,11 @@ class TestStreamingBehavior:
                 delivery_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await delivery_task
-            return _StreamDeliveryShutdownTimeoutError("Timed out shutting down stream delivery controller")
+            return StreamDeliveryShutdownTimeoutError("Timed out shutting down stream delivery controller")
 
         with (
-            patch("mindroom.streaming._consume_stream_with_progress_supervision", new=fail_stream_supervision),
-            patch("mindroom.streaming._shutdown_stream_delivery", new=timeout_shutdown),
+            patch("mindroom.streaming.consume_stream_with_progress_supervision", new=fail_stream_supervision),
+            patch("mindroom.streaming.shutdown_stream_delivery", new=timeout_shutdown),
             pytest.raises(
                 StreamingDeliveryError,
                 match="Timed out shutting down stream delivery controller",
@@ -4576,9 +4576,9 @@ class TestStreamingBehavior:
             ),
         )
 
-        delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
-        delivery_task = asyncio.create_task(_drive_stream_delivery(mock_client, streaming, delivery_queue))
-        delivery_queue.put_nowait(_DeliveryRequest(force_refresh=True, allow_empty_progress=True))
+        delivery_queue: asyncio.Queue[DeliveryRequest | None] = asyncio.Queue()
+        delivery_task = asyncio.create_task(drive_stream_delivery(mock_client, streaming, delivery_queue))
+        delivery_queue.put_nowait(DeliveryRequest(force_refresh=True, allow_empty_progress=True))
 
         async def response_stream() -> AsyncIterator[object]:
             await first_send_started.wait()
@@ -4594,7 +4594,7 @@ class TestStreamingBehavior:
             await asyncio.sleep(0)
             allow_first_send_to_finish.set()
             await consume_task
-            shutdown_error = await _shutdown_stream_delivery(delivery_queue, delivery_task)
+            shutdown_error = await shutdown_stream_delivery(delivery_queue, delivery_task)
 
         assert shutdown_error is None
         assert mock_client.room_send.call_count == 2

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -31,7 +31,7 @@ from mindroom.matrix.cache.thread_history_result import (
     THREAD_HISTORY_SOURCE_HOMESERVER,
     THREAD_HISTORY_SOURCE_STALE_CACHE,
 )
-from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
+from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.client import ResolvedVisibleMessage, RoomThreadsPageError, get_room_threads_page
 from mindroom.matrix.client_delivery import build_threaded_edit_content as _build_threaded_edit_content_impl
 from mindroom.matrix.client_thread_history import (
@@ -2265,13 +2265,13 @@ class TestThreadHistoryCache:
         client: nio.AsyncClient,
         event_cache: SqliteEventCache,
         runtime_started_at: float,
-    ) -> tuple[MatrixConversationCache, _EventCacheWriteCoordinator]:
+    ) -> tuple[MatrixConversationCache, EventCacheWriteCoordinator]:
         runtime_paths = test_runtime_paths(tmp_path)
         config = bind_runtime_paths(
             Config(agents={"general": AgentConfig(display_name="General Agent")}),
             runtime_paths,
         )
-        coordinator = _EventCacheWriteCoordinator(logger=MagicMock(), background_task_owner=object())
+        coordinator = EventCacheWriteCoordinator(logger=MagicMock(), background_task_owner=object())
         runtime = BotRuntimeState(
             client=client,
             config=config,

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -23,7 +23,7 @@ from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
 from mindroom.conversation_resolver import MessageContext
 from mindroom.matrix.cache import ThreadHistoryResult
 from mindroom.matrix.cache.event_cache import ThreadCacheState
-from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
+from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.users import AgentMatrixUser
@@ -1301,7 +1301,7 @@ class TestExtractedModuleLoggerRebinding:
         event_cache = AsyncMock()
         event_cache.append_event.side_effect = RuntimeError("cache write failed")
         bot.event_cache = event_cache
-        bot.event_cache_write_coordinator = _EventCacheWriteCoordinator(
+        bot.event_cache_write_coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=bot._runtime_view,
         )

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -52,7 +52,7 @@ from mindroom.matrix.cache.thread_writes import (
     _apply_thread_redaction_mutation,
     _collect_sync_timeline_cache_updates,
 )
-from mindroom.matrix.cache.write_coordinator import _EventCacheWriteCoordinator
+from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.client import DeliveredMatrixEvent, PermanentMatrixStartupError, ResolvedVisibleMessage
 from mindroom.matrix.conversation_cache import MatrixConversationCache
 from mindroom.matrix.event_info import EventInfo
@@ -266,9 +266,9 @@ def _runtime_event_cache() -> AsyncMock:
     return make_event_cache_mock()
 
 
-def _runtime_write_coordinator() -> _EventCacheWriteCoordinator:
+def _runtime_write_coordinator() -> EventCacheWriteCoordinator:
     """Return one real coordinator for runtime-state tests."""
-    return _EventCacheWriteCoordinator(
+    return EventCacheWriteCoordinator(
         logger=MagicMock(),
         background_task_owner=object(),
     )
@@ -361,7 +361,7 @@ def _conversation_runtime(
     *,
     client: nio.AsyncClient | None = None,
     event_cache: SqliteEventCache | None = None,
-    coordinator: _EventCacheWriteCoordinator | None = None,
+    coordinator: EventCacheWriteCoordinator | None = None,
 ) -> BotRuntimeState:
     """Build one minimal live runtime state for conversation-cache tests."""
     config = _conversation_runtime_config()
@@ -514,9 +514,9 @@ async def _assert_thread_read_guard_rejects_cache_when_unknown_live_mutation_rac
     client.room_messages.assert_awaited_once()
 
 
-def _install_runtime_write_coordinator(bot: AgentBot) -> _EventCacheWriteCoordinator:
+def _install_runtime_write_coordinator(bot: AgentBot) -> EventCacheWriteCoordinator:
     """Attach one explicit runtime write coordinator to a bot test double."""
-    coordinator = _EventCacheWriteCoordinator(
+    coordinator = EventCacheWriteCoordinator(
         logger=MagicMock(),
         background_task_owner=bot._runtime_view,
     )
@@ -1854,7 +1854,7 @@ class TestThreadingBehavior:
         )
 
         shared_cache = SqliteEventCache(bot.config.cache.resolve_db_path(bot.runtime_paths))
-        shared_coordinator = _EventCacheWriteCoordinator(
+        shared_coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -3273,7 +3273,7 @@ class TestThreadingBehavior:
         )
         event_cache.append_event = AsyncMock()
         bot.event_cache = event_cache
-        bot.event_cache_write_coordinator = _EventCacheWriteCoordinator(
+        bot.event_cache_write_coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=bot._runtime_view,
         )
@@ -3316,7 +3316,7 @@ class TestThreadingBehavior:
         event_cache.get_event = AsyncMock(return_value=None)
         event_cache.append_event = AsyncMock()
         bot.event_cache = event_cache
-        bot.event_cache_write_coordinator = _EventCacheWriteCoordinator(
+        bot.event_cache_write_coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=bot._runtime_view,
         )
@@ -3809,7 +3809,7 @@ class TestThreadingBehavior:
         real_event_cache = SqliteEventCache(bot.storage_path / "plain-reply-thread-membership.db")
         await real_event_cache.initialize()
         bot.event_cache = real_event_cache
-        bot.event_cache_write_coordinator = _EventCacheWriteCoordinator(
+        bot.event_cache_write_coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=bot._runtime_view,
         )
@@ -3875,7 +3875,7 @@ class TestThreadingBehavior:
         real_event_cache = SqliteEventCache(bot.storage_path / "plain-reply-second-hop-membership.db")
         await real_event_cache.initialize()
         bot.event_cache = real_event_cache
-        bot.event_cache_write_coordinator = _EventCacheWriteCoordinator(
+        bot.event_cache_write_coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=bot._runtime_view,
         )
@@ -3958,7 +3958,7 @@ class TestThreadingBehavior:
         real_event_cache = SqliteEventCache(bot.storage_path / "media-ingress-thread-membership.db")
         await real_event_cache.initialize()
         bot.event_cache = real_event_cache
-        bot.event_cache_write_coordinator = _EventCacheWriteCoordinator(
+        bot.event_cache_write_coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=bot._runtime_view,
         )
@@ -4606,7 +4606,7 @@ class TestThreadingBehavior:
         real_event_cache = SqliteEventCache(bot.storage_path / "plain-reply-edit-thread-membership.db")
         await real_event_cache.initialize()
         bot.event_cache = real_event_cache
-        bot.event_cache_write_coordinator = _EventCacheWriteCoordinator(
+        bot.event_cache_write_coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=bot._runtime_view,
         )
@@ -4752,7 +4752,7 @@ class TestThreadingBehavior:
     @pytest.mark.asyncio
     async def test_wait_for_room_idle_returns_after_completed_tail_task(self) -> None:
         """Room-idle waiting should not livelock on a tail task that already finished."""
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -4845,7 +4845,7 @@ class TestThreadingBehavior:
         monkeypatch.setattr(timing_module, "logger", timing_logger)
         event_cache = _runtime_event_cache()
         coordinator_logger = MagicMock()
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=coordinator_logger,
             background_task_owner=object(),
         )
@@ -4913,7 +4913,7 @@ class TestThreadingBehavior:
     async def test_outbound_final_streaming_edit_is_preserved_after_coalesced_intermediates(self) -> None:
         """A final outbound stream edit should stay queued behind the latest intermediate edit."""
         event_cache = _runtime_event_cache()
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -4979,7 +4979,7 @@ class TestThreadingBehavior:
     async def test_outbound_plain_edits_are_not_coalesced(self) -> None:
         """Normal outbound edits should retain the existing one-cache-update-per-edit behavior."""
         event_cache = _runtime_event_cache()
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -5040,7 +5040,7 @@ class TestThreadingBehavior:
         monkeypatch.setenv("MINDROOM_TIMING", "1")
         timing_logger = MagicMock()
         monkeypatch.setattr(timing_module, "logger", timing_logger)
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -5102,7 +5102,7 @@ class TestThreadingBehavior:
             "mindroom.matrix.cache.write_coordinator.time.perf_counter",
             lambda: next(perf_counter_values),
         )
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -5138,7 +5138,7 @@ class TestThreadingBehavior:
         monkeypatch.setenv("MINDROOM_TIMING", "1")
         timing_logger = MagicMock()
         monkeypatch.setattr(timing_module, "logger", timing_logger)
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -5204,7 +5204,7 @@ class TestThreadingBehavior:
         monkeypatch.setenv("MINDROOM_TIMING", "1")
         timing_logger = MagicMock()
         monkeypatch.setattr(timing_module, "logger", timing_logger)
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -5249,7 +5249,7 @@ class TestThreadingBehavior:
         monkeypatch.setenv("MINDROOM_TIMING", "1")
         timing_logger = MagicMock()
         monkeypatch.setattr(timing_module, "logger", timing_logger)
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -5303,7 +5303,7 @@ class TestThreadingBehavior:
         monkeypatch.setenv("MINDROOM_TIMING", "1")
         timing_logger = MagicMock()
         monkeypatch.setattr(timing_module, "logger", timing_logger)
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -5358,7 +5358,7 @@ class TestThreadingBehavior:
         monkeypatch.setenv("MINDROOM_TIMING", "1")
         timing_logger = MagicMock()
         monkeypatch.setattr(timing_module, "logger", timing_logger)
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -5443,7 +5443,7 @@ class TestThreadingBehavior:
             "mindroom.matrix.cache.write_coordinator.time.perf_counter",
             Mock(side_effect=AssertionError("perf_counter should stay unused when timing is disabled")),
         )
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=object(),
         )
@@ -6780,7 +6780,7 @@ class TestThreadingBehavior:
         allow_first_failure = asyncio.Event()
         second_update_finished = asyncio.Event()
         owner = object()
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=owner,
         )
@@ -6825,7 +6825,7 @@ class TestThreadingBehavior:
         release_first_update = asyncio.Event()
         second_update_started = asyncio.Event()
         owner = object()
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=owner,
         )
@@ -6874,7 +6874,7 @@ class TestThreadingBehavior:
         release_first_update = asyncio.Event()
         second_update_started = asyncio.Event()
         owner = object()
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=owner,
         )
@@ -6920,7 +6920,7 @@ class TestThreadingBehavior:
         sibling_thread_started = asyncio.Event()
         release_sibling_thread = asyncio.Event()
         owner = object()
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=owner,
         )
@@ -7324,7 +7324,7 @@ class TestThreadingBehavior:
         release_blocker = asyncio.Event()
         queued_update_started = asyncio.Event()
         owner = object()
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=owner,
         )
@@ -7367,7 +7367,7 @@ class TestThreadingBehavior:
         release_first_update = asyncio.Event()
         third_update_started = asyncio.Event()
         owner = object()
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=owner,
         )
@@ -7427,7 +7427,7 @@ class TestThreadingBehavior:
         follow_up_thread_started = asyncio.Event()
         release_follow_up_thread = asyncio.Event()
         owner = object()
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=owner,
         )
@@ -7612,7 +7612,7 @@ class TestThreadingBehavior:
     async def test_run_room_update_does_not_log_handled_exception_as_background_failure(self) -> None:
         """Awaited room updates should not be logged as unhandled background task failures."""
         owner = object()
-        coordinator = _EventCacheWriteCoordinator(
+        coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
             background_task_owner=owner,
         )

--- a/tests/test_tool_config_sync.py
+++ b/tests/test_tool_config_sync.py
@@ -9,7 +9,7 @@ import pytest
 # Import tools to ensure they're registered
 import mindroom.tools  # noqa: F401
 from mindroom.constants import RuntimePaths
-from mindroom.tool_system.metadata import _TOOL_REGISTRY, TOOL_METADATA, ToolManagedInitArg
+from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, ToolManagedInitArg
 from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
 
 SKIP_CUSTOM = {"homeassistant", "gmail", "google_calendar", "google_drive", "google_sheets", "openclaw_compat"}
@@ -23,12 +23,12 @@ IGNORED_AGNO_PARAMS = {
 }
 
 
-@pytest.mark.parametrize("tool_name", list(_TOOL_REGISTRY.keys()))
+@pytest.mark.parametrize("tool_name", list(TOOL_REGISTRY.keys()))
 def test_all(tool_name: str) -> None:
     """Test that all tools have matching ConfigFields and agno parameters."""
     if tool_name in SKIP_CUSTOM:
         pytest.skip(f"{tool_name} is a custom tool, skipping test")
-    tool_factory = _TOOL_REGISTRY[tool_name]
+    tool_factory = TOOL_REGISTRY[tool_name]
     try:
         tool_class = tool_factory()
     except NotImplementedError:

--- a/tests/test_tool_dependencies.py
+++ b/tests/test_tool_dependencies.py
@@ -24,8 +24,8 @@ from mindroom.tool_system.dependencies import (
     install_command_for_current_python,
 )
 from mindroom.tool_system.metadata import (
-    _TOOL_REGISTRY,
     TOOL_METADATA,
+    TOOL_REGISTRY,
     SetupType,
     ToolCategory,
     ToolMetadata,
@@ -54,7 +54,7 @@ def test_all_tools_can_be_imported() -> None:
     """Test that all registered tools can be imported from the registry."""
     failed = []
 
-    for tool_name, factory in _TOOL_REGISTRY.items():
+    for tool_name, factory in TOOL_REGISTRY.items():
         metadata = TOOL_METADATA.get(tool_name)
         requires_config = metadata and metadata.status == ToolStatus.REQUIRES_CONFIG
 
@@ -188,7 +188,7 @@ def test_get_tool_by_name_retries_after_auto_install(monkeypatch: pytest.MonkeyP
             raise ImportError(msg)
         return DummyToolkit
 
-    _TOOL_REGISTRY[tool_name] = flaky_factory
+    TOOL_REGISTRY[tool_name] = flaky_factory
     TOOL_METADATA[tool_name] = ToolMetadata(
         name=tool_name,
         display_name="Auto Install Test Tool",
@@ -209,7 +209,7 @@ def test_get_tool_by_name_retries_after_auto_install(monkeypatch: pytest.MonkeyP
         assert isinstance(tool, DummyToolkit)
         assert calls["count"] == 2
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 
@@ -232,7 +232,7 @@ def test_get_tool_by_name_raises_when_auto_install_fails(monkeypatch: pytest.Mon
         msg = "dependency missing forever"
         raise ImportError(msg)
 
-    _TOOL_REGISTRY[tool_name] = failing_factory
+    TOOL_REGISTRY[tool_name] = failing_factory
     TOOL_METADATA[tool_name] = ToolMetadata(
         name=tool_name,
         display_name="Auto Install Failure Tool",
@@ -252,7 +252,7 @@ def test_get_tool_by_name_raises_when_auto_install_fails(monkeypatch: pytest.Mon
         with pytest.raises(ImportError, match="dependency missing forever"):
             get_tool_by_name(tool_name, TEST_RUNTIME_PATHS, worker_target=None)
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -51,7 +51,7 @@ from mindroom.orchestrator import _MultiAgentOrchestrator
 from mindroom.sync_bridge_state import is_loop_blocked_by_sync_tool_bridge
 from mindroom.tool_approval import _shutdown_approval_store
 from mindroom.tool_system import tool_hooks
-from mindroom.tool_system.metadata import _TOOL_REGISTRY, TOOL_METADATA, ToolCategory, register_tool_with_metadata
+from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, ToolCategory, register_tool_with_metadata
 from mindroom.tool_system.runtime_context import (
     ToolDispatchContext,
     ToolRuntimeContext,
@@ -2639,7 +2639,7 @@ async def test_agent_bot_tool_runtime_context_routes_custom_events_from_tool_hoo
         async def echo(self, text: str) -> str:
             return text.upper()
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
 
     @register_tool_with_metadata(
@@ -2729,8 +2729,8 @@ async def test_agent_bot_tool_runtime_context_routes_custom_events_from_tool_hoo
             ),
         ]
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
 
@@ -2912,7 +2912,7 @@ async def test_create_agent_prepends_bridge_to_real_tool_functions(tmp_path: Pat
             self.calls.append(text)
             return text
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
 
     @register_tool_with_metadata(
@@ -2964,8 +2964,8 @@ async def test_create_agent_prepends_bridge_to_real_tool_functions(tmp_path: Pat
         assert DemoToolkit.calls == []
         assert after_seen == [(config, runtime_paths_for(config), str(plugin_state_root), True)]
     finally:
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
 

--- a/tests/test_tool_system_facade_boundaries.py
+++ b/tests/test_tool_system_facade_boundaries.py
@@ -161,6 +161,7 @@ def _catalog_private_importers() -> dict[str, set[str]]:
 
 
 def _private_registry_state_importers_outside_tool_system() -> set[tuple[str, str]]:
+    private_registry_state_exports = _private_registry_state_exports()
     importers: set[tuple[str, str]] = set()
     for py_path in SOURCE_ROOT.rglob("*.py"):
         if py_path.is_relative_to(SOURCE_ROOT / "tool_system"):
@@ -173,7 +174,7 @@ def _private_registry_state_importers_outside_tool_system() -> set[tuple[str, st
                 and _resolve_import_from_module(importer_module, node) == "mindroom.tool_system.registry_state"
             ):
                 for alias in node.names:
-                    if alias.name.startswith("_"):
+                    if alias.name in private_registry_state_exports:
                         importers.add((importer_module, alias.name))
             elif isinstance(node, ast.Import):
                 for alias in node.names:
@@ -291,7 +292,7 @@ def test_tach_does_not_expose_catalog_private_registry_helpers() -> None:
 def test_private_registry_state_import_is_whitelisted_outside_tool_system() -> None:
     """Only the MCP registry may import private registry state directly outside tool_system."""
     assert _private_registry_state_importers_outside_tool_system() == {
-        ("mindroom.mcp.registry", "_TOOL_REGISTRY"),
+        ("mindroom.mcp.registry", "TOOL_REGISTRY"),
     }
 
 

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -34,15 +34,15 @@ from mindroom.tool_system.metadata import (
     serialize_tool_validation_snapshot,
 )
 from mindroom.tool_system.registry_state import (
-    _PLUGIN_MODULE_PREFIX,
-    _TOOL_REGISTRY,
+    PLUGIN_MODULE_PREFIX,
     TOOL_METADATA,
-    _capture_tool_registry_snapshot,
-    _restore_tool_registry_snapshot,
+    TOOL_REGISTRY,
+    capture_tool_registry_snapshot,
+    restore_tool_registry_snapshot,
 )
 from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, resolve_worker_target
 
-_BASE_TOOL_REGISTRY = _TOOL_REGISTRY.copy()
+_BASE_TOOL_REGISTRY = TOOL_REGISTRY.copy()
 _BASE_TOOL_METADATA = TOOL_METADATA.copy()
 _SKIP_PARALLEL_FACTORY_IMPORTS = {"daytona", "openbb"}
 _OPTIONAL_TOOL_IMPORTS = frozenset({"telegram"})
@@ -50,8 +50,8 @@ _OPTIONAL_TOOL_IMPORTS = frozenset({"telegram"})
 
 def _restore_builtin_tool_metadata_state() -> None:
     """Reset tool registries to the built-in metadata snapshot."""
-    _TOOL_REGISTRY.clear()
-    _TOOL_REGISTRY.update(_BASE_TOOL_REGISTRY)
+    TOOL_REGISTRY.clear()
+    TOOL_REGISTRY.update(_BASE_TOOL_REGISTRY)
     TOOL_METADATA.clear()
     TOOL_METADATA.update(_BASE_TOOL_METADATA)
 
@@ -113,7 +113,7 @@ def test_export_tools_metadata_json_resets_leaked_registry_entries() -> None:
         exported_names = {tool["name"] for tool in export_tools_metadata()}
         assert tool_name not in exported_names
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
         _restore_builtin_tool_metadata_state()
 
@@ -137,7 +137,7 @@ def test_plugin_validation_uses_sys_modules_snapshot(tmp_path: Path, monkeypatch
     snapshot_modules = SnapshotOnlyModules(sys.modules.copy())
     monkeypatch.setattr(metadata_module.sys, "modules", snapshot_modules)
 
-    snapshot = _capture_tool_registry_snapshot()
+    snapshot = capture_tool_registry_snapshot()
     assert isinstance(snapshot.plugin_modules, dict)
 
     module_name = _execute_validation_plugin_module("demo", plugin_root, module_path, {})
@@ -191,8 +191,8 @@ def test_restore_tool_registry_snapshot_uses_sys_modules_snapshot(
         def copy(self) -> dict[str, ModuleType]:
             return dict(self)
 
-    snapshot = _capture_tool_registry_snapshot()
-    leaked_module_name = f"{_PLUGIN_MODULE_PREFIX}leaked"
+    snapshot = capture_tool_registry_snapshot()
+    leaked_module_name = f"{PLUGIN_MODULE_PREFIX}leaked"
     assert leaked_module_name not in snapshot.plugin_modules
 
     leaked_module = ModuleType(leaked_module_name)
@@ -202,7 +202,7 @@ def test_restore_tool_registry_snapshot_uses_sys_modules_snapshot(
     snapshot_modules[leaked_module_name] = leaked_module
     monkeypatch.setattr(metadata_module.sys, "modules", snapshot_modules)
 
-    _restore_tool_registry_snapshot(snapshot)
+    restore_tool_registry_snapshot(snapshot)
 
     assert leaked_module_name not in metadata_module.sys.modules
 
@@ -242,7 +242,7 @@ def test_registered_tools_declare_managed_init_args_for_explicit_constructor_inp
     """Built-in tools must opt in explicitly instead of relying on hidden constructor inference."""
     managed_arg_names = {managed_arg.value for managed_arg in ToolManagedInitArg}
 
-    for tool_name, tool_factory in _TOOL_REGISTRY.items():
+    for tool_name, tool_factory in TOOL_REGISTRY.items():
         metadata = TOOL_METADATA[tool_name]
         if tool_name in _SKIP_PARALLEL_FACTORY_IMPORTS:
             continue
@@ -265,7 +265,7 @@ def test_registered_tools_declare_managed_init_args_for_explicit_constructor_inp
         )
 
     for tool_name, metadata in TOOL_METADATA.items():
-        if tool_name not in _TOOL_REGISTRY:
+        if tool_name not in TOOL_REGISTRY:
             assert metadata.managed_init_args == (), (
                 f"{tool_name} is metadata-only and should not declare managed init args: "
                 f"{[managed_arg.value for managed_arg in metadata.managed_init_args]}"
@@ -305,7 +305,7 @@ def test_get_tool_by_name_does_not_infer_hidden_constructor_kwargs(tmp_path: Pat
                 worker_target=None,
             )
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 
@@ -367,7 +367,7 @@ def test_get_tool_by_name_passes_declared_managed_init_args(tmp_path: Path) -> N
             worker_key=None,
         )
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 
@@ -411,7 +411,7 @@ def test_validate_authored_overrides_accepts_declared_field_types_and_nulls() ->
             "endpoint": "https://example.com",
         }
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 
@@ -442,7 +442,7 @@ def test_validate_authored_overrides_accepts_inherit_sentinel_for_required_field
             config_path_prefix="agents.code.tools[0]",
         ) == {"workspace_id": _AUTHORED_OVERRIDE_INHERIT}
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 
@@ -476,7 +476,7 @@ def test_validate_authored_overrides_accepts_string_lists_for_text_fields_with_a
             config_path_prefix="agents.code.tools[0]",
         ) == {"patterns": "GITEA_*, WHISPER_URL"}
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 
@@ -534,7 +534,7 @@ def test_validate_authored_overrides_rejects_bad_types_and_password_fields() -> 
                 config_path_prefix="agents.code.tools[0]",
             )
     finally:
-        _TOOL_REGISTRY.pop(tool_name, None)
+        TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
 
 

--- a/tests/test_workloop_thread_scope.py
+++ b/tests/test_workloop_thread_scope.py
@@ -44,7 +44,7 @@ from mindroom.hooks.registry import HookRegistryState
 from mindroom.logging_config import get_logger
 from mindroom.message_target import MessageTarget
 from mindroom.scheduling import ScheduledWorkflow
-from mindroom.tool_system.metadata import _TOOL_REGISTRY, TOOL_METADATA, get_tool_by_name
+from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, get_tool_by_name
 from mindroom.tool_system.plugins import load_plugins
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 from mindroom.tool_system.skills import _get_plugin_skill_roots, set_plugin_skill_roots
@@ -272,7 +272,7 @@ def loaded_workloop(tmp_path: Path) -> Generator[_LoadedWorkloop, None, None]:
         runtime_paths,
     )
 
-    original_registry = _TOOL_REGISTRY.copy()
+    original_registry = TOOL_REGISTRY.copy()
     original_metadata = TOOL_METADATA.copy()
     original_plugin_roots = _get_plugin_skill_roots()
     original_plugin_cache = plugin_module._PLUGIN_CACHE.copy()
@@ -292,8 +292,8 @@ def loaded_workloop(tmp_path: Path) -> Generator[_LoadedWorkloop, None, None]:
         for module_name in list(sys.modules):
             if module_name == "plugins.workloop" or module_name.startswith("plugins.workloop."):
                 sys.modules.pop(module_name, None)
-        _TOOL_REGISTRY.clear()
-        _TOOL_REGISTRY.update(original_registry)
+        TOOL_REGISTRY.clear()
+        TOOL_REGISTRY.update(original_registry)
         TOOL_METADATA.clear()
         TOOL_METADATA.update(original_metadata)
         plugin_module._PLUGIN_CACHE.clear()

--- a/uv.lock
+++ b/uv.lock
@@ -4243,7 +4243,7 @@ dev = [
     { name = "markdown-gfm-admonition" },
     { name = "pre-commit", specifier = ">=4.2" },
     { name = "pre-commit-uv", specifier = ">=4.1.4" },
-    { name = "privata", specifier = ">=0.1.7" },
+    { name = "privata", specifier = ">=0.2.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
@@ -6039,11 +6039,11 @@ wheels = [
 
 [[package]]
 name = "privata"
-version = "0.1.7"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/47/0d8678f9691e676fbaaa849a2996407faebeb7c9e228d19cd6bade866b39/privata-0.1.7.tar.gz", hash = "sha256:4d0b6493f6f7827e025933a6b52ff6e353ddc0cbd39e98ea2edecdb94403863f", size = 63288, upload-time = "2026-05-06T01:10:48.881Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/cf/2718134675043c14d3422ed5102ab49247ab2327748fc56deff35da1287a/privata-0.2.0.tar.gz", hash = "sha256:19752d0f27769c736acc0e70ab91b0c686549bc93326cd4f2804aa7f5802b208", size = 64315, upload-time = "2026-05-06T02:34:01.28Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/de/ea7e4f3306487fc915b3cdffae1368fd64e7eabd7f6632c527f6eb5788da/privata-0.1.7-py3-none-any.whl", hash = "sha256:b4f83d3b2c107c663053228c124ea11fccabe1e3bdc7ae1932b55963aa8d375a", size = 15543, upload-time = "2026-05-06T01:10:47.255Z" },
+    { url = "https://files.pythonhosted.org/packages/27/68/f16ede7bd586950bd431c6b6ac282c8405af09bc6b550c94376f4f7dc5ac/privata-0.2.0-py3-none-any.whl", hash = "sha256:b35621e706f898c8d559e10190fd58c9bd53f7b758382b5aa3aeab92a57f94a8", size = 16118, upload-time = "2026-05-06T02:34:00.097Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- update the dev dependency requirement for Privata to the 0.2 series
- refresh `uv.lock` to install `privata==0.2.0`
- rename intentionally shared cross-module helpers from private underscore names to public names
- update Tach interfaces for the now-public restricted module surfaces

## Verification
- `uv run ruff check src tests`
- `uv run tach check --dependencies --interfaces`
- `uv run privata .`
- `uv run pytest` - 6222 passed, 56 skipped
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* **API Restructuring**: Extensive refactoring to expose internal utilities as public APIs across sandbox runner, attachments, config management, custom tools, streaming, and tool system modules, improving stability and consistency of public interfaces.
* **Dependency Update**: Bumped `privata` from 0.1.7 to 0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->