### PR TITLE
Refactor plugin import transactions

### DIFF
--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -9,7 +9,6 @@ import os
 import sys
 from dataclasses import asdict, dataclass
 from enum import Enum
-from importlib import util as importlib_util
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -868,29 +867,34 @@ def _execute_validation_plugin_module(
     """Execute one plugin module into a temporary validation import context."""
     runtime_module_name = plugin_module._module_name(plugin_name, plugin_root, module_path)
     validation_module_name = f"{runtime_module_name}{_VALIDATION_PLUGIN_MODULE_SUFFIX}{id(registrations_by_module)}"
-    previous_packages = plugin_module._snapshot_plugin_package_chain(plugin_name, plugin_root, module_path)
-    plugin_module._install_plugin_package_chain(plugin_name, plugin_root, module_path)
-    spec = importlib_util.spec_from_file_location(validation_module_name, module_path)
-    if spec is None or spec.loader is None:
-        plugin_module._restore_plugin_package_chain(previous_packages)
-        msg = f"Failed to load plugin validation module: {module_path}"
-        raise ToolMetadataValidationError(msg)
-
     previous_module = sys.modules.get(validation_module_name)
+    try:
+        module, loader, previous_packages = plugin_module._prepare_plugin_module_execution(
+            plugin_name,
+            plugin_root,
+            module_path,
+            validation_module_name,
+        )
+    except plugin_module._PluginModuleSpecError:
+        msg = f"Failed to load plugin validation module: {module_path}"
+        raise ToolMetadataValidationError(msg) from None
+
     loaded_modules = sys.modules.copy()
+    if previous_module is None:
+        loaded_modules.pop(validation_module_name, None)
+    else:
+        loaded_modules[validation_module_name] = previous_module
     previous_modules_within_root = {
         module_name: loaded_module
         for module_name, loaded_module in loaded_modules.items()
         if _module_origin_within_root(loaded_module, plugin_root)
     }
-    module = importlib_util.module_from_spec(spec)
-    sys.modules[validation_module_name] = module
     try:
         with (
             scoped_plugin_registration_store(registrations_by_module),
             scoped_plugin_registration_owner(validation_module_name),
         ):
-            spec.loader.exec_module(module)
+            loader.exec_module(module)
     except Exception as exc:
         msg = f"Plugin validation module execution failed for {module_path}: {exc}"
         raise ToolMetadataValidationError(msg) from exc

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -867,23 +867,14 @@ def _execute_validation_plugin_module(
     """Execute one plugin module into a temporary validation import context."""
     runtime_module_name = plugin_module._module_name(plugin_name, plugin_root, module_path)
     validation_module_name = f"{runtime_module_name}{_VALIDATION_PLUGIN_MODULE_SUFFIX}{id(registrations_by_module)}"
-    previous_module = sys.modules.get(validation_module_name)
-    try:
-        module, loader, previous_packages = plugin_module._prepare_plugin_module_execution(
-            plugin_name,
-            plugin_root,
-            module_path,
-            validation_module_name,
-        )
-    except plugin_module._PluginModuleSpecError:
-        msg = f"Failed to load plugin validation module: {module_path}"
-        raise ToolMetadataValidationError(msg) from None
-
     loaded_modules = sys.modules.copy()
-    if previous_module is None:
-        loaded_modules.pop(validation_module_name, None)
-    else:
-        loaded_modules[validation_module_name] = previous_module
+    previous_module = loaded_modules.get(validation_module_name)
+    prepared_module = plugin_module._prepare_module(plugin_name, plugin_root, module_path, validation_module_name)
+    if prepared_module is None:
+        msg = f"Failed to load plugin validation module: {module_path}"
+        raise ToolMetadataValidationError(msg)
+    module, loader, previous_packages = prepared_module
+
     previous_modules_within_root = {
         module_name: loaded_module
         for module_name, loaded_module in loaded_modules.items()

--- a/src/mindroom/tool_system/plugin_imports.py
+++ b/src/mindroom/tool_system/plugin_imports.py
@@ -9,11 +9,15 @@ from dataclasses import dataclass
 from importlib import util
 from pathlib import Path
 from types import ModuleType
+from typing import TYPE_CHECKING
 
 from mindroom.config.plugin import PluginEntryConfig  # noqa: TC001
 from mindroom.constants import RuntimePaths, resolve_config_relative_path
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.plugin_identity import validate_plugin_name
+
+if TYPE_CHECKING:
+    from importlib.abc import Loader
 
 logger = get_logger(__name__)
 
@@ -61,6 +65,10 @@ class _ModuleCacheEntry:
     mtime: float
     module_name: str
     module: ModuleType
+
+
+class _PluginModuleSpecError(RuntimeError):
+    """Raised when importlib cannot build a plugin module spec."""
 
 
 _PLUGIN_CACHE: dict[Path, _PluginCacheEntry] = {}
@@ -404,3 +412,21 @@ def _restore_plugin_package_chain(previous_packages: dict[str, ModuleType | None
             sys.modules.pop(package_name, None)
         else:
             sys.modules[package_name] = previous_module
+
+
+def _prepare_plugin_module_execution(
+    plugin_name: str,
+    plugin_root: Path,
+    module_path: Path,
+    module_name: str,
+) -> tuple[ModuleType, Loader, dict[str, ModuleType | None]]:
+    previous_packages = _snapshot_plugin_package_chain(plugin_name, plugin_root, module_path)
+    _install_plugin_package_chain(plugin_name, plugin_root, module_path)
+    spec = util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        _restore_plugin_package_chain(previous_packages)
+        raise _PluginModuleSpecError(str(module_path))
+
+    module = util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    return module, spec.loader, previous_packages

--- a/src/mindroom/tool_system/plugin_imports.py
+++ b/src/mindroom/tool_system/plugin_imports.py
@@ -9,21 +9,19 @@ from dataclasses import dataclass
 from importlib import util
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING
+from typing import Any
 
 from mindroom.config.plugin import PluginEntryConfig  # noqa: TC001
 from mindroom.constants import RuntimePaths, resolve_config_relative_path
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.plugin_identity import validate_plugin_name
 
-if TYPE_CHECKING:
-    from importlib.abc import Loader
-
 logger = get_logger(__name__)
 
 _PLUGIN_MANIFEST = "mindroom.plugin.json"
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _WARNED_PLUGIN_MESSAGES: set[tuple[str, Path]] = set()
+_PreparedPluginModule = tuple[ModuleType, Any, dict[str, ModuleType | None]] | None
 
 
 class PluginValidationError(ValueError):
@@ -65,10 +63,6 @@ class _ModuleCacheEntry:
     mtime: float
     module_name: str
     module: ModuleType
-
-
-class _PluginModuleSpecError(RuntimeError):
-    """Raised when importlib cannot build a plugin module spec."""
 
 
 _PLUGIN_CACHE: dict[Path, _PluginCacheEntry] = {}
@@ -414,19 +408,12 @@ def _restore_plugin_package_chain(previous_packages: dict[str, ModuleType | None
             sys.modules[package_name] = previous_module
 
 
-def _prepare_plugin_module_execution(
-    plugin_name: str,
-    plugin_root: Path,
-    module_path: Path,
-    module_name: str,
-) -> tuple[ModuleType, Loader, dict[str, ModuleType | None]]:
-    previous_packages = _snapshot_plugin_package_chain(plugin_name, plugin_root, module_path)
-    _install_plugin_package_chain(plugin_name, plugin_root, module_path)
-    spec = util.spec_from_file_location(module_name, module_path)
-    if spec is None or spec.loader is None:
+def _prepare_module(name: str, root: Path, path: Path, module_name: str) -> _PreparedPluginModule:
+    previous_packages = _snapshot_plugin_package_chain(name, root, path)
+    _install_plugin_package_chain(name, root, path)
+    if (spec := util.spec_from_file_location(module_name, path)) is None or spec.loader is None:
         _restore_plugin_package_chain(previous_packages)
-        raise _PluginModuleSpecError(str(module_path))
+        return None
 
-    module = util.module_from_spec(spec)
-    sys.modules[module_name] = module
+    module = sys.modules[module_name] = util.module_from_spec(spec)
     return module, spec.loader, previous_packages

--- a/src/mindroom/tool_system/plugins.py
+++ b/src/mindroom/tool_system/plugins.py
@@ -426,17 +426,12 @@ def load_plugin_module(
     if cached is not None and cached.module_name != module_name:
         sys.modules.pop(cached.module_name, None)
 
-    try:
-        module, _, previous_packages = plugin_imports._prepare_plugin_module_execution(
-            plugin_name,
-            plugin_root,
-            module_path,
-            module_name,
-        )
-    except plugin_imports._PluginModuleSpecError:
+    prepared_module = plugin_imports._prepare_module(plugin_name, plugin_root, module_path, module_name)
+    if prepared_module is None:
         msg = f"Failed to load plugin {kind} module: {module_path}"
-        logger.error("Failed to load plugin module", path=str(module_path), kind=kind)  # noqa: TRY400
-        raise _PluginValidationError(msg) from None
+        logger.error("Failed to load plugin module", path=str(module_path), kind=kind)
+        raise _PluginValidationError(msg)
+    module, _, previous_packages = prepared_module
 
     try:
         if kind == "tools":

--- a/src/mindroom/tool_system/plugins.py
+++ b/src/mindroom/tool_system/plugins.py
@@ -6,7 +6,6 @@ import asyncio
 import sys
 import tokenize
 from dataclasses import dataclass
-from importlib import util
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from mindroom.config.plugin import PluginEntryConfig  # noqa: TC001
@@ -427,17 +426,18 @@ def load_plugin_module(
     if cached is not None and cached.module_name != module_name:
         sys.modules.pop(cached.module_name, None)
 
-    previous_packages = plugin_imports._snapshot_plugin_package_chain(plugin_name, plugin_root, module_path)
-    plugin_imports._install_plugin_package_chain(plugin_name, plugin_root, module_path)
-    spec = util.spec_from_file_location(module_name, module_path)
-    if spec is None or spec.loader is None:
-        plugin_imports._restore_plugin_package_chain(previous_packages)
+    try:
+        module, _, previous_packages = plugin_imports._prepare_plugin_module_execution(
+            plugin_name,
+            plugin_root,
+            module_path,
+            module_name,
+        )
+    except plugin_imports._PluginModuleSpecError:
         msg = f"Failed to load plugin {kind} module: {module_path}"
-        logger.error("Failed to load plugin module", path=str(module_path), kind=kind)
-        raise _PluginValidationError(msg)
+        logger.error("Failed to load plugin module", path=str(module_path), kind=kind)  # noqa: TRY400
+        raise _PluginValidationError(msg) from None
 
-    module = util.module_from_spec(spec)
-    sys.modules[module_name] = module
     try:
         if kind == "tools":
             with scoped_plugin_registration_owner(module_name):

--- a/tests/test_plugin_imports.py
+++ b/tests/test_plugin_imports.py
@@ -6,15 +6,15 @@ import sys
 from types import ModuleType
 from typing import TYPE_CHECKING
 
-import pytest
-
 from mindroom.tool_system import plugin_imports
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
 
-def test_prepare_plugin_module_execution_installs_package_chain(tmp_path: Path) -> None:
+
+def test_prepare_module_installs_package_chain(tmp_path: Path) -> None:
     """Prepared plugin module execution should install packages and expose the module."""
     plugin_root = tmp_path / "plugins" / "demo"
     package_dir = plugin_root / "nested"
@@ -28,7 +28,7 @@ def test_prepare_plugin_module_execution_installs_package_chain(tmp_path: Path) 
     ]
 
     try:
-        module, loader, _ = plugin_imports._prepare_plugin_module_execution(
+        module, loader, _ = plugin_imports._prepare_module(
             "demo",
             plugin_root,
             module_path,
@@ -46,7 +46,7 @@ def test_prepare_plugin_module_execution_installs_package_chain(tmp_path: Path) 
             sys.modules.pop(package_name, None)
 
 
-def test_prepare_plugin_module_execution_restores_package_chain_on_spec_failure(
+def test_prepare_module_restores_package_chain_on_spec_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -65,14 +65,14 @@ def test_prepare_plugin_module_execution_restores_package_chain_on_spec_failure(
     monkeypatch.setattr(plugin_imports.util, "spec_from_file_location", lambda *_args, **_kwargs: None)
 
     try:
-        with pytest.raises(plugin_imports._PluginModuleSpecError):
-            plugin_imports._prepare_plugin_module_execution(
-                "demo",
-                plugin_root,
-                module_path,
-                plugin_imports._module_name("demo", plugin_root, module_path),
-            )
+        module_execution = plugin_imports._prepare_module(
+            "demo",
+            plugin_root,
+            module_path,
+            plugin_imports._module_name("demo", plugin_root, module_path),
+        )
 
+        assert module_execution is None
         assert sys.modules[package_names[0]] is existing_package
         for package_name in package_names[1:]:
             assert package_name not in sys.modules

--- a/tests/test_plugin_imports.py
+++ b/tests/test_plugin_imports.py
@@ -1,0 +1,81 @@
+"""Tests for low-level plugin import transaction helpers."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom.tool_system import plugin_imports
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_prepare_plugin_module_execution_installs_package_chain(tmp_path: Path) -> None:
+    """Prepared plugin module execution should install packages and expose the module."""
+    plugin_root = tmp_path / "plugins" / "demo"
+    package_dir = plugin_root / "nested"
+    package_dir.mkdir(parents=True)
+    module_path = package_dir / "tools.py"
+    module_path.write_text("VALUE = 42\n", encoding="utf-8")
+
+    module_name = plugin_imports._module_name("demo", plugin_root, module_path)
+    package_names = [
+        package_name for package_name, _ in plugin_imports._package_chain_names("demo", plugin_root, module_path)
+    ]
+
+    try:
+        module, loader, _ = plugin_imports._prepare_plugin_module_execution(
+            "demo",
+            plugin_root,
+            module_path,
+            module_name,
+        )
+        loader.exec_module(module)
+
+        assert module.VALUE == 42
+        assert sys.modules[module_name] is module
+        for package_name in package_names:
+            assert package_name in sys.modules
+    finally:
+        sys.modules.pop(module_name, None)
+        for package_name in package_names:
+            sys.modules.pop(package_name, None)
+
+
+def test_prepare_plugin_module_execution_restores_package_chain_on_spec_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Spec failures should restore pre-existing packages and remove synthetic ones."""
+    plugin_root = tmp_path / "plugins" / "demo"
+    package_dir = plugin_root / "nested"
+    package_dir.mkdir(parents=True)
+    module_path = package_dir / "tools.py"
+    module_path.write_text("VALUE = 42\n", encoding="utf-8")
+
+    package_names = [
+        package_name for package_name, _ in plugin_imports._package_chain_names("demo", plugin_root, module_path)
+    ]
+    existing_package = ModuleType(package_names[0])
+    sys.modules[package_names[0]] = existing_package
+    monkeypatch.setattr(plugin_imports.util, "spec_from_file_location", lambda *_args, **_kwargs: None)
+
+    try:
+        with pytest.raises(plugin_imports._PluginModuleSpecError):
+            plugin_imports._prepare_plugin_module_execution(
+                "demo",
+                plugin_root,
+                module_path,
+                plugin_imports._module_name("demo", plugin_root, module_path),
+            )
+
+        assert sys.modules[package_names[0]] is existing_package
+        for package_name in package_names[1:]:
+            assert package_name not in sys.modules
+    finally:
+        for package_name in package_names:
+            sys.modules.pop(package_name, None)


### PR DESCRIPTION
## Summary
- add a low-level plugin module execution prep helper in plugin_imports
- reuse it from runtime plugin loading and validation metadata loading
- add characterization coverage for success and spec-failure package-chain restoration

## Verification
- uv sync --all-extras
- uv run pytest tests/test_plugin_imports.py tests/test_plugins.py tests/test_tools_metadata.py -q --no-cov
- uv run pre-commit run --files src/mindroom/tool_system/plugin_imports.py src/mindroom/tool_system/plugins.py src/mindroom/tool_system/metadata.py tests/test_plugin_imports.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced tool metadata framework with registration decorators and validation infrastructure
  * Enhanced plugin loading with automatic dependency management and pre-validation checks

* **Tests**
  * Added comprehensive test coverage for plugin import behavior and state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->