### PR TITLE
Refactor OAuth state validation

### DIFF
--- a/src/mindroom/oauth/state.py
+++ b/src/mindroom/oauth/state.py
@@ -10,7 +10,7 @@ import threading
 import time
 from contextlib import contextmanager
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 from mindroom.logging_config import get_logger
@@ -128,6 +128,25 @@ def issue_opaque_oauth_state(
     return token
 
 
+def _validated_oauth_state_data(record: object, *, kind: str, now: float) -> dict[str, Any]:
+    if not isinstance(record, dict):
+        msg = "OAuth state is invalid or expired"
+        raise OAuthProviderError(msg)
+    state_record = cast("dict[str, Any]", record)
+    if state_record.get("kind") != kind:
+        msg = "OAuth state does not match this integration"
+        raise OAuthProviderError(msg)
+    expires_at = state_record.get("exp")
+    if not isinstance(expires_at, int | float) or expires_at <= now:
+        msg = "OAuth state is invalid or expired"
+        raise OAuthProviderError(msg)
+    data = state_record.get("data")
+    if not isinstance(data, dict):
+        msg = "OAuth state is invalid or expired"
+        raise OAuthProviderError(msg)
+    return data
+
+
 def read_opaque_oauth_state(
     runtime_paths: RuntimePaths,
     *,
@@ -139,25 +158,7 @@ def read_opaque_oauth_state(
     with _locked_state_store(runtime_paths, now=now, save_on_exit=False) as states:
         record = states.get(token)
 
-    if not isinstance(record, dict):
-        msg = "OAuth state is invalid or expired"
-        raise OAuthProviderError(msg)
-    if record.get("kind") != kind:
-        msg = "OAuth state does not match this integration"
-        raise OAuthProviderError(msg)
-    expires_at = record.get("exp")
-    if not isinstance(expires_at, int | float):
-        msg = "OAuth state is invalid or expired"
-        raise OAuthProviderError(msg)
-    if expires_at <= now:
-        msg = "OAuth state is invalid or expired"
-        raise OAuthProviderError(msg)
-
-    data = record.get("data")
-    if not isinstance(data, dict):
-        msg = "OAuth state is invalid or expired"
-        raise OAuthProviderError(msg)
-    return data
+    return _validated_oauth_state_data(record, kind=kind, now=now)
 
 
 def consume_opaque_oauth_state(
@@ -170,18 +171,4 @@ def consume_opaque_oauth_state(
     now = time.time()
     with _locked_state_store(runtime_paths, now=now) as states:
         record = states.pop(token, None)
-    if not isinstance(record, dict):
-        msg = "OAuth state is invalid or expired"
-        raise OAuthProviderError(msg)
-    if record.get("kind") != kind:
-        msg = "OAuth state does not match this integration"
-        raise OAuthProviderError(msg)
-    expires_at = record.get("exp")
-    if not isinstance(expires_at, int | float) or expires_at <= now:
-        msg = "OAuth state is invalid or expired"
-        raise OAuthProviderError(msg)
-    data = record.get("data")
-    if not isinstance(data, dict):
-        msg = "OAuth state is invalid or expired"
-        raise OAuthProviderError(msg)
-    return data
+    return _validated_oauth_state_data(record, kind=kind, now=now)

--- a/tests/test_oauth_state.py
+++ b/tests/test_oauth_state.py
@@ -8,13 +8,17 @@ import json
 import multiprocessing
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
 
 from mindroom.constants import resolve_primary_runtime_paths
 from mindroom.oauth.providers import OAuthProviderError
-from mindroom.oauth.state import issue_opaque_oauth_state, read_opaque_oauth_state
+from mindroom.oauth.state import consume_opaque_oauth_state, issue_opaque_oauth_state, read_opaque_oauth_state
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _state_file(storage_root: Path) -> Path:
@@ -96,6 +100,45 @@ def test_read_opaque_oauth_state_does_not_write_to_disk(tmp_path: Path) -> None:
         assert read_opaque_oauth_state(runtime_paths, kind="test_state", token=token) == {"value": "stored"}
 
     mock_save.assert_not_called()
+
+
+def test_consume_opaque_oauth_state_removes_token_before_kind_validation(tmp_path: Path) -> None:
+    runtime_paths = resolve_primary_runtime_paths(storage_path=tmp_path / "storage", process_env={})
+    token = issue_opaque_oauth_state(
+        runtime_paths,
+        kind="other_state",
+        ttl_seconds=60,
+        data={"value": "stored"},
+    )
+
+    with pytest.raises(OAuthProviderError, match="OAuth state does not match this integration"):
+        consume_opaque_oauth_state(runtime_paths, kind="test_state", token=token)
+
+    with pytest.raises(OAuthProviderError, match="OAuth state is invalid or expired"):
+        read_opaque_oauth_state(runtime_paths, kind="other_state", token=token)
+
+
+@pytest.mark.parametrize(
+    "accessor",
+    [read_opaque_oauth_state, consume_opaque_oauth_state],
+)
+def test_opaque_oauth_state_rejects_non_mapping_data(
+    tmp_path: Path,
+    accessor: Callable[..., dict[str, Any]],
+) -> None:
+    runtime_paths = resolve_primary_runtime_paths(storage_path=tmp_path / "storage", process_env={})
+    token = issue_opaque_oauth_state(
+        runtime_paths,
+        kind="test_state",
+        ttl_seconds=60,
+        data={"value": "stored"},
+    )
+    stored = json.loads(_state_file(runtime_paths.storage_root).read_text(encoding="utf-8"))
+    stored["states"][token]["data"] = "invalid"
+    _state_file(runtime_paths.storage_root).write_text(json.dumps(stored), encoding="utf-8")
+
+    with pytest.raises(OAuthProviderError, match="OAuth state is invalid or expired"):
+        accessor(runtime_paths, kind="test_state", token=token)
 
 
 def test_corrupt_state_file_renamed_to_corrupt_suffix(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Extract shared opaque OAuth state record validation into a private helper.
- Preserve read lookup versus consume pop behavior, kind/expiry/data validation, store save behavior, and existing OAuthProviderError messages.
- Add focused characterization coverage for consume-before-validation behavior and non-dict data rejection across read/consume.

## Verification
- uv run pytest tests/test_oauth_state.py -q -n 0 --no-cov
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/oauth/state.py tests/test_oauth_state.py

Production line delta: src/mindroom/oauth/state.py 187 -> 174 (-13).
