### PR TITLE
Refactor Matrix cache event batch grouping

### DIFF
--- a/src/mindroom/matrix/cache/event_batching.py
+++ b/src/mindroom/matrix/cache/event_batching.py
@@ -1,0 +1,18 @@
+"""Pure Matrix event batch grouping helpers for cache backends."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .event_normalization import normalize_event_source_for_cache
+
+
+def group_lookup_events_by_room(
+    events: list[tuple[str, str, dict[str, Any]]],
+) -> dict[str, list[tuple[str, dict[str, Any]]]]:
+    """Return normalized lookup events grouped by room encounter order."""
+    events_by_room: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+    for event_id, room_id, event_data in events:
+        normalized_event = normalize_event_source_for_cache(event_data, event_id=event_id)
+        events_by_room.setdefault(room_id, []).append((event_id, normalized_event))
+    return events_by_room

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -14,6 +14,7 @@ import psycopg
 from mindroom.logging_config import get_logger
 
 from . import postgres_event_cache_events, postgres_event_cache_threads
+from .event_batching import group_lookup_events_by_room
 from .event_cache import EventCacheBackendUnavailableError
 from .event_normalization import normalize_event_source_for_cache
 from .postgres_agent_message_snapshot import load_postgres_agent_message_snapshot
@@ -978,12 +979,7 @@ class PostgresEventCache:
             return
 
         cached_at = time.time()
-        events_by_room: dict[str, list[tuple[str, dict[str, Any]]]] = {}
-        for event_id, room_id, event_data in events:
-            normalized_event = normalize_event_source_for_cache(event_data, event_id=event_id)
-            events_by_room.setdefault(room_id, []).append((event_id, normalized_event))
-
-        for room_id, room_events in events_by_room.items():
+        for room_id, room_events in group_lookup_events_by_room(events).items():
             await self._write_operation(
                 room_id,
                 operation="store_events_batch",

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -14,6 +14,7 @@ import aiosqlite
 from mindroom.logging_config import get_logger
 
 from . import sqlite_event_cache_events, sqlite_event_cache_threads
+from .event_batching import group_lookup_events_by_room
 from .event_normalization import normalize_event_source_for_cache
 from .sqlite_agent_message_snapshot import load_sqlite_agent_message_snapshot
 
@@ -601,12 +602,7 @@ class SqliteEventCache:
             return
 
         cached_at = time.time()
-        events_by_room: dict[str, list[tuple[str, dict[str, Any]]]] = {}
-        for event_id, room_id, event_data in events:
-            normalized_event = normalize_event_source_for_cache(event_data, event_id=event_id)
-            events_by_room.setdefault(room_id, []).append((event_id, normalized_event))
-
-        for room_id, room_events in events_by_room.items():
+        for room_id, room_events in group_lookup_events_by_room(events).items():
             await self._write_operation(
                 room_id,
                 operation="store_events_batch",

--- a/tach.toml
+++ b/tach.toml
@@ -1095,6 +1095,7 @@ visibility = [
 path = "mindroom.matrix.cache"
 depends_on = [
     "mindroom.matrix.cache.agent_message_snapshot",
+    "mindroom.matrix.cache.event_batching",
     "mindroom.matrix.cache.event_cache",
     "mindroom.matrix.cache.event_normalization",
     "mindroom.matrix.cache.write_coordinator",
@@ -1155,6 +1156,12 @@ path = "mindroom.matrix.cache.event_normalization"
 depends_on = []
 
 [[modules]]
+path = "mindroom.matrix.cache.event_batching"
+depends_on = [
+    "mindroom.matrix.cache.event_normalization",
+]
+
+[[modules]]
 path = "mindroom.matrix.cache.thread_reads"
 depends_on = [
     "mindroom.matrix.cache.thread_cache_helpers",
@@ -1195,6 +1202,7 @@ depends_on = []
 [[modules]]
 path = "mindroom.matrix.cache.sqlite_event_cache"
 depends_on = [
+    "mindroom.matrix.cache.event_batching",
     "mindroom.matrix.cache.event_normalization",
     "mindroom.logging_config",
     "mindroom.matrix.cache.sqlite_agent_message_snapshot",
@@ -1206,6 +1214,7 @@ visibility = ["mindroom.runtime_support"]
 [[modules]]
 path = "mindroom.matrix.cache.postgres_event_cache"
 depends_on = [
+    "mindroom.matrix.cache.event_batching",
     "mindroom.matrix.cache.event_cache",
     "mindroom.matrix.cache.event_normalization",
     "mindroom.logging_config",

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -21,6 +21,7 @@ from mindroom.matrix.cache import (
     sqlite_event_cache_threads,
     thread_cache_rejection_reason,
 )
+from mindroom.matrix.cache.event_batching import group_lookup_events_by_room
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.client_thread_history import fetch_thread_history
 from mindroom.matrix.conversation_cache import _cached_room_get_event
@@ -175,6 +176,72 @@ def test_event_cache_normalization_is_backend_neutral() -> None:
         "event_id": "$event",
         "sender": "@user:localhost",
         "origin_server_ts": 1234,
+    }
+
+
+def test_group_lookup_events_by_room_normalizes_and_preserves_order() -> None:
+    """Lookup event batch grouping should be shared by durable cache backends."""
+    grouped_events = group_lookup_events_by_room(
+        [
+            (
+                "$a",
+                "!alpha:localhost",
+                {
+                    "type": "m.room.message",
+                    "content": {"body": "alpha first"},
+                    "com.mindroom.dispatch_pipeline_timing": {"resolution_ms": 12},
+                },
+            ),
+            (
+                "$b",
+                "!beta:localhost",
+                {
+                    "type": "m.room.message",
+                    "event_id": "$already-present",
+                    "content": {"body": "beta first"},
+                },
+            ),
+            (
+                "$c",
+                "!alpha:localhost",
+                {
+                    "type": "m.room.message",
+                    "content": {"body": "alpha second"},
+                },
+            ),
+        ],
+    )
+
+    assert list(grouped_events) == ["!alpha:localhost", "!beta:localhost"]
+    assert grouped_events == {
+        "!alpha:localhost": [
+            (
+                "$a",
+                {
+                    "type": "m.room.message",
+                    "content": {"body": "alpha first"},
+                    "event_id": "$a",
+                },
+            ),
+            (
+                "$c",
+                {
+                    "type": "m.room.message",
+                    "content": {"body": "alpha second"},
+                    "event_id": "$c",
+                },
+            ),
+        ],
+        "!beta:localhost": [
+            (
+                "$b",
+                {
+                    "type": "m.room.message",
+                    "event_id": "$already-present",
+                    "content": {"body": "beta first"},
+                },
+            ),
+        ],
     }
 
 


### PR DESCRIPTION
## Summary
- Extract shared lookup-event batch normalization/grouping for Matrix cache backends.
- Reuse the helper from SQLite and PostgreSQL `store_events_batch` without changing DB operations, schema, ordering, or invalidation behavior.
- Add focused coverage for room encounter order, per-room event order, and cache event normalization.

## Verification
- `uv run pytest tests/test_event_cache.py -k group_lookup_events_by_room_normalizes_and_preserves_order -n 0 --no-cov -q`
- `uv run pytest tests/test_event_cache.py tests/test_event_cache_backends.py tests/test_matrix_cache_agent_message_snapshot.py -n 0 --no-cov -q`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/matrix/cache/event_batching.py src/mindroom/matrix/cache/sqlite_event_cache.py src/mindroom/matrix/cache/postgres_event_cache.py tests/test_event_cache.py tach.toml`