### PR TITLE
refactor: extract hook room state adapters

### DIFF
--- a/src/mindroom/hooks/state.py
+++ b/src/mindroom/hooks/state.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from functools import partial
+from typing import TYPE_CHECKING, Any, cast
 
 import nio
 
@@ -10,36 +11,50 @@ if TYPE_CHECKING:
     from .types import HookRoomStatePutter, HookRoomStateQuerier
 
 
+async def _query_hook_room_state(
+    client: nio.AsyncClient,
+    room_id: str,
+    event_type: str,
+    state_key: str | None = None,
+) -> dict[str, Any] | None:
+    """Query Matrix room state with hook adapter semantics."""
+    if state_key is not None:
+        resp = await client.room_get_state_event(room_id, event_type, state_key)
+        if isinstance(resp, nio.RoomGetStateEventError):
+            return None
+        return resp.content
+
+    resp = await client.room_get_state(room_id)
+    if isinstance(resp, nio.RoomGetStateError):
+        return None
+    return {ev["state_key"]: ev["content"] for ev in resp.events if ev.get("type") == event_type}
+
+
 def build_hook_room_state_querier(
     client: nio.AsyncClient,
 ) -> HookRoomStateQuerier:
     """Return a querier bound to one Matrix client.
 
-    The returned closure queries room state events via the Matrix client.
+    The returned adapter queries room state events via the Matrix client.
     When *state_key* is provided it fetches a single state event; when
     ``None`` it returns all events matching *event_type* as a
     ``{state_key: content}`` dict. Matrix error response objects are
     converted to ``None``; transport exceptions from the client
     propagate to the caller.
     """
+    return cast("HookRoomStateQuerier", partial(_query_hook_room_state, client))
 
-    async def _query(
-        room_id: str,
-        event_type: str,
-        state_key: str | None = None,
-    ) -> dict[str, Any] | None:
-        if state_key is not None:
-            resp = await client.room_get_state_event(room_id, event_type, state_key)
-            if isinstance(resp, nio.RoomGetStateEventError):
-                return None
-            return resp.content
 
-        resp = await client.room_get_state(room_id)
-        if isinstance(resp, nio.RoomGetStateError):
-            return None
-        return {ev["state_key"]: ev["content"] for ev in resp.events if ev.get("type") == event_type}
-
-    return _query
+async def _put_hook_room_state(
+    client: nio.AsyncClient,
+    room_id: str,
+    event_type: str,
+    state_key: str,
+    content: dict[str, Any],
+) -> bool:
+    """Write Matrix room state with hook adapter semantics."""
+    resp = await client.room_put_state(room_id, event_type, content, state_key=state_key)
+    return not isinstance(resp, nio.RoomPutStateError)
 
 
 def build_hook_room_state_putter(
@@ -47,22 +62,12 @@ def build_hook_room_state_putter(
 ) -> HookRoomStatePutter:
     """Return a putter bound to one Matrix client.
 
-    The returned closure writes a single room state event via the Matrix
+    The returned adapter writes a single room state event via the Matrix
     client and returns ``True`` on success, ``False`` on Matrix error
     response. Transport exceptions from the client propagate to the
     caller.
     """
-
-    async def _put(
-        room_id: str,
-        event_type: str,
-        state_key: str,
-        content: dict[str, Any],
-    ) -> bool:
-        resp = await client.room_put_state(room_id, event_type, content, state_key=state_key)
-        return not isinstance(resp, nio.RoomPutStateError)
-
-    return _put
+    return cast("HookRoomStatePutter", partial(_put_hook_room_state, client))
 
 
 def chain_hook_room_state_queriers(

--- a/tests/test_hook_room_state.py
+++ b/tests/test_hook_room_state.py
@@ -19,6 +19,7 @@ from mindroom.hooks import (
     build_hook_room_state_putter,
     build_hook_room_state_querier,
 )
+from mindroom.hooks.state import _put_hook_room_state, _query_hook_room_state
 from mindroom.hooks.types import EVENT_MESSAGE_RECEIVED
 from mindroom.logging_config import get_logger
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
@@ -78,6 +79,41 @@ def _lifecycle_context(
 
 
 # -- build_hook_room_state_querier tests --
+
+
+@pytest.mark.asyncio
+async def test_query_hook_room_state_helper_with_state_key_returns_content() -> None:
+    """Low-level hook state query helper preserves single-event lookup semantics."""
+    client = AsyncMock(spec=nio.AsyncClient)
+    resp = MagicMock(spec=nio.RoomGetStateEventResponse)
+    resp.content = {"tags": {"pending-restart": True}}
+    client.room_get_state_event.return_value = resp
+
+    result = await _query_hook_room_state(client, "!room:localhost", "com.mindroom.thread.tags", "$thread1")
+
+    assert result == {"tags": {"pending-restart": True}}
+    client.room_get_state_event.assert_awaited_once_with(
+        "!room:localhost",
+        "com.mindroom.thread.tags",
+        "$thread1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_hook_room_state_helper_without_state_key_returns_filtered_dict() -> None:
+    """Low-level hook state query helper preserves full-state filtering semantics."""
+    client = AsyncMock(spec=nio.AsyncClient)
+    resp = MagicMock(spec=nio.RoomGetStateResponse)
+    resp.events = [
+        {"type": "com.mindroom.thread.tags", "state_key": "$t1", "content": {"tags": {"pending": True}}},
+        {"type": "m.room.name", "state_key": "", "content": {"name": "Lobby"}},
+    ]
+    client.room_get_state.return_value = resp
+
+    result = await _query_hook_room_state(client, "!room:localhost", "com.mindroom.thread.tags", None)
+
+    assert result == {"$t1": {"tags": {"pending": True}}}
+    client.room_get_state.assert_awaited_once_with("!room:localhost")
 
 
 @pytest.mark.asyncio
@@ -254,6 +290,23 @@ async def test_lifecycle_context_query_room_state_delegates(tmp_path: object) ->
 
 
 # -- build_hook_room_state_putter tests --
+
+
+@pytest.mark.asyncio
+async def test_put_hook_room_state_helper_returns_false_on_matrix_error() -> None:
+    """Low-level hook state put helper preserves Matrix-error handling."""
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.room_put_state.return_value = nio.RoomPutStateError(message="forbidden")
+
+    result = await _put_hook_room_state(client, "!room:localhost", "com.mindroom.thread.tags", "$thread1", {})
+
+    assert result is False
+    client.room_put_state.assert_awaited_once_with(
+        "!room:localhost",
+        "com.mindroom.thread.tags",
+        {},
+        state_key="$thread1",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Extract hook Matrix room-state query/write adapter logic into low-level helpers in `hooks/state.py`.
- Keep builder APIs, Matrix call shapes, event type/state key behavior, JSON shapes, and Matrix error semantics unchanged.
- Add characterization coverage for the extracted helper behavior.

## Duplicate flows examined
- `build_hook_room_state_querier` and `build_hook_room_state_putter` in `src/mindroom/hooks/state.py`: same closure-based client adapter pattern and Matrix error-to-sentinel behavior. Refactored.
- Scheduled task Matrix state reads/writes in `src/mindroom/scheduling.py`: `get_scheduled_tasks_for_room`, `get_scheduled_task`, `_persist_scheduled_task_state`, `list_scheduled_tasks`, `cancel_scheduled_task`, `cancel_all_scheduled_tasks`, and `restore_scheduled_tasks`. Not refactored because they check concrete response classes, preserve command-specific logging/messages, or intentionally ignore put-state Matrix error responses.

## Verification
- `uv sync --all-extras`
- Red phase: `uv run pytest tests/test_hook_room_state.py -x -n 0 --no-cov -v` failed on missing helper imports before production edits.
- `uv run pytest tests/test_hook_room_state.py -x -n 0 --no-cov -v`
- `uv run pytest tests/test_hook_room_state.py tests/test_hook_schedule.py tests/test_scheduling.py -n 0 --no-cov -v`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/hooks/state.py tests/test_hook_room_state.py`
- `uv run pytest -n 0 --no-cov` printed `6261 passed, 56 skipped, 64 warnings in 228.44s`; the pytest process then hung on a resource-tracker child and was terminated after the pass summary.
