### PR TITLE
Rename matrix identifiers import alias

### DIFF
--- a/src/mindroom/matrix/identity.py
+++ b/src/mindroom/matrix/identity.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, ClassVar
 
-from mindroom import matrix_identifiers as _matrix_identifiers
+from mindroom import matrix_identifiers
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths
 from mindroom.matrix.state import managed_account_usernames
 
@@ -39,7 +39,7 @@ class MatrixID:
     username: str
     domain: str
 
-    AGENT_PREFIX: ClassVar[str] = _matrix_identifiers.AGENT_USERNAME_PREFIX
+    AGENT_PREFIX: ClassVar[str] = matrix_identifiers.AGENT_USERNAME_PREFIX
 
     @classmethod
     def parse(cls, matrix_id: str) -> MatrixID:
@@ -54,7 +54,7 @@ class MatrixID:
         runtime_paths: RuntimePaths,
     ) -> MatrixID:
         """Create a MatrixID for an agent."""
-        return cls(username=_matrix_identifiers.agent_username_localpart(agent_name, runtime_paths), domain=domain)
+        return cls(username=matrix_identifiers.agent_username_localpart(agent_name, runtime_paths), domain=domain)
 
     @classmethod
     def from_username(cls, username: str, domain: str) -> MatrixID:
@@ -77,7 +77,7 @@ class MatrixID:
 
         persisted_usernames = managed_account_usernames(runtime_paths)
         for account_key, active_name in _active_managed_agent_account_names(config).items():
-            expected_username = persisted_usernames.get(account_key) or _matrix_identifiers.agent_username_localpart(
+            expected_username = persisted_usernames.get(account_key) or matrix_identifiers.agent_username_localpart(
                 active_name,
                 runtime_paths,
             )

--- a/tests/test_config_architecture_boundaries.py
+++ b/tests/test_config_architecture_boundaries.py
@@ -103,14 +103,7 @@ def test_matrix_identity_does_not_reexport_identifier_helpers() -> None:
     tree = ast.parse(MATRIX_IDENTITY_MODULE.read_text(encoding="utf-8"))
     exported_names: set[str] = set()
     direct_naming_imports: list[str] = []
-    public_identifier_module_imports: list[str] = []
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module == "mindroom":
-            public_identifier_module_imports.extend(
-                alias.name
-                for alias in node.names
-                if alias.name == "matrix_identifiers" and not (alias.asname or "").startswith("_")
-            )
         if isinstance(node, ast.ImportFrom) and node.module == "mindroom.matrix_identifiers":
             direct_naming_imports.extend(alias.name for alias in node.names if alias.name in MATRIX_IDENTIFIER_HELPERS)
         if not isinstance(node, ast.Assign):
@@ -120,7 +113,6 @@ def test_matrix_identity_does_not_reexport_identifier_helpers() -> None:
         if isinstance(node.value, ast.List):
             exported_names.update(item.value for item in node.value.elts if isinstance(item, ast.Constant))
 
-    assert public_identifier_module_imports == []
     assert sorted(direct_naming_imports) == []
     assert sorted(exported_names & MATRIX_IDENTIFIER_HELPERS) == []
 


### PR DESCRIPTION
## Summary
- Rename `matrix_identifiers` usage in Matrix identity to avoid the private `_matrix_identifiers` import alias.
- Update the architecture-boundary test so module imports are allowed while direct helper re-exports remain blocked.

## Verification
- `uv run pytest tests/test_config_architecture_boundaries.py tests/test_matrix_identity.py -x -n 0 --no-cov -v`
- `uv run pytest -n 0 --no-cov`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements for better maintainability.

* **Tests**
  * Simplified test logic for improved clarity and reliability.

**Note:** This release contains internal improvements with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->