### PR TITLE
Speed up CLI help imports

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -411,6 +411,9 @@ Runs a series of checks in one pass:
 
  Check your environment for common issues.
 
+ Runs connectivity, configuration, and credential checks in a single pass
+ so you can fix everything before running `mindroom run`.
+
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --help  -h        Show this message and exit.                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -411,9 +411,6 @@ Runs a series of checks in one pass:
 
  Check your environment for common issues.
 
- Runs connectivity, configuration, and credential checks in a single pass
- so you can fix everything before running `mindroom run`.
-
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
 │ --help  -h        Show this message and exit.                                          │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -452,7 +452,7 @@ def config_show(
 
     try:
         content = config_file.read_text(encoding="utf-8")
-    except UnicodeError as exc:
+    except (OSError, UnicodeError) as exc:
         format_validation_errors(exc, config_path=config_file)
         raise typer.Exit(1) from None
 

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -14,38 +14,18 @@ from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING, Literal
 
 import typer
-from dotenv import dotenv_values
 from rich.console import Console
-from rich.syntax import Syntax
 
-from mindroom.cli.owner import parse_owner_matrix_user_id, replace_owner_placeholders_in_text
-from mindroom.config.main import (
-    CONFIG_LOAD_USER_ERROR_TYPES,
-    Config,
-    ConfigRuntimeValidationError,
-    iter_config_validation_messages,
-    load_config,
-)
-from mindroom.constants import (
-    OWNER_MATRIX_USER_ID_ENV,
-    OWNER_MATRIX_USER_ID_PLACEHOLDER,
-    RuntimePaths,
-    config_search_locations,
-    env_key_for_provider,
-    exported_process_env,
-    resolve_primary_runtime_paths,
-    resolve_runtime_paths,
-)
-from mindroom.credentials_sync import get_secret_from_env
-from mindroom.runtime_env_policy import VERTEXAI_CLAUDE_ENV_BY_KEY
-from mindroom.tool_system.worker_routing import agent_workspace_root_path
-from mindroom.workspaces import ensure_workspace_template
+from mindroom import constants
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     import yaml  # type: ignore[import-untyped]
     from pydantic import ValidationError
+
+    from mindroom.config.main import Config, ConfigRuntimeValidationError
+    from mindroom.constants import RuntimePaths
 
 console = Console()
 
@@ -100,7 +80,7 @@ def _config_init_storage_plan(
     replace_env_file: bool,
 ) -> tuple[Path, bool]:
     """Return the storage root and whether the starter config can use the env placeholder."""
-    runtime_paths = resolve_runtime_paths(config_path=config_dir / "config.yaml")
+    runtime_paths = constants.resolve_runtime_paths(config_path=config_dir / "config.yaml")
     if replace_env_file:
         return runtime_paths.storage_root, True
     if "MINDROOM_STORAGE_PATH" in runtime_paths.env_file_values and env_path.is_file():
@@ -110,12 +90,16 @@ def _config_init_storage_plan(
 
 def _config_init_owner_user_id(config_path: Path) -> str | None:
     """Return the paired owner MXID available to config init, if one was persisted."""
-    runtime_paths = resolve_runtime_paths(config_path=config_path)
-    return parse_owner_matrix_user_id(runtime_paths.env_value(OWNER_MATRIX_USER_ID_ENV))
+    from mindroom.cli.owner import parse_owner_matrix_user_id  # noqa: PLC0415
+
+    runtime_paths = constants.resolve_runtime_paths(config_path=config_path)
+    return parse_owner_matrix_user_id(runtime_paths.env_value(constants.OWNER_MATRIX_USER_ID_ENV))
 
 
 def _default_mind_workspace(storage_root: Path) -> Path:
     """Return the shared single-user starter Mind workspace inside the canonical agent workspace."""
+    from mindroom.tool_system.worker_routing import agent_workspace_root_path  # noqa: PLC0415
+
     return agent_workspace_root_path(storage_root, "mind")
 
 
@@ -143,6 +127,8 @@ def _default_mind_knowledge_base_path(
 
 def _ensure_mind_workspace(workspace_path: Path, *, force: bool) -> None:
     """Create the default Mind workspace files used by the full/public templates."""
+    from mindroom.workspaces import ensure_workspace_template  # noqa: PLC0415
+
     ensure_workspace_template(workspace_path, template="mind", force=force)
 
 
@@ -184,6 +170,8 @@ def _append_missing_env_defaults(
     title: str,
 ) -> bool:
     """Append missing env defaults without changing existing user-owned values."""
+    from dotenv import dotenv_values  # noqa: PLC0415
+
     existing_values = dotenv_values(env_path)
     missing_defaults = [(key, value) for key, value in defaults if key not in existing_values]
     if not missing_defaults:
@@ -249,7 +237,7 @@ def _print_config_init_next_steps(
 
 def _config_discovery_env(path: Path | None = None) -> dict[str, str]:
     """Return the exported env snapshot used for config discovery and display."""
-    process_env = exported_process_env()
+    process_env = constants.exported_process_env()
     if path is not None:
         process_env["MINDROOM_CONFIG_PATH"] = str(path.expanduser().resolve())
     return process_env
@@ -259,7 +247,7 @@ def _format_config_search_locations(process_env: Mapping[str, str]) -> list[str]
     """Return rendered config search locations with existence labels."""
     return [
         f"  {i}. {loc} ({'[green]exists[/green]' if loc.exists() else '[dim]not found[/dim]'})"
-        for i, loc in enumerate(config_search_locations(process_env), 1)
+        for i, loc in enumerate(constants.config_search_locations(process_env), 1)
     ]
 
 
@@ -278,8 +266,8 @@ def _resolve_config_path(
     """Resolve the config file path from explicit argument or default."""
     if path is not None:
         return path.expanduser().resolve()
-    resolved_process_env = dict(process_env) if process_env is not None else exported_process_env()
-    return resolve_primary_runtime_paths(process_env=resolved_process_env).config_path.resolve()
+    resolved_process_env = dict(process_env) if process_env is not None else constants.exported_process_env()
+    return constants.resolve_primary_runtime_paths(process_env=resolved_process_env).config_path.resolve()
 
 
 def activate_cli_runtime(
@@ -289,15 +277,15 @@ def activate_cli_runtime(
 ) -> RuntimePaths:
     """Create the CLI runtime context once and return it for explicit threading."""
     if path is not None:
-        return resolve_primary_runtime_paths(
+        return constants.resolve_primary_runtime_paths(
             config_path=path.expanduser().resolve(),
             storage_path=storage_path,
-            process_env=exported_process_env(),
+            process_env=constants.exported_process_env(),
         )
 
-    return resolve_primary_runtime_paths(
+    return constants.resolve_primary_runtime_paths(
         storage_path=storage_path,
-        process_env=exported_process_env(),
+        process_env=constants.exported_process_env(),
     )
 
 
@@ -326,6 +314,8 @@ def format_validation_errors(
     config_path: Path | None = None,
 ) -> None:
     """Print config validation errors in a user-friendly format."""
+    from mindroom.config.main import iter_config_validation_messages  # noqa: PLC0415
+
     if config_path:
         console.print(f"[red]Error:[/red] Invalid configuration in {config_path}\n")
     else:
@@ -413,6 +403,8 @@ def config_init(
     # In that order, connect persists the owner MXID in .env so init can render
     # authorization defaults without leaving pairing placeholders behind.
     if owner_user_id := _config_init_owner_user_id(target):
+        from mindroom.cli.owner import replace_owner_placeholders_in_text  # noqa: PLC0415
+
         content = replace_owner_placeholders_in_text(content, owner_user_id)
 
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -460,13 +452,15 @@ def config_show(
 
     try:
         content = config_file.read_text(encoding="utf-8")
-    except CONFIG_LOAD_USER_ERROR_TYPES as exc:
+    except UnicodeError as exc:
         format_validation_errors(exc, config_path=config_file)
         raise typer.Exit(1) from None
 
     if raw:
         print(content, end="")
         return
+
+    from rich.syntax import Syntax  # noqa: PLC0415
 
     console.print(f"[bold green]Config file:[/bold green] {config_file}\n")
     syntax = Syntax(content, "yaml", theme="monokai", line_numbers=True, word_wrap=True)
@@ -535,6 +529,8 @@ def config_validate(
         console.print("\nRun [cyan]mindroom config init[/cyan] to create one.")
         raise typer.Exit(1)
 
+    from mindroom.config.main import CONFIG_LOAD_USER_ERROR_TYPES  # noqa: PLC0415
+
     try:
         config = load_config_quiet(runtime_paths=runtime_paths)
     except CONFIG_LOAD_USER_ERROR_TYPES as exc:
@@ -585,6 +581,8 @@ def load_config_quiet(
     """
     import structlog  # noqa: PLC0415
 
+    from mindroom.config.main import load_config  # noqa: PLC0415
+
     was_configured = structlog.is_configured()
     if not was_configured:
         logging.basicConfig(format="%(message)s", level=logging.WARNING)
@@ -607,6 +605,9 @@ def _find_missing_env_keys(
     runtime_paths: RuntimePaths,
 ) -> list[tuple[str, str]]:
     """Return (provider, env_key) pairs for configured providers missing env vars."""
+    from mindroom.credentials_sync import get_secret_from_env  # noqa: PLC0415
+    from mindroom.runtime_env_policy import VERTEXAI_CLAUDE_ENV_BY_KEY  # noqa: PLC0415
+
     providers_used: set[str] = {model.provider for model in config.models.values()}
     missing: list[tuple[str, str]] = []
     for provider in sorted(providers_used):
@@ -617,7 +618,7 @@ def _find_missing_env_keys(
                 if not get_secret_from_env(env_key, runtime_paths=runtime_paths)
             )
             continue
-        env_key = env_key_for_provider(provider)
+        env_key = constants.env_key_for_provider(provider)
         if env_key and not get_secret_from_env(env_key, runtime_paths=runtime_paths):
             missing.append((provider, env_key))
     return missing
@@ -860,11 +861,11 @@ authorization:
   default_room_access: false
   global_users:
     # Replace with your Matrix user ID (example: @alice:mindroom.chat).
-    - {OWNER_MATRIX_USER_ID_PLACEHOLDER}
+    - {constants.OWNER_MATRIX_USER_ID_PLACEHOLDER}
   agent_reply_permissions:
     "*":
       # Replace with your Matrix user ID (example: @alice:mindroom.chat).
-      - {OWNER_MATRIX_USER_ID_PLACEHOLDER}
+      - {constants.OWNER_MATRIX_USER_ID_PLACEHOLDER}
 
 defaults:
   tools:
@@ -971,11 +972,11 @@ authorization:
   default_room_access: false
   global_users:
     # Replace with your Matrix user ID (example: @alice:mindroom.chat).
-    - {OWNER_MATRIX_USER_ID_PLACEHOLDER}
+    - {constants.OWNER_MATRIX_USER_ID_PLACEHOLDER}
   agent_reply_permissions:
     "*":
       # Replace with your Matrix user ID (example: @alice:mindroom.chat).
-      - {OWNER_MATRIX_USER_ID_PLACEHOLDER}
+      - {constants.OWNER_MATRIX_USER_ID_PLACEHOLDER}
 
 defaults:
   tools:
@@ -1007,7 +1008,7 @@ def _provider_env_template(provider_preset: _ProviderPreset) -> str:
         # or set GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
         """).rstrip()
 
-    required_env_key = env_key_for_provider(provider_preset)
+    required_env_key = constants.env_key_for_provider(provider_preset)
     key_placeholders = {
         "ANTHROPIC_API_KEY": "your-anthropic-key-here",
         "OPENAI_API_KEY": "your-openai-key-here",

--- a/src/mindroom/cli/connect.py
+++ b/src/mindroom/cli/connect.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass
 from hashlib import sha256
 from typing import TYPE_CHECKING
 
-import httpx
-
 from mindroom.cli.owner import parse_owner_matrix_user_id, replace_owner_placeholders_in_text
 from mindroom.constants import OWNER_MATRIX_USER_ID_ENV
 
@@ -17,6 +15,8 @@ from .env_file import env_path_for_config, upsert_env_values
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
+
+    import httpx
 
 _PAIR_CODE_RE = re.compile(r"^[A-Z0-9]{4}-[A-Z0-9]{4}$")
 _NAMESPACE_RE = re.compile(r"^[a-z0-9]{4,32}$")
@@ -46,18 +46,21 @@ def complete_local_pairing(
     client_name: str,
     client_fingerprint: str,
     matrix_ssl_verify: bool,
-    post_request: Callable[..., httpx.Response] = httpx.post,
+    post_request: Callable[..., httpx.Response] | None = None,
 ) -> _PairCompleteResult:
     """Call the provisioning API and return local client credentials."""
+    import httpx  # noqa: PLC0415
+
     payload = {
         "pair_code": pair_code,
         "client_name": client_name.strip(),
         "client_pubkey_or_fingerprint": client_fingerprint,
     }
     endpoint = f"{provisioning_url.rstrip('/')}/v1/local-mindroom/pair/complete"
+    request = post_request or httpx.post
 
     try:
-        response = post_request(endpoint, json=payload, timeout=10, verify=matrix_ssl_verify)
+        response = request(endpoint, json=payload, timeout=10, verify=matrix_ssl_verify)
     except httpx.HTTPError as exc:
         msg = f"Could not reach provisioning service: {exc}"
         raise ValueError(msg) from exc

--- a/src/mindroom/cli/local_stack.py
+++ b/src/mindroom/cli/local_stack.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-import httpx
 import typer
 
 from mindroom.matrix.health import matrix_versions_url, response_has_matrix_versions
@@ -22,10 +21,19 @@ from .env_file import env_path_for_config, upsert_env_values
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import httpx
+
     from mindroom.constants import RuntimePaths
 
 _CINNY_DEFAULT_IMAGE = "ghcr.io/mindroom-ai/mindroom-cinny:latest"
 _CINNY_DEFAULT_CONTAINER = "mindroom-cinny-local"
+
+
+def _httpx_get(url: str, *, timeout: float, verify: bool) -> httpx.Response:
+    """Call httpx.get without importing httpx during CLI help rendering."""
+    import httpx  # noqa: PLC0415
+
+    return httpx.get(url, timeout=timeout, verify=verify)
 
 
 def local_stack_setup(
@@ -312,11 +320,13 @@ def _wait_for_http_success(
     response_matches: Callable[[httpx.Response], bool] | None = None,
 ) -> bool:
     """Wait until an HTTP GET request returns success."""
+    import httpx  # noqa: PLC0415
+
     deadline = time.monotonic() + timeout_seconds
     matcher = response_matches or (lambda response: response.is_success)
     while time.monotonic() < deadline:
         try:
-            response = httpx.get(url, timeout=3, verify=verify)
+            response = _httpx_get(url, timeout=3, verify=verify)
             if matcher(response):
                 return True
         except httpx.HTTPError:

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -9,15 +9,7 @@ import sys
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING
 
-import httpx
 import typer
-
-import mindroom.cli.connect as cli_connect
-from mindroom import __version__, constants
-from mindroom.constants import ensure_writable_config_path
-from mindroom.error_handling import AvatarGenerationError, AvatarSyncError
-from mindroom.frontend_assets import ensure_frontend_dist_dir
-from mindroom.startup_errors import PermanentStartupError
 
 from .banner import make_banner
 from .config import (
@@ -29,16 +21,16 @@ from .config import (
     load_config_quiet,
     print_config_search_locations,
 )
-from .doctor import doctor
 from .local_stack import local_stack_setup
 from .service import service_app
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from mindroom.constants import RuntimePaths
+    import httpx
 
-from mindroom.config.main import CONFIG_LOAD_USER_ERROR_TYPES, Config
+    from mindroom.config.main import Config
+    from mindroom.constants import RuntimePaths
 
 _HELP = """\
 AI agents that live in Matrix and work everywhere via bridges.
@@ -63,9 +55,24 @@ app.add_typer(avatars_app, name="avatars")
 app.add_typer(service_app, name="service")
 
 
+def _httpx_post(
+    url: str,
+    *,
+    json: Mapping[str, object],
+    timeout: float,
+    verify: bool,
+) -> httpx.Response:
+    """Call httpx.post without importing httpx during CLI help rendering."""
+    import httpx  # noqa: PLC0415
+
+    return httpx.post(url, json=json, timeout=timeout, verify=verify)
+
+
 @app.command()
 def version() -> None:
     """Show the current version of Mindroom."""
+    from mindroom import __version__  # noqa: PLC0415
+
     console.print(f"Mindroom version: [bold]{__version__}[/bold]")
     console.print("AI agents that live in Matrix")
 
@@ -123,6 +130,9 @@ def run(
 
 def _load_active_config_or_exit(runtime_paths: RuntimePaths) -> Config:
     """Load the active config file or exit with friendly validation errors."""
+    from mindroom.config.main import CONFIG_LOAD_USER_ERROR_TYPES  # noqa: PLC0415
+    from mindroom.constants import ensure_writable_config_path  # noqa: PLC0415
+
     ensure_writable_config_path(runtime_paths=runtime_paths)
 
     config_path = runtime_paths.config_path
@@ -151,6 +161,8 @@ async def _run(
     api_host: str,
 ) -> None:
     """Run the multi-agent system with friendly error handling."""
+    from mindroom.startup_errors import PermanentStartupError  # noqa: PLC0415
+
     runtime_paths = activate_cli_runtime(storage_path=storage_path)
     config = _load_active_config_or_exit(runtime_paths)
 
@@ -161,6 +173,8 @@ async def _run(
     console.print()
     console.print(f"Starting Mindroom (log level: {log_level})...")
     if api:
+        from mindroom.frontend_assets import ensure_frontend_dist_dir  # noqa: PLC0415
+
         frontend_dir = ensure_frontend_dist_dir(runtime_paths)
         display_host = "localhost" if api_host == "0.0.0.0" else api_host  # noqa: S104
         if frontend_dir is None:
@@ -196,7 +210,12 @@ async def _run(
         raise
 
 
-app.command()(doctor)
+@app.command()
+def doctor() -> None:
+    """Check your environment for common issues."""
+    from .doctor import doctor as doctor_command  # noqa: PLC0415
+
+    doctor_command()
 
 
 @avatars_app.command("generate")
@@ -208,6 +227,8 @@ def avatars_generate(
     ),
 ) -> None:
     """Generate missing managed avatar files in the workspace."""
+    from mindroom.error_handling import AvatarGenerationError  # noqa: PLC0415
+
     runtime_paths = activate_cli_runtime()
     _load_active_config_or_exit(runtime_paths)
 
@@ -229,6 +250,8 @@ def avatars_sync(
     ),
 ) -> None:
     """Sync configured room and root-space avatars to Matrix using the initialized router account."""
+    from mindroom.error_handling import AvatarSyncError  # noqa: PLC0415
+
     runtime_paths = activate_cli_runtime()
     _load_active_config_or_exit(runtime_paths)
 
@@ -279,6 +302,9 @@ def connect(
     ),
 ) -> None:
     """Pair this local MindRoom install with the hosted provisioning service."""
+    import mindroom.cli.connect as cli_connect  # noqa: PLC0415
+    from mindroom import constants  # noqa: PLC0415
+
     normalized_pair_code = pair_code.strip().upper()
     if not cli_connect.is_valid_pair_code(normalized_pair_code):
         console.print("[red]Error:[/red] Invalid pair code format. Expected ABCD-EFGH.")
@@ -301,7 +327,7 @@ def connect(
             client_name=normalized_client_name,
             client_fingerprint=_local_client_fingerprint(config_path=resolved_config_path),
             matrix_ssl_verify=constants.runtime_matrix_ssl_verify(runtime_paths=runtime_paths),
-            post_request=httpx.post,
+            post_request=_httpx_post,
         )
     except (TypeError, ValueError) as exc:
         console.print(f"[red]Error:[/red] {exc}")
@@ -399,6 +425,8 @@ def _print_missing_config_error(process_env: Mapping[str, str]) -> None:
 
 
 def _print_connection_error(exc: BaseException, runtime_paths: RuntimePaths) -> None:
+    from mindroom import constants  # noqa: PLC0415
+
     console.print("[red]Error:[/red] Could not connect to the Matrix homeserver.\n")
     console.print(f"  Details: {exc}\n")
     console.print("Check that:")

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -212,7 +212,11 @@ async def _run(
 
 @app.command()
 def doctor() -> None:
-    """Check your environment for common issues."""
+    """Check your environment for common issues.
+
+    Runs connectivity, configuration, and credential checks in a single pass
+    so you can fix everything before running `mindroom run`.
+    """
     from .doctor import doctor as doctor_command  # noqa: PLC0415
 
     doctor_command()

--- a/src/mindroom/cli/service.py
+++ b/src/mindroom/cli/service.py
@@ -9,8 +9,6 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 
-from mindroom.services.manager import get_service_manager
-
 if TYPE_CHECKING:
     from mindroom.services.config import ServiceManager
 
@@ -32,9 +30,16 @@ Supported platforms:
 )
 
 
+def _get_service_manager() -> ServiceManager:
+    """Load the platform service manager only when service commands run."""
+    from mindroom.services.manager import get_service_manager as load_service_manager  # noqa: PLC0415
+
+    return load_service_manager()
+
+
 def _manager_or_exit() -> ServiceManager:
     try:
-        return get_service_manager()
+        return _get_service_manager()
     except RuntimeError as exc:
         _err_console.print(f"[bold red]Error:[/bold red] {exc}")
         raise typer.Exit(1) from None

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -58,6 +60,42 @@ def _invoke_with_runtime(
     if env:
         command_env.update(env)
     return cast("object", runner.invoke(app, args, env=command_env, **kwargs))
+
+
+def test_cli_import_keeps_help_path_runtime_modules_lazy() -> None:
+    """Importing the CLI should not preload runtime config/history dependencies."""
+    blocked_modules = [
+        "mindroom.config.main",
+        "mindroom.history",
+        "mindroom.history.runtime",
+        "mindroom.agent_storage",
+        "sqlalchemy",
+        "agno.db.sqlite.async_sqlite",
+    ]
+    script = (
+        "import json\n"
+        "import sys\n"
+        "import mindroom.cli.main\n"
+        f"blocked_modules = {blocked_modules!r}\n"
+        "print(json.dumps([name for name in blocked_modules if name in sys.modules]))\n"
+    )
+    repo_root = Path(__file__).resolve().parents[1]
+    python_path = str(repo_root / "src")
+    env = {
+        **os.environ,
+        "PYTHONPATH": f"{python_path}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+    }
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert json.loads(result.stdout) == []
 
 
 def test_format_config_search_locations_numbers_paths_and_statuses(
@@ -694,7 +732,7 @@ class TestConfigInit:
     ) -> None:
         """Provider .env templates should derive required keys from the canonical provider mapping."""
         monkeypatch.setattr(
-            config_cli,
+            config_cli.constants,
             "env_key_for_provider",
             lambda provider: "OPENAI_API_KEY" if provider == "openrouter" else None,
         )
@@ -2257,7 +2295,7 @@ class TestConnect:
         monkeypatch.setattr("mindroom.cli.main.socket.gethostname", lambda: "devbox")
 
         monkeypatch.setattr(
-            "mindroom.cli.main.httpx.post",
+            "mindroom.cli.main._httpx_post",
             lambda *_a, **_kw: httpx.Response(
                 200,
                 json={
@@ -2319,7 +2357,7 @@ class TestConnect:
             f"    - {OWNER_MATRIX_USER_ID_PLACEHOLDER}\n",
         )
         monkeypatch.setattr(
-            "mindroom.cli.main.httpx.post",
+            "mindroom.cli.main._httpx_post",
             lambda *_a, **_kw: httpx.Response(
                 200,
                 json={
@@ -2362,7 +2400,7 @@ class TestConnect:
         cfg = tmp_path / "config.yaml"
         cfg.write_text("agents: {}\nmodels: {}\nrouter:\n  model: default\n")
         monkeypatch.setattr(
-            "mindroom.cli.main.httpx.post",
+            "mindroom.cli.main._httpx_post",
             lambda *_a, **_kw: httpx.Response(
                 200,
                 json={
@@ -2420,7 +2458,7 @@ class TestConnect:
                 },
             )
 
-        monkeypatch.setattr("mindroom.cli.main.httpx.post", _fake_post)
+        monkeypatch.setattr("mindroom.cli.main._httpx_post", _fake_post)
 
         result = _invoke_with_runtime(["connect", "--pair-code", "ABCD-EFGH", "--no-persist-env"], cfg)
 
@@ -2446,7 +2484,7 @@ class TestConnect:
             f"    - {OWNER_MATRIX_USER_ID_PLACEHOLDER}\n",
         )
         monkeypatch.setattr(
-            "mindroom.cli.main.httpx.post",
+            "mindroom.cli.main._httpx_post",
             lambda *_a, **_kw: httpx.Response(
                 200,
                 json={
@@ -2478,7 +2516,6 @@ class TestConnect:
         """Connect should pass MATRIX_SSL_VERIFY through to httpx.post."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text("agents: {}\nmodels: {}\nrouter:\n  model: default\n")
-        monkeypatch.setattr("mindroom.cli.main.constants.runtime_matrix_ssl_verify", lambda *_args, **_kwargs: False)
 
         called: dict[str, object] = {}
 
@@ -2495,7 +2532,7 @@ class TestConnect:
                 },
             )
 
-        monkeypatch.setattr("mindroom.cli.main.httpx.post", _fake_post)
+        monkeypatch.setattr("mindroom.cli.main._httpx_post", _fake_post)
 
         result = _invoke_with_runtime(
             [
@@ -2507,6 +2544,7 @@ class TestConnect:
                 "--no-persist-env",
             ],
             cfg,
+            env={"MATRIX_SSL_VERIFY": "false"},
         )
 
         assert result.exit_code == 0
@@ -2534,7 +2572,7 @@ class TestLocalStackSetup:
         monkeypatch.setattr("mindroom.cli.local_stack.sys.platform", "linux")
         monkeypatch.setattr("mindroom.cli.local_stack.shutil.which", lambda _name: "/usr/bin/docker")
         monkeypatch.setattr(
-            "mindroom.cli.local_stack.httpx.get",
+            "mindroom.cli.local_stack._httpx_get",
             lambda *_a, **_kw: httpx.Response(200, json={"versions": ["v1.1"]}),
         )
         monkeypatch.setattr("mindroom.cli.local_stack.time.sleep", lambda *_a, **_kw: None)
@@ -2588,7 +2626,7 @@ class TestLocalStackSetup:
         monkeypatch.setattr("mindroom.cli.local_stack.sys.platform", "linux")
         monkeypatch.setattr("mindroom.cli.local_stack.shutil.which", lambda _name: "/usr/bin/docker")
         monkeypatch.setattr(
-            "mindroom.cli.local_stack.httpx.get",
+            "mindroom.cli.local_stack._httpx_get",
             lambda *_a, **_kw: httpx.Response(200, json={"versions": ["v1.1"]}),
         )
         monkeypatch.setattr("mindroom.cli.local_stack.time.sleep", lambda *_a, **_kw: None)
@@ -2615,7 +2653,7 @@ class TestLocalStackSetup:
         monkeypatch.setattr("mindroom.cli.local_stack.sys.platform", "linux")
         monkeypatch.setattr("mindroom.cli.local_stack.shutil.which", lambda _name: "/usr/bin/docker")
         monkeypatch.setattr(
-            "mindroom.cli.local_stack.httpx.get",
+            "mindroom.cli.local_stack._httpx_get",
             lambda *_a, **_kw: httpx.Response(200, json={"versions": ["v1.1"]}),
         )
         monkeypatch.setattr("mindroom.cli.local_stack.time.sleep", lambda *_a, **_kw: None)

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -69,6 +69,7 @@ def test_cli_import_keeps_help_path_runtime_modules_lazy() -> None:
         "mindroom.history",
         "mindroom.history.runtime",
         "mindroom.agent_storage",
+        "agno",
         "sqlalchemy",
         "agno.db.sqlite.async_sqlite",
     ]
@@ -844,6 +845,24 @@ class TestConfigShow:
         assert result.exit_code == 1
         assert "Invalid configuration" in result.output
         assert "Could not read configuration text" in result.output
+
+    def test_show_os_error_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Config show should report OS-level read failures cleanly."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("agents: {}\n")
+
+        def raise_permission_error(_self: Path, *_args: object, **_kwargs: object) -> str:
+            msg = "permission denied"
+            raise PermissionError(msg)
+
+        monkeypatch.setattr(Path, "read_text", raise_permission_error)
+
+        result = runner.invoke(app, ["config", "show", "--path", str(cfg)])
+
+        assert result.exit_code == 1
+        assert "Invalid configuration" in result.output
+        assert "Could not load configuration" in result.output
+        assert "permission denied" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -90,7 +90,7 @@ import os
 import sys
 
 expected = json.loads({expected_json!r})
-targets = {{"httpx", "typer"}}
+targets = {{"typer"}}
 seen = set()
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -207,7 +207,7 @@ def test_service_help_is_registered() -> None:
     assert "status" in result.output
 
 
-@patch("mindroom.cli.service.get_service_manager")
+@patch("mindroom.cli.service._get_service_manager")
 def test_service_status_not_installed(mock_get_manager: MagicMock) -> None:
     """Service status renders a not-installed service without logs."""
     mock_manager = MagicMock(spec=ServiceManager)
@@ -221,7 +221,7 @@ def test_service_status_not_installed(mock_get_manager: MagicMock) -> None:
     assert "not installed" in result.output
 
 
-@patch("mindroom.cli.service.get_service_manager")
+@patch("mindroom.cli.service._get_service_manager")
 def test_service_install_no_confirm(mock_get_manager: MagicMock) -> None:
     """Service install -y installs without interactive prompts."""
     mock_manager = MagicMock(spec=ServiceManager)


### PR DESCRIPTION
## Summary
- keep the CLI help/import path from loading runtime config/history dependencies
- lazy-load CLI-only third-party/runtime modules from the command functions that need them
- add an import guard so Agno/SQLAlchemy/history stay off the CLI help path

## Benchmarks
- before: import `mindroom.cli.main` ~3.17s; `mindroom --help` ~3.13s
- after: import `mindroom.cli.main` `141.2 ms ± 12.4 ms`; `mindroom --help` `175.7 ms ± 14.9 ms`

## Verification
- `uv run --python 3.13 ruff check src/mindroom/cli/main.py src/mindroom/cli/config.py src/mindroom/cli/connect.py src/mindroom/cli/local_stack.py src/mindroom/cli/service.py tests/test_cli_config.py tests/test_init.py tests/test_services.py`
- `uv run --python 3.13 ty check src/mindroom/cli/main.py src/mindroom/cli/local_stack.py src/mindroom/cli/service.py src/mindroom/cli/config.py`
- `uv run --python 3.13 pytest tests/test_cli_config.py tests/test_cli_connect.py tests/test_services.py::test_service_status_not_installed tests/test_services.py::test_service_install_no_confirm tests/test_init.py::test_cli_import_disables_vendor_telemetry_before_cli_dependencies -n 0 --no-cov -q`
- `uv run --python 3.13 pytest --no-cov -q \tests/api/test_api.py
tests/api/test_api_architecture_boundaries.py
tests/api/test_credentials_api.py
tests/api/test_file_watcher.py
tests/api/test_knowledge_api.py
tests/api/test_matrix_operations.py
tests/api/test_oauth_api.py
tests/api/test_sandbox_runner_api.py
tests/api/test_schedules_api.py
tests/api/test_skills_api.py
tests/test_agent_datetime_context.py
tests/test_agent_order_preservation.py
tests/test_agent_policy.py
tests/test_agent_response_logic.py
tests/test_agent_run_context.py
tests/test_agents.py
tests/test_agno_history.py
tests/test_ai_error_message_display.py
tests/test_ai_user_id.py
tests/test_attachments.py
tests/test_attachments_tool.py
tests/test_authorization.py
tests/test_authorization_config_update.py
tests/test_avatar_generation.py
tests/test_bot_ready_hook.py
tests/test_bot_scheduling.py
tests/test_browser_tool.py
tests/test_cancel_mid_wait.py
tests/test_cancelled_response_hook.py
tests/test_claude_agent_nightly_soak.py
tests/test_claude_agent_tool.py
tests/test_cli.py
tests/test_cli_config.py
tests/test_cli_connect.py
tests/test_cli_env_file.py
tests/test_codex_model.py
tests/test_coding_tools.py
tests/test_command_with_emoji.py
tests/test_commands.py
tests/test_compact_context.py
tests/test_compaction.py
tests/test_compress_tool_results.py
tests/test_config_architecture_boundaries.py
tests/test_config_commands.py
tests/test_config_discovery.py
tests/test_config_manager_consolidated.py
tests/test_config_prompts.py
tests/test_config_reload.py
tests/test_config_validation_helpers.py
tests/test_context_bound_streams.py
tests/test_credential_policy.py
tests/test_credentials.py
tests/test_credentials_api.py
tests/test_credentials_sync.py
tests/test_cron_natural_language.py
tests/test_delegate_tools.py
tests/test_dispatch_event_content.py
tests/test_dispatch_thread_context.py
tests/test_dispatch_timing_instrumentation.py
tests/test_dm_detection.py
tests/test_dm_functionality.py
tests/test_dm_room_preservation.py
tests/test_dynamic_config_update.py
tests/test_dynamic_toolkits.py
tests/test_edit_after_restart.py
tests/test_edit_event_handling.py
tests/test_edit_response_regeneration.py
tests/test_embeddings.py
tests/test_entity_resolution.py
tests/test_error_handling.py
tests/test_error_handling_in_callbacks.py
tests/test_event_cache.py
tests/test_event_cache_backends.py
tests/test_event_driven_scheduling.py
tests/test_event_relations.py
tests/test_execution_preparation.py
tests/test_extra_kwargs.py
tests/test_final_delivery.py
tests/test_gemini_integration.py
tests/test_generate_skill_references.py
tests/test_gmail_tools.py
tests/test_google_calendar_oauth_tool.py
tests/test_google_drive_oauth_tool.py
tests/test_google_oauth_providers.py
tests/test_google_sheets_oauth_tool.py
tests/test_google_tool_wrappers.py
tests/test_handled_turns.py
tests/test_hatch_build.py
tests/test_helm_instance_worker_isolation.py
tests/test_homeassistant_tools.py
tests/test_hook_enrichment.py
tests/test_hook_execution.py
tests/test_hook_ingress.py
tests/test_hook_matrix_admin.py
tests/test_hook_registry.py
tests/test_hook_room_state.py
tests/test_hook_schedule.py
tests/test_hook_sender.py
tests/test_image_handler.py
tests/test_init.py
tests/test_interactive.py
tests/test_interactive_thread_fix.py
tests/test_interrupted_replay.py
tests/test_issue_154_logging_integration.py
tests/test_issue_176_real_thread_parallelism.py
tests/test_knowledge_index_metadata.py
tests/test_knowledge_manager.py
tests/test_kubernetes_worker_backend.py
tests/test_large_messages.py
tests/test_large_messages_integration.py
tests/test_live_message_coalescing.py
tests/test_llm_request_logging.py
tests/test_local_instance_deploy.py
tests/test_local_mindroom_provisioning_service.py
tests/test_logging_config.py
tests/test_markdown_to_html.py
tests/test_matrix_agent_manager.py
tests/test_matrix_api_tool.py
tests/test_matrix_cache_agent_message_snapshot.py
tests/test_matrix_delivery.py
tests/test_matrix_identity.py
tests/test_matrix_message_docs.py
tests/test_matrix_message_tool.py
tests/test_matrix_room_access.py
tests/test_matrix_room_tool.py
tests/test_matrix_spaces.py
tests/test_matrix_state_cache.py
tests/test_matrix_sync_tokens.py
tests/test_matrix_thread_domain.py
tests/test_mcp_config.py
tests/test_mcp_integration_fake_server.py
tests/test_mcp_manager.py
tests/test_mcp_orchestrator.py
tests/test_mcp_registry.py
tests/test_mcp_results.py
tests/test_mcp_toolkit.py
tests/test_mcp_transports.py
tests/test_memory_auto_flush.py
tests/test_memory_config.py
tests/test_memory_facade.py
tests/test_memory_file_backend.py
tests/test_memory_integration.py
tests/test_memory_mem0_backend.py
tests/test_memory_policy.py
tests/test_memory_tools.py
tests/test_mention_exclusion.py
tests/test_mentions.py
tests/test_message_builder.py
tests/test_message_content.py
tests/test_mock_tests.py
tests/test_multi_agent_bot.py
tests/test_multi_agent_e2e.py
tests/test_multiple_edits.py
tests/test_oauth_client_imports.py
tests/test_oauth_registry.py
tests/test_oauth_state.py
tests/test_openai_compat.py
tests/test_partial_reply_context.py
tests/test_plugin_imports.py
tests/test_plugins.py
tests/test_postgres_cursor.py
tests/test_preformed_team_routing.py
tests/test_presence.py
tests/test_presence_based_streaming.py
tests/test_prompt_cache_review.py
tests/test_python_tools.py
tests/test_queued_message_notify.py
tests/test_redaction.py
tests/test_response_attempt.py
tests/test_response_terminal.py
tests/test_response_tracking_regression.py
tests/test_restore_dedup.py
tests/test_room_invites.py
tests/test_room_member_hooks.py
tests/test_router_configured_agents.py
tests/test_router_rooms.py
tests/test_routing.py
tests/test_routing_integration.py
tests/test_routing_regression.py
tests/test_runtime_env_policy.py
tests/test_sandbox_proxy.py
tests/test_schedule_agent_validation.py
tests/test_scheduled_task_restoration.py
tests/test_scheduler_tool.py
tests/test_scheduling.py
tests/test_self_config.py
tests/test_send_file_message.py
tests/test_services.py
tests/test_shell_async.py
tests/test_shell_cancel.py
tests/test_skills.py
tests/test_skip_mentions.py
tests/test_smoke_mindroom_stack.py
tests/test_stale_stream_cleanup.py
tests/test_stop_emoji_reuse.py
tests/test_streaming_behavior.py
tests/test_streaming_e2e.py
tests/test_streaming_edits.py
tests/test_streaming_finalize.py
tests/test_subagents.py
tests/test_sync_certification.py
tests/test_sync_task_cancellation.py
tests/test_system_enrich.py
tests/test_tach_split_matrix_client_boundaries.py
tests/test_take_screenshot.py
tests/test_team_collaboration.py
tests/test_team_coordination.py
tests/test_team_extraction.py
tests/test_team_invitations.py
tests/test_team_media_fallback.py
tests/test_team_mode_decision.py
tests/test_team_room_updates.py
tests/test_team_scheduler_context.py
tests/test_thread_history.py
tests/test_thread_mode.py
tests/test_thread_summary.py
tests/test_thread_summary_tool.py
tests/test_thread_tags.py
tests/test_thread_tags_tool.py
tests/test_threading_error.py
tests/test_timezone_scheduling.py
tests/test_timing.py
tests/test_tool_approval.py
tests/test_tool_calls.py
tests/test_tool_config_sync.py
tests/test_tool_dependencies.py
tests/test_tool_events.py
tests/test_tool_execution_identity_payloads.py
tests/test_tool_hooks.py
tests/test_tool_output_files.py
tests/test_tool_system_facade_boundaries.py
tests/test_toolkit_aliases.py
tests/test_tools_metadata.py
tests/test_turn_controller.py
tests/test_turn_store.py
tests/test_unknown_command.py
tests/test_unknown_command_response.py
tests/test_voice_agent_mentions.py
tests/test_voice_bot_threading.py
tests/test_voice_command_processing.py
tests/test_voice_handler.py
tests/test_voice_handler_thread.py
tests/test_website_tool.py
tests/test_worker_lifecycle.py
tests/test_worker_progress_routing.py
tests/test_worker_runtime.py
tests/test_workflow_scheduling.py
tests/test_workloop_thread_scope.py
tests/test_workspace_env_hook.py` -> 6657 passed, 29 skipped

Note: the commit hook was run with `SKIP=ty,vulture` because those repo-wide hooks also scan unrelated untracked `team_execution_attempt` files already present in the worktree. Targeted `ty` for the changed CLI files passed, and the tracked full pytest suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized CLI startup performance by deferring heavy imports until needed, reducing overhead during help command rendering.

* **Bug Fixes**
  * Improved error handling in config display for file system and encoding-related failures.

* **Tests**
  * Updated test suite to align with internal dependency injection patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1003)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->