### PR TITLE
refactor: share workspace home env fragment

### DIFF
--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -633,15 +633,7 @@ def _workspace_home_contract_env(
     prepared: sandbox_worker_prep.PreparedWorkerRequest | None,
 ) -> dict[str, str]:
     """Build the env contract for an already-resolved worker workspace."""
-    env = {
-        "HOME": str(workspace),
-        "MINDROOM_AGENT_WORKSPACE": str(workspace),
-        "XDG_CONFIG_HOME": str(workspace / ".config"),
-        "XDG_DATA_HOME": str(workspace / ".local" / "share"),
-        "XDG_STATE_HOME": str(workspace / ".local" / "state"),
-    }
-    env.update(_worker_owned_env(prepared))
-    return env
+    return constants.workspace_home_identity_env(workspace) | _worker_owned_env(prepared)
 
 
 def _worker_owned_env(prepared: sandbox_worker_prep.PreparedWorkerRequest | None) -> dict[str, str]:

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -181,6 +181,19 @@ WORKER_RUNTIME_ENV_NAMES = frozenset(
 WORKSPACE_HOME_CONTRACT_ENV_NAMES = _WORKSPACE_HOME_IDENTITY_ENV_NAMES | WORKER_RUNTIME_ENV_NAMES
 
 
+def workspace_home_identity_env(workspace: Path | str) -> dict[str, str]:
+    """Build the workspace HOME identity env fragment."""
+    workspace_text = str(workspace)
+    workspace_path = Path(workspace_text)
+    return {
+        "HOME": workspace_text,
+        "MINDROOM_AGENT_WORKSPACE": workspace_text,
+        "XDG_CONFIG_HOME": str(workspace_path / ".config"),
+        "XDG_DATA_HOME": str(workspace_path / ".local" / "share"),
+        "XDG_STATE_HOME": str(workspace_path / ".local" / "state"),
+    }
+
+
 def is_workspace_env_overlay_name_allowed(name: str) -> bool:
     """Return whether one env var name may be returned from `.mindroom/worker-env.sh`.
 

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -19,7 +19,12 @@ from typing import Annotated, cast
 from agno.tools.toolkit import Toolkit
 from pydantic import BeforeValidator
 
-from mindroom.constants import WORKSPACE_HOME_CONTRACT_ENV_NAMES, RuntimePaths, shell_execution_runtime_env_values
+from mindroom.constants import (
+    WORKSPACE_HOME_CONTRACT_ENV_NAMES,
+    RuntimePaths,
+    shell_execution_runtime_env_values,
+    workspace_home_identity_env,
+)
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.metadata import (
     ConfigField,
@@ -133,11 +138,7 @@ def _workspace_home_contract_env_from_process_env(base_process_env: dict[str, st
     if not workspace or base_process_env.get("HOME") != workspace:
         return {}
 
-    expected_identity = {
-        "XDG_CONFIG_HOME": str(Path(workspace) / ".config"),
-        "XDG_DATA_HOME": str(Path(workspace) / ".local" / "share"),
-        "XDG_STATE_HOME": str(Path(workspace) / ".local" / "state"),
-    }
+    expected_identity = workspace_home_identity_env(workspace)
     if any(base_process_env.get(name) != value for name, value in expected_identity.items()):
         return {}
 

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -14,9 +14,9 @@ from unittest.mock import patch
 import pytest
 from agno.tools.function import Function, FunctionCall, FunctionExecutionResult
 
-from mindroom.constants import RuntimePaths, resolve_runtime_paths
+from mindroom.constants import RuntimePaths, resolve_runtime_paths, workspace_home_identity_env
 from mindroom.tool_system.metadata import get_tool_by_name
-from mindroom.tools.shell import _process_registry, shell_tools
+from mindroom.tools.shell import _process_registry, _workspace_home_contract_env_from_process_env, shell_tools
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -600,6 +600,38 @@ async def test_sweep_stale_records(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Env passthrough
 # ---------------------------------------------------------------------------
+
+
+def test_workspace_home_identity_env_builds_shell_identity_fragment(tmp_path: Path) -> None:
+    """The shared workspace HOME fragment should use stable workspace-relative XDG paths."""
+    workspace = tmp_path / "workspace"
+
+    assert workspace_home_identity_env(workspace) == {
+        "HOME": str(workspace),
+        "MINDROOM_AGENT_WORKSPACE": str(workspace),
+        "XDG_CONFIG_HOME": str(workspace / ".config"),
+        "XDG_DATA_HOME": str(workspace / ".local" / "share"),
+        "XDG_STATE_HOME": str(workspace / ".local" / "state"),
+    }
+
+
+def test_workspace_home_contract_env_requires_full_identity_fragment(tmp_path: Path) -> None:
+    """Shell subprocesses should forward the workspace contract only when identity is coherent."""
+    workspace = tmp_path / "workspace"
+    base_env = {
+        **workspace_home_identity_env(workspace),
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+        "PIP_CACHE_DIR": str(tmp_path / "cache" / "pip"),
+        "UV_CACHE_DIR": str(tmp_path / "cache" / "uv"),
+        "PYTHONPYCACHEPREFIX": str(tmp_path / "cache" / "pycache"),
+        "VIRTUAL_ENV": str(tmp_path / "venv"),
+    }
+
+    assert _workspace_home_contract_env_from_process_env(base_env) == base_env
+
+    mismatched_env = dict(base_env)
+    mismatched_env["XDG_DATA_HOME"] = str(tmp_path / "other-data")
+    assert _workspace_home_contract_env_from_process_env(mismatched_env) == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a pure workspace_home_identity_env helper for the shared HOME/MINDROOM_AGENT_WORKSPACE/XDG identity fragment
- reuse it in shell-side workspace contract validation and sandbox runner contract construction
- add shell characterization tests for the identity fragment and coherent workspace contract forwarding

## Tests
- uv run pytest tests/test_shell_async.py -q -n 0 --no-cov
- uv run pytest tests/test_shell_async.py tests/api/test_sandbox_runner_api.py -q -k 'workspace_home_identity_env or workspace_home_contract or worker_subprocess_env_preserves_parent_path or sandbox_runner_applies_shell_path_prepend_override' -n 0 --no-cov
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/constants.py src/mindroom/tools/shell.py src/mindroom/api/sandbox_runner.py tests/test_shell_async.py

## Notes
- Full pytest was not run; this PR is scoped to shell/sandbox env fragment construction.