### PR TITLE
refactor: share hook wire format helpers

### DIFF
--- a/src/mindroom/hooks/context.py
+++ b/src/mindroom/hooks/context.py
@@ -17,7 +17,13 @@ from .state import (
     chain_hook_room_state_putters,
     chain_hook_room_state_queriers,
 )
-from .types import EVENT_TOOL_AFTER_CALL, EVENT_TOOL_BEFORE_CALL, EnrichmentCachePolicy, EnrichmentItem
+from .types import (
+    EVENT_TOOL_AFTER_CALL,
+    EVENT_TOOL_BEFORE_CALL,
+    EnrichmentCachePolicy,
+    EnrichmentItem,
+    format_hook_source,
+)
 
 
 class _UnsetType:
@@ -91,7 +97,6 @@ async def _send_bound_message(
     if message_sender is None:
         logger.warning("send_message called but no sender registered")
         return None
-    source_hook = f"{plugin_name}:{event_name}"
     resolved_extra_content = dict(extra_content or {})
     if requester_id:
         resolved_extra_content.setdefault(ORIGINAL_SENDER_KEY, requester_id)
@@ -101,7 +106,7 @@ async def _send_bound_message(
         room_id,
         text,
         thread_id,
-        source_hook,
+        format_hook_source(plugin_name, event_name),
         resolved_extra_content or None,
         trigger_dispatch=trigger_dispatch,
     )
@@ -762,7 +767,7 @@ def _requester_id_for_hook_send(
     trigger_dispatch: bool = False,
 ) -> str | None:
     """Return the requester identity to preserve on hook-originated sends."""
-    envelope = _message_envelope_for_hook_context(context)
+    envelope = message_envelope_for_hook_context(context)
     if envelope is not None:
         requester_id = envelope.requester_id
     elif isinstance(context, ScheduleFiredContext):
@@ -785,7 +790,7 @@ def _message_received_depth_for_hook_send(context: object) -> int:
 
 def _current_message_received_depth(context: object) -> int:
     """Return the inbound synthetic hook-chain depth for one hook context."""
-    envelope = _message_envelope_for_hook_context(context)
+    envelope = message_envelope_for_hook_context(context)
     if envelope is not None:
         return envelope.message_received_depth
     if isinstance(context, CustomEventContext | ToolBeforeCallContext | ToolAfterCallContext):
@@ -793,7 +798,7 @@ def _current_message_received_depth(context: object) -> int:
     return 0
 
 
-def _message_envelope_for_hook_context(context: object) -> MessageEnvelope | None:
+def message_envelope_for_hook_context(context: object) -> MessageEnvelope | None:
     """Return the message envelope carried by one hook context when present."""
     if isinstance(context, MessageReceivedContext | MessageEnrichContext | SystemEnrichContext):
         return context.envelope

--- a/src/mindroom/hooks/execution.py
+++ b/src/mindroom/hooks/execution.py
@@ -12,17 +12,14 @@ from typing import TYPE_CHECKING, cast
 from mindroom.logging_config import get_logger
 
 from .context import (
-    AfterResponseContext,
     AgentLifecycleContext,
     BeforeResponseContext,
-    CancelledResponseContext,
     CompactionHookContext,
     CustomEventContext,
     FinalResponseDraft,
     FinalResponseTransformContext,
     HookContext,
     MessageEnrichContext,
-    MessageEnvelope,
     MessageReceivedContext,
     ReactionReceivedContext,
     ResponseDraft,
@@ -31,6 +28,7 @@ from .context import (
     SystemEnrichContext,
     ToolAfterCallContext,
     ToolBeforeCallContext,
+    message_envelope_for_hook_context,
 )
 from .types import EVENT_MESSAGE_RECEIVED, EnrichmentItem, RegisteredHook, default_timeout_ms_for_event
 
@@ -59,7 +57,7 @@ class _HookInvocationResult:
 def _scope_agent_name(context: _HookExecutionContext) -> str | None:
     if isinstance(context, ToolBeforeCallContext | ToolAfterCallContext):
         return context.agent_name
-    envelope = _context_scope_envelope(context)
+    envelope = message_envelope_for_hook_context(context)
     if envelope is not None:
         return envelope.agent_name
     if isinstance(context, MessageEnrichContext | SystemEnrichContext):
@@ -74,7 +72,7 @@ def _scope_agent_name(context: _HookExecutionContext) -> str | None:
 def _scope_room_ids(context: _HookExecutionContext) -> tuple[str, ...]:  # noqa: PLR0911
     if isinstance(context, ToolBeforeCallContext | ToolAfterCallContext):
         return (context.room_id,) if context.room_id else ()
-    envelope = _context_scope_envelope(context)
+    envelope = message_envelope_for_hook_context(context)
     if envelope is not None:
         return (envelope.room_id,)
     if isinstance(context, ScheduleFiredContext | ReactionReceivedContext):
@@ -102,18 +100,6 @@ def _hook_in_scope(hook: RegisteredHook, context: _HookExecutionContext) -> bool
             return False
 
     return True
-
-
-def _context_scope_envelope(context: _HookExecutionContext) -> MessageEnvelope | None:
-    if isinstance(context, MessageReceivedContext | MessageEnrichContext | SystemEnrichContext):
-        return context.envelope
-    if isinstance(context, BeforeResponseContext | FinalResponseTransformContext):
-        return context.draft.envelope
-    if isinstance(context, AfterResponseContext):
-        return context.result.envelope
-    if isinstance(context, CancelledResponseContext):
-        return context.info.envelope
-    return None
 
 
 def _context_logger(hook: RegisteredHook) -> object:

--- a/src/mindroom/hooks/ingress.py
+++ b/src/mindroom/hooks/ingress.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from mindroom.dispatch_source import is_automation_source_kind
 
 from .types import EVENT_MESSAGE_RECEIVED
+from .types import split_hook_source as _split_hook_source
 
 if TYPE_CHECKING:
     from .context import MessageEnvelope
@@ -21,16 +22,6 @@ class HookIngressPolicy:
     skip_message_received_plugin_names: frozenset[str] = frozenset()
     bypass_unmentioned_agent_gate: bool = False
     allow_full_dispatch: bool = True
-
-
-def _split_hook_source(hook_source: str | None) -> tuple[str | None, str | None]:
-    """Return ``(plugin_name, event_name)`` from one serialized hook source tag."""
-    if not isinstance(hook_source, str):
-        return None, None
-    plugin_name, _, source_event_name = hook_source.partition(":")
-    if not plugin_name or not source_event_name:
-        return None, None
-    return plugin_name, source_event_name
 
 
 def hook_ingress_policy(envelope: MessageEnvelope) -> HookIngressPolicy:

--- a/src/mindroom/hooks/types.py
+++ b/src/mindroom/hooks/types.py
@@ -77,6 +77,21 @@ _DEFAULT_CUSTOM_EVENT_TIMEOUT_MS = 1000
 EnrichmentCachePolicy = Literal["stable", "volatile"]
 
 
+def format_hook_source(plugin_name: str, event_name: str) -> str:
+    """Return one serialized hook provenance tag."""
+    return f"{plugin_name}:{event_name}"
+
+
+def split_hook_source(hook_source: str | None) -> tuple[str | None, str | None]:
+    """Return ``(plugin_name, event_name)`` from one serialized hook provenance tag."""
+    if not isinstance(hook_source, str):
+        return None, None
+    plugin_name, _, source_event_name = hook_source.partition(":")
+    if not plugin_name or not source_event_name:
+        return None, None
+    return plugin_name, source_event_name
+
+
 class HookMessageSender(Protocol):
     """Async sender protocol used by hook contexts for Matrix relays."""
 

--- a/tests/test_hook_ingress.py
+++ b/tests/test_hook_ingress.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from mindroom.dispatch_source import is_automation_source_kind
 from mindroom.hooks.context import MessageEnvelope
 from mindroom.hooks.ingress import _split_hook_source, hook_ingress_policy, should_handle_interactive_text_response
+from mindroom.hooks.types import format_hook_source
 from mindroom.message_target import MessageTarget
 
 
@@ -38,6 +39,14 @@ def test_split_hook_source_parses_serialized_tag() -> None:
     )
     assert _split_hook_source("bad") == (None, None)
     assert _split_hook_source(None) == (None, None)
+
+
+def test_hook_source_formatter_matches_ingress_parser() -> None:
+    """Serialized hook provenance should round-trip through the ingress parser."""
+    source = format_hook_source("origin-plugin", "message:received")
+
+    assert source == "origin-plugin:message:received"
+    assert _split_hook_source(source) == ("origin-plugin", "message:received")
 
 
 def test_hook_ingress_policy_skips_origin_plugin_on_first_message_received_hop() -> None:


### PR DESCRIPTION
## Summary
- add shared hook-source format/parse helpers in the hook types module
- reuse the hook context envelope accessor from execution scope checks
- add a characterization test for hook-source serialization/parsing compatibility

## Verification
- uv run pytest tests/test_hook_ingress.py tests/test_hook_execution.py::test_emit_final_response_transform_preserves_send_requester_and_depth tests/test_hook_sender.py::test_hook_context_send_message_supports_multiple_hook_sends -q
- uv run pre-commit run --files src/mindroom/hooks/context.py src/mindroom/hooks/execution.py src/mindroom/hooks/ingress.py src/mindroom/hooks/types.py tests/test_hook_ingress.py
- uv run pytest (failed under xdist: 4 failures; exact failures passed when rerun serially)
- uv run pytest tests/test_multi_agent_bot.py::TestAgentBot::test_non_router_bot_truncated_approval_race_sends_notice_via_orchestrator tests/test_oauth_state.py::test_issue_opaque_oauth_state_keeps_concurrent_process_writes tests/test_tool_approval.py::test_request_approval_truncated_approval_fails_closed tests/test_tool_approval.py::test_truncated_approval_action_sends_denial_notice -n 0 -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored hook system with new public utilities for hook provenance handling and envelope context resolution, improving code organization and reusability across the codebase.

* **Tests**
  * Added test coverage for hook source formatting and parsing round-trip validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->