### PR TITLE
Extract knowledge index metadata codec

### DIFF
--- a/src/mindroom/knowledge/index_metadata.py
+++ b/src/mindroom/knowledge/index_metadata.py
@@ -1,0 +1,133 @@
+"""Published knowledge index metadata JSON helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Container, Mapping
+    from pathlib import Path
+
+
+@dataclass(frozen=True)
+class IndexMetadataFields:
+    """Shared fields persisted in knowledge index metadata."""
+
+    settings: tuple[str, ...]
+    status: str
+    collection: str | None = None
+    last_published_at: str | None = None
+    published_revision: str | None = None
+    indexed_count: int | None = None
+    source_signature: str | None = None
+
+
+def load_index_metadata_payload(metadata_path: Path) -> dict[str, object] | None:
+    """Load a JSON object from an index metadata file."""
+    if not metadata_path.exists():
+        return None
+    try:
+        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return dict(payload)
+
+
+def optional_metadata_str(value: object) -> str | None:
+    """Return non-empty persisted metadata strings."""
+    return value if isinstance(value, str) and value else None
+
+
+def _coerce_nonnegative_metadata_int(value: object) -> int | None:
+    """Coerce JSON metadata values into a nonnegative integer."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value >= 0:
+        return value
+    if isinstance(value, float) and value.is_integer() and value >= 0:
+        return int(value)
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
+def parse_index_metadata_fields(
+    payload: Mapping[str, object],
+    *,
+    allowed_statuses: Container[str],
+    require_complete_fields_for_all_statuses: bool = False,
+) -> IndexMetadataFields | None:
+    """Parse the shared published-index fields from a JSON object."""
+    raw_settings = payload.get("settings")
+    raw_status = payload.get("status")
+    if (
+        not isinstance(raw_settings, list)
+        or not all(isinstance(item, str) for item in raw_settings)
+        or not isinstance(raw_status, str)
+        or raw_status not in allowed_statuses
+    ):
+        return None
+
+    collection = optional_metadata_str(payload.get("collection"))
+    indexed_count = _coerce_nonnegative_metadata_int(payload.get("indexed_count"))
+    source_signature = optional_metadata_str(payload.get("source_signature"))
+    if (require_complete_fields_for_all_statuses or raw_status == "complete") and (
+        collection is None or indexed_count is None or source_signature is None
+    ):
+        return None
+
+    return IndexMetadataFields(
+        settings=cast("tuple[str, ...]", tuple(raw_settings)),
+        status=raw_status,
+        collection=collection,
+        last_published_at=optional_metadata_str(payload.get("last_published_at")),
+        published_revision=optional_metadata_str(payload.get("published_revision")),
+        indexed_count=indexed_count,
+        source_signature=source_signature,
+    )
+
+
+def build_index_metadata_payload(
+    fields: IndexMetadataFields,
+    *,
+    extra_fields: Mapping[str, object | None] | None = None,
+) -> dict[str, object]:
+    """Build a JSON payload with stable published-index field names."""
+    payload: dict[str, object] = {
+        "settings": list(fields.settings),
+        "status": fields.status,
+    }
+    payload.update(
+        {
+            key: value
+            for key, value in (
+                ("collection", fields.collection),
+                ("last_published_at", fields.last_published_at),
+                ("published_revision", fields.published_revision),
+                ("indexed_count", fields.indexed_count),
+                ("source_signature", fields.source_signature),
+            )
+            if value is not None
+        },
+    )
+    if extra_fields is not None:
+        payload.update({key: value for key, value in extra_fields.items() if value is not None})
+    return payload
+
+
+def write_index_metadata_payload(metadata_path: Path, payload: Mapping[str, object]) -> None:
+    """Atomically persist a published-index JSON payload."""
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = metadata_path.with_name(f".{metadata_path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        tmp_path.write_text(json.dumps(dict(payload), sort_keys=True), encoding="utf-8")
+        tmp_path.replace(metadata_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise

--- a/src/mindroom/knowledge/index_metadata.py
+++ b/src/mindroom/knowledge/index_metadata.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import os
 import uuid
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -13,47 +12,31 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@dataclass(frozen=True)
-class IndexMetadataFields:
-    """Shared fields persisted in knowledge index metadata."""
-
-    settings: tuple[str, ...]
-    status: str
-    collection: str | None = None
-    last_published_at: str | None = None
-    published_revision: str | None = None
-    indexed_count: int | None = None
-    source_signature: str | None = None
+_IndexMetadataFields = tuple[tuple[str, ...], str, str | None, str | None, str | None, int | None, str | None]
 
 
-def load_index_metadata_payload(metadata_path: Path) -> dict[str, object] | None:
-    """Load a JSON object from an index metadata file."""
-    if not metadata_path.exists():
-        return None
+def load_index_metadata_payload(metadata_path: Path) -> dict[str, object] | None:  # noqa: D103
     try:
-        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+        payload = json.loads(metadata_path.read_text(encoding="utf-8")) if metadata_path.exists() else None
     except (OSError, json.JSONDecodeError):
         return None
-    if not isinstance(payload, dict):
-        return None
-    return dict(payload)
+    return dict(payload) if isinstance(payload, dict) else None
 
 
-def optional_metadata_str(value: object) -> str | None:
-    """Return non-empty persisted metadata strings."""
+def optional_metadata_str(value: object) -> str | None:  # noqa: D103
     return value if isinstance(value, str) and value else None
 
 
 def _coerce_nonnegative_metadata_int(value: object) -> int | None:
-    """Coerce JSON metadata values into a nonnegative integer."""
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int) and value >= 0:
-        return value
-    if isinstance(value, float) and value.is_integer() and value >= 0:
-        return int(value)
-    if isinstance(value, str) and value.strip().isdigit():
-        return int(value.strip())
+    match value:
+        case bool():
+            return None
+        case int() if value >= 0:
+            return value
+        case float() if value.is_integer() and value >= 0:
+            return int(value)
+        case str() if value.strip().isdigit():
+            return int(value.strip())
     return None
 
 
@@ -62,7 +45,7 @@ def parse_index_metadata_fields(
     *,
     allowed_statuses: Container[str],
     require_complete_fields_for_all_statuses: bool = False,
-) -> IndexMetadataFields | None:
+) -> _IndexMetadataFields | None:
     """Parse the shared published-index fields from a JSON object."""
     raw_settings = payload.get("settings")
     raw_status = payload.get("status")
@@ -82,51 +65,33 @@ def parse_index_metadata_fields(
     ):
         return None
 
-    return IndexMetadataFields(
-        settings=cast("tuple[str, ...]", tuple(raw_settings)),
-        status=raw_status,
-        collection=collection,
-        last_published_at=optional_metadata_str(payload.get("last_published_at")),
-        published_revision=optional_metadata_str(payload.get("published_revision")),
-        indexed_count=indexed_count,
-        source_signature=source_signature,
+    return (
+        cast("tuple[str, ...]", tuple(raw_settings)),
+        raw_status,
+        collection,
+        optional_metadata_str(payload.get("last_published_at")),
+        optional_metadata_str(payload.get("published_revision")),
+        indexed_count,
+        source_signature,
     )
 
 
-def build_index_metadata_payload(
-    fields: IndexMetadataFields,
+def write_index_metadata_payload(  # noqa: D103
+    metadata_path: Path,
     *,
-    extra_fields: Mapping[str, object | None] | None = None,
-) -> dict[str, object]:
-    """Build a JSON payload with stable published-index field names."""
-    payload: dict[str, object] = {
-        "settings": list(fields.settings),
-        "status": fields.status,
+    settings: tuple[str, ...],
+    status: str,
+    **fields: object | None,
+) -> None:
+    payload = {
+        "settings": list(settings),
+        "status": status,
+        **{key: value for key, value in fields.items() if value is not None},
     }
-    payload.update(
-        {
-            key: value
-            for key, value in (
-                ("collection", fields.collection),
-                ("last_published_at", fields.last_published_at),
-                ("published_revision", fields.published_revision),
-                ("indexed_count", fields.indexed_count),
-                ("source_signature", fields.source_signature),
-            )
-            if value is not None
-        },
-    )
-    if extra_fields is not None:
-        payload.update({key: value for key, value in extra_fields.items() if value is not None})
-    return payload
-
-
-def write_index_metadata_payload(metadata_path: Path, payload: Mapping[str, object]) -> None:
-    """Atomically persist a published-index JSON payload."""
     metadata_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = metadata_path.with_name(f".{metadata_path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
     try:
-        tmp_path.write_text(json.dumps(dict(payload), sort_keys=True), encoding="utf-8")
+        tmp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
         tmp_path.replace(metadata_path)
     except Exception:
         tmp_path.unlink(missing_ok=True)

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -36,8 +36,6 @@ from mindroom.embeddings import (
 )
 from mindroom.knowledge.chunking import SafeFixedSizeChunking
 from mindroom.knowledge.index_metadata import (
-    IndexMetadataFields,
-    build_index_metadata_payload,
     load_index_metadata_payload,
     parse_index_metadata_fields,
     write_index_metadata_payload,
@@ -892,14 +890,23 @@ class KnowledgeManager:
         )
         if fields is None:
             return None
+        (
+            settings,
+            status,
+            collection,
+            last_published_at,
+            published_revision,
+            indexed_count,
+            source_signature,
+        ) = fields
         return _PersistedIndexState(
-            fields.settings,
-            cast('Literal["resetting", "indexing", "complete"]', fields.status),
-            collection=fields.collection,
-            last_published_at=fields.last_published_at,
-            published_revision=fields.published_revision,
-            indexed_count=fields.indexed_count,
-            source_signature=fields.source_signature,
+            settings,
+            cast('Literal["resetting", "indexing", "complete"]', status),
+            collection=collection,
+            last_published_at=last_published_at,
+            published_revision=published_revision,
+            indexed_count=indexed_count,
+            source_signature=source_signature,
         )
 
     def _save_persisted_index_state(
@@ -913,18 +920,16 @@ class KnowledgeManager:
         indexed_count: int | None = None,
         source_signature: str | None = None,
     ) -> None:
-        payload = build_index_metadata_payload(
-            IndexMetadataFields(
-                settings=settings or self._indexing_settings,
-                status=status,
-                collection=collection,
-                last_published_at=last_published_at,
-                published_revision=published_revision,
-                indexed_count=indexed_count,
-                source_signature=source_signature,
-            ),
+        write_index_metadata_payload(
+            self._indexing_settings_path,
+            settings=settings or self._indexing_settings,
+            status=status,
+            collection=collection,
+            last_published_at=last_published_at,
+            published_revision=published_revision,
+            indexed_count=indexed_count,
+            source_signature=source_signature,
         )
-        write_index_metadata_payload(self._indexing_settings_path, payload)
 
     def _load_git_lfs_hydrated_head(self) -> str | None:
         try:

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
-import json
 import os
 import subprocess
 import time
@@ -36,6 +35,13 @@ from mindroom.embeddings import (
     effective_knowledge_embedder_signature,
 )
 from mindroom.knowledge.chunking import SafeFixedSizeChunking
+from mindroom.knowledge.index_metadata import (
+    IndexMetadataFields,
+    build_index_metadata_payload,
+    load_index_metadata_payload,
+    parse_index_metadata_fields,
+    write_index_metadata_payload,
+)
 from mindroom.knowledge.redaction import (
     credential_free_url_identity,
     embedded_http_userinfo,
@@ -342,20 +348,6 @@ def _create_embedder(config: Config, runtime_paths: RuntimePaths) -> Embedder:
         "Supported providers: openai, ollama, sentence_transformers"
     )
     raise ValueError(msg)
-
-
-def _coerce_int(value: object) -> int | None:
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value) if value.is_integer() else None
-    if isinstance(value, str):
-        stripped = value.strip()
-        if stripped and stripped.lstrip("-").isdigit():
-            return int(stripped)
-    return None
 
 
 def _credential_free_repo_url(repo_url: str) -> str:
@@ -890,49 +882,24 @@ class KnowledgeManager:
             return True
 
     def _load_persisted_index_state(self) -> _PersistedIndexState | None:
-        if not self._indexing_settings_path.exists():
+        payload = load_index_metadata_payload(self._indexing_settings_path)
+        if payload is None:
             return None
-        try:
-            payload = json.loads(self._indexing_settings_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            return None
-
-        if not isinstance(payload, dict):
-            return None
-        raw_settings = payload.get("settings")
-        raw_status = payload.get("status")
-        raw_collection = payload.get("collection")
-        raw_indexed_count = payload.get("indexed_count")
-        indexed_count = _coerce_int(raw_indexed_count)
-        raw_source_signature = payload.get("source_signature")
-        if (
-            not isinstance(raw_settings, list)
-            or not all(isinstance(item, str) for item in raw_settings)
-            or raw_status not in _INDEXING_STATUSES
-            or not isinstance(raw_collection, str)
-            or not raw_collection
-            or indexed_count is None
-            or indexed_count < 0
-            or not isinstance(raw_source_signature, str)
-            or not raw_source_signature
-        ):
-            return None
-        raw_last_published_at = payload.get("last_published_at")
-        last_published_at = (
-            raw_last_published_at if isinstance(raw_last_published_at, str) and raw_last_published_at else None
+        fields = parse_index_metadata_fields(
+            payload,
+            allowed_statuses=_INDEXING_STATUSES,
+            require_complete_fields_for_all_statuses=True,
         )
-        raw_published_revision = payload.get("published_revision")
-        published_revision = (
-            raw_published_revision if isinstance(raw_published_revision, str) and raw_published_revision else None
-        )
+        if fields is None:
+            return None
         return _PersistedIndexState(
-            tuple(raw_settings),
-            cast('Literal["resetting", "indexing", "complete"]', raw_status),
-            collection=raw_collection,
-            last_published_at=last_published_at,
-            published_revision=published_revision,
-            indexed_count=indexed_count,
-            source_signature=raw_source_signature,
+            fields.settings,
+            cast('Literal["resetting", "indexing", "complete"]', fields.status),
+            collection=fields.collection,
+            last_published_at=fields.last_published_at,
+            published_revision=fields.published_revision,
+            indexed_count=fields.indexed_count,
+            source_signature=fields.source_signature,
         )
 
     def _save_persisted_index_state(
@@ -946,30 +913,18 @@ class KnowledgeManager:
         indexed_count: int | None = None,
         source_signature: str | None = None,
     ) -> None:
-        persisted_settings = settings or self._indexing_settings
-        payload: dict[str, object] = {
-            "settings": list(persisted_settings),
-            "status": status,
-        }
-        if collection is not None:
-            payload["collection"] = collection
-        if last_published_at is not None:
-            payload["last_published_at"] = last_published_at
-        if published_revision is not None:
-            payload["published_revision"] = published_revision
-        if indexed_count is not None:
-            payload["indexed_count"] = indexed_count
-        if source_signature is not None:
-            payload["source_signature"] = source_signature
-        tmp_path = self._indexing_settings_path.with_name(
-            f".{self._indexing_settings_path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp",
+        payload = build_index_metadata_payload(
+            IndexMetadataFields(
+                settings=settings or self._indexing_settings,
+                status=status,
+                collection=collection,
+                last_published_at=last_published_at,
+                published_revision=published_revision,
+                indexed_count=indexed_count,
+                source_signature=source_signature,
+            ),
         )
-        try:
-            tmp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
-            tmp_path.replace(self._indexing_settings_path)
-        except Exception:
-            tmp_path.unlink(missing_ok=True)
-            raise
+        write_index_metadata_payload(self._indexing_settings_path, payload)
 
     def _load_git_lfs_hydrated_head(self) -> str | None:
         try:

--- a/src/mindroom/knowledge/registry.py
+++ b/src/mindroom/knowledge/registry.py
@@ -8,9 +8,6 @@ importing this module directly.
 from __future__ import annotations
 
 import asyncio
-import json
-import os
-import uuid
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -18,6 +15,14 @@ from typing import TYPE_CHECKING, Literal, ParamSpec, Protocol, TypeVar, cast
 
 import mindroom.knowledge.manager as manager_module
 from mindroom.knowledge.availability import KnowledgeAvailability
+from mindroom.knowledge.index_metadata import (
+    IndexMetadataFields,
+    build_index_metadata_payload,
+    load_index_metadata_payload,
+    optional_metadata_str,
+    parse_index_metadata_fields,
+    write_index_metadata_payload,
+)
 from mindroom.logging_config import get_logger
 from mindroom.runtime_resolution import resolve_knowledge_binding
 
@@ -117,6 +122,7 @@ class _PublishedIndexVectorDb(Protocol):
 _published_indexes: dict[PublishedIndexKey, _PublishedIndexHandle] = {}
 _PRIVATE_KNOWLEDGE_BASE_ID_PREFIX = "__agent_private__:"
 _MAX_PRIVATE_PUBLISHED_INDEXES = 128
+_PUBLISHED_INDEX_STATUSES = {"resetting", "indexing", "complete", "failed"}
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
@@ -249,105 +255,58 @@ def published_index_metadata_path(key: PublishedIndexKey) -> Path:
     return _published_index_storage_path(key) / "indexing_settings.json"
 
 
-def _coerce_nonnegative_int(value: object) -> int | None:
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int) and value >= 0:
-        return value
-    if isinstance(value, float) and value.is_integer() and value >= 0:
-        return int(value)
-    if isinstance(value, str) and value.strip().isdigit():
-        return int(value.strip())
-    return None
-
-
-def _coerce_status(value: object) -> Literal["resetting", "indexing", "complete", "failed"] | None:
-    if value in {"resetting", "indexing", "complete", "failed"}:
-        return cast('Literal["resetting", "indexing", "complete", "failed"]', value)
-    return None
-
-
 def _coerce_refresh_job(value: object) -> Literal["idle", "pending", "running", "failed"]:
     if value in {"idle", "pending", "running", "failed"}:
         return cast('Literal["idle", "pending", "running", "failed"]', value)
     return "idle"
 
 
-def _optional_str(value: object) -> str | None:
-    return value if isinstance(value, str) and value else None
-
-
 def load_published_index_state(metadata_path: Path) -> PublishedIndexState | None:
     """Load published index metadata."""
-    if not metadata_path.exists():
+    payload = load_index_metadata_payload(metadata_path)
+    if payload is None:
         return None
-    try:
-        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    if not isinstance(payload, dict):
-        return None
-
-    raw_settings = payload.get("settings")
-    status = _coerce_status(payload.get("status"))
-    if not isinstance(raw_settings, list) or not all(isinstance(item, str) for item in raw_settings) or status is None:
-        return None
-
-    collection = _optional_str(payload.get("collection"))
-    indexed_count = _coerce_nonnegative_int(payload.get("indexed_count"))
-    source_signature = _optional_str(payload.get("source_signature"))
-    if status == "complete" and (collection is None or indexed_count is None or source_signature is None):
+    fields = parse_index_metadata_fields(payload, allowed_statuses=_PUBLISHED_INDEX_STATUSES)
+    if fields is None:
         return None
 
     return PublishedIndexState(
-        settings=tuple(raw_settings),
-        status=status,
-        collection=collection,
-        last_published_at=_optional_str(payload.get("last_published_at")),
-        published_revision=_optional_str(payload.get("published_revision")),
-        indexed_count=indexed_count,
-        source_signature=source_signature,
+        settings=fields.settings,
+        status=cast('Literal["resetting", "indexing", "complete", "failed"]', fields.status),
+        collection=fields.collection,
+        last_published_at=fields.last_published_at,
+        published_revision=fields.published_revision,
+        indexed_count=fields.indexed_count,
+        source_signature=fields.source_signature,
         refresh_job=_coerce_refresh_job(payload.get("refresh_job")),
-        reason=_optional_str(payload.get("reason")),
-        last_error=_optional_str(payload.get("last_error")),
-        updated_at=_optional_str(payload.get("updated_at")),
-        last_refresh_at=_optional_str(payload.get("last_refresh_at")),
+        reason=optional_metadata_str(payload.get("reason")),
+        last_error=optional_metadata_str(payload.get("last_error")),
+        updated_at=optional_metadata_str(payload.get("updated_at")),
+        last_refresh_at=optional_metadata_str(payload.get("last_refresh_at")),
     )
 
 
 def save_published_index_state(metadata_path: Path, state: PublishedIndexState) -> None:
     """Atomically persist published index metadata."""
-    payload: dict[str, object] = {
-        "settings": list(state.settings),
-        "status": state.status,
-        "refresh_job": state.refresh_job,
-    }
-    payload.update(
-        {
-            key: value
-            for key, value in (
-                ("collection", state.collection),
-                ("last_published_at", state.last_published_at),
-                ("published_revision", state.published_revision),
-                ("indexed_count", state.indexed_count),
-                ("source_signature", state.source_signature),
-                ("reason", state.reason),
-                ("last_error", state.last_error),
-                ("updated_at", state.updated_at),
-                ("last_refresh_at", state.last_refresh_at),
-            )
-            if value is not None
+    payload = build_index_metadata_payload(
+        IndexMetadataFields(
+            settings=state.settings,
+            status=state.status,
+            collection=state.collection,
+            last_published_at=state.last_published_at,
+            published_revision=state.published_revision,
+            indexed_count=state.indexed_count,
+            source_signature=state.source_signature,
+        ),
+        extra_fields={
+            "refresh_job": state.refresh_job,
+            "reason": state.reason,
+            "last_error": state.last_error,
+            "updated_at": state.updated_at,
+            "last_refresh_at": state.last_refresh_at,
         },
     )
-
-    metadata_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = metadata_path.with_name(f".{metadata_path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
-    try:
-        tmp_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
-        tmp_path.replace(metadata_path)
-    except Exception:
-        tmp_path.unlink(missing_ok=True)
-        raise
+    write_index_metadata_payload(metadata_path, payload)
 
 
 def published_index_refresh_state(

--- a/src/mindroom/knowledge/registry.py
+++ b/src/mindroom/knowledge/registry.py
@@ -16,8 +16,6 @@ from typing import TYPE_CHECKING, Literal, ParamSpec, Protocol, TypeVar, cast
 import mindroom.knowledge.manager as manager_module
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.index_metadata import (
-    IndexMetadataFields,
-    build_index_metadata_payload,
     load_index_metadata_payload,
     optional_metadata_str,
     parse_index_metadata_fields,
@@ -269,15 +267,24 @@ def load_published_index_state(metadata_path: Path) -> PublishedIndexState | Non
     fields = parse_index_metadata_fields(payload, allowed_statuses=_PUBLISHED_INDEX_STATUSES)
     if fields is None:
         return None
+    (
+        settings,
+        status,
+        collection,
+        last_published_at,
+        published_revision,
+        indexed_count,
+        source_signature,
+    ) = fields
 
     return PublishedIndexState(
-        settings=fields.settings,
-        status=cast('Literal["resetting", "indexing", "complete", "failed"]', fields.status),
-        collection=fields.collection,
-        last_published_at=fields.last_published_at,
-        published_revision=fields.published_revision,
-        indexed_count=fields.indexed_count,
-        source_signature=fields.source_signature,
+        settings=settings,
+        status=cast('Literal["resetting", "indexing", "complete", "failed"]', status),
+        collection=collection,
+        last_published_at=last_published_at,
+        published_revision=published_revision,
+        indexed_count=indexed_count,
+        source_signature=source_signature,
         refresh_job=_coerce_refresh_job(payload.get("refresh_job")),
         reason=optional_metadata_str(payload.get("reason")),
         last_error=optional_metadata_str(payload.get("last_error")),
@@ -288,25 +295,21 @@ def load_published_index_state(metadata_path: Path) -> PublishedIndexState | Non
 
 def save_published_index_state(metadata_path: Path, state: PublishedIndexState) -> None:
     """Atomically persist published index metadata."""
-    payload = build_index_metadata_payload(
-        IndexMetadataFields(
-            settings=state.settings,
-            status=state.status,
-            collection=state.collection,
-            last_published_at=state.last_published_at,
-            published_revision=state.published_revision,
-            indexed_count=state.indexed_count,
-            source_signature=state.source_signature,
-        ),
-        extra_fields={
-            "refresh_job": state.refresh_job,
-            "reason": state.reason,
-            "last_error": state.last_error,
-            "updated_at": state.updated_at,
-            "last_refresh_at": state.last_refresh_at,
-        },
+    write_index_metadata_payload(
+        metadata_path,
+        settings=state.settings,
+        status=state.status,
+        collection=state.collection,
+        last_published_at=state.last_published_at,
+        published_revision=state.published_revision,
+        indexed_count=state.indexed_count,
+        source_signature=state.source_signature,
+        refresh_job=state.refresh_job,
+        reason=state.reason,
+        last_error=state.last_error,
+        updated_at=state.updated_at,
+        last_refresh_at=state.last_refresh_at,
     )
-    write_index_metadata_payload(metadata_path, payload)
 
 
 def published_index_refresh_state(

--- a/tach.toml
+++ b/tach.toml
@@ -1942,9 +1942,18 @@ path = "mindroom.knowledge.chunking"
 depends_on = []
 
 [[modules]]
+path = "mindroom.knowledge.index_metadata"
+depends_on = []
+visibility = [
+    "mindroom.knowledge.manager",
+    "mindroom.knowledge.registry",
+]
+
+[[modules]]
 path = "mindroom.knowledge.registry"
 depends_on = [
     "mindroom.knowledge.availability",
+    "mindroom.knowledge.index_metadata",
     "mindroom.knowledge.manager",
     "mindroom.runtime_resolution",
 ]
@@ -1954,6 +1963,7 @@ path = "mindroom.knowledge.manager"
 depends_on = [
     "mindroom.constants",
     "mindroom.knowledge.chunking",
+    "mindroom.knowledge.index_metadata",
     "mindroom.knowledge.redaction",
 ]
 

--- a/tests/test_knowledge_index_metadata.py
+++ b/tests/test_knowledge_index_metadata.py
@@ -1,0 +1,109 @@
+"""Knowledge published-index metadata codec tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mindroom.knowledge.index_metadata import (
+    IndexMetadataFields,
+    build_index_metadata_payload,
+    load_index_metadata_payload,
+    parse_index_metadata_fields,
+    write_index_metadata_payload,
+)
+
+
+def test_index_metadata_fields_support_registry_and_manager_strictness(tmp_path: Path) -> None:
+    """Metadata parsing keeps registry leniency separate from manager strictness."""
+    metadata_path = tmp_path / "indexing_settings.json"
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "settings": ["base", "storage"],
+                "status": "indexing",
+                "refresh_job": "running",
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    payload = load_index_metadata_payload(metadata_path)
+    assert payload is not None
+    assert (
+        parse_index_metadata_fields(
+            payload,
+            allowed_statuses={"resetting", "indexing", "complete"},
+            require_complete_fields_for_all_statuses=True,
+        )
+        is None
+    )
+
+    fields = parse_index_metadata_fields(
+        payload,
+        allowed_statuses={"resetting", "indexing", "complete", "failed"},
+        require_complete_fields_for_all_statuses=False,
+    )
+
+    assert fields == IndexMetadataFields(settings=("base", "storage"), status="indexing")
+
+
+def test_build_index_metadata_payload_preserves_field_names_and_omits_none_values() -> None:
+    """Payload building preserves on-disk field names and omits absent optional fields."""
+    payload = build_index_metadata_payload(
+        IndexMetadataFields(
+            settings=("base", "storage"),
+            status="complete",
+            collection="published_collection",
+            last_published_at="2026-01-02T03:04:05+00:00",
+            indexed_count=7,
+            source_signature="source-signature",
+        ),
+        extra_fields={
+            "refresh_job": "idle",
+            "reason": None,
+            "last_refresh_at": "2026-01-02T03:05:06+00:00",
+        },
+    )
+
+    assert payload == {
+        "settings": ["base", "storage"],
+        "status": "complete",
+        "collection": "published_collection",
+        "last_published_at": "2026-01-02T03:04:05+00:00",
+        "indexed_count": 7,
+        "source_signature": "source-signature",
+        "refresh_job": "idle",
+        "last_refresh_at": "2026-01-02T03:05:06+00:00",
+    }
+
+
+def test_write_index_metadata_payload_uses_unique_temp_and_cleans_failed_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Atomic writes use unique hidden temp files and clean them up on failure."""
+    metadata_path = tmp_path / "indexing_settings.json"
+    attempted_temp_paths: list[Path] = []
+    original_replace = Path.replace
+
+    def _fail_temp_replace(self: Path, target: Path) -> Path:
+        if self.parent == tmp_path and self.name.startswith(".indexing_settings.json.") and self.name.endswith(".tmp"):
+            attempted_temp_paths.append(self)
+            msg = "replace failed"
+            raise OSError(msg)
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", _fail_temp_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        write_index_metadata_payload(
+            metadata_path,
+            {"settings": ["base"], "status": "complete"},
+        )
+
+    assert attempted_temp_paths
+    assert attempted_temp_paths[0].name != "indexing_settings.json.tmp"
+    assert not attempted_temp_paths[0].exists()

--- a/tests/test_knowledge_index_metadata.py
+++ b/tests/test_knowledge_index_metadata.py
@@ -8,8 +8,6 @@ from pathlib import Path
 import pytest
 
 from mindroom.knowledge.index_metadata import (
-    IndexMetadataFields,
-    build_index_metadata_payload,
     load_index_metadata_payload,
     parse_index_metadata_fields,
     write_index_metadata_payload,
@@ -47,27 +45,27 @@ def test_index_metadata_fields_support_registry_and_manager_strictness(tmp_path:
         require_complete_fields_for_all_statuses=False,
     )
 
-    assert fields == IndexMetadataFields(settings=("base", "storage"), status="indexing")
+    assert fields == (("base", "storage"), "indexing", None, None, None, None, None)
 
 
-def test_build_index_metadata_payload_preserves_field_names_and_omits_none_values() -> None:
+def test_write_index_metadata_payload_preserves_field_names_and_omits_none_values(tmp_path: Path) -> None:
     """Payload building preserves on-disk field names and omits absent optional fields."""
-    payload = build_index_metadata_payload(
-        IndexMetadataFields(
-            settings=("base", "storage"),
-            status="complete",
-            collection="published_collection",
-            last_published_at="2026-01-02T03:04:05+00:00",
-            indexed_count=7,
-            source_signature="source-signature",
-        ),
-        extra_fields={
-            "refresh_job": "idle",
-            "reason": None,
-            "last_refresh_at": "2026-01-02T03:05:06+00:00",
-        },
+    metadata_path = tmp_path / "indexing_settings.json"
+
+    write_index_metadata_payload(
+        metadata_path,
+        settings=("base", "storage"),
+        status="complete",
+        collection="published_collection",
+        last_published_at="2026-01-02T03:04:05+00:00",
+        indexed_count=7,
+        source_signature="source-signature",
+        refresh_job="idle",
+        reason=None,
+        last_refresh_at="2026-01-02T03:05:06+00:00",
     )
 
+    payload = json.loads(metadata_path.read_text(encoding="utf-8"))
     assert payload == {
         "settings": ["base", "storage"],
         "status": "complete",
@@ -101,7 +99,8 @@ def test_write_index_metadata_payload_uses_unique_temp_and_cleans_failed_replace
     with pytest.raises(OSError, match="replace failed"):
         write_index_metadata_payload(
             metadata_path,
-            {"settings": ["base"], "status": "complete"},
+            settings=("base",),
+            status="complete",
         )
 
     assert attempted_temp_paths


### PR DESCRIPTION
## Summary
- add a focused published-index metadata codec for common field parsing, payload building, and atomic JSON writes
- reuse it from knowledge manager and registry while preserving manager strictness and registry refresh metadata fields
- add focused codec tests and update Tach boundaries for the new knowledge helper module

## Verification
- uv run pytest tests/test_knowledge_index_metadata.py tests/test_knowledge_manager.py::test_index_metadata_without_source_signature_is_unavailable_and_schedules_refresh tests/test_knowledge_manager.py::test_metadata_state_alone_serves_published_index tests/test_knowledge_manager.py::test_stale_metadata_without_collection_returns_unavailable_index tests/test_knowledge_manager.py::test_published_metadata_write_uses_unique_temp_and_cleans_failed_replace tests/api/test_knowledge_api.py::test_knowledge_status_reads_index_metadata_without_initializing -q -n 0 --no-cov
- uv run pre-commit run --files src/mindroom/knowledge/index_metadata.py src/mindroom/knowledge/manager.py src/mindroom/knowledge/registry.py tests/test_knowledge_index_metadata.py tach.toml