### PR TITLE
refactor: share root space invite helper

### DIFF
--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1500,13 +1500,15 @@ class _MultiAgentOrchestrator:
 
         current_members = await get_room_members(router_bot.client, root_space_id)
         for user_id in sorted(invite_user_ids):
-            if user_id in current_members:
-                continue
-            success = await invite_to_room(router_bot.client, root_space_id, user_id)
-            if success:
-                logger.info("invited_user_to_root_space", user_id=user_id, room_id=root_space_id)
-            else:
-                logger.warning("invite_user_to_root_space_failed", user_id=user_id, room_id=root_space_id)
+            log_context = {"user_id": user_id, "room_id": root_space_id}
+            await self._invite_user_if_missing(
+                root_space_id,
+                user_id,
+                current_members,
+                success_message="invited_user_to_root_space",
+                failure_message="invite_user_to_root_space_failed",
+                log_context=log_context,
+            )
 
     async def _invite_user_if_missing(
         self,
@@ -1516,6 +1518,7 @@ class _MultiAgentOrchestrator:
         *,
         success_message: str,
         failure_message: str,
+        log_context: dict[str, str] | None = None,
     ) -> None:
         """Invite one user if they are not already a member."""
         router_bot = self._router_bot()
@@ -1526,10 +1529,10 @@ class _MultiAgentOrchestrator:
             return
         success = await invite_to_room(router_bot.client, room_id, user_id)
         if success:
-            logger.info(success_message)
+            logger.info(success_message, **(log_context or {}))
             current_members.add(user_id)
         else:
-            logger.warning(failure_message)
+            logger.warning(failure_message, **(log_context or {}))
 
     async def _invite_internal_user_to_rooms(
         self,

--- a/tests/test_matrix_spaces.py
+++ b/tests/test_matrix_spaces.py
@@ -473,6 +473,32 @@ async def test_orchestrator_ensure_root_space_invites_authorized_user_without_in
 
 
 @pytest.mark.asyncio
+async def test_orchestrator_ensure_root_space_skips_existing_members(tmp_path) -> None:  # noqa: ANN001
+    """Root Space invitations should skip users already in the Space."""
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
+    orchestrator.config = _config_with_runtime_paths(
+        tmp_path,
+        agents={"general": {"display_name": "General", "rooms": ["lobby"]}},
+        matrix_space={"enabled": True},
+        mindroom_user={"username": "mindroom_user", "display_name": "MindRoomUser"},
+        authorization={"global_users": ["@owner:example.com"]},
+    )
+    router_bot = MagicMock()
+    router_bot.client = AsyncMock()
+    orchestrator.agent_bots[ROUTER_AGENT_NAME] = router_bot
+    internal_user_id = orchestrator.config.get_mindroom_user_id(orchestrator.runtime_paths)
+
+    with (
+        patch("mindroom.orchestrator.ensure_root_space", new=AsyncMock(return_value="!space:localhost")),
+        patch("mindroom.orchestrator.get_room_members", new=AsyncMock(return_value={internal_user_id})),
+        patch("mindroom.orchestrator.invite_to_room", new=AsyncMock(return_value=True)) as mock_invite,
+    ):
+        await orchestrator._ensure_root_space({"lobby": "!lobby:localhost"})
+
+    mock_invite.assert_awaited_once_with(router_bot.client, "!space:localhost", "@owner:example.com")
+
+
+@pytest.mark.asyncio
 async def test_setup_rooms_and_memberships_runs_root_space_after_each_room_reconciliation(tmp_path) -> None:  # noqa: ANN001
     """Space reconciliation should happen as a post-room phase during startup."""
     orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))


### PR DESCRIPTION
## Summary
- route root Space user invites through the existing orchestrator `_invite_user_if_missing` helper
- preserve root Space invite Matrix calls and structured log event names/fields
- add characterization coverage for skipping users already in the root Space

## Duplicate flow examined
- `_ensure_root_space` root Space invite loop
- `_invite_user_if_missing` managed room invite helper used by internal-user, authorized-user, and configured-bot invite flows
- `BotRoomLifecycle.on_invite` invite acceptance/join flow was inspected but left unchanged because it handles inbound invite policy, persistence, and joins rather than router-issued invitations

## Verification
- `uv sync --all-extras`
- `uv run pytest tests/test_matrix_spaces.py::test_orchestrator_ensure_root_space_skips_existing_members -q` before production edit
- `uv run pytest tests/test_matrix_spaces.py::test_orchestrator_ensure_root_space_invites_internal_and_authorized_users tests/test_matrix_spaces.py::test_orchestrator_ensure_root_space_invites_authorized_user_without_internal_user tests/test_matrix_spaces.py::test_orchestrator_ensure_root_space_skips_existing_members tests/test_room_invites.py -n 0 --no-cov -q`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/orchestrator.py tests/test_matrix_spaces.py`