### PR TITLE
Refactor tool approval rule matching

### DIFF
--- a/src/mindroom/tool_approval.py
+++ b/src/mindroom/tool_approval.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from types import ModuleType
 
+    from mindroom.config.approval import ApprovalRuleConfig
     from mindroom.config.main import Config
     from mindroom.matrix.cache.event_cache import ConversationEventCache
 
@@ -161,22 +162,22 @@ def _clear_script_cache() -> None:
         _SCRIPT_CACHE.clear()
 
 
+def _matching_tool_approval_rule(config: Config, tool_name: str) -> ApprovalRuleConfig | None:
+    return next((rule for rule in config.tool_approval.rules if fnmatchcase(tool_name, rule.match)), None)
+
+
 def tool_requires_approval_for_openai_compat(
     config: Config,
     tool_name: str,
 ) -> bool:
     """Return whether one `/v1` tool must be hidden because approval may be required."""
     approval_config = config.tool_approval
-    require_approval = approval_config.default == "require_approval"
-
-    for rule in approval_config.rules:
-        if not fnmatchcase(tool_name, rule.match):
-            continue
-        if rule.action is not None:
-            return rule.action == "require_approval"
-        return True
-
-    return require_approval
+    rule = _matching_tool_approval_rule(config, tool_name)
+    if rule is None:
+        return approval_config.default == "require_approval"
+    if rule.action is not None:
+        return rule.action == "require_approval"
+    return True
 
 
 def resolve_tool_approval_approver(
@@ -208,31 +209,29 @@ async def evaluate_tool_approval(
     require_approval = approval_config.default == "require_approval"
     timeout_seconds = approval_config.timeout_days * 24 * 60 * 60
 
-    for rule in approval_config.rules:
-        if not fnmatchcase(tool_name, rule.match):
-            continue
-        if rule.timeout_days is not None:
-            timeout_seconds = rule.timeout_days * 24 * 60 * 60
-        if rule.action is not None:
-            return rule.action == "require_approval", timeout_seconds
+    rule = _matching_tool_approval_rule(config, tool_name)
+    if rule is None:
+        return require_approval, timeout_seconds
+    if rule.timeout_days is not None:
+        timeout_seconds = rule.timeout_days * 24 * 60 * 60
+    if rule.action is not None:
+        return rule.action == "require_approval", timeout_seconds
 
-        assert rule.script is not None
-        module, resolved_path = _load_script_module(rule.script, runtime_paths)
-        check = _check_callable_from_module(module, resolved_path)
-        try:
-            result = check(tool_name, arguments, agent_name)
-            if inspect.isawaitable(result):
-                result = await result
-        except Exception as exc:
-            logger.warning("Approval script raised", script_path=str(resolved_path), exc_info=True)
-            msg = f"Approval script '{resolved_path}' failed with {type(exc).__name__}"
-            raise ToolApprovalScriptError(msg) from exc
-        if not isinstance(result, bool):
-            msg = f"Approval script '{resolved_path}' returned a non-bool result."
-            raise ToolApprovalScriptError(msg)
-        return result, timeout_seconds
-
-    return require_approval, timeout_seconds
+    assert rule.script is not None
+    module, resolved_path = _load_script_module(rule.script, runtime_paths)
+    check = _check_callable_from_module(module, resolved_path)
+    try:
+        result = check(tool_name, arguments, agent_name)
+        if inspect.isawaitable(result):
+            result = await result
+    except Exception as exc:
+        logger.warning("Approval script raised", script_path=str(resolved_path), exc_info=True)
+        msg = f"Approval script '{resolved_path}' failed with {type(exc).__name__}"
+        raise ToolApprovalScriptError(msg) from exc
+    if not isinstance(result, bool):
+        msg = f"Approval script '{resolved_path}' returned a non-bool result."
+        raise ToolApprovalScriptError(msg)
+    return result, timeout_seconds
 
 
 async def request_tool_approval_for_call(call: ToolApprovalCall) -> ApprovalDecision | None:

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -42,6 +42,7 @@ from mindroom.tool_approval import (
     is_process_approval_card,
     request_tool_approval_for_call,
     resolve_tool_approval_approver,
+    tool_requires_approval_for_openai_compat,
 )
 from tests.conftest import bind_runtime_paths, test_runtime_paths
 
@@ -2319,6 +2320,110 @@ async def test_evaluate_tool_approval_rule_action_requires_approval(tmp_path: Pa
 
     assert requires_approval is True
     assert timeout_seconds > 0
+
+
+@pytest.mark.asyncio
+async def test_tool_approval_rule_matching_uses_first_matching_action_for_both_callers(tmp_path: Path) -> None:
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={"code": AgentConfig(display_name="Code", role="Help with coding")},
+            models={"default": ModelConfig(provider="openai", id="gpt-5.4")},
+            tool_approval={
+                "default": "auto_approve",
+                "rules": [
+                    {"match": "read_*", "action": "auto_approve", "timeout_days": 2},
+                    {"match": "read_file", "action": "require_approval", "timeout_days": 9},
+                ],
+            },
+        ),
+        runtime_paths,
+    )
+
+    requires_approval, timeout_seconds = await evaluate_tool_approval(
+        config,
+        runtime_paths,
+        "read_file",
+        {"path": "notes.txt"},
+        "code",
+    )
+
+    assert requires_approval is False
+    assert timeout_seconds == 2 * 24 * 60 * 60
+    assert tool_requires_approval_for_openai_compat(config, "read_file") is False
+
+
+@pytest.mark.asyncio
+async def test_tool_approval_script_rule_listing_requires_approval_but_evaluation_runs_script(tmp_path: Path) -> None:
+    runtime_paths = test_runtime_paths(tmp_path)
+    script_path = tmp_path / "approval.py"
+    script_path.write_text(
+        "def check(tool_name, arguments, agent_name):\n    return arguments['requires_approval']\n",
+        encoding="utf-8",
+    )
+    config = bind_runtime_paths(
+        Config(
+            agents={"code": AgentConfig(display_name="Code", role="Help with coding")},
+            models={"default": ModelConfig(provider="openai", id="gpt-5.4")},
+            tool_approval={
+                "default": "auto_approve",
+                "timeout_days": 4,
+                "rules": [{"match": "write_*", "script": str(script_path), "timeout_days": 1}],
+            },
+        ),
+        runtime_paths,
+    )
+
+    requires_approval, timeout_seconds = await evaluate_tool_approval(
+        config,
+        runtime_paths,
+        "write_file",
+        {"requires_approval": False},
+        "code",
+    )
+
+    assert requires_approval is False
+    assert timeout_seconds == 24 * 60 * 60
+    assert tool_requires_approval_for_openai_compat(config, "write_file") is True
+
+
+@pytest.mark.parametrize(
+    ("default", "expected"),
+    [
+        ("auto_approve", False),
+        ("require_approval", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_tool_approval_rule_matching_falls_back_to_default_for_both_callers(
+    tmp_path: Path,
+    default: str,
+    expected: bool,
+) -> None:
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={"code": AgentConfig(display_name="Code", role="Help with coding")},
+            models={"default": ModelConfig(provider="openai", id="gpt-5.4")},
+            tool_approval={
+                "default": default,
+                "rules": [{"match": "write_*", "action": "require_approval"}],
+            },
+        ),
+        runtime_paths,
+    )
+
+    requires_approval, timeout_seconds = await evaluate_tool_approval(
+        config,
+        runtime_paths,
+        "read_file",
+        {"path": "notes.txt"},
+        "code",
+    )
+
+    assert requires_approval is expected
+    assert timeout_seconds == 7 * 24 * 60 * 60
+    assert tool_requires_approval_for_openai_compat(config, "read_file") is expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Extract shared first-match approval rule lookup for OpenAI-compatible listing and runtime evaluation
- Preserve script-backed listing behavior, default fallback, first-match precedence, timeout selection, and script execution behavior
- Add focused characterization coverage for shared rule matching semantics

## Verification
- uv run pytest tests/test_tool_approval.py -n 0 --no-cov -v
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/tool_approval.py tests/test_tool_approval.py