### PR TITLE
Refactor coalesced event content extraction

### DIFF
--- a/src/mindroom/coalescing_batch.py
+++ b/src/mindroom/coalescing_batch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from .attachments import merge_attachment_ids, parse_attachment_ids_from_event_source
 from .constants import ORIGINAL_SENDER_KEY, VOICE_RAW_AUDIO_FALLBACK_KEY
@@ -13,6 +13,7 @@ from .dispatch_handoff import (
     MediaDispatchEvent,
     PendingDispatchMetadata,
     dispatch_prompt_for_event,
+    event_content_dict,
     is_media_dispatch_event,
 )
 
@@ -59,15 +60,6 @@ class CoalescedBatch:
     dispatch_metadata: tuple[PendingDispatchMetadata, ...] = ()
 
 
-def _event_content_dict(event: DispatchEvent) -> dict[str, object] | None:
-    if not isinstance(event.source, dict):
-        return None
-    content = event.source.get("content")
-    if not isinstance(content, dict):
-        return None
-    return cast("dict[str, object]", content)
-
-
 def _pending_event_trusts_internal_payload(pending_event: PendingEvent) -> bool:
     return pending_event.trust_internal_payload_metadata
 
@@ -90,7 +82,7 @@ def _batch_metadata(pending_events: list[PendingEvent]) -> tuple[str | None, boo
     for pending_event in pending_events:
         if not _pending_event_trusts_internal_payload(pending_event):
             continue
-        content = _event_content_dict(pending_event.event)
+        content = event_content_dict(pending_event.event)
         if content is None:
             continue
         if original_sender is None:

--- a/src/mindroom/dispatch_handoff.py
+++ b/src/mindroom/dispatch_handoff.py
@@ -105,7 +105,8 @@ class DispatchHandoff:
     dispatch_metadata: tuple[PendingDispatchMetadata, ...] = ()
 
 
-def _event_content_dict(event: DispatchEvent) -> dict[str, object] | None:
+def event_content_dict(event: DispatchEvent) -> dict[str, object] | None:
+    """Return Matrix content from a dispatch event when it has mapping content."""
     if not isinstance(event.source, dict):
         return None
     content = event.source.get("content")
@@ -142,7 +143,7 @@ def _collect_batch_mentions_and_formatted_bodies(
     skip_mentions = False
     inspected_content = False
     for pending_event in pending_events:
-        content = _event_content_dict(pending_event.event)
+        content = event_content_dict(pending_event.event)
         if content is None:
             continue
         inspected_content = True

--- a/tests/test_dispatch_event_content.py
+++ b/tests/test_dispatch_event_content.py
@@ -1,0 +1,30 @@
+"""Tests for shared dispatch event content extraction."""
+
+from __future__ import annotations
+
+from mindroom.dispatch_handoff import PreparedTextEvent, event_content_dict
+
+
+def test_event_content_dict_returns_matrix_content_mapping() -> None:
+    """Return the source content mapping without copying it."""
+    content: dict[str, object] = {"body": "hello", "msgtype": "m.text"}
+    event = PreparedTextEvent(
+        sender="@user:localhost",
+        event_id="$event",
+        body="hello",
+        source={"content": content},
+    )
+
+    assert event_content_dict(event) is content
+
+
+def test_event_content_dict_ignores_non_mapping_content() -> None:
+    """Return None when Matrix content is not a mapping."""
+    event = PreparedTextEvent(
+        sender="@user:localhost",
+        event_id="$event",
+        body="hello",
+        source={"content": "not a mapping"},
+    )
+
+    assert event_content_dict(event) is None


### PR DESCRIPTION
## Summary
- Expose shared `event_content_dict()` from `dispatch_handoff.py` for typed dispatch events.
- Remove the duplicate Matrix event content helper from `coalescing_batch.py`.
- Add focused characterization tests for mapping and non-mapping content.

## Line gate
- Production delta: +6/-13, net -7 lines.

## Verification
- `uv run pytest tests/test_dispatch_event_content.py tests/test_live_message_coalescing.py::test_build_coalesced_batch_keeps_normalized_voice_out_of_media_events tests/test_live_message_coalescing.py::test_batch_dispatch_event_preserves_original_sender tests/test_live_message_coalescing.py::test_batch_dispatch_event_preserves_attachment_ids tests/test_live_message_coalescing.py::test_coalesced_attachment_ids_reach_envelope_and_model_payload tests/test_live_message_coalescing.py::test_coalesced_non_primary_mention_reaches_final_envelope tests/test_live_message_coalescing.py::test_untrusted_coalesced_payload_metadata_spoofing_does_not_reach_envelope_or_payload -q -n 0 --no-cov` -> 8 passed.
- `uv run tach check --dependencies --interfaces` -> All modules validated.
- `uv run pre-commit run --files src/mindroom/coalescing_batch.py src/mindroom/dispatch_handoff.py tests/test_dispatch_event_content.py` -> passed.
