### PR TITLE
Fix Vertex ADC startup credential errors

### DIFF
--- a/src/mindroom/cli/doctor.py
+++ b/src/mindroom/cli/doctor.py
@@ -16,10 +16,12 @@ from anthropic import APIStatusError
 from google.auth.exceptions import DefaultCredentialsError, RefreshError
 
 from mindroom import constants
-from mindroom.constants import RuntimePaths, env_key_for_provider
+from mindroom.constants import RuntimePaths, env_key_for_provider, runtime_env_path
 from mindroom.embeddings import create_sentence_transformers_embedder
+from mindroom.google_adc import load_google_application_credentials
 from mindroom.matrix.health import matrix_versions_url, response_has_matrix_versions
 from mindroom.runtime_env_policy import VERTEXAI_CLAUDE_ENV_BY_KEY
+from mindroom.startup_errors import PermanentStartupError
 
 from .config import activate_cli_runtime, console, load_config_quiet
 
@@ -286,6 +288,25 @@ def _validate_provider_key(
     return _http_check(url, headers)
 
 
+def _classify_vertexai_claude_error(
+    exc: APIStatusError
+    | DefaultCredentialsError
+    | RefreshError
+    | RuntimeError
+    | TypeError
+    | ValueError
+    | httpx.HTTPError,
+) -> tuple[bool | None, str]:
+    """Classify one Vertex AI Claude validation failure for doctor output."""
+    if isinstance(exc, APIStatusError):
+        return False, f"HTTP {exc.status_code}"
+    if isinstance(exc, DefaultCredentialsError):
+        return None, str(exc)
+    if isinstance(exc, RefreshError):
+        return False, str(exc)
+    return None, str(exc)
+
+
 def _validate_vertexai_claude_connection(
     model_config: ModelConfig,
     runtime_paths: RuntimePaths,
@@ -304,6 +325,16 @@ def _validate_vertexai_claude_connection(
     if missing:
         return None, f"missing {', '.join(missing)}"
 
+    client_params = dict(extra_kwargs.get("client_params") or {})
+    google_application_credentials = runtime_env_path(runtime_paths, "GOOGLE_APPLICATION_CREDENTIALS")
+    if "credentials" not in client_params and google_application_credentials is not None:
+        try:
+            client_params["credentials"] = load_google_application_credentials(str(google_application_credentials))
+        except PermanentStartupError as exc:
+            return False, str(exc)
+    if client_params:
+        extra_kwargs["client_params"] = client_params
+
     extra_kwargs.setdefault("project_id", project_id)
     extra_kwargs.setdefault("region", region)
     extra_kwargs.setdefault("timeout", 10)
@@ -319,14 +350,16 @@ def _validate_vertexai_claude_connection(
         client.messages.create(
             **request_kwargs,
         )
-    except APIStatusError as exc:
-        return False, f"HTTP {exc.status_code}"
-    except DefaultCredentialsError as exc:
-        return None, str(exc)
-    except RefreshError as exc:
-        return False, str(exc)
-    except (RuntimeError, TypeError, ValueError, httpx.HTTPError) as exc:
-        return None, str(exc)
+    except (
+        APIStatusError,
+        DefaultCredentialsError,
+        RefreshError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+        httpx.HTTPError,
+    ) as exc:
+        return _classify_vertexai_claude_error(exc)
 
     return True, ""
 

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -17,6 +17,7 @@ from mindroom import __version__, constants
 from mindroom.constants import ensure_writable_config_path
 from mindroom.error_handling import AvatarGenerationError, AvatarSyncError
 from mindroom.frontend_assets import ensure_frontend_dist_dir
+from mindroom.startup_errors import PermanentStartupError
 
 from .banner import make_banner
 from .config import (
@@ -184,6 +185,9 @@ async def _run(
         console.print("\nStopped")
     except ConnectionError as exc:
         _print_connection_error(exc, runtime_paths)
+        raise typer.Exit(1) from None
+    except PermanentStartupError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from None
     except OSError as exc:
         if "connect" in str(exc).lower() or "refused" in str(exc).lower():

--- a/src/mindroom/google_adc.py
+++ b/src/mindroom/google_adc.py
@@ -1,0 +1,75 @@
+"""Google Application Default Credential loading helpers."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from mindroom.startup_errors import PermanentStartupError
+
+if TYPE_CHECKING:
+    from google.auth.credentials import Credentials as GoogleCredentials
+
+_GOOGLE_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
+
+class GoogleApplicationCredentialsError(PermanentStartupError):
+    """Raised when Google Application Default Credentials are invalid for startup."""
+
+
+def _google_adc_file_type(credentials_path: str) -> str | None:
+    """Return the ADC JSON credential type without invoking google-auth loaders."""
+    try:
+        with Path(credentials_path).open(encoding="utf-8") as credentials_file:
+            credentials_info = json.load(credentials_file)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(credentials_info, dict):
+        return None
+    credentials_type = credentials_info.get("type")
+    return credentials_type if isinstance(credentials_type, str) else None
+
+
+def load_google_application_credentials(credentials_path: str) -> GoogleCredentials:
+    """Load Google ADC credentials for Vertex-backed model clients."""
+    if not Path(credentials_path).is_file():
+        msg = (
+            "GOOGLE_APPLICATION_CREDENTIALS points to a file that does not exist: "
+            f"{credentials_path}. Fix the path, recreate the credential file, or unset "
+            "GOOGLE_APPLICATION_CREDENTIALS if this MindRoom instance should not use Vertex AI."
+        )
+        raise GoogleApplicationCredentialsError(msg)
+
+    credentials_type = _google_adc_file_type(credentials_path)
+    try:
+        if credentials_type == "service_account":
+            service_account = importlib.import_module("google.oauth2.service_account")
+            credentials_cls = service_account.Credentials
+            credentials = credentials_cls.from_service_account_file(
+                credentials_path,
+                scopes=[_GOOGLE_CLOUD_PLATFORM_SCOPE],
+            )
+            return cast("GoogleCredentials", credentials)
+
+        if credentials_type == "authorized_user":
+            oauth_credentials = importlib.import_module("google.oauth2.credentials")
+            credentials_cls = oauth_credentials.Credentials
+            credentials = credentials_cls.from_authorized_user_file(
+                credentials_path,
+                scopes=[_GOOGLE_CLOUD_PLATFORM_SCOPE],
+            )
+            return cast("GoogleCredentials", credentials)
+
+        google_auth = importlib.import_module("google.auth")
+        load_credentials_from_file = google_auth.load_credentials_from_file
+        credentials, _project_id = load_credentials_from_file(
+            credentials_path,
+            scopes=[_GOOGLE_CLOUD_PLATFORM_SCOPE],
+        )
+        return cast("GoogleCredentials", credentials)
+    except Exception as exc:
+        msg = f"Failed to load GOOGLE_APPLICATION_CREDENTIALS at {credentials_path}: {exc}"
+        raise GoogleApplicationCredentialsError(msg) from exc

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -11,6 +11,7 @@ import nio
 
 from mindroom.constants import RuntimePaths, encryption_keys_dir, runtime_matrix_ssl_verify
 from mindroom.logging_config import get_logger
+from mindroom.startup_errors import PermanentStartupError
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -27,7 +28,7 @@ _PERMANENT_MATRIX_STARTUP_ERROR_CODES = frozenset(
 )
 
 
-class PermanentMatrixStartupError(ValueError):
+class PermanentMatrixStartupError(PermanentStartupError):
     """Raised for Matrix startup failures that should not be retried."""
 
 

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
-import json
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from agno.models.anthropic import Claude
@@ -20,16 +17,15 @@ from mindroom.codex_model import CodexResponses, derive_codex_prompt_cache_key, 
 from mindroom.constants import RuntimePaths, runtime_env_path
 from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host
+from mindroom.google_adc import load_google_application_credentials
 from mindroom.llm_request_logging import install_llm_request_logging
 from mindroom.logging_config import get_logger
 from mindroom.runtime_env_policy import VERTEXAI_CLAUDE_ENV_BY_KEY
-from mindroom.startup_errors import PermanentStartupError
 from mindroom.vertex_claude_compat import MindroomVertexAIClaude
 from mindroom.vertex_claude_prompt_cache import install_vertex_claude_prompt_cache_hook
 
 if TYPE_CHECKING:
     from agno.models.base import Model
-    from google.auth.credentials import Credentials as GoogleCredentials
 
     from mindroom.config.main import Config
     from mindroom.config.models import ModelConfig
@@ -39,68 +35,10 @@ logger = get_logger(__name__)
 
 __all__ = ["get_model_instance"]
 
-_GOOGLE_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
-
-
-class _ModelCredentialError(PermanentStartupError):
-    """Raised when a model credential configuration is invalid."""
-
 
 def _canonical_provider(provider: str) -> str:
     """Return normalized provider key for model dispatch."""
     return provider.strip().lower().replace("-", "_")
-
-
-def _google_adc_file_type(credentials_path: str) -> str | None:
-    """Return the ADC JSON credential type without invoking google-auth loaders."""
-    try:
-        with Path(credentials_path).open(encoding="utf-8") as credentials_file:
-            credentials_info = json.load(credentials_file)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None
-
-    if not isinstance(credentials_info, dict):
-        return None
-    credentials_type = credentials_info.get("type")
-    return credentials_type if isinstance(credentials_type, str) else None
-
-
-def _load_google_application_credentials(credentials_path: str) -> GoogleCredentials:
-    """Load Google ADC credentials for Vertex-backed model clients."""
-    if not Path(credentials_path).is_file():
-        msg = (
-            "GOOGLE_APPLICATION_CREDENTIALS points to a file that does not exist: "
-            f"{credentials_path}. Fix the path, recreate the credential file, or unset "
-            "GOOGLE_APPLICATION_CREDENTIALS if this MindRoom instance should not use Vertex AI."
-        )
-        raise _ModelCredentialError(msg)
-
-    credentials_type = _google_adc_file_type(credentials_path)
-    if credentials_type == "service_account":
-        service_account = importlib.import_module("google.oauth2.service_account")
-        credentials_cls = service_account.Credentials
-        credentials = credentials_cls.from_service_account_file(
-            credentials_path,
-            scopes=[_GOOGLE_CLOUD_PLATFORM_SCOPE],
-        )
-        return cast("GoogleCredentials", credentials)
-
-    if credentials_type == "authorized_user":
-        oauth_credentials = importlib.import_module("google.oauth2.credentials")
-        credentials_cls = oauth_credentials.Credentials
-        credentials = credentials_cls.from_authorized_user_file(
-            credentials_path,
-            scopes=[_GOOGLE_CLOUD_PLATFORM_SCOPE],
-        )
-        return cast("GoogleCredentials", credentials)
-
-    google_auth = importlib.import_module("google.auth")
-    load_credentials_from_file = google_auth.load_credentials_from_file
-    credentials, _project_id = load_credentials_from_file(
-        credentials_path,
-        scopes=[_GOOGLE_CLOUD_PLATFORM_SCOPE],
-    )
-    return cast("GoogleCredentials", credentials)
 
 
 def _create_model_for_provider(  # noqa: C901, PLR0912
@@ -139,7 +77,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0912
         if "credentials" not in client_params and (
             google_application_credentials := runtime_env_path(runtime_paths, "GOOGLE_APPLICATION_CREDENTIALS")
         ):
-            client_params["credentials"] = _load_google_application_credentials(str(google_application_credentials))
+            client_params["credentials"] = load_google_application_credentials(str(google_application_credentials))
         if client_params:
             extra_kwargs["client_params"] = client_params
 

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -23,6 +23,7 @@ from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host
 from mindroom.llm_request_logging import install_llm_request_logging
 from mindroom.logging_config import get_logger
 from mindroom.runtime_env_policy import VERTEXAI_CLAUDE_ENV_BY_KEY
+from mindroom.startup_errors import PermanentStartupError
 from mindroom.vertex_claude_compat import MindroomVertexAIClaude
 from mindroom.vertex_claude_prompt_cache import install_vertex_claude_prompt_cache_hook
 
@@ -39,6 +40,10 @@ logger = get_logger(__name__)
 __all__ = ["get_model_instance"]
 
 _GOOGLE_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
+
+class _ModelCredentialError(PermanentStartupError):
+    """Raised when a model credential configuration is invalid."""
 
 
 def _canonical_provider(provider: str) -> str:
@@ -62,10 +67,28 @@ def _google_adc_file_type(credentials_path: str) -> str | None:
 
 def _load_google_application_credentials(credentials_path: str) -> GoogleCredentials:
     """Load Google ADC credentials for Vertex-backed model clients."""
-    if _google_adc_file_type(credentials_path) == "service_account":
+    if not Path(credentials_path).is_file():
+        msg = (
+            "GOOGLE_APPLICATION_CREDENTIALS points to a file that does not exist: "
+            f"{credentials_path}. Fix the path, recreate the credential file, or unset "
+            "GOOGLE_APPLICATION_CREDENTIALS if this MindRoom instance should not use Vertex AI."
+        )
+        raise _ModelCredentialError(msg)
+
+    credentials_type = _google_adc_file_type(credentials_path)
+    if credentials_type == "service_account":
         service_account = importlib.import_module("google.oauth2.service_account")
         credentials_cls = service_account.Credentials
         credentials = credentials_cls.from_service_account_file(
+            credentials_path,
+            scopes=[_GOOGLE_CLOUD_PLATFORM_SCOPE],
+        )
+        return cast("GoogleCredentials", credentials)
+
+    if credentials_type == "authorized_user":
+        oauth_credentials = importlib.import_module("google.oauth2.credentials")
+        credentials_cls = oauth_credentials.Credentials
+        credentials = credentials_cls.from_authorized_user_file(
             credentials_path,
             scopes=[_GOOGLE_CLOUD_PLATFORM_SCOPE],
         )

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -23,7 +23,6 @@ from mindroom.cancellation import (
 )
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths, runtime_matrix_ssl_verify
 from mindroom.logging_config import get_logger
-from mindroom.matrix.client_session import PermanentMatrixStartupError
 from mindroom.matrix.health import (
     MATRIX_SYNC_STARTUP_GRACE_SECONDS,
     MATRIX_SYNC_WATCHDOG_TIMEOUT_SECONDS,
@@ -32,6 +31,7 @@ from mindroom.matrix.health import (
 )
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.runtime_state import set_runtime_starting
+from mindroom.startup_errors import PermanentStartupError
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Coroutine
@@ -171,7 +171,7 @@ def retry_delay_seconds(
 
 def is_permanent_startup_error(exc: Exception) -> bool:
     """Return whether a startup exception is clearly non-retryable."""
-    return isinstance(exc, PermanentMatrixStartupError)
+    return isinstance(exc, PermanentStartupError)
 
 
 async def cancel_task(

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -499,6 +499,7 @@ class _MultiAgentOrchestrator:
                         await run_with_retry(
                             f"Updating Matrix room memberships for {entity_name}",
                             partial(self._setup_rooms_and_memberships, bots_to_setup),
+                            permanent_error_check=is_permanent_startup_error,
                             update_runtime_state=False,
                         )
                     self._start_sync_task(entity_name, bot)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1108,6 +1108,7 @@ class _MultiAgentOrchestrator:
         await run_with_retry(
             "Setting up Matrix rooms and memberships",
             lambda: self._setup_rooms_and_memberships(started_bots),
+            permanent_error_check=is_permanent_startup_error,
         )
         interrupted_threads = await self._cleanup_stale_streams_after_restart(started_bots, config)
         await self._auto_resume_after_restart(interrupted_threads, config)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -54,6 +54,7 @@ from mindroom.mcp.toolkit import bind_mcp_server_manager
 from mindroom.memory import MemoryAutoFlushWorker, auto_flush_enabled
 from mindroom.runtime_state import reset_runtime_state, set_runtime_failed, set_runtime_ready, set_runtime_starting
 from mindroom.scheduling import set_scheduling_hook_registry
+from mindroom.startup_errors import PermanentStartupError
 from mindroom.tool_approval import shutdown_approval_runtime
 from mindroom.tool_system.plugins import (
     PluginReloadResult,
@@ -2004,6 +2005,10 @@ async def main(
     except KeyboardInterrupt:
         shutdown_requested.set()
         logger.info("Multi-agent bot system stopped by user")
+    except PermanentStartupError as exc:
+        shutdown_requested.set()
+        logger.error("MindRoom startup failed", error=str(exc))  # noqa: TRY400
+        raise
     except Exception:
         shutdown_requested.set()
         logger.exception("Error in MindRoom runtime")

--- a/src/mindroom/startup_errors.py
+++ b/src/mindroom/startup_errors.py
@@ -1,0 +1,7 @@
+"""Shared startup error types."""
+
+from __future__ import annotations
+
+
+class PermanentStartupError(ValueError):
+    """Raised for startup failures that should not be retried."""

--- a/tach.toml
+++ b/tach.toml
@@ -160,6 +160,7 @@ depends_on = [
     "mindroom.constants",
     "mindroom.credentials",
     "mindroom.credentials_sync",
+    "mindroom.google_adc",
     "mindroom.llm_request_logging",
     "mindroom.logging_config",
     "mindroom.vertex_claude_prompt_cache",
@@ -180,6 +181,14 @@ visibility = [
 [[modules]]
 path = "mindroom.metadata_merge"
 depends_on = []
+
+[[modules]]
+path = "mindroom.google_adc"
+depends_on = ["mindroom.startup_errors"]
+visibility = [
+    "mindroom.cli.doctor",
+    "mindroom.model_loading",
+]
 
 [[modules]]
 path = "mindroom.agent_policy"
@@ -1644,6 +1653,7 @@ depends_on = [
     "mindroom.config.main",
     "mindroom.constants",
     "mindroom.embeddings",
+    "mindroom.google_adc",
     "mindroom.matrix.health",
 ]
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -28,6 +28,7 @@ from mindroom.constants import OWNER_MATRIX_USER_ID_ENV, OWNER_MATRIX_USER_ID_PL
 from mindroom.error_handling import AvatarGenerationError, AvatarSyncError
 from mindroom.handled_turns import HandledTurnLedger
 from mindroom.matrix.state import MatrixState
+from mindroom.startup_errors import PermanentStartupError
 from tests.conftest import normalize_console_output
 
 runner = CliRunner()
@@ -1114,6 +1115,24 @@ class TestRunErrorHandling:
         assert result.exit_code == 1
         assert "Invalid configuration" in result.output
         assert "Could not read configuration text" in result.output
+
+    def test_run_permanent_startup_error_prints_message_without_traceback(self, tmp_path: Path) -> None:
+        """Permanent startup failures should not dump an implementation traceback."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "models:\n  default:\n    provider: vertexai_claude\n    id: claude-sonnet-4-6\n"
+            "agents:\n  assistant:\n    display_name: Assistant\n    model: default\n"
+            "router:\n  model: default\n",
+            encoding="utf-8",
+        )
+        mock_main = AsyncMock(side_effect=PermanentStartupError("GOOGLE_APPLICATION_CREDENTIALS is invalid"))
+
+        with patch("mindroom.orchestrator.main", mock_main):
+            result = _invoke_with_runtime(["run"], cfg)
+
+        assert result.exit_code == 1
+        assert "GOOGLE_APPLICATION_CREDENTIALS is invalid" in result.output
+        assert "Traceback" not in result.output
 
     def test_avatars_generate_reports_avatar_generation_failure(
         self,

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1677,6 +1677,7 @@ class TestDoctor:
         storage = tmp_path / "storage"
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "mindroom-test")
         monkeypatch.setenv("CLOUD_ML_REGION", "us-central1")
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         _patch_homeserver_ok(monkeypatch)
 
@@ -1718,6 +1719,60 @@ class TestDoctor:
             "timeout": 10,
         }
 
+    def test_vertexai_claude_connection_uses_runtime_adc_credentials(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Doctor should pass resolved runtime ADC credentials to the Vertex client."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(_VALID_VERTEXAI_CLAUDE_CONFIG)
+        (tmp_path / ".env").write_text("GOOGLE_APPLICATION_CREDENTIALS=adc.json\n", encoding="utf-8")
+        storage = tmp_path / "storage"
+        fake_credentials = object()
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "mindroom-test")
+        monkeypatch.setenv("CLOUD_ML_REGION", "us-central1")
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        _patch_homeserver_ok(monkeypatch)
+
+        called: dict[str, object] = {}
+
+        def _load_adc(path: str) -> object:
+            called["adc_path"] = path
+            return fake_credentials
+
+        class _FakeMessages:
+            def create(self, **kwargs: object) -> SimpleNamespace:
+                called["kwargs"] = kwargs
+                return SimpleNamespace(content=[{"type": "text", "text": "OK"}])
+
+        class _FakeVertexModel:
+            def __init__(self, **kwargs: object) -> None:
+                called["client_kwargs"] = kwargs
+                self.id = str(kwargs["id"])
+
+            def get_request_params(self) -> dict[str, object]:
+                return {"timeout": called["client_kwargs"]["timeout"]}
+
+            def get_client(self) -> SimpleNamespace:
+                return SimpleNamespace(messages=_FakeMessages())
+
+        monkeypatch.setattr("mindroom.cli.doctor.load_google_application_credentials", _load_adc)
+        monkeypatch.setattr("mindroom.cli.doctor.VertexAIClaude", _FakeVertexModel)
+
+        result = _invoke_with_runtime(["doctor"], cfg, storage_path=storage)
+
+        assert result.exit_code == 0
+        assert called["adc_path"] == str((tmp_path / "adc.json").resolve())
+        assert called["client_kwargs"] == {
+            "id": "claude-sonnet-4-6",
+            "project_id": "mindroom-test",
+            "region": "us-central1",
+            "timeout": 10,
+            "client_params": {"credentials": fake_credentials},
+        }
+
     def test_vertexai_claude_connection_checks_each_configured_model(
         self,
         tmp_path: Path,
@@ -1729,6 +1784,7 @@ class TestDoctor:
         storage = tmp_path / "storage"
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "mindroom-test")
         monkeypatch.setenv("CLOUD_ML_REGION", "us-central1")
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         _patch_homeserver_ok(monkeypatch)
 
@@ -1792,6 +1848,7 @@ class TestDoctor:
         storage = tmp_path / "storage"
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "mindroom-test")
         monkeypatch.setenv("CLOUD_ML_REGION", "us-central1")
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         _patch_homeserver_ok(monkeypatch)
 
@@ -1818,6 +1875,52 @@ class TestDoctor:
         assert "ADC" in result.output
         assert "unavailable" in result.output
 
+    def test_vertexai_claude_missing_adc_file_is_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Doctor fails when an explicit Vertex AI ADC file path is invalid."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(_VALID_VERTEXAI_CLAUDE_CONFIG)
+        storage = tmp_path / "storage"
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "mindroom-test")
+        monkeypatch.setenv("CLOUD_ML_REGION", "us-central1")
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(tmp_path / "missing-adc.json"))
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        _patch_homeserver_ok(monkeypatch)
+
+        result = _invoke_with_runtime(["doctor"], cfg, storage_path=storage)
+
+        assert result.exit_code == 1
+        output = normalize_console_output(result.output)
+        assert "vertexai_claude connection failed for claude-sonnet-4-6" in output
+        assert "GOOGLE_APPLICATION_CREDENTIALS points to a file that does not exist" in output
+
+    def test_vertexai_claude_invalid_adc_file_is_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Doctor fails when an explicit Vertex AI ADC file cannot be loaded."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(_VALID_VERTEXAI_CLAUDE_CONFIG)
+        storage = tmp_path / "storage"
+        adc_path = tmp_path / "invalid-adc.json"
+        adc_path.write_text('{"type":"authorized_user"}\n', encoding="utf-8")
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "mindroom-test")
+        monkeypatch.setenv("CLOUD_ML_REGION", "us-central1")
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(adc_path))
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        _patch_homeserver_ok(monkeypatch)
+
+        result = _invoke_with_runtime(["doctor"], cfg, storage_path=storage)
+
+        assert result.exit_code == 1
+        output = normalize_console_output(result.output)
+        assert "vertexai_claude connection failed for claude-sonnet-4-6" in output
+        assert "Failed to load GOOGLE_APPLICATION_CREDENTIALS" in output
+
     def test_vertexai_claude_api_rejection_is_failure(
         self,
         tmp_path: Path,
@@ -1829,6 +1932,7 @@ class TestDoctor:
         storage = tmp_path / "storage"
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "mindroom-test")
         monkeypatch.setenv("CLOUD_ML_REGION", "us-central1")
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         _patch_homeserver_ok(monkeypatch)
 

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -16,6 +16,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.model_loading import get_model_instance
+from mindroom.startup_errors import PermanentStartupError
 from mindroom.vertex_claude_compat import MindroomVertexAIClaude, _strip_vertex_claude_tool_strict
 from mindroom.vertex_claude_prompt_cache import (
     _copy_messages_with_vertex_prompt_cache_breakpoint,
@@ -597,7 +598,7 @@ def test_vertexai_claude_loads_runtime_google_application_credentials(monkeypatc
             return type("FakeOauthCredentialsModule", (), {"Credentials": FakeAuthorizedUserCredentials})
         return original_import_module(module_name)
 
-    monkeypatch.setattr("mindroom.model_loading.importlib.import_module", fake_import_module)
+    monkeypatch.setattr("mindroom.google_adc.importlib.import_module", fake_import_module)
 
     model = get_model_instance(config, runtime_paths, "vertex_claude_model")
 
@@ -635,7 +636,43 @@ def test_vertexai_claude_rejects_missing_runtime_google_application_credentials(
     )
     config = Config(**config_data)
 
-    with pytest.raises(ValueError, match="GOOGLE_APPLICATION_CREDENTIALS points to a file that does not exist"):
+    with pytest.raises(
+        PermanentStartupError,
+        match="GOOGLE_APPLICATION_CREDENTIALS points to a file that does not exist",
+    ):
+        get_model_instance(config, runtime_paths, "vertex_claude_model")
+
+
+def test_vertexai_claude_rejects_invalid_runtime_google_application_credentials() -> None:
+    """Invalid ADC files should fail as permanent startup errors."""
+    config_data = {
+        "models": {
+            "vertex_claude_model": {
+                "provider": "vertexai_claude",
+                "id": "claude-sonnet-4-6",
+                "extra_kwargs": {
+                    "project_id": "demo-project",
+                    "region": "us-central1",
+                },
+            },
+        },
+        "router": {
+            "model": "vertex_claude_model",
+        },
+        "agents": {},
+    }
+
+    runtime_root = Path(tempfile.mkdtemp())
+    credentials_path = runtime_root / "invalid-google-credentials.json"
+    credentials_path.write_text('{"type":"authorized_user"}\n', encoding="utf-8")
+    runtime_paths = resolve_runtime_paths(
+        config_path=runtime_root / "config.yaml",
+        storage_path=runtime_root / "mindroom_data",
+        process_env={"GOOGLE_APPLICATION_CREDENTIALS": str(credentials_path)},
+    )
+    config = Config(**config_data)
+
+    with pytest.raises(PermanentStartupError, match="Failed to load GOOGLE_APPLICATION_CREDENTIALS"):
         get_model_instance(config, runtime_paths, "vertex_claude_model")
 
 
@@ -690,7 +727,7 @@ def test_vertexai_claude_loads_service_account_credentials_directly(
             return type("FakeServiceAccountModule", (), {"Credentials": FakeServiceAccountCredentials})
         return original_import_module(module_name)
 
-    monkeypatch.setattr("mindroom.model_loading.importlib.import_module", fake_import_module)
+    monkeypatch.setattr("mindroom.google_adc.importlib.import_module", fake_import_module)
 
     model = get_model_instance(config, runtime_paths, "vertex_claude_model")
 

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -577,19 +577,66 @@ def test_vertexai_claude_loads_runtime_google_application_credentials(monkeypatc
     )
     config = Config(**config_data)
     fake_google_credentials = object()
+    import_order: list[str] = []
 
-    def fake_load_credentials_from_file(path: str, *, scopes: list[str]) -> tuple[object, str]:
-        assert Path(path).resolve() == credentials_path.resolve()
-        assert scopes == ["https://www.googleapis.com/auth/cloud-platform"]
-        return fake_google_credentials, "ignored-project"
+    class FakeAuthorizedUserCredentials:
+        @classmethod
+        def from_authorized_user_file(cls, path: str, *, scopes: list[str]) -> object:
+            assert Path(path).resolve() == credentials_path.resolve()
+            assert scopes == ["https://www.googleapis.com/auth/cloud-platform"]
+            return fake_google_credentials
 
-    monkeypatch.setattr("google.auth.load_credentials_from_file", fake_load_credentials_from_file)
+    original_import_module = importlib.import_module
+
+    def fake_import_module(module_name: str) -> object:
+        import_order.append(module_name)
+        if module_name == "google.auth":
+            msg = "google.auth should not be used for authorized-user ADC"
+            raise AssertionError(msg)
+        if module_name == "google.oauth2.credentials":
+            return type("FakeOauthCredentialsModule", (), {"Credentials": FakeAuthorizedUserCredentials})
+        return original_import_module(module_name)
+
+    monkeypatch.setattr("mindroom.model_loading.importlib.import_module", fake_import_module)
 
     model = get_model_instance(config, runtime_paths, "vertex_claude_model")
 
     assert isinstance(model, VertexAIClaude)
     assert model.client_params is not None
     assert model.client_params["credentials"] is fake_google_credentials
+    assert import_order == ["google.oauth2.credentials"]
+
+
+def test_vertexai_claude_rejects_missing_runtime_google_application_credentials() -> None:
+    """Missing GOOGLE_APPLICATION_CREDENTIALS should fail with an actionable error."""
+    config_data = {
+        "models": {
+            "vertex_claude_model": {
+                "provider": "vertexai_claude",
+                "id": "claude-sonnet-4-6",
+                "extra_kwargs": {
+                    "project_id": "demo-project",
+                    "region": "us-central1",
+                },
+            },
+        },
+        "router": {
+            "model": "vertex_claude_model",
+        },
+        "agents": {},
+    }
+
+    runtime_root = Path(tempfile.mkdtemp())
+    credentials_path = runtime_root / "missing-google-credentials.json"
+    runtime_paths = resolve_runtime_paths(
+        config_path=runtime_root / "config.yaml",
+        storage_path=runtime_root / "mindroom_data",
+        process_env={"GOOGLE_APPLICATION_CREDENTIALS": str(credentials_path)},
+    )
+    config = Config(**config_data)
+
+    with pytest.raises(ValueError, match="GOOGLE_APPLICATION_CREDENTIALS points to a file that does not exist"):
+        get_model_instance(config, runtime_paths, "vertex_claude_model")
 
 
 def test_vertexai_claude_loads_service_account_credentials_directly(

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -119,6 +119,7 @@ from mindroom.response_runner import (
 )
 from mindroom.runtime_state import get_runtime_state, reset_runtime_state, set_runtime_ready
 from mindroom.runtime_support import StartupThreadPrewarmRegistry
+from mindroom.startup_errors import PermanentStartupError
 from mindroom.streaming import StreamingDeliveryError
 from mindroom.teams import TeamIntent, TeamMemberStatus, TeamMode, TeamOutcome, TeamResolution, TeamResolutionMember
 from mindroom.thread_summary import thread_summary_message_count_hint
@@ -13156,6 +13157,28 @@ class TestMultiAgentOrchestrator:
 
         assert "general" in orchestrator.agent_bots
         mock_schedule_retry.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_background_bot_recovery_stops_on_permanent_room_setup_failure(self, tmp_path: Path) -> None:
+        """Recovered background starts should not retry permanent room setup failures forever."""
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        orchestrator.config = MagicMock()
+
+        bot = MagicMock()
+        bot.agent_name = "general"
+        bot.try_start = AsyncMock(return_value=True)
+        orchestrator.agent_bots = {"general": bot}
+
+        with (
+            patch.object(orchestrator, "_retry_blocked_mcp_entities", new=AsyncMock(return_value=set())),
+            patch.object(
+                orchestrator,
+                "_setup_rooms_and_memberships",
+                new=AsyncMock(side_effect=PermanentStartupError("bad ADC")),
+            ),
+            pytest.raises(PermanentStartupError, match="bad ADC"),
+        ):
+            await orchestrator._run_bot_start_retry("general")
 
     @pytest.mark.asyncio
     async def test_shutdown_expires_in_flight_approval_send_after_event_id_arrives(  # noqa: PLR0915


### PR DESCRIPTION
## Summary
- add a shared Google ADC loader for Vertex AI Claude that resolves `GOOGLE_APPLICATION_CREDENTIALS` through the MindRoom runtime path rules
- load service-account and authorized-user ADC JSON through typed Google credential loaders before falling back to `google.auth.load_credentials_from_file`
- surface missing or invalid explicit ADC files as permanent startup errors with actionable messages
- pass resolved ADC credential objects into both runtime model loading and `mindroom doctor`, so doctor validates the same credential path runtime uses
- classify permanent startup errors centrally so Matrix room setup and bot recovery stop retrying non-retryable credential failures
- print permanent startup errors from `mindroom run` without a traceback

## Tests
- `uv run ruff check src/mindroom/cli/doctor.py src/mindroom/cli/main.py src/mindroom/google_adc.py src/mindroom/model_loading.py src/mindroom/orchestration/runtime.py src/mindroom/orchestrator.py src/mindroom/startup_errors.py tests/test_cli_config.py tests/test_extra_kwargs.py tests/test_multi_agent_bot.py`
- `uv run tach check --dependencies --interfaces`
- `uv run pytest tests/test_cli_config.py::TestDoctor::test_vertexai_claude_connection_uses_runtime_adc_credentials tests/test_cli_config.py::TestDoctor::test_vertexai_claude_missing_adc_file_is_failure tests/test_cli_config.py::TestDoctor::test_vertexai_claude_invalid_adc_file_is_failure tests/test_cli_config.py::TestDoctor::test_vertexai_claude_connection_check_passes tests/test_cli_config.py::TestDoctor::test_vertexai_claude_connection_checks_each_configured_model tests/test_cli_config.py::TestDoctor::test_vertexai_claude_missing_adc_is_warning tests/test_cli_config.py::TestDoctor::test_vertexai_claude_api_rejection_is_failure tests/test_extra_kwargs.py::test_vertexai_claude_loads_runtime_google_application_credentials tests/test_extra_kwargs.py::test_vertexai_claude_rejects_missing_runtime_google_application_credentials tests/test_extra_kwargs.py::test_vertexai_claude_rejects_invalid_runtime_google_application_credentials tests/test_extra_kwargs.py::test_vertexai_claude_loads_service_account_credentials_directly tests/test_multi_agent_bot.py::TestMultiAgentOrchestrator::test_background_bot_recovery_stops_on_permanent_room_setup_failure -x -n 0 --no-cov -v`
- GitHub PR checks pass, including `test (3.13)`, `tach`, builds, and smoke
