### PR TITLE
Default visible router echo on

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -399,7 +399,7 @@ knowledge_bases:
 # Voice message handling (optional)
 voice:
   enabled: false                   # Default: false
-  visible_router_echo: false       # Optional: show the normalized voice text from the router
+  visible_router_echo: true        # Optional: show the normalized voice text from the router
   stt:
     provider: openai               # Default: openai
     model: whisper-1               # Default: whisper-1

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -91,7 +91,8 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a multi-agent room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-Set `voice.visible_router_echo: true` if you also want the router to post the normalized voice text as a display-only message when it is allowed to reply.
+By default, `voice.visible_router_echo: true` also lets the router post the normalized voice text as a display-only message when it is allowed to reply.
+Set `voice.visible_router_echo: false` to suppress that display-only echo.
 See [Voice Messages](../voice.md) for the detailed dispatch behavior.
 
 ### Configuration Confirmations

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -286,7 +286,7 @@ Enable voice message processing with speech-to-text:
 ```yaml
 voice:
   enabled: false
-  visible_router_echo: false  # Post transcript as visible router message
+  visible_router_echo: true  # Post transcript as visible router message
   stt:
     provider: openai
     model: whisper-1

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -29,7 +29,7 @@ Enable STT and voice-intelligence formatting in `config.yaml`:
 ```yaml
 voice:
   enabled: true
-  visible_router_echo: false
+  visible_router_echo: true
   stt:
     provider: openai
     model: whisper-1

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -172,10 +172,10 @@ If multiple eligible agents remain and the audio does not already target one of 
 
 ### Visibility rule
 
-MindRoom does not automatically post the transcript to the room.
-A visible router message appears only when the router must disambiguate between multiple eligible responders.
-If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent replies directly without an extra router message.
-Setting `voice.visible_router_echo: true` adds a visible router-authored echo of the normalized voice text when the router is actually allowed to process the event, without changing which event agents actually answer.
+By default, MindRoom posts a display-only router echo of normalized voice text when the router is allowed to process the event.
+The router handoff message still appears only when the router must disambiguate between multiple eligible responders.
+If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent replies directly to the original audio event.
+Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event agents actually answer.
 
 ### Attachment access
 

--- a/frontend/src/components/VoiceConfig/VoiceConfig.test.tsx
+++ b/frontend/src/components/VoiceConfig/VoiceConfig.test.tsx
@@ -46,7 +46,7 @@ describe("VoiceConfig", () => {
     },
     voice: {
       enabled: true,
-      visible_router_echo: false,
+      visible_router_echo: true,
       stt: {
         provider: "custom",
         model: "whisper-1",
@@ -124,7 +124,7 @@ describe("VoiceConfig", () => {
     await waitFor(() => {
       expect(mockUpdateVoiceConfig).toHaveBeenCalledWith({
         enabled: true,
-        visible_router_echo: false,
+        visible_router_echo: true,
         stt: {
           provider: "openai",
           model: "whisper-1",
@@ -158,7 +158,7 @@ describe("VoiceConfig", () => {
       expect(mockSaveConfig).toHaveBeenCalled();
       expect(mockUpdateVoiceConfig).toHaveBeenLastCalledWith({
         enabled: true,
-        visible_router_echo: false,
+        visible_router_echo: true,
         stt: {
           provider: "openai",
           model: "whisper-1",
@@ -251,6 +251,8 @@ describe("VoiceConfig", () => {
 
   it("updates visible router echo from the voice tab", async () => {
     const config = createConfig();
+    if (!config.voice) throw new Error("Expected voice config");
+    config.voice.visible_router_echo = false;
     setMockStore(config);
 
     render(<VoiceConfig />);

--- a/frontend/src/components/VoiceConfig/VoiceConfig.tsx
+++ b/frontend/src/components/VoiceConfig/VoiceConfig.tsx
@@ -29,7 +29,7 @@ const OPENAI_TRANSCRIPTION_ENDPOINT =
 
 const DEFAULT_VOICE_CONFIG: VoiceConfigType = {
   enabled: false,
-  visible_router_echo: false,
+  visible_router_echo: true,
   stt: {
     provider: "openai",
     model: "whisper-1",

--- a/frontend/src/store/configStore.test.ts
+++ b/frontend/src/store/configStore.test.ts
@@ -2069,7 +2069,7 @@ describe("configStore", () => {
         },
         voice: {
           enabled: false,
-          visible_router_echo: false,
+          visible_router_echo: true,
           stt: {
             provider: "openai",
             model: "whisper-1",

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1121,7 +1121,7 @@ knowledge_bases:
 # Voice message handling (optional)
 voice:
   enabled: false                   # Default: false
-  visible_router_echo: false       # Optional: show the normalized voice text from the router
+  visible_router_echo: true        # Optional: show the normalized voice text from the router
   stt:
     provider: openai               # Default: openai
     model: whisper-1               # Default: whisper-1
@@ -10708,7 +10708,7 @@ Enable STT and voice-intelligence formatting in `config.yaml`:
 ```
 voice:
   enabled: true
-  visible_router_echo: false
+  visible_router_echo: true
   stt:
     provider: openai
     model: whisper-1

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2291,7 +2291,7 @@ By default (`matrix_room_access.mode: single_user_private`), rooms remain invite
 
 ### Voice Message Processing
 
-Audio events are handled through the shared media pipeline on all bots. The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a multi-agent room. When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message. Set `voice.visible_router_echo: true` if you also want the router to post the normalized voice text as a display-only message when it is allowed to reply. See [Voice Messages](https://docs.mindroom.chat/voice/index.md) for the detailed dispatch behavior.
+Audio events are handled through the shared media pipeline on all bots. The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a multi-agent room. When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message. By default, `voice.visible_router_echo: true` also lets the router post the normalized voice text as a display-only message when it is allowed to reply. Set `voice.visible_router_echo: false` to suppress that display-only echo. See [Voice Messages](https://docs.mindroom.chat/voice/index.md) for the detailed dispatch behavior.
 
 ### Configuration Confirmations
 
@@ -10837,7 +10837,7 @@ Audio still works when the router is absent. In that case, agents handle the nor
 
 ### Visibility rule
 
-MindRoom does not automatically post the transcript to the room. A visible router message appears only when the router must disambiguate between multiple eligible responders. If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent replies directly without an extra router message. Setting `voice.visible_router_echo: true` adds a visible router-authored echo of the normalized voice text when the router is actually allowed to process the event, without changing which event agents actually answer.
+By default, MindRoom posts a display-only router echo of normalized voice text when the router is allowed to process the event. The router handoff message still appears only when the router must disambiguate between multiple eligible responders. If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent replies directly to the original audio event. Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event agents actually answer.
 
 ### Attachment access
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -393,7 +393,7 @@ knowledge_bases:
 # Voice message handling (optional)
 voice:
   enabled: false                   # Default: false
-  visible_router_echo: false       # Optional: show the normalized voice text from the router
+  visible_router_echo: true        # Optional: show the normalized voice text from the router
   stt:
     provider: openai               # Default: openai
     model: whisper-1               # Default: whisper-1

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -87,7 +87,7 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a multi-agent room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-Set `voice.visible_router_echo: true` if you also want the router to post the normalized voice text as a display-only message when it is allowed to reply. See [Voice Messages](https://docs.mindroom.chat/voice/index.md) for the detailed dispatch behavior.
+By default, `voice.visible_router_echo: true` also lets the router post the normalized voice text as a display-only message when it is allowed to reply. Set `voice.visible_router_echo: false` to suppress that display-only echo. See [Voice Messages](https://docs.mindroom.chat/voice/index.md) for the detailed dispatch behavior.
 
 ### Configuration Confirmations
 

--- a/skills/mindroom-docs/references/page__voice__index.md
+++ b/skills/mindroom-docs/references/page__voice__index.md
@@ -168,10 +168,10 @@ If multiple eligible agents remain and the audio does not already target one of 
 
 ### Visibility rule
 
-MindRoom does not automatically post the transcript to the room.
-A visible router message appears only when the router must disambiguate between multiple eligible responders.
-If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent replies directly without an extra router message.
-Setting `voice.visible_router_echo: true` adds a visible router-authored echo of the normalized voice text when the router is actually allowed to process the event, without changing which event agents actually answer.
+By default, MindRoom posts a display-only router echo of normalized voice text when the router is allowed to process the event.
+The router handoff message still appears only when the router must disambiguate between multiple eligible responders.
+If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent replies directly to the original audio event.
+Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event agents actually answer.
 
 ### Attachment access
 

--- a/skills/mindroom-docs/references/page__voice__index.md
+++ b/skills/mindroom-docs/references/page__voice__index.md
@@ -25,7 +25,7 @@ Enable STT and voice-intelligence formatting in `config.yaml`:
 ```yaml
 voice:
   enabled: true
-  visible_router_echo: false
+  visible_router_echo: true
   stt:
     provider: openai
     model: whisper-1

--- a/src/mindroom/config/voice.py
+++ b/src/mindroom/config/voice.py
@@ -25,7 +25,7 @@ class VoiceConfig(BaseModel):
 
     enabled: bool = Field(default=False, description="Enable voice message processing")
     visible_router_echo: bool = Field(
-        default=False,
+        default=True,
         description="Post the normalized voice transcript or fallback as a visible router message",
     )
     stt: _VoiceSTTConfig = Field(default_factory=_VoiceSTTConfig, description="STT configuration")

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -902,7 +902,7 @@ async def test_router_and_agent_share_audio_normalization_when_router_is_present
         Config(
             agents={"home": {"display_name": "HomeAssistant", "rooms": ["!test:example.com"]}},
             authorization={"default_room_access": True},
-            voice={"enabled": True},
+            voice={"enabled": True, "visible_router_echo": False},
         ),
         tmp_path,
     )
@@ -1173,7 +1173,7 @@ async def test_router_routes_transcribed_audio_when_multiple_agents_are_present(
                 "research": {"display_name": "ResearchAgent", "rooms": ["!test:example.com"]},
             },
             authorization={"default_room_access": True},
-            voice={"enabled": True},
+            voice={"enabled": True, "visible_router_echo": False},
         ),
         tmp_path,
     )

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -83,6 +83,7 @@ class TestVoiceHandler:
         """Test that voice handler is disabled when not configured."""
         config = Config()
         assert not config.voice.enabled
+        assert config.voice.visible_router_echo
 
     def test_voice_handler_enabled_with_config(self) -> None:
         """Test that voice handler is enabled when configured."""


### PR DESCRIPTION
## Summary
- make `voice.visible_router_echo` default to `true` in backend config
- align the frontend voice config default and tests
- update voice configuration docs and docs reference corpus

## Tests
- `uv run pytest -q`
- `bun run test:unit src/components/VoiceConfig/VoiceConfig.test.tsx src/store/configStore.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice transcriptions (router echo of normalized voice text) are visible by default, improving in-conversation visibility.

* **Documentation**
  * Updated configuration guides and voice/router docs to reflect the new default and how to suppress the echo.

* **Tests**
  * Test suites and UI config tests updated to validate the new default and toggle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->