### PR TITLE
Refactor CLI env file mutations

### DIFF
--- a/src/mindroom/cli/connect.py
+++ b/src/mindroom/cli/connect.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from hashlib import sha256
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
@@ -13,8 +12,11 @@ import httpx
 from mindroom.cli.owner import parse_owner_matrix_user_id, replace_owner_placeholders_in_text
 from mindroom.constants import OWNER_MATRIX_USER_ID_ENV
 
+from .env_file import env_path_for_config, upsert_env_values
+
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
 _PAIR_CODE_RE = re.compile(r"^[A-Z0-9]{4}-[A-Z0-9]{4}$")
 _NAMESPACE_RE = re.compile(r"^[a-z0-9]{4,32}$")
@@ -106,11 +108,6 @@ def persist_local_provisioning_env(
     config_path: str | Path,
 ) -> Path:
     """Write local provisioning credentials to .env next to the active config file."""
-    resolved_config_path = Path(config_path).expanduser().resolve()
-    env_path = resolved_config_path.parent / ".env"
-    env_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
-
     updates = {
         "MINDROOM_PROVISIONING_URL": provisioning_url.rstrip("/"),
         "MINDROOM_LOCAL_CLIENT_ID": client_id,
@@ -119,11 +116,8 @@ def persist_local_provisioning_env(
     }
     if parsed_owner_user_id := parse_owner_matrix_user_id(owner_user_id):
         updates[OWNER_MATRIX_USER_ID_ENV] = parsed_owner_user_id
-    for key, value in updates.items():
-        lines = _upsert_env_var(lines, key, value)
 
-    env_path.write_text(f"{'\n'.join(lines)}\n", encoding="utf-8")
-    return env_path
+    return upsert_env_values(env_path_for_config(config_path), updates)
 
 
 def replace_owner_placeholders_in_config(*, config_path: Path, owner_user_id: str) -> bool:
@@ -185,14 +179,3 @@ def _extract_error_detail(response: httpx.Response) -> str:
         if detail is not None:
             return str(detail)
     return "unknown error"
-
-
-def _upsert_env_var(lines: list[str], key: str, value: str) -> list[str]:
-    """Upsert a single KEY=value entry while preserving unrelated lines."""
-    pattern = re.compile(rf"^\s*(?:export\s+)?{re.escape(key)}\s*=")
-    for idx, line in enumerate(lines):
-        if pattern.match(line):
-            lines[idx] = f"{key}={value}"
-            return lines
-    lines.append(f"{key}={value}")
-    return lines

--- a/src/mindroom/cli/env_file.py
+++ b/src/mindroom/cli/env_file.py
@@ -1,0 +1,37 @@
+"""Line-preserving helpers for CLI-managed `.env` files."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+def env_path_for_config(config_path: str | Path) -> Path:
+    """Return the `.env` path next to the active config file."""
+    resolved_config_path = Path(config_path).expanduser().resolve()
+    return resolved_config_path.parent / ".env"
+
+
+def upsert_env_values(env_path: Path, values: Mapping[str, str]) -> Path:
+    """Upsert KEY=value entries while preserving unrelated lines."""
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+
+    for key, value in values.items():
+        _upsert_env_value(lines, key, value)
+
+    env_path.write_text(f"{'\n'.join(lines)}\n", encoding="utf-8")
+    return env_path
+
+
+def _upsert_env_value(lines: list[str], key: str, value: str) -> None:
+    pattern = re.compile(rf"^\s*(?:export\s+)?{re.escape(key)}\s*=")
+    for idx, line in enumerate(lines):
+        if pattern.match(line):
+            lines[idx] = f"{key}={value}"
+            return
+    lines.append(f"{key}={value}")

--- a/src/mindroom/cli/local_stack.py
+++ b/src/mindroom/cli/local_stack.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 import shutil
 import subprocess
 import sys
@@ -18,6 +17,7 @@ import typer
 from mindroom.matrix.health import matrix_versions_url, response_has_matrix_versions
 
 from .config import activate_cli_runtime, console
+from .env_file import env_path_for_config, upsert_env_values
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -154,31 +154,14 @@ def _persist_local_matrix_env(
     config_path: Path,
 ) -> Path:
     """Write local Matrix settings to .env next to the active config file."""
-    env_path = config_path.expanduser().resolve().parent / ".env"
-    env_path.parent.mkdir(parents=True, exist_ok=True)
-    lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
-
-    updates = {
-        "MATRIX_HOMESERVER": homeserver_url,
-        "MATRIX_SSL_VERIFY": "false",
-        "MATRIX_SERVER_NAME": server_name,
-    }
-    for key, value in updates.items():
-        lines = _upsert_env_var(lines, key, value)
-
-    env_path.write_text(f"{'\n'.join(lines)}\n", encoding="utf-8")
-    return env_path
-
-
-def _upsert_env_var(lines: list[str], key: str, value: str) -> list[str]:
-    """Upsert a single KEY=value entry while preserving unrelated lines."""
-    pattern = re.compile(rf"^\s*(?:export\s+)?{re.escape(key)}\s*=")
-    for idx, line in enumerate(lines):
-        if pattern.match(line):
-            lines[idx] = f"{key}={value}"
-            return lines
-    lines.append(f"{key}={value}")
-    return lines
+    return upsert_env_values(
+        env_path_for_config(config_path),
+        {
+            "MATRIX_HOMESERVER": homeserver_url,
+            "MATRIX_SSL_VERIFY": "false",
+            "MATRIX_SERVER_NAME": server_name,
+        },
+    )
 
 
 def _require_supported_platform() -> None:

--- a/tach.toml
+++ b/tach.toml
@@ -1556,8 +1556,17 @@ depends_on = [
 [[modules]]
 path = "mindroom.cli.connect"
 depends_on = [
+    "mindroom.cli.env_file",
     "mindroom.cli.owner",
     "mindroom.constants",
+]
+
+[[modules]]
+path = "mindroom.cli.env_file"
+depends_on = []
+visibility = [
+    "mindroom.cli.connect",
+    "mindroom.cli.local_stack",
 ]
 
 [[modules]]
@@ -1582,6 +1591,7 @@ depends_on = [
 path = "mindroom.cli.local_stack"
 depends_on = [
     "mindroom.cli.config",
+    "mindroom.cli.env_file",
     "mindroom.matrix.health",
 ]
 

--- a/tests/test_cli_env_file.py
+++ b/tests/test_cli_env_file.py
@@ -1,0 +1,48 @@
+"""Tests for CLI `.env` file mutation helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.cli.env_file import env_path_for_config, upsert_env_values
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_env_path_for_config_uses_config_directory(tmp_path: Path) -> None:
+    """The active config path should determine which sibling `.env` file is updated."""
+    config_path = tmp_path / "nested" / "config.yaml"
+
+    assert env_path_for_config(config_path) == config_path.parent.resolve() / ".env"
+
+
+def test_upsert_env_values_preserves_lines_and_rewrites_exported_keys(tmp_path: Path) -> None:
+    """Upserting values should preserve unrelated lines while normalizing replaced keys."""
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "# keep this comment\nexport MATRIX_HOMESERVER=https://old.example\nUNRELATED=value\n\n",
+        encoding="utf-8",
+    )
+
+    result = upsert_env_values(
+        env_path,
+        {
+            "MATRIX_HOMESERVER": "http://localhost:8008",
+            "MATRIX_SSL_VERIFY": "false",
+        },
+    )
+
+    assert result == env_path
+    assert env_path.read_text(encoding="utf-8") == (
+        "# keep this comment\nMATRIX_HOMESERVER=http://localhost:8008\nUNRELATED=value\n\nMATRIX_SSL_VERIFY=false\n"
+    )
+
+
+def test_upsert_env_values_creates_parent_directory_and_file(tmp_path: Path) -> None:
+    """Creating a missing env file should still use the same KEY=value format."""
+    env_path = tmp_path / "missing" / ".env"
+
+    upsert_env_values(env_path, {"MINDROOM_NAMESPACE": "a1b2c3d4"})
+
+    assert env_path.read_text(encoding="utf-8") == "MINDROOM_NAMESPACE=a1b2c3d4\n"


### PR DESCRIPTION
## Summary
- add a small line-preserving CLI `.env` upsert helper
- migrate `connect` and `local-stack` env persistence to the shared helper
- add helper characterization tests and Tach boundary metadata

## Verification
- `uv sync --all-extras`
- `uv run pytest tests/test_cli_env_file.py tests/test_cli_connect.py tests/test_cli_config.py::TestLocalStackSetup -q` -> 16 passed
- `uv run pre-commit run --files src/mindroom/cli/env_file.py src/mindroom/cli/connect.py src/mindroom/cli/local_stack.py tests/test_cli_env_file.py tach.toml` -> passed
- `uv run tach check --dependencies --interfaces` -> passed
- `uv run pytest -q` -> 1 failed, 6240 passed, 56 skipped; failure was `tests/test_live_message_coalescing.py::test_same_sender_different_threads_dispatch_separately`
- `uv run pytest tests/test_live_message_coalescing.py::test_same_sender_different_threads_dispatch_separately -q` -> 1 passed
