### PR TITLE
Refactor OAuth connection-required formatting

### DIFF
--- a/src/mindroom/oauth/client.py
+++ b/src/mindroom/oauth/client.py
@@ -146,13 +146,8 @@ class ScopedOAuthClientMixin:
             self._runtime_paths,
             worker_target=self._worker_target,
         )
-        message = build_oauth_connect_instruction(
-            self._oauth_provider,
-            self._runtime_paths,
-            worker_target=self._worker_target,
-        )
         return OAuthConnectionRequired(
-            message,
+            build_oauth_connect_instruction(self._oauth_provider, connect_url),
             provider_id=self._oauth_provider.id,
             connect_url=connect_url,
         )

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -314,16 +314,9 @@ def oauth_connect_url(
 
 def build_oauth_connect_instruction(
     provider: OAuthProvider,
-    runtime_paths: RuntimePaths,
-    *,
-    worker_target: ResolvedWorkerTarget | None = None,
+    connect_url: str,
 ) -> str:
     """Return a concise user-facing connection instruction for a tool result."""
-    connect_url = oauth_connect_url(
-        provider,
-        runtime_paths,
-        worker_target=worker_target,
-    )
     return (
         f"{provider.display_name} is not connected for this agent. "
         f"Open this MindRoom link to connect it, then retry the request: {connect_url}"

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -12,6 +12,7 @@ from mindroom.oauth.google_drive import _GOOGLE_DRIVE_OAUTH_SCOPES, google_drive
 from mindroom.oauth.google_gmail import _GOOGLE_GMAIL_OAUTH_SCOPES, google_gmail_oauth_provider
 from mindroom.oauth.google_sheets import _GOOGLE_SHEETS_OAUTH_SCOPES, google_sheets_oauth_provider
 from mindroom.oauth.providers import OAuthConnectionRequired, oauth_connection_required_payload
+from mindroom.oauth.service import build_oauth_connect_instruction
 
 if TYPE_CHECKING:
     from mindroom.oauth.providers import OAuthProvider
@@ -168,3 +169,15 @@ def test_oauth_connection_required_payload_preserves_structured_fields() -> None
         "provider": "google_drive",
         "connect_url": "/api/oauth/google_drive/connect?agent_name=general",
     }
+
+
+def test_build_oauth_connect_instruction_formats_shared_message() -> None:
+    """OAuth connection instructions should have one shared service formatter."""
+    assert build_oauth_connect_instruction(
+        google_drive_oauth_provider(),
+        "/api/oauth/google_drive/connect?agent_name=general",
+    ) == (
+        "Google Drive is not connected for this agent. "
+        "Open this MindRoom link to connect it, then retry the request: "
+        "/api/oauth/google_drive/connect?agent_name=general"
+    )

--- a/tests/test_google_tool_wrappers.py
+++ b/tests/test_google_tool_wrappers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
@@ -17,7 +18,9 @@ from mindroom.custom_tools.google_calendar import GoogleCalendarTools
 from mindroom.custom_tools.google_drive import GoogleDriveTools
 from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, google_service_account_configured
 from mindroom.custom_tools.google_sheets import GoogleSheetsTools
+from mindroom.oauth import client as oauth_client_module
 from mindroom.oauth.client import ScopedOAuthClientMixin
+from mindroom.oauth.providers import OAuthConnectionRequired
 from mindroom.tool_system.metadata import get_tool_by_name
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
 
@@ -239,6 +242,64 @@ def test_google_wrappers_load_provider_oauth_credentials(
 
     assert isinstance(tool, (GmailTools, GoogleCalendarTools, GoogleDriveTools, GoogleSheetsTools))
     assert tool._load_token_data() is not None
+
+
+def test_scoped_oauth_client_structured_auth_failure_returns_oauth_required_json_string() -> None:
+    """Scoped OAuth tools should return the public OAuth-required payload as a JSON string."""
+    tool = object.__new__(GoogleDriveTools)
+    result = tool._structured_auth_failure(
+        OAuthConnectionRequired(
+            "Google Drive is not connected for this agent.",
+            provider_id="google_drive",
+            connect_url="/api/oauth/google_drive/connect?agent_name=general",
+        ),
+    )
+
+    payload = json.loads(result)
+    assert list(payload) == ["error", "oauth_connection_required", "provider", "connect_url"]
+    assert payload == {
+        "error": "Google Drive is not connected for this agent.",
+        "oauth_connection_required": True,
+        "provider": "google_drive",
+        "connect_url": "/api/oauth/google_drive/connect?agent_name=general",
+    }
+
+
+def test_scoped_oauth_client_connection_required_uses_shared_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_paths: RuntimePaths,
+) -> None:
+    """Client OAuth prompts should share the service-owned instruction text."""
+    tool = object.__new__(GoogleDriveTools)
+    tool._oauth_provider = GoogleDriveTools._oauth_provider
+    tool._runtime_paths = runtime_paths
+    tool._worker_target = None
+
+    def connect_url(provider: object, runtime_paths_arg: RuntimePaths, *, worker_target: object) -> str:
+        assert provider is GoogleDriveTools._oauth_provider
+        assert runtime_paths_arg is runtime_paths
+        assert worker_target is None
+        return "https://connect.example.test"
+
+    monkeypatch.setattr(
+        oauth_client_module,
+        "oauth_connect_url",
+        connect_url,
+    )
+    seen: list[tuple[object, str]] = []
+
+    def build_instruction(provider: object, connect_url: str) -> str:
+        seen.append((provider, connect_url))
+        return f"shared instruction: {connect_url}"
+
+    monkeypatch.setattr(oauth_client_module, "build_oauth_connect_instruction", build_instruction)
+
+    exc = tool._connection_required()
+
+    assert str(exc) == "shared instruction: https://connect.example.test"
+    assert exc.provider_id == "google_drive"
+    assert exc.connect_url == "https://connect.example.test"
+    assert seen == [(GoogleDriveTools._oauth_provider, "https://connect.example.test")]
 
 
 def test_google_wrapper_skips_stored_oauth_when_service_account_env_is_configured(


### PR DESCRIPTION
## Summary
- reuse the service-owned OAuth connect instruction formatter in `ScopedOAuthClientMixin._connection_required`
- keep OAuth connection-required payload serialization centralized through the existing provider helper
- add focused coverage for the OAuth client JSON-string path, shared instruction formatter, and existing dict-return boundaries

## Verification
- `uv run pytest tests/test_google_tool_wrappers.py::test_scoped_oauth_client_structured_auth_failure_returns_oauth_required_json_string tests/test_google_tool_wrappers.py::test_scoped_oauth_client_connection_required_uses_shared_instruction tests/test_google_oauth_providers.py::test_oauth_connection_required_payload_preserves_structured_fields tests/test_google_oauth_providers.py::test_build_oauth_connect_instruction_formats_shared_message tests/test_tool_hooks.py::test_oauth_required_tool_result_is_recorded_when_debug_enabled tests/api/test_sandbox_runner_api.py::test_execute_request_inprocess_serializes_oauth_connection_required tests/api/test_sandbox_runner_api.py::test_execute_request_inprocess_serializes_oauth_connection_required_from_tool_construction -q -n 0 --no-cov`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/oauth/client.py src/mindroom/oauth/service.py tests/test_google_tool_wrappers.py tests/test_google_oauth_providers.py`