### PR TITLE
refactor: normalize turn run source metadata

### DIFF
--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -170,15 +170,12 @@ class TurnStore:
         """
         metadata = self._build_run_metadata_for_handled_turn(handled_turn) or {}
         if additional_source_event_ids:
-            source_event_ids = [
-                event_id
-                for event_id in metadata.get(constants.MATRIX_SOURCE_EVENT_IDS_METADATA_KEY, [])
-                if isinstance(event_id, str) and event_id
-            ]
-            for event_id in additional_source_event_ids:
-                if not event_id or event_id in source_event_ids:
-                    continue
-                source_event_ids.append(event_id)
+            source_event_ids = list(
+                _normalized_matrix_source_event_ids(metadata.get(constants.MATRIX_SOURCE_EVENT_IDS_METADATA_KEY)),
+            )
+            for event_id in _normalized_matrix_source_event_ids(list(additional_source_event_ids)):
+                if event_id not in source_event_ids:
+                    source_event_ids.append(event_id)
             if source_event_ids:
                 metadata[constants.MATRIX_SOURCE_EVENT_IDS_METADATA_KEY] = source_event_ids
         return metadata or None
@@ -292,16 +289,10 @@ class TurnStore:
         raw_response_event_id = metadata.get(constants.MATRIX_RESPONSE_EVENT_ID_METADATA_KEY)
         response_event_id = raw_response_event_id if isinstance(raw_response_event_id, str) else None
         handled_turn = HandledTurnState.create(
-            raw_source_event_ids if isinstance(raw_source_event_ids, list) else [anchor_event_id],
+            _normalized_matrix_source_event_ids(raw_source_event_ids, fallback_event_id=anchor_event_id),
             response_event_id=response_event_id,
             source_event_prompts=raw_prompt_map if isinstance(raw_prompt_map, dict) else None,
         )
-        if not handled_turn.source_event_ids:
-            handled_turn = HandledTurnState.from_source_event_id(
-                anchor_event_id,
-                response_event_id=response_event_id,
-                source_event_prompts=raw_prompt_map if isinstance(raw_prompt_map, dict) else None,
-            )
         return _PersistedTurnMetadata(
             anchor_event_id=anchor_event_id,
             source_event_ids=handled_turn.source_event_ids,
@@ -475,3 +466,19 @@ class TurnStore:
                 history_scope=turn_record.history_scope.key,
             )
         return removed_any
+
+
+def _normalized_matrix_source_event_ids(
+    raw_source_event_ids: object,
+    *,
+    fallback_event_id: str | None = None,
+) -> tuple[str, ...]:
+    """Return normalized Matrix source-event IDs with optional anchor fallback."""
+    if isinstance(raw_source_event_ids, list):
+        raw_string_event_ids = [event_id for event_id in raw_source_event_ids if isinstance(event_id, str)]
+        source_event_ids = HandledTurnState.create(raw_string_event_ids).source_event_ids
+        if source_event_ids:
+            return source_event_ids
+    if fallback_event_id is None:
+        return ()
+    return HandledTurnState.from_source_event_id(fallback_event_id).source_event_ids

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -6,11 +6,12 @@ import ast
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from mindroom import constants
 from mindroom.bot import AgentBot
 from mindroom.config.main import Config
 from mindroom.handled_turns import HandledTurnState
 from mindroom.matrix.users import AgentMatrixUser
-from mindroom.turn_store import TurnStore, TurnStoreDeps
+from mindroom.turn_store import TurnStore, TurnStoreDeps, _normalized_matrix_source_event_ids
 from tests.conftest import TEST_PASSWORD, bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 
@@ -43,6 +44,70 @@ def test_turn_store_constructs_private_ledger_from_tracking_base_path(tmp_path: 
     turn_record = reloaded_store.get_turn_record("$event")
     assert turn_record is not None
     assert turn_record.response_event_id == "$response"
+
+
+def test_normalized_matrix_source_event_ids_deduplicates_and_falls_back_to_anchor() -> None:
+    """Run metadata source IDs should use handled-turn normalization with anchor fallback."""
+    assert _normalized_matrix_source_event_ids(["$first", "", "$first", "$anchor"]) == ("$first", "$anchor")
+    assert _normalized_matrix_source_event_ids([None, "$first", 2, "$first"]) == ("$first",)
+    assert _normalized_matrix_source_event_ids([], fallback_event_id="$anchor") == ("$anchor",)
+    assert _normalized_matrix_source_event_ids("not-a-list", fallback_event_id="$anchor") == ("$anchor",)
+    assert _normalized_matrix_source_event_ids([""], fallback_event_id="") == ()
+
+
+def test_build_run_metadata_uses_shared_source_event_id_normalization(tmp_path: Path) -> None:
+    """Additional run metadata source IDs should normalize the same way as persisted parsing."""
+    store = TurnStore(
+        TurnStoreDeps(
+            agent_name="agent",
+            tracking_base_path=tmp_path,
+            state_writer=MagicMock(),
+            resolver=MagicMock(),
+            tool_runtime=MagicMock(),
+        ),
+    )
+    handled_turn = HandledTurnState.create(["$first", "$anchor"])
+
+    metadata = store.build_run_metadata(
+        handled_turn,
+        additional_source_event_ids=("", "$first", "$selection", "$selection"),
+    )
+
+    assert metadata == {
+        constants.MATRIX_SOURCE_EVENT_IDS_METADATA_KEY: ["$first", "$anchor", "$selection"],
+    }
+
+
+def test_persisted_turn_metadata_uses_shared_source_event_id_normalization(tmp_path: Path) -> None:
+    """Persisted run metadata parsing should normalize IDs and filter prompt entries."""
+    store = TurnStore(
+        TurnStoreDeps(
+            agent_name="agent",
+            tracking_base_path=tmp_path,
+            state_writer=MagicMock(),
+            resolver=MagicMock(),
+            tool_runtime=MagicMock(),
+        ),
+    )
+
+    metadata = store._persisted_turn_metadata_for_run(
+        {
+            constants.MATRIX_EVENT_ID_METADATA_KEY: "$anchor",
+            constants.MATRIX_SOURCE_EVENT_IDS_METADATA_KEY: ["$first", "", "$first", "$anchor"],
+            constants.MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY: {
+                "$first": "first",
+                "$anchor": "anchor",
+                "$extra": "ignored",
+            },
+            constants.MATRIX_RESPONSE_EVENT_ID_METADATA_KEY: "$response",
+        },
+    )
+
+    assert metadata is not None
+    assert metadata.anchor_event_id == "$anchor"
+    assert metadata.source_event_ids == ("$first", "$anchor")
+    assert metadata.source_event_prompts == {"$first": "first", "$anchor": "anchor"}
+    assert metadata.response_event_id == "$response"
 
 
 def test_only_turn_store_imports_handled_turn_ledger_in_production() -> None:


### PR DESCRIPTION
## Summary
- add one shared turn-store helper for Matrix source-event ID normalization
- use it when extending run metadata and parsing persisted run metadata
- add characterization coverage for helper behavior and both turn-store call sites

## Tests
- uv run pytest tests/test_turn_store.py tests/test_handled_turns.py -q -n 0 --no-cov
- uv run pre-commit run --files src/mindroom/turn_store.py tests/test_turn_store.py
- uv run tach check --dependencies --interfaces
- uv run pytest -q --no-cov