### PR TITLE
CRED-002: share Google OAuth provider skeleton

### DIFF
--- a/src/mindroom/oauth/google.py
+++ b/src/mindroom/oauth/google.py
@@ -31,7 +31,7 @@ GOOGLE_IDENTITY_SCOPES = (
 )
 
 
-def google_token_parser(
+def _google_token_parser(
     provider: OAuthProvider,
     token_response: Mapping[str, Any],
     client_config: OAuthClientConfig,
@@ -100,7 +100,40 @@ def google_token_parser(
     return OAuthTokenResult(token_data=token_data, claims=claims, claims_verified=True)
 
 
-def google_domain_env_names(provider_id: str, suffix: str) -> tuple[str, ...]:
+def _google_domain_env_names(provider_id: str, suffix: str) -> tuple[str, ...]:
     """Return provider-specific environment variable names for Google domain settings."""
     prefix = provider_id.upper()
     return (f"{prefix}_{suffix}", f"MINDROOM_OAUTH_{prefix}_{suffix}")
+
+
+def _google_oauth_provider(
+    *,
+    provider_id: str,
+    display_name: str,
+    scopes: tuple[str, ...],
+    credential_service: str,
+    tool_config_service: str,
+    client_config_services: tuple[str, ...],
+    status_capabilities: tuple[str, ...],
+) -> OAuthProvider:
+    """Return a Google OAuth provider with shared Google OAuth defaults."""
+    return OAuthProvider(
+        id=provider_id,
+        display_name=display_name,
+        authorization_url="https://accounts.google.com/o/oauth2/v2/auth",
+        token_url="https://oauth2.googleapis.com/token",  # noqa: S106
+        scopes=scopes,
+        credential_service=credential_service,
+        tool_config_service=tool_config_service,
+        client_config_services=client_config_services,
+        shared_client_config_services=("google_oauth_client",),
+        allowed_email_domains_env=_google_domain_env_names(provider_id, "ALLOWED_EMAIL_DOMAINS"),
+        allowed_hosted_domains_env=_google_domain_env_names(provider_id, "ALLOWED_HOSTED_DOMAINS"),
+        extra_auth_params={
+            "access_type": "offline",
+            "include_granted_scopes": "true",
+            "prompt": "consent",
+        },
+        status_capabilities=status_capabilities,
+        token_parser=_google_token_parser,
+    )

--- a/src/mindroom/oauth/google_calendar.py
+++ b/src/mindroom/oauth/google_calendar.py
@@ -2,38 +2,27 @@
 
 from __future__ import annotations
 
-from mindroom.oauth.google import (
-    GOOGLE_IDENTITY_SCOPES,
-    google_domain_env_names,
-    google_token_parser,
-)
-from mindroom.oauth.providers import OAuthProvider
+from typing import TYPE_CHECKING
+
+import mindroom.oauth.google as google_oauth
+
+if TYPE_CHECKING:
+    from mindroom.oauth.providers import OAuthProvider
 
 _GOOGLE_CALENDAR_OAUTH_SCOPES = (
-    *GOOGLE_IDENTITY_SCOPES,
+    *google_oauth.GOOGLE_IDENTITY_SCOPES,
     "https://www.googleapis.com/auth/calendar",
 )
 
 
 def google_calendar_oauth_provider() -> OAuthProvider:
     """Return the built-in Google Calendar provider definition."""
-    return OAuthProvider(
-        id="google_calendar",
+    return google_oauth._google_oauth_provider(
+        provider_id="google_calendar",
         display_name="Google Calendar",
-        authorization_url="https://accounts.google.com/o/oauth2/v2/auth",
-        token_url="https://oauth2.googleapis.com/token",  # noqa: S106
         scopes=_GOOGLE_CALENDAR_OAUTH_SCOPES,
         credential_service="google_calendar_oauth",
         tool_config_service="google_calendar",
         client_config_services=("google_calendar_oauth_client",),
-        shared_client_config_services=("google_oauth_client",),
-        allowed_email_domains_env=google_domain_env_names("google_calendar", "ALLOWED_EMAIL_DOMAINS"),
-        allowed_hosted_domains_env=google_domain_env_names("google_calendar", "ALLOWED_HOSTED_DOMAINS"),
-        extra_auth_params={
-            "access_type": "offline",
-            "include_granted_scopes": "true",
-            "prompt": "consent",
-        },
         status_capabilities=("Calendar event read/write",),
-        token_parser=google_token_parser,
     )

--- a/src/mindroom/oauth/google_drive.py
+++ b/src/mindroom/oauth/google_drive.py
@@ -2,41 +2,30 @@
 
 from __future__ import annotations
 
-from mindroom.oauth.google import (
-    GOOGLE_IDENTITY_SCOPES,
-    google_domain_env_names,
-    google_token_parser,
-)
-from mindroom.oauth.providers import OAuthProvider
+from typing import TYPE_CHECKING
+
+import mindroom.oauth.google as google_oauth
+
+if TYPE_CHECKING:
+    from mindroom.oauth.providers import OAuthProvider
 
 _GOOGLE_DRIVE_OAUTH_SCOPES = (
-    *GOOGLE_IDENTITY_SCOPES,
+    *google_oauth.GOOGLE_IDENTITY_SCOPES,
     "https://www.googleapis.com/auth/drive.readonly",
 )
 
 
 def google_drive_oauth_provider() -> OAuthProvider:
     """Return the built-in Google Drive provider definition."""
-    return OAuthProvider(
-        id="google_drive",
+    return google_oauth._google_oauth_provider(
+        provider_id="google_drive",
         display_name="Google Drive",
-        authorization_url="https://accounts.google.com/o/oauth2/v2/auth",
-        token_url="https://oauth2.googleapis.com/token",  # noqa: S106
         scopes=_GOOGLE_DRIVE_OAUTH_SCOPES,
         credential_service="google_drive_oauth",
         tool_config_service="google_drive",
         client_config_services=("google_drive_oauth_client",),
-        shared_client_config_services=("google_oauth_client",),
-        allowed_email_domains_env=google_domain_env_names("google_drive", "ALLOWED_EMAIL_DOMAINS"),
-        allowed_hosted_domains_env=google_domain_env_names("google_drive", "ALLOWED_HOSTED_DOMAINS"),
-        extra_auth_params={
-            "access_type": "offline",
-            "include_granted_scopes": "true",
-            "prompt": "consent",
-        },
         status_capabilities=(
             "Drive file search",
             "Drive file read",
         ),
-        token_parser=google_token_parser,
     )

--- a/src/mindroom/oauth/google_gmail.py
+++ b/src/mindroom/oauth/google_gmail.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-from mindroom.oauth.google import (
-    GOOGLE_IDENTITY_SCOPES,
-    google_domain_env_names,
-    google_token_parser,
-)
-from mindroom.oauth.providers import OAuthProvider
+from typing import TYPE_CHECKING
+
+import mindroom.oauth.google as google_oauth
+
+if TYPE_CHECKING:
+    from mindroom.oauth.providers import OAuthProvider
 
 _GOOGLE_GMAIL_OAUTH_SCOPES = (
-    *GOOGLE_IDENTITY_SCOPES,
+    *google_oauth.GOOGLE_IDENTITY_SCOPES,
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.modify",
     "https://www.googleapis.com/auth/gmail.compose",
@@ -19,23 +19,12 @@ _GOOGLE_GMAIL_OAUTH_SCOPES = (
 
 def google_gmail_oauth_provider() -> OAuthProvider:
     """Return the built-in Gmail provider definition."""
-    return OAuthProvider(
-        id="google_gmail",
+    return google_oauth._google_oauth_provider(
+        provider_id="google_gmail",
         display_name="Gmail",
-        authorization_url="https://accounts.google.com/o/oauth2/v2/auth",
-        token_url="https://oauth2.googleapis.com/token",  # noqa: S106
         scopes=_GOOGLE_GMAIL_OAUTH_SCOPES,
         credential_service="google_gmail_oauth",
         tool_config_service="gmail",
         client_config_services=("google_gmail_oauth_client",),
-        shared_client_config_services=("google_oauth_client",),
-        allowed_email_domains_env=google_domain_env_names("google_gmail", "ALLOWED_EMAIL_DOMAINS"),
-        allowed_hosted_domains_env=google_domain_env_names("google_gmail", "ALLOWED_HOSTED_DOMAINS"),
-        extra_auth_params={
-            "access_type": "offline",
-            "include_granted_scopes": "true",
-            "prompt": "consent",
-        },
         status_capabilities=("Gmail read/modify/compose",),
-        token_parser=google_token_parser,
     )

--- a/src/mindroom/oauth/google_sheets.py
+++ b/src/mindroom/oauth/google_sheets.py
@@ -2,38 +2,27 @@
 
 from __future__ import annotations
 
-from mindroom.oauth.google import (
-    GOOGLE_IDENTITY_SCOPES,
-    google_domain_env_names,
-    google_token_parser,
-)
-from mindroom.oauth.providers import OAuthProvider
+from typing import TYPE_CHECKING
+
+import mindroom.oauth.google as google_oauth
+
+if TYPE_CHECKING:
+    from mindroom.oauth.providers import OAuthProvider
 
 _GOOGLE_SHEETS_OAUTH_SCOPES = (
-    *GOOGLE_IDENTITY_SCOPES,
+    *google_oauth.GOOGLE_IDENTITY_SCOPES,
     "https://www.googleapis.com/auth/spreadsheets",
 )
 
 
 def google_sheets_oauth_provider() -> OAuthProvider:
     """Return the built-in Google Sheets provider definition."""
-    return OAuthProvider(
-        id="google_sheets",
+    return google_oauth._google_oauth_provider(
+        provider_id="google_sheets",
         display_name="Google Sheets",
-        authorization_url="https://accounts.google.com/o/oauth2/v2/auth",
-        token_url="https://oauth2.googleapis.com/token",  # noqa: S106
         scopes=_GOOGLE_SHEETS_OAUTH_SCOPES,
         credential_service="google_sheets_oauth",
         tool_config_service="google_sheets",
         client_config_services=("google_sheets_oauth_client",),
-        shared_client_config_services=("google_oauth_client",),
-        allowed_email_domains_env=google_domain_env_names("google_sheets", "ALLOWED_EMAIL_DOMAINS"),
-        allowed_hosted_domains_env=google_domain_env_names("google_sheets", "ALLOWED_HOSTED_DOMAINS"),
-        extra_auth_params={
-            "access_type": "offline",
-            "include_granted_scopes": "true",
-            "prompt": "consent",
-        },
         status_capabilities=("Sheets read/write",),
-        token_parser=google_token_parser,
     )

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -1,0 +1,153 @@
+"""Tests for built-in Google OAuth provider definitions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom.oauth.google import _google_oauth_provider, _google_token_parser
+from mindroom.oauth.google_calendar import _GOOGLE_CALENDAR_OAUTH_SCOPES, google_calendar_oauth_provider
+from mindroom.oauth.google_drive import _GOOGLE_DRIVE_OAUTH_SCOPES, google_drive_oauth_provider
+from mindroom.oauth.google_gmail import _GOOGLE_GMAIL_OAUTH_SCOPES, google_gmail_oauth_provider
+from mindroom.oauth.google_sheets import _GOOGLE_SHEETS_OAUTH_SCOPES, google_sheets_oauth_provider
+
+if TYPE_CHECKING:
+    from mindroom.oauth.providers import OAuthProvider
+
+GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"  # noqa: S105
+GOOGLE_EXTRA_AUTH_PARAMS = {
+    "access_type": "offline",
+    "include_granted_scopes": "true",
+    "prompt": "consent",
+}
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [
+        (
+            google_calendar_oauth_provider(),
+            {
+                "id": "google_calendar",
+                "display_name": "Google Calendar",
+                "scopes": _GOOGLE_CALENDAR_OAUTH_SCOPES,
+                "credential_service": "google_calendar_oauth",
+                "tool_config_service": "google_calendar",
+                "client_config_services": ("google_calendar_oauth_client",),
+                "status_capabilities": ("Calendar event read/write",),
+            },
+        ),
+        (
+            google_drive_oauth_provider(),
+            {
+                "id": "google_drive",
+                "display_name": "Google Drive",
+                "scopes": _GOOGLE_DRIVE_OAUTH_SCOPES,
+                "credential_service": "google_drive_oauth",
+                "tool_config_service": "google_drive",
+                "client_config_services": ("google_drive_oauth_client",),
+                "status_capabilities": ("Drive file search", "Drive file read"),
+            },
+        ),
+        (
+            google_gmail_oauth_provider(),
+            {
+                "id": "google_gmail",
+                "display_name": "Gmail",
+                "scopes": _GOOGLE_GMAIL_OAUTH_SCOPES,
+                "credential_service": "google_gmail_oauth",
+                "tool_config_service": "gmail",
+                "client_config_services": ("google_gmail_oauth_client",),
+                "status_capabilities": ("Gmail read/modify/compose",),
+            },
+        ),
+        (
+            google_sheets_oauth_provider(),
+            {
+                "id": "google_sheets",
+                "display_name": "Google Sheets",
+                "scopes": _GOOGLE_SHEETS_OAUTH_SCOPES,
+                "credential_service": "google_sheets_oauth",
+                "tool_config_service": "google_sheets",
+                "client_config_services": ("google_sheets_oauth_client",),
+                "status_capabilities": ("Sheets read/write",),
+            },
+        ),
+    ],
+)
+def test_public_google_oauth_providers_preserve_service_specific_fields(
+    provider: OAuthProvider,
+    expected: dict[str, object],
+) -> None:
+    """Public Google provider factories preserve service-specific metadata."""
+    assert provider.id == expected["id"]
+    assert provider.display_name == expected["display_name"]
+    assert provider.scopes == expected["scopes"]
+    assert provider.credential_service == expected["credential_service"]
+    assert provider.tool_config_service == expected["tool_config_service"]
+    assert provider.client_config_services == expected["client_config_services"]
+    assert provider.status_capabilities == expected["status_capabilities"]
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        google_calendar_oauth_provider(),
+        google_drive_oauth_provider(),
+        google_gmail_oauth_provider(),
+        google_sheets_oauth_provider(),
+    ],
+)
+def test_public_google_oauth_providers_preserve_shared_google_oauth_fields(provider: OAuthProvider) -> None:
+    """Public Google provider factories preserve shared Google OAuth metadata."""
+    provider_prefix = provider.id.upper()
+
+    assert provider.authorization_url == GOOGLE_AUTHORIZATION_URL
+    assert provider.token_url == GOOGLE_TOKEN_URL
+    assert provider.shared_client_config_services == ("google_oauth_client",)
+    assert provider.allowed_email_domains_env == (
+        f"{provider_prefix}_ALLOWED_EMAIL_DOMAINS",
+        f"MINDROOM_OAUTH_{provider_prefix}_ALLOWED_EMAIL_DOMAINS",
+    )
+    assert provider.allowed_hosted_domains_env == (
+        f"{provider_prefix}_ALLOWED_HOSTED_DOMAINS",
+        f"MINDROOM_OAUTH_{provider_prefix}_ALLOWED_HOSTED_DOMAINS",
+    )
+    assert provider.extra_auth_params == GOOGLE_EXTRA_AUTH_PARAMS
+    assert provider.token_parser is _google_token_parser
+
+
+def test_google_oauth_provider_helper_builds_common_google_provider_skeleton() -> None:
+    """The private Google helper builds the shared provider skeleton."""
+    provider = _google_oauth_provider(
+        provider_id="google_example",
+        display_name="Google Example",
+        scopes=("openid", "https://www.googleapis.com/auth/example"),
+        credential_service="google_example_oauth",
+        tool_config_service="google_example",
+        client_config_services=("google_example_oauth_client",),
+        status_capabilities=("Example read/write",),
+    )
+
+    assert provider.id == "google_example"
+    assert provider.display_name == "Google Example"
+    assert provider.authorization_url == GOOGLE_AUTHORIZATION_URL
+    assert provider.token_url == GOOGLE_TOKEN_URL
+    assert provider.scopes == ("openid", "https://www.googleapis.com/auth/example")
+    assert provider.credential_service == "google_example_oauth"
+    assert provider.tool_config_service == "google_example"
+    assert provider.client_config_services == ("google_example_oauth_client",)
+    assert provider.shared_client_config_services == ("google_oauth_client",)
+    assert provider.allowed_email_domains_env == (
+        "GOOGLE_EXAMPLE_ALLOWED_EMAIL_DOMAINS",
+        "MINDROOM_OAUTH_GOOGLE_EXAMPLE_ALLOWED_EMAIL_DOMAINS",
+    )
+    assert provider.allowed_hosted_domains_env == (
+        "GOOGLE_EXAMPLE_ALLOWED_HOSTED_DOMAINS",
+        "MINDROOM_OAUTH_GOOGLE_EXAMPLE_ALLOWED_HOSTED_DOMAINS",
+    )
+    assert provider.extra_auth_params == GOOGLE_EXTRA_AUTH_PARAMS
+    assert provider.status_capabilities == ("Example read/write",)
+    assert provider.token_parser is _google_token_parser


### PR DESCRIPTION
## Summary
- add a private Google OAuth provider skeleton helper
- keep public Google Calendar, Drive, Gmail, and Sheets provider factories with explicit service metadata
- add characterization tests for provider-specific and shared Google OAuth fields

## Verification
- uv run pytest tests/test_google_oauth_providers.py tests/test_google_calendar_oauth_tool.py tests/test_google_drive_oauth_tool.py tests/test_google_sheets_oauth_tool.py tests/api/test_oauth_api.py -q -n 0 --no-cov -p no:tach
- uv run pre-commit run --files src/mindroom/oauth/google.py src/mindroom/oauth/google_calendar.py src/mindroom/oauth/google_drive.py src/mindroom/oauth/google_gmail.py src/mindroom/oauth/google_sheets.py tests/test_google_oauth_providers.py