### PR TITLE
Refactor API snapshot publication

### DIFF
--- a/src/mindroom/api/config_lifecycle.py
+++ b/src/mindroom/api/config_lifecycle.py
@@ -308,11 +308,15 @@ def _request_or_current_snapshot(request: Request) -> ApiSnapshot:
 def _published_snapshot(
     snapshot: ApiSnapshot,
     *,
+    increment_generation: bool = True,
+    runtime_paths: constants.RuntimePaths | None = None,
     config_data: dict[str, Any] | None = None,
     runtime_config: Config | None | object = _UNSET,
     config_load_result: ConfigLoadResult | None | object = _UNSET,
+    auth_state: object = _UNSET,
 ) -> ApiSnapshot:
     """Return one new published snapshot with an incremented generation."""
+    updated_runtime_paths = snapshot.runtime_paths if runtime_paths is None else runtime_paths
     updated_config_data = snapshot.config_data if config_data is None else config_data
     updated_runtime_config = (
         snapshot.runtime_config if runtime_config is _UNSET else cast("Config | None", runtime_config)
@@ -322,12 +326,15 @@ def _published_snapshot(
         if config_load_result is _UNSET
         else cast("ConfigLoadResult | None", config_load_result)
     )
+    updated_auth_state = snapshot.auth_state if auth_state is _UNSET else auth_state
     return replace(
         snapshot,
-        generation=snapshot.generation + 1,
+        generation=snapshot.generation + 1 if increment_generation else snapshot.generation,
+        runtime_paths=updated_runtime_paths,
         config_data=updated_config_data,
         runtime_config=updated_runtime_config,
         config_load_result=updated_load_result,
+        auth_state=updated_auth_state,
     )
 
 

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -5,7 +5,7 @@ import asyncio
 import threading
 from contextlib import asynccontextmanager, suppress
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -15,9 +15,9 @@ from pydantic import BaseModel, ConfigDict, Field
 from mindroom import constants
 from mindroom.agent_policy import build_agent_policy_seeds, resolve_agent_policy_index
 from mindroom.api import config_lifecycle
-from mindroom.api.auth import ApiAuthState, verify_user
+from mindroom.api.auth import ApiAuthState, verify_user  # noqa: F401
 from mindroom.api.auth import router as auth_router
-from mindroom.api.config_lifecycle import ApiSnapshot, ApiState, ConfigLoadResult
+from mindroom.api.config_lifecycle import ApiSnapshot, ApiState, ConfigLoadResult  # noqa: F401
 
 # Import routers
 from mindroom.api.credentials import router as credentials_router
@@ -53,7 +53,6 @@ if TYPE_CHECKING:
 
     from mindroom.config.main import Config
 logger = get_logger(__name__)
-_UNSET = object()
 _WORKER_CLEANUP_INTERVAL_ENV = "MINDROOM_WORKER_CLEANUP_INTERVAL_SECONDS"
 
 
@@ -207,36 +206,6 @@ def _api_runtime_paths(request: Request) -> constants.RuntimePaths:
     return config_lifecycle.api_runtime_paths(request)
 
 
-def _published_snapshot(
-    snapshot: ApiSnapshot,
-    *,
-    increment_generation: bool = True,
-    runtime_paths: constants.RuntimePaths | None = None,
-    config_data: dict[str, Any] | None = None,
-    runtime_config: Config | None | object = _UNSET,
-    config_load_result: ConfigLoadResult | None | object = _UNSET,
-    auth_state: ApiAuthState | None | object = _UNSET,
-) -> ApiSnapshot:
-    """Return one new published snapshot with an incremented generation."""
-    updated_runtime_paths = snapshot.runtime_paths if runtime_paths is None else runtime_paths
-    updated_config_data = snapshot.config_data if config_data is None else config_data
-    updated_runtime_config = snapshot.runtime_config if runtime_config is _UNSET else runtime_config
-    updated_config_load_result = (
-        snapshot.config_load_result
-        if config_load_result is _UNSET
-        else cast("ConfigLoadResult | None", config_load_result)
-    )
-    updated_auth_state = snapshot.auth_state if auth_state is _UNSET else auth_state
-    return ApiSnapshot(
-        generation=snapshot.generation + 1 if increment_generation else snapshot.generation,
-        runtime_paths=updated_runtime_paths,
-        config_data=updated_config_data,
-        runtime_config=cast("Config | None", updated_runtime_config),
-        config_load_result=updated_config_load_result,
-        auth_state=updated_auth_state,
-    )
-
-
 def _app_context(api_app: FastAPI) -> ApiSnapshot:
     """Return the committed API snapshot for one app instance."""
     return config_lifecycle.require_api_state(api_app).snapshot
@@ -275,7 +244,7 @@ def initialize_api_app(api_app: FastAPI, runtime_paths: constants.RuntimePaths) 
         config_load_result = (
             current_snapshot.config_load_result if current_snapshot.runtime_paths == runtime_paths else None
         )
-        previous_state.snapshot = _published_snapshot(
+        previous_state.snapshot = config_lifecycle._published_snapshot(
             current_snapshot,
             runtime_paths=runtime_paths,
             config_data=config_data,

--- a/src/mindroom/api/runtime_reload.py
+++ b/src/mindroom/api/runtime_reload.py
@@ -2,50 +2,18 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
-
-from fastapi import FastAPI, HTTPException
+from typing import TYPE_CHECKING
 
 from mindroom.api import config_lifecycle
-from mindroom.api.config_lifecycle import ApiSnapshot, ConfigLoadResult
 from mindroom.workers.runtime import clear_worker_validation_snapshot_cache
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from fastapi import FastAPI
+
     from mindroom import constants
-    from mindroom.config.main import Config
-
-_UNSET = object()
-
-
-def _published_snapshot(
-    snapshot: ApiSnapshot,
-    *,
-    runtime_paths: constants.RuntimePaths | None = None,
-    config_data: dict[str, Any] | None = None,
-    runtime_config: Config | None | object = _UNSET,
-    config_load_result: ConfigLoadResult | None | object = _UNSET,
-    auth_state: object = _UNSET,
-) -> ApiSnapshot:
-    """Return one new published snapshot with an incremented generation."""
-    updated_runtime_paths = snapshot.runtime_paths if runtime_paths is None else runtime_paths
-    updated_config_data = snapshot.config_data if config_data is None else config_data
-    updated_runtime_config = snapshot.runtime_config if runtime_config is _UNSET else runtime_config
-    updated_config_load_result = (
-        snapshot.config_load_result
-        if config_load_result is _UNSET
-        else cast("ConfigLoadResult | None", config_load_result)
-    )
-    updated_auth_state = snapshot.auth_state if auth_state is _UNSET else auth_state
-    return ApiSnapshot(
-        generation=snapshot.generation + 1,
-        runtime_paths=updated_runtime_paths,
-        config_data=updated_config_data,
-        runtime_config=cast("Config | None", updated_runtime_config),
-        config_load_result=updated_config_load_result,
-        auth_state=updated_auth_state,
-    )
+    from mindroom.api.config_lifecycle import ApiSnapshot
 
 
 def _reload_api_runtime_config(
@@ -64,10 +32,7 @@ def _reload_api_runtime_config(
             current_snapshot.generation != expected_snapshot.generation
             or current_snapshot.runtime_paths != expected_snapshot.runtime_paths
         ):
-            raise HTTPException(
-                status_code=409,
-                detail="Configuration changed while request was in progress. Retry the operation.",
-            )
+            raise config_lifecycle._stale_snapshot_error()
         target_runtime_paths = runtime_paths if mutate_runtime is None else mutate_runtime(runtime_paths)
         app_state.api_auth_account_id = target_runtime_paths.env_value("ACCOUNT_ID")
         auth_state = current_snapshot.auth_state if current_snapshot.runtime_paths == target_runtime_paths else None
@@ -78,7 +43,7 @@ def _reload_api_runtime_config(
         config_load_result = (
             current_snapshot.config_load_result if current_snapshot.runtime_paths == target_runtime_paths else None
         )
-        refreshed_snapshot = _published_snapshot(
+        refreshed_snapshot = config_lifecycle._published_snapshot(
             current_snapshot,
             runtime_paths=target_runtime_paths,
             config_data=config_data,
@@ -88,7 +53,7 @@ def _reload_api_runtime_config(
         )
         api_state.snapshot = refreshed_snapshot
         result, validated_payload, loaded_runtime_config = config_lifecycle._load_config_result(target_runtime_paths)
-        api_state.snapshot = _published_snapshot(
+        api_state.snapshot = config_lifecycle._published_snapshot(
             refreshed_snapshot,
             config_data=validated_payload if validated_payload is not None else refreshed_snapshot.config_data,
             runtime_config=loaded_runtime_config

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -136,7 +136,7 @@ def _publish_committed_runtime_config(
     runtime_config = Config.validate_with_runtime(authored_payload, runtime_paths)
     context.config_data = runtime_config.authored_model_dump()
     context.runtime_config = runtime_config
-    context.config_load_result = main.ConfigLoadResult(success=True)
+    context.config_load_result = config_lifecycle.ConfigLoadResult(success=True)
     context.auth_state = None
 
 
@@ -152,6 +152,54 @@ def test_api_main_does_not_reexport_config_lifecycle_pass_through_helpers() -> N
         "_load_config_from_file",
     ):
         assert not hasattr(main, helper_name)
+
+
+def test_config_lifecycle_published_snapshot_owns_optional_runtime_fields(tmp_path: Path) -> None:
+    """Snapshot publication should preserve, replace, and clear every committed field centrally."""
+    first_runtime = constants.resolve_primary_runtime_paths(
+        config_path=tmp_path / "first.yaml",
+        process_env={},
+    )
+    second_runtime = constants.resolve_primary_runtime_paths(
+        config_path=tmp_path / "second.yaml",
+        process_env={},
+    )
+    runtime_config = Config.validate_with_runtime(_authored_config_payload("old"), first_runtime)
+    load_result = config_lifecycle.ConfigLoadResult(success=True)
+    auth_state = cast("auth.ApiAuthState", object())
+    snapshot = main.ApiSnapshot(
+        generation=7,
+        runtime_paths=first_runtime,
+        config_data={"agents": {"old": {"display_name": "Old"}}},
+        runtime_config=runtime_config,
+        config_load_result=load_result,
+        auth_state=auth_state,
+    )
+
+    preserved = config_lifecycle._published_snapshot(snapshot, increment_generation=False)
+
+    assert preserved.generation == 7
+    assert preserved.runtime_paths == first_runtime
+    assert preserved.config_data is snapshot.config_data
+    assert preserved.runtime_config is runtime_config
+    assert preserved.config_load_result is load_result
+    assert preserved.auth_state is auth_state
+
+    cleared = config_lifecycle._published_snapshot(
+        snapshot,
+        runtime_paths=second_runtime,
+        config_data={},
+        runtime_config=None,
+        config_load_result=None,
+        auth_state=None,
+    )
+
+    assert cleared.generation == 8
+    assert cleared.runtime_paths == second_runtime
+    assert cleared.config_data == {}
+    assert cleared.runtime_config is None
+    assert cleared.config_load_result is None
+    assert cleared.auth_state is None
 
 
 class _ContextSwapLock:
@@ -571,7 +619,7 @@ def test_load_config_into_app_discards_stale_results_after_runtime_swap(tmp_path
 
     context = main._app_context(fresh_app)
     assert context.runtime_paths == second_runtime
-    assert context.config_load_result == main.ConfigLoadResult(success=True)
+    assert context.config_load_result == config_lifecycle.ConfigLoadResult(success=True)
     assert set(context.config_data["agents"]) == {"second"}
 
 
@@ -617,7 +665,7 @@ def test_load_config_into_app_ignores_runtime_mismatches_after_api_runtime_swap(
 
     assert config_lifecycle.load_config_into_app(first_runtime, fresh_app) is False
     assert set(main._app_context(fresh_app).config_data["agents"]) == {"second"}
-    assert main._app_context(fresh_app).config_load_result == main.ConfigLoadResult(success=True)
+    assert main._app_context(fresh_app).config_load_result == config_lifecycle.ConfigLoadResult(success=True)
 
 
 def test_reload_api_runtime_config_does_not_clear_worker_snapshot_on_failed_load(tmp_path: Path) -> None:
@@ -625,7 +673,7 @@ def test_reload_api_runtime_config_does_not_clear_worker_snapshot_on_failed_load
     fresh_app = FastAPI()
     runtime_paths = _runtime_paths(tmp_path)
     main.initialize_api_app(fresh_app, runtime_paths)
-    failure = main.ConfigLoadResult(success=False, error_status_code=422, error_detail="bad config")
+    failure = config_lifecycle.ConfigLoadResult(success=False, error_status_code=422, error_detail="bad config")
 
     with (
         patch.object(config_lifecycle, "_load_config_result", return_value=(failure, None, None)),
@@ -654,13 +702,13 @@ def test_read_app_committed_config_uses_current_context_after_runtime_swap(tmp_p
         generation=0,
         runtime_paths=first_runtime,
         config_data=_validated_authored_payload(first_runtime, "old"),
-        config_load_result=main.ConfigLoadResult(success=True),
+        config_load_result=config_lifecycle.ConfigLoadResult(success=True),
     )
     second_snapshot = main.ApiSnapshot(
         generation=1,
         runtime_paths=second_runtime,
         config_data=_validated_authored_payload(second_runtime, "new"),
-        config_load_result=main.ConfigLoadResult(success=True),
+        config_load_result=config_lifecycle.ConfigLoadResult(success=True),
     )
     fresh_app_state = config_lifecycle.ensure_app_state(fresh_app)
     fresh_app_state.api_state = main.ApiState(
@@ -708,13 +756,13 @@ def test_write_app_committed_config_uses_current_context_after_runtime_swap(tmp_
         generation=0,
         runtime_paths=first_runtime,
         config_data=_validated_authored_payload(first_runtime, "old"),
-        config_load_result=main.ConfigLoadResult(success=True),
+        config_load_result=config_lifecycle.ConfigLoadResult(success=True),
     )
     second_snapshot = main.ApiSnapshot(
         generation=1,
         runtime_paths=second_runtime,
         config_data=_validated_authored_payload(second_runtime, "new"),
-        config_load_result=main.ConfigLoadResult(success=True),
+        config_load_result=config_lifecycle.ConfigLoadResult(success=True),
     )
     fresh_app_state = config_lifecycle.ensure_app_state(fresh_app)
     fresh_app_state.api_state = main.ApiState(
@@ -2461,7 +2509,7 @@ def test_save_config_can_recover_from_invalid_reload(
     saved_config = yaml.safe_load(temp_config_file.read_text(encoding="utf-8"))
     assert saved_config["agents"]["recovered_agent"]["display_name"] == "Recovered Agent"
     assert "plugins" not in saved_config
-    assert main._app_context(main.app).config_load_result == main.ConfigLoadResult(success=True)
+    assert main._app_context(main.app).config_load_result == config_lifecycle.ConfigLoadResult(success=True)
 
 
 def test_get_raw_config_source_returns_current_invalid_file(
@@ -2528,7 +2576,7 @@ def test_save_raw_config_source_can_recover_from_invalid_reload(
 
     assert response.status_code == 200
     assert temp_config_file.read_text(encoding="utf-8") == valid_source
-    assert main._app_context(main.app).config_load_result == main.ConfigLoadResult(success=True)
+    assert main._app_context(main.app).config_load_result == config_lifecycle.ConfigLoadResult(success=True)
 
     load_response = test_client.post("/api/config/load")
     assert load_response.status_code == 200
@@ -2772,7 +2820,7 @@ def test_write_app_committed_config_checks_current_config_load_result_after_acqu
         "agents": {"assistant": {"display_name": "Assistant", "role": "test", "rooms": []}},
     }
     context.config_data = yaml.safe_load(yaml.safe_dump(original_config))
-    context.config_load_result = main.ConfigLoadResult(success=True)
+    context.config_load_result = config_lifecycle.ConfigLoadResult(success=True)
 
     class _SignalingLock:
         def __init__(self) -> None:
@@ -2822,7 +2870,7 @@ def test_write_app_committed_config_checks_current_config_load_result_after_acqu
             writer_thread = threading.Thread(target=_run_write)
             writer_thread.start()
             assert signaling_lock.blocked.wait(timeout=1)
-            context.config_load_result = main.ConfigLoadResult(
+            context.config_load_result = config_lifecycle.ConfigLoadResult(
                 success=False,
                 error_status_code=422,
                 error_detail=error_detail,


### PR DESCRIPTION
## Summary
- Make config_lifecycle._published_snapshot handle runtime paths, auth state, config load result, and optional generation increments.
- Remove duplicated snapshot publication helpers from api/main.py and api/runtime_reload.py.
- Route runtime reload stale-snapshot rejection through config_lifecycle._stale_snapshot_error.

## Tests
- uv run pytest tests/api/test_api.py -n 0 --no-cov -q
- uv run pre-commit run --files src/mindroom/api/config_lifecycle.py src/mindroom/api/main.py src/mindroom/api/runtime_reload.py tests/api/test_api.py