### PR TITLE
Extract sandbox attachment protocol helpers

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import binascii
-import hashlib
 import inspect
 import io
 import json
@@ -57,7 +55,7 @@ from mindroom.tool_system.output_files import (
     validate_output_path_syntax,
     write_bytes_to_output_path,
 )
-from mindroom.tool_system.sandbox_proxy import sandbox_proxy_config, to_json_compatible
+from mindroom.tool_system.sandbox_proxy import decode_attachment_save_bytes, sandbox_proxy_config, to_json_compatible
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
     WorkerScope,
@@ -1316,22 +1314,6 @@ def _save_attachment_output_path(payload: SandboxRunnerSaveAttachmentRequest) ->
     return payload.mindroom_output_path if payload.mindroom_output_path is not None else payload.save_to_disk
 
 
-def _decode_attachment_save_bytes(payload: SandboxRunnerSaveAttachmentRequest) -> bytes | str:
-    """Decode and integrity-check one save-attachment payload."""
-    if payload.size_bytes is not None and (type(payload.size_bytes) is not int or payload.size_bytes < 0):
-        return "Attachment size_bytes must be a non-negative integer."
-    try:
-        payload_bytes = base64.b64decode(payload.bytes_b64.encode("ascii"), validate=True)
-    except (UnicodeEncodeError, binascii.Error):
-        return "Attachment bytes are not valid base64."
-    if payload.size_bytes is not None and len(payload_bytes) != payload.size_bytes:
-        return "Attachment byte length does not match the request receipt."
-    actual_sha256 = hashlib.sha256(payload_bytes).hexdigest()
-    if not secrets.compare_digest(actual_sha256, payload.sha256):
-        return "Attachment SHA256 does not match the request payload."
-    return payload_bytes
-
-
 @router.post("/save-attachment", response_model=SandboxRunnerSaveAttachmentResponse)
 async def save_attachment_to_worker(  # noqa: C901, PLR0911
     request: Request,
@@ -1361,7 +1343,11 @@ async def save_attachment_to_worker(  # noqa: C901, PLR0911
     if raw_path_error is not None:
         return SandboxRunnerSaveAttachmentResponse(ok=False, error=raw_path_error, failure_kind="tool")
 
-    decoded_bytes = _decode_attachment_save_bytes(payload)
+    decoded_bytes = decode_attachment_save_bytes(
+        bytes_b64=payload.bytes_b64,
+        sha256=payload.sha256,
+        size_bytes=payload.size_bytes,
+    )
     if isinstance(decoded_bytes, str):
         return SandboxRunnerSaveAttachmentResponse(ok=False, error=decoded_bytes, failure_kind="tool")
 

--- a/src/mindroom/tool_system/sandbox_proxy.py
+++ b/src/mindroom/tool_system/sandbox_proxy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import functools
 import hashlib
 import json
@@ -13,7 +14,7 @@ from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 import httpx
 
@@ -60,6 +61,12 @@ _DEFAULT_INLINE_ATTACHMENT_BYTES = 16 * 1024 * 1024
 _ATTACHMENT_SAVE_WORKSPACE_CONSUMER_TOOLS = frozenset({"file", "coding", "python", "shell"})
 
 
+class _AttachmentSavePayloadFields(TypedDict):
+    bytes_b64: str
+    sha256: str
+    size_bytes: int
+
+
 @dataclass(frozen=True)
 class WorkerAttachmentSaveReceipt:
     """Receipt returned after writing attachment bytes into a worker workspace."""
@@ -67,6 +74,62 @@ class WorkerAttachmentSaveReceipt:
     worker_path: str
     size_bytes: int
     sha256: str
+
+
+def _attachment_save_payload_fields(payload_bytes: bytes) -> _AttachmentSavePayloadFields:
+    """Return the byte-integrity fields for one save-attachment request."""
+    return {
+        "bytes_b64": base64.b64encode(payload_bytes).decode("ascii"),
+        "sha256": hashlib.sha256(payload_bytes).hexdigest(),
+        "size_bytes": len(payload_bytes),
+    }
+
+
+def decode_attachment_save_bytes(*, bytes_b64: str, sha256: str, size_bytes: int | None) -> bytes | str:
+    """Decode and integrity-check one save-attachment payload."""
+    if size_bytes is not None and (type(size_bytes) is not int or size_bytes < 0):
+        return "Attachment size_bytes must be a non-negative integer."
+    try:
+        payload_bytes = base64.b64decode(bytes_b64.encode("ascii"), validate=True)
+    except (UnicodeEncodeError, binascii.Error):
+        return "Attachment bytes are not valid base64."
+    if size_bytes is not None and len(payload_bytes) != size_bytes:
+        return "Attachment byte length does not match the request receipt."
+    actual_sha256 = hashlib.sha256(payload_bytes).hexdigest()
+    if not secrets.compare_digest(actual_sha256, sha256):
+        return "Attachment SHA256 does not match the request payload."
+    return payload_bytes
+
+
+def _validate_attachment_save_receipt(
+    data: Mapping[str, object],
+    *,
+    requested_path: str,
+    byte_count: int,
+    sha256: str,
+) -> WorkerAttachmentSaveReceipt | str:
+    """Validate one successful worker save response against the sent bytes."""
+    worker_path = data.get("worker_path")
+    response_size = data.get("size_bytes")
+    response_sha256 = data.get("sha256")
+    if (
+        not isinstance(worker_path, str)
+        or type(response_size) is not int
+        or response_size < 0
+        or not isinstance(response_sha256, str)
+    ):
+        return "Sandbox save-attachment response is missing its receipt fields."
+    if worker_path != requested_path:
+        return "Sandbox save-attachment response path does not match the requested workspace path."
+    if response_size != byte_count:
+        return "Sandbox save-attachment response size does not match the sent bytes."
+    if not secrets.compare_digest(response_sha256, sha256):
+        return "Sandbox save-attachment response SHA256 does not match the sent bytes."
+    return WorkerAttachmentSaveReceipt(
+        worker_path=worker_path,
+        size_bytes=response_size,
+        sha256=response_sha256,
+    )
 
 
 @dataclass(frozen=True)
@@ -560,56 +623,21 @@ def _validated_worker_save_receipt(
     runtime_paths: RuntimePaths,
     proxy_config: _SandboxProxyConfig,
 ) -> WorkerAttachmentSaveReceipt:
-    """Validate one successful worker save response against the sent bytes."""
-    worker_path = data.get("worker_path")
-    response_size = data.get("size_bytes")
-    response_sha256 = data.get("sha256")
-    if (
-        not isinstance(worker_path, str)
-        or type(response_size) is not int
-        or response_size < 0
-        or not isinstance(response_sha256, str)
-    ):
-        msg = "Sandbox save-attachment response is missing its receipt fields."
-        _record_worker_save_failure(
-            worker_handle=worker_handle,
-            runtime_paths=runtime_paths,
-            proxy_config=proxy_config,
-            error=msg,
-        )
-        raise RuntimeError(msg)
-    if worker_path != requested_path:
-        msg = "Sandbox save-attachment response path does not match the requested workspace path."
-        _record_worker_save_failure(
-            worker_handle=worker_handle,
-            runtime_paths=runtime_paths,
-            proxy_config=proxy_config,
-            error=msg,
-        )
-        raise RuntimeError(msg)
-    if response_size != byte_count:
-        msg = "Sandbox save-attachment response size does not match the sent bytes."
-        _record_worker_save_failure(
-            worker_handle=worker_handle,
-            runtime_paths=runtime_paths,
-            proxy_config=proxy_config,
-            error=msg,
-        )
-        raise RuntimeError(msg)
-    if not secrets.compare_digest(response_sha256, sha256):
-        msg = "Sandbox save-attachment response SHA256 does not match the sent bytes."
-        _record_worker_save_failure(
-            worker_handle=worker_handle,
-            runtime_paths=runtime_paths,
-            proxy_config=proxy_config,
-            error=msg,
-        )
-        raise RuntimeError(msg)
-    return WorkerAttachmentSaveReceipt(
-        worker_path=worker_path,
-        size_bytes=response_size,
-        sha256=response_sha256,
+    result = _validate_attachment_save_receipt(
+        data,
+        requested_path=requested_path,
+        byte_count=byte_count,
+        sha256=sha256,
     )
+    if isinstance(result, str):
+        _record_worker_save_failure(
+            worker_handle=worker_handle,
+            runtime_paths=runtime_paths,
+            proxy_config=proxy_config,
+            error=result,
+        )
+        raise RuntimeError(result)  # noqa: TRY004
+    return result
 
 
 def save_attachment_to_worker(
@@ -651,16 +679,14 @@ def save_attachment_to_worker(
     if worker_handle is None and proxy_config.proxy_url is None:
         return None
 
-    sha256 = hashlib.sha256(payload_bytes).hexdigest()
+    attachment_fields = _attachment_save_payload_fields(payload_bytes)
     request_payload: dict[str, object] = {
         **worker_payload,
         "attachment_id": attachment_id,
         "mindroom_output_path": mindroom_output_path,
-        "sha256": sha256,
-        "size_bytes": byte_count,
+        **attachment_fields,
         "mime_type": mime_type,
         "filename": filename,
-        "bytes_b64": base64.b64encode(payload_bytes).decode("ascii"),
     }
 
     try:
@@ -697,7 +723,7 @@ def save_attachment_to_worker(
             data,
             requested_path=mindroom_output_path,
             byte_count=byte_count,
-            sha256=sha256,
+            sha256=attachment_fields["sha256"],
             worker_handle=worker_handle,
             runtime_paths=runtime_paths,
             proxy_config=proxy_config,

--- a/tach.toml
+++ b/tach.toml
@@ -2810,6 +2810,7 @@ from = ["mindroom.sync_bridge_state"]
 expose = [
     "WorkerAttachmentSaveReceipt",
     "attachment_save_uses_worker",
+    "decode_attachment_save_bytes",
     "inline_attachment_byte_limit",
     "maybe_wrap_toolkit_for_sandbox_proxy",
     "sandbox_proxy_config",

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -80,6 +80,118 @@ _TEST_AUTH_TOKEN = "test-token"  # noqa: S105
 _TEST_RUNTIME_PATHS = resolve_runtime_paths(config_path=Path("config.yaml"), process_env={})
 
 
+def test_attachment_save_protocol_payload_fields_round_trip() -> None:
+    """Attachment save payload helpers should preserve the current wire fields."""
+    payload_bytes = b"attachment-bytes"
+    fields = sandbox_proxy_module._attachment_save_payload_fields(payload_bytes)
+
+    assert fields == {
+        "bytes_b64": base64.b64encode(payload_bytes).decode("ascii"),
+        "sha256": hashlib.sha256(payload_bytes).hexdigest(),
+        "size_bytes": len(payload_bytes),
+    }
+    assert (
+        sandbox_proxy_module.decode_attachment_save_bytes(
+            bytes_b64=fields["bytes_b64"],
+            sha256=fields["sha256"],
+            size_bytes=fields["size_bytes"],
+        )
+        == payload_bytes
+    )
+
+
+@pytest.mark.parametrize(
+    ("bytes_b64", "sha256", "size_bytes", "expected_error"),
+    [
+        ("abc", "0" * 64, True, "Attachment size_bytes must be a non-negative integer."),
+        ("not valid base64", "0" * 64, None, "Attachment bytes are not valid base64."),
+        (
+            base64.b64encode(b"payload").decode("ascii"),
+            hashlib.sha256(b"payload").hexdigest(),
+            999,
+            "Attachment byte length does not match the request receipt.",
+        ),
+        (
+            base64.b64encode(b"payload").decode("ascii"),
+            "0" * 64,
+            len(b"payload"),
+            "Attachment SHA256 does not match the request payload.",
+        ),
+    ],
+)
+def test_attachment_save_protocol_decode_preserves_error_strings(
+    bytes_b64: str,
+    sha256: str,
+    size_bytes: int | None,
+    expected_error: str,
+) -> None:
+    """Malformed attachment payloads should keep the current runner error text."""
+    assert (
+        sandbox_proxy_module.decode_attachment_save_bytes(
+            bytes_b64=bytes_b64,
+            sha256=sha256,
+            size_bytes=size_bytes,
+        )
+        == expected_error
+    )
+
+
+@pytest.mark.parametrize(
+    ("response_payload", "expected_error"),
+    [
+        (
+            {"worker_path": "sample.bin", "size_bytes": True, "sha256": "0" * 64},
+            "Sandbox save-attachment response is missing its receipt fields.",
+        ),
+        (
+            {"worker_path": "other.bin", "size_bytes": 16, "sha256": "0" * 64},
+            "Sandbox save-attachment response path does not match the requested workspace path.",
+        ),
+        (
+            {"worker_path": "sample.bin", "size_bytes": 999, "sha256": "0" * 64},
+            "Sandbox save-attachment response size does not match the sent bytes.",
+        ),
+        (
+            {"worker_path": "sample.bin", "size_bytes": 16, "sha256": "0" * 64},
+            "Sandbox save-attachment response SHA256 does not match the sent bytes.",
+        ),
+    ],
+)
+def test_attachment_save_protocol_receipt_validation_preserves_error_strings(
+    response_payload: dict[str, object],
+    expected_error: str,
+) -> None:
+    """Bad worker receipts should keep the current primary-side error text."""
+    payload_bytes = b"attachment-bytes"
+    result = sandbox_proxy_module._validate_attachment_save_receipt(
+        response_payload,
+        requested_path="sample.bin",
+        byte_count=len(payload_bytes),
+        sha256=hashlib.sha256(payload_bytes).hexdigest(),
+    )
+
+    assert result == expected_error
+
+
+def test_attachment_save_protocol_receipt_validation_returns_dataclass() -> None:
+    """Valid worker receipts should keep the current receipt field names."""
+    payload_bytes = b"attachment-bytes"
+    sha256 = hashlib.sha256(payload_bytes).hexdigest()
+
+    receipt = sandbox_proxy_module._validate_attachment_save_receipt(
+        {"worker_path": "sample.bin", "size_bytes": len(payload_bytes), "sha256": sha256},
+        requested_path="sample.bin",
+        byte_count=len(payload_bytes),
+        sha256=sha256,
+    )
+
+    assert receipt == sandbox_proxy_module.WorkerAttachmentSaveReceipt(
+        worker_path="sample.bin",
+        size_bytes=len(payload_bytes),
+        sha256=sha256,
+    )
+
+
 def _runtime_paths_from_env() -> RuntimePaths:
     return resolve_runtime_paths(config_path=Path("config.yaml"), process_env=dict(os.environ))
 


### PR DESCRIPTION
## Summary
- Add characterization coverage for save-attachment payload, decode, and receipt validation behavior.
- Extract the shared attachment byte decode/integrity helper used by the runner and primary proxy path.
- Keep request-field and receipt validation helpers private in sandbox_proxy; expose only the runner-used decode helper through Tach.

## Verification
- uv sync --all-extras
- uv run pytest tests/test_sandbox_proxy.py -n 0 --no-cov -v
- uv run pytest tests/api/test_sandbox_runner_api.py::test_worker_attachment_save_can_be_read_through_shell_home -n 0 --no-cov -v
- uv run pre-commit run --files src/mindroom/api/sandbox_runner.py src/mindroom/tool_system/sandbox_proxy.py tests/test_sandbox_proxy.py tach.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced attachment save workflow with improved validation and error handling for more robust operations.

* **Tests**
  * Added unit tests for attachment save payload validation and error message preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->