### PR TITLE
refactor: share attachment ID prompt helpers

### DIFF
--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -36,7 +36,7 @@ from .matrix.media import (
 from .timing import emit_elapsed_timing
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
     from .matrix.client import ResolvedVisibleMessage
 
@@ -131,25 +131,29 @@ def _thread_history_message_in_scope(message: ResolvedVisibleMessage, thread_id:
     return thread_id in (message.thread_id, message.event_id)
 
 
+def unique_attachment_ids(attachment_ids: Iterable[str]) -> list[str]:
+    """Return unique non-empty attachment IDs preserving first-seen order."""
+    unique_ids: list[str] = []
+    seen_attachment_ids: set[str] = set()
+    for attachment_id in attachment_ids:
+        if attachment_id and attachment_id not in seen_attachment_ids:
+            seen_attachment_ids.add(attachment_id)
+            unique_ids.append(attachment_id)
+    return unique_ids
+
+
 def merge_attachment_ids(*attachment_id_lists: list[str]) -> list[str]:
     """Merge attachment IDs preserving first-seen order."""
-    merged: list[str] = []
-    seen_attachment_ids: set[str] = set()
-    for attachment_ids in attachment_id_lists:
-        for attachment_id in attachment_ids:
-            if attachment_id and attachment_id not in seen_attachment_ids:
-                seen_attachment_ids.add(attachment_id)
-                merged.append(attachment_id)
-    return merged
-
-
-def _append_attachment_ids_prompt(prompt: str, attachment_ids: list[str]) -> str:
-    """Append attachment guidance to a prompt when attachment IDs are available."""
-    if not attachment_ids:
-        return prompt
-    return (
-        f"{prompt}\n\nAvailable attachment IDs: {', '.join(attachment_ids)}. Use tool calls to inspect or process them."
+    return unique_attachment_ids(
+        attachment_id for attachment_ids in attachment_id_lists for attachment_id in attachment_ids
     )
+
+
+def format_attachment_ids_prompt(attachment_ids: list[str]) -> str | None:
+    """Return attachment guidance prompt text when attachment IDs are available."""
+    if not attachment_ids:
+        return None
+    return f"Available attachment IDs: {', '.join(attachment_ids)}. Use tool calls to inspect or process them."
 
 
 def _attachments_dir(storage_path: Path) -> Path:

--- a/src/mindroom/inbound_turn_normalizer.py
+++ b/src/mindroom/inbound_turn_normalizer.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from mindroom.attachment_media import resolve_attachment_media
 from mindroom.attachments import (
+    format_attachment_ids_prompt,
     merge_attachment_ids,
     parse_attachment_ids_from_thread_history,
     register_matrix_media_attachment,
@@ -368,14 +369,7 @@ class InboundTurnNormalizer:
             attachment_images = (
                 [*attachment_images, *request.fallback_images] if attachment_images else list(request.fallback_images)
             )
-        attachment_prompt = (
-            (
-                "Available attachment IDs: "
-                f"{', '.join(resolved_attachment_ids)}. Use tool calls to inspect or process them."
-            )
-            if resolved_attachment_ids
-            else None
-        )
+        attachment_prompt = format_attachment_ids_prompt(resolved_attachment_ids)
         return DispatchPayload(
             prompt=request.prompt,
             model_prompt=attachment_prompt,

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 from uuid import uuid4
 
+from mindroom.attachments import unique_attachment_ids
 from mindroom.hooks import (
     CustomEventContext,
     HookContextSupport,
@@ -507,11 +508,7 @@ def attachment_id_available_in_tool_runtime_context(
 
 def list_tool_runtime_attachment_ids(context: ToolRuntimeContext) -> list[str]:
     """Return all attachment IDs currently available in runtime context order."""
-    attachment_ids: list[str] = []
-    for attachment_id in (*context.attachment_ids, *context.runtime_attachment_ids):
-        if attachment_id and attachment_id not in attachment_ids:
-            attachment_ids.append(attachment_id)
-    return attachment_ids
+    return unique_attachment_ids((*context.attachment_ids, *context.runtime_attachment_ids))
 
 
 def append_tool_runtime_attachment_id(attachment_id: str) -> ToolRuntimeContext | None:

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -16,6 +16,7 @@ from mindroom.attachments import (
     _attachment_id_for_event,
     _register_image_attachment,
     filter_attachments_for_context,
+    format_attachment_ids_prompt,
     load_attachment,
     merge_attachment_ids,
     parse_attachment_ids_from_event_source,
@@ -23,6 +24,7 @@ from mindroom.attachments import (
     register_local_attachment,
     resolve_attachments,
     resolve_thread_attachment_ids,
+    unique_attachment_ids,
 )
 from tests.conftest import make_visible_message
 
@@ -266,6 +268,19 @@ def test_merge_attachment_ids_preserves_order() -> None:
     """Merge should preserve first-seen ordering across sources."""
     merged = merge_attachment_ids(["att_1", "att_2"], ["att_2", "att_3"], ["att_1"])
     assert merged == ["att_1", "att_2", "att_3"]
+
+
+def test_unique_attachment_ids_preserves_first_seen_order() -> None:
+    """Attachment ID ordering should keep first occurrence and skip blanks."""
+    attachment_ids = unique_attachment_ids(["att_1", "att_2", "att_1", "", "att_3", "att_2"])
+    assert attachment_ids == ["att_1", "att_2", "att_3"]
+
+
+def test_format_attachment_ids_prompt_preserves_user_facing_text() -> None:
+    """Attachment prompt wording is shared and remains exact."""
+    prompt = format_attachment_ids_prompt(["att_1", "att_2"])
+    assert prompt == "Available attachment IDs: att_1, att_2. Use tool calls to inspect or process them."
+    assert format_attachment_ids_prompt([]) is None
 
 
 def test_filter_attachments_for_context_enforces_room_and_thread(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add shared attachment ID ordering and prompt formatting helpers
- reuse the prompt formatter in inbound dispatch payloads
- reuse ordered unique IDs in tool runtime attachment listing

## Tests
- uv run pytest tests/test_attachments.py tests/test_multi_agent_bot.py::TestAgentBot::test_build_dispatch_payload_merges_fallback_images_with_registered_attachments tests/test_multi_agent_bot.py::TestAgentBot::test_build_dispatch_payload_with_attachments_keeps_raw_prompt_clean tests/test_attachments_tool.py::test_attachments_tool_registers_file_and_updates_runtime_context tests/test_attachments_tool.py::test_attachments_tool_register_attachment_available_after_task_boundary tests/test_attachments_tool.py::test_send_context_attachments_sends_local_file_paths_by_auto_registering -q -n 0 --no-cov
- uv run pre-commit run --files src/mindroom/attachments.py src/mindroom/inbound_turn_normalizer.py src/mindroom/tool_system/runtime_context.py tests/test_attachments.py

Production line delta: 23 insertions, 28 deletions across production files, net -5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved attachment ID deduplication logic to preserve order and eliminate duplicates more efficiently.
  * Enhanced attachment prompt formatting for better consistency.
  * Streamlined internal attachment handling across multiple modules.

* **Tests**
  * Added comprehensive test coverage for attachment deduplication and prompt formatting to ensure stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->