### PR TITLE
refactor: share runtime config persistence helper

### DIFF
--- a/src/mindroom/api/config_lifecycle.py
+++ b/src/mindroom/api/config_lifecycle.py
@@ -217,7 +217,7 @@ def _save_raw_config_source_to_file(
     constants.safe_replace(tmp_path, config_path)
 
 
-def persist_runtime_validated_config(
+def _persist_runtime_validated_config(
     runtime_config: Config,
     runtime_paths: constants.RuntimePaths,
 ) -> None:
@@ -254,6 +254,16 @@ def _validated_config_payload(
     """Normalize and validate one config payload against the active runtime."""
     validated_config = Config.validate_with_runtime(raw_config, runtime_paths)
     return validated_config, validated_config.authored_model_dump()
+
+
+def validate_and_persist_config_payload(
+    raw_config: dict[str, Any],
+    runtime_paths: constants.RuntimePaths,
+) -> Config:
+    """Validate and persist one authored config payload against the active runtime."""
+    validated_config, _ = _validated_config_payload(raw_config, runtime_paths)
+    _persist_runtime_validated_config(validated_config, runtime_paths)
+    return validated_config
 
 
 def register_api_app(api_app: FastAPI) -> None:

--- a/src/mindroom/commands/config_commands.py
+++ b/src/mindroom/commands/config_commands.py
@@ -142,11 +142,6 @@ def _parse_value(value_str: str) -> Any:  # noqa: ANN401
     return value_str
 
 
-def _validate_config_dict(config_dict: dict[str, Any], runtime_paths: RuntimePaths) -> Config:
-    """Validate one config payload against the active runtime context."""
-    return Config.validate_with_runtime(config_dict, runtime_paths)
-
-
 def _format_value(value: Any) -> str:  # noqa: ANN401
     """Format a value for display as YAML.
 
@@ -245,7 +240,7 @@ async def handle_config_command(  # noqa: C901, PLR0911, PLR0912
             _set_nested_value(test_config_dict, config_path_str, value)
 
             # Validate the modified config
-            _validate_config_dict(test_config_dict, runtime_paths)
+            Config.validate_with_runtime(test_config_dict, runtime_paths)
         except (KeyError, IndexError) as e:
             return f"❌ Configuration path error: `{config_path_str}`\nError: {e}", None
         except (ValidationError, ConfigRuntimeValidationError) as e:
@@ -328,14 +323,11 @@ async def apply_config_change(
         # Apply the specific change
         _set_nested_value(config_dict, config_path_str, new_value)
 
-        # Validate the modified config
         try:
-            new_config = _validate_config_dict(config_dict, runtime_paths)
+            config_lifecycle.validate_and_persist_config_payload(config_dict, runtime_paths)
         except (ValidationError, ConfigRuntimeValidationError) as ve:
             return format_invalid_config_message(ve, footer=_CONFIG_CHANGE_REJECTED_MESSAGE)
 
-        # Save to file and advance any in-process API snapshot immediately.
-        config_lifecycle.persist_runtime_validated_config(new_config, runtime_paths)
         return (  # noqa: TRY300
             f"✅ **Configuration updated successfully!**\n\n"
             f"Changes saved to {path} and will affect new agent interactions."

--- a/src/mindroom/custom_tools/config_manager.py
+++ b/src/mindroom/custom_tools/config_manager.py
@@ -11,7 +11,7 @@ import yaml
 from agno.tools import Toolkit
 from pydantic import ValidationError
 
-from mindroom.api import config_lifecycle
+from mindroom.api.config_lifecycle import validate_and_persist_config_payload
 from mindroom.authorization import get_available_agents_in_room
 from mindroom.commands.parsing import get_command_help
 from mindroom.config.agent import AgentConfig, TeamConfig
@@ -78,12 +78,6 @@ def validate_knowledge_bases(
     if not available:
         return f"Error: Unknown knowledge bases: {invalid}. No knowledge bases are configured."
     return f"Error: Unknown knowledge bases: {invalid}. Available knowledge bases: {available}."
-
-
-def save_runtime_validated_config(config: Config, runtime_paths: RuntimePaths) -> None:
-    """Revalidate the full config against the active runtime before writing it."""
-    validated = Config.validate_with_runtime(config.authored_model_dump(), runtime_paths)
-    config_lifecycle.persist_runtime_validated_config(validated, runtime_paths)
 
 
 class _InfoType(str, Enum):
@@ -644,7 +638,7 @@ class ConfigManagerTools(Toolkit):
             config.agents[agent_name] = new_agent
 
             # Save config
-            save_runtime_validated_config(config, self.runtime_paths)
+            validate_and_persist_config_payload(config.authored_model_dump(), self.runtime_paths)
 
             # Build success message
             tools_str = ", ".join(tools) if tools else "None"
@@ -759,7 +753,7 @@ class ConfigManagerTools(Toolkit):
                 return "No changes made. All provided values are the same as current configuration."
 
             # Save config
-            save_runtime_validated_config(config, self.runtime_paths)
+            validate_and_persist_config_payload(config.authored_model_dump(), self.runtime_paths)
 
             return f"✅ Successfully updated agent '{agent_name}'!\n\n**Changes:**\n" + "\n".join(
                 f"- {c}" for c in changes
@@ -808,7 +802,7 @@ class ConfigManagerTools(Toolkit):
             config.teams[team_name] = new_team
 
             # Save config
-            save_runtime_validated_config(config, self.runtime_paths)
+            validate_and_persist_config_payload(config.authored_model_dump(), self.runtime_paths)
 
             return (
                 f"✅ Successfully created team '{team_name}'!\n\n"

--- a/src/mindroom/custom_tools/self_config.py
+++ b/src/mindroom/custom_tools/self_config.py
@@ -8,12 +8,12 @@ import yaml
 from agno.tools import Toolkit
 from pydantic import ValidationError
 
+from mindroom.api.config_lifecycle import validate_and_persist_config_payload
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import ConfigRuntimeValidationError, format_invalid_config_message, load_config_or_user_error
 from mindroom.config.models import AgentLearningMode  # noqa: TC001
 from mindroom.custom_tools.config_manager import (
     preserve_tool_overrides,
-    save_runtime_validated_config,
     validate_knowledge_bases,
 )
 from mindroom.logging_config import get_logger
@@ -208,7 +208,7 @@ class SelfConfigTools(Toolkit):
 
         config.agents[self.agent_name] = validated_agent
         try:
-            save_runtime_validated_config(config, self.runtime_paths)
+            validate_and_persist_config_payload(config.authored_model_dump(), self.runtime_paths)
         except (ValidationError, ConfigRuntimeValidationError) as exc:
             return format_invalid_config_message(exc, footer=_CONFIG_CHANGE_REJECTED_MESSAGE)
         except Exception as e:

--- a/tests/test_config_commands.py
+++ b/tests/test_config_commands.py
@@ -13,6 +13,7 @@ import pytest
 import yaml
 
 from mindroom import constants as constants_mod
+from mindroom.api import config_lifecycle
 from mindroom.commands.config_commands import (
     _format_value,
     _get_nested_value,
@@ -26,6 +27,7 @@ from mindroom.commands.config_confirmation import add_confirmation_reactions
 from mindroom.commands.handler import CommandHandlerContext, handle_command
 from mindroom.commands.parsing import Command, CommandType, _CommandParser
 from mindroom.config.auth import AuthorizationConfig
+from mindroom.config.main import Config, ConfigRuntimeValidationError
 from mindroom.constants import resolve_runtime_paths
 from mindroom.handled_turns import HandledTurnState
 from mindroom.hooks import HookRegistry
@@ -36,6 +38,50 @@ from tests.conftest import make_event_cache_mock
 
 def _runtime_paths_for_config(config_path: Path) -> constants_mod.RuntimePaths:
     return resolve_runtime_paths(config_path=config_path)
+
+
+def test_validate_and_persist_config_payload_validates_and_writes_authored_payload(tmp_path: Path) -> None:
+    """Runtime config payload persistence should validate before writing."""
+    config_path = tmp_path / "config.yaml"
+    runtime_paths = _runtime_paths_for_config(config_path)
+    config = Config(models={"default": {"provider": "openai", "id": "gpt-5.4"}})
+    config.save_to_yaml(config_path)
+    payload = config.authored_model_dump()
+    payload["agents"] = {
+        "writer": {
+            "display_name": "Writer",
+            "role": "Write docs",
+            "rooms": ["Lab"],
+        },
+    }
+
+    validated = config_lifecycle.validate_and_persist_config_payload(payload, runtime_paths)
+
+    assert validated.agents["writer"].display_name == "Writer"
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["agents"]["writer"]["rooms"] == ["Lab"]
+
+
+def test_validate_and_persist_config_payload_rejects_without_overwriting(tmp_path: Path) -> None:
+    """Runtime config payload persistence should leave the file untouched on validation failure."""
+    plugin_root = tmp_path / "plugins" / "bad-name"
+    plugin_root.mkdir(parents=True)
+    (plugin_root / "mindroom.plugin.json").write_text(
+        json.dumps({"name": "BadName", "tools_module": None, "skills": []}),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "config.yaml"
+    runtime_paths = _runtime_paths_for_config(config_path)
+    config = Config(models={"default": {"provider": "openai", "id": "gpt-5.4"}})
+    config.save_to_yaml(config_path)
+    original_source = config_path.read_text(encoding="utf-8")
+    payload = config.authored_model_dump()
+    payload["plugins"] = ["./plugins/bad-name"]
+
+    with pytest.raises(ConfigRuntimeValidationError):
+        config_lifecycle.validate_and_persist_config_payload(payload, runtime_paths)
+
+    assert config_path.read_text(encoding="utf-8") == original_source
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Move runtime config payload validate-and-persist behavior into `config_lifecycle.validate_and_persist_config_payload`.
- Reuse it from `!config` apply, config manager create/update/team writes, and self-config writes.
- Add characterization tests for successful persistence and failed validation leaving the config file untouched.

## Test Plan
- [x] `uv sync --all-extras`
- [x] `uv run pytest tests/test_config_commands.py tests/test_config_manager_consolidated.py tests/test_self_config.py -q -n 0 --no-cov`
- [x] `uv run tach check --dependencies --interfaces`
- [x] `uv run pre-commit run --files src/mindroom/api/config_lifecycle.py src/mindroom/commands/config_commands.py src/mindroom/custom_tools/config_manager.py src/mindroom/custom_tools/self_config.py tests/test_config_commands.py`
- [x] `uv run pytest -q -n 0 --no-cov`