### PR TITLE
refactor: share scheduling read model helpers

### DIFF
--- a/src/mindroom/api/schedules.py
+++ b/src/mindroom/api/schedules.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from dataclasses import asdict
+from datetime import datetime  # noqa: TC003 - Pydantic resolves postponed annotations at runtime.
 from typing import TYPE_CHECKING, Annotated, Literal
 
-from croniter import CroniterError, croniter
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
@@ -13,18 +13,18 @@ from mindroom import constants
 from mindroom.api import config_lifecycle
 from mindroom.api.config_lifecycle import api_runtime_paths
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths
-from mindroom.logging_config import get_logger
 from mindroom.matrix.rooms import get_room_alias_from_id, resolve_room_aliases
 from mindroom.matrix.users import create_agent_user, login_agent_user
 from mindroom.scheduling import (
-    SCHEDULE_TYPE_CHANGE_NOT_SUPPORTED_ERROR,
-    CronSchedule,
+    ScheduledTaskReadModel,
     ScheduledTaskRecord,
-    ScheduledWorkflow,
+    build_edited_scheduled_workflow,
+    build_scheduled_task_read_model,
     cancel_scheduled_task,
     get_scheduled_task,
     get_scheduled_tasks_for_room,
     save_edited_scheduled_task,
+    scheduled_task_read_sort_key,
 )
 
 if TYPE_CHECKING:
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
 
 router = APIRouter(prefix="/api/schedules", tags=["schedules"])
-logger = get_logger(__name__)
 
 
 class ScheduledTaskResponse(BaseModel):
@@ -100,135 +99,10 @@ def _configured_room_ids(runtime_config: Config, runtime_paths: RuntimePaths) ->
     return list(dict.fromkeys(resolved_rooms))
 
 
-def _cron_schedule_from_expression(cron_expression: str) -> CronSchedule:
-    """Convert and validate a cron expression into a CronSchedule."""
-    raw_expression = cron_expression.strip()
-    fields = raw_expression.split()
-    if len(fields) != 5:
-        msg = "Cron expression must have exactly 5 fields: minute hour day month weekday"
-        raise ValueError(msg)
-
-    # Validate expression syntax
-    croniter(raw_expression, datetime.now(UTC))
-    minute, hour, day, month, weekday = fields
-    return CronSchedule(minute=minute, hour=hour, day=day, month=month, weekday=weekday)
-
-
-def _to_response_task(
-    task: ScheduledTaskRecord,
-    runtime_paths: RuntimePaths,
-) -> ScheduledTaskResponse:
-    """Map an internal scheduled task record to the API response model."""
-    workflow = task.workflow
-    cron_expression = workflow.cron_schedule.to_cron_string() if workflow.cron_schedule else None
-    cron_description = workflow.cron_schedule.to_natural_language() if workflow.cron_schedule else None
-
-    next_run_at: datetime | None = None
-    if workflow.schedule_type == "once":
-        next_run_at = workflow.execute_at
-    elif cron_expression:
-        try:
-            next_run_at = croniter(cron_expression, datetime.now(UTC)).get_next(datetime)
-        except CroniterError:
-            logger.warning(
-                "Failed to compute next run time for scheduled task",
-                task_id=task.task_id,
-                cron_expression=cron_expression,
-            )
-
+def _to_response_task(task: ScheduledTaskReadModel, runtime_paths: RuntimePaths) -> ScheduledTaskResponse:
     return ScheduledTaskResponse(
-        task_id=task.task_id,
-        room_id=task.room_id,
         room_alias=get_room_alias_from_id(task.room_id, runtime_paths=runtime_paths),
-        status=task.status,
-        schedule_type=workflow.schedule_type,
-        execute_at=workflow.execute_at,
-        next_run_at=next_run_at,
-        cron_expression=cron_expression,
-        cron_description=cron_description,
-        description=workflow.description,
-        message=workflow.message,
-        thread_id=workflow.thread_id,
-        new_thread=workflow.new_thread,
-        created_by=workflow.created_by,
-        created_at=task.created_at,
-    )
-
-
-def _task_sort_key(task: ScheduledTaskResponse) -> tuple[int, datetime]:
-    """Sort pending tasks first, then by next execution time."""
-    status_rank = 0 if task.status == "pending" else 1
-    scheduled_time = task.next_run_at or datetime.max.replace(tzinfo=UTC)
-    return (status_rank, scheduled_time)
-
-
-def _resolve_schedule_fields(
-    request: UpdateScheduleRequest,
-    existing_workflow: ScheduledWorkflow,
-) -> tuple[Literal["once", "cron"], datetime | None, CronSchedule | None]:
-    """Resolve and validate schedule-related updates for a task edit."""
-    if request.schedule_type and request.schedule_type != existing_workflow.schedule_type:
-        raise HTTPException(
-            status_code=400,
-            detail=SCHEDULE_TYPE_CHANGE_NOT_SUPPORTED_ERROR,
-        )
-
-    schedule_type = existing_workflow.schedule_type
-    if schedule_type == "once":
-        if request.cron_expression is not None:
-            raise HTTPException(status_code=400, detail="cron_expression is only valid for cron schedules")
-        execute_at = request.execute_at or existing_workflow.execute_at
-        if execute_at is None:
-            raise HTTPException(status_code=400, detail="execute_at is required for one-time schedules")
-        return (schedule_type, execute_at, None)
-
-    if request.execute_at is not None:
-        raise HTTPException(status_code=400, detail="execute_at is only valid for one-time schedules")
-
-    cron_schedule = existing_workflow.cron_schedule
-    if request.cron_expression is not None:
-        try:
-            cron_schedule = _cron_schedule_from_expression(request.cron_expression)
-        except (ValueError, CroniterError) as e:
-            raise HTTPException(status_code=400, detail=f"Invalid cron expression: {e!s}") from e
-    if cron_schedule is None:
-        raise HTTPException(status_code=400, detail="cron_expression is required for cron schedules")
-    return (schedule_type, None, cron_schedule)
-
-
-def _resolve_message_fields(
-    request: UpdateScheduleRequest,
-    existing_workflow: ScheduledWorkflow,
-) -> tuple[str, str]:
-    """Resolve and validate message/description fields for a task edit."""
-    message_source = request.message if request.message is not None else existing_workflow.message
-    message = message_source.strip()
-    if not message:
-        raise HTTPException(status_code=400, detail="message cannot be empty")
-
-    description_source = request.description if request.description is not None else existing_workflow.description
-    description = description_source.strip() or message
-    return (message, description)
-
-
-def _build_updated_workflow(
-    request: UpdateScheduleRequest,
-    existing_workflow: ScheduledWorkflow,
-    resolved_room_id: str,
-) -> ScheduledWorkflow:
-    """Build an updated workflow from validated edit inputs."""
-    schedule_type, execute_at, cron_schedule = _resolve_schedule_fields(request, existing_workflow)
-    message, description = _resolve_message_fields(request, existing_workflow)
-    return ScheduledWorkflow(
-        schedule_type=schedule_type,
-        execute_at=execute_at,
-        cron_schedule=cron_schedule,
-        message=message,
-        description=description,
-        created_by=existing_workflow.created_by,
-        thread_id=existing_workflow.thread_id,
-        room_id=resolved_room_id,
-        new_thread=existing_workflow.new_thread,
+        **asdict(task),
     )
 
 
@@ -263,19 +137,22 @@ async def list_schedules(
 
     client = await _get_router_client(runtime_paths)
     try:
-        tasks: list[ScheduledTaskResponse] = []
+        tasks: list[ScheduledTaskReadModel] = []
         for resolved_room_id in room_ids:
-            room_tasks = await get_scheduled_tasks_for_room(
+            room_tasks: list[ScheduledTaskRecord] = await get_scheduled_tasks_for_room(
                 client=client,
                 room_id=resolved_room_id,
                 include_non_pending=include_cancelled,
             )
-            tasks.extend(_to_response_task(task, runtime_paths) for task in room_tasks)
+            tasks.extend(build_scheduled_task_read_model(task) for task in room_tasks)
     finally:
         await client.close()
 
-    tasks.sort(key=_task_sort_key)
-    return ListSchedulesResponse(timezone=runtime_config.timezone, tasks=tasks)
+    tasks.sort(key=scheduled_task_read_sort_key)
+    return ListSchedulesResponse(
+        timezone=runtime_config.timezone,
+        tasks=[_to_response_task(task, runtime_paths) for task in tasks],
+    )
 
 
 @router.put("/{task_id}", response_model=ScheduledTaskResponse)
@@ -294,8 +171,16 @@ async def update_schedule(
         if not existing_task:
             raise HTTPException(status_code=404, detail=f"Task `{task_id}` not found")
 
-        updated_workflow = _build_updated_workflow(request, existing_task.workflow, resolved_room_id)
         try:
+            updated_workflow = build_edited_scheduled_workflow(
+                existing_task.workflow,
+                room_id=resolved_room_id,
+                message=request.message,
+                description=request.description,
+                schedule_type=request.schedule_type,
+                execute_at=request.execute_at,
+                cron_expression=request.cron_expression,
+            )
             updated_task = await save_edited_scheduled_task(
                 client=client,
                 room_id=resolved_room_id,
@@ -306,7 +191,7 @@ async def update_schedule(
         except ValueError as e:
             raise HTTPException(status_code=400, detail=f"{e!s}") from e
 
-        return _to_response_task(updated_task, runtime_paths)
+        return _to_response_task(build_scheduled_task_read_model(updated_task), runtime_paths)
     finally:
         await client.close()
 

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -16,7 +16,7 @@ import humanize
 import nio
 from agno.agent import Agent
 from cron_descriptor import get_description
-from croniter import croniter
+from croniter import CroniterError, croniter
 from pydantic import BaseModel, Field
 
 from mindroom import model_loading
@@ -55,7 +55,7 @@ _SCHEDULED_TASK_EVENT_TYPE = "com.mindroom.scheduled.task"
 _MESSAGE_PREVIEW_LENGTH = 50
 
 # Shared validation message for edit attempts that change task type.
-SCHEDULE_TYPE_CHANGE_NOT_SUPPORTED_ERROR = "Changing schedule_type is not supported; cancel and recreate the schedule"
+_SCHEDULE_TYPE_CHANGE_NOT_SUPPORTED_ERROR = "Changing schedule_type is not supported; cancel and recreate the schedule"
 
 # How often running tasks should re-check persisted Matrix state for edits/cancellations.
 _TASK_STATE_POLL_INTERVAL_SECONDS = 30
@@ -153,6 +153,26 @@ class ScheduledTaskRecord:
 
 
 @dataclass(frozen=True)
+class ScheduledTaskReadModel:
+    """Display-neutral scheduled task fields derived from persisted state."""
+
+    task_id: str
+    room_id: str
+    status: str
+    schedule_type: Literal["once", "cron"]
+    execute_at: datetime | None
+    next_run_at: datetime | None
+    cron_expression: str | None
+    cron_description: str | None
+    description: str
+    message: str
+    thread_id: str | None
+    new_thread: bool
+    created_by: str | None
+    created_at: datetime | None
+
+
+@dataclass(frozen=True)
 class SchedulingRuntime:
     """Live scheduling collaborators required to create or edit running tasks."""
 
@@ -183,6 +203,111 @@ def _parse_datetime(value: object) -> datetime | None:
         return datetime.fromisoformat(normalized)
     except ValueError:
         return None
+
+
+def _raise_schedule_edit_error(message: str) -> typing.NoReturn:
+    raise ValueError(message)
+
+
+def build_scheduled_task_read_model(
+    task: ScheduledTaskRecord,
+    current_time: datetime | None = None,
+) -> ScheduledTaskReadModel:
+    """Build API/chat-neutral display fields for a scheduled task."""
+    workflow = task.workflow
+    cron_expression = workflow.cron_schedule.to_cron_string() if workflow.cron_schedule else None
+    cron_description = workflow.cron_schedule.to_natural_language() if workflow.cron_schedule else None
+    next_run_at = workflow.execute_at if workflow.schedule_type == "once" else None
+    if workflow.schedule_type == "cron" and cron_expression:
+        try:
+            next_run_at = croniter(cron_expression, current_time or datetime.now(UTC)).get_next(datetime)
+        except CroniterError:
+            next_run_at = None
+
+    return ScheduledTaskReadModel(
+        task_id=task.task_id,
+        room_id=task.room_id,
+        status=task.status,
+        schedule_type=workflow.schedule_type,
+        execute_at=workflow.execute_at,
+        next_run_at=next_run_at,
+        cron_expression=cron_expression,
+        cron_description=cron_description,
+        description=workflow.description,
+        message=workflow.message,
+        thread_id=workflow.thread_id,
+        new_thread=workflow.new_thread,
+        created_by=workflow.created_by,
+        created_at=task.created_at,
+    )
+
+
+def scheduled_task_read_sort_key(task: ScheduledTaskReadModel) -> tuple[int, datetime]:
+    """Sort pending tasks first, then by next execution time."""
+    status_rank = 0 if task.status == "pending" else 1
+    scheduled_time = task.next_run_at or datetime.max.replace(tzinfo=UTC)
+    return (status_rank, scheduled_time)
+
+
+def build_edited_scheduled_workflow(  # noqa: C901
+    existing_workflow: ScheduledWorkflow,
+    room_id: str,
+    *,
+    message: str | None = None,
+    description: str | None = None,
+    schedule_type: Literal["once", "cron"] | None = None,
+    execute_at: datetime | None = None,
+    cron_expression: str | None = None,
+) -> ScheduledWorkflow:
+    """Build a validated patch-style workflow edit while preserving immutable metadata."""
+    if schedule_type and schedule_type != existing_workflow.schedule_type:
+        _raise_schedule_edit_error(_SCHEDULE_TYPE_CHANGE_NOT_SUPPORTED_ERROR)
+
+    schedule_type = existing_workflow.schedule_type
+    if schedule_type == "once":
+        if cron_expression is not None:
+            _raise_schedule_edit_error("cron_expression is only valid for cron schedules")
+        execute_at = execute_at or existing_workflow.execute_at
+        if execute_at is None:
+            _raise_schedule_edit_error("execute_at is required for one-time schedules")
+        cron_schedule = None
+    else:
+        if execute_at is not None:
+            _raise_schedule_edit_error("execute_at is only valid for one-time schedules")
+        cron_schedule = existing_workflow.cron_schedule
+        if cron_expression is not None:
+            raw_expression = cron_expression.strip()
+            fields = raw_expression.split()
+            if len(fields) != 5:
+                _raise_schedule_edit_error(
+                    "Invalid cron expression: Cron expression must have exactly 5 fields: minute hour day month weekday",
+                )
+            try:
+                croniter(raw_expression, datetime.now(UTC))
+            except (ValueError, CroniterError) as e:
+                _raise_schedule_edit_error(f"Invalid cron expression: {e!s}")
+            minute, hour, day, month, weekday = fields
+            cron_schedule = CronSchedule(minute=minute, hour=hour, day=day, month=month, weekday=weekday)
+        if cron_schedule is None:
+            _raise_schedule_edit_error("cron_expression is required for cron schedules")
+        execute_at = None
+
+    message_value = (message if message is not None else existing_workflow.message).strip()
+    if not message_value:
+        _raise_schedule_edit_error("message cannot be empty")
+    description_value = (description if description is not None else existing_workflow.description).strip()
+
+    return ScheduledWorkflow(
+        schedule_type=schedule_type,
+        execute_at=execute_at,
+        cron_schedule=cron_schedule,
+        message=message_value,
+        description=description_value or message_value,
+        created_by=existing_workflow.created_by,
+        thread_id=existing_workflow.thread_id,
+        room_id=room_id,
+        new_thread=existing_workflow.new_thread,
+    )
 
 
 def _parse_scheduled_task_record(
@@ -615,7 +740,7 @@ async def save_edited_scheduled_task(
         raise ValueError(msg)
 
     if workflow.schedule_type != existing_task.workflow.schedule_type:
-        raise ValueError(SCHEDULE_TYPE_CHANGE_NOT_SUPPORTED_ERROR)
+        raise ValueError(_SCHEDULE_TYPE_CHANGE_NOT_SUPPORTED_ERROR)
 
     await _persist_scheduled_task_state(
         client=client,

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -23,6 +23,8 @@ from mindroom.scheduling import (
     SchedulingRuntime,
     _run_cron_task,
     _run_once_task,
+    build_edited_scheduled_workflow,
+    build_scheduled_task_read_model,
     cancel_all_scheduled_tasks,
     clear_deferred_overdue_tasks,
     drain_deferred_overdue_tasks,
@@ -32,6 +34,7 @@ from mindroom.scheduling import (
     restore_scheduled_tasks,
     save_edited_scheduled_task,
     schedule_task,
+    scheduled_task_read_sort_key,
 )
 from tests.conftest import bind_runtime_paths, make_event_cache_mock
 
@@ -91,6 +94,115 @@ def _record(
         created_at=datetime.now(UTC),
         workflow=workflow,
     )
+
+
+def test_scheduled_task_read_model_derives_display_fields_and_sort_order() -> None:
+    """Schedule read models should preserve API-visible derived fields."""
+    current_time = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    once_record = _record(
+        "once123",
+        ScheduledWorkflow(
+            schedule_type="once",
+            execute_at=datetime(2026, 1, 2, 9, 30, tzinfo=UTC),
+            message="one-time message",
+            description="One-time task",
+            new_thread=True,
+        ),
+        status="cancelled",
+    )
+    cron_record = _record(
+        "cron123",
+        ScheduledWorkflow(
+            schedule_type="cron",
+            cron_schedule=CronSchedule(minute="0", hour="9", day="*", month="*", weekday="*"),
+            message="cron message",
+            description="Cron task",
+            created_by="@user:server",
+            thread_id="$thread1",
+        ),
+    )
+
+    once_model = build_scheduled_task_read_model(once_record, current_time=current_time)
+    cron_model = build_scheduled_task_read_model(cron_record, current_time=current_time)
+
+    assert once_model.task_id == "once123"
+    assert once_model.status == "cancelled"
+    assert once_model.next_run_at == datetime(2026, 1, 2, 9, 30, tzinfo=UTC)
+    assert once_model.cron_expression is None
+    assert once_model.new_thread is True
+    assert cron_model.cron_expression == "0 9 * * *"
+    assert cron_model.cron_description == "At 09:00"
+    assert cron_model.next_run_at == datetime(2026, 1, 2, 9, 0, tzinfo=UTC)
+    assert cron_model.created_by == "@user:server"
+    assert cron_model.thread_id == "$thread1"
+    assert sorted([once_model, cron_model], key=scheduled_task_read_sort_key) == [cron_model, once_model]
+
+
+def test_build_edited_scheduled_workflow_preserves_metadata_and_strips_text() -> None:
+    """Patch-style edits should preserve ownership/thread metadata while normalizing text."""
+    existing = ScheduledWorkflow(
+        schedule_type="cron",
+        cron_schedule=CronSchedule(minute="0", hour="9", day="*", month="*", weekday="*"),
+        message="original message",
+        description="Original description",
+        created_by="@user:server",
+        thread_id="$thread1",
+        room_id="!old:server",
+        new_thread=True,
+    )
+
+    updated = build_edited_scheduled_workflow(
+        existing,
+        room_id="!new:server",
+        schedule_type="cron",
+        cron_expression="30 8 * * 1-5",
+        message="  updated message  ",
+        description="   ",
+    )
+
+    assert updated == ScheduledWorkflow(
+        schedule_type="cron",
+        cron_schedule=CronSchedule(minute="30", hour="8", day="*", month="*", weekday="1-5"),
+        execute_at=None,
+        message="updated message",
+        description="updated message",
+        created_by="@user:server",
+        thread_id="$thread1",
+        room_id="!new:server",
+        new_thread=True,
+    )
+
+
+def test_build_edited_scheduled_workflow_rejects_invalid_field_combinations() -> None:
+    """Patch-style edits should keep existing API validation messages."""
+    existing_once = ScheduledWorkflow(
+        schedule_type="once",
+        execute_at=datetime(2026, 1, 2, 9, 30, tzinfo=UTC),
+        message="original message",
+        description="Original description",
+    )
+    existing_cron = ScheduledWorkflow(
+        schedule_type="cron",
+        cron_schedule=CronSchedule(minute="0", hour="9", day="*", month="*", weekday="*"),
+        message="original message",
+        description="Original description",
+    )
+
+    with pytest.raises(ValueError, match="Changing schedule_type is not supported"):
+        build_edited_scheduled_workflow(existing_once, room_id="!room:server", schedule_type="cron")
+
+    with pytest.raises(ValueError, match="cron_expression is only valid for cron schedules"):
+        build_edited_scheduled_workflow(existing_once, room_id="!room:server", cron_expression="0 9 * * *")
+
+    with pytest.raises(ValueError, match="execute_at is only valid for one-time schedules"):
+        build_edited_scheduled_workflow(
+            existing_cron,
+            room_id="!room:server",
+            execute_at=datetime(2026, 1, 3, 9, 30, tzinfo=UTC),
+        )
+
+    with pytest.raises(ValueError, match="message cannot be empty"):
+        build_edited_scheduled_workflow(existing_once, room_id="!room:server", message="   ")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- move schedule API read-model derivation and sort behavior into scheduling-domain helpers
- move patch-style schedule edit workflow construction into scheduling.py while preserving API DTOs
- add characterization coverage for read-model fields, sort order, and edit validation/preservation

## Verification
- uv run pytest tests/api/test_schedules_api.py tests/test_scheduling.py -q -n 0 --no-cov
- uv run pre-commit run --files src/mindroom/api/schedules.py src/mindroom/scheduling.py tests/test_scheduling.py
- uv run pytest -q -n 0 --no-cov