### PR TITLE
Add MindRoom user service install commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,22 +35,24 @@ mindroom [OPTIONS] COMMAND [ARGS]...
  mindroom config init   Create a starter config
  mindroom run           Start the system
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --install-completion            Install completion for the current shell.              │
-│ --show-completion               Show completion for the current shell, to copy it or   │
-│                                 customize the installation.                            │
-│ --help                -h        Show this message and exit.                            │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ version             Show the current version of Mindroom.                              │
-│ run                 Run the mindroom multi-agent system.                               │
-│ doctor              Check your environment for common issues.                          │
-│ connect             Pair this local MindRoom install with the hosted provisioning      │
-│                     service.                                                           │
-│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.            │
-│ config              Manage MindRoom configuration files.                               │
-│ avatars             Generate and sync managed avatar assets.                           │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --install-completion            Install completion for the current shell.    │
+│ --show-completion               Show completion for the current shell, to    │
+│                                 copy it or customize the installation.       │
+│ --help                -h        Show this message and exit.                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ version             Show the current version of Mindroom.                    │
+│ run                 Run the mindroom multi-agent system.                     │
+│ doctor              Check your environment for common issues.                │
+│ connect             Pair this local MindRoom install with the hosted         │
+│                     provisioning service.                                    │
+│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.  │
+│ config              Manage MindRoom configuration files.                     │
+│ avatars             Generate and sync managed avatar assets.                 │
+│ service             Install and manage MindRoom as a background user         │
+│                     service.                                                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -78,9 +80,9 @@ Show the current MindRoom version.
 
  Show the current version of Mindroom.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -114,22 +116,25 @@ Start MindRoom with your configuration.
  - Manages agent room memberships
  - Starts the bundled dashboard/API server (disable with --no-api)
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, WARNING,  │
-│                                          ERROR)                                        │
-│                                          [env var: LOG_LEVEL]                          │
-│                                          [default: INFO]                               │
-│ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
-│                                          (state, sessions, tracking)                   │
-│ --api               --no-api             Start the bundled dashboard/API server        │
-│                                          alongside the bot                             │
-│                                          [default: api]                                │
-│ --api-port                      INTEGER  Port for the bundled dashboard/API server     │
-│                                          [default: 8765]                               │
-│ --api-host                      TEXT     Host for the bundled dashboard/API server     │
-│                                          [default: 0.0.0.0]                            │
-│ --help          -h                       Show this message and exit.                   │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, │
+│                                          WARNING, ERROR)                     │
+│                                          [env var: LOG_LEVEL]                │
+│                                          [default: INFO]                     │
+│ --storage-path  -s              PATH     Base directory for persistent       │
+│                                          MindRoom data (state, sessions,     │
+│                                          tracking)                           │
+│ --api               --no-api             Start the bundled dashboard/API     │
+│                                          server alongside the bot            │
+│                                          [default: api]                      │
+│ --api-port                      INTEGER  Port for the bundled dashboard/API  │
+│                                          server                              │
+│                                          [default: 8765]                     │
+│ --api-host                      TEXT     Host for the bundled dashboard/API  │
+│                                          server                              │
+│                                          [default: 0.0.0.0]                  │
+│ --help          -h                       Show this message and exit.         │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -157,14 +162,14 @@ Generate and sync managed avatar assets.
 
  Generate and sync managed avatar assets.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ generate   Generate missing managed avatar files in the workspace.                     │
-│ sync       Sync configured room and root-space avatars to Matrix using the initialized │
-│            router account.                                                             │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ generate   Generate missing managed avatar files in the workspace.           │
+│ sync       Sync configured room and root-space avatars to Matrix using the   │
+│            initialized router account.                                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -196,10 +201,10 @@ Use `--force` to overwrite them after changing avatar prompts or styles.
 
  Generate missing managed avatar files in the workspace.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --force            Overwrite existing managed workspace avatar files.                  │
-│ --help   -h        Show this message and exit.                                         │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --force            Overwrite existing managed workspace avatar files.        │
+│ --help   -h        Show this message and exit.                               │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -227,13 +232,155 @@ Use `--force` to replace them.
 
  Usage: root avatars sync [OPTIONS]
 
- Sync configured room and root-space avatars to Matrix using the initialized router
- account.
+ Sync configured room and root-space avatars to Matrix using the initialized
+ router account.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --force            Replace existing Matrix room and root-space avatars.                │
-│ --help   -h        Show this message and exit.                                         │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --force            Replace existing Matrix room and root-space avatars.      │
+│ --help   -h        Show this message and exit.                               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+```
+
+<!-- OUTPUT:END -->
+
+## service
+
+Install and manage MindRoom as a background user service.
+MindRoom runs through `uv tool run` and starts automatically at login.
+On macOS, MindRoom uses launchd user agents.
+On Linux, MindRoom uses systemd user services.
+
+<!-- CODE:START -->
+<!-- from mindroom.cli.main import app -->
+<!-- from typer.testing import CliRunner -->
+<!-- runner = CliRunner() -->
+<!-- result = runner.invoke(app, ["service", "--help"]) -->
+<!-- print("```") -->
+<!-- print(result.output) -->
+<!-- print("```") -->
+<!-- CODE:END -->
+<!-- OUTPUT:START -->
+<!-- ⚠️ This content is auto-generated by `markdown-code-runner`. -->
+```
+
+ Usage: root service [OPTIONS] COMMAND [ARGS]...
+
+ Install and manage MindRoom as a background user service.
+
+ MindRoom runs through `uv tool run` and starts automatically at login.
+
+ Supported platforms:
+ - macOS: launchd (`~/Library/LaunchAgents/`)
+ - Linux: systemd user services (`~/.config/systemd/user/`)
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ install     Install and start MindRoom as a background user service.         │
+│ uninstall   Stop and remove the MindRoom user service.                       │
+│ status      Show MindRoom service status and recent logs.                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+```
+
+<!-- OUTPUT:END -->
+
+### service install
+
+Install and start MindRoom as a background user service.
+Use `--no-confirm` for non-interactive setup.
+
+<!-- CODE:START -->
+<!-- from mindroom.cli.main import app -->
+<!-- from typer.testing import CliRunner -->
+<!-- runner = CliRunner() -->
+<!-- result = runner.invoke(app, ["service", "install", "--help"]) -->
+<!-- print("```") -->
+<!-- print(result.output) -->
+<!-- print("```") -->
+<!-- CODE:END -->
+<!-- OUTPUT:START -->
+<!-- ⚠️ This content is auto-generated by `markdown-code-runner`. -->
+```
+
+ Usage: root service install [OPTIONS]
+
+ Install and start MindRoom as a background user service.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --skip-deps             Skip uv dependency check.                            │
+│ --no-confirm  -y        Skip confirmation prompts.                           │
+│ --help        -h        Show this message and exit.                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+```
+
+<!-- OUTPUT:END -->
+
+### service status
+
+Show MindRoom service status and recent logs.
+
+<!-- CODE:START -->
+<!-- from mindroom.cli.main import app -->
+<!-- from typer.testing import CliRunner -->
+<!-- runner = CliRunner() -->
+<!-- result = runner.invoke(app, ["service", "status", "--help"]) -->
+<!-- print("```") -->
+<!-- print(result.output) -->
+<!-- print("```") -->
+<!-- CODE:END -->
+<!-- OUTPUT:START -->
+<!-- ⚠️ This content is auto-generated by `markdown-code-runner`. -->
+```
+
+ Usage: root service status [OPTIONS]
+
+ Show MindRoom service status and recent logs.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --logs  -l      INTEGER  Number of recent log lines to show. Use 0 to hide   │
+│                          logs.                                               │
+│                          [default: 10]                                       │
+│ --help  -h               Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+```
+
+<!-- OUTPUT:END -->
+
+### service uninstall
+
+Stop and remove the MindRoom user service.
+On macOS, log files are preserved under `~/Library/Logs/mindroom/`.
+
+<!-- CODE:START -->
+<!-- from mindroom.cli.main import app -->
+<!-- from typer.testing import CliRunner -->
+<!-- runner = CliRunner() -->
+<!-- result = runner.invoke(app, ["service", "uninstall", "--help"]) -->
+<!-- print("```") -->
+<!-- print(result.output) -->
+<!-- print("```") -->
+<!-- CODE:END -->
+<!-- OUTPUT:START -->
+<!-- ⚠️ This content is auto-generated by `markdown-code-runner`. -->
+```
+
+ Usage: root service uninstall [OPTIONS]
+
+ Stop and remove the MindRoom user service.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --no-confirm  -y        Skip confirmation prompts.                           │
+│ --help        -h        Show this message and exit.                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -272,9 +419,9 @@ Runs a series of checks in one pass:
  Runs connectivity, configuration, and credential checks in a single pass
  so you can fix everything before running `mindroom run`.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -303,16 +450,16 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 
  Manage MindRoom configuration files.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ init       Create a starter config.yaml with example agents and models.                │
-│ show       Display the current config file with syntax highlighting.                   │
-│ edit       Open config.yaml in your default editor.                                    │
-│ validate   Validate config.yaml and check for common issues.                           │
-│ path       Show the resolved config file path and search locations.                    │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ init       Create a starter config.yaml with example agents and models.      │
+│ show       Display the current config file with syntax highlighting.         │
+│ edit       Open config.yaml in your default editor.                          │
+│ validate   Validate config.yaml and check for common issues.                 │
+│ path       Show the resolved config file path and search locations.          │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -453,50 +600,55 @@ By default this command also writes `MATRIX_HOMESERVER`, `MATRIX_SERVER_NAME`, a
 
  Start local Synapse + MindRoom Cinny using Docker only.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --synapse-dir                                 PATH                 Directory           │
-│                                                                    containing Synapse  │
-│                                                                    docker-compose.yml  │
-│                                                                    (from               │
-│                                                                    mindroom-stack      │
-│                                                                    settings).          │
-│                                                                    [default:           │
-│                                                                    local/matrix]       │
-│ --homeserver-url                              TEXT                 Homeserver URL that │
-│                                                                    Cinny and MindRoom  │
-│                                                                    should use.         │
-│                                                                    [default:           │
-│                                                                    http://localhost:8… │
-│ --server-name                                 TEXT                 Matrix server name  │
-│                                                                    (default: inferred  │
-│                                                                    from                │
-│                                                                    --homeserver-url    │
-│                                                                    hostname).          │
-│ --cinny-port                                  INTEGER RANGE        Local host port for │
-│                                               [1<=x<=65535]        the MindRoom Cinny  │
-│                                                                    container.          │
-│                                                                    [default: 8080]     │
-│ --cinny-image                                 TEXT                 Docker image for    │
-│                                                                    MindRoom Cinny.     │
-│                                                                    [default:           │
-│                                                                    ghcr.io/mindroom-a… │
-│ --cinny-container-n…                          TEXT                 Container name for  │
-│                                                                    MindRoom Cinny.     │
-│                                                                    [default:           │
-│                                                                    mindroom-cinny-loc… │
-│ --skip-synapse                                                     Skip starting       │
-│                                                                    Synapse (assume it  │
-│                                                                    is already          │
-│                                                                    running).           │
-│ --persist-env             --no-persist-env                         Persist Matrix      │
-│                                                                    local dev settings  │
-│                                                                    to .env next to     │
-│                                                                    config.yaml.        │
-│                                                                    [default:           │
-│                                                                    persist-env]        │
-│ --help                -h                                           Show this message   │
-│                                                                    and exit.           │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --synapse-dir                             PATH              Directory        │
+│                                                             containing       │
+│                                                             Synapse          │
+│                                                             docker-compose.… │
+│                                                             (from            │
+│                                                             mindroom-stack   │
+│                                                             settings).       │
+│                                                             [default:        │
+│                                                             local/matrix]    │
+│ --homeserver-url                          TEXT              Homeserver URL   │
+│                                                             that Cinny and   │
+│                                                             MindRoom should  │
+│                                                             use.             │
+│                                                             [default:        │
+│                                                             http://localhos… │
+│ --server-name                             TEXT              Matrix server    │
+│                                                             name (default:   │
+│                                                             inferred from    │
+│                                                             --homeserver-url │
+│                                                             hostname).       │
+│ --cinny-port                              INTEGER RANGE     Local host port  │
+│                                           [1<=x<=65535]     for the MindRoom │
+│                                                             Cinny container. │
+│                                                             [default: 8080]  │
+│ --cinny-image                             TEXT              Docker image for │
+│                                                             MindRoom Cinny.  │
+│                                                             [default:        │
+│                                                             ghcr.io/mindroo… │
+│ --cinny-containe…                         TEXT              Container name   │
+│                                                             for MindRoom     │
+│                                                             Cinny.           │
+│                                                             [default:        │
+│                                                             mindroom-cinny-… │
+│ --skip-synapse                                              Skip starting    │
+│                                                             Synapse (assume  │
+│                                                             it is already    │
+│                                                             running).        │
+│ --persist-env          --no-persist-e…                      Persist Matrix   │
+│                                                             local dev        │
+│                                                             settings to .env │
+│                                                             next to          │
+│                                                             config.yaml.     │
+│                                                             [default:        │
+│                                                             persist-env]     │
+│ --help             -h                                       Show this        │
+│                                                             message and      │
+│                                                             exit.            │
+╰──────────────────────────────────────────────────────────────────────────────╯
 
 
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,24 +35,23 @@ mindroom [OPTIONS] COMMAND [ARGS]...
  mindroom config init   Create a starter config
  mindroom run           Start the system
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --install-completion            Install completion for the current shell.    │
-│ --show-completion               Show completion for the current shell, to    │
-│                                 copy it or customize the installation.       │
-│ --help                -h        Show this message and exit.                  │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ version             Show the current version of Mindroom.                    │
-│ run                 Run the mindroom multi-agent system.                     │
-│ doctor              Check your environment for common issues.                │
-│ connect             Pair this local MindRoom install with the hosted         │
-│                     provisioning service.                                    │
-│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.  │
-│ config              Manage MindRoom configuration files.                     │
-│ avatars             Generate and sync managed avatar assets.                 │
-│ service             Install and manage MindRoom as a background user         │
-│                     service.                                                 │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --install-completion            Install completion for the current shell.              │
+│ --show-completion               Show completion for the current shell, to copy it or   │
+│                                 customize the installation.                            │
+│ --help                -h        Show this message and exit.                            │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ version             Show the current version of Mindroom.                              │
+│ run                 Run the mindroom multi-agent system.                               │
+│ doctor              Check your environment for common issues.                          │
+│ connect             Pair this local MindRoom install with the hosted provisioning      │
+│                     service.                                                           │
+│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.            │
+│ config              Manage MindRoom configuration files.                               │
+│ avatars             Generate and sync managed avatar assets.                           │
+│ service             Install and manage MindRoom as a background user service.          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -80,9 +79,9 @@ Show the current MindRoom version.
 
  Show the current version of Mindroom.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -116,25 +115,22 @@ Start MindRoom with your configuration.
  - Manages agent room memberships
  - Starts the bundled dashboard/API server (disable with --no-api)
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, │
-│                                          WARNING, ERROR)                     │
-│                                          [env var: LOG_LEVEL]                │
-│                                          [default: INFO]                     │
-│ --storage-path  -s              PATH     Base directory for persistent       │
-│                                          MindRoom data (state, sessions,     │
-│                                          tracking)                           │
-│ --api               --no-api             Start the bundled dashboard/API     │
-│                                          server alongside the bot            │
-│                                          [default: api]                      │
-│ --api-port                      INTEGER  Port for the bundled dashboard/API  │
-│                                          server                              │
-│                                          [default: 8765]                     │
-│ --api-host                      TEXT     Host for the bundled dashboard/API  │
-│                                          server                              │
-│                                          [default: 0.0.0.0]                  │
-│ --help          -h                       Show this message and exit.         │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, WARNING,  │
+│                                          ERROR)                                        │
+│                                          [env var: LOG_LEVEL]                          │
+│                                          [default: INFO]                               │
+│ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
+│                                          (state, sessions, tracking)                   │
+│ --api               --no-api             Start the bundled dashboard/API server        │
+│                                          alongside the bot                             │
+│                                          [default: api]                                │
+│ --api-port                      INTEGER  Port for the bundled dashboard/API server     │
+│                                          [default: 8765]                               │
+│ --api-host                      TEXT     Host for the bundled dashboard/API server     │
+│                                          [default: 0.0.0.0]                            │
+│ --help          -h                       Show this message and exit.                   │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -162,14 +158,14 @@ Generate and sync managed avatar assets.
 
  Generate and sync managed avatar assets.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ generate   Generate missing managed avatar files in the workspace.           │
-│ sync       Sync configured room and root-space avatars to Matrix using the   │
-│            initialized router account.                                       │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ generate   Generate missing managed avatar files in the workspace.                     │
+│ sync       Sync configured room and root-space avatars to Matrix using the initialized │
+│            router account.                                                             │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -201,10 +197,10 @@ Use `--force` to overwrite them after changing avatar prompts or styles.
 
  Generate missing managed avatar files in the workspace.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --force            Overwrite existing managed workspace avatar files.        │
-│ --help   -h        Show this message and exit.                               │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --force            Overwrite existing managed workspace avatar files.                  │
+│ --help   -h        Show this message and exit.                                         │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -232,13 +228,13 @@ Use `--force` to replace them.
 
  Usage: root avatars sync [OPTIONS]
 
- Sync configured room and root-space avatars to Matrix using the initialized
- router account.
+ Sync configured room and root-space avatars to Matrix using the initialized router
+ account.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --force            Replace existing Matrix room and root-space avatars.      │
-│ --help   -h        Show this message and exit.                               │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --force            Replace existing Matrix room and root-space avatars.                │
+│ --help   -h        Show this message and exit.                                         │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -275,14 +271,14 @@ On Linux, MindRoom uses systemd user services.
  - macOS: launchd (`~/Library/LaunchAgents/`)
  - Linux: systemd user services (`~/.config/systemd/user/`)
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ install     Install and start MindRoom as a background user service.         │
-│ uninstall   Stop and remove the MindRoom user service.                       │
-│ status      Show MindRoom service status and recent logs.                    │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ install     Install and start MindRoom as a background user service.                   │
+│ uninstall   Stop and remove the MindRoom user service.                                 │
+│ status      Show MindRoom service status and recent logs.                              │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -311,11 +307,11 @@ Use `--no-confirm` for non-interactive setup.
 
  Install and start MindRoom as a background user service.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --skip-deps             Skip uv dependency check.                            │
-│ --no-confirm  -y        Skip confirmation prompts.                           │
-│ --help        -h        Show this message and exit.                          │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --skip-deps             Skip uv dependency check.                                      │
+│ --no-confirm  -y        Skip confirmation prompts.                                     │
+│ --help        -h        Show this message and exit.                                    │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -343,12 +339,11 @@ Show MindRoom service status and recent logs.
 
  Show MindRoom service status and recent logs.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --logs  -l      INTEGER  Number of recent log lines to show. Use 0 to hide   │
-│                          logs.                                               │
-│                          [default: 10]                                       │
-│ --help  -h               Show this message and exit.                         │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --logs  -l      INTEGER  Number of recent log lines to show. Use 0 to hide logs.       │
+│                          [default: 10]                                                 │
+│ --help  -h               Show this message and exit.                                   │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -377,10 +372,10 @@ On macOS, log files are preserved under `~/Library/Logs/mindroom/`.
 
  Stop and remove the MindRoom user service.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --no-confirm  -y        Skip confirmation prompts.                           │
-│ --help        -h        Show this message and exit.                          │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --no-confirm  -y        Skip confirmation prompts.                                     │
+│ --help        -h        Show this message and exit.                                    │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -419,9 +414,9 @@ Runs a series of checks in one pass:
  Runs connectivity, configuration, and credential checks in a single pass
  so you can fix everything before running `mindroom run`.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -450,16 +445,16 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 
  Manage MindRoom configuration files.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ init       Create a starter config.yaml with example agents and models.      │
-│ show       Display the current config file with syntax highlighting.         │
-│ edit       Open config.yaml in your default editor.                          │
-│ validate   Validate config.yaml and check for common issues.                 │
-│ path       Show the resolved config file path and search locations.          │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ init       Create a starter config.yaml with example agents and models.                │
+│ show       Display the current config file with syntax highlighting.                   │
+│ edit       Open config.yaml in your default editor.                                    │
+│ validate   Validate config.yaml and check for common issues.                           │
+│ path       Show the resolved config file path and search locations.                    │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```
@@ -600,55 +595,50 @@ By default this command also writes `MATRIX_HOMESERVER`, `MATRIX_SERVER_NAME`, a
 
  Start local Synapse + MindRoom Cinny using Docker only.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --synapse-dir                             PATH              Directory        │
-│                                                             containing       │
-│                                                             Synapse          │
-│                                                             docker-compose.… │
-│                                                             (from            │
-│                                                             mindroom-stack   │
-│                                                             settings).       │
-│                                                             [default:        │
-│                                                             local/matrix]    │
-│ --homeserver-url                          TEXT              Homeserver URL   │
-│                                                             that Cinny and   │
-│                                                             MindRoom should  │
-│                                                             use.             │
-│                                                             [default:        │
-│                                                             http://localhos… │
-│ --server-name                             TEXT              Matrix server    │
-│                                                             name (default:   │
-│                                                             inferred from    │
-│                                                             --homeserver-url │
-│                                                             hostname).       │
-│ --cinny-port                              INTEGER RANGE     Local host port  │
-│                                           [1<=x<=65535]     for the MindRoom │
-│                                                             Cinny container. │
-│                                                             [default: 8080]  │
-│ --cinny-image                             TEXT              Docker image for │
-│                                                             MindRoom Cinny.  │
-│                                                             [default:        │
-│                                                             ghcr.io/mindroo… │
-│ --cinny-containe…                         TEXT              Container name   │
-│                                                             for MindRoom     │
-│                                                             Cinny.           │
-│                                                             [default:        │
-│                                                             mindroom-cinny-… │
-│ --skip-synapse                                              Skip starting    │
-│                                                             Synapse (assume  │
-│                                                             it is already    │
-│                                                             running).        │
-│ --persist-env          --no-persist-e…                      Persist Matrix   │
-│                                                             local dev        │
-│                                                             settings to .env │
-│                                                             next to          │
-│                                                             config.yaml.     │
-│                                                             [default:        │
-│                                                             persist-env]     │
-│ --help             -h                                       Show this        │
-│                                                             message and      │
-│                                                             exit.            │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --synapse-dir                                 PATH                 Directory           │
+│                                                                    containing Synapse  │
+│                                                                    docker-compose.yml  │
+│                                                                    (from               │
+│                                                                    mindroom-stack      │
+│                                                                    settings).          │
+│                                                                    [default:           │
+│                                                                    local/matrix]       │
+│ --homeserver-url                              TEXT                 Homeserver URL that │
+│                                                                    Cinny and MindRoom  │
+│                                                                    should use.         │
+│                                                                    [default:           │
+│                                                                    http://localhost:8… │
+│ --server-name                                 TEXT                 Matrix server name  │
+│                                                                    (default: inferred  │
+│                                                                    from                │
+│                                                                    --homeserver-url    │
+│                                                                    hostname).          │
+│ --cinny-port                                  INTEGER RANGE        Local host port for │
+│                                               [1<=x<=65535]        the MindRoom Cinny  │
+│                                                                    container.          │
+│                                                                    [default: 8080]     │
+│ --cinny-image                                 TEXT                 Docker image for    │
+│                                                                    MindRoom Cinny.     │
+│                                                                    [default:           │
+│                                                                    ghcr.io/mindroom-a… │
+│ --cinny-container-n…                          TEXT                 Container name for  │
+│                                                                    MindRoom Cinny.     │
+│                                                                    [default:           │
+│                                                                    mindroom-cinny-loc… │
+│ --skip-synapse                                                     Skip starting       │
+│                                                                    Synapse (assume it  │
+│                                                                    is already          │
+│                                                                    running).           │
+│ --persist-env             --no-persist-env                         Persist Matrix      │
+│                                                                    local dev settings  │
+│                                                                    to .env next to     │
+│                                                                    config.yaml.        │
+│                                                                    [default:           │
+│                                                                    persist-env]        │
+│ --help                -h                                           Show this message   │
+│                                                                    and exit.           │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 
 ```

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13989,24 +13989,23 @@ mindroom [OPTIONS] COMMAND [ARGS]...
  mindroom config init   Create a starter config
  mindroom run           Start the system
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --install-completion            Install completion for the current shell.    │
-│ --show-completion               Show completion for the current shell, to    │
-│                                 copy it or customize the installation.       │
-│ --help                -h        Show this message and exit.                  │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ version             Show the current version of Mindroom.                    │
-│ run                 Run the mindroom multi-agent system.                     │
-│ doctor              Check your environment for common issues.                │
-│ connect             Pair this local MindRoom install with the hosted         │
-│                     provisioning service.                                    │
-│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.  │
-│ config              Manage MindRoom configuration files.                     │
-│ avatars             Generate and sync managed avatar assets.                 │
-│ service             Install and manage MindRoom as a background user         │
-│                     service.                                                 │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --install-completion            Install completion for the current shell.              │
+│ --show-completion               Show completion for the current shell, to copy it or   │
+│                                 customize the installation.                            │
+│ --help                -h        Show this message and exit.                            │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ version             Show the current version of Mindroom.                              │
+│ run                 Run the mindroom multi-agent system.                               │
+│ doctor              Check your environment for common issues.                          │
+│ connect             Pair this local MindRoom install with the hosted provisioning      │
+│                     service.                                                           │
+│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.            │
+│ config              Manage MindRoom configuration files.                               │
+│ avatars             Generate and sync managed avatar assets.                           │
+│ service             Install and manage MindRoom as a background user service.          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## version
@@ -14018,9 +14017,9 @@ Show the current MindRoom version.
 
  Show the current version of Mindroom.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## run
@@ -14038,25 +14037,22 @@ Start MindRoom with your configuration.
  - Manages agent room memberships
  - Starts the bundled dashboard/API server (disable with --no-api)
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, │
-│                                          WARNING, ERROR)                     │
-│                                          [env var: LOG_LEVEL]                │
-│                                          [default: INFO]                     │
-│ --storage-path  -s              PATH     Base directory for persistent       │
-│                                          MindRoom data (state, sessions,     │
-│                                          tracking)                           │
-│ --api               --no-api             Start the bundled dashboard/API     │
-│                                          server alongside the bot            │
-│                                          [default: api]                      │
-│ --api-port                      INTEGER  Port for the bundled dashboard/API  │
-│                                          server                              │
-│                                          [default: 8765]                     │
-│ --api-host                      TEXT     Host for the bundled dashboard/API  │
-│                                          server                              │
-│                                          [default: 0.0.0.0]                  │
-│ --help          -h                       Show this message and exit.         │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, WARNING,  │
+│                                          ERROR)                                        │
+│                                          [env var: LOG_LEVEL]                          │
+│                                          [default: INFO]                               │
+│ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
+│                                          (state, sessions, tracking)                   │
+│ --api               --no-api             Start the bundled dashboard/API server        │
+│                                          alongside the bot                             │
+│                                          [default: api]                                │
+│ --api-port                      INTEGER  Port for the bundled dashboard/API server     │
+│                                          [default: 8765]                               │
+│ --api-host                      TEXT     Host for the bundled dashboard/API server     │
+│                                          [default: 0.0.0.0]                            │
+│ --help          -h                       Show this message and exit.                   │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars
@@ -14068,14 +14064,14 @@ Generate and sync managed avatar assets.
 
  Generate and sync managed avatar assets.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ generate   Generate missing managed avatar files in the workspace.           │
-│ sync       Sync configured room and root-space avatars to Matrix using the   │
-│            initialized router account.                                       │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ generate   Generate missing managed avatar files in the workspace.                     │
+│ sync       Sync configured room and root-space avatars to Matrix using the initialized │
+│            router account.                                                             │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars generate
@@ -14087,10 +14083,10 @@ Generate missing managed avatar files in the workspace. In a source checkout, ge
 
  Generate missing managed avatar files in the workspace.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --force            Overwrite existing managed workspace avatar files.        │
-│ --help   -h        Show this message and exit.                               │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --force            Overwrite existing managed workspace avatar files.                  │
+│ --help   -h        Show this message and exit.                                         │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars sync
@@ -14100,13 +14096,13 @@ Sync configured room and root-space avatars to Matrix using the initialized rout
 ```
  Usage: root avatars sync [OPTIONS]
 
- Sync configured room and root-space avatars to Matrix using the initialized
- router account.
+ Sync configured room and root-space avatars to Matrix using the initialized router
+ account.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --force            Replace existing Matrix room and root-space avatars.      │
-│ --help   -h        Show this message and exit.                               │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --force            Replace existing Matrix room and root-space avatars.                │
+│ --help   -h        Show this message and exit.                                         │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## service
@@ -14124,14 +14120,14 @@ Install and manage MindRoom as a background user service. MindRoom runs through 
  - macOS: launchd (`~/Library/LaunchAgents/`)
  - Linux: systemd user services (`~/.config/systemd/user/`)
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ install     Install and start MindRoom as a background user service.         │
-│ uninstall   Stop and remove the MindRoom user service.                       │
-│ status      Show MindRoom service status and recent logs.                    │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ install     Install and start MindRoom as a background user service.                   │
+│ uninstall   Stop and remove the MindRoom user service.                                 │
+│ status      Show MindRoom service status and recent logs.                              │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### service install
@@ -14143,11 +14139,11 @@ Install and start MindRoom as a background user service. Use `--no-confirm` for 
 
  Install and start MindRoom as a background user service.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --skip-deps             Skip uv dependency check.                            │
-│ --no-confirm  -y        Skip confirmation prompts.                           │
-│ --help        -h        Show this message and exit.                          │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --skip-deps             Skip uv dependency check.                                      │
+│ --no-confirm  -y        Skip confirmation prompts.                                     │
+│ --help        -h        Show this message and exit.                                    │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### service status
@@ -14159,12 +14155,11 @@ Show MindRoom service status and recent logs.
 
  Show MindRoom service status and recent logs.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --logs  -l      INTEGER  Number of recent log lines to show. Use 0 to hide   │
-│                          logs.                                               │
-│                          [default: 10]                                       │
-│ --help  -h               Show this message and exit.                         │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --logs  -l      INTEGER  Number of recent log lines to show. Use 0 to hide logs.       │
+│                          [default: 10]                                                 │
+│ --help  -h               Show this message and exit.                                   │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### service uninstall
@@ -14176,10 +14171,10 @@ Stop and remove the MindRoom user service. On macOS, log files are preserved und
 
  Stop and remove the MindRoom user service.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --no-confirm  -y        Skip confirmation prompts.                           │
-│ --help        -h        Show this message and exit.                          │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --no-confirm  -y        Skip confirmation prompts.                                     │
+│ --help        -h        Show this message and exit.                                    │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## doctor
@@ -14202,9 +14197,9 @@ Runs a series of checks in one pass:
  Runs connectivity, configuration, and credential checks in a single pass
  so you can fix everything before running `mindroom run`.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## config
@@ -14216,16 +14211,16 @@ Manage MindRoom configuration files. The `config` subgroup contains commands for
 
  Manage MindRoom configuration files.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ init       Create a starter config.yaml with example agents and models.      │
-│ show       Display the current config file with syntax highlighting.         │
-│ edit       Open config.yaml in your default editor.                          │
-│ validate   Validate config.yaml and check for common issues.                 │
-│ path       Show the resolved config file path and search locations.          │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ init       Create a starter config.yaml with example agents and models.                │
+│ show       Display the current config file with syntax highlighting.                   │
+│ edit       Open config.yaml in your default editor.                                    │
+│ validate   Validate config.yaml and check for common issues.                           │
+│ path       Show the resolved config file path and search locations.                    │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### config init
@@ -14344,55 +14339,50 @@ By default this command also writes `MATRIX_HOMESERVER`, `MATRIX_SERVER_NAME`, a
 
  Start local Synapse + MindRoom Cinny using Docker only.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --synapse-dir                             PATH              Directory        │
-│                                                             containing       │
-│                                                             Synapse          │
-│                                                             docker-compose.… │
-│                                                             (from            │
-│                                                             mindroom-stack   │
-│                                                             settings).       │
-│                                                             [default:        │
-│                                                             local/matrix]    │
-│ --homeserver-url                          TEXT              Homeserver URL   │
-│                                                             that Cinny and   │
-│                                                             MindRoom should  │
-│                                                             use.             │
-│                                                             [default:        │
-│                                                             http://localhos… │
-│ --server-name                             TEXT              Matrix server    │
-│                                                             name (default:   │
-│                                                             inferred from    │
-│                                                             --homeserver-url │
-│                                                             hostname).       │
-│ --cinny-port                              INTEGER RANGE     Local host port  │
-│                                           [1<=x<=65535]     for the MindRoom │
-│                                                             Cinny container. │
-│                                                             [default: 8080]  │
-│ --cinny-image                             TEXT              Docker image for │
-│                                                             MindRoom Cinny.  │
-│                                                             [default:        │
-│                                                             ghcr.io/mindroo… │
-│ --cinny-containe…                         TEXT              Container name   │
-│                                                             for MindRoom     │
-│                                                             Cinny.           │
-│                                                             [default:        │
-│                                                             mindroom-cinny-… │
-│ --skip-synapse                                              Skip starting    │
-│                                                             Synapse (assume  │
-│                                                             it is already    │
-│                                                             running).        │
-│ --persist-env          --no-persist-e…                      Persist Matrix   │
-│                                                             local dev        │
-│                                                             settings to .env │
-│                                                             next to          │
-│                                                             config.yaml.     │
-│                                                             [default:        │
-│                                                             persist-env]     │
-│ --help             -h                                       Show this        │
-│                                                             message and      │
-│                                                             exit.            │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --synapse-dir                                 PATH                 Directory           │
+│                                                                    containing Synapse  │
+│                                                                    docker-compose.yml  │
+│                                                                    (from               │
+│                                                                    mindroom-stack      │
+│                                                                    settings).          │
+│                                                                    [default:           │
+│                                                                    local/matrix]       │
+│ --homeserver-url                              TEXT                 Homeserver URL that │
+│                                                                    Cinny and MindRoom  │
+│                                                                    should use.         │
+│                                                                    [default:           │
+│                                                                    http://localhost:8… │
+│ --server-name                                 TEXT                 Matrix server name  │
+│                                                                    (default: inferred  │
+│                                                                    from                │
+│                                                                    --homeserver-url    │
+│                                                                    hostname).          │
+│ --cinny-port                                  INTEGER RANGE        Local host port for │
+│                                               [1<=x<=65535]        the MindRoom Cinny  │
+│                                                                    container.          │
+│                                                                    [default: 8080]     │
+│ --cinny-image                                 TEXT                 Docker image for    │
+│                                                                    MindRoom Cinny.     │
+│                                                                    [default:           │
+│                                                                    ghcr.io/mindroom-a… │
+│ --cinny-container-n…                          TEXT                 Container name for  │
+│                                                                    MindRoom Cinny.     │
+│                                                                    [default:           │
+│                                                                    mindroom-cinny-loc… │
+│ --skip-synapse                                                     Skip starting       │
+│                                                                    Synapse (assume it  │
+│                                                                    is already          │
+│                                                                    running).           │
+│ --persist-env             --no-persist-env                         Persist Matrix      │
+│                                                                    local dev settings  │
+│                                                                    to .env next to     │
+│                                                                    config.yaml.        │
+│                                                                    [default:           │
+│                                                                    persist-env]        │
+│ --help                -h                                           Show this message   │
+│                                                                    and exit.           │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## Examples

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13989,22 +13989,24 @@ mindroom [OPTIONS] COMMAND [ARGS]...
  mindroom config init   Create a starter config
  mindroom run           Start the system
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --install-completion            Install completion for the current shell.              │
-│ --show-completion               Show completion for the current shell, to copy it or   │
-│                                 customize the installation.                            │
-│ --help                -h        Show this message and exit.                            │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ version             Show the current version of Mindroom.                              │
-│ run                 Run the mindroom multi-agent system.                               │
-│ doctor              Check your environment for common issues.                          │
-│ connect             Pair this local MindRoom install with the hosted provisioning      │
-│                     service.                                                           │
-│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.            │
-│ config              Manage MindRoom configuration files.                               │
-│ avatars             Generate and sync managed avatar assets.                           │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --install-completion            Install completion for the current shell.    │
+│ --show-completion               Show completion for the current shell, to    │
+│                                 copy it or customize the installation.       │
+│ --help                -h        Show this message and exit.                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ version             Show the current version of Mindroom.                    │
+│ run                 Run the mindroom multi-agent system.                     │
+│ doctor              Check your environment for common issues.                │
+│ connect             Pair this local MindRoom install with the hosted         │
+│                     provisioning service.                                    │
+│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.  │
+│ config              Manage MindRoom configuration files.                     │
+│ avatars             Generate and sync managed avatar assets.                 │
+│ service             Install and manage MindRoom as a background user         │
+│                     service.                                                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## version
@@ -14016,9 +14018,9 @@ Show the current MindRoom version.
 
  Show the current version of Mindroom.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## run
@@ -14036,22 +14038,25 @@ Start MindRoom with your configuration.
  - Manages agent room memberships
  - Starts the bundled dashboard/API server (disable with --no-api)
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, WARNING,  │
-│                                          ERROR)                                        │
-│                                          [env var: LOG_LEVEL]                          │
-│                                          [default: INFO]                               │
-│ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
-│                                          (state, sessions, tracking)                   │
-│ --api               --no-api             Start the bundled dashboard/API server        │
-│                                          alongside the bot                             │
-│                                          [default: api]                                │
-│ --api-port                      INTEGER  Port for the bundled dashboard/API server     │
-│                                          [default: 8765]                               │
-│ --api-host                      TEXT     Host for the bundled dashboard/API server     │
-│                                          [default: 0.0.0.0]                            │
-│ --help          -h                       Show this message and exit.                   │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, │
+│                                          WARNING, ERROR)                     │
+│                                          [env var: LOG_LEVEL]                │
+│                                          [default: INFO]                     │
+│ --storage-path  -s              PATH     Base directory for persistent       │
+│                                          MindRoom data (state, sessions,     │
+│                                          tracking)                           │
+│ --api               --no-api             Start the bundled dashboard/API     │
+│                                          server alongside the bot            │
+│                                          [default: api]                      │
+│ --api-port                      INTEGER  Port for the bundled dashboard/API  │
+│                                          server                              │
+│                                          [default: 8765]                     │
+│ --api-host                      TEXT     Host for the bundled dashboard/API  │
+│                                          server                              │
+│                                          [default: 0.0.0.0]                  │
+│ --help          -h                       Show this message and exit.         │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars
@@ -14063,14 +14068,14 @@ Generate and sync managed avatar assets.
 
  Generate and sync managed avatar assets.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ generate   Generate missing managed avatar files in the workspace.                     │
-│ sync       Sync configured room and root-space avatars to Matrix using the initialized │
-│            router account.                                                             │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ generate   Generate missing managed avatar files in the workspace.           │
+│ sync       Sync configured room and root-space avatars to Matrix using the   │
+│            initialized router account.                                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars generate
@@ -14082,10 +14087,10 @@ Generate missing managed avatar files in the workspace. In a source checkout, ge
 
  Generate missing managed avatar files in the workspace.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --force            Overwrite existing managed workspace avatar files.                  │
-│ --help   -h        Show this message and exit.                                         │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --force            Overwrite existing managed workspace avatar files.        │
+│ --help   -h        Show this message and exit.                               │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars sync
@@ -14095,13 +14100,86 @@ Sync configured room and root-space avatars to Matrix using the initialized rout
 ```
  Usage: root avatars sync [OPTIONS]
 
- Sync configured room and root-space avatars to Matrix using the initialized router
- account.
+ Sync configured room and root-space avatars to Matrix using the initialized
+ router account.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --force            Replace existing Matrix room and root-space avatars.                │
-│ --help   -h        Show this message and exit.                                         │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --force            Replace existing Matrix room and root-space avatars.      │
+│ --help   -h        Show this message and exit.                               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+## service
+
+Install and manage MindRoom as a background user service. MindRoom runs through `uv tool run` and starts automatically at login. On macOS, MindRoom uses launchd user agents. On Linux, MindRoom uses systemd user services.
+
+```
+ Usage: root service [OPTIONS] COMMAND [ARGS]...
+
+ Install and manage MindRoom as a background user service.
+
+ MindRoom runs through `uv tool run` and starts automatically at login.
+
+ Supported platforms:
+ - macOS: launchd (`~/Library/LaunchAgents/`)
+ - Linux: systemd user services (`~/.config/systemd/user/`)
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ install     Install and start MindRoom as a background user service.         │
+│ uninstall   Stop and remove the MindRoom user service.                       │
+│ status      Show MindRoom service status and recent logs.                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+### service install
+
+Install and start MindRoom as a background user service. Use `--no-confirm` for non-interactive setup.
+
+```
+ Usage: root service install [OPTIONS]
+
+ Install and start MindRoom as a background user service.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --skip-deps             Skip uv dependency check.                            │
+│ --no-confirm  -y        Skip confirmation prompts.                           │
+│ --help        -h        Show this message and exit.                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+### service status
+
+Show MindRoom service status and recent logs.
+
+```
+ Usage: root service status [OPTIONS]
+
+ Show MindRoom service status and recent logs.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --logs  -l      INTEGER  Number of recent log lines to show. Use 0 to hide   │
+│                          logs.                                               │
+│                          [default: 10]                                       │
+│ --help  -h               Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+### service uninstall
+
+Stop and remove the MindRoom user service. On macOS, log files are preserved under `~/Library/Logs/mindroom/`.
+
+```
+ Usage: root service uninstall [OPTIONS]
+
+ Stop and remove the MindRoom user service.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --no-confirm  -y        Skip confirmation prompts.                           │
+│ --help        -h        Show this message and exit.                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## doctor
@@ -14124,9 +14202,9 @@ Runs a series of checks in one pass:
  Runs connectivity, configuration, and credential checks in a single pass
  so you can fix everything before running `mindroom run`.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## config
@@ -14138,16 +14216,16 @@ Manage MindRoom configuration files. The `config` subgroup contains commands for
 
  Manage MindRoom configuration files.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ init       Create a starter config.yaml with example agents and models.                │
-│ show       Display the current config file with syntax highlighting.                   │
-│ edit       Open config.yaml in your default editor.                                    │
-│ validate   Validate config.yaml and check for common issues.                           │
-│ path       Show the resolved config file path and search locations.                    │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ init       Create a starter config.yaml with example agents and models.      │
+│ show       Display the current config file with syntax highlighting.         │
+│ edit       Open config.yaml in your default editor.                          │
+│ validate   Validate config.yaml and check for common issues.                 │
+│ path       Show the resolved config file path and search locations.          │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### config init
@@ -14266,50 +14344,55 @@ By default this command also writes `MATRIX_HOMESERVER`, `MATRIX_SERVER_NAME`, a
 
  Start local Synapse + MindRoom Cinny using Docker only.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --synapse-dir                                 PATH                 Directory           │
-│                                                                    containing Synapse  │
-│                                                                    docker-compose.yml  │
-│                                                                    (from               │
-│                                                                    mindroom-stack      │
-│                                                                    settings).          │
-│                                                                    [default:           │
-│                                                                    local/matrix]       │
-│ --homeserver-url                              TEXT                 Homeserver URL that │
-│                                                                    Cinny and MindRoom  │
-│                                                                    should use.         │
-│                                                                    [default:           │
-│                                                                    http://localhost:8… │
-│ --server-name                                 TEXT                 Matrix server name  │
-│                                                                    (default: inferred  │
-│                                                                    from                │
-│                                                                    --homeserver-url    │
-│                                                                    hostname).          │
-│ --cinny-port                                  INTEGER RANGE        Local host port for │
-│                                               [1<=x<=65535]        the MindRoom Cinny  │
-│                                                                    container.          │
-│                                                                    [default: 8080]     │
-│ --cinny-image                                 TEXT                 Docker image for    │
-│                                                                    MindRoom Cinny.     │
-│                                                                    [default:           │
-│                                                                    ghcr.io/mindroom-a… │
-│ --cinny-container-n…                          TEXT                 Container name for  │
-│                                                                    MindRoom Cinny.     │
-│                                                                    [default:           │
-│                                                                    mindroom-cinny-loc… │
-│ --skip-synapse                                                     Skip starting       │
-│                                                                    Synapse (assume it  │
-│                                                                    is already          │
-│                                                                    running).           │
-│ --persist-env             --no-persist-env                         Persist Matrix      │
-│                                                                    local dev settings  │
-│                                                                    to .env next to     │
-│                                                                    config.yaml.        │
-│                                                                    [default:           │
-│                                                                    persist-env]        │
-│ --help                -h                                           Show this message   │
-│                                                                    and exit.           │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --synapse-dir                             PATH              Directory        │
+│                                                             containing       │
+│                                                             Synapse          │
+│                                                             docker-compose.… │
+│                                                             (from            │
+│                                                             mindroom-stack   │
+│                                                             settings).       │
+│                                                             [default:        │
+│                                                             local/matrix]    │
+│ --homeserver-url                          TEXT              Homeserver URL   │
+│                                                             that Cinny and   │
+│                                                             MindRoom should  │
+│                                                             use.             │
+│                                                             [default:        │
+│                                                             http://localhos… │
+│ --server-name                             TEXT              Matrix server    │
+│                                                             name (default:   │
+│                                                             inferred from    │
+│                                                             --homeserver-url │
+│                                                             hostname).       │
+│ --cinny-port                              INTEGER RANGE     Local host port  │
+│                                           [1<=x<=65535]     for the MindRoom │
+│                                                             Cinny container. │
+│                                                             [default: 8080]  │
+│ --cinny-image                             TEXT              Docker image for │
+│                                                             MindRoom Cinny.  │
+│                                                             [default:        │
+│                                                             ghcr.io/mindroo… │
+│ --cinny-containe…                         TEXT              Container name   │
+│                                                             for MindRoom     │
+│                                                             Cinny.           │
+│                                                             [default:        │
+│                                                             mindroom-cinny-… │
+│ --skip-synapse                                              Skip starting    │
+│                                                             Synapse (assume  │
+│                                                             it is already    │
+│                                                             running).        │
+│ --persist-env          --no-persist-e…                      Persist Matrix   │
+│                                                             local dev        │
+│                                                             settings to .env │
+│                                                             next to          │
+│                                                             config.yaml.     │
+│                                                             [default:        │
+│                                                             persist-env]     │
+│ --help             -h                                       Show this        │
+│                                                             message and      │
+│                                                             exit.            │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## Examples

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -19,24 +19,23 @@ mindroom [OPTIONS] COMMAND [ARGS]...
  mindroom config init   Create a starter config
  mindroom run           Start the system
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --install-completion            Install completion for the current shell.    │
-│ --show-completion               Show completion for the current shell, to    │
-│                                 copy it or customize the installation.       │
-│ --help                -h        Show this message and exit.                  │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ version             Show the current version of Mindroom.                    │
-│ run                 Run the mindroom multi-agent system.                     │
-│ doctor              Check your environment for common issues.                │
-│ connect             Pair this local MindRoom install with the hosted         │
-│                     provisioning service.                                    │
-│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.  │
-│ config              Manage MindRoom configuration files.                     │
-│ avatars             Generate and sync managed avatar assets.                 │
-│ service             Install and manage MindRoom as a background user         │
-│                     service.                                                 │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --install-completion            Install completion for the current shell.              │
+│ --show-completion               Show completion for the current shell, to copy it or   │
+│                                 customize the installation.                            │
+│ --help                -h        Show this message and exit.                            │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ version             Show the current version of Mindroom.                              │
+│ run                 Run the mindroom multi-agent system.                               │
+│ doctor              Check your environment for common issues.                          │
+│ connect             Pair this local MindRoom install with the hosted provisioning      │
+│                     service.                                                           │
+│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.            │
+│ config              Manage MindRoom configuration files.                               │
+│ avatars             Generate and sync managed avatar assets.                           │
+│ service             Install and manage MindRoom as a background user service.          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## version
@@ -48,9 +47,9 @@ Show the current MindRoom version.
 
  Show the current version of Mindroom.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## run
@@ -68,25 +67,22 @@ Start MindRoom with your configuration.
  - Manages agent room memberships
  - Starts the bundled dashboard/API server (disable with --no-api)
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, │
-│                                          WARNING, ERROR)                     │
-│                                          [env var: LOG_LEVEL]                │
-│                                          [default: INFO]                     │
-│ --storage-path  -s              PATH     Base directory for persistent       │
-│                                          MindRoom data (state, sessions,     │
-│                                          tracking)                           │
-│ --api               --no-api             Start the bundled dashboard/API     │
-│                                          server alongside the bot            │
-│                                          [default: api]                      │
-│ --api-port                      INTEGER  Port for the bundled dashboard/API  │
-│                                          server                              │
-│                                          [default: 8765]                     │
-│ --api-host                      TEXT     Host for the bundled dashboard/API  │
-│                                          server                              │
-│                                          [default: 0.0.0.0]                  │
-│ --help          -h                       Show this message and exit.         │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, WARNING,  │
+│                                          ERROR)                                        │
+│                                          [env var: LOG_LEVEL]                          │
+│                                          [default: INFO]                               │
+│ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
+│                                          (state, sessions, tracking)                   │
+│ --api               --no-api             Start the bundled dashboard/API server        │
+│                                          alongside the bot                             │
+│                                          [default: api]                                │
+│ --api-port                      INTEGER  Port for the bundled dashboard/API server     │
+│                                          [default: 8765]                               │
+│ --api-host                      TEXT     Host for the bundled dashboard/API server     │
+│                                          [default: 0.0.0.0]                            │
+│ --help          -h                       Show this message and exit.                   │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars
@@ -98,14 +94,14 @@ Generate and sync managed avatar assets.
 
  Generate and sync managed avatar assets.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ generate   Generate missing managed avatar files in the workspace.           │
-│ sync       Sync configured room and root-space avatars to Matrix using the   │
-│            initialized router account.                                       │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ generate   Generate missing managed avatar files in the workspace.                     │
+│ sync       Sync configured room and root-space avatars to Matrix using the initialized │
+│            router account.                                                             │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars generate
@@ -121,10 +117,10 @@ Use `--force` to overwrite them after changing avatar prompts or styles.
 
  Generate missing managed avatar files in the workspace.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --force            Overwrite existing managed workspace avatar files.        │
-│ --help   -h        Show this message and exit.                               │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --force            Overwrite existing managed workspace avatar files.                  │
+│ --help   -h        Show this message and exit.                                         │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars sync
@@ -136,13 +132,13 @@ Use `--force` to replace them.
 ```
  Usage: root avatars sync [OPTIONS]
 
- Sync configured room and root-space avatars to Matrix using the initialized
- router account.
+ Sync configured room and root-space avatars to Matrix using the initialized router
+ account.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --force            Replace existing Matrix room and root-space avatars.      │
-│ --help   -h        Show this message and exit.                               │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --force            Replace existing Matrix room and root-space avatars.                │
+│ --help   -h        Show this message and exit.                                         │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## service
@@ -163,14 +159,14 @@ On Linux, MindRoom uses systemd user services.
  - macOS: launchd (`~/Library/LaunchAgents/`)
  - Linux: systemd user services (`~/.config/systemd/user/`)
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ install     Install and start MindRoom as a background user service.         │
-│ uninstall   Stop and remove the MindRoom user service.                       │
-│ status      Show MindRoom service status and recent logs.                    │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ install     Install and start MindRoom as a background user service.                   │
+│ uninstall   Stop and remove the MindRoom user service.                                 │
+│ status      Show MindRoom service status and recent logs.                              │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### service install
@@ -183,11 +179,11 @@ Use `--no-confirm` for non-interactive setup.
 
  Install and start MindRoom as a background user service.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --skip-deps             Skip uv dependency check.                            │
-│ --no-confirm  -y        Skip confirmation prompts.                           │
-│ --help        -h        Show this message and exit.                          │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --skip-deps             Skip uv dependency check.                                      │
+│ --no-confirm  -y        Skip confirmation prompts.                                     │
+│ --help        -h        Show this message and exit.                                    │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### service status
@@ -199,12 +195,11 @@ Show MindRoom service status and recent logs.
 
  Show MindRoom service status and recent logs.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --logs  -l      INTEGER  Number of recent log lines to show. Use 0 to hide   │
-│                          logs.                                               │
-│                          [default: 10]                                       │
-│ --help  -h               Show this message and exit.                         │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --logs  -l      INTEGER  Number of recent log lines to show. Use 0 to hide logs.       │
+│                          [default: 10]                                                 │
+│ --help  -h               Show this message and exit.                                   │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### service uninstall
@@ -217,10 +212,10 @@ On macOS, log files are preserved under `~/Library/Logs/mindroom/`.
 
  Stop and remove the MindRoom user service.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --no-confirm  -y        Skip confirmation prompts.                           │
-│ --help        -h        Show this message and exit.                          │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --no-confirm  -y        Skip confirmation prompts.                                     │
+│ --help        -h        Show this message and exit.                                    │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## doctor
@@ -243,9 +238,9 @@ Runs a series of checks in one pass:
  Runs connectivity, configuration, and credential checks in a single pass
  so you can fix everything before running `mindroom run`.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## config
@@ -258,16 +253,16 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 
  Manage MindRoom configuration files.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ init       Create a starter config.yaml with example agents and models.      │
-│ show       Display the current config file with syntax highlighting.         │
-│ edit       Open config.yaml in your default editor.                          │
-│ validate   Validate config.yaml and check for common issues.                 │
-│ path       Show the resolved config file path and search locations.          │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                          │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ init       Create a starter config.yaml with example agents and models.                │
+│ show       Display the current config file with syntax highlighting.                   │
+│ edit       Open config.yaml in your default editor.                                    │
+│ validate   Validate config.yaml and check for common issues.                           │
+│ path       Show the resolved config file path and search locations.                    │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### config init
@@ -392,55 +387,50 @@ By default this command also writes `MATRIX_HOMESERVER`, `MATRIX_SERVER_NAME`, a
 
  Start local Synapse + MindRoom Cinny using Docker only.
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --synapse-dir                             PATH              Directory        │
-│                                                             containing       │
-│                                                             Synapse          │
-│                                                             docker-compose.… │
-│                                                             (from            │
-│                                                             mindroom-stack   │
-│                                                             settings).       │
-│                                                             [default:        │
-│                                                             local/matrix]    │
-│ --homeserver-url                          TEXT              Homeserver URL   │
-│                                                             that Cinny and   │
-│                                                             MindRoom should  │
-│                                                             use.             │
-│                                                             [default:        │
-│                                                             http://localhos… │
-│ --server-name                             TEXT              Matrix server    │
-│                                                             name (default:   │
-│                                                             inferred from    │
-│                                                             --homeserver-url │
-│                                                             hostname).       │
-│ --cinny-port                              INTEGER RANGE     Local host port  │
-│                                           [1<=x<=65535]     for the MindRoom │
-│                                                             Cinny container. │
-│                                                             [default: 8080]  │
-│ --cinny-image                             TEXT              Docker image for │
-│                                                             MindRoom Cinny.  │
-│                                                             [default:        │
-│                                                             ghcr.io/mindroo… │
-│ --cinny-containe…                         TEXT              Container name   │
-│                                                             for MindRoom     │
-│                                                             Cinny.           │
-│                                                             [default:        │
-│                                                             mindroom-cinny-… │
-│ --skip-synapse                                              Skip starting    │
-│                                                             Synapse (assume  │
-│                                                             it is already    │
-│                                                             running).        │
-│ --persist-env          --no-persist-e…                      Persist Matrix   │
-│                                                             local dev        │
-│                                                             settings to .env │
-│                                                             next to          │
-│                                                             config.yaml.     │
-│                                                             [default:        │
-│                                                             persist-env]     │
-│ --help             -h                                       Show this        │
-│                                                             message and      │
-│                                                             exit.            │
-╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
+│ --synapse-dir                                 PATH                 Directory           │
+│                                                                    containing Synapse  │
+│                                                                    docker-compose.yml  │
+│                                                                    (from               │
+│                                                                    mindroom-stack      │
+│                                                                    settings).          │
+│                                                                    [default:           │
+│                                                                    local/matrix]       │
+│ --homeserver-url                              TEXT                 Homeserver URL that │
+│                                                                    Cinny and MindRoom  │
+│                                                                    should use.         │
+│                                                                    [default:           │
+│                                                                    http://localhost:8… │
+│ --server-name                                 TEXT                 Matrix server name  │
+│                                                                    (default: inferred  │
+│                                                                    from                │
+│                                                                    --homeserver-url    │
+│                                                                    hostname).          │
+│ --cinny-port                                  INTEGER RANGE        Local host port for │
+│                                               [1<=x<=65535]        the MindRoom Cinny  │
+│                                                                    container.          │
+│                                                                    [default: 8080]     │
+│ --cinny-image                                 TEXT                 Docker image for    │
+│                                                                    MindRoom Cinny.     │
+│                                                                    [default:           │
+│                                                                    ghcr.io/mindroom-a… │
+│ --cinny-container-n…                          TEXT                 Container name for  │
+│                                                                    MindRoom Cinny.     │
+│                                                                    [default:           │
+│                                                                    mindroom-cinny-loc… │
+│ --skip-synapse                                                     Skip starting       │
+│                                                                    Synapse (assume it  │
+│                                                                    is already          │
+│                                                                    running).           │
+│ --persist-env             --no-persist-env                         Persist Matrix      │
+│                                                                    local dev settings  │
+│                                                                    to .env next to     │
+│                                                                    config.yaml.        │
+│                                                                    [default:           │
+│                                                                    persist-env]        │
+│ --help                -h                                           Show this message   │
+│                                                                    and exit.           │
+╰────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## Examples

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -19,22 +19,24 @@ mindroom [OPTIONS] COMMAND [ARGS]...
  mindroom config init   Create a starter config
  mindroom run           Start the system
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --install-completion            Install completion for the current shell.              │
-│ --show-completion               Show completion for the current shell, to copy it or   │
-│                                 customize the installation.                            │
-│ --help                -h        Show this message and exit.                            │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ version             Show the current version of Mindroom.                              │
-│ run                 Run the mindroom multi-agent system.                               │
-│ doctor              Check your environment for common issues.                          │
-│ connect             Pair this local MindRoom install with the hosted provisioning      │
-│                     service.                                                           │
-│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.            │
-│ config              Manage MindRoom configuration files.                               │
-│ avatars             Generate and sync managed avatar assets.                           │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --install-completion            Install completion for the current shell.    │
+│ --show-completion               Show completion for the current shell, to    │
+│                                 copy it or customize the installation.       │
+│ --help                -h        Show this message and exit.                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ version             Show the current version of Mindroom.                    │
+│ run                 Run the mindroom multi-agent system.                     │
+│ doctor              Check your environment for common issues.                │
+│ connect             Pair this local MindRoom install with the hosted         │
+│                     provisioning service.                                    │
+│ local-stack-setup   Start local Synapse + MindRoom Cinny using Docker only.  │
+│ config              Manage MindRoom configuration files.                     │
+│ avatars             Generate and sync managed avatar assets.                 │
+│ service             Install and manage MindRoom as a background user         │
+│                     service.                                                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## version
@@ -46,9 +48,9 @@ Show the current MindRoom version.
 
  Show the current version of Mindroom.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## run
@@ -66,22 +68,25 @@ Start MindRoom with your configuration.
  - Manages agent room memberships
  - Starts the bundled dashboard/API server (disable with --no-api)
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, WARNING,  │
-│                                          ERROR)                                        │
-│                                          [env var: LOG_LEVEL]                          │
-│                                          [default: INFO]                               │
-│ --storage-path  -s              PATH     Base directory for persistent MindRoom data   │
-│                                          (state, sessions, tracking)                   │
-│ --api               --no-api             Start the bundled dashboard/API server        │
-│                                          alongside the bot                             │
-│                                          [default: api]                                │
-│ --api-port                      INTEGER  Port for the bundled dashboard/API server     │
-│                                          [default: 8765]                               │
-│ --api-host                      TEXT     Host for the bundled dashboard/API server     │
-│                                          [default: 0.0.0.0]                            │
-│ --help          -h                       Show this message and exit.                   │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --log-level     -l              TEXT     Set the logging level (DEBUG, INFO, │
+│                                          WARNING, ERROR)                     │
+│                                          [env var: LOG_LEVEL]                │
+│                                          [default: INFO]                     │
+│ --storage-path  -s              PATH     Base directory for persistent       │
+│                                          MindRoom data (state, sessions,     │
+│                                          tracking)                           │
+│ --api               --no-api             Start the bundled dashboard/API     │
+│                                          server alongside the bot            │
+│                                          [default: api]                      │
+│ --api-port                      INTEGER  Port for the bundled dashboard/API  │
+│                                          server                              │
+│                                          [default: 8765]                     │
+│ --api-host                      TEXT     Host for the bundled dashboard/API  │
+│                                          server                              │
+│                                          [default: 0.0.0.0]                  │
+│ --help          -h                       Show this message and exit.         │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars
@@ -93,14 +98,14 @@ Generate and sync managed avatar assets.
 
  Generate and sync managed avatar assets.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ generate   Generate missing managed avatar files in the workspace.                     │
-│ sync       Sync configured room and root-space avatars to Matrix using the initialized │
-│            router account.                                                             │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ generate   Generate missing managed avatar files in the workspace.           │
+│ sync       Sync configured room and root-space avatars to Matrix using the   │
+│            initialized router account.                                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars generate
@@ -116,10 +121,10 @@ Use `--force` to overwrite them after changing avatar prompts or styles.
 
  Generate missing managed avatar files in the workspace.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --force            Overwrite existing managed workspace avatar files.                  │
-│ --help   -h        Show this message and exit.                                         │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --force            Overwrite existing managed workspace avatar files.        │
+│ --help   -h        Show this message and exit.                               │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## avatars sync
@@ -131,13 +136,91 @@ Use `--force` to replace them.
 ```
  Usage: root avatars sync [OPTIONS]
 
- Sync configured room and root-space avatars to Matrix using the initialized router
- account.
+ Sync configured room and root-space avatars to Matrix using the initialized
+ router account.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --force            Replace existing Matrix room and root-space avatars.                │
-│ --help   -h        Show this message and exit.                                         │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --force            Replace existing Matrix room and root-space avatars.      │
+│ --help   -h        Show this message and exit.                               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+## service
+
+Install and manage MindRoom as a background user service.
+MindRoom runs through `uv tool run` and starts automatically at login.
+On macOS, MindRoom uses launchd user agents.
+On Linux, MindRoom uses systemd user services.
+
+```
+ Usage: root service [OPTIONS] COMMAND [ARGS]...
+
+ Install and manage MindRoom as a background user service.
+
+ MindRoom runs through `uv tool run` and starts automatically at login.
+
+ Supported platforms:
+ - macOS: launchd (`~/Library/LaunchAgents/`)
+ - Linux: systemd user services (`~/.config/systemd/user/`)
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ install     Install and start MindRoom as a background user service.         │
+│ uninstall   Stop and remove the MindRoom user service.                       │
+│ status      Show MindRoom service status and recent logs.                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+### service install
+
+Install and start MindRoom as a background user service.
+Use `--no-confirm` for non-interactive setup.
+
+```
+ Usage: root service install [OPTIONS]
+
+ Install and start MindRoom as a background user service.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --skip-deps             Skip uv dependency check.                            │
+│ --no-confirm  -y        Skip confirmation prompts.                           │
+│ --help        -h        Show this message and exit.                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+### service status
+
+Show MindRoom service status and recent logs.
+
+```
+ Usage: root service status [OPTIONS]
+
+ Show MindRoom service status and recent logs.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --logs  -l      INTEGER  Number of recent log lines to show. Use 0 to hide   │
+│                          logs.                                               │
+│                          [default: 10]                                       │
+│ --help  -h               Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+### service uninstall
+
+Stop and remove the MindRoom user service.
+On macOS, log files are preserved under `~/Library/Logs/mindroom/`.
+
+```
+ Usage: root service uninstall [OPTIONS]
+
+ Stop and remove the MindRoom user service.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --no-confirm  -y        Skip confirmation prompts.                           │
+│ --help        -h        Show this message and exit.                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## doctor
@@ -160,9 +243,9 @@ Runs a series of checks in one pass:
  Runs connectivity, configuration, and credential checks in a single pass
  so you can fix everything before running `mindroom run`.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## config
@@ -175,16 +258,16 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 
  Manage MindRoom configuration files.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --help  -h        Show this message and exit.                                          │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
-│ init       Create a starter config.yaml with example agents and models.                │
-│ show       Display the current config file with syntax highlighting.                   │
-│ edit       Open config.yaml in your default editor.                                    │
-│ validate   Validate config.yaml and check for common issues.                           │
-│ path       Show the resolved config file path and search locations.                    │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ init       Create a starter config.yaml with example agents and models.      │
+│ show       Display the current config file with syntax highlighting.         │
+│ edit       Open config.yaml in your default editor.                          │
+│ validate   Validate config.yaml and check for common issues.                 │
+│ path       Show the resolved config file path and search locations.          │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### config init
@@ -309,50 +392,55 @@ By default this command also writes `MATRIX_HOMESERVER`, `MATRIX_SERVER_NAME`, a
 
  Start local Synapse + MindRoom Cinny using Docker only.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --synapse-dir                                 PATH                 Directory           │
-│                                                                    containing Synapse  │
-│                                                                    docker-compose.yml  │
-│                                                                    (from               │
-│                                                                    mindroom-stack      │
-│                                                                    settings).          │
-│                                                                    [default:           │
-│                                                                    local/matrix]       │
-│ --homeserver-url                              TEXT                 Homeserver URL that │
-│                                                                    Cinny and MindRoom  │
-│                                                                    should use.         │
-│                                                                    [default:           │
-│                                                                    http://localhost:8… │
-│ --server-name                                 TEXT                 Matrix server name  │
-│                                                                    (default: inferred  │
-│                                                                    from                │
-│                                                                    --homeserver-url    │
-│                                                                    hostname).          │
-│ --cinny-port                                  INTEGER RANGE        Local host port for │
-│                                               [1<=x<=65535]        the MindRoom Cinny  │
-│                                                                    container.          │
-│                                                                    [default: 8080]     │
-│ --cinny-image                                 TEXT                 Docker image for    │
-│                                                                    MindRoom Cinny.     │
-│                                                                    [default:           │
-│                                                                    ghcr.io/mindroom-a… │
-│ --cinny-container-n…                          TEXT                 Container name for  │
-│                                                                    MindRoom Cinny.     │
-│                                                                    [default:           │
-│                                                                    mindroom-cinny-loc… │
-│ --skip-synapse                                                     Skip starting       │
-│                                                                    Synapse (assume it  │
-│                                                                    is already          │
-│                                                                    running).           │
-│ --persist-env             --no-persist-env                         Persist Matrix      │
-│                                                                    local dev settings  │
-│                                                                    to .env next to     │
-│                                                                    config.yaml.        │
-│                                                                    [default:           │
-│                                                                    persist-env]        │
-│ --help                -h                                           Show this message   │
-│                                                                    and exit.           │
-╰────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --synapse-dir                             PATH              Directory        │
+│                                                             containing       │
+│                                                             Synapse          │
+│                                                             docker-compose.… │
+│                                                             (from            │
+│                                                             mindroom-stack   │
+│                                                             settings).       │
+│                                                             [default:        │
+│                                                             local/matrix]    │
+│ --homeserver-url                          TEXT              Homeserver URL   │
+│                                                             that Cinny and   │
+│                                                             MindRoom should  │
+│                                                             use.             │
+│                                                             [default:        │
+│                                                             http://localhos… │
+│ --server-name                             TEXT              Matrix server    │
+│                                                             name (default:   │
+│                                                             inferred from    │
+│                                                             --homeserver-url │
+│                                                             hostname).       │
+│ --cinny-port                              INTEGER RANGE     Local host port  │
+│                                           [1<=x<=65535]     for the MindRoom │
+│                                                             Cinny container. │
+│                                                             [default: 8080]  │
+│ --cinny-image                             TEXT              Docker image for │
+│                                                             MindRoom Cinny.  │
+│                                                             [default:        │
+│                                                             ghcr.io/mindroo… │
+│ --cinny-containe…                         TEXT              Container name   │
+│                                                             for MindRoom     │
+│                                                             Cinny.           │
+│                                                             [default:        │
+│                                                             mindroom-cinny-… │
+│ --skip-synapse                                              Skip starting    │
+│                                                             Synapse (assume  │
+│                                                             it is already    │
+│                                                             running).        │
+│ --persist-env          --no-persist-e…                      Persist Matrix   │
+│                                                             local dev        │
+│                                                             settings to .env │
+│                                                             next to          │
+│                                                             config.yaml.     │
+│                                                             [default:        │
+│                                                             persist-env]     │
+│ --help             -h                                       Show this        │
+│                                                             message and      │
+│                                                             exit.            │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## Examples

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -30,6 +30,7 @@ from .config import (
 )
 from .doctor import doctor
 from .local_stack import local_stack_setup
+from .service import service_app
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -58,6 +59,7 @@ app = typer.Typer(
 avatars_app = typer.Typer(help="Generate and sync managed avatar assets.")
 app.add_typer(config_app, name="config")
 app.add_typer(avatars_app, name="avatars")
+app.add_typer(service_app, name="service")
 
 
 @app.command()

--- a/src/mindroom/cli/service.py
+++ b/src/mindroom/cli/service.py
@@ -1,0 +1,158 @@
+"""CLI commands for installing MindRoom as a user service."""
+
+from __future__ import annotations
+
+import platform
+from typing import TYPE_CHECKING
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+from mindroom.services.manager import get_service_manager
+
+if TYPE_CHECKING:
+    from mindroom.services.config import ServiceManager
+
+_console = Console()
+_err_console = Console(stderr=True)
+
+service_app = typer.Typer(
+    name="service",
+    help="""Install and manage MindRoom as a background user service.
+
+MindRoom runs through `uv tool run` and starts automatically at login.
+
+Supported platforms:
+- macOS: launchd (`~/Library/LaunchAgents/`)
+- Linux: systemd user services (`~/.config/systemd/user/`)
+""",
+    rich_markup_mode="markdown",
+    no_args_is_help=True,
+)
+
+
+def _manager_or_exit() -> ServiceManager:
+    try:
+        return get_service_manager()
+    except RuntimeError as exc:
+        _err_console.print(f"[bold red]Error:[/bold red] {exc}")
+        raise typer.Exit(1) from None
+
+
+def _confirm_action(message: str) -> bool:
+    """Ask for confirmation and return whether the user accepted."""
+    try:
+        answer = _console.input(f"[bold]{message} [Y/n]: [/bold]").strip().lower()
+    except (KeyboardInterrupt, EOFError):
+        _console.print("\n[dim]Cancelled.[/dim]")
+        raise typer.Exit(0) from None
+    return not answer or answer == "y"
+
+
+def _ensure_uv_installed(*, no_confirm: bool) -> None:
+    """Ensure uv is installed before service installation."""
+    manager = _manager_or_exit()
+    uv_installed, uv_path = manager.check_uv_installed()
+    if uv_installed:
+        _console.print(f"  [green]uv installed:[/green] {uv_path}")
+        return
+
+    _console.print("[yellow]uv is required to run the MindRoom service.[/yellow]")
+    if not no_confirm and not _confirm_action("Install uv now?"):
+        _console.print("[yellow]Install uv from https://docs.astral.sh/uv/ and run this command again.[/yellow]")
+        raise typer.Exit(1)
+
+    _console.print("Installing uv...")
+    success, message = manager.install_uv()
+    if not success:
+        _err_console.print(f"[bold red]Error:[/bold red] {message}")
+        raise typer.Exit(1)
+    _console.print(f"  [green]{message}[/green]")
+
+
+@service_app.command("install")
+def install_service(
+    skip_deps: bool = typer.Option(False, "--skip-deps", help="Skip uv dependency check."),
+    no_confirm: bool = typer.Option(False, "--no-confirm", "-y", help="Skip confirmation prompts."),
+) -> None:
+    """Install and start MindRoom as a background user service."""
+    manager = _manager_or_exit()
+
+    if not skip_deps:
+        _ensure_uv_installed(no_confirm=no_confirm)
+
+    if not no_confirm:
+        _console.print()
+        _console.print("[bold]Will install:[/bold] MindRoom user service")
+        if not _confirm_action("Continue?"):
+            _console.print("[dim]Cancelled.[/dim]")
+            raise typer.Exit(0)
+
+    result = manager.install_service()
+    if not result.success:
+        _err_console.print(f"[bold red]Error:[/bold red] {result.message}")
+        raise typer.Exit(1)
+
+    log_hint = f"View logs: [cyan]{manager.get_log_command()}[/cyan]"
+    if result.log_dir is not None:
+        log_hint = f"View logs: [cyan]{result.log_dir}/[/cyan]"
+    _console.print(
+        Panel(
+            f"[green]{result.message}[/green]\n\nCheck status: [cyan]mindroom service status[/cyan]\n{log_hint}",
+            title="Service Installed",
+            border_style="green",
+        ),
+    )
+
+
+@service_app.command("uninstall")
+def uninstall_service(
+    no_confirm: bool = typer.Option(False, "--no-confirm", "-y", help="Skip confirmation prompts."),
+) -> None:
+    """Stop and remove the MindRoom user service."""
+    manager = _manager_or_exit()
+    if not no_confirm:
+        _console.print("[bold]Will uninstall:[/bold] MindRoom user service")
+        if not _confirm_action("Continue?"):
+            _console.print("[dim]Cancelled.[/dim]")
+            raise typer.Exit(0)
+
+    result = manager.uninstall_service()
+    if not result.success:
+        _err_console.print(f"[bold red]Error:[/bold red] {result.message}")
+        raise typer.Exit(1)
+    _console.print(f"[green]{result.message}[/green]")
+    if platform.system() == "Darwin":
+        _console.print("[dim]Log files are preserved at ~/Library/Logs/mindroom/[/dim]")
+
+
+@service_app.command("status")
+def service_status(
+    logs: int = typer.Option(10, "--logs", "-l", help="Number of recent log lines to show. Use 0 to hide logs."),
+) -> None:
+    """Show MindRoom service status and recent logs."""
+    manager = _manager_or_exit()
+    status = manager.get_service_status()
+
+    if not status.installed:
+        _console.print("MindRoom service: [dim]not installed[/dim]")
+    elif status.running:
+        _console.print(f"MindRoom service: [green]running[/green] (pid {status.pid})")
+    else:
+        _console.print("MindRoom service: [yellow]installed but not running[/yellow]")
+
+    if logs > 0 and status.installed:
+        log_lines = manager.get_recent_logs(logs)
+        if log_lines:
+            _console.print()
+            _console.print(f"[dim]Recent logs ({len(log_lines)} lines):[/dim]")
+            for line in log_lines:
+                display_line = line[:120] + "..." if len(line) > 120 else line
+                _console.print(f"  [dim]{display_line}[/dim]")
+        elif status.running:
+            _console.print()
+            _console.print("[dim]No recent logs available[/dim]")
+
+    _console.print()
+    _console.print(f"[dim]Full logs: {manager.get_log_command()}[/dim]")

--- a/src/mindroom/services/__init__.py
+++ b/src/mindroom/services/__init__.py
@@ -1,0 +1,1 @@
+"""User service installation helpers for MindRoom."""

--- a/src/mindroom/services/config.py
+++ b/src/mindroom/services/config.py
@@ -1,0 +1,100 @@
+"""Shared configuration for MindRoom user service managers."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+SERVICE_NAME = "mindroom"
+_PACKAGE_NAME = "mindroom"
+
+
+@dataclass(frozen=True)
+class ServiceStatus:
+    """Status of the MindRoom user service."""
+
+    installed: bool
+    running: bool
+    pid: int | None = None
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    """Result of installing the MindRoom user service."""
+
+    success: bool
+    message: str
+    log_dir: Path | None = None
+
+
+@dataclass(frozen=True)
+class UninstallResult:
+    """Result of uninstalling the MindRoom user service."""
+
+    success: bool
+    message: str
+    was_running: bool = False
+
+
+class ServiceManager(NamedTuple):
+    """Platform-specific MindRoom service manager interface."""
+
+    check_uv_installed: Callable[[], tuple[bool, Path | None]]
+    install_uv: Callable[[], tuple[bool, str]]
+    install_service: Callable[[], InstallResult]
+    uninstall_service: Callable[[], UninstallResult]
+    get_service_status: Callable[[], ServiceStatus]
+    get_log_command: Callable[[], str]
+    get_recent_logs: Callable[[int], list[str]]
+
+
+def build_service_command(uv_path: Path) -> list[str]:
+    """Build the command for running MindRoom through uv tool run."""
+    return [str(uv_path), "tool", "run", "--from", _PACKAGE_NAME, "mindroom", "run"]
+
+
+def find_uv(extra_paths: list[Path] | None = None) -> Path | None:
+    """Find uv, preferring common install locations over virtualenv shims."""
+    paths = [
+        Path.home() / ".local" / "bin" / "uv",
+        Path.home() / ".cargo" / "bin" / "uv",
+        Path("/usr/local/bin/uv"),
+    ]
+    if extra_paths:
+        paths = extra_paths + paths
+
+    for path in paths:
+        if path.is_file() and os.access(path, os.X_OK):
+            return path
+
+    which_result = shutil.which("uv")
+    return Path(which_result) if which_result else None
+
+
+def install_uv() -> tuple[bool, str]:
+    """Install uv using the official installer."""
+    try:
+        result = subprocess.run(
+            ["curl", "-LsSf", "https://astral.sh/uv/install.sh"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        subprocess.run(
+            ["sh"],
+            input=result.stdout,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        return False, f"Failed to install uv: {exc}"
+    return True, "uv installed successfully"

--- a/src/mindroom/services/launchd.py
+++ b/src/mindroom/services/launchd.py
@@ -1,0 +1,158 @@
+"""launchd service management for MindRoom on macOS."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import plistlib
+import subprocess
+from pathlib import Path
+
+from mindroom.services.config import (
+    InstallResult,
+    ServiceManager,
+    ServiceStatus,
+    UninstallResult,
+    build_service_command,
+    find_uv,
+    install_uv,
+)
+
+_MACOS_UV_PATHS = [Path("/opt/homebrew/bin/uv")]
+_LABEL = "chat.mindroom.local"
+
+
+def _get_plist_path() -> Path:
+    """Return the launchd plist path."""
+    return Path.home() / "Library" / "LaunchAgents" / f"{_LABEL}.plist"
+
+
+def _get_log_dir() -> Path:
+    """Return the launchd log directory."""
+    return Path.home() / "Library" / "Logs" / "mindroom"
+
+
+def _get_log_command() -> str:
+    """Return the command for following service logs."""
+    return f"tail -f {_get_log_dir()}/*.log"
+
+
+def _get_recent_logs(num_lines: int = 10) -> list[str]:
+    """Return recent service logs."""
+    log_dir = _get_log_dir()
+    lines: list[str] = []
+    for log_file in [log_dir / "stdout.log", log_dir / "stderr.log"]:
+        if log_file.exists():
+            try:
+                with log_file.open(encoding="utf-8") as f:
+                    lines = [line.rstrip() for line in f.readlines()[-num_lines:]]
+            except OSError:
+                continue
+            if lines:
+                break
+    return lines
+
+
+def _generate_plist(uv_path: Path, home_dir: Path, log_dir: Path) -> dict[str, object]:
+    """Generate the launchd plist dictionary."""
+    return {
+        "Label": _LABEL,
+        "ProgramArguments": build_service_command(uv_path),
+        "RunAtLoad": True,
+        "KeepAlive": True,
+        "WorkingDirectory": str(home_dir),
+        "StandardOutPath": str(log_dir / "stdout.log"),
+        "StandardErrorPath": str(log_dir / "stderr.log"),
+    }
+
+
+def _get_service_status() -> ServiceStatus:
+    """Return the installed/running status of the launchd service."""
+    if not _get_plist_path().exists():
+        return ServiceStatus(installed=False, running=False)
+
+    result = subprocess.run(
+        ["launchctl", "print", f"gui/{os.getuid()}/{_LABEL}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return ServiceStatus(installed=True, running=False)
+
+    pid = None
+    for line in result.stdout.splitlines():
+        if "pid =" in line.lower():
+            _, _, raw_pid = line.partition("=")
+            with contextlib.suppress(ValueError):
+                pid = int(raw_pid.strip())
+            break
+
+    running = pid is not None and pid != 0
+    return ServiceStatus(installed=True, running=running, pid=pid if running else None)
+
+
+def _install_service() -> InstallResult:
+    """Install and start the launchd service."""
+    uv_path = find_uv(extra_paths=_MACOS_UV_PATHS)
+    if uv_path is None:
+        return InstallResult(success=False, message="uv not found. Install it from https://docs.astral.sh/uv/")
+
+    home_dir = Path.home()
+    log_dir = _get_log_dir()
+    plist_path = _get_plist_path()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with plist_path.open("wb") as f:
+        plistlib.dump(_generate_plist(uv_path, home_dir, log_dir), f)
+
+    uid = os.getuid()
+    subprocess.run(["launchctl", "bootout", f"gui/{uid}", str(plist_path)], capture_output=True, check=False)
+    result = subprocess.run(
+        ["launchctl", "bootstrap", f"gui/{uid}", str(plist_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return InstallResult(success=False, message=f"Failed to load service: {result.stderr.strip()}", log_dir=log_dir)
+
+    return InstallResult(success=True, message="Installed and started", log_dir=log_dir)
+
+
+def _uninstall_service() -> UninstallResult:
+    """Stop and remove the launchd service."""
+    plist_path = _get_plist_path()
+    if not plist_path.exists():
+        return UninstallResult(success=True, message="Service was not installed")
+
+    result = subprocess.run(
+        ["launchctl", "bootout", f"gui/{os.getuid()}", str(plist_path)],
+        capture_output=True,
+        check=False,
+    )
+    was_running = result.returncode == 0
+    plist_path.unlink()
+    return UninstallResult(
+        success=True,
+        message="Service stopped and removed" if was_running else "Service removed",
+        was_running=was_running,
+    )
+
+
+def _check_uv_installed() -> tuple[bool, Path | None]:
+    """Return whether uv is installed."""
+    uv_path = find_uv(extra_paths=_MACOS_UV_PATHS)
+    return uv_path is not None, uv_path
+
+
+manager = ServiceManager(
+    check_uv_installed=_check_uv_installed,
+    install_uv=install_uv,
+    install_service=_install_service,
+    uninstall_service=_uninstall_service,
+    get_service_status=_get_service_status,
+    get_log_command=_get_log_command,
+    get_recent_logs=_get_recent_logs,
+)

--- a/src/mindroom/services/launchd.py
+++ b/src/mindroom/services/launchd.py
@@ -17,7 +17,7 @@ from mindroom.services.config import (
     find_uv,
     install_uv,
 )
-from mindroom.services.runtime import resolve_service_environment
+from mindroom.services.runtime import ServiceConfigMissingError, resolve_service_environment
 
 _MACOS_UV_PATHS = [Path("/opt/homebrew/bin/uv")]
 _LABEL = "chat.mindroom.local"
@@ -105,6 +105,11 @@ def _install_service() -> InstallResult:
     if uv_path is None:
         return InstallResult(success=False, message="uv not found. Install it from https://docs.astral.sh/uv/")
 
+    try:
+        service_environment = resolve_service_environment(uv_path)
+    except ServiceConfigMissingError as exc:
+        return InstallResult(success=False, message=str(exc))
+
     home_dir = Path.home()
     log_dir = _get_log_dir()
     plist_path = _get_plist_path()
@@ -112,7 +117,7 @@ def _install_service() -> InstallResult:
     plist_path.parent.mkdir(parents=True, exist_ok=True)
 
     with plist_path.open("wb") as f:
-        plistlib.dump(_generate_plist(uv_path, home_dir, log_dir, resolve_service_environment()), f)
+        plistlib.dump(_generate_plist(uv_path, home_dir, log_dir, service_environment), f)
 
     uid = os.getuid()
     subprocess.run(["launchctl", "bootout", f"gui/{uid}", str(plist_path)], capture_output=True, check=False)

--- a/src/mindroom/services/launchd.py
+++ b/src/mindroom/services/launchd.py
@@ -17,6 +17,7 @@ from mindroom.services.config import (
     find_uv,
     install_uv,
 )
+from mindroom.services.runtime import resolve_service_environment
 
 _MACOS_UV_PATHS = [Path("/opt/homebrew/bin/uv")]
 _LABEL = "chat.mindroom.local"
@@ -53,11 +54,17 @@ def _get_recent_logs(num_lines: int = 10) -> list[str]:
     return lines
 
 
-def _generate_plist(uv_path: Path, home_dir: Path, log_dir: Path) -> dict[str, object]:
+def _generate_plist(
+    uv_path: Path,
+    home_dir: Path,
+    log_dir: Path,
+    service_environment: dict[str, str],
+) -> dict[str, object]:
     """Generate the launchd plist dictionary."""
     return {
         "Label": _LABEL,
         "ProgramArguments": build_service_command(uv_path),
+        "EnvironmentVariables": service_environment,
         "RunAtLoad": True,
         "KeepAlive": True,
         "WorkingDirectory": str(home_dir),
@@ -105,7 +112,7 @@ def _install_service() -> InstallResult:
     plist_path.parent.mkdir(parents=True, exist_ok=True)
 
     with plist_path.open("wb") as f:
-        plistlib.dump(_generate_plist(uv_path, home_dir, log_dir), f)
+        plistlib.dump(_generate_plist(uv_path, home_dir, log_dir, resolve_service_environment()), f)
 
     uid = os.getuid()
     subprocess.run(["launchctl", "bootout", f"gui/{uid}", str(plist_path)], capture_output=True, check=False)

--- a/src/mindroom/services/manager.py
+++ b/src/mindroom/services/manager.py
@@ -1,0 +1,27 @@
+"""Platform selection for MindRoom user service managers."""
+
+from __future__ import annotations
+
+import platform
+from typing import TYPE_CHECKING
+
+from mindroom.services.launchd import manager as launchd_manager
+from mindroom.services.systemd import manager as systemd_manager
+
+if TYPE_CHECKING:
+    from mindroom.services.config import ServiceManager
+
+
+def get_service_manager() -> ServiceManager:
+    """Return the launchd or systemd user service manager for this platform."""
+    system = platform.system()
+    if system == "Darwin":
+        return launchd_manager
+    if system == "Linux":
+        return systemd_manager
+    msg = (
+        f"Unsupported platform: {system}\n\n"
+        "MindRoom user services are managed with launchd on macOS and systemd on Linux.\n"
+        "Run MindRoom manually instead with: mindroom run"
+    )
+    raise RuntimeError(msg)

--- a/src/mindroom/services/runtime.py
+++ b/src/mindroom/services/runtime.py
@@ -2,13 +2,45 @@
 
 from __future__ import annotations
 
-from mindroom.constants import resolve_primary_runtime_paths
+from pathlib import Path
+
+from mindroom.constants import resolve_primary_runtime_paths, subprocess_path_with_prepends
+
+_USER_PATH_ENTRIES = (
+    str(Path.home() / ".local" / "bin"),
+    str(Path.home() / ".cargo" / "bin"),
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+)
 
 
-def resolve_service_environment() -> dict[str, str]:
+class ServiceConfigMissingError(RuntimeError):
+    """Raised when service installation cannot find an active MindRoom config."""
+
+
+def resolve_service_environment(uv_path: Path) -> dict[str, str]:
     """Resolve the runtime path environment captured by installed services."""
     runtime_paths = resolve_primary_runtime_paths()
+    if not runtime_paths.config_path.exists():
+        msg = (
+            f"No config.yaml found at {runtime_paths.config_path}. "
+            "Run `mindroom config init` to create one before installing the service."
+        )
+        raise ServiceConfigMissingError(msg)
+
+    path = subprocess_path_with_prepends(
+        runtime_paths.process_env.get("PATH"),
+        prepend_entries=(str(uv_path.parent), *_USER_PATH_ENTRIES),
+    )
+    if path is None:
+        path = ""
+
     return {
         "MINDROOM_CONFIG_PATH": str(runtime_paths.config_path),
         "MINDROOM_STORAGE_PATH": str(runtime_paths.storage_root),
+        "PATH": path,
     }

--- a/src/mindroom/services/runtime.py
+++ b/src/mindroom/services/runtime.py
@@ -1,0 +1,14 @@
+"""Runtime context helpers for installed MindRoom services."""
+
+from __future__ import annotations
+
+from mindroom.constants import resolve_primary_runtime_paths
+
+
+def resolve_service_environment() -> dict[str, str]:
+    """Resolve the runtime path environment captured by installed services."""
+    runtime_paths = resolve_primary_runtime_paths()
+    return {
+        "MINDROOM_CONFIG_PATH": str(runtime_paths.config_path),
+        "MINDROOM_STORAGE_PATH": str(runtime_paths.storage_root),
+    }

--- a/src/mindroom/services/systemd.py
+++ b/src/mindroom/services/systemd.py
@@ -16,7 +16,7 @@ from mindroom.services.config import (
     find_uv,
     install_uv,
 )
-from mindroom.services.runtime import resolve_service_environment
+from mindroom.services.runtime import ServiceConfigMissingError, resolve_service_environment
 
 _LINUX_UV_PATHS = [Path("/usr/bin/uv")]
 
@@ -127,8 +127,13 @@ def _install_service() -> InstallResult:
 
     unit_path = _get_unit_path()
     unit_name = _get_unit_name()
+    try:
+        service_environment = resolve_service_environment(uv_path)
+    except ServiceConfigMissingError as exc:
+        return InstallResult(success=False, message=str(exc))
+
     unit_path.parent.mkdir(parents=True, exist_ok=True)
-    unit_path.write_text(_generate_unit_file(uv_path, resolve_service_environment()), encoding="utf-8")
+    unit_path.write_text(_generate_unit_file(uv_path, service_environment), encoding="utf-8")
 
     subprocess.run(["systemctl", "--user", "stop", unit_name], capture_output=True, check=False)
 

--- a/src/mindroom/services/systemd.py
+++ b/src/mindroom/services/systemd.py
@@ -16,6 +16,7 @@ from mindroom.services.config import (
     find_uv,
     install_uv,
 )
+from mindroom.services.runtime import resolve_service_environment
 
 _LINUX_UV_PATHS = [Path("/usr/bin/uv")]
 
@@ -58,15 +59,26 @@ def _get_recent_logs(num_lines: int = 10) -> list[str]:
     return [line.rstrip() for line in result.stdout.splitlines() if line.strip()]
 
 
-def _generate_unit_file(uv_path: Path) -> str:
+def _quote_environment_assignment(name: str, value: str) -> str:
+    """Return one safely quoted systemd Environment assignment."""
+    escaped_value = value.replace("\\", "\\\\").replace('"', '\\"').replace("%", "%%")
+    return f'"{name}={escaped_value}"'
+
+
+def _generate_unit_file(uv_path: Path, service_environment: dict[str, str]) -> str:
     """Generate the systemd unit file content."""
     exec_start = " ".join(shlex.quote(part) for part in build_service_command(uv_path))
+    environment = "\n".join(
+        f"Environment={_quote_environment_assignment(name, value)}"
+        for name, value in sorted(service_environment.items())
+    )
     return f"""[Unit]
 Description=MindRoom
 After=network.target
 
 [Service]
 ExecStart={exec_start}
+{environment}
 Restart=on-failure
 RestartSec=5
 
@@ -116,7 +128,7 @@ def _install_service() -> InstallResult:
     unit_path = _get_unit_path()
     unit_name = _get_unit_name()
     unit_path.parent.mkdir(parents=True, exist_ok=True)
-    unit_path.write_text(_generate_unit_file(uv_path), encoding="utf-8")
+    unit_path.write_text(_generate_unit_file(uv_path, resolve_service_environment()), encoding="utf-8")
 
     subprocess.run(["systemctl", "--user", "stop", unit_name], capture_output=True, check=False)
 

--- a/src/mindroom/services/systemd.py
+++ b/src/mindroom/services/systemd.py
@@ -1,0 +1,186 @@
+"""systemd user service management for MindRoom on Linux."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+from mindroom.services.config import (
+    SERVICE_NAME,
+    InstallResult,
+    ServiceManager,
+    ServiceStatus,
+    UninstallResult,
+    build_service_command,
+    find_uv,
+    install_uv,
+)
+
+_LINUX_UV_PATHS = [Path("/usr/bin/uv")]
+
+
+def _get_unit_name() -> str:
+    """Return the systemd unit name."""
+    return f"{SERVICE_NAME}.service"
+
+
+def _get_unit_path() -> Path:
+    """Return the systemd user unit path."""
+    return Path.home() / ".config" / "systemd" / "user" / _get_unit_name()
+
+
+def _get_log_command() -> str:
+    """Return the command for following service logs."""
+    return f"journalctl --user -u {SERVICE_NAME} -f"
+
+
+def _get_recent_logs(num_lines: int = 10) -> list[str]:
+    """Return recent service logs from journalctl."""
+    result = subprocess.run(
+        [
+            "journalctl",
+            "--user",
+            "-u",
+            SERVICE_NAME,
+            "-n",
+            str(num_lines),
+            "--no-pager",
+            "-o",
+            "cat",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return [line.rstrip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _generate_unit_file(uv_path: Path) -> str:
+    """Generate the systemd unit file content."""
+    exec_start = " ".join(shlex.quote(part) for part in build_service_command(uv_path))
+    return f"""[Unit]
+Description=MindRoom
+After=network.target
+
+[Service]
+ExecStart={exec_start}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+
+
+def _get_service_status() -> ServiceStatus:
+    """Return the installed/running status of the systemd user service."""
+    if not _get_unit_path().exists():
+        return ServiceStatus(installed=False, running=False)
+
+    unit_name = _get_unit_name()
+    result = subprocess.run(
+        ["systemctl", "--user", "is-active", unit_name],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    running = result.returncode == 0 and result.stdout.strip() == "active"
+    pid = None
+    if running:
+        pid_result = subprocess.run(
+            ["systemctl", "--user", "show", unit_name, "--property=MainPID"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if pid_result.returncode == 0:
+            _, _, raw_pid = pid_result.stdout.strip().partition("=")
+            try:
+                parsed_pid = int(raw_pid)
+            except ValueError:
+                parsed_pid = 0
+            pid = parsed_pid or None
+
+    return ServiceStatus(installed=True, running=running, pid=pid)
+
+
+def _install_service() -> InstallResult:
+    """Install and start the systemd user service."""
+    uv_path = find_uv(extra_paths=_LINUX_UV_PATHS)
+    if uv_path is None:
+        return InstallResult(success=False, message="uv not found. Install it from https://docs.astral.sh/uv/")
+
+    unit_path = _get_unit_path()
+    unit_name = _get_unit_name()
+    unit_path.parent.mkdir(parents=True, exist_ok=True)
+    unit_path.write_text(_generate_unit_file(uv_path), encoding="utf-8")
+
+    subprocess.run(["systemctl", "--user", "stop", unit_name], capture_output=True, check=False)
+
+    result = subprocess.run(
+        ["systemctl", "--user", "daemon-reload"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return InstallResult(success=False, message=f"Failed to reload systemd: {result.stderr.strip()}")
+
+    result = subprocess.run(
+        ["systemctl", "--user", "enable", unit_name],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return InstallResult(success=False, message=f"Failed to enable service: {result.stderr.strip()}")
+
+    result = subprocess.run(
+        ["systemctl", "--user", "start", unit_name],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return InstallResult(success=False, message=f"Failed to start service: {result.stderr.strip()}")
+
+    return InstallResult(success=True, message="Installed and started")
+
+
+def _uninstall_service() -> UninstallResult:
+    """Stop and remove the systemd user service."""
+    unit_path = _get_unit_path()
+    unit_name = _get_unit_name()
+    if not unit_path.exists():
+        return UninstallResult(success=True, message="Service was not installed")
+
+    was_running = _get_service_status().running
+    subprocess.run(["systemctl", "--user", "stop", unit_name], capture_output=True, check=False)
+    subprocess.run(["systemctl", "--user", "disable", unit_name], capture_output=True, check=False)
+    unit_path.unlink()
+    subprocess.run(["systemctl", "--user", "daemon-reload"], capture_output=True, check=False)
+    return UninstallResult(
+        success=True,
+        message="Service stopped and removed" if was_running else "Service removed",
+        was_running=was_running,
+    )
+
+
+def _check_uv_installed() -> tuple[bool, Path | None]:
+    """Return whether uv is installed."""
+    uv_path = find_uv(extra_paths=_LINUX_UV_PATHS)
+    return uv_path is not None, uv_path
+
+
+manager = ServiceManager(
+    check_uv_installed=_check_uv_installed,
+    install_uv=install_uv,
+    install_service=_install_service,
+    uninstall_service=_uninstall_service,
+    get_service_status=_get_service_status,
+    get_log_command=_get_log_command,
+    get_recent_logs=_get_recent_logs,
+)

--- a/tach.toml
+++ b/tach.toml
@@ -1698,11 +1698,21 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.services.launchd"
-depends_on = ["mindroom.services.config"]
+depends_on = [
+    "mindroom.services.config",
+    "mindroom.services.runtime",
+]
+
+[[modules]]
+path = "mindroom.services.runtime"
+depends_on = ["mindroom.constants"]
 
 [[modules]]
 path = "mindroom.services.systemd"
-depends_on = ["mindroom.services.config"]
+depends_on = [
+    "mindroom.services.config",
+    "mindroom.services.runtime",
+]
 
 [[modules]]
 path = "mindroom.commands"

--- a/tach.toml
+++ b/tach.toml
@@ -1656,6 +1656,13 @@ depends_on = [
 ]
 
 [[modules]]
+path = "mindroom.cli.service"
+depends_on = [
+    "mindroom.services.config",
+    "mindroom.services.manager",
+]
+
+[[modules]]
 path = "mindroom.cli.main"
 depends_on = [
     "mindroom",
@@ -1665,12 +1672,37 @@ depends_on = [
     "mindroom.cli.connect",
     "mindroom.cli.doctor",
     "mindroom.cli.local_stack",
+    "mindroom.cli.service",
     "mindroom.config.main",
     "mindroom.constants",
     "mindroom.error_handling",
     "mindroom.frontend_assets",
     "mindroom.orchestrator",
 ]
+
+[[modules]]
+path = "mindroom.services"
+depends_on = []
+
+[[modules]]
+path = "mindroom.services.config"
+depends_on = []
+
+[[modules]]
+path = "mindroom.services.manager"
+depends_on = [
+    "mindroom.services.config",
+    "mindroom.services.launchd",
+    "mindroom.services.systemd",
+]
+
+[[modules]]
+path = "mindroom.services.launchd"
+depends_on = ["mindroom.services.config"]
+
+[[modules]]
+path = "mindroom.services.systemd"
+depends_on = ["mindroom.services.config"]
 
 [[modules]]
 path = "mindroom.commands"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -21,7 +21,7 @@ from mindroom.services.config import (
 )
 from mindroom.services.launchd import _generate_plist
 from mindroom.services.manager import get_service_manager
-from mindroom.services.runtime import resolve_service_environment
+from mindroom.services.runtime import ServiceConfigMissingError, resolve_service_environment
 from mindroom.services.systemd import _generate_unit_file, _get_unit_name
 
 runner = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb"})
@@ -114,6 +114,7 @@ def test_systemd_unit_runs_mindroom() -> None:
         {
             "MINDROOM_CONFIG_PATH": "/Users/test/Mind Room/config.yaml",
             "MINDROOM_STORAGE_PATH": "/Users/test/Mind Room/data%root",
+            "PATH": "/Users/test/.local/bin:/usr/bin",
         },
     )
 
@@ -122,6 +123,7 @@ def test_systemd_unit_runs_mindroom() -> None:
     assert "ExecStart=/usr/bin/uv tool run --from mindroom mindroom run" in unit
     assert 'Environment="MINDROOM_CONFIG_PATH=/Users/test/Mind Room/config.yaml"' in unit
     assert 'Environment="MINDROOM_STORAGE_PATH=/Users/test/Mind Room/data%%root"' in unit
+    assert 'Environment="PATH=/Users/test/.local/bin:/usr/bin"' in unit
     assert "Restart=on-failure" in unit
 
 
@@ -130,6 +132,7 @@ def test_launchd_plist_runs_mindroom(tmp_path: Path) -> None:
     service_environment = {
         "MINDROOM_CONFIG_PATH": str(tmp_path / "config.yaml"),
         "MINDROOM_STORAGE_PATH": str(tmp_path / "mindroom_data"),
+        "PATH": f"{tmp_path}/bin:/usr/bin",
     }
     plist_data = _generate_plist(tmp_path / "uv", tmp_path, tmp_path / "logs", service_environment)
     rendered = plistlib.dumps(plist_data)
@@ -152,16 +155,36 @@ def test_resolve_service_environment_captures_active_runtime(monkeypatch: pytest
     """Installed services capture the same config and storage context as the invoking CLI."""
     config_path = tmp_path / "local config.yaml"
     storage_path = tmp_path / "local storage"
+    uv_path = tmp_path / "custom uv bin" / "uv"
+    uv_path.parent.mkdir()
+    uv_path.touch()
     config_path.write_text("agents: {}\n", encoding="utf-8")
     monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
     monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_path))
+    monkeypatch.setenv("PATH", "/existing/bin")
 
-    service_environment = resolve_service_environment()
+    service_environment = resolve_service_environment(uv_path)
 
-    assert service_environment == {
-        "MINDROOM_CONFIG_PATH": str(config_path.resolve()),
-        "MINDROOM_STORAGE_PATH": str(storage_path.resolve()),
-    }
+    assert service_environment["MINDROOM_CONFIG_PATH"] == str(config_path.resolve())
+    assert service_environment["MINDROOM_STORAGE_PATH"] == str(storage_path.resolve())
+    path_entries = service_environment["PATH"].split(":")
+    assert path_entries[0] == str(uv_path.parent)
+    assert str(Path.home() / ".local" / "bin") in path_entries
+    assert "/opt/homebrew/bin" in path_entries
+    assert "/usr/local/bin" in path_entries
+    assert "/existing/bin" in path_entries
+
+
+def test_resolve_service_environment_requires_existing_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Service install fails before writing a service when no active config exists."""
+    config_path = tmp_path / "missing.yaml"
+    monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
+
+    with pytest.raises(ServiceConfigMissingError, match="mindroom config init"):
+        resolve_service_environment(tmp_path / "uv")
 
 
 def test_service_help_is_registered() -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -21,6 +21,7 @@ from mindroom.services.config import (
 )
 from mindroom.services.launchd import _generate_plist
 from mindroom.services.manager import get_service_manager
+from mindroom.services.runtime import resolve_service_environment
 from mindroom.services.systemd import _generate_unit_file, _get_unit_name
 
 runner = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb"})
@@ -108,17 +109,29 @@ def test_get_service_manager_unsupported(mock_system: MagicMock) -> None:
 
 def test_systemd_unit_runs_mindroom() -> None:
     """The generated systemd unit starts MindRoom and restarts on failure."""
-    unit = _generate_unit_file(Path("/usr/bin/uv"))
+    unit = _generate_unit_file(
+        Path("/usr/bin/uv"),
+        {
+            "MINDROOM_CONFIG_PATH": "/Users/test/Mind Room/config.yaml",
+            "MINDROOM_STORAGE_PATH": "/Users/test/Mind Room/data%root",
+        },
+    )
 
     assert _get_unit_name() == "mindroom.service"
     assert "Description=MindRoom" in unit
     assert "ExecStart=/usr/bin/uv tool run --from mindroom mindroom run" in unit
+    assert 'Environment="MINDROOM_CONFIG_PATH=/Users/test/Mind Room/config.yaml"' in unit
+    assert 'Environment="MINDROOM_STORAGE_PATH=/Users/test/Mind Room/data%%root"' in unit
     assert "Restart=on-failure" in unit
 
 
 def test_launchd_plist_runs_mindroom(tmp_path: Path) -> None:
     """The generated launchd plist starts MindRoom and writes logs."""
-    plist_data = _generate_plist(tmp_path / "uv", tmp_path, tmp_path / "logs")
+    service_environment = {
+        "MINDROOM_CONFIG_PATH": str(tmp_path / "config.yaml"),
+        "MINDROOM_STORAGE_PATH": str(tmp_path / "mindroom_data"),
+    }
+    plist_data = _generate_plist(tmp_path / "uv", tmp_path, tmp_path / "logs", service_environment)
     rendered = plistlib.dumps(plist_data)
 
     assert plist_data["Label"] == "chat.mindroom.local"
@@ -131,7 +144,24 @@ def test_launchd_plist_runs_mindroom(tmp_path: Path) -> None:
         "mindroom",
         "run",
     ]
+    assert plist_data["EnvironmentVariables"] == service_environment
     assert b"StandardOutPath" in rendered
+
+
+def test_resolve_service_environment_captures_active_runtime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Installed services capture the same config and storage context as the invoking CLI."""
+    config_path = tmp_path / "local config.yaml"
+    storage_path = tmp_path / "local storage"
+    config_path.write_text("agents: {}\n", encoding="utf-8")
+    monkeypatch.setenv("MINDROOM_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("MINDROOM_STORAGE_PATH", str(storage_path))
+
+    service_environment = resolve_service_environment()
+
+    assert service_environment == {
+        "MINDROOM_CONFIG_PATH": str(config_path.resolve()),
+        "MINDROOM_STORAGE_PATH": str(storage_path.resolve()),
+    }
 
 
 def test_service_help_is_registered() -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,174 @@
+"""Tests for MindRoom user service installation helpers."""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from mindroom.cli.main import app
+from mindroom.services.config import (
+    InstallResult,
+    ServiceManager,
+    ServiceStatus,
+    build_service_command,
+    find_uv,
+    install_uv,
+)
+from mindroom.services.launchd import _generate_plist
+from mindroom.services.manager import get_service_manager
+from mindroom.services.systemd import _generate_unit_file, _get_unit_name
+
+runner = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb"})
+
+
+def test_build_service_command_runs_mindroom_with_uv_tool(tmp_path: Path) -> None:
+    """The service command runs the published MindRoom CLI through uv."""
+    uv_path = tmp_path / "uv"
+    uv_path.touch()
+
+    command = build_service_command(uv_path)
+
+    assert command == [
+        str(uv_path),
+        "tool",
+        "run",
+        "--from",
+        "mindroom",
+        "mindroom",
+        "run",
+    ]
+
+
+def test_find_uv_prefers_extra_paths(tmp_path: Path) -> None:
+    """find_uv returns an executable passed through extra_paths first."""
+    uv_path = tmp_path / "uv"
+    uv_path.touch()
+    uv_path.chmod(0o755)
+
+    assert find_uv(extra_paths=[uv_path]) == uv_path
+
+
+@patch("subprocess.run")
+def test_install_uv_success(mock_run: MagicMock) -> None:
+    """install_uv reports success when curl and sh both succeed."""
+    mock_run.return_value = MagicMock(stdout="install script")
+
+    success, message = install_uv()
+
+    assert success is True
+    assert message == "uv installed successfully"
+    curl_call, shell_call = mock_run.call_args_list
+    assert curl_call.kwargs["text"] is True
+    assert isinstance(shell_call.kwargs["input"], str)
+    assert shell_call.kwargs["text"] is True
+
+
+@patch("subprocess.run")
+def test_install_uv_failure(mock_run: MagicMock) -> None:
+    """install_uv returns a user-facing failure message on subprocess errors."""
+    mock_run.side_effect = subprocess.CalledProcessError(1, "curl")
+
+    success, message = install_uv()
+
+    assert success is False
+    assert "Failed to install uv" in message
+
+
+@patch("mindroom.services.manager.platform.system", return_value="Darwin")
+def test_get_service_manager_macos(mock_system: MagicMock) -> None:
+    """Darwin platforms use the launchd manager."""
+    manager = get_service_manager()
+
+    assert isinstance(manager, ServiceManager)
+    mock_system.assert_called_once()
+
+
+@patch("mindroom.services.manager.platform.system", return_value="Linux")
+def test_get_service_manager_linux(mock_system: MagicMock) -> None:
+    """Linux platforms use the systemd manager."""
+    manager = get_service_manager()
+
+    assert isinstance(manager, ServiceManager)
+    mock_system.assert_called_once()
+
+
+@patch("mindroom.services.manager.platform.system", return_value="Windows")
+def test_get_service_manager_unsupported(mock_system: MagicMock) -> None:
+    """Unsupported platforms fail with a clear RuntimeError."""
+    with pytest.raises(RuntimeError, match="Unsupported platform"):
+        get_service_manager()
+
+    mock_system.assert_called_once()
+
+
+def test_systemd_unit_runs_mindroom() -> None:
+    """The generated systemd unit starts MindRoom and restarts on failure."""
+    unit = _generate_unit_file(Path("/usr/bin/uv"))
+
+    assert _get_unit_name() == "mindroom.service"
+    assert "Description=MindRoom" in unit
+    assert "ExecStart=/usr/bin/uv tool run --from mindroom mindroom run" in unit
+    assert "Restart=on-failure" in unit
+
+
+def test_launchd_plist_runs_mindroom(tmp_path: Path) -> None:
+    """The generated launchd plist starts MindRoom and writes logs."""
+    plist_data = _generate_plist(tmp_path / "uv", tmp_path, tmp_path / "logs")
+    rendered = plistlib.dumps(plist_data)
+
+    assert plist_data["Label"] == "chat.mindroom.local"
+    assert plist_data["ProgramArguments"] == [
+        str(tmp_path / "uv"),
+        "tool",
+        "run",
+        "--from",
+        "mindroom",
+        "mindroom",
+        "run",
+    ]
+    assert b"StandardOutPath" in rendered
+
+
+def test_service_help_is_registered() -> None:
+    """The top-level CLI exposes the service command group."""
+    result = runner.invoke(app, ["service", "--help"])
+
+    assert result.exit_code == 0
+    assert "install" in result.output
+    assert "uninstall" in result.output
+    assert "status" in result.output
+
+
+@patch("mindroom.cli.service.get_service_manager")
+def test_service_status_not_installed(mock_get_manager: MagicMock) -> None:
+    """Service status renders a not-installed service without logs."""
+    mock_manager = MagicMock(spec=ServiceManager)
+    mock_manager.get_service_status.return_value = ServiceStatus(installed=False, running=False)
+    mock_manager.get_log_command.return_value = "tail logs"
+    mock_get_manager.return_value = mock_manager
+
+    result = runner.invoke(app, ["service", "status"])
+
+    assert result.exit_code == 0
+    assert "not installed" in result.output
+
+
+@patch("mindroom.cli.service.get_service_manager")
+def test_service_install_no_confirm(mock_get_manager: MagicMock) -> None:
+    """Service install -y installs without interactive prompts."""
+    mock_manager = MagicMock(spec=ServiceManager)
+    mock_manager.check_uv_installed.return_value = (True, Path("/usr/bin/uv"))
+    mock_manager.install_service.return_value = InstallResult(success=True, message="Installed and started")
+    mock_manager.get_log_command.return_value = "journalctl --user -u mindroom -f"
+    mock_get_manager.return_value = mock_manager
+
+    result = runner.invoke(app, ["service", "install", "-y"])
+
+    assert result.exit_code == 0
+    assert "Installed and started" in result.output
+    mock_manager.install_service.assert_called_once_with()


### PR DESCRIPTION
## Summary
- add `mindroom service install/status/uninstall` for background user service management
- add launchd and systemd user service managers copied/adapted from agent-cli patterns
- capture the active `MINDROOM_CONFIG_PATH`, `MINDROOM_STORAGE_PATH`, and service `PATH` so installed services run the same runtime context and can find `uv` for optional dependency installs
- reject service installation before writing launchd/systemd files when no active config exists
- add focused tests and Tach boundaries for the new service modules

## Testing
- `uv run pytest tests/test_services.py -x -n 0 --no-cov -v`
- `uv run tach check --dependencies --interfaces`
- `uv run pre-commit run --all-files`
- `uv run pytest -q` (6547 passed, 125 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level service command with install, uninstall, and status subcommands to run MindRoom as a user service on macOS (launchd) and Linux (systemd); status shows installed/running state, PID, and recent logs; install can auto-install runtime tooling and skip confirmations.

* **Reliability**
  * Service installs validate and preserve the active config, storage path, and a robust PATH; install now aborts if required config is missing.

* **Documentation**
  * CLI docs and references updated with service usage and options.

* **Tests**
  * Added tests covering service env resolution, unit/plist generation, CLI wiring, platform routing, and missing-config behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->