### PR TITLE
Handle router-only mentions

### DIFF
--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -143,3 +143,9 @@ Users can always mention agents directly with `@agent_name` to bypass routing.
 ## Note on the Router Agent
 
 The router is always present and cannot be disabled. It automatically joins any room with configured agents. If no `router` section is configured, it uses the default model.
+The router account is not a conversational AI agent to tag directly.
+If a message mentions only the router and no other users or agents, the router replies with the rules of engagement instead of answering the prompt.
+Mention a specific agent when you want that agent to answer, or mention multiple agents when you want them to collaborate.
+When one human and one agent are already talking in a thread, continuing without an explicit tag is fine.
+Once a thread has multiple human users or multiple agent participants, tag the agent or agents you want next.
+In a new untagged message, automatic routing can still choose an agent when that is appropriate.

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -143,6 +143,7 @@ Users can always mention agents directly with `@agent_name` to bypass routing.
 ## Note on the Router Agent
 
 The router is always present and cannot be disabled. It automatically joins any room with configured agents. If no `router` section is configured, it uses the default model.
+
 The router account is not a conversational AI agent to tag directly.
 If a message mentions only the router and no other users or agents, the router replies with the rules of engagement instead of answering the prompt.
 Mention a specific agent when you want that agent to answer, or mention multiple agents when you want them to collaborate.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2325,7 +2325,7 @@ Users can always mention agents directly with `@agent_name` to bypass routing.
 
 ## Note on the Router Agent
 
-The router is always present and cannot be disabled. It automatically joins any room with configured agents. If no `router` section is configured, it uses the default model.
+The router is always present and cannot be disabled. It automatically joins any room with configured agents. If no `router` section is configured, it uses the default model. The router account is not a conversational AI agent to tag directly. If a message mentions only the router and no other users or agents, the router replies with the rules of engagement instead of answering the prompt. Mention a specific agent when you want that agent to answer, or mention multiple agents when you want them to collaborate. When one human and one agent are already talking in a thread, continuing without an explicit tag is fine. Once a thread has multiple human users or multiple agent participants, tag the agent or agents you want next. In a new untagged message, automatic routing can still choose an agent when that is appropriate.
 
 # Toolkit Configuration
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2325,7 +2325,9 @@ Users can always mention agents directly with `@agent_name` to bypass routing.
 
 ## Note on the Router Agent
 
-The router is always present and cannot be disabled. It automatically joins any room with configured agents. If no `router` section is configured, it uses the default model. The router account is not a conversational AI agent to tag directly. If a message mentions only the router and no other users or agents, the router replies with the rules of engagement instead of answering the prompt. Mention a specific agent when you want that agent to answer, or mention multiple agents when you want them to collaborate. When one human and one agent are already talking in a thread, continuing without an explicit tag is fine. Once a thread has multiple human users or multiple agent participants, tag the agent or agents you want next. In a new untagged message, automatic routing can still choose an agent when that is appropriate.
+The router is always present and cannot be disabled. It automatically joins any room with configured agents. If no `router` section is configured, it uses the default model.
+
+The router account is not a conversational AI agent to tag directly. If a message mentions only the router and no other users or agents, the router replies with the rules of engagement instead of answering the prompt. Mention a specific agent when you want that agent to answer, or mention multiple agents when you want them to collaborate. When one human and one agent are already talking in a thread, continuing without an explicit tag is fine. Once a thread has multiple human users or multiple agent participants, tag the agent or agents you want next. In a new untagged message, automatic routing can still choose an agent when that is appropriate.
 
 # Toolkit Configuration
 

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -138,3 +138,9 @@ Users can always mention agents directly with `@agent_name` to bypass routing.
 ## Note on the Router Agent
 
 The router is always present and cannot be disabled. It automatically joins any room with configured agents. If no `router` section is configured, it uses the default model.
+The router account is not a conversational AI agent to tag directly.
+If a message mentions only the router and no other users or agents, the router replies with the rules of engagement instead of answering the prompt.
+Mention a specific agent when you want that agent to answer, or mention multiple agents when you want them to collaborate.
+When one human and one agent are already talking in a thread, continuing without an explicit tag is fine.
+Once a thread has multiple human users or multiple agent participants, tag the agent or agents you want next.
+In a new untagged message, automatic routing can still choose an agent when that is appropriate.

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -138,6 +138,7 @@ Users can always mention agents directly with `@agent_name` to bypass routing.
 ## Note on the Router Agent
 
 The router is always present and cannot be disabled. It automatically joins any room with configured agents. If no `router` section is configured, it uses the default model.
+
 The router account is not a conversational AI agent to tag directly.
 If a message mentions only the router and no other users or agents, the router replies with the rules of engagement instead of answering the prompt.
 Mention a specific agent when you want that agent to answer, or mention multiple agents when you want them to collaborate.

--- a/src/mindroom/thread_utils.py
+++ b/src/mindroom/thread_utils.py
@@ -48,6 +48,21 @@ def _is_bot_or_agent(sender: str, config: Config, runtime_paths: RuntimePaths) -
     return bool(extract_agent_name(sender, config, runtime_paths)) or sender in config.bot_accounts
 
 
+def is_router_only_agent_mention(
+    mentioned_agents: Sequence[MatrixID],
+    *,
+    has_non_agent_mentions: bool,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> bool:
+    """Return whether the message only targeted the router managed account."""
+    if has_non_agent_mentions or not mentioned_agents:
+        return False
+
+    mentioned_agent_names = {agent.agent_name(config, runtime_paths) for agent in mentioned_agents}
+    return mentioned_agent_names == {ROUTER_AGENT_NAME}
+
+
 def check_agent_mentioned(
     event_source: dict,
     agent_id: MatrixID | None,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -89,6 +89,7 @@ from mindroom.routing import suggest_agent_for_message
 from mindroom.thread_utils import (
     check_agent_mentioned,
     get_configured_agents_for_room,
+    is_router_only_agent_mention,
     thread_requires_explicit_agent_targeting,
 )
 from mindroom.timing import (
@@ -611,7 +612,12 @@ class TurnController:
             self.deps.runtime_paths,
         )
         if mentioned_agents or has_non_agent_mentions:
-            return True
+            return not is_router_only_agent_mention(
+                mentioned_agents,
+                has_non_agent_mentions=has_non_agent_mentions,
+                config=self.deps.runtime.config,
+                runtime_paths=self.deps.runtime_paths,
+            )
         if thread_id is None:
             return False
 

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -97,9 +97,10 @@ class _DispatchPlan:
 
 _ROUTER_ONLY_MENTION_GUIDANCE = (
     "🧭 Rules of engagement: mention a specific agent when you want that agent to answer, or mention multiple "
-    "agents when you want them to collaborate. If one human and one agent are talking in a conversation, you can "
-    "keep going without an explicit tag. As soon as multiple agents or multiple users are involved, explicitly "
-    "tag the agent or agents you want. The router is not a conversational AI agent you can tag directly."
+    "agents when you want them to collaborate. If one human and one agent are already talking in a thread, you "
+    "can keep going without an explicit tag. Once a thread has multiple human users or multiple agent "
+    "participants, explicitly tag the agent or agents you want next. In a new untagged message, automatic routing "
+    "can still choose an agent when appropriate. The router is not a conversational AI agent you can tag directly."
 )
 
 

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -45,6 +45,7 @@ from mindroom.thread_utils import (
     get_agents_in_thread,
     get_all_mentioned_agents_in_thread,
     has_multiple_non_agent_users_in_thread,
+    is_router_only_agent_mention,
     should_agent_respond,
     thread_requires_explicit_agent_targeting,
 )
@@ -92,6 +93,14 @@ class _DispatchPlan:
     media_events: list[MediaDispatchEvent] | None = None
     router_event: DispatchEvent | None = None
     ignore_reason: Literal["router"] | None = None
+
+
+_ROUTER_ONLY_MENTION_GUIDANCE = (
+    "🧭 Rules of engagement: mention a specific agent when you want that agent to answer, or mention multiple "
+    "agents when you want them to collaborate. If one human and one agent are talking in a conversation, you can "
+    "keep going without an explicit tag. As soon as multiple agents or multiple users are involved, explicitly "
+    "tag the agent or agents you want. The router is not a conversational AI agent you can tag directly."
+)
 
 
 @dataclass(frozen=True)
@@ -451,6 +460,20 @@ class TurnPolicy:
         context = dispatch.context
         planning_thread_history = context.planning_thread_history
         requester_user_id = dispatch.requester_user_id
+        if is_router_only_agent_mention(
+            context.mentioned_agents,
+            has_non_agent_mentions=context.has_non_agent_mentions,
+            config=self.deps.runtime.config,
+            runtime_paths=self.deps.runtime_paths,
+        ):
+            return _DispatchPlan(
+                kind="respond",
+                response_action=ResponseAction(
+                    kind="reject",
+                    rejection_message=_ROUTER_ONLY_MENTION_GUIDANCE,
+                ),
+            )
+
         if not context.mentioned_agents and not context.has_non_agent_mentions:
             if context.planning_thread_history_unavailable:
                 self.deps.logger.info("Skipping routing: thread policy history unavailable")

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -466,39 +466,40 @@ class TurnPolicy:
             config=self.deps.runtime.config,
             runtime_paths=self.deps.runtime_paths,
         ):
-            return _DispatchPlan(
+            plan = _DispatchPlan(
                 kind="respond",
                 response_action=ResponseAction(
                     kind="reject",
                     rejection_message=_ROUTER_ONLY_MENTION_GUIDANCE,
                 ),
             )
-
-        if not context.mentioned_agents and not context.has_non_agent_mentions:
-            if context.planning_thread_history_unavailable:
-                self.deps.logger.info("Skipping routing: thread policy history unavailable")
-                return _DispatchPlan(kind="ignore", ignore_reason="router")
-            if context.is_thread and thread_requires_explicit_agent_targeting(
-                planning_thread_history,
-                sender_id=requester_user_id,
-                config=self.deps.runtime.config,
-                runtime_paths=self.deps.runtime_paths,
-            ):
-                self.deps.logger.info("Skipping routing: thread already requires explicit agent targeting")
-                return _DispatchPlan(kind="ignore", ignore_reason="router")
+        elif context.mentioned_agents or context.has_non_agent_mentions:
+            plan = _DispatchPlan(kind="ignore", ignore_reason="router")
+        elif context.planning_thread_history_unavailable:
+            self.deps.logger.info("Skipping routing: thread policy history unavailable")
+            plan = _DispatchPlan(kind="ignore", ignore_reason="router")
+        elif context.is_thread and thread_requires_explicit_agent_targeting(
+            planning_thread_history,
+            sender_id=requester_user_id,
+            config=self.deps.runtime.config,
+            runtime_paths=self.deps.runtime_paths,
+        ):
+            self.deps.logger.info("Skipping routing: thread already requires explicit agent targeting")
+            plan = _DispatchPlan(kind="ignore", ignore_reason="router")
+        else:
             available_agents = await self.available_agents_for_sender(room, requester_user_id)
             if len(available_agents) == 1:
                 self.deps.logger.info("Skipping routing: only one agent present")
-                return _DispatchPlan(kind="ignore", ignore_reason="router")
-            return _DispatchPlan(
-                kind="route",
-                router_message=message,
-                extra_content=extra_content,
-                media_events=media_events,
-                router_event=router_event or event,
-            )
-
-        return _DispatchPlan(kind="ignore", ignore_reason="router")
+                plan = _DispatchPlan(kind="ignore", ignore_reason="router")
+            else:
+                plan = _DispatchPlan(
+                    kind="route",
+                    router_message=message,
+                    extra_content=extra_content,
+                    media_events=media_events,
+                    router_event=router_event or event,
+                )
+        return plan
 
     @timed("dispatch_action_resolution")
     async def plan_turn(

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -7925,8 +7925,9 @@ class TestAgentBot:
         assert content["body"].startswith("🧭")
         assert "router is not a conversational AI agent" in content["body"]
         assert "mention a specific agent" in content["body"]
-        assert "one human and one agent" in content["body"]
-        assert "multiple agents or multiple users" in content["body"]
+        assert "one human and one agent are already talking in a thread" in content["body"]
+        assert "thread has multiple human users or multiple agent participants" in content["body"]
+        assert "automatic routing can still choose an agent" in content["body"]
 
     @pytest.mark.asyncio
     async def test_agent_receives_images_from_thread_root_after_routing(

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -7869,6 +7869,66 @@ class TestAgentBot:
         bot._turn_controller._execute_router_relay.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_router_replies_with_guidance_when_only_router_is_mentioned(self, tmp_path: Path) -> None:
+        """Mentioning only the router should explain that users must tag real agents."""
+        agent_user = AgentMatrixUser(
+            agent_name="router",
+            user_id="@mindroom_router:localhost",
+            display_name="Router Agent",
+            password=TEST_PASSWORD,
+            access_token="mock_test_token",  # noqa: S106
+        )
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        _install_runtime_cache_support(bot)
+        _wrap_extracted_collaborators(bot)
+        bot.client = AsyncMock()
+        bot.client.room_send.return_value = _room_send_response("$router_guidance")
+        tracker = _set_turn_store_tracker(bot, MagicMock())
+        tracker.has_responded.return_value = False
+
+        room = MagicMock(spec=nio.MatrixRoom)
+        room.room_id = "!test:localhost"
+        room.canonical_alias = None
+        room.encrypted = False
+        room.users = {
+            "@mindroom_router:localhost": MagicMock(),
+            "@mindroom_calculator:localhost": MagicMock(),
+            "@mindroom_general:localhost": MagicMock(),
+            "@user:localhost": MagicMock(),
+        }
+        bot.client.rooms = {room.room_id: room}
+
+        event = self._make_handler_event("message", sender="@user:localhost", event_id="$router_only")
+        event.body = "@mindroom_router:localhost help me"
+        event.source = {
+            "content": {
+                "body": event.body,
+                "m.mentions": {"user_ids": ["@mindroom_router:localhost"]},
+            },
+        }
+
+        with (
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
+            patch("mindroom.turn_controller.is_dm_room", new_callable=AsyncMock, return_value=False),
+            patch(
+                "mindroom.turn_controller.interactive.handle_text_response",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            await bot._on_message(room, event)
+            await drain_coalescing(bot)
+
+        bot.client.room_send.assert_awaited_once()
+        content = bot.client.room_send.await_args.kwargs["content"]
+        assert content["body"].startswith("🧭")
+        assert "router is not a conversational AI agent" in content["body"]
+        assert "mention a specific agent" in content["body"]
+        assert "one human and one agent" in content["body"]
+        assert "multiple agents or multiple users" in content["body"]
+
+    @pytest.mark.asyncio
     async def test_agent_receives_images_from_thread_root_after_routing(
         self,
         mock_agent_user: AgentMatrixUser,


### PR DESCRIPTION
## Summary
- Detect when a message mentions only the router account and no other users or agents.
- Send deterministic router guidance instead of silently ignoring the message.
- Include the rules that one human plus one agent can continue without tags, while multiple agents or multiple users require explicit tags.

## Test Plan
- [x] uv run pre-commit run --all-files
- [x] uv run ruff check src/mindroom/thread_utils.py src/mindroom/turn_controller.py src/mindroom/turn_policy.py tests/test_multi_agent_bot.py
- [x] uv run pytest tests/test_multi_agent_bot.py::TestAgentBot::test_router_replies_with_guidance_when_only_router_is_mentioned tests/test_routing.py -q -n 0 --no-cov
- [x] uv run pytest tests/test_tool_approval.py::test_request_approval_truncated_approval_fails_closed -q -n 0 --no-cov

## Notes
- uv run pytest was attempted twice with default xdist and coverage. The latest full run had one unrelated timeout in tests/test_tool_approval.py::test_request_approval_truncated_approval_fails_closed; the same test passed when rerun isolated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Router detects messages that mention only the router and replies with guidance asking users to tag a conversational agent.

* **Behavior Changes**
  * Messages that mention only the router are now explicitly rejected with a guidance reply instead of being silently routed or ignored.

* **Documentation**
  * Added a “Note on the Router Agent” explaining expected behavior and tagging guidance.

* **Tests**
  * Added a test verifying the router guidance reply when it is the sole mention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->