### PR TITLE
fix: avoid aliased hook source parser import

### DIFF
--- a/src/mindroom/hooks/ingress.py
+++ b/src/mindroom/hooks/ingress.py
@@ -7,11 +7,12 @@ from typing import TYPE_CHECKING
 
 from mindroom.dispatch_source import is_automation_source_kind
 
-from .types import EVENT_MESSAGE_RECEIVED
-from .types import split_hook_source as _split_hook_source
+from .types import EVENT_MESSAGE_RECEIVED, split_hook_source
 
 if TYPE_CHECKING:
     from .context import MessageEnvelope
+
+_split_hook_source = split_hook_source
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mindroom/hooks/ingress.py
+++ b/src/mindroom/hooks/ingress.py
@@ -12,8 +12,6 @@ from .types import EVENT_MESSAGE_RECEIVED, split_hook_source
 if TYPE_CHECKING:
     from .context import MessageEnvelope
 
-_split_hook_source = split_hook_source
-
 
 @dataclass(frozen=True, slots=True)
 class HookIngressPolicy:
@@ -30,7 +28,7 @@ def hook_ingress_policy(envelope: MessageEnvelope) -> HookIngressPolicy:
     if envelope.source_kind not in {"hook", "hook_dispatch"}:
         return HookIngressPolicy()
 
-    plugin_name, source_event_name = _split_hook_source(envelope.hook_source)
+    plugin_name, source_event_name = split_hook_source(envelope.hook_source)
     policy = HookIngressPolicy(
         bypass_unmentioned_agent_gate=envelope.source_kind == "hook_dispatch",
     )

--- a/tests/test_hook_ingress.py
+++ b/tests/test_hook_ingress.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from mindroom.dispatch_source import is_automation_source_kind
 from mindroom.hooks.context import MessageEnvelope
-from mindroom.hooks.ingress import _split_hook_source, hook_ingress_policy, should_handle_interactive_text_response
-from mindroom.hooks.types import format_hook_source
+from mindroom.hooks.ingress import hook_ingress_policy, should_handle_interactive_text_response
+from mindroom.hooks.types import format_hook_source, split_hook_source
 from mindroom.message_target import MessageTarget
 
 
@@ -33,12 +33,12 @@ def _envelope(
 
 def test_split_hook_source_parses_serialized_tag() -> None:
     """Hook provenance tags should split into plugin and event name once."""
-    assert _split_hook_source("origin-plugin:message:received") == (
+    assert split_hook_source("origin-plugin:message:received") == (
         "origin-plugin",
         "message:received",
     )
-    assert _split_hook_source("bad") == (None, None)
-    assert _split_hook_source(None) == (None, None)
+    assert split_hook_source("bad") == (None, None)
+    assert split_hook_source(None) == (None, None)
 
 
 def test_hook_source_formatter_matches_ingress_parser() -> None:
@@ -46,7 +46,7 @@ def test_hook_source_formatter_matches_ingress_parser() -> None:
     source = format_hook_source("origin-plugin", "message:received")
 
     assert source == "origin-plugin:message:received"
-    assert _split_hook_source(source) == ("origin-plugin", "message:received")
+    assert split_hook_source(source) == ("origin-plugin", "message:received")
 
 
 def test_hook_ingress_policy_skips_origin_plugin_on_first_message_received_hop() -> None:


### PR DESCRIPTION
## Summary
- import split_hook_source directly in hook ingress
- keep the private test-facing alias as a module assignment instead of an import alias

## Tests
- uv run pytest tests/test_hook_ingress.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated imports and updated hook ingress to use the public API directly, removing redundant internal references.

* **Tests**
  * Updated tests to rely on the public API, added edge-case validations and round-trip checks for hook source handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->