### PR TITLE
refactor: share OAuth credential target payload

### DIFF
--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -32,6 +32,7 @@ from mindroom.oauth.service import (
     OAuthConnectTarget,
     consume_oauth_connect_token,
     lookup_oauth_connect_token,
+    oauth_credential_target_payload,
     oauth_credentials_usable,
     oauth_provider_service_account_configured,
     oauth_success_redirect_url,
@@ -177,15 +178,7 @@ def _issue_authorization_url(
 
 
 def _target_binding_payload(provider: OAuthProvider, target: RequestCredentialsTarget) -> dict[str, str]:
-    worker_target = worker_target_for_credentials_target(target)
-    worker_key = worker_target.worker_key if worker_target is not None else None
-    return {
-        "provider": provider.id,
-        "credential_service": provider.credential_service,
-        "agent_name": target.agent_name or "",
-        "worker_scope": target.worker_scope or "unscoped",
-        "worker_key": worker_key or "",
-    }
+    return oauth_credential_target_payload(provider, worker_target_for_credentials_target(target))
 
 
 def _verify_connect_target_authorized(

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -58,6 +58,23 @@ class OAuthConnectTarget:
     requester_id: str | None
 
 
+def oauth_credential_target_payload(
+    provider: OAuthProvider,
+    worker_target: ResolvedWorkerTarget | None,
+) -> dict[str, str]:
+    """Return serializable OAuth state payload for one credential target."""
+    agent_name = worker_target.routing_agent_name if worker_target is not None else None
+    worker_scope = worker_target.worker_scope if worker_target is not None else None
+    worker_key = worker_target.worker_key if worker_target is not None else None
+    return {
+        "provider": provider.id,
+        "credential_service": provider.credential_service,
+        "agent_name": agent_name or "",
+        "worker_scope": worker_scope or "unscoped",
+        "worker_key": worker_key or "",
+    }
+
+
 def _issue_oauth_connect_token(
     provider: OAuthProvider,
     runtime_paths: RuntimePaths,
@@ -68,19 +85,13 @@ def _issue_oauth_connect_token(
         return None
     requester_id = worker_target.execution_identity.requester_id
 
-    connect_target = OAuthConnectTarget(
-        provider_id=provider.id,
-        credential_service=provider.credential_service,
-        agent_name=worker_target.routing_agent_name,
-        worker_scope=worker_target.worker_scope or "unscoped",
-        worker_key=worker_target.worker_key,
-        requester_id=requester_id,
-    )
+    payload = oauth_credential_target_payload(provider, worker_target)
+    payload["requester_id"] = requester_id or ""
     return issue_opaque_oauth_state(
         runtime_paths,
         kind=_OAUTH_CONNECT_TOKEN_KIND,
         ttl_seconds=_OAUTH_CONNECT_TOKEN_TTL_SECONDS,
-        data=_oauth_connect_target_payload(connect_target),
+        data=payload,
     )
 
 
@@ -134,18 +145,6 @@ def consume_oauth_connect_token(
         msg = "OAuth connect link target changed"
         raise OAuthProviderError(msg)
     return connect_target
-
-
-def _oauth_connect_target_payload(connect_target: OAuthConnectTarget) -> dict[str, str]:
-    """Return serializable OAuth state payload for one connect target."""
-    return {
-        "provider": connect_target.provider_id,
-        "credential_service": connect_target.credential_service,
-        "agent_name": connect_target.agent_name or "",
-        "worker_scope": connect_target.worker_scope,
-        "worker_key": connect_target.worker_key,
-        "requester_id": connect_target.requester_id or "",
-    }
 
 
 def _mindroom_public_base_url(runtime_paths: RuntimePaths, provider: OAuthProvider | None = None) -> str:

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -240,6 +240,45 @@ def _worker_key_for_matrix_user_scope(requester_id: str, worker_scope: WorkerSco
     return worker_key
 
 
+def test_oauth_credential_target_payload_matches_worker_target_fields() -> None:
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    worker_target = resolve_worker_target("user_agent", "general", execution_identity=identity)
+    assert worker_target is not None
+
+    payload = oauth_service.oauth_credential_target_payload(provider, worker_target)
+
+    assert payload == {
+        "provider": "google_drive",
+        "credential_service": "google_drive_oauth",
+        "agent_name": "general",
+        "worker_scope": "user_agent",
+        "worker_key": worker_target.worker_key,
+    }
+
+
+def test_oauth_credential_target_payload_represents_unscoped_target() -> None:
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+
+    payload = oauth_service.oauth_credential_target_payload(provider, None)
+
+    assert payload == {
+        "provider": "google_drive",
+        "credential_service": "google_drive_oauth",
+        "agent_name": "",
+        "worker_scope": "unscoped",
+        "worker_key": "",
+    }
+
+
 def test_plugin_config_registers_oauth_provider(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugin"
     plugin_dir.mkdir()


### PR DESCRIPTION
## Summary
- Add one OAuth service helper for serializing provider/service/agent/scope/worker-key target bindings.
- Reuse it from dashboard OAuth pending state and conversation connect token issuance.
- Cover scoped and unscoped payload shapes with characterization tests.

## Verification
- uv sync --all-extras
- uv run pytest tests/api/test_oauth_api.py -k 'oauth_credential_target_payload' -x -n 0 --no-cov -v
- uv run pytest tests/api/test_credentials_api.py tests/api/test_oauth_api.py -x -n 0 --no-cov -v
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/api/oauth.py src/mindroom/oauth/service.py tests/api/test_oauth_api.py
- uv run pytest -n 0 --no-cov printed: 6260 passed, 56 skipped, 64 warnings in 276.80s; pytest then hung in multiprocessing resource tracker teardown and was terminated