### PR TITLE
Refactor force compaction state mutation

### DIFF
--- a/src/mindroom/history/manual.py
+++ b/src/mindroom/history/manual.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from mindroom.history.policy import manual_compaction_unavailable_message, resolve_history_execution_plan
 from mindroom.history.runtime import open_scope_session_context
-from mindroom.history.storage import add_pending_force_compaction_scope, read_scope_state, write_scope_state
+from mindroom.history.storage import add_pending_force_compaction_scope, read_scope_state, set_force_compaction_state
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -81,8 +81,7 @@ def request_compaction_before_next_reply(
 
         session = scope_context.session
         current_state = read_scope_state(session, scope_context.scope)
-        next_state = replace(current_state, force_compact_before_next_run=True)
-        write_scope_state(session, scope_context.scope, next_state)
+        set_force_compaction_state(session, scope_context.scope, current_state, force=True)
         scope_context.storage.upsert_session(session)
 
         next_session_state = session_state

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -41,6 +41,7 @@ from mindroom.history.storage import (
     clear_force_compaction_state,
     consume_pending_force_compaction_scope,
     read_scope_state,
+    set_force_compaction_state,
     write_scope_state,
 )
 from mindroom.history.types import (
@@ -1409,8 +1410,7 @@ def _prepare_scope_state_for_run(
 ) -> HistoryScopeState:
     state = read_scope_state(session, scope)
     if consume_pending_force_compaction_scope(session, scope):
-        state = replace(state, force_compact_before_next_run=True)
-        write_scope_state(session, scope, state)
+        state = set_force_compaction_state(session, scope, state, force=True)
         storage.upsert_session(session)
     if state.force_compact_before_next_run and not execution_plan.destructive_compaction_available:
         state = clear_force_compaction_state(session, scope, state)

--- a/src/mindroom/history/storage.py
+++ b/src/mindroom/history/storage.py
@@ -85,9 +85,20 @@ def clear_force_compaction_state(
     state: HistoryScopeState,
 ) -> HistoryScopeState:
     """Clear the next-run force flag in one session scope."""
-    cleared_state = replace(state, force_compact_before_next_run=False)
-    write_scope_state(session, scope, cleared_state)
-    return cleared_state
+    return set_force_compaction_state(session, scope, state, force=False)
+
+
+def set_force_compaction_state(
+    session: AgentSession | TeamSession,
+    scope: HistoryScope,
+    state: HistoryScopeState,
+    *,
+    force: bool,
+) -> HistoryScopeState:
+    """Set the next-run force flag in one session scope."""
+    next_state = replace(state, force_compact_before_next_run=force)
+    write_scope_state(session, scope, next_state)
+    return next_state
 
 
 def add_pending_force_compaction_scope(

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -85,6 +85,7 @@ from mindroom.history.runtime import (
 from mindroom.history.storage import (
     read_scope_seen_event_ids,
     read_scope_state,
+    set_force_compaction_state,
     update_scope_seen_event_ids,
     write_scope_state,
 )
@@ -5581,6 +5582,34 @@ def test_scope_seen_event_ids_survive_scope_state_writes(tmp_path: Path) -> None
     write_scope_state(session, scope, HistoryScopeState(force_compact_before_next_run=True))
 
     assert read_scope_seen_event_ids(session, scope) == {"event-1"}
+
+
+def test_set_force_compaction_state_updates_only_force_flag(tmp_path: Path) -> None:
+    _config, _runtime_paths_value = _make_config(tmp_path)
+    scope = HistoryScope(kind="agent", scope_id="test_agent")
+    session = _session("session-1")
+    state = HistoryScopeState(
+        last_summary_model="summary-model",
+        last_compacted_run_count=3,
+    )
+
+    forced_state = set_force_compaction_state(session, scope, state, force=True)
+
+    assert forced_state == HistoryScopeState(
+        last_summary_model="summary-model",
+        last_compacted_run_count=3,
+        force_compact_before_next_run=True,
+    )
+    assert read_scope_state(session, scope) == forced_state
+
+    cleared_state = set_force_compaction_state(session, scope, forced_state, force=False)
+
+    assert cleared_state == HistoryScopeState(
+        last_summary_model="summary-model",
+        last_compacted_run_count=3,
+        force_compact_before_next_run=False,
+    )
+    assert read_scope_state(session, scope) == cleared_state
 
 
 def test_scope_seen_event_ids_include_persisted_response_event_ids(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a storage-local helper for setting the scoped force-compaction flag
- route manual scheduling and pending runtime consumption through the shared mutation helper
- add a focused storage characterization test for the helper preserving existing fields

## Verification
- uv run pytest tests/test_agno_history.py::test_set_force_compaction_state_updates_only_force_flag tests/test_compact_context.py::test_request_compaction_before_next_reply_is_public_manual_seam tests/test_compact_context.py::test_compact_context_persists_pending_force_flag_across_stale_run_save -q
- uv run pre-commit run --files src/mindroom/history/manual.py src/mindroom/history/runtime.py src/mindroom/history/storage.py tests/test_agno_history.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal architecture for managing history compaction state flags, consolidating state update and persistence logic into a unified mechanism to enhance consistency and maintainability across different session and scope contexts.

* **Tests**
  * Added comprehensive test coverage for the updated force compaction state management system, ensuring accurate state transitions and reliable persistence behavior across various session scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->