### PR TITLE
fix(orchestrator): fail on unexpected runtime exit

### DIFF
--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -155,6 +155,13 @@ def _raise_embedded_api_server_exit(api_server: _EmbeddedApiServerContext, *, re
     raise RuntimeError(msg)
 
 
+def _raise_orchestrator_exit(*, reason: str) -> NoReturn:
+    """Raise the fatal lifecycle error for an unexpected orchestrator exit."""
+    logger.error("fatal_orchestrator_exit", reason=reason)
+    msg = "MindRoom orchestrator exited unexpectedly"
+    raise RuntimeError(msg)
+
+
 @dataclass
 class _ConfigReloadDrainState:
     """Track response-drain state for a queued config reload."""
@@ -1808,6 +1815,14 @@ async def _wait_for_runtime_completion(
     if api_task is not None:
         monitored_tasks.add(api_task)
     done, _pending = await asyncio.wait(monitored_tasks, return_when=asyncio.FIRST_COMPLETED)
+    logger.info(
+        "runtime_completion_detected",
+        completed_tasks=sorted(task.get_name() for task in done),
+        orchestrator_done=orchestrator_task in done,
+        api_done=api_task in done if api_task is not None else False,
+        shutdown_requested_done=shutdown_wait_task in done,
+        shutdown_requested=shutdown_requested.is_set(),
+    )
     await _consume_completed_runtime_tasks(
         done,
         orchestrator_task=orchestrator_task,
@@ -1844,17 +1859,41 @@ async def _consume_completed_runtime_tasks(
         if task is None or task not in done:
             continue
         try:
+            task_name = task.get_name()
             if api_task is not None and task is api_task:
                 await _await_api_task_completion(
                     api_task,
                     shutdown_requested=shutdown_requested,
                     api_server=api_server,
                 )
+                logger.info(
+                    "runtime_task_completed",
+                    task_name=task_name,
+                    shutdown_requested=shutdown_requested.is_set(),
+                )
                 continue
             await task
+            if task is orchestrator_task:
+                if shutdown_requested.is_set():
+                    logger.info(
+                        "orchestrator_task_completed_after_shutdown_request",
+                        task_name=task_name,
+                    )
+                    continue
+                _raise_orchestrator_exit(
+                    reason="Orchestrator task finished while application shutdown was not requested",
+                )
+            logger.info(
+                "runtime_task_completed",
+                task_name=task_name,
+                shutdown_requested=shutdown_requested.is_set(),
+            )
+            continue
         except asyncio.CancelledError:
+            logger.info("runtime_task_cancelled", task_name=task.get_name())
             continue
         except Exception as exc:
+            logger.exception("runtime_task_failed", task_name=task.get_name())
             failures.append(exc)
     if failures:
         raise failures[0]

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -1533,6 +1533,31 @@ class TestAgentBot:
             await asyncio.gather(orchestrator_task, shutdown_wait_task, api_task, return_exceptions=True)
 
     @pytest.mark.asyncio
+    async def test_runtime_completion_raises_when_orchestrator_returns_without_shutdown_request(self) -> None:
+        """A clean orchestrator return without a shutdown signal should restart the service."""
+        shutdown_requested = asyncio.Event()
+
+        async def _orchestrator_done() -> None:
+            return None
+
+        orchestrator_task = asyncio.create_task(_orchestrator_done(), name="orchestrator")
+        shutdown_wait_task = asyncio.create_task(shutdown_requested.wait(), name="application_shutdown_wait")
+        await asyncio.sleep(0)
+
+        try:
+            with pytest.raises(RuntimeError, match="MindRoom orchestrator exited unexpectedly"):
+                await _wait_for_runtime_completion(
+                    orchestrator_task=orchestrator_task,
+                    shutdown_wait_task=shutdown_wait_task,
+                    api_task=None,
+                    shutdown_requested=shutdown_requested,
+                    api_server=_EmbeddedApiServerContext(host="127.0.0.1", port=0),
+                )
+        finally:
+            shutdown_wait_task.cancel()
+            await asyncio.gather(orchestrator_task, shutdown_wait_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
     async def test_orchestrator_main_logs_api_shutdown_timeout_before_cancelling_stuck_api_task(
         self,
         tmp_path: Path,
@@ -1811,7 +1836,7 @@ class TestAgentBot:
         observed_logging_root: Path | None = None
         observed_credentials_root: Path | None = None
         mock_orchestrator = MagicMock()
-        mock_orchestrator.start = AsyncMock()
+        mock_orchestrator.start = AsyncMock(side_effect=RuntimeError("stop after storage capture"))
         mock_orchestrator.stop = AsyncMock()
 
         def _capture_logging(*, level: str, runtime_paths: RuntimePaths) -> None:
@@ -1827,6 +1852,7 @@ class TestAgentBot:
             patch("mindroom.orchestrator.setup_logging", side_effect=_capture_logging),
             patch("mindroom.orchestrator.sync_env_to_credentials", side_effect=_capture_credentials_sync),
             patch("mindroom.orchestrator._MultiAgentOrchestrator", return_value=mock_orchestrator),
+            pytest.raises(RuntimeError, match="stop after storage capture"),
         ):
             await main(log_level="INFO", runtime_paths=self._runtime_paths(runtime_storage), api=False)
 


### PR DESCRIPTION
Cherry-picks `f84fc4355` from `gitea/main` onto `origin/main`.

## Summary
- Treats unexpected orchestrator task completion as a fatal runtime error unless shutdown was requested.
- Adds runtime completion diagnostics for monitored tasks.
- Updates runtime lifecycle tests for the new fatal path.

## Verification
- `uv run --all-extras pytest tests/test_multi_agent_bot.py::TestAgentBot::test_runtime_completion_raises_when_orchestrator_returns_without_shutdown_request tests/test_multi_agent_bot.py::TestAgentBot::test_runtime_completion_raises_done_orchestrator_failure_before_clean_shutdown_return tests/test_multi_agent_bot.py::TestAgentBot::test_runtime_completion_raises_orchestrator_failure_during_api_shutdown_grace tests/test_multi_agent_bot.py::TestAgentBot::test_orchestrator_main_fails_when_api_server_exits_unexpectedly tests/test_multi_agent_bot.py::TestAgentBot::test_orchestrator_main_commits_runtime_storage_root_before_logging_and_credential_sync -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection and reporting of unexpected runtime terminations
  * Improved task completion monitoring with structured logging for better diagnostic visibility into system behavior

* **Tests**
  * Added test coverage for runtime exit scenarios and proper resource cleanup

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1007)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->