### PR TITLE
Refactor auto-flush session loading

### DIFF
--- a/src/mindroom/memory/auto_flush.py
+++ b/src/mindroom/memory/auto_flush.py
@@ -11,11 +11,9 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from agno.agent import Agent
-from agno.db.base import SessionType
-from agno.session.agent import AgentSession
 
 from mindroom import model_loading
-from mindroom.agent_storage import create_session_storage
+from mindroom.agent_storage import create_session_storage, get_agent_session
 from mindroom.logging_config import get_logger
 from mindroom.memory.functions import append_agent_daily_memory, list_all_agent_memories
 from mindroom.runtime_resolution import resolve_agent_execution
@@ -24,6 +22,8 @@ from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
+
+    from agno.session.agent import AgentSession
 
     from mindroom.config.main import Config
     from mindroom.config.memory import MemoryAutoFlushConfig
@@ -335,15 +335,6 @@ def reprioritize_auto_flush_sessions(
     _notify_workers()
 
 
-def _coerce_agent_session(raw_session: object) -> AgentSession | None:
-    if isinstance(raw_session, AgentSession):
-        return raw_session
-    if isinstance(raw_session, dict):
-        session_payload = cast("dict[str, Any]", raw_session)
-        return AgentSession.from_dict(session_payload)
-    return None
-
-
 def _load_agent_session(
     config: Config,
     runtime_paths: RuntimePaths,
@@ -358,8 +349,7 @@ def _load_agent_session(
         runtime_paths,
         execution_identity=execution_identity,
     )
-    raw_session = storage.get_session(session_id, SessionType.AGENT)
-    return _coerce_agent_session(raw_session)
+    return get_agent_session(storage, session_id)
 
 
 def _entry_priority_key(entry: _FlushSessionEntry, now: int) -> tuple[int, int]:

--- a/tests/test_memory_auto_flush.py
+++ b/tests/test_memory_auto_flush.py
@@ -764,6 +764,29 @@ def test_load_agent_session_passes_execution_identity_for_private_agents(
     assert captured["session_id"] == "session-alice"
 
 
+def test_load_agent_session_uses_canonical_session_helper(
+    config: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-flush should not locally coerce raw Agno session payloads."""
+    storage = object()
+    sentinel = object()
+
+    def _fake_create_session_storage(*_args: object, **_kwargs: object) -> object:
+        return storage
+
+    monkeypatch.setattr("mindroom.memory.auto_flush.create_session_storage", _fake_create_session_storage)
+    monkeypatch.setattr(
+        "mindroom.memory.auto_flush.get_agent_session",
+        lambda actual_storage, session_id: (
+            sentinel if actual_storage is storage and session_id == "session-1" else None
+        ),
+        raising=False,
+    )
+
+    assert _load_agent_session(config, runtime_paths_for(config), "general", "session-1") is sentinel
+
+
 def test_reprioritize_private_sessions_stays_within_private_scope(tmp_path: Path) -> None:
     """Private auto-flush reprioritization must not cross requester boundaries."""
     config = _private_auto_flush_config(tmp_path)


### PR DESCRIPTION
## Summary
- Replace auto-flush local AgentSession coercion with the canonical get_agent_session helper.
- Add a focused auto-flush test that asserts session loading delegates to the canonical helper.

## Verification
- uv run pytest tests/test_memory_auto_flush.py tests/test_interrupted_replay.py tests/test_compact_context.py -q
- uv run pre-commit run --files src/mindroom/memory/auto_flush.py tests/test_memory_auto_flush.py
- uv run pytest -q -n 4

## Notes
- No DB schema or session semantics changes.