### PR TITLE
Fix macOS service log command

### DIFF
--- a/src/mindroom/custom_tools/website.py
+++ b/src/mindroom/custom_tools/website.py
@@ -4,18 +4,16 @@ from __future__ import annotations
 
 import json
 import re
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from urllib.parse import urljoin, urlparse, urlsplit, urlunsplit
 
 import httpx
 from agno.knowledge.document import Document
+from agno.knowledge.knowledge import Knowledge  # noqa: TC002 - metadata sync resolves runtime type hints.
 from agno.knowledge.reader.website_reader import WebsiteReader
 from agno.tools import Toolkit
 from agno.utils.log import log_debug, log_error, log_warning
 from bs4 import BeautifulSoup, Tag
-
-if TYPE_CHECKING:
-    from agno.knowledge.knowledge import Knowledge
 
 _PREFERRED_CONTENT_SELECTORS = (
     "main",

--- a/src/mindroom/services/launchd.py
+++ b/src/mindroom/services/launchd.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import os
 import plistlib
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -35,7 +36,10 @@ def _get_log_dir() -> Path:
 
 def _get_log_command() -> str:
     """Return the command for following service logs."""
-    return f"tail -f {_get_log_dir()}/*.log"
+    log_dir = _get_log_dir()
+    stdout_log = shlex.quote(str(log_dir / "stdout.log"))
+    stderr_log = shlex.quote(str(log_dir / "stderr.log"))
+    return f"tail -f {stdout_log} {stderr_log}"
 
 
 def _get_recent_logs(num_lines: int = 10) -> list[str]:
@@ -114,6 +118,8 @@ def _install_service() -> InstallResult:
     log_dir = _get_log_dir()
     plist_path = _get_plist_path()
     log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "stdout.log").touch()
+    (log_dir / "stderr.log").touch()
     plist_path.parent.mkdir(parents=True, exist_ok=True)
 
     with plist_path.open("wb") as f:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -19,7 +19,8 @@ from mindroom.services.config import (
     find_uv,
     install_uv,
 )
-from mindroom.services.launchd import _generate_plist, _get_log_command as _get_launchd_log_command
+from mindroom.services.launchd import _generate_plist
+from mindroom.services.launchd import _get_log_command as _get_launchd_log_command
 from mindroom.services.manager import get_service_manager
 from mindroom.services.runtime import ServiceConfigMissingError, resolve_service_environment
 from mindroom.services.systemd import _generate_unit_file, _get_unit_name

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -19,7 +19,7 @@ from mindroom.services.config import (
     find_uv,
     install_uv,
 )
-from mindroom.services.launchd import _generate_plist
+from mindroom.services.launchd import _generate_plist, _get_log_command as _get_launchd_log_command
 from mindroom.services.manager import get_service_manager
 from mindroom.services.runtime import ServiceConfigMissingError, resolve_service_environment
 from mindroom.services.systemd import _generate_unit_file, _get_unit_name
@@ -149,6 +149,15 @@ def test_launchd_plist_runs_mindroom(tmp_path: Path) -> None:
     ]
     assert plist_data["EnvironmentVariables"] == service_environment
     assert b"StandardOutPath" in rendered
+
+
+def test_launchd_log_command_uses_explicit_files() -> None:
+    """The launchd log command avoids zsh nomatch failures from an empty glob."""
+    command = _get_launchd_log_command()
+
+    assert "*.log" not in command
+    assert "stdout.log" in command
+    assert "stderr.log" in command
 
 
 def test_resolve_service_environment_captures_active_runtime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- avoid zsh nomatch failures by printing explicit macOS service log files instead of a `*.log` glob
- create the launchd stdout/stderr log files during service install so fresh installs have tail targets immediately
- add a regression test for the launchd log command

## Testing
- `uv run pytest tests/test_services.py -q`

Full local `uv run pytest --tb=short` was also attempted after `uv sync --all-extras`, but this checkout has unrelated local-state failures: deleted `config.yaml`, exported config discovery pointing at `~/.mindroom/config.yaml`, a real Google API key in the environment, and `test_tool_config_sync.py::test_all[website]` raising `NameError: Knowledge is not defined`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Use explicit stdout/stderr log file paths and ensure log files exist before service start to improve logging reliability.

* **Refactor**
  * Tighter, safer website content extraction and sanitized logging; crawl flow and host-constrained link queuing improved for more accurate results.

* **Tests**
  * Added tests verifying explicit log-path usage and preventing wildcard log patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1000)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->