### PR TITLE
refactor: share Matrix byte upload helper

### DIFF
--- a/src/mindroom/matrix/avatar.py
+++ b/src/mindroom/matrix/avatar.py
@@ -1,13 +1,12 @@
 """Matrix avatar management helpers."""
 
-import io
 import mimetypes
 from pathlib import Path
 
 import nio
 
 from mindroom.logging_config import get_logger
-from mindroom.matrix.media import upload_content_uri
+from mindroom.matrix.media import upload_content_uri, upload_media_bytes
 
 logger = get_logger(__name__)
 
@@ -52,16 +51,11 @@ async def _upload_avatar_file(
     with avatar_path.open("rb") as f:
         avatar_data = f.read()
 
-    file_size = len(avatar_data)
-
-    def data_provider(_upload_monitor: object, _unused_data: object) -> io.BytesIO:
-        return io.BytesIO(avatar_data)
-
-    upload_result = await client.upload(
-        data_provider=data_provider,
+    upload_result = await upload_media_bytes(
+        client,
+        avatar_data,
         content_type=content_type,
         filename=avatar_path.name,
-        filesize=file_size,
     )
 
     # nio returns tuple (response, error)

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import io
 import mimetypes
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -19,7 +18,7 @@ from nio.exceptions import OlmTrustError
 from mindroom.config.matrix import ignore_unverified_devices_for_config
 from mindroom.logging_config import get_logger
 from mindroom.matrix.large_messages import prepare_large_message
-from mindroom.matrix.media import upload_content_uri
+from mindroom.matrix.media import upload_content_uri, upload_media_bytes
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_matrix_edit_content
 from mindroom.timing import emit_timing_event
@@ -313,17 +312,12 @@ async def _upload_file_as_mxc(
             "size": len(file_bytes),
         }
 
-    _upload_payload = upload_bytes
-
-    def data_provider(_monitor: object, _data: object) -> io.BytesIO:
-        return io.BytesIO(_upload_payload)
-
     try:
-        upload_response = await client.upload(
-            data_provider=data_provider,
+        upload_response = await upload_media_bytes(
+            client,
+            upload_bytes,
             content_type=upload_mimetype,
             filename=upload_name,
-            filesize=len(upload_bytes),
         )
     except Exception:
         logger.exception("Failed uploading Matrix file", path=str(file_path))

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -6,7 +6,6 @@ JSON and send a compact preview event with a pointer to that sidecar.
 
 from __future__ import annotations
 
-import io
 import json
 from time import monotonic
 from typing import Any
@@ -27,7 +26,7 @@ from mindroom.constants import (
     VOICE_RAW_AUDIO_FALLBACK_KEY,
 )
 from mindroom.logging_config import get_logger
-from mindroom.matrix.media import upload_content_uri
+from mindroom.matrix.media import upload_content_uri, upload_media_bytes
 from mindroom.matrix.message_builder import markdown_to_html
 
 logger = get_logger(__name__)
@@ -291,7 +290,7 @@ def _create_preview(
     return _prefix_by_bytes(text, target_bytes) + continuation_indicator
 
 
-async def _upload_text_as_mxc(  # noqa: C901
+async def _upload_text_as_mxc(
     client: nio.AsyncClient,
     text: str,
     room_id: str | None = None,
@@ -350,19 +349,15 @@ async def _upload_text_as_mxc(  # noqa: C901
     else:
         upload_data = text_bytes
 
-    # Upload the file
-    def data_provider(_monitor: object, _data: object) -> io.BytesIO:
-        return io.BytesIO(upload_data)
-
     enc_filename = f"{filename}.enc" if room_encrypted else filename
 
     try:
         # nio.upload returns Tuple[Union[UploadResponse, UploadError], Optional[Dict[str, Any]]]
-        upload_result, _encryption_dict = await client.upload(
-            data_provider=data_provider,
+        upload_result, _encryption_dict = await upload_media_bytes(
+            client,
+            upload_data,
             content_type="application/octet-stream" if room_encrypted else mimetype,
             filename=enc_filename,
-            filesize=len(upload_data),
         )
 
         # Check if upload was successful

--- a/src/mindroom/matrix/media.py
+++ b/src/mindroom/matrix/media.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeGuard
@@ -94,6 +95,26 @@ def upload_content_uri(upload_result: object) -> str | None:
     if isinstance(upload_response, nio.UploadResponse) and upload_response.content_uri:
         return str(upload_response.content_uri)
     return None
+
+
+async def upload_media_bytes(
+    client: nio.AsyncClient,
+    upload_bytes: bytes,
+    *,
+    content_type: str,
+    filename: str,
+) -> tuple[nio.UploadResponse | nio.UploadError, dict[str, object] | None]:
+    """Upload an in-memory byte payload through nio's callback-based upload API."""
+
+    def data_provider(_monitor: object, _data: object) -> io.BytesIO:
+        return io.BytesIO(upload_bytes)
+
+    return await client.upload(
+        data_provider=data_provider,
+        content_type=content_type,
+        filename=filename,
+        filesize=len(upload_bytes),
+    )
 
 
 def _event_id_for_log(event: nio.RoomMessageMedia | nio.RoomEncryptedMedia) -> str | None:

--- a/tests/test_image_handler.py
+++ b/tests/test_image_handler.py
@@ -15,6 +15,7 @@ from mindroom.matrix.media import (
     extract_media_caption,
     resolve_image_mime_type,
     upload_content_uri,
+    upload_media_bytes,
 )
 
 
@@ -87,6 +88,31 @@ class TestUploadContentUri:
     def test_non_upload_response_returns_none(self) -> None:
         """Upload errors and unrelated objects should not produce an MXC URI."""
         assert upload_content_uri(object()) is None
+
+
+class TestUploadMediaBytes:
+    """Test Matrix byte payload upload helper."""
+
+    @pytest.mark.asyncio
+    async def test_upload_media_bytes_uses_nio_data_provider(self) -> None:
+        """The helper should preserve nio's callback-shaped upload contract."""
+        client = AsyncMock(spec=nio.AsyncClient)
+        response = nio.UploadResponse.from_dict({"content_uri": "mxc://server/media"})
+        client.upload.return_value = (response, {})
+
+        result = await upload_media_bytes(
+            client,
+            b"payload",
+            content_type="text/plain",
+            filename="message.txt",
+        )
+
+        assert result == (response, {})
+        upload_call = client.upload.call_args
+        assert upload_call.kwargs["content_type"] == "text/plain"
+        assert upload_call.kwargs["filename"] == "message.txt"
+        assert upload_call.kwargs["filesize"] == 7
+        assert upload_call.kwargs["data_provider"](None, None).read() == b"payload"
 
 
 class TestDownloadImage:


### PR DESCRIPTION
## Summary
- add `upload_media_bytes` in `matrix.media` for nio's callback-shaped byte uploads
- reuse it from large-message sidecars, file attachment upload, and avatar upload
- keep caller-owned encryption metadata, MXC URI normalization, payload shapes, and error logging intact

## Line gate
Production delta: `+34/-30`, net `+4` lines.

## Duplication examined
- `src/mindroom/matrix/large_messages.py::_upload_text_as_mxc` sidecar upload
- `src/mindroom/matrix/client_delivery.py::_upload_file_as_mxc` file attachment upload
- `src/mindroom/matrix/avatar.py::_upload_avatar_file` avatar upload
- `src/mindroom/matrix/media.py::upload_content_uri` existing upload-response normalization
- `src/mindroom/matrix/message_content.py::_sidecar_mxc_url` and `_download_mxc_text` MXC sidecar resolution/download path, left unchanged because current main already has the download/media primitive split from PR #927 and another extraction would be broader than the gate

## Verification
- `uv sync --all-extras`
- `uv run pytest tests/test_image_handler.py tests/test_send_file_message.py tests/test_large_messages.py tests/test_large_messages_integration.py tests/test_avatar_generation.py -q -n 0 --no-cov`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/matrix/media.py src/mindroom/matrix/large_messages.py src/mindroom/matrix/client_delivery.py src/mindroom/matrix/avatar.py tests/test_image_handler.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined media upload handling across avatar, message delivery, and large message modules with a centralized upload utility for improved consistency and maintainability.

* **Tests**
  * Added comprehensive test coverage for media upload functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->