### PR TITLE
Refactor OAuth required payload serialization

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -36,7 +36,7 @@ from mindroom.attachments import normalize_attachment_id
 from mindroom.config.main import Config, load_config, normalized_config_data
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager
 from mindroom.logging_config import get_logger
-from mindroom.oauth.providers import OAuthConnectionRequired
+from mindroom.oauth.providers import OAuthConnectionRequired, oauth_connection_required_payload
 from mindroom.runtime_resolution import resolve_agent_runtime
 from mindroom.tool_system.catalog import (
     TOOL_METADATA,
@@ -1015,12 +1015,7 @@ async def _execute_request_inprocess(
 
 def _oauth_connection_required_result(exc: OAuthConnectionRequired) -> dict[str, object]:
     """Serialize OAuthConnectionRequired as the same structured tool result used in-process."""
-    return {
-        "error": str(exc),
-        "oauth_connection_required": True,
-        "provider": exc.provider_id,
-        "connect_url": exc.connect_url,
-    }
+    return oauth_connection_required_payload(exc)
 
 
 def _subprocess_failure_response(

--- a/src/mindroom/oauth/client.py
+++ b/src/mindroom/oauth/client.py
@@ -13,7 +13,7 @@ from google.auth.transport import requests as google_requests
 from google.oauth2 import credentials as google_credentials
 
 from mindroom.credentials import load_scoped_credentials, save_scoped_credentials
-from mindroom.oauth.providers import OAuthConnectionRequired, OAuthProvider
+from mindroom.oauth.providers import OAuthConnectionRequired, OAuthProvider, oauth_connection_required_payload
 from mindroom.oauth.service import (
     oauth_connect_url,
     oauth_credentials_have_required_scopes,
@@ -159,14 +159,7 @@ class ScopedOAuthClientMixin:
         raise self._connection_required()
 
     def _structured_auth_failure(self, exc: OAuthConnectionRequired) -> str:
-        return json.dumps(
-            {
-                "error": str(exc),
-                "oauth_connection_required": True,
-                "provider": exc.provider_id,
-                "connect_url": exc.connect_url,
-            },
-        )
+        return json.dumps(oauth_connection_required_payload(exc))
 
     def _ensure_structured_auth(self) -> str | None:
         auth_source = self._select_auth_source()

--- a/src/mindroom/oauth/providers.py
+++ b/src/mindroom/oauth/providers.py
@@ -62,6 +62,16 @@ class OAuthConnectionRequired(OAuthProviderError):  # noqa: N818
         self.connect_url = connect_url
 
 
+def oauth_connection_required_payload(exc: OAuthConnectionRequired) -> dict[str, object]:
+    """Return the structured tool payload for one OAuth connection prompt."""
+    return {
+        "error": str(exc),
+        "oauth_connection_required": True,
+        "provider": exc.provider_id,
+        "connect_url": exc.connect_url,
+    }
+
+
 @dataclass(frozen=True, slots=True)
 class OAuthClientConfig:
     """Resolved OAuth client settings for one runtime."""

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -26,7 +26,7 @@ from mindroom.hooks import (
 )
 from mindroom.llm_request_logging import current_llm_request_log_context
 from mindroom.logging_config import get_logger
-from mindroom.oauth.providers import OAuthConnectionRequired
+from mindroom.oauth.providers import OAuthConnectionRequired, oauth_connection_required_payload
 from mindroom.sync_bridge_state import sync_tool_bridge_blocked_loop
 from mindroom.timing import emit_timing_event
 from mindroom.tool_approval import ToolApprovalCall, ToolApprovalScriptError, request_tool_approval_for_call
@@ -636,12 +636,7 @@ async def _execute_bridge(
             agent_name=resolved_context.agent_name or None,
         )
     except OAuthConnectionRequired as exc:
-        result = {
-            "error": str(exc),
-            "oauth_connection_required": True,
-            "provider": exc.provider_id,
-            "connect_url": exc.connect_url,
-        }
+        result = oauth_connection_required_payload(exc)
         duration_ms = (time.perf_counter() - started_at) * 1000
         _record_debug_tool_success(
             tool_name=tool_name,

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -11,6 +11,7 @@ from mindroom.oauth.google_calendar import _GOOGLE_CALENDAR_OAUTH_SCOPES, google
 from mindroom.oauth.google_drive import _GOOGLE_DRIVE_OAUTH_SCOPES, google_drive_oauth_provider
 from mindroom.oauth.google_gmail import _GOOGLE_GMAIL_OAUTH_SCOPES, google_gmail_oauth_provider
 from mindroom.oauth.google_sheets import _GOOGLE_SHEETS_OAUTH_SCOPES, google_sheets_oauth_provider
+from mindroom.oauth.providers import OAuthConnectionRequired, oauth_connection_required_payload
 
 if TYPE_CHECKING:
     from mindroom.oauth.providers import OAuthProvider
@@ -151,3 +152,19 @@ def test_google_oauth_provider_helper_builds_common_google_provider_skeleton() -
     assert provider.extra_auth_params == GOOGLE_EXTRA_AUTH_PARAMS
     assert provider.status_capabilities == ("Example read/write",)
     assert provider.token_parser is _google_token_parser
+
+
+def test_oauth_connection_required_payload_preserves_structured_fields() -> None:
+    """OAuth-required tool payloads keep the established public field names."""
+    exc = OAuthConnectionRequired(
+        "Google Drive is not connected for this agent.",
+        provider_id="google_drive",
+        connect_url="/api/oauth/google_drive/connect?agent_name=general",
+    )
+
+    assert oauth_connection_required_payload(exc) == {
+        "error": "Google Drive is not connected for this agent.",
+        "oauth_connection_required": True,
+        "provider": "google_drive",
+        "connect_url": "/api/oauth/google_drive/connect?agent_name=general",
+    }


### PR DESCRIPTION
## Summary
- add a shared OAuthConnectionRequired payload helper
- reuse it in OAuth client JSON responses, sandbox runner responses, and tool hooks
- add a focused characterization test for the structured payload shape

## Tests
- uv run pytest tests/test_google_oauth_providers.py::test_oauth_connection_required_payload_preserves_structured_fields tests/test_google_calendar_oauth_tool.py::test_google_calendar_public_method_returns_structured_connect_instruction tests/api/test_sandbox_runner_api.py::test_execute_request_inprocess_serializes_oauth_connection_required tests/api/test_sandbox_runner_api.py::test_execute_request_inprocess_serializes_oauth_connection_required_from_tool_construction tests/test_tool_hooks.py::test_oauth_required_tool_result_is_recorded_when_debug_enabled -n 0 --no-cov -q
- uv run pre-commit run --files src/mindroom/oauth/providers.py src/mindroom/oauth/client.py src/mindroom/api/sandbox_runner.py src/mindroom/tool_system/tool_hooks.py tests/test_google_oauth_providers.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated OAuth connection error handling across the system for consistency.
  * Improved test coverage for OAuth error serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->