### PR TITLE
Fix sync cancellation test mock state

### DIFF
--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -586,6 +586,7 @@ async def test_full_state_only_after_successful_first_sync() -> None:
     bot.last_sync_time = None
     bot._first_sync_done = False
     bot._sync_shutting_down = False
+    bot._room_member_join_hooks_armed = False
     bot.client = FakeClient()
     bot.orchestrator = None
     bot._runtime_view = BotRuntimeState(


### PR DESCRIPTION
## Summary
- Add the room-member hook arming flag to the sync cancellation test's AgentBot mock setup
- Matches the real AgentBot constructor default so the test can call the real _on_sync_response method

## Verification
- uv run pytest tests/test_sync_task_cancellation.py::test_full_state_only_after_successful_first_sync -q --no-cov
- uv run pytest tests/test_sync_task_cancellation.py -q --no-cov
- uv run ruff check tests/test_sync_task_cancellation.py
- uv run ruff format --check tests/test_sync_task_cancellation.py
- uv run ty check tests/test_sync_task_cancellation.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for sync task cancellation and watchdog restart edge cases, including regression tests for several runtime correctness fixes.

*Note: This release contains no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->