### PR TITLE
refactor: share credential-free repo URL normalization

### DIFF
--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -7,7 +7,6 @@ from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
-from urllib.parse import urlparse, urlunparse
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, ValidationInfo, field_validator, model_validator
@@ -53,6 +52,7 @@ from mindroom.constants import (
     resolve_runtime_paths,
     safe_replace,
 )
+from mindroom.git_urls import credential_free_repo_url
 
 # config layer loads BEFORE the history runtime; import leaf types so config load does not drag in agents+tools.
 from mindroom.history.types import HistoryPolicy, ResolvedHistorySettings
@@ -286,44 +286,12 @@ class _KnowledgeBaseSourceSemantics:
     git_lfs: bool
 
 
-def _credential_free_repo_url_for_config_validation(repo_url: str) -> str:
-    """Return a comparable Git URL identity without credential-bearing URL fields."""
-    parsed = urlparse(repo_url)
-    if not parsed.scheme or not parsed.netloc:
-        return repo_url
-    path = parsed.path.split(";", 1)[0]
-    if parsed.scheme == "ssh" and "@" in parsed.netloc and parsed.password is None:
-        userinfo, host = parsed.netloc.rsplit("@", 1)
-        if userinfo and ":" not in userinfo:
-            return urlunparse(
-                parsed._replace(
-                    netloc=f"{userinfo}@{host}",
-                    path=path,
-                    params="",
-                    query="",
-                    fragment="",
-                ),
-            )
-    netloc = parsed.netloc.rsplit("@", 1)[-1]
-    return urlunparse(
-        parsed._replace(
-            netloc=netloc,
-            path=path,
-            params="",
-            query="",
-            fragment="",
-        ),
-    )
-
-
 def _knowledge_base_source_semantics(base_config: KnowledgeBaseConfig) -> _KnowledgeBaseSourceSemantics:
     """Return the source semantics for duplicate-path compatibility checks."""
     git_config = base_config.git
     return _KnowledgeBaseSourceSemantics(
         git_enabled=git_config is not None,
-        git_repo_identity=_credential_free_repo_url_for_config_validation(git_config.repo_url)
-        if git_config is not None
-        else "",
+        git_repo_identity=credential_free_repo_url(git_config.repo_url) if git_config is not None else "",
         git_branch=git_config.branch if git_config is not None else "",
         git_credentials_service=git_config.credentials_service if git_config is not None else None,
         git_lfs=git_config.lfs if git_config is not None else False,

--- a/src/mindroom/git_urls.py
+++ b/src/mindroom/git_urls.py
@@ -1,0 +1,39 @@
+"""Git URL normalization helpers."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse, urlunparse
+
+
+def _strip_path_params(path: str) -> str:
+    return path.split(";", 1)[0]
+
+
+def credential_free_repo_url(repo_url: str) -> str:
+    """Return a repository URL suitable for persistent Git config and comparison."""
+    parsed = urlparse(repo_url)
+    if not parsed.scheme or not parsed.netloc:
+        return repo_url
+    path = _strip_path_params(parsed.path)
+    if parsed.scheme == "ssh" and "@" in parsed.netloc and parsed.password is None:
+        userinfo, host = parsed.netloc.rsplit("@", 1)
+        if userinfo and ":" not in userinfo:
+            return urlunparse(
+                parsed._replace(
+                    netloc=f"{userinfo}@{host}",
+                    path=path,
+                    params="",
+                    query="",
+                    fragment="",
+                ),
+            )
+    netloc = parsed.netloc.rsplit("@", 1)[-1]
+    return urlunparse(
+        parsed._replace(
+            netloc=netloc,
+            path=path,
+            params="",
+            query="",
+            fragment="",
+        ),
+    )

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -41,6 +41,7 @@ from mindroom.knowledge.index_metadata import (
     write_index_metadata_payload,
 )
 from mindroom.knowledge.redaction import (
+    credential_free_repo_url,
     credential_free_url_identity,
     embedded_http_userinfo,
     redact_credentials_in_text,
@@ -348,36 +349,6 @@ def _create_embedder(config: Config, runtime_paths: RuntimePaths) -> Embedder:
     raise ValueError(msg)
 
 
-def _credential_free_repo_url(repo_url: str) -> str:
-    """Return a repository URL suitable for persistent Git config."""
-    parsed = urlparse(repo_url)
-    if not parsed.scheme or not parsed.netloc:
-        return repo_url
-    path = parsed.path.split(";", 1)[0]
-    if parsed.scheme == "ssh" and "@" in parsed.netloc and parsed.password is None:
-        userinfo, host = parsed.netloc.rsplit("@", 1)
-        if userinfo and ":" not in userinfo:
-            return urlunparse(
-                parsed._replace(
-                    netloc=f"{userinfo}@{host}",
-                    path=path,
-                    params="",
-                    query="",
-                    fragment="",
-                ),
-            )
-    hostname = parsed.netloc.rsplit("@", 1)[-1]
-    return urlunparse(
-        parsed._replace(
-            netloc=hostname,
-            path=path,
-            params="",
-            query="",
-            fragment="",
-        ),
-    )
-
-
 def _authenticated_repo_url(
     repo_url: str,
     credentials_service: str | None,
@@ -458,7 +429,7 @@ def _git_auth_env(
     runtime_paths: RuntimePaths,
 ) -> dict[str, str] | None:
     """Return process-local Git config that injects credentials without persisting them."""
-    clean_url = _credential_free_repo_url(repo_url)
+    clean_url = credential_free_repo_url(repo_url)
     parsed_clean_url = urlparse(clean_url)
 
     embedded_userinfo = embedded_http_userinfo(repo_url)
@@ -1109,7 +1080,7 @@ class KnowledgeManager:
             self._git_repo_present = True
             await self._ensure_git_lfs_repository_ready(knowledge_root)
             current_remote = (await self._run_git(["remote", "get-url", "origin"])).strip()
-            expected_remote = _credential_free_repo_url(git_config.repo_url)
+            expected_remote = credential_free_repo_url(git_config.repo_url)
             if current_remote != expected_remote:
                 await self._run_git(["remote", "set-url", "origin", expected_remote])
             return False
@@ -1124,7 +1095,7 @@ class KnowledgeManager:
         knowledge_root.parent.mkdir(parents=True, exist_ok=True)
         if git_config.lfs:
             await self._ensure_git_lfs_available(cwd=knowledge_root.parent)
-        clone_url = _credential_free_repo_url(git_config.repo_url)
+        clone_url = credential_free_repo_url(git_config.repo_url)
         await self._run_git(
             [
                 "clone",

--- a/src/mindroom/knowledge/redaction.py
+++ b/src/mindroom/knowledge/redaction.py
@@ -8,11 +8,20 @@ from base64 import b64decode
 from binascii import Error as BinasciiError
 from urllib.parse import unquote, urlparse, urlunparse
 
+from mindroom.git_urls import credential_free_repo_url
+
 _URL_PATTERN: re.Pattern[str] = re.compile(r"[a-zA-Z][a-zA-Z0-9+.-]*://[^\s'\"<>]+")
 _AUTHORIZATION_HEADER_PATTERN: re.Pattern[str] = re.compile(
     r"\bAuthorization:\s*(Basic|Bearer)\s+([^\s'\"<>]+)",
     re.IGNORECASE,
 )
+__all__ = [
+    "credential_free_repo_url",
+    "credential_free_url_identity",
+    "embedded_http_userinfo",
+    "redact_credentials_in_text",
+    "redact_url_credentials",
+]
 
 
 def _strip_path_params(path: str) -> str:

--- a/tach.toml
+++ b/tach.toml
@@ -952,6 +952,7 @@ depends_on = [
     "mindroom.config.voice",
     "mindroom.constants",
     "mindroom.entity_resolution",
+    "mindroom.git_urls",
     "mindroom.history.types",
     "mindroom.logging_config",
     "mindroom.matrix_identifiers",
@@ -1978,6 +1979,10 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.knowledge.redaction"
+depends_on = ["mindroom.git_urls"]
+
+[[modules]]
+path = "mindroom.git_urls"
 depends_on = []
 
 [[modules]]

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -42,7 +42,7 @@ from mindroom.knowledge.manager import (
     list_git_tracked_knowledge_files,
     list_knowledge_files,
 )
-from mindroom.knowledge.redaction import credential_free_url_identity, redact_url_credentials
+from mindroom.knowledge.redaction import credential_free_repo_url, credential_free_url_identity, redact_url_credentials
 from mindroom.knowledge.refresh_runner import knowledge_binding_mutation_lock, refresh_knowledge_binding
 from mindroom.knowledge.registry import (
     _clear_published_indexes,
@@ -6446,7 +6446,7 @@ def test_redact_url_credentials_hides_entire_http_userinfo() -> None:
         == "https://***@example.com/org/repo.git"
     )
     assert (
-        knowledge_manager_module._credential_free_repo_url(
+        credential_free_repo_url(
             "https://user:password@example.com/repo.git?token=secret#frag-secret",
         )
         == "https://example.com/repo.git"
@@ -6456,7 +6456,7 @@ def test_redact_url_credentials_hides_entire_http_userinfo() -> None:
 def test_credential_free_repo_url_preserves_passwordless_ssh_username() -> None:
     """Passwordless SSH transport usernames are part of the clone identity."""
     assert (
-        knowledge_manager_module._credential_free_repo_url(
+        credential_free_repo_url(
             "ssh://git@example.com/org/repo.git;token=secret?query=secret#frag-secret",
         )
         == "ssh://git@example.com/org/repo.git"
@@ -6466,13 +6466,13 @@ def test_credential_free_repo_url_preserves_passwordless_ssh_username() -> None:
 def test_credential_free_repo_url_strips_secret_bearing_userinfo() -> None:
     """Persistent clone URLs must not retain passwords, HTTP userinfo, query strings, or fragments."""
     assert (
-        knowledge_manager_module._credential_free_repo_url(
+        credential_free_repo_url(
             "ssh://git:secret@example.com/org/repo.git;token=secret?query=secret#frag-secret",
         )
         == "ssh://example.com/org/repo.git"
     )
     assert (
-        knowledge_manager_module._credential_free_repo_url(
+        credential_free_repo_url(
             "https://user@example.com/org/repo.git;token=secret?query=secret#frag-secret",
         )
         == "https://example.com/org/repo.git"


### PR DESCRIPTION
## Summary
- add a narrow credential_free_repo_url helper for credential-free Git repository identity normalization
- migrate knowledge Git remote handling and config duplicate-root semantics to the shared helper
- keep the knowledge redaction module as the public import surface while using a neutral leaf module to avoid config/knowledge import cycles

## Verification
- uv run pytest tests/test_knowledge_manager.py -k "credential_free_repo_url or redact_url_credentials or exact_duplicate_git_roots" -n 0 --no-cov -q
- uv run pre-commit run --files src/mindroom/git_urls.py src/mindroom/knowledge/redaction.py src/mindroom/knowledge/manager.py src/mindroom/config/main.py tests/test_knowledge_manager.py tach.toml
- uv run pytest -n 0 --no-cov

## Line gate
Production delta: +54 / -67, net -13 lines.