### PR TITLE
Refactor file/coding path safety helpers

### DIFF
--- a/src/mindroom/custom_tools/coding.py
+++ b/src/mindroom/custom_tools/coding.py
@@ -20,10 +20,22 @@ import shutil
 import subprocess
 import unicodedata
 from dataclasses import dataclass
-from glob import has_magic
 from pathlib import Path
 
 from agno.tools import Toolkit
+
+from mindroom.tools.path_safety import (
+    format_path_for_output as _relativize_path,
+)
+from mindroom.tools.path_safety import (
+    is_within_base_dir,
+)
+from mindroom.tools.path_safety import (
+    resolve_base_dir_path as _resolve_path,
+)
+from mindroom.tools.path_safety import (
+    split_search_pattern as _normalize_search_root,
+)
 
 _MAX_LINES = 2000
 _MAX_BYTES = 50 * 1024  # 50KB
@@ -339,32 +351,6 @@ def _make_diff(
     return "\n".join(diff_lines)
 
 
-def _outside_base_dir_message(path: str, resolved: Path, base_dir: Path) -> str:
-    """Explain why a path was blocked by the base-dir restriction."""
-    return (
-        f"Path '{path}' resolves to '{resolved}', which is outside base_dir '{base_dir}'. "
-        "Set restrict_to_base_dir=false to allow access outside base_dir."
-    )
-
-
-def _resolve_path(base_dir: Path, path: str, restrict_to_base_dir: bool = True) -> Path:
-    """Resolve a path relative to base_dir, optionally preventing traversal."""
-    p = Path(path)
-    if not p.is_absolute():
-        p = base_dir / p
-    resolved = p.resolve()
-    if not restrict_to_base_dir:
-        return resolved
-
-    base_resolved = base_dir.resolve()
-    try:
-        resolved.relative_to(base_resolved)
-    except ValueError:
-        msg = _outside_base_dir_message(path, resolved, base_resolved)
-        raise ValueError(msg) from None
-    return resolved
-
-
 def _is_git_repo(base_dir: Path) -> bool:
     """Check whether base_dir is inside a git working tree."""
     current = base_dir.resolve()
@@ -544,20 +530,6 @@ def _resolve_and_read(base_dir: Path, path: str, restrict_to_base_dir: bool = Tr
         return resolved, resolved.read_text(encoding="utf-8", errors="replace")
     except OSError as e:
         return f"Error reading file: {e}"
-
-
-def _normalize_search_root(search_path: Path, pattern: str) -> tuple[Path, str]:
-    """Resolve parent-traversal prefixes out of a glob pattern."""
-    parts = list(Path(pattern).parts)
-    first_glob_index = next((index for index, part in enumerate(parts) if has_magic(part)), len(parts))
-    static_parts = parts[:first_glob_index]
-    glob_parts = parts[first_glob_index:]
-    if not glob_parts and static_parts:
-        glob_parts = [static_parts.pop()]
-
-    normalized_root = search_path.joinpath(*static_parts).resolve()
-    normalized_pattern = str(Path(*glob_parts)) if glob_parts else "."
-    return normalized_root, normalized_pattern
 
 
 class CodingTools(Toolkit):
@@ -897,14 +869,6 @@ def _run_ripgrep(
     return _format_rg_output(result.stdout, limit, context, base_dir)
 
 
-def _relativize_path(path_text: str, base_dir: Path) -> str:
-    """Make an absolute path relative to base_dir for consistent output."""
-    try:
-        return str(Path(path_text).relative_to(base_dir))
-    except ValueError:
-        return path_text
-
-
 def _format_rg_line(event: _RgEvent, base_dir: Path) -> str:
     """Format a ripgrep event as one output line."""
     marker = ":" if event.event_type == "match" else "-"
@@ -1054,21 +1018,14 @@ def _filter_hidden_and_ignored(files: list[Path], search_path: Path) -> list[Pat
     search_root = search_path.resolve()
     visible: list[Path] = []
     for filepath in files:
-        try:
-            resolved = filepath.resolve()
-        except OSError:
-            continue
-        try:
-            resolved.relative_to(search_root)
-        except ValueError:
-            # Ignore files reached through symlinks that escape the search root.
+        if not is_within_base_dir(filepath, search_root):
             continue
         if not filepath.is_file():
             continue
         try:
             rel = filepath.relative_to(search_path)
         except ValueError:
-            rel = resolved
+            rel = filepath.resolve()
         if any(part.startswith(".") for part in rel.parts):
             continue
         visible.append(filepath)

--- a/src/mindroom/custom_tools/coding.py
+++ b/src/mindroom/custom_tools/coding.py
@@ -25,16 +25,10 @@ from pathlib import Path
 from agno.tools import Toolkit
 
 from mindroom.tools.path_safety import (
-    format_path_for_output as _relativize_path,
-)
-from mindroom.tools.path_safety import (
+    format_path_for_output,
     is_within_base_dir,
-)
-from mindroom.tools.path_safety import (
-    resolve_base_dir_path as _resolve_path,
-)
-from mindroom.tools.path_safety import (
-    split_search_pattern as _normalize_search_root,
+    resolve_base_dir_path,
+    split_search_pattern,
 )
 
 _MAX_LINES = 2000
@@ -517,7 +511,7 @@ def _find_files_in(
 def _resolve_and_read(base_dir: Path, path: str, restrict_to_base_dir: bool = True) -> tuple[Path, str] | str:
     """Resolve path and read file content. Returns (resolved, content) or error string."""
     try:
-        resolved = _resolve_path(base_dir, path, restrict_to_base_dir)
+        resolved = resolve_base_dir_path(base_dir, path, restrict_to_base_dir)
     except ValueError as e:
         return f"Error: {e}"
 
@@ -630,7 +624,7 @@ class CodingTools(Toolkit):
 
         """
         try:
-            resolved = _resolve_path(self.base_dir, path, self.restrict_to_base_dir)
+            resolved = resolve_base_dir_path(self.base_dir, path, self.restrict_to_base_dir)
         except ValueError as e:
             return f"Error: {e}"
 
@@ -673,12 +667,14 @@ class CodingTools(Toolkit):
 
         """
         try:
-            search_path = _resolve_path(self.base_dir, path, self.restrict_to_base_dir) if path else self.base_dir
+            search_path = (
+                resolve_base_dir_path(self.base_dir, path, self.restrict_to_base_dir) if path else self.base_dir
+            )
         except ValueError as e:
             return f"Error: {e}"
         effective_glob = glob
         if not self.restrict_to_base_dir and glob is not None:
-            normalized_path, normalized_glob = _normalize_search_root(search_path, glob)
+            normalized_path, normalized_glob = split_search_pattern(search_path, glob)
             if normalized_path.exists():
                 search_path = normalized_path
                 effective_glob = normalized_glob
@@ -732,12 +728,14 @@ class CodingTools(Toolkit):
 
         """
         try:
-            search_path = _resolve_path(self.base_dir, path, self.restrict_to_base_dir) if path else self.base_dir
+            search_path = (
+                resolve_base_dir_path(self.base_dir, path, self.restrict_to_base_dir) if path else self.base_dir
+            )
         except ValueError as e:
             return f"Error: {e}"
         search_pattern = pattern
         if not self.restrict_to_base_dir:
-            normalized_path, normalized_pattern = _normalize_search_root(search_path, pattern)
+            normalized_path, normalized_pattern = split_search_pattern(search_path, pattern)
             if normalized_path.exists():
                 search_path = normalized_path
                 search_pattern = normalized_pattern
@@ -768,7 +766,7 @@ class CodingTools(Toolkit):
 
         """
         try:
-            target = _resolve_path(self.base_dir, path, self.restrict_to_base_dir) if path else self.base_dir
+            target = resolve_base_dir_path(self.base_dir, path, self.restrict_to_base_dir) if path else self.base_dir
         except ValueError as e:
             return f"Error: {e}"
 
@@ -872,7 +870,7 @@ def _run_ripgrep(
 def _format_rg_line(event: _RgEvent, base_dir: Path) -> str:
     """Format a ripgrep event as one output line."""
     marker = ":" if event.event_type == "match" else "-"
-    rel_path = _relativize_path(event.path_text, base_dir)
+    rel_path = format_path_for_output(event.path_text, base_dir)
     return f"{rel_path}{marker}{event.line_number}{marker}{_truncate_line(event.line_text.rstrip())}"
 
 

--- a/src/mindroom/oauth/client.py
+++ b/src/mindroom/oauth/client.py
@@ -15,6 +15,7 @@ from google.oauth2 import credentials as google_credentials
 from mindroom.credentials import load_scoped_credentials, save_scoped_credentials
 from mindroom.oauth.providers import OAuthConnectionRequired, OAuthProvider, oauth_connection_required_payload
 from mindroom.oauth.service import (
+    build_oauth_connect_instruction,
     oauth_connect_url,
     oauth_credentials_have_required_scopes,
     oauth_credentials_match_client_id,
@@ -145,9 +146,10 @@ class ScopedOAuthClientMixin:
             self._runtime_paths,
             worker_target=self._worker_target,
         )
-        message = (
-            f"{self._oauth_provider.display_name} is not connected for this agent. "
-            f"Open this MindRoom link to connect it, then retry the request: {connect_url}"
+        message = build_oauth_connect_instruction(
+            self._oauth_provider,
+            self._runtime_paths,
+            worker_target=self._worker_target,
         )
         return OAuthConnectionRequired(
             message,

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -297,7 +297,7 @@ def oauth_connect_url(
     provider: OAuthProvider,
     runtime_paths: RuntimePaths,
     *,
-    worker_target: ResolvedWorkerTarget | None,
+    worker_target: ResolvedWorkerTarget | None = None,
 ) -> str:
     """Return a browser-openable MindRoom OAuth link for one credential scope."""
     agent_name = worker_target.routing_agent_name if worker_target is not None else None
@@ -316,7 +316,7 @@ def build_oauth_connect_instruction(
     provider: OAuthProvider,
     runtime_paths: RuntimePaths,
     *,
-    worker_target: ResolvedWorkerTarget | None,
+    worker_target: ResolvedWorkerTarget | None = None,
 ) -> str:
     """Return a concise user-facing connection instruction for a tool result."""
     connect_url = oauth_connect_url(

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -15,7 +15,7 @@ from zoneinfo import ZoneInfo
 import humanize
 import nio
 from agno.agent import Agent
-from cron_descriptor import get_description
+from cron_descriptor import Options, get_description
 from croniter import CroniterError, croniter
 from pydantic import BaseModel, Field
 
@@ -114,7 +114,8 @@ class CronSchedule(BaseModel):
         """Convert cron schedule to natural language description."""
         try:
             cron_str = self.to_cron_string()
-            return str(get_description(cron_str))
+            options = Options(use_24hour_time_format=True)
+            return str(get_description(cron_str, options))
         except Exception:
             return f"Cron: {self.to_cron_string()}"
 

--- a/src/mindroom/tools/file.py
+++ b/src/mindroom/tools/file.py
@@ -18,19 +18,11 @@ from mindroom.tool_system.metadata import (
     register_tool_with_metadata,
 )
 from mindroom.tools.path_safety import (
-    blocked_file_action_message as _blocked_path_message,
-)
-from mindroom.tools.path_safety import (
-    format_path_for_output as _format_path_for_output,
-)
-from mindroom.tools.path_safety import (
-    is_within_base_dir as _is_within_base_dir,
-)
-from mindroom.tools.path_safety import (
+    blocked_file_action_message,
+    format_path_for_output,
+    is_within_base_dir,
     resolve_base_dir_path,
-)
-from mindroom.tools.path_safety import (
-    split_search_pattern as _split_search_pattern,
+    split_search_pattern,
 )
 
 
@@ -87,7 +79,7 @@ class _MindRoomFileTools(AgnoFileTools):
             safe, file_path = self.check_escape(file_name)
             if not safe:
                 log_error(f"Attempted to save file: {file_name}")
-                return _blocked_path_message("saving file", file_name, self.base_dir)
+                return blocked_file_action_message("saving file", file_name, self.base_dir)
             log_debug(f"Saving contents to {file_path}")
             if not file_path.parent.exists():
                 file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -107,7 +99,7 @@ class _MindRoomFileTools(AgnoFileTools):
             safe, file_path = self.check_escape(file_name)
             if not safe:
                 log_error(f"Attempted to read file: {file_name}")
-                return _blocked_path_message("reading file", file_name, self.base_dir)
+                return blocked_file_action_message("reading file", file_name, self.base_dir)
             contents = file_path.read_text(encoding=encoding)
             lines = contents.split(self.line_separator)
             return self.line_separator.join(lines[start_line : end_line + 1])
@@ -129,7 +121,7 @@ class _MindRoomFileTools(AgnoFileTools):
             safe, file_path = self.check_escape(file_name)
             if not safe:
                 log_error(f"Attempted to replace file chunk: {file_name}")
-                return _blocked_path_message("replacing file chunk", file_name, self.base_dir)
+                return blocked_file_action_message("replacing file chunk", file_name, self.base_dir)
             contents = file_path.read_text(encoding=encoding)
             lines = contents.split(self.line_separator)
             start = lines[0:start_line]
@@ -150,7 +142,7 @@ class _MindRoomFileTools(AgnoFileTools):
             safe, file_path = self.check_escape(file_name)
             if not safe:
                 log_error(f"Attempted to read file: {file_name}")
-                return _blocked_path_message("reading file", file_name, self.base_dir)
+                return blocked_file_action_message("reading file", file_name, self.base_dir)
             contents = file_path.read_text(encoding=encoding)
             if len(contents) > self.max_file_length:
                 return "Error reading file: file too long. Use read_file_chunk instead"
@@ -172,7 +164,7 @@ class _MindRoomFileTools(AgnoFileTools):
                 path.unlink()
                 return ""
             log_error(f"Attempt to delete file outside {self.base_dir}: {file_name}")
-            return _blocked_path_message("removing file", file_name, self.base_dir)
+            return blocked_file_action_message("removing file", file_name, self.base_dir)
         except Exception as e:
             log_error(f"Error removing {file_name}: {e}")
             return f"Error removing file: {e}"
@@ -184,9 +176,9 @@ class _MindRoomFileTools(AgnoFileTools):
             log_debug(f"Reading files in : {self.base_dir}/{directory}")
             safe, resolved_directory = self.check_escape(str(directory))
             if not safe:
-                return _blocked_path_message("listing files", str(directory), self.base_dir)
+                return blocked_file_action_message("listing files", str(directory), self.base_dir)
             return json.dumps(
-                [_format_path_for_output(file_path, self.base_dir) for file_path in resolved_directory.iterdir()],
+                [format_path_for_output(file_path, self.base_dir) for file_path in resolved_directory.iterdir()],
                 indent=4,
             )
         except Exception as e:
@@ -199,14 +191,14 @@ class _MindRoomFileTools(AgnoFileTools):
             if not pattern or not pattern.strip():
                 return "Error: Pattern cannot be empty"
 
-            search_root, glob_pattern = _split_search_pattern(self.base_dir, pattern)
-            if self.restrict_to_base_dir and not _is_within_base_dir(search_root, self.base_dir):
-                return _blocked_path_message("searching files", pattern, self.base_dir)
+            search_root, glob_pattern = split_search_pattern(self.base_dir, pattern)
+            if self.restrict_to_base_dir and not is_within_base_dir(search_root, self.base_dir):
+                return blocked_file_action_message("searching files", pattern, self.base_dir)
 
             log_debug(f"Searching files in {search_root} with pattern {glob_pattern}")
             matching_files = []
             for file_path in search_root.glob(glob_pattern):
-                if self.restrict_to_base_dir and not _is_within_base_dir(file_path, self.base_dir):
+                if self.restrict_to_base_dir and not is_within_base_dir(file_path, self.base_dir):
                     continue
                 matching_files.append(file_path)
             if self.expose_base_directory:
@@ -218,7 +210,7 @@ class _MindRoomFileTools(AgnoFileTools):
                     "files": file_paths,
                 }
             else:
-                file_paths = [_format_path_for_output(file_path, self.base_dir) for file_path in matching_files]
+                file_paths = [format_path_for_output(file_path, self.base_dir) for file_path in matching_files]
                 result = {
                     "pattern": pattern,
                     "matches_found": len(file_paths),

--- a/src/mindroom/tools/file.py
+++ b/src/mindroom/tools/file.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import json
-from glob import has_magic
-from pathlib import Path
+from pathlib import Path  # noqa: TC003 - toolkit introspection evaluates constructor annotations.
 from typing import Any, cast
 
 from agno.tools.file import FileTools as AgnoFileTools
@@ -18,52 +17,21 @@ from mindroom.tool_system.metadata import (
     ToolStatus,
     register_tool_with_metadata,
 )
-
-
-def _blocked_path_message(action: str, requested_path: str, base_dir: Path) -> str:
-    """Explain why a file-tool path was blocked."""
-    return (
-        f"Error {action}: path '{requested_path}' is outside base_dir '{base_dir}'. "
-        "Set restrict_to_base_dir=false to allow access outside base_dir."
-    )
-
-
-def _format_path_for_output(path: Path, base_dir: Path) -> str:
-    """Prefer base-dir-relative output, falling back to absolute paths outside the base dir."""
-    try:
-        return str(path.relative_to(base_dir))
-    except ValueError:
-        return str(path)
-
-
-def _is_within_base_dir(path: Path, base_dir: Path) -> bool:
-    """Check whether a resolved path stays within base_dir."""
-    try:
-        path.resolve().relative_to(base_dir.resolve())
-    except (OSError, ValueError):
-        return False
-    return True
-
-
-def _split_search_pattern(base_dir: Path, pattern: str) -> tuple[Path, str]:
-    """Resolve the concrete search root ahead of the first glob component."""
-    pattern_path = Path(pattern)
-    if pattern_path.is_absolute():
-        search_root = Path(pattern_path.anchor)
-        parts = list(pattern_path.relative_to(search_root).parts)
-    else:
-        search_root = base_dir
-        parts = list(pattern_path.parts)
-
-    first_glob_index = next((index for index, part in enumerate(parts) if has_magic(part)), len(parts))
-    static_parts = parts[:first_glob_index]
-    glob_parts = parts[first_glob_index:]
-    if not glob_parts and static_parts:
-        glob_parts = [static_parts.pop()]
-
-    resolved_root = search_root.joinpath(*static_parts).resolve()
-    resolved_pattern = str(Path(*glob_parts)) if glob_parts else "."
-    return resolved_root, resolved_pattern
+from mindroom.tools.path_safety import (
+    blocked_file_action_message as _blocked_path_message,
+)
+from mindroom.tools.path_safety import (
+    format_path_for_output as _format_path_for_output,
+)
+from mindroom.tools.path_safety import (
+    is_within_base_dir as _is_within_base_dir,
+)
+from mindroom.tools.path_safety import (
+    resolve_base_dir_path,
+)
+from mindroom.tools.path_safety import (
+    split_search_pattern as _split_search_pattern,
+)
 
 
 class _MindRoomFileTools(AgnoFileTools):
@@ -107,11 +75,11 @@ class _MindRoomFileTools(AgnoFileTools):
 
     def check_escape(self, relative_path: str) -> tuple[bool, Path]:
         """Check whether a path stays within base_dir when restriction is enabled."""
-        return self._check_path(
-            relative_path,
-            self.base_dir,
-            restrict_to_base_dir=self.restrict_to_base_dir,
-        )
+        try:
+            return True, resolve_base_dir_path(self.base_dir, relative_path, self.restrict_to_base_dir)
+        except ValueError:
+            log_error(f"Path escapes base directory: {relative_path}")
+            return False, self.base_dir
 
     def save_file(self, contents: str, file_name: str, overwrite: bool = True, encoding: str = "utf-8") -> str:
         """Save content to a file, with clear blocked-path errors."""

--- a/src/mindroom/tools/path_safety.py
+++ b/src/mindroom/tools/path_safety.py
@@ -1,0 +1,72 @@
+"""Shared path-safety helpers for local file-oriented tools."""
+
+from __future__ import annotations
+
+from glob import has_magic
+from pathlib import Path
+
+_BASE_DIR_ESCAPE_HINT = "Set restrict_to_base_dir=false to allow access outside base_dir."
+
+
+def _blocked_base_dir_message(path: str, resolved: Path, base_dir: Path) -> str:
+    """Explain why a resolved path escaped the configured base directory."""
+    return f"Path '{path}' resolves to '{resolved}', which is outside base_dir '{base_dir}'. {_BASE_DIR_ESCAPE_HINT}"
+
+
+def blocked_file_action_message(action: str, requested_path: str, base_dir: Path) -> str:
+    """Explain why a file-tool action was blocked."""
+    return f"Error {action}: path '{requested_path}' is outside base_dir '{base_dir}'. {_BASE_DIR_ESCAPE_HINT}"
+
+
+def format_path_for_output(path: str | Path, base_dir: Path) -> str:
+    """Prefer base-dir-relative output, falling back to absolute paths outside the base dir."""
+    try:
+        return str(Path(path).relative_to(base_dir))
+    except ValueError:
+        return str(path)
+
+
+def is_within_base_dir(path: Path, base_dir: Path) -> bool:
+    """Check whether a resolved path stays within base_dir."""
+    try:
+        path.resolve().relative_to(base_dir.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def resolve_base_dir_path(base_dir: Path, path: str, restrict_to_base_dir: bool = True) -> Path:
+    """Resolve a path relative to base_dir, optionally preventing traversal."""
+    requested = Path(path)
+    candidate = requested if requested.is_absolute() else base_dir / requested
+    resolved = candidate.resolve()
+    if not restrict_to_base_dir:
+        return resolved
+
+    base_resolved = base_dir.resolve()
+    try:
+        resolved.relative_to(base_resolved)
+    except ValueError:
+        raise ValueError(_blocked_base_dir_message(path, resolved, base_resolved)) from None
+    return resolved
+
+
+def split_search_pattern(base_dir: Path, pattern: str) -> tuple[Path, str]:
+    """Resolve the concrete search root ahead of the first glob component."""
+    pattern_path = Path(pattern)
+    if pattern_path.is_absolute():
+        search_root = Path(pattern_path.anchor)
+        parts = list(pattern_path.relative_to(search_root).parts)
+    else:
+        search_root = base_dir
+        parts = list(pattern_path.parts)
+
+    first_glob_index = next((index for index, part in enumerate(parts) if has_magic(part)), len(parts))
+    static_parts = parts[:first_glob_index]
+    glob_parts = parts[first_glob_index:]
+    if not glob_parts and static_parts:
+        glob_parts = [static_parts.pop()]
+
+    resolved_root = search_root.joinpath(*static_parts).resolve()
+    resolved_pattern = str(Path(*glob_parts)) if glob_parts else "."
+    return resolved_root, resolved_pattern

--- a/tests/test_coding_tools.py
+++ b/tests/test_coding_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from typing import TYPE_CHECKING
 
@@ -17,6 +18,12 @@ from mindroom.custom_tools.coding import (
     _truncate_line,
 )
 from mindroom.tools.file import file_tools
+from mindroom.tools.path_safety import (
+    _blocked_base_dir_message,
+    format_path_for_output,
+    resolve_base_dir_path,
+    split_search_pattern,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -1024,6 +1031,52 @@ class TestPathTraversal:
         """Tilde paths are not expanded and treated as literal relative paths."""
         result = tools.read_file("~/../../etc/passwd")
         assert "Error" in result
+
+
+class TestPathSafetyHelpers:
+    """Characterization tests for shared file/coding path helpers."""
+
+    def test_resolve_base_dir_path_preserves_coding_blocked_message(self, tmp_path: Path) -> None:
+        """Blocked path resolution should keep the coding-tool error text."""
+        base_dir = tmp_path / "base"
+        outside_dir = tmp_path / "outside"
+        base_dir.mkdir()
+        outside_dir.mkdir()
+        outside_file = outside_dir / "secret.txt"
+        outside_file.write_text("secret\n")
+
+        expected = _blocked_base_dir_message(str(outside_file), outside_file, base_dir)
+        with pytest.raises(ValueError, match=re.escape(expected)) as exc_info:
+            resolve_base_dir_path(base_dir, str(outside_file))
+
+        assert str(exc_info.value) == expected
+
+    def test_format_path_for_output_prefers_base_relative_paths(self, tmp_path: Path) -> None:
+        """Output formatting should use relative paths only inside base_dir."""
+        base_dir = tmp_path / "base"
+        outside_dir = tmp_path / "outside"
+        base_file = base_dir / "src" / "app.py"
+        outside_file = outside_dir / "secret.txt"
+        base_file.parent.mkdir(parents=True)
+        outside_dir.mkdir()
+
+        assert format_path_for_output(base_file, base_dir) == "src/app.py"
+        assert format_path_for_output(outside_file, base_dir) == str(outside_file)
+
+    def test_split_search_pattern_preserves_absolute_and_parent_traversal_patterns(self, tmp_path: Path) -> None:
+        """Glob-root splitting should preserve existing absolute and ../ behavior."""
+        base_dir = tmp_path / "base"
+        outside_dir = tmp_path / "outside"
+        base_dir.mkdir()
+        outside_dir.mkdir()
+
+        absolute_root, absolute_pattern = split_search_pattern(base_dir, str(outside_dir / "*.txt"))
+        parent_root, parent_pattern = split_search_pattern(base_dir, "../outside/*.txt")
+
+        assert absolute_root == outside_dir.resolve()
+        assert absolute_pattern == "*.txt"
+        assert parent_root == outside_dir.resolve()
+        assert parent_pattern == "*.txt"
 
 
 class TestRestrictToBaseDir:


### PR DESCRIPTION
## Summary
- Extract shared file/coding path safety helpers into `src/mindroom/tools/path_safety.py`
- Reuse the shared helpers from file and coding tools while preserving existing blocked-path messages and output formatting
- Add characterization tests for blocked path messages, base-dir relative formatting, and search glob splitting

## Verification
- `uv run pytest tests/test_coding_tools.py::TestPathSafetyHelpers -q -n 0 --no-cov` - 3 passed
- `uv run pytest tests/test_coding_tools.py -q -n 0 --no-cov` - 118 passed
- `uv run pytest -q -n 0 --no-cov` - 1 failed, 6260 passed, 56 skipped; failure was `tests/test_tool_config_sync.py::test_all[file]` with `NameError: name 'Path' is not defined`
- `uv run pytest 'tests/test_tool_config_sync.py::test_all[file]' -q -n 0 --no-cov` - 1 passed after restoring runtime `Path` import for toolkit introspection
- `uv run pytest tests/test_coding_tools.py 'tests/test_tool_config_sync.py::test_all[file]' -q -n 0 --no-cov` - 119 passed
- `uv run pre-commit run --files src/mindroom/tools/path_safety.py src/mindroom/tools/file.py src/mindroom/custom_tools/coding.py tests/test_coding_tools.py` - passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cron schedules now display time descriptions using 24-hour format for improved readability.

* **Improvements**
  * Enhanced path validation and security across file operations with clearer error messages.
  * Refined OAuth connection error messages for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->