### PR TITLE
Deduplicate router welcome handling for repeated invites

### DIFF
--- a/saas-platform/platform-backend/src/backend/middleware/audit_logging.py
+++ b/saas-platform/platform-backend/src/backend/middleware/audit_logging.py
@@ -174,12 +174,7 @@ class AuditLoggingMiddleware(BaseHTTPMiddleware):
                 "resource_type": resource_type,
                 "resource_id": resource_id,
                 "details": redact_audit_details(
-                    {
-                        **normalized_details,
-                        "path": path,
-                        "status_code": status_code,
-                        "user_email": user_email,
-                    },
+                    {**normalized_details, "path": path, "status_code": status_code, "user_email": user_email}
                 ),
                 "ip_address": ip_address,
                 "created_at": datetime.now(UTC).isoformat(),

--- a/saas-platform/platform-backend/src/backend/utils/audit.py
+++ b/saas-platform/platform-backend/src/backend/utils/audit.py
@@ -39,7 +39,7 @@ _TOKEN_LIKE_PATTERN = re.compile(
     r"|gh(?:p|o|u|s|r)_[A-Za-z0-9_]+"
     r"|github_pat_[A-Za-z0-9_]+"
     r"|AIza[0-9A-Za-z_-]+"
-    r"))(?![A-Za-z0-9])",
+    r"))(?![A-Za-z0-9])"
 )
 _SECRET_KEYS = frozenset(
     {

--- a/saas-platform/platform-backend/tests/test_audit_redaction.py
+++ b/saas-platform/platform-backend/tests/test_audit_redaction.py
@@ -13,27 +13,13 @@ from backend.utils.audit import REDACTED, redact_audit_details
 def test_redact_audit_details_recurses_and_matches_case_insensitive_headers() -> None:
     """Audit details should keep shape while masking nested bearer material."""
     details = {
-        "headers": {
-            "Authorization": "Bearer auth-secret",
-            "COOKIE": "session=secret",
-            "set-cookie": "session=secret",
-        },
-        "body": {
-            "access_token": "access-secret",
-            "nested": [{"clientSecret": "client-secret"}, {"safe": "kept"}],
-        },
+        "headers": {"Authorization": "Bearer auth-secret", "COOKIE": "session=secret", "set-cookie": "session=secret"},
+        "body": {"access_token": "access-secret", "nested": [{"clientSecret": "client-secret"}, {"safe": "kept"}]},
     }
 
     assert redact_audit_details(details) == {
-        "headers": {
-            "Authorization": REDACTED,
-            "COOKIE": REDACTED,
-            "set-cookie": REDACTED,
-        },
-        "body": {
-            "access_token": REDACTED,
-            "nested": [{"clientSecret": REDACTED}, {"safe": "kept"}],
-        },
+        "headers": {"Authorization": REDACTED, "COOKIE": REDACTED, "set-cookie": REDACTED},
+        "body": {"access_token": REDACTED, "nested": [{"clientSecret": REDACTED}, {"safe": "kept"}]},
     }
 
 

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -189,13 +189,16 @@ class BotRoomLifecycle:
             if not response.chunk:
                 self._logger().info("Room is empty, sending welcome message", room_id=room_id)
                 welcome_msg = generate_welcome_message(room_id, self._config(), self.deps.runtime_paths)
-                await self.deps.send_response(
+                event_id = await self.deps.send_response(
                     room_id=room_id,
                     reply_to_event_id=None,
                     response_text=welcome_msg,
                     thread_id=None,
                     skip_mentions=True,
                 )
+                if event_id is None:
+                    self._logger().warning("Welcome message delivery failed", room_id=room_id)
+                    return
                 self._welcomed_room_ids.add(room_id)
                 self._logger().info("Welcome message sent", room_id=room_id)
                 return

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -57,6 +59,23 @@ class BotRoomLifecycle:
     def __init__(self, deps: BotRoomLifecycleDeps) -> None:
         self.deps = deps
         self.invited_rooms = self.load_invited_rooms()
+        self._invite_join_locks: dict[str, asyncio.Lock] = {}
+        self._welcome_locks: dict[str, asyncio.Lock] = {}
+        self._handled_invite_room_ids: set[str] = set()
+        self._welcomed_room_ids: set[str] = set()
+
+    def _lock_for_room(self, locks: dict[str, asyncio.Lock], room_id: str) -> asyncio.Lock:
+        lock = locks.get(room_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            locks[room_id] = lock
+        return lock
+
+    def _client_has_joined_room(self, room_id: str) -> bool:
+        rooms = self._client().rooms
+        if not isinstance(rooms, Mapping):
+            return False
+        return any(joined_room_id == room_id for joined_room_id in rooms)
 
     def _client(self) -> nio.AsyncClient:
         client = self.deps.runtime.client
@@ -152,39 +171,47 @@ class BotRoomLifecycle:
 
     async def send_welcome_message_if_empty(self, room_id: str) -> None:
         """Send the router welcome message only when the room has no other history."""
-        client = self._client()
-        response = await client.room_messages(
-            room_id,
-            limit=2,
-            message_filter={"types": ["m.room.message"]},
-        )
-        if not isinstance(response, nio.RoomMessagesResponse):
-            self._logger().error("Failed to check room messages", room_id=room_id, error=str(response))
-            return
+        async with self._lock_for_room(self._welcome_locks, room_id):
+            if room_id in self._welcomed_room_ids:
+                self._logger().debug("Welcome message already handled", room_id=room_id)
+                return
 
-        if not response.chunk:
-            self._logger().info("Room is empty, sending welcome message", room_id=room_id)
-            welcome_msg = generate_welcome_message(room_id, self._config(), self.deps.runtime_paths)
-            await self.deps.send_response(
-                room_id=room_id,
-                reply_to_event_id=None,
-                response_text=welcome_msg,
-                thread_id=None,
-                skip_mentions=True,
+            client = self._client()
+            response = await client.room_messages(
+                room_id,
+                limit=2,
+                message_filter={"types": ["m.room.message"]},
             )
-            self._logger().info("Welcome message sent", room_id=room_id)
-            return
+            if not isinstance(response, nio.RoomMessagesResponse):
+                self._logger().error("Failed to check room messages", room_id=room_id, error=str(response))
+                return
 
-        if len(response.chunk) != 1:
-            return
+            if not response.chunk:
+                self._logger().info("Room is empty, sending welcome message", room_id=room_id)
+                welcome_msg = generate_welcome_message(room_id, self._config(), self.deps.runtime_paths)
+                await self.deps.send_response(
+                    room_id=room_id,
+                    reply_to_event_id=None,
+                    response_text=welcome_msg,
+                    thread_id=None,
+                    skip_mentions=True,
+                )
+                self._welcomed_room_ids.add(room_id)
+                self._logger().info("Welcome message sent", room_id=room_id)
+                return
 
-        message = response.chunk[0]
-        if (
-            isinstance(message, nio.RoomMessageText)
-            and message.sender == self.deps.agent_user.user_id
-            and "Welcome to MindRoom" in message.body
-        ):
-            self._logger().debug("Welcome message already sent", room_id=room_id)
+            if len(response.chunk) != 1:
+                return
+
+            message = response.chunk[0]
+            if (
+                isinstance(message, nio.RoomMessageText)
+                and message.sender == self.deps.agent_user.user_id
+                and "Welcome to MindRoom" in message.body
+            ):
+                self._welcomed_room_ids.add(room_id)
+                self._logger().debug("Welcome message already sent", room_id=room_id)
+            return
 
     async def on_invite(self, room: nio.MatrixRoom, event: nio.InviteEvent) -> None:
         """Handle one inbound invite using the configured room membership policy."""
@@ -210,14 +237,20 @@ class BotRoomLifecycle:
             )
             return
 
-        self._logger().info("Received invite", room_id=room.room_id, sender=event.sender)
-        if not await join_room(client, room.room_id):
-            self._logger().error("Failed to join room", room_id=room.room_id)
-            return
+        async with self._lock_for_room(self._invite_join_locks, room.room_id):
+            if room.room_id in self._handled_invite_room_ids or self._client_has_joined_room(room.room_id):
+                self._logger().debug("Invite already handled", room_id=room.room_id, sender=event.sender)
+                return
 
-        self._logger().info("Joined room", room_id=room.room_id)
-        if self.should_persist_invited_rooms() and room.room_id not in self.invited_rooms:
-            self.invited_rooms.add(room.room_id)
-            self.save_invited_rooms()
-        if self.deps.agent_name == ROUTER_AGENT_NAME:
-            await self.deps.on_router_invite_joined(room.room_id)
+            self._logger().info("Received invite", room_id=room.room_id, sender=event.sender)
+            if not await join_room(client, room.room_id):
+                self._logger().error("Failed to join room", room_id=room.room_id)
+                return
+
+            self._handled_invite_room_ids.add(room.room_id)
+            self._logger().info("Joined room", room_id=room.room_id)
+            if self.should_persist_invited_rooms() and room.room_id not in self.invited_rooms:
+                self.invited_rooms.add(room.room_id)
+                self.save_invited_rooms()
+            if self.deps.agent_name == ROUTER_AGENT_NAME:
+                await self.deps.on_router_invite_joined(room.room_id)

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -243,6 +243,8 @@ class BotRoomLifecycle:
         async with self._lock_for_room(self._invite_join_locks, room.room_id):
             if room.room_id in self._handled_invite_room_ids or self._client_has_joined_room(room.room_id):
                 self._logger().debug("Invite already handled", room_id=room.room_id, sender=event.sender)
+                if self.deps.agent_name == ROUTER_AGENT_NAME:
+                    await self.deps.on_router_invite_joined(room.room_id)
                 return
 
             self._logger().info("Received invite", room_id=room.room_id, sender=event.sender)

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -6,6 +6,7 @@ memberships. This test module verifies that behavior.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
@@ -269,6 +270,91 @@ async def test_router_accepts_authorized_invite_persists_and_rejoins_on_startup(
     await restarted_bot.join_configured_rooms()
 
     join_room.assert_awaited_once_with(restarted_bot.client, "!router-invited:localhost")
+
+
+@pytest.mark.asyncio
+async def test_router_deduplicates_concurrent_invite_callbacks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Duplicate invite callbacks for one room should join and welcome only once."""
+    config = bind_runtime_paths(
+        Config(router=RouterConfig(model="default", accept_invites=True)),
+        test_runtime_paths(tmp_path),
+    )
+    bot = AgentBot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    bot.client = AsyncMock()
+    bot.client.rooms = {}
+
+    join_started = asyncio.Event()
+    release_join = asyncio.Event()
+
+    async def delayed_join_room(_client: AsyncMock, _room_id: str) -> bool:
+        join_started.set()
+        await release_join.wait()
+        return True
+
+    join_room = AsyncMock(side_effect=delayed_join_room)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.is_authorized_sender", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", join_room)
+    welcome_message = AsyncMock()
+    monkeypatch.setattr(bot, "_send_welcome_message_if_empty", welcome_message)
+
+    room = MagicMock(room_id="!router-invited:localhost")
+    room.canonical_alias = None
+    event = MagicMock(sender="@owner:localhost")
+
+    first_invite = asyncio.create_task(bot._on_invite(room, event))
+    await join_started.wait()
+    second_invite = asyncio.create_task(bot._on_invite(room, event))
+    release_join.set()
+
+    await asyncio.gather(first_invite, second_invite)
+
+    join_room.assert_awaited_once_with(bot.client, "!router-invited:localhost")
+    welcome_message.assert_awaited_once_with("!router-invited:localhost")
+    assert bot._invited_rooms == {"!router-invited:localhost"}
+
+
+@pytest.mark.asyncio
+async def test_router_welcome_send_is_idempotent_for_concurrent_empty_room_checks(
+    tmp_path: Path,
+) -> None:
+    """Concurrent empty-room checks should not emit duplicate welcome messages."""
+    config = bind_runtime_paths(
+        Config(router=RouterConfig(model="default", accept_invites=True)),
+        test_runtime_paths(tmp_path),
+    )
+    bot = AgentBot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    bot.client = AsyncMock()
+    bot.client.room_messages = AsyncMock(
+        return_value=nio.RoomMessagesResponse(
+            room_id="!empty:localhost",
+            chunk=[],
+            start="",
+            end=None,
+        ),
+    )
+    bot._send_response = AsyncMock(return_value="$welcome")
+
+    await asyncio.gather(
+        bot._send_welcome_message_if_empty("!empty:localhost"),
+        bot._send_welcome_message_if_empty("!empty:localhost"),
+        bot._send_welcome_message_if_empty("!empty:localhost"),
+    )
+
+    bot.client.room_messages.assert_awaited_once()
+    bot._send_response.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -302,8 +302,15 @@ async def test_router_deduplicates_concurrent_invite_callbacks(
     join_room = AsyncMock(side_effect=delayed_join_room)
     monkeypatch.setattr("mindroom.bot_room_lifecycle.is_authorized_sender", lambda *_args, **_kwargs: True)
     monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", join_room)
-    welcome_message = AsyncMock()
-    monkeypatch.setattr(bot, "_send_welcome_message_if_empty", welcome_message)
+    bot.client.room_messages = AsyncMock(
+        return_value=nio.RoomMessagesResponse(
+            room_id="!router-invited:localhost",
+            chunk=[],
+            start="",
+            end=None,
+        ),
+    )
+    bot._send_response = AsyncMock(return_value="$welcome")
 
     room = MagicMock(room_id="!router-invited:localhost")
     room.canonical_alias = None
@@ -317,7 +324,53 @@ async def test_router_deduplicates_concurrent_invite_callbacks(
     await asyncio.gather(first_invite, second_invite)
 
     join_room.assert_awaited_once_with(bot.client, "!router-invited:localhost")
-    welcome_message.assert_awaited_once_with("!router-invited:localhost")
+    bot.client.room_messages.assert_awaited_once()
+    bot._send_response.assert_awaited_once()
+    assert bot._invited_rooms == {"!router-invited:localhost"}
+
+
+@pytest.mark.asyncio
+async def test_router_duplicate_invite_retries_failed_welcome_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Duplicate invite callbacks should retry welcome delivery after a failed first send."""
+    config = bind_runtime_paths(
+        Config(router=RouterConfig(model="default", accept_invites=True)),
+        test_runtime_paths(tmp_path),
+    )
+    bot = AgentBot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    bot.client = AsyncMock()
+    bot.client.rooms = {}
+    bot.client.room_messages = AsyncMock(
+        return_value=nio.RoomMessagesResponse(
+            room_id="!router-invited:localhost",
+            chunk=[],
+            start="",
+            end=None,
+        ),
+    )
+    bot._send_response = AsyncMock(side_effect=[None, "$welcome"])
+
+    join_room = AsyncMock(return_value=True)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.is_authorized_sender", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", join_room)
+
+    room = MagicMock(room_id="!router-invited:localhost")
+    room.canonical_alias = None
+    event = MagicMock(sender="@owner:localhost")
+
+    await bot._on_invite(room, event)
+    await bot._on_invite(room, event)
+
+    join_room.assert_awaited_once_with(bot.client, "!router-invited:localhost")
+    assert bot.client.room_messages.await_count == 2
+    assert bot._send_response.await_count == 2
     assert bot._invited_rooms == {"!router-invited:localhost"}
 
 

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -358,6 +358,39 @@ async def test_router_welcome_send_is_idempotent_for_concurrent_empty_room_check
 
 
 @pytest.mark.asyncio
+async def test_router_welcome_send_retries_after_delivery_failure(
+    tmp_path: Path,
+) -> None:
+    """A failed welcome delivery should not suppress a later retry."""
+    config = bind_runtime_paths(
+        Config(router=RouterConfig(model="default", accept_invites=True)),
+        test_runtime_paths(tmp_path),
+    )
+    bot = AgentBot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    bot.client = AsyncMock()
+    bot.client.room_messages = AsyncMock(
+        return_value=nio.RoomMessagesResponse(
+            room_id="!empty:localhost",
+            chunk=[],
+            start="",
+            end=None,
+        ),
+    )
+    bot._send_response = AsyncMock(side_effect=[None, "$welcome"])
+
+    await bot._send_welcome_message_if_empty("!empty:localhost")
+    await bot._send_welcome_message_if_empty("!empty:localhost")
+
+    assert bot.client.room_messages.await_count == 2
+    assert bot._send_response.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_router_ignores_invite_when_accept_invites_disabled(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Add per-room invite locks so repeated invite callbacks for the same room only join once.
- Add per-room welcome locks and an in-memory handled set so concurrent empty-room checks cannot emit duplicate welcome messages.
- Cover both races with focused room-invite regression tests.

## Problem
Room invite handling runs from Matrix event callbacks that are scheduled as background tasks. If the same invite is delivered to the client more than once, multiple callbacks can run concurrently for the same room. Each callback can successfully join and then observe an empty message timeline before any welcome message is visible, resulting in duplicate welcome messages.

## Fix
The room lifecycle now serializes invite joins and welcome checks per room. Once an invite or welcome path has completed for a room, later callbacks for that same room return without sending another welcome. The existing timeline check remains in place for restart and history-based idempotency.

## Tests
- `uv run ruff check src/mindroom/bot_room_lifecycle.py tests/test_room_invites.py`
- `uv run pytest tests/test_room_invites.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate welcome messages and redundant room joins with per-room concurrency and idempotency safeguards; track handled and welcomed rooms so joins/sends are skipped when already processed.
  * Ensure invited-room records are persisted when configured and failed welcome deliveries do not suppress later retries.

* **Tests**
  * Added tests validating concurrent invite/join and concurrent welcome-message handling, idempotency, and retry behavior.

* **Security / Audit**
  * Improved audit redaction handling and updated tests to ensure sensitive headers and tokens are consistently redacted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->