### PR TITLE
refactor: share non-DM room filtering

### DIFF
--- a/src/mindroom/api/matrix_operations.py
+++ b/src/mindroom/api/matrix_operations.py
@@ -10,7 +10,7 @@ from mindroom import constants
 from mindroom.api.config_lifecycle import read_committed_config_and_runtime
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_name, leave_room
-from mindroom.matrix.rooms import resolve_room_aliases
+from mindroom.matrix.rooms import filter_non_dm_rooms, resolve_room_aliases
 from mindroom.matrix.users import create_agent_user, login_agent_user
 
 logger = get_logger(__name__)
@@ -105,8 +105,8 @@ async def _get_agent_matrix_rooms(
     # Resolve room aliases to room IDs for comparison
     configured_room_ids = resolve_room_aliases(configured_room_aliases, runtime_paths=runtime_paths)
 
-    # Calculate unconfigured rooms (joined but not in config)
-    unconfigured_rooms = [room for room in joined_rooms if room not in configured_room_ids]
+    rooms_not_configured = [room for room in joined_rooms if room not in configured_room_ids]
+    unconfigured_rooms = await filter_non_dm_rooms(client, rooms_not_configured)
 
     # Get room names for unconfigured rooms
     unconfigured_room_details = []

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -859,10 +859,7 @@ class AgentBot:
 
     async def leave_unconfigured_rooms(self) -> None:
         """Leave any rooms this agent is no longer configured for."""
-        rooms_to_leave = await self._room_lifecycle.rooms_to_actually_leave()
-        if not rooms_to_leave:
-            return
-        await self._room_lifecycle.leave_unconfigured_rooms(room_ids=rooms_to_leave)
+        await self._room_lifecycle.leave_unconfigured_rooms()
 
     async def ensure_user_account(self) -> None:
         """Ensure this agent has a Matrix user account.

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -18,7 +18,7 @@ from mindroom.matrix.invited_rooms_store import (
     should_accept_invites,
     should_persist_invited_rooms,
 )
-from mindroom.matrix.rooms import is_dm_room, leave_non_dm_rooms
+from mindroom.matrix.rooms import filter_non_dm_rooms, leave_non_dm_rooms
 from mindroom.matrix.state import matrix_state_for_runtime
 from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 
@@ -123,7 +123,7 @@ class BotRoomLifecycle:
         client = self._client()
         await leave_non_dm_rooms(
             client,
-            room_ids if room_ids is not None else await self.rooms_to_actually_leave(),
+            room_ids if room_ids is not None else await self.rooms_to_leave(),
         )
 
     async def rooms_to_leave(self) -> list[str]:
@@ -148,7 +148,7 @@ class BotRoomLifecycle:
         """Return the exact rooms this bot will leave after DM filtering."""
         client = self._client()
         room_ids = await self.rooms_to_leave()
-        return [room_id for room_id in room_ids if not await is_dm_room(client, room_id)]
+        return await filter_non_dm_rooms(client, room_ids)
 
     async def send_welcome_message_if_empty(self, room_id: str) -> None:
         """Send the router welcome message only when the room has no other history."""

--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -694,6 +694,11 @@ async def is_dm_room(client: nio.AsyncClient, room_id: str) -> bool:
     return is_dm
 
 
+async def filter_non_dm_rooms(client: nio.AsyncClient, room_ids: list[str]) -> list[str]:
+    """Return rooms from *room_ids* that are not DM rooms."""
+    return [room_id for room_id in room_ids if not await is_dm_room(client, room_id)]
+
+
 async def leave_non_dm_rooms(
     client: nio.AsyncClient,
     room_ids: list[str],

--- a/tests/api/test_matrix_operations.py
+++ b/tests/api/test_matrix_operations.py
@@ -67,6 +67,10 @@ class TestMatrixOperations:
                 "mindroom.api.matrix_operations.get_joined_rooms",
                 return_value=["test_room", "team_room", "!extra_room:localhost", "!dm_room:localhost"],
             ),
+            patch(
+                "mindroom.matrix.rooms.is_dm_room",
+                side_effect=lambda _client, room_id: room_id == "!dm_room:localhost",
+            ),
         ):
             response = test_client.get("/api/matrix/agents/rooms")
 
@@ -81,12 +85,12 @@ class TestMatrixOperations:
             assert entities_by_id["test_agent"]["display_name"] == "Test Agent"
             assert "test_room" in entities_by_id["test_agent"]["configured_rooms"]
             assert "!extra_room:localhost" in entities_by_id["test_agent"]["unconfigured_rooms"]
-            assert "!dm_room:localhost" in entities_by_id["test_agent"]["unconfigured_rooms"]
+            assert "!dm_room:localhost" not in entities_by_id["test_agent"]["unconfigured_rooms"]
 
             assert entities_by_id["test_team"]["display_name"] == "Test Team"
             assert "team_room" in entities_by_id["test_team"]["configured_rooms"]
             assert "!extra_room:localhost" in entities_by_id["test_team"]["unconfigured_rooms"]
-            assert "!dm_room:localhost" in entities_by_id["test_team"]["unconfigured_rooms"]
+            assert "!dm_room:localhost" not in entities_by_id["test_team"]["unconfigured_rooms"]
 
     @pytest.mark.asyncio
     async def test_get_specific_agent_rooms(

--- a/tests/test_dm_detection.py
+++ b/tests/test_dm_detection.py
@@ -208,3 +208,20 @@ class TestDMDetection:
         assert first_result is True
         assert second_result is False
         assert client.list_direct_rooms.call_count == 2
+
+    async def test_filter_non_dm_rooms_preserves_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test non-DM room filtering keeps only non-DM rooms in input order."""
+        client = AsyncMock()
+        dm_room_ids = {"!dm1:server", "!dm2:server"}
+
+        async def mock_is_dm_room(_client: AsyncMock, room_id: str) -> bool:
+            return room_id in dm_room_ids
+
+        monkeypatch.setattr(rooms, "is_dm_room", mock_is_dm_room)
+
+        result = await rooms.filter_non_dm_rooms(
+            client,
+            ["!room1:server", "!dm1:server", "!room2:server", "!dm2:server"],
+        )
+
+        assert result == ["!room1:server", "!room2:server"]


### PR DESCRIPTION
## Summary
- add a shared filter_non_dm_rooms helper for Matrix room DM preservation checks
- use it for API unconfigured-room reporting and bot lifecycle room previews
- route actual leave cleanup through the existing leave_non_dm_rooms path so leave logging/errors stay centralized

## Verification
- uv run pytest tests/api/test_matrix_operations.py tests/test_dm_detection.py tests/test_room_invites.py -n 0 --no-cov -q
- uv run pre-commit run --files src/mindroom/api/matrix_operations.py src/mindroom/bot.py src/mindroom/bot_room_lifecycle.py src/mindroom/matrix/rooms.py tests/api/test_matrix_operations.py tests/test_dm_detection.py