### PR TITLE
refactor: share subprocess PATH composition

### DIFF
--- a/src/mindroom/api/sandbox_exec.py
+++ b/src/mindroom/api/sandbox_exec.py
@@ -256,8 +256,10 @@ def worker_subprocess_env(paths: LocalWorkerStatePaths) -> dict[str, str]:
     env["PYTHONPYCACHEPREFIX"] = str(paths.cache_dir / "pycache")
     env["VIRTUAL_ENV"] = str(paths.venv_dir)
 
-    current_path = env.get("PATH", "")
-    env["PATH"] = f"{paths.venv_dir / 'bin'}:{current_path}" if current_path else str(paths.venv_dir / "bin")
+    env["PATH"] = constants.subprocess_path_with_prepends(
+        env.get("PATH"),
+        prepend_entries=(str(paths.venv_dir / "bin"),),
+    ) or str(paths.venv_dir / "bin")
 
     python_path_parts = [str(_project_src_path()), *_current_runtime_site_packages()]
     existing_python_path = env.get("PYTHONPATH", "")

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -194,6 +194,32 @@ def workspace_home_identity_env(workspace: Path | str) -> dict[str, str]:
     }
 
 
+def subprocess_path_with_prepends(
+    current_path: str | None,
+    *,
+    prepend_entries: tuple[str, ...] = (),
+) -> str | None:
+    """Return a PATH value with prepended entries first and duplicate entries removed."""
+    if current_path is None and not prepend_entries:
+        return current_path
+
+    path_entries = [entry for entry in prepend_entries if entry]
+    if current_path:
+        path_entries.extend(entry for entry in current_path.split(os.pathsep) if entry)
+
+    if not path_entries:
+        return current_path
+
+    deduped_entries: list[str] = []
+    seen_entries: set[str] = set()
+    for entry in path_entries:
+        if entry in seen_entries:
+            continue
+        seen_entries.add(entry)
+        deduped_entries.append(entry)
+    return os.pathsep.join(deduped_entries)
+
+
 def is_workspace_env_overlay_name_allowed(name: str) -> bool:
     """Return whether one env var name may be returned from `.mindroom/worker-env.sh`.
 

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -23,6 +23,7 @@ from mindroom.constants import (
     WORKSPACE_HOME_CONTRACT_ENV_NAMES,
     RuntimePaths,
     shell_execution_runtime_env_values,
+    subprocess_path_with_prepends,
     workspace_home_identity_env,
 )
 from mindroom.logging_config import get_logger
@@ -106,32 +107,6 @@ def _shell_path_prepend_entries(shell_path_prepend: str | None) -> tuple[str, ..
     return tuple(part.strip() for part in re.split(r"[\n,]+", shell_path_prepend) if part.strip())
 
 
-def _shell_subprocess_path(
-    current_path: str | None,
-    *,
-    prepend_entries: tuple[str, ...] = (),
-) -> str | None:
-    """Return the PATH value for shell subprocesses."""
-    if current_path is None and not prepend_entries:
-        return current_path
-
-    path_entries = [entry for entry in prepend_entries if entry]
-    if current_path:
-        path_entries.extend(entry for entry in current_path.split(os.pathsep) if entry)
-
-    if not path_entries:
-        return current_path
-
-    deduped_entries: list[str] = []
-    seen_entries: set[str] = set()
-    for entry in path_entries:
-        if entry in seen_entries:
-            continue
-        seen_entries.add(entry)
-        deduped_entries.append(entry)
-    return os.pathsep.join(deduped_entries)
-
-
 def _workspace_home_contract_env_from_process_env(base_process_env: dict[str, str]) -> dict[str, str]:
     """Return MindRoom-owned workspace env only when the full workspace contract is present."""
     workspace = base_process_env.get("MINDROOM_AGENT_WORKSPACE")
@@ -159,7 +134,7 @@ def _shell_subprocess_env(
     if base_process_env is not None:
         env.update(_workspace_home_contract_env_from_process_env(base_process_env))
 
-    path_value = _shell_subprocess_path(
+    path_value = subprocess_path_with_prepends(
         env.get("PATH"),
         prepend_entries=_shell_path_prepend_entries(shell_path_prepend),
     )

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -1234,8 +1234,9 @@ def test_worker_subprocess_env_preserves_parent_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Worker subprocesses should keep PATH without re-exporting tool config env vars."""
-    monkeypatch.setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+    """Worker subprocesses should prepend the worker venv once and keep parent PATH."""
+    paths = local_workers_module._local_worker_state_paths_for_root(tmp_path / "worker")
+    monkeypatch.setenv("PATH", f"{paths.venv_dir}/bin:/usr/local/bin:/usr/bin:/bin")
     config_dir = tmp_path / "cfg"
     config_dir.mkdir(parents=True, exist_ok=True)
     config_path = config_dir / "config.yaml"
@@ -1247,12 +1248,10 @@ def test_worker_subprocess_env_preserves_parent_path(
         f"GOOGLE_APPLICATION_CREDENTIALS={credentials_path}\n",
         encoding="utf-8",
     )
-    paths = local_workers_module._local_worker_state_paths_for_root(tmp_path / "worker")
 
     env = sandbox_exec_module.worker_subprocess_env(paths)
 
-    assert env["PATH"].startswith(f"{paths.venv_dir}/bin:")
-    assert env["PATH"].endswith("/usr/local/bin:/usr/bin:/bin")
+    assert env["PATH"] == f"{paths.venv_dir}/bin:/usr/local/bin:/usr/bin:/bin"
     assert "GOOGLE_CLOUD_PROJECT" not in env
     assert "GOOGLE_CLOUD_LOCATION" not in env
     assert "GOOGLE_APPLICATION_CREDENTIALS" not in env

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -41,6 +41,7 @@ from mindroom.constants import (
     sandbox_shell_execution_runtime_env_values,
     shell_execution_runtime_env_values,
     shell_extra_env_values,
+    subprocess_path_with_prepends,
 )
 from mindroom.credentials import get_runtime_credentials_manager, save_scoped_credentials
 from mindroom.hooks import HookRegistry
@@ -1469,13 +1470,13 @@ def test_get_tool_by_name_does_not_expose_runtime_env_to_file_backed_python_exec
 
 def test_shell_subprocess_path_keeps_existing_path_without_prepend() -> None:
     """Shell PATH normalization should preserve the base PATH when nothing is prepended."""
-    assert shell_tool_module._shell_subprocess_path("/usr/local/bin:/usr/bin:/bin") == "/usr/local/bin:/usr/bin:/bin"
+    assert subprocess_path_with_prepends("/usr/local/bin:/usr/bin:/bin") == "/usr/local/bin:/usr/bin:/bin"
 
 
 def test_shell_subprocess_path_uses_only_prepend_entries_for_empty_path() -> None:
     """Configured path entries should still be available when PATH is empty."""
     assert (
-        shell_tool_module._shell_subprocess_path(
+        subprocess_path_with_prepends(
             "",
             prepend_entries=("/opt/custom/bin", "/opt/worker/bin"),
         )
@@ -1486,7 +1487,7 @@ def test_shell_subprocess_path_uses_only_prepend_entries_for_empty_path() -> Non
 def test_shell_subprocess_path_prepends_configured_entries_and_dedupes() -> None:
     """Configured path entries should stay first without duplicating existing PATH entries."""
     assert (
-        shell_tool_module._shell_subprocess_path(
+        subprocess_path_with_prepends(
             "/usr/bin:/opt/existing/bin:/bin",
             prepend_entries=("/opt/custom/bin", "/opt/existing/bin"),
         )


### PR DESCRIPTION
## Summary
- move shell PATH prepend/dedupe logic into a shared constants helper
- reuse the helper when worker subprocess env prepends the worker venv bin path
- pin worker PATH order/dedup behavior in the existing sandbox env test

## Line gate
- Production delta: +3 lines (src/mindroom/constants.py +26, src/mindroom/tools/shell.py -25 net with import/call updates, src/mindroom/api/sandbox_exec.py +2 net)

## Verification
- uv run pytest tests/test_sandbox_proxy.py::test_shell_subprocess_path_keeps_existing_path_without_prepend tests/test_sandbox_proxy.py::test_shell_subprocess_path_uses_only_prepend_entries_for_empty_path tests/test_sandbox_proxy.py::test_shell_subprocess_path_prepends_configured_entries_and_dedupes tests/test_sandbox_proxy.py::test_shell_subprocess_env_path_passthrough_without_prepend tests/test_sandbox_proxy.py::test_shell_subprocess_env_prefers_explicit_base_process_env tests/test_sandbox_proxy.py::test_shell_subprocess_env_forces_vendor_telemetry_over_runtime_env tests/test_sandbox_proxy.py::test_subprocess_env_for_request_forces_vendor_telemetry_over_execution_env tests/test_sandbox_proxy.py::test_shell_subprocess_env_preserves_workspace_home_contract_names tests/test_sandbox_proxy.py::test_shell_subprocess_env_prefers_runtime_env_when_no_workspace_contract tests/api/test_sandbox_runner_api.py::test_worker_subprocess_env_preserves_parent_path tests/test_shell_async.py::test_workspace_home_contract_env_requires_full_identity_fragment -q -n 0 --no-cov
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/constants.py src/mindroom/tools/shell.py src/mindroom/api/sandbox_exec.py tests/test_sandbox_proxy.py tests/api/test_sandbox_runner_api.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated subprocess environment PATH handling logic for improved consistency and maintainability across the codebase.

* **Tests**
  * Enhanced test determinism for subprocess environment configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->