### PR TITLE
refactor: share Matrix reply target extraction

### DIFF
--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 import nio
 
 from mindroom.constants import STREAM_STATUS_KEY
-from mindroom.matrix.event_info import EventInfo
+from mindroom.matrix.event_info import EventInfo, reply_to_event_id_from_content
 from mindroom.matrix.identity import active_internal_sender_ids
 from mindroom.matrix.message_content import extract_and_resolve_message, extract_edit_body, resolve_event_source_content
 from mindroom.matrix.visible_body import bundled_visible_body_preview, visible_body_from_event_source
@@ -111,7 +111,7 @@ class ResolvedVisibleMessage:
     @property
     def reply_to_event_id(self) -> str | None:
         """Return the explicit reply target encoded on the visible content."""
-        return _reply_to_event_id_from_content(self.content)
+        return reply_to_event_id_from_content(self.content)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert the resolved message back to the public dictionary shape."""
@@ -330,20 +330,6 @@ async def thread_root_body_preview(
         trusted_sender_ids=trusted_sender_ids,
     )
     return message_preview(visible_body)
-
-
-def _reply_to_event_id_from_content(content: Mapping[str, Any] | None) -> str | None:
-    """Return the explicit reply target encoded on one visible content payload."""
-    if content is None:
-        return None
-    relates_to = content.get("m.relates_to")
-    if not isinstance(relates_to, Mapping):
-        return None
-    in_reply_to = relates_to.get("m.in_reply_to")
-    if not isinstance(in_reply_to, Mapping):
-        return None
-    reply_to_event_id = in_reply_to.get("event_id")
-    return reply_to_event_id if isinstance(reply_to_event_id, str) else None
 
 
 def replace_visible_message(

--- a/src/mindroom/matrix/event_info.py
+++ b/src/mindroom/matrix/event_info.py
@@ -21,6 +21,22 @@ def origin_server_ts_from_event_source(event_source: object) -> int | float | No
     return None
 
 
+def reply_to_event_id_from_content(content: Mapping[str, object] | None) -> str | None:
+    """Return the explicit reply target encoded on one Matrix content payload."""
+    if content is None:
+        return None
+    relates_to = content.get("m.relates_to")
+    if not isinstance(relates_to, Mapping):
+        return None
+    relates_to = cast("Mapping[str, object]", relates_to)
+    in_reply_to = relates_to.get("m.in_reply_to")
+    if not isinstance(in_reply_to, Mapping):
+        return None
+    in_reply_to = cast("Mapping[str, object]", in_reply_to)
+    reply_to_event_id = in_reply_to.get("event_id")
+    return reply_to_event_id if isinstance(reply_to_event_id, str) else None
+
+
 @dataclass
 class EventInfo:
     """Comprehensive analysis of Matrix event relations."""
@@ -158,14 +174,8 @@ def _analyze_event_relations(event_source: dict | None) -> EventInfo:
     reaction_key = relates_to.get("key") if is_reaction else None
     reaction_target_event_id = relates_to_event_id if is_reaction else None
 
-    # Reply analysis
-    # Replies can exist within threads or as standalone
-    # They have m.in_reply_to field
-    in_reply_to = relates_to.get("m.in_reply_to", {})
-    if not isinstance(in_reply_to, dict):
-        in_reply_to = {}
-    raw_reply_to_event_id = in_reply_to.get("event_id")
-    reply_to_event_id = raw_reply_to_event_id if isinstance(raw_reply_to_event_id, str) else None
+    # Reply analysis: replies can exist within threads or as standalone.
+    reply_to_event_id = reply_to_event_id_from_content(content)
     is_reply = reply_to_event_id is not None
 
     # Determine if this event can be a thread root (per MSC3440)

--- a/tach.toml
+++ b/tach.toml
@@ -2292,7 +2292,7 @@ expose = [
 from = ["mindroom.matrix.conversation_cache"]
 
 [[interfaces]]
-expose = ["EventInfo", "origin_server_ts_from_event_source"]
+expose = ["EventInfo", "origin_server_ts_from_event_source", "reply_to_event_id_from_content"]
 from = ["mindroom.matrix.event_info"]
 
 [[interfaces]]

--- a/tests/test_event_relations.py
+++ b/tests/test_event_relations.py
@@ -1,6 +1,10 @@
 """Tests for comprehensive event relation analysis."""
 
-from mindroom.matrix.event_info import EventInfo, origin_server_ts_from_event_source
+from mindroom.matrix.event_info import (
+    EventInfo,
+    origin_server_ts_from_event_source,
+    reply_to_event_id_from_content,
+)
 
 
 class TestEventRelations:
@@ -185,6 +189,25 @@ class TestEventRelations:
 
             assert info.is_reply is False
             assert info.reply_to_event_id is None
+
+    def test_reply_to_event_id_from_content_extracts_only_string_reply_targets(self) -> None:
+        """Reply target extraction should share the Matrix relation traversal."""
+        assert (
+            reply_to_event_id_from_content(
+                {"m.relates_to": {"m.in_reply_to": {"event_id": "$target:localhost"}}},
+            )
+            == "$target:localhost"
+        )
+
+        assert reply_to_event_id_from_content(None) is None
+        assert reply_to_event_id_from_content({"m.relates_to": "invalid"}) is None
+        assert reply_to_event_id_from_content({"m.relates_to": {"m.in_reply_to": "invalid"}}) is None
+        assert (
+            reply_to_event_id_from_content(
+                {"m.relates_to": {"m.in_reply_to": {"event_id": 123}}},
+            )
+            is None
+        )
 
     def test_origin_server_ts_from_event_source_returns_numeric_timestamp(self) -> None:
         """Raw Matrix timestamp extraction should have one shared non-throwing helper."""


### PR DESCRIPTION
## Summary
- add `reply_to_event_id_from_content` in `matrix.event_info` as the shared Matrix reply relation extractor
- use the helper from `EventInfo` relation analysis and `ResolvedVisibleMessage.reply_to_event_id`
- expose the helper in Tach and cover malformed/non-string reply targets

## LOC gate
- Production src delta: +20/-24, net -4 LOC
- Gate passes because production LOC decreases while removing duplicate reply-target traversal.

## Verification
- RED: `uv run pytest tests/test_event_relations.py -q` failed with ImportError for missing helper before production edits
- `uv run pytest tests/test_event_relations.py tests/test_message_content.py -q -n 0 --no-cov` passed: 52 passed
- `uv sync --all-extras` completed
- `uv run pre-commit run --files src/mindroom/matrix/event_info.py src/mindroom/matrix/client_visible_messages.py tests/test_event_relations.py tach.toml` passed
- `uv run tach check --dependencies --interfaces` passed
- `git diff --check` passed

## Note
The referenced generated audit report path was not present in the fresh `origin/main` worktree or the original checkout, so the implementation was based on the duplicated functions visible in the scoped source files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of reply-to message resolution by consolidating logic into a shared helper function, enhancing code maintainability and consistency.

* **Tests**
  * Added test coverage for reply-to event extraction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->