### PR TITLE
FLOW-002: share Matrix send cache tracking

### DIFF
--- a/src/mindroom/hooks/__init__.py
+++ b/src/mindroom/hooks/__init__.py
@@ -41,7 +41,7 @@ from .enrichment import render_enrichment_block, render_system_enrichment_block
 from .execution import emit, emit_collect, emit_final_response_transform, emit_gate, emit_transform
 from .ingress import HookIngressPolicy, hook_ingress_policy, should_handle_interactive_text_response
 from .registry import HookRegistry, HookRegistryPlugin, HookRegistryState
-from .sender import build_hook_message_sender, send_hook_message
+from .sender import build_hook_message_sender, send_and_track_message, send_hook_message
 from .state import build_hook_room_state_putter, build_hook_room_state_querier
 from .types import (
     BUILTIN_EVENT_NAMES,
@@ -153,6 +153,7 @@ __all__ = [
     "iter_module_hooks",
     "render_enrichment_block",
     "render_system_enrichment_block",
+    "send_and_track_message",
     "send_hook_message",
     "should_handle_interactive_text_response",
     "validate_event_name",

--- a/src/mindroom/hooks/sender.py
+++ b/src/mindroom/hooks/sender.py
@@ -30,6 +30,20 @@ async def _send_message_result(
     return await send_message_result(client, room_id, content, config=config)
 
 
+async def send_and_track_message(
+    client: nio.AsyncClient,
+    room_id: str,
+    content: dict[str, Any],
+    config: Config,
+    conversation_cache: ConversationCacheProtocol,
+) -> DeliveredMatrixEvent | None:
+    """Send already-built Matrix content and record successful delivery in the cache."""
+    delivered = await _send_message_result(client, room_id, content, config=config)
+    if delivered is not None:
+        conversation_cache.notify_outbound_message(room_id, delivered.event_id, delivered.content_sent)
+    return delivered
+
+
 def _resolve_hook_sender_domain(
     client: nio.AsyncClient,
     *,
@@ -87,9 +101,8 @@ async def send_hook_message(
         latest_thread_event_id=latest_thread_event_id,
         extra_content=content_extra,
     )
-    delivered = await _send_message_result(client, room_id, content, config=config)
+    delivered = await send_and_track_message(client, room_id, content, config, conversation_cache)
     if delivered is not None:
-        conversation_cache.notify_outbound_message(room_id, delivered.event_id, delivered.content_sent)
         return delivered.event_id
     return None
 

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -31,9 +31,9 @@ from mindroom.hooks import (
     build_hook_room_state_putter,
     build_hook_room_state_querier,
     emit,
+    send_and_track_message,
 )
 from mindroom.logging_config import bound_log_context, get_logger
-from mindroom.matrix.client_delivery import send_message_result
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.mentions import format_message_with_mentions, parse_mentions_in_text
 from mindroom.matrix.message_builder import build_message_content
@@ -806,13 +806,7 @@ async def _notify_scheduled_workflow_failure(
         conversation_cache,
     )
     try:
-        delivered = await send_message_result(client, workflow.room_id, error_content, config=config)
-        if delivered is not None:
-            conversation_cache.notify_outbound_message(
-                workflow.room_id,
-                delivered.event_id,
-                delivered.content_sent,
-            )
+        await send_and_track_message(client, workflow.room_id, error_content, config, conversation_cache)
     except Exception:
         logger.exception("Failed to send scheduled workflow failure message")
 
@@ -880,14 +874,9 @@ async def _execute_scheduled_workflow(
             if workflow.created_by:
                 content[ORIGINAL_SENDER_KEY] = workflow.created_by
             content["com.mindroom.source_kind"] = "scheduled"
-            delivered = await send_message_result(client, workflow.room_id, content, config=config)
+            delivered = await send_and_track_message(client, workflow.room_id, content, config, conversation_cache)
             if delivered is None:
                 _raise_scheduled_workflow_send_error()
-            conversation_cache.notify_outbound_message(
-                workflow.room_id,
-                delivered.event_id,
-                delivered.content_sent,
-            )
             logger.info(
                 "Executed scheduled workflow",
                 description=workflow.description,
@@ -1021,13 +1010,7 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     error_message,
                     conversation_cache,
                 )
-                delivered = await send_message_result(client, workflow.room_id, error_content, config=config)
-                if delivered is not None:
-                    conversation_cache.notify_outbound_message(
-                        workflow.room_id,
-                        delivered.event_id,
-                        delivered.content_sent,
-                    )
+                await send_and_track_message(client, workflow.room_id, error_content, config, conversation_cache)
     finally:
         _cleanup_task_if_current(task_id, running_tasks)
 
@@ -1134,13 +1117,7 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
                     error_message,
                     conversation_cache,
                 )
-                delivered = await send_message_result(client, workflow.room_id, error_content, config=config)
-                if delivered is not None:
-                    conversation_cache.notify_outbound_message(
-                        workflow.room_id,
-                        delivered.event_id,
-                        delivered.content_sent,
-                    )
+                await send_and_track_message(client, workflow.room_id, error_content, config, conversation_cache)
             if latest_pending_task is not None:
                 try:
                     await _save_one_time_task_status(

--- a/tach.toml
+++ b/tach.toml
@@ -2727,6 +2727,7 @@ expose = [
     "iter_module_hooks",
     "render_enrichment_block",
     "render_system_enrichment_block",
+    "send_and_track_message",
     "send_hook_message",
     "should_handle_interactive_text_response",
     "validate_event_name",

--- a/tests/test_hook_schedule.py
+++ b/tests/test_hook_schedule.py
@@ -95,7 +95,7 @@ async def test_schedule_hook_rewrites_message_text(tmp_path: Path) -> None:
     conversation_cache = _conversation_cache(latest_thread_event_id="$latest")
 
     with patch(
-        "mindroom.scheduling.send_message_result",
+        "mindroom.hooks.sender._send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
     ) as mock_send:
         await _execute_scheduled_workflow(
@@ -122,7 +122,7 @@ async def test_schedule_hook_can_suppress_synthetic_message(tmp_path: Path) -> N
     set_scheduling_hook_registry(HookRegistry.from_plugins([_plugin("schedule-plugin", [suppress])]))
 
     with patch(
-        "mindroom.scheduling.send_message_result",
+        "mindroom.hooks.sender._send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
     ) as mock_send:
         await _execute_scheduled_workflow(
@@ -155,7 +155,7 @@ async def test_schedule_hook_suppression_log_includes_workflow_thread_context(
     capsys.readouterr()
 
     with patch(
-        "mindroom.scheduling.send_message_result",
+        "mindroom.hooks.sender._send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
     ):
         await _execute_scheduled_workflow(
@@ -286,16 +286,10 @@ async def test_schedule_hook_send_message_inherits_context_thread_id(tmp_path: P
     client.user_id = "@mindroom_router:localhost"
     conversation_cache = _conversation_cache(latest_thread_event_id="$latest")
 
-    with (
-        patch(
-            "mindroom.hooks.sender._send_message_result",
-            new=AsyncMock(side_effect=delivered_matrix_side_effect("$hook-event")),
-        ) as mock_hook_send,
-        patch(
-            "mindroom.scheduling.send_message_result",
-            new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
-        ) as mock_schedule_send,
-    ):
+    with patch(
+        "mindroom.hooks.sender._send_message_result",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$hook-event")),
+    ) as mock_hook_send:
         await _execute_scheduled_workflow(
             client,
             _workflow("Resume work"),
@@ -309,7 +303,7 @@ async def test_schedule_hook_send_message_inherits_context_thread_id(tmp_path: P
         "$thread",
         caller_label="hook_sender",
     )
-    mock_schedule_send.assert_not_called()
+    mock_hook_send.assert_awaited_once()
     content = mock_hook_send.await_args.args[2]
     assert content["body"] == "resume"
     assert content["m.relates_to"]["event_id"] == "$thread"
@@ -330,16 +324,10 @@ async def test_schedule_hook_send_message_allows_explicit_room_level_opt_out(tmp
     client.user_id = "@mindroom_router:localhost"
     conversation_cache = _conversation_cache(latest_thread_event_id=None)
 
-    with (
-        patch(
-            "mindroom.hooks.sender._send_message_result",
-            new=AsyncMock(side_effect=delivered_matrix_side_effect("$hook-event")),
-        ) as mock_hook_send,
-        patch(
-            "mindroom.scheduling.send_message_result",
-            new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
-        ) as mock_schedule_send,
-    ):
+    with patch(
+        "mindroom.hooks.sender._send_message_result",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$hook-event")),
+    ) as mock_hook_send:
         await _execute_scheduled_workflow(
             client,
             _workflow("Resume work"),
@@ -353,7 +341,7 @@ async def test_schedule_hook_send_message_allows_explicit_room_level_opt_out(tmp
         None,
         caller_label="hook_sender",
     )
-    mock_schedule_send.assert_not_called()
+    mock_hook_send.assert_awaited_once()
     content = mock_hook_send.await_args.args[2]
     assert content["body"] == "room-level"
     assert "m.relates_to" not in content
@@ -436,16 +424,10 @@ async def test_schedule_hook_send_message_can_trigger_dispatch(tmp_path: Path) -
     client.user_id = "@mindroom_router:localhost"
     conversation_cache = _conversation_cache(latest_thread_event_id="$latest")
 
-    with (
-        patch(
-            "mindroom.hooks.sender._send_message_result",
-            new=AsyncMock(side_effect=delivered_matrix_side_effect("$hook-event")),
-        ) as mock_hook_send,
-        patch(
-            "mindroom.scheduling.send_message_result",
-            new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
-        ) as mock_schedule_send,
-    ):
+    with patch(
+        "mindroom.hooks.sender._send_message_result",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$hook-event")),
+    ) as mock_hook_send:
         await _execute_scheduled_workflow(
             client,
             _workflow("Resume work"),
@@ -454,7 +436,7 @@ async def test_schedule_hook_send_message_can_trigger_dispatch(tmp_path: Path) -
             conversation_cache,
         )
 
-    mock_schedule_send.assert_not_called()
+    mock_hook_send.assert_awaited_once()
     content = mock_hook_send.await_args.args[2]
     assert content["body"] == "dispatch"
     assert content["com.mindroom.source_kind"] == "hook_dispatch"

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -41,6 +41,7 @@ from mindroom.hooks import (
 )
 from mindroom.hooks.execution import emit
 from mindroom.hooks.sender import HookMessageSender as SenderAlias
+from mindroom.hooks.sender import send_and_track_message
 from mindroom.inbound_turn_normalizer import DispatchPayload
 from mindroom.logging_config import get_logger
 from mindroom.matrix.users import AgentMatrixUser
@@ -81,6 +82,44 @@ def _config(tmp_path: Path) -> Config:
 def test_hooks_package_reexports_hook_message_sender() -> None:
     """The public hooks package should keep exporting HookMessageSender."""
     assert HookMessageSender is SenderAlias
+
+
+@pytest.mark.asyncio
+async def test_send_and_track_message_records_delivered_content(tmp_path: Path) -> None:
+    """Shared send tracking should cache the exact content returned by delivery."""
+    config = _config(tmp_path)
+    content = {"msgtype": "m.text", "body": "already built"}
+    delivered_content = {"msgtype": "m.text", "body": "already built", "server": "normalized"}
+    conversation_cache = MagicMock()
+
+    async def mock_send(
+        _client: object,
+        _room_id: str,
+        _content: dict[str, object],
+        *,
+        config: Config,
+    ) -> object:
+        assert isinstance(config, Config)
+        return delivered_matrix_event("$tracked", delivered_content)
+
+    with patch("mindroom.hooks.sender._send_message_result", side_effect=mock_send) as mock_send_result:
+        delivered = await send_and_track_message(
+            AsyncMock(),
+            "!room:localhost",
+            content,
+            config,
+            conversation_cache,
+        )
+
+    assert delivered is not None
+    assert delivered.event_id == "$tracked"
+    mock_send_result.assert_awaited_once()
+    assert mock_send_result.await_args.args[2] is content
+    conversation_cache.notify_outbound_message.assert_called_once_with(
+        "!room:localhost",
+        "$tracked",
+        delivered_content,
+    )
 
 
 def _plugin(name: str, callbacks: list[object]) -> object:

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -418,7 +418,7 @@ class TestExecuteScheduledWorkflow:
 
         conversation_cache = _conversation_cache(latest_thread_event_id="$latest456")
         with patch(
-            "mindroom.scheduling.send_message_result",
+            "mindroom.hooks.sender._send_message_result",
             new=AsyncMock(
                 return_value=DeliveredMatrixEvent(
                     event_id="$event123",
@@ -474,7 +474,7 @@ class TestExecuteScheduledWorkflow:
         )
 
         with patch(
-            "mindroom.scheduling.send_message_result",
+            "mindroom.hooks.sender._send_message_result",
             new=AsyncMock(
                 return_value=DeliveredMatrixEvent(
                     event_id="$event456",
@@ -541,7 +541,7 @@ class TestExecuteScheduledWorkflow:
         )
 
         with patch(
-            "mindroom.scheduling.send_message_result",
+            "mindroom.hooks.sender._send_message_result",
             new=AsyncMock(
                 return_value=DeliveredMatrixEvent(
                     event_id="$event789",
@@ -586,7 +586,7 @@ class TestExecuteScheduledWorkflow:
             ],
         )
 
-        with patch("mindroom.scheduling.send_message_result", new=mock_send):
+        with patch("mindroom.hooks.sender._send_message_result", new=mock_send):
             # Should not raise, but log error
             await _execute_scheduled_workflow(
                 client,
@@ -619,7 +619,7 @@ class TestExecuteScheduledWorkflow:
 
         with (
             patch(
-                "mindroom.scheduling.send_message_result",
+                "mindroom.hooks.sender._send_message_result",
                 new=AsyncMock(
                     side_effect=[
                         None,
@@ -658,7 +658,7 @@ class TestExecuteScheduledWorkflow:
             room_id=None,  # No room ID
         )
 
-        with patch("mindroom.scheduling.send_message_result", new=AsyncMock()) as mock_send:
+        with patch("mindroom.hooks.sender._send_message_result", new=AsyncMock()) as mock_send:
             await _execute_scheduled_workflow(
                 client,
                 workflow,


### PR DESCRIPTION
## Summary
- add a narrow hook sender helper for already-built Matrix content send + outbound cache notification
- reuse it from hook sends and scheduled workflow send/failure tails without changing content construction
- update Tach hook interface for the new public helper

## Verification
- uv sync --all-extras
- uv run pytest tests/test_hook_sender.py::test_send_and_track_message_records_delivered_content tests/test_hook_schedule.py tests/test_workflow_scheduling.py tests/test_scheduling.py -q -n 0 --no-cov
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files tach.toml src/mindroom/hooks/__init__.py src/mindroom/hooks/sender.py src/mindroom/scheduling.py tests/test_hook_sender.py tests/test_hook_schedule.py tests/test_workflow_scheduling.py
- uv run pytest -q -n 0 --no-cov