### PR TITLE
Refactor credentials worker target resolution

### DIFF
--- a/src/mindroom/api/credentials.py
+++ b/src/mindroom/api/credentials.py
@@ -547,7 +547,7 @@ def load_credentials_for_target(service: str, target: RequestCredentialsTarget) 
         return load_scoped_credentials(
             service,
             credentials_manager=target.base_manager,
-            worker_target=_worker_target_for_credentials_target(target),
+            worker_target=worker_target_for_credentials_target(target),
             allowed_shared_services=target.allowed_shared_services,
         )
 
@@ -579,7 +579,8 @@ def _service_uses_primary_runtime_global_store(service: str, target: RequestCred
     return credential_service_policy(service, target.worker_scope).uses_primary_runtime_global_credentials
 
 
-def _worker_target_for_credentials_target(target: RequestCredentialsTarget) -> ResolvedWorkerTarget | None:
+def worker_target_for_credentials_target(target: RequestCredentialsTarget) -> ResolvedWorkerTarget | None:
+    """Resolve the worker target represented by one credentials request target."""
     if target.worker_scope is None:
         return None
     return resolve_worker_target(
@@ -600,7 +601,7 @@ def _save_credentials_for_target(service: str, credentials: dict[str, Any], targ
         service,
         credentials,
         credentials_manager=target.base_manager,
-        worker_target=_worker_target_for_credentials_target(target),
+        worker_target=worker_target_for_credentials_target(target),
     )
 
 
@@ -631,7 +632,7 @@ def _delete_credentials_for_target(service: str, target: RequestCredentialsTarge
     delete_scoped_credentials(
         service,
         credentials_manager=target.base_manager,
-        worker_target=_worker_target_for_credentials_target(target),
+        worker_target=worker_target_for_credentials_target(target),
     )
 
 

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -18,6 +18,7 @@ from mindroom.api.credentials import (
     consume_pending_oauth_request,
     issue_pending_oauth_state,
     resolve_request_credentials_target,
+    worker_target_for_credentials_target,
 )
 from mindroom.credentials import delete_scoped_credentials, load_scoped_credentials, save_scoped_credentials
 from mindroom.logging_config import get_logger
@@ -36,7 +37,6 @@ from mindroom.oauth.service import (
     oauth_success_redirect_url,
     sanitized_oauth_token_result,
 )
-from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, resolve_worker_target
 
 if TYPE_CHECKING:
     from mindroom.api.credentials import RequestCredentialsTarget
@@ -177,28 +177,15 @@ def _issue_authorization_url(
 
 
 def _target_binding_payload(provider: OAuthProvider, target: RequestCredentialsTarget) -> dict[str, str]:
-    worker_target = resolve_worker_target(
-        target.worker_scope,
-        target.agent_name,
-        execution_identity=target.execution_identity,
-    )
+    worker_target = worker_target_for_credentials_target(target)
+    worker_key = worker_target.worker_key if worker_target is not None else None
     return {
         "provider": provider.id,
         "credential_service": provider.credential_service,
         "agent_name": target.agent_name or "",
         "worker_scope": target.worker_scope or "unscoped",
-        "worker_key": worker_target.worker_key or "",
+        "worker_key": worker_key or "",
     }
-
-
-def _resolved_worker_target_for_credentials(target: RequestCredentialsTarget) -> ResolvedWorkerTarget | None:
-    if target.worker_scope is None:
-        return None
-    return resolve_worker_target(
-        target.worker_scope,
-        target.agent_name,
-        execution_identity=target.execution_identity,
-    )
 
 
 def _verify_connect_target_authorized(
@@ -383,7 +370,6 @@ async def callback(provider_id: str, request: Request) -> RedirectResponse:
     await _require_oauth_api_user(request)
     provider, runtime_paths = _load_provider(request, provider_id)
     pending = consume_pending_oauth_request(request, provider.id, state)
-    worker_target: ResolvedWorkerTarget | None = None
     target = resolve_request_credentials_target(
         request,
         agent_name=pending.agent_name,
@@ -402,7 +388,7 @@ async def callback(provider_id: str, request: Request) -> RedirectResponse:
         )
         provider.validate_claims(token_result, runtime_paths)
         safe_result = sanitized_oauth_token_result(provider, token_result)
-        worker_target = _resolved_worker_target_for_credentials(target)
+        worker_target = worker_target_for_credentials_target(target)
         credentials_manager = target.base_manager
         existing_credentials = load_scoped_credentials(
             provider.credential_service,
@@ -443,7 +429,7 @@ async def status(provider_id: str, request: Request, agent_name: str | None = No
         service_names=(provider.credential_service,),
         allow_private_scopes=True,
     )
-    worker_target = _resolved_worker_target_for_credentials(target)
+    worker_target = worker_target_for_credentials_target(target)
     credentials = (
         load_scoped_credentials(
             provider.credential_service,
@@ -493,7 +479,7 @@ async def disconnect(provider_id: str, request: Request, agent_name: str | None 
         service_names=(provider.credential_service,),
         allow_private_scopes=True,
     )
-    worker_target = _resolved_worker_target_for_credentials(target)
+    worker_target = worker_target_for_credentials_target(target)
     delete_scoped_credentials(
         provider.credential_service,
         credentials_manager=target.base_manager,

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -15,7 +15,7 @@ from mindroom.api.main import app, initialize_api_app
 from mindroom.config.main import Config
 from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.oauth.providers import OAuthProvider
-from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_key
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_key, resolve_worker_target
 
 
 def _config_with_worker_scope(
@@ -247,6 +247,57 @@ class TestCredentialsAPI:
 
         assert response.status_code == 200
         mock_credentials_manager.for_worker.assert_called_once_with(expected_worker_key)
+
+    def test_credentials_target_worker_resolver_matches_worker_routing(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Credentials and OAuth paths should share one target-to-worker conversion."""
+        runtime_paths = main._app_runtime_paths(client.app)
+        manager = get_runtime_credentials_manager(runtime_paths)
+        identity = ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="general",
+            requester_id="@alice:example.org",
+            room_id=None,
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+        )
+        target = credentials_api.RequestCredentialsTarget(
+            runtime_paths=runtime_paths,
+            base_manager=manager,
+            target_manager=manager,
+            worker_scope="user_agent",
+            agent_name="general",
+            execution_identity=identity,
+        )
+
+        worker_target = credentials_api.worker_target_for_credentials_target(target)
+
+        assert worker_target == resolve_worker_target(
+            "user_agent",
+            "general",
+            execution_identity=identity,
+        )
+
+    def test_credentials_target_worker_resolver_returns_none_for_unscoped_target(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Unscoped credential operations must keep using the primary credentials store."""
+        runtime_paths = main._app_runtime_paths(client.app)
+        manager = get_runtime_credentials_manager(runtime_paths)
+        target = credentials_api.RequestCredentialsTarget(
+            runtime_paths=runtime_paths,
+            base_manager=manager,
+            target_manager=manager,
+            worker_scope=None,
+            agent_name="general",
+            execution_identity=None,
+        )
+
+        assert credentials_api.worker_target_for_credentials_target(target) is None
 
     def test_rejects_shared_only_integration_services_for_isolating_scope(
         self,


### PR DESCRIPTION
## Summary
- expose `worker_target_for_credentials_target()` for resolved dashboard credential targets
- reuse it from credentials storage helpers and OAuth target binding/status/callback/disconnect paths
- remove the duplicate OAuth-local worker target resolver

## Verification
- `uv sync --all-extras`
- `uv run pytest tests/api/test_credentials_api.py -k "credentials_target_worker_resolver" -q` (red before implementation, then green)
- `uv run pytest tests/api/test_credentials_api.py tests/api/test_oauth_api.py -q`
- `uv run pre-commit run --files src/mindroom/api/credentials.py src/mindroom/api/oauth.py tests/api/test_credentials_api.py`

## Production line delta
- `src/mindroom/api/credentials.py`: +1 net
- `src/mindroom/api/oauth.py`: -14 net
- total production delta: -13 lines
