### PR TITLE
Refactor MCP media artifact decoding

### DIFF
--- a/src/mindroom/mcp/results.py
+++ b/src/mindroom/mcp/results.py
@@ -64,16 +64,19 @@ def _text_lines_from_blocks(content_blocks: Iterable[object]) -> list[str]:
     return lines
 
 
+def _mcp_block_data_as_bytes(data: str) -> bytes:
+    try:
+        return base64.b64decode(data)
+    except Exception:
+        return data.encode("utf-8")
+
+
 def _image_artifacts_from_blocks(content_blocks: Iterable[object]) -> list[Image]:
     images: list[Image] = []
     for block in content_blocks:
         if not isinstance(block, ImageContent):
             continue
-        try:
-            image_bytes = base64.b64decode(block.data)
-        except Exception:
-            image_bytes = block.data.encode("utf-8")
-        images.append(Image(content=image_bytes, mime_type=block.mimeType))
+        images.append(Image(content=_mcp_block_data_as_bytes(block.data), mime_type=block.mimeType))
     return images
 
 
@@ -82,11 +85,7 @@ def _audio_artifacts_from_blocks(content_blocks: Iterable[object]) -> list[Audio
     for block in content_blocks:
         if not isinstance(block, AudioContent):
             continue
-        try:
-            audio_bytes = base64.b64decode(block.data)
-        except Exception:
-            audio_bytes = block.data.encode("utf-8")
-        audios.append(Audio(content=audio_bytes, mime_type=block.mimeType))
+        audios.append(Audio(content=_mcp_block_data_as_bytes(block.data), mime_type=block.mimeType))
     return audios
 
 

--- a/tests/test_mcp_results.py
+++ b/tests/test_mcp_results.py
@@ -110,3 +110,24 @@ def test_tool_result_from_call_result_converts_audio_blocks() -> None:
     assert result.audios is not None
     assert result.audios[0].content == audio_bytes
     assert result.audios[0].mime_type == "audio/ogg"
+
+
+def test_tool_result_from_call_result_keeps_invalid_base64_media_as_utf8_bytes() -> None:
+    """Keep permissive MCP media decoding for non-base64 payloads."""
+    image_data = "not-base64-image"
+    audio_data = "not-base64-audio"
+    result = tool_result_from_call_result(
+        "demo",
+        CallToolResult(
+            content=[
+                ImageContent(type="image", data=image_data, mimeType="image/png"),
+                AudioContent(type="audio", data=audio_data, mimeType="audio/wav"),
+            ],
+        ),
+    )
+    assert result.images is not None
+    assert result.images[0].content == image_data.encode("utf-8")
+    assert result.images[0].mime_type == "image/png"
+    assert result.audios is not None
+    assert result.audios[0].content == audio_data.encode("utf-8")
+    assert result.audios[0].mime_type == "audio/wav"


### PR DESCRIPTION
## Summary
- share permissive MCP media block data decoding between image and audio artifact extraction
- add characterization coverage for invalid-base64 image and audio payload fallback

## Verification
- uv run pytest tests/test_mcp_results.py -q
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/mcp/results.py tests/test_mcp_results.py