### PR TITLE
refactor: share ToolExecutionIdentity payload parsing

### DIFF
--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -15,7 +15,7 @@ from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict
 
 if os.name != "nt":
     import fcntl
@@ -54,7 +54,12 @@ from mindroom.knowledge.registry import (
 )
 from mindroom.logging_config import get_logger
 from mindroom.runtime_resolution import resolve_knowledge_binding
-from mindroom.tool_system.worker_routing import ToolExecutionIdentity
+from mindroom.tool_system.worker_routing import (
+    SerializedToolExecutionIdentity,
+    ToolExecutionIdentity,
+    parse_tool_execution_identity_payload,
+    serialize_tool_execution_identity,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -80,7 +85,7 @@ class _SubprocessRefreshRequest:
     config_data: dict[str, object]
     config_path: str
     storage_root: str
-    execution_identity: dict[str, object] | None = None
+    execution_identity: SerializedToolExecutionIdentity | None = None
     force_reindex: bool = False
 
 
@@ -275,7 +280,9 @@ def _serialize_subprocess_refresh_request(
         config_data=config.authored_model_dump(),
         config_path=str(runtime_paths.config_path),
         storage_root=str(runtime_paths.storage_root),
-        execution_identity=None if execution_identity is None else asdict(execution_identity),
+        execution_identity=None
+        if execution_identity is None
+        else serialize_tool_execution_identity(execution_identity),
         force_reindex=force_reindex,
     )
     return json.dumps(asdict(payload), sort_keys=True).encode()
@@ -871,40 +878,6 @@ def _load_subprocess_refresh_request(payload: bytes) -> _SubprocessRefreshReques
     )
 
 
-def _optional_str_payload_field(payload: dict[str, object], field_name: str) -> str | None:
-    value = payload.get(field_name)
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        msg = f"Knowledge refresh execution_identity.{field_name} must be a string when present"
-        raise TypeError(msg)
-    return value
-
-
-def _execution_identity_from_payload(payload: dict[str, object] | None) -> ToolExecutionIdentity | None:
-    if payload is None:
-        return None
-    channel = payload.get("channel")
-    if channel not in ("matrix", "openai_compat"):
-        msg = "Knowledge refresh execution_identity.channel must be matrix or openai_compat"
-        raise TypeError(msg)
-    agent_name = payload.get("agent_name")
-    if not isinstance(agent_name, str) or not agent_name.strip():
-        msg = "Knowledge refresh execution_identity.agent_name must be a non-empty string"
-        raise TypeError(msg)
-    return ToolExecutionIdentity(
-        channel=cast("Literal['matrix', 'openai_compat']", channel),
-        agent_name=agent_name,
-        requester_id=_optional_str_payload_field(payload, "requester_id"),
-        room_id=_optional_str_payload_field(payload, "room_id"),
-        thread_id=_optional_str_payload_field(payload, "thread_id"),
-        resolved_thread_id=_optional_str_payload_field(payload, "resolved_thread_id"),
-        session_id=_optional_str_payload_field(payload, "session_id"),
-        tenant_id=_optional_str_payload_field(payload, "tenant_id"),
-        account_id=_optional_str_payload_field(payload, "account_id"),
-    )
-
-
 async def _run_subprocess_refresh_request(payload: bytes) -> KnowledgeRefreshResult:
     request = _load_subprocess_refresh_request(payload)
     runtime_paths = resolve_runtime_paths(
@@ -913,7 +886,14 @@ async def _run_subprocess_refresh_request(payload: bytes) -> KnowledgeRefreshRes
         process_env=dict(os.environ),
     )
     config = Config.validate_with_runtime(request.config_data, runtime_paths, tolerate_plugin_load_errors=True)
-    execution_identity = _execution_identity_from_payload(request.execution_identity)
+    execution_identity = (
+        None
+        if request.execution_identity is None
+        else parse_tool_execution_identity_payload(
+            request.execution_identity,
+            error_prefix="Knowledge refresh execution_identity",
+        )
+    )
     return await refresh_knowledge_binding(
         request.base_id,
         config=config,

--- a/src/mindroom/memory/auto_flush.py
+++ b/src/mindroom/memory/auto_flush.py
@@ -8,7 +8,7 @@ import re
 import threading
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 from agno.agent import Agent
 
@@ -17,7 +17,12 @@ from mindroom.agent_storage import create_session_storage, get_agent_session
 from mindroom.logging_config import get_logger
 from mindroom.memory.functions import append_agent_daily_memory, list_all_agent_memories
 from mindroom.runtime_resolution import resolve_agent_execution
-from mindroom.tool_system.worker_routing import ToolExecutionIdentity
+from mindroom.tool_system.worker_routing import (
+    SerializedToolExecutionIdentity,
+    ToolExecutionIdentity,
+    parse_tool_execution_identity_payload,
+    serialize_tool_execution_identity,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -41,7 +46,7 @@ class _FlushSessionEntry(TypedDict, total=False):
     agent_name: str
     session_id: str
     worker_key: str | None
-    execution_identity: _SerializedExecutionIdentity | None
+    execution_identity: SerializedToolExecutionIdentity | None
     dirty: bool
     in_flight: bool
     first_dirty_at: int
@@ -61,20 +66,6 @@ class _FlushState(TypedDict):
 
     version: int
     sessions: dict[str, _FlushSessionEntry]
-
-
-class _SerializedExecutionIdentity(TypedDict):
-    """JSON-safe execution identity for persisted flush entries."""
-
-    channel: str
-    agent_name: str
-    requester_id: str | None
-    room_id: str | None
-    thread_id: str | None
-    resolved_thread_id: str | None
-    session_id: str | None
-    tenant_id: str | None
-    account_id: str | None
 
 
 def _state_path(storage_path: Path) -> Path:
@@ -97,61 +88,11 @@ def _session_key(agent_name: str, session_id: str, worker_key: str | None = None
     return f"{agent_name}:{worker_key}:{session_id}"
 
 
-def _serialize_execution_identity(identity: ToolExecutionIdentity) -> _SerializedExecutionIdentity:
-    return {
-        "channel": identity.channel,
-        "agent_name": identity.agent_name,
-        "requester_id": identity.requester_id,
-        "room_id": identity.room_id,
-        "thread_id": identity.thread_id,
-        "resolved_thread_id": identity.resolved_thread_id,
-        "session_id": identity.session_id,
-        "tenant_id": identity.tenant_id,
-        "account_id": identity.account_id,
-    }
-
-
-def _deserialize_execution_identity(raw_identity: object) -> ToolExecutionIdentity | None:
-    if not isinstance(raw_identity, dict):
-        return None
-    payload = cast("dict[str, object]", raw_identity)
-    channel = payload.get("channel")
-    agent_name = payload.get("agent_name")
-    if not isinstance(channel, str) or not isinstance(agent_name, str):
-        return None
-    optional_keys = (
-        "requester_id",
-        "room_id",
-        "thread_id",
-        "resolved_thread_id",
-        "session_id",
-        "tenant_id",
-        "account_id",
-    )
-    optional_values: dict[str, str | None] = {}
-    for key in optional_keys:
-        value = payload.get(key)
-        if value is not None and not isinstance(value, str):
-            return None
-        optional_values[key] = value
-    return ToolExecutionIdentity(
-        channel=cast("Any", channel),
-        agent_name=agent_name,
-        requester_id=optional_values["requester_id"],
-        room_id=optional_values["room_id"],
-        thread_id=optional_values["thread_id"],
-        resolved_thread_id=optional_values["resolved_thread_id"],
-        session_id=optional_values["session_id"],
-        tenant_id=optional_values["tenant_id"],
-        account_id=optional_values["account_id"],
-    )
-
-
 def _resolve_flush_scope(
     config: Config,
     agent_name: str,
     execution_identity: ToolExecutionIdentity | None,
-) -> tuple[str | None, _SerializedExecutionIdentity | None]:
+) -> tuple[str | None, SerializedToolExecutionIdentity | None]:
     resolved_execution = resolve_agent_execution(
         agent_name,
         config,
@@ -163,7 +104,10 @@ def _resolve_flush_scope(
     if resolved_identity is None:
         msg = f"Private agent '{agent_name}' requires an execution identity for memory auto-flush"
         raise ValueError(msg)
-    return resolved_execution.worker_key, _serialize_execution_identity(resolved_identity)
+    return resolved_execution.worker_key, serialize_tool_execution_identity(
+        resolved_identity,
+        include_transport_agent_name=False,
+    )
 
 
 def _sanitize_session_entry(raw_entry: object) -> _FlushSessionEntry | None:
@@ -176,7 +120,10 @@ def _sanitize_session_entry(raw_entry: object) -> _FlushSessionEntry | None:
     if worker_key is not None and not isinstance(worker_key, str):
         entry.pop("worker_key", None)
     execution_identity = entry.get("execution_identity")
-    if execution_identity is not None and _deserialize_execution_identity(execution_identity) is None:
+    if (
+        execution_identity is not None
+        and parse_tool_execution_identity_payload(execution_identity, strict=False) is None
+    ):
         entry.pop("execution_identity", None)
     return cast("_FlushSessionEntry", entry)
 
@@ -188,7 +135,7 @@ def _stale_private_session_entry(
 ) -> bool:
     agent_config = config.agents.get(agent_name)
     worker_key = entry.get("worker_key")
-    execution_identity = _deserialize_execution_identity(entry.get("execution_identity"))
+    execution_identity = parse_tool_execution_identity_payload(entry.get("execution_identity"), strict=False)
     if agent_config is None or agent_config.private is None:
         return worker_key is not None or execution_identity is not None
     if not isinstance(worker_key, str) or execution_identity is None:
@@ -635,7 +582,10 @@ class MemoryAutoFlushWorker:
             batch_key = _flush_batch_key(config, agent_name, entry)
             if per_agent_count.get(batch_key, 0) >= max_per_agent:
                 continue
-            entry_execution_identity = _deserialize_execution_identity(entry.get("execution_identity"))
+            entry_execution_identity = parse_tool_execution_identity_payload(
+                entry.get("execution_identity"),
+                strict=False,
+            )
 
             session = _load_agent_session(
                 config,
@@ -697,7 +647,7 @@ class MemoryAutoFlushWorker:
         session_updated_at = entry.get("last_session_updated_at")
         if not isinstance(agent_name, str) or not isinstance(session_id, str):
             return
-        entry_execution_identity = _deserialize_execution_identity(entry.get("execution_identity"))
+        entry_execution_identity = parse_tool_execution_identity_payload(entry.get("execution_identity"), strict=False)
 
         wrote_memory = False
         try:

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import AsyncGenerator as AsyncGeneratorABC
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol, cast, runtime_checkable
 
@@ -63,6 +63,87 @@ class ToolExecutionIdentity:
     tenant_id: str | None = None
     account_id: str | None = None
     transport_agent_name: str | None = None
+
+
+type SerializedToolExecutionIdentity = dict[str, object]
+
+
+_TOOL_EXECUTION_IDENTITY_OPTIONAL_PAYLOAD_FIELDS = (
+    "requester_id",
+    "room_id",
+    "thread_id",
+    "resolved_thread_id",
+    "session_id",
+    "tenant_id",
+    "account_id",
+    "transport_agent_name",
+)
+
+
+def serialize_tool_execution_identity(
+    identity: ToolExecutionIdentity,
+    *,
+    include_transport_agent_name: bool = True,
+) -> SerializedToolExecutionIdentity:
+    """Return a JSON-safe payload for one execution identity."""
+    payload = cast("SerializedToolExecutionIdentity", asdict(identity))
+    if not include_transport_agent_name:
+        payload.pop("transport_agent_name", None)
+    return payload
+
+
+def parse_tool_execution_identity_payload(
+    payload: object,
+    *,
+    strict: bool = True,
+    error_prefix: str = "Tool execution_identity",
+) -> ToolExecutionIdentity | None:
+    """Parse one JSON execution-identity payload with strict or lenient error handling."""
+    if not isinstance(payload, dict):
+        return _invalid_tool_execution_identity_payload(strict, f"{error_prefix} must be an object")
+
+    raw_payload = cast("dict[str, object]", payload)
+    channel = raw_payload.get("channel")
+    if channel not in ("matrix", "openai_compat"):
+        return _invalid_tool_execution_identity_payload(
+            strict,
+            f"{error_prefix}.channel must be matrix or openai_compat",
+        )
+
+    agent_name = raw_payload.get("agent_name")
+    if not isinstance(agent_name, str) or not agent_name.strip():
+        return _invalid_tool_execution_identity_payload(
+            strict,
+            f"{error_prefix}.agent_name must be a non-empty string",
+        )
+
+    optional_values: dict[str, str | None] = {}
+    for field_name in _TOOL_EXECUTION_IDENTITY_OPTIONAL_PAYLOAD_FIELDS:
+        value = raw_payload.get(field_name)
+        if value is not None and not isinstance(value, str):
+            return _invalid_tool_execution_identity_payload(
+                strict,
+                f"{error_prefix}.{field_name} must be a string when present",
+            )
+        optional_values[field_name] = value
+
+    return ToolExecutionIdentity(
+        channel=cast("_ExecutionChannel", channel),
+        agent_name=agent_name,
+        requester_id=optional_values["requester_id"],
+        room_id=optional_values["room_id"],
+        thread_id=optional_values["thread_id"],
+        resolved_thread_id=optional_values["resolved_thread_id"],
+        session_id=optional_values["session_id"],
+        tenant_id=optional_values["tenant_id"],
+        account_id=optional_values["account_id"],
+        transport_agent_name=optional_values["transport_agent_name"],
+    )
+
+
+def _invalid_tool_execution_identity_payload(strict: bool, message: str) -> None:
+    if strict:
+        raise TypeError(message)
 
 
 @dataclass(frozen=True)

--- a/tach.toml
+++ b/tach.toml
@@ -2577,6 +2577,7 @@ from = ["mindroom.tool_system.plugin_identity"]
 expose = [
     "ResolvedWorkerTarget",
     "ResolvedWorkerKeyScope",
+    "SerializedToolExecutionIdentity",
     "ToolExecutionIdentity",
     "WorkerScope",
     "active_tool_execution_identity",
@@ -2587,6 +2588,7 @@ expose = [
     "build_worker_target_from_runtime_env",
     "get_tool_execution_identity",
     "private_instance_scope_root_path",
+    "parse_tool_execution_identity_payload",
     "require_worker_key_for_scope",
     "resolve_agent_owned_path",
     "resolve_agent_state_storage_path",
@@ -2597,6 +2599,7 @@ expose = [
     "resolved_worker_key_scope",
     "run_with_tool_execution_identity",
     "shared_storage_root",
+    "serialize_tool_execution_identity",
     "stream_with_tool_execution_identity",
     "supports_tool_name_for_worker_scope",
     "tool_stays_local",

--- a/tests/test_tool_execution_identity_payloads.py
+++ b/tests/test_tool_execution_identity_payloads.py
@@ -1,0 +1,89 @@
+"""Tests for ToolExecutionIdentity JSON payload helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from mindroom.tool_system.worker_routing import (
+    ToolExecutionIdentity,
+    parse_tool_execution_identity_payload,
+    serialize_tool_execution_identity,
+)
+
+
+def _identity() -> ToolExecutionIdentity:
+    return ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id="$thread",
+        resolved_thread_id="$thread",
+        session_id="session-1",
+        tenant_id="tenant-1",
+        account_id="account-1",
+        transport_agent_name="mindroom_general",
+    )
+
+
+def test_serialize_tool_execution_identity_preserves_payload_fields_by_caller() -> None:
+    """Callers should choose whether their existing payload includes transport_agent_name."""
+    identity = _identity()
+
+    full_payload = serialize_tool_execution_identity(identity)
+    compact_payload = serialize_tool_execution_identity(identity, include_transport_agent_name=False)
+
+    assert full_payload == {
+        "channel": "matrix",
+        "agent_name": "general",
+        "requester_id": "@alice:example.org",
+        "room_id": "!room:example.org",
+        "thread_id": "$thread",
+        "resolved_thread_id": "$thread",
+        "session_id": "session-1",
+        "tenant_id": "tenant-1",
+        "account_id": "account-1",
+        "transport_agent_name": "mindroom_general",
+    }
+    assert compact_payload == {
+        "channel": "matrix",
+        "agent_name": "general",
+        "requester_id": "@alice:example.org",
+        "room_id": "!room:example.org",
+        "thread_id": "$thread",
+        "resolved_thread_id": "$thread",
+        "session_id": "session-1",
+        "tenant_id": "tenant-1",
+        "account_id": "account-1",
+    }
+
+
+def test_parse_tool_execution_identity_payload_strict_uses_caller_error_prefix() -> None:
+    """Strict subprocess parsing should keep caller-owned error messages."""
+    payload = serialize_tool_execution_identity(_identity())
+    payload["requester_id"] = 123
+
+    with pytest.raises(
+        TypeError,
+        match=r"Knowledge refresh execution_identity\.requester_id must be a string when present",
+    ):
+        parse_tool_execution_identity_payload(
+            payload,
+            error_prefix="Knowledge refresh execution_identity",
+        )
+
+
+def test_parse_tool_execution_identity_payload_lenient_returns_none_for_invalid_payload() -> None:
+    """Persisted state parsing should drop invalid identities without raising."""
+    payload = serialize_tool_execution_identity(_identity(), include_transport_agent_name=False)
+    payload["tenant_id"] = {"not": "a string"}
+
+    assert parse_tool_execution_identity_payload(payload, strict=False) is None
+    assert parse_tool_execution_identity_payload("not an object", strict=False) is None
+
+
+def test_parse_tool_execution_identity_payload_round_trips_transport_agent_name() -> None:
+    """Full payload parsing should preserve transport_agent_name when present."""
+    parsed = parse_tool_execution_identity_payload(serialize_tool_execution_identity(_identity()))
+
+    assert parsed == _identity()


### PR DESCRIPTION
## Summary
- add shared ToolExecutionIdentity payload serializer/parser near worker routing
- replace strict knowledge refresh subprocess parsing and lenient memory auto-flush parsing with shared helpers
- add focused payload characterization tests and Tach interface entries

## Verification
- uv run pytest tests/test_tool_execution_identity_payloads.py tests/test_knowledge_manager.py::test_scheduled_refresh_subprocess_receives_config_snapshot tests/test_knowledge_manager.py::test_subprocess_refresh_tolerates_broken_unused_plugin tests/test_memory_auto_flush.py::test_mark_dirty_separates_private_agent_sessions_by_requester_scope tests/test_memory_auto_flush.py::test_worker_flush_private_agent_uses_persisted_private_scope -q -n 0 --no-cov
- uv run pre-commit run --files src/mindroom/tool_system/worker_routing.py src/mindroom/knowledge/refresh_runner.py src/mindroom/memory/auto_flush.py tests/test_tool_execution_identity_payloads.py tach.toml
- uv run tach check --dependencies --interfaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JSON serialization support for tool execution identities with new public APIs: `serialize_tool_execution_identity()` and `parse_tool_execution_identity_payload()` functions, plus `SerializedToolExecutionIdentity` type.

* **Refactor**
  * Unified internal serialization flows to use the new tool execution identity serialization mechanism.

* **Tests**
  * Added comprehensive test coverage for tool execution identity payload serialization and deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->