### PR TITLE
MAT-002: normalize Matrix upload content URIs

### DIFF
--- a/src/mindroom/matrix/avatar.py
+++ b/src/mindroom/matrix/avatar.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import nio
 
 from mindroom.logging_config import get_logger
+from mindroom.matrix.media import upload_content_uri
 
 logger = get_logger(__name__)
 
@@ -76,11 +77,12 @@ async def _upload_avatar_file(
         logger.error("avatar_upload_failed", path=str(avatar_path), error=str(upload_response))
         return None
 
-    if not upload_response.content_uri:
+    mxc_uri = upload_content_uri(upload_response)
+    if mxc_uri is None:
         logger.error("avatar_upload_missing_content_uri", path=str(avatar_path))
         return None
 
-    return str(upload_response.content_uri)
+    return mxc_uri
 
 
 async def _set_avatar_from_file(

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -19,6 +19,7 @@ from nio.exceptions import OlmTrustError
 from mindroom.config.matrix import ignore_unverified_devices_for_config
 from mindroom.logging_config import get_logger
 from mindroom.matrix.large_messages import prepare_large_message
+from mindroom.matrix.media import upload_content_uri
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_matrix_edit_content
 from mindroom.timing import emit_timing_event
@@ -328,13 +329,11 @@ async def _upload_file_as_mxc(
         logger.exception("Failed uploading Matrix file", path=str(file_path))
         return None, None
 
-    upload_result = upload_response[0] if isinstance(upload_response, tuple) else upload_response
-
-    if not isinstance(upload_result, nio.UploadResponse) or not upload_result.content_uri:
-        logger.error("Failed file upload response", path=str(file_path), response=str(upload_result))
+    mxc_uri = upload_content_uri(upload_response)
+    if mxc_uri is None:
+        logger.error("Failed file upload response", path=str(file_path), response=str(upload_response))
         return None, None
 
-    mxc_uri = str(upload_result.content_uri)
     upload_payload: dict[str, Any] = {"info": info}
     if encrypted_file_payload is not None:
         encrypted_file_payload["url"] = mxc_uri

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -27,6 +27,7 @@ from mindroom.constants import (
     VOICE_RAW_AUDIO_FALLBACK_KEY,
 )
 from mindroom.logging_config import get_logger
+from mindroom.matrix.media import upload_content_uri
 from mindroom.matrix.message_builder import markdown_to_html
 
 logger = get_logger(__name__)
@@ -373,11 +374,11 @@ async def _upload_text_as_mxc(  # noqa: C901
             )
             return None, None
 
-        if not upload_result.content_uri:
+        mxc_uri = upload_content_uri(upload_result)
+        if mxc_uri is None:
             logger.error("Upload response missing content_uri")
             return None, None
 
-        mxc_uri = str(upload_result.content_uri)
         file_info["url"] = mxc_uri
 
     except Exception:

--- a/src/mindroom/matrix/media.py
+++ b/src/mindroom/matrix/media.py
@@ -88,6 +88,14 @@ def parse_matrix_media_dispatch_event_source(
     return parsed_event if is_matrix_media_dispatch_event(parsed_event) else None
 
 
+def upload_content_uri(upload_result: object) -> str | None:
+    """Return the MXC URI from a direct or tuple-shaped nio upload response."""
+    upload_response = upload_result[0] if isinstance(upload_result, tuple) else upload_result
+    if isinstance(upload_response, nio.UploadResponse) and upload_response.content_uri:
+        return str(upload_response.content_uri)
+    return None
+
+
 def _event_id_for_log(event: nio.RoomMessageMedia | nio.RoomEncryptedMedia) -> str | None:
     event_id = event.event_id
     return event_id if isinstance(event_id, str) else None

--- a/tests/test_image_handler.py
+++ b/tests/test_image_handler.py
@@ -10,7 +10,12 @@ from agno.media import Image
 from agno.utils.models.claude import _format_image_for_message
 
 from mindroom.matrix import image_handler
-from mindroom.matrix.media import _sniff_image_mime_type, extract_media_caption, resolve_image_mime_type
+from mindroom.matrix.media import (
+    _sniff_image_mime_type,
+    extract_media_caption,
+    resolve_image_mime_type,
+    upload_content_uri,
+)
 
 
 class TestExtractCaption:
@@ -55,6 +60,33 @@ class TestExtractCaption:
         """Both body and filename absent/empty."""
         event = self._make_event(body="")
         assert extract_media_caption(event, default="[Attached image]") == "[Attached image]"
+
+
+class TestUploadContentUri:
+    """Test Matrix upload response normalization."""
+
+    def test_direct_upload_response_returns_content_uri(self) -> None:
+        """A direct nio upload response should expose its MXC URI."""
+        response = nio.UploadResponse.from_dict({"content_uri": "mxc://server/media"})
+
+        assert upload_content_uri(response) == "mxc://server/media"
+
+    def test_tuple_upload_response_returns_first_response_content_uri(self) -> None:
+        """The tuple shape returned by nio upload should normalize through its first item."""
+        response = nio.UploadResponse.from_dict({"content_uri": "mxc://server/media"})
+
+        assert upload_content_uri((response, {"unused": True})) == "mxc://server/media"
+
+    def test_missing_content_uri_returns_none(self) -> None:
+        """Upload responses without content_uri should be treated as failed uploads."""
+        response = MagicMock(spec=nio.UploadResponse)
+        response.content_uri = ""
+
+        assert upload_content_uri(response) is None
+
+    def test_non_upload_response_returns_none(self) -> None:
+        """Upload errors and unrelated objects should not produce an MXC URI."""
+        assert upload_content_uri(object()) is None
 
 
 class TestDownloadImage:


### PR DESCRIPTION
## Summary
- Add a small Matrix media helper that normalizes direct and tuple-shaped nio upload responses to an MXC content URI.
- Reuse it from avatar uploads, file delivery uploads, and large-message sidecar uploads.
- Add focused characterization tests for direct, tuple, missing-URI, and non-upload response shapes.

## Verification
- uv sync --all-extras
- uv run pytest tests/test_image_handler.py::TestUploadContentUri -q -n 0 --no-cov (red before implementation: ImportError for missing upload_content_uri; green after implementation: 4 passed)
- uv run pytest tests/test_image_handler.py tests/test_send_file_message.py tests/test_large_messages.py tests/test_large_messages_integration.py tests/test_avatar_generation.py -q -n 0 --no-cov (126 passed)
- uv run pre-commit run --files src/mindroom/matrix/media.py src/mindroom/matrix/avatar.py src/mindroom/matrix/client_delivery.py src/mindroom/matrix/large_messages.py tests/test_image_handler.py (passed)
- uv run pytest -q -n 0 --no-cov (6262 passed, 56 skipped)

## Line Gate
Production delta: +10 lines (19 insertions, 9 deletions across production files).