### PR TITLE
refactor: share history budget helper

### DIFF
--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -27,10 +27,10 @@ from mindroom.history import (
     ResolvedReplayPlan,
     ScopeSessionContext,
     apply_replay_plan,
+    context_budget_after_reserve,
     estimate_preparation_static_tokens,
     estimate_preparation_static_tokens_for_team,
     finalize_history_preparation,
-    normalize_compaction_budget_tokens,
     prepare_bound_scope_history,
     prepare_scope_history,
     read_scope_seen_event_ids,
@@ -521,7 +521,7 @@ def _fallback_static_token_budget(*, context_window: int | None, reserve_tokens:
     """Return the total static-token budget available to Matrix-thread fallback prompts."""
     if context_window is None or context_window <= 0:
         return None
-    return max(0, context_window - normalize_compaction_budget_tokens(reserve_tokens, context_window))
+    return context_budget_after_reserve(context_window, reserve_tokens)
 
 
 def _thread_history_before_current_event(

--- a/src/mindroom/history/__init__.py
+++ b/src/mindroom/history/__init__.py
@@ -9,6 +9,7 @@ from mindroom.history.compaction import (
 from mindroom.history.manual import (
     request_compaction_before_next_reply,
 )
+from mindroom.history.policy import context_budget_after_reserve
 from mindroom.history.runtime import (
     PreparedScopeHistory,
     ScopeSessionContext,
@@ -64,6 +65,7 @@ __all__ = [
     "close_agent_runtime_state_dbs",
     "close_team_runtime_state_dbs",
     "compute_prompt_token_breakdown",
+    "context_budget_after_reserve",
     "create_scope_session_storage",
     "estimate_preparation_static_tokens",
     "estimate_preparation_static_tokens_for_team",

--- a/src/mindroom/history/policy.py
+++ b/src/mindroom/history/policy.py
@@ -207,6 +207,12 @@ def _resolve_summary_input_budget(
     return summary_input_budget_tokens, None
 
 
+def context_budget_after_reserve(context_window_tokens: int, reserve_tokens: int, spent_tokens: int = 0) -> int:
+    """Return the usable context budget after clamped reserve and known prompt cost."""
+    normalized_reserve_tokens = normalize_compaction_budget_tokens(reserve_tokens, context_window_tokens)
+    return max(0, context_window_tokens - normalized_reserve_tokens - spent_tokens)
+
+
 def _resolve_replay_threshold_tokens(
     *,
     compaction_config: CompactionConfig,
@@ -228,11 +234,10 @@ def _resolve_replay_budget_tokens(
 ) -> int:
     ceiling_tokens = threshold_tokens
     if has_authored_compaction_config:
-        normalized_reserve_tokens = normalize_compaction_budget_tokens(
-            compaction_config.reserve_tokens,
-            replay_window_tokens,
+        ceiling_tokens = min(
+            ceiling_tokens,
+            context_budget_after_reserve(replay_window_tokens, compaction_config.reserve_tokens),
         )
-        ceiling_tokens = min(ceiling_tokens, max(0, replay_window_tokens - normalized_reserve_tokens))
     return max(0, ceiling_tokens - static_prompt_tokens)
 
 
@@ -242,8 +247,4 @@ def _resolve_replay_budget_without_compaction(
     replay_window_tokens: int,
     static_prompt_tokens: int,
 ) -> int:
-    normalized_reserve_tokens = normalize_compaction_budget_tokens(
-        compaction_config.reserve_tokens,
-        replay_window_tokens,
-    )
-    return max(0, replay_window_tokens - normalized_reserve_tokens - static_prompt_tokens)
+    return context_budget_after_reserve(replay_window_tokens, compaction_config.reserve_tokens, static_prompt_tokens)

--- a/tach.toml
+++ b/tach.toml
@@ -2649,6 +2649,7 @@ expose = [
     "close_agent_runtime_state_dbs",
     "close_team_runtime_state_dbs",
     "compute_prompt_token_breakdown",
+    "context_budget_after_reserve",
     "create_scope_session_storage",
     "estimate_preparation_static_tokens",
     "estimate_preparation_static_tokens_for_team",

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -70,7 +70,11 @@ from mindroom.history.compaction import (
     estimate_prompt_visible_history_tokens,
     estimate_session_summary_tokens,
 )
-from mindroom.history.policy import classify_compaction_decision, resolve_history_execution_plan
+from mindroom.history.policy import (
+    classify_compaction_decision,
+    context_budget_after_reserve,
+    resolve_history_execution_plan,
+)
 from mindroom.history.runtime import (
     _plan_replay_that_fits,
     _prepare_history_for_run,
@@ -4535,6 +4539,25 @@ def test_resolve_history_execution_plan_marks_non_positive_summary_budget_unavai
     assert execution_plan.summary_input_budget_tokens == 0
     assert execution_plan.destructive_compaction_available is False
     assert execution_plan.unavailable_reason == "non_positive_summary_input_budget"
+
+
+@pytest.mark.parametrize(
+    ("context_window_tokens", "reserve_tokens", "spent_tokens", "expected"),
+    [
+        (1_000, 100, 25, 875),
+        (1_000, 800, 10, 490),
+        (1_000, 100, 2_000, 0),
+        (0, 100, 10, 0),
+        (-10, 5, 3, 0),
+    ],
+)
+def test_context_budget_after_reserve_preserves_replay_budget_bounds(
+    context_window_tokens: int,
+    reserve_tokens: int,
+    spent_tokens: int,
+    expected: int,
+) -> None:
+    assert context_budget_after_reserve(context_window_tokens, reserve_tokens, spent_tokens) == expected
 
 
 def test_resolve_history_execution_plan_keeps_replay_headroom_when_compaction_disabled(

--- a/tests/test_execution_preparation.py
+++ b/tests/test_execution_preparation.py
@@ -9,6 +9,7 @@ from mindroom.execution_preparation import (
     _build_matrix_prompt_with_thread_history,
     _build_unseen_context_messages,
     _collect_history_messages,
+    _fallback_static_token_budget,
 )
 from tests.conftest import make_visible_message
 
@@ -117,6 +118,14 @@ def test_build_matrix_prompt_with_thread_history_truncates_visible_body_to_max_l
     assert message.text.startswith("okok")
     assert message.text.endswith("…")
     assert len(message.text) <= 200
+
+
+def test_fallback_static_token_budget_preserves_context_window_bounds() -> None:
+    """Fallback static budgeting should keep missing and reserve-clamped bounds."""
+    assert _fallback_static_token_budget(context_window=None, reserve_tokens=100) is None
+    assert _fallback_static_token_budget(context_window=0, reserve_tokens=100) is None
+    assert _fallback_static_token_budget(context_window=1_000, reserve_tokens=800) == 500
+    assert _fallback_static_token_budget(context_window=1_000, reserve_tokens=100) == 900
 
 
 def test_unseen_context_keeps_self_sent_relayed_user_message() -> None:


### PR DESCRIPTION
## Summary
- add a policy-owned `context_budget_after_reserve` helper for reserve-clamped context budget arithmetic
- reuse it for replay hard budgets, authored reserve ceilings, and execution fallback static budgets
- add focused bounds tests for replay/static budget behavior

## Production line delta
- `src/mindroom/history/policy.py`: +1
- `src/mindroom/history/__init__.py`: +2
- `src/mindroom/execution_preparation.py`: +0
- production total: +3

## Verification
- `uv sync --all-extras`
- RED: `uv run pytest tests/test_agno_history.py::test_context_budget_after_reserve_preserves_replay_budget_bounds tests/test_execution_preparation.py::test_fallback_static_token_budget_preserves_context_window_bounds -q -n 0 --no-cov` failed because `context_budget_after_reserve` was missing
- `uv run pytest tests/test_execution_preparation.py tests/test_agno_history.py::test_context_budget_after_reserve_preserves_replay_budget_bounds tests/test_agno_history.py::test_resolve_history_execution_plan_uses_compaction_model_window_only_for_summary_budget tests/test_agno_history.py::test_resolve_history_execution_plan_marks_non_positive_summary_budget_unavailable tests/test_agno_history.py::test_resolve_history_execution_plan_keeps_replay_headroom_when_compaction_disabled tests/test_agno_history.py::test_prepare_history_for_run_without_budget_returns_configured_replay_plan tests/test_agno_history.py::test_prepare_history_for_run_tracks_disabled_replay_separately_from_session_persistence -q -n 0 --no-cov`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --files src/mindroom/history/policy.py src/mindroom/history/__init__.py src/mindroom/execution_preparation.py tach.toml tests/test_agno_history.py tests/test_execution_preparation.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated context budget calculation logic into a centralized helper function for improved maintainability and consistency across the system.

* **Tests**
  * Added test coverage for budget calculation behavior to ensure correct handling across various context and reserve scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->