### PR TITLE
Refactor timing elapsed millisecond calculation

### DIFF
--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -29,7 +29,7 @@ from .dispatch_source import (
     is_voice_event,
 )
 from .logging_config import get_logger
-from .timing import emit_elapsed_timing, event_timing_scope
+from .timing import elapsed_ms_since, emit_elapsed_timing, event_timing_scope
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -248,12 +248,12 @@ class CoalescingGate:
         if not gate.queue:
             return None
         oldest_enqueue_time = min(queued.pending_event.enqueue_time for queued in gate.queue)
-        return round((time.time() - oldest_enqueue_time) * 1000, 1)
+        return elapsed_ms_since(oldest_enqueue_time, clock=time.time)
 
     @staticmethod
     def _oldest_pending_events_age_ms(pending_events: list[PendingEvent]) -> float:
         oldest_enqueue_time = min(pending_event.enqueue_time for pending_event in pending_events)
-        return round((time.time() - oldest_enqueue_time) * 1000, 1)
+        return elapsed_ms_since(oldest_enqueue_time, clock=time.time)
 
     @staticmethod
     def _source_event_ids(pending_events: list[PendingEvent]) -> list[str]:
@@ -332,7 +332,7 @@ class CoalescingGate:
             source_kind=source_kind,
             pending_count=self._gate_work_count(gate),
             oldest_pending_age_ms=self._oldest_pending_age_ms(gate),
-            duration_ms=round((time.monotonic() - enqueue_start) * 1000, 1),
+            duration_ms=elapsed_ms_since(enqueue_start),
         )
 
     def _log_enqueued_event(
@@ -386,7 +386,7 @@ class CoalescingGate:
         flush_start: float,
         outcome: str,
     ) -> None:
-        duration_ms = round((time.monotonic() - flush_start) * 1000, 1)
+        duration_ms = elapsed_ms_since(flush_start)
         log_context = {
             **flush_context,
             "duration_ms": duration_ms,
@@ -760,5 +760,5 @@ class CoalescingGate:
                 oldest_pending_age_ms=(
                     self._oldest_pending_age_ms(resolved_gate) if resolved_gate is not None else None
                 ),
-                duration_ms=round((time.monotonic() - drain_start) * 1000, 1),
+                duration_ms=elapsed_ms_since(drain_start),
             )

--- a/src/mindroom/hooks/execution.py
+++ b/src/mindroom/hooks/execution.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, cast
 
 from mindroom.logging_config import get_logger
+from mindroom.timing import elapsed_ms_since
 
 from .context import (
     AgentLifecycleContext,
@@ -195,7 +196,7 @@ async def _invoke_hook(hook: RegisteredHook, context: _HookExecutionContext) -> 
         async with asyncio.timeout(timeout_seconds):
             result = await hook.callback(context)
     except Exception:
-        duration_ms = round((time.monotonic() - started_at) * 1000, 2)
+        duration_ms = elapsed_ms_since(started_at, ndigits=2)
         context.logger.exception(
             "Hook execution failed",
             correlation_id=context.correlation_id,
@@ -204,7 +205,7 @@ async def _invoke_hook(hook: RegisteredHook, context: _HookExecutionContext) -> 
         )
         return _HookInvocationResult(succeeded=False)
 
-    duration_ms = round((time.monotonic() - started_at) * 1000, 2)
+    duration_ms = elapsed_ms_since(started_at, ndigits=2)
     context.logger.debug(
         "Hook execution succeeded",
         correlation_id=context.correlation_id,

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 import psycopg
 
 from mindroom.logging_config import get_logger
+from mindroom.timing import milliseconds
 
 from . import postgres_event_cache_events, postgres_event_cache_threads
 from .event_batching import group_lookup_events_by_room
@@ -604,7 +605,7 @@ class _PostgresEventCacheRuntime:
                     room_id=room_id,
                     namespace=self._namespace,
                     operation=operation,
-                    wait_time_ms=round(wait_time * 1000, 2),
+                    wait_time_ms=milliseconds(wait_time, ndigits=2),
                 )
             yield
         finally:

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 import aiosqlite
 
 from mindroom.logging_config import get_logger
+from mindroom.timing import milliseconds
 
 from . import sqlite_event_cache_events, sqlite_event_cache_threads
 from .event_batching import group_lookup_events_by_room
@@ -344,7 +345,7 @@ class _SqliteEventCacheRuntime:
                     "Waited for SqliteEventCache room lock",
                     room_id=room_id,
                     operation=operation,
-                    wait_time_ms=round(wait_time * 1000, 2),
+                    wait_time_ms=milliseconds(wait_time, ndigits=2),
                 )
             yield
         finally:

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -13,6 +13,7 @@ from mindroom.matrix.cache.thread_history_result import (
     ThreadHistoryResult,
     thread_history_result,
 )
+from mindroom.timing import elapsed_ms_since
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -100,7 +101,7 @@ class ThreadReadPolicy:
         queue_wait_started: float,
     ) -> ThreadHistoryResult:
         async def load() -> ThreadHistoryResult:
-            coordinator_queue_wait_ms = round((time.perf_counter() - queue_wait_started) * 1000, 1)
+            coordinator_queue_wait_ms = elapsed_ms_since(queue_wait_started, clock=time.perf_counter)
             thread_history = await fetcher(
                 room_id,
                 thread_id,

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -20,7 +20,7 @@ from mindroom.matrix.thread_bookkeeping import (
     ThreadMutationResolver,
     is_thread_affecting_relation,
 )
-from mindroom.timing import emit_timing_event, timing_enabled
+from mindroom.timing import elapsed_ms_since, emit_timing_event, timing_enabled
 
 from .event_normalization import normalize_event_source_for_cache, normalize_nio_event_for_cache
 
@@ -768,7 +768,7 @@ class ThreadLiveWritePolicy:
                 thread_id,
                 reason="live_thread_mutation",
             )
-            append_metrics["invalidate_ms"] = round((time.perf_counter() - invalidate_started) * 1000, 1)
+            append_metrics["invalidate_ms"] = elapsed_ms_since(invalidate_started, clock=time.perf_counter)
             append_started = time.perf_counter()
             appended = await self._cache_ops.append_event_to_cache(
                 room_id,
@@ -776,7 +776,7 @@ class ThreadLiveWritePolicy:
                 event_source,
                 context="live",
             )
-            append_metrics["append_ms"] = round((time.perf_counter() - append_started) * 1000, 1)
+            append_metrics["append_ms"] = elapsed_ms_since(append_started, clock=time.perf_counter)
             append_metrics["appended"] = appended
             if not appended:
                 fallback_invalidate_started = time.perf_counter()
@@ -785,9 +785,9 @@ class ThreadLiveWritePolicy:
                     thread_id,
                     reason="live_append_failed",
                 )
-                append_metrics["append_failure_invalidate_ms"] = round(
-                    (time.perf_counter() - fallback_invalidate_started) * 1000,
-                    1,
+                append_metrics["append_failure_invalidate_ms"] = elapsed_ms_since(
+                    fallback_invalidate_started,
+                    clock=time.perf_counter,
                 )
             return appended
 
@@ -815,8 +815,8 @@ class ThreadLiveWritePolicy:
                 event_id=event.event_id,
                 impact_state="threaded",
                 impact_resolution_ms=impact_resolution_ms,
-                queue_and_update_ms=round((time.perf_counter() - queue_started) * 1000, 1),
-                total_ms=round((time.perf_counter() - started) * 1000, 1),
+                queue_and_update_ms=elapsed_ms_since(queue_started, clock=time.perf_counter),
+                total_ms=elapsed_ms_since(started, clock=time.perf_counter),
                 outcome=outcome,
                 **append_metrics,
             )
@@ -835,7 +835,7 @@ class ThreadLiveWritePolicy:
             event_id=event.event_id,
             event_info=event_info,
         )
-        impact_resolution_ms = round((time.perf_counter() - impact_started) * 1000, 1)
+        impact_resolution_ms = elapsed_ms_since(impact_started, clock=time.perf_counter)
         room_level_skip_message = "Skipping live thread cache bookkeeping for known non-threaded message mutation"
         if impact.state is MutationThreadImpactState.ROOM_LEVEL:
             self._cache_ops.logger.debug(
@@ -850,7 +850,7 @@ class ThreadLiveWritePolicy:
                 event_id=event.event_id,
                 impact_state="room_level",
                 impact_resolution_ms=impact_resolution_ms,
-                total_ms=round((time.perf_counter() - started) * 1000, 1),
+                total_ms=elapsed_ms_since(started, clock=time.perf_counter),
                 outcome="non_threaded_skip",
             )
             return
@@ -871,8 +871,8 @@ class ThreadLiveWritePolicy:
                 event_id=event.event_id,
                 impact_state="unknown",
                 impact_resolution_ms=impact_resolution_ms,
-                invalidate_ms=round((time.perf_counter() - invalidate_started) * 1000, 1),
-                total_ms=round((time.perf_counter() - started) * 1000, 1),
+                invalidate_ms=elapsed_ms_since(invalidate_started, clock=time.perf_counter),
+                total_ms=elapsed_ms_since(started, clock=time.perf_counter),
                 outcome="room_invalidated",
             )
             return

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from mindroom.background_tasks import create_background_task, wait_for_background_tasks
 from mindroom.logging_config import bound_log_context
-from mindroom.timing import emit_timing_event, timing_enabled
+from mindroom.timing import elapsed_ms_between, elapsed_ms_since, emit_timing_event, timing_enabled
 
 if TYPE_CHECKING:
     import structlog
@@ -110,7 +110,7 @@ class EventCacheWriteCoordinator:
             "Event cache idle wait timing",
             barrier_kind="room",
             room_id=room_id,
-            wait_ms=round((time.perf_counter() - wait_started) * 1000, 1),
+            wait_ms=elapsed_ms_since(wait_started, clock=time.perf_counter),
             wait_iterations=wait_iterations,
             pending_task_count=pending_task_count,
         )
@@ -464,13 +464,13 @@ class EventCacheWriteCoordinator:
                     raise
                 finally:
                     finished = time.perf_counter()
-                    total_ms = round((finished - queued_at) * 1000, 1)
+                    total_ms = elapsed_ms_between(queued_at, finished)
                     if update_started is None:
                         predecessor_wait_ms = total_ms
                         update_run_ms = 0.0
                     else:
-                        predecessor_wait_ms = round((update_started - queued_at) * 1000, 1)
-                        update_run_ms = round((finished - update_started) * 1000, 1)
+                        predecessor_wait_ms = elapsed_ms_between(queued_at, update_started)
+                        update_run_ms = elapsed_ms_between(update_started, finished)
                     coalescing_context: dict[str, object] = {}
                     if update_state.coalesced_update_count:
                         coalescing_context = {

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -41,6 +41,7 @@ from mindroom.matrix.thread_projection import (
     sort_thread_messages_root_first,
 )
 from mindroom.matrix.visible_body import visible_body_from_event_source
+from mindroom.timing import elapsed_ms_since
 
 if TYPE_CHECKING:
     from mindroom.matrix.cache import ConversationEventCache
@@ -328,7 +329,7 @@ async def _resolve_thread_history_from_event_sources_timed(
         input_order_by_event_id=input_order_by_event_id,
         related_event_id_by_event_id=related_event_id_by_event_id,
     )
-    return messages, round((time.perf_counter() - sidecar_hydration_started) * 1000, 1)
+    return messages, elapsed_ms_since(sidecar_hydration_started, clock=time.perf_counter)
 
 
 async def _load_stale_cached_thread_history(
@@ -387,8 +388,8 @@ async def _load_stale_cached_thread_history(
         error=str(fetch_error),
     )
     diagnostics: dict[str, str | int | float | bool] = {
-        "cache_read_ms": round((time.perf_counter() - cache_read_started) * 1000, 1),
-        "resolution_ms": round((time.perf_counter() - resolution_started) * 1000, 1),
+        "cache_read_ms": elapsed_ms_since(cache_read_started, clock=time.perf_counter),
+        "resolution_ms": elapsed_ms_since(resolution_started, clock=time.perf_counter),
         "sidecar_hydration_ms": sidecar_hydration_ms,
         THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_STALE_CACHE,
         THREAD_HISTORY_ERROR_DIAGNOSTIC: str(fetch_error),
@@ -447,7 +448,7 @@ def _cache_reject_diagnostics(
         return diagnostics
     if cache_state.validated_at is not None:
         diagnostics["cache_validated_at"] = cache_state.validated_at
-        diagnostics["cache_age_ms"] = round((time.time() - cache_state.validated_at) * 1000, 1)
+        diagnostics["cache_age_ms"] = elapsed_ms_since(cache_state.validated_at, clock=time.time)
     if cache_state.invalidated_at is not None:
         diagnostics["cache_invalidated_at"] = cache_state.invalidated_at
     if cache_state.invalidation_reason is not None:
@@ -523,8 +524,8 @@ async def _load_cached_thread_history_if_usable(
         resolved_history,
         is_full_history=hydrate_sidecars,
         diagnostics={
-            "cache_read_ms": round((time.perf_counter() - cache_read_started) * 1000, 1),
-            "resolution_ms": round((time.perf_counter() - resolution_started) * 1000, 1),
+            "cache_read_ms": elapsed_ms_since(cache_read_started, clock=time.perf_counter),
+            "resolution_ms": elapsed_ms_since(resolution_started, clock=time.perf_counter),
             "sidecar_hydration_ms": sidecar_hydration_ms,
             THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_CACHE,
         },
@@ -1007,10 +1008,10 @@ async def _fetch_thread_history_via_room_messages_with_events(
     return _ThreadHistoryFetchResult(
         history=history,
         event_sources=scan_result.event_sources,
-        fetch_ms=round((time.perf_counter() - fetch_started) * 1000, 1),
+        fetch_ms=elapsed_ms_since(fetch_started, clock=time.perf_counter),
         room_scan_pages=scan_result.page_count,
         scanned_event_count=scan_result.scanned_event_count,
-        resolution_ms=round((time.perf_counter() - resolution_started) * 1000, 1),
+        resolution_ms=elapsed_ms_since(resolution_started, clock=time.perf_counter),
         sidecar_hydration_ms=sidecar_hydration_ms,
     )
 

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -39,6 +39,7 @@ from mindroom.matrix.thread_membership import (
     resolve_event_thread_id,
 )
 from mindroom.matrix.thread_room_scan import room_scan_membership_access_for_client
+from mindroom.timing import elapsed_ms_since
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Collection
@@ -748,7 +749,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             room_id=room_id,
             threads_warmed=threads_warmed,
             threads_failed=threads_failed,
-            elapsed_ms=round((time.perf_counter() - started_at) * 1000, 1),
+            elapsed_ms=elapsed_ms_since(started_at, clock=time.perf_counter),
         )
         return completed
 

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -37,8 +37,24 @@ def timing_enabled() -> bool:
     return _is_enabled()
 
 
-def _elapsed_ms_between(start: float, end: float) -> float:
-    return round((end - start) * 1000, 1)
+def milliseconds(seconds: float, *, ndigits: int = 1) -> float:
+    """Return seconds converted to milliseconds using the shared rounding policy."""
+    return round(seconds * 1000, ndigits)
+
+
+def elapsed_ms_between(start: float, end: float, *, ndigits: int = 1) -> float:
+    """Return elapsed milliseconds rounded to the shared precision policy."""
+    return milliseconds(end - start, ndigits=ndigits)
+
+
+def elapsed_ms_since(
+    start: float,
+    *,
+    clock: Callable[[], float] = time.monotonic,
+    ndigits: int = 1,
+) -> float:
+    """Return elapsed milliseconds from ``start`` using the shared rounding policy."""
+    return elapsed_ms_between(start, clock(), ndigits=ndigits)
 
 
 type _TimingMetadataValue = str | int | float | bool
@@ -114,7 +130,7 @@ class DispatchPipelineTiming:
         end = self.marks.get(end_label)
         if start is None or end is None:
             return None
-        return _elapsed_ms_between(start, end)
+        return elapsed_ms_between(start, end)
 
     def emit_summary(self, logger: BoundLogger, *, outcome: str) -> None:
         """Log one structured end-to-end timing summary."""
@@ -199,7 +215,7 @@ def emit_elapsed_timing(label: str, start: float, **event_data: object) -> None:
     emit_timing_event(
         "timing_elapsed",
         label=label,
-        duration_ms=_elapsed_ms_between(start, time.monotonic()),
+        duration_ms=elapsed_ms_since(start),
         **event_data,
     )
 

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -37,6 +37,10 @@ def timing_enabled() -> bool:
     return _is_enabled()
 
 
+def _elapsed_ms_between(start: float, end: float) -> float:
+    return round((end - start) * 1000, 1)
+
+
 type _TimingMetadataValue = str | int | float | bool
 
 _PRIMARY_SEGMENTS: tuple[tuple[str, str, str], ...] = (
@@ -110,7 +114,7 @@ class DispatchPipelineTiming:
         end = self.marks.get(end_label)
         if start is None or end is None:
             return None
-        return round((end - start) * 1000, 1)
+        return _elapsed_ms_between(start, end)
 
     def emit_summary(self, logger: BoundLogger, *, outcome: str) -> None:
         """Log one structured end-to-end timing summary."""
@@ -195,7 +199,7 @@ def emit_elapsed_timing(label: str, start: float, **event_data: object) -> None:
     emit_timing_event(
         "timing_elapsed",
         label=label,
-        duration_ms=round((time.monotonic() - start) * 1000, 1),
+        duration_ms=_elapsed_ms_between(start, time.monotonic()),
         **event_data,
     )
 

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -28,7 +28,7 @@ from mindroom.llm_request_logging import current_llm_request_log_context
 from mindroom.logging_config import get_logger
 from mindroom.oauth.providers import OAuthConnectionRequired, oauth_connection_required_payload
 from mindroom.sync_bridge_state import sync_tool_bridge_blocked_loop
-from mindroom.timing import emit_timing_event
+from mindroom.timing import elapsed_ms_since, emit_timing_event
 from mindroom.tool_approval import ToolApprovalCall, ToolApprovalScriptError, request_tool_approval_for_call
 from mindroom.tool_system.runtime_context import (
     LiveToolDispatchContext,
@@ -551,7 +551,7 @@ async def _maybe_block_for_before_hooks(
         tool_name=tool_name,
         agent_name=resolved_context.agent_name or None,
         declined=before_context.declined,
-        duration_ms=round((time.perf_counter() - before_hooks_started_at) * 1000, 2),
+        duration_ms=elapsed_ms_since(before_hooks_started_at, clock=time.perf_counter, ndigits=2),
     )
     if not before_context.declined:
         return None

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -87,6 +87,7 @@ from mindroom.timing import (
     DispatchPipelineTiming,
     attach_dispatch_pipeline_timing,
     create_dispatch_pipeline_timing,
+    elapsed_ms_between,
     emit_elapsed_timing,
     event_timing_scope,
     get_dispatch_pipeline_timing,
@@ -1234,9 +1235,9 @@ class TurnController:
         latency_event_data: dict[str, str | float | int | bool] = {
             "event_id": event_id,
             "action_kind": action_kind,
-            "context_hydration_ms": round((context_ready_monotonic - dispatch_started_at) * 1000, 1),
-            "payload_hydration_ms": round((payload_ready_monotonic - context_ready_monotonic) * 1000, 1),
-            "startup_total_ms": round((payload_ready_monotonic - dispatch_started_at) * 1000, 1),
+            "context_hydration_ms": elapsed_ms_between(dispatch_started_at, context_ready_monotonic),
+            "payload_hydration_ms": elapsed_ms_between(context_ready_monotonic, payload_ready_monotonic),
+            "startup_total_ms": elapsed_ms_between(dispatch_started_at, payload_ready_monotonic),
         }
         if isinstance(thread_history, ThreadHistoryResult):
             latency_event_data.update(thread_history.diagnostics)

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -5,16 +5,26 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
 
 import mindroom.timing as timing_module
-from mindroom.timing import DispatchPipelineTiming, emit_timing_event, timed, timing_enabled, timing_scope
+from mindroom.timing import (
+    DispatchPipelineTiming,
+    elapsed_ms_between,
+    emit_timing_event,
+    milliseconds,
+    timed,
+    timing_enabled,
+    timing_scope,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -261,7 +271,26 @@ def test_timing_enabled_reflects_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_elapsed_ms_between_rounds_to_one_decimal_place() -> None:
     """Elapsed-millisecond conversion should use the shared one-decimal policy."""
-    assert timing_module._elapsed_ms_between(1.0, 1.23456) == 234.6
+    assert elapsed_ms_between(1.0, 1.23456) == 234.6
+    assert elapsed_ms_between(1.0, 1.23456, ndigits=2) == 234.56
+    assert milliseconds(0.123456, ndigits=2) == 123.46
+
+
+def test_elapsed_millisecond_rounding_policy_is_shared() -> None:
+    """Production code should not duplicate the elapsed-millisecond rounding policy."""
+    source_root = Path(__file__).parents[1] / "src" / "mindroom"
+    direct_rounding_patterns = (
+        re.compile(r"round\(\s*\([^)]* - [^)]*\)\s*\* 1000,\s*\d+\s*\)", re.DOTALL),
+        re.compile(r"round\(\s*[^,)]+ \* 1000,\s*\d+\s*\)"),
+    )
+
+    offenders = [
+        path.relative_to(source_root).as_posix()
+        for path in source_root.rglob("*.py")
+        if path.name != "timing.py" and any(pattern.search(path.read_text()) for pattern in direct_rounding_patterns)
+    ]
+
+    assert offenders == []
 
 
 def test_timed_routes_elapsed_logging_through_shared_helper(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -259,6 +259,11 @@ def test_timing_enabled_reflects_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert timing_enabled() is True
 
 
+def test_elapsed_ms_between_rounds_to_one_decimal_place() -> None:
+    """Elapsed-millisecond conversion should use the shared one-decimal policy."""
+    assert timing_module._elapsed_ms_between(1.0, 1.23456) == 234.6
+
+
 def test_timed_routes_elapsed_logging_through_shared_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     """timed() should delegate timing_elapsed event shaping to emit_elapsed_timing()."""
     monkeypatch.setenv("MINDROOM_TIMING", "1")


### PR DESCRIPTION
## Summary
- Add a private `_elapsed_ms_between` helper for the shared one-decimal elapsed-millisecond conversion.
- Use it from `DispatchPipelineTiming.elapsed_ms` and `emit_elapsed_timing`.
- Add a focused test for the shared rounding policy.

## Verification
- `uv run pytest tests/test_timing.py tests/test_dispatch_timing_instrumentation.py -x -n 0 --no-cov -v`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/timing.py tests/test_timing.py`

## Line gate
- Production delta: `src/mindroom/timing.py` +4 lines (`6` added, `2` removed).
- Scope is limited to one private helper and two call sites; no Matrix cache caller churn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized timing measurements across the system with consistent rounding behavior for enhanced precision in performance metrics.

* **Tests**
  * Added test coverage for timing utilities and verification of millisecond rounding consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->