### PR TITLE
refactor: share Google Drive number coercion

### DIFF
--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING, Any
 
 from agno.tools.google.drive import GoogleDriveTools as AgnoGoogleDriveTools
@@ -11,6 +10,7 @@ from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, 
 from mindroom.logging_config import get_logger
 from mindroom.oauth.client import ScopedOAuthClientMixin
 from mindroom.oauth.google_drive import google_drive_oauth_provider
+from mindroom.tool_system.metadata import coerce_optional_finite_number
 from mindroom.tool_system.toolkit_aliases import apply_toolkit_function_aliases
 
 if TYPE_CHECKING:
@@ -25,6 +25,13 @@ _MODEL_FUNCTION_NAME_ALIASES = {
     "search_files": "google_drive_search_files",
     "read_file": "google_drive_read_file",
 }
+
+
+def _max_read_size_finite_error(value: object) -> TypeError | ValueError:
+    msg = "Google Drive max_read_size must be a finite number"
+    if isinstance(value, str):
+        return ValueError(msg)
+    return TypeError(msg)
 
 
 class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, AgnoGoogleDriveTools):
@@ -66,31 +73,16 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
         apply_toolkit_function_aliases(self, _MODEL_FUNCTION_NAME_ALIASES)
 
     def _coerce_max_read_size(self, value: object) -> int | float | None:
-        if value is None:
-            return None
-        if isinstance(value, bool):
+        try:
+            return coerce_optional_finite_number(value)
+        except OverflowError as exc:
+            raise _max_read_size_finite_error(value) from exc
+        except TypeError as exc:
             msg = "Google Drive max_read_size must be a number"
-            raise TypeError(msg)
-        if isinstance(value, int | float) and math.isfinite(value):
-            return value
-        if isinstance(value, int | float):
-            msg = "Google Drive max_read_size must be a finite number"
-            raise TypeError(msg)
-        if isinstance(value, str):
-            raw_value = value.strip()
-            if not raw_value:
-                return None
-            try:
-                parsed = float(raw_value)
-            except ValueError as exc:
-                msg = "Google Drive max_read_size must be a number"
-                raise ValueError(msg) from exc
-            if not math.isfinite(parsed):
-                msg = "Google Drive max_read_size must be a finite number"
-                raise ValueError(msg)
-            return int(parsed) if parsed.is_integer() else parsed
-        msg = "Google Drive max_read_size must be a number"
-        raise TypeError(msg)
+            raise TypeError(msg) from exc
+        except ValueError as exc:
+            msg = "Google Drive max_read_size must be a number"
+            raise ValueError(msg) from exc
 
     def _should_fallback_to_original_auth(self) -> bool:
         return google_service_account_configured(self.service_account_path, self._runtime_paths)

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -338,33 +338,40 @@ def sanitize_tool_init_overrides(
     }
 
 
-def _coerce_number_tool_config_value(tool_name: str, field_name: str, value: object) -> int | float | object:
-    """Normalize a persisted dashboard number field before passing it to a tool constructor."""
+def coerce_optional_finite_number(value: object) -> int | float | None:
+    """Normalize an optional finite number from runtime config text or JSON values."""
     if value is None:
-        return _OMIT_TOOL_CONFIG_ARG
+        return None
     if isinstance(value, bool):
-        msg = f"Stored config value for '{tool_name}.{field_name}' must be a number."
-        raise ToolConfigOverrideError(msg)
-    if isinstance(value, int | float) and math.isfinite(value):
-        return value
+        raise TypeError
     if isinstance(value, int | float):
-        msg = f"Stored config value for '{tool_name}.{field_name}' must be a finite number."
-        raise ToolConfigOverrideError(msg)
+        if math.isfinite(value):
+            return value
+        raise OverflowError
     if isinstance(value, str):
         raw_value = value.strip()
         if not raw_value:
-            return _OMIT_TOOL_CONFIG_ARG
-        try:
-            parsed = float(raw_value)
-        except ValueError as exc:
-            msg = f"Stored config value for '{tool_name}.{field_name}' must be a number."
-            raise ToolConfigOverrideError(msg) from exc
+            return None
+        parsed = float(raw_value)
         if not math.isfinite(parsed):
-            msg = f"Stored config value for '{tool_name}.{field_name}' must be a finite number."
-            raise ToolConfigOverrideError(msg)
+            raise OverflowError
         return int(parsed) if parsed.is_integer() else parsed
-    msg = f"Stored config value for '{tool_name}.{field_name}' must be a number."
-    raise ToolConfigOverrideError(msg)
+    raise TypeError
+
+
+def _coerce_number_tool_config_value(tool_name: str, field_name: str, value: object) -> int | float | object:
+    """Normalize a persisted dashboard number field before passing it to a tool constructor."""
+    try:
+        coerced = coerce_optional_finite_number(value)
+    except OverflowError as exc:
+        msg = f"Stored config value for '{tool_name}.{field_name}' must be a finite number."
+        raise ToolConfigOverrideError(msg) from exc
+    except (TypeError, ValueError) as exc:
+        msg = f"Stored config value for '{tool_name}.{field_name}' must be a number."
+        raise ToolConfigOverrideError(msg) from exc
+    if coerced is None:
+        return _OMIT_TOOL_CONFIG_ARG
+    return coerced
 
 
 def _coerce_runtime_tool_config_value(tool_name: str, field: ConfigField, value: object) -> object:

--- a/tests/test_google_tool_wrappers.py
+++ b/tests/test_google_tool_wrappers.py
@@ -366,3 +366,55 @@ def test_google_wrapper_valid_provided_creds_skip_service_account_fallback(
 
     assert tool._ensure_structured_auth() is None
     assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("max_read_size", "expected"),
+    [
+        ("42", 42),
+        ("42.5", 42.5),
+        ("", 10485760),
+        (None, 10485760),
+    ],
+)
+def test_google_drive_constructor_coerces_optional_max_read_size(
+    max_read_size: object,
+    expected: float,
+    runtime_paths: RuntimePaths,
+    tmp_path: Path,
+) -> None:
+    """Direct constructor overrides should match stored dashboard number coercion."""
+    tool = GoogleDriveTools(
+        runtime_paths=runtime_paths,
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        creds=ValidCredentials(),
+        max_read_size=max_read_size,
+    )
+
+    assert tool.max_read_size == expected
+
+
+@pytest.mark.parametrize(
+    ("max_read_size", "error_type", "match"),
+    [
+        (True, TypeError, "Google Drive max_read_size must be a number"),
+        ("not-a-number", ValueError, "Google Drive max_read_size must be a number"),
+        (float("inf"), TypeError, "Google Drive max_read_size must be a finite number"),
+        ("inf", ValueError, "Google Drive max_read_size must be a finite number"),
+    ],
+)
+def test_google_drive_constructor_rejects_invalid_max_read_size_with_current_errors(
+    max_read_size: object,
+    error_type: type[Exception],
+    match: str,
+    runtime_paths: RuntimePaths,
+    tmp_path: Path,
+) -> None:
+    """Direct constructor validation should keep current exception types and messages."""
+    with pytest.raises(error_type, match=match):
+        GoogleDriveTools(
+            runtime_paths=runtime_paths,
+            credentials_manager=CredentialsManager(tmp_path / "credentials"),
+            creds=ValidCredentials(),
+            max_read_size=max_read_size,
+        )


### PR DESCRIPTION
## Summary
- add a small shared optional finite-number coercion helper
- route Google Drive max_read_size constructor parsing through the helper while preserving existing exception types and messages
- add direct-constructor characterization tests for Google Drive max_read_size coercion

## Tests
- uv run pytest tests/test_google_tool_wrappers.py tests/test_google_drive_oauth_tool.py -q
- uv run pre-commit run --files src/mindroom/custom_tools/google_drive.py src/mindroom/tool_system/metadata.py tests/test_google_tool_wrappers.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for Google Drive configuration parameters with more descriptive error messages for invalid inputs.
  * Enhanced support for flexible input formats when specifying optional numeric parameters.

* **Tests**
  * Added comprehensive test coverage for parameter validation and type coercion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->