### PR TITLE
fix: preserve queued notices for voice follow-ups

### DIFF
--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -295,6 +295,8 @@ class CoalescingGate:
     def _queue_kind(pending_event: PendingEvent) -> _QueueKind:
         if pending_event.dispatch_policy_source_kind == COALESCING_BYPASS_ACTIVE_THREAD_FOLLOW_UP:
             return _QueueKind.BYPASS
+        if any(item.requires_solo_batch for item in pending_event.dispatch_metadata):
+            return _QueueKind.BYPASS
         if is_coalescing_exempt_source_kind(pending_event.event, pending_event.source_kind):
             return _QueueKind.BYPASS
         if _is_command_event(pending_event.event, fallback_source_kind=pending_event.source_kind):

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import enum
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypeVar, cast
 
@@ -38,9 +37,14 @@ _LockedResponseResult = TypeVar("_LockedResponseResult")
 class _QueuedMessageState:
     """Track queued human ingress while one response lifecycle holds the lock."""
 
-    pending_human_messages: int = 0
+    pending_human_message_event_ids: set[str] = field(default_factory=set)
     _active_response_turns: int = 0
     _event: asyncio.Event = field(default_factory=asyncio.Event)
+
+    @property
+    def pending_human_messages(self) -> int:
+        """Return the number of distinct queued human events."""
+        return len(self.pending_human_message_event_ids)
 
     def begin_response_turn(self) -> bool:
         existing_turn = self._active_response_turns > 0
@@ -52,14 +56,16 @@ class _QueuedMessageState:
             return
         self._active_response_turns -= 1
 
-    def add_waiting_human_message(self) -> None:
-        self.pending_human_messages += 1
+    def add_waiting_human_message(self, source_event_id: str) -> bool:
+        previous_count = self.pending_human_messages
+        self.pending_human_message_event_ids.add(source_event_id)
         self._event.set()
+        return self.pending_human_messages != previous_count
 
-    def consume_waiting_human_message(self) -> None:
-        if self.pending_human_messages == 0:
+    def consume_waiting_human_message(self, source_event_id: str) -> None:
+        if source_event_id not in self.pending_human_message_event_ids:
             return
-        self.pending_human_messages -= 1
+        self.pending_human_message_event_ids.remove(source_event_id)
         if self.pending_human_messages == 0:
             self._event.clear()
 
@@ -76,22 +82,18 @@ class _QueuedMessageState:
         return self._event.is_set()
 
 
-class _QueuedHumanNotice(enum.Enum):
-    NONE = "none"
-    WAITING = "waiting"
-
-
 @dataclass(slots=True)
 class QueuedHumanNoticeReservation:
     """Owned reservation for a queued-human notice created before dispatch starts."""
 
     _state: _QueuedMessageState
+    _source_event_id: str
     _active: bool = True
 
     def _release_waiting_human_message(self) -> None:
         if not self._active:
             return
-        self._state.consume_waiting_human_message()
+        self._state.consume_waiting_human_message(self._source_event_id)
         self._active = False
 
     def consume(self) -> None:
@@ -173,8 +175,9 @@ class ResponseLifecycleCoordinator:
         if not self._has_active_response_for_thread_key(thread_key):
             return None
         queued_signal = self._get_or_create_queued_signal(target)
-        queued_signal.add_waiting_human_message()
-        return QueuedHumanNoticeReservation(queued_signal)
+        if not queued_signal.add_waiting_human_message(response_envelope.source_event_id):
+            return None
+        return QueuedHumanNoticeReservation(queued_signal, response_envelope.source_event_id)
 
     def _begin_response_turn_notice(
         self,
@@ -183,27 +186,28 @@ class ResponseLifecycleCoordinator:
         queued_signal: _QueuedMessageState,
         response_envelope: MessageEnvelope | None,
         queued_notice_reservation: QueuedHumanNoticeReservation | None,
-    ) -> _QueuedHumanNotice:
+    ) -> str | None:
         existing_turn = queued_signal.begin_response_turn()
         if queued_notice_reservation is not None:
-            return _QueuedHumanNotice.NONE
+            return None
         if not (existing_turn or lifecycle_lock.locked()):
-            return _QueuedHumanNotice.NONE
+            return None
         if not self._should_signal_queued_message(response_envelope):
-            return _QueuedHumanNotice.NONE
-        queued_signal.add_waiting_human_message()
-        return _QueuedHumanNotice.WAITING
+            return None
+        assert response_envelope is not None
+        if not queued_signal.add_waiting_human_message(response_envelope.source_event_id):
+            return None
+        return response_envelope.source_event_id
 
     def _consume_queued_human_notice(
         self,
         *,
-        notice: _QueuedHumanNotice,
+        notice: str | None,
         queued_signal: _QueuedMessageState,
-    ) -> _QueuedHumanNotice:
-        if notice is _QueuedHumanNotice.NONE:
-            return notice
-        queued_signal.consume_waiting_human_message()
-        return _QueuedHumanNotice.NONE
+    ) -> None:
+        if notice is None:
+            return
+        queued_signal.consume_waiting_human_message(notice)
 
     async def run_locked_response(
         self,

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -228,6 +228,7 @@ class ResponseLifecycleCoordinator:
             queued_notice_reservation=queued_notice_reservation,
         )
         lock_acquired = False
+        reservation_consumed = False
         try:
             if pipeline_timing is not None:
                 pipeline_timing.mark("lock_wait_start")
@@ -238,6 +239,7 @@ class ResponseLifecycleCoordinator:
             try:
                 if queued_notice_reservation is not None:
                     queued_notice_reservation.consume()
+                    reservation_consumed = True
                 notice = self._consume_queued_human_notice(
                     notice=notice,
                     queued_signal=queued_signal,
@@ -248,6 +250,8 @@ class ResponseLifecycleCoordinator:
                 if lock_acquired:
                     lifecycle_lock.release()
         finally:
+            if queued_notice_reservation is not None and not reservation_consumed:
+                queued_notice_reservation.cancel()
             self._consume_queued_human_notice(
                 notice=notice,
                 queued_signal=queued_signal,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -451,6 +451,11 @@ class TurnController:
             return False
         return self.deps.response_runner.has_active_response_for_target(target)
 
+    @staticmethod
+    def _same_response_lifecycle_target(left: MessageTarget, right: MessageTarget) -> bool:
+        """Return whether two targets share the same response lifecycle lock."""
+        return left.room_id == right.room_id and left.resolved_thread_id == right.resolved_thread_id
+
     async def _enqueue_active_thread_follow_up(
         self,
         *,
@@ -462,6 +467,7 @@ class TurnController:
         requester_user_id: str,
         dispatch_timing: DispatchPipelineTiming | None,
         trust_internal_payload_metadata: bool | None = None,
+        queued_notice_reservation: QueuedHumanNoticeReservation | None = None,
     ) -> None:
         """Queue an active-thread follow-up while preserving its mid-turn notice."""
         if dispatch_timing is not None:
@@ -469,10 +475,11 @@ class TurnController:
                 coalescing_bypassed=True,
                 coalescing_bypass_reason="active_thread_follow_up",
             )
-        queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
-            target=target,
-            response_envelope=envelope,
-        )
+        if queued_notice_reservation is None:
+            queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
+                target=target,
+                response_envelope=envelope,
+            )
         try:
             await self._enqueue_for_dispatch(
                 event,
@@ -506,6 +513,7 @@ class TurnController:
         requester_user_id: str,
         dispatch_timing: DispatchPipelineTiming | None,
         trust_internal_payload_metadata: bool | None = None,
+        queued_notice_reservation: QueuedHumanNoticeReservation | None = None,
     ) -> None:
         """Queue one normalized text event with shared active-follow-up handling."""
         target = self.deps.resolver.build_message_target(
@@ -528,19 +536,30 @@ class TurnController:
                 requester_user_id=requester_user_id,
                 dispatch_timing=dispatch_timing,
                 trust_internal_payload_metadata=trust_internal_payload_metadata,
+                queued_notice_reservation=queued_notice_reservation,
             )
             return
-        await self._enqueue_for_dispatch(
-            dispatch_event,
-            room,
-            source_kind=envelope.source_kind,
-            dispatch_policy_source_kind=envelope.dispatch_policy_source_kind,
-            hook_source=envelope.hook_source,
-            message_received_depth=envelope.message_received_depth,
-            requester_user_id=requester_user_id,
-            coalescing_key=(room.room_id, coalescing_thread_id, requester_user_id),
-            trust_internal_payload_metadata=trust_internal_payload_metadata,
-        )
+        try:
+            await self._enqueue_for_dispatch(
+                dispatch_event,
+                room,
+                source_kind=envelope.source_kind,
+                dispatch_policy_source_kind=envelope.dispatch_policy_source_kind,
+                hook_source=envelope.hook_source,
+                message_received_depth=envelope.message_received_depth,
+                requester_user_id=requester_user_id,
+                coalescing_key=(room.room_id, coalescing_thread_id, requester_user_id),
+                queued_notice_reservation=queued_notice_reservation,
+                trust_internal_payload_metadata=trust_internal_payload_metadata,
+            )
+        except asyncio.CancelledError:
+            if queued_notice_reservation is not None:
+                queued_notice_reservation.cancel()
+            raise
+        except Exception:
+            if queued_notice_reservation is not None:
+                queued_notice_reservation.cancel()
+            raise
 
     async def _enqueue_media_for_dispatch(
         self,
@@ -1982,7 +2001,11 @@ class TurnController:
             dispatch_timing=dispatch_timing,
         )
 
-        if await self._dispatch_special_media_as_text(room, prechecked_event):
+        if await self._dispatch_special_media_as_text(
+            room,
+            prechecked_event,
+            coalescing_thread_id=coalescing_thread_id,
+        ):
             return
         if not is_matrix_media_dispatch_event(prechecked_event.event):
             return
@@ -1998,6 +2021,8 @@ class TurnController:
         self,
         room: nio.MatrixRoom,
         prechecked_event: _PrecheckedInboundMediaEvent,
+        *,
+        coalescing_thread_id: str | None,
     ) -> bool:
         """Handle media events that normalize into the text dispatch pipeline."""
         event = prechecked_event.event
@@ -2008,6 +2033,8 @@ class TurnController:
                     event=event,
                     requester_user_id=prechecked_event.requester_user_id,
                 ),
+                coalescing_thread_id=coalescing_thread_id,
+                has_coalescing_thread_context=True,
             )
             return True
         if is_file_message_event(event):
@@ -2024,8 +2051,17 @@ class TurnController:
         self,
         room: nio.MatrixRoom,
         prechecked_event: _PrecheckedEvent[AudioMessageEvent],
+        *,
+        coalescing_thread_id: str | None = None,
+        has_coalescing_thread_context: bool = False,
     ) -> None:
-        """Normalize audio into a synthetic text event and reuse text dispatch."""
+        """Normalize audio into a synthetic text event and reuse text dispatch.
+
+        ``coalescing_thread_id`` is a pre-STT target computed by media ingress.
+        Direct helper calls lack that ingress context unless explicitly marked;
+        in that case reservation waits for the normalized voice event's final
+        thread target.
+        """
         event = prechecked_event.event
 
         if is_agent_id(event.sender, self.deps.runtime.config, self.deps.runtime_paths):
@@ -2037,49 +2073,94 @@ class TurnController:
             self._mark_source_events_responded(HandledTurnState.from_source_event_id(event.event_id))
             return
 
-        dispatch_timing = get_dispatch_pipeline_timing(event.source)
-        if dispatch_timing is not None:
-            dispatch_timing.mark("ingress_normalize_start")
-        normalized_voice = await self.deps.normalizer.prepare_voice_event(
-            VoiceNormalizationRequest(
+        target = None
+        queued_notice_reservation = None
+        if has_coalescing_thread_context:
+            target = self.deps.resolver.build_message_target(
+                room_id=room.room_id,
+                thread_id=coalescing_thread_id,
+                reply_to_event_id=event.event_id,
+                event_source=event.source,
+            )
+            envelope = self.deps.resolver.build_ingress_envelope(
+                room_id=room.room_id,
+                event=cast("DispatchEvent", event),
+                requester_user_id=prechecked_event.requester_user_id,
+                thread_id=coalescing_thread_id,
+                source_kind="voice",
+            )
+            queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
+                target=target,
+                response_envelope=envelope,
+            )
+        reservation_released_or_handed_off = False
+        try:
+            dispatch_timing = get_dispatch_pipeline_timing(event.source)
+            if dispatch_timing is not None:
+                dispatch_timing.mark("ingress_normalize_start")
+            normalized_voice = await self.deps.normalizer.prepare_voice_event(
+                VoiceNormalizationRequest(
+                    room=room,
+                    event=event,
+                ),
+            )
+            if dispatch_timing is not None:
+                dispatch_timing.mark("ingress_normalize_ready")
+            if normalized_voice is None:
+                self._mark_source_events_responded(HandledTurnState.from_source_event_id(event.event_id))
+                return
+            attach_dispatch_pipeline_timing(
+                normalized_voice.event.source,
+                dispatch_timing,
+            )
+
+            await self._maybe_send_visible_voice_echo(
+                room,
+                event,
+                text=normalized_voice.event.body,
+                thread_id=normalized_voice.effective_thread_id,
+            )
+
+            envelope = self.deps.resolver.build_ingress_envelope(
+                room_id=room.room_id,
+                event=normalized_voice.event,
+                requester_user_id=prechecked_event.requester_user_id,
+                thread_id=normalized_voice.effective_thread_id,
+                source_kind="voice",
+            )
+            normalized_target = self.deps.resolver.build_message_target(
+                room_id=room.room_id,
+                thread_id=normalized_voice.effective_thread_id,
+                reply_to_event_id=normalized_voice.event.event_id,
+                event_source=normalized_voice.event.source,
+            )
+            if queued_notice_reservation is None:
+                queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
+                    target=normalized_target,
+                    response_envelope=envelope,
+                )
+            elif target is not None and not self._same_response_lifecycle_target(target, normalized_target):
+                if queued_notice_reservation is not None:
+                    queued_notice_reservation.cancel()
+                queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
+                    target=normalized_target,
+                    response_envelope=envelope,
+                )
+            await self._enqueue_prepared_text_for_dispatch(
                 room=room,
-                event=event,
-            ),
-        )
-        if dispatch_timing is not None:
-            dispatch_timing.mark("ingress_normalize_ready")
-        if normalized_voice is None:
-            self._mark_source_events_responded(HandledTurnState.from_source_event_id(event.event_id))
-            return
-        attach_dispatch_pipeline_timing(
-            normalized_voice.event.source,
-            dispatch_timing,
-        )
-
-        await self._maybe_send_visible_voice_echo(
-            room,
-            event,
-            text=normalized_voice.event.body,
-            thread_id=normalized_voice.effective_thread_id,
-        )
-
-        envelope = self.deps.resolver.build_ingress_envelope(
-            room_id=room.room_id,
-            event=normalized_voice.event,
-            requester_user_id=prechecked_event.requester_user_id,
-            thread_id=normalized_voice.effective_thread_id,
-            source_kind="voice",
-        )
-        await self._enqueue_prepared_text_for_dispatch(
-            room=room,
-            prepared_event=normalized_voice.event,
-            dispatch_event=normalized_voice.event,
-            envelope=envelope,
-            coalescing_thread_id=normalized_voice.effective_thread_id,
-            requester_user_id=prechecked_event.requester_user_id,
-            dispatch_timing=dispatch_timing,
-            trust_internal_payload_metadata=True,
-        )
+                prepared_event=normalized_voice.event,
+                dispatch_event=normalized_voice.event,
+                envelope=envelope,
+                coalescing_thread_id=normalized_voice.effective_thread_id,
+                requester_user_id=prechecked_event.requester_user_id,
+                dispatch_timing=dispatch_timing,
+                trust_internal_payload_metadata=True,
+                queued_notice_reservation=queued_notice_reservation,
+            )
+            reservation_released_or_handed_off = True
+        finally:
+            if not reservation_released_or_handed_off and queued_notice_reservation is not None:
+                queued_notice_reservation.cancel()
 
     async def _dispatch_file_sidecar_text_preview(
         self,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -2140,8 +2140,7 @@ class TurnController:
                     response_envelope=envelope,
                 )
             elif target is not None and not self._same_response_lifecycle_target(target, normalized_target):
-                if queued_notice_reservation is not None:
-                    queued_notice_reservation.cancel()
+                queued_notice_reservation.cancel()
                 queued_notice_reservation = self.deps.response_runner.reserve_waiting_human_message(
                     target=normalized_target,
                     response_envelope=envelope,

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -35,6 +35,7 @@ from mindroom.conversation_resolver import MessageContext
 from mindroom.dispatch_handoff import (
     DispatchIngressMetadata,
     DispatchPayloadMetadata,
+    PendingDispatchMetadata,
     PreparedTextEvent,
     _build_batch_dispatch_event,
     build_dispatch_handoff,
@@ -1581,6 +1582,54 @@ async def test_bypass_preserves_fifo_order_behind_existing_normal_work() -> None
 
     await _wait_for(lambda: calls == [["$m1"], ["$hook"], ["$m2"]])
 
+    assert _coalescing_gate_is_idle(gate)
+
+
+@pytest.mark.asyncio
+async def test_room_mode_voice_queued_notice_is_solo_barrier_before_nearby_normal_message() -> None:
+    """Room-scoped voice notices should dispatch solo instead of joining normal debounce batches."""
+    room = _make_room()
+    voice = _text_event(event_id="$voice-room", body="voice transcript", server_timestamp=1000, source_kind="voice")
+    normal = _text_event(event_id="$normal", body="nearby text", server_timestamp=1001)
+    reservation = MagicMock()
+    metadata = (
+        PendingDispatchMetadata(
+            kind="queued_notice_reservation",
+            payload=reservation,
+            close=reservation.cancel,
+            requires_solo_batch=True,
+        ),
+    )
+    calls: list[list[str]] = []
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        calls.append(list(batch.source_event_ids))
+        if batch.source_event_ids == ["$voice-room"]:
+            assert batch.dispatch_metadata == metadata
+            return
+        assert batch.dispatch_metadata == ()
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 5.0,
+        upload_grace_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+    )
+    key = ("!room:localhost", None, "@user:localhost")
+
+    await gate.enqueue(
+        key,
+        PendingEvent(event=voice, room=room, source_kind="voice", dispatch_metadata=metadata),
+    )
+    await gate.enqueue(key, PendingEvent(event=normal, room=room, source_kind="message"))
+
+    await _wait_for(lambda: calls == [["$voice-room"]], deadline_seconds=0.2)
+    reservation.cancel.assert_not_called()
+
+    await gate.drain_all()
+
+    assert calls == [["$voice-room"], ["$normal"]]
+    reservation.cancel.assert_not_called()
     assert _coalescing_gate_is_idle(gate)
 
 

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -10466,6 +10466,8 @@ class TestAgentBot:
 
         mock_echo.assert_awaited_once()
         mock_reserve_waiting_human_message.assert_called_once()
+        reserved_target = mock_reserve_waiting_human_message.call_args.kwargs["target"]
+        assert reserved_target.resolved_thread_id == "$thread_root"
         reserved_envelope = mock_reserve_waiting_human_message.call_args.kwargs["response_envelope"]
         assert reserved_envelope.source_kind == "voice"
         mock_start.assert_awaited_once()

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -1962,6 +1962,54 @@ def test_queued_human_reservation_is_idempotent(tmp_path: Path) -> None:
     assert not queued_signal.is_set()
 
 
+@pytest.mark.asyncio
+async def test_handed_off_reservation_is_cancelled_when_lock_wait_is_cancelled(tmp_path: Path) -> None:
+    """A reservation handed to the lifecycle should not leak if lock acquisition is cancelled."""
+    bot = _bot(tmp_path)
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$event")
+    envelope = _envelope(
+        dispatch_policy_source_kind=COALESCING_BYPASS_ACTIVE_THREAD_FOLLOW_UP,
+        source_event_id="$event",
+        target=target,
+    )
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    lifecycle = coordinator._lifecycle_coordinator
+    queued_signal = lifecycle._get_or_create_queued_signal(target)
+    queued_signal.begin_response_turn()
+    reservation = lifecycle.reserve_waiting_human_message(target=target, response_envelope=envelope)
+    assert reservation is not None
+    assert queued_signal.pending_human_messages == 1
+
+    lock = lifecycle._response_lifecycle_lock(target)
+    await lock.acquire()
+
+    async def locked_operation(_target: MessageTarget) -> str:
+        msg = "lock wait should be cancelled before the operation runs"
+        raise AssertionError(msg)
+
+    try:
+        task = asyncio.create_task(
+            lifecycle.run_locked_response(
+                target=target,
+                response_envelope=envelope,
+                queued_notice_reservation=reservation,
+                pipeline_timing=None,
+                locked_operation=locked_operation,
+            ),
+        )
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        lock.release()
+        queued_signal.finish_response_turn()
+
+    assert queued_signal.pending_human_messages == 0
+    assert not queued_signal.is_set()
+    assert not queued_signal.has_active_response_turn()
+
+
 def test_reserved_follow_up_cannot_join_multi_event_batch(tmp_path: Path) -> None:
     """A reserved active follow-up mixed into a multi-event batch should fail and clear."""
     bot = _bot(tmp_path)

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -51,6 +51,7 @@ from mindroom.post_response_effects import (
     apply_post_response_effects,
 )
 from mindroom.prompts import QUEUED_MESSAGE_NOTICE_TEXT
+from mindroom.response_lifecycle import _QueuedMessageState
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
 from mindroom.teams import TeamMode, _create_team_instance
 from mindroom.turn_controller import _PrecheckedEvent
@@ -311,6 +312,28 @@ class _StaticQueuedState:
 
     def has_pending_human_messages(self) -> bool:
         return self.pending
+
+
+def test_queued_message_state_tracks_source_event_ids_idempotently() -> None:
+    """Queued-message state should track distinct source events, not anonymous increments."""
+    state = _QueuedMessageState()
+
+    assert state.add_waiting_human_message("$event")
+    assert not state.add_waiting_human_message("$event")
+
+    assert state.has_pending_human_messages()
+    assert state.pending_human_messages == 1
+    assert state.is_set()
+
+    state.consume_waiting_human_message("$unknown")
+    assert state.pending_human_messages == 1
+
+    state.consume_waiting_human_message("$event")
+    state.consume_waiting_human_message("$event")
+
+    assert not state.has_pending_human_messages()
+    assert state.pending_human_messages == 0
+    assert not state.is_set()
 
 
 @contextmanager
@@ -1241,8 +1264,9 @@ async def test_generate_team_response_helper_sets_queued_signal(tmp_path: Path) 
 async def test_generate_response_preserves_later_queued_human_message(tmp_path: Path) -> None:
     """The next active turn must still see any later human messages that were already queued."""
     bot = _bot(tmp_path)
-    response_envelope = _envelope()
-    response_target = response_envelope.target
+    response_envelope_b = _envelope(source_event_id="$event-b")
+    response_envelope_c = _envelope(source_event_id="$event-c")
+    response_target = response_envelope_b.target
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lifecycle = coordinator._lifecycle_coordinator
     lifecycle_lock = lifecycle._response_lifecycle_lock(response_target)
@@ -1269,7 +1293,7 @@ async def test_generate_response_preserves_later_queued_human_message(tmp_path: 
                     thread_id=None,
                     thread_history=[],
                     user_id="@user:localhost",
-                    response_envelope=response_envelope,
+                    response_envelope=response_envelope_b,
                 ),
             )
             await asyncio.wait_for(queued_signal.wait(), timeout=0.2)
@@ -1281,7 +1305,7 @@ async def test_generate_response_preserves_later_queued_human_message(tmp_path: 
                     thread_id=None,
                     thread_history=[],
                     user_id="@user:localhost",
-                    response_envelope=response_envelope,
+                    response_envelope=response_envelope_c,
                 ),
             )
             for _ in range(20):
@@ -1309,8 +1333,9 @@ async def test_generate_response_preserves_later_queued_human_message(tmp_path: 
 async def test_generate_team_response_preserves_later_queued_human_message(tmp_path: Path) -> None:
     """Team queue notices must also survive when more than one human turn is waiting."""
     bot = _bot(tmp_path)
-    response_envelope = _envelope()
-    response_target = response_envelope.target
+    response_envelope_b = _envelope(source_event_id="$team-event-b")
+    response_envelope_c = _envelope(source_event_id="$team-event-c")
+    response_target = response_envelope_b.target
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
     lifecycle = coordinator._lifecycle_coordinator
     lifecycle_lock = lifecycle._response_lifecycle_lock(response_target)
@@ -1339,7 +1364,7 @@ async def test_generate_team_response_preserves_later_queued_human_message(tmp_p
                     thread_history=[],
                     requester_user_id="@user:localhost",
                     payload=DispatchPayload(prompt="hello"),
-                    response_envelope=response_envelope,
+                    response_envelope=response_envelope_b,
                 ),
             )
             await asyncio.wait_for(queued_signal.wait(), timeout=0.2)
@@ -1353,7 +1378,7 @@ async def test_generate_team_response_preserves_later_queued_human_message(tmp_p
                     thread_history=[],
                     requester_user_id="@user:localhost",
                     payload=DispatchPayload(prompt="hello again"),
-                    response_envelope=response_envelope,
+                    response_envelope=response_envelope_c,
                 ),
             )
             for _ in range(20):

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -10,10 +11,12 @@ import nio
 import pytest
 from agno.media import Audio
 
+from mindroom import inbound_turn_normalizer
 from mindroom.attachments import _attachment_id_for_event, load_attachment
 from mindroom.bot import AgentBot
 from mindroom.config.main import Config
 from mindroom.conversation_resolver import MessageContext
+from mindroom.dispatch_handoff import PreparedTextEvent
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from tests.conftest import (
@@ -251,3 +254,332 @@ async def test_voice_plain_reply_to_thread_message_stays_threaded_transitively(
     attachment = load_attachment(bot.storage_path, _attachment_id_for_event("$voice789"))
     assert attachment is not None
     assert attachment.thread_id == "$thread_root"
+
+
+@pytest.mark.asyncio
+async def test_voice_message_signals_active_turn_before_stt(mock_home_bot: AgentBot) -> None:
+    """Audio follow-ups should notify an active response before transcription finishes."""
+    bot = mock_home_bot
+    room = MagicMock(spec=nio.MatrixRoom)
+    room.room_id = "!test:server"
+    room.canonical_alias = None
+    room.users = {
+        "@mindroom_home:localhost": MagicMock(),
+        "@user:example.com": MagicMock(),
+    }
+    room.members_synced = True
+
+    voice_event = _make_voice_event(
+        event_id="$voice-blocked",
+        source={
+            "content": {
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+        },
+    )
+    target = bot._turn_controller.deps.resolver.build_message_target(
+        room_id=room.room_id,
+        thread_id="$thread_root",
+        reply_to_event_id=voice_event.event_id,
+        event_source=voice_event.source,
+    )
+    lifecycle = unwrap_extracted_collaborator(bot._response_runner)._lifecycle_coordinator
+    queued_signal = lifecycle._get_or_create_queued_signal(target)
+    prepare_started = asyncio.Event()
+    allow_prepare = asyncio.Event()
+
+    async def prepare_voice_event(*_args: object, **_kwargs: object) -> None:
+        prepare_started.set()
+        await allow_prepare.wait()
+
+    queued_signal.begin_response_turn()
+    try:
+        with (
+            patch.object(
+                bot._turn_controller.deps.resolver,
+                "coalescing_thread_id",
+                new=AsyncMock(return_value="$thread_root"),
+            ),
+            patch.object(
+                bot._turn_controller.deps.normalizer,
+                "prepare_voice_event",
+                new=AsyncMock(side_effect=prepare_voice_event),
+            ),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
+        ):
+            task = asyncio.create_task(bot._on_media_message(room, voice_event))
+            await asyncio.wait_for(prepare_started.wait(), timeout=0.2)
+            assert queued_signal.pending_human_messages == 1
+            allow_prepare.set()
+            await task
+    finally:
+        queued_signal.finish_response_turn()
+
+    assert queued_signal.pending_human_messages == 0
+    assert not queued_signal.is_set()
+
+
+@pytest.mark.parametrize(
+    "echo_error",
+    [
+        RuntimeError("echo failed"),
+        asyncio.CancelledError(),
+    ],
+)
+@pytest.mark.asyncio
+async def test_voice_message_clears_active_turn_signal_when_post_stt_echo_fails(
+    mock_home_bot: AgentBot,
+    echo_error: BaseException,
+) -> None:
+    """Post-STT failures before dispatch handoff should release the pre-STT reservation."""
+    bot = mock_home_bot
+    room = MagicMock(spec=nio.MatrixRoom)
+    room.room_id = "!test:server"
+    room.canonical_alias = None
+    room.users = {
+        "@mindroom_home:localhost": MagicMock(),
+        "@user:example.com": MagicMock(),
+    }
+    room.members_synced = True
+
+    voice_event = _make_voice_event(
+        event_id="$voice-echo-fails",
+        source={
+            "content": {
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+        },
+    )
+    target = bot._turn_controller.deps.resolver.build_message_target(
+        room_id=room.room_id,
+        thread_id="$thread_root",
+        reply_to_event_id=voice_event.event_id,
+        event_source=voice_event.source,
+    )
+    lifecycle = unwrap_extracted_collaborator(bot._response_runner)._lifecycle_coordinator
+    queued_signal = lifecycle._get_or_create_queued_signal(target)
+    normalized_voice = inbound_turn_normalizer._VoiceNormalizationResult(
+        event=PreparedTextEvent(
+            sender=voice_event.sender,
+            event_id=voice_event.event_id,
+            body="🎤 continue",
+            source={"content": {"body": "🎤 continue", "com.mindroom.source_kind": "voice"}},
+            server_timestamp=voice_event.server_timestamp,
+            source_kind_override="voice",
+        ),
+        effective_thread_id="$thread_root",
+    )
+
+    async def fail_visible_echo(*_args: object, **_kwargs: object) -> None:
+        assert queued_signal.pending_human_messages == 1
+        raise echo_error
+
+    queued_signal.begin_response_turn()
+    try:
+        with (
+            patch.object(
+                bot._turn_controller.deps.resolver,
+                "coalescing_thread_id",
+                new=AsyncMock(return_value="$thread_root"),
+            ),
+            patch.object(
+                bot._turn_controller.deps.normalizer,
+                "prepare_voice_event",
+                new=AsyncMock(return_value=normalized_voice),
+            ),
+            patch.object(
+                bot._turn_controller,
+                "_maybe_send_visible_voice_echo",
+                new=AsyncMock(side_effect=fail_visible_echo),
+            ),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
+            pytest.raises(type(echo_error)),
+        ):
+            await bot._on_media_message(room, voice_event)
+    finally:
+        queued_signal.finish_response_turn()
+
+    assert queued_signal.pending_human_messages == 0
+    assert not queued_signal.is_set()
+
+
+@pytest.mark.asyncio
+async def test_voice_message_retargets_queued_notice_when_stt_thread_changes(
+    mock_home_bot: AgentBot,
+) -> None:
+    """A post-STT target change should cancel the pre-STT notice and reserve the final target."""
+    bot = mock_home_bot
+    room = MagicMock(spec=nio.MatrixRoom)
+    room.room_id = "!test:server"
+    room.canonical_alias = None
+    room.users = {
+        "@mindroom_home:localhost": MagicMock(),
+        "@user:example.com": MagicMock(),
+    }
+    room.members_synced = True
+
+    voice_event = _make_voice_event(
+        event_id="$voice-retargeted",
+        source={
+            "content": {
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$pre_stt_thread"},
+            },
+        },
+    )
+    normalized_event = PreparedTextEvent(
+        sender=voice_event.sender,
+        event_id=voice_event.event_id,
+        body="🎤 continue somewhere else",
+        source={"content": {"body": "🎤 continue somewhere else", "com.mindroom.source_kind": "voice"}},
+        server_timestamp=voice_event.server_timestamp,
+        source_kind_override="voice",
+    )
+    normalized_voice = inbound_turn_normalizer._VoiceNormalizationResult(
+        event=normalized_event,
+        effective_thread_id="$post_stt_thread",
+    )
+    pre_stt_target = bot._turn_controller.deps.resolver.build_message_target(
+        room_id=room.room_id,
+        thread_id="$pre_stt_thread",
+        reply_to_event_id=voice_event.event_id,
+        event_source=voice_event.source,
+    )
+    post_stt_target = bot._turn_controller.deps.resolver.build_message_target(
+        room_id=room.room_id,
+        thread_id="$post_stt_thread",
+        reply_to_event_id=normalized_event.event_id,
+        event_source=normalized_event.source,
+    )
+    lifecycle = unwrap_extracted_collaborator(bot._response_runner)._lifecycle_coordinator
+    pre_stt_signal = lifecycle._get_or_create_queued_signal(pre_stt_target)
+    post_stt_signal = lifecycle._get_or_create_queued_signal(post_stt_target)
+    captured_reservations: list[object] = []
+
+    async def capture_enqueue(*_args: object, **kwargs: object) -> None:
+        assert pre_stt_signal.pending_human_messages == 0
+        assert post_stt_signal.pending_human_messages == 1
+        reservation = kwargs["queued_notice_reservation"]
+        assert reservation is not None
+        captured_reservations.append(reservation)
+        reservation.cancel()
+
+    pre_stt_signal.begin_response_turn()
+    post_stt_signal.begin_response_turn()
+    try:
+        with (
+            patch.object(
+                bot._turn_controller.deps.resolver,
+                "coalescing_thread_id",
+                new=AsyncMock(return_value="$pre_stt_thread"),
+            ),
+            patch.object(
+                bot._turn_controller.deps.normalizer,
+                "prepare_voice_event",
+                new=AsyncMock(return_value=normalized_voice),
+            ),
+            patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
+            patch.object(bot._turn_controller, "_enqueue_for_dispatch", new=AsyncMock(side_effect=capture_enqueue)),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
+        ):
+            await bot._on_media_message(room, voice_event)
+    finally:
+        pre_stt_signal.finish_response_turn()
+        post_stt_signal.finish_response_turn()
+
+    assert len(captured_reservations) == 1
+    assert pre_stt_signal.pending_human_messages == 0
+    assert post_stt_signal.pending_human_messages == 0
+    assert not pre_stt_signal.is_set()
+    assert not post_stt_signal.is_set()
+
+
+@pytest.mark.asyncio
+async def test_room_mode_voice_notice_survives_until_queued_dispatch_owns_it(
+    mock_home_bot: AgentBot,
+) -> None:
+    """Room-mode voice should signal the room-level active turn before STT finishes."""
+    bot = mock_home_bot
+    bot.config.agents["home"].thread_mode = "room"
+    room = MagicMock(spec=nio.MatrixRoom)
+    room.room_id = "!test:server"
+    room.canonical_alias = None
+    room.users = {
+        "@mindroom_home:localhost": MagicMock(),
+        "@user:example.com": MagicMock(),
+    }
+    room.members_synced = True
+
+    voice_event = _make_voice_event(
+        event_id="$voice-room-mode",
+        source={
+            "content": {
+                "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread_root"},
+            },
+        },
+    )
+    normalized_voice = inbound_turn_normalizer._VoiceNormalizationResult(
+        event=PreparedTextEvent(
+            sender=voice_event.sender,
+            event_id=voice_event.event_id,
+            body="🎤 room mode follow-up",
+            source={"content": {"body": "🎤 room mode follow-up", "com.mindroom.source_kind": "voice"}},
+            server_timestamp=voice_event.server_timestamp,
+            source_kind_override="voice",
+        ),
+        effective_thread_id=None,
+    )
+    target = bot._turn_controller.deps.resolver.build_message_target(
+        room_id=room.room_id,
+        thread_id=None,
+        reply_to_event_id=voice_event.event_id,
+        event_source=voice_event.source,
+    )
+    lifecycle = unwrap_extracted_collaborator(bot._response_runner)._lifecycle_coordinator
+    queued_signal = lifecycle._get_or_create_queued_signal(target)
+    captured_reservations: list[object] = []
+    prepare_started = asyncio.Event()
+    allow_prepare = asyncio.Event()
+
+    async def prepare_voice_event(
+        *_args: object,
+        **_kwargs: object,
+    ) -> inbound_turn_normalizer._VoiceNormalizationResult:
+        prepare_started.set()
+        await allow_prepare.wait()
+        return normalized_voice
+
+    async def capture_enqueue(*_args: object, **kwargs: object) -> None:
+        assert queued_signal.pending_human_messages == 1
+        reservation = kwargs["queued_notice_reservation"]
+        assert reservation is not None
+        captured_reservations.append(reservation)
+        reservation.cancel()
+
+    queued_signal.begin_response_turn()
+    try:
+        with (
+            patch.object(
+                bot._turn_controller.deps.resolver,
+                "coalescing_thread_id",
+                new=AsyncMock(return_value=None),
+            ),
+            patch.object(
+                bot._turn_controller.deps.normalizer,
+                "prepare_voice_event",
+                new=AsyncMock(side_effect=prepare_voice_event),
+            ),
+            patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
+            patch.object(bot._turn_controller, "_enqueue_for_dispatch", new=AsyncMock(side_effect=capture_enqueue)),
+            patch("mindroom.turn_controller.is_authorized_sender", return_value=True),
+        ):
+            task = asyncio.create_task(bot._on_media_message(room, voice_event))
+            await asyncio.wait_for(prepare_started.wait(), timeout=0.2)
+            assert queued_signal.pending_human_messages == 1
+            allow_prepare.set()
+            await task
+    finally:
+        queued_signal.finish_response_turn()
+
+    assert len(captured_reservations) == 1
+    assert queued_signal.pending_human_messages == 0
+    assert not queued_signal.is_set()

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
+from contextlib import suppress
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -293,6 +294,7 @@ async def test_voice_message_signals_active_turn_before_stt(mock_home_bot: Agent
         await allow_prepare.wait()
 
     queued_signal.begin_response_turn()
+    task: asyncio.Task[None] | None = None
     try:
         with (
             patch.object(
@@ -313,6 +315,10 @@ async def test_voice_message_signals_active_turn_before_stt(mock_home_bot: Agent
             allow_prepare.set()
             await task
     finally:
+        if task is not None and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
         queued_signal.finish_response_turn()
 
     assert queued_signal.pending_human_messages == 0
@@ -556,6 +562,7 @@ async def test_room_mode_voice_notice_survives_until_queued_dispatch_owns_it(
         reservation.cancel()
 
     queued_signal.begin_response_turn()
+    task: asyncio.Task[None] | None = None
     try:
         with (
             patch.object(
@@ -578,6 +585,10 @@ async def test_room_mode_voice_notice_survives_until_queued_dispatch_owns_it(
             allow_prepare.set()
             await task
     finally:
+        if task is not None and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
         queued_signal.finish_response_turn()
 
     assert len(captured_reservations) == 1


### PR DESCRIPTION
Cherry-picks `4c261802b` from `gitea/main` onto `origin/main`, with minimal alignment for current `origin/main` tests and module-privacy policy.

## Summary
- Reserves queued-human notice state before voice/audio normalization when an active turn exists.
- Carries or retargets that reservation through normalized dispatch.
- Keeps reserved voice dispatches from being absorbed into normal coalescing batches.

## Verification
- `uv run --all-extras pytest tests/test_voice_bot_threading.py tests/test_queued_message_notify.py tests/test_live_message_coalescing.py tests/test_multi_agent_bot.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Coalescing now respects per-dispatch metadata to force solo (bypass) batching.
  * Queued-human tracking is idempotent by tracking distinct source-event IDs and safely consuming them.
  * Voice/media flows preserve pre-transcription context and reliably cancel or re-reserve queued notices on handoff failures or retargeting; reservation cleanup is tightened.

* **Tests**
  * Added extensive tests for voice notice lifecycle, coalescing behavior, queued-message idempotency, and reservation cancellation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1006)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->