### PR TITLE
Clarify responder candidate naming

### DIFF
--- a/src/mindroom/custom_tools/config_manager.py
+++ b/src/mindroom/custom_tools/config_manager.py
@@ -459,7 +459,7 @@ class ConfigManagerTools(Toolkit):
             return "Agents in This Room", []
 
         registry = entity_identity_registry(config, self.runtime_paths)
-        available_agent_names = {
+        available_responder_names = {
             agent_name
             for matrix_id in responder_candidate_entities_from_cached_room(
                 room,
@@ -470,7 +470,7 @@ class ConfigManagerTools(Toolkit):
             if (agent_name := registry.current_entity_name_for_user_id(matrix_id.full_id, include_router=False))
             is not None
         }
-        agent_entries = [(name, agent) for name, agent in all_agents if name in available_agent_names]
+        agent_entries = [(name, agent) for name, agent in all_agents if name in available_responder_names]
         return "Agents in This Room", agent_entries
 
     def _list_agents(self, *, agent_scope: _AgentScope = "current_room") -> str:

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -773,12 +773,17 @@ async def _parse_workflow_schedule(
     if current_time is None:
         current_time = datetime.now(UTC)
 
-    assert available_responders, "No agents or teams available for scheduling"
+    if not available_responders:
+        return _WorkflowParseError(
+            error="No agents or teams available for scheduling.",
+            suggestion="Try again in a room or thread where at least one agent or team can respond.",
+        )
     registry = entity_identity_registry(config, runtime_paths)
     agent_list = ", ".join(
         f"@{entity_name}"
-        for agent_id in available_responders
-        if (entity_name := registry.current_entity_name_for_user_id(agent_id.full_id, include_router=False)) is not None
+        for responder_id in available_responders
+        if (entity_name := registry.current_entity_name_for_user_id(responder_id.full_id, include_router=False))
+        is not None
     )
 
     prompt = config.render_prompt(

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -766,18 +766,18 @@ async def _parse_workflow_schedule(
     request: str,
     config: Config,
     runtime_paths: RuntimePaths,
-    available_agents: typing.Sequence[MatrixID],
+    available_responders: typing.Sequence[MatrixID],
     current_time: datetime | None = None,
 ) -> ScheduledWorkflow | _WorkflowParseError:
     """Parse natural language into structured workflow using AI."""
     if current_time is None:
         current_time = datetime.now(UTC)
 
-    assert available_agents, "No agents or teams available for scheduling"
+    assert available_responders, "No agents or teams available for scheduling"
     registry = entity_identity_registry(config, runtime_paths)
     agent_list = ", ".join(
         f"@{entity_name}"
-        for agent_id in available_agents
+        for agent_id in available_responders
         if (entity_name := registry.current_entity_name_for_user_id(agent_id.full_id, include_router=False)) is not None
     )
 
@@ -1348,7 +1348,7 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
     if mentioned_agents is None:
         mentioned_agents = _extract_mentioned_agents_from_text(full_text, config, runtime_paths)
 
-    sender_visible_room_agents = await responder_candidate_entities_for_room(
+    sender_visible_room_responders = await responder_candidate_entities_for_room(
         client,
         room,
         scheduled_by,
@@ -1356,9 +1356,9 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
         runtime_paths,
     )
 
-    available_agents: list[MatrixID] = []
+    available_responders: list[MatrixID] = []
     if new_thread:
-        available_agents = list(sender_visible_room_agents)
+        available_responders = list(sender_visible_room_responders)
     else:
         if thread_id:
             thread_history = list(
@@ -1369,21 +1369,21 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 ),
             )
             thread_agents = get_agents_in_thread(thread_history, config, runtime_paths)
-            available_agents = [agent for agent in thread_agents if agent in sender_visible_room_agents]
+            available_responders = [agent for agent in thread_agents if agent in sender_visible_room_responders]
 
         if mentioned_agents:
             for mid in mentioned_agents:
-                if mid not in available_agents and mid in sender_visible_room_agents:
-                    available_agents.append(mid)
+                if mid not in available_responders and mid in sender_visible_room_responders:
+                    available_responders.append(mid)
 
-        if not available_agents:
-            available_agents = list(sender_visible_room_agents)
+        if not available_responders:
+            available_responders = list(sender_visible_room_responders)
 
-    if not available_agents:
+    if not available_responders:
         return (None, "❌ No agents or teams in this room are allowed to reply to you.")
 
-    # Parse the workflow request with available agents
-    workflow_result = await _parse_workflow_schedule(full_text, config, runtime_paths, available_agents)
+    # Parse the workflow request with available responders.
+    workflow_result = await _parse_workflow_schedule(full_text, config, runtime_paths, available_responders)
 
     if isinstance(workflow_result, _WorkflowParseError):
         error_msg = f"❌ {workflow_result.error}"
@@ -1401,7 +1401,7 @@ async def schedule_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
     # Validate that all mentioned agents or teams are accessible.
     validation_result = await _validate_agent_mentions(
         workflow_result.message,
-        available_agents,
+        available_responders,
         config,
         runtime_paths,
     )

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -786,16 +786,16 @@ def _select_team_request(
     available_responders = available_responders_in_room
     if available_responders is None:
         available_responders = get_available_responders_in_room(room, config, runtime_paths)
-    normalized_available_agents = _normalize_team_request_members(available_responders, config, runtime_paths)
-    if len(normalized_available_agents) <= 1:
+    normalized_available_responders = _normalize_team_request_members(available_responders, config, runtime_paths)
+    if len(normalized_available_responders) <= 1:
         return _SelectedTeamRequest(None, [])
 
     logger.info(
         "team_formation_requested",
         trigger="dm_room_multiple_agents",
-        agents=[agent.full_id for agent in normalized_available_agents],
+        agents=[responder.full_id for responder in normalized_available_responders],
     )
-    return _SelectedTeamRequest(TeamIntent.DM_AUTO_TEAM, normalized_available_agents)
+    return _SelectedTeamRequest(TeamIntent.DM_AUTO_TEAM, normalized_available_responders)
 
 
 def _sender_unavailable_team_agents_message(agent_names: list[str], *, prefix: str = "Team request") -> str:

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -615,7 +615,7 @@ async def decide_team_formation(
     use_ai_decision: bool = True,
     is_dm_room: bool = False,
     is_thread: bool = False,
-    available_agents_in_room: list[MatrixID] | None = None,
+    available_responders_in_room: list[MatrixID] | None = None,
     materializable_agent_names: set[str] | None = None,
 ) -> TeamResolution:
     """Determine if a team should form and with which mode.
@@ -632,7 +632,7 @@ async def decide_team_formation(
         use_ai_decision: Whether to use AI for mode selection
         is_dm_room: Whether this is a DM room
         is_thread: Whether the current message is in a thread
-        available_agents_in_room: Optional pre-filtered room agents for sender-visible availability
+        available_responders_in_room: Optional pre-filtered room responders for sender-visible availability
         materializable_agent_names: Optional live agent names that can currently produce a response
 
     Returns:
@@ -648,7 +648,7 @@ async def decide_team_formation(
         runtime_paths,
         is_dm_room=is_dm_room,
         is_thread=is_thread,
-        available_agents_in_room=available_agents_in_room,
+        available_responders_in_room=available_responders_in_room,
     )
     if team_request.intent is None or not team_request.requested_members:
         return TeamResolution.none()
@@ -658,7 +658,7 @@ async def decide_team_formation(
         config,
         runtime_paths,
         room=room,
-        sender_visible_agents=available_agents_in_room,
+        sender_visible_responders=available_responders_in_room,
         materializable_agent_names=materializable_agent_names,
     )
     resolution = _resolve_team_request(
@@ -750,7 +750,7 @@ def _select_team_request(
     *,
     is_dm_room: bool,
     is_thread: bool,
-    available_agents_in_room: list[MatrixID] | None,
+    available_responders_in_room: list[MatrixID] | None,
 ) -> _SelectedTeamRequest:
     """Return the normalized team request implied by one message context."""
     normalized_tagged_agents = _normalize_team_request_members(tagged_agents, config, runtime_paths)
@@ -783,10 +783,10 @@ def _select_team_request(
     if not (is_dm_room and not is_thread and not normalized_tagged_agents and room and config):
         return _SelectedTeamRequest(None, [])
 
-    available_agents = available_agents_in_room
-    if available_agents is None:
-        available_agents = get_available_responders_in_room(room, config, runtime_paths)
-    normalized_available_agents = _normalize_team_request_members(available_agents, config, runtime_paths)
+    available_responders = available_responders_in_room
+    if available_responders is None:
+        available_responders = get_available_responders_in_room(room, config, runtime_paths)
+    normalized_available_agents = _normalize_team_request_members(available_responders, config, runtime_paths)
     if len(normalized_available_agents) <= 1:
         return _SelectedTeamRequest(None, [])
 
@@ -848,12 +848,12 @@ def _evaluate_team_members(
     runtime_paths: RuntimePaths,
     *,
     room: nio.MatrixRoom | None,
-    sender_visible_agents: list[MatrixID] | None,
+    sender_visible_responders: list[MatrixID] | None,
     materializable_agent_names: set[str] | None,
 ) -> list[TeamResolutionMember]:
     """Evaluate one status and response capability for each requested member."""
     room_visible_ids: set[str] | None = None
-    if sender_visible_agents is None and room is not None and config is not None:
+    if sender_visible_responders is None and room is not None and config is not None:
         room_visible_ids = {
             agent_id.full_id
             for agent_id in _normalize_team_request_members(
@@ -863,10 +863,10 @@ def _evaluate_team_members(
             )
         }
     sender_visible_ids: set[str] | None = None
-    if sender_visible_agents is not None:
+    if sender_visible_responders is not None:
         sender_visible_ids = {
             agent_id.full_id
-            for agent_id in _normalize_team_request_members(sender_visible_agents, config, runtime_paths)
+            for agent_id in _normalize_team_request_members(sender_visible_responders, config, runtime_paths)
         }
 
     unsupported_agents: dict[str, tuple[str, ...] | None] = {}
@@ -1074,7 +1074,7 @@ def resolve_configured_team(
         config,
         runtime_paths,
         room=None,
-        sender_visible_agents=None,
+        sender_visible_responders=None,
         materializable_agent_names=materializable_agent_names,
     )
     return _resolve_team_request(

--- a/src/mindroom/thread_utils.py
+++ b/src/mindroom/thread_utils.py
@@ -184,19 +184,21 @@ def thread_requires_explicit_agent_targeting(
     sender_id: str,
     config: Config,
     runtime_paths: RuntimePaths,
-    available_agents_in_room: Sequence[MatrixID] | None = None,
+    available_responders_in_room: Sequence[MatrixID] | None = None,
 ) -> bool:
     """Return whether a thread already has visible ownership or multiple human participants."""
-    sender_visible_agents = authorization.filter_responders_by_sender_permissions(
+    sender_visible_responders = authorization.filter_responders_by_sender_permissions(
         get_agents_in_thread(thread_history, config, runtime_paths),
         sender_id,
         config,
         runtime_paths,
     )
-    if available_agents_in_room is not None:
-        available_agent_ids = {agent.full_id for agent in available_agents_in_room}
-        sender_visible_agents = [agent for agent in sender_visible_agents if agent.full_id in available_agent_ids]
-    if sender_visible_agents:
+    if available_responders_in_room is not None:
+        available_responder_ids = {responder.full_id for responder in available_responders_in_room}
+        sender_visible_responders = [
+            responder for responder in sender_visible_responders if responder.full_id in available_responder_ids
+        ]
+    if sender_visible_responders:
         return True
     return has_multiple_non_agent_users_in_thread(thread_history, config, runtime_paths)
 
@@ -238,7 +240,7 @@ def should_agent_respond(  # noqa: PLR0911
     has_non_agent_mentions: bool = False,
     *,
     sender_id: str,
-    available_agents_in_room: list[MatrixID] | None = None,
+    available_responders_in_room: list[MatrixID] | None = None,
 ) -> bool:
     """Determine if an agent should respond to a message individually.
 
@@ -255,23 +257,23 @@ def should_agent_respond(  # noqa: PLR0911
         mentioned_agents: List of all agent MatrixIDs mentioned in the message
         has_non_agent_mentions: True when the message explicitly tags a non-agent user
         sender_id: Sender Matrix ID used for per-agent reply permissions
-        available_agents_in_room: Optional precomputed sender-visible agents for the room
+        available_responders_in_room: Optional precomputed sender-visible responders for the room
 
     """
     if not authorization.is_sender_allowed_for_agent_reply(sender_id, agent_name, config, runtime_paths):
         return False
 
-    available_agents = available_agents_in_room
-    if available_agents is None:
-        available_agents = authorization.responder_candidate_entities_from_cached_room(
+    available_responders = available_responders_in_room
+    if available_responders is None:
+        available_responders = authorization.responder_candidate_entities_from_cached_room(
             room,
             sender_id,
             config,
             runtime_paths,
         )
     agent_matrix_id = entity_identity_registry(config, runtime_paths).current_id(agent_name)
-    available_agent_ids = {agent.full_id for agent in available_agents}
-    if agent_matrix_id.full_id not in available_agent_ids:
+    available_responder_ids = {responder.full_id for responder in available_responders}
+    if agent_matrix_id.full_id not in available_responder_ids:
         return False
 
     # Always respond if mentioned
@@ -282,9 +284,9 @@ def should_agent_respond(  # noqa: PLR0911
     if mentioned_agents or has_non_agent_mentions:
         return False
 
-    # Non-thread messages: auto-respond if we're the only visible agent in the room.
+    # Non-thread messages: auto-respond if we're the only visible responder in the room.
     if not is_thread:
-        return len(available_agents) == 1 and available_agents[0] == agent_matrix_id
+        return len(available_responders) == 1 and available_responders[0] == agent_matrix_id
 
     # In threads with multiple human participants, always require explicit mention.
     if has_multiple_non_agent_users_in_thread(thread_history, config, runtime_paths):
@@ -299,9 +301,9 @@ def should_agent_respond(  # noqa: PLR0911
         config,
         runtime_paths,
     )
-    agents_in_thread = [agent for agent in agents_in_thread if agent.full_id in available_agent_ids]
+    agents_in_thread = [agent for agent in agents_in_thread if agent.full_id in available_responder_ids]
     if agents_in_thread:
         return len(agents_in_thread) == 1 and agents_in_thread[0] == agent_matrix_id
 
-    # No agents in thread yet — respond if we're the only visible agent.
-    return len(available_agents) == 1 and available_agents[0] == agent_matrix_id
+    # No agents in thread yet: respond if we're the only visible responder.
+    return len(available_responders) == 1 and available_responders[0] == agent_matrix_id

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -657,7 +657,7 @@ class TurnController:
             return False
         if thread_history is None:
             return False
-        available_agents = await self.deps.turn_policy.responder_candidates_for_room(
+        available_responders = await self.deps.turn_policy.responder_candidates_for_room(
             room,
             requester_user_id,
         )
@@ -666,7 +666,7 @@ class TurnController:
             sender_id=requester_user_id,
             config=self.deps.runtime.config,
             runtime_paths=self.deps.runtime_paths,
-            available_agents_in_room=available_agents,
+            available_responders_in_room=available_responders,
         )
 
     async def _coalescing_key_for_event(

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -674,6 +674,8 @@ class TurnPolicy:
             self.deps.runtime_paths,
         )
         if team_action is None:
+            # Use sender-visible responders here so explicit team requests can distinguish
+            # hidden members from visible-but-not-materializable members.
             form_team = await self.decide_team_for_sender(
                 agents_in_thread,
                 context,

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -452,7 +452,7 @@ class TurnPolicy:
         message: str,
         is_dm: bool,
         *,
-        available_agents_in_room: list[MatrixID] | None = None,
+        available_responders_in_room: list[MatrixID] | None = None,
         materializable_agent_names: set[str] | None = None,
     ) -> TeamResolution:
         """Decide team formation using sender-visible candidates without losing explicit intent."""
@@ -475,8 +475,8 @@ class TurnPolicy:
         )
         if materializable_agent_names is None:
             materializable_agent_names = self.materializable_agent_names()
-        if available_agents_in_room is None:
-            available_agents_in_room = await self.responder_candidates_for_room(
+        if available_responders_in_room is None:
+            available_responders_in_room = await self.responder_candidates_for_room(
                 room,
                 requester_user_id,
                 materializable_agent_names=materializable_agent_names,
@@ -492,7 +492,7 @@ class TurnPolicy:
             runtime_paths=self.deps.runtime_paths,
             is_dm_room=is_dm,
             is_thread=context.is_thread,
-            available_agents_in_room=available_agents_in_room,
+            available_responders_in_room=available_responders_in_room,
             materializable_agent_names=materializable_agent_names,
         )
 
@@ -533,7 +533,7 @@ class TurnPolicy:
             self.deps.logger.info("Skipping routing: thread policy history unavailable")
             plan = _DispatchPlan(kind="ignore", ignore_reason="router")
         else:
-            available_agents = await self.responder_candidates_for_room(
+            available_responders = await self.responder_candidates_for_room(
                 room,
                 requester_user_id,
             )
@@ -542,11 +542,11 @@ class TurnPolicy:
                 sender_id=requester_user_id,
                 config=self.deps.runtime.config,
                 runtime_paths=self.deps.runtime_paths,
-                available_agents_in_room=available_agents,
+                available_responders_in_room=available_responders,
             ):
                 self.deps.logger.info("Skipping routing: thread already requires explicit responder targeting")
                 plan = _DispatchPlan(kind="ignore", ignore_reason="router")
-            elif len(available_agents) == 1:
+            elif len(available_responders) == 1:
                 self.deps.logger.info("Skipping routing: only one responder candidate")
                 plan = _DispatchPlan(kind="ignore", ignore_reason="router")
             else:
@@ -622,24 +622,26 @@ class TurnPolicy:
             if materializable_agent_names is not None
             else None
         )
-        sender_visible_agents_in_room = await responder_candidate_entities_for_room(
+        sender_visible_responders_in_room = await responder_candidate_entities_for_room(
             self.deps.runtime.client,
             room,
             requester_user_id,
             self.deps.runtime.config,
             self.deps.runtime_paths,
         )
-        available_agents_in_room = self.filter_materializable_responders(
-            sender_visible_agents_in_room,
+        available_responders_in_room = self.filter_materializable_responders(
+            sender_visible_responders_in_room,
             materializable_agent_names=materializable_agent_names,
             live_entity_names=live_entity_names,
         )
         registry = entity_identity_registry(self.deps.runtime.config, self.deps.runtime_paths)
         agent_matrix_id = registry.current_id(self.deps.agent_name)
-        agent_is_responder_candidate = agent_matrix_id.full_id in {agent.full_id for agent in available_agents_in_room}
+        agent_is_responder_candidate = agent_matrix_id.full_id in {
+            agent.full_id for agent in available_responders_in_room
+        }
         team_action = self.explicit_configured_team_rejection_action(
             context,
-            sender_visible_agents_in_room,
+            sender_visible_responders_in_room,
             materializable_agent_names=materializable_agent_names,
             live_entity_names=live_entity_names,
         )
@@ -660,8 +662,8 @@ class TurnPolicy:
             )
             single_visible_self = (
                 not is_thread_history_degraded(context.thread_history)
-                and len(available_agents_in_room) == 1
-                and available_agents_in_room[0] == agent_matrix_id
+                and len(available_responders_in_room) == 1
+                and available_responders_in_room[0] == agent_matrix_id
             )
             if should_continue_active_thread or single_visible_self:
                 return ResponseAction(kind="individual")
@@ -679,10 +681,10 @@ class TurnPolicy:
                 requester_user_id,
                 message,
                 is_dm,
-                available_agents_in_room=sender_visible_agents_in_room,
+                available_responders_in_room=sender_visible_responders_in_room,
                 materializable_agent_names=materializable_agent_names,
             )
-            team_action = self.team_response_action(form_team, available_agents_in_room)
+            team_action = self.team_response_action(form_team, available_responders_in_room)
         if team_action is not None:
             return team_action
 
@@ -697,7 +699,7 @@ class TurnPolicy:
             mentioned_agents=context.mentioned_agents,
             has_non_agent_mentions=context.has_non_agent_mentions,
             sender_id=requester_user_id,
-            available_agents_in_room=available_agents_in_room,
+            available_responders_in_room=available_responders_in_room,
         ):
             if agent_is_responder_candidate and self._should_queue_follow_up_in_active_response_thread(
                 context=context,

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -637,7 +637,7 @@ class TurnPolicy:
         registry = entity_identity_registry(self.deps.runtime.config, self.deps.runtime_paths)
         agent_matrix_id = registry.current_id(self.deps.agent_name)
         agent_is_responder_candidate = agent_matrix_id.full_id in {
-            agent.full_id for agent in available_responders_in_room
+            responder.full_id for responder in available_responders_in_room
         }
         team_action = self.explicit_configured_team_rejection_action(
             context,

--- a/tests/test_dynamic_config_update.py
+++ b/tests/test_dynamic_config_update.py
@@ -273,7 +273,7 @@ class TestDynamicConfigUpdate:
                     request,
                     updated_config,
                     runtime_paths,
-                    available_agents=[
+                    available_responders=[
                         MatrixID(username="email_assistant", domain="localhost"),
                         MatrixID(username="callagent", domain="localhost"),
                     ],

--- a/tests/test_event_driven_scheduling.py
+++ b/tests/test_event_driven_scheduling.py
@@ -91,7 +91,7 @@ class TestEventDrivenScheduling:
             "If I get an email about 'urgent', call me",
             mock_config,
             runtime_paths,
-            available_agents=[_mid("email_assistant"), _mid("phone_agent")],
+            available_responders=[_mid("email_assistant"), _mid("phone_agent")],
         )
 
         # Verify the result is a workflow (not an error)
@@ -136,7 +136,7 @@ class TestEventDrivenScheduling:
             "When Bitcoin drops below $40k, notify me",
             mock_config,
             runtime_paths,
-            available_agents=[_mid("crypto_agent"), _mid("notification_agent")],
+            available_responders=[_mid("crypto_agent"), _mid("notification_agent")],
         )
 
         # Verify
@@ -174,7 +174,7 @@ class TestEventDrivenScheduling:
             "If server CPU goes above 80%, scale up",
             mock_config,
             runtime_paths,
-            available_agents=[_mid("monitoring_agent"), _mid("ops_agent")],
+            available_responders=[_mid("monitoring_agent"), _mid("ops_agent")],
         )
 
         # Verify
@@ -212,7 +212,7 @@ class TestEventDrivenScheduling:
             "When the build fails, create a ticket",
             mock_config,
             runtime_paths,
-            available_agents=[_mid("ci_agent"), _mid("ticket_agent")],
+            available_responders=[_mid("ci_agent"), _mid("ticket_agent")],
         )
 
         # Verify
@@ -250,7 +250,7 @@ class TestEventDrivenScheduling:
             "When someone mentions our product on Reddit, analyze it",
             mock_config,
             runtime_paths,
-            available_agents=[_mid("reddit_agent"), _mid("analyst")],
+            available_responders=[_mid("reddit_agent"), _mid("analyst")],
         )
 
         # Verify
@@ -288,7 +288,7 @@ class TestEventDrivenScheduling:
             "Whenever I get an email from my boss, notify me immediately",
             mock_config,
             runtime_paths,
-            available_agents=[_mid("email_assistant"), _mid("notification_agent")],
+            available_responders=[_mid("email_assistant"), _mid("notification_agent")],
         )
 
         # Verify
@@ -326,7 +326,7 @@ class TestEventDrivenScheduling:
             "Test request",
             mock_config,
             runtime_paths,
-            available_agents=[_mid("test_agent")],
+            available_responders=[_mid("test_agent")],
         )
 
         # Verify the prompt contains generic event-driven guidance

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -8365,7 +8365,7 @@ class TestAgentBot:
             )
 
         assert mock_decide.await_count == 1
-        assert mock_decide.call_args.kwargs["available_agents_in_room"] == [
+        assert mock_decide.call_args.kwargs["available_responders_in_room"] == [
             entity_ids(config, runtime_paths_for(config))["calculator"],
         ]
         assert mock_decide.call_args.kwargs["materializable_agent_names"] == {"calculator"}

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -712,7 +712,7 @@ class TestRoutingRegression:
         assert action.kind == "individual"
         candidate_names = [
             entity_name_for_id(candidate, test_config, runtime_paths)
-            for candidate in mock_should_agent_respond.call_args.kwargs["available_agents_in_room"]
+            for candidate in mock_should_agent_respond.call_args.kwargs["available_responders_in_room"]
         ]
         assert candidate_names == ["alpha"]
 

--- a/tests/test_team_collaboration.py
+++ b/tests/test_team_collaboration.py
@@ -838,7 +838,7 @@ class TestRouterTeamFormation:
             config=config,
             room=room,
             use_ai_decision=False,
-            available_agents_in_room=[],
+            available_responders_in_room=[],
         )
 
         assert result.outcome is TeamOutcome.REJECT
@@ -878,7 +878,7 @@ class TestRouterTeamFormation:
             config=config,
             room=room,
             use_ai_decision=False,
-            available_agents_in_room=[
+            available_responders_in_room=[
                 entity_ids(config, runtime_paths)["calculator"],
                 entity_ids(config, runtime_paths)["general"],
             ],
@@ -923,7 +923,7 @@ class TestRouterTeamFormation:
             config=config,
             room=room,
             use_ai_decision=False,
-            available_agents_in_room=[entity_ids(config, runtime_paths_for(config))["calculator"]],
+            available_responders_in_room=[entity_ids(config, runtime_paths_for(config))["calculator"]],
             materializable_agent_names={"calculator"},
         )
 
@@ -1022,7 +1022,7 @@ class TestRouterTeamFormation:
             config=config,
             room=room,
             use_ai_decision=False,
-            available_agents_in_room=[
+            available_responders_in_room=[
                 entity_ids(config, runtime_paths_for(config))["alpha"],
                 entity_ids(config, runtime_paths_for(config))["calculator"],
             ],
@@ -1078,7 +1078,7 @@ class TestRouterTeamFormation:
             config=config,
             room=room,
             use_ai_decision=False,
-            available_agents_in_room=[
+            available_responders_in_room=[
                 entity_ids(config, runtime_paths_for(config))["alpha"],
                 entity_ids(config, runtime_paths_for(config))["general"],
                 entity_ids(config, runtime_paths_for(config))["calculator"],

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -187,7 +187,7 @@ class TestParseWorkflowSchedule:
             "Every Monday at 9am, research AI news and email me a summary",
             config=mock_config,
             runtime_paths=runtime_paths_for(mock_config),
-            available_agents=[_mid("research"), _mid("email_assistant")],
+            available_responders=[_mid("research"), _mid("email_assistant")],
         )
 
         assert isinstance(result, ScheduledWorkflow)
@@ -220,7 +220,7 @@ class TestParseWorkflowSchedule:
             "ping me in 5 minutes to check the deployment",
             config=mock_config,
             runtime_paths=runtime_paths_for(mock_config),
-            available_agents=[_mid("general")],
+            available_responders=[_mid("general")],
         )
 
         assert isinstance(result, ScheduledWorkflow)
@@ -246,7 +246,7 @@ class TestParseWorkflowSchedule:
             "Daily at 9am, give me a market analysis",
             config=mock_config,
             runtime_paths=runtime_paths_for(mock_config),
-            available_agents=[_mid("finance")],
+            available_responders=[_mid("finance")],
         )
 
         assert isinstance(result, ScheduledWorkflow)
@@ -271,7 +271,7 @@ class TestParseWorkflowSchedule:
             "Schedule something",
             config=mock_config,
             runtime_paths=runtime_paths_for(mock_config),
-            available_agents=[_mid("general")],
+            available_responders=[_mid("general")],
         )
 
         assert isinstance(result, _WorkflowParseError)
@@ -302,7 +302,7 @@ class TestParseWorkflowSchedule:
             "remind me later",
             config=mock_config,
             runtime_paths=runtime_paths_for(mock_config),
-            available_agents=[
+            available_responders=[
                 _mid("general"),
                 _mid("research"),
                 _mid("finance"),
@@ -392,7 +392,7 @@ class TestParseWorkflowSchedule:
             "If someone mentions urgent then notify the team immediately",
             config=mock_config,
             runtime_paths=runtime_paths_for(mock_config),
-            available_agents=[_mid("general")],
+            available_responders=[_mid("general")],
         )
 
         assert isinstance(result, _WorkflowParseError)

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -278,6 +278,24 @@ class TestParseWorkflowSchedule:
         assert "Error parsing schedule" in result.error
         assert result.suggestion is not None
 
+    @patch("mindroom.scheduling.Agent")
+    async def test_parse_empty_available_responders_returns_parse_error(
+        self,
+        mock_agent_class: Mock,
+        mock_config: MagicMock,
+    ) -> None:
+        """Empty responder sets should fail deterministically for direct callers."""
+        result = await _parse_workflow_schedule(
+            "Schedule something",
+            config=mock_config,
+            runtime_paths=runtime_paths_for(mock_config),
+            available_responders=[],
+        )
+
+        assert isinstance(result, _WorkflowParseError)
+        assert result.error == "No agents or teams available for scheduling."
+        mock_agent_class.assert_not_called()
+
     @patch("mindroom.model_loading.get_model_instance")
     @patch("mindroom.scheduling.Agent")
     async def test_parse_formats_available_agents_without_double_at(

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import nio
 import pytest
 
-from mindroom.config.agent import AgentConfig
+from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import ORIGINAL_SENDER_KEY
@@ -76,13 +76,16 @@ def mock_config() -> Config:
                 "shell": AgentConfig(display_name="Shell"),
                 "analyst": AgentConfig(display_name="Analyst"),
             },
+            teams={
+                "ops": TeamConfig(display_name="Ops Team", role="Operations team", agents=["research", "analyst"]),
+            },
             models={"default": ModelConfig(provider="test", id="test-model")},
         ),
     )
     persist_entity_accounts(
         config,
         runtime_paths_for(config),
-        usernames={alias: alias for alias in ["router", *config.agents]},
+        usernames={alias: alias for alias in ["router", *config.agents, *config.teams]},
     )
     return config
 
@@ -323,13 +326,14 @@ class TestParseWorkflowSchedule:
             available_responders=[
                 _mid("general"),
                 _mid("research"),
+                _mid("ops"),
                 _mid("finance"),
                 _mid("analyst"),
             ],
         )
 
         prompt = mock_agent.arun.call_args.args[0]
-        assert "Available agents and teams: @general, @research, @finance, @analyst" in prompt
+        assert "Available agents and teams: @general, @research, @ops, @finance, @analyst" in prompt
         assert "@@" not in prompt
 
     @patch("mindroom.model_loading.get_model_instance")


### PR DESCRIPTION
## Summary
- Rename stale room-candidate variables and keyword arguments from agents to responders where they may include agents or teams
- Keep explicitly agent-only subagent wording unchanged
- Update tests for the renamed internal keyword arguments

## Tests
- uv run ruff check src/mindroom/turn_policy.py src/mindroom/turn_controller.py src/mindroom/thread_utils.py src/mindroom/teams.py src/mindroom/scheduling.py src/mindroom/custom_tools/config_manager.py tests/test_dynamic_config_update.py tests/test_event_driven_scheduling.py tests/test_workflow_scheduling.py tests/test_multi_agent_bot.py tests/test_routing_regression.py tests/test_team_collaboration.py
- uv run pytest tests/test_team_collaboration.py tests/test_routing_regression.py tests/test_scheduling.py tests/test_event_driven_scheduling.py tests/test_workflow_scheduling.py tests/test_dynamic_config_update.py tests/test_multi_agent_bot.py::TestAgentBot::test_decide_team_for_sender_passes_sender_filtered_dm_agents -q -n 0 --no-cov
- uv run pre-commit run --all-files
- uv run pytest -q --no-cov

## Summary by Sourcery

Clarify terminology and boundaries between agents and responders in routing, scheduling, and team-formation logic.

Enhancements:
- Rename room-level candidate variables and parameters from agents to responders across thread handling, routing, scheduling, and team collaboration modules to reflect inclusion of teams as well as agents.
- Align config management and identity utilities with the responder naming to ensure consistent room-scoped listing and filtering of candidates.

Tests:
- Update routing, scheduling, team collaboration, dynamic config, and event-driven scheduling tests to use the new responder-oriented parameter names and expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified responder selection across scheduling, team formation, routing and turn-taking so reply eligibility is more consistent and reliable in rooms and threads.

* **Tests**
  * Updated and expanded tests for scheduling and routing, including a new test that verifies the user-facing error "No agents or teams available for scheduling."

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1015)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->