### PR TITLE
Deduplicate Matrix sync token normalization

### DIFF
--- a/src/mindroom/matrix/sync_certification.py
+++ b/src/mindroom/matrix/sync_certification.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from mindroom.matrix.sync_token_values import normalize_sync_token
+
 
 class SyncTrustState(Enum):
     """Runtime state for restored sync-token cache trust."""
@@ -60,18 +62,10 @@ class _SyncCertificationStart:
     legacy_token: bool = False
 
 
-def _non_empty_token(token: str | None) -> str | None:
-    """Return a normalized token when it can be persisted or restored."""
-    if not isinstance(token, str):
-        return None
-    normalized = token.strip()
-    return normalized or None
-
-
 def start_from_loaded_token(loaded: SyncCheckpoint | str | None) -> _SyncCertificationStart:
     """Build initial certifier state from a loaded token or checkpoint."""
     if isinstance(loaded, SyncCheckpoint):
-        token = _non_empty_token(loaded.token)
+        token = normalize_sync_token(loaded.token)
         if token is None:
             return _SyncCertificationStart(
                 state=SyncTrustState.COLD,
@@ -82,7 +76,7 @@ def start_from_loaded_token(loaded: SyncCheckpoint | str | None) -> _SyncCertifi
             sync_token=token,
         )
 
-    token = _non_empty_token(loaded) if isinstance(loaded, str) else None
+    token = normalize_sync_token(loaded)
     return _SyncCertificationStart(
         state=SyncTrustState.COLD,
         sync_token=token,
@@ -106,7 +100,7 @@ def _uncertain_decision(
 
 def _uncertain_reason(cache_result: SyncCacheWriteResult, *, next_batch: str | None) -> str | None:
     """Return why one sync response cannot certify a checkpoint."""
-    if _non_empty_token(next_batch) is None:
+    if normalize_sync_token(next_batch) is None:
         return "missing_next_batch"
     if cache_result.errors:
         return "cache_write_failed"
@@ -132,7 +126,7 @@ def certify_sync_response(
             reset_client_token=state is SyncTrustState.PENDING and first_sync,
         )
 
-    token = _non_empty_token(next_batch)
+    token = normalize_sync_token(next_batch)
     if token is None:
         return _uncertain_decision(reason="missing_next_batch")
 

--- a/src/mindroom/matrix/sync_token_values.py
+++ b/src/mindroom/matrix/sync_token_values.py
@@ -1,0 +1,10 @@
+"""Shared Matrix sync-token value normalization."""
+
+from __future__ import annotations
+
+
+def normalize_sync_token(value: object) -> str | None:
+    """Return a stripped sync token or ``None`` for invalid or empty values."""
+    if not isinstance(value, str):
+        return None
+    return value.strip() or None

--- a/src/mindroom/matrix/sync_tokens.py
+++ b/src/mindroom/matrix/sync_tokens.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from mindroom.matrix.sync_certification import SyncCheckpoint
+from mindroom.matrix.sync_token_values import normalize_sync_token
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -37,14 +38,6 @@ def _sync_token_certification_path(storage_path: Path, agent_name: str) -> Path:
     return storage_path / "sync_tokens" / f"{agent_name}.token.certified"
 
 
-def _normalized_token(value: object) -> str | None:
-    """Return a safe sync token string parsed from disk."""
-    if not isinstance(value, str):
-        return None
-    token = value.strip()
-    return token or None
-
-
 def _record_from_json(text: str) -> _SyncTokenRecord | None:
     """Return a token record from the JSON checkpoint format."""
     try:
@@ -53,7 +46,7 @@ def _record_from_json(text: str) -> _SyncTokenRecord | None:
         return None
     if not isinstance(payload, dict) or payload.get("version") != _SYNC_TOKEN_RECORD_VERSION:
         return None
-    token = _normalized_token(payload.get("token"))
+    token = normalize_sync_token(payload.get("token"))
     if token is None:
         return None
     checkpoint = SyncCheckpoint(token=token)
@@ -76,7 +69,7 @@ def save_sync_token(
 ) -> None:
     """Persist one cache-certified sync token checkpoint."""
     token_path = _sync_token_path(storage_path, agent_name)
-    token_value = _normalized_token(token)
+    token_value = normalize_sync_token(token)
     if token_value is None:
         msg = "Certified sync tokens require a non-empty token"
         raise ValueError(msg)
@@ -117,7 +110,7 @@ def load_sync_token_record(storage_path: Path, agent_name: str) -> _SyncTokenRec
     if token_text.lstrip().startswith("{"):
         return _record_from_json(token_text)
 
-    token = _normalized_token(token_text)
+    token = normalize_sync_token(token_text)
     if token is None:
         return None
     return _SyncTokenRecord(token=token)

--- a/tests/test_sync_certification.py
+++ b/tests/test_sync_certification.py
@@ -15,6 +15,22 @@ from mindroom.matrix.sync_certification import (
     start_from_loaded_token,
     sync_cache_write_diagnostics,
 )
+from mindroom.matrix.sync_token_values import normalize_sync_token
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("s_token", "s_token"),
+        ("  s_token\n", "s_token"),
+        (" \t\n", None),
+        (None, None),
+        (123, None),
+    ],
+)
+def test_normalize_sync_token_accepts_only_non_empty_strings(value: object, expected: str | None) -> None:
+    """Sync-token normalization should have one Matrix-local source of truth."""
+    assert normalize_sync_token(value) == expected
 
 
 def test_start_without_token_is_cold() -> None:


### PR DESCRIPTION
## Summary
- Add a neutral Matrix sync-token normalization helper for non-empty stripped token values.
- Reuse it from sync-token persistence and sync certification to remove duplicate private normalizers.
- Add focused characterization coverage for accepted and rejected token values.

## Verification
- uv sync --all-extras
- uv run pytest tests/test_sync_certification.py tests/test_matrix_sync_tokens.py -x -n 0 --no-cov -v
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/matrix/sync_certification.py src/mindroom/matrix/sync_tokens.py src/mindroom/matrix/sync_token_values.py tests/test_sync_certification.py