### PR TITLE
Clean up configurable prompt follow-ups

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -524,22 +524,22 @@ MindRoom validates configured prompt placeholders at config load, and unsupporte
 Prompt placeholders are not Jinja and not Python `str.format`; MindRoom only replaces exact `{field_name}` placeholders.
 Only bare placeholder names are supported; compound access, conversions, and format specs such as `{message.text}`, `{message!r}`, or `{message:.2f}` are rejected.
 Escape literal braces as `{{` and `}}` inside prompt overrides that use placeholders.
-Changing root prompt overrides in a running process restarts existing agents, teams, and the router through hot reload.
+Changing construction-time root prompt overrides in a running process restarts existing agents, teams, and the router through hot reload.
+Prompt overrides that are read per request are picked up without restarting bots.
 
 ## Managed Avatars
 
 MindRoom can generate managed avatars for agents, teams, rooms, and the optional root Matrix Space.
-Use the optional `avatars.prompts` block to override the built-in prompt styles without editing Python code.
-Every field is optional and falls back to MindRoom's built-in defaults when omitted.
+Use the root `prompts` block to override the built-in avatar prompt styles without editing Python code.
+Every omitted prompt falls back to MindRoom's built-in default.
 
 ```yaml
-avatars:
-  prompts:
-    character_style: "professional AI avatar portrait, abstract geometric silhouette"
-    room_style: "minimalist wayfinding icon, precise geometry, strong silhouette"
-    agent_system_prompt: "You are creating distinctive visual elements for a professional AI agent avatar."
-    team_system_prompt: "You are creating distinctive visual elements for a professional AI team avatar."
-    room_system_prompt: "You are creating a refined, minimalist icon design for a room avatar."
+prompts:
+  AVATAR_CHARACTER_STYLE: "professional AI avatar portrait, abstract geometric silhouette"
+  AVATAR_ROOM_STYLE: "minimalist wayfinding icon, precise geometry, strong silhouette"
+  AVATAR_AGENT_SYSTEM_PROMPT: "You are creating distinctive visual elements for a professional AI agent avatar."
+  AVATAR_TEAM_SYSTEM_PROMPT: "You are creating distinctive visual elements for a professional AI team avatar."
+  AVATAR_ROOM_SYSTEM_PROMPT: "You are creating a refined, minimalist icon design for a room avatar."
 ```
 
 `mindroom avatars generate` only creates missing local avatar files by default.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1223,20 +1223,19 @@ prompts:
     Return only the agent name.
 ```
 
-Discover allowed names by inspecting `src/mindroom/prompts.py` or by importing `PROMPT_DEFAULT_NAMES` from `mindroom.prompts`. For prompts with `{...}` placeholders, discover the allowed fields from `PROMPT_TEMPLATE_FIELDS` in `mindroom.prompts`. MindRoom validates configured prompt placeholders at config load, and unsupported placeholders fail validation before runtime. Prompt placeholders are not Jinja and not Python `str.format`; MindRoom only replaces exact `{field_name}` placeholders. Only bare placeholder names are supported; compound access, conversions, and format specs such as `{message.text}`, `{message!r}`, or `{message:.2f}` are rejected. Escape literal braces as `{{` and `}}` inside prompt overrides that use placeholders. Changing root prompt overrides in a running process restarts existing agents, teams, and the router through hot reload.
+Discover allowed names by inspecting `src/mindroom/prompts.py` or by importing `PROMPT_DEFAULT_NAMES` from `mindroom.prompts`. For prompts with `{...}` placeholders, discover the allowed fields from `PROMPT_TEMPLATE_FIELDS` in `mindroom.prompts`. MindRoom validates configured prompt placeholders at config load, and unsupported placeholders fail validation before runtime. Prompt placeholders are not Jinja and not Python `str.format`; MindRoom only replaces exact `{field_name}` placeholders. Only bare placeholder names are supported; compound access, conversions, and format specs such as `{message.text}`, `{message!r}`, or `{message:.2f}` are rejected. Escape literal braces as `{{` and `}}` inside prompt overrides that use placeholders. Changing construction-time root prompt overrides in a running process restarts existing agents, teams, and the router through hot reload. Prompt overrides that are read per request are picked up without restarting bots.
 
 ## Managed Avatars
 
-MindRoom can generate managed avatars for agents, teams, rooms, and the optional root Matrix Space. Use the optional `avatars.prompts` block to override the built-in prompt styles without editing Python code. Every field is optional and falls back to MindRoom's built-in defaults when omitted.
+MindRoom can generate managed avatars for agents, teams, rooms, and the optional root Matrix Space. Use the root `prompts` block to override the built-in avatar prompt styles without editing Python code. Every omitted prompt falls back to MindRoom's built-in default.
 
 ```
-avatars:
-  prompts:
-    character_style: "professional AI avatar portrait, abstract geometric silhouette"
-    room_style: "minimalist wayfinding icon, precise geometry, strong silhouette"
-    agent_system_prompt: "You are creating distinctive visual elements for a professional AI agent avatar."
-    team_system_prompt: "You are creating distinctive visual elements for a professional AI team avatar."
-    room_system_prompt: "You are creating a refined, minimalist icon design for a room avatar."
+prompts:
+  AVATAR_CHARACTER_STYLE: "professional AI avatar portrait, abstract geometric silhouette"
+  AVATAR_ROOM_STYLE: "minimalist wayfinding icon, precise geometry, strong silhouette"
+  AVATAR_AGENT_SYSTEM_PROMPT: "You are creating distinctive visual elements for a professional AI agent avatar."
+  AVATAR_TEAM_SYSTEM_PROMPT: "You are creating distinctive visual elements for a professional AI team avatar."
+  AVATAR_ROOM_SYSTEM_PROMPT: "You are creating a refined, minimalist icon design for a room avatar."
 ```
 
 `mindroom avatars generate` only creates missing local avatar files by default. Run `mindroom avatars generate --force` to overwrite existing managed workspace avatar files after changing prompts or styles. `mindroom avatars sync` only fills missing Matrix avatars by default. Run `mindroom avatars sync --force` to replace existing Matrix room or root-space avatars.

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -518,22 +518,22 @@ MindRoom validates configured prompt placeholders at config load, and unsupporte
 Prompt placeholders are not Jinja and not Python `str.format`; MindRoom only replaces exact `{field_name}` placeholders.
 Only bare placeholder names are supported; compound access, conversions, and format specs such as `{message.text}`, `{message!r}`, or `{message:.2f}` are rejected.
 Escape literal braces as `{{` and `}}` inside prompt overrides that use placeholders.
-Changing root prompt overrides in a running process restarts existing agents, teams, and the router through hot reload.
+Changing construction-time root prompt overrides in a running process restarts existing agents, teams, and the router through hot reload.
+Prompt overrides that are read per request are picked up without restarting bots.
 
 ## Managed Avatars
 
 MindRoom can generate managed avatars for agents, teams, rooms, and the optional root Matrix Space.
-Use the optional `avatars.prompts` block to override the built-in prompt styles without editing Python code.
-Every field is optional and falls back to MindRoom's built-in defaults when omitted.
+Use the root `prompts` block to override the built-in avatar prompt styles without editing Python code.
+Every omitted prompt falls back to MindRoom's built-in default.
 
 ```yaml
-avatars:
-  prompts:
-    character_style: "professional AI avatar portrait, abstract geometric silhouette"
-    room_style: "minimalist wayfinding icon, precise geometry, strong silhouette"
-    agent_system_prompt: "You are creating distinctive visual elements for a professional AI agent avatar."
-    team_system_prompt: "You are creating distinctive visual elements for a professional AI team avatar."
-    room_system_prompt: "You are creating a refined, minimalist icon design for a room avatar."
+prompts:
+  AVATAR_CHARACTER_STYLE: "professional AI avatar portrait, abstract geometric silhouette"
+  AVATAR_ROOM_STYLE: "minimalist wayfinding icon, precise geometry, strong silhouette"
+  AVATAR_AGENT_SYSTEM_PROMPT: "You are creating distinctive visual elements for a professional AI agent avatar."
+  AVATAR_TEAM_SYSTEM_PROMPT: "You are creating distinctive visual elements for a professional AI team avatar."
+  AVATAR_ROOM_SYSTEM_PROMPT: "You are creating a refined, minimalist icon design for a room avatar."
 ```
 
 `mindroom avatars generate` only creates missing local avatar files by default.

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -1156,7 +1156,6 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         runtime_paths=runtime_paths,
     )
 
-    logger.info("using_yaml_agent_config", agent=agent_name)
     role = full_context + agent_config.role
     instructions = list(agent_config.instructions)
 

--- a/src/mindroom/avatar_generation.py
+++ b/src/mindroom/avatar_generation.py
@@ -26,13 +26,6 @@ from mindroom.matrix.rooms import get_room_id
 from mindroom.matrix.state import MatrixState, matrix_state_for_runtime
 from mindroom.matrix.users import AgentMatrixUser, login_agent_user
 from mindroom.matrix_identifiers import extract_server_name_from_homeserver
-from mindroom.prompts import (
-    AVATAR_AGENT_SYSTEM_PROMPT,
-    AVATAR_CHARACTER_STYLE,
-    AVATAR_ROOM_STYLE,
-    AVATAR_ROOM_SYSTEM_PROMPT,
-    AVATAR_TEAM_SYSTEM_PROMPT,
-)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -86,17 +79,6 @@ class _AvatarTarget:
     entity_name: str
     role: str
     team_members: tuple[_AvatarTeamMember, ...] = ()
-
-
-@dataclass(frozen=True)
-class _AvatarPromptSettings:
-    """Resolved prompt/style settings used for managed avatar generation."""
-
-    character_style: str
-    room_style: str
-    agent_system_prompt: str
-    team_system_prompt: str
-    room_system_prompt: str
 
 
 @cache
@@ -154,56 +136,23 @@ def _has_missing_managed_avatars(config: Config, runtime_paths: constants.Runtim
     return bool(_missing_avatar_targets(config, runtime_paths))
 
 
-def _resolve_avatar_prompt_settings(config: Config) -> _AvatarPromptSettings:
-    """Resolve avatar prompt settings from config with built-in fallbacks."""
-    avatar_prompt_overrides = config.avatars.prompts
-    return _AvatarPromptSettings(
-        character_style=config.get_prompt("AVATAR_CHARACTER_STYLE")
-        if avatar_prompt_overrides is None or avatar_prompt_overrides.character_style is None
-        else avatar_prompt_overrides.character_style,
-        room_style=config.get_prompt("AVATAR_ROOM_STYLE")
-        if avatar_prompt_overrides is None or avatar_prompt_overrides.room_style is None
-        else avatar_prompt_overrides.room_style,
-        agent_system_prompt=(
-            config.get_prompt("AVATAR_AGENT_SYSTEM_PROMPT")
-            if avatar_prompt_overrides is None or avatar_prompt_overrides.agent_system_prompt is None
-            else avatar_prompt_overrides.agent_system_prompt
-        ),
-        team_system_prompt=(
-            config.get_prompt("AVATAR_TEAM_SYSTEM_PROMPT")
-            if avatar_prompt_overrides is None or avatar_prompt_overrides.team_system_prompt is None
-            else avatar_prompt_overrides.team_system_prompt
-        ),
-        room_system_prompt=config.get_prompt("AVATAR_ROOM_SYSTEM_PROMPT")
-        if avatar_prompt_overrides is None or avatar_prompt_overrides.room_system_prompt is None
-        else avatar_prompt_overrides.room_system_prompt,
-    )
-
-
 async def _generate_prompt(
     client: genai.Client,
     target: _AvatarTarget,
-    prompt_settings: _AvatarPromptSettings | None = None,
+    config: Config,
 ) -> str:
     """Generate an image prompt based on the entity's role using AI."""
-    resolved_prompt_settings = prompt_settings or _AvatarPromptSettings(
-        character_style=AVATAR_CHARACTER_STYLE,
-        room_style=AVATAR_ROOM_STYLE,
-        agent_system_prompt=AVATAR_AGENT_SYSTEM_PROMPT,
-        team_system_prompt=AVATAR_TEAM_SYSTEM_PROMPT,
-        room_system_prompt=AVATAR_ROOM_SYSTEM_PROMPT,
-    )
     if target.entity_type in {"rooms", "spaces"}:
-        system_prompt = resolved_prompt_settings.room_system_prompt
+        system_prompt = config.get_prompt("AVATAR_ROOM_SYSTEM_PROMPT")
         user_prompt = f"Room name: {target.entity_name}\nPurpose: {target.role}"
     elif target.entity_type == "teams":
-        system_prompt = resolved_prompt_settings.team_system_prompt
+        system_prompt = config.get_prompt("AVATAR_TEAM_SYSTEM_PROMPT")
         user_prompt = f"Team name: {target.entity_name}\nTeam role: {target.role}"
         if target.team_members:
             members_info = "\n".join(f"- {member.name}: {member.role}" for member in target.team_members)
             user_prompt = f"{user_prompt}\nTeam members:\n{members_info}"
     else:
-        system_prompt = resolved_prompt_settings.agent_system_prompt
+        system_prompt = config.get_prompt("AVATAR_AGENT_SYSTEM_PROMPT")
         user_prompt = f"Agent name: {target.entity_name}\nRole: {target.role}\nType: {target.entity_type}"
 
     response = await client.aio.models.generate_content(
@@ -221,9 +170,9 @@ async def _generate_prompt(
 
     visual_elements = response.text.strip()
     base_style = (
-        resolved_prompt_settings.room_style
+        config.get_prompt("AVATAR_ROOM_STYLE")
         if target.entity_type in {"rooms", "spaces"}
-        else resolved_prompt_settings.character_style
+        else config.get_prompt("AVATAR_CHARACTER_STYLE")
     )
     final_prompt = f"{base_style}, {visual_elements}"
 
@@ -249,9 +198,9 @@ async def _generate_avatar(
     client: genai.Client,
     target: _AvatarTarget,
     runtime_paths: constants.RuntimePaths,
+    config: Config,
     *,
     force: bool = False,
-    prompt_settings: _AvatarPromptSettings | None = None,
 ) -> None:
     """Generate an avatar for a single entity if it does not exist."""
     avatar_path = _get_avatar_path(target.entity_type, target.entity_name, runtime_paths)
@@ -267,7 +216,7 @@ async def _generate_avatar(
     if target.team_members:
         console.print(f"   [dim]Team members: {', '.join(member.name for member in target.team_members)}[/dim]")
 
-    prompt = await _generate_prompt(client, target, prompt_settings)
+    prompt = await _generate_prompt(client, target, config)
     response = await client.aio.models.generate_content(
         model=_IMAGE_MODEL,
         contents=prompt,
@@ -562,7 +511,6 @@ async def _generate_missing_avatars(
         return False
 
     client = genai.Client(api_key=api_key)
-    prompt_settings = _resolve_avatar_prompt_settings(config)
     targets = _build_avatar_generation_targets(config, selected_targets)
     _print_avatar_generation_plan(selected_targets)
 
@@ -579,8 +527,8 @@ async def _generate_missing_avatars(
                         client,
                         target,
                         runtime_paths,
+                        config,
                         force=force,
-                        prompt_settings=prompt_settings,
                     )
                     for target in targets
                 ),

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -177,27 +177,10 @@ class _StaticCompactionConfigSemantics:
     authored_model: _AuthoredOptionalModel
 
 
-class AvatarPromptsConfig(BaseModel):
-    """Optional prompt/style overrides for managed avatar generation."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    character_style: str | None = Field(default=None, description="Base style for agent and team avatars")
-    room_style: str | None = Field(default=None, description="Base style for room and space avatars")
-    agent_system_prompt: str | None = Field(default=None, description="Prompt template for agent avatars")
-    team_system_prompt: str | None = Field(default=None, description="Prompt template for team avatars")
-    room_system_prompt: str | None = Field(default=None, description="Prompt template for room and space avatars")
-
-
 class AvatarConfig(BaseModel):
     """Managed avatar generation configuration."""
 
     model_config = ConfigDict(extra="forbid")
-
-    prompts: AvatarPromptsConfig | None = Field(
-        default=None,
-        description="Optional prompt/style overrides for managed avatar generation",
-    )
 
 
 def _history_policy_from_limits(

--- a/src/mindroom/orchestration/config_updates.py
+++ b/src/mindroom/orchestration/config_updates.py
@@ -18,6 +18,25 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_ENTITY_CONSTRUCTION_PROMPTS = frozenset(
+    {
+        "AGENT_IDENTITY_CONTEXT_TEMPLATE",
+        "CODEX_DEFAULT_INSTRUCTIONS",
+        "CONTEXT_TRUNCATION_MARKER_TEMPLATE",
+        "DATETIME_CONTEXT_TEMPLATE",
+        "DELEGATE_TOOLKIT_INSTRUCTIONS_TEMPLATE",
+        "DYNAMIC_TOOLING_INSTRUCTION_TEMPLATE",
+        "DYNAMIC_TOOLS_TOOLKIT_INSTRUCTIONS",
+        "HIDDEN_TOOL_CALLS_PROMPT",
+        "INTERACTIVE_QUESTION_PROMPT",
+        "OPENAI_COMPAT_HISTORY_GUIDANCE",
+        "OUTPUT_REDIRECT_PROMPT",
+        "PERSONALITY_CONTEXT_SECTION_HEADING",
+        "QUEUED_MESSAGE_NOTICE_TEXT",
+        "SKILLS_TOOL_USAGE_PROMPT",
+    },
+)
+
 
 @dataclass(frozen=True)
 class ConfigUpdatePlan:
@@ -183,9 +202,14 @@ def _entities_referencing_mcp_servers(
     return old_entities | new_entities
 
 
-def _root_prompts_changed(config: Config, new_config: Config) -> bool:
-    """Return whether any root built-in prompt overrides changed."""
-    return config.prompts != new_config.prompts
+def _changed_entity_construction_prompts(config: Config, new_config: Config) -> set[str]:
+    """Return root prompt overrides that require entity reconstruction."""
+    changed_prompt_names = {
+        prompt_name
+        for prompt_name in set(config.prompts) | set(new_config.prompts)
+        if config.get_prompt(prompt_name) != new_config.get_prompt(prompt_name)
+    }
+    return changed_prompt_names & _ENTITY_CONSTRUCTION_PROMPTS
 
 
 def build_config_update_plan(
@@ -204,11 +228,13 @@ def build_config_update_plan(
         agent_bots,
         changed_mcp_servers,
     )
-    if _root_prompts_changed(current_config, new_config):
+    changed_entity_construction_prompts = _changed_entity_construction_prompts(current_config, new_config)
+    if changed_entity_construction_prompts:
         prompt_affected_entities = existing_entities & configured_entities
         if prompt_affected_entities:
             logger.info(
-                "root_prompts_changed_restart_required",
+                "entity_construction_prompts_changed_restart_required",
+                prompts=sorted(changed_entity_construction_prompts),
                 entities=sorted(prompt_affected_entities),
             )
         entities_to_restart |= prompt_affected_entities

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -995,6 +995,7 @@ async def test_compaction_summary_uses_configured_system_prompt() -> None:
         summary_prompt="Custom compaction instructions.",
     )
 
+    assert model.seen_messages[0].role == "system"
     assert model.seen_messages[0].content == "Custom compaction instructions."
 
 

--- a/tests/test_avatar_generation.py
+++ b/tests/test_avatar_generation.py
@@ -91,8 +91,8 @@ def test_get_console_returns_shared_console_instance() -> None:
     assert generate_avatars._get_console() is generate_avatars._get_console()
 
 
-def test_resolve_avatar_prompt_settings_applies_overrides_and_defaults(tmp_path: Path) -> None:
-    """Avatar prompt settings should honor authored overrides and fall back to built-ins."""
+def test_config_prompt_overrides_drive_avatar_prompt_generation(tmp_path: Path) -> None:
+    """Avatar generation should use root prompt overrides for avatar styles."""
     config = _config_with_runtime_paths(
         {
             "models": {"default": {"provider": "anthropic", "id": "claude-sonnet-4-6"}},
@@ -103,23 +103,19 @@ def test_resolve_avatar_prompt_settings_applies_overrides_and_defaults(tmp_path:
                     "model": "default",
                 },
             },
-            "avatars": {
-                "prompts": {
-                    "character_style": "custom character style",
-                    "room_system_prompt": "custom room system prompt",
-                },
+            "prompts": {
+                "AVATAR_CHARACTER_STYLE": "custom character style",
+                "AVATAR_ROOM_SYSTEM_PROMPT": "custom room system prompt",
             },
         },
         tmp_path,
     )
 
-    prompt_settings = generate_avatars._resolve_avatar_prompt_settings(config)
-
-    assert prompt_settings.character_style == "custom character style"
-    assert prompt_settings.room_system_prompt == "custom room system prompt"
-    assert prompt_settings.room_style == AVATAR_ROOM_STYLE
-    assert prompt_settings.agent_system_prompt == AVATAR_AGENT_SYSTEM_PROMPT
-    assert prompt_settings.team_system_prompt == AVATAR_TEAM_SYSTEM_PROMPT
+    assert config.get_prompt("AVATAR_CHARACTER_STYLE") == "custom character style"
+    assert config.get_prompt("AVATAR_ROOM_SYSTEM_PROMPT") == "custom room system prompt"
+    assert config.get_prompt("AVATAR_ROOM_STYLE") == AVATAR_ROOM_STYLE
+    assert config.get_prompt("AVATAR_AGENT_SYSTEM_PROMPT") == AVATAR_AGENT_SYSTEM_PROMPT
+    assert config.get_prompt("AVATAR_TEAM_SYSTEM_PROMPT") == AVATAR_TEAM_SYSTEM_PROMPT
 
 
 @pytest.mark.asyncio
@@ -475,6 +471,7 @@ async def test_generate_prompt_uses_gemini_prompt_model() -> None:
     """Prompt generation should call the Gemini text model and compose the base style."""
     generate_content = AsyncMock(return_value=SimpleNamespace(text="teal and copper, visor eyes"))
     client = SimpleNamespace(aio=SimpleNamespace(models=SimpleNamespace(generate_content=generate_content)))
+    config = generate_avatars.Config()
 
     prompt = await generate_avatars._generate_prompt(
         client,
@@ -483,6 +480,7 @@ async def test_generate_prompt_uses_gemini_prompt_model() -> None:
             entity_name="research",
             role="Finds information",
         ),
+        config,
     )
 
     assert prompt == f"{AVATAR_CHARACTER_STYLE}, teal and copper, visor eyes"
@@ -497,6 +495,7 @@ async def test_generate_prompt_uses_room_style_for_spaces() -> None:
     """Space avatars should use the same icon-style prompt path as rooms."""
     generate_content = AsyncMock(return_value=SimpleNamespace(text="deep blue, doorway outline"))
     client = SimpleNamespace(aio=SimpleNamespace(models=SimpleNamespace(generate_content=generate_content)))
+    config = generate_avatars.Config()
 
     prompt = await generate_avatars._generate_prompt(
         client,
@@ -505,6 +504,7 @@ async def test_generate_prompt_uses_room_style_for_spaces() -> None:
             entity_name="root_space",
             role="Workspace space that organizes rooms",
         ),
+        config,
     )
 
     assert prompt == f"{AVATAR_ROOM_STYLE}, deep blue, doorway outline"
@@ -540,6 +540,7 @@ async def test_generate_avatar_writes_generated_image(monkeypatch: pytest.Monkey
             role="Helpful assistant",
         ),
         _runtime_paths(tmp_path),
+        generate_avatars.Config(),
     )
 
     assert avatar_path.read_bytes() == b"avatar-bytes"
@@ -572,6 +573,7 @@ async def test_generate_avatar_skips_existing_file_without_force(
             role="Helpful assistant",
         ),
         _runtime_paths(tmp_path),
+        generate_avatars.Config(),
     )
 
     assert avatar_path.read_bytes() == b"existing-avatar"
@@ -611,6 +613,7 @@ async def test_generate_avatar_force_overwrites_existing_file(
             role="Helpful assistant",
         ),
         _runtime_paths(tmp_path),
+        generate_avatars.Config(),
         force=True,
     )
 
@@ -650,13 +653,13 @@ async def test_run_avatar_generation_includes_team_rooms_and_root_space(
         _client: object,
         target: generate_avatars._AvatarTarget,
         runtime_paths: constants_mod.RuntimePaths,
+        _config: generate_avatars.Config,
         *,
         force: bool = False,
-        prompt_settings: generate_avatars._AvatarPromptSettings | None = None,
     ) -> None:
         del runtime_paths
+        del _config
         del force
-        del prompt_settings
         avatar_path = workspace_avatar_dir / target.entity_type / f"{target.entity_name}.png"
         avatar_path.parent.mkdir(parents=True, exist_ok=True)
         avatar_path.write_bytes(b"generated")

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -1398,8 +1398,8 @@ def test_get_changed_agents_detects_tool_override_updates() -> None:
     assert changed == {"agent1"}
 
 
-def test_config_update_plan_restarts_running_entities_when_root_prompts_change() -> None:
-    """Root prompt overrides should restart running agents, teams, and router."""
+def test_config_update_plan_restarts_running_entities_when_construction_prompts_change() -> None:
+    """Construction-time root prompt overrides should restart running agents, teams, and router."""
     old_config = _runtime_bound_config(
         Config(
             agents={"general": AgentConfig(display_name="General Agent")},
@@ -1439,6 +1439,49 @@ def test_config_update_plan_restarts_running_entities_when_root_prompts_change()
 
     assert plan.entities_to_restart == running_entities
     assert plan.only_support_service_changes is False
+
+
+def test_config_update_plan_does_not_restart_for_request_time_prompt_change() -> None:
+    """Request-time prompt overrides should not tear down running entities."""
+    old_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent")},
+            teams={
+                "team1": TeamConfig(
+                    display_name="Team 1",
+                    role="Collaborate",
+                    agents=["general"],
+                ),
+            },
+            router=RouterConfig(model="default"),
+        ),
+    )
+    new_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent")},
+            teams={
+                "team1": TeamConfig(
+                    display_name="Team 1",
+                    role="Collaborate",
+                    agents=["general"],
+                ),
+            },
+            router=RouterConfig(model="default"),
+            prompts={"ROUTER_AGENT_SELECTION_PROMPT_TEMPLATE": "Pick one agent: {agents_info}\n{message}"},
+        ),
+    )
+
+    running_entities = {ROUTER_AGENT_NAME, "general", "team1"}
+    plan = build_config_update_plan(
+        current_config=old_config,
+        new_config=new_config,
+        configured_entities=running_entities,
+        existing_entities=running_entities,
+        agent_bots={entity: AsyncMock() for entity in running_entities},
+    )
+
+    assert plan.entities_to_restart == set()
+    assert plan.only_support_service_changes is True
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Removed the duplicate `avatars.prompts` override surface so managed avatars use only the root `prompts:` registry for `AVATAR_*` prompt overrides.
- Removed the stale `using_yaml_agent_config` log now that there is no alternate rich-prompt branch.
- Dropped avatar prompt settings plumbing/defaults that bypassed configured prompt overrides; avatar prompt generation now receives `Config` directly.
- Narrowed hot-reload restarts to root prompt changes that affect entity construction, while request-time prompt changes are picked up without bot restarts.
- Added the requested compaction system-role assertion and updated docs/skill references.

## Test Plan
- `uv run pytest tests/test_avatar_generation.py tests/test_config_reload.py::test_config_update_plan_restarts_running_entities_when_construction_prompts_change tests/test_config_reload.py::test_config_update_plan_does_not_restart_for_request_time_prompt_change tests/test_config_prompts.py tests/test_agno_history.py::test_compaction_summary_uses_configured_system_prompt -n 0 --no-cov -v`
- `uv run pre-commit run --all-files`
- `uv run pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that construction-time prompt overrides trigger hot reload (restarting agents, teams, and router), while per-request prompts apply without restarts.
  * Updated managed avatars configuration to use new prompt key format.

* **Refactor**
  * Improved avatar generation prompt resolution from runtime configuration.

* **Tests**
  * Added coverage for construction-time vs per-request prompt override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->