### PR TITLE
refactor: register dynamic tools metadata as builtin

### DIFF
--- a/src/mindroom/tools/dynamic_tools.py
+++ b/src/mindroom/tools/dynamic_tools.py
@@ -5,17 +5,25 @@ The actual toolkit requires agent and session context and is instantiated
 directly in ``create_agent()``, so it is NOT added to ``TOOL_REGISTRY``.
 """
 
-from mindroom.tool_system.metadata import TOOL_METADATA, SetupType, ToolCategory, ToolMetadata, ToolStatus
+from mindroom.tool_system.metadata import (
+    SetupType,
+    ToolCategory,
+    ToolMetadata,
+    ToolStatus,
+    register_builtin_tool_metadata,
+)
 
-TOOL_METADATA["dynamic_tools"] = ToolMetadata(
-    name="dynamic_tools",
-    display_name="Dynamic Tools",
-    description="Load and unload allowed toolkits for the current session",
-    category=ToolCategory.DEVELOPMENT,
-    status=ToolStatus.AVAILABLE,
-    setup_type=SetupType.NONE,
-    icon="PackagePlus",
-    icon_color="text-sky-500",
-    config_fields=[],
-    dependencies=[],
+register_builtin_tool_metadata(
+    ToolMetadata(
+        name="dynamic_tools",
+        display_name="Dynamic Tools",
+        description="Load and unload allowed toolkits for the current session",
+        category=ToolCategory.DEVELOPMENT,
+        status=ToolStatus.AVAILABLE,
+        setup_type=SetupType.NONE,
+        icon="PackagePlus",
+        icon_color="text-sky-500",
+        config_fields=[],
+        dependencies=[],
+    ),
 )

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -35,6 +35,8 @@ from mindroom.tool_system.metadata import (
     serialize_tool_validation_snapshot,
 )
 from mindroom.tool_system.registry_state import (
+    BUILTIN_TOOL_METADATA,
+    BUILTIN_TOOL_REGISTRY,
     PLUGIN_MODULE_PREFIX,
     TOOL_METADATA,
     TOOL_REGISTRY,
@@ -274,6 +276,23 @@ def test_tool_metadata_consistency() -> None:
         assert metadata.category, f"Tool {tool_name} missing category"
         assert metadata.status, f"Tool {tool_name} missing status"
         assert metadata.setup_type, f"Tool {tool_name} missing setup_type"
+
+
+def test_dynamic_tools_is_durable_metadata_only_builtin(tmp_path: Path) -> None:
+    """Dynamic tools metadata should survive runtime registry rebuilding without a factory."""
+    metadata = TOOL_METADATA["dynamic_tools"]
+
+    assert BUILTIN_TOOL_METADATA["dynamic_tools"] == metadata
+    assert "dynamic_tools" not in BUILTIN_TOOL_REGISTRY
+    assert "dynamic_tools" not in TOOL_REGISTRY
+
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={},
+    )
+
+    assert metadata_module.resolved_tool_metadata_for_runtime(runtime_paths, Config())["dynamic_tools"] == metadata
 
 
 def test_tool_metadata_does_not_advertise_env_var_fallbacks() -> None:


### PR DESCRIPTION
## Summary
- Register dynamic_tools metadata through register_builtin_tool_metadata, matching sibling metadata-only tools.
- Keep dynamic_tools metadata-only: no toolkit factory is registered and metadata values stay unchanged.
- Add characterization coverage for durable built-in metadata and absence from TOOL_REGISTRY.

## Verification
- uv sync --all-extras
- uv run pytest tests/test_tools_metadata.py -q
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/tools/dynamic_tools.py tests/test_tools_metadata.py

## Duplication examined
- src/mindroom/tools/dynamic_tools.py module-level metadata registration
- src/mindroom/tools/delegate.py metadata-only registration
- src/mindroom/tools/self_config.py metadata-only registration
- src/mindroom/tools/compact_context.py metadata-only registration
- src/mindroom/tools/memory.py metadata-only registration
- mindroom.tool_system.registry_state.register_builtin_tool_metadata
- mindroom.tool_system.registry_state.resolved_tool_state
- mindroom.tool_system.metadata._resolved_tool_state_for_runtime / resolved_tool_metadata_for_runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated tool metadata registration to use a centralized function instead of direct dictionary assignment.
  * Modified imports to pull registration utilities and metadata types from a unified metadata module.

* **Tests**
  * Expanded test registry imports to include additional built-in metadata and registry constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->