### PR TITLE
Refactor canonical room thread session IDs

### DIFF
--- a/src/mindroom/custom_tools/subagents.py
+++ b/src/mindroom/custom_tools/subagents.py
@@ -21,7 +21,7 @@ from mindroom.thread_summary import (
     update_last_summary_count,
 )
 from mindroom.thread_tags import ThreadTagsError, normalize_tag_name, set_thread_tag
-from mindroom.thread_utils import create_session_id
+from mindroom.thread_utils import create_session_id, parse_session_id
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
 
 if TYPE_CHECKING:
@@ -208,11 +208,7 @@ def _bounded_offset(offset: int | None) -> int:
 
 
 def _session_key_to_room_thread(session_key: str) -> tuple[str, str | None]:
-    marker = ":$"
-    if marker in session_key:
-        room_id, thread_suffix = session_key.rsplit(marker, 1)
-        return room_id, f"${thread_suffix}"
-    return session_key, None
+    return parse_session_id(session_key)
 
 
 def _agent_thread_mode(context: ToolRuntimeContext, agent_name: str, room_id: str | None = None) -> str:

--- a/src/mindroom/message_target.py
+++ b/src/mindroom/message_target.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from mindroom.thread_utils import create_session_id
+
 if TYPE_CHECKING:
     from mindroom.scheduling import ScheduledWorkflow
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
@@ -30,10 +32,7 @@ class MessageTarget:
         """Return the canonical room/thread log fields for this target."""
         return {"room_id": self.room_id, "thread_id": self.resolved_thread_id}
 
-    @staticmethod
-    def _build_session_id(room_id: str, resolved_thread_id: str | None) -> str:
-        """Build the canonical persisted session ID for one target."""
-        return room_id if resolved_thread_id is None else f"{room_id}:{resolved_thread_id}"
+    _build_session_id = staticmethod(create_session_id)
 
     @classmethod
     def for_scheduled_task(

--- a/src/mindroom/thread_utils.py
+++ b/src/mindroom/thread_utils.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, cast
 from mindroom import authorization
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.matrix.identity import MatrixID, extract_agent_name
-from mindroom.matrix.rooms import resolve_room_aliases
 from mindroom.matrix.visible_body import visible_content_from_content
 
 if TYPE_CHECKING:
@@ -76,6 +75,12 @@ def create_session_id(room_id: str, thread_id: str | None) -> str:
     """Create a session ID with thread awareness."""
     # Thread sessions include thread ID
     return f"{room_id}:{thread_id}" if thread_id else room_id
+
+
+def parse_session_id(session_id: str) -> tuple[str, str | None]:
+    """Parse the canonical persisted room/thread session ID."""
+    room_id, marker, thread_suffix = session_id.rpartition(":$")
+    return (room_id, f"${thread_suffix}") if marker else (session_id, None)
 
 
 def get_agents_in_thread(
@@ -208,6 +213,7 @@ def get_configured_agents_for_room(
     """
     configured_agents: list[MatrixID] = []
     config_ids = config.get_ids(runtime_paths)
+    from mindroom.matrix.rooms import resolve_room_aliases  # noqa: PLC0415
 
     # Check which agents should be in this room
     for agent_name, agent_config in config.agents.items():

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -16,7 +16,7 @@ from mindroom.constants import ORIGINAL_SENDER_KEY, resolve_runtime_paths
 from mindroom.custom_tools import subagents as subagents_module
 from mindroom.custom_tools.subagents import SubAgentsTools
 from mindroom.thread_summary import THREAD_SUMMARY_MAX_LENGTH
-from mindroom.thread_utils import create_session_id
+from mindroom.thread_utils import create_session_id, parse_session_id
 from mindroom.tool_system.metadata import TOOL_METADATA, get_tool_by_name
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 from tests.conftest import delivered_matrix_side_effect, make_event_cache_mock
@@ -767,6 +767,24 @@ def test_load_registry_returns_existing_dict_without_migration(tmp_path: Path) -
 
     registry = subagents_module._load_registry(ctx)
     assert registry == old_data
+
+
+def test_subagent_session_key_reverse_parse_matches_canonical_parser() -> None:
+    """Subagent registry session keys should reverse-parse through the canonical parser."""
+    room_id = "!room:with:colons:localhost"
+    thread_id = "$thread$with$dollars:localhost"
+    session_key = create_session_id(room_id, thread_id)
+
+    assert parse_session_id(session_key) == (room_id, thread_id)
+    assert subagents_module._session_key_to_room_thread(session_key) == (room_id, thread_id)
+
+
+def test_subagent_session_key_reverse_parse_keeps_room_level_keys() -> None:
+    """Subagent registry room-level session keys should not invent a thread id."""
+    room_id = "!room:with:colons:localhost"
+
+    assert parse_session_id(room_id) == (room_id, None)
+    assert subagents_module._session_key_to_room_thread(room_id) == (room_id, None)
 
 
 def test_resolve_by_label_require_thread_skips_entries_without_thread_id(tmp_path: Path) -> None:

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -29,7 +29,7 @@ from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.streaming import StreamingResponse, send_streaming_response
-from mindroom.thread_utils import create_session_id
+from mindroom.thread_utils import create_session_id, parse_session_id
 from mindroom.tool_system.runtime_context import ToolRuntimeContext
 
 if TYPE_CHECKING:
@@ -518,6 +518,23 @@ class TestCreateSessionIdWithNoneThread:
         session_id = create_session_id("!room:localhost", "$thread123")
         assert session_id == "!room:localhost:$thread123"
 
+    def test_room_level_session_round_trip_keeps_room_id_with_colons(self) -> None:
+        """Room-level session parsing should preserve room ids containing colons."""
+        room_id = "!room:with:colons:localhost"
+        session_id = create_session_id(room_id, None)
+
+        assert session_id == room_id
+        assert parse_session_id(session_id) == (room_id, None)
+
+    def test_thread_level_session_round_trip_keeps_event_id_with_dollars(self) -> None:
+        """Thread-level session parsing should preserve Matrix event ids containing dollars."""
+        room_id = "!room:with:colons:localhost"
+        thread_id = "$thread$with$dollars:localhost"
+        session_id = create_session_id(room_id, thread_id)
+
+        assert session_id == f"{room_id}:{thread_id}"
+        assert parse_session_id(session_id) == (room_id, thread_id)
+
     def test_message_target_room_mode_reuses_room_level_session_format(self) -> None:
         """Room-mode MessageTarget sessions should match create_session_id(None)."""
         target = MessageTarget.resolve(
@@ -529,6 +546,20 @@ class TestCreateSessionIdWithNoneThread:
         assert target.source_thread_id is None
         assert target.resolved_thread_id is None
         assert target.session_id == create_session_id("!room:localhost", None)
+
+    def test_message_target_thread_session_round_trips_through_canonical_parser(self) -> None:
+        """Thread-mode MessageTarget sessions should use the canonical persisted format."""
+        room_id = "!room:with:colons:localhost"
+        thread_id = "$thread$with$dollars:localhost"
+
+        target = MessageTarget.resolve(
+            room_id=room_id,
+            thread_id=thread_id,
+            reply_to_event_id="$event456",
+        )
+
+        assert target.session_id == create_session_id(room_id, thread_id)
+        assert parse_session_id(target.session_id) == (room_id, thread_id)
 
     def test_message_target_plain_reply_keeps_room_level_session(self) -> None:
         """Plain reply targets should not derive thread or session identity."""


### PR DESCRIPTION
## Summary
- centralize canonical room/thread session ID reverse parsing in thread_utils
- delegate MessageTarget session ID construction to the existing thread_utils constructor
- reuse the canonical parser for subagent session registry keys

## Verification
- uv run pytest tests/test_thread_mode.py::TestCreateSessionIdWithNoneThread tests/test_subagents.py::test_subagent_session_key_reverse_parse_matches_canonical_parser tests/test_subagents.py::test_subagent_session_key_reverse_parse_keeps_room_level_keys -q -n 0 --no-cov
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/message_target.py src/mindroom/thread_utils.py src/mindroom/custom_tools/subagents.py tests/test_thread_mode.py tests/test_subagents.py