### PR TITLE
Fix browser, attachment, and website tool regressions

### DIFF
--- a/docs/tools/web-scraping-and-browser.md
+++ b/docs/tools/web-scraping-and-browser.md
@@ -99,7 +99,8 @@ crawl("https://matrix.org/blog/", search_query="bridges and federation")
 
 #### What It Does
 
-With normal MindRoom YAML configuration, `website` exposes `read_url(url)` and returns JSON-serialized `Document` objects from Agno's `WebsiteReader`.
+With normal MindRoom YAML configuration, `website` exposes `read_url(url)` and returns JSON-serialized `Document` objects from MindRoom's WebsiteReader variant.
+That reader keeps Agno's crawl and document shape while filtering search UI, navigation, headers, footers, sidebars, hidden content, and modals before choosing the page text.
 If a `Knowledge` object is injected programmatically through the `knowledge` constructor argument, the tool exposes `add_website_to_knowledge(url)` instead of `read_url()`.
 That means the same registry entry can act either as a simple page reader or as a knowledge-base ingestion hook depending on how it is constructed.
 In normal hand-authored `config.yaml`, you should treat this as a quick page-reading tool.
@@ -661,7 +662,7 @@ get_page_content()
 
 #### What It Does
 
-`browser` exposes one callable, `browser(action=...)`, with actions such as `status`, `start`, `stop`, `profiles`, `tabs`, `open`, `focus`, `close`, `snapshot`, `screenshot`, `navigate`, `console`, `pdf`, `upload`, `dialog`, and `act`.
+`browser` exposes one callable, `browser(action=...)`, with actions such as `status`, `start`, `stop`, `profiles`, `tabs`, `open`, `focus`, `close`, `snapshot`, `screenshot`, `navigate`, `console`, `pdf`, `upload`, `dialog`, `act`, `help`, and `actions`.
 It manages named browser profiles, with `mindroom` as the default profile name.
 It creates tabs, tracks the active tab, records console entries, and resolves temporary element refs from `snapshot()` into later `act()` and `screenshot()` calls.
 `snapshot()` can return either `ai` or `aria` format.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -4328,7 +4328,7 @@ crawl("https://matrix.org/blog/", search_query="bridges and federation")
 
 #### What It Does
 
-With normal MindRoom YAML configuration, `website` exposes `read_url(url)` and returns JSON-serialized `Document` objects from Agno's `WebsiteReader`. If a `Knowledge` object is injected programmatically through the `knowledge` constructor argument, the tool exposes `add_website_to_knowledge(url)` instead of `read_url()`. That means the same registry entry can act either as a simple page reader or as a knowledge-base ingestion hook depending on how it is constructed. In normal hand-authored `config.yaml`, you should treat this as a quick page-reading tool.
+With normal MindRoom YAML configuration, `website` exposes `read_url(url)` and returns JSON-serialized `Document` objects from MindRoom's WebsiteReader variant. That reader keeps Agno's crawl and document shape while filtering search UI, navigation, headers, footers, sidebars, hidden content, and modals before choosing the page text. If a `Knowledge` object is injected programmatically through the `knowledge` constructor argument, the tool exposes `add_website_to_knowledge(url)` instead of `read_url()`. That means the same registry entry can act either as a simple page reader or as a knowledge-base ingestion hook depending on how it is constructed. In normal hand-authored `config.yaml`, you should treat this as a quick page-reading tool.
 
 #### Configuration
 
@@ -4835,7 +4835,7 @@ get_page_content()
 
 #### What It Does
 
-`browser` exposes one callable, `browser(action=...)`, with actions such as `status`, `start`, `stop`, `profiles`, `tabs`, `open`, `focus`, `close`, `snapshot`, `screenshot`, `navigate`, `console`, `pdf`, `upload`, `dialog`, and `act`. It manages named browser profiles, with `mindroom` as the default profile name. It creates tabs, tracks the active tab, records console entries, and resolves temporary element refs from `snapshot()` into later `act()` and `screenshot()` calls. `snapshot()` can return either `ai` or `aria` format. `act()` currently supports `click`, `type`, `press`, `hover`, `drag`, `select`, `fill`, `resize`, `wait`, `evaluate`, and `close`. Only `target="host"` is supported on this branch, so sandbox or node targeting fields currently return an error. If `output_dir` is unset, screenshots and PDFs are written under `<storage>/browser`. The runtime picks Chromium from `BROWSER_EXECUTABLE_PATH`, `chromium`, or `google-chrome-stable` when available.
+`browser` exposes one callable, `browser(action=...)`, with actions such as `status`, `start`, `stop`, `profiles`, `tabs`, `open`, `focus`, `close`, `snapshot`, `screenshot`, `navigate`, `console`, `pdf`, `upload`, `dialog`, `act`, `help`, and `actions`. It manages named browser profiles, with `mindroom` as the default profile name. It creates tabs, tracks the active tab, records console entries, and resolves temporary element refs from `snapshot()` into later `act()` and `screenshot()` calls. `snapshot()` can return either `ai` or `aria` format. `act()` currently supports `click`, `type`, `press`, `hover`, `drag`, `select`, `fill`, `resize`, `wait`, `evaluate`, and `close`. Only `target="host"` is supported on this branch, so sandbox or node targeting fields currently return an error. If `output_dir` is unset, screenshots and PDFs are written under `<storage>/browser`. The runtime picks Chromium from `BROWSER_EXECUTABLE_PATH`, `chromium`, or `google-chrome-stable` when available.
 
 #### Configuration
 

--- a/skills/mindroom-docs/references/page__tools__web-scraping-and-browser__index.md
+++ b/skills/mindroom-docs/references/page__tools__web-scraping-and-browser__index.md
@@ -95,7 +95,8 @@ crawl("https://matrix.org/blog/", search_query="bridges and federation")
 
 #### What It Does
 
-With normal MindRoom YAML configuration, `website` exposes `read_url(url)` and returns JSON-serialized `Document` objects from Agno's `WebsiteReader`.
+With normal MindRoom YAML configuration, `website` exposes `read_url(url)` and returns JSON-serialized `Document` objects from MindRoom's WebsiteReader variant.
+That reader keeps Agno's crawl and document shape while filtering search UI, navigation, headers, footers, sidebars, hidden content, and modals before choosing the page text.
 If a `Knowledge` object is injected programmatically through the `knowledge` constructor argument, the tool exposes `add_website_to_knowledge(url)` instead of `read_url()`.
 That means the same registry entry can act either as a simple page reader or as a knowledge-base ingestion hook depending on how it is constructed.
 In normal hand-authored `config.yaml`, you should treat this as a quick page-reading tool.
@@ -657,7 +658,7 @@ get_page_content()
 
 #### What It Does
 
-`browser` exposes one callable, `browser(action=...)`, with actions such as `status`, `start`, `stop`, `profiles`, `tabs`, `open`, `focus`, `close`, `snapshot`, `screenshot`, `navigate`, `console`, `pdf`, `upload`, `dialog`, and `act`.
+`browser` exposes one callable, `browser(action=...)`, with actions such as `status`, `start`, `stop`, `profiles`, `tabs`, `open`, `focus`, `close`, `snapshot`, `screenshot`, `navigate`, `console`, `pdf`, `upload`, `dialog`, `act`, `help`, and `actions`.
 It manages named browser profiles, with `mindroom` as the default profile name.
 It creates tabs, tracks the active tab, records console entries, and resolves temporary element refs from `snapshot()` into later `act()` and `screenshot()` calls.
 `snapshot()` can return either `ai` or `aria` format.

--- a/src/mindroom/custom_tools/attachments.py
+++ b/src/mindroom/custom_tools/attachments.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import mimetypes
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 from agno.tools import Toolkit
 
@@ -45,6 +46,8 @@ if TYPE_CHECKING:
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
 
+_LocalAttachmentKind = Literal["audio", "file", "image", "video"]
+
 
 @dataclass(frozen=True)
 class _AttachmentSendResult:
@@ -65,6 +68,17 @@ def _attachment_tool_payload(status: str, **kwargs: object) -> str:
     }
     payload.update(kwargs)
     return json.dumps(payload, sort_keys=True)
+
+
+def _infer_local_attachment_metadata(local_path: Path) -> tuple[_LocalAttachmentKind, str, str | None]:
+    """Infer attachment metadata for local files registered by path."""
+    mime_type, _encoding = mimetypes.guess_type(local_path.name)
+    if mime_type is None:
+        return "file", local_path.name, None
+    media_type = mime_type.split("/", 1)[0].lower()
+    if media_type in {"audio", "image", "video"}:
+        return cast("_LocalAttachmentKind", media_type), local_path.name, mime_type
+    return "file", local_path.name, mime_type
 
 
 def _get_attachment_listing(
@@ -182,10 +196,13 @@ def _register_attachment_file_path(
         return None, "Attachment storage path is unavailable in this runtime path."
 
     resolved_path = Path(file_path).expanduser().resolve()
+    kind, filename, mime_type = _infer_local_attachment_metadata(resolved_path)
     attachment_record = register_local_attachment(
         context.storage_path,
         resolved_path,
-        kind="file",
+        kind=kind,
+        filename=filename,
+        mime_type=mime_type,
         room_id=context.room_id,
         thread_id=context.resolved_thread_id,
         sender=context.requester_id,

--- a/src/mindroom/custom_tools/browser.py
+++ b/src/mindroom/custom_tools/browser.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 
 from agno.tools import Toolkit
 from playwright.async_api import BrowserContext, ConsoleMessage, Dialog, Page, Playwright, async_playwright
+from playwright.async_api import Error as PlaywrightError
 
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.runtime_context import get_tool_runtime_context
@@ -32,10 +33,12 @@ _DEFAULT_TIMEOUT_MS = 30_000
 _MAX_CONSOLE_ENTRIES = 200
 _VIEWPORT_WIDTH = 1280
 _VIEWPORT_HEIGHT = 720
+_PLAYWRIGHT_INSTALL_COMMAND = "uv run playwright install chromium"
 
 logger = get_logger(__name__)
 
 _BROWSER_ACTIONS = {
+    "actions",
     "status",
     "start",
     "stop",
@@ -52,7 +55,54 @@ _BROWSER_ACTIONS = {
     "upload",
     "dialog",
     "act",
+    "help",
 }
+
+_ACT_REQUEST_KINDS = (
+    "click",
+    "type",
+    "press",
+    "hover",
+    "drag",
+    "select",
+    "fill",
+    "resize",
+    "wait",
+    "evaluate",
+    "close",
+)
+
+_BROWSER_ACTION_TABLE = (
+    {"action": "status", "description": "Report whether the selected browser profile is running."},
+    {"action": "start", "description": "Start the selected browser profile."},
+    {"action": "stop", "description": "Stop the selected browser profile."},
+    {"action": "profiles", "description": "List known browser profiles."},
+    {"action": "tabs", "description": "List tabs for the selected browser profile."},
+    {"action": "open", "description": "Open targetUrl in a new tab."},
+    {"action": "focus", "description": "Focus targetId."},
+    {"action": "close", "description": "Close targetId or the active tab."},
+    {"action": "snapshot", "description": "Capture a model-friendly page snapshot and element refs."},
+    {"action": "screenshot", "description": "Save a screenshot to the browser output directory."},
+    {"action": "navigate", "description": "Navigate targetId or the active tab to targetUrl."},
+    {"action": "console", "description": "Read collected console entries."},
+    {"action": "pdf", "description": "Save the current page as a PDF."},
+    {"action": "upload", "description": "Upload local paths through an input selector or ref."},
+    {"action": "dialog", "description": "Arm how the next browser dialog should be handled."},
+    {"action": "act", "description": "Run a browser interaction described by request.kind."},
+    {"action": "help", "description": "Return this browser action and request-kind table."},
+    {"action": "actions", "description": "Alias for help."},
+)
+
+_ACT_REQUEST_DESCRIPTION = (
+    "Act request object for action='act'. Set request.kind to one of: click, type, press, hover, drag, select, "
+    "fill, resize, wait, evaluate, close. "
+    "Common shapes: click {kind, ref, doubleClick?, button?, modifiers?}; "
+    "type {kind, ref, text, submit?, slowly?}; press {kind, key}; "
+    "hover {kind, ref}; drag {kind, startRef, endRef}; "
+    "select {kind, ref, values}; fill {kind, fields:[{ref|selector,value}]}; "
+    "resize {kind, width, height}; wait {kind, timeMs?|text?|textGone?}; "
+    "evaluate {kind, fn, ref?}; close {kind}. Refs come from action='snapshot'."
+)
 
 _SNAPSHOT_JS = """
 ({ selector, limit, depth, interactiveOnly }) => {
@@ -248,6 +298,99 @@ def _clear_stale_singleton_locks(_profile_dir: Path) -> None:
             )
 
 
+def _browser_help_payload(action: str) -> dict[str, Any]:
+    """Return a compact browser action discovery payload."""
+    return {
+        "action": action,
+        "actions": sorted(_BROWSER_ACTIONS),
+        "actKinds": list(_ACT_REQUEST_KINDS),
+        "actRequestDescription": _ACT_REQUEST_DESCRIPTION,
+        "actionTable": list(_BROWSER_ACTION_TABLE),
+        "status": "ok",
+    }
+
+
+def _unknown_browser_action_message(action: str) -> str:
+    """Return an actionable unknown-action error for browser callers."""
+    valid_actions = ", ".join(sorted(_BROWSER_ACTIONS))
+    return (
+        f"Unknown action: {action}. Valid actions: {valid_actions}. "
+        "For click/type/press/hover/drag/select/fill/resize/wait/evaluate/close interactions, "
+        "use action='act' with request.kind='click' (or another act kind). "
+        "Use action='help' to inspect the full table."
+    )
+
+
+def _playwright_cache_root(expected_executable_path: Path | None) -> Path | None:
+    """Return the Playwright browser cache root for an executable path."""
+    if expected_executable_path is None:
+        return None
+    for parent in expected_executable_path.parents:
+        if parent.name == "ms-playwright":
+            return parent
+    return None
+
+
+def _playwright_revision_dir_name(expected_executable_path: Path | None) -> str | None:
+    """Return the expected Playwright revision directory from an executable path."""
+    if expected_executable_path is None:
+        return None
+    for parent in expected_executable_path.parents:
+        if re.fullmatch(r"(chromium|chromium_headless_shell)-\d+", parent.name):
+            return parent.name
+    return None
+
+
+def _installed_playwright_chromium_revisions(cache_root: Path | None) -> list[str]:
+    """List locally cached Playwright Chromium revisions."""
+    if cache_root is None or not cache_root.is_dir():
+        return []
+    return sorted(
+        entry.name
+        for entry in cache_root.iterdir()
+        if entry.is_dir() and re.fullmatch(r"(chromium|chromium_headless_shell)-\d+", entry.name)
+    )
+
+
+def _friendly_playwright_browser_error_message(exc: PlaywrightError) -> str | None:
+    """Translate Playwright's install banner into MindRoom-specific guidance."""
+    raw_message = str(exc)
+    expected_path: Path | None = None
+    executable_match = re.search(r"Executable doesn't exist at (?P<path>[^\n]+)", raw_message)
+    if executable_match is not None:
+        expected_path = Path(executable_match.group("path").strip()).expanduser()
+    elif "Looks like Playwright was just installed or updated" not in raw_message:
+        return None
+
+    cache_root = _playwright_cache_root(expected_path)
+    expected_revision = _playwright_revision_dir_name(expected_path)
+    installed_revisions = _installed_playwright_chromium_revisions(cache_root)
+
+    expected_text = (
+        f"Expected Chromium runtime revision {expected_revision}"
+        if expected_revision is not None
+        else "Expected the Chromium runtime revision pinned by the installed Playwright package"
+    )
+    cache_text = f" in {cache_root}" if cache_root is not None else ""
+    installed_text = (
+        f" Cached Chromium revisions: {', '.join(installed_revisions)}."
+        if installed_revisions
+        else " No cached Chromium runtime for that revision was found."
+    )
+    return (
+        f"{expected_text}{cache_text}.{installed_text} Run `{_PLAYWRIGHT_INSTALL_COMMAND}` from the MindRoom checkout."
+    )
+
+
+class _BrowserFunctionNotRegisteredError(RuntimeError):
+    """Raised when the BrowserTools entrypoint is missing after Toolkit registration."""
+
+    _MESSAGE = "Browser function was not registered"
+
+    def __init__(self) -> None:
+        super().__init__(self._MESSAGE)
+
+
 class BrowserTools(Toolkit):
     """Browser control for MindRoom agents."""
 
@@ -260,6 +403,31 @@ class BrowserTools(Toolkit):
         if self._output_dir is not None:
             self._output_dir.mkdir(parents=True, exist_ok=True)
         self._close_task: asyncio.Task[None] | None = None
+        self._describe_browser_schema()
+
+    def _describe_browser_schema(self) -> None:
+        """Attach explicit model-facing descriptions for browser action routing."""
+        function = self.async_functions.get("browser")
+        if function is None:
+            raise _BrowserFunctionNotRegisteredError
+        function.process_entrypoint(strict=False)
+        parameters = dict(function.parameters)
+        properties = dict(parameters.get("properties") or {})
+
+        action_schema = dict(properties.get("action") or {})
+        action_schema["description"] = (
+            f"Browser action. Valid actions: {', '.join(sorted(_BROWSER_ACTIONS))}. "
+            "Use action='help' to inspect the full table."
+        )
+        action_schema["enum"] = sorted(_BROWSER_ACTIONS)
+        properties["action"] = action_schema
+
+        request_schema = dict(properties.get("request") or {})
+        request_schema["description"] = _ACT_REQUEST_DESCRIPTION
+        properties["request"] = request_schema
+
+        parameters["properties"] = properties
+        function.parameters = parameters
 
     async def _close_profiles(self) -> None:
         """Close all active browser profiles."""
@@ -309,7 +477,7 @@ class BrowserTools(Toolkit):
         """Control browser state and actions.
 
         Args:
-            action: Browser action (status/start/stop/profiles/tabs/open/focus/close/snapshot/screenshot/navigate/console/pdf/upload/dialog/act)
+            action: Browser action (status/start/stop/profiles/tabs/open/focus/close/snapshot/screenshot/navigate/console/pdf/upload/dialog/act/help/actions)
             target: Browser target location. Only ``host`` is currently supported.
             node: Node id compatibility field; unsupported in MindRoom runtime.
             profile: Browser profile name (defaults to ``mindroom``).
@@ -344,8 +512,10 @@ class BrowserTools(Toolkit):
         """
         normalized_action = action.strip().lower()
         if normalized_action not in _BROWSER_ACTIONS:
-            msg = f"Unknown action: {action}"
+            msg = _unknown_browser_action_message(action)
             raise ValueError(msg)
+        if normalized_action in {"actions", "help"}:
+            return json.dumps(_browser_help_payload(normalized_action), sort_keys=True)
 
         self._validate_target(target=target, node=node)
         profile_name = _clean_str(profile) or _DEFAULT_PROFILE
@@ -1000,7 +1170,17 @@ class BrowserTools(Toolkit):
             launch_kwargs = _persistent_launch_kwargs(self._runtime_paths, profile_name, headless=True)
             user_data_dir = Path(str(launch_kwargs["user_data_dir"]))
             _clear_stale_singleton_locks(user_data_dir)
-            context = await playwright.chromium.launch_persistent_context(**launch_kwargs)
+            try:
+                context = await playwright.chromium.launch_persistent_context(**launch_kwargs)
+            except PlaywrightError as exc:
+                await playwright.stop()
+                friendly_message = _friendly_playwright_browser_error_message(exc)
+                if friendly_message is not None:
+                    raise RuntimeError(friendly_message) from exc
+                raise
+            except Exception:
+                await playwright.stop()
+                raise
             state = _BrowserProfileState(playwright=playwright, context=context)
             self._profiles[profile_name] = state
 

--- a/src/mindroom/custom_tools/website.py
+++ b/src/mindroom/custom_tools/website.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+from ipaddress import ip_address
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
 
@@ -107,12 +108,36 @@ def _safe_url_for_log(url: str) -> str:
     return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
 
 
+def _normalized_hostname(url: str) -> str:
+    """Return the normalized hostname component for crawl domain checks."""
+    return (urlparse(url).hostname or "").rstrip(".").lower()
+
+
+def _is_ip_address(host: str) -> bool:
+    """Return whether a host is an IPv4 or IPv6 address."""
+    try:
+        ip_address(host)
+    except ValueError:
+        return False
+    return True
+
+
+def _url_matches_primary_domain(url: str, primary_domain: str) -> bool:
+    """Return whether a URL belongs to the crawl's primary domain boundary."""
+    host = _normalized_hostname(url)
+    if not host or not primary_domain:
+        return False
+    return host == primary_domain or host.endswith(f".{primary_domain}")
+
+
 class _MindRoomWebsiteReader(WebsiteReader):
     """WebsiteReader variant that avoids selecting early search/navigation sections."""
 
     def _get_primary_domain(self, url: str) -> str:
         """Extract the primary domain without treating URL userinfo as part of the host."""
-        host = urlparse(url).hostname or ""
+        host = _normalized_hostname(url)
+        if _is_ip_address(host):
+            return host
         return ".".join(host.split(".")[-2:])
 
     def _queue_links(self, soup: BeautifulSoup, current_url: str, current_depth: int, primary_domain: str) -> None:
@@ -124,7 +149,9 @@ class _MindRoomWebsiteReader(WebsiteReader):
             href_str = str(link["href"])
             full_url = urljoin(current_url, href_str)
             parsed_url = urlparse(full_url)
-            if not parsed_url.netloc.endswith(primary_domain) or parsed_url.path.endswith((".pdf", ".jpg", ".png")):
+            if not _url_matches_primary_domain(full_url, primary_domain) or parsed_url.path.endswith(
+                (".pdf", ".jpg", ".png"),
+            ):
                 continue
 
             full_url_str = str(full_url)
@@ -143,7 +170,7 @@ class _MindRoomWebsiteReader(WebsiteReader):
         """Return whether a queued crawl URL is outside the current crawl budget."""
         return (
             current_url in self._visited
-            or not urlparse(current_url).netloc.endswith(primary_domain)
+            or not _url_matches_primary_domain(current_url, primary_domain)
             or (current_depth > self.max_depth and current_url != starting_url)
             or num_links >= self.max_links
         )

--- a/src/mindroom/custom_tools/website.py
+++ b/src/mindroom/custom_tools/website.py
@@ -1,0 +1,160 @@
+"""MindRoom website tools with stricter page-content extraction."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit, urlunsplit
+
+from agno.knowledge.reader.website_reader import WebsiteReader
+from agno.tools import Toolkit
+from agno.utils.log import log_debug
+from bs4 import BeautifulSoup, Tag
+
+if TYPE_CHECKING:
+    from agno.knowledge.document import Document
+    from agno.knowledge.knowledge import Knowledge
+else:
+    type Document = Any
+    type Knowledge = Any
+
+_PREFERRED_CONTENT_SELECTORS = (
+    "main",
+    "article",
+    "[role='main']",
+    "#content",
+    "#main",
+    "#article",
+    ".page-body",
+    ".main-content",
+    ".post-content",
+    ".entry-content",
+    ".article-body",
+    ".content",
+)
+
+_UNWANTED_SELECTORS = (
+    "script",
+    "style",
+    "noscript",
+    "nav",
+    "header",
+    "footer",
+    "aside",
+    "[hidden]",
+    "[aria-hidden='true']",
+    ".modal",
+    ".search-modal",
+)
+
+_LOW_VALUE_NAME_PATTERN = re.compile(r"(?:^|[-_])(nav|navbar|menu|search|modal|header|footer|sidebar)(?:$|[-_])")
+
+
+def _normalize_text(text: str) -> str:
+    """Collapse HTML extraction whitespace into stable plain text."""
+    return " ".join(text.split())
+
+
+def _element_text(element: Tag) -> str:
+    """Return normalized visible text for a candidate content element."""
+    return _normalize_text(element.get_text(" ", strip=True))
+
+
+def _has_low_value_name(element: Tag) -> bool:
+    """Return whether the element is likely navigation, search, or page chrome."""
+    names: list[str] = []
+    element_id = element.get("id")
+    if isinstance(element_id, str):
+        names.append(element_id.lower())
+    classes = element.get("class")
+    if isinstance(classes, list):
+        names.extend(str(class_name).lower() for class_name in classes)
+    return any(_LOW_VALUE_NAME_PATTERN.search(name) for name in names)
+
+
+def _remove_unwanted_elements(soup: BeautifulSoup) -> None:
+    """Remove common page chrome before selecting main text."""
+    for selector in _UNWANTED_SELECTORS:
+        for element in soup.select(selector):
+            element.decompose()
+
+
+def _best_text_candidate(candidates: list[Tag], *, min_chars: int = 40) -> str | None:
+    """Return the longest non-chrome text candidate."""
+    scored: list[tuple[int, str]] = []
+    for candidate in candidates:
+        if _has_low_value_name(candidate):
+            continue
+        text = _element_text(candidate)
+        if len(text) < min_chars:
+            continue
+        scored.append((len(text), text))
+    if not scored:
+        return None
+    return max(scored, key=lambda item: item[0])[1]
+
+
+def _safe_url_for_log(url: str) -> str:
+    """Return a URL safe for logs by dropping query and fragment data."""
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
+class _MindRoomWebsiteReader(WebsiteReader):
+    """WebsiteReader variant that avoids selecting early search/navigation sections."""
+
+    def _extract_main_content(self, soup: BeautifulSoup) -> str:
+        """Extract the best available page body text."""
+        content_soup = BeautifulSoup(str(soup), "html.parser")
+        _remove_unwanted_elements(content_soup)
+
+        for selector in _PREFERRED_CONTENT_SELECTORS:
+            candidates = [element for element in content_soup.select(selector) if isinstance(element, Tag)]
+            best_text = _best_text_candidate(candidates)
+            if best_text is not None:
+                return best_text
+
+        sections = [element for element in content_soup.find_all("section") if isinstance(element, Tag)]
+        best_section = _best_text_candidate(sections)
+        if best_section is not None:
+            return best_section
+
+        body = content_soup.body if isinstance(content_soup.body, Tag) else content_soup
+        return _normalize_text(body.get_text(" ", strip=True))
+
+
+class WebsiteTools(Toolkit):
+    """Agno-compatible website toolkit using MindRoom's fixed extractor."""
+
+    def __init__(
+        self,
+        knowledge: Knowledge | None = None,
+        **kwargs: Any,  # noqa: ANN401 - mirrors Agno Toolkit passthrough kwargs.
+    ) -> None:
+        self.knowledge = knowledge
+
+        tools: list[Any] = []
+        if self.knowledge is not None:
+            tools.append(self.add_website_to_knowledge)
+        else:
+            tools.append(self.read_url)
+
+        super().__init__(name="website_tools", tools=tools, **kwargs)
+
+    def add_website_to_knowledge(self, url: str) -> str:
+        """Add a website's content to the configured knowledge base."""
+        if self.knowledge is None:
+            return "Knowledge base not provided"
+
+        log_debug(f"Adding to knowledge base: {_safe_url_for_log(url)}")
+        self.knowledge.insert(url=url, reader=_MindRoomWebsiteReader())
+        return "Success"
+
+    def read_url(self, url: str) -> str:
+        """Read a URL and return relevant documents from the website."""
+        website = _MindRoomWebsiteReader()
+
+        log_debug(f"Reading website: {_safe_url_for_log(url)}")
+        relevant_docs: list[Document] = website.read(url=url)
+        return json.dumps([doc.to_dict() for doc in relevant_docs])

--- a/src/mindroom/custom_tools/website.py
+++ b/src/mindroom/custom_tools/website.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import re
-from ipaddress import ip_address
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
 
@@ -113,35 +112,19 @@ def _normalized_hostname(url: str) -> str:
     return (urlparse(url).hostname or "").rstrip(".").lower()
 
 
-def _is_ip_address(host: str) -> bool:
-    """Return whether a host is an IPv4 or IPv6 address."""
-    try:
-        ip_address(host)
-    except ValueError:
-        return False
-    return True
-
-
-def _url_matches_primary_domain(url: str, primary_domain: str) -> bool:
-    """Return whether a URL belongs to the crawl's primary domain boundary."""
+def _url_matches_crawl_host(url: str, crawl_host: str) -> bool:
+    """Return whether a URL belongs to the crawl's exact starting host."""
     host = _normalized_hostname(url)
-    if not host or not primary_domain:
+    if not host or not crawl_host:
         return False
-    return host == primary_domain or host.endswith(f".{primary_domain}")
+    return host == crawl_host
 
 
 class _MindRoomWebsiteReader(WebsiteReader):
     """WebsiteReader variant that avoids selecting early search/navigation sections."""
 
-    def _get_primary_domain(self, url: str) -> str:
-        """Extract the primary domain without treating URL userinfo as part of the host."""
-        host = _normalized_hostname(url)
-        if _is_ip_address(host):
-            return host
-        return ".".join(host.split(".")[-2:])
-
-    def _queue_links(self, soup: BeautifulSoup, current_url: str, current_depth: int, primary_domain: str) -> None:
-        """Queue same-domain crawl links from the unmodified page soup."""
+    def _queue_links(self, soup: BeautifulSoup, current_url: str, current_depth: int, crawl_host: str) -> None:
+        """Queue same-host crawl links from the unmodified page soup."""
         for link in soup.find_all("a", href=True):
             if not isinstance(link, Tag):
                 continue
@@ -149,7 +132,7 @@ class _MindRoomWebsiteReader(WebsiteReader):
             href_str = str(link["href"])
             full_url = urljoin(current_url, href_str)
             parsed_url = urlparse(full_url)
-            if not _url_matches_primary_domain(full_url, primary_domain) or parsed_url.path.endswith(
+            if not _url_matches_crawl_host(full_url, crawl_host) or parsed_url.path.endswith(
                 (".pdf", ".jpg", ".png"),
             ):
                 continue
@@ -165,24 +148,23 @@ class _MindRoomWebsiteReader(WebsiteReader):
         starting_url: str,
         current_depth: int,
         num_links: int,
-        primary_domain: str,
+        crawl_host: str,
     ) -> bool:
         """Return whether a queued crawl URL is outside the current crawl budget."""
         return (
             current_url in self._visited
-            or not _url_matches_primary_domain(current_url, primary_domain)
+            or not _url_matches_crawl_host(current_url, crawl_host)
             or (current_depth > self.max_depth and current_url != starting_url)
             or num_links >= self.max_links
         )
 
-    def _log_http_status_error(self, *, safe_current_url: str, error: httpx.HTTPStatusError, async_mode: bool) -> None:
+    def _log_http_status_error(self, *, safe_current_url: str, error: httpx.HTTPStatusError) -> None:
         """Log HTTP crawl failures without including provider exception text."""
-        if 300 <= error.response.status_code < 400 and not async_mode:
+        if 300 <= error.response.status_code < 400:
             log_debug(f"Redirect encountered for {safe_current_url}, skipping")
             return
 
-        prefix = "HTTP status error while crawling asynchronously" if async_mode else "HTTP status error while crawling"
-        log_warning(f"{prefix} {safe_current_url}: {error.response.status_code}")
+        log_warning(f"HTTP status error while crawling {safe_current_url}: {error.response.status_code}")
 
     def _documents_from_crawl(
         self,
@@ -212,7 +194,7 @@ class _MindRoomWebsiteReader(WebsiteReader):
         *,
         current_url: str,
         current_depth: int,
-        primary_domain: str,
+        crawl_host: str,
         crawler_result: dict[str, str],
     ) -> bool:
         """Extract content from a response and queue crawl links from the original soup."""
@@ -221,14 +203,14 @@ class _MindRoomWebsiteReader(WebsiteReader):
         if main_content:
             crawler_result[current_url] = main_content
 
-        self._queue_links(soup, current_url, current_depth, primary_domain)
+        self._queue_links(soup, current_url, current_depth, crawl_host)
         return bool(main_content)
 
     def crawl(self, url: str, starting_depth: int = 1) -> dict[str, str]:
         """Crawl a website while logging only sanitized URL forms."""
         num_links = 0
         crawler_result: dict[str, str] = {}
-        primary_domain = self._get_primary_domain(url)
+        crawl_host = _normalized_hostname(url)
 
         self._visited = set()
         self._urls_to_crawl = [(url, starting_depth)]
@@ -239,7 +221,7 @@ class _MindRoomWebsiteReader(WebsiteReader):
                 starting_url=url,
                 current_depth=current_depth,
                 num_links=num_links,
-                primary_domain=primary_domain,
+                crawl_host=crawl_host,
             ):
                 continue
 
@@ -259,11 +241,11 @@ class _MindRoomWebsiteReader(WebsiteReader):
                     response,
                     current_url=current_url,
                     current_depth=current_depth,
-                    primary_domain=primary_domain,
+                    crawl_host=crawl_host,
                     crawler_result=crawler_result,
                 )
             except httpx.HTTPStatusError as e:
-                self._log_http_status_error(safe_current_url=safe_current_url, error=e, async_mode=False)
+                self._log_http_status_error(safe_current_url=safe_current_url, error=e)
                 if current_url == url and not crawler_result and not (300 <= e.response.status_code < 400):
                     raise
             except httpx.RequestError as e:
@@ -280,63 +262,6 @@ class _MindRoomWebsiteReader(WebsiteReader):
 
         return crawler_result
 
-    async def async_crawl(self, url: str, starting_depth: int = 1) -> dict[str, str]:
-        """Asynchronously crawl a website while logging only sanitized URL forms."""
-        num_links = 0
-        crawler_result: dict[str, str] = {}
-        primary_domain = self._get_primary_domain(url)
-
-        self._visited = set()
-        self._urls_to_crawl = [(url, starting_depth)]
-
-        async_client = httpx.AsyncClient(proxy=self.proxy) if self.proxy else httpx.AsyncClient()
-        async with async_client as client:
-            while self._urls_to_crawl and num_links < self.max_links:
-                current_url, current_depth = self._urls_to_crawl.pop(0)
-                if self._should_skip_crawl_url(
-                    current_url=current_url,
-                    starting_url=url,
-                    current_depth=current_depth,
-                    num_links=num_links,
-                    primary_domain=primary_domain,
-                ):
-                    continue
-
-                self._visited.add(current_url)
-                await self.async_delay()
-                safe_current_url = _safe_url_for_log(current_url)
-
-                try:
-                    log_debug(f"Crawling asynchronously: {safe_current_url}")
-                    response = await client.get(current_url, timeout=self.timeout, follow_redirects=True)
-                    response.raise_for_status()
-                    num_links += self._record_response_content(
-                        response,
-                        current_url=current_url,
-                        current_depth=current_depth,
-                        primary_domain=primary_domain,
-                        crawler_result=crawler_result,
-                    )
-                except httpx.HTTPStatusError as e:
-                    self._log_http_status_error(safe_current_url=safe_current_url, error=e, async_mode=True)
-                    if current_url == url and not crawler_result:
-                        raise
-                except httpx.RequestError as e:
-                    log_warning(
-                        f"Request error while crawling asynchronously {safe_current_url}: {e.__class__.__name__}",
-                    )
-                    if current_url == url and not crawler_result:
-                        raise
-                except Exception as e:
-                    log_warning(f"Failed to crawl asynchronously {safe_current_url}: {e.__class__.__name__}")
-                    if current_url == url and not crawler_result:
-                        raise httpx.RequestError(_FAILED_STARTING_URL, request=None) from e
-
-        if not crawler_result:
-            raise httpx.RequestError(_FAILED_CRAWL_CONTENT, request=None)
-
-        return crawler_result
-
     def read(self, url: str, name: str | None = None) -> list[Document]:
         """Read a website while logging only sanitized URL forms."""
         log_debug(f"Reading: {_safe_url_for_log(url)}")
@@ -344,15 +269,6 @@ class _MindRoomWebsiteReader(WebsiteReader):
             return self._documents_from_crawl(self.crawl(url), url=url, name=name)
         except (httpx.HTTPStatusError, httpx.RequestError) as e:
             log_error(f"Error reading website {_safe_url_for_log(url)}: {e.__class__.__name__}")
-            raise
-
-    async def async_read(self, url: str, name: str | None = None) -> list[Document]:
-        """Asynchronously read a website while logging only sanitized URL forms."""
-        log_debug(f"Reading asynchronously: {_safe_url_for_log(url)}")
-        try:
-            return self._documents_from_crawl(await self.async_crawl(url), url=url, name=name)
-        except (httpx.HTTPStatusError, httpx.RequestError) as e:
-            log_error(f"Error reading website asynchronously {_safe_url_for_log(url)}: {e.__class__.__name__}")
             raise
 
     def _extract_main_content(self, soup: BeautifulSoup) -> str:

--- a/src/mindroom/custom_tools/website.py
+++ b/src/mindroom/custom_tools/website.py
@@ -16,8 +16,6 @@ from bs4 import BeautifulSoup, Tag
 
 if TYPE_CHECKING:
     from agno.knowledge.knowledge import Knowledge
-else:
-    type Knowledge = Any
 
 _PREFERRED_CONTENT_SELECTORS = (
     "main",

--- a/src/mindroom/custom_tools/website.py
+++ b/src/mindroom/custom_tools/website.py
@@ -5,18 +5,18 @@ from __future__ import annotations
 import json
 import re
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
 
+import httpx
+from agno.knowledge.document import Document
 from agno.knowledge.reader.website_reader import WebsiteReader
 from agno.tools import Toolkit
-from agno.utils.log import log_debug
+from agno.utils.log import log_debug, log_error, log_warning
 from bs4 import BeautifulSoup, Tag
 
 if TYPE_CHECKING:
-    from agno.knowledge.document import Document
     from agno.knowledge.knowledge import Knowledge
 else:
-    type Document = Any
     type Knowledge = Any
 
 _PREFERRED_CONTENT_SELECTORS = (
@@ -49,6 +49,8 @@ _UNWANTED_SELECTORS = (
 )
 
 _LOW_VALUE_NAME_PATTERN = re.compile(r"(?:^|[-_])(nav|navbar|menu|search|modal|header|footer|sidebar)(?:$|[-_])")
+_FAILED_CRAWL_CONTENT = "Failed to extract any content"
+_FAILED_STARTING_URL = "Failed to crawl starting URL"
 
 
 def _normalize_text(text: str) -> str:
@@ -96,13 +98,235 @@ def _best_text_candidate(candidates: list[Tag], *, min_chars: int = 40) -> str |
 
 
 def _safe_url_for_log(url: str) -> str:
-    """Return a URL safe for logs by dropping query and fragment data."""
+    """Return a URL safe for logs by dropping credentials, query, and fragment data."""
     parts = urlsplit(url)
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+    host = parts.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = f"{host}:{parts.port}" if parts.port is not None else host
+    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
 
 
 class _MindRoomWebsiteReader(WebsiteReader):
     """WebsiteReader variant that avoids selecting early search/navigation sections."""
+
+    def _get_primary_domain(self, url: str) -> str:
+        """Extract the primary domain without treating URL userinfo as part of the host."""
+        host = urlparse(url).hostname or ""
+        return ".".join(host.split(".")[-2:])
+
+    def _queue_links(self, soup: BeautifulSoup, current_url: str, current_depth: int, primary_domain: str) -> None:
+        """Queue same-domain crawl links from the unmodified page soup."""
+        for link in soup.find_all("a", href=True):
+            if not isinstance(link, Tag):
+                continue
+
+            href_str = str(link["href"])
+            full_url = urljoin(current_url, href_str)
+            parsed_url = urlparse(full_url)
+            if not parsed_url.netloc.endswith(primary_domain) or parsed_url.path.endswith((".pdf", ".jpg", ".png")):
+                continue
+
+            full_url_str = str(full_url)
+            if full_url_str not in self._visited and (full_url_str, current_depth + 1) not in self._urls_to_crawl:
+                self._urls_to_crawl.append((full_url_str, current_depth + 1))
+
+    def _should_skip_crawl_url(
+        self,
+        *,
+        current_url: str,
+        starting_url: str,
+        current_depth: int,
+        num_links: int,
+        primary_domain: str,
+    ) -> bool:
+        """Return whether a queued crawl URL is outside the current crawl budget."""
+        return (
+            current_url in self._visited
+            or not urlparse(current_url).netloc.endswith(primary_domain)
+            or (current_depth > self.max_depth and current_url != starting_url)
+            or num_links >= self.max_links
+        )
+
+    def _log_http_status_error(self, *, safe_current_url: str, error: httpx.HTTPStatusError, async_mode: bool) -> None:
+        """Log HTTP crawl failures without including provider exception text."""
+        if 300 <= error.response.status_code < 400 and not async_mode:
+            log_debug(f"Redirect encountered for {safe_current_url}, skipping")
+            return
+
+        prefix = "HTTP status error while crawling asynchronously" if async_mode else "HTTP status error while crawling"
+        log_warning(f"{prefix} {safe_current_url}: {error.response.status_code}")
+
+    def _documents_from_crawl(
+        self,
+        crawler_result: dict[str, str],
+        *,
+        url: str,
+        name: str | None,
+    ) -> list[Document]:
+        """Build Agno documents from crawled page content."""
+        documents: list[Document] = []
+        for crawled_url, crawled_content in crawler_result.items():
+            document = Document(
+                name=name or url,
+                id=str(crawled_url),
+                meta_data={"url": str(crawled_url)},
+                content=crawled_content,
+            )
+            if self.chunk:
+                documents.extend(self.chunk_document(document))
+            else:
+                documents.append(document)
+        return documents
+
+    def _record_response_content(
+        self,
+        response: httpx.Response,
+        *,
+        current_url: str,
+        current_depth: int,
+        primary_domain: str,
+        crawler_result: dict[str, str],
+    ) -> bool:
+        """Extract content from a response and queue crawl links from the original soup."""
+        soup = BeautifulSoup(response.content, "html.parser")
+        main_content = self._extract_main_content(soup)
+        if main_content:
+            crawler_result[current_url] = main_content
+
+        self._queue_links(soup, current_url, current_depth, primary_domain)
+        return bool(main_content)
+
+    def crawl(self, url: str, starting_depth: int = 1) -> dict[str, str]:
+        """Crawl a website while logging only sanitized URL forms."""
+        num_links = 0
+        crawler_result: dict[str, str] = {}
+        primary_domain = self._get_primary_domain(url)
+
+        self._visited = set()
+        self._urls_to_crawl = [(url, starting_depth)]
+        while self._urls_to_crawl:
+            current_url, current_depth = self._urls_to_crawl.pop(0)
+            if self._should_skip_crawl_url(
+                current_url=current_url,
+                starting_url=url,
+                current_depth=current_depth,
+                num_links=num_links,
+                primary_domain=primary_domain,
+            ):
+                continue
+
+            self._visited.add(current_url)
+            self.delay()
+            safe_current_url = _safe_url_for_log(current_url)
+
+            try:
+                log_debug(f"Crawling: {safe_current_url}")
+                response = (
+                    httpx.get(current_url, timeout=self.timeout, proxy=self.proxy, follow_redirects=True)
+                    if self.proxy
+                    else httpx.get(current_url, timeout=self.timeout, follow_redirects=True)
+                )
+                response.raise_for_status()
+                num_links += self._record_response_content(
+                    response,
+                    current_url=current_url,
+                    current_depth=current_depth,
+                    primary_domain=primary_domain,
+                    crawler_result=crawler_result,
+                )
+            except httpx.HTTPStatusError as e:
+                self._log_http_status_error(safe_current_url=safe_current_url, error=e, async_mode=False)
+                if current_url == url and not crawler_result and not (300 <= e.response.status_code < 400):
+                    raise
+            except httpx.RequestError as e:
+                log_warning(f"Request error while crawling {safe_current_url}: {e.__class__.__name__}")
+                if current_url == url and not crawler_result:
+                    raise
+            except Exception as e:
+                log_warning(f"Failed to crawl {safe_current_url}: {e.__class__.__name__}")
+                if current_url == url and not crawler_result:
+                    raise httpx.RequestError(_FAILED_STARTING_URL, request=None) from e
+
+        if not crawler_result:
+            raise httpx.RequestError(_FAILED_CRAWL_CONTENT, request=None)
+
+        return crawler_result
+
+    async def async_crawl(self, url: str, starting_depth: int = 1) -> dict[str, str]:
+        """Asynchronously crawl a website while logging only sanitized URL forms."""
+        num_links = 0
+        crawler_result: dict[str, str] = {}
+        primary_domain = self._get_primary_domain(url)
+
+        self._visited = set()
+        self._urls_to_crawl = [(url, starting_depth)]
+
+        async_client = httpx.AsyncClient(proxy=self.proxy) if self.proxy else httpx.AsyncClient()
+        async with async_client as client:
+            while self._urls_to_crawl and num_links < self.max_links:
+                current_url, current_depth = self._urls_to_crawl.pop(0)
+                if self._should_skip_crawl_url(
+                    current_url=current_url,
+                    starting_url=url,
+                    current_depth=current_depth,
+                    num_links=num_links,
+                    primary_domain=primary_domain,
+                ):
+                    continue
+
+                self._visited.add(current_url)
+                await self.async_delay()
+                safe_current_url = _safe_url_for_log(current_url)
+
+                try:
+                    log_debug(f"Crawling asynchronously: {safe_current_url}")
+                    response = await client.get(current_url, timeout=self.timeout, follow_redirects=True)
+                    response.raise_for_status()
+                    num_links += self._record_response_content(
+                        response,
+                        current_url=current_url,
+                        current_depth=current_depth,
+                        primary_domain=primary_domain,
+                        crawler_result=crawler_result,
+                    )
+                except httpx.HTTPStatusError as e:
+                    self._log_http_status_error(safe_current_url=safe_current_url, error=e, async_mode=True)
+                    if current_url == url and not crawler_result:
+                        raise
+                except httpx.RequestError as e:
+                    log_warning(
+                        f"Request error while crawling asynchronously {safe_current_url}: {e.__class__.__name__}",
+                    )
+                    if current_url == url and not crawler_result:
+                        raise
+                except Exception as e:
+                    log_warning(f"Failed to crawl asynchronously {safe_current_url}: {e.__class__.__name__}")
+                    if current_url == url and not crawler_result:
+                        raise httpx.RequestError(_FAILED_STARTING_URL, request=None) from e
+
+        if not crawler_result:
+            raise httpx.RequestError(_FAILED_CRAWL_CONTENT, request=None)
+
+        return crawler_result
+
+    def read(self, url: str, name: str | None = None) -> list[Document]:
+        """Read a website while logging only sanitized URL forms."""
+        log_debug(f"Reading: {_safe_url_for_log(url)}")
+        try:
+            return self._documents_from_crawl(self.crawl(url), url=url, name=name)
+        except (httpx.HTTPStatusError, httpx.RequestError) as e:
+            log_error(f"Error reading website {_safe_url_for_log(url)}: {e.__class__.__name__}")
+            raise
+
+    async def async_read(self, url: str, name: str | None = None) -> list[Document]:
+        """Asynchronously read a website while logging only sanitized URL forms."""
+        log_debug(f"Reading asynchronously: {_safe_url_for_log(url)}")
+        try:
+            return self._documents_from_crawl(await self.async_crawl(url), url=url, name=name)
+        except (httpx.HTTPStatusError, httpx.RequestError) as e:
+            log_error(f"Error reading website asynchronously {_safe_url_for_log(url)}: {e.__class__.__name__}")
+            raise
 
     def _extract_main_content(self, soup: BeautifulSoup) -> str:
         """Extract the best available page body text."""

--- a/src/mindroom/tools/browser.py
+++ b/src/mindroom/tools/browser.py
@@ -38,7 +38,10 @@ if TYPE_CHECKING:
             label="Output Directory",
             type="text",
             required=False,
-            description="Optional directory for browser screenshots, PDFs, and downloads.",
+            description=(
+                "Optional directory for browser screenshots, PDFs, and downloads. "
+                "Defaults to the active storage path's browser/ directory."
+            ),
         ),
     ],
     function_names=("browser",),

--- a/src/mindroom/tools/browser.py
+++ b/src/mindroom/tools/browser.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     display_name="Browser",
     description=(
         "OpenClaw-style browser control (status/start/stop/profiles/tabs/open/focus/close/"
-        "snapshot/screenshot/navigate/console/pdf/upload/dialog/act)"
+        "snapshot/screenshot/navigate/console/pdf/upload/dialog/act/help/actions)"
     ),
     category=ToolCategory.RESEARCH,
     status=ToolStatus.AVAILABLE,

--- a/src/mindroom/tools/website.py
+++ b/src/mindroom/tools/website.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from mindroom.custom_tools.website import WebsiteTools
 from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
-
-if TYPE_CHECKING:
-    from agno.tools.website import WebsiteTools
 
 
 @register_tool_with_metadata(
@@ -34,6 +30,4 @@ if TYPE_CHECKING:
 )
 def website_tools() -> type[WebsiteTools]:
     """Return website tools for web scraping and content extraction."""
-    from agno.tools.website import WebsiteTools
-
     return WebsiteTools

--- a/src/mindroom/tools/website.py
+++ b/src/mindroom/tools/website.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from mindroom.custom_tools.website import WebsiteTools
+from typing import TYPE_CHECKING
+
 from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+
+if TYPE_CHECKING:
+    from mindroom.custom_tools.website import WebsiteTools
 
 
 @register_tool_with_metadata(
@@ -30,4 +34,6 @@ from mindroom.tool_system.metadata import ConfigField, SetupType, ToolCategory, 
 )
 def website_tools() -> type[WebsiteTools]:
     """Return website tools for web scraping and content extraction."""
+    from mindroom.custom_tools.website import WebsiteTools
+
     return WebsiteTools

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -8910,7 +8910,7 @@
         {
           "authored_override": true,
           "default": null,
-          "description": "Optional directory for browser screenshots, PDFs, and downloads.",
+          "description": "Optional directory for browser screenshots, PDFs, and downloads. Defaults to the active storage path's browser/ directory.",
           "label": "Output Directory",
           "name": "output_dir",
           "options": null,

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -8924,7 +8924,7 @@
       "dependencies": [
         "playwright"
       ],
-      "description": "OpenClaw-style browser control (status/start/stop/profiles/tabs/open/focus/close/snapshot/screenshot/navigate/console/pdf/upload/dialog/act)",
+      "description": "OpenClaw-style browser control (status/start/stop/profiles/tabs/open/focus/close/snapshot/screenshot/navigate/console/pdf/upload/dialog/act/help/actions)",
       "display_name": "Browser",
       "docs_url": "https://github.com/openclaw/openclaw/blob/main/docs/tools/browser.md",
       "function_names": [

--- a/tests/test_attachments_tool.py
+++ b/tests/test_attachments_tool.py
@@ -872,6 +872,30 @@ async def test_attachments_tool_registers_file_and_updates_runtime_context(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_attachments_tool_register_attachment_infers_file_metadata(tmp_path: Path) -> None:
+    """Registering a local path should preserve filename, MIME type, and media kind."""
+    tool = AttachmentTools()
+    generated_file = tmp_path / "clip.wav"
+    generated_file.write_bytes(b"RIFF\x00\x00\x00\x00WAVEfmt ")
+    ctx = _tool_context(tmp_path)
+
+    with tool_runtime_context(ctx):
+        payload = json.loads(await tool.register_attachment(str(generated_file)))
+
+    assert payload["status"] == "ok"
+    assert payload["attachment"]["filename"] == "clip.wav"
+    assert payload["attachment"]["mime_type"].startswith("audio/")
+    assert payload["attachment"]["kind"] == "audio"
+
+    attachment = load_attachment(tmp_path, payload["attachment_id"])
+    assert attachment is not None
+    assert attachment.filename == "clip.wav"
+    assert attachment.mime_type is not None
+    assert attachment.mime_type.startswith("audio/")
+    assert attachment.kind == "audio"
+
+
+@pytest.mark.asyncio
 async def test_attachments_tool_register_attachment_available_after_task_boundary(tmp_path: Path) -> None:
     """Registered attachments should remain available when a later tool call runs in another task."""
     tool = AttachmentTools()

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -299,6 +299,22 @@ def test_browser_metadata_documents_default_output_dir() -> None:
     assert "storage path's browser/ directory" in output_dir_field.description
 
 
+def test_browser_metadata_lists_discovery_actions() -> None:
+    """Dashboard metadata should expose the callable discovery actions."""
+    description = TOOL_METADATA["browser"].description
+
+    assert "help" in description
+    assert "actions" in description
+
+
+def test_browser_docs_list_discovery_actions() -> None:
+    """Tool docs should expose the callable discovery actions."""
+    docs = Path("docs/tools/web-scraping-and-browser.md").read_text(encoding="utf-8")
+
+    assert "`help`" in docs
+    assert "`actions`" in docs
+
+
 @pytest.mark.asyncio
 async def test_browser_open_requires_target_url() -> None:
     """Open action requires targetUrl."""

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -12,6 +12,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from playwright.async_api import Error as PlaywrightError
 
 from mindroom.constants import resolve_primary_runtime_paths
 from mindroom.custom_tools.browser import (
@@ -24,6 +25,7 @@ from mindroom.custom_tools.browser import (
     _persistent_launch_kwargs,
     _profile_dir,
 )
+from mindroom.tool_system.metadata import TOOL_METADATA
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 from tests.conftest import make_conversation_cache_mock, make_event_cache_mock
 
@@ -222,6 +224,79 @@ async def test_browser_unknown_action_raises() -> None:
 
     with pytest.raises(ValueError, match="Unknown action: nope"):
         await tool.browser(action="nope")
+
+
+@pytest.mark.asyncio
+async def test_browser_unknown_action_lists_valid_actions() -> None:
+    """Unknown browser actions should point callers at the valid action vocabulary."""
+    tool = BrowserTools(TEST_RUNTIME_PATHS)
+
+    with pytest.raises(ValueError, match="Unknown action: click") as exc_info:
+        await tool.browser(action="click")
+
+    message = str(exc_info.value)
+    assert "Unknown action: click" in message
+    assert "Valid actions:" in message
+    assert "act" in message
+    assert "request.kind='click'" in message
+
+
+@pytest.mark.asyncio
+async def test_browser_help_returns_action_table() -> None:
+    """The browser tool should expose a callable discovery path."""
+    tool = BrowserTools(TEST_RUNTIME_PATHS)
+
+    payload = json.loads(await tool.browser(action="help"))
+
+    assert payload["action"] == "help"
+    assert payload["status"] == "ok"
+    assert "act" in payload["actions"]
+    assert "help" in payload["actions"]
+    assert "click" in payload["actKinds"]
+    assert "evaluate" in payload["actKinds"]
+    assert any(entry["action"] == "act" for entry in payload["actionTable"])
+
+
+def test_browser_function_schema_documents_actions_and_act_request() -> None:
+    """Tool schema should make browser actions and act request kinds discoverable."""
+    tool = BrowserTools(TEST_RUNTIME_PATHS)
+
+    parameters = tool.async_functions["browser"].parameters
+    properties = parameters["properties"]
+
+    action_schema = properties["action"]
+    assert "act" in action_schema["enum"]
+    assert "help" in action_schema["enum"]
+
+    request_description = properties["request"]["description"]
+    assert "request.kind" in request_description
+    assert "click" in request_description
+    assert "evaluate" in request_description
+
+
+def test_browser_schema_description_requires_registered_browser_function() -> None:
+    """BrowserTools should fail fast if the browser entrypoint is missing."""
+    tool = BrowserTools(TEST_RUNTIME_PATHS)
+    function = tool.async_functions.pop("browser")
+    try:
+        with pytest.raises(RuntimeError, match="Browser function was not registered"):
+            tool._describe_browser_schema()
+    finally:
+        tool.async_functions["browser"] = function
+
+
+def test_browser_docstring_lists_discovery_actions() -> None:
+    """The source docstring should match the browser action vocabulary."""
+    assert BrowserTools.browser.__doc__ is not None
+    assert "/act/help/actions" in BrowserTools.browser.__doc__
+
+
+def test_browser_metadata_documents_default_output_dir() -> None:
+    """Dashboard metadata should mention where screenshots/PDFs land by default."""
+    output_dir_field = next(field for field in TOOL_METADATA["browser"].config_fields if field.name == "output_dir")
+
+    assert output_dir_field.description is not None
+    assert "storage path's browser/ directory" in output_dir_field.description
 
 
 @pytest.mark.asyncio
@@ -439,6 +514,56 @@ async def test_ensure_profile_creates_user_data_dir_on_disk(
     user_data_dir = Path(str(launch_kwargs["user_data_dir"]))
     assert user_data_dir.is_dir()
     assert stat.S_IMODE(user_data_dir.stat().st_mode) == 0o700
+
+
+@pytest.mark.asyncio
+async def test_ensure_profile_rewrites_playwright_browser_revision_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Playwright binary revision mismatches should produce actionable MindRoom guidance."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={},
+    )
+    tool = BrowserTools(runtime_paths)
+    playwright_message = (
+        "Executable doesn't exist at "
+        "/home/alice/.cache/ms-playwright/chromium_headless_shell-1208/chrome-linux/headless_shell\n"
+        "╔════════════════════════════════════════════════════════════╗\n"
+        "║ Looks like Playwright was just installed or updated.       ║\n"
+        "║ Please run the following command to download new browsers: ║\n"
+        "║                                                            ║\n"
+        "║     playwright install                                     ║\n"
+        "╚════════════════════════════════════════════════════════════╝"
+    )
+
+    class _FakeChromium:
+        async def launch_persistent_context(self, **_kwargs: object) -> _FakeContext:
+            raise PlaywrightError(playwright_message)
+
+    class _FakePlaywright:
+        def __init__(self) -> None:
+            self.chromium = _FakeChromium()
+            self.stop = AsyncMock()
+
+    playwright = _FakePlaywright()
+
+    class _FakePlaywrightStarter:
+        async def start(self) -> _FakePlaywright:
+            return playwright
+
+    monkeypatch.setattr("mindroom.custom_tools.browser.async_playwright", lambda: _FakePlaywrightStarter())
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await tool._ensure_profile("mindroom")
+
+    message = str(exc_info.value)
+    assert "chromium_headless_shell-1208" in message
+    assert "uv run playwright install chromium" in message
+    assert "Looks like Playwright was just installed or updated" not in message
+    playwright.stop.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -242,13 +242,14 @@ async def test_browser_unknown_action_lists_valid_actions() -> None:
 
 
 @pytest.mark.asyncio
-async def test_browser_help_returns_action_table() -> None:
-    """The browser tool should expose a callable discovery path."""
+@pytest.mark.parametrize("action", ["help", "actions"])
+async def test_browser_discovery_actions_return_action_table(action: str) -> None:
+    """The browser tool should expose callable discovery paths."""
     tool = BrowserTools(TEST_RUNTIME_PATHS)
 
-    payload = json.loads(await tool.browser(action="help"))
+    payload = json.loads(await tool.browser(action=action))
 
-    assert payload["action"] == "help"
+    assert payload["action"] == action
     assert payload["status"] == "ok"
     assert "act" in payload["actions"]
     assert "help" in payload["actions"]

--- a/tests/test_tool_dependencies.py
+++ b/tests/test_tool_dependencies.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import textwrap
 import tomllib
 from pathlib import Path
 from types import SimpleNamespace
@@ -132,6 +133,38 @@ def test_core_runtime_imports_are_declared_as_base_dependencies() -> None:
         assert dependency_name in base_dependencies, (
             f"{module_path} imports {dependency_name!r} directly and it should be declared in project.dependencies"
         )
+
+
+def test_website_tool_registry_import_does_not_require_website_extra() -> None:
+    """Registry imports should not import optional website implementation dependencies."""
+    script = """
+    import importlib.abc
+    import sys
+
+
+    class BlockWebsiteImplementation(importlib.abc.MetaPathFinder):
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == "mindroom.custom_tools.website" or fullname.startswith("bs4"):
+                raise ImportError(f"blocked optional website dependency: {fullname}")
+            return None
+
+
+    sys.meta_path.insert(0, BlockWebsiteImplementation())
+    import mindroom.tools
+    import mindroom.tools.website
+
+    assert "mindroom.custom_tools.website" not in sys.modules
+    print("ok")
+    """
+
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_vertexai_claude_google_auth_is_declared_as_base_dependency() -> None:

--- a/tests/test_website_tool.py
+++ b/tests/test_website_tool.py
@@ -91,6 +91,55 @@ def test_website_read_url_crawls_links_from_chrome_without_returning_chrome_text
     assert "Detailed reference material" in content_by_url[docs_url]
 
 
+def test_website_reader_crawls_starting_url_with_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same-domain checks should ignore URL ports when crawling."""
+    start_url = "https://example.test:8443/docs"
+    html = """
+    <html>
+      <body>
+        <main>
+          <h1>Docs</h1>
+          <p>Reference material with enough text to exercise ported URL crawling.</p>
+        </main>
+      </body>
+    </html>
+    """
+
+    def fake_get(url: str, *, timeout: int, follow_redirects: bool) -> httpx.Response:
+        assert url == start_url
+        assert timeout == 10
+        assert follow_redirects is True
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, content=html.encode(), request=request)
+
+    def no_delay(_reader: _MindRoomWebsiteReader, min_seconds: int = 1, max_seconds: int = 3) -> None:
+        assert min_seconds == 1
+        assert max_seconds == 3
+
+    monkeypatch.setattr("mindroom.custom_tools.website.httpx.get", fake_get)
+    monkeypatch.setattr(_MindRoomWebsiteReader, "delay", no_delay)
+
+    documents = _MindRoomWebsiteReader().read(start_url)
+
+    assert documents[0].meta_data["url"] == start_url
+    assert "ported URL crawling" in documents[0].content
+
+
+def test_website_reader_rejects_domain_suffix_lookalikes() -> None:
+    """Same-domain checks should not treat badexample.com as example.com."""
+    reader = _MindRoomWebsiteReader()
+
+    primary_domain = reader._get_primary_domain("https://example.com/")
+
+    assert reader._should_skip_crawl_url(
+        current_url="https://badexample.com/private",
+        starting_url="https://example.com/",
+        current_depth=1,
+        num_links=0,
+        primary_domain=primary_domain,
+    )
+
+
 def test_safe_url_for_log_strips_userinfo_query_and_fragment() -> None:
     """Website logs should keep origin/path context without exposing secrets."""
     assert (

--- a/tests/test_website_tool.py
+++ b/tests/test_website_tool.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
 from bs4 import BeautifulSoup
 
-from mindroom.custom_tools.website import WebsiteTools, _MindRoomWebsiteReader
+from mindroom.custom_tools.website import WebsiteTools, _MindRoomWebsiteReader, _safe_url_for_log
 from mindroom.tools.website import website_tools
 
 if TYPE_CHECKING:
@@ -90,10 +91,28 @@ def test_website_read_url_crawls_links_from_chrome_without_returning_chrome_text
     assert "Detailed reference material" in content_by_url[docs_url]
 
 
-def test_website_tool_logs_urls_without_query_or_fragment(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Website tools should not put caller query strings or fragments in logs."""
-    full_url = "https://example.test/docs?token=secret#private"
+def test_safe_url_for_log_strips_userinfo_query_and_fragment() -> None:
+    """Website logs should keep origin/path context without exposing secrets."""
+    assert (
+        _safe_url_for_log("https://user:pass@example.test:8443/docs?token=secret#private")
+        == "https://example.test:8443/docs"
+    )
+
+
+def test_website_reader_logs_sanitized_urls_without_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Website reads should not leak caller URL secrets through wrapper or reader logs."""
+    full_url = "https://user:secret@example.test/docs?token=query-secret#frag-secret"
     logged_messages: list[str] = []
+    html = """
+    <html>
+      <body>
+        <main>
+          <h1>Docs</h1>
+          <p>Reference material with enough page text to exercise the reader.</p>
+        </main>
+      </body>
+    </html>
+    """
 
     class FakeKnowledge:
         def insert(self, *, url: str, reader: object) -> None:
@@ -103,22 +122,36 @@ def test_website_tool_logs_urls_without_query_or_fragment(monkeypatch: pytest.Mo
     def fake_log_debug(message: str) -> None:
         logged_messages.append(message)
 
-    def fake_read(_reader: _MindRoomWebsiteReader, *, url: str) -> list[object]:
+    def fake_get(url: str, *, timeout: int, follow_redirects: bool) -> httpx.Response:
         assert url == full_url
-        return []
+        assert timeout == 10
+        assert follow_redirects is True
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, content=html.encode(), request=request)
+
+    def no_delay(_reader: _MindRoomWebsiteReader, min_seconds: int = 1, max_seconds: int = 3) -> None:
+        assert min_seconds == 1
+        assert max_seconds == 3
 
     monkeypatch.setattr("mindroom.custom_tools.website.log_debug", fake_log_debug)
-    monkeypatch.setattr(_MindRoomWebsiteReader, "read", fake_read)
+    monkeypatch.setattr("agno.knowledge.reader.website_reader.log_debug", fake_log_debug)
+    monkeypatch.setattr("agno.knowledge.reader.website_reader.httpx.get", fake_get)
+    monkeypatch.setattr(_MindRoomWebsiteReader, "delay", no_delay)
 
     WebsiteTools().read_url(full_url)
     WebsiteTools(knowledge=FakeKnowledge()).add_website_to_knowledge(full_url)
 
     assert logged_messages == [
         "Reading website: https://example.test/docs",
+        "Reading: https://example.test/docs",
+        "Crawling: https://example.test/docs",
         "Adding to knowledge base: https://example.test/docs",
     ]
-    assert "secret" not in " ".join(logged_messages)
-    assert "private" not in " ".join(logged_messages)
+    joined_messages = " ".join(logged_messages)
+    assert full_url not in joined_messages
+    assert "user:secret" not in joined_messages
+    assert "query-secret" not in joined_messages
+    assert "frag-secret" not in joined_messages
 
 
 def test_website_tool_adds_urls_to_knowledge_with_mindroom_reader() -> None:
@@ -149,3 +182,10 @@ def test_website_tool_adds_urls_to_knowledge_with_mindroom_reader() -> None:
 def test_website_tool_factory_uses_mindroom_reader() -> None:
     """The configured website toolkit should use MindRoom's fixed extractor."""
     assert website_tools().__module__ == "mindroom.custom_tools.website"
+
+
+def test_website_docs_describe_mindroom_reader() -> None:
+    """Website docs should describe the reader users actually get."""
+    docs = Path("docs/tools/web-scraping-and-browser.md").read_text(encoding="utf-8")
+
+    assert "MindRoom's WebsiteReader variant" in docs

--- a/tests/test_website_tool.py
+++ b/tests/test_website_tool.py
@@ -1,0 +1,151 @@
+"""Tests for MindRoom website scraping tools."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import httpx
+from bs4 import BeautifulSoup
+
+from mindroom.custom_tools.website import WebsiteTools, _MindRoomWebsiteReader
+from mindroom.tools.website import website_tools
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_website_reader_prefers_content_body_over_search_modal() -> None:
+    """A hidden or early search section should not replace the page body."""
+    html = """
+    <html>
+      <body>
+        <aside id="search" aria-hidden="true">
+          <section class="search-header">
+            <a>Search</a>
+          </section>
+        </aside>
+        <main class="page-body">
+          <section>
+            <h1>Biography</h1>
+            <p>Bas Nijholt builds open source scientific software and AI tooling.</p>
+          </section>
+        </main>
+      </body>
+    </html>
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    content = _MindRoomWebsiteReader()._extract_main_content(soup)
+
+    assert "Biography" in content
+    assert "open source scientific software" in content
+    assert "Search" not in content
+
+
+def test_website_read_url_crawls_links_from_chrome_without_returning_chrome_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Page chrome can contain crawl links without becoming extracted content."""
+    root_url = "https://example.test/"
+    docs_url = "https://example.test/docs"
+    pages = {
+        root_url: """
+        <html>
+          <body>
+            <nav><a href="/docs">Docs Navigation</a></nav>
+            <main><h1>Home</h1><p>Welcome to the product guide.</p></main>
+          </body>
+        </html>
+        """,
+        docs_url: """
+        <html>
+          <body>
+            <main><h1>Docs</h1><p>Detailed reference material lives here.</p></main>
+          </body>
+        </html>
+        """,
+    }
+
+    def fake_get(url: str, *, timeout: int, follow_redirects: bool) -> httpx.Response:
+        assert timeout == 10
+        assert follow_redirects is True
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, content=pages[url].encode(), request=request)
+
+    def no_delay(_reader: _MindRoomWebsiteReader, min_seconds: int = 1, max_seconds: int = 3) -> None:
+        assert min_seconds == 1
+        assert max_seconds == 3
+
+    monkeypatch.setattr("agno.knowledge.reader.website_reader.httpx.get", fake_get)
+    monkeypatch.setattr(_MindRoomWebsiteReader, "delay", no_delay)
+
+    documents = json.loads(WebsiteTools().read_url(root_url))
+    content_by_url = {document["meta_data"]["url"]: document["content"] for document in documents}
+
+    assert list(content_by_url) == [root_url, docs_url]
+    assert "Welcome to the product guide" in content_by_url[root_url]
+    assert "Docs Navigation" not in content_by_url[root_url]
+    assert "Detailed reference material" in content_by_url[docs_url]
+
+
+def test_website_tool_logs_urls_without_query_or_fragment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Website tools should not put caller query strings or fragments in logs."""
+    full_url = "https://example.test/docs?token=secret#private"
+    logged_messages: list[str] = []
+
+    class FakeKnowledge:
+        def insert(self, *, url: str, reader: object) -> None:
+            assert url == full_url
+            assert isinstance(reader, _MindRoomWebsiteReader)
+
+    def fake_log_debug(message: str) -> None:
+        logged_messages.append(message)
+
+    def fake_read(_reader: _MindRoomWebsiteReader, *, url: str) -> list[object]:
+        assert url == full_url
+        return []
+
+    monkeypatch.setattr("mindroom.custom_tools.website.log_debug", fake_log_debug)
+    monkeypatch.setattr(_MindRoomWebsiteReader, "read", fake_read)
+
+    WebsiteTools().read_url(full_url)
+    WebsiteTools(knowledge=FakeKnowledge()).add_website_to_knowledge(full_url)
+
+    assert logged_messages == [
+        "Reading website: https://example.test/docs",
+        "Adding to knowledge base: https://example.test/docs",
+    ]
+    assert "secret" not in " ".join(logged_messages)
+    assert "private" not in " ".join(logged_messages)
+
+
+def test_website_tool_adds_urls_to_knowledge_with_mindroom_reader() -> None:
+    """Knowledge ingestion should use the same fixed website reader as read_url."""
+
+    @dataclass
+    class CapturedInsert:
+        url: str
+        reader: object
+
+    class FakeKnowledge:
+        def __init__(self) -> None:
+            self.captured: CapturedInsert | None = None
+
+        def insert(self, *, url: str, reader: object) -> None:
+            self.captured = CapturedInsert(url=url, reader=reader)
+
+    knowledge = FakeKnowledge()
+
+    result = WebsiteTools(knowledge=knowledge).add_website_to_knowledge("https://example.test")
+
+    assert result == "Success"
+    assert knowledge.captured is not None
+    assert knowledge.captured.url == "https://example.test"
+    assert isinstance(knowledge.captured.reader, _MindRoomWebsiteReader)
+
+
+def test_website_tool_factory_uses_mindroom_reader() -> None:
+    """The configured website toolkit should use MindRoom's fixed extractor."""
+    assert website_tools().__module__ == "mindroom.custom_tools.website"

--- a/tests/test_website_tool.py
+++ b/tests/test_website_tool.py
@@ -126,18 +126,67 @@ def test_website_reader_crawls_starting_url_with_port(monkeypatch: pytest.Monkey
 
 
 def test_website_reader_rejects_domain_suffix_lookalikes() -> None:
-    """Same-domain checks should not treat badexample.com as example.com."""
+    """Same-host checks should not treat badexample.com as example.com."""
     reader = _MindRoomWebsiteReader()
-
-    primary_domain = reader._get_primary_domain("https://example.com/")
 
     assert reader._should_skip_crawl_url(
         current_url="https://badexample.com/private",
         starting_url="https://example.com/",
         current_depth=1,
         num_links=0,
-        primary_domain=primary_domain,
+        crawl_host="example.com",
     )
+
+
+def test_website_reader_rejects_public_suffix_sibling_hosts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same-host crawling should not treat unrelated public-suffix siblings as in scope."""
+    start_url = "https://service.co.uk/"
+    attacker_url = "https://attacker.co.uk/private"
+    requested_urls: list[str] = []
+    pages = {
+        start_url: """
+        <html>
+          <body>
+            <nav><a href="https://attacker.co.uk/private">Attacker</a></nav>
+            <main>
+              <h1>Service docs</h1>
+              <p>Reference material with enough text to keep the starting page.</p>
+            </main>
+          </body>
+        </html>
+        """,
+        attacker_url: """
+        <html>
+          <body>
+            <main>
+              <h1>Private</h1>
+              <p>Unrelated sibling host content that must never be crawled.</p>
+            </main>
+          </body>
+        </html>
+        """,
+    }
+
+    def fake_get(url: str, *, timeout: int, follow_redirects: bool) -> httpx.Response:
+        requested_urls.append(url)
+        assert timeout == 10
+        assert follow_redirects is True
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, content=pages[url].encode(), request=request)
+
+    def no_delay(_reader: _MindRoomWebsiteReader, min_seconds: int = 1, max_seconds: int = 3) -> None:
+        assert min_seconds == 1
+        assert max_seconds == 3
+
+    monkeypatch.setattr("mindroom.custom_tools.website.httpx.get", fake_get)
+    monkeypatch.setattr(_MindRoomWebsiteReader, "delay", no_delay)
+
+    documents = _MindRoomWebsiteReader().read(start_url)
+
+    assert requested_urls == [start_url]
+    assert [document.meta_data["url"] for document in documents] == [start_url]
+    assert "starting page" in documents[0].content
+    assert "sibling host content" not in documents[0].content
 
 
 def test_safe_url_for_log_strips_userinfo_query_and_fragment() -> None:


### PR DESCRIPTION
## Summary
- Add browser action discovery/help, document valid action and act request shapes in generated schemas, and rewrite Playwright revision mismatch launch errors into actionable install guidance.
- Preserve filename, MIME type, and media kind when registering local file attachments.
- Route the website tool through a MindRoom reader that filters navigation/search chrome so `read_url` returns page content instead of short nav labels.
- Document the browser screenshot output directory default and refresh tool metadata.

## Verification
- `uv sync --all-extras`
- `uv run pre-commit run --all-files` in clean worktree `/tmp/mindroom-pr-check-yKC2J8`
- `uv run pytest` in clean worktree `/tmp/mindroom-pr-check-yKC2J8`: 6637 passed, 29 skipped
- `uv run pytest tests/test_browser_tool.py tests/test_attachments_tool.py tests/test_website_tool.py -q`: 76 passed
- Live sanity: `WebsiteTools().read_url("https://nijho.lt")` returns biography/page text instead of repeated `Search` entries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Website toolkit: MindRoom-specific reader that extracts main page content, crawls same-domain links, and can read URLs or add sites to knowledge.
  * Browser discovery: `help`/`actions` responses exposing supported operations and action/request schemas.

* **Bug Fixes**
  * Friendlier browser startup errors with actionable, cache/revision-aware guidance.
  * Attachments now infer filename, MIME type, and kind (audio/image/video/file) from local paths.
  * Browser output_dir docs clarify default storage location.

* **Tests**
  * Added coverage for attachments, browser discovery/errors, website reader behavior, import-time wiring, and docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->