### PR TITLE
Refactor response runner terminal placeholder cleanup

### DIFF
--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -45,7 +45,11 @@ from mindroom.response_attempt import (
     ResponseAttemptRunner,
     log_cancelled_response,
 )
-from mindroom.response_terminal import PendingVisibleResponse, build_terminal_stream_transport_outcome
+from mindroom.response_terminal import (
+    PendingVisibleResponse,
+    build_placeholder_terminal_stream_transport_outcome,
+    build_terminal_stream_transport_outcome,
+)
 from mindroom.streaming import (
     PROGRESS_PLACEHOLDER,
     ReplacementStreamingResponse,
@@ -2215,6 +2219,33 @@ class ResponseRunner:
             delivery_failure_reason = failure_reason
             delivery_cancelled = True
 
+        async def finalize_pre_delivery_terminal_response(
+            event_id: str,
+            *,
+            terminal_status: Literal["cancelled", "error"],
+            failure_reason: str,
+        ) -> None:
+            nonlocal final_delivery_outcome
+            final_delivery_outcome = await self.deps.delivery_gateway.finalize_streamed_response(
+                FinalizeStreamedResponseRequest(
+                    target=resolved_target,
+                    stream_transport_outcome=build_placeholder_terminal_stream_transport_outcome(
+                        event_id,
+                        terminal_status=terminal_status,
+                        failure_reason=failure_reason,
+                        placeholder_body=PROGRESS_PLACEHOLDER,
+                    ),
+                    initial_delivery_kind="edited" if request.existing_event_id else "sent",
+                    response_kind="ai",
+                    response_envelope=resolved_response_envelope,
+                    correlation_id=resolved_correlation_id,
+                    tool_trace=None,
+                    extra_content=None,
+                    existing_event_id=request.existing_event_id,
+                    existing_event_is_placeholder=request.existing_event_is_placeholder,
+                ),
+            )
+
         async def generate(message_id: str | None) -> None:
             nonlocal final_delivery_outcome, tracked_event_id
             if message_id is not None:
@@ -2274,25 +2305,10 @@ class ResponseRunner:
                     request.existing_event_id if request.existing_event_is_placeholder else None
                 )
                 if event_id is not None:
-                    final_delivery_outcome = await self.deps.delivery_gateway.finalize_streamed_response(
-                        FinalizeStreamedResponseRequest(
-                            target=resolved_target,
-                            stream_transport_outcome=StreamTransportOutcome(
-                                last_physical_stream_event_id=event_id,
-                                terminal_status="cancelled",
-                                rendered_body=PROGRESS_PLACEHOLDER,
-                                visible_body_state="placeholder_only",
-                                failure_reason=delivery_failure_reason,
-                            ),
-                            initial_delivery_kind="edited" if request.existing_event_id else "sent",
-                            response_kind="ai",
-                            response_envelope=resolved_response_envelope,
-                            correlation_id=resolved_correlation_id,
-                            tool_trace=None,
-                            extra_content=None,
-                            existing_event_id=request.existing_event_id,
-                            existing_event_is_placeholder=request.existing_event_is_placeholder,
-                        ),
+                    await finalize_pre_delivery_terminal_response(
+                        event_id,
+                        terminal_status="cancelled",
+                        failure_reason=delivery_failure_reason,
                     )
                 else:
                     final_delivery_outcome = FinalDeliveryOutcome(
@@ -2311,25 +2327,10 @@ class ResponseRunner:
                     request.existing_event_id if request.existing_event_is_placeholder else None
                 )
                 if event_id is not None:
-                    final_delivery_outcome = await self.deps.delivery_gateway.finalize_streamed_response(
-                        FinalizeStreamedResponseRequest(
-                            target=resolved_target,
-                            stream_transport_outcome=StreamTransportOutcome(
-                                last_physical_stream_event_id=event_id,
-                                terminal_status="error",
-                                rendered_body=PROGRESS_PLACEHOLDER,
-                                visible_body_state="placeholder_only",
-                                failure_reason=delivery_failure_reason,
-                            ),
-                            initial_delivery_kind="edited" if request.existing_event_id else "sent",
-                            response_kind="ai",
-                            response_envelope=resolved_response_envelope,
-                            correlation_id=resolved_correlation_id,
-                            tool_trace=None,
-                            extra_content=None,
-                            existing_event_id=request.existing_event_id,
-                            existing_event_is_placeholder=request.existing_event_is_placeholder,
-                        ),
+                    await finalize_pre_delivery_terminal_response(
+                        event_id,
+                        terminal_status="error",
+                        failure_reason=delivery_failure_reason,
                     )
                 else:
                     final_delivery_outcome = FinalDeliveryOutcome(
@@ -2347,25 +2348,10 @@ class ResponseRunner:
                     request.existing_event_id if request.existing_event_is_placeholder else None
                 )
                 if event_id is not None:
-                    final_delivery_outcome = await self.deps.delivery_gateway.finalize_streamed_response(
-                        FinalizeStreamedResponseRequest(
-                            target=resolved_target,
-                            stream_transport_outcome=StreamTransportOutcome(
-                                last_physical_stream_event_id=event_id,
-                                terminal_status="cancelled",
-                                rendered_body=PROGRESS_PLACEHOLDER,
-                                visible_body_state="placeholder_only",
-                                failure_reason=delivery_failure_reason or "interrupted",
-                            ),
-                            initial_delivery_kind="edited" if request.existing_event_id else "sent",
-                            response_kind="ai",
-                            response_envelope=resolved_response_envelope,
-                            correlation_id=resolved_correlation_id,
-                            tool_trace=None,
-                            extra_content=None,
-                            existing_event_id=request.existing_event_id,
-                            existing_event_is_placeholder=request.existing_event_is_placeholder,
-                        ),
+                    await finalize_pre_delivery_terminal_response(
+                        event_id,
+                        terminal_status="cancelled",
+                        failure_reason=delivery_failure_reason or "interrupted",
                     )
                 else:
                     final_delivery_outcome = FinalDeliveryOutcome(

--- a/src/mindroom/response_terminal.py
+++ b/src/mindroom/response_terminal.py
@@ -64,8 +64,30 @@ def build_terminal_stream_transport_outcome(
     )
 
 
+def build_placeholder_terminal_stream_transport_outcome(
+    event_id: str,
+    *,
+    terminal_status: TerminalFailureStatus,
+    failure_reason: str,
+    placeholder_body: str,
+) -> StreamTransportOutcome:
+    """Build the canonical stream outcome for a committed placeholder."""
+    return build_terminal_stream_transport_outcome(
+        PendingVisibleResponse(
+            tracked_event_id=None,
+            run_message_id=event_id,
+            existing_event_id=None,
+            existing_event_is_placeholder=False,
+        ),
+        terminal_status=terminal_status,
+        failure_reason=failure_reason,
+        placeholder_body=placeholder_body,
+    )
+
+
 __all__ = [
     "PendingVisibleResponse",
     "TerminalFailureStatus",
+    "build_placeholder_terminal_stream_transport_outcome",
     "build_terminal_stream_transport_outcome",
 ]

--- a/tests/test_response_terminal.py
+++ b/tests/test_response_terminal.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from mindroom.response_terminal import PendingVisibleResponse, build_terminal_stream_transport_outcome
+from mindroom.response_terminal import (
+    PendingVisibleResponse,
+    TerminalFailureStatus,
+    build_placeholder_terminal_stream_transport_outcome,
+    build_terminal_stream_transport_outcome,
+)
 
 
 @pytest.mark.parametrize(
@@ -85,3 +90,22 @@ def test_terminal_stream_outcome_resolves_visible_placeholder_state(
     assert outcome.failure_reason == "delivery failed"
     assert outcome.rendered_body == ("Thinking..." if expected_placeholder_only else None)
     assert outcome.visible_body_state == ("placeholder_only" if expected_placeholder_only else "none")
+
+
+@pytest.mark.parametrize("terminal_status", ["cancelled", "error"])
+def test_placeholder_terminal_stream_outcome_matches_response_runner_cleanup_shape(
+    terminal_status: TerminalFailureStatus,
+) -> None:
+    """Pre-delivery response runner failures should preserve placeholder cleanup fields."""
+    outcome = build_placeholder_terminal_stream_transport_outcome(
+        "$thinking",
+        terminal_status=terminal_status,
+        failure_reason="delivery failed",
+        placeholder_body="Thinking...",
+    )
+
+    assert outcome.last_physical_stream_event_id == "$thinking"
+    assert outcome.terminal_status == terminal_status
+    assert outcome.failure_reason == "delivery failed"
+    assert outcome.rendered_body == "Thinking..."
+    assert outcome.visible_body_state == "placeholder_only"


### PR DESCRIPTION
## Summary
- Add a focused terminal helper for committed placeholder-only stream outcomes.
- Reuse it from response runner pre-delivery cancellation/error cleanup paths.
- Add characterization coverage for the placeholder cleanup transport shape.

## Verification
- uv sync --all-extras
- uv run pytest tests/test_response_terminal.py tests/test_ai_user_id.py -k 'early_cancellation_redacts_thinking_placeholder or finalizes_cancelled_task_before_delivery or generate_response_locked_persists_minimal_interrupted_history_after_task_cancel or placeholder_terminal_stream_outcome' -q -n 0 --no-cov
- uv run pytest tests/test_response_terminal.py -q -n 0 --no-cov
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/response_runner.py src/mindroom/response_terminal.py tests/test_response_terminal.py