### PR TITLE
Support Shared Drives in Google Drive tool

### DIFF
--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+import mimetypes
 from typing import TYPE_CHECKING, Any, cast
 
 from agno.tools.google.drive import GoogleDriveTools as AgnoGoogleDriveTools
-from agno.tools.google.drive import authenticate
+from agno.tools.google.drive import MediaIoBaseDownload, WorkspaceType, authenticate
 from agno.utils.log import log_error
 from googleapiclient.errors import HttpError
 
@@ -113,7 +114,7 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
                 "q": effective_query,
                 "pageSize": max_results,
                 "orderBy": "modifiedTime desc",
-                "fields": self.SEARCH_FIELDS,
+                "fields": f"incompleteSearch, {self.SEARCH_FIELDS}",
                 "includeItemsFromAllDrives": True,
                 "supportsAllDrives": True,
                 "corpora": "allDrives",
@@ -128,10 +129,108 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
                     "files": files,
                     "count": len(files),
                     "nextPageToken": results.get("nextPageToken"),
+                    "incompleteSearch": results.get("incompleteSearch", False),
                 },
             )
         except HttpError as exc:
             return json.dumps({"error": f"Google Drive API error: {exc}"})
         except Exception as exc:
             log_error(f"Could not search Google Drive files: {exc}")
+            return json.dumps({"error": f"Unexpected error: {type(exc).__name__}: {exc}"})
+
+    @authenticate
+    def read_file(self, file_id: str) -> str:
+        """Read a Drive file and return its text content, including files in Shared Drives."""
+        try:
+            service = cast("Any", self.service)
+            metadata = self._get_file_metadata(file_id, self.READ_METADATA_FIELDS)
+            mime_type = metadata.get("mimeType", "")
+
+            if mime_type in self.TEXT_EXPORT_TYPES:
+                export_mime = self.TEXT_EXPORT_TYPES[mime_type]
+            elif mime_type.startswith(WorkspaceType.WORKSPACE_PREFIX):
+                return json.dumps(
+                    {"error": f"Cannot read {mime_type} as text. Use download_file instead.", "file": metadata},
+                )
+            else:
+                export_mime = None
+
+            if export_mime:
+                request = service.files().export_media(fileId=file_id, mimeType=export_mime)
+                content_bytes = self._download_bytes(request)
+            else:
+                file_size = int(metadata.get("size", 0))
+                if file_size > self.max_read_size:
+                    return json.dumps(
+                        {
+                            "error": f"File is {file_size} bytes, exceeds max_read_size ({self.max_read_size}). Use download_file instead.",
+                            "file": metadata,
+                        },
+                    )
+                request = service.files().get_media(fileId=file_id, supportsAllDrives=True)
+                content_bytes = self._download_bytes(request)
+
+            content = content_bytes.decode("utf-8", errors="replace")
+            return json.dumps(
+                {
+                    "file": metadata,
+                    "content": content,
+                    "contentLength": len(content),
+                    "exportMimeType": export_mime,
+                },
+            )
+        except HttpError as exc:
+            return json.dumps({"error": f"Google Drive API error: {exc}"})
+        except Exception as exc:
+            log_error(f"Could not read Google Drive file {file_id}: {exc}")
+            return json.dumps({"error": f"Unexpected error: {type(exc).__name__}: {exc}"})
+
+    @authenticate
+    def download_file(self, file_id: str, export_format: str | None = None) -> str:
+        """Download a Drive file and save it locally, including files in Shared Drives."""
+        try:
+            service = cast("Any", self.service)
+            metadata = self._get_file_metadata(file_id, "id,name,mimeType")
+            mime_type = metadata.get("mimeType", "")
+            path = self.download_dir / metadata.get("name", file_id)
+
+            if export_format:
+                target_mime = export_format
+                ext = mimetypes.guess_extension(export_format) or ""
+            elif mime_type in self.DOWNLOAD_EXPORT_TYPES:
+                target_mime, ext = self.DOWNLOAD_EXPORT_TYPES[mime_type]
+            elif mime_type.startswith(WorkspaceType.WORKSPACE_PREFIX):
+                return json.dumps({"error": f"Unsupported Workspace file type for download: {mime_type}"})
+            else:
+                target_mime = None
+                ext = ""
+
+            if not path.suffix and ext:
+                path = path.with_suffix(ext)
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+            if target_mime:
+                request = service.files().export_media(fileId=file_id, mimeType=target_mime)
+                path.write_bytes(self._download_bytes(request))
+                return json.dumps(
+                    {
+                        "fileId": file_id,
+                        "path": str(path),
+                        "status": "exported",
+                        "exportMimeType": target_mime,
+                        "originalMimeType": mime_type,
+                    },
+                )
+
+            request = service.files().get_media(fileId=file_id, supportsAllDrives=True)
+            with path.open("wb") as file_handle:
+                downloader = MediaIoBaseDownload(file_handle, request)
+                done = False
+                while not done:
+                    _, done = downloader.next_chunk()
+            return json.dumps({"fileId": file_id, "path": str(path), "status": "downloaded"})
+        except HttpError as exc:
+            return json.dumps({"error": f"Google Drive API error: {exc}"})
+        except Exception as exc:
+            log_error(f"Could not download file '{file_id}': {exc}")
             return json.dumps({"error": f"Unexpected error: {type(exc).__name__}: {exc}"})

--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import json
+from typing import TYPE_CHECKING, Any, cast
 
 from agno.tools.google.drive import GoogleDriveTools as AgnoGoogleDriveTools
+from agno.tools.google.drive import authenticate
+from agno.utils.log import log_error
+from googleapiclient.errors import HttpError
 
 from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, google_service_account_configured
 from mindroom.logging_config import get_logger
@@ -86,3 +90,48 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
 
     def _should_fallback_to_original_auth(self) -> bool:
         return google_service_account_configured(self.service_account_path, self._runtime_paths)
+
+    def _get_file_metadata(self, file_id: str, fields: str) -> dict[str, Any]:
+        service = cast("Any", self.service)
+        return service.files().get(fileId=file_id, fields=fields, supportsAllDrives=True).execute()
+
+    @authenticate
+    def search_files(self, query: str | None = None, max_results: int = 10, page_token: str | None = None) -> str:
+        """Search Google Drive using a query expression, including files in Shared Drives."""
+        if max_results < 1:
+            return json.dumps({"error": "max_results must be greater than 0"})
+
+        try:
+            service = cast("Any", self.service)
+            if self.include_trashed:
+                effective_query = query or ""
+            elif query:
+                effective_query = f"({query}) and trashed=false"
+            else:
+                effective_query = "trashed=false"
+            list_kwargs: dict[str, Any] = {
+                "q": effective_query,
+                "pageSize": max_results,
+                "orderBy": "modifiedTime desc",
+                "fields": self.SEARCH_FIELDS,
+                "includeItemsFromAllDrives": True,
+                "supportsAllDrives": True,
+                "corpora": "allDrives",
+            }
+            if page_token:
+                list_kwargs["pageToken"] = page_token
+            results = service.files().list(**list_kwargs).execute()
+            files = results.get("files", [])
+            return json.dumps(
+                {
+                    "query": effective_query,
+                    "files": files,
+                    "count": len(files),
+                    "nextPageToken": results.get("nextPageToken"),
+                },
+            )
+        except HttpError as exc:
+            return json.dumps({"error": f"Google Drive API error: {exc}"})
+        except Exception as exc:
+            log_error(f"Could not search Google Drive files: {exc}")
+            return json.dumps({"error": f"Unexpected error: {type(exc).__name__}: {exc}"})

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -8,6 +8,7 @@ import json
 from collections.abc import AsyncIterator, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agno.agent import Agent
 from agno.agent._tools import parse_tools
@@ -22,6 +23,9 @@ from mindroom.custom_tools.google_drive import GoogleDriveTools
 from mindroom.oauth.google_drive import _GOOGLE_DRIVE_OAUTH_SCOPES
 from mindroom.tool_system.metadata import get_tool_by_name
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
+
+if TYPE_CHECKING:
+    import pytest
 
 
 class MinimalModel(Model):
@@ -63,21 +67,29 @@ class _FakeDriveFilesResource:
     def __init__(self) -> None:
         self.list_kwargs: dict[str, object] | None = None
         self.get_kwargs: dict[str, object] | None = None
+        self.get_media_kwargs: dict[str, object] | None = None
+        self.file_metadata: dict[str, object] = {
+            "name": "Shared folder",
+            "mimeType": "application/vnd.google-apps.folder",
+            "webViewLink": "https://drive.google.com/drive/folders/example",
+        }
 
     def list(self, **kwargs: object) -> _FakeDriveRequest:
         self.list_kwargs = kwargs
-        return _FakeDriveRequest({"files": [], "nextPageToken": None})
+        return _FakeDriveRequest({"files": [], "nextPageToken": None, "incompleteSearch": True})
 
     def get(self, **kwargs: object) -> _FakeDriveRequest:
         self.get_kwargs = kwargs
         return _FakeDriveRequest(
             {
                 "id": kwargs["fileId"],
-                "name": "Shared folder",
-                "mimeType": "application/vnd.google-apps.folder",
-                "webViewLink": "https://drive.google.com/drive/folders/example",
+                **self.file_metadata,
             },
         )
+
+    def get_media(self, **kwargs: object) -> _FakeDriveRequest:
+        self.get_media_kwargs = kwargs
+        return _FakeDriveRequest({})
 
 
 class _FakeDriveService:
@@ -90,6 +102,18 @@ class _FakeDriveService:
 
 class _ValidCredentials:
     valid = True
+
+
+class _FakeMediaIoBaseDownload:
+    def __init__(self, file_handle: object, _request: object) -> None:
+        self._file_handle = file_handle
+        self._done = False
+
+    def next_chunk(self) -> tuple[None, bool]:
+        if not self._done:
+            self._file_handle.write(b"hello")
+            self._done = True
+        return None, self._done
 
 
 def _runtime_paths_with_google_drive_client(
@@ -501,11 +525,12 @@ def test_google_drive_search_includes_shared_drive_parameters(tmp_path: Path) ->
     )
 
     assert result["count"] == 0
+    assert result["incompleteSearch"] is True
     assert service.files_resource.list_kwargs == {
         "q": "('folder-id' in parents) and trashed=false",
         "pageSize": 3,
         "orderBy": "modifiedTime desc",
-        "fields": tool.SEARCH_FIELDS,
+        "fields": f"incompleteSearch, {tool.SEARCH_FIELDS}",
         "includeItemsFromAllDrives": True,
         "supportsAllDrives": True,
         "corpora": "allDrives",
@@ -529,5 +554,62 @@ def test_google_drive_read_metadata_supports_shared_drive_files(tmp_path: Path) 
     assert service.files_resource.get_kwargs == {
         "fileId": "shared-drive-folder-id",
         "fields": tool.READ_METADATA_FIELDS,
+        "supportsAllDrives": True,
+    }
+
+
+def test_google_drive_read_media_supports_shared_drive_files(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths_with_google_drive_client(tmp_path)
+    tool = GoogleDriveTools(
+        runtime_paths=runtime_paths,
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        creds=_ValidCredentials(),
+    )
+    service = _FakeDriveService()
+    service.files_resource.file_metadata = {
+        "name": "notes.txt",
+        "mimeType": "text/plain",
+        "size": "5",
+        "webViewLink": "https://drive.google.com/file/d/example",
+    }
+    tool.service = service
+    tool._download_bytes = lambda _request: b"hello"
+
+    result = json.loads(tool.read_file("shared-drive-file-id"))
+
+    assert result["content"] == "hello"
+    assert service.files_resource.get_media_kwargs == {
+        "fileId": "shared-drive-file-id",
+        "supportsAllDrives": True,
+    }
+
+
+def test_google_drive_download_media_supports_shared_drive_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("mindroom.custom_tools.google_drive.MediaIoBaseDownload", _FakeMediaIoBaseDownload)
+    runtime_paths = _runtime_paths_with_google_drive_client(tmp_path)
+    tool = GoogleDriveTools(
+        runtime_paths=runtime_paths,
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        creds=_ValidCredentials(),
+        download_file=True,
+        download_dir=tmp_path,
+    )
+    service = _FakeDriveService()
+    service.files_resource.file_metadata = {
+        "name": "notes.txt",
+        "mimeType": "text/plain",
+        "webViewLink": "https://drive.google.com/file/d/example",
+    }
+    tool.service = service
+
+    result = json.loads(tool.download_file("shared-drive-file-id"))
+
+    assert result["status"] == "downloaded"
+    assert Path(result["path"]).read_text() == "hello"
+    assert service.files_resource.get_media_kwargs == {
+        "fileId": "shared-drive-file-id",
         "supportsAllDrives": True,
     }

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -51,6 +51,47 @@ class MinimalModel(Model):
         return response
 
 
+class _FakeDriveRequest:
+    def __init__(self, response: dict[str, object]) -> None:
+        self._response = response
+
+    def execute(self) -> dict[str, object]:
+        return self._response
+
+
+class _FakeDriveFilesResource:
+    def __init__(self) -> None:
+        self.list_kwargs: dict[str, object] | None = None
+        self.get_kwargs: dict[str, object] | None = None
+
+    def list(self, **kwargs: object) -> _FakeDriveRequest:
+        self.list_kwargs = kwargs
+        return _FakeDriveRequest({"files": [], "nextPageToken": None})
+
+    def get(self, **kwargs: object) -> _FakeDriveRequest:
+        self.get_kwargs = kwargs
+        return _FakeDriveRequest(
+            {
+                "id": kwargs["fileId"],
+                "name": "Shared folder",
+                "mimeType": "application/vnd.google-apps.folder",
+                "webViewLink": "https://drive.google.com/drive/folders/example",
+            },
+        )
+
+
+class _FakeDriveService:
+    def __init__(self) -> None:
+        self.files_resource = _FakeDriveFilesResource()
+
+    def files(self) -> _FakeDriveFilesResource:
+        return self.files_resource
+
+
+class _ValidCredentials:
+    valid = True
+
+
 def _runtime_paths_with_google_drive_client(
     tmp_path: Path,
     process_env: dict[str, str] | None = None,
@@ -438,3 +479,55 @@ def test_google_drive_blank_numeric_config_uses_tool_default(tmp_path: Path) -> 
 
     assert isinstance(tool, GoogleDriveTools)
     assert tool.max_read_size == 10485760
+
+
+def test_google_drive_search_includes_shared_drive_parameters(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths_with_google_drive_client(tmp_path)
+    cursor = "next-page"
+    tool = GoogleDriveTools(
+        runtime_paths=runtime_paths,
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        creds=_ValidCredentials(),
+    )
+    service = _FakeDriveService()
+    tool.service = service
+
+    result = json.loads(
+        tool.search_files(
+            query="'folder-id' in parents",
+            max_results=3,
+            page_token=cursor,
+        ),
+    )
+
+    assert result["count"] == 0
+    assert service.files_resource.list_kwargs == {
+        "q": "('folder-id' in parents) and trashed=false",
+        "pageSize": 3,
+        "orderBy": "modifiedTime desc",
+        "fields": tool.SEARCH_FIELDS,
+        "includeItemsFromAllDrives": True,
+        "supportsAllDrives": True,
+        "corpora": "allDrives",
+        "pageToken": cursor,
+    }
+
+
+def test_google_drive_read_metadata_supports_shared_drive_files(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths_with_google_drive_client(tmp_path)
+    tool = GoogleDriveTools(
+        runtime_paths=runtime_paths,
+        credentials_manager=CredentialsManager(tmp_path / "credentials"),
+        creds=_ValidCredentials(),
+    )
+    service = _FakeDriveService()
+    tool.service = service
+
+    result = json.loads(tool.read_file("shared-drive-folder-id"))
+
+    assert result["error"] == "Cannot read application/vnd.google-apps.folder as text. Use download_file instead."
+    assert service.files_resource.get_kwargs == {
+        "fileId": "shared-drive-folder-id",
+        "fields": tool.READ_METADATA_FIELDS,
+        "supportsAllDrives": True,
+    }


### PR DESCRIPTION
## Summary
- include Shared Drive files in Google Drive search/list calls
- pass Shared Drive support when fetching Drive file metadata
- add focused tests for the Drive API request parameters

## Tests
- uv run --extra google-drive pytest tests/test_google_drive_oauth_tool.py
- uv run --extra google-drive pytest tests/test_google_tool_wrappers.py
- uv run --extra google-drive ruff check src/mindroom/custom_tools/google_drive.py tests/test_google_drive_oauth_tool.py
- uv run --extra google-drive ruff format --check src/mindroom/custom_tools/google_drive.py tests/test_google_drive_oauth_tool.py
- uv run --extra google-drive ty check src/mindroom/custom_tools/google_drive.py tests/test_google_drive_oauth_tool.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Drive search now returns JSON-formatted results, with improved error handling and authenticated access.
  * Added metadata retrieval and explicit support for files in shared drives.

* **Tests**
  * Added comprehensive tests covering shared-drive search, metadata read, media read, and download flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->