### PR TITLE
Configure Gemini Code Assist

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,12 @@
+have_fun: false
+memory_config:
+  disabled: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: false

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,9 @@
+# MindRoom Code Review Style Guide
+
+Read `CLAUDE.md` at the repository root before reviewing changes.
+Treat `CLAUDE.md` as the authoritative source for MindRoom architecture, workflow, model preferences, code style, documentation style, and testing expectations.
+
+Review changes with a blocker-first mindset.
+Prioritize correctness, security, data loss, race conditions, broken Matrix behavior, broken deployment behavior, and missing tests over stylistic comments.
+
+When `CLAUDE.md` and this file differ, follow `CLAUDE.md`.


### PR DESCRIPTION
## Summary
- Add `.gemini/config.yaml` to enable Gemini Code Assist PR summaries and code reviews for non-draft PRs.
- Add `.gemini/styleguide.md` as a lightweight pointer to root `CLAUDE.md`, keeping MindRoom review guidance in one source of truth.

## Test Plan
- [x] `uv run python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.gemini/config.yaml').read_text()); assert Path('.gemini/styleguide.md').read_text().strip(); print('gemini config ok')"`
- [x] `uv run pytest` - 6659 passed, 29 skipped, 191 warnings in 297.13s
- [x] Commit hook checks for changed files, including `check yaml`, `Enforce narrow Tach boundaries`, and `Enforce module privacy`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development configuration to tune automated review behavior, code-review thresholds, and pull-request review defaults.
* **Documentation**
  * Added a style guide outlining review priorities, workflow preferences, and guidance to follow the primary CLAUDE document when conflicts arise.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1011)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->