### PR TITLE
Strip prompt roles before persisting history

### DIFF
--- a/src/mindroom/agent_storage.py
+++ b/src/mindroom/agent_storage.py
@@ -2,20 +2,25 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, cast
 
 from agno.db.base import BaseDb, SessionType
 from agno.db.sqlite import SqliteDb
 from agno.learn import LearningMachine
+from agno.run.agent import RunOutput
+from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
 
+from mindroom.constants import prompt_roles_for_history_storage
 from mindroom.runtime_resolution import resolve_agent_runtime
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from agno.agent import Agent
+    from agno.session import Session
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
@@ -45,6 +50,7 @@ def create_state_storage(
     *,
     subdir: str,
     session_table: str,
+    prompt_roles: frozenset[str] | None = None,
 ) -> BaseDb:
     """Create persistent Agno state storage from an already-resolved state root."""
     return _create_sqlite_state_storage(
@@ -52,6 +58,7 @@ def create_state_storage(
         state_root=state_root,
         subdir=subdir,
         session_table=session_table,
+        prompt_roles=prompt_roles,
     )
 
 
@@ -61,11 +68,19 @@ def _create_sqlite_state_storage(
     *,
     subdir: str,
     session_table: str,
+    prompt_roles: frozenset[str] | None = None,
 ) -> SqliteDb:
     """Create a persistent SQLite database from an already-resolved state root."""
     db_dir = state_root / subdir
     db_dir.mkdir(parents=True, exist_ok=True)
-    return SqliteDb(session_table=session_table, db_file=str(db_dir / f"{storage_name}.db"))
+    db_file = str(db_dir / f"{storage_name}.db")
+    if prompt_roles is not None:
+        return _PromptSanitizingSqliteDb(
+            prompt_roles=prompt_roles,
+            session_table=session_table,
+            db_file=db_file,
+        )
+    return SqliteDb(session_table=session_table, db_file=db_file)
 
 
 def create_session_storage(
@@ -82,6 +97,7 @@ def create_session_storage(
         subdir="sessions",
         session_table=f"{agent_name}_sessions",
         execution_identity=execution_identity,
+        prompt_roles=prompt_roles_for_history_storage(),
     )
 
 
@@ -93,6 +109,7 @@ def _create_agent_state_db(
     *,
     subdir: str,
     session_table: str,
+    prompt_roles: frozenset[str] | None = None,
 ) -> BaseDb:
     """Create persistent storage for one agent state category."""
     state_storage_path = resolve_agent_runtime(
@@ -106,7 +123,72 @@ def _create_agent_state_db(
         state_root=state_storage_path,
         subdir=subdir,
         session_table=session_table,
+        prompt_roles=prompt_roles,
     )
+
+
+class _PromptSanitizingSqliteDb(SqliteDb):
+    """SQLite session DB that strips prompt messages before durable persistence."""
+
+    def __init__(
+        self,
+        *,
+        prompt_roles: frozenset[str],
+        session_table: str,
+        db_file: str,
+    ) -> None:
+        super().__init__(session_table=session_table, db_file=db_file)
+        self._prompt_roles = prompt_roles
+
+    def upsert_session(
+        self,
+        session: Session,
+        deserialize: bool | None = True,
+    ) -> Session | dict[str, Any] | None:
+        return super().upsert_session(
+            _session_without_prompt_messages(session, self._prompt_roles),
+            deserialize=deserialize,
+        )
+
+    def upsert_sessions(
+        self,
+        sessions: list[Session],
+        deserialize: bool | None = True,
+        preserve_updated_at: bool = False,
+    ) -> list[Session | dict[str, Any]]:
+        return super().upsert_sessions(
+            [_session_without_prompt_messages(session, self._prompt_roles) for session in sessions],
+            deserialize=deserialize,
+            preserve_updated_at=preserve_updated_at,
+        )
+
+
+def _session_without_prompt_messages(session: Session, prompt_roles: frozenset[str]) -> Session:
+    if not _session_has_prompt_messages(session, prompt_roles):
+        return session
+    sanitized_session = deepcopy(session)
+    _strip_prompt_messages_from_session(sanitized_session, prompt_roles)
+    return sanitized_session
+
+
+def _session_has_prompt_messages(session: Session, prompt_roles: frozenset[str]) -> bool:
+    if not isinstance(session, (AgentSession, TeamSession)) or not session.runs:
+        return False
+    return any(
+        isinstance(run, (RunOutput, TeamRunOutput))
+        and run.messages is not None
+        and any(message.role in prompt_roles for message in run.messages)
+        for run in session.runs
+    )
+
+
+def _strip_prompt_messages_from_session(session: Session, prompt_roles: frozenset[str]) -> None:
+    if not isinstance(session, (AgentSession, TeamSession)) or not session.runs:
+        return
+    for run in session.runs:
+        if not isinstance(run, (RunOutput, TeamRunOutput)) or not run.messages:
+            continue
+        run.messages = [message for message in run.messages if message.role not in prompt_roles]
 
 
 def create_culture_storage(culture_name: str, storage_path: Path) -> BaseDb:

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -21,6 +21,8 @@ ROUTER_AGENT_NAME = "router"
 MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS = 180.0
 DEFAULT_TOOL_OUTPUT_AUTO_SAVE_THRESHOLD_BYTES = 50 * 1024
 _MINDROOM_DISPATCH_THREAD_READ_TIMEOUT_SECONDS = 1.0
+_STANDARD_HISTORY_ROLES = frozenset({"user", "assistant", "tool"})
+_PROMPT_HISTORY_STORAGE_ROLES = frozenset({"system", "developer"})
 
 # Search order for existing files: env var > ./config.yaml > ~/.mindroom/config.yaml
 _CONFIG_SEARCH_PATHS = [Path("config.yaml"), Path.home() / ".mindroom" / "config.yaml"]
@@ -50,6 +52,15 @@ WORKER_RUNTIME_ENV_NAMES = frozenset(
     },
 )
 WORKSPACE_HOME_CONTRACT_ENV_NAMES = _WORKSPACE_HOME_IDENTITY_ENV_NAMES | WORKER_RUNTIME_ENV_NAMES
+
+
+def prompt_roles_for_history_storage(system_message_role: str = "system") -> frozenset[str]:
+    """Return prompt roles that should be stripped before durable history storage."""
+    roles = set(_PROMPT_HISTORY_STORAGE_ROLES)
+    configured_role = system_message_role.strip()
+    if configured_role and configured_role not in _STANDARD_HISTORY_ROLES:
+        roles.add(configured_role)
+    return frozenset(roles)
 
 
 def workspace_home_identity_env(workspace: Path | str) -> dict[str, str]:

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -29,7 +29,7 @@ from agno.utils.message import filter_tool_calls
 from pydantic import BaseModel
 
 from mindroom.cancellation import request_task_cancel
-from mindroom.constants import MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS
+from mindroom.constants import MINDROOM_COMPACTION_CHUNK_TIMEOUT_SECONDS, prompt_roles_for_history_storage
 from mindroom.history.storage import (
     metadata_with_merged_seen_event_ids,
     read_scope_state,
@@ -1287,7 +1287,8 @@ def _compaction_replay_messages(
     run: RunOutput | TeamRunOutput,
     history_settings: ResolvedHistorySettings,
 ) -> list[Message]:
-    messages = [deepcopy(message) for message in run.messages or []]
+    skip_roles = set(_history_skip_roles(history_settings))
+    messages = [deepcopy(message) for message in run.messages or [] if message.role not in skip_roles]
     if history_settings.max_tool_calls_from_history is not None and messages:
         filter_tool_calls(messages, history_settings.max_tool_calls_from_history)
     _strip_stale_anthropic_replay_fields(messages)
@@ -1578,11 +1579,12 @@ def _agent_session_history_messages(
     history_settings: ResolvedHistorySettings,
     limit: int | None,
 ) -> list[Message]:
+    skip_roles = _history_skip_roles(history_settings)
     if history_settings.policy.mode == "runs":
-        return session.get_messages(agent_id=scope_id, last_n_runs=limit)
+        return session.get_messages(agent_id=scope_id, last_n_runs=limit, skip_roles=skip_roles)
     if history_settings.policy.mode == "messages":
-        return session.get_messages(agent_id=scope_id, limit=limit)
-    return session.get_messages(agent_id=scope_id)
+        return session.get_messages(agent_id=scope_id, limit=limit, skip_roles=skip_roles)
+    return session.get_messages(agent_id=scope_id, skip_roles=skip_roles)
 
 
 def _team_session_history_messages(
@@ -1592,11 +1594,17 @@ def _team_session_history_messages(
     history_settings: ResolvedHistorySettings,
     limit: int | None,
 ) -> list[Message]:
+    skip_roles = _history_skip_roles(history_settings)
     if history_settings.policy.mode == "runs":
-        return session.get_messages(team_id=scope_id, last_n_runs=limit)
+        return session.get_messages(team_id=scope_id, last_n_runs=limit, skip_roles=skip_roles)
     if history_settings.policy.mode == "messages":
-        return session.get_messages(team_id=scope_id, limit=limit)
-    return session.get_messages(team_id=scope_id)
+        return session.get_messages(team_id=scope_id, limit=limit, skip_roles=skip_roles)
+    return session.get_messages(team_id=scope_id, skip_roles=skip_roles)
+
+
+def _history_skip_roles(history_settings: ResolvedHistorySettings) -> list[str]:
+    """Return prompt roles that should never be materialized as persisted history."""
+    return sorted(prompt_roles_for_history_storage(history_settings.system_message_role))
 
 
 def completed_top_level_runs(session: AgentSession | TeamSession) -> list[RunOutput | TeamRunOutput]:

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -71,7 +71,6 @@ _EXCERPT_METADATA_OMIT_KEYS = frozenset(
         "tools_schema",
     },
 )
-_STANDARD_HISTORY_ROLES = frozenset({"user", "assistant", "tool"})
 _COMPACTION_CANCEL_DRAIN_TIMEOUT_SECONDS = 1.0
 type _ToolDefinition = dict[str, object]
 
@@ -1288,8 +1287,7 @@ def _compaction_replay_messages(
     run: RunOutput | TeamRunOutput,
     history_settings: ResolvedHistorySettings,
 ) -> list[Message]:
-    skip_roles = set(_history_skip_roles(history_settings) or [])
-    messages = [deepcopy(message) for message in run.messages or [] if message.role not in skip_roles]
+    messages = [deepcopy(message) for message in run.messages or []]
     if history_settings.max_tool_calls_from_history is not None and messages:
         filter_tool_calls(messages, history_settings.max_tool_calls_from_history)
     _strip_stale_anthropic_replay_fields(messages)
@@ -1580,12 +1578,11 @@ def _agent_session_history_messages(
     history_settings: ResolvedHistorySettings,
     limit: int | None,
 ) -> list[Message]:
-    skip_roles = _history_skip_roles(history_settings)
     if history_settings.policy.mode == "runs":
-        return session.get_messages(agent_id=scope_id, last_n_runs=limit, skip_roles=skip_roles)
+        return session.get_messages(agent_id=scope_id, last_n_runs=limit)
     if history_settings.policy.mode == "messages":
-        return session.get_messages(agent_id=scope_id, limit=limit, skip_roles=skip_roles)
-    return session.get_messages(agent_id=scope_id, skip_roles=skip_roles)
+        return session.get_messages(agent_id=scope_id, limit=limit)
+    return session.get_messages(agent_id=scope_id)
 
 
 def _team_session_history_messages(
@@ -1595,21 +1592,11 @@ def _team_session_history_messages(
     history_settings: ResolvedHistorySettings,
     limit: int | None,
 ) -> list[Message]:
-    skip_roles = _history_skip_roles(history_settings)
     if history_settings.policy.mode == "runs":
-        return session.get_messages(team_id=scope_id, last_n_runs=limit, skip_roles=skip_roles)
+        return session.get_messages(team_id=scope_id, last_n_runs=limit)
     if history_settings.policy.mode == "messages":
-        return session.get_messages(team_id=scope_id, limit=limit, skip_roles=skip_roles)
-    return session.get_messages(team_id=scope_id, skip_roles=skip_roles)
-
-
-def _history_skip_roles(history_settings: ResolvedHistorySettings) -> list[str] | None:
-    """Return the effective Agno skip_roles filter for persisted history replay."""
-    if not history_settings.skip_history_system_role:
-        return None
-    if history_settings.system_message_role in _STANDARD_HISTORY_ROLES:
-        return None
-    return [history_settings.system_message_role]
+        return session.get_messages(team_id=scope_id, limit=limit)
+    return session.get_messages(team_id=scope_id)
 
 
 def completed_top_level_runs(session: AgentSession | TeamSession) -> list[RunOutput | TeamRunOutput]:

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -23,6 +23,7 @@ from mindroom.agent_storage import (
     get_agent_session,
     get_team_session,
 )
+from mindroom.constants import prompt_roles_for_history_storage
 from mindroom.history.compaction import (
     compact_scope_history,
     completed_top_level_runs,
@@ -1216,6 +1217,7 @@ def create_scope_session_storage(
         state_root=_team_scope_state_root(storage_name=storage_name, runtime_paths=runtime_paths),
         subdir="sessions",
         session_table=f"{storage_name}_sessions",
+        prompt_roles=prompt_roles_for_history_storage(),
     )
 
 

--- a/tach.toml
+++ b/tach.toml
@@ -112,7 +112,10 @@ visibility = [
 
 [[modules]]
 path = "mindroom.agent_storage"
-depends_on = ["mindroom.runtime_resolution"]
+depends_on = [
+    "mindroom.constants",
+    "mindroom.runtime_resolution",
+]
 visibility = [
     "mindroom.agents",
     "mindroom.conversation_state_writer",
@@ -728,6 +731,7 @@ visibility = [
 path = "mindroom.history.runtime"
 depends_on = [
     "mindroom.agent_storage",
+    "mindroom.constants",
     "mindroom.history.compaction",
     "mindroom.history.policy",
     "mindroom.history.storage",

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -623,6 +623,46 @@ def test_create_agent_enables_agno_native_history_replay(tmp_path: Path) -> None
     assert agent.store_history_messages is False
 
 
+def test_session_storage_strips_prompt_roles_before_persisting_history(tmp_path: Path) -> None:
+    config, runtime_paths = _make_config(tmp_path)
+    storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    session = _session(
+        "session-1",
+        runs=[
+            _completed_run(
+                "run-1",
+                messages=[
+                    Message(role="system", content="Current system prompt"),
+                    Message(role="developer", content="Current developer prompt"),
+                    Message(role="user", content="user request"),
+                    Message(role="assistant", content="assistant answer"),
+                    Message(role="tool", content="tool result"),
+                ],
+            ),
+        ],
+    )
+
+    storage.upsert_session(session)
+
+    assert session.runs is not None
+    assert [(message.role, message.content) for message in session.runs[0].messages or []] == [
+        ("system", "Current system prompt"),
+        ("developer", "Current developer prompt"),
+        ("user", "user request"),
+        ("assistant", "assistant answer"),
+        ("tool", "tool result"),
+    ]
+
+    persisted = get_agent_session(storage, "session-1")
+    assert persisted is not None
+    assert persisted.runs is not None
+    assert [(message.role, message.content) for message in persisted.runs[0].messages or []] == [
+        ("user", "user request"),
+        ("assistant", "assistant answer"),
+        ("tool", "tool result"),
+    ]
+
+
 def test_create_agent_uses_active_model_override(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(
@@ -2902,6 +2942,8 @@ async def test_prepare_history_for_run_context_window_guard_preserves_custom_sys
         ],
     )
     storage.upsert_session(session)
+    persisted = get_agent_session(storage, "session-1")
+    assert persisted is not None
     agent = _agent(db=storage)
 
     prepared = await prepare_history_for_run_for_test(
@@ -2913,7 +2955,7 @@ async def test_prepare_history_for_run_context_window_guard_preserves_custom_sys
         config=config,
         execution_identity=None,
         storage=storage,
-        session=session,
+        session=persisted,
         history_settings=ResolvedHistorySettings(
             policy=HistoryPolicy(mode="all"),
             max_tool_calls_from_history=None,
@@ -3249,26 +3291,22 @@ def test_build_summary_input_skips_when_previous_summary_cannot_be_preserved() -
     assert "<previous_summary>" in summary_input
 
 
-def test_build_summary_input_excludes_persisted_system_prompt() -> None:
-    run = _completed_run(
-        "run-1",
-        messages=[
-            Message(role="system", content="Persisted system prompt that should not be summarized"),
-            Message(role="user", content="user request"),
-            Message(role="assistant", content="assistant answer"),
-        ],
-    )
+def test_build_summary_input_preserves_previous_summary_text() -> None:
+    run = _completed_run("run-1")
 
     summary_input, included_runs = _build_summary_input(
-        previous_summary=None,
+        previous_summary="Useful prior conversation.\n\n## Your Identity\nIDENTITY.md\nCurrent Date and Time",
         compacted_runs=[run],
         max_input_tokens=1_000,
     )
 
     assert included_runs == [run]
-    assert "Persisted system prompt" not in summary_input
-    assert "user request" in summary_input
-    assert "assistant answer" in summary_input
+    assert "<previous_summary>" in summary_input
+    assert "Useful prior conversation" in summary_input
+    assert "IDENTITY.md" in summary_input
+    assert "Current Date and Time" in summary_input
+    assert "run-1 question" in summary_input
+    assert "run-1 answer" in summary_input
 
 
 def test_build_summary_input_honors_tool_call_history_limit() -> None:
@@ -3315,7 +3353,6 @@ def test_estimate_prompt_visible_history_tokens_uses_agno_message_limit_selectio
             _completed_run(
                 "run-1",
                 messages=[
-                    Message(role="system", content="Persisted system"),
                     Message(role="user", content="old user"),
                     Message(
                         role="assistant",
@@ -3348,47 +3385,6 @@ def test_estimate_prompt_visible_history_tokens_uses_agno_message_limit_selectio
     )
 
     expected_messages = [
-        Message(role="user", content="new user"),
-        Message(role="assistant", content="new assistant"),
-    ]
-    assert estimated_tokens == _estimate_history_messages_tokens(expected_messages)
-
-
-def test_estimate_prompt_visible_history_tokens_honors_custom_system_message_role() -> None:
-    session = _session(
-        "session-1",
-        runs=[
-            _completed_run(
-                "run-1",
-                messages=[
-                    Message(role="developer", content="Persisted developer prompt"),
-                    Message(role="user", content="old user"),
-                    Message(role="assistant", content="old assistant"),
-                ],
-            ),
-            _completed_run(
-                "run-2",
-                messages=[
-                    Message(role="user", content="new user"),
-                    Message(role="assistant", content="new assistant"),
-                ],
-            ),
-        ],
-    )
-    history_settings = ResolvedHistorySettings(
-        policy=HistoryPolicy(mode="messages", limit=3),
-        max_tool_calls_from_history=None,
-        system_message_role="developer",
-    )
-
-    estimated_tokens = estimate_prompt_visible_history_tokens(
-        session=session,
-        scope=HistoryScope(kind="agent", scope_id="test_agent"),
-        history_settings=history_settings,
-    )
-
-    expected_messages = [
-        Message(role="assistant", content="old assistant"),
         Message(role="user", content="new user"),
         Message(role="assistant", content="new assistant"),
     ]

--- a/tests/test_agno_history.py
+++ b/tests/test_agno_history.py
@@ -57,6 +57,7 @@ from mindroom.execution_preparation import (
 from mindroom.history import PreparedHistoryState
 from mindroom.history.compaction import (
     _build_summary_input,
+    _compaction_replay_messages,
     _emit_compaction_hook,
     _estimate_history_messages_tokens,
     _estimate_tool_definition_tokens,
@@ -3309,6 +3310,68 @@ def test_build_summary_input_preserves_previous_summary_text() -> None:
     assert "run-1 answer" in summary_input
 
 
+def test_compaction_replay_messages_exclude_legacy_persisted_prompt_roles() -> None:
+    run = _completed_run(
+        "run-1",
+        messages=[
+            Message(role="system", content="legacy system prompt"),
+            Message(role="developer", content="legacy developer prompt"),
+            Message(role="instructions", content="legacy custom prompt"),
+            Message(role="user", content="user request"),
+            Message(role="assistant", content="assistant answer"),
+            Message(role="tool", content="tool result"),
+        ],
+    )
+
+    replay_messages = _compaction_replay_messages(
+        run,
+        ResolvedHistorySettings(
+            policy=HistoryPolicy(mode="all"),
+            max_tool_calls_from_history=None,
+            system_message_role="instructions",
+        ),
+    )
+
+    assert [(message.role, message.content) for message in replay_messages] == [
+        ("user", "user request"),
+        ("assistant", "assistant answer"),
+        ("tool", "tool result"),
+    ]
+
+
+def test_build_summary_input_excludes_legacy_persisted_prompt_roles() -> None:
+    run = _completed_run(
+        "run-1",
+        messages=[
+            Message(role="system", content="Persisted system prompt that should not be summarized"),
+            Message(role="developer", content="Persisted developer prompt that should not be summarized"),
+            Message(role="instructions", content="Persisted custom prompt that should not be summarized"),
+            Message(role="user", content="user request"),
+            Message(role="assistant", content="assistant answer"),
+            Message(role="tool", content="tool result"),
+        ],
+    )
+
+    summary_input, included_runs = _build_summary_input(
+        previous_summary=None,
+        compacted_runs=[run],
+        history_settings=ResolvedHistorySettings(
+            policy=HistoryPolicy(mode="all"),
+            max_tool_calls_from_history=None,
+            system_message_role="instructions",
+        ),
+        max_input_tokens=1_000,
+    )
+
+    assert included_runs == [run]
+    assert "Persisted system prompt" not in summary_input
+    assert "Persisted developer prompt" not in summary_input
+    assert "Persisted custom prompt" not in summary_input
+    assert "user request" in summary_input
+    assert "assistant answer" in summary_input
+    assert "tool result" in summary_input
+
+
 def test_build_summary_input_honors_tool_call_history_limit() -> None:
     run = _completed_run(
         "run-1",
@@ -3344,6 +3407,47 @@ def test_build_summary_input_honors_tool_call_history_limit() -> None:
     assert "first result" not in summary_input
     assert "call-2" in summary_input
     assert "second result" in summary_input
+
+
+def test_estimate_prompt_visible_history_tokens_excludes_legacy_persisted_prompt_roles() -> None:
+    conversation_messages = [
+        Message(role="user", content="user request"),
+        Message(role="assistant", content="assistant answer"),
+        Message(role="tool", content="tool result"),
+    ]
+    history_settings = ResolvedHistorySettings(
+        policy=HistoryPolicy(mode="all"),
+        max_tool_calls_from_history=None,
+        system_message_role="instructions",
+    )
+    contaminated_session = _session(
+        "session-1",
+        runs=[
+            _completed_run(
+                "run-1",
+                messages=[
+                    Message(role="system", content="legacy system prompt " * 20),
+                    Message(role="developer", content="legacy developer prompt " * 20),
+                    Message(role="instructions", content="legacy custom prompt " * 20),
+                    *conversation_messages,
+                ],
+            ),
+        ],
+    )
+    clean_session = _session(
+        "session-1",
+        runs=[_completed_run("run-1", messages=conversation_messages)],
+    )
+
+    assert estimate_prompt_visible_history_tokens(
+        session=contaminated_session,
+        scope=HistoryScope(kind="agent", scope_id="test_agent"),
+        history_settings=history_settings,
+    ) == estimate_prompt_visible_history_tokens(
+        session=clean_session,
+        scope=HistoryScope(kind="agent", scope_id="test_agent"),
+        history_settings=history_settings,
+    )
 
 
 def test_estimate_prompt_visible_history_tokens_uses_agno_message_limit_selection() -> None:


### PR DESCRIPTION
## Summary
- Strip `system` and `developer` prompt-role messages at the Agno session storage boundary before durable Agent/Team history is written.
- Keep compaction, replay, and history token estimation operating on persisted conversation history only.
- Preserve normal user/assistant/tool conversation content, including text that happens to mention files such as `IDENTITY.md` or `AGENTS.md`.

## Notes
Prompt text is still sent to the model as the current run prompt, but it is removed before Agno session history is persisted.
Compaction receives durable conversation history and any existing durable summary; it does not inspect summary text for special markers.

## Test Plan
- [x] `uv run pytest tests/test_agno_history.py -k 'session_storage_strips_prompt_roles or previous_summary_text or estimate_prompt_visible_history_tokens_uses_agno_message_limit_selection' -n 0 --no-cov -v`
- [x] `uv run pytest tests/test_agno_history.py -n 0 --no-cov -v`
- [x] `uv run pre-commit run --all-files`
- [x] `uv run pytest` (`6668 passed, 29 skipped`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persisted session storage now strips configured prompt/system roles before saving.
  * Team-scope storage allows configurable prompt-role selection for history sanitization.

* **Bug Fixes**
  * Persisted history no longer contains prompt/system messages; user/assistant/tool content is retained.
  * History compaction and replay preserve previous summary text intact.

* **Tests**
  * Added/updated tests verifying prompt-role stripping and summary preservation.

* **Chores**
  * Updated internal constants and wiring for history-role configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1013)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->