### PR TITLE
Extract streaming tool tracker

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -71,11 +71,9 @@ from mindroom.memory import MemoryPromptParts, build_memory_prompt_parts, strip_
 from mindroom.metadata_merge import deep_merge_metadata
 from mindroom.timing import DispatchPipelineTiming, emit_timing_event, timed
 from mindroom.tool_system.events import (
+    StreamingToolTracker,
     complete_pending_tool_block,
-    extract_tool_completed_info,
     format_tool_combined,
-    format_tool_completed_event,
-    format_tool_started_event,
 )
 
 if TYPE_CHECKING:
@@ -83,7 +81,6 @@ if TYPE_CHECKING:
 
     from agno.agent import Agent
     from agno.knowledge.knowledge import Knowledge
-    from agno.models.response import ToolExecution
 
     from mindroom.config.main import Config
     from mindroom.history import CompactionLifecycle
@@ -220,8 +217,7 @@ class _StreamingAttemptState:
     tool_count: int = 0
     observed_tool_calls: int = 0
     observed_request_metric_fields: set[str] = field(default_factory=set)
-    pending_tools: list[_PendingStreamingTool] = field(default_factory=list)
-    completed_tools: list[ToolTraceEntry] = field(default_factory=list)
+    tool_tracker: StreamingToolTracker = field(default_factory=StreamingToolTracker)
     latest_model_id: str | None = None
     latest_model_provider: str | None = None
     latest_request_input_tokens: int | None = None
@@ -237,13 +233,13 @@ class _StreamingAttemptState:
     user_error: Exception | None = None
     stream_exception: Exception | None = None
 
+    @property
+    def pending_tools(self) -> list[Any]:
+        return self.tool_tracker.pending_tools
 
-@dataclass
-class _PendingStreamingTool:
-    tool_name: str
-    trace_entry: ToolTraceEntry
-    tool_call_id: str | None = None
-    visible_tool_index: int | None = None
+    @property
+    def completed_tools(self) -> list[ToolTraceEntry]:
+        return self.tool_tracker.completed_tools
 
 
 def _extract_response_content(response: RunOutput, *, show_tool_calls: bool = True) -> str:
@@ -289,27 +285,6 @@ def _extract_tool_trace(response: RunOutput) -> list[ToolTraceEntry]:
 def _extract_cancelled_tool_trace(response: RunOutput) -> tuple[list[ToolTraceEntry], list[ToolTraceEntry]]:
     """Extract completed and unfinished tool traces from an interrupted RunOutput."""
     return split_interrupted_tool_trace(response.tools)
-
-
-def _find_matching_pending_stream_tool(
-    pending_tools: list[_PendingStreamingTool],
-    tool: ToolExecution | None,
-) -> int | None:
-    """Return the newest pending tool matching a completion event."""
-    call_id = tool_execution_call_id(tool)
-    if call_id is not None:
-        for pos in range(len(pending_tools) - 1, -1, -1):
-            if pending_tools[pos].tool_call_id == call_id:
-                return pos
-    info = extract_tool_completed_info(tool)
-    if info is None:
-        return None
-    tool_name, _ = info
-    for pos in range(len(pending_tools) - 1, -1, -1):
-        pending_tool = pending_tools[pos]
-        if pending_tool.tool_call_id is None and pending_tool.tool_name == tool_name:
-            return pos
-    return None
 
 
 def _stream_attempt_has_progress(state: _StreamingAttemptState) -> bool:
@@ -473,22 +448,13 @@ def _track_stream_tool_started(
     """Track started tool-call metadata for streaming output."""
     state.observed_tool_calls += 1
     display_tool_index = state.tool_count + 1 if show_tool_calls else None
-    tool_msg, trace_entry = format_tool_started_event(event.tool, tool_index=display_tool_index)
-    if trace_entry is not None:
-        state.pending_tools.append(
-            _PendingStreamingTool(
-                tool_name=trace_entry.tool_name,
-                trace_entry=trace_entry,
-                tool_call_id=tool_execution_call_id(event.tool),
-                visible_tool_index=display_tool_index,
-            ),
-        )
+    started = state.tool_tracker.start(event.tool, tool_index=display_tool_index)
     if not show_tool_calls or display_tool_index is None:
         return
 
     state.tool_count = display_tool_index
-    if tool_msg:
-        state.full_response += tool_msg
+    if started.visible_text:
+        state.full_response += started.visible_text
 
 
 def _track_stream_tool_completed(
@@ -499,29 +465,24 @@ def _track_stream_tool_completed(
     agent_name: str,
 ) -> None:
     """Track completed tool-call metadata for streaming output."""
-    info = extract_tool_completed_info(event.tool)
-    if info is None:
+    completion = state.tool_tracker.complete(event.tool)
+    if completion is None:
         return
-    tool_name, result = info
-    pending_trace_pos = _find_matching_pending_stream_tool(state.pending_tools, event.tool)
-    pending_tool = state.pending_tools.pop(pending_trace_pos) if pending_trace_pos is not None else None
-    _, completed_trace = format_tool_completed_event(event.tool)
-    if completed_trace is not None:
-        state.completed_tools.append(completed_trace)
     if not show_tool_calls:
         return
 
+    pending_tool = completion.pending_tool
     if pending_tool is None or pending_tool.visible_tool_index is None:
         logger.warning(
             "Missing pending tool start in AI stream; skipping completion marker",
-            tool_name=tool_name,
+            tool_name=completion.tool_name,
             agent=agent_name,
         )
         return
     state.full_response, _ = complete_pending_tool_block(
         state.full_response,
-        tool_name,
-        result,
+        completion.tool_name,
+        completion.result,
         tool_index=pending_tool.visible_tool_index,
     )
 

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -448,13 +448,13 @@ def _track_stream_tool_started(
     """Track started tool-call metadata for streaming output."""
     state.observed_tool_calls += 1
     display_tool_index = state.tool_count + 1 if show_tool_calls else None
-    started = state.tool_tracker.start(event.tool, tool_index=display_tool_index)
+    tool_msg, _ = state.tool_tracker.start(event.tool, tool_index=display_tool_index)
     if not show_tool_calls or display_tool_index is None:
         return
 
     state.tool_count = display_tool_index
-    if started.visible_text:
-        state.full_response += started.visible_text
+    if tool_msg:
+        state.full_response += tool_msg
 
 
 def _track_stream_tool_completed(
@@ -468,21 +468,21 @@ def _track_stream_tool_completed(
     completion = state.tool_tracker.complete(event.tool)
     if completion is None:
         return
+    tool_name, result, pending_tool, _ = completion
     if not show_tool_calls:
         return
 
-    pending_tool = completion.pending_tool
     if pending_tool is None or pending_tool.visible_tool_index is None:
         logger.warning(
             "Missing pending tool start in AI stream; skipping completion marker",
-            tool_name=completion.tool_name,
+            tool_name=tool_name,
             agent=agent_name,
         )
         return
     state.full_response, _ = complete_pending_tool_block(
         state.full_response,
-        completion.tool_name,
-        completion.result,
+        tool_name,
+        result,
         tool_index=pending_tool.visible_tool_index,
     )
 

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -13,11 +13,10 @@ from agno.run.agent import RunCompletedEvent, RunContentEvent, ToolCallCompleted
 from mindroom.logging_config import get_logger
 from mindroom.timing import emit_timing_event
 from mindroom.tool_system.events import (
+    StreamingToolTracker,
     StructuredStreamChunk,
     ToolTraceEntry,
     complete_pending_tool_block,
-    extract_tool_completed_info,
-    format_tool_started_event,
 )
 
 if TYPE_CHECKING:
@@ -208,7 +207,7 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
     delivery_queue: asyncio.Queue[DeliveryRequest | None],
 ) -> None:
     """Consume stream chunks and apply incremental message updates."""
-    pending_tools: list[tuple[str, int, str]] = []
+    tool_tracker = StreamingToolTracker()
 
     async for chunk in response_stream:
         if isinstance(chunk, str):
@@ -252,14 +251,13 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
                 continue
 
             tool_index = len(streaming.tool_trace) + 1
-            text_chunk, trace_entry = format_tool_started_event(chunk.tool, tool_index=tool_index)
-            if trace_entry is not None:
-                streaming.tool_trace.append(trace_entry)
-                pending_tools.append((trace_entry.tool_name, tool_index, text_chunk))
+            started = tool_tracker.start(chunk.tool, tool_index=tool_index)
+            if started.trace_entry is not None:
+                streaming.tool_trace.append(started.trace_entry)
             await _apply_visible_text_chunk(
                 streaming,
                 delivery_queue,
-                text_chunk,
+                started.visible_text,
                 apply_chunk=streaming._append_incremental_text,
                 boundary_refresh=True,
                 wait_for_capture=(
@@ -268,42 +266,33 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
             )
             continue
         elif isinstance(chunk, ToolCallCompletedEvent):
-            info = extract_tool_completed_info(chunk.tool)
-            if info:
-                tool_name, result = info
+            completion = tool_tracker.complete(chunk.tool)
+            if completion is not None:
                 if streaming.show_tool_calls:
-                    match_pos = next(
-                        (pos for pos in range(len(pending_tools) - 1, -1, -1) if pending_tools[pos][0] == tool_name),
-                        None,
-                    )
-                    if match_pos is None:
+                    pending_tool = completion.pending_tool
+                    if pending_tool is None or pending_tool.visible_tool_index is None:
                         logger.warning(
                             "Missing pending tool start in streaming response; skipping completion marker",
-                            tool_name=tool_name,
+                            tool_name=completion.tool_name,
                         )
                         _queue_delivery_request(delivery_queue, progress_hint=True)
                         continue
-                    _, tool_index, _ = pending_tools.pop(match_pos)
+                    tool_index = pending_tool.visible_tool_index
                     prior_delta_at = streaming.last_delta_at
                     previous_text = streaming.accumulated_text
-                    streaming.accumulated_text, trace_entry = complete_pending_tool_block(
+                    streaming.accumulated_text, _ = complete_pending_tool_block(
                         streaming.accumulated_text,
-                        tool_name,
-                        result,
+                        completion.tool_name,
+                        completion.result,
                         tool_index=tool_index,
                     )
                     text_changed = streaming.accumulated_text != previous_text
                     if text_changed:
                         streaming._mark_nonadditive_text_mutation()
-                    if 0 < tool_index <= len(streaming.tool_trace):
-                        existing_entry = streaming.tool_trace[tool_index - 1]
-                        existing_entry.type = "tool_call_completed"
-                        existing_entry.result_preview = trace_entry.result_preview
-                        existing_entry.truncated = existing_entry.truncated or trace_entry.truncated
-                    else:
+                    if not tool_tracker.update_visible_trace_entry(streaming.tool_trace, completion):
                         logger.warning(
                             "Missing tool trace slot in streaming response for completion",
-                            tool_name=tool_name,
+                            tool_name=completion.tool_name,
                             tool_index=tool_index,
                             trace_len=len(streaming.tool_trace),
                         )
@@ -325,7 +314,9 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
             delivery_queue,
             text_chunk,
             apply_chunk=streaming._update,
-            replacement_suffixes=tuple(marker_text for _, _, marker_text in pending_tools),
+            replacement_suffixes=tuple(
+                pending.visible_text for pending in tool_tracker.pending_tools if pending.visible_text
+            ),
         )
 
 

--- a/src/mindroom/streaming_delivery.py
+++ b/src/mindroom/streaming_delivery.py
@@ -251,13 +251,13 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
                 continue
 
             tool_index = len(streaming.tool_trace) + 1
-            started = tool_tracker.start(chunk.tool, tool_index=tool_index)
-            if started.trace_entry is not None:
-                streaming.tool_trace.append(started.trace_entry)
+            text_chunk, trace_entry = tool_tracker.start(chunk.tool, tool_index=tool_index)
+            if trace_entry is not None:
+                streaming.tool_trace.append(trace_entry)
             await _apply_visible_text_chunk(
                 streaming,
                 delivery_queue,
-                started.visible_text,
+                text_chunk,
                 apply_chunk=streaming._append_incremental_text,
                 boundary_refresh=True,
                 wait_for_capture=(
@@ -268,12 +268,12 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
         elif isinstance(chunk, ToolCallCompletedEvent):
             completion = tool_tracker.complete(chunk.tool)
             if completion is not None:
+                tool_name, result, pending_tool, completed_trace = completion
                 if streaming.show_tool_calls:
-                    pending_tool = completion.pending_tool
                     if pending_tool is None or pending_tool.visible_tool_index is None:
                         logger.warning(
                             "Missing pending tool start in streaming response; skipping completion marker",
-                            tool_name=completion.tool_name,
+                            tool_name=tool_name,
                         )
                         _queue_delivery_request(delivery_queue, progress_hint=True)
                         continue
@@ -282,17 +282,17 @@ async def _consume_streaming_chunks(  # noqa: C901, PLR0912, PLR0915
                     previous_text = streaming.accumulated_text
                     streaming.accumulated_text, _ = complete_pending_tool_block(
                         streaming.accumulated_text,
-                        completion.tool_name,
-                        completion.result,
+                        tool_name,
+                        result,
                         tool_index=tool_index,
                     )
                     text_changed = streaming.accumulated_text != previous_text
                     if text_changed:
                         streaming._mark_nonadditive_text_mutation()
-                    if not tool_tracker.update_visible_trace_entry(streaming.tool_trace, completion):
+                    if not tool_tracker.update_visible_trace_entry(streaming.tool_trace, pending_tool, completed_trace):
                         logger.warning(
                             "Missing tool trace slot in streaming response for completion",
-                            tool_name=completion.tool_name,
+                            tool_name=tool_name,
                             tool_index=tool_index,
                             trace_len=len(streaming.tool_trace),
                         )

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -52,7 +52,7 @@ from mindroom.history import (
     team_tool_definition_payloads_for_logging,
     update_scope_seen_event_ids,
 )
-from mindroom.history.interrupted_replay import split_interrupted_tool_trace, tool_execution_call_id
+from mindroom.history.interrupted_replay import split_interrupted_tool_trace
 from mindroom.hooks import EnrichmentItem, render_system_enrichment_block
 from mindroom.knowledge import KnowledgeAvailabilityDetail, resolve_agent_knowledge_access
 from mindroom.llm_request_logging import (
@@ -72,12 +72,11 @@ from mindroom.team_exact_members import (
     resolve_live_shared_agent_names,
 )
 from mindroom.tool_system.events import (
+    StreamingToolTracker,
     StructuredStreamChunk,
     ToolTraceEntry,
     complete_pending_tool_block,
-    extract_tool_completed_info,
     format_tool_completed_event,
-    format_tool_started_event,
 )
 
 if TYPE_CHECKING:
@@ -151,15 +150,6 @@ _MATRIX_TEAM_THREAD_HISTORY_RENDER_LIMITS = ThreadHistoryRenderLimits(
 def _append_additional_context(entity: Agent | Team, context_chunk: str) -> None:
     existing_context = entity.additional_context.strip() if entity.additional_context else ""
     entity.additional_context = f"{existing_context}\n\n{context_chunk}" if existing_context else context_chunk
-
-
-@dataclass
-class _PendingTeamTool:
-    scope_key: str
-    tool_name: str
-    trace_entry: ToolTraceEntry
-    tool_call_id: str | None = None
-    visible_tool_index: int | None = None
 
 
 class TeamMode(str, Enum):
@@ -1987,8 +1977,9 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
     run_metadata: dict[str, Any] | None = None
     canonical_per_member: dict[str, str] = {}
     canonical_consensus = ""
-    completed_tools: list[ToolTraceEntry] = []
-    pending_tools: list[_PendingTeamTool] = []
+    tool_tracker = StreamingToolTracker()
+    completed_tools = tool_tracker.completed_tools
+    pending_tools = tool_tracker.pending_tools
 
     def _empty_canonical_partial_text() -> str:
         return ""
@@ -2106,31 +2097,6 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                     interrupted_tools=[pending.trace_entry for pending in pending_tools],
                 )
 
-            def _find_pending_tool_index(
-                *,
-                scope_key: str,
-                tool: ToolExecution | None,
-            ) -> int | None:
-                call_id = tool_execution_call_id(tool)
-                if call_id is not None:
-                    for pos in range(len(pending_tools) - 1, -1, -1):
-                        pending_tool = pending_tools[pos]
-                        if pending_tool.scope_key == scope_key and pending_tool.tool_call_id == call_id:
-                            return pos
-                info = extract_tool_completed_info(tool)
-                if not info:
-                    return None
-                tool_name, _ = info
-                for pos in range(len(pending_tools) - 1, -1, -1):
-                    pending_tool = pending_tools[pos]
-                    if (
-                        pending_tool.scope_key == scope_key
-                        and pending_tool.tool_call_id is None
-                        and pending_tool.tool_name == tool_name
-                    ):
-                        return pos
-                return None
-
             def _start_tool(
                 *,
                 scope_key: str,
@@ -2139,23 +2105,13 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
             ) -> None:
                 nonlocal next_tool_index
                 tool_index = next_tool_index if show_tool_calls else None
-                tool_msg, trace_entry = format_tool_started_event(tool, tool_index=tool_index)
-                if trace_entry is not None:
-                    pending_tools.append(
-                        _PendingTeamTool(
-                            scope_key=scope_key,
-                            tool_name=trace_entry.tool_name,
-                            trace_entry=trace_entry,
-                            tool_call_id=tool_execution_call_id(tool),
-                            visible_tool_index=tool_index,
-                        ),
-                    )
+                started = tool_tracker.start(tool, scope_key=scope_key, tool_index=tool_index)
                 if not show_tool_calls or tool_index is None:
                     return
-                if tool_msg:
-                    apply_visible_text(tool_msg)
-                if trace_entry is not None:
-                    tool_trace.append(trace_entry)
+                if started.visible_text:
+                    apply_visible_text(started.visible_text)
+                if started.trace_entry is not None:
+                    tool_trace.append(started.trace_entry)
                 next_tool_index += 1
 
             def _complete_tool(
@@ -2165,44 +2121,34 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                 set_visible_text: Callable[[str], None],
                 tool: ToolExecution | None,
             ) -> None:
-                info = extract_tool_completed_info(tool)
-                if not info:
+                completion = tool_tracker.complete(tool, scope_key=scope_key)
+                if completion is None:
                     return
 
-                tool_name, result = info
-                pending_trace_pos = _find_pending_tool_index(scope_key=scope_key, tool=tool)
-                pending_tool = pending_tools.pop(pending_trace_pos) if pending_trace_pos is not None else None
-                _, completed_trace = format_tool_completed_event(tool)
-                if completed_trace is not None:
-                    completed_tools.append(completed_trace)
                 if not show_tool_calls:
                     return
 
+                pending_tool = completion.pending_tool
                 if pending_tool is None or pending_tool.visible_tool_index is None:
                     logger.warning(
                         "Missing pending tool start in team stream; skipping completion marker",
-                        tool_name=tool_name,
+                        tool_name=completion.tool_name,
                         scope=scope_key,
                     )
                     return
 
-                updated_text, trace_entry = complete_pending_tool_block(
+                updated_text, _ = complete_pending_tool_block(
                     get_visible_text(),
-                    tool_name,
-                    result,
+                    completion.tool_name,
+                    completion.result,
                     tool_index=pending_tool.visible_tool_index,
                 )
                 set_visible_text(updated_text)
 
-                if 0 < pending_tool.visible_tool_index <= len(tool_trace):
-                    existing_entry = tool_trace[pending_tool.visible_tool_index - 1]
-                    existing_entry.type = "tool_call_completed"
-                    existing_entry.result_preview = trace_entry.result_preview
-                    existing_entry.truncated = existing_entry.truncated or trace_entry.truncated
-                else:
+                if not tool_tracker.update_visible_trace_entry(tool_trace, completion):
                     logger.warning(
                         "Missing tool trace slot in team stream for completion",
-                        tool_name=tool_name,
+                        tool_name=completion.tool_name,
                         tool_index=pending_tool.visible_tool_index,
                         trace_len=len(tool_trace),
                     )
@@ -2244,9 +2190,10 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                     canonical_consensus = ""
                     visible_consensus = ""
                     tool_trace = []
-                    completed_tools = []
+                    tool_tracker = StreamingToolTracker()
+                    completed_tools = tool_tracker.completed_tools
                     next_tool_index = 1
-                    pending_tools = []
+                    pending_tools = tool_tracker.pending_tools
                     emitted_output = False
                     retry_requested = False
 

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -2105,13 +2105,13 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
             ) -> None:
                 nonlocal next_tool_index
                 tool_index = next_tool_index if show_tool_calls else None
-                started = tool_tracker.start(tool, scope_key=scope_key, tool_index=tool_index)
+                tool_msg, trace_entry = tool_tracker.start(tool, scope_key=scope_key, tool_index=tool_index)
                 if not show_tool_calls or tool_index is None:
                     return
-                if started.visible_text:
-                    apply_visible_text(started.visible_text)
-                if started.trace_entry is not None:
-                    tool_trace.append(started.trace_entry)
+                if tool_msg:
+                    apply_visible_text(tool_msg)
+                if trace_entry is not None:
+                    tool_trace.append(trace_entry)
                 next_tool_index += 1
 
             def _complete_tool(
@@ -2124,31 +2124,31 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                 completion = tool_tracker.complete(tool, scope_key=scope_key)
                 if completion is None:
                     return
+                tool_name, result, pending_tool, completed_trace = completion
 
                 if not show_tool_calls:
                     return
 
-                pending_tool = completion.pending_tool
                 if pending_tool is None or pending_tool.visible_tool_index is None:
                     logger.warning(
                         "Missing pending tool start in team stream; skipping completion marker",
-                        tool_name=completion.tool_name,
+                        tool_name=tool_name,
                         scope=scope_key,
                     )
                     return
 
                 updated_text, _ = complete_pending_tool_block(
                     get_visible_text(),
-                    completion.tool_name,
-                    completion.result,
+                    tool_name,
+                    result,
                     tool_index=pending_tool.visible_tool_index,
                 )
                 set_visible_text(updated_text)
 
-                if not tool_tracker.update_visible_trace_entry(tool_trace, completion):
+                if not tool_tracker.update_visible_trace_entry(tool_trace, pending_tool, completed_trace):
                     logger.warning(
                         "Missing tool trace slot in team stream for completion",
-                        tool_name=completion.tool_name,
+                        tool_name=tool_name,
                         tool_index=pending_tool.visible_tool_index,
                         trace_len=len(tool_trace),
                     )

--- a/src/mindroom/tool_system/events.py
+++ b/src/mindroom/tool_system/events.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, cast
 
-from agno.models.response import ToolExecution  # noqa: TC002 - used in isinstance checks
+from agno.models.response import ToolExecution
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -47,6 +47,141 @@ class StructuredStreamChunk:
 
     content: str
     tool_trace: list[ToolTraceEntry] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingStreamingTool:
+    scope_key: str
+    tool_name: str
+    trace_entry: ToolTraceEntry
+    tool_call_id: str | None = None
+    visible_tool_index: int | None = None
+    visible_text: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class _StreamingToolStart:
+    visible_text: str
+    trace_entry: ToolTraceEntry | None
+    pending_tool: _PendingStreamingTool | None
+
+
+@dataclass(frozen=True, slots=True)
+class _StreamingToolCompletion:
+    tool_name: str
+    result: object | None
+    pending_tool: _PendingStreamingTool | None
+    completed_trace: ToolTraceEntry | None
+
+
+@dataclass(slots=True)
+class StreamingToolTracker:
+    """Track pending and completed tool traces for one streaming response."""
+
+    pending_tools: list[_PendingStreamingTool] = field(default_factory=list)
+    completed_tools: list[ToolTraceEntry] = field(default_factory=list)
+
+    def start(
+        self,
+        tool: ToolExecution | None,
+        *,
+        scope_key: str = "",
+        tool_index: int | None = None,
+    ) -> _StreamingToolStart:
+        """Record one started tool call and return its visible marker."""
+        visible_text, trace_entry = format_tool_started_event(tool, tool_index=tool_index)
+        pending_tool = None
+        if trace_entry is not None:
+            pending_tool = _PendingStreamingTool(
+                scope_key=scope_key,
+                tool_name=trace_entry.tool_name,
+                trace_entry=trace_entry,
+                tool_call_id=_streaming_tool_call_id(tool),
+                visible_tool_index=tool_index,
+                visible_text=visible_text,
+            )
+            self.pending_tools.append(pending_tool)
+        return _StreamingToolStart(
+            visible_text=visible_text,
+            trace_entry=trace_entry,
+            pending_tool=pending_tool,
+        )
+
+    def complete(
+        self,
+        tool: ToolExecution | None,
+        *,
+        scope_key: str = "",
+    ) -> _StreamingToolCompletion | None:
+        """Record one completed tool call and return the matched pending state."""
+        info = extract_tool_completed_info(tool)
+        if info is None:
+            return None
+
+        tool_name, result = info
+        pending_pos = self._find_pending_tool_index(scope_key=scope_key, tool=tool)
+        pending_tool = self.pending_tools.pop(pending_pos) if pending_pos is not None else None
+        _, completed_trace = format_tool_completed_event(tool)
+        if completed_trace is not None:
+            self.completed_tools.append(completed_trace)
+        return _StreamingToolCompletion(
+            tool_name=tool_name,
+            result=result,
+            pending_tool=pending_tool,
+            completed_trace=completed_trace,
+        )
+
+    def update_visible_trace_entry(
+        self,
+        tool_trace: list[ToolTraceEntry],
+        completion: _StreamingToolCompletion,
+    ) -> bool:
+        """Update the visible trace snapshot slot for a matched completion."""
+        pending_tool = completion.pending_tool
+        if pending_tool is None or pending_tool.visible_tool_index is None or completion.completed_trace is None:
+            return False
+        if not 0 < pending_tool.visible_tool_index <= len(tool_trace):
+            return False
+        existing_entry = tool_trace[pending_tool.visible_tool_index - 1]
+        existing_entry.type = "tool_call_completed"
+        existing_entry.result_preview = completion.completed_trace.result_preview
+        existing_entry.truncated = existing_entry.truncated or completion.completed_trace.truncated
+        return True
+
+    def _find_pending_tool_index(
+        self,
+        *,
+        scope_key: str,
+        tool: ToolExecution | None,
+    ) -> int | None:
+        call_id = _streaming_tool_call_id(tool)
+        if call_id is not None:
+            for pos in range(len(self.pending_tools) - 1, -1, -1):
+                pending_tool = self.pending_tools[pos]
+                if pending_tool.scope_key == scope_key and pending_tool.tool_call_id == call_id:
+                    return pos
+        info = extract_tool_completed_info(tool)
+        if info is None:
+            return None
+        tool_name, _ = info
+        for pos in range(len(self.pending_tools) - 1, -1, -1):
+            pending_tool = self.pending_tools[pos]
+            if (
+                pending_tool.scope_key == scope_key
+                and pending_tool.tool_call_id is None
+                and pending_tool.tool_name == tool_name
+            ):
+                return pos
+        return None
+
+
+def _streaming_tool_call_id(tool: ToolExecution | None) -> str | None:
+    if not isinstance(tool, ToolExecution):
+        return None
+    if not isinstance(tool.tool_call_id, str):
+        return None
+    call_id = tool.tool_call_id.strip()
+    return call_id or None
 
 
 def _to_compact_text(value: object) -> str:

--- a/src/mindroom/tool_system/events.py
+++ b/src/mindroom/tool_system/events.py
@@ -59,21 +59,6 @@ class _PendingStreamingTool:
     visible_text: str = ""
 
 
-@dataclass(frozen=True, slots=True)
-class _StreamingToolStart:
-    visible_text: str
-    trace_entry: ToolTraceEntry | None
-    pending_tool: _PendingStreamingTool | None
-
-
-@dataclass(frozen=True, slots=True)
-class _StreamingToolCompletion:
-    tool_name: str
-    result: object | None
-    pending_tool: _PendingStreamingTool | None
-    completed_trace: ToolTraceEntry | None
-
-
 @dataclass(slots=True)
 class StreamingToolTracker:
     """Track pending and completed tool traces for one streaming response."""
@@ -87,32 +72,28 @@ class StreamingToolTracker:
         *,
         scope_key: str = "",
         tool_index: int | None = None,
-    ) -> _StreamingToolStart:
+    ) -> tuple[str, ToolTraceEntry | None]:
         """Record one started tool call and return its visible marker."""
         visible_text, trace_entry = format_tool_started_event(tool, tool_index=tool_index)
-        pending_tool = None
         if trace_entry is not None:
-            pending_tool = _PendingStreamingTool(
-                scope_key=scope_key,
-                tool_name=trace_entry.tool_name,
-                trace_entry=trace_entry,
-                tool_call_id=_streaming_tool_call_id(tool),
-                visible_tool_index=tool_index,
-                visible_text=visible_text,
+            self.pending_tools.append(
+                _PendingStreamingTool(
+                    scope_key=scope_key,
+                    tool_name=trace_entry.tool_name,
+                    trace_entry=trace_entry,
+                    tool_call_id=_streaming_tool_call_id(tool),
+                    visible_tool_index=tool_index,
+                    visible_text=visible_text,
+                ),
             )
-            self.pending_tools.append(pending_tool)
-        return _StreamingToolStart(
-            visible_text=visible_text,
-            trace_entry=trace_entry,
-            pending_tool=pending_tool,
-        )
+        return visible_text, trace_entry
 
     def complete(
         self,
         tool: ToolExecution | None,
         *,
         scope_key: str = "",
-    ) -> _StreamingToolCompletion | None:
+    ) -> tuple[str, object | None, _PendingStreamingTool | None, ToolTraceEntry | None] | None:
         """Record one completed tool call and return the matched pending state."""
         info = extract_tool_completed_info(tool)
         if info is None:
@@ -124,28 +105,23 @@ class StreamingToolTracker:
         _, completed_trace = format_tool_completed_event(tool)
         if completed_trace is not None:
             self.completed_tools.append(completed_trace)
-        return _StreamingToolCompletion(
-            tool_name=tool_name,
-            result=result,
-            pending_tool=pending_tool,
-            completed_trace=completed_trace,
-        )
+        return tool_name, result, pending_tool, completed_trace
 
     def update_visible_trace_entry(
         self,
         tool_trace: list[ToolTraceEntry],
-        completion: _StreamingToolCompletion,
+        pending_tool: _PendingStreamingTool | None,
+        completed_trace: ToolTraceEntry | None,
     ) -> bool:
         """Update the visible trace snapshot slot for a matched completion."""
-        pending_tool = completion.pending_tool
-        if pending_tool is None or pending_tool.visible_tool_index is None or completion.completed_trace is None:
+        if pending_tool is None or pending_tool.visible_tool_index is None or completed_trace is None:
             return False
         if not 0 < pending_tool.visible_tool_index <= len(tool_trace):
             return False
         existing_entry = tool_trace[pending_tool.visible_tool_index - 1]
         existing_entry.type = "tool_call_completed"
-        existing_entry.result_preview = completion.completed_trace.result_preview
-        existing_entry.truncated = existing_entry.truncated or completion.completed_trace.truncated
+        existing_entry.result_preview = completed_trace.result_preview
+        existing_entry.truncated = existing_entry.truncated or completed_trace.truncated
         return True
 
     def _find_pending_tool_index(
@@ -176,12 +152,9 @@ class StreamingToolTracker:
 
 
 def _streaming_tool_call_id(tool: ToolExecution | None) -> str | None:
-    if not isinstance(tool, ToolExecution):
-        return None
-    if not isinstance(tool.tool_call_id, str):
-        return None
-    call_id = tool.tool_call_id.strip()
-    return call_id or None
+    if isinstance(tool, ToolExecution) and isinstance(tool.tool_call_id, str):
+        return tool.tool_call_id.strip() or None
+    return None
 
 
 def _to_compact_text(value: object) -> str:

--- a/tach.toml
+++ b/tach.toml
@@ -2756,6 +2756,7 @@ from = ["mindroom.history.turn_recorder"]
 
 [[interfaces]]
 expose = [
+    "StreamingToolTracker",
     "StructuredStreamChunk",
     "ToolTraceEntry",
     "build_tool_trace_content",

--- a/tests/test_tool_events.py
+++ b/tests/test_tool_events.py
@@ -10,6 +10,7 @@ from mindroom.tool_system.events import (
     _MAX_TOOL_RESULT_DISPLAY_CHARS,
     _MAX_TOOL_TRACE_EVENTS,
     _TOOL_TRACE_KEY,
+    StreamingToolTracker,
     ToolTraceEntry,
     _format_tool_started,
     build_tool_trace_content,
@@ -316,6 +317,74 @@ def test_complete_pending_tool_block_no_result_marks_completed() -> None:
 
     assert updated == "🔧 `save_file` [1]"
     assert trace.result_preview is None
+
+
+def test_streaming_tool_tracker_records_hidden_pending_and_completion() -> None:
+    """Hidden tool calls should still preserve pending and completed trace state."""
+    tracker = StreamingToolTracker()
+    started = tracker.start(ToolExecution(tool_call_id="call-1", tool_name="save_file", tool_args={"file": "a.py"}))
+
+    assert started.visible_text
+    assert len(tracker.pending_tools) == 1
+    assert [pending.trace_entry for pending in tracker.pending_tools] == [started.trace_entry]
+
+    completed = tracker.complete(ToolExecution(tool_call_id="call-1", tool_name="save_file", result="ok"))
+
+    assert completed is not None
+    assert completed.pending_tool == started.pending_tool
+    assert completed.tool_name == "save_file"
+    assert completed.result == "ok"
+    assert tracker.pending_tools == []
+    assert len(tracker.completed_tools) == 1
+    assert tracker.completed_tools[0].result_preview == "ok"
+
+
+def test_streaming_tool_tracker_uses_scope_for_name_fallback_matching() -> None:
+    """Fallback matching by tool name must not cross team/member scopes."""
+    tracker = StreamingToolTracker()
+    member_start = tracker.start(ToolExecution(tool_name="search", tool_args={"q": "member"}), scope_key="agent:code")
+    team_start = tracker.start(ToolExecution(tool_name="search", tool_args={"q": "team"}), scope_key="team")
+
+    completed = tracker.complete(ToolExecution(tool_name="search", result="team result"), scope_key="team")
+
+    assert completed is not None
+    assert completed.pending_tool == team_start.pending_tool
+    assert [pending.trace_entry for pending in tracker.pending_tools] == [member_start.trace_entry]
+
+
+def test_streaming_tool_tracker_prefers_call_id_over_newest_same_named_tool() -> None:
+    """Call IDs should keep same-named concurrent tools paired with their own completion."""
+    tracker = StreamingToolTracker()
+    first_start = tracker.start(ToolExecution(tool_call_id="first", tool_name="save_file", tool_args={"file": "a.py"}))
+    tracker.start(ToolExecution(tool_call_id="second", tool_name="save_file", tool_args={"file": "b.py"}))
+
+    completed = tracker.complete(ToolExecution(tool_call_id="first", tool_name="save_file", result="saved a"))
+
+    assert completed is not None
+    assert completed.pending_tool == first_start.pending_tool
+    assert [pending.tool_call_id for pending in tracker.pending_tools] == ["second"]
+
+
+def test_streaming_tool_tracker_updates_visible_trace_slot() -> None:
+    """Visible tool trace snapshots should be converted from started to completed in-place."""
+    tracker = StreamingToolTracker()
+    visible_trace: list[ToolTraceEntry] = []
+    started = tracker.start(ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}), tool_index=1)
+    assert started.trace_entry is not None
+    visible_trace.append(started.trace_entry)
+
+    completed = tracker.complete(ToolExecution(tool_name="save_file", result="ok"))
+
+    assert completed is not None
+    assert tracker.update_visible_trace_entry(visible_trace, completed) is True
+    assert visible_trace == [
+        ToolTraceEntry(
+            type="tool_call_completed",
+            tool_name="save_file",
+            args_preview="file=a.py",
+            result_preview="ok",
+        ),
+    ]
 
 
 def test_build_tool_trace_content_preserves_all_events_for_v2_indexing() -> None:

--- a/tests/test_tool_events.py
+++ b/tests/test_tool_events.py
@@ -322,18 +322,22 @@ def test_complete_pending_tool_block_no_result_marks_completed() -> None:
 def test_streaming_tool_tracker_records_hidden_pending_and_completion() -> None:
     """Hidden tool calls should still preserve pending and completed trace state."""
     tracker = StreamingToolTracker()
-    started = tracker.start(ToolExecution(tool_call_id="call-1", tool_name="save_file", tool_args={"file": "a.py"}))
+    visible_text, trace_entry = tracker.start(
+        ToolExecution(tool_call_id="call-1", tool_name="save_file", tool_args={"file": "a.py"}),
+    )
 
-    assert started.visible_text
+    assert visible_text
     assert len(tracker.pending_tools) == 1
-    assert [pending.trace_entry for pending in tracker.pending_tools] == [started.trace_entry]
+    pending_tool = tracker.pending_tools[0]
+    assert pending_tool.trace_entry == trace_entry
 
     completed = tracker.complete(ToolExecution(tool_call_id="call-1", tool_name="save_file", result="ok"))
 
     assert completed is not None
-    assert completed.pending_tool == started.pending_tool
-    assert completed.tool_name == "save_file"
-    assert completed.result == "ok"
+    tool_name, result, matched_pending_tool, _ = completed
+    assert matched_pending_tool == pending_tool
+    assert tool_name == "save_file"
+    assert result == "ok"
     assert tracker.pending_tools == []
     assert len(tracker.completed_tools) == 1
     assert tracker.completed_tools[0].result_preview == "ok"
@@ -342,26 +346,33 @@ def test_streaming_tool_tracker_records_hidden_pending_and_completion() -> None:
 def test_streaming_tool_tracker_uses_scope_for_name_fallback_matching() -> None:
     """Fallback matching by tool name must not cross team/member scopes."""
     tracker = StreamingToolTracker()
-    member_start = tracker.start(ToolExecution(tool_name="search", tool_args={"q": "member"}), scope_key="agent:code")
-    team_start = tracker.start(ToolExecution(tool_name="search", tool_args={"q": "team"}), scope_key="team")
+    _member_msg, member_trace = tracker.start(
+        ToolExecution(tool_name="search", tool_args={"q": "member"}),
+        scope_key="agent:code",
+    )
+    _team_msg, team_trace = tracker.start(ToolExecution(tool_name="search", tool_args={"q": "team"}), scope_key="team")
 
     completed = tracker.complete(ToolExecution(tool_name="search", result="team result"), scope_key="team")
 
     assert completed is not None
-    assert completed.pending_tool == team_start.pending_tool
-    assert [pending.trace_entry for pending in tracker.pending_tools] == [member_start.trace_entry]
+    _tool_name, _result, matched_pending_tool, _completed_trace = completed
+    assert matched_pending_tool is not None
+    assert matched_pending_tool.trace_entry == team_trace
+    assert [pending.trace_entry for pending in tracker.pending_tools] == [member_trace]
 
 
 def test_streaming_tool_tracker_prefers_call_id_over_newest_same_named_tool() -> None:
     """Call IDs should keep same-named concurrent tools paired with their own completion."""
     tracker = StreamingToolTracker()
-    first_start = tracker.start(ToolExecution(tool_call_id="first", tool_name="save_file", tool_args={"file": "a.py"}))
+    tracker.start(ToolExecution(tool_call_id="first", tool_name="save_file", tool_args={"file": "a.py"}))
+    first_pending_tool = tracker.pending_tools[0]
     tracker.start(ToolExecution(tool_call_id="second", tool_name="save_file", tool_args={"file": "b.py"}))
 
     completed = tracker.complete(ToolExecution(tool_call_id="first", tool_name="save_file", result="saved a"))
 
     assert completed is not None
-    assert completed.pending_tool == first_start.pending_tool
+    _tool_name, _result, matched_pending_tool, _completed_trace = completed
+    assert matched_pending_tool == first_pending_tool
     assert [pending.tool_call_id for pending in tracker.pending_tools] == ["second"]
 
 
@@ -369,14 +380,18 @@ def test_streaming_tool_tracker_updates_visible_trace_slot() -> None:
     """Visible tool trace snapshots should be converted from started to completed in-place."""
     tracker = StreamingToolTracker()
     visible_trace: list[ToolTraceEntry] = []
-    started = tracker.start(ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}), tool_index=1)
-    assert started.trace_entry is not None
-    visible_trace.append(started.trace_entry)
+    _tool_msg, trace_entry = tracker.start(
+        ToolExecution(tool_name="save_file", tool_args={"file": "a.py"}),
+        tool_index=1,
+    )
+    assert trace_entry is not None
+    visible_trace.append(trace_entry)
 
     completed = tracker.complete(ToolExecution(tool_name="save_file", result="ok"))
 
     assert completed is not None
-    assert tracker.update_visible_trace_entry(visible_trace, completed) is True
+    _tool_name, _result, pending_tool, completed_trace = completed
+    assert tracker.update_visible_trace_entry(visible_trace, pending_tool, completed_trace) is True
     assert visible_trace == [
         ToolTraceEntry(
             type="tool_call_completed",


### PR DESCRIPTION
## Summary
- extract shared StreamingToolTracker into tool trace events for pending/completed streaming tool state
- wire agent, team, and streaming delivery paths through the tracker while preserving visible text and Matrix delivery ownership
- add characterization tests for hidden/pending completions, scoped matching, call-id matching, and visible trace slot updates

## Verification
- uv run pytest tests/test_tool_events.py tests/test_streaming_behavior.py tests/test_streaming_finalize.py tests/test_large_messages_integration.py -q -n 0 --no-cov
- uv run pytest tests/test_team_media_fallback.py -q -n 0 --no-cov -k 'stream and (tool or media or retry or cancelled or errored or completed)'\n- uv run pytest tests/test_ai_user_id.py -q -n 0 --no-cov -k 'stream_agent_response and (hidden_interrupted_tool_state or pending_tool_identity or retry or cancelled or final_event or metadata)'\n- uv run pre-commit run --files src/mindroom/tool_system/events.py src/mindroom/ai.py src/mindroom/teams.py src/mindroom/streaming_delivery.py tests/test_tool_events.py tach.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced StreamingToolTracker for managing tool execution state in streaming responses.

* **Refactor**
  * Refactored tool-tracking mechanism across multiple modules to use centralized tracker.

* **Tests**
  * Added comprehensive test coverage for tool tracker functionality, including scope-based matching and trace updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->