### PR TITLE
Keep OpenAI-compatible runs independent of Matrix accounts

### DIFF
--- a/docs/openai-api.md
+++ b/docs/openai-api.md
@@ -127,7 +127,8 @@ An OpenAI-compatible run can expose fewer tool functions than the same agent in 
 
 ### Auto-routing
 
-Select the `auto` model to let MindRoom's router pick the best agent for each message, the same routing logic used in Matrix rooms.
+Select the `auto` model to let MindRoom's router pick the best OpenAI-compatible agent for each message.
+Auto-routing on `/v1` considers agents only; use explicit `team/<team_name>` models to run teams.
 Once routing resolves a specific agent, session continuity and streamed identity bind to that resolved agent name, not the literal `auto` label.
 
 ### Teams

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13206,7 +13206,8 @@ An OpenAI-compatible run can expose fewer tool functions than the same agent in 
 
 ### Auto-routing
 
-Select the `auto` model to let MindRoom's router pick the best agent for each message, the same routing logic used in Matrix rooms.
+Select the `auto` model to let MindRoom's router pick the best OpenAI-compatible agent for each message.
+Auto-routing on `/v1` considers agents only; use explicit `team/<team_name>` models to run teams.
 Once routing resolves a specific agent, session continuity and streamed identity bind to that resolved agent name, not the literal `auto` label.
 
 ### Teams

--- a/skills/mindroom-docs/references/page__openai-api__index.md
+++ b/skills/mindroom-docs/references/page__openai-api__index.md
@@ -123,7 +123,8 @@ An OpenAI-compatible run can expose fewer tool functions than the same agent in 
 
 ### Auto-routing
 
-Select the `auto` model to let MindRoom's router pick the best agent for each message, the same routing logic used in Matrix rooms.
+Select the `auto` model to let MindRoom's router pick the best OpenAI-compatible agent for each message.
+Auto-routing on `/v1` considers agents only; use explicit `team/<team_name>` models to run teams.
 Once routing resolves a specific agent, session continuity and streamed identity bind to that resolved agent name, not the literal `auto` label.
 
 ### Teams

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -946,6 +946,56 @@ def _resolve_agent_dynamic_tool_selection(
     )
 
 
+def _render_agent_identity_context(
+    agent_name: str,
+    display_name: str,
+    config: Config,
+    runtime_paths: constants.RuntimePaths,
+    *,
+    model_provider: str,
+    model_id: str,
+    include_openai_compat_guidance: bool,
+) -> str:
+    openai_compat_history_guidance = config.get_prompt("OPENAI_COMPAT_HISTORY_GUIDANCE")
+    if include_openai_compat_guidance:
+        openai_context = render_prompt_template(
+            config.get_prompt("OPENAI_COMPAT_AGENT_IDENTITY_CONTEXT_TEMPLATE"),
+            agent_name=agent_name,
+            display_name=display_name,
+            model_provider=model_provider,
+            model_id=model_id,
+            openai_compat_history_guidance=openai_compat_history_guidance,
+        )
+        has_custom_matrix_identity = "AGENT_IDENTITY_CONTEXT_TEMPLATE" in config.prompts
+        has_custom_openai_identity = "OPENAI_COMPAT_AGENT_IDENTITY_CONTEXT_TEMPLATE" in config.prompts
+        if not has_custom_matrix_identity or has_custom_openai_identity:
+            return openai_context
+        overridden_identity_context = render_prompt_template(
+            config.get_prompt("AGENT_IDENTITY_CONTEXT_TEMPLATE"),
+            display_name=display_name,
+            matrix_id="not available in OpenAI-compatible API",
+            model_provider=model_provider,
+            model_id=model_id,
+            openai_compat_history_guidance=openai_compat_history_guidance,
+        )
+        return overridden_identity_context + openai_context
+
+    matrix_id = MatrixID.from_agent(
+        agent_name,
+        config.get_domain(runtime_paths),
+        runtime_paths,
+    ).full_id
+    return build_agent_identity_context(
+        display_name=display_name,
+        matrix_id=matrix_id,
+        model_provider=model_provider,
+        model_id=model_id,
+        include_openai_compat_guidance=False,
+        identity_context_template=config.get_prompt("AGENT_IDENTITY_CONTEXT_TEMPLATE"),
+        openai_compat_history_guidance=openai_compat_history_guidance,
+    )
+
+
 @timed("system_prompt_assembly.agent_create.skills_load")
 def _load_agent_skills(
     agent_name: str,
@@ -1133,20 +1183,14 @@ def create_agent(  # noqa: PLR0915, C901, PLR0912
         model_provider = "AI"
         model_id = model_name
 
-    # Add identity context to all agents using the unified template
-    matrix_id = MatrixID.from_agent(
+    identity_context = _render_agent_identity_context(
         agent_name,
-        config.get_domain(runtime_paths),
+        agent_config.display_name,
+        config,
         runtime_paths,
-    ).full_id
-    identity_context = build_agent_identity_context(
-        display_name=agent_config.display_name,
-        matrix_id=matrix_id,
         model_provider=model_provider,
         model_id=model_id,
         include_openai_compat_guidance=include_openai_compat_guidance,
-        identity_context_template=config.get_prompt("AGENT_IDENTITY_CONTEXT_TEMPLATE"),
-        openai_compat_history_guidance=config.get_prompt("OPENAI_COMPAT_HISTORY_GUIDANCE"),
     )
 
     # Add current date context with the user's configured timezone

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -14,7 +14,7 @@ import time
 from contextlib import ExitStack
 from dataclasses import dataclass, field
 from html import escape
-from typing import TYPE_CHECKING, Annotated, Literal, NoReturn, cast
+from typing import TYPE_CHECKING, Annotated, Literal, cast
 from uuid import uuid4
 
 from agno.run.agent import (
@@ -53,14 +53,12 @@ from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
 from mindroom.routing import suggest_agent
 from mindroom.teams import (
     TeamMode,
-    TeamOutcome,
     build_materialized_team_instance,
     format_team_response,
     is_cancelled_run_output,
     is_errored_run_output,
     materialize_exact_team_members,
     prepare_materialized_team_execution,
-    resolve_configured_team,
 )
 from mindroom.tool_system.events import format_tool_completed_event, format_tool_started_event
 from mindroom.tool_system.worker_routing import (
@@ -1113,11 +1111,6 @@ def _allocate_next_tool_id(tool_state: _ToolStreamState) -> str:
     return tool_id
 
 
-def _raise_unmaterializable_team(team_name: str, reason: str | None) -> NoReturn:
-    msg = reason or f"Team '{team_name}' cannot be materialized"
-    raise ValueError(msg)
-
-
 def _resolve_started_tool_id(tool: ToolExecution, tool_state: _ToolStreamState) -> str:
     tool_call_id = _extract_tool_call_id(tool)
 
@@ -1360,13 +1353,12 @@ def _build_team(
 ) -> tuple[list[Agent], Team, TeamMode]:
     """Create member agents and build one agno.Team for a configured team.
 
-    Raises ValueError when the configured team cannot be materialized.
+    Raises when the configured team cannot be materialized.
     """
     team_config = config.teams[team_name]
     mode = TeamMode(team_config.mode)
-    config_ids = config.get_ids(runtime_paths)
-    requested_members = [config_ids[member_name] for member_name in team_config.agents]
     model_name = team_config.model or "default"
+    config.assert_team_agents_supported(team_config.agents, team_name=team_name)
 
     team_members = materialize_exact_team_members(
         team_config.agents,
@@ -1380,17 +1372,6 @@ def _build_team(
         reason_prefix=f"Team '{team_name}'",
     )
     try:
-        final_resolution = resolve_configured_team(
-            team_name,
-            requested_members,
-            mode,
-            config,
-            runtime_paths,
-            materializable_agent_names=team_members.materialized_agent_names,
-        )
-        if final_resolution.outcome is not TeamOutcome.TEAM:
-            _raise_unmaterializable_team(team_name, final_resolution.reason)
-
         team = build_materialized_team_instance(
             requested_agent_names=team_members.requested_agent_names,
             agents=team_members.agents,
@@ -1500,8 +1481,9 @@ async def _non_stream_team_completion(
                     unavailable_bases,
                     refresh_scheduler,
                 )
-            except ValueError as e:
-                return _error_response(500, str(e), error_type="server_error")
+            except Exception:
+                logger.exception("Team build failed", team=team_name)
+                return _error_response(500, "Team execution failed", error_type="server_error")
 
             logger.info(
                 "Team completion request",
@@ -1638,9 +1620,10 @@ async def _stream_team_completion(  # noqa: C901, PLR0915
                     unavailable_bases,
                     refresh_scheduler,
                 )
-        except ValueError as e:
+        except Exception:
+            logger.exception("Team build failed", team=team_name)
             await _cleanup()
-            return _error_response(500, str(e), error_type="server_error")
+            return _error_response(500, "Team execution failed", error_type="server_error")
 
         logger.info(
             "Team streaming request",

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -31,6 +31,7 @@ __all__ = [
     "MEMORY_EXISTING_SNIPPETS_TEMPLATE",
     "MEMORY_NO_EXISTING_SNIPPETS",
     "MIXED_PARTIAL_REPLY_HEADER",
+    "OPENAI_COMPAT_AGENT_IDENTITY_CONTEXT_TEMPLATE",
     "OPENAI_COMPAT_HISTORY_GUIDANCE",
     "OUTPUT_REDIRECT_PROMPT",
     "PERSONALITY_CONTEXT_SECTION_HEADING",
@@ -69,6 +70,13 @@ OPENAI_COMPAT_HISTORY_GUIDANCE = (
     "In OpenAI-compatible API contexts, prior turns may instead appear as plain `role: body` lines. "
     "Always use the sender or role labels exactly as provided in the prompt.\n"
 )
+
+OPENAI_COMPAT_AGENT_IDENTITY_CONTEXT_TEMPLATE = """## Your Identity
+You are {display_name}, the MindRoom agent exposed through the OpenAI-compatible API as model `{agent_name}`.
+You are powered by the {model_provider} model: {model_id}.
+{openai_compat_history_guidance}Follow your assigned role and any leader-assigned subtasks; respond only to requests relevant to your assignment.
+
+"""
 
 
 INTERACTIVE_QUESTION_PROMPT = """When you need the user to choose between options, create an interactive question by including this JSON in your response with the following format:
@@ -429,6 +437,15 @@ PROMPT_TEMPLATE_FIELDS = MappingProxyType(
             {
                 "display_name",
                 "matrix_id",
+                "model_provider",
+                "model_id",
+                "openai_compat_history_guidance",
+            },
+        ),
+        "OPENAI_COMPAT_AGENT_IDENTITY_CONTEXT_TEMPLATE": frozenset(
+            {
+                "agent_name",
+                "display_name",
                 "model_provider",
                 "model_id",
                 "openai_compat_history_guidance",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -198,10 +198,18 @@ def test_agent_identity_prompt_can_be_overridden_from_config() -> None:
     }
 
     agent = _create_agent_for_test("general", config)
+    openai_compat_agent = _create_agent_for_test(
+        "general",
+        config,
+        include_openai_compat_guidance=True,
+    )
 
     assert "## Custom Identity" in agent.role
     assert "Name=GeneralAgent;" in agent.role
     assert "## Your Identity" not in agent.role
+    assert "## Custom Identity" in openai_compat_agent.role
+    assert "Matrix=not available in OpenAI-compatible API" in openai_compat_agent.role
+    assert "OpenAI-compatible API" in openai_compat_agent.role
 
 
 def test_create_agent_includes_openai_compat_guidance_only_when_requested() -> None:
@@ -217,6 +225,9 @@ def test_create_agent_includes_openai_compat_guidance_only_when_requested() -> N
 
     assert OPENAI_COMPAT_HISTORY_GUIDANCE not in matrix_agent.role
     assert OPENAI_COMPAT_HISTORY_GUIDANCE in openai_compat_agent.role
+    assert "OpenAI-compatible API" in openai_compat_agent.role
+    assert "Matrix ID:" not in openai_compat_agent.role
+    assert "## Matrix Reply Targeting" not in openai_compat_agent.role
 
 
 def test_create_agent_includes_matrix_reply_targeting_policy() -> None:

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -25,7 +25,7 @@ from agno.run.agent import RunContentEvent, RunOutput
 from agno.run.team import RunContentEvent as TeamContentEvent
 from agno.run.team import TeamRunOutput
 from agno.team import Team as AgnoTeam
-from fastapi import Request
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.testclient import TestClient
 from starlette.background import BackgroundTask
@@ -54,6 +54,7 @@ from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.utils import KnowledgeAvailabilityDetail, _KnowledgeResolution
 from mindroom.llm_request_logging import current_llm_request_log_context
 from mindroom.matrix.client import ResolvedVisibleMessage
+from mindroom.memory import MemoryPromptParts
 from mindroom.prompts import QUEUED_MESSAGE_NOTICE_TEXT
 from mindroom.team_exact_members import ResolvedExactTeamMembers
 from mindroom.teams import TeamMode
@@ -994,6 +995,50 @@ class TestChatCompletions:
         assert observed_agent_names == ["general"]
         assert len(observed_session_ids) == 1
         assert observed_session_ids[0] is not None
+
+    def test_agent_completion_does_not_require_persisted_matrix_accounts(self, tmp_path: Path) -> None:
+        """OpenAI-compatible agent completions should not prepare or require Matrix accounts."""
+        config = Config(
+            agents={
+                "general": AgentConfig(
+                    display_name="GeneralAgent",
+                    role="General-purpose assistant",
+                    rooms=[],
+                ),
+            },
+            models={"default": ModelConfig(provider="ollama", id="test-model")},
+            router=RouterConfig(model="default"),
+        )
+        runtime_paths = resolve_runtime_paths(
+            config_path=tmp_path / "config.yaml",
+            storage_path=tmp_path / "data",
+            process_env={"OPENAI_COMPAT_ALLOW_UNAUTHENTICATED": "true"},
+        )
+        app = FastAPI()
+        app.include_router(openai_compat.router)
+        initialize_api_app(app, runtime_paths)
+
+        with (
+            patch("mindroom.api.openai_compat._load_config", return_value=(config, runtime_paths)),
+            patch("mindroom.model_loading.get_model_instance", return_value=Ollama(id="test-model")),
+            patch("mindroom.ai.build_memory_prompt_parts", new=AsyncMock(return_value=MemoryPromptParts())),
+            patch(
+                "mindroom.ai._run_cached_agent_attempt",
+                new=AsyncMock(return_value=RunOutput(content="Agent reply")),
+            ),
+            TestClient(app) as client,
+        ):
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "general",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["content"] == "Agent reply"
+        assert not constants.matrix_state_file(runtime_paths=runtime_paths).exists()
 
     def test_openai_execution_identity_ignores_request_user(self) -> None:
         """OpenAI-compatible execution identity should not trust the request-body user."""
@@ -3837,12 +3882,16 @@ class TestTeamCompletion:
         assert full.index("Team started. ") < full.index("Team execution failed.")
         assert lines[-1] == "data: [DONE]"
 
-    def test_team_build_failure_returns_500(self, team_app_client: TestClient) -> None:
-        """Team build failures should surface a server error response."""
-        with patch(
-            "mindroom.api.openai_compat._build_team",
-            side_effect=ValueError("Team 'super_team' cannot be materialized"),
-        ):
+    @pytest.mark.parametrize(
+        "build_error",
+        [
+            ValueError("Team 'super_team' cannot be materialized"),
+            RuntimeError("team build failed"),
+        ],
+    )
+    def test_team_build_failure_returns_500(self, team_app_client: TestClient, build_error: Exception) -> None:
+        """Team build failures should not expose internal exception details."""
+        with patch("mindroom.api.openai_compat._build_team", side_effect=build_error):
             response = team_app_client.post(
                 "/v1/chat/completions",
                 json={
@@ -3852,10 +3901,25 @@ class TestTeamCompletion:
             )
 
         assert response.status_code == 500
-        assert response.json()["error"]["message"] == "Team 'super_team' cannot be materialized"
+        assert response.json()["error"]["message"] == "Team execution failed"
 
-    def test_team_member_materialization_failure_returns_friendly_500(self, team_app_client: TestClient) -> None:
-        """Configured team failures should surface the user-facing materialization error."""
+    def test_team_streaming_build_failure_returns_500(self, team_app_client: TestClient) -> None:
+        """Streaming team build failures should surface a server error response before SSE starts."""
+        with patch("mindroom.api.openai_compat._build_team", side_effect=RuntimeError("team build failed")):
+            response = team_app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "team/super_team",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "stream": True,
+                },
+            )
+
+        assert response.status_code == 500
+        assert response.json()["error"]["message"] == "Team execution failed"
+
+    def test_team_member_materialization_failure_returns_generic_500(self, team_app_client: TestClient) -> None:
+        """Configured team build failures should not expose internal exception details."""
         with (
             patch("mindroom.model_loading.get_model_instance", return_value=MagicMock()),
             patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
@@ -3874,9 +3938,7 @@ class TestTeamCompletion:
 
         assert response.status_code == 500
         assert response.json()["error"]["type"] == "server_error"
-        assert response.json()["error"]["message"] == (
-            "Team 'super_team' includes agent 'code' that could not be materialized for this request."
-        )
+        assert response.json()["error"]["message"] == "Team execution failed"
 
     def test_team_execution_failure_500(self, team_app_client: TestClient) -> None:
         """Team execution exception returns 500."""
@@ -4508,8 +4570,52 @@ class TestTeamCompletion:
         assert team.num_history_runs is None
         assert team.num_history_messages is None
 
-    def test_build_team_closes_materialized_agents_when_resolution_rejects_team(self) -> None:
-        """Configured-team validation failures should close partially built member resources."""
+    def test_build_team_openai_compat_does_not_require_persisted_matrix_accounts(
+        self,
+        team_config: Config,
+        tmp_path: Path,
+    ) -> None:
+        """OpenAI-compatible team construction should not require Matrix account preparation."""
+        runtime_paths = resolve_runtime_paths(
+            config_path=tmp_path / "config.yaml",
+            storage_path=tmp_path / "data",
+        )
+        execution_identity = build_tool_execution_identity(
+            channel="openai_compat",
+            agent_name="team/super_team",
+            session_id="openai-team-session",
+            runtime_paths=runtime_paths,
+            requester_id=None,
+            room_id=None,
+            thread_id=None,
+            resolved_thread_id=None,
+        )
+
+        agents: list[AgnoAgent] | None = None
+        team: AgnoTeam | None = None
+        with patch("mindroom.model_loading.get_model_instance", return_value=Ollama(id="test-model")):
+            agents, team, mode = openai_compat._build_team(
+                "super_team",
+                team_config,
+                runtime_paths,
+                execution_identity=execution_identity,
+                session_id="openai-team-session",
+            )
+
+        try:
+            assert mode is TeamMode.COORDINATE
+            assert [agent.id for agent in agents] == ["general", "code"]
+            assert not constants.matrix_state_file(runtime_paths=runtime_paths).exists()
+        finally:
+            if agents is not None and team is not None:
+                openai_compat.close_team_runtime_state_dbs(
+                    agents=agents,
+                    team_db=team.db,
+                    shared_scope_storage=None,
+                )
+
+    def test_build_team_closes_materialized_agents_when_team_build_fails(self) -> None:
+        """Configured-team build failures should close partially built member resources."""
         config = Config(
             agents={"general": AgentConfig(display_name="GeneralAgent", role="General", rooms=[])},
             models={"default": ModelConfig(provider="openai", id="test-model")},
@@ -4537,18 +4643,13 @@ class TestTeamCompletion:
                 ),
             ),
             patch(
-                "mindroom.api.openai_compat.resolve_configured_team",
-                return_value=SimpleNamespace(
-                    outcome=openai_compat.TeamOutcome.NONE,
-                    reason="Team 'coord_team' cannot be materialized",
-                ),
+                "mindroom.api.openai_compat.build_materialized_team_instance",
+                side_effect=RuntimeError("team build failed"),
             ),
             patch("mindroom.api.openai_compat.close_team_runtime_state_dbs") as mock_close,
+            pytest.raises(RuntimeError, match="team build failed"),
         ):
-            from mindroom.api.openai_compat import _build_team  # noqa: PLC0415
-
-            with pytest.raises(ValueError, match="cannot be materialized"):
-                _build_team("coord_team", config, _runtime_paths(), execution_identity=None)
+            openai_compat._build_team("coord_team", config, _runtime_paths(), execution_identity=None)
 
         mock_close.assert_called_once_with(
             agents=[built_agent],


### PR DESCRIPTION
## Summary
- Use a dedicated OpenAI-compatible identity prompt that does not assume Matrix room membership or a Matrix account.
- Build OpenAI-compatible teams without the Matrix identity-based team resolution path.
- Clarify that /v1 auto-routing considers OpenAI-compatible agents, with teams available through explicit team/<team_name> models.

Split out from #990 so it can be reviewed and merged first.

## Verification
- `uv run python .github/scripts/generate_skill_references.py`
- `uv run pytest tests/test_agents.py::test_create_agent_includes_openai_compat_guidance_only_when_requested tests/test_openai_compat.py::TestChatCompletions::test_agent_completion_does_not_require_persisted_matrix_accounts tests/test_openai_compat.py::TestTeamCompletion::test_build_team_openai_compat_does_not_require_persisted_matrix_accounts tests/test_openai_compat.py::TestTeamCompletion::test_build_team_closes_materialized_agents_when_team_build_fails -q -n 0 --no-cov` -> 4 passed
- `uv run ruff check src/mindroom/agents.py src/mindroom/api/openai_compat.py src/mindroom/prompts.py tests/test_agents.py tests/test_openai_compat.py`
- `uv run pytest tests/test_openai_compat.py tests/test_agents.py -q -n 0 --no-cov` -> 332 passed
- `git diff --check`
- commit hooks: pre-commit passed for staged files

## Summary by Sourcery

Decouple OpenAI-compatible agents and teams from Matrix-specific identity and account assumptions while clarifying OpenAI auto-routing behavior.

New Features:
- Introduce a dedicated identity prompt template for OpenAI-compatible agents that avoids Matrix-specific context.

Enhancements:
- Ensure OpenAI-compatible agent and team runs do not prepare or require persisted Matrix accounts.
- Simplify team materialization by relying on direct team construction and validation instead of separate resolution outcomes.

Documentation:
- Clarify that OpenAI-compatible auto-routing on /v1 considers agents only and requires explicit team/<team_name> models for teams.

Tests:
- Add regression tests verifying OpenAI-compatible agent and team executions do not create Matrix state and that partially built team resources are closed on failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the OpenAI-compatible `/v1` `auto` model routes only among agents; teams must be invoked via explicit `team/<team_name>` models.

* **Improvements**
  * Unified OpenAI-compatible agent identity rendering and strengthened team execution/error handling to return a generic failure message on build errors.

* **Tests**
  * Expanded OpenAI-compat tests for agent prompts, team flows, error cases, and no‑Matrix‑state behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1014)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->