### PR TITLE
refactor: share OpenAI team preparation helper

### DIFF
--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -14,7 +14,7 @@ import time
 from contextlib import ExitStack
 from dataclasses import dataclass, field
 from html import escape
-from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn, cast
+from typing import TYPE_CHECKING, Annotated, Literal, NoReturn, cast
 from uuid import uuid4
 
 from agno.run.agent import (
@@ -40,32 +40,24 @@ from mindroom.agent_run_context import prepend_knowledge_availability_notice
 from mindroom.ai import (
     AIStreamChunk,
     ai_response,
-    build_matrix_run_metadata,
     stream_agent_response,
 )
-from mindroom.ai_run_metadata import build_prepared_history_metadata_content
 from mindroom.api import config_lifecycle
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths, runtime_env_flag
-from mindroom.execution_preparation import (
-    prepare_bound_team_run_context,
-    render_prepared_team_messages_text,
-)
+from mindroom.execution_preparation import render_prepared_team_messages_text
 from mindroom.history import (
     ScopeSessionContext,
     close_team_runtime_state_dbs,
     open_bound_scope_session_context,
-    team_tool_definition_payloads_for_logging,
 )
 from mindroom.knowledge import KnowledgeAvailabilityDetail, resolve_agent_knowledge_access
 from mindroom.llm_request_logging import (
     bind_llm_request_log_context,
     build_llm_request_log_context,
-    model_params_payload,
     stream_with_llm_request_log_context,
 )
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
-from mindroom.metadata_merge import deep_merge_metadata
 from mindroom.routing import suggest_agent
 from mindroom.teams import (
     TeamMode,
@@ -75,6 +67,7 @@ from mindroom.teams import (
     is_cancelled_run_output,
     is_errored_run_output,
     materialize_exact_team_members,
+    prepare_materialized_team_execution,
     resolve_configured_team,
 )
 from mindroom.tool_system.events import format_tool_completed_event, format_tool_started_event
@@ -96,7 +89,6 @@ if TYPE_CHECKING:
     from agno.agent import Agent
     from agno.db.base import BaseDb
     from agno.knowledge.knowledge import Knowledge
-    from agno.models.message import Message
     from agno.models.response import ToolExecution
     from agno.run.agent import RunOutputEvent
     from agno.run.team import TeamRunOutputEvent
@@ -104,7 +96,6 @@ if TYPE_CHECKING:
     from starlette.types import Receive, Scope, Send
 
     from mindroom.config.main import Config
-    from mindroom.history import CompactionOutcome
     from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
 logger = get_logger(__name__)
 
@@ -245,14 +236,6 @@ class _PreparedOpenAITeamPrompt:
     """Prepared team prompt plus the run metadata that must reach Agno."""
 
     prompt: str
-    run_metadata: dict[str, object] | None
-
-
-@dataclass(frozen=True, slots=True)
-class _PreparedOpenAIMaterializedTeamExecution:
-    """Prepared team execution state needed by the OpenAI-compatible API."""
-
-    messages: tuple[Message, ...]
     run_metadata: dict[str, object] | None
 
 
@@ -1447,73 +1430,6 @@ def _is_failed_team_output(response: TeamRunOutput | RunOutput) -> bool:
     return is_errored_run_output(response) or is_cancelled_run_output(response)
 
 
-async def _prepare_materialized_team_execution(
-    *,
-    scope_context: ScopeSessionContext | None,
-    agents: list[Agent],
-    team: Team,
-    message: str,
-    thread_history: Sequence[ResolvedVisibleMessage] | None,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    active_model_name: str | None,
-    reply_to_event_id: str | None,
-    active_event_ids: frozenset[str],
-    response_sender_id: str | None,
-    current_sender_id: str | None,
-    room_id: str | None,
-    thread_id: str | None,
-    requester_id: str | None,
-    correlation_id: str | None,
-    compaction_outcomes_collector: list[CompactionOutcome] | None,
-    configured_team_name: str | None,
-    matrix_run_metadata: dict[str, object] | None = None,
-) -> _PreparedOpenAIMaterializedTeamExecution:
-    """Prepare one team run using only public execution-preparation interfaces."""
-    prepared_execution = await prepare_bound_team_run_context(
-        scope_context=scope_context,
-        agents=agents,
-        team=team,
-        prompt=message,
-        thread_history=thread_history,
-        config=config,
-        runtime_paths=runtime_paths,
-        entity_name=configured_team_name,
-        active_model_name=active_model_name,
-        active_context_window=config.resolve_runtime_model(
-            entity_name=configured_team_name,
-            active_model_name=active_model_name,
-        ).context_window,
-        reply_to_event_id=reply_to_event_id,
-        active_event_ids=active_event_ids,
-        response_sender_id=response_sender_id,
-        current_sender_id=current_sender_id,
-        compaction_outcomes_collector=compaction_outcomes_collector,
-    )
-    run_extra_content = build_prepared_history_metadata_content(prepared_execution.prepared_history)
-    run_metadata = build_matrix_run_metadata(
-        reply_to_event_id,
-        prepared_execution.unseen_event_ids,
-        room_id=room_id,
-        thread_id=thread_id,
-        requester_id=requester_id,
-        correlation_id=correlation_id,
-        tools_schema=team_tool_definition_payloads_for_logging(team),
-        model_params=model_params_payload(team.model) if team.model is not None else {},
-        extra_metadata=cast(
-            "dict[str, object] | None",
-            deep_merge_metadata(
-                cast("dict[str, Any] | None", matrix_run_metadata),
-                run_extra_content,
-            ),
-        ),
-    )
-    return _PreparedOpenAIMaterializedTeamExecution(
-        messages=prepared_execution.messages,
-        run_metadata=cast("dict[str, object] | None", run_metadata),
-    )
-
-
 async def _prepare_openai_team_prompt(
     *,
     scope_context: ScopeSessionContext | None,
@@ -1527,7 +1443,7 @@ async def _prepare_openai_team_prompt(
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> _PreparedOpenAITeamPrompt:
     """Prepare the final prompt for one OpenAI-compatible team run."""
-    prepared_execution = await _prepare_materialized_team_execution(
+    prepared_execution = await prepare_materialized_team_execution(
         scope_context=scope_context,
         agents=agents,
         team=team,
@@ -1550,7 +1466,7 @@ async def _prepare_openai_team_prompt(
     )
     return _PreparedOpenAITeamPrompt(
         prompt=render_prepared_team_messages_text(prepared_execution.messages),
-        run_metadata=prepared_execution.run_metadata,
+        run_metadata=cast("dict[str, object] | None", prepared_execution.run_metadata),
     )
 
 

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1441,7 +1441,7 @@ def build_materialized_team_instance(
     )
 
 
-async def _prepare_materialized_team_execution(
+async def prepare_materialized_team_execution(
     *,
     scope_context: ScopeSessionContext | None,
     agents: list[Agent],
@@ -1612,7 +1612,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                 model_name=model_name,
                 configured_team_name=configured_team_name,
             )
-            prepared_execution = await _prepare_materialized_team_execution(
+            prepared_execution = await prepare_materialized_team_execution(
                 scope_context=scope_context,
                 agents=agents,
                 team=team,
@@ -2015,7 +2015,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                 model_name=model_name,
                 configured_team_name=configured_team_name,
             )
-            prepared_execution = await _prepare_materialized_team_execution(
+            prepared_execution = await prepare_materialized_team_execution(
                 scope_context=scope_context,
                 agents=team_members.agents,
                 team=team,
@@ -2504,6 +2504,7 @@ __all__ = [
     "is_cancelled_run_output",
     "is_errored_run_output",
     "materialize_exact_team_members",
+    "prepare_materialized_team_execution",
     "resolve_configured_team",
     "resolve_live_shared_agent_names",
     "select_model_for_team",

--- a/tach.toml
+++ b/tach.toml
@@ -2068,6 +2068,7 @@ expose = [
     "resolve_configured_team",
     "decide_team_formation",
     "materialize_exact_team_members",
+    "prepare_materialized_team_execution",
     "build_materialized_team_instance",
     "format_team_response",
     "is_cancelled_run_output",

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -2630,6 +2630,74 @@ def team_app_client(team_config: Config) -> Iterator[TestClient]:
 class TestTeamCompletion:
     """Tests for team model support (Phase 3)."""
 
+    @pytest.mark.asyncio
+    async def test_prepare_openai_team_prompt_uses_non_matrix_team_preparation_defaults(
+        self,
+        team_config: Config,
+        tmp_path: Path,
+    ) -> None:
+        """OpenAI team prompt preparation should preserve non-Matrix request defaults."""
+        runtime_paths = resolve_runtime_paths(config_path=tmp_path / "config.yaml")
+        execution_identity = build_tool_execution_identity(
+            channel="openai_compat",
+            agent_name="team/super_team",
+            session_id="session-openai-team",
+            runtime_paths=runtime_paths,
+            requester_id=None,
+            room_id=None,
+            thread_id=None,
+            resolved_thread_id=None,
+        )
+        mock_team = _make_test_team()
+        mock_agents = [_make_test_agent("GeneralAgent")]
+        prepared_messages = (
+            Message(role="assistant", content="Previous team reply"),
+            Message(role="user", content="Build it"),
+        )
+        run_metadata = {"correlation_id": "metadata-correlation"}
+
+        with patch(
+            "mindroom.api.openai_compat.prepare_materialized_team_execution",
+            new_callable=AsyncMock,
+        ) as mock_prepare:
+            mock_prepare.return_value = SimpleNamespace(
+                messages=prepared_messages,
+                run_metadata=run_metadata,
+            )
+
+            prepared = await openai_compat._prepare_openai_team_prompt(
+                scope_context=None,
+                team_name="super_team",
+                agents=mock_agents,
+                team=mock_team,
+                prompt="Build it",
+                config=team_config,
+                runtime_paths=runtime_paths,
+                thread_history=[],
+                execution_identity=execution_identity,
+            )
+
+        assert prepared.prompt == "assistant: Previous team reply\n\nBuild it"
+        assert prepared.run_metadata is run_metadata
+        assert mock_prepare.await_count == 1
+        preparation_kwargs = mock_prepare.await_args.kwargs
+        assert preparation_kwargs["agents"] == mock_agents
+        assert preparation_kwargs["team"] is mock_team
+        assert preparation_kwargs["message"] == "Build it"
+        assert preparation_kwargs["thread_history"] == []
+        assert preparation_kwargs["reply_to_event_id"] is None
+        assert preparation_kwargs["active_event_ids"] == frozenset()
+        assert preparation_kwargs["response_sender_id"] is None
+        assert preparation_kwargs["current_sender_id"] is None
+        assert preparation_kwargs["room_id"] is None
+        assert preparation_kwargs["thread_id"] is None
+        assert preparation_kwargs["requester_id"] is None
+        assert re.fullmatch(r"[0-9a-f]{32}", preparation_kwargs["correlation_id"])
+        assert preparation_kwargs["compaction_outcomes_collector"] is None
+        assert preparation_kwargs["configured_team_name"] == "super_team"
+        assert preparation_kwargs["matrix_run_metadata"] is None
+        assert preparation_kwargs["active_model_name"] == "default"
+
     def test_team_listed_in_models(self, team_app_client: TestClient) -> None:
         """Teams appear in /v1/models with team/ prefix."""
         response = team_app_client.get("/v1/models")
@@ -2662,7 +2730,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -2741,7 +2809,7 @@ class TestTeamCompletion:
             patch("mindroom.api.openai_compat.materialize_exact_team_members", side_effect=fake_materialize),
             patch("mindroom.api.openai_compat.build_materialized_team_instance", return_value=mock_team),
             patch(
-                "mindroom.api.openai_compat.prepare_bound_team_run_context",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -2757,7 +2825,7 @@ class TestTeamCompletion:
         assert response.status_code == 200
         assert (
             "Knowledge base `docs` is initializing and unavailable for semantic search this turn."
-            in mock_prepare.await_args.kwargs["prompt"]
+            in mock_prepare.await_args.kwargs["message"]
         )
         assert scheduled_base_ids == ["docs"]
 
@@ -2829,7 +2897,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new=AsyncMock(side_effect=mock_prepare_team_execution),
             ),
         ):
@@ -2873,7 +2941,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -2906,7 +2974,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -2938,7 +3006,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -2975,7 +3043,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -3092,7 +3160,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new=AsyncMock(side_effect=mock_prepare_team_execution),
             ),
         ):
@@ -3182,7 +3250,7 @@ class TestTeamCompletion:
             patch("mindroom.api.openai_compat.materialize_exact_team_members", side_effect=fake_materialize),
             patch("mindroom.api.openai_compat.build_materialized_team_instance", return_value=mock_team),
             patch(
-                "mindroom.api.openai_compat.prepare_bound_team_run_context",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -3199,7 +3267,7 @@ class TestTeamCompletion:
         assert response.status_code == 200
         assert (
             "Knowledge base `docs` is refreshing against newer config and may be stale this turn."
-            in mock_prepare.await_args.kwargs["prompt"]
+            in mock_prepare.await_args.kwargs["message"]
         )
         assert scheduled_base_ids == ["docs"]
 
@@ -3219,7 +3287,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -3259,7 +3327,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -3477,7 +3545,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -4088,7 +4156,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -4143,7 +4211,7 @@ class TestTeamCompletion:
                 return_value=(mock_agents, mock_team, TeamMode.COORDINATE),
             ),
             patch(
-                "mindroom.api.openai_compat._prepare_materialized_team_execution",
+                "mindroom.api.openai_compat.prepare_materialized_team_execution",
                 new_callable=AsyncMock,
             ) as mock_prepare,
         ):
@@ -4269,12 +4337,12 @@ class TestTeamCompletion:
                     new=AsyncMock(side_effect=fake_prepare_bound_team_run_context),
                 ),
                 patch(
-                    "mindroom.api.openai_compat.team_tool_definition_payloads_for_logging",
+                    "mindroom.teams.team_tool_definition_payloads_for_logging",
                     return_value=[{"name": "demo_tool", "description": "Demo"}],
                     create=True,
                 ),
                 patch(
-                    "mindroom.api.openai_compat.model_params_payload",
+                    "mindroom.teams.model_params_payload",
                     return_value={"temperature": 0.7},
                     create=True,
                 ),

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -159,10 +159,7 @@ def test_flattened_seams_keep_public_exports_at_the_behavior_layer() -> None:
             "queued_message_signal_context",
             "scrub_queued_notice_session_context",
         ),
-        "mindroom.teams": (
-            "PreparedMaterializedTeamExecution",
-            "prepare_materialized_team_execution",
-        ),
+        "mindroom.teams": ("PreparedMaterializedTeamExecution",),
     }
     for module_name, attrs in hidden_attrs.items():
         module = importlib.import_module(module_name)

--- a/tests/test_system_enrich.py
+++ b/tests/test_system_enrich.py
@@ -44,7 +44,7 @@ from mindroom.memory import MemoryPromptParts
 from mindroom.message_target import MessageTarget
 from mindroom.response_runner import ResponseRequest
 from mindroom.team_exact_members import ResolvedExactTeamMembers
-from mindroom.teams import TeamMode, _prepare_materialized_team_execution, build_materialized_team_instance
+from mindroom.teams import TeamMode, build_materialized_team_instance, prepare_materialized_team_execution
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
@@ -416,7 +416,7 @@ async def test_prepare_materialized_team_execution_applies_system_enrichment_to_
             model_name=None,
             configured_team_name=None,
         )
-        await _prepare_materialized_team_execution(
+        await prepare_materialized_team_execution(
             scope_context=None,
             agents=team_members.agents,
             team=team,
@@ -495,7 +495,7 @@ async def test_prepare_materialized_team_execution_returns_prompt_helpers(tmp_pa
             model_name=None,
             configured_team_name=None,
         )
-        prepared_execution = await _prepare_materialized_team_execution(
+        prepared_execution = await prepare_materialized_team_execution(
             scope_context=None,
             agents=team_members.agents,
             team=team,

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -54,9 +54,9 @@ from mindroom.team_exact_members import (
 from mindroom.teams import (
     TeamMode,
     _materialize_team_members,
-    _prepare_materialized_team_execution,
     _team_response_stream_raw,
     materialize_exact_team_members,
+    prepare_materialized_team_execution,
     team_response,
     team_response_stream,
 )
@@ -827,7 +827,7 @@ async def test_prepare_materialized_team_execution_scrubs_queued_notices_when_ca
             "mindroom.execution_preparation._prepare_bound_team_execution_context",
             new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
         ):
-            await _prepare_materialized_team_execution(
+            await prepare_materialized_team_execution(
                 scope_context=scope_context,
                 agents=[fake_agent],
                 team=mock_team,
@@ -869,7 +869,7 @@ async def test_prepare_materialized_team_execution_forwards_explicit_thread_hist
         "mindroom.teams.prepare_bound_team_run_context",
         new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
     ):
-        await _prepare_materialized_team_execution(
+        await prepare_materialized_team_execution(
             scope_context=None,
             agents=[fake_agent],
             team=mock_team,
@@ -913,7 +913,7 @@ async def test_prepare_materialized_team_execution_appends_system_enrichment_con
         "mindroom.teams.prepare_bound_team_run_context",
         new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
     ):
-        await _prepare_materialized_team_execution(
+        await prepare_materialized_team_execution(
             scope_context=None,
             agents=[fake_agent],
             team=mock_team,
@@ -971,7 +971,7 @@ async def test_prepare_materialized_team_execution_carries_compaction_metadata_a
         "mindroom.teams.prepare_bound_team_run_context",
         new=AsyncMock(side_effect=fake_prepare_bound_team_run_context),
     ):
-        prepared = await _prepare_materialized_team_execution(
+        prepared = await prepare_materialized_team_execution(
             scope_context=None,
             agents=[fake_agent],
             team=mock_team,


### PR DESCRIPTION
## Summary
- expose the existing materialized team preparation helper from mindroom.teams and reuse it from the OpenAI-compatible team prompt path
- remove the duplicated OpenAI-local preparation dataclass/helper while preserving prompt rendering and run metadata shape
- add characterization coverage for OpenAI non-Matrix team preparation defaults and update Tach interface exposure

## Verification
- uv sync --all-extras
- uv run pytest tests/test_openai_compat.py::TestTeamCompletion::test_prepare_openai_team_prompt_uses_non_matrix_team_preparation_defaults -q
- uv run pytest tests/test_openai_compat.py::TestTeamCompletion -q
- uv run pytest tests/test_openai_compat.py -q
- uv run pytest tests/test_team_media_fallback.py::test_prepare_materialized_team_execution_scrubs_queued_notices_when_called_directly tests/test_team_media_fallback.py::test_prepare_materialized_team_execution_forwards_explicit_thread_history_render_limits tests/test_team_media_fallback.py::test_prepare_materialized_team_execution_appends_system_enrichment_context tests/test_team_media_fallback.py::test_prepare_materialized_team_execution_carries_compaction_metadata_and_timing tests/test_system_enrich.py::test_prepare_materialized_team_execution_applies_system_enrichment_to_team_and_members tests/test_system_enrich.py::test_prepare_materialized_team_execution_returns_prompt_helpers -q
- uv run pytest tests/test_routing.py::test_flattened_seams_keep_public_exports_at_the_behavior_layer -q
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/api/openai_compat.py src/mindroom/teams.py tach.toml tests/test_openai_compat.py tests/test_team_media_fallback.py tests/test_system_enrich.py tests/test_routing.py
- uv run pytest -q