### PR TITLE
Refactor MCP remote transport openers

### DIFF
--- a/src/mindroom/mcp/transports.py
+++ b/src/mindroom/mcp/transports.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp.client.sse import sse_client
@@ -18,6 +18,7 @@ _ENV_REFERENCE_PATTERN = re.compile(r"\$\{([^}]+)\}")
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Mapping
     from contextlib import AbstractAsyncContextManager
+    from typing import Any
 
     from mindroom.constants import RuntimePaths
     from mindroom.mcp.config import MCPServerConfig, MCPTransport
@@ -26,6 +27,9 @@ _TransportStreams = tuple[
     MemoryObjectReceiveStream[SessionMessage | Exception],
     MemoryObjectSendStream[SessionMessage],
 ]
+
+if TYPE_CHECKING:
+    _RemoteTransportClient = Callable[..., AbstractAsyncContextManager[tuple[Any, ...]]]
 
 
 @dataclass(frozen=True)
@@ -85,37 +89,23 @@ async def _open_stdio(
 
 
 @asynccontextmanager
-async def _open_sse(
+async def _open_remote_transport(
     server_config: MCPServerConfig,
     runtime_paths: RuntimePaths,
+    *,
+    transport: MCPTransport,
+    client: _RemoteTransportClient,
 ) -> AsyncIterator[_TransportStreams]:
     if server_config.url is None:
-        msg = "sse MCP servers require url"
+        msg = f"{transport} MCP servers require url"
         raise ValueError(msg)
-    async with sse_client(
+    async with client(
         server_config.url,
         headers=_interpolate_mcp_headers(server_config.headers, runtime_paths),
         timeout=server_config.startup_timeout_seconds,
         sse_read_timeout=server_config.call_timeout_seconds,
     ) as streams:
-        yield streams
-
-
-@asynccontextmanager
-async def _open_streamable_http(
-    server_config: MCPServerConfig,
-    runtime_paths: RuntimePaths,
-) -> AsyncIterator[_TransportStreams]:
-    if server_config.url is None:
-        msg = "streamable-http MCP servers require url"
-        raise ValueError(msg)
-    async with streamablehttp_client(
-        server_config.url,
-        headers=_interpolate_mcp_headers(server_config.headers, runtime_paths),
-        timeout=server_config.startup_timeout_seconds,
-        sse_read_timeout=server_config.call_timeout_seconds,
-    ) as streams:
-        yield streams[0], streams[1]
+        yield cast("_TransportStreams", streams[:2])
 
 
 def build_transport_handle(
@@ -127,11 +117,24 @@ def build_transport_handle(
     if server_config.transport == "stdio":
         return _MCPTransportHandle(transport="stdio", opener=lambda: _open_stdio(server_config, runtime_paths))
     if server_config.transport == "sse":
-        return _MCPTransportHandle(transport="sse", opener=lambda: _open_sse(server_config, runtime_paths))
+        return _MCPTransportHandle(
+            transport="sse",
+            opener=lambda: _open_remote_transport(
+                server_config,
+                runtime_paths,
+                transport="sse",
+                client=sse_client,
+            ),
+        )
     if server_config.transport == "streamable-http":
         return _MCPTransportHandle(
             transport="streamable-http",
-            opener=lambda: _open_streamable_http(server_config, runtime_paths),
+            opener=lambda: _open_remote_transport(
+                server_config,
+                runtime_paths,
+                transport="streamable-http",
+                client=streamablehttp_client,
+            ),
         )
     msg = f"Unsupported MCP transport for server '{server_id}': {server_config.transport}"
     raise ValueError(msg)

--- a/tests/test_mcp_transports.py
+++ b/tests/test_mcp_transports.py
@@ -2,18 +2,24 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, cast
 
+import pytest
+
+import mindroom.mcp.transports as transport_module
 from mindroom.constants import resolve_runtime_paths
 from mindroom.mcp.config import MCPServerConfig
 from mindroom.mcp.transports import (
     _build_stdio_server_parameters,
     _interpolate_mcp_env,
     _interpolate_mcp_headers,
+    _TransportStreams,
     build_transport_handle,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from pathlib import Path
 
     from mindroom.constants import RuntimePaths
@@ -73,3 +79,108 @@ def test_build_transport_handle_returns_expected_transport(tmp_path: Path) -> No
         ).transport
         == "sse"
     )
+
+
+@pytest.mark.asyncio
+async def test_open_sse_interpolates_headers_and_passes_timeouts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Open SSE transports with interpolated headers and configured timeouts."""
+    runtime_paths = _runtime_paths(tmp_path)
+    streams = cast("_TransportStreams", (object(), object()))
+    captured: dict[str, object] = {}
+
+    @asynccontextmanager
+    async def fake_sse_client(
+        url: str,
+        **kwargs: object,
+    ) -> AsyncIterator[_TransportStreams]:
+        captured.update(url=url, **kwargs)
+        yield streams
+
+    monkeypatch.setattr(transport_module, "sse_client", fake_sse_client)
+    server_config = MCPServerConfig(
+        transport="sse",
+        url="https://mcp.example/sse",
+        headers={"Authorization": "Bearer ${API_TOKEN}"},
+        startup_timeout_seconds=1.5,
+        call_timeout_seconds=2.5,
+    )
+
+    handle = build_transport_handle("demo", server_config, runtime_paths)
+
+    async with handle.opener() as opened_streams:
+        assert opened_streams == streams
+
+    assert captured == {
+        "url": "https://mcp.example/sse",
+        "headers": {"Authorization": "Bearer secret-token"},
+        "timeout": 1.5,
+        "sse_read_timeout": 2.5,
+    }
+
+
+@pytest.mark.asyncio
+async def test_open_streamable_http_interpolates_headers_passes_timeouts_and_drops_session_getter(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Open streamable HTTP transports while dropping the session id getter."""
+    runtime_paths = _runtime_paths(tmp_path)
+    read_stream = object()
+    write_stream = object()
+    captured: dict[str, object] = {}
+
+    @asynccontextmanager
+    async def fake_streamablehttp_client(
+        url: str,
+        **kwargs: object,
+    ) -> AsyncIterator[tuple[object, object, object]]:
+        captured.update(url=url, **kwargs)
+        yield read_stream, write_stream, lambda: "session-id"
+
+    monkeypatch.setattr(transport_module, "streamablehttp_client", fake_streamablehttp_client)
+    server_config = MCPServerConfig(
+        transport="streamable-http",
+        url="https://mcp.example/mcp",
+        headers={"X-Token": "${API_TOKEN}"},
+        startup_timeout_seconds=3.5,
+        call_timeout_seconds=4.5,
+    )
+
+    handle = build_transport_handle("demo", server_config, runtime_paths)
+
+    async with handle.opener() as streams:
+        assert streams == (read_stream, write_stream)
+
+    assert captured == {
+        "url": "https://mcp.example/mcp",
+        "headers": {"X-Token": "secret-token"},
+        "timeout": 3.5,
+        "sse_read_timeout": 4.5,
+    }
+
+
+@pytest.mark.asyncio
+async def test_open_sse_requires_runtime_url(tmp_path: Path) -> None:
+    """Keep the SSE runtime guard for configs that bypass model validation."""
+    runtime_paths = _runtime_paths(tmp_path)
+    server_config = MCPServerConfig.model_construct(transport="sse", url=None)
+    handle = build_transport_handle("demo", server_config, runtime_paths)
+
+    with pytest.raises(ValueError, match="sse MCP servers require url"):
+        async with handle.opener():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_open_streamable_http_requires_runtime_url(tmp_path: Path) -> None:
+    """Keep the streamable HTTP runtime guard for configs that bypass model validation."""
+    runtime_paths = _runtime_paths(tmp_path)
+    server_config = MCPServerConfig.model_construct(transport="streamable-http", url=None)
+    handle = build_transport_handle("demo", server_config, runtime_paths)
+
+    with pytest.raises(ValueError, match="streamable-http MCP servers require url"):
+        async with handle.opener():
+            pass


### PR DESCRIPTION
## Summary
- Replace duplicated SSE and streamable HTTP opener bodies with one private remote transport opener.
- Preserve URL guard messages, header interpolation, timeout propagation, and streamable HTTP tuple truncation.
- Add focused MCP transport characterization tests for the remote opener flows.

## Line gate
Production delta in src/mindroom/mcp/transports.py: +27/-24, net +3 lines. This is roughly flat while removing duplicated opener bodies.

## Verification
- uv run pytest tests/test_mcp_transports.py -x -n 0 --no-cov -v
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/mcp/transports.py tests/test_mcp_transports.py
