### PR TITLE
fix: clamp AI run context cache split

### DIFF
--- a/src/mindroom/ai_run_metadata.py
+++ b/src/mindroom/ai_run_metadata.py
@@ -110,15 +110,23 @@ def _build_context_payload(
         "input_tokens": context_input_tokens,
         "window_tokens": context_window,
     }
+    bounded_cache_read_tokens: int | None = None
     if cache_read_tokens is not None and cache_read_tokens > 0:
-        payload["cache_read_input_tokens"] = cache_read_tokens
-    if cache_write_tokens is not None and cache_write_tokens > 0:
-        payload["cache_write_input_tokens"] = cache_write_tokens
+        bounded_cache_read_tokens = min(cache_read_tokens, context_input_tokens)
+        if bounded_cache_read_tokens > 0:
+            payload["cache_read_input_tokens"] = bounded_cache_read_tokens
+    uncached_input_tokens: int | None = None
     if cache_read_tokens is not None or cache_write_tokens is not None:
         # Cache writes were not read from cache, so they remain in the non-cache-read bucket.
-        uncached_input_tokens = context_input_tokens - (cache_read_tokens or 0)
+        uncached_input_tokens = context_input_tokens - (bounded_cache_read_tokens or 0)
         if uncached_input_tokens >= 0:
             payload["uncached_input_tokens"] = uncached_input_tokens
+    if (
+        cache_write_tokens is not None
+        and cache_write_tokens > 0
+        and (uncached_input_tokens is None or cache_write_tokens <= uncached_input_tokens)
+    ):
+        payload["cache_write_input_tokens"] = cache_write_tokens
     return payload
 
 

--- a/src/mindroom/ai_run_metadata.py
+++ b/src/mindroom/ai_run_metadata.py
@@ -124,7 +124,8 @@ def _build_context_payload(
     if (
         cache_write_tokens is not None
         and cache_write_tokens > 0
-        and (uncached_input_tokens is None or cache_write_tokens <= uncached_input_tokens)
+        and uncached_input_tokens is not None
+        and cache_write_tokens <= uncached_input_tokens
     ):
         payload["cache_write_input_tokens"] = cache_write_tokens
     return payload

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -413,6 +413,48 @@ def test_ai_run_metadata_fallback_usage_only_backfills_missing_fields(tmp_path: 
     assert usage["time_to_first_token"] == format(0.12, ".12g")
 
 
+def test_ai_run_metadata_bounds_context_cache_split_to_displayed_context(tmp_path: Path) -> None:
+    """Context cache counters should not exceed the context size exposed to clients."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={"test_agent": AgentConfig(display_name="Test Agent")},
+            defaults=DefaultsConfig(tools=[]),
+            models={
+                "default": ModelConfig(
+                    provider="vertexai_claude",
+                    id="claude-opus-4-7",
+                    context_window=200_000,
+                ),
+            },
+        ),
+        runtime_paths,
+    )
+
+    metadata = build_ai_run_metadata_content(
+        agent_name="test_agent",
+        config=config,
+        runtime_paths=runtime_paths,
+        run_id="run-1",
+        session_id="session-1",
+        status="completed",
+        model="claude-opus-4-7",
+        model_provider="VertexAI",
+        metrics={"input_tokens": 153_294, "cache_read_tokens": 281_264},
+        context_input_tokens=153_294,
+        context_cache_read_tokens=281_264,
+        context_cache_write_tokens=500,
+    )
+
+    assert metadata is not None
+    context = metadata[AI_RUN_METADATA_KEY]["context"]
+    assert context["input_tokens"] == 153_294
+    assert context["window_tokens"] == 200_000
+    assert context["cache_read_input_tokens"] == 153_294
+    assert context["uncached_input_tokens"] == 0
+    assert "cache_write_input_tokens" not in context
+
+
 def test_team_scope_storage_is_shared_across_requesters(tmp_path: Path) -> None:
     """Team history storage is scoped to the shared conversation, not the sender."""
     config, runtime_paths = _make_prepare_config(tmp_path)


### PR DESCRIPTION
Cherry-picks `98bb91fc4` from `gitea/main` onto `origin/main`.

## Summary
- Bounds displayed cache-read tokens to the displayed context input size.
- Avoids reporting cache-write tokens when all displayed input is already cache-read.

## Verification
- `uv run --all-extras pytest tests/test_compaction.py::test_ai_run_metadata_bounds_context_cache_split_to_displayed_context -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how context token counts are reported so displayed context sizes are capped to the model window, positive cache reads are bounded, and zero-value cache-write fields are omitted—resulting in more accurate and consistent metadata.

* **Tests**
  * Added test coverage that verifies the bounded token reporting and omission behavior for large cache-read scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1008)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->