### PR TITLE
refactor: share prepared text ingress dispatch

### DIFF
--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -643,6 +643,53 @@ class TurnController:
         attach_dispatch_pipeline_timing(prepared_event.source, dispatch_timing)
         return prepared_event
 
+    async def _dispatch_prepared_text_like_ingress(
+        self,
+        *,
+        room: nio.MatrixRoom,
+        prepared_event: PreparedTextEvent,
+        dispatch_event: TextDispatchEvent,
+        requester_user_id: str,
+        dispatch_timing: DispatchPipelineTiming | None,
+    ) -> None:
+        """Run shared ingress dispatch for text events and sidecar text previews."""
+        envelope = self.deps.resolver.build_ingress_envelope(
+            room_id=room.room_id,
+            event=prepared_event,
+            requester_user_id=requester_user_id,
+        )
+        if self._should_skip_deep_synthetic_full_dispatch(
+            event_id=prepared_event.event_id,
+            envelope=envelope,
+        ):
+            return
+        coalescing_thread_id = await self.deps.resolver.coalescing_thread_id(room, prepared_event)
+        if should_handle_interactive_text_response(envelope):
+            selection = await interactive.handle_text_response(
+                self._client(),
+                room,
+                prepared_event,
+                self.deps.agent_name,
+                resolved_thread_id=coalescing_thread_id,
+            )
+            if selection is not None:
+                await self.handle_interactive_selection(
+                    room,
+                    selection=selection,
+                    user_id=prepared_event.sender,
+                    source_event_id=prepared_event.event_id,
+                )
+                return
+        await self._enqueue_prepared_text_for_dispatch(
+            room=room,
+            prepared_event=prepared_event,
+            dispatch_event=dispatch_event,
+            envelope=envelope,
+            coalescing_thread_id=coalescing_thread_id,
+            requester_user_id=requester_user_id,
+            dispatch_timing=dispatch_timing,
+        )
+
     async def _enqueue_for_dispatch(
         self,
         event: DispatchEvent,
@@ -1483,7 +1530,7 @@ class TurnController:
         async with self.deps.resolver.turn_thread_cache_scope():
             await self._handle_message_inner(room, event)
 
-    async def _handle_message_inner(  # noqa: PLR0911
+    async def _handle_message_inner(
         self,
         room: nio.MatrixRoom,
         event: nio.RoomMessageText,
@@ -1549,39 +1596,10 @@ class TurnController:
             prechecked_event.event,
             dispatch_timing=dispatch_timing,
         )
-        envelope = self.deps.resolver.build_ingress_envelope(
-            room_id=room.room_id,
-            event=prepared_event,
-            requester_user_id=prechecked_event.requester_user_id,
-        )
-        if self._should_skip_deep_synthetic_full_dispatch(
-            event_id=prepared_event.event_id,
-            envelope=envelope,
-        ):
-            return
-        coalescing_thread_id = await self.deps.resolver.coalescing_thread_id(room, prepared_event)
-        if should_handle_interactive_text_response(envelope):
-            selection = await interactive.handle_text_response(
-                self._client(),
-                room,
-                prepared_event,
-                self.deps.agent_name,
-                resolved_thread_id=coalescing_thread_id,
-            )
-            if selection is not None:
-                await self.handle_interactive_selection(
-                    room,
-                    selection=selection,
-                    user_id=prepared_event.sender,
-                    source_event_id=prepared_event.event_id,
-                )
-                return
-        await self._enqueue_prepared_text_for_dispatch(
+        await self._dispatch_prepared_text_like_ingress(
             room=room,
             prepared_event=prepared_event,
             dispatch_event=prechecked_event.event,
-            envelope=envelope,
-            coalescing_thread_id=coalescing_thread_id,
             requester_user_id=prechecked_event.requester_user_id,
             dispatch_timing=dispatch_timing,
         )
@@ -1985,39 +2003,10 @@ class TurnController:
             dispatch_timing.mark("ingress_normalize_ready")
         assert prepared_text_event is not None
         attach_dispatch_pipeline_timing(prepared_text_event.source, dispatch_timing)
-        envelope = self.deps.resolver.build_ingress_envelope(
-            room_id=room.room_id,
-            event=prepared_text_event,
-            requester_user_id=prechecked_event.requester_user_id,
-        )
-        if self._should_skip_deep_synthetic_full_dispatch(
-            event_id=prepared_text_event.event_id,
-            envelope=envelope,
-        ):
-            return True
-        coalescing_thread_id = await self.deps.resolver.coalescing_thread_id(room, prepared_text_event)
-        if should_handle_interactive_text_response(envelope):
-            selection = await interactive.handle_text_response(
-                self._client(),
-                room,
-                prepared_text_event,
-                self.deps.agent_name,
-                resolved_thread_id=coalescing_thread_id,
-            )
-            if selection is not None:
-                await self.handle_interactive_selection(
-                    room,
-                    selection=selection,
-                    user_id=prepared_text_event.sender,
-                    source_event_id=prepared_text_event.event_id,
-                )
-                return True
-        await self._enqueue_prepared_text_for_dispatch(
+        await self._dispatch_prepared_text_like_ingress(
             room=room,
             prepared_event=prepared_text_event,
             dispatch_event=prepared_text_event,
-            envelope=envelope,
-            coalescing_thread_id=coalescing_thread_id,
             requester_user_id=prechecked_event.requester_user_id,
             dispatch_timing=dispatch_timing,
         )

--- a/tests/test_turn_controller.py
+++ b/tests/test_turn_controller.py
@@ -13,6 +13,7 @@ from mindroom import interactive
 from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
+from mindroom.dispatch_handoff import PreparedTextEvent
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.streaming import send_streaming_response
 from tests.conftest import (
@@ -312,3 +313,127 @@ async def test_on_message_passes_resolved_thread_id_to_interactive_text_response
     mock_handle_text_response.assert_awaited_once()
     assert mock_handle_text_response.await_args.kwargs["resolved_thread_id"] == "$thread-root:localhost"
     mock_dispatch_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sidecar_preview_passes_resolved_thread_id_to_interactive_text_response(
+    tmp_path: Path,
+) -> None:
+    """Sidecar previews should use the same interactive matching thread id as text messages."""
+    config = bind_runtime_paths(
+        Config(agents={"general": AgentConfig(display_name="General")}),
+        test_runtime_paths(tmp_path),
+    )
+    config.memory.backend = "file"
+
+    agent_user = AgentMatrixUser(
+        agent_name="general",
+        user_id="@mindroom_general:localhost",
+        display_name="GeneralAgent",
+        password="test_password",  # noqa: S106
+    )
+    bot = AgentBot(
+        agent_user=agent_user,
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        rooms=["!test:localhost"],
+    )
+    bot.client = AsyncMock()
+
+    room = nio.MatrixRoom(room_id="!test:localhost", own_user_id="@mindroom_general:localhost")
+    sidecar_event = nio.RoomMessageFile.from_dict(
+        {
+            "content": {
+                "body": "1 [Message continues in attached file]",
+                "msgtype": "m.file",
+                "info": {"mimetype": "application/json"},
+                "io.mindroom.long_text": {
+                    "version": 2,
+                    "encoding": "matrix_event_content_json",
+                },
+                "url": "mxc://server/sidecar-selection",
+            },
+            "event_id": "$sidecar-selection:localhost",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1000000,
+            "type": "m.room.message",
+            "room_id": "!test:localhost",
+        },
+    )
+    sidecar_event.source = {
+        "content": {
+            "body": "1 [Message continues in attached file]",
+            "msgtype": "m.file",
+            "info": {"mimetype": "application/json"},
+            "io.mindroom.long_text": {
+                "version": 2,
+                "encoding": "matrix_event_content_json",
+            },
+            "url": "mxc://server/sidecar-selection",
+        },
+        "event_id": "$sidecar-selection:localhost",
+        "sender": "@user:localhost",
+        "origin_server_ts": 1000000,
+        "type": "m.room.message",
+        "room_id": "!test:localhost",
+    }
+    prepared_event = PreparedTextEvent(
+        sender="@user:localhost",
+        event_id="$sidecar-selection:localhost",
+        body="1",
+        source={
+            "content": {
+                "body": "1",
+                "msgtype": "m.text",
+            },
+            "event_id": "$sidecar-selection:localhost",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1000000,
+            "type": "m.room.message",
+            "room_id": "!test:localhost",
+        },
+        server_timestamp=1000000,
+    )
+
+    wrap_extracted_collaborators(bot, "_turn_policy", "_inbound_turn_normalizer")
+    replace_turn_controller_deps(
+        bot,
+        resolver=bot._conversation_resolver,
+        turn_policy=bot._turn_policy,
+        normalizer=bot._inbound_turn_normalizer,
+    )
+
+    with (
+        patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
+        patch.object(bot._turn_policy, "can_reply_to_sender", return_value=True),
+        patch.object(
+            bot._conversation_resolver,
+            "coalescing_thread_id",
+            new_callable=AsyncMock,
+            return_value="$thread-root:localhost",
+        ),
+        patch.object(
+            bot._inbound_turn_normalizer,
+            "prepare_file_sidecar_text_event",
+            new_callable=AsyncMock,
+            return_value=prepared_event,
+        ),
+        patch(
+            "mindroom.turn_controller.interactive.handle_text_response",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_handle_text_response,
+        patch.object(
+            bot._turn_controller,
+            "_enqueue_prepared_text_for_dispatch",
+            new_callable=AsyncMock,
+        ) as mock_enqueue,
+    ):
+        await bot._turn_controller._handle_media_message_inner(room, sidecar_event)
+
+    mock_handle_text_response.assert_awaited_once()
+    assert mock_handle_text_response.await_args.kwargs["resolved_thread_id"] == "$thread-root:localhost"
+    mock_enqueue.assert_awaited_once()
+    assert mock_enqueue.await_args.kwargs["prepared_event"] is prepared_event
+    assert mock_enqueue.await_args.kwargs["dispatch_event"] is prepared_event


### PR DESCRIPTION
## Summary
- Extract the shared prepared text-like ingress tail for raw text messages and sidecar-backed text previews into a private TurnController helper.
- Add a sidecar preview characterization test for interactive thread-id matching before the refactor.

## Tests
- uv run pytest tests/test_turn_controller.py tests/test_voice_command_processing.py::test_router_processes_own_sidecar_commands_using_original_sender tests/test_voice_command_processing.py::test_router_parses_sidecar_schedule_command_from_canonical_body tests/test_voice_command_processing.py::test_router_treats_sidecar_skill_command_as_unknown_command tests/test_voice_command_processing.py::test_router_skips_unauthorized_sidecar_commands_before_hydration -q
- uv run pre-commit run --files src/mindroom/turn_controller.py tests/test_turn_controller.py
- uv run tach check --dependencies --interfaces

## Duplication Examined
- Raw text ingress after normalization in TurnController._handle_message_inner.
- Sidecar file preview ingress after normalization in TurnController._dispatch_file_sidecar_text_preview.
- Audio media normalization in TurnController._on_audio_media_message, left separate because it uses voice source metadata and skips interactive text-response handling.
- Turn policy planning in src/mindroom/turn_policy.py and inbound normalization in src/mindroom/inbound_turn_normalizer.py, no duplicate production flow changed there.

Production line delta: src/mindroom/turn_controller.py 50 insertions / 61 deletions, net -11.