### PR TITLE
Refactor MCP filter overlap validation

### DIFF
--- a/src/mindroom/mcp/config.py
+++ b/src/mindroom/mcp/config.py
@@ -39,6 +39,13 @@ def validate_mcp_function_name(value: str, *, subject: str) -> str:
     return value
 
 
+def validate_mcp_tool_filter_overlap(include_tools: list[str], exclude_tools: list[str], *, message: str) -> None:
+    """Reject tool names that appear in both include and exclude filters."""
+    if overlap := sorted(set(include_tools) & set(exclude_tools)):
+        msg = f"{message}: {', '.join(overlap)}"
+        raise ValueError(msg)
+
+
 def normalize_mcp_server_id(server_id: str) -> str:
     """Validate and normalize one MCP server id."""
     return _validate_mcp_identifier(server_id, subject="MCP server id")
@@ -82,14 +89,6 @@ class MCPServerConfig(BaseModel):
                 normalized.append(stripped)
         return normalized
 
-    def _validate_tool_filters(self) -> None:
-        include_tools = set(self.include_tools)
-        exclude_tools = set(self.exclude_tools)
-        overlap = sorted(include_tools & exclude_tools)
-        if overlap:
-            msg = f"MCP include_tools and exclude_tools overlap: {', '.join(overlap)}"
-            raise ValueError(msg)
-
     def _validate_stdio_transport(self) -> None:
         if not self.command or not self.command.strip():
             msg = "stdio MCP servers require a non-empty command"
@@ -121,7 +120,11 @@ class MCPServerConfig(BaseModel):
     @model_validator(mode="after")
     def validate_transport_fields(self) -> Self:
         """Validate the transport-specific config shape."""
-        self._validate_tool_filters()
+        validate_mcp_tool_filter_overlap(
+            self.include_tools,
+            self.exclude_tools,
+            message="MCP include_tools and exclude_tools overlap",
+        )
 
         if self.transport == "stdio":
             self._validate_stdio_transport()

--- a/src/mindroom/mcp/registry.py
+++ b/src/mindroom/mcp/registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+from mindroom.mcp.config import validate_mcp_tool_filter_overlap
 from mindroom.mcp.errors import MCPError
 from mindroom.mcp.toolkit import MindRoomMCPToolkit, require_mcp_server_manager
 from mindroom.tool_system.catalog import (
@@ -94,10 +95,8 @@ def validate_mcp_agent_overrides(tool_name: str, overrides: dict[str, object]) -
 
     include_tools = cast("list[str]", overrides.get("include_tools", []))
     exclude_tools = cast("list[str]", overrides.get("exclude_tools", []))
-    overlap = sorted(set(include_tools) & set(exclude_tools))
-    if overlap:
-        msg = f"Invalid per-agent override for '{tool_name}': include_tools and exclude_tools overlap: {', '.join(overlap)}"
-        raise ValueError(msg)
+    message = f"Invalid per-agent override for '{tool_name}': include_tools and exclude_tools overlap"
+    validate_mcp_tool_filter_overlap(include_tools, exclude_tools, message=message)
 
     timeout_seconds = overrides.get("call_timeout_seconds")
     if timeout_seconds is not None and (

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -38,13 +38,14 @@ def test_mcp_server_config_rejects_invalid_transport_mix() -> None:
 
 def test_mcp_server_config_rejects_overlapping_filters() -> None:
     """Reject overlapping include and exclude tool filters."""
-    with pytest.raises(ValueError, match="include_tools and exclude_tools overlap"):
+    with pytest.raises(ValueError, match="MCP include_tools and exclude_tools overlap") as exc_info:
         MCPServerConfig(
             transport="stdio",
             command="npx",
-            include_tools=["echo"],
-            exclude_tools=["echo"],
+            include_tools=["ping", "echo"],
+            exclude_tools=["echo", "ping"],
         )
+    assert str(exc_info.value.errors()[0]["ctx"]["error"]) == "MCP include_tools and exclude_tools overlap: echo, ping"
 
 
 def test_mcp_server_config_normalizes_tool_filters() -> None:

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -16,6 +16,7 @@ from mindroom.mcp.registry import (
     mcp_tool_name,
     resolved_mcp_tool_state,
     sync_mcp_tool_registry,
+    validate_mcp_agent_overrides,
 )
 from mindroom.mcp.toolkit import bind_mcp_server_manager
 from mindroom.tool_system.metadata import TOOL_METADATA, TOOL_REGISTRY, get_tool_by_name
@@ -300,3 +301,31 @@ def test_mcp_tool_names_are_shared_only(tmp_path: Path) -> None:
 
     assert mcp_server_id_from_tool_name("mcp_demo") == "demo"
     assert supports_tool_name_for_worker_scope("mcp_demo", "user") is False
+
+
+def test_validate_mcp_agent_overrides_rejects_overlapping_filters_with_exact_message() -> None:
+    """Preserve the public per-agent MCP filter-overlap error."""
+    with pytest.raises(ValueError, match="include_tools and exclude_tools overlap") as exc_info:
+        validate_mcp_agent_overrides(
+            "mcp_demo",
+            {
+                "include_tools": ["ping", "echo"],
+                "exclude_tools": ["echo", "ping"],
+            },
+        )
+
+    assert (
+        str(exc_info.value)
+        == "Invalid per-agent override for 'mcp_demo': include_tools and exclude_tools overlap: echo, ping"
+    )
+
+
+def test_validate_mcp_agent_overrides_rejects_invalid_call_timeout_with_exact_message() -> None:
+    """Keep per-agent timeout validation behavior independent from filter validation."""
+    with pytest.raises(ValueError, match="expected a number greater than 0") as exc_info:
+        validate_mcp_agent_overrides("mcp_demo", {"call_timeout_seconds": 0})
+
+    assert (
+        str(exc_info.value)
+        == "Invalid per-agent override for 'mcp_demo.call_timeout_seconds': expected a number greater than 0"
+    )


### PR DESCRIPTION
## Summary
- Add one shared MCP include/exclude overlap validator in `src/mindroom/mcp/config.py`.
- Use it from server-level MCP config validation and per-agent MCP override validation.
- Preserve existing overlap error text and keep `call_timeout_seconds` override validation local to `validate_mcp_agent_overrides`.

## Scope
- Touched MCP config/registry and focused MCP tests only.
- Did not touch dynamic registry reconciliation.

## Line gate
- Production delta: +2 net lines (`src/mindroom/mcp/config.py` +3, `src/mindroom/mcp/registry.py` -1).
- Complexity drops by replacing duplicate sorted include/exclude intersection/error construction with one helper.

## Verification
- `uv sync --all-extras`
- Rebased onto latest `origin/main` before final checks.
- `uv run pytest tests/test_mcp_config.py::test_mcp_server_config_rejects_overlapping_filters tests/test_mcp_config.py::test_config_rejects_invalid_mcp_assignment_overrides tests/test_mcp_registry.py::test_validate_mcp_agent_overrides_rejects_overlapping_filters_with_exact_message tests/test_mcp_registry.py::test_validate_mcp_agent_overrides_rejects_invalid_call_timeout_with_exact_message tests/test_tools_metadata.py::test_get_tool_by_name_rejects_invalid_mcp_assignment_overrides -q` -> 5 passed
- `uv run tach check --dependencies --interfaces` -> All modules validated
- `uv run pre-commit run --files src/mindroom/mcp/config.py src/mindroom/mcp/registry.py tests/test_mcp_config.py tests/test_mcp_registry.py` -> passed
