### PR TITLE
Refactor custom tool JSON payload helper

### DIFF
--- a/src/mindroom/custom_tools/matrix_api.py
+++ b/src/mindroom/custom_tools/matrix_api.py
@@ -14,6 +14,7 @@ from agno.tools import Toolkit
 from mindroom.config.matrix import ignore_unverified_devices_for_config
 from mindroom.custom_tools.attachment_helpers import room_access_allowed
 from mindroom.custom_tools.matrix_helpers import check_rate_limit
+from mindroom.custom_tools.tool_payloads import custom_tool_payload
 from mindroom.logging_config import get_logger
 from mindroom.matrix.thread_bookkeeping import (
     MutationThreadImpactState,
@@ -142,9 +143,7 @@ class MatrixApiTools(Toolkit):
 
     @staticmethod
     def _payload(status: str, **kwargs: object) -> str:
-        payload: dict[str, object] = {"status": status, "tool": "matrix_api"}
-        payload.update(kwargs)
-        return json.dumps(payload, sort_keys=True)
+        return custom_tool_payload("matrix_api", status, **kwargs)
 
     @classmethod
     def _context_error(cls) -> str:

--- a/src/mindroom/custom_tools/matrix_message.py
+++ b/src/mindroom/custom_tools/matrix_message.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from collections import defaultdict, deque
 from threading import Lock
 from typing import ClassVar
@@ -12,6 +11,7 @@ from agno.tools import Toolkit
 from mindroom.custom_tools import matrix_conversation_operations
 from mindroom.custom_tools.attachment_helpers import normalize_str_list, resolve_context_thread_id, room_access_allowed
 from mindroom.custom_tools.matrix_helpers import check_rate_limit
+from mindroom.custom_tools.tool_payloads import custom_tool_payload
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
 
 
@@ -41,9 +41,7 @@ class MatrixMessageTools(Toolkit):
 
     @staticmethod
     def _payload(status: str, **kwargs: object) -> str:
-        payload: dict[str, object] = {"status": status, "tool": "matrix_message"}
-        payload.update(kwargs)
-        return json.dumps(payload, sort_keys=True)
+        return custom_tool_payload("matrix_message", status, **kwargs)
 
     @classmethod
     def _operation_result_payload(

--- a/src/mindroom/custom_tools/matrix_room.py
+++ b/src/mindroom/custom_tools/matrix_room.py
@@ -14,6 +14,7 @@ from aiohttp import ClientError
 
 from mindroom.custom_tools.attachment_helpers import room_access_allowed
 from mindroom.custom_tools.matrix_helpers import check_rate_limit
+from mindroom.custom_tools.tool_payloads import custom_tool_payload
 from mindroom.matrix.client_thread_history import RoomThreadsPageError, get_room_threads_page
 from mindroom.matrix.client_visible_messages import (
     message_preview,
@@ -55,9 +56,7 @@ class MatrixRoomTools(Toolkit):
 
     @staticmethod
     def _payload(status: str, **kwargs: object) -> str:
-        payload: dict[str, object] = {"status": status, "tool": "matrix_room"}
-        payload.update(kwargs)
-        return json.dumps(payload, sort_keys=True)
+        return custom_tool_payload("matrix_room", status, **kwargs)
 
     @classmethod
     def _context_error(cls) -> str:

--- a/src/mindroom/custom_tools/thread_summary.py
+++ b/src/mindroom/custom_tools/thread_summary.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 from agno.tools import Toolkit
 
 from mindroom.custom_tools.attachment_helpers import (
@@ -11,6 +9,7 @@ from mindroom.custom_tools.attachment_helpers import (
     resolve_requested_room_id,
     room_access_allowed,
 )
+from mindroom.custom_tools.tool_payloads import custom_tool_payload
 from mindroom.matrix.conversation_cache import resolve_thread_root_event_id_for_client
 from mindroom.thread_summary import ThreadSummaryWriteError, set_manual_thread_summary
 from mindroom.tool_system.runtime_context import get_tool_runtime_context
@@ -27,9 +26,7 @@ class ThreadSummaryTools(Toolkit):
 
     @staticmethod
     def _payload(status: str, **kwargs: object) -> str:
-        payload: dict[str, object] = {"status": status, "tool": "thread_summary"}
-        payload.update(kwargs)
-        return json.dumps(payload, sort_keys=True)
+        return custom_tool_payload("thread_summary", status, **kwargs)
 
     @classmethod
     def _context_error(cls) -> str:

--- a/src/mindroom/custom_tools/thread_tags.py
+++ b/src/mindroom/custom_tools/thread_tags.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
 
 from agno.tools import Toolkit
@@ -13,6 +12,7 @@ from mindroom.custom_tools.attachment_helpers import (
     resolve_requested_room_id,
     room_access_allowed,
 )
+from mindroom.custom_tools.tool_payloads import custom_tool_payload
 from mindroom.matrix.conversation_cache import resolve_thread_root_event_id_for_client
 from mindroom.thread_tags import (
     ThreadTagRecord,
@@ -72,9 +72,7 @@ class ThreadTagsTools(Toolkit):
 
     @staticmethod
     def _payload(status: str, **kwargs: object) -> str:
-        payload: dict[str, object] = {"status": status, "tool": "thread_tags"}
-        payload.update(kwargs)
-        return json.dumps(payload, sort_keys=True)
+        return custom_tool_payload("thread_tags", status, **kwargs)
 
     @classmethod
     def _context_error(cls) -> str:

--- a/src/mindroom/custom_tools/tool_payloads.py
+++ b/src/mindroom/custom_tools/tool_payloads.py
@@ -1,0 +1,12 @@
+"""Shared JSON payload helpers for custom tools."""
+
+from __future__ import annotations
+
+import json
+
+
+def custom_tool_payload(tool_name: str, status: str, **fields: object) -> str:
+    """Build the deterministic JSON payload returned by custom tools."""
+    payload: dict[str, object] = {"status": status, "tool": tool_name}
+    payload.update(fields)
+    return json.dumps(payload, sort_keys=True)


### PR DESCRIPTION
## Summary
- Add a small custom_tool_payload helper for deterministic custom-tool JSON responses.
- Keep each tool's local _payload/_context_error wrappers so tool names, actions, messages, and payload fields stay unchanged.
- Apply it to matrix_api, matrix_message, matrix_room, thread_summary, and thread_tags only.

## Line Gate
Production delta: +22/-19 raw lines, net +3.

## Functions/flows examined
- MatrixApiTools._payload / _context_error / _error_payload
- MatrixMessageTools._payload / _context_error / _operation_result_payload / matrix_message preflight
- MatrixRoomTools._payload / _context_error / _input_error / matrix_room preflight
- ThreadSummaryTools._payload / _context_error / set_thread_summary wrapper flow
- ThreadTagsTools._payload / _context_error / tag_thread / untag_thread / list_thread_tags wrapper flows

## Verification
- uv run pytest tests/test_matrix_api_tool.py tests/test_matrix_message_tool.py tests/test_matrix_room_tool.py tests/test_thread_summary_tool.py tests/test_thread_tags_tool.py -q -n 0 --no-cov
- uv run tach check --dependencies --interfaces
- uv run pre-commit run --files src/mindroom/custom_tools/tool_payloads.py src/mindroom/custom_tools/matrix_api.py src/mindroom/custom_tools/matrix_message.py src/mindroom/custom_tools/matrix_room.py src/mindroom/custom_tools/thread_summary.py src/mindroom/custom_tools/thread_tags.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated payload generation logic across custom tools to use a shared utility function, improving code organization and maintainability without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->