### PR TITLE
refactor: share postgres cache cursor helpers

### DIFF
--- a/src/mindroom/matrix/cache/postgres_cursor.py
+++ b/src/mindroom/matrix/cache/postgres_cursor.py
@@ -1,0 +1,48 @@
+"""Small PostgreSQL cursor helpers for Matrix cache queries."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, LiteralString
+
+if TYPE_CHECKING:
+    from psycopg import AsyncConnection
+
+
+async def fetchone(
+    db: AsyncConnection,
+    query: LiteralString,
+    params: tuple[object, ...],
+) -> tuple[Any, ...] | None:
+    """Execute one query, fetch one row, and close the cursor."""
+    cursor = await db.execute(query, params)
+    try:
+        return await cursor.fetchone()
+    finally:
+        await cursor.close()
+
+
+async def fetchall(
+    db: AsyncConnection,
+    query: LiteralString,
+    params: tuple[object, ...],
+) -> list[tuple[Any, ...]]:
+    """Execute one query, fetch all rows as tuples, and close the cursor."""
+    cursor = await db.execute(query, params)
+    try:
+        rows = await cursor.fetchall()
+        return [tuple(row) for row in rows]
+    finally:
+        await cursor.close()
+
+
+async def rowcount(
+    db: AsyncConnection,
+    query: LiteralString,
+    params: tuple[object, ...],
+) -> int:
+    """Execute one query, return its row count, and close the cursor."""
+    cursor = await db.execute(query, params)
+    try:
+        return 0 if cursor.rowcount is None else int(cursor.rowcount)
+    finally:
+        await cursor.close()

--- a/src/mindroom/matrix/cache/postgres_event_cache_events.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_events.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, LiteralString
+from typing import TYPE_CHECKING, Any
 
 from mindroom.matrix.event_info import EventInfo
+
+from .postgres_cursor import fetchall, fetchone, rowcount
 
 if TYPE_CHECKING:
     from psycopg import AsyncConnection
@@ -31,43 +33,6 @@ class _CachedEventRow:
 
     event: dict[str, Any]
     cached_at: float | None
-
-
-async def _fetchone(
-    db: AsyncConnection,
-    query: LiteralString,
-    params: tuple[object, ...],
-) -> tuple[Any, ...] | None:
-    cursor = await db.execute(query, params)
-    try:
-        return await cursor.fetchone()
-    finally:
-        await cursor.close()
-
-
-async def _fetchall(
-    db: AsyncConnection,
-    query: LiteralString,
-    params: tuple[object, ...],
-) -> list[tuple[Any, ...]]:
-    cursor = await db.execute(query, params)
-    try:
-        rows = await cursor.fetchall()
-        return [tuple(row) for row in rows]
-    finally:
-        await cursor.close()
-
-
-async def _rowcount(
-    db: AsyncConnection,
-    query: LiteralString,
-    params: tuple[object, ...],
-) -> int:
-    cursor = await db.execute(query, params)
-    try:
-        return 0 if cursor.rowcount is None else int(cursor.rowcount)
-    finally:
-        await cursor.close()
 
 
 def event_id_for_cache(event: dict[str, Any]) -> str:
@@ -112,7 +77,7 @@ async def load_event(
     event_id: str,
 ) -> dict[str, Any] | None:
     """Return one cached event payload by event ID."""
-    row = await _fetchone(
+    row = await fetchone(
         db,
         """
         SELECT event_json
@@ -136,7 +101,7 @@ async def load_recent_room_events(
     """Return recent cached room events of one type, newest first."""
     if limit <= 0:
         return []
-    rows = await _fetchall(
+    rows = await fetchall(
         db,
         """
         SELECT event_json
@@ -163,7 +128,7 @@ async def load_latest_edit(
 ) -> dict[str, Any] | None:
     """Return the latest cached edit event for one original event."""
     if sender is None:
-        row = await _fetchone(
+        row = await fetchone(
             db,
             """
             SELECT mindroom_event_cache_events.event_json
@@ -181,7 +146,7 @@ async def load_latest_edit(
         )
         return None if row is None else json.loads(row[0])
 
-    row = await _fetchone(
+    row = await fetchone(
         db,
         """
         SELECT mindroom_event_cache_events.event_json
@@ -209,7 +174,7 @@ async def load_latest_edit_row(
     original_event_id: str,
 ) -> _CachedEventRow | None:
     """Return the latest cached edit event plus its lookup-row write time."""
-    row = await _fetchone(
+    row = await fetchone(
         db,
         """
         SELECT mindroom_event_cache_events.event_json, mindroom_event_cache_events.cached_at
@@ -240,7 +205,7 @@ async def load_mxc_text(
     mxc_url: str,
 ) -> str | None:
     """Return one durably cached MXC text payload when present."""
-    row = await _fetchone(
+    row = await fetchone(
         db,
         """
         SELECT text_content
@@ -302,7 +267,7 @@ async def load_thread_id_for_event(
     event_id: str,
 ) -> str | None:
     """Return the cached thread ID for one event."""
-    row = await _fetchone(
+    row = await fetchone(
         db,
         """
         SELECT thread_id
@@ -497,7 +462,7 @@ async def _dependent_edit_event_ids(
     original_event_id: str,
 ) -> list[str]:
     """Return cached edit event IDs that target one original event."""
-    rows = await _fetchall(
+    rows = await fetchall(
         db,
         """
         SELECT edit_event_id
@@ -518,7 +483,7 @@ async def delete_cached_events(
     """Delete point-lookup cache rows for the provided event IDs."""
     if not event_ids:
         return 0
-    return await _rowcount(
+    return await rowcount(
         db,
         """
         DELETE FROM mindroom_event_cache_events
@@ -538,7 +503,7 @@ async def delete_event_thread_rows(
     """Delete durable event-to-thread rows for the provided event IDs."""
     if not event_ids:
         return 0
-    return await _rowcount(
+    return await rowcount(
         db,
         """
         DELETE FROM mindroom_event_cache_event_threads
@@ -559,7 +524,7 @@ async def delete_event_edit_rows(
     """Delete derived edit-index rows affected by one event redaction."""
     deleted_rows = 0
     if event_ids:
-        deleted_rows += await _rowcount(
+        deleted_rows += await rowcount(
             db,
             """
             DELETE FROM mindroom_event_cache_event_edits
@@ -568,7 +533,7 @@ async def delete_event_edit_rows(
             (namespace, room_id, event_ids),
         )
     if original_event_id is not None:
-        deleted_rows += await _rowcount(
+        deleted_rows += await rowcount(
             db,
             """
             DELETE FROM mindroom_event_cache_event_edits
@@ -644,7 +609,7 @@ async def _delete_room_thread_events(
     """Delete cached thread rows for the provided event IDs within one room."""
     if not event_ids:
         return 0
-    return await _rowcount(
+    return await rowcount(
         db,
         """
         DELETE FROM mindroom_event_cache_thread_events
@@ -683,7 +648,7 @@ async def _redacted_event_ids_for_candidates(
     """Return the subset of candidate event IDs that are durably tombstoned."""
     if not event_ids:
         return frozenset()
-    rows = await _fetchall(
+    rows = await fetchall(
         db,
         """
         SELECT event_id

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 import time
-from typing import TYPE_CHECKING, Any, LiteralString
+from typing import TYPE_CHECKING, Any
 
 from .event_cache import ThreadCacheState
 from .event_normalization import normalize_event_source_for_cache
+from .postgres_cursor import fetchall, fetchone
 from .postgres_event_cache_events import (
     delete_cached_events,
     delete_event_edit_rows,
@@ -33,31 +34,6 @@ _INCREMENTAL_THREAD_REVALIDATION_REASONS = frozenset(
 )
 
 
-async def _fetchone(
-    db: AsyncConnection,
-    query: LiteralString,
-    params: tuple[object, ...],
-) -> tuple[Any, ...] | None:
-    cursor = await db.execute(query, params)
-    try:
-        return await cursor.fetchone()
-    finally:
-        await cursor.close()
-
-
-async def _fetchall(
-    db: AsyncConnection,
-    query: LiteralString,
-    params: tuple[object, ...],
-) -> list[tuple[Any, ...]]:
-    cursor = await db.execute(query, params)
-    try:
-        rows = await cursor.fetchall()
-        return [tuple(row) for row in rows]
-    finally:
-        await cursor.close()
-
-
 async def load_thread_events(
     db: AsyncConnection,
     *,
@@ -66,7 +42,7 @@ async def load_thread_events(
     thread_id: str,
 ) -> list[dict[str, Any]] | None:
     """Return cached events for one thread sorted by timestamp."""
-    rows = await _fetchall(
+    rows = await fetchall(
         db,
         """
         SELECT event_json
@@ -89,7 +65,7 @@ async def load_recent_room_thread_ids(
     limit: int,
 ) -> list[str]:
     """Return thread IDs for one room ordered by the newest locally cached event timestamp."""
-    rows = await _fetchall(
+    rows = await fetchall(
         db,
         """
         SELECT thread_id
@@ -112,7 +88,7 @@ async def _load_thread_cache_state_row(
     thread_id: str,
 ) -> tuple[float | None, float | None, str | None, float | None, str | None] | None:
     """Return one raw thread-cache-state row joined with room invalidation state."""
-    row = await _fetchone(
+    row = await fetchone(
         db,
         """
         SELECT
@@ -545,7 +521,7 @@ async def append_existing_thread_event(
         return False
 
     serialized_event = serialize_cached_event(event_id, normalized_event)
-    row = await _fetchone(
+    row = await fetchone(
         db,
         """
         SELECT 1
@@ -632,7 +608,7 @@ async def _thread_event_ids_for_thread(
     thread_id: str,
 ) -> list[str]:
     """Return cached event IDs currently stored for one thread."""
-    rows = await _fetchall(
+    rows = await fetchall(
         db,
         """
         SELECT event_id
@@ -651,7 +627,7 @@ async def _thread_event_ids_for_room(
     room_id: str,
 ) -> list[str]:
     """Return cached event IDs currently stored for every thread in one room."""
-    rows = await _fetchall(
+    rows = await fetchall(
         db,
         """
         SELECT event_id

--- a/tach.toml
+++ b/tach.toml
@@ -1145,6 +1145,7 @@ path = "mindroom.matrix.cache.postgres_event_cache_threads"
 depends_on = [
     "mindroom.matrix.cache.event_cache",
     "mindroom.matrix.cache.event_normalization",
+    "mindroom.matrix.cache.postgres_cursor",
     "mindroom.matrix.cache.postgres_event_cache_events",
 ]
 
@@ -1193,7 +1194,16 @@ depends_on = [
 [[modules]]
 path = "mindroom.matrix.cache.postgres_event_cache_events"
 depends_on = [
+    "mindroom.matrix.cache.postgres_cursor",
     "mindroom.matrix.event_info",
+]
+
+[[modules]]
+path = "mindroom.matrix.cache.postgres_cursor"
+depends_on = []
+visibility = [
+    "mindroom.matrix.cache.postgres_event_cache_events",
+    "mindroom.matrix.cache.postgres_event_cache_threads",
 ]
 
 [[modules]]

--- a/tests/test_postgres_cursor.py
+++ b/tests/test_postgres_cursor.py
@@ -1,0 +1,91 @@
+"""Tests for shared PostgreSQL cursor helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, LiteralString, cast
+
+import pytest
+
+from mindroom.matrix.cache import postgres_cursor
+
+if TYPE_CHECKING:
+    from psycopg import AsyncConnection
+
+
+@dataclass(slots=True)
+class _FakeCursor:
+    fetchone_result: tuple[Any, ...] | None = None
+    fetchall_result: list[list[Any] | tuple[Any, ...]] | None = None
+    rowcount: int | None = None
+    fetchall_error: Exception | None = None
+    closed: bool = False
+
+    async def fetchone(self) -> tuple[Any, ...] | None:
+        return self.fetchone_result
+
+    async def fetchall(self) -> list[list[Any] | tuple[Any, ...]]:
+        if self.fetchall_error is not None:
+            raise self.fetchall_error
+        return [] if self.fetchall_result is None else self.fetchall_result
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@dataclass(slots=True)
+class _FakeConnection:
+    cursor: _FakeCursor
+
+    async def execute(self, query: LiteralString, params: tuple[object, ...]) -> _FakeCursor:
+        assert query == "SELECT %s"
+        assert params == ("value",)
+        return self.cursor
+
+
+def _db(cursor: _FakeCursor) -> AsyncConnection:
+    return cast("AsyncConnection", _FakeConnection(cursor))
+
+
+@pytest.mark.asyncio
+async def test_postgres_cursor_fetchone_closes_cursor() -> None:
+    """Fetchone should close its cursor after returning one row."""
+    cursor = _FakeCursor(fetchone_result=("row",))
+
+    row = await postgres_cursor.fetchone(_db(cursor), "SELECT %s", ("value",))
+
+    assert row == ("row",)
+    assert cursor.closed is True
+
+
+@pytest.mark.asyncio
+async def test_postgres_cursor_fetchall_normalizes_rows_and_closes_cursor() -> None:
+    """Fetchall should return tuple rows and close its cursor."""
+    cursor = _FakeCursor(fetchall_result=[["a", 1], ("b", 2)])
+
+    rows = await postgres_cursor.fetchall(_db(cursor), "SELECT %s", ("value",))
+
+    assert rows == [("a", 1), ("b", 2)]
+    assert cursor.closed is True
+
+
+@pytest.mark.asyncio
+async def test_postgres_cursor_fetchall_closes_cursor_after_error() -> None:
+    """Fetchall should close its cursor when fetching raises."""
+    cursor = _FakeCursor(fetchall_error=RuntimeError("fetch failed"))
+
+    with pytest.raises(RuntimeError, match="fetch failed"):
+        await postgres_cursor.fetchall(_db(cursor), "SELECT %s", ("value",))
+
+    assert cursor.closed is True
+
+
+@pytest.mark.asyncio
+async def test_postgres_cursor_rowcount_normalizes_none_and_closes_cursor() -> None:
+    """Rowcount should return zero for missing row counts and close its cursor."""
+    cursor = _FakeCursor(rowcount=None)
+
+    count = await postgres_cursor.rowcount(_db(cursor), "SELECT %s", ("value",))
+
+    assert count == 0
+    assert cursor.closed is True


### PR DESCRIPTION
## Summary
- Add a small shared PostgreSQL cursor helper for Matrix cache queries.
- Replace duplicated `_fetchone` / `_fetchall` implementations in postgres event and thread cache modules.
- Move matching rowcount cursor-close behavior into the same helper.

## Duplication examined
- `postgres_event_cache_events._fetchone`
- `postgres_event_cache_events._fetchall`
- `postgres_event_cache_events._rowcount`
- `postgres_event_cache_threads._fetchone`
- `postgres_event_cache_threads._fetchall`

## LOC gate
Production `src/` delta: `+73/-84`, net `-11` LOC.
This passes the gate because production code shrinks while preserving cursor closing, row tuple normalization, and SQL query semantics.

## Verification
- `uv sync --all-extras` passed.
- `uv run pytest tests/test_postgres_cursor.py tests/test_event_cache_backends.py -k 'postgres_event_cache_round_trips_core_conversation_cache_behavior or postgres_cursor' -x -n 0 --no-cov -v` passed: 5 passed, 28 deselected.
- `uv run pre-commit run --files src/mindroom/matrix/cache/postgres_cursor.py src/mindroom/matrix/cache/postgres_event_cache_events.py src/mindroom/matrix/cache/postgres_event_cache_threads.py tests/test_postgres_cursor.py tach.toml` passed.
- Commit hook pre-commit passed for staged files.
- `uv run tach check --dependencies --interfaces` passed.
- `git diff --check` passed.
- Additional full `uv run pytest -n 0 --no-cov` printed `6342 passed, 56 skipped` but did not return after the summary due a post-summary teardown/resource-tracker hang; it was terminated, so this was not a clean exit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal database cursor handling by introducing centralized utilities across cache modules, reducing code duplication and enhancing maintainability.

* **Tests**
  * Added comprehensive test coverage for database cursor operations to ensure proper resource management and operational reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->