### PR TITLE
Refactor optional dependency retry installs

### DIFF
--- a/src/mindroom/api/auth.py
+++ b/src/mindroom/api/auth.py
@@ -18,7 +18,7 @@ from mindroom.api.config_lifecycle import ApiSnapshot
 from mindroom.api.config_lifecycle import request_snapshot as request_api_snapshot
 from mindroom.api.config_lifecycle import store_request_snapshot as store_request_api_snapshot
 from mindroom.matrix.identity import try_parse_historical_matrix_user_id
-from mindroom.tool_system.dependencies import auto_install_enabled, auto_install_tool_extra
+from mindroom.tool_system.dependencies import auto_install_enabled, auto_install_optional_extra_for_import_retry
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
@@ -162,7 +162,7 @@ def _init_supabase_auth(
         disabled_hint = ""
         if not auto_install_enabled(runtime_paths):
             disabled_hint = " Auto-install is disabled by MINDROOM_NO_AUTO_INSTALL_TOOLS."
-        if not auto_install_tool_extra("supabase", runtime_paths):
+        if not auto_install_optional_extra_for_import_retry("supabase", runtime_paths):
             msg = (
                 "SUPABASE_URL and SUPABASE_ANON_KEY are set but the 'supabase' package is not available."
                 f"{disabled_hint} Install it with: pip install 'mindroom[supabase]'"

--- a/src/mindroom/tool_system/dependencies.py
+++ b/src/mindroom/tool_system/dependencies.py
@@ -228,28 +228,38 @@ def _auto_install_optional_extra(extra_name: str, runtime_paths: RuntimePaths) -
     return _install_optional_extras([resolved_extra_name], quiet=True)
 
 
-def auto_install_tool_extra(tool_name: str, runtime_paths: RuntimePaths) -> bool:
-    """Auto-install a tool extra when supported and enabled."""
-    return _auto_install_optional_extra(tool_name, runtime_paths)
+def auto_install_optional_extra_for_import_retry(extra_name: str, runtime_paths: RuntimePaths) -> bool:
+    """Auto-install an optional extra and invalidate import caches before a retry."""
+    installed = _auto_install_optional_extra(extra_name, runtime_paths)
+    if installed:
+        importlib.invalidate_caches()
+    return installed
 
 
-def ensure_optional_deps(dependencies: list[str], extra_name: str, runtime_paths: RuntimePaths) -> None:
+def ensure_optional_deps(
+    dependencies: list[str],
+    extra_name: str,
+    runtime_paths: RuntimePaths,
+    *,
+    missing_message: str | None = None,
+) -> bool:
     """Ensure dependencies are installed, auto-installing via optional extra if needed."""
     if check_deps_installed(dependencies):
-        return
-    if not _auto_install_optional_extra(extra_name, runtime_paths):
+        return False
+    if not auto_install_optional_extra_for_import_retry(extra_name, runtime_paths):
         missing = ", ".join(dependencies)
-        msg = f"Missing dependencies: {missing}. Install with: pip install 'mindroom[{extra_name}]'"
-        raise ImportError(msg)
-    importlib.invalidate_caches()
+        if missing_message is None:
+            missing_message = f"Missing dependencies: {missing}. Install with: pip install 'mindroom[{extra_name}]'"
+        raise ImportError(missing_message)
+    return True
 
 
-def ensure_tool_deps(dependencies: list[str], tool_extra: str, runtime_paths: RuntimePaths) -> None:
-    """Ensure dependencies are installed, auto-installing via tool extra if needed.
-
-    Uses find_spec to check availability (no side effects), then auto-installs
-    and invalidates import caches if necessary.
-
-    Raises ImportError if dependencies cannot be satisfied.
-    """
-    ensure_optional_deps(dependencies, tool_extra, runtime_paths)
+def ensure_tool_deps(
+    dependencies: list[str],
+    tool_extra: str,
+    runtime_paths: RuntimePaths,
+    *,
+    missing_message: str | None = None,
+) -> bool:
+    """Ensure tool dependencies are installed, auto-installing via tool extra if needed."""
+    return ensure_optional_deps(dependencies, tool_extra, runtime_paths, missing_message=missing_message)

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import functools
-import importlib
 import math
 import os
 import sys
@@ -16,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 import mindroom.tool_system.plugin_imports as plugin_module
 from mindroom.credentials import get_runtime_credentials_manager, load_scoped_credentials
 from mindroom.logging_config import get_logger
-from mindroom.tool_system.dependencies import auto_install_tool_extra, check_deps_installed
+from mindroom.tool_system.dependencies import auto_install_optional_extra_for_import_retry, ensure_tool_deps
 from mindroom.tool_system.output_files import ToolOutputFilePolicy, wrap_toolkit_for_output_files
 from mindroom.tool_system.registry_state import (
     BUILTIN_TOOL_METADATA,
@@ -616,28 +615,31 @@ def get_tool_by_name(
     # Pre-check dependencies using find_spec (no side effects) before importing
     metadata = TOOL_METADATA.get(tool_name)
     deps = metadata.dependencies if metadata and metadata.dependencies else []
-    if deps and not check_deps_installed(deps):
-        if not auto_install_tool_extra(tool_name, runtime_paths):
-            missing = ", ".join(deps)
+    if deps:
+        missing = ", ".join(deps)
+        try:
+            installed = ensure_tool_deps(
+                deps,
+                tool_name,
+                runtime_paths,
+                missing_message=f"Missing dependencies for tool '{tool_name}': {missing}",
+            )
+        except ImportError:
             logger.warning("tool_dependencies_missing", tool_name=tool_name, missing_dependencies=missing)
             logger.warning("tool_dependency_install_required", tool_name=tool_name)
-            msg = f"Missing dependencies for tool '{tool_name}': {missing}"
-            raise ImportError(msg)
-        logger.info("tool_optional_dependencies_auto_installed", tool_name=tool_name)
-        importlib.invalidate_caches()
+            raise
+        if installed:
+            logger.info("tool_optional_dependencies_auto_installed", tool_name=tool_name)
 
     try:
         return build()
     except ImportError as first_error:
-        # Safety net: deps may not be exhaustively listed in metadata
-        if not auto_install_tool_extra(tool_name, runtime_paths):
+        if not auto_install_optional_extra_for_import_retry(tool_name, runtime_paths):
             logger.warning("tool_import_failed", tool_name=tool_name, error=str(first_error))
             logger.warning("tool_dependency_install_required", tool_name=tool_name)
             raise
 
         logger.info("auto_installing_tool_optional_dependencies", tool_name=tool_name)
-        importlib.invalidate_caches()
-
         try:
             return build()
         except ImportError as second_error:

--- a/tach.toml
+++ b/tach.toml
@@ -2534,7 +2534,7 @@ exclusive = true
 [[interfaces]]
 expose = [
     "auto_install_enabled",
-    "auto_install_tool_extra",
+    "auto_install_optional_extra_for_import_retry",
     "check_deps_installed",
     "ensure_optional_deps",
     "ensure_tool_deps",

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -248,7 +248,7 @@ def test_init_supabase_auth_raises_when_auto_install_disabled(
 
     monkeypatch.setattr(auth.importlib, "import_module", _missing_supabase)
     monkeypatch.setattr(auth, "auto_install_enabled", lambda _runtime_paths: False)
-    monkeypatch.setattr(auth, "auto_install_tool_extra", _auto_install)
+    monkeypatch.setattr("mindroom.tool_system.dependencies._auto_install_optional_extra", _auto_install)
 
     with pytest.raises(ImportError, match="MINDROOM_NO_AUTO_INSTALL_TOOLS"):
         auth._init_supabase_auth(runtime_paths, "https://supabase.test", "anon-key")
@@ -271,13 +271,50 @@ def test_init_supabase_auth_raises_when_auto_install_fails(monkeypatch: pytest.M
 
     monkeypatch.setattr(auth.importlib, "import_module", _missing_supabase)
     monkeypatch.setattr(auth, "auto_install_enabled", lambda _runtime_paths: True)
-    monkeypatch.setattr(auth, "auto_install_tool_extra", _auto_install)
+    monkeypatch.setattr("mindroom.tool_system.dependencies._auto_install_optional_extra", _auto_install)
 
     with pytest.raises(ImportError, match=r"mindroom\[supabase\]") as err:
         auth._init_supabase_auth(runtime_paths, "https://supabase.test", "anon-key")
 
     assert install_calls == ["supabase"]
     assert "MINDROOM_NO_AUTO_INSTALL_TOOLS" not in str(err.value)
+
+
+def test_init_supabase_auth_retries_import_after_auto_install(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Supabase auth should retry the import once after installing the optional extra."""
+    imported_modules: list[str] = []
+    install_calls: list[str] = []
+    runtime_paths = _runtime_paths(tmp_path)
+
+    class FakeClient:
+        pass
+
+    def create_client(url: str, key: str) -> FakeClient:
+        assert url == "https://supabase.test"
+        assert key == "anon-key"
+        return FakeClient()
+
+    def import_module(module_name: str) -> SimpleNamespace:
+        imported_modules.append(module_name)
+        if len(imported_modules) == 1:
+            raise ModuleNotFoundError(module_name)
+        return SimpleNamespace(create_client=create_client)
+
+    def auto_install(extra_name: str, _runtime_paths: constants.RuntimePaths) -> bool:
+        install_calls.append(extra_name)
+        return True
+
+    monkeypatch.setattr(auth.importlib, "import_module", import_module)
+    monkeypatch.setattr("mindroom.tool_system.dependencies._auto_install_optional_extra", auto_install)
+
+    supabase_auth = auth._init_supabase_auth(runtime_paths, "https://supabase.test", "anon-key")
+
+    assert isinstance(supabase_auth, FakeClient)
+    assert imported_modules == ["supabase", "supabase"]
+    assert install_calls == ["supabase"]
 
 
 def test_validate_supabase_token_catches_supabase_auth_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_tool_dependencies.py
+++ b/tests/test_tool_dependencies.py
@@ -20,6 +20,7 @@ from mindroom.tool_system.dependencies import (
     _install_via_uv_sync,
     _pip_name_to_import,
     auto_install_enabled,
+    auto_install_optional_extra_for_import_retry,
     check_deps_installed,
     install_command_for_current_python,
 )
@@ -201,7 +202,7 @@ def test_get_tool_by_name_retries_after_auto_install(monkeypatch: pytest.MonkeyP
     )
 
     monkeypatch.setattr(
-        "mindroom.tool_system.metadata.auto_install_tool_extra",
+        "mindroom.tool_system.dependencies._auto_install_optional_extra",
         lambda name, runtime_paths: name == tool_name and runtime_paths == TEST_RUNTIME_PATHS,
     )
     try:
@@ -245,7 +246,7 @@ def test_get_tool_by_name_raises_when_auto_install_fails(monkeypatch: pytest.Mon
     )
 
     monkeypatch.setattr(
-        "mindroom.tool_system.metadata.auto_install_tool_extra",
+        "mindroom.tool_system.dependencies._auto_install_optional_extra",
         lambda _name, _runtime_paths: False,
     )
     try:
@@ -254,6 +255,46 @@ def test_get_tool_by_name_raises_when_auto_install_fails(monkeypatch: pytest.Mon
     finally:
         TOOL_REGISTRY.pop(tool_name, None)
         TOOL_METADATA.pop(tool_name, None)
+
+
+def test_auto_install_optional_extra_for_import_retry_invalidates_caches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Optional import retries should refresh import caches after installing."""
+    installed: list[str] = []
+    invalidated: list[bool] = []
+
+    def auto_install(extra_name: str, runtime_paths: object) -> bool:
+        assert runtime_paths == TEST_RUNTIME_PATHS
+        installed.append(extra_name)
+        return True
+
+    monkeypatch.setattr("mindroom.tool_system.dependencies._auto_install_optional_extra", auto_install)
+    monkeypatch.setattr(
+        "mindroom.tool_system.dependencies.importlib.invalidate_caches",
+        lambda: invalidated.append(True),
+    )
+
+    assert auto_install_optional_extra_for_import_retry("supabase", TEST_RUNTIME_PATHS)
+
+    assert installed == ["supabase"]
+    assert invalidated == [True]
+
+
+def test_auto_install_optional_extra_for_import_retry_skips_cache_invalidation_when_install_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failed optional installs should not invalidate import caches before callers raise."""
+    invalidated: list[bool] = []
+
+    monkeypatch.setattr("mindroom.tool_system.dependencies._auto_install_optional_extra", lambda *_args: False)
+    monkeypatch.setattr(
+        "mindroom.tool_system.dependencies.importlib.invalidate_caches",
+        lambda: invalidated.append(True),
+    )
+
+    assert not auto_install_optional_extra_for_import_retry("supabase", TEST_RUNTIME_PATHS)
+    assert invalidated == []
 
 
 def test_check_deps_installed_positive_and_negative() -> None:


### PR DESCRIPTION
## Summary
- add a shared optional-extra install helper that invalidates import caches before retrying imports
- route tool metadata prechecks, tool import retry, and Supabase auth retry through the shared helper/ensure path
- add characterization tests for cache invalidation and Supabase import retry behavior

## Verification
- uv sync --all-extras
- uv run pytest tests/test_tool_dependencies.py tests/api/test_api.py::test_init_supabase_auth_returns_none_without_credentials tests/api/test_api.py::test_init_supabase_auth_raises_when_auto_install_disabled tests/api/test_api.py::test_init_supabase_auth_raises_when_auto_install_fails tests/api/test_api.py::test_init_supabase_auth_retries_import_after_auto_install -q -n 0 --no-cov
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/tool_system/dependencies.py src/mindroom/tool_system/metadata.py src/mindroom/api/auth.py tests/test_tool_dependencies.py tests/api/test_api.py tach.toml

Production line delta: +12
