### PR TITLE
refactor: share cancellation logging helper

### DIFF
--- a/src/mindroom/cancellation.py
+++ b/src/mindroom/cancellation.py
@@ -58,4 +58,13 @@ def _cancel_failure_reason(cancel_source: CancelSource) -> str:
     return "interrupted"
 
 
+def cancel_source_from_failure_reason(failure_reason: str | None) -> CancelSource:
+    """Return cancellation provenance from one canonical failure reason."""
+    if failure_reason == "sync_restart_cancelled":
+        return "sync_restart"
+    if failure_reason == "cancelled_by_user":
+        return "user_stop"
+    return "interrupted"
+
+
 cancel_failure_reason = _cancel_failure_reason

--- a/src/mindroom/cancellation.py
+++ b/src/mindroom/cancellation.py
@@ -38,6 +38,17 @@ def build_cancelled_error(reason: str | None) -> asyncio.CancelledError:
     return asyncio.CancelledError(reason or "Run cancelled")
 
 
+def classify_cancel_source(exc: asyncio.CancelledError) -> CancelSource:
+    """Return the visible cancellation provenance for one CancelledError."""
+    if len(exc.args) == 0:
+        return "interrupted"
+    if exc.args[0] == USER_STOP_CANCEL_MSG:
+        return "user_stop"
+    if exc.args[0] == SYNC_RESTART_CANCEL_MSG:
+        return "sync_restart"
+    return "interrupted"
+
+
 def _cancel_failure_reason(cancel_source: CancelSource) -> str:
     """Return the canonical failure reason for one cancellation provenance."""
     if cancel_source == "sync_restart":

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -33,12 +33,10 @@ from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_message_content
 from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
 from mindroom.streaming import (
-    SYNC_RESTART_CANCEL_MSG,
-    USER_STOP_CANCEL_MSG,
-    CancelSource,
     StreamingResponse,
     build_cancelled_response_update,
     cancel_failure_reason,
+    classify_cancel_source,
     send_streaming_response,
 )
 
@@ -387,12 +385,7 @@ class DeliveryGateway:
     @staticmethod
     def _cancelled_error_failure_reason(error: asyncio.CancelledError) -> str:
         """Normalize CancelledError values to the canonical cancellation reason strings."""
-        cancel_source: CancelSource = "interrupted"
-        if error.args and error.args[0] == USER_STOP_CANCEL_MSG:
-            cancel_source = "user_stop"
-        elif error.args and error.args[0] == SYNC_RESTART_CANCEL_MSG:
-            cancel_source = "sync_restart"
-        return cancel_failure_reason(cancel_source)
+        return cancel_failure_reason(classify_cancel_source(error))
 
     async def _cleanup_completed_placeholder_only_stream(
         self,

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -17,6 +17,7 @@ from mindroom.cancellation import (
     USER_STOP_CANCEL_MSG,
     CancelSource,
     cancel_failure_reason,
+    classify_cancel_source,
     request_task_cancel,
 )
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths, runtime_matrix_ssl_verify
@@ -33,6 +34,8 @@ from mindroom.runtime_state import set_runtime_starting
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Coroutine
+
+    import structlog
 
     from mindroom.bot import AgentBot, TeamBot
     from mindroom.config.main import Config
@@ -64,6 +67,7 @@ __all__ = [
     "create_temp_user",
     "is_permanent_startup_error",
     "is_sync_restart_cancel",
+    "log_cancelled_response",
     "matrix_sync_startup_timeout_seconds",
     "request_task_cancel",
     "retry_delay_seconds",
@@ -74,20 +78,32 @@ __all__ = [
 ]
 
 
-def classify_cancel_source(exc: asyncio.CancelledError) -> CancelSource:
-    """Return the visible cancellation provenance for one CancelledError."""
-    if len(exc.args) == 0:
-        return "interrupted"
-    if exc.args[0] == USER_STOP_CANCEL_MSG:
-        return "user_stop"
-    if exc.args[0] == SYNC_RESTART_CANCEL_MSG:
-        return "sync_restart"
-    return "interrupted"
-
-
 def is_sync_restart_cancel(exc: asyncio.CancelledError) -> bool:
     """Return whether one cancellation was caused by a sync restart."""
     return classify_cancel_source(exc) == "sync_restart"
+
+
+def log_cancelled_response(
+    logger: structlog.stdlib.BoundLogger,
+    *,
+    exc: asyncio.CancelledError,
+    message_id: str | None,
+    restart_message: str,
+    user_stop_message: str,
+    interrupted_message: str,
+) -> None:
+    """Log one CancelledError with the right provenance label."""
+    cancel_source = classify_cancel_source(exc)
+    if cancel_source == "sync_restart":
+        logger.info(restart_message, message_id=message_id)
+    elif cancel_source == "user_stop":
+        logger.info(user_stop_message, message_id=message_id)
+    else:
+        logger.warning(
+            interrupted_message,
+            message_id=message_id,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
 
 
 def matrix_sync_startup_timeout_seconds(runtime_paths: RuntimePaths) -> float:

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -17,6 +17,7 @@ from mindroom.cancellation import (
     USER_STOP_CANCEL_MSG,
     CancelSource,
     cancel_failure_reason,
+    cancel_source_from_failure_reason,
     classify_cancel_source,
     request_task_cancel,
 )
@@ -34,6 +35,7 @@ from mindroom.runtime_state import set_runtime_starting
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Coroutine
+    from types import TracebackType
 
     import structlog
 
@@ -60,6 +62,7 @@ __all__ = [
     "EntityStartResults",
     "cancel_failure_reason",
     "cancel_logged_task",
+    "cancel_source_from_failure_reason",
     "cancel_sync_task",
     "cancel_task",
     "classify_cancel_source",
@@ -68,6 +71,7 @@ __all__ = [
     "is_permanent_startup_error",
     "is_sync_restart_cancel",
     "log_cancelled_response",
+    "log_cancelled_response_source",
     "matrix_sync_startup_timeout_seconds",
     "request_task_cancel",
     "retry_delay_seconds",
@@ -93,17 +97,37 @@ def log_cancelled_response(
     interrupted_message: str,
 ) -> None:
     """Log one CancelledError with the right provenance label."""
-    cancel_source = classify_cancel_source(exc)
+    log_cancelled_response_source(
+        logger,
+        cancel_source=classify_cancel_source(exc),
+        message_id=message_id,
+        restart_message=restart_message,
+        user_stop_message=user_stop_message,
+        interrupted_message=interrupted_message,
+        exc_info=(type(exc), exc, exc.__traceback__),
+    )
+
+
+def log_cancelled_response_source(
+    logger: structlog.stdlib.BoundLogger,
+    *,
+    cancel_source: CancelSource,
+    message_id: str | None,
+    restart_message: str,
+    user_stop_message: str,
+    interrupted_message: str,
+    exc_info: tuple[type[BaseException], BaseException, TracebackType | None] | bool | None = None,
+) -> None:
+    """Log one resolved cancellation source with caller-specific text."""
     if cancel_source == "sync_restart":
         logger.info(restart_message, message_id=message_id)
     elif cancel_source == "user_stop":
         logger.info(user_stop_message, message_id=message_id)
     else:
-        logger.warning(
-            interrupted_message,
-            message_id=message_id,
-            exc_info=(type(exc), exc, exc.__traceback__),
-        )
+        kwargs: dict[str, Any] = {"message_id": message_id}
+        if exc_info is not None:
+            kwargs["exc_info"] = exc_info
+        logger.warning(interrupted_message, **kwargs)
 
 
 def matrix_sync_startup_timeout_seconds(runtime_paths: RuntimePaths) -> float:

--- a/src/mindroom/response_attempt.py
+++ b/src/mindroom/response_attempt.py
@@ -10,7 +10,7 @@ from mindroom.constants import STREAM_STATUS_KEY, STREAM_STATUS_PENDING
 from mindroom.delivery_gateway import SendTextRequest
 from mindroom.logging_config import bound_log_context
 from mindroom.matrix.presence import is_user_online
-from mindroom.orchestration.runtime import cancel_failure_reason, classify_cancel_source
+from mindroom.orchestration.runtime import cancel_failure_reason, classify_cancel_source, log_cancelled_response
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
@@ -53,29 +53,6 @@ class ResponseAttemptRequest:
     run_id: str | None = None
     pipeline_timing: DispatchPipelineTiming | None = None
     on_cancelled: Callable[[str], None] | None = None
-
-
-def log_cancelled_response(
-    logger: structlog.stdlib.BoundLogger,
-    *,
-    exc: asyncio.CancelledError,
-    message_id: str | None,
-    restart_message: str,
-    user_stop_message: str,
-    interrupted_message: str,
-) -> None:
-    """Log one CancelledError with the right provenance label."""
-    cancel_source = classify_cancel_source(exc)
-    if cancel_source == "sync_restart":
-        logger.info(restart_message, message_id=message_id)
-    elif cancel_source == "user_stop":
-        logger.info(user_stop_message, message_id=message_id)
-    else:
-        logger.warning(
-            interrupted_message,
-            message_id=message_id,
-            exc_info=(type(exc), exc, exc.__traceback__),
-        )
 
 
 @dataclass(frozen=True)

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -37,13 +37,18 @@ from mindroom.memory import (
     store_conversation_memory,
     strip_user_turn_time_prefix,
 )
-from mindroom.orchestration.runtime import cancel_failure_reason, classify_cancel_source
+from mindroom.orchestration.runtime import (
+    cancel_failure_reason,
+    cancel_source_from_failure_reason,
+    classify_cancel_source,
+    log_cancelled_response,
+    log_cancelled_response_source,
+)
 from mindroom.post_response_effects import PostResponseEffectsSupport, ResponseOutcome
 from mindroom.response_attempt import (
     ResponseAttemptDeps,
     ResponseAttemptRequest,
     ResponseAttemptRunner,
-    log_cancelled_response,
 )
 from mindroom.response_terminal import (
     PendingVisibleResponse,
@@ -1280,17 +1285,15 @@ class ResponseRunner:
         except StreamingDeliveryError as error:
             stream_transport_outcome = error.transport_outcome
             if stream_transport_outcome.terminal_status == "cancelled":
-                if stream_transport_outcome.failure_reason == "sync_restart_cancelled":
-                    self.deps.logger.info(
-                        "Team streaming response interrupted by sync restart",
-                        message_id=error.event_id,
-                    )
-                else:
-                    self.deps.logger.warning(
-                        "Team streaming response cancelled — traceback for diagnosis",
-                        message_id=error.event_id,
-                        exc_info=True,
-                    )
+                log_cancelled_response_source(
+                    self.deps.logger,
+                    cancel_source=cancel_source_from_failure_reason(stream_transport_outcome.failure_reason),
+                    message_id=error.event_id,
+                    restart_message="Team streaming response interrupted by sync restart",
+                    user_stop_message="Team streaming response cancelled by user",
+                    interrupted_message="Team streaming response interrupted — traceback for diagnosis",
+                    exc_info=(type(error.error), error.error, error.error.__traceback__),
+                )
             else:
                 self.deps.logger.exception("Error in team streaming response", error=str(error.error))
             if error.event_id:
@@ -1962,17 +1965,15 @@ class ResponseRunner:
         except StreamingDeliveryError as error:
             stream_transport_outcome = error.transport_outcome
             if stream_transport_outcome.terminal_status == "cancelled":
-                if stream_transport_outcome.failure_reason == "sync_restart_cancelled":
-                    self.deps.logger.info(
-                        "Bot streaming response interrupted by sync restart",
-                        message_id=error.event_id,
-                    )
-                else:
-                    self.deps.logger.warning(
-                        "Bot streaming response cancelled — traceback for diagnosis",
-                        message_id=error.event_id,
-                        exc_info=True,
-                    )
+                log_cancelled_response_source(
+                    self.deps.logger,
+                    cancel_source=cancel_source_from_failure_reason(stream_transport_outcome.failure_reason),
+                    message_id=error.event_id,
+                    restart_message="Bot streaming response interrupted by sync restart",
+                    user_stop_message="Bot streaming response cancelled by user",
+                    interrupted_message="Bot streaming response interrupted — traceback for diagnosis",
+                    exc_info=(type(error.error), error.error, error.error.__traceback__),
+                )
             else:
                 self.deps.logger.exception("Error in streaming response", error=str(error.error))
             tool_trace[:] = error.tool_trace

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -31,6 +31,7 @@ from mindroom.orchestration.runtime import (
     CancelSource,
     cancel_failure_reason,
     classify_cancel_source,
+    log_cancelled_response,
 )
 from mindroom.streaming_delivery import (
     DeliveryRequest,
@@ -240,25 +241,6 @@ def build_cancelled_response_update(
     if not stripped_text or stripped_text == _PROGRESS_PLACEHOLDER:
         return note, stream_status
     return f"{stripped_text}\n\n{note}", stream_status
-
-
-def _log_stream_cancellation(
-    *,
-    exc: asyncio.CancelledError,
-    cancel_source: Literal["user_stop", "sync_restart", "interrupted"],
-    message_id: str | None,
-) -> None:
-    """Log one streaming cancellation with its resolved provenance."""
-    if cancel_source == "sync_restart":
-        logger.info("Streaming response interrupted by sync restart", message_id=message_id)
-    elif cancel_source == "user_stop":
-        logger.info("Streaming response cancelled by user", message_id=message_id)
-    else:
-        logger.warning(
-            "Streaming response interrupted — traceback for diagnosis",
-            message_id=message_id,
-            exc_info=(type(exc), exc, exc.__traceback__),
-        )
 
 
 @dataclass(frozen=True)
@@ -1154,7 +1136,14 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
                         terminal_status="cancelled",
                         tool_trace_collector=tool_trace_collector,
                     ) from delivery_cleanup_error
-            _log_stream_cancellation(exc=exc, cancel_source=cancel_source, message_id=streaming.event_id)
+            log_cancelled_response(
+                logger,
+                exc=exc,
+                message_id=streaming.event_id,
+                restart_message="Streaming response interrupted by sync restart",
+                user_stop_message="Streaming response cancelled by user",
+                interrupted_message="Streaming response interrupted — traceback for diagnosis",
+            )
             transport_outcome = await streaming.finalize(client, cancel_source=cancel_source)
             raise StreamingDeliveryError(
                 exc,

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -24,10 +24,12 @@ from mindroom.orchestration.runtime import (
     EntityStartResults,
     _MatrixSyncStalledError,
     _SyncIteration,
+    cancel_source_from_failure_reason,
     cancel_sync_task,
     classify_cancel_source,
     is_sync_restart_cancel,
     log_cancelled_response,
+    log_cancelled_response_source,
     matrix_sync_startup_timeout_seconds,
     stop_entities,
     sync_forever_with_restart,
@@ -269,6 +271,24 @@ async def test_cancel_failure_reason_matches_cancel_source() -> None:
 
 
 @pytest.mark.parametrize(
+    ("failure_reason", "expected_cancel_source"),
+    [
+        ("cancelled_by_user", "user_stop"),
+        ("sync_restart_cancelled", "sync_restart"),
+        ("interrupted", "interrupted"),
+        ("other", "interrupted"),
+        (None, "interrupted"),
+    ],
+)
+def test_cancel_source_from_failure_reason_matches_canonical_reasons(
+    failure_reason: str | None,
+    expected_cancel_source: str,
+) -> None:
+    """Canonical terminal failure reasons should map back to cancellation provenance."""
+    assert cancel_source_from_failure_reason(failure_reason) == expected_cancel_source
+
+
+@pytest.mark.parametrize(
     ("cancel_error", "expected_method", "expected_message"),
     [
         (asyncio.CancelledError(USER_STOP_CANCEL_MSG), "info", "Response cancelled by user"),
@@ -306,6 +326,48 @@ def test_log_cancelled_response_preserves_caller_messages_and_traceback(
         )
     else:
         assert "exc_info" not in log_call.kwargs
+
+
+def test_log_cancelled_response_source_logs_user_stop_without_traceback() -> None:
+    """Resolved user-stop provenance should remain an expected info-level cancellation."""
+    logger = MagicMock()
+
+    log_cancelled_response_source(
+        logger,
+        cancel_source="user_stop",
+        message_id="$event",
+        restart_message="Response interrupted by sync restart",
+        user_stop_message="Response cancelled by user",
+        interrupted_message="Response interrupted — traceback for diagnosis",
+        exc_info=True,
+    )
+
+    logger.info.assert_called_once_with("Response cancelled by user", message_id="$event")
+    logger.warning.assert_not_called()
+
+
+def test_log_cancelled_response_source_logs_interrupted_with_traceback() -> None:
+    """Resolved generic interruptions should keep diagnostic traceback details."""
+    logger = MagicMock()
+    cancel_error = asyncio.CancelledError("other")
+    exc_info = (type(cancel_error), cancel_error, cancel_error.__traceback__)
+
+    log_cancelled_response_source(
+        logger,
+        cancel_source="interrupted",
+        message_id="$event",
+        restart_message="Response interrupted by sync restart",
+        user_stop_message="Response cancelled by user",
+        interrupted_message="Response interrupted — traceback for diagnosis",
+        exc_info=exc_info,
+    )
+
+    logger.warning.assert_called_once_with(
+        "Response interrupted — traceback for diagnosis",
+        message_id="$event",
+        exc_info=exc_info,
+    )
+    logger.info.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -12,7 +12,11 @@ import pytest
 
 from mindroom.bot import AgentBot
 from mindroom.bot_runtime_view import BotRuntimeState
-from mindroom.cancellation import SYNC_RESTART_CANCEL_MSG, USER_STOP_CANCEL_MSG, _cancel_failure_reason
+from mindroom.cancellation import (
+    SYNC_RESTART_CANCEL_MSG,
+    USER_STOP_CANCEL_MSG,
+    _cancel_failure_reason,
+)
 from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths
 from mindroom.orchestration import runtime as runtime_helpers
@@ -23,6 +27,7 @@ from mindroom.orchestration.runtime import (
     cancel_sync_task,
     classify_cancel_source,
     is_sync_restart_cancel,
+    log_cancelled_response,
     matrix_sync_startup_timeout_seconds,
     stop_entities,
     sync_forever_with_restart,
@@ -261,6 +266,46 @@ async def test_cancel_failure_reason_matches_cancel_source() -> None:
     assert _cancel_failure_reason("user_stop") == "cancelled_by_user"
     assert _cancel_failure_reason("sync_restart") == "sync_restart_cancelled"
     assert _cancel_failure_reason("interrupted") == "interrupted"
+
+
+@pytest.mark.parametrize(
+    ("cancel_error", "expected_method", "expected_message"),
+    [
+        (asyncio.CancelledError(USER_STOP_CANCEL_MSG), "info", "Response cancelled by user"),
+        (asyncio.CancelledError(SYNC_RESTART_CANCEL_MSG), "info", "Response interrupted by sync restart"),
+        (asyncio.CancelledError("other"), "warning", "Response interrupted — traceback for diagnosis"),
+    ],
+)
+def test_log_cancelled_response_preserves_caller_messages_and_traceback(
+    cancel_error: asyncio.CancelledError,
+    expected_method: str,
+    expected_message: str,
+) -> None:
+    """Cancellation logging should preserve provenance-specific text and traceback details."""
+    logger = MagicMock()
+
+    log_cancelled_response(
+        logger,
+        exc=cancel_error,
+        message_id="$event",
+        restart_message="Response interrupted by sync restart",
+        user_stop_message="Response cancelled by user",
+        interrupted_message="Response interrupted — traceback for diagnosis",
+    )
+
+    log_method = getattr(logger, expected_method)
+    log_method.assert_called_once()
+    log_call = log_method.call_args
+    assert log_call.args == (expected_message,)
+    assert log_call.kwargs["message_id"] == "$event"
+    if expected_method == "warning":
+        assert log_call.kwargs["exc_info"] == (
+            type(cancel_error),
+            cancel_error,
+            cancel_error.__traceback__,
+        )
+    else:
+        assert "exc_info" not in log_call.kwargs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Move cancellation source classification into `mindroom.cancellation` and re-export it through `orchestration.runtime`.
- Share one `log_cancelled_response` helper for response attempts and streaming cancellations while keeping caller-specific log text unchanged.
- Reuse the shared cancellation classifier in delivery-gateway cancellation failure reason mapping.
- Add characterization coverage for provenance-specific cancellation logging.

## Verification
- `uv sync --all-extras`
- RED: `uv run pytest tests/test_sync_task_cancellation.py -q -k log_cancelled_response -n 0 --no-cov` failed before implementation with missing helper import.
- `uv run pytest tests/test_sync_task_cancellation.py tests/test_response_attempt.py tests/test_streaming_finalize.py tests/test_streaming_behavior.py tests/test_streaming_edits.py tests/test_stale_stream_cleanup.py tests/test_matrix_delivery.py -n 0 --no-cov`
- `uv run pytest tests/test_sync_task_cancellation.py tests/test_response_attempt.py tests/test_streaming_finalize.py tests/test_final_delivery.py tests/test_matrix_delivery.py -n 0 --no-cov`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/cancellation.py src/mindroom/orchestration/runtime.py src/mindroom/response_attempt.py src/mindroom/streaming.py src/mindroom/delivery_gateway.py tests/test_sync_task_cancellation.py`
- `uv run pytest -n 0 --no-cov`