### PR TITLE
Refactor run retry helpers

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -155,13 +155,6 @@ class _PreparedAgentRun:
         return ai_runtime.copy_run_input(self.messages)
 
 
-def _next_retry_run_id(run_id: str | None) -> str | None:
-    """Return a fresh Agno run identifier for a retry attempt."""
-    if run_id is None:
-        return None
-    return str(uuid4())
-
-
 def _prompt_current_sender_id(user_id: str | None, *, include_openai_compat_guidance: bool) -> str | None:
     """Return the Matrix current sender ID when prompt formatting should include it."""
     if include_openai_compat_guidance:
@@ -181,12 +174,6 @@ def _build_timing_scope(
         if candidate:
             return candidate[:20]
     return "unknown"
-
-
-def _note_attempt_run_id(run_id_callback: Callable[[str], None] | None, run_id: str | None) -> None:
-    """Publish the current run_id before starting a real Agno run attempt."""
-    if run_id_callback is not None and run_id is not None:
-        run_id_callback(run_id)
 
 
 @timed("system_prompt_assembly.system_enrichment_render")
@@ -1034,7 +1021,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                             )
                             attempt_prompt = ai_runtime.append_inline_media_fallback_to_run_input(run_input)
                             attempt_media_inputs = MediaInputs()
-                            attempt_run_id = _next_retry_run_id(run_id)
+                            attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                             continue
 
                         logger.exception("Error generating AI response", agent=agent_name)
@@ -1053,7 +1040,7 @@ async def ai_response(  # noqa: C901, PLR0912, PLR0915
                             )
                             attempt_prompt = ai_runtime.append_inline_media_fallback_to_run_input(run_input)
                             attempt_media_inputs = MediaInputs()
-                            attempt_run_id = _next_retry_run_id(run_id)
+                            attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                             continue
 
                         logger.warning("AI response returned errored run output", agent=agent_name, error=error_text)
@@ -1502,7 +1489,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     try:
                         if pipeline_timing is not None:
                             pipeline_timing.mark("model_request_sent", overwrite=True)
-                        _note_attempt_run_id(run_id_callback, attempt_run_id)
+                        ai_runtime.note_attempt_run_id(run_id_callback, attempt_run_id)
                         request_context = _attempt_request_log_context(
                             agent_id=agent_name,
                             session_id=session_id,
@@ -1557,7 +1544,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                         ):
                             attempt_prompt = ai_runtime.append_inline_media_fallback_to_run_input(run_input)
                             attempt_media_inputs = MediaInputs()
-                            attempt_run_id = _next_retry_run_id(run_id)
+                            attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                             continue
                         logger.exception("Error starting streaming AI response")
                         yield get_user_friendly_error_message(e, agent_name)
@@ -1566,7 +1553,7 @@ async def stream_agent_response(  # noqa: C901, PLR0912, PLR0915
                     if state.retry_requested:
                         attempt_prompt = ai_runtime.append_inline_media_fallback_to_run_input(run_input)
                         attempt_media_inputs = MediaInputs()
-                        attempt_run_id = _next_retry_run_id(run_id)
+                        attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                         continue
 
                     if state.user_error is not None:

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, cast
+from uuid import uuid4
 
 from agno.db.base import SessionType
 from agno.models.message import Message
@@ -34,6 +35,8 @@ __all__ = [
     "cleanup_queued_notice_state",
     "copy_run_input",
     "install_queued_message_notice_hook",
+    "next_retry_run_id",
+    "note_attempt_run_id",
     "queued_message_signal_context",
     "scrub_queued_notice_session_context",
 ]
@@ -319,7 +322,14 @@ def install_queued_message_notice_hook(model: Model) -> None:
     model_dict["_handle_function_call_media"] = _handle_function_call_media_with_notice
 
 
-def _note_attempt_run_id(run_id_callback: Callable[[str], None] | None, run_id: str | None) -> None:
+def next_retry_run_id(run_id: str | None) -> str | None:
+    """Return a fresh Agno run identifier for a retry attempt."""
+    if run_id is None:
+        return None
+    return str(uuid4())
+
+
+def note_attempt_run_id(run_id_callback: Callable[[str], None] | None, run_id: str | None) -> None:
     """Publish the current run_id before starting a real Agno run attempt."""
     if run_id_callback is not None and run_id is not None:
         run_id_callback(run_id)
@@ -338,7 +348,7 @@ async def cached_agent_run(
 ) -> RunOutput:
     """Shared wrapper for one ``agent.arun()`` call."""
     media_inputs = media or MediaInputs()
-    _note_attempt_run_id(run_id_callback, run_id)
+    note_attempt_run_id(run_id_callback, run_id)
     prepared_input = attach_media_to_run_input(run_input, media_inputs)
     return await agent.arun(
         prepared_input,

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast
-from uuid import uuid4
 
 from agno.agent import Agent
 from agno.db.base import SessionType
@@ -176,13 +175,6 @@ class _PreparedMaterializedTeamExecution:
     def context_messages(self) -> tuple[Message, ...]:
         """Return replayed context messages without the current user turn."""
         return self.messages[:-1]
-
-
-def _next_retry_run_id(run_id: str | None) -> str | None:
-    """Return a fresh Agno run identifier for a retry attempt."""
-    if run_id is None:
-        return None
-    return str(uuid4())
 
 
 class _TeamModeDecision(BaseModel):
@@ -1639,8 +1631,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                 current_media_inputs: MediaInputs,
                 current_run_id: str | None,
             ) -> object:
-                if run_id_callback is not None and current_run_id is not None:
-                    run_id_callback(current_run_id)
+                ai_runtime.note_attempt_run_id(run_id_callback, current_run_id)
                 prepared_input = (
                     ai_runtime.attach_media_to_run_input(current_prompt, current_media_inputs)
                     if current_media_inputs.has_any()
@@ -1694,7 +1685,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                             )
                             attempt_prompt = append_inline_media_fallback_prompt(prompt)
                             attempt_media_inputs = MediaInputs()
-                            attempt_run_id = _next_retry_run_id(run_id)
+                            attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                             continue
 
                         logger.exception("team_response_failed", agents=agent_list)
@@ -1725,7 +1716,7 @@ async def team_response(  # noqa: C901, PLR0912, PLR0915
                             )
                             attempt_prompt = append_inline_media_fallback_prompt(prompt)
                             attempt_media_inputs = MediaInputs()
-                            attempt_run_id = _next_retry_run_id(run_id)
+                            attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                             continue
                         logger.warning("Team response returned errored run output", agents=agent_list, error=error_text)
 
@@ -2197,8 +2188,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                     emitted_output = False
                     retry_requested = False
 
-                    if run_id_callback is not None and attempt_run_id is not None:
-                        run_id_callback(attempt_run_id)
+                    ai_runtime.note_attempt_run_id(run_id_callback, attempt_run_id)
 
                     raw_stream = await _team_response_stream_raw(
                         team=team,
@@ -2268,7 +2258,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                     )
                                     attempt_prompt = append_inline_media_fallback_prompt(prepared_prompt)
                                     attempt_media_inputs = MediaInputs()
-                                    attempt_run_id = _next_retry_run_id(run_id)
+                                    attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                                     retry_requested = True
                                     break
                                 yield get_user_friendly_error_message(Exception(error_text), team_label)
@@ -2310,7 +2300,7 @@ async def team_response_stream(  # noqa: C901, PLR0912, PLR0915
                                 )
                                 attempt_prompt = append_inline_media_fallback_prompt(prepared_prompt)
                                 attempt_media_inputs = MediaInputs()
-                                attempt_run_id = _next_retry_run_id(run_id)
+                                attempt_run_id = ai_runtime.next_retry_run_id(run_id)
                                 retry_requested = True
                                 break
                             yield get_user_friendly_error_message(Exception(error_text), team_label)


### PR DESCRIPTION
## Summary
- Share the Agno retry run-id generator from `ai_runtime` instead of keeping local copies in agent and team paths.
- Share the simple run-id callback notifier for agent cached runs, agent streaming, and team run attempts.
- Leave cancellation message text, exception types, response lifecycles, and streaming tool tracking unchanged.

## Line gate
- Production delta: 23 insertions, 36 deletions, net -13 lines across `src/mindroom/ai.py`, `src/mindroom/ai_runtime.py`, and `src/mindroom/teams.py`.

## Duplication checked
- `ai.py`: `_next_retry_run_id`, `_note_attempt_run_id`, retry call sites in `ai_response`, retry/callback call sites in `stream_agent_response`, cancellation helpers left untouched.
- `ai_runtime.py`: existing `_note_attempt_run_id` in `cached_agent_run`, promoted to shared `note_attempt_run_id`, plus `next_retry_run_id`.
- `teams.py`: local `_next_retry_run_id`, inline callback checks in `team_response` and `team_response_stream`, cancellation helpers left untouched.
- `execution_preparation.py`: prepared execution wrapper duplication reviewed, no change because it is outside the tiny retry/cancellation helper scope.

## Verification
- `uv run pytest tests/test_ai_user_id.py::TestUserIdPassthrough::test_ai_response_retries_errored_run_output_with_fresh_run_id tests/test_ai_user_id.py::TestUserIdPassthrough::test_ai_response_persists_retry_run_id_after_hard_cancellation tests/test_ai_user_id.py::TestUserIdPassthrough::test_stream_agent_response_retries_with_fresh_run_id tests/test_ai_user_id.py::TestUserIdPassthrough::test_stream_agent_response_persists_retry_run_id_after_hard_cancellation tests/test_team_media_fallback.py::test_team_response_retries_errored_plain_run_output_with_fresh_run_id tests/test_team_media_fallback.py::test_team_response_retries_errored_run_output_with_fresh_run_id tests/test_team_media_fallback.py::test_team_response_tracks_retry_run_id_after_hard_cancellation tests/test_team_media_fallback.py::test_team_response_stream_retries_errored_output_with_fresh_run_id tests/test_team_media_fallback.py::test_team_response_stream_tracks_retry_run_id_after_hard_cancellation -q -n 0 --no-cov`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/ai.py src/mindroom/ai_runtime.py src/mindroom/teams.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling during streaming operations with clearer error messages.

* **Refactor**
  * Optimized internal retry and run-id management across AI operations by consolidating utilities into a centralized runtime API layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->