### PR TITLE
refactor: derive config env template keys from provider mapping

### DIFF
--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -75,13 +75,6 @@ _DEFAULT_MODEL_PRESETS: dict[_ProviderPreset, tuple[str, str]] = {
     "vertexai_claude": ("vertexai_claude", "claude-sonnet-4-6"),
 }
 
-_REQUIRED_ENV_KEYS: dict[_ProviderPreset, tuple[str, ...]] = {
-    "anthropic": ("ANTHROPIC_API_KEY",),
-    "codex": (),
-    "openai": ("OPENAI_API_KEY",),
-    "openrouter": ("OPENROUTER_API_KEY",),
-    "vertexai_claude": (),
-}
 _PUBLIC_HOSTED_ENV_DEFAULTS: tuple[tuple[str, str], ...] = (
     ("MATRIX_HOMESERVER", "https://mindroom.chat"),
     ("MATRIX_SERVER_NAME", "mindroom.chat"),
@@ -1014,7 +1007,7 @@ def _provider_env_template(provider_preset: _ProviderPreset) -> str:
         # or set GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
         """).rstrip()
 
-    required_env_keys = set(_REQUIRED_ENV_KEYS[provider_preset])
+    required_env_key = env_key_for_provider(provider_preset)
     key_placeholders = {
         "ANTHROPIC_API_KEY": "your-anthropic-key-here",
         "OPENAI_API_KEY": "your-openai-key-here",
@@ -1022,6 +1015,6 @@ def _provider_env_template(provider_preset: _ProviderPreset) -> str:
     }
     provider_lines: list[str] = ["# AI provider API keys (set the uncommented keys for this preset)"]
     for env_key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
-        prefix = "" if env_key in required_env_keys else "# "
+        prefix = "" if env_key == required_env_key else "# "
         provider_lines.append(f"{prefix}{env_key}={key_placeholders[env_key]}")
     return "\n".join(provider_lines)

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -20,6 +20,7 @@ from typer.testing import CliRunner
 
 import mindroom.constants as constants_module
 from mindroom.agents import ensure_default_agent_workspaces
+from mindroom.cli import config as config_cli
 from mindroom.cli.config import _format_config_search_locations, activate_cli_runtime
 from mindroom.cli.main import _load_active_config_or_exit, app
 from mindroom.config.main import Config
@@ -682,6 +683,22 @@ class TestConfigInit:
         content = target.read_text()
         assert "provider: openrouter" in content
         assert "anthropic/claude-sonnet-4.6" in content
+
+    def test_provider_env_template_uses_canonical_provider_env_key(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Provider .env templates should derive required keys from the canonical provider mapping."""
+        monkeypatch.setattr(
+            config_cli,
+            "env_key_for_provider",
+            lambda provider: "OPENAI_API_KEY" if provider == "openrouter" else None,
+        )
+
+        env_content = config_cli._provider_env_template("openrouter")
+
+        assert "\nOPENAI_API_KEY=your-openai-key-here" in f"\n{env_content}"
+        assert "\n# OPENROUTER_API_KEY=your-openrouter-key-here" in f"\n{env_content}"
 
     def test_init_codex_preset_uses_codex_models(self, tmp_path: Path) -> None:
         """Config init --provider codex uses Codex subscription defaults."""


### PR DESCRIPTION
## Summary
- remove the duplicate config-init required provider env-key table
- derive starter .env required API key rendering from env_key_for_provider
- add a characterization test that catches drift from the canonical provider mapping

## Duplicate flows examined
- src/mindroom/cli/doctor.py provider API-key checks: already use env_key_for_provider for model, memory LLM, and memory embedder validation
- src/mindroom/cli/config.py config validate missing-env checks: already use env_key_for_provider, with a Vertex-specific multi-key branch
- src/mindroom/cli/config.py config init .env template rendering: had separate _REQUIRED_ENV_KEYS table duplicating provider-to-env-key choices
- src/mindroom/constants.py PROVIDER_ENV_KEYS/env_key_for_provider: kept as the source of truth

## Verification
- uv sync --all-extras
- uv run pytest tests/test_cli_config.py::TestConfigInit::test_provider_env_template_uses_canonical_provider_env_key -q (red before implementation, green after)
- uv run pytest tests/test_cli_config.py::TestConfigInit tests/test_cli_config.py::TestConfigValidate tests/test_cli_config.py::TestDoctor -n 0 --no-cov -q (74 passed)
- uv run pre-commit run --files src/mindroom/cli/config.py tests/test_cli_config.py (passed)
- uv run tach check --dependencies --interfaces (passed)
- uv run pytest --no-cov --cov-report= -q (1 unrelated failure: tests/test_tool_dependencies.py::test_all_tools_can_be_imported timed out after 60s while importing OpenBB/Intrinio through Pydantic schema generation; 6258 passed, 56 skipped)

## Line delta
- production: src/mindroom/cli/config.py +2/-9, net -7
- tests: tests/test_cli_config.py +17/-0