### PR TITLE
refactor: share context-bound async stream wrappers

### DIFF
--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -5,18 +5,18 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-from collections.abc import AsyncGenerator as AsyncGeneratorABC
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import asdict, fields, is_dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, cast
 
 from agno.models.message import Message
 from pydantic import BaseModel
 
 from mindroom.constants import MATRIX_SOURCE_EVENT_IDS_METADATA_KEY, MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY
+from mindroom.tool_system.context_bound_streams import context_bound_async_stream
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Coroutine, Iterator, Sequence
@@ -27,14 +27,6 @@ if TYPE_CHECKING:
     from mindroom.config.models import DebugConfig
 
 _INSTALLED_ATTR = "_mindroom_llm_request_logging_installed"
-
-
-@runtime_checkable
-class _AsyncClosableIterator(Protocol):
-    """Minimal async-iterator surface that can be closed explicitly."""
-
-    async def aclose(self) -> None:
-        """Close the async iterator and release any underlying resources."""
 
 
 _SKIP_MODEL_PARAM_NAMES = {
@@ -253,27 +245,16 @@ def bind_llm_request_log_context(**context: object) -> Iterator[None]:
         _REQUEST_CONTEXT.reset(token)
 
 
-async def stream_with_llm_request_log_context[StreamEventT](
+def stream_with_llm_request_log_context[StreamEventT](
     stream_generator: AsyncIterator[StreamEventT],
     *,
     request_context: dict[str, object],
 ) -> AsyncIterator[StreamEventT]:
     """Advance one async stream with request-log context bound per item pull."""
-    stream: AsyncIterator[StreamEventT] | None = None
-    try:
-        with bind_llm_request_log_context(**request_context):
-            stream = stream_generator.__aiter__()
-        while True:
-            try:
-                with bind_llm_request_log_context(**request_context):
-                    event = await stream.__anext__()
-            except StopAsyncIteration:
-                return
-            yield event
-    finally:
-        if isinstance(stream, (AsyncGeneratorABC, _AsyncClosableIterator)):
-            with bind_llm_request_log_context(**request_context):
-                await stream.aclose()
+    return context_bound_async_stream(
+        context_factory=lambda: bind_llm_request_log_context(**request_context),
+        stream_factory=stream_generator.__aiter__,
+    )
 
 
 async def _write_llm_request_log(

--- a/src/mindroom/tool_system/context_bound_streams.py
+++ b/src/mindroom/tool_system/context_bound_streams.py
@@ -1,0 +1,45 @@
+"""Async stream helpers for short-lived context-manager bindings."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator as AsyncGeneratorABC
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+    from contextlib import AbstractContextManager
+
+
+@runtime_checkable
+class _AsyncClosableIterator(Protocol):
+    """Minimal async-iterator surface that can be closed explicitly."""
+
+    async def aclose(self) -> None:
+        """Close the async iterator and release any underlying resources."""
+
+
+def context_bound_async_stream[ChunkT](
+    *,
+    context_factory: Callable[[], AbstractContextManager[object]],
+    stream_factory: Callable[[], AsyncIterator[ChunkT]],
+) -> AsyncIterator[ChunkT]:
+    """Wrap an async iterator with context bound for factory, pulls, and close only."""
+
+    async def wrapped_stream() -> AsyncIterator[ChunkT]:
+        stream: AsyncIterator[ChunkT] | None = None
+        try:
+            with context_factory():
+                stream = stream_factory()
+            while True:
+                try:
+                    with context_factory():
+                        chunk = await anext(stream)
+                except StopAsyncIteration:
+                    return
+                yield chunk
+        finally:
+            if isinstance(stream, (AsyncGeneratorABC, _AsyncClosableIterator)):
+                with context_factory():
+                    await stream.aclose()
+
+    return wrapped_stream()

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import AsyncGenerator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, TypeVar
 from uuid import uuid4
 
 from mindroom.hooks import (
@@ -22,6 +21,7 @@ from mindroom.hooks import (
 )
 from mindroom.logging_config import get_logger
 from mindroom.message_target import MessageTarget
+from mindroom.tool_system.context_bound_streams import context_bound_async_stream
 from mindroom.tool_system.plugin_identity import validate_plugin_name
 from mindroom.tool_system.worker_routing import build_tool_execution_identity
 
@@ -46,14 +46,6 @@ if TYPE_CHECKING:
 
 _ToolContextReturn = TypeVar("_ToolContextReturn")
 _StreamChunk = TypeVar("_StreamChunk")
-
-
-@runtime_checkable
-class _AsyncClosableIterator(Protocol):
-    """Minimal async-iterator surface that can be closed explicitly."""
-
-    async def aclose(self) -> None:
-        """Close the async iterator and release any underlying resources."""
 
 
 @contextmanager
@@ -361,25 +353,10 @@ class ToolRuntimeSupport:
         stream_factory: Callable[[], AsyncIterator[_StreamChunk]],
     ) -> AsyncIterator[_StreamChunk]:
         """Wrap one async iterator without spanning tool-runtime tokens across yields."""
-
-        async def wrapped_stream() -> AsyncIterator[_StreamChunk]:
-            stream: AsyncIterator[_StreamChunk] | None = None
-            try:
-                with _tool_runtime_context_scope(tool_context):
-                    stream = stream_factory()
-                while True:
-                    try:
-                        with _tool_runtime_context_scope(tool_context):
-                            chunk = await anext(stream)
-                    except StopAsyncIteration:
-                        return
-                    yield chunk
-            finally:
-                if isinstance(stream, (AsyncGenerator, _AsyncClosableIterator)):
-                    with _tool_runtime_context_scope(tool_context):
-                        await stream.aclose()
-
-        return wrapped_stream()
+        return context_bound_async_stream(
+            context_factory=lambda: _tool_runtime_context_scope(tool_context),
+            stream_factory=stream_factory,
+        )
 
 
 _TOOL_RUNTIME_CONTEXT: ContextVar[ToolRuntimeContext | None] = ContextVar(

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import hashlib
 import re
-from collections.abc import AsyncGenerator as AsyncGeneratorABC
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Literal, cast
+
+from mindroom.tool_system.context_bound_streams import context_bound_async_stream
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Collection, Iterator
@@ -39,14 +40,6 @@ _LOCAL_ONLY_SHARED_INTEGRATION_TOOL_NAMES = frozenset(
         "homeassistant",
     },
 )
-
-
-@runtime_checkable
-class _AsyncClosableIterator(Protocol):
-    """Minimal async-iterator surface that can be closed explicitly."""
-
-    async def aclose(self) -> None:
-        """Close the async iterator and release any underlying resources."""
 
 
 @dataclass(frozen=True)
@@ -138,25 +131,10 @@ def stream_with_tool_execution_identity[ChunkT](
     stream_factory: Callable[[], AsyncIterator[ChunkT]],
 ) -> AsyncIterator[ChunkT]:
     """Wrap one async iterator without spanning execution-identity tokens across yields."""
-
-    async def wrapped_stream() -> AsyncIterator[ChunkT]:
-        stream: AsyncIterator[ChunkT] | None = None
-        try:
-            with tool_execution_identity(identity):
-                stream = stream_factory()
-            while True:
-                try:
-                    with tool_execution_identity(identity):
-                        chunk = await anext(stream)
-                except StopAsyncIteration:
-                    return
-                yield chunk
-        finally:
-            if isinstance(stream, (AsyncGeneratorABC, _AsyncClosableIterator)):
-                with tool_execution_identity(identity):
-                    await stream.aclose()
-
-    return wrapped_stream()
+    return context_bound_async_stream(
+        context_factory=lambda: tool_execution_identity(identity),
+        stream_factory=stream_factory,
+    )
 
 
 def _normalize_worker_key_part(value: str) -> str:

--- a/tach.toml
+++ b/tach.toml
@@ -1688,7 +1688,17 @@ path = "mindroom.tool_system.runtime_context"
 depends_on = [
     "mindroom.hooks",
     "mindroom.scheduling",
+    "mindroom.tool_system.context_bound_streams",
     "mindroom.tool_system.plugin_identity",
+    "mindroom.tool_system.worker_routing",
+]
+
+[[modules]]
+path = "mindroom.tool_system.context_bound_streams"
+depends_on = []
+visibility = [
+    "mindroom.llm_request_logging",
+    "mindroom.tool_system.runtime_context",
     "mindroom.tool_system.worker_routing",
 ]
 
@@ -1748,6 +1758,7 @@ depends_on = ["mindroom.tool_system.plugin_imports"]
 path = "mindroom.tool_system.worker_routing"
 depends_on = [
     "mindroom.mcp.registry",
+    "mindroom.tool_system.context_bound_streams",
 ]
 
 [[modules]]

--- a/tests/test_context_bound_streams.py
+++ b/tests/test_context_bound_streams.py
@@ -1,0 +1,181 @@
+"""Tests for context-bound async stream helpers."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom.llm_request_logging import (
+    bind_llm_request_log_context,
+    current_llm_request_log_context,
+    stream_with_llm_request_log_context,
+)
+from mindroom.tool_system.context_bound_streams import context_bound_async_stream
+from mindroom.tool_system.worker_routing import (
+    ToolExecutionIdentity,
+    get_tool_execution_identity,
+    stream_with_tool_execution_identity,
+    tool_execution_identity,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+
+_STREAM_CONTEXT: ContextVar[str | None] = ContextVar("test_stream_context", default=None)
+
+
+@contextmanager
+def _bind_stream_context(value: str | None) -> Iterator[None]:
+    token = _STREAM_CONTEXT.set(value)
+    try:
+        yield
+    finally:
+        _STREAM_CONTEXT.reset(token)
+
+
+class _ClosableStream:
+    def __init__(self, values: list[str]) -> None:
+        self._values = values
+        self.observed_contexts: list[str | None] = []
+
+    def __aiter__(self) -> _ClosableStream:
+        return self
+
+    async def __anext__(self) -> str:
+        if not self._values:
+            raise StopAsyncIteration
+        self.observed_contexts.append(_STREAM_CONTEXT.get())
+        return self._values.pop(0)
+
+    async def aclose(self) -> None:
+        self.observed_contexts.append(_STREAM_CONTEXT.get())
+
+
+class _ClosableIdentityStream:
+    def __init__(self, values: list[str]) -> None:
+        self._values = values
+        self.observed_identities: list[ToolExecutionIdentity | None] = []
+
+    def __aiter__(self) -> _ClosableIdentityStream:
+        return self
+
+    async def __anext__(self) -> str:
+        if not self._values:
+            raise StopAsyncIteration
+        self.observed_identities.append(get_tool_execution_identity())
+        return self._values.pop(0)
+
+    async def aclose(self) -> None:
+        self.observed_identities.append(get_tool_execution_identity())
+
+
+class _ClosableRequestLogStream:
+    def __init__(self, values: list[str]) -> None:
+        self._values = values
+        self.observed_contexts: list[dict[str, object]] = []
+
+    def __aiter__(self) -> _ClosableRequestLogStream:
+        return self
+
+    async def __anext__(self) -> str:
+        if not self._values:
+            raise StopAsyncIteration
+        self.observed_contexts.append(current_llm_request_log_context())
+        return self._values.pop(0)
+
+    async def aclose(self) -> None:
+        self.observed_contexts.append(current_llm_request_log_context())
+
+
+def _identity(agent_name: str) -> ToolExecutionIdentity:
+    return ToolExecutionIdentity(
+        channel="matrix",
+        agent_name=agent_name,
+        requester_id=f"@{agent_name}:example.com",
+        room_id="!room:example.com",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=f"{agent_name}-session",
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_bound_async_stream_binds_factory_next_and_close_without_spanning_yields() -> None:
+    """The wrapper should bind context only while touching the wrapped stream."""
+    source = _ClosableStream(["first", "second"])
+    observed_factory_contexts: list[str | None] = []
+    observed_yield_contexts: list[str | None] = []
+
+    def factory() -> AsyncIterator[str]:
+        observed_factory_contexts.append(_STREAM_CONTEXT.get())
+        return source
+
+    with _bind_stream_context("outer"):
+        stream = context_bound_async_stream(
+            context_factory=lambda: _bind_stream_context("inner"),
+            stream_factory=factory,
+        )
+        observed_yield_contexts.append(_STREAM_CONTEXT.get())
+        assert await anext(stream) == "first"
+        observed_yield_contexts.append(_STREAM_CONTEXT.get())
+        await stream.aclose()
+        observed_yield_contexts.append(_STREAM_CONTEXT.get())
+
+    assert observed_factory_contexts == ["inner"]
+    assert source.observed_contexts == ["inner", "inner"]
+    assert observed_yield_contexts == ["outer", "outer", "outer"]
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_identity_stream_binds_factory_next_and_close_without_spanning_yields() -> None:
+    """Tool execution streams should not leak their identity into caller yield points."""
+    inner_identity = _identity("inner")
+    outer_identity = _identity("outer")
+    source = _ClosableIdentityStream(["first", "second"])
+    observed_factory_identities: list[ToolExecutionIdentity | None] = []
+    observed_yield_identities: list[ToolExecutionIdentity | None] = []
+
+    def factory() -> AsyncIterator[str]:
+        observed_factory_identities.append(get_tool_execution_identity())
+        return source
+
+    with tool_execution_identity(outer_identity):
+        stream = stream_with_tool_execution_identity(inner_identity, stream_factory=factory)
+        observed_yield_identities.append(get_tool_execution_identity())
+        assert await anext(stream) == "first"
+        observed_yield_identities.append(get_tool_execution_identity())
+        await stream.aclose()
+        observed_yield_identities.append(get_tool_execution_identity())
+
+    assert observed_factory_identities == [inner_identity]
+    assert source.observed_identities == [inner_identity, inner_identity]
+    assert observed_yield_identities == [outer_identity, outer_identity, outer_identity]
+
+
+@pytest.mark.asyncio
+async def test_llm_request_log_stream_binds_next_and_close_without_spanning_yields() -> None:
+    """Request-log streams should bind request context only while touching the stream."""
+    source = _ClosableRequestLogStream(["first", "second"])
+    observed_yield_contexts: list[dict[str, object]] = []
+
+    with bind_llm_request_log_context(correlation_id="outer"):
+        stream = stream_with_llm_request_log_context(
+            source,
+            request_context={"correlation_id": "inner"},
+        )
+        observed_yield_contexts.append(current_llm_request_log_context())
+        assert await anext(stream) == "first"
+        observed_yield_contexts.append(current_llm_request_log_context())
+        await stream.aclose()
+        observed_yield_contexts.append(current_llm_request_log_context())
+
+    assert source.observed_contexts == [{"correlation_id": "inner"}, {"correlation_id": "inner"}]
+    assert observed_yield_contexts == [
+        {"correlation_id": "outer"},
+        {"correlation_id": "outer"},
+        {"correlation_id": "outer"},
+    ]


### PR DESCRIPTION
## Summary
- Add a narrow `context_bound_async_stream` helper for context-manager-bound async stream factories, pulls, and closes.
- Delegate tool runtime, worker execution identity, and LLM request logging stream wrappers to the shared helper.
- Add characterization tests for context binding and early close behavior.

## Verification
- `uv sync --all-extras`
- `uv run pytest tests/test_context_bound_streams.py -q -n 0 --no-cov`
- `uv run pytest tests/test_llm_request_logging.py tests/test_ai_user_id.py::test_stream_with_request_log_context_closes_wrapped_stream_on_early_close tests/test_ai_user_id.py::TestUserIdPassthrough::test_execution_identity_stream_factory_masks_outer_context tests/test_ai_user_id.py::TestUserIdPassthrough::test_tool_runtime_stream_factory_masks_outer_context -q -n 0 --no-cov`
- `uv run pytest tests/test_context_bound_streams.py tests/test_llm_request_logging.py tests/test_ai_user_id.py::test_stream_with_request_log_context_closes_wrapped_stream_on_early_close tests/test_ai_user_id.py::TestUserIdPassthrough::test_execution_identity_stream_factory_masks_outer_context tests/test_ai_user_id.py::TestUserIdPassthrough::test_tool_runtime_stream_factory_masks_outer_context -q -n 0 --no-cov`
- `uv run ruff check src/mindroom/tool_system/context_bound_streams.py src/mindroom/tool_system/runtime_context.py src/mindroom/tool_system/worker_routing.py src/mindroom/llm_request_logging.py tests/test_context_bound_streams.py`
- `uv run pre-commit run --files tach.toml src/mindroom/tool_system/context_bound_streams.py src/mindroom/tool_system/runtime_context.py src/mindroom/tool_system/worker_routing.py src/mindroom/llm_request_logging.py tests/test_context_bound_streams.py`
- `uv run tach check --dependencies --interfaces`
- `uv run pytest -q -n 0 --no-cov`

## Line Gate
Production delta: 65 insertions / 84 deletions, net -19 production lines.