### PR TITLE
Extract config validation helpers

### DIFF
--- a/src/mindroom/config/agent.py
+++ b/src/mindroom/config/agent.py
@@ -15,6 +15,7 @@ from mindroom.config.models import (
     ToolConfigEntry,
     validate_unique_tool_entries,
 )
+from mindroom.config.validation import duplicate_items, validate_history_limit_choice
 from mindroom.tool_system.worker_routing import WorkerScope, agent_workspace_relative_path
 
 CultureMode = Literal["automatic", "agentic", "manual"]
@@ -303,9 +304,10 @@ class AgentConfig(BaseModel):
 
     @model_validator(mode="after")
     def _check_history_config(self) -> Self:
-        if self.num_history_runs is not None and self.num_history_messages is not None:
-            msg = "num_history_runs and num_history_messages are mutually exclusive"
-            raise ValueError(msg)
+        validate_history_limit_choice(
+            num_history_runs=self.num_history_runs,
+            num_history_messages=self.num_history_messages,
+        )
         if self.private is not None and self.worker_scope is not None:
             msg = "Private agents derive their execution scope from private.per; configure private or worker_scope, not both"
             raise ValueError(msg)
@@ -344,7 +346,7 @@ class AgentConfig(BaseModel):
     @classmethod
     def validate_unique_allowed_toolkits(cls, toolkits: list[str]) -> list[str]:
         """Ensure each allowed toolkit is listed at most once."""
-        duplicates = _duplicate_items(toolkits)
+        duplicates = duplicate_items(toolkits)
         if duplicates:
             msg = f"Duplicate allowed_toolkits are not allowed: {', '.join(duplicates)}"
             raise ValueError(msg)
@@ -354,7 +356,7 @@ class AgentConfig(BaseModel):
     @classmethod
     def validate_unique_initial_toolkits(cls, toolkits: list[str]) -> list[str]:
         """Ensure each initial toolkit is listed at most once."""
-        duplicates = _duplicate_items(toolkits)
+        duplicates = duplicate_items(toolkits)
         if duplicates:
             msg = f"Duplicate initial_toolkits are not allowed: {', '.join(duplicates)}"
             raise ValueError(msg)
@@ -364,7 +366,7 @@ class AgentConfig(BaseModel):
     @classmethod
     def validate_unique_knowledge_bases(cls, knowledge_bases: list[str]) -> list[str]:
         """Ensure each knowledge base assignment appears at most once per agent."""
-        duplicates = _duplicate_items(knowledge_bases)
+        duplicates = duplicate_items(knowledge_bases)
         if duplicates:
             msg = f"Duplicate knowledge bases are not allowed: {', '.join(duplicates)}"
             raise ValueError(msg)
@@ -375,17 +377,6 @@ class AgentConfig(BaseModel):
     def validate_context_files(cls, values: list[str]) -> list[str]:
         """Ensure configured context files stay inside the canonical workspace."""
         return [agent_workspace_relative_path(value).as_posix() for value in values]
-
-
-def _duplicate_items(values: list[str]) -> list[str]:
-    """Return duplicate items while preserving first duplicate order."""
-    seen: set[str] = set()
-    duplicates: list[str] = []
-    for value in values:
-        if value in seen and value not in duplicates:
-            duplicates.append(value)
-        seen.add(value)
-    return duplicates
 
 
 class TeamConfig(BaseModel):
@@ -428,7 +419,7 @@ class TeamConfig(BaseModel):
     @classmethod
     def validate_unique_agents(cls, agents: list[str]) -> list[str]:
         """Ensure each team member appears at most once."""
-        duplicates = _duplicate_items(agents)
+        duplicates = duplicate_items(agents)
         if duplicates:
             msg = f"Duplicate agents are not allowed in a team: {', '.join(duplicates)}"
             raise ValueError(msg)
@@ -437,9 +428,10 @@ class TeamConfig(BaseModel):
     @model_validator(mode="after")
     def validate_history_settings(self) -> Self:
         """Ensure team history replay knobs stay unambiguous."""
-        if self.num_history_runs is not None and self.num_history_messages is not None:
-            msg = "num_history_runs and num_history_messages are mutually exclusive"
-            raise ValueError(msg)
+        validate_history_limit_choice(
+            num_history_runs=self.num_history_runs,
+            num_history_messages=self.num_history_messages,
+        )
         return self
 
 
@@ -457,7 +449,7 @@ class CultureConfig(BaseModel):
     @classmethod
     def validate_unique_agents(cls, agents: list[str]) -> list[str]:
         """Ensure each agent is assigned at most once per culture."""
-        duplicates = _duplicate_items(agents)
+        duplicates = duplicate_items(agents)
         if duplicates:
             msg = f"Duplicate agents are not allowed in a culture: {', '.join(duplicates)}"
             raise ValueError(msg)

--- a/src/mindroom/config/auth.py
+++ b/src/mindroom/config/auth.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field, field_validator
 
+from mindroom.config.validation import duplicate_items
+
 
 class AuthorizationConfig(BaseModel):
     """Authorization configuration with fine-grained permissions."""
@@ -46,14 +48,7 @@ class AuthorizationConfig(BaseModel):
     @classmethod
     def validate_unique_aliases(cls, aliases: dict[str, list[str]]) -> dict[str, list[str]]:
         """Ensure each alias is assigned to at most one canonical user."""
-        seen_aliases: set[str] = set()
-        duplicates: list[str] = []
-        for alias_list in aliases.values():
-            for alias in alias_list:
-                if alias in seen_aliases and alias not in duplicates:
-                    duplicates.append(alias)
-                seen_aliases.add(alias)
-
+        duplicates = duplicate_items([alias for alias_list in aliases.values() for alias in alias_list])
         if duplicates:
             msg = f"Duplicate bridge aliases are not allowed: {', '.join(duplicates)}"
             raise ValueError(msg)

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, Self, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_serializer, model_validator
 
+from mindroom.config.validation import duplicate_items, validate_history_limit_choice
 from mindroom.credential_policy import credential_service_policy
 from mindroom.credentials import validate_service_name
 from mindroom.tool_system.worker_routing import WorkerScope  # noqa: TC001
@@ -190,13 +191,7 @@ def validate_unique_tool_entries(
     scope_name: str,
 ) -> list[ToolConfigEntry]:
     """Ensure each normalized tool name appears at most once within one scope."""
-    seen: set[str] = set()
-    duplicates: list[str] = []
-    for entry in tools:
-        if entry.name in seen and entry.name not in duplicates:
-            duplicates.append(entry.name)
-        seen.add(entry.name)
-
+    duplicates = duplicate_items([entry.name for entry in tools])
     if duplicates:
         msg = f"Duplicate {scope_name} tools are not allowed: {', '.join(duplicates)}"
         raise ValueError(msg)
@@ -423,9 +418,10 @@ class DefaultsConfig(BaseModel):
 
     @model_validator(mode="after")
     def _check_history_config(self) -> Self:
-        if self.num_history_runs is not None and self.num_history_messages is not None:
-            msg = "num_history_runs and num_history_messages are mutually exclusive"
-            raise ValueError(msg)
+        validate_history_limit_choice(
+            num_history_runs=self.num_history_runs,
+            num_history_messages=self.num_history_messages,
+        )
         return self
 
     @property

--- a/src/mindroom/config/validation.py
+++ b/src/mindroom/config/validation.py
@@ -1,0 +1,25 @@
+"""Small shared helpers for config validators."""
+
+from __future__ import annotations
+
+
+def duplicate_items(values: list[str]) -> list[str]:
+    """Return duplicate items while preserving first duplicate order."""
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for value in values:
+        if value in seen and value not in duplicates:
+            duplicates.append(value)
+        seen.add(value)
+    return duplicates
+
+
+def validate_history_limit_choice(
+    *,
+    num_history_runs: int | None,
+    num_history_messages: int | None,
+) -> None:
+    """Reject ambiguous history replay limit settings."""
+    if num_history_runs is not None and num_history_messages is not None:
+        msg = "num_history_runs and num_history_messages are mutually exclusive"
+        raise ValueError(msg)

--- a/tests/test_config_validation_helpers.py
+++ b/tests/test_config_validation_helpers.py
@@ -1,0 +1,107 @@
+"""Focused tests for shared config validation helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from mindroom.config.agent import AgentConfig, CultureConfig, TeamConfig
+from mindroom.config.auth import AuthorizationConfig
+from mindroom.config.models import DefaultsConfig, ToolkitDefinition
+from mindroom.config.validation import duplicate_items, validate_history_limit_choice
+
+
+def test_duplicate_items_preserves_first_duplicate_encounter_order() -> None:
+    """Duplicate reporting should follow the first repeated occurrence."""
+    assert duplicate_items(["alpha", "beta", "gamma", "beta", "alpha", "beta"]) == ["beta", "alpha"]
+
+
+def test_history_limit_choice_rejects_both_limits_with_existing_message() -> None:
+    """Shared history validation should keep the existing user-facing message."""
+    with pytest.raises(ValueError, match="num_history_runs and num_history_messages are mutually exclusive"):
+        validate_history_limit_choice(num_history_runs=2, num_history_messages=10)
+
+
+@pytest.mark.parametrize(
+    ("factory", "match"),
+    [
+        (
+            lambda: ToolkitDefinition(tools=["shell", "file", "shell", "file"]),
+            "Duplicate toolkit tools are not allowed: shell, file",
+        ),
+        (
+            lambda: AgentConfig(
+                display_name="Code",
+                allowed_toolkits=["dev", "research", "dev", "research"],
+            ),
+            "Duplicate allowed_toolkits are not allowed: dev, research",
+        ),
+        (
+            lambda: AgentConfig(
+                display_name="Code",
+                initial_toolkits=["dev", "research", "dev", "research"],
+            ),
+            "Duplicate initial_toolkits are not allowed: dev, research",
+        ),
+        (
+            lambda: AgentConfig(
+                display_name="Code",
+                knowledge_bases=["docs", "runbooks", "docs", "runbooks"],
+            ),
+            "Duplicate knowledge bases are not allowed: docs, runbooks",
+        ),
+        (
+            lambda: TeamConfig(
+                display_name="Team",
+                role="Work",
+                agents=["code", "research", "code", "research"],
+            ),
+            "Duplicate agents are not allowed in a team: code, research",
+        ),
+        (
+            lambda: CultureConfig(agents=["code", "research", "code", "research"]),
+            "Duplicate agents are not allowed in a culture: code, research",
+        ),
+        (
+            lambda: AuthorizationConfig(
+                aliases={
+                    "@alice:example.com": ["@telegram_1:example.com", "@discord_1:example.com"],
+                    "@bob:example.com": ["@telegram_1:example.com", "@discord_1:example.com"],
+                },
+            ),
+            "Duplicate bridge aliases are not allowed: @telegram_1:example.com, @discord_1:example.com",
+        ),
+    ],
+)
+def test_duplicate_validators_preserve_error_order(factory: object, match: str) -> None:
+    """Config duplicate validators should preserve encounter-ordered duplicate names."""
+    with pytest.raises(ValueError, match=match):
+        factory()
+
+
+@pytest.mark.parametrize(
+    ("factory", "match"),
+    [
+        (
+            lambda: DefaultsConfig(num_history_runs=2, num_history_messages=10),
+            "num_history_runs and num_history_messages are mutually exclusive",
+        ),
+        (
+            lambda: AgentConfig(display_name="Code", num_history_runs=2, num_history_messages=10),
+            "num_history_runs and num_history_messages are mutually exclusive",
+        ),
+        (
+            lambda: TeamConfig(
+                display_name="Team",
+                role="Work",
+                agents=["code"],
+                num_history_runs=2,
+                num_history_messages=10,
+            ),
+            "num_history_runs and num_history_messages are mutually exclusive",
+        ),
+    ],
+)
+def test_history_limit_validators_preserve_error_message(factory: object, match: str) -> None:
+    """Defaults, agents, and teams should reject ambiguous history limits consistently."""
+    with pytest.raises(ValueError, match=match):
+        factory()


### PR DESCRIPTION
## Summary
- Add a small shared config validation helper module for ordered duplicate detection and history-limit mutual exclusion.
- Reuse it from agent/team/culture, defaults/toolkit tools, and authorization alias validators while preserving existing error text and duplicate ordering.
- Add focused tests covering helper behavior and validator error ordering/messages.

## Test Plan
- uv run pytest tests/test_config_validation_helpers.py tests/test_dynamic_toolkits.py::test_config_rejects_duplicate_tool_entries_inside_one_toolkit tests/test_authorization.py::test_duplicate_bridge_alias_rejected tests/test_self_config.py::TestUpdateOwnConfig::test_update_rejects_mutually_exclusive_history_fields -n 0 --no-cov -q
- uv run pre-commit run --files src/mindroom/config/agent.py src/mindroom/config/auth.py src/mindroom/config/models.py src/mindroom/config/validation.py tests/test_config_validation_helpers.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated configuration validation logic to ensure consistent duplicate detection and history-limit enforcement across agent, authorization, and model configurations.

* **Tests**
  * Added comprehensive test coverage for configuration validation helpers to verify error handling and detection order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->