### PR TITLE
test: run backend tests with all extras

### DIFF
--- a/justfile
+++ b/justfile
@@ -205,7 +205,7 @@ test-front:
 # Run core backend tests (pytest) with optional arguments
 test-backend *args:
     uv sync --all-extras
-    uv run pytest {{args}}
+    uv run --all-extras pytest {{args}}
 
 # Check for public symbols that should be private
 check-module-privacy:

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -296,7 +296,7 @@ async def _wait_for_sent_pending(
     *,
     room_id: str = "!room:localhost",
 ) -> PendingApproval:
-    async with asyncio.timeout(1):
+    async with asyncio.timeout(5):
         while True:
             if sender.await_args is not None:
                 content = sender.await_args.kwargs.get("content")


### PR DESCRIPTION
Cherry-picks `def81730b` from `gitea/main` onto `origin/main`.

## Summary
- Updates the backend test `just` recipe to run pytest with `uv run --all-extras`.
- Gives the pending approval helper a longer timeout to reduce local flake sensitivity.

## Verification
- `just test-backend tests/test_tool_hooks.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by increasing async polling timeout.

* **Chores**
  * Updated test execution configuration to include all extras.

**Note:** These are internal improvements with no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1005)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->