### PR TITLE
Refactor Matrix thread visible helpers

### DIFF
--- a/src/mindroom/matrix/thread_bookkeeping.py
+++ b/src/mindroom/matrix/thread_bookkeeping.py
@@ -20,6 +20,7 @@ from mindroom.matrix.thread_membership import (
     ThreadResolutionState,
     ThreadRootProof,
     fetch_event_info_for_client,
+    page_event_info_counts_as_thread_child_proof,
     resolve_event_thread_membership,
     resolve_related_event_thread_membership,
 )
@@ -337,7 +338,7 @@ class ThreadMutationResolver:
             if cached_proof is not None:
                 return cached_proof
             if any(
-                _page_event_info_counts_as_thread_child_proof(
+                page_event_info_counts_as_thread_child_proof(
                     thread_root_id,
                     event_id=event_id,
                     event_info=event_info,
@@ -417,21 +418,3 @@ def _event_source_counts_as_thread_child_proof(
     if event_info.is_edit and event_info.original_event_id == thread_root_id:
         return False
     return isinstance(event_info.thread_id, str) and event_info.thread_id == thread_root_id
-
-
-def _page_event_info_counts_as_thread_child_proof(
-    thread_root_id: str,
-    *,
-    event_id: str,
-    event_info: EventInfo,
-) -> bool:
-    """Return whether one page-local event proves a root has thread children."""
-    if event_id == thread_root_id:
-        return False
-    return any(
-        candidate_thread_id == thread_root_id
-        for candidate_thread_id in (
-            event_info.thread_id,
-            event_info.thread_id_from_edit,
-        )
-    )

--- a/src/mindroom/matrix/thread_membership.py
+++ b/src/mindroom/matrix/thread_membership.py
@@ -323,13 +323,10 @@ def map_backed_thread_membership_access(
 
     async def prove_thread_root(_room_id: str, thread_root_id: str) -> ThreadRootProof:
         has_children = any(
-            event_id != thread_root_id
-            and any(
-                candidate_thread_id == thread_root_id
-                for candidate_thread_id in (
-                    event_info.thread_id,
-                    event_info.thread_id_from_edit,
-                )
+            page_event_info_counts_as_thread_child_proof(
+                thread_root_id,
+                event_id=event_id,
+                event_info=event_info,
             )
             for event_id, event_info in event_infos.items()
         )
@@ -339,6 +336,24 @@ def map_backed_thread_membership_access(
         lookup_thread_id=lookup_thread_id,
         fetch_event_info=fetch_event_info,
         prove_thread_root=prove_thread_root,
+    )
+
+
+def page_event_info_counts_as_thread_child_proof(
+    thread_root_id: str,
+    *,
+    event_id: str,
+    event_info: EventInfo,
+) -> bool:
+    """Return whether one page-local event proves a root has thread children."""
+    if event_id == thread_root_id:
+        return False
+    return any(
+        candidate_thread_id == thread_root_id
+        for candidate_thread_id in (
+            event_info.thread_id,
+            event_info.thread_id_from_edit,
+        )
     )
 
 

--- a/src/mindroom/thread_utils.py
+++ b/src/mindroom/thread_utils.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, cast
 
 from mindroom import authorization
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.matrix.identity import MatrixID, extract_agent_name
 from mindroom.matrix.rooms import resolve_room_aliases
+from mindroom.matrix.visible_body import visible_content_from_content
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 _MATRIX_PILL_RE = re.compile(r"""href=["']https://matrix\.to/#/(@[^"':]+:[^"']+)["']""")
 
 
-def _extract_mentioned_user_ids(content: dict[str, Any]) -> list[str]:
+def _extract_mentioned_user_ids(content: dict[str, object]) -> list[str]:
     """Extract mentioned user IDs from message content.
 
     Checks ``m.mentions.user_ids`` first.  When that field is absent or empty
@@ -32,24 +33,15 @@ def _extract_mentioned_user_ids(content: dict[str, Any]) -> list[str]:
     HTML pills (``<a href="https://matrix.to/#/@user:domain">``) from
     ``formatted_body``.
     """
-    mentions = content.get("m.mentions", {})
-    user_ids: list[str] = mentions.get("user_ids", [])
-    if user_ids:
-        return user_ids
+    mentions = content.get("m.mentions")
+    user_ids = cast("dict[str, object]", mentions).get("user_ids") if isinstance(mentions, dict) else None
+    if isinstance(user_ids, list) and user_ids:
+        return [user_id for user_id in user_ids if isinstance(user_id, str)]
 
-    # Fallback: parse formatted_body for HTML pills
-    formatted_body = content.get("formatted_body", "")
-    if formatted_body:
+    formatted_body = content.get("formatted_body")
+    if isinstance(formatted_body, str):
         return _MATRIX_PILL_RE.findall(formatted_body)
     return []
-
-
-def _visible_message_content(content: dict[str, Any]) -> dict[str, Any]:
-    """Return the visible message content layer for mention detection."""
-    new_content = content.get("m.new_content")
-    if isinstance(new_content, dict):
-        return new_content
-    return content
 
 
 def _is_bot_or_agent(sender: str, config: Config, runtime_paths: RuntimePaths) -> bool:
@@ -71,7 +63,7 @@ def check_agent_mentioned(
     (i.e. a real human user).
     """
     raw_content = event_source.get("content", {})
-    content = _visible_message_content(raw_content) if isinstance(raw_content, dict) else {}
+    content = visible_content_from_content(raw_content) if isinstance(raw_content, dict) else {}
     all_mentioned_ids = _extract_mentioned_user_ids(content)
     mentioned_agents = _agents_from_user_ids(all_mentioned_ids, config, runtime_paths)
     am_i_mentioned = agent_id in mentioned_agents

--- a/tests/test_matrix_thread_domain.py
+++ b/tests/test_matrix_thread_domain.py
@@ -23,6 +23,7 @@ from mindroom.matrix.thread_bookkeeping import (
 from mindroom.matrix.thread_membership import (
     ThreadResolution,
     map_backed_thread_membership_access,
+    page_event_info_counts_as_thread_child_proof,
     resolve_event_thread_membership,
 )
 from mindroom.tool_system.runtime_context import ToolRuntimeContext
@@ -35,6 +36,80 @@ def _message_event_info(content: dict[str, object]) -> EventInfo:
             "type": "m.room.message",
             "content": content,
         },
+    )
+
+
+def test_page_event_info_counts_as_thread_child_proof_preserves_thread_semantics() -> None:
+    """Page-local root proof should count only non-root children of the candidate thread."""
+    thread_root_id = "$thread-root:localhost"
+    explicit_child = _message_event_info(
+        {
+            "body": "thread reply",
+            "msgtype": "m.text",
+            "m.relates_to": {
+                "rel_type": "m.thread",
+                "event_id": thread_root_id,
+            },
+        },
+    )
+    edit_child = _message_event_info(
+        {
+            "body": "* edited reply",
+            "msgtype": "m.text",
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": "$reply:localhost",
+            },
+            "m.new_content": {
+                "body": "edited reply",
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": thread_root_id,
+                },
+            },
+        },
+    )
+    root_info = _message_event_info(
+        {
+            "body": "root",
+            "msgtype": "m.text",
+            "m.relates_to": {
+                "rel_type": "m.thread",
+                "event_id": thread_root_id,
+            },
+        },
+    )
+    unrelated = _message_event_info(
+        {
+            "body": "other thread",
+            "msgtype": "m.text",
+            "m.relates_to": {
+                "rel_type": "m.thread",
+                "event_id": "$other-root:localhost",
+            },
+        },
+    )
+
+    assert page_event_info_counts_as_thread_child_proof(
+        thread_root_id,
+        event_id="$reply:localhost",
+        event_info=explicit_child,
+    )
+    assert page_event_info_counts_as_thread_child_proof(
+        thread_root_id,
+        event_id="$reply-edit:localhost",
+        event_info=edit_child,
+    )
+    assert not page_event_info_counts_as_thread_child_proof(
+        thread_root_id,
+        event_id=thread_root_id,
+        event_info=root_info,
+    )
+    assert not page_event_info_counts_as_thread_child_proof(
+        thread_root_id,
+        event_id="$other-reply:localhost",
+        event_info=unrelated,
     )
 
 


### PR DESCRIPTION
## Summary
- Move the page-local EventInfo child-proof predicate into thread membership and reuse it from mutation bookkeeping.
- Reuse the existing visible Matrix content-layer helper for thread mention detection.
- Add focused coverage for page-local child-proof semantics including edit-derived thread IDs and root self-exclusion.

## Test Plan
- uv run pytest tests/test_matrix_thread_domain.py::test_page_event_info_counts_as_thread_child_proof_preserves_thread_semantics -q -n 0 --no-cov
- uv run pytest tests/test_matrix_thread_domain.py tests/test_routing.py tests/test_agent_order_preservation.py -n 0 --no-cov -q
- uv run pre-commit run --files src/mindroom/matrix/thread_membership.py src/mindroom/matrix/thread_bookkeeping.py src/mindroom/thread_utils.py tests/test_matrix_thread_domain.py
- uv run pytest -n 0 --no-cov -q printed: 6240 passed, 56 skipped, 64 warnings in 439.82s; process then hung after summary and was terminated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized thread-detection logic to centralize common functionality and improve code maintainability.
* **Tests**
  * Added test coverage for thread semantics to ensure correct behavior in message threading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->