### PR TITLE
MAT-005: centralize Matrix managed account identity

### DIFF
--- a/src/mindroom/matrix/identity.py
+++ b/src/mindroom/matrix/identity.py
@@ -24,6 +24,8 @@ __all__ = [
     "active_internal_sender_ids",
     "extract_agent_name",
     "is_agent_id",
+    "managed_account_key",
+    "managed_account_user_id",
     "parse_current_matrix_user_id",
     "parse_historical_matrix_user_id",
     "try_parse_historical_matrix_user_id",
@@ -260,21 +262,34 @@ def extract_agent_name(sender_id: str, config: Config, runtime_paths: RuntimePat
     return mid.agent_name(config, runtime_paths)
 
 
+def managed_account_key(entity_name: str) -> str:
+    """Return the Matrix state account key for a managed agent-like entity."""
+    return f"agent_{entity_name}"
+
+
+def managed_account_user_id(account_key: str, domain: str, runtime_paths: RuntimePaths) -> str | None:
+    """Return a persisted managed account's full Matrix user ID."""
+    username = managed_account_usernames(runtime_paths).get(account_key)
+    if username is None:
+        return None
+    return MatrixID.from_username(username, domain).full_id
+
+
 def _active_managed_account_keys(config: Config) -> frozenset[str]:
     """Return persisted Matrix account keys for currently active managed accounts."""
-    account_keys = {f"agent_{ROUTER_AGENT_NAME}"}
-    account_keys.update(f"agent_{agent_name}" for agent_name in config.agents)
-    account_keys.update(f"agent_{team_name}" for team_name in config.teams)
+    account_keys = {managed_account_key(ROUTER_AGENT_NAME)}
+    account_keys.update(managed_account_key(agent_name) for agent_name in config.agents)
+    account_keys.update(managed_account_key(team_name) for team_name in config.teams)
     if config.mindroom_user is not None:
-        account_keys.add("agent_user")
+        account_keys.add(managed_account_key("user"))
     return frozenset(account_keys)
 
 
 def _active_managed_agent_account_names(config: Config) -> dict[str, str]:
     """Return active persisted Matrix account keys mapped to agent/team/router names."""
-    account_names = {f"agent_{ROUTER_AGENT_NAME}": ROUTER_AGENT_NAME}
-    account_names.update({f"agent_{agent_name}": agent_name for agent_name in config.agents})
-    account_names.update({f"agent_{team_name}": team_name for team_name in config.teams})
+    account_names = {managed_account_key(ROUTER_AGENT_NAME): ROUTER_AGENT_NAME}
+    account_names.update({managed_account_key(agent_name): agent_name for agent_name in config.agents})
+    account_names.update({managed_account_key(team_name): team_name for team_name in config.teams})
     return account_names
 
 
@@ -290,7 +305,7 @@ def _configured_active_account_sender_ids(config: Config, runtime_paths: Runtime
     }
     mindroom_user_id = config.get_mindroom_user_id(runtime_paths)
     if mindroom_user_id is not None:
-        sender_ids["agent_user"] = mindroom_user_id
+        sender_ids[managed_account_key("user")] = mindroom_user_id
     return sender_ids
 
 
@@ -298,12 +313,11 @@ def active_internal_sender_ids(config: Config, runtime_paths: RuntimePaths) -> f
     """Return sender IDs trusted for live authorization and relay decisions."""
     sender_ids: set[str] = set()
     current_domain = config.get_domain(runtime_paths)
-    persisted_usernames = managed_account_usernames(runtime_paths)
     configured_sender_ids = _configured_active_account_sender_ids(config, runtime_paths)
     for account_key in _active_managed_account_keys(config):
-        username = persisted_usernames.get(account_key)
-        if username is None:
+        user_id = managed_account_user_id(account_key, current_domain, runtime_paths)
+        if user_id is None:
             sender_ids.add(configured_sender_ids[account_key])
             continue
-        sender_ids.add(MatrixID.from_username(username, current_domain).full_id)
+        sender_ids.add(user_id)
     return frozenset(sender_ids)

--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -23,7 +23,7 @@ from mindroom.matrix.client_room_admin import (
     leave_room,
 )
 from mindroom.matrix.client_session import matrix_client
-from mindroom.matrix.identity import MatrixID
+from mindroom.matrix.identity import managed_account_user_id
 from mindroom.matrix.state import MatrixRoom, MatrixState, matrix_state_for_runtime
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
 from mindroom.matrix_identifiers import (
@@ -553,7 +553,10 @@ async def ensure_user_in_rooms(
         return
 
     server_name = extract_server_name_from_homeserver(homeserver, runtime_paths=runtime_paths)
-    user_id = MatrixID.from_username(user_account.username, server_name).full_id
+    user_id = managed_account_user_id(INTERNAL_USER_ACCOUNT_KEY, server_name, runtime_paths)
+    if user_id is None:
+        logger.warning("No user account found, skipping user room membership")
+        return
 
     # Create a client for the user to join rooms
     async with matrix_client(homeserver, runtime_paths, user_id=user_id) as user_client:

--- a/src/mindroom/matrix/users.py
+++ b/src/mindroom/matrix/users.py
@@ -12,7 +12,7 @@ from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths, runtime_matrix_h
 from mindroom.logging_config import get_logger
 from mindroom.matrix import provisioning
 from mindroom.matrix.client_session import login, matrix_client, matrix_startup_error, restore_login
-from mindroom.matrix.identity import MatrixID
+from mindroom.matrix.identity import MatrixID, managed_account_key
 from mindroom.matrix.state import MatrixState, matrix_state_for_runtime
 from mindroom.matrix_identifiers import agent_username_localpart, extract_server_name_from_homeserver
 
@@ -24,13 +24,8 @@ _INVALID_REGISTRATION_TOKEN_MESSAGE = (
 )
 
 
-def _account_key_for_agent(agent_name: str) -> str:
-    """Build the Matrix state account key for an agent-like entity."""
-    return f"agent_{agent_name}"
-
-
 INTERNAL_USER_AGENT_NAME = "user"
-INTERNAL_USER_ACCOUNT_KEY = _account_key_for_agent(INTERNAL_USER_AGENT_NAME)
+INTERNAL_USER_ACCOUNT_KEY = managed_account_key(INTERNAL_USER_AGENT_NAME)
 
 
 def _extract_domain_from_user_id(user_id: str) -> str:
@@ -72,7 +67,7 @@ def _get_agent_credentials(
 
     """
     state = matrix_state_for_runtime(runtime_paths)
-    agent_key = _account_key_for_agent(agent_name)
+    agent_key = managed_account_key(agent_name)
     account = state.get_account(agent_key)
     if account:
         return {
@@ -105,7 +100,7 @@ def _save_agent_credentials(
 
     """
     state = MatrixState.load(runtime_paths=runtime_paths)
-    agent_key = _account_key_for_agent(agent_name)
+    agent_key = managed_account_key(agent_name)
     server_name = extract_server_name_from_homeserver(
         runtime_matrix_homeserver(runtime_paths),
         runtime_paths=runtime_paths,

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -33,7 +33,7 @@ from mindroom.knowledge.watch import KnowledgeSourceWatcher
 from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_members, invite_to_room
 from mindroom.matrix.client_session import PermanentMatrixStartupError
 from mindroom.matrix.health import reset_matrix_sync_health
-from mindroom.matrix.identity import MatrixID
+from mindroom.matrix.identity import MatrixID, managed_account_user_id
 from mindroom.matrix.rooms import (
     ensure_all_rooms_exist,
     ensure_root_space,
@@ -46,7 +46,6 @@ from mindroom.matrix.stale_stream_cleanup import (
     auto_resume_interrupted_threads,
     cleanup_stale_streaming_messages,
 )
-from mindroom.matrix.state import matrix_state_for_runtime
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY, INTERNAL_USER_AGENT_NAME, create_agent_user
 from mindroom.matrix_identifiers import extract_server_name_from_homeserver
 from mindroom.mcp.manager import MCPServerManager
@@ -1543,16 +1542,14 @@ class _MultiAgentOrchestrator:
             return authorized_user_ids
         assert router_bot.client is not None
 
-        state = matrix_state_for_runtime(self.runtime_paths)
-        user_account = state.get_account(INTERNAL_USER_ACCOUNT_KEY)
-        if config.mindroom_user is None or not user_account:
-            return authorized_user_ids
-
         server_name = extract_server_name_from_homeserver(
             constants.runtime_matrix_homeserver(runtime_paths=self.runtime_paths),
             runtime_paths=self.runtime_paths,
         )
-        user_id = MatrixID.from_username(user_account.username, server_name).full_id
+        user_id = managed_account_user_id(INTERNAL_USER_ACCOUNT_KEY, server_name, self.runtime_paths)
+        if config.mindroom_user is None or user_id is None:
+            return authorized_user_ids
+
         authorized_user_ids.discard(user_id)
         for room_id in joined_rooms:
             room_members = await get_room_members(router_bot.client, room_id)

--- a/tests/test_matrix_identity.py
+++ b/tests/test_matrix_identity.py
@@ -17,6 +17,8 @@ from mindroom.matrix.identity import (
     _ThreadStateKey,
     extract_agent_name,
     is_agent_id,
+    managed_account_key,
+    managed_account_user_id,
     parse_current_matrix_user_id,
     parse_historical_matrix_user_id,
     try_parse_historical_matrix_user_id,
@@ -308,6 +310,20 @@ class TestHelperFunctions:
             == "general"
         )
         assert is_agent_id(f"@mindroom_general_oldns:{domain}", self.config, runtime_paths) is True
+
+    def test_managed_account_user_id_resolves_persisted_username(self, tmp_path: Path) -> None:
+        """Managed account user-id resolution should preserve persisted username drift."""
+        self.config = _bind_runtime_paths(self.config, tmp_path)
+        runtime_paths = runtime_paths_for(self.config)
+        domain = self.config.get_domain(runtime_paths)
+        account_key = managed_account_key("general")
+        state = MatrixState()
+        state.add_account(account_key, "mindroom_general_oldns", "pw", domain=domain)
+        state.save(runtime_paths=runtime_paths)
+
+        assert account_key == "agent_general"
+        assert managed_account_user_id(account_key, domain, runtime_paths) == f"@mindroom_general_oldns:{domain}"
+        assert managed_account_user_id(managed_account_key("missing"), domain, runtime_paths) is None
 
     def test_matrix_id_agent_name_trusts_persisted_current_username_drift(self, tmp_path: Path) -> None:
         """MatrixID.agent_name should use the same live drift-aware identity seam."""

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -11732,7 +11732,6 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.get_joined_rooms", new=AsyncMock(return_value=list(room_members))),
             patch("mindroom.orchestrator.get_room_members", side_effect=mock_get_room_members),
             patch("mindroom.orchestrator.invite_to_room", mock_invite),
-            patch("mindroom.orchestrator.matrix_state_for_runtime", return_value=MatrixState()),
         ):
             await orchestrator._ensure_room_invitations()
 
@@ -11779,7 +11778,6 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.get_joined_rooms", new=AsyncMock(return_value=["!room1:localhost"])),
             patch("mindroom.orchestrator.get_room_members", side_effect=mock_get_room_members),
             patch("mindroom.orchestrator.invite_to_room", mock_invite),
-            patch("mindroom.orchestrator.matrix_state_for_runtime", return_value=MatrixState()),
         ):
             await orchestrator._ensure_room_invitations()
 
@@ -11810,6 +11808,7 @@ class TestMultiAgentOrchestrator:
 
         state = MatrixState()
         state.add_account(INTERNAL_USER_ACCOUNT_KEY, "legacy_internal_user", "legacy-password")
+        state.save(runtime_paths=orchestrator.runtime_paths)
 
         async def mock_get_room_members(_client: AsyncMock, _room_id: str) -> set[str]:
             return {"@mindroom_general:localhost", "@mindroom_router:localhost"}
@@ -11821,7 +11820,6 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.get_joined_rooms", new=AsyncMock(return_value=["!room1:localhost"])),
             patch("mindroom.orchestrator.get_room_members", side_effect=mock_get_room_members),
             patch("mindroom.orchestrator.invite_to_room", mock_invite),
-            patch("mindroom.orchestrator.matrix_state_for_runtime", return_value=state),
         ):
             await orchestrator._ensure_room_invitations()
 
@@ -11858,7 +11856,6 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.get_joined_rooms", new=AsyncMock(return_value=["!ad-hoc:localhost"])),
             patch("mindroom.orchestrator.get_room_members", new=AsyncMock()) as mock_get_room_members,
             patch("mindroom.orchestrator.invite_to_room", AsyncMock()) as mock_invite,
-            patch("mindroom.orchestrator.matrix_state_for_runtime", return_value=MatrixState()),
         ):
             await orchestrator._ensure_room_invitations()
 


### PR DESCRIPTION
## Summary
- Add shared Matrix managed-account key and persisted user-id helpers in `matrix.identity`.
- Reuse the shared helpers from Matrix user persistence, active internal sender resolution, room joins, and internal-user room invites.
- Add characterization coverage for persisted username drift through managed account user-id resolution.

## Test Plan
- [x] `uv run pytest tests/test_matrix_identity.py::TestHelperFunctions::test_managed_account_user_id_resolves_persisted_username -q -n 0 --no-cov` (red before implementation: import failed for missing helper; green after implementation: 1 passed)
- [x] `uv run pytest tests/test_matrix_identity.py tests/test_cli.py tests/test_matrix_spaces.py::test_orchestrator_ensure_root_space_invites_internal_and_authorized_users tests/test_matrix_spaces.py::test_orchestrator_ensure_root_space_invites_authorized_user_without_internal_user tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_ensure_room_invitations_invites_authorized_users tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_ensure_room_invitations_skips_non_matrix_authorization_entries tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_ensure_room_invitations_skips_internal_user_when_unconfigured tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_ensure_room_invitations_ignores_persisted_ad_hoc_invited_rooms -q -n 0 --no-cov` (87 passed)
- [x] `uv run pre-commit run --files src/mindroom/matrix/identity.py src/mindroom/matrix/users.py src/mindroom/matrix/rooms.py src/mindroom/orchestrator.py tests/test_matrix_identity.py tests/test_multi_agent_bot.py` (passed)
- [x] `uv run pytest -q -n 0 --no-cov` printed final pytest summary `6259 passed, 56 skipped, 64 warnings in 236.71s`; process did not return after summary and was killed, so shell exit was 143.
