### PR TITLE
refactor: share memory scope storage traversal

### DIFF
--- a/src/mindroom/memory/_file_backend.py
+++ b/src/mindroom/memory/_file_backend.py
@@ -14,9 +14,9 @@ from mindroom.timing import timed
 from ._policy import (
     agent_name_from_scope_user_id,
     agent_scope_user_id,
+    allowed_scope_storage_paths,
     build_team_user_id,
     effective_storage_paths_for_context,
-    get_allowed_memory_user_ids,
     get_team_ids_for_agent,
     resolve_file_memory_resolution,
     storage_paths_for_scope_user_id,
@@ -457,24 +457,23 @@ def _find_file_anchor_memory_result(
     *,
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> MemoryResult | None:
-    for scope_user_id in sorted(get_allowed_memory_user_ids(caller_context, config)):
-        for target_storage_path in storage_paths_for_scope_user_id(
-            scope_user_id,
-            storage_path,
+    for scope_user_id, target_storage_path in allowed_scope_storage_paths(
+        caller_context,
+        storage_path,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
+    ):
+        resolution = resolve_file_memory_resolution(
+            target_storage_path,
             config,
             runtime_paths,
+            agent_name=agent_name_from_scope_user_id(scope_user_id),
+            original_storage_path=storage_path,
             execution_identity=execution_identity,
-        ):
-            resolution = resolve_file_memory_resolution(
-                target_storage_path,
-                config,
-                runtime_paths,
-                agent_name=agent_name_from_scope_user_id(scope_user_id),
-                original_storage_path=storage_path,
-                execution_identity=execution_identity,
-            )
-            if result := _get_scope_memory_by_id(scope_user_id, memory_id, resolution, config):
-                return result
+        )
+        if result := _get_scope_memory_by_id(scope_user_id, memory_id, resolution, config):
+            return result
     return None
 
 
@@ -713,26 +712,14 @@ def get_file_agent_memory(
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> MemoryResult | None:
     """Return one file-backed memory visible to the caller."""
-    for scope_user_id in sorted(get_allowed_memory_user_ids(caller_context, config)):
-        for target_storage_path in storage_paths_for_scope_user_id(
-            scope_user_id,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-        ):
-            resolution = resolve_file_memory_resolution(
-                target_storage_path,
-                config,
-                runtime_paths,
-                agent_name=agent_name_from_scope_user_id(scope_user_id),
-                original_storage_path=storage_path,
-                execution_identity=execution_identity,
-            )
-            result = _get_scope_memory_by_id(scope_user_id, memory_id, resolution, config)
-            if result is not None:
-                return result
-    return None
+    return _find_file_anchor_memory_result(
+        memory_id,
+        caller_context,
+        storage_path,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
+    )
 
 
 def update_file_agent_memory(

--- a/src/mindroom/memory/_mem0_backend.py
+++ b/src/mindroom/memory/_mem0_backend.py
@@ -10,6 +10,7 @@ from mindroom.timing import timed
 
 from ._policy import (
     agent_scope_user_id,
+    allowed_scope_storage_paths,
     build_team_user_id,
     effective_storage_paths_for_context,
     get_allowed_memory_user_ids,
@@ -182,17 +183,16 @@ async def _find_mem0_anchor_memory_result(
     create_memory: _MemoryFactory,
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> MemoryResult | None:
-    for scope_user_id in sorted(get_allowed_memory_user_ids(caller_context, config)):
-        for target_storage_path in storage_paths_for_scope_user_id(
-            scope_user_id,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-        ):
-            memory = await create_memory(target_storage_path, config)
-            if result := await _get_scoped_memory_by_id(memory, memory_id, caller_context, config):
-                return result
+    for _scope_user_id, target_storage_path in allowed_scope_storage_paths(
+        caller_context,
+        storage_path,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
+    ):
+        memory = await create_memory(target_storage_path, config)
+        if result := await _get_scoped_memory_by_id(memory, memory_id, caller_context, config):
+            return result
     return None
 
 
@@ -374,19 +374,15 @@ async def get_mem0_agent_memory(
     create_memory: _MemoryFactory,
 ) -> MemoryResult | None:
     """Return one mem0 memory visible to the caller."""
-    for scope_user_id in sorted(get_allowed_memory_user_ids(caller_context, config)):
-        for target_storage_path in storage_paths_for_scope_user_id(
-            scope_user_id,
-            storage_path,
-            config,
-            runtime_paths,
-            execution_identity=execution_identity,
-        ):
-            memory = await create_memory(target_storage_path, config)
-            result = await _get_scoped_memory_by_id(memory, memory_id, caller_context, config)
-            if result is not None:
-                return result
-    return None
+    return await _find_mem0_anchor_memory_result(
+        memory_id,
+        caller_context,
+        storage_path,
+        config,
+        runtime_paths,
+        create_memory=create_memory,
+        execution_identity=execution_identity,
+    )
 
 
 async def update_mem0_agent_memory(

--- a/src/mindroom/memory/_policy.py
+++ b/src/mindroom/memory/_policy.py
@@ -9,6 +9,7 @@ from mindroom.runtime_resolution import resolve_agent_runtime
 from ._shared import FileMemoryResolution
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     from mindroom.config.main import Config
@@ -150,6 +151,24 @@ def storage_paths_for_scope_user_id(
         return [_effective_storage_path_for_agent(agent_name, config, runtime_paths, execution_identity)]
     msg = f"Unsupported memory scope user_id: {scope_user_id}"
     raise ValueError(msg)
+
+
+def allowed_scope_storage_paths(
+    caller_context: str | list[str],
+    storage_path: Path,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None = None,
+) -> Iterator[tuple[str, Path]]:
+    for scope_user_id in sorted(get_allowed_memory_user_ids(caller_context, config)):
+        for target_storage_path in storage_paths_for_scope_user_id(
+            scope_user_id,
+            storage_path,
+            config,
+            runtime_paths,
+            execution_identity=execution_identity,
+        ):
+            yield scope_user_id, target_storage_path
 
 
 def get_allowed_memory_user_ids(caller_context: str | list[str], config: Config) -> set[str]:

--- a/tests/test_memory_policy.py
+++ b/tests/test_memory_policy.py
@@ -11,6 +11,7 @@ from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
 from mindroom.memory._policy import (
     agent_scope_user_id,
+    allowed_scope_storage_paths,
     effective_storage_paths_for_context,
     get_allowed_memory_user_ids,
     get_team_ids_for_agent,
@@ -79,6 +80,24 @@ def test_get_allowed_memory_user_ids_for_team_context(config: Config) -> None:
         "agent_general",
         "team_calculator+general",
     }
+
+
+def test_allowed_scope_storage_paths_orders_scopes_and_expands_storage_roots(
+    tmp_path: Path,
+    config: Config,
+) -> None:
+    """Allowed scope traversal is sorted and expands each scope to its storage roots."""
+    config.agents = {
+        "general": AgentConfig(display_name="General"),
+        "calculator": AgentConfig(display_name="Calculator"),
+    }
+    config.teams = {"pair": MockTeamConfig(agents=["general", "calculator"])}
+
+    assert list(allowed_scope_storage_paths("general", tmp_path, config, runtime_paths_for(config))) == [
+        ("agent_general", agent_state_root_path(tmp_path, "general")),
+        ("team_calculator+general", agent_state_root_path(tmp_path, "general")),
+        ("team_calculator+general", agent_state_root_path(tmp_path, "calculator")),
+    ]
 
 
 def test_effective_storage_paths_for_mixed_private_team_is_rejected(tmp_path: Path, config: Config) -> None:


### PR DESCRIPTION
## Summary
- Add a small memory policy iterator for allowed scope/storage traversal.
- Reuse it in file and mem0 anchor lookup paths.
- Add a characterization test for traversal ordering and storage-root expansion.

## Test Plan
- uv run pytest tests/test_memory_policy.py::test_allowed_scope_storage_paths_orders_scopes_and_expands_storage_roots -q -n 0 --no-cov
- uv run pytest tests/test_memory_policy.py tests/test_memory_facade.py tests/test_memory_mem0_backend.py -q -n 0 --no-cov
- uv run pre-commit run --files src/mindroom/memory/_policy.py src/mindroom/memory/_file_backend.py src/mindroom/memory/_mem0_backend.py tests/test_memory_policy.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency of memory lookup operations across different scope contexts, including agent and team scopes
  * Centralized cross-scope memory resolution logic for enhanced maintainability and consistency
  * Streamlined enumeration of memory scopes and storage path resolution across backend implementations

* **Tests**
  * Added comprehensive test coverage for scope-aware memory policy behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->