### PR TITLE
refactor: share plugin watch root pruning

### DIFF
--- a/src/mindroom/orchestration/plugin_watch.py
+++ b/src/mindroom/orchestration/plugin_watch.py
@@ -111,15 +111,20 @@ def _collect_plugin_root_changes(
     return changed_paths
 
 
+def _drop_unconfigured_plugin_root_snapshots(
+    configured_roots: tuple[Path, ...],
+    last_snapshot_by_root: dict[Path, dict[Path, int]],
+) -> None:
+    for root in set(last_snapshot_by_root) - set(configured_roots):
+        last_snapshot_by_root.pop(root, None)
+
+
 def sync_plugin_root_snapshots(
     configured_roots: tuple[Path, ...],
     last_snapshot_by_root: dict[Path, dict[Path, int]],
 ) -> None:
     """Drop removed roots and seed baselines for newly configured ones."""
-    configured_root_set = set(configured_roots)
-    for root in tuple(last_snapshot_by_root):
-        if root not in configured_root_set:
-            last_snapshot_by_root.pop(root, None)
+    _drop_unconfigured_plugin_root_snapshots(configured_roots, last_snapshot_by_root)
     for root in configured_roots:
         if root in last_snapshot_by_root:
             continue
@@ -137,10 +142,7 @@ def replace_plugin_root_snapshots(
     last_snapshot_by_root: dict[Path, dict[Path, int]],
 ) -> None:
     """Replace watcher baselines with the snapshots that match the applied plugin runtime."""
-    configured_root_set = set(configured_roots)
-    for root in tuple(last_snapshot_by_root):
-        if root not in configured_root_set:
-            last_snapshot_by_root.pop(root, None)
+    _drop_unconfigured_plugin_root_snapshots(configured_roots, last_snapshot_by_root)
     for root in configured_roots:
         last_snapshot_by_root[root] = root_snapshots.get(root, {}).copy()
 

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -24,7 +24,10 @@ from mindroom.file_watcher import _tree_snapshot
 from mindroom.hooks import EVENT_MESSAGE_RECEIVED, HookRegistry
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.orchestration.config_updates import ConfigUpdatePlan, _get_changed_agents
-from mindroom.orchestration.plugin_watch import watch_plugins_task
+from mindroom.orchestration.plugin_watch import (
+    _drop_unconfigured_plugin_root_snapshots,
+    watch_plugins_task,
+)
 from mindroom.orchestration.runtime import create_logged_task
 from mindroom.orchestrator import _ConfigReloadDrainState, _MultiAgentOrchestrator, _watch_skills_task
 from mindroom.tool_system.plugins import PluginReloadResult
@@ -355,6 +358,20 @@ async def test_plugin_watcher_debounces_changes_and_ignores_unconfigured_roots(
     assert (plugin_root / "hooks.py") in changed_paths
     assert (plugin_root / "helper.py") in changed_paths
     assert all(path.is_relative_to(plugin_root) for path in changed_paths)
+
+
+def test_plugin_watcher_drops_unconfigured_root_snapshots(tmp_path: Path) -> None:
+    """Plugin watcher snapshot pruning should remove only unconfigured roots."""
+    configured_root = tmp_path / "plugins" / "configured"
+    removed_root = tmp_path / "plugins" / "removed"
+    snapshots = {
+        configured_root: {configured_root / "hooks.py": 1},
+        removed_root: {removed_root / "hooks.py": 1},
+    }
+
+    _drop_unconfigured_plugin_root_snapshots((configured_root,), snapshots)
+
+    assert snapshots == {configured_root: {configured_root / "hooks.py": 1}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Extract local `_drop_unconfigured_plugin_root_snapshots` helper in `plugin_watch.py`.
- Reuse it from `sync_plugin_root_snapshots` and `replace_plugin_root_snapshots`.
- Add a focused pruning test in existing plugin watcher coverage.

## LOC gate
Production `src/` delta: +2 physical lines (`git diff --numstat -- src`: 10 added, 8 deleted).
This passes the gate as a slight LOC increase with clear quality improvement: the duplicated root-pruning loop now has one local source of truth, with no broader watcher abstraction.

## Verification
- `uv run pytest tests/test_config_reload.py::test_plugin_watcher_drops_unconfigured_root_snapshots -q` (RED before implementation: failed on missing helper import; GREEN after implementation: passed)
- `uv run pytest tests/test_config_reload.py -k plugin_watcher -n 0 -q` (8 passed, 28 deselected)
- `uv run pytest tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_update_config_preserves_watcher_dirty_state_for_stale_prepared_plugin_snapshot -n 0 -q` (1 passed)
- `uv sync --all-extras`
- `uv run tach check --dependencies --interfaces` (passed)
- `uv run pre-commit run --files src/mindroom/orchestration/plugin_watch.py tests/test_config_reload.py` (passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced plugin watcher synchronization to properly reflect plugin configuration changes.
  * Improved handling of plugin updates and removals for more reliable monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->