### PR TITLE
Link backticked Matrix IDs as mentions

### DIFF
--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -93,6 +93,7 @@ The router only posts a visible handoff when it must disambiguate between multip
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
 By default, `voice.visible_router_echo: true` also lets the router post the normalized voice text as a display-only message when it is allowed to reply.
 Set `voice.visible_router_echo: false` to suppress that display-only echo.
+
 See [Voice Messages](../voice.md) for the detailed dispatch behavior.
 
 ### Configuration Confirmations

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2291,7 +2291,9 @@ By default (`matrix_room_access.mode: single_user_private`), rooms remain invite
 
 ### Voice Message Processing
 
-Audio events are handled through the shared media pipeline on all bots. The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a multi-agent room. When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message. By default, `voice.visible_router_echo: true` also lets the router post the normalized voice text as a display-only message when it is allowed to reply. Set `voice.visible_router_echo: false` to suppress that display-only echo. See [Voice Messages](https://docs.mindroom.chat/voice/index.md) for the detailed dispatch behavior.
+Audio events are handled through the shared media pipeline on all bots. The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a multi-agent room. When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message. By default, `voice.visible_router_echo: true` also lets the router post the normalized voice text as a display-only message when it is allowed to reply. Set `voice.visible_router_echo: false` to suppress that display-only echo.
+
+See [Voice Messages](https://docs.mindroom.chat/voice/index.md) for the detailed dispatch behavior.
 
 ### Configuration Confirmations
 

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -87,7 +87,10 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a multi-agent room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-By default, `voice.visible_router_echo: true` also lets the router post the normalized voice text as a display-only message when it is allowed to reply. Set `voice.visible_router_echo: false` to suppress that display-only echo. See [Voice Messages](https://docs.mindroom.chat/voice/index.md) for the detailed dispatch behavior.
+By default, `voice.visible_router_echo: true` also lets the router post the normalized voice text as a display-only message when it is allowed to reply.
+Set `voice.visible_router_echo: false` to suppress that display-only echo.
+
+See [Voice Messages](https://docs.mindroom.chat/voice/index.md) for the detailed dispatch behavior.
 
 ### Configuration Confirmations
 

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -344,11 +344,21 @@ def _apply_replacements(
     parts: list[str] = []
     last_end = 0
     for replacement in replacements:
-        parts.append(text[last_end : replacement.start])
+        start = replacement.start
+        end = replacement.end
+        if _is_wrapped_in_single_backticks(text, replacement.start, replacement.end):
+            start -= 1
+            end += 1
+        parts.append(text[last_end:start])
         parts.append(replacement.markdown_text if use_markdown else replacement.plain_text)
-        last_end = replacement.end
+        last_end = end
     parts.append(text[last_end:])
     return "".join(parts)
+
+
+def _is_wrapped_in_single_backticks(text: str, start: int, end: int) -> bool:
+    """Return whether one replacement is wrapped as exactly one inline code token."""
+    return start > 0 and end < len(text) and text[start - 1] == "`" and text[end] == "`"
 
 
 def format_message_with_mentions(

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -291,6 +291,24 @@ class TestMentionParsing:
             "@bas.nijholt:chat-mindroom.example.com</a> -- noted.</p>\n"
         )
 
+    def test_format_message_with_backticked_full_matrix_user_id_creates_clickable_mention(self) -> None:
+        """Accidentally backticked MXIDs should become normal clickable mentions."""
+        config = _make_config(_default_runtime_paths())
+
+        content = _format_message_with_mentions(
+            config,
+            "Mind ID is `@mindroom_mind_5ckzneqq:mindroom.chat`.",
+            sender_domain="matrix.org",
+        )
+
+        assert content["body"] == "Mind ID is @mindroom_mind_5ckzneqq:mindroom.chat."
+        assert content["m.mentions"]["user_ids"] == ["@mindroom_mind_5ckzneqq:mindroom.chat"]
+        assert (
+            content["formatted_body"]
+            == '<p>Mind ID is <a href="https://matrix.to/#/@mindroom_mind_5ckzneqq:mindroom.chat">'
+            "@mindroom_mind_5ckzneqq:mindroom.chat</a>.</p>\n"
+        )
+
     def test_format_message_with_full_matrix_user_id_excludes_sentence_period(self) -> None:
         """Sentence punctuation should not become part of a full Matrix ID mention."""
         config = _make_config(_default_runtime_paths())


### PR DESCRIPTION
## Summary
- treat a Matrix ID wrapped as an inline-code token as an intended mention
- strip the accidental single backticks from both the plain Matrix body and markdown replacement
- add a regression test proving the formatted body renders a normal Matrix link instead of code-wrapped markdown
- include regenerated mindroom-docs reference output from pre-commit

## Tests
- uv run pytest tests/test_mentions.py -q
- uv run pytest
- uv run pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mentions are now correctly detected and rendered as clickable links even when wrapped in inline code backticks.

* **Documentation**
  * Reflowed the Voice Message Processing guidance and separated the “See Voice Messages” reference for clearer reading.

* **Tests**
  * Added a test to verify backticked mentions are parsed and rendered correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->