### PR TITLE
Extract Google service account fallback helper

### DIFF
--- a/src/mindroom/custom_tools/gmail.py
+++ b/src/mindroom/custom_tools/gmail.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from agno.tools.gmail import GmailTools as AgnoGmailTools
 
-from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin
+from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, google_service_account_configured
 from mindroom.logging_config import get_logger
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.oauth.google_gmail import google_gmail_oauth_provider
@@ -64,5 +64,4 @@ class GmailTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, AgnoGmai
         self._wrap_oauth_function_entrypoints()
 
     def _should_fallback_to_original_auth(self) -> bool:
-        """Prefer the upstream auth path when a service account is configured."""
-        return bool(self.service_account_path or self._runtime_paths.env_value("GOOGLE_SERVICE_ACCOUNT_FILE"))
+        return google_service_account_configured(self.service_account_path, self._runtime_paths)

--- a/src/mindroom/custom_tools/google_calendar.py
+++ b/src/mindroom/custom_tools/google_calendar.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from agno.tools.googlecalendar import GoogleCalendarTools as AgnoGoogleCalendarTools
 
-from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin
+from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, google_service_account_configured
 from mindroom.logging_config import get_logger
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.oauth.google_calendar import google_calendar_oauth_provider
@@ -75,5 +75,4 @@ class GoogleCalendarTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin,
         self._wrap_oauth_function_entrypoints()
 
     def _should_fallback_to_original_auth(self) -> bool:
-        """Prefer the upstream auth path when a service account is configured."""
-        return bool(self.service_account_path or self._runtime_paths.env_value("GOOGLE_SERVICE_ACCOUNT_FILE"))
+        return google_service_account_configured(self.service_account_path, self._runtime_paths)

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from agno.tools.google.drive import GoogleDriveTools as AgnoGoogleDriveTools
 
-from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin
+from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, google_service_account_configured
 from mindroom.logging_config import get_logger
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.oauth.google_drive import google_drive_oauth_provider
@@ -93,5 +93,4 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
         raise TypeError(msg)
 
     def _should_fallback_to_original_auth(self) -> bool:
-        """Prefer the upstream auth path when a service account is configured."""
-        return bool(self.service_account_path or self._runtime_paths.env_value("GOOGLE_SERVICE_ACCOUNT_FILE"))
+        return google_service_account_configured(self.service_account_path, self._runtime_paths)

--- a/src/mindroom/custom_tools/google_service.py
+++ b/src/mindroom/custom_tools/google_service.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import threading
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from mindroom.constants import RuntimePaths
 
 
 class _GoogleServiceThreadState(threading.local):
     def __init__(self) -> None:
         self.service: Any | None = None
+
+
+def google_service_account_configured(service_account_path: str | None, runtime_paths: RuntimePaths) -> bool:
+    """Return whether Google upstream service-account auth is configured."""
+    return bool(service_account_path or runtime_paths.env_value("GOOGLE_SERVICE_ACCOUNT_FILE"))
 
 
 class ThreadLocalGoogleServiceMixin:

--- a/src/mindroom/custom_tools/google_sheets.py
+++ b/src/mindroom/custom_tools/google_sheets.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from agno.tools.googlesheets import GoogleSheetsTools as AgnoGoogleSheetsTools
 
-from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin
+from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, google_service_account_configured
 from mindroom.logging_config import get_logger
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.oauth.google_sheets import google_sheets_oauth_provider
@@ -71,8 +71,7 @@ class GoogleSheetsTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, A
         self._wrap_oauth_function_entrypoints()
 
     def _should_fallback_to_original_auth(self) -> bool:
-        """Prefer the upstream auth path when a service account is configured."""
-        return bool(self.service_account_path or self._runtime_paths.env_value("GOOGLE_SERVICE_ACCOUNT_FILE"))
+        return google_service_account_configured(self.service_account_path, self._runtime_paths)
 
     def _normalize_dashboard_config_kwargs(self, kwargs: dict[str, Any]) -> None:
         """Map dashboard field names onto Agno's constructor argument names."""

--- a/tests/test_google_tool_wrappers.py
+++ b/tests/test_google_tool_wrappers.py
@@ -15,7 +15,7 @@ from mindroom.custom_tools import google_service
 from mindroom.custom_tools.gmail import GmailTools
 from mindroom.custom_tools.google_calendar import GoogleCalendarTools
 from mindroom.custom_tools.google_drive import GoogleDriveTools
-from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin
+from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, google_service_account_configured
 from mindroom.custom_tools.google_sheets import GoogleSheetsTools
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.tool_system.metadata import get_tool_by_name
@@ -141,6 +141,25 @@ def test_google_service_state_first_access_is_thread_safe(monkeypatch: pytest.Mo
         results = list(executor.map(lambda _: set_and_read_thread_service(), range(2)))
 
     assert results == [True, True]
+
+
+def test_google_service_account_configured_checks_instance_and_runtime_values(
+    runtime_paths: RuntimePaths,
+    tmp_path: Path,
+) -> None:
+    """Service-account fallback should honor explicit and runtime configuration."""
+    service_account_path = tmp_path / "service-account.json"
+    runtime_paths_with_env = replace(
+        runtime_paths,
+        process_env={
+            **runtime_paths.process_env,
+            "GOOGLE_SERVICE_ACCOUNT_FILE": str(service_account_path),
+        },
+    )
+
+    assert google_service_account_configured(str(service_account_path), runtime_paths) is True
+    assert google_service_account_configured(None, runtime_paths_with_env) is True
+    assert google_service_account_configured(None, runtime_paths) is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Extract shared Google service-account fallback predicate into `custom_tools.google_service`
- Reuse it from Gmail, Calendar, Drive, and Sheets wrappers without changing constructors or OAuth flow ordering
- Add a focused helper test for explicit service-account path, runtime env fallback, and no-config behavior

## Verification
- `uv sync --all-extras`
- `uv run pytest tests/test_google_tool_wrappers.py::test_google_service_account_configured_checks_instance_and_runtime_values -n 0 --no-cov -v` (red before helper, green after)
- `uv run pytest tests/test_google_tool_wrappers.py tests/test_google_calendar_oauth_tool.py tests/test_google_drive_oauth_tool.py tests/test_google_sheets_oauth_tool.py tests/test_gmail_tools.py -n 0 --no-cov -v`
- `uv run pre-commit run --files src/mindroom/custom_tools/gmail.py src/mindroom/custom_tools/google_calendar.py src/mindroom/custom_tools/google_drive.py src/mindroom/custom_tools/google_service.py src/mindroom/custom_tools/google_sheets.py tests/test_google_tool_wrappers.py`

## Notes
Production line delta across touched production files: +4 net lines.