### PR TITLE
refactor: reuse matrix api rate limit helper

### DIFF
--- a/src/mindroom/custom_tools/matrix_api.py
+++ b/src/mindroom/custom_tools/matrix_api.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import time
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from threading import Lock
@@ -14,6 +13,7 @@ from agno.tools import Toolkit
 
 from mindroom.config.matrix import ignore_unverified_devices_for_config
 from mindroom.custom_tools.attachment_helpers import room_access_allowed
+from mindroom.custom_tools.matrix_helpers import check_rate_limit
 from mindroom.logging_config import get_logger
 from mindroom.matrix.thread_bookkeeping import (
     MutationThreadImpactState,
@@ -518,34 +518,18 @@ class MatrixApiTools(Toolkit):
         *,
         action: str,
     ) -> str | None:
-        weight = cls._WRITE_ACTION_WEIGHTS[action]
-        key = (context.agent_name, context.requester_id, room_id)
-        now = time.monotonic()
-        cutoff = now - cls._RATE_LIMIT_WINDOW_SECONDS
-
-        with cls._rate_limit_lock:
-            history = cls._recent_write_units[key]
-            while history and history[0] < cutoff:
-                history.popleft()
-            if len(history) + weight > cls._RATE_LIMIT_MAX_UNITS:
-                return (
-                    "Rate limit exceeded for matrix_api writes "
-                    f"({cls._RATE_LIMIT_MAX_UNITS} units per {int(cls._RATE_LIMIT_WINDOW_SECONDS)}s)."
-                )
-            history.extend(now for _ in range(weight))
-
-            stale_keys: list[tuple[str, str, str]] = []
-            for other_key, other_history in cls._recent_write_units.items():
-                if other_key == key:
-                    continue
-                while other_history and other_history[0] < cutoff:
-                    other_history.popleft()
-                if not other_history:
-                    stale_keys.append(other_key)
-            for stale_key in stale_keys:
-                del cls._recent_write_units[stale_key]
-
-        return None
+        return check_rate_limit(
+            lock=cls._rate_limit_lock,
+            recent_actions=cls._recent_write_units,
+            window_seconds=cls._RATE_LIMIT_WINDOW_SECONDS,
+            max_actions=cls._RATE_LIMIT_MAX_UNITS,
+            tool_name="matrix_api",
+            context=context,
+            room_id=room_id,
+            weight=cls._WRITE_ACTION_WEIGHTS[action],
+            limit_label="matrix_api writes",
+            limit_budget_label="units",
+        )
 
     @classmethod
     def _audit_write(

--- a/src/mindroom/custom_tools/matrix_helpers.py
+++ b/src/mindroom/custom_tools/matrix_helpers.py
@@ -22,6 +22,8 @@ def check_rate_limit(
     context: ToolRuntimeContext,
     room_id: str,
     weight: int = 1,
+    limit_label: str | None = None,
+    limit_budget_label: str | None = None,
 ) -> str | None:
     """Enforce a per-(agent, requester, room) sliding-window rate limit.
 
@@ -37,7 +39,11 @@ def check_rate_limit(
         while history and history[0] < cutoff:
             history.popleft()
         if len(history) + action_weight > max_actions:
-            return f"Rate limit exceeded for {tool_name} actions ({max_actions} per {int(window_seconds)}s)."
+            subject = limit_label or f"{tool_name} actions"
+            budget = f"{max_actions} per {int(window_seconds)}s"
+            if limit_budget_label is not None:
+                budget = f"{max_actions} {limit_budget_label} per {int(window_seconds)}s"
+            return f"Rate limit exceeded for {subject} ({budget})."
         history.extend(now for _ in range(action_weight))
 
         stale_keys: list[tuple[str, str, str]] = []

--- a/tests/test_matrix_api_tool.py
+++ b/tests/test_matrix_api_tool.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import tempfile
+from collections import defaultdict, deque
 from pathlib import Path
+from threading import Lock
 from unittest.mock import AsyncMock, Mock, patch
 
 import nio
@@ -14,6 +16,7 @@ import mindroom.tools  # noqa: F401
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.custom_tools.matrix_api import MatrixApiTools, _MatrixSearchResponse
+from mindroom.custom_tools.matrix_helpers import check_rate_limit
 from mindroom.matrix.thread_bookkeeping import MutationThreadImpact
 from mindroom.tool_system.metadata import TOOL_METADATA, get_tool_by_name
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
@@ -1745,9 +1748,31 @@ async def test_matrix_api_rate_limit_uses_weighted_budget() -> None:
 
     assert [payload["status"] for payload in (first, second, third, fourth)] == ["ok", "ok", "ok", "ok"]
     assert fifth["status"] == "error"
-    assert "Rate limit exceeded" in fifth["message"]
+    assert fifth["message"] == "Rate limit exceeded for matrix_api writes (8 units per 60s)."
     assert ctx.client.room_put_state.await_count == 4
     ctx.client.room_send.assert_not_awaited()
+
+
+def test_matrix_rate_limit_helper_preserves_matrix_api_budget_message() -> None:
+    """The shared helper should keep matrix_api's user-facing units wording."""
+    ctx = _make_context()
+    recent_actions: dict[tuple[str, str, str], deque[float]] = defaultdict(deque)
+
+    error = check_rate_limit(
+        lock=Lock(),
+        recent_actions=recent_actions,
+        window_seconds=60.0,
+        max_actions=2,
+        tool_name="matrix_api",
+        context=ctx,
+        room_id=ctx.room_id,
+        weight=3,
+        limit_label="matrix_api writes",
+        limit_budget_label="units",
+    )
+
+    assert error == "Rate limit exceeded for matrix_api writes (2 units per 60s)."
+    assert list(recent_actions[(ctx.agent_name, ctx.requester_id, ctx.room_id)]) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Route MatrixApiTools write rate limiting through the shared Matrix custom-tool helper.
- Preserve matrix_api write-unit error wording and weighted budget behavior.
- Add focused characterization coverage for the helper message and exact matrix_api rate-limit payload.

## Verification
- uv run pytest tests/test_matrix_api_tool.py tests/test_matrix_message_tool.py tests/test_matrix_room_tool.py -k 'rate_limit' -q
- uv run pre-commit run --files src/mindroom/custom_tools/matrix_api.py src/mindroom/custom_tools/matrix_helpers.py tests/test_matrix_api_tool.py
- uv run pytest -q (2 unrelated failures: tests/test_oauth_state.py::test_issue_opaque_oauth_state_keeps_concurrent_process_writes, tests/test_tool_approval.py::test_truncated_approval_action_sends_denial_notice; both passed on exact rerun)
- uv run pytest tests/test_oauth_state.py::test_issue_opaque_oauth_state_keeps_concurrent_process_writes tests/test_tool_approval.py::test_truncated_approval_action_sends_denial_notice -q