### PR TITLE
Enable thread tags for generated mind agent

### DIFF
--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -813,6 +813,7 @@ agents:
       - scheduler
       - subagents
       - matrix_message
+      - thread_tags
     skills:
       - mindroom-docs
     instructions:

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -158,6 +158,7 @@ class TestConfigInit:
             "scheduler",
             "subagents",
             "matrix_message",
+            "thread_tags",
         ]
         assert mind["skills"] == ["mindroom-docs"]
         assert config["knowledge_bases"]["mind_memory"]["path"] == (


### PR DESCRIPTION
## Summary
- add `thread_tags` to the explicit tool list for the generated `mind` agent in `mindroom config init`
- update the config init regression test to assert the tool is present

## Tests
- `uv run pytest tests/test_cli_config.py -k 'init_full_profile_adds_mindroom_style_mind' -q`\n- `uv run pytest`\n- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `thread_tags` tool is now enabled by default in starter configurations when initializing a new Mind agent profile.

* **Tests**
  * Updated configuration initialization tests to verify the new default tool inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->