### PR TITLE
docs: clarify agent reply targeting policy

### DIFF
--- a/src/mindroom/agent_prompts.py
+++ b/src/mindroom/agent_prompts.py
@@ -9,6 +9,10 @@ When working in teams with other agents, you should identify yourself as {displa
 In Matrix chat contexts, conversation history may be provided inside a `<conversation>` block, with each prior message wrapped as `<msg from="@user:server"><![CDATA[body]]></msg>`. The `from` attribute is the sender's full Matrix ID, and the CDATA body preserves code snippets, markdown, and other special characters exactly as written. The current message you are responding to may also be wrapped in the same `<msg from="...">` tag.
 {openai_compat_history_guidance}When mentioning a user in your reply, always write the complete Matrix ID including the homeserver (e.g. `@alice:example.org`), never just the localpart before the colon. The chat client renders the full ID as a clickable mention pill.
 
+## Matrix Reply Targeting
+MindRoom dispatches agent turns before you see a message. In one-on-one or single-agent conversations, you may be selected automatically. In multi-agent or multi-human rooms and threads, users must use an explicit Matrix mention of the target agent for that agent to be selected. A natural-language addressing style, such as using an agent's display name in plain text, is not a Matrix mention.
+If a user later asks why you did not answer an earlier message, explain that you were not dispatched for that message unless you were explicitly mentioned, routed by the router, or selected as the only eligible agent. Do not apologize as if you saw the message and chose not to reply.
+
 """
 
 _OPENAI_COMPAT_HISTORY_GUIDANCE = (

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -154,6 +154,19 @@ def test_create_agent_includes_openai_compat_guidance_only_when_requested() -> N
     assert agent_prompts._OPENAI_COMPAT_HISTORY_GUIDANCE in openai_compat_agent.role
 
 
+def test_create_agent_includes_matrix_reply_targeting_policy() -> None:
+    """Agents should understand when the dispatcher requires explicit Matrix mentions."""
+    config = _test_config()
+
+    agent = _create_agent_for_test("general", config)
+
+    assert "## Matrix Reply Targeting" in agent.role
+    assert "explicit Matrix mention" in agent.role
+    assert "multi-agent or multi-human" in agent.role
+    assert "not dispatched" in agent.role
+    assert "natural-language addressing" in agent.role
+
+
 def test_config_round_trips_structured_agent_tool_entries() -> None:
     """Structured tool entries should stay authored while runtime access stays name-based."""
     runtime_paths = _runtime_paths(Path(tempfile.mkdtemp()))


### PR DESCRIPTION
## Summary
- Add Matrix reply targeting guidance to the shared agent identity prompt.
- Clarify explicit mention requirements in multi-participant contexts.
- Add a regression test covering prompt inclusion.

## Tests
- uv run pytest tests/test_agents.py
- uv run ruff check src/mindroom/agent_prompts.py tests/test_agents.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now provide improved responses in multi-agent and multi-human conversation scenarios
  * Enhanced handling of agent mention targeting and message routing
  * Better explanations when agents don't respond to specific messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->