### PR TITLE
refactor: centralize worker visibility policy

### DIFF
--- a/src/mindroom/api/sandbox_worker_prep.py
+++ b/src/mindroom/api/sandbox_worker_prep.py
@@ -15,7 +15,7 @@ from mindroom.api import sandbox_exec
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.sandbox_proxy import sandbox_proxy_config
 from mindroom.tool_system.worker_routing import (
-    resolved_worker_key_scope,
+    requires_explicit_private_agent_visibility,
     visible_state_roots_for_worker_key,
     worker_dir_name,
 )
@@ -247,7 +247,7 @@ def _explicit_private_agent_names(
     private_agent_names: frozenset[str] | None,
 ) -> frozenset[str]:
     """Require explicit private-agent visibility for user-agent worker resolution."""
-    if resolved_worker_key_scope(worker_key) != "user_agent":
+    if not requires_explicit_private_agent_visibility(worker_key):
         return frozenset()
     if private_agent_names is None:
         msg = f"user_agent workers require explicit private-agent visibility: {worker_key}"

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -524,6 +524,11 @@ def resolved_worker_key_scope(worker_key: str) -> ResolvedWorkerKeyScope | None:
     return cast("ResolvedWorkerKeyScope", scope)
 
 
+def requires_explicit_private_agent_visibility(worker_key: str) -> bool:
+    """Return whether visible private-agent names must be supplied for this worker."""
+    return resolved_worker_key_scope(worker_key) == "user_agent"
+
+
 def _worker_key_agent_name(worker_key: str) -> str | None:
     """Return the encoded agent name for one resolved worker key, when present."""
     scope = resolved_worker_key_scope(worker_key)

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Protocol, cast
 from mindroom import constants
 from mindroom.constants import RuntimePaths
 from mindroom.credentials import SHARED_CREDENTIALS_PATH_ENV
-from mindroom.tool_system.worker_routing import resolved_worker_key_scope, visible_state_roots_for_worker_key
+from mindroom.tool_system import worker_routing
 from mindroom.workers.backend import WorkerBackendError
 
 if TYPE_CHECKING:
@@ -989,16 +989,16 @@ class KubernetesResourceManager:
         private_agent_names: frozenset[str] | None,
     ) -> list[dict[str, object]]:
         mounted_storage_root = Path(self.config.storage_mount_path)
-        if resolved_worker_key_scope(worker_key) == "user_agent" and private_agent_names is None:
+        if worker_routing.requires_explicit_private_agent_visibility(worker_key) and private_agent_names is None:
             msg = f"user_agent workers require explicit private-agent visibility: {worker_key}"
             raise WorkerBackendError(msg)
         effective_private_agent_names = private_agent_names or frozenset()
-        visible_state_roots = visible_state_roots_for_worker_key(
+        visible_state_roots = worker_routing.visible_state_roots_for_worker_key(
             mounted_storage_root,
             worker_key,
             private_agent_names=effective_private_agent_names,
         )
-        local_visible_state_roots = visible_state_roots_for_worker_key(
+        local_visible_state_roots = worker_routing.visible_state_roots_for_worker_key(
             self.storage_root,
             worker_key,
             private_agent_names=effective_private_agent_names,

--- a/tach.toml
+++ b/tach.toml
@@ -2608,6 +2608,7 @@ expose = [
     "private_instance_scope_root_path",
     "parse_tool_execution_identity_payload",
     "require_worker_key_for_scope",
+    "requires_explicit_private_agent_visibility",
     "resolve_agent_owned_path",
     "resolve_agent_state_storage_path",
     "resolve_unscoped_worker_key",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -45,6 +45,7 @@ from mindroom.tool_system.worker_routing import (
     agent_state_root_path,
     agent_workspace_root_path,
     private_instance_scope_root_path,
+    requires_explicit_private_agent_visibility,
     resolve_agent_owned_path,
     resolve_agent_state_storage_path,
     resolve_unscoped_worker_key,
@@ -1883,6 +1884,15 @@ def test_visible_state_roots_for_user_worker_include_private_instance_namespace(
         shared_storage_root(tmp_path) / "agents",
         private_instance_scope_root_path(tmp_path, worker_key),
     )
+
+
+def test_worker_visibility_policy_requires_explicit_private_names_only_for_user_agent_scope() -> None:
+    """Only user-agent scoped workers need caller-provided private-agent visibility."""
+    assert requires_explicit_private_agent_visibility("v1:tenant:user_agent:@alice:example.org:mind")
+    assert not requires_explicit_private_agent_visibility("v1:tenant:user:@alice:example.org")
+    assert not requires_explicit_private_agent_visibility("v1:tenant:shared:mind")
+    assert not requires_explicit_private_agent_visibility("v1:tenant:unscoped:mind")
+    assert not requires_explicit_private_agent_visibility("legacy-worker-key")
 
 
 def test_visible_state_roots_for_private_user_agent_workers_hide_shared_agent_root(


### PR DESCRIPTION
## Summary
- add a pure `requires_explicit_private_agent_visibility()` predicate in `worker_routing.py`
- reuse it from sandbox request prep and Kubernetes scoped storage mounts while preserving local exception types/messages
- export the new worker-routing interface in `tach.toml` and add a routing-level policy test

## Line Delta
Production files: +5 net lines (`sandbox_worker_prep.py` 2/2, `worker_routing.py` 5/0, `kubernetes_resources.py` 4/4).

## Duplication Examined
- `sandbox_worker_prep._explicit_private_agent_names`
- `KubernetesResourceManager._scoped_storage_mounts`
- `worker_routing.resolved_worker_key_scope` / `visible_state_roots_for_worker_key`
- TTL clamp duplication between `sandbox_worker_prep._bounded_ttl_seconds` and `sandbox_proxy._read_credential_lease_ttl`; skipped because the duplicate call site is in excluded proxy scope.

## Verification
- `uv sync --all-extras`
- `uv run pytest tests/api/test_sandbox_runner_api.py::test_prepare_worker_request_shared_worker_does_not_read_private_agent_names tests/api/test_sandbox_runner_api.py::test_prepare_worker_request_user_agent_private_visibility_comes_from_explicit_names tests/api/test_sandbox_runner_api.py::test_prepare_worker_request_rejects_sibling_private_agent_root_for_user_agent_workers tests/api/test_sandbox_runner_api.py::test_prepare_worker_request_requires_explicit_private_visibility_for_user_agent_workers tests/test_kubernetes_worker_backend.py::test_kubernetes_backend_mounts_broad_agents_tree_for_user_scope tests/test_kubernetes_worker_backend.py::test_kubernetes_backend_user_agent_mounts_require_explicit_private_visibility tests/test_kubernetes_worker_backend.py::test_kubernetes_backend_user_agent_mounts_private_root_from_worker_spec tests/test_kubernetes_worker_backend.py::test_kubernetes_backend_recreates_user_agent_deployment_when_private_visibility_changes tests/test_agents.py::test_worker_visibility_policy_requires_explicit_private_names_only_for_user_agent_scope -q -n 0 --no-cov`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/tool_system/worker_routing.py src/mindroom/api/sandbox_worker_prep.py src/mindroom/workers/backends/kubernetes_resources.py tests/test_agents.py tach.toml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced private-agent visibility requirements to enforce clearer policies for specific worker types.
  * Centralized worker routing logic across system components for improved consistency.

* **Tests**
  * Added test coverage for private-agent visibility requirements validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->