### PR TITLE
refactor: share dynamic tool registry reconciliation

### DIFF
--- a/src/mindroom/mcp/registry.py
+++ b/src/mindroom/mcp/registry.py
@@ -15,7 +15,7 @@ from mindroom.tool_system.catalog import (
     ToolMetadata,
     ToolStatus,
 )
-from mindroom.tool_system.registry_state import TOOL_REGISTRY
+from mindroom.tool_system.registry_state import TOOL_REGISTRY, reconcile_dynamic_tool_state
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -44,11 +44,6 @@ def mcp_server_id_from_tool_name(tool_name: str) -> str | None:
         return None
     server_id = tool_name.removeprefix(_MCP_TOOL_PREFIX)
     return server_id or None
-
-
-def _mcp_registry_tool_names() -> set[str]:
-    """Return all active dynamic MCP tool names."""
-    return set(_MCP_TOOL_NAMES)
 
 
 def _registered_mcp_tool_names() -> set[str]:
@@ -163,24 +158,6 @@ def _tool_factory(server_id: str) -> Callable[[], type[Toolkit]]:
     return factory
 
 
-def _register_mcp_tool(server_id: str, server_config: MCPServerConfig) -> None:
-    """Register one dynamic MCP tool entry."""
-    tool_name = mcp_tool_name(server_id)
-    if tool_name not in _registered_mcp_tool_names() and (tool_name in TOOL_METADATA or tool_name in TOOL_REGISTRY):
-        msg = f"MCP tool '{tool_name}' conflicts with an existing registered tool"
-        raise ValueError(msg)
-    TOOL_METADATA[tool_name] = _tool_metadata(server_id, server_config)
-    TOOL_REGISTRY[tool_name] = _tool_factory(server_id)
-    _MCP_TOOL_NAMES.add(tool_name)
-
-
-def _unregister_mcp_tool(tool_name: str) -> None:
-    """Remove one dynamic MCP tool entry."""
-    TOOL_METADATA.pop(tool_name, None)
-    TOOL_REGISTRY.pop(tool_name, None)
-    _MCP_TOOL_NAMES.discard(tool_name)
-
-
 def _desired_server_entries(config: Config | None) -> dict[str, MCPServerConfig]:
     if config is None:
         return {}
@@ -192,21 +169,16 @@ def _desired_server_entries(config: Config | None) -> dict[str, MCPServerConfig]
 def sync_mcp_tool_registry(config: Config | None) -> None:
     """Reconcile the dynamic registry entries for configured MCP servers."""
     desired_registry, desired_metadata = resolved_mcp_tool_state(config)
-    desired_tool_names = set(desired_registry)
-    registered_mcp_tool_names = _registered_mcp_tool_names()
-    existing_non_mcp_tool_names = {*TOOL_METADATA, *TOOL_REGISTRY} - registered_mcp_tool_names
-    conflicting_tool_names = sorted(desired_tool_names & existing_non_mcp_tool_names)
-    if conflicting_tool_names:
-        msg = f"MCP tool '{conflicting_tool_names[0]}' conflicts with an existing registered tool"
-        raise ValueError(msg)
-
-    for tool_name in sorted(registered_mcp_tool_names - desired_tool_names):
-        _unregister_mcp_tool(tool_name)
-
-    for tool_name in desired_tool_names:
-        TOOL_METADATA[tool_name] = desired_metadata[tool_name]
-        TOOL_REGISTRY[tool_name] = desired_registry[tool_name]
-
+    desired_tool_names = reconcile_dynamic_tool_state(
+        TOOL_REGISTRY,
+        TOOL_METADATA,
+        desired_registry,
+        desired_metadata,
+        owned_tool_names=_registered_mcp_tool_names(),
+        collision_error=lambda tool_name: ValueError(
+            f"MCP tool '{tool_name}' conflicts with an existing registered tool",
+        ),
+    )
     _MCP_TOOL_NAMES.clear()
     _MCP_TOOL_NAMES.update(desired_tool_names)
 

--- a/src/mindroom/tool_system/registry_state.py
+++ b/src/mindroom/tool_system/registry_state.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, cast
 from mindroom.tool_system import plugin_imports
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable, Iterable, Iterator, Mapping
     from pathlib import Path
     from types import ModuleType
 
@@ -138,16 +138,46 @@ def resolved_tool_state(
     return desired_registry, desired_metadata
 
 
+def reconcile_dynamic_tool_state(
+    current_registry: dict[str, Callable[[], type[Toolkit]]],
+    current_metadata: dict[str, ToolMetadata],
+    desired_registry: Mapping[str, Callable[[], type[Toolkit]]],
+    desired_metadata: Mapping[str, ToolMetadata],
+    *,
+    owned_tool_names: Iterable[str],
+    collision_error: Callable[[str], Exception],
+) -> set[str]:
+    """Replace one owned dynamic namespace in shared registry state."""
+    desired_tool_names = {*desired_registry, *desired_metadata}
+    owned_tool_names = set(owned_tool_names)
+    existing_non_owned_tool_names = {*current_registry, *current_metadata} - owned_tool_names
+    conflicting_tool_names = sorted(desired_tool_names & existing_non_owned_tool_names)
+    if conflicting_tool_names:
+        raise collision_error(conflicting_tool_names[0])
+    for tool_name in sorted(owned_tool_names - desired_tool_names):
+        current_registry.pop(tool_name, None)
+        current_metadata.pop(tool_name, None)
+    for tool_name in desired_tool_names - set(desired_registry):
+        current_registry.pop(tool_name, None)
+    current_registry.update(desired_registry)
+    current_metadata.update(desired_metadata)
+    return desired_tool_names
+
+
 def synchronize_plugin_tools(active_plugins: list[tuple[str, str]]) -> None:
     """Rebuild the active plugin tool overlay from cached per-module registrations."""
     desired_registry, desired_metadata = resolved_tool_state(
         active_plugins,
         _PLUGIN_TOOL_METADATA_BY_MODULE,
     )
-    TOOL_REGISTRY.clear()
-    TOOL_REGISTRY.update(desired_registry)
-    TOOL_METADATA.clear()
-    TOOL_METADATA.update(desired_metadata)
+    reconcile_dynamic_tool_state(
+        TOOL_REGISTRY,
+        TOOL_METADATA,
+        desired_registry,
+        desired_metadata,
+        owned_tool_names={*TOOL_REGISTRY, *TOOL_METADATA},
+        collision_error=ValueError,
+    )
 
 
 def _reject_plugin_builtin_tool_collision(tool_name: str) -> None:

--- a/tach.toml
+++ b/tach.toml
@@ -2491,6 +2491,7 @@ expose = [
     "capture_tool_registry_snapshot",
     "clear_plugin_tool_registrations",
     "locked_tool_registry_state",
+    "reconcile_dynamic_tool_state",
     "register_plugin_tool_metadata",
     "resolved_tool_state",
     "restore_plugin_tool_registrations",

--- a/tests/test_tool_system_facade_boundaries.py
+++ b/tests/test_tool_system_facade_boundaries.py
@@ -293,6 +293,7 @@ def test_private_registry_state_import_is_whitelisted_outside_tool_system() -> N
     """Only the MCP registry may import private registry state directly outside tool_system."""
     assert _private_registry_state_importers_outside_tool_system() == {
         ("mindroom.mcp.registry", "TOOL_REGISTRY"),
+        ("mindroom.mcp.registry", "reconcile_dynamic_tool_state"),
     }
 
 

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -3,6 +3,7 @@
 import inspect
 import json
 import sys
+from dataclasses import replace
 from pathlib import Path
 from types import ModuleType
 from typing import Never
@@ -38,6 +39,7 @@ from mindroom.tool_system.registry_state import (
     TOOL_METADATA,
     TOOL_REGISTRY,
     capture_tool_registry_snapshot,
+    reconcile_dynamic_tool_state,
     restore_tool_registry_snapshot,
 )
 from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, resolve_worker_target
@@ -54,6 +56,61 @@ def _restore_builtin_tool_metadata_state() -> None:
     TOOL_REGISTRY.update(_BASE_TOOL_REGISTRY)
     TOOL_METADATA.clear()
     TOOL_METADATA.update(_BASE_TOOL_METADATA)
+
+
+def test_reconcile_dynamic_tool_state_replaces_only_owned_entries() -> None:
+    """Dynamic registry reconciliation should preserve unrelated tools and remove stale owned entries."""
+    factory = TOOL_REGISTRY["shell"]
+    replacement_factory = TOOL_REGISTRY["python"]
+    unrelated_metadata = replace(TOOL_METADATA["shell"], name="unrelated")
+    stale_metadata = replace(TOOL_METADATA["shell"], name="stale_owned")
+    desired_metadata = replace(TOOL_METADATA["python"], name="owned")
+    metadata_only = replace(TOOL_METADATA["shell"], name="metadata_only")
+    current_registry = {
+        "unrelated": factory,
+        "stale_owned": factory,
+        "owned": factory,
+        "metadata_only": factory,
+    }
+    current_metadata = {
+        "unrelated": unrelated_metadata,
+        "stale_owned": stale_metadata,
+        "owned": stale_metadata,
+        "metadata_only": stale_metadata,
+    }
+
+    reconciled_tool_names = reconcile_dynamic_tool_state(
+        current_registry,
+        current_metadata,
+        {"owned": replacement_factory},
+        {"owned": desired_metadata, "metadata_only": metadata_only},
+        owned_tool_names={"stale_owned", "owned", "metadata_only"},
+        collision_error=ValueError,
+    )
+
+    assert reconciled_tool_names == {"owned", "metadata_only"}
+    assert current_registry == {"unrelated": factory, "owned": replacement_factory}
+    assert current_metadata == {
+        "unrelated": unrelated_metadata,
+        "owned": desired_metadata,
+        "metadata_only": metadata_only,
+    }
+
+
+def test_reconcile_dynamic_tool_state_rejects_non_owned_collisions() -> None:
+    """Desired dynamic entries must not overwrite tools outside the owned namespace."""
+    factory = TOOL_REGISTRY["shell"]
+    metadata = replace(TOOL_METADATA["shell"], name="shared")
+
+    with pytest.raises(ValueError, match="shared collision"):
+        reconcile_dynamic_tool_state(
+            {"shared": factory},
+            {"shared": metadata},
+            {"shared": factory},
+            {"shared": metadata},
+            owned_tool_names=set(),
+            collision_error=lambda tool_name: ValueError(f"{tool_name} collision"),
+        )
 
 
 def test_export_tools_metadata_json() -> None:


### PR DESCRIPTION
## Summary
- add shared registry-state reconciliation for owned dynamic tool namespaces
- reuse it for plugin and MCP tool sync while removing stale MCP helper code
- add characterization coverage for stale owned entries, metadata-only entries, collision rejection, and the registry-state private interface

## Verification
- uv sync --all-extras
- uv run pytest tests/test_tools_metadata.py::test_reconcile_dynamic_tool_state_replaces_only_owned_entries tests/test_tools_metadata.py::test_reconcile_dynamic_tool_state_rejects_non_owned_collisions tests/test_mcp_registry.py tests/test_tool_system_facade_boundaries.py::test_private_registry_state_import_is_whitelisted_outside_tool_system -q -n 0 --no-cov
- uv run pytest tests/test_plugins.py::test_load_plugins_preserves_metadata_only_built_in_tools tests/test_plugins.py::test_load_plugins_removes_stale_tools_when_enabled_plugin_changes_exports tests/test_plugins.py::test_load_plugins_rejects_built_in_tool_name_collisions tests/test_plugins.py::test_load_plugins_rejects_plugin_tool_name_collisions tests/test_plugins.py::test_load_plugins_rejects_duplicate_tool_names_within_one_plugin -q -n 0 --no-cov
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/tool_system/registry_state.py src/mindroom/mcp/registry.py tests/test_tools_metadata.py tests/test_tool_system_facade_boundaries.py tach.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved tool registry synchronization with enhanced state management and ownership tracking.
  * Strengthened collision detection when registering tools to prevent conflicts.
  * Modernized MCP tool discovery and configuration handling for greater reliability.
  * Refined internal tool state management with better reconciliation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->