### PR TITLE
Refactor scheduled task restore parsing

### DIFF
--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -1606,7 +1606,7 @@ async def cancel_all_scheduled_tasks(
     return result
 
 
-async def restore_scheduled_tasks(  # noqa: C901, PLR0912
+async def restore_scheduled_tasks(  # noqa: C901
     client: nio.AsyncClient,
     room_id: str,
     config: Config,
@@ -1625,79 +1625,60 @@ async def restore_scheduled_tasks(  # noqa: C901, PLR0912
         return 0
 
     restored_count = 0
-    for event in response.events:
-        if event["type"] != _SCHEDULED_TASK_EVENT_TYPE:
-            continue
+    for task in _parse_task_records_from_state(room_id, response, include_non_pending=False):
+        task_id = task.task_id
+        workflow = task.workflow
 
-        content = event["content"]
-        if content.get("status") != "pending":
-            continue
-
-        try:
-            task_id: str = event["state_key"]
-
-            # Parse the workflow
-            workflow_data = json.loads(content["workflow"])
-            workflow = ScheduledWorkflow(**workflow_data)
-
-            # Validate workflow has required fields
-            if workflow.schedule_type == "once":
-                if not workflow.execute_at:
-                    logger.warning("skipping_one_time_task_without_execution_time", task_id=task_id)
-                    continue
-                # Handle past one-time tasks: execute if within grace period, fail if too old
-                if workflow.execute_at <= datetime.now(UTC):
-                    missed_by = (datetime.now(UTC) - workflow.execute_at).total_seconds()
-                    if missed_by > _MISSED_TASK_MAX_AGE_SECONDS:
-                        logger.warning(
-                            "Skipping ancient missed task",
-                            task_id=task_id,
-                            missed_by_seconds=missed_by,
-                        )
-                        try:
-                            await _persist_scheduled_task_state(
-                                client=client,
-                                room_id=room_id,
-                                task_id=task_id,
-                                workflow=workflow,
-                                status="failed",
-                                created_at=content.get("created_at"),
-                            )
-                        except Exception:
-                            logger.exception("Failed to mark ancient task as failed", task_id=task_id)
-                        continue
-                    if _queue_deferred_overdue_task(task_id, workflow):
-                        logger.warning(
-                            "Queued missed one-time task until sync is ready",
-                            task_id=task_id,
-                            missed_by_seconds=missed_by,
-                        )
-                        restored_count += 1
-                    continue
-            elif workflow.schedule_type == "cron":
-                if not workflow.cron_schedule:
-                    logger.warning("skipping_recurring_task_without_cron_schedule", task_id=task_id)
-                    continue
-            else:
-                logger.warning("unknown_schedule_type", task_id=task_id, schedule_type=workflow.schedule_type)
+        if workflow.schedule_type == "once":
+            if not workflow.execute_at:
+                logger.warning("skipping_one_time_task_without_execution_time", task_id=task_id)
                 continue
-
-            # Start the appropriate task
-            if _start_scheduled_task(
-                client,
-                task_id,
-                workflow,
-                config,
-                runtime_paths,
-                event_cache,
-                conversation_cache,
-                matrix_admin=build_hook_matrix_admin(client, runtime_paths),
-            ):
-                restored_count += 1
-
-        except (KeyError, ValueError, json.JSONDecodeError):
-            logger.exception("Failed to restore task")
+            # Handle past one-time tasks: execute if within grace period, fail if too old
+            now = datetime.now(UTC)
+            if workflow.execute_at <= now:
+                missed_by = (now - workflow.execute_at).total_seconds()
+                if missed_by > _MISSED_TASK_MAX_AGE_SECONDS:
+                    logger.warning(
+                        "Skipping ancient missed task",
+                        task_id=task_id,
+                        missed_by_seconds=missed_by,
+                    )
+                    try:
+                        await _persist_scheduled_task_state(
+                            client=client,
+                            room_id=room_id,
+                            task_id=task_id,
+                            workflow=workflow,
+                            status="failed",
+                            created_at=task.created_at,
+                        )
+                    except Exception:
+                        logger.exception("Failed to mark ancient task as failed", task_id=task_id)
+                    continue
+                if _queue_deferred_overdue_task(task_id, workflow):
+                    logger.warning(
+                        "Queued missed one-time task until sync is ready",
+                        task_id=task_id,
+                        missed_by_seconds=missed_by,
+                    )
+                    restored_count += 1
+                continue
+        elif workflow.schedule_type == "cron" and not workflow.cron_schedule:
+            logger.warning("skipping_recurring_task_without_cron_schedule", task_id=task_id)
             continue
+
+        # Start the appropriate task
+        if _start_scheduled_task(
+            client,
+            task_id,
+            workflow,
+            config,
+            runtime_paths,
+            event_cache,
+            conversation_cache,
+            matrix_admin=build_hook_matrix_admin(client, runtime_paths),
+        ):
+            restored_count += 1
 
     if restored_count > 0:
         logger.info("Restored scheduled tasks in room", room_id=room_id, restored_count=restored_count)

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -405,6 +405,72 @@ async def test_restore_scheduled_tasks_does_not_queue_when_nothing_is_overdue() 
 
 
 @pytest.mark.asyncio
+async def test_restore_scheduled_tasks_uses_canonical_state_parser_for_mixed_records() -> None:
+    """Restore should skip non-pending and malformed records while restoring valid pending records."""
+    client = AsyncMock()
+    cron_workflow = ScheduledWorkflow(
+        schedule_type="cron",
+        cron_schedule=CronSchedule(minute="0", hour="9", day="*", month="*", weekday="*"),
+        message="Run the daily report",
+        description="Daily report",
+        thread_id="$thread123",
+        room_id="!test:server",
+    )
+    state_response = nio.RoomGetStateResponse.from_dict(
+        [
+            {
+                "type": _SCHEDULED_TASK_EVENT_TYPE,
+                "state_key": "malformed_content",
+                "content": "not a dict",
+                "event_id": "$state_malformed_content",
+                "sender": "@system:server",
+                "origin_server_ts": 1234567888,
+            },
+            {
+                "type": _SCHEDULED_TASK_EVENT_TYPE,
+                "state_key": "old_cancelled",
+                "content": {
+                    "status": "cancelled",
+                },
+                "event_id": "$state_cancelled",
+                "sender": "@system:server",
+                "origin_server_ts": 1234567889,
+            },
+            {
+                "type": _SCHEDULED_TASK_EVENT_TYPE,
+                "state_key": "task_cron",
+                "content": {
+                    "workflow": cron_workflow.model_dump_json(),
+                    "status": "pending",
+                    "created_at": datetime.now(UTC).isoformat(),
+                },
+                "event_id": "$state_task_cron",
+                "sender": "@system:server",
+                "origin_server_ts": 1234567890,
+            },
+        ],
+        room_id="!test:server",
+    )
+    client.room_get_state = AsyncMock(return_value=state_response)
+    conversation_cache = _conversation_cache(latest_thread_event_id="$latest")
+
+    with patch("mindroom.scheduling._start_scheduled_task", return_value=True) as mock_start:
+        restored = await restore_scheduled_tasks(
+            client=client,
+            room_id="!test:server",
+            config=MagicMock(),
+            runtime_paths=_runtime_paths(),
+            event_cache=_event_cache(),
+            conversation_cache=conversation_cache,
+        )
+
+    assert restored == 1
+    mock_start.assert_called_once()
+    assert mock_start.call_args.args[1] == "task_cron"
+    assert len(scheduling._deferred_overdue_tasks) == 0
+
+
+@pytest.mark.asyncio
 async def test_list_scheduled_tasks_real_implementation() -> None:
     """Test list_scheduled_tasks with real implementation, only mocking Matrix API."""
     # Create mock client


### PR DESCRIPTION
## Summary
- Refactor scheduled task restore to consume canonical parsed ScheduledTaskRecord values from Matrix state.
- Preserve overdue one-time handling, ancient missed-task failure persistence, cron validation, Matrix state keys, and restore start behavior.
- Add characterization coverage for mixed pending, non-pending, and malformed restore records.

## Verification
- uv run pytest tests/test_scheduling.py::test_restore_scheduled_tasks_uses_canonical_state_parser_for_mixed_records -q -n 0 --no-cov (failed before implementation with AttributeError on malformed raw content; passed after refactor)
- uv run pytest tests/test_scheduling.py tests/test_scheduled_task_restoration.py tests/api/test_schedules_api.py -n 0 --no-cov (49 passed on final SHA)
- uv run pre-commit run --files src/mindroom/scheduling.py tests/test_scheduling.py (passed on final SHA)
- uv run pytest -n 0 --no-cov (6245 passed, 56 skipped on pre-final SHA 473bfd76 before final rebase onto unrelated upstream #901/#903)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Enhanced recovery of scheduled tasks after application restart, with improved handling of expired one-time tasks and malformed records to ensure system reliability.

* **Tests**
  - Added test coverage for task record parsing and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->