### PR TITLE
refactor: share tool output receipt builder

### DIFF
--- a/src/mindroom/custom_tools/attachments.py
+++ b/src/mindroom/custom_tools/attachments.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from agno.tools import Toolkit
 
@@ -24,6 +23,7 @@ from mindroom.matrix.client_delivery import send_file_message
 from mindroom.tool_system.output_files import (
     ToolOutputFilePolicy,
     ensure_output_path_schema_optional,
+    saved_tool_output_receipt,
     validate_output_path,
     validate_output_path_syntax,
     write_bytes_to_output_path,
@@ -511,7 +511,7 @@ class AttachmentTools(Toolkit):
             return validate_output_path(local_policy, output_path)
         return "mindroom_output_path requires an agent workspace in this runtime path."
 
-    async def _save_attachment_to_output_path(  # noqa: C901, PLR0911, PLR0912
+    async def _save_attachment_to_output_path(  # noqa: C901, PLR0911
         self,
         context: ToolRuntimeContext,
         *,
@@ -588,13 +588,12 @@ class AttachmentTools(Toolkit):
                 "ok",
                 attachment_id=requested_attachment_id,
                 attachment=attachment_payload,
-                mindroom_tool_output={
-                    "status": "saved_to_file",
-                    "path": worker_receipt.worker_path,
-                    "bytes": worker_receipt.size_bytes,
-                    "format": "binary",
-                    "sha256": worker_receipt.sha256,
-                },
+                mindroom_tool_output=saved_tool_output_receipt(
+                    path=worker_receipt.worker_path,
+                    byte_count=worker_receipt.size_bytes,
+                    output_format="binary",
+                    sha256=worker_receipt.sha256,
+                ),
             )
 
         if local_policy is None:
@@ -607,24 +606,9 @@ class AttachmentTools(Toolkit):
         if isinstance(write_result, str):
             return _attachment_tool_payload("error", attachment_id=requested_attachment_id, message=write_result)
 
-        output_receipt = write_result.receipt["mindroom_tool_output"]
-        if not isinstance(output_receipt, Mapping):
-            return _attachment_tool_payload(
-                "error",
-                attachment_id=requested_attachment_id,
-                message="Failed to build attachment save receipt.",
-            )
-        output_receipt_map = cast("Mapping[str, object]", output_receipt)
-        receipt_path = output_receipt_map.get("path")
-        if not isinstance(receipt_path, str):
-            return _attachment_tool_payload(
-                "error",
-                attachment_id=requested_attachment_id,
-                message="Failed to build attachment save receipt.",
-            )
         attachment_payload.update(
             {
-                "save_path": receipt_path,
+                "save_path": output_path,
                 "size_bytes": write_result.byte_count,
                 "sha256": sha256,
             },
@@ -633,10 +617,13 @@ class AttachmentTools(Toolkit):
             "ok",
             attachment_id=requested_attachment_id,
             attachment=attachment_payload,
-            mindroom_tool_output={
-                **output_receipt,
-                "sha256": sha256,
-            },
+            mindroom_tool_output=saved_tool_output_receipt(
+                path=output_path,
+                byte_count=write_result.byte_count,
+                output_format="binary",
+                overwritten=write_result.overwritten,
+                sha256=sha256,
+            ),
         )
 
     async def register_attachment(self, file_path: str) -> str:

--- a/src/mindroom/tool_system/output_files.py
+++ b/src/mindroom/tool_system/output_files.py
@@ -113,14 +113,35 @@ def _success_receipt(
     overwritten: bool,
 ) -> dict[str, object]:
     return {
-        "mindroom_tool_output": {
-            "status": "saved_to_file",
-            "path": path,
-            "bytes": byte_count,
-            "format": output_format,
-            "overwritten": overwritten,
-        },
+        "mindroom_tool_output": saved_tool_output_receipt(
+            path=path,
+            byte_count=byte_count,
+            output_format=output_format,
+            overwritten=overwritten,
+        ),
     }
+
+
+def saved_tool_output_receipt(
+    *,
+    path: str,
+    byte_count: int,
+    output_format: Literal["text", "json", "binary"],
+    overwritten: bool | None = None,
+    sha256: str | None = None,
+) -> dict[str, object]:
+    """Return the canonical inner ``mindroom_tool_output`` saved-file receipt."""
+    receipt: dict[str, object] = {
+        "status": "saved_to_file",
+        "path": path,
+        "bytes": byte_count,
+        "format": output_format,
+    }
+    if overwritten is not None:
+        receipt["overwritten"] = overwritten
+    if sha256 is not None:
+        receipt["sha256"] = sha256
+    return receipt
 
 
 def _error_receipt(error: str) -> dict[str, object]:

--- a/tests/test_attachments_tool.py
+++ b/tests/test_attachments_tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import hashlib
 import json
 import stat
 import time
@@ -210,6 +211,14 @@ async def test_attachments_tool_get_attachment_mindroom_output_path_writes_prima
     assert payload["mindroom_tool_output"]["status"] == "saved_to_file"
     assert payload["mindroom_tool_output"]["path"] == "inputs/sample.txt"
     assert payload["mindroom_tool_output"]["format"] == "binary"
+    assert payload["mindroom_tool_output"] == {
+        "status": "saved_to_file",
+        "path": "inputs/sample.txt",
+        "bytes": 5,
+        "format": "binary",
+        "overwritten": False,
+        "sha256": hashlib.sha256(b"hello").hexdigest(),
+    }
 
 
 @pytest.mark.asyncio
@@ -388,7 +397,13 @@ async def test_attachments_tool_get_attachment_selective_proxy_uses_worker_for_w
 
     assert payload["status"] == "ok"
     assert payload["attachment"]["save_path"] == "inputs/sample.txt"
-    assert payload["mindroom_tool_output"]["path"] == "inputs/sample.txt"
+    assert payload["mindroom_tool_output"] == {
+        "status": "saved_to_file",
+        "path": "inputs/sample.txt",
+        "bytes": 5,
+        "format": "binary",
+        "sha256": "sha256",
+    }
     assert not any(workspace.rglob("*"))
     mocked_save.assert_called_once()
     assert mocked_save.call_args.kwargs["worker_tools_override"] == worker_tools_override

--- a/tests/test_tool_output_files.py
+++ b/tests/test_tool_output_files.py
@@ -31,6 +31,7 @@ from mindroom.tool_system.output_files import (
     ToolOutputFilePolicy,
     _wrap_function_for_output_files,
     ensure_output_path_schema_optional,
+    saved_tool_output_receipt,
     wrap_toolkit_for_output_files,
 )
 from mindroom.tool_system.tool_hooks import build_tool_hook_bridge, prepend_tool_hook_bridge
@@ -105,6 +106,26 @@ def test_ensure_output_path_schema_optional_preserves_custom_schema_shape() -> N
         "description": "Context attachment.",
     }
     _assert_output_path_schema_is_optional(function)
+
+
+def test_saved_tool_output_receipt_keeps_canonical_key_order() -> None:
+    receipt = saved_tool_output_receipt(
+        path="notes/result.txt",
+        byte_count=5,
+        output_format="binary",
+        overwritten=False,
+        sha256="abc123",
+    )
+
+    assert list(receipt) == ["status", "path", "bytes", "format", "overwritten", "sha256"]
+    assert receipt == {
+        "status": "saved_to_file",
+        "path": "notes/result.txt",
+        "bytes": 5,
+        "format": "binary",
+        "overwritten": False,
+        "sha256": "abc123",
+    }
 
 
 def _plugin(*callbacks: object) -> object:


### PR DESCRIPTION
## Summary
- add `saved_tool_output_receipt` as the canonical inner `mindroom_tool_output` saved-file receipt builder
- reuse it from attachment worker and local output-path saves while preserving `sha256`, `overwritten`, and worker path behavior
- add focused receipt-shape assertions for output-file and attachment saves

## Verification
- `uv run pytest tests/test_tool_output_files.py tests/test_attachments_tool.py -q --no-cov -n 0`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/tool_system/output_files.py src/mindroom/custom_tools/attachments.py tests/test_tool_output_files.py tests/test_attachments_tool.py`