### PR TITLE
Guard agent-scoped credential management

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -168,6 +168,10 @@ Use `authorization.agent_reply_permissions` to restrict which users each respond
 - A `*` user entry means "allow any sender" for that specific entity.
 - If an entity is not present in the map, it has no extra reply restriction.
 - Alias mapping from `authorization.aliases` is applied before matching, so bridged IDs inherit canonical user permissions.
+- The same allowlist gates dashboard credential and OAuth management when a request targets an agent with `agent_name`.
+- Unauthorized agent-scoped credential requests return HTTP 403 before credentials are read, written, connected, or disconnected.
+- Under trusted upstream auth, MindRoom checks the resolved Matrix requester from the configured Matrix user ID header or email-to-Matrix template.
+- Under standalone API-key auth, set `MINDROOM_OWNER_USER_ID` so agent-scoped credential management resolves to the owner Matrix user instead of the generic standalone principal.
 - Internal MindRoom identities (agents, teams, router, and the internal `mindroom_user`) always bypass reply permissions — they are system participants, not end users.
 - `bot_accounts` are **not** exempt. Bridge bots listed in `bot_accounts` are still subject to reply permission checks.
 - Keys that do not match any configured agent, team, `router`, or `*` are rejected at config load time.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -228,6 +228,11 @@ Credentials support scoping via query parameters:
 - `agent_name` — scope credentials to a specific agent
 - `execution_scope` — scope credentials to a specific worker scope (e.g., `shared`, `unscoped`)
 
+When `agent_name` is present, credential routes require the authenticated dashboard requester to be allowed by `authorization.agent_reply_permissions` for that agent.
+Unauthorized agent-scoped requests return HTTP 403.
+Trusted upstream deployments should provide a Matrix requester identity through the configured Matrix user ID header or email-to-Matrix template.
+Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard requests manage credentials as the owner Matrix user.
+
 ### Knowledge
 
 | Method | Endpoint | Description |

--- a/docs/oauth-framework.md
+++ b/docs/oauth-framework.md
@@ -10,6 +10,8 @@ Providers supply only provider-specific metadata and parsing behavior, such as O
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/status`, and `/api/oauth/{provider}/disconnect`.
 Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider.
 Dashboard OAuth state is opaque, time-limited, single-use, and bound to the authenticated MindRoom user plus the persisted agent execution scope resolved by the existing credentials target machinery.
+When an OAuth request targets an agent with `agent_name`, MindRoom also requires the authenticated dashboard requester to satisfy `authorization.agent_reply_permissions` for that agent.
+Unauthorized agent-scoped OAuth connect, authorize, status, disconnect, and callback requests return HTTP 403 before credentials are exposed or changed.
 Conversation OAuth links use an additional opaque, time-limited, single-use connect token that binds the browser flow to the requester that produced the missing-credentials tool result.
 That connect token also carries the requester identity from the tool runtime, and MindRoom rejects redemption unless the authenticated dashboard user resolves to the same requester for scoped credentials.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` through pairing so dashboard credential management and agent-issued OAuth links resolve to the owner Matrix user instead of the generic dashboard API-key principal.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -669,6 +669,11 @@ Credentials support scoping via query parameters:
 - `agent_name` — scope credentials to a specific agent
 - `execution_scope` — scope credentials to a specific worker scope (e.g., `shared`, `unscoped`)
 
+When `agent_name` is present, credential routes require the authenticated dashboard requester to be allowed by `authorization.agent_reply_permissions` for that agent.
+Unauthorized agent-scoped requests return HTTP 403.
+Trusted upstream deployments should provide a Matrix requester identity through the configured Matrix user ID header or email-to-Matrix template.
+Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard requests manage credentials as the owner Matrix user.
+
 ### Knowledge
 
 | Method | Endpoint | Description |
@@ -11170,6 +11175,8 @@ Providers supply only provider-specific metadata and parsing behavior, such as O
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/status`, and `/api/oauth/{provider}/disconnect`.
 Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider.
 Dashboard OAuth state is opaque, time-limited, single-use, and bound to the authenticated MindRoom user plus the persisted agent execution scope resolved by the existing credentials target machinery.
+When an OAuth request targets an agent with `agent_name`, MindRoom also requires the authenticated dashboard requester to satisfy `authorization.agent_reply_permissions` for that agent.
+Unauthorized agent-scoped OAuth connect, authorize, status, disconnect, and callback requests return HTTP 403 before credentials are exposed or changed.
 Conversation OAuth links use an additional opaque, time-limited, single-use connect token that binds the browser flow to the requester that produced the missing-credentials tool result.
 That connect token also carries the requester identity from the tool runtime, and MindRoom rejects redemption unless the authenticated dashboard user resolves to the same requester for scoped credentials.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` through pairing so dashboard credential management and agent-issued OAuth links resolve to the owner Matrix user instead of the generic dashboard API-key principal.
@@ -13069,6 +13076,10 @@ Use `authorization.agent_reply_permissions` to restrict which users each respond
 - A `*` user entry means "allow any sender" for that specific entity.
 - If an entity is not present in the map, it has no extra reply restriction.
 - Alias mapping from `authorization.aliases` is applied before matching, so bridged IDs inherit canonical user permissions.
+- The same allowlist gates dashboard credential and OAuth management when a request targets an agent with `agent_name`.
+- Unauthorized agent-scoped credential requests return HTTP 403 before credentials are read, written, connected, or disconnected.
+- Under trusted upstream auth, MindRoom checks the resolved Matrix requester from the configured Matrix user ID header or email-to-Matrix template.
+- Under standalone API-key auth, set `MINDROOM_OWNER_USER_ID` so agent-scoped credential management resolves to the owner Matrix user instead of the generic standalone principal.
 - Internal MindRoom identities (agents, teams, router, and the internal `mindroom_user`) always bypass reply permissions — they are system participants, not end users.
 - `bot_accounts` are **not** exempt. Bridge bots listed in `bot_accounts` are still subject to reply permission checks.
 - Keys that do not match any configured agent, team, `router`, or `*` are rejected at config load time.

--- a/skills/mindroom-docs/references/page__authorization__index.md
+++ b/skills/mindroom-docs/references/page__authorization__index.md
@@ -164,6 +164,10 @@ Use `authorization.agent_reply_permissions` to restrict which users each respond
 - A `*` user entry means "allow any sender" for that specific entity.
 - If an entity is not present in the map, it has no extra reply restriction.
 - Alias mapping from `authorization.aliases` is applied before matching, so bridged IDs inherit canonical user permissions.
+- The same allowlist gates dashboard credential and OAuth management when a request targets an agent with `agent_name`.
+- Unauthorized agent-scoped credential requests return HTTP 403 before credentials are read, written, connected, or disconnected.
+- Under trusted upstream auth, MindRoom checks the resolved Matrix requester from the configured Matrix user ID header or email-to-Matrix template.
+- Under standalone API-key auth, set `MINDROOM_OWNER_USER_ID` so agent-scoped credential management resolves to the owner Matrix user instead of the generic standalone principal.
 - Internal MindRoom identities (agents, teams, router, and the internal `mindroom_user`) always bypass reply permissions — they are system participants, not end users.
 - `bot_accounts` are **not** exempt. Bridge bots listed in `bot_accounts` are still subject to reply permission checks.
 - Keys that do not match any configured agent, team, `router`, or `*` are rejected at config load time.

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -224,6 +224,11 @@ Credentials support scoping via query parameters:
 - `agent_name` — scope credentials to a specific agent
 - `execution_scope` — scope credentials to a specific worker scope (e.g., `shared`, `unscoped`)
 
+When `agent_name` is present, credential routes require the authenticated dashboard requester to be allowed by `authorization.agent_reply_permissions` for that agent.
+Unauthorized agent-scoped requests return HTTP 403.
+Trusted upstream deployments should provide a Matrix requester identity through the configured Matrix user ID header or email-to-Matrix template.
+Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard requests manage credentials as the owner Matrix user.
+
 ### Knowledge
 
 | Method | Endpoint | Description |

--- a/skills/mindroom-docs/references/page__oauth-framework__index.md
+++ b/skills/mindroom-docs/references/page__oauth-framework__index.md
@@ -6,6 +6,8 @@ Providers supply only provider-specific metadata and parsing behavior, such as O
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/status`, and `/api/oauth/{provider}/disconnect`.
 Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider.
 Dashboard OAuth state is opaque, time-limited, single-use, and bound to the authenticated MindRoom user plus the persisted agent execution scope resolved by the existing credentials target machinery.
+When an OAuth request targets an agent with `agent_name`, MindRoom also requires the authenticated dashboard requester to satisfy `authorization.agent_reply_permissions` for that agent.
+Unauthorized agent-scoped OAuth connect, authorize, status, disconnect, and callback requests return HTTP 403 before credentials are exposed or changed.
 Conversation OAuth links use an additional opaque, time-limited, single-use connect token that binds the browser flow to the requester that produced the missing-credentials tool result.
 That connect token also carries the requester identity from the tool runtime, and MindRoom rejects redemption unless the authenticated dashboard user resolves to the same requester for scoped credentials.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` through pairing so dashboard credential management and agent-issued OAuth links resolve to the owner Matrix user instead of the generic dashboard API-key principal.

--- a/src/mindroom/api/credentials.py
+++ b/src/mindroom/api/credentials.py
@@ -412,7 +412,7 @@ def resolve_dashboard_agent_execution_scope_request(
     )
 
 
-def _require_agent_credential_management_authorized(
+def require_agent_credential_management_authorized(
     request: Request,
     *,
     config: Config,
@@ -498,7 +498,7 @@ def resolve_request_credentials_target(
             execution_identity=None,
             allowed_shared_services=None,
         )
-    execution_identity = _require_agent_credential_management_authorized(
+    execution_identity = require_agent_credential_management_authorized(
         request,
         config=config,
         runtime_paths=runtime_paths,
@@ -855,7 +855,6 @@ class _DashboardCredentialAccess:
     ) -> _DashboardCredentialAccess:
         """Resolve dashboard credential access for one request."""
         oauth_services = _oauth_services_for_request(request)
-        oauth_services.reject_non_editable_services(service_names)
         allow_oauth_private_scopes = any(
             oauth_services.allows_private_scope_for(service) for service in service_names
         ) and _request_may_target_scoped_credentials(request, agent_name)
@@ -865,6 +864,7 @@ class _DashboardCredentialAccess:
             service_names=service_names,
             allow_private_scopes=allow_private_scopes or allow_oauth_private_scopes,
         )
+        oauth_services.reject_non_editable_services(service_names)
         return cls(target=target, oauth_services=oauth_services)
 
     def match(self, service: str) -> _OAuthCredentialServiceMatch | None:
@@ -1167,16 +1167,14 @@ async def copy_credentials(
     """Copy credentials from one service to another."""
     service = _validated_service(service)
     source_service = _validated_service(source_service)
-    destination_match = _oauth_service_match(request, service)
-    source_match = _oauth_service_match(request, source_service)
-    _reject_oauth_token_service(destination_match)
-    _reject_oauth_token_service(source_match)
-    _reject_oauth_client_config_copy(source_service, source_match, service, destination_match)
     access = _DashboardCredentialAccess.resolve(
         request,
         agent_name=agent_name,
         service_names=(service, source_service),
     )
+    destination_match = _oauth_service_match(request, service)
+    source_match = _oauth_service_match(request, source_service)
+    _reject_oauth_client_config_copy(source_service, source_match, service, destination_match)
     source_creds = access.load(source_service)
     destination_creds = access.load(service)
 
@@ -1202,9 +1200,9 @@ async def validate_credentials(
 ) -> dict[str, Any]:
     """Test if credentials are valid for a service."""
     service = _validated_service(service)
-    _reject_oauth_token_service(_oauth_service_match(request, service))
     # This is a placeholder - actual testing would depend on the service
     target = resolve_request_credentials_target(request, agent_name=agent_name, service_names=(service,))
+    _reject_oauth_token_service(_oauth_service_match(request, service))
     credentials = load_credentials_for_target(service, target)
 
     if not credentials:

--- a/src/mindroom/api/credentials.py
+++ b/src/mindroom/api/credentials.py
@@ -14,6 +14,7 @@ from mindroom.agent_policy import (
     resolve_agent_policy_from_data,
 )
 from mindroom.api import config_lifecycle
+from mindroom.authorization import is_sender_allowed_for_agent_credential_management
 from mindroom.config.main import Config
 from mindroom.credential_policy import (
     OAUTH_CREDENTIAL_FIELDS,
@@ -411,6 +412,30 @@ def resolve_dashboard_agent_execution_scope_request(
     )
 
 
+def _require_agent_credential_management_authorized(
+    request: Request,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    agent_name: str,
+) -> ToolExecutionIdentity:
+    """Require the dashboard requester to be allowed to manage one agent's credentials."""
+    execution_identity = build_dashboard_execution_identity(
+        request,
+        agent_name,
+        runtime_paths=runtime_paths,
+    )
+    requester_id = execution_identity.requester_id
+    if requester_id is None or not is_sender_allowed_for_agent_credential_management(
+        requester_id,
+        agent_name=agent_name,
+        config=config,
+        runtime_paths=runtime_paths,
+    ):
+        raise HTTPException(status_code=403, detail=f"Not authorized to manage credentials for agent '{agent_name}'")
+    return execution_identity
+
+
 def _reject_raw_worker_targeting(request: Request) -> None:
     for param_name in ("worker_key", "source_worker_key"):
         if request.query_params.get(param_name):
@@ -474,6 +499,12 @@ def resolve_request_credentials_target(
             execution_identity=None,
             allowed_shared_services=None,
         )
+    execution_identity = _require_agent_credential_management_authorized(
+        request,
+        config=config,
+        runtime_paths=runtime_paths,
+        agent_name=scope_request.agent_name,
+    )
     execution_scope = scope_request.requested_execution_scope
     if execution_scope is None:
         return RequestCredentialsTarget(
@@ -514,11 +545,6 @@ def resolve_request_credentials_target(
             ),
         )
 
-    execution_identity = build_dashboard_execution_identity(
-        request,
-        scope_request.agent_name,
-        runtime_paths=runtime_paths,
-    )
     _reject_unbound_private_dashboard_requester(execution_scope, execution_identity)
     worker_key = require_worker_key_for_scope(
         execution_scope,

--- a/src/mindroom/api/credentials.py
+++ b/src/mindroom/api/credentials.py
@@ -430,7 +430,6 @@ def _require_agent_credential_management_authorized(
         requester_id,
         agent_name=agent_name,
         config=config,
-        runtime_paths=runtime_paths,
     ):
         raise HTTPException(status_code=403, detail=f"Not authorized to manage credentials for agent '{agent_name}'")
     return execution_identity

--- a/src/mindroom/api/homeassistant_integration.py
+++ b/src/mindroom/api/homeassistant_integration.py
@@ -263,6 +263,11 @@ async def connect_token(
 
     # Normalize the instance URL
     instance_url = _normalize_instance_url(config.instance_url)
+    target = resolve_request_credentials_target(
+        request,
+        agent_name=agent_name,
+        service_names=("homeassistant",),
+    )
 
     # Test the connection
     try:
@@ -275,8 +280,6 @@ async def connect_token(
             detail=f"Failed to connect to Home Assistant: {e!s}",
         ) from e
 
-    # Save configuration
-    target = resolve_request_credentials_target(request, agent_name=agent_name, service_names=("homeassistant",))
     _save_config(
         target,
         {

--- a/src/mindroom/api/tools.py
+++ b/src/mindroom/api/tools.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from mindroom.agent_policy import dashboard_credentials_supported_for_scope
 from mindroom.api import config_lifecycle
 from mindroom.api.credentials import (
-    build_dashboard_execution_identity,
+    require_agent_credential_management_authorized,
     resolve_dashboard_agent_execution_scope_request,
     resolve_dashboard_execution_scope_override,
 )
@@ -213,12 +213,18 @@ def _resolve_tool_availability_context(
     status_authoritative = not scope_request.draft_scope_preview and dashboard_credentials_supported_for_scope(
         execution_scope,
     )
-    execution_identity = (
-        build_dashboard_execution_identity(
+    authorized_identity = (
+        require_agent_credential_management_authorized(
             request,
-            scope_request.agent_name,
+            config=config,
             runtime_paths=runtime_paths,
+            agent_name=scope_request.agent_name,
         )
+        if scope_request.agent_name is not None
+        else None
+    )
+    execution_identity = (
+        authorized_identity
         if status_authoritative and scope_request.agent_name is not None and execution_scope is not None
         else None
     )

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -163,6 +163,9 @@ def is_sender_allowed_for_agent_credential_management(
     try:
         return is_sender_allowed_for_agent_reply(sender_id, agent_name, config, runtime_paths)
     except MissingManagedEntityAccountError:
+        # Dashboard/API credential requests can run before Matrix managed accounts exist.
+        # In that state the internal-sender bypass is unavailable, but the user allowlist
+        # remains the credential-management policy.
         return _is_sender_allowed_by_agent_reply_allowlist(sender_id, agent_name, config)
 
 

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -163,10 +163,9 @@ def is_sender_allowed_for_agent_credential_management(
     try:
         return is_sender_allowed_for_agent_reply(sender_id, agent_name, config, runtime_paths)
     except MissingManagedEntityAccountError:
-        # Dashboard/API credential requests can run before Matrix managed accounts exist.
-        # In that state the internal-sender bypass is unavailable, but the user allowlist
-        # remains the credential-management policy.
-        return _is_sender_allowed_by_agent_reply_allowlist(sender_id, agent_name, config)
+        # The configured user allowlist was already checked. Missing managed accounts
+        # only mean the internal-sender bypass cannot be evaluated for dashboard/API requests.
+        return False
 
 
 def get_effective_sender_id_for_reply_permissions(

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -10,6 +10,7 @@ import nio
 
 from mindroom.constants import ORIGINAL_SENDER_KEY
 from mindroom.entity_resolution import (
+    MissingManagedEntityAccountError,
     configured_routable_entity_ids_for_room,
     current_internal_sender_ids,
     entity_identity_registry,
@@ -129,6 +130,16 @@ def is_sender_allowed_for_agent_reply(
     Internal MindRoom identities (agents/teams/router and internal user) bypass
     this allowlist because they are system participants, not end users.
     """
+    if _is_sender_allowed_by_agent_reply_allowlist(sender_id, agent_name, config):
+        return True
+
+    # Internal MindRoom participants are not restricted by per-user reply lists.
+    # Bridge bot accounts are intentionally not exempt.
+    return sender_id in current_internal_sender_ids(config, runtime_paths)
+
+
+def _is_sender_allowed_by_agent_reply_allowlist(sender_id: str, agent_name: str, config: Config) -> bool:
+    """Check only the configured per-agent reply allowlist for one sender."""
     agent_reply_permissions = config.authorization.agent_reply_permissions
     allowed_users = agent_reply_permissions.get(agent_name)
     if allowed_users is None:
@@ -138,13 +149,21 @@ def is_sender_allowed_for_agent_reply(
     if "*" in allowed_users:
         return True
 
-    # Internal MindRoom participants are not restricted by per-user reply lists.
-    # Bridge bot accounts are intentionally not exempt.
-    if sender_id in current_internal_sender_ids(config, runtime_paths):
-        return True
-
     resolved_sender = config.authorization.resolve_alias(sender_id)
     return any(fnmatchcase(resolved_sender, allowed_user) for allowed_user in allowed_users)
+
+
+def is_sender_allowed_for_agent_credential_management(
+    sender_id: str,
+    agent_name: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> bool:
+    """Check whether a dashboard requester may manage credentials for one agent."""
+    try:
+        return is_sender_allowed_for_agent_reply(sender_id, agent_name, config, runtime_paths)
+    except MissingManagedEntityAccountError:
+        return _is_sender_allowed_by_agent_reply_allowlist(sender_id, agent_name, config)
 
 
 def get_effective_sender_id_for_reply_permissions(

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -10,7 +10,6 @@ import nio
 
 from mindroom.constants import ORIGINAL_SENDER_KEY
 from mindroom.entity_resolution import (
-    MissingManagedEntityAccountError,
     configured_routable_entity_ids_for_room,
     current_internal_sender_ids,
     entity_identity_registry,
@@ -157,15 +156,9 @@ def is_sender_allowed_for_agent_credential_management(
     sender_id: str,
     agent_name: str,
     config: Config,
-    runtime_paths: RuntimePaths,
 ) -> bool:
     """Check whether a dashboard requester may manage credentials for one agent."""
-    try:
-        return is_sender_allowed_for_agent_reply(sender_id, agent_name, config, runtime_paths)
-    except MissingManagedEntityAccountError:
-        # The configured user allowlist was already checked. Missing managed accounts
-        # only mean the internal-sender bypass cannot be evaluated for dashboard/API requests.
-        return False
+    return _is_sender_allowed_by_agent_reply_allowlist(sender_id, agent_name, config)
 
 
 def get_effective_sender_id_for_reply_permissions(

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -12,6 +12,20 @@ from fastapi.testclient import TestClient
 from mindroom.api import config_lifecycle
 
 
+def trusted_upstream_headers(
+    *,
+    user_id: str = "alice",
+    email: str = "alice@example.com",
+    matrix_user_id: str = "@alice:example.org",
+) -> dict[str, str]:
+    """Return trusted-upstream auth headers for API tests."""
+    return {
+        "X-Trusted-User": user_id,
+        "X-Trusted-Email": email,
+        "X-Trusted-Matrix-User": matrix_user_id,
+    }
+
+
 @pytest.fixture
 def temp_config_file(tmp_path: Path) -> Generator[Path, None, None]:
     """Create a temporary config file for testing."""

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -3,13 +3,16 @@
 # Import the app after we can mock the config path
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import yaml
 from fastapi.testclient import TestClient
 
 from mindroom.api import config_lifecycle
+
+if TYPE_CHECKING:
+    from mindroom.constants import RuntimePaths
 
 
 def trusted_upstream_headers(
@@ -24,6 +27,26 @@ def trusted_upstream_headers(
         "X-Trusted-Email": email,
         "X-Trusted-Matrix-User": matrix_user_id,
     }
+
+
+def use_trusted_upstream_runtime(api_app: object) -> "RuntimePaths":
+    """Reinitialize one API app with trusted-upstream auth enabled."""
+    from mindroom import constants  # noqa: PLC0415
+    from mindroom.api import main  # noqa: PLC0415
+
+    runtime_paths = main._app_runtime_paths(api_app)
+    trusted_runtime_paths = constants.resolve_primary_runtime_paths(
+        config_path=runtime_paths.config_path,
+        storage_path=runtime_paths.storage_root,
+        process_env={
+            "MINDROOM_TRUSTED_UPSTREAM_AUTH_ENABLED": "true",
+            "MINDROOM_TRUSTED_UPSTREAM_USER_ID_HEADER": "X-Trusted-User",
+            "MINDROOM_TRUSTED_UPSTREAM_EMAIL_HEADER": "X-Trusted-Email",
+            "MINDROOM_TRUSTED_UPSTREAM_MATRIX_USER_ID_HEADER": "X-Trusted-Matrix-User",
+        },
+    )
+    main.initialize_api_app(api_app, trusted_runtime_paths)
+    return trusted_runtime_paths
 
 
 @pytest.fixture

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -34,6 +34,7 @@ from mindroom.matrix.state import MatrixState
 from mindroom.runtime_state import reset_runtime_state, set_runtime_ready, set_runtime_starting
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_key
 from mindroom.workers.models import WorkerHandle
+from tests.api.conftest import trusted_upstream_headers
 
 TEST_WORKER_AUTH = "token"
 
@@ -81,28 +82,46 @@ def _runtime_paths(tmp_path: Path, *, process_env: dict[str, str] | None = None)
 def _config_with_worker_scope(
     worker_scope: str | None,
     *,
+    authorization: dict[str, Any] | None = None,
     worker_grantable_credentials: list[str] | None = None,
 ) -> Config:
-    config = Config.model_validate(
-        {
-            "models": {"default": {"provider": "openai", "id": "gpt-4o-mini"}},
-            "agents": {
-                "general": {
-                    "display_name": "General",
-                    "role": "test",
-                    "tools": ["homeassistant"],
-                    "instructions": ["hi"],
-                    "rooms": ["lobby"],
-                },
-            },
-            "defaults": {
-                "markdown": True,
-                "worker_grantable_credentials": worker_grantable_credentials,
+    payload: dict[str, Any] = {
+        "models": {"default": {"provider": "openai", "id": "gpt-4o-mini"}},
+        "agents": {
+            "general": {
+                "display_name": "General",
+                "role": "test",
+                "tools": ["homeassistant"],
+                "instructions": ["hi"],
+                "rooms": ["lobby"],
             },
         },
-    )
+        "defaults": {
+            "markdown": True,
+            "worker_grantable_credentials": worker_grantable_credentials,
+        },
+    }
+    if authorization is not None:
+        payload["authorization"] = authorization
+    config = Config.model_validate(payload)
     config.agents["general"].worker_scope = worker_scope
     return config
+
+
+def _use_trusted_upstream_runtime(api_app: FastAPI) -> constants.RuntimePaths:
+    runtime_paths = main._app_runtime_paths(api_app)
+    trusted_runtime_paths = constants.resolve_primary_runtime_paths(
+        config_path=runtime_paths.config_path,
+        storage_path=runtime_paths.storage_root,
+        process_env={
+            "MINDROOM_TRUSTED_UPSTREAM_AUTH_ENABLED": "true",
+            "MINDROOM_TRUSTED_UPSTREAM_USER_ID_HEADER": "X-Trusted-User",
+            "MINDROOM_TRUSTED_UPSTREAM_EMAIL_HEADER": "X-Trusted-Email",
+            "MINDROOM_TRUSTED_UPSTREAM_MATRIX_USER_ID_HEADER": "X-Trusted-Matrix-User",
+        },
+    )
+    main.initialize_api_app(api_app, trusted_runtime_paths)
+    return trusted_runtime_paths
 
 
 def _authored_config_payload(agent_name: str) -> dict[str, Any]:
@@ -1577,6 +1596,42 @@ def test_get_tools_unknown_agent_rejected(test_client: TestClient) -> None:
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Unknown agent: missing"
+
+
+def test_get_tools_requires_agent_reply_permission_for_agent_scoped_status(test_client: TestClient) -> None:
+    """Agent-scoped tool availability should not expose credential-backed state to unauthorized users."""
+    runtime_paths = _use_trusted_upstream_runtime(main.app)
+    config = _config_with_worker_scope(
+        "shared",
+        authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
+    )
+    tools = [
+        {
+            "name": "homeassistant",
+            "display_name": "Home Assistant",
+            "description": "Home automation",
+            "category": "home",
+            "status": "requires_config",
+            "setup_type": "special",
+            "auth_provider": None,
+            "config_fields": [],
+        },
+    ]
+    bob_headers = trusted_upstream_headers(
+        user_id="bob",
+        email="bob@example.org",
+        matrix_user_id="@bob:example.org",
+    )
+
+    with (
+        patch("mindroom.api.tools._read_tools_runtime_config", return_value=(config, runtime_paths)),
+        patch("mindroom.api.tools.export_tools_metadata", return_value=tools),
+        patch("mindroom.api.tools.load_scoped_credentials") as mock_load_scoped_credentials,
+    ):
+        response = test_client.get("/api/tools/?agent_name=general", headers=bob_headers)
+
+    assert response.status_code == 403
+    mock_load_scoped_credentials.assert_not_called()
 
 
 def test_get_tools_marks_allowlisted_shared_ui_scoped_tools_available(test_client: TestClient) -> None:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -34,7 +34,7 @@ from mindroom.matrix.state import MatrixState
 from mindroom.runtime_state import reset_runtime_state, set_runtime_ready, set_runtime_starting
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_key
 from mindroom.workers.models import WorkerHandle
-from tests.api.conftest import trusted_upstream_headers
+from tests.api.conftest import trusted_upstream_headers, use_trusted_upstream_runtime
 
 TEST_WORKER_AUTH = "token"
 
@@ -106,22 +106,6 @@ def _config_with_worker_scope(
     config = Config.model_validate(payload)
     config.agents["general"].worker_scope = worker_scope
     return config
-
-
-def _use_trusted_upstream_runtime(api_app: FastAPI) -> constants.RuntimePaths:
-    runtime_paths = main._app_runtime_paths(api_app)
-    trusted_runtime_paths = constants.resolve_primary_runtime_paths(
-        config_path=runtime_paths.config_path,
-        storage_path=runtime_paths.storage_root,
-        process_env={
-            "MINDROOM_TRUSTED_UPSTREAM_AUTH_ENABLED": "true",
-            "MINDROOM_TRUSTED_UPSTREAM_USER_ID_HEADER": "X-Trusted-User",
-            "MINDROOM_TRUSTED_UPSTREAM_EMAIL_HEADER": "X-Trusted-Email",
-            "MINDROOM_TRUSTED_UPSTREAM_MATRIX_USER_ID_HEADER": "X-Trusted-Matrix-User",
-        },
-    )
-    main.initialize_api_app(api_app, trusted_runtime_paths)
-    return trusted_runtime_paths
 
 
 def _authored_config_payload(agent_name: str) -> dict[str, Any]:
@@ -1600,7 +1584,7 @@ def test_get_tools_unknown_agent_rejected(test_client: TestClient) -> None:
 
 def test_get_tools_requires_agent_reply_permission_for_agent_scoped_status(test_client: TestClient) -> None:
     """Agent-scoped tool availability should not expose credential-backed state to unauthorized users."""
-    runtime_paths = _use_trusted_upstream_runtime(main.app)
+    runtime_paths = use_trusted_upstream_runtime(main.app)
     config = _config_with_worker_scope(
         "shared",
         authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -16,6 +16,7 @@ from mindroom.config.main import Config
 from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.oauth.providers import OAuthProvider
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_key, resolve_worker_target
+from tests.api.conftest import trusted_upstream_headers
 
 
 def _config_with_worker_scope(
@@ -80,19 +81,6 @@ def _use_trusted_upstream_runtime(api_app: object) -> constants.RuntimePaths:
     )
     initialize_api_app(api_app, trusted_runtime_paths)
     return trusted_runtime_paths
-
-
-def _trusted_upstream_headers(
-    *,
-    user_id: str,
-    email: str,
-    matrix_user_id: str,
-) -> dict[str, str]:
-    return {
-        "X-Trusted-User": user_id,
-        "X-Trusted-Email": email,
-        "X-Trusted-Matrix-User": matrix_user_id,
-    }
 
 
 @pytest.fixture
@@ -1427,7 +1415,7 @@ class TestCredentialsAPI:
             authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
         )
         _publish_committed_runtime_config(client.app, config)
-        bob_headers = _trusted_upstream_headers(
+        bob_headers = trusted_upstream_headers(
             user_id="bob",
             email="bob@example.org",
             matrix_user_id="@bob:example.org",

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -21,26 +21,28 @@ from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_w
 def _config_with_worker_scope(
     worker_scope: str | None,
     *,
+    authorization: dict[str, object] | None = None,
     worker_grantable_credentials: list[str] | None = None,
 ) -> Config:
-    config = Config.model_validate(
-        {
-            "models": {"default": {"provider": "openai", "id": "gpt-4o-mini"}},
-            "agents": {
-                "general": {
-                    "display_name": "General",
-                    "role": "test",
-                    "tools": ["calculator"],
-                    "instructions": ["hi"],
-                    "rooms": ["lobby"],
-                },
-            },
-            "defaults": {
-                "markdown": True,
-                "worker_grantable_credentials": worker_grantable_credentials,
+    payload: dict[str, object] = {
+        "models": {"default": {"provider": "openai", "id": "gpt-4o-mini"}},
+        "agents": {
+            "general": {
+                "display_name": "General",
+                "role": "test",
+                "tools": ["calculator"],
+                "instructions": ["hi"],
+                "rooms": ["lobby"],
             },
         },
-    )
+        "defaults": {
+            "markdown": True,
+            "worker_grantable_credentials": worker_grantable_credentials,
+        },
+    }
+    if authorization is not None:
+        payload["authorization"] = authorization
+    config = Config.model_validate(payload)
     config.agents["general"].worker_scope = worker_scope
     return config
 
@@ -62,6 +64,35 @@ def _use_owner_runtime(api_app: object, matrix_user_id: str = "@alice:example.or
     )
     initialize_api_app(api_app, owner_runtime_paths)
     return owner_runtime_paths
+
+
+def _use_trusted_upstream_runtime(api_app: object) -> constants.RuntimePaths:
+    runtime_paths = main._app_runtime_paths(api_app)
+    trusted_runtime_paths = constants.resolve_primary_runtime_paths(
+        config_path=runtime_paths.config_path,
+        storage_path=runtime_paths.storage_root,
+        process_env={
+            "MINDROOM_TRUSTED_UPSTREAM_AUTH_ENABLED": "true",
+            "MINDROOM_TRUSTED_UPSTREAM_USER_ID_HEADER": "X-Trusted-User",
+            "MINDROOM_TRUSTED_UPSTREAM_EMAIL_HEADER": "X-Trusted-Email",
+            "MINDROOM_TRUSTED_UPSTREAM_MATRIX_USER_ID_HEADER": "X-Trusted-Matrix-User",
+        },
+    )
+    initialize_api_app(api_app, trusted_runtime_paths)
+    return trusted_runtime_paths
+
+
+def _trusted_upstream_headers(
+    *,
+    user_id: str,
+    email: str,
+    matrix_user_id: str,
+) -> dict[str, str]:
+    return {
+        "X-Trusted-User": user_id,
+        "X-Trusted-Email": email,
+        "X-Trusted-Matrix-User": matrix_user_id,
+    }
 
 
 @pytest.fixture
@@ -1387,6 +1418,33 @@ class TestCredentialsAPI:
 
         assert response.status_code == 404
         assert response.json()["detail"] == "Unknown agent: missing"
+
+    def test_agent_credentials_require_agent_reply_permission(self, client: TestClient) -> None:
+        """Agent-scoped credential routes should reject requesters outside the agent allowlist."""
+        _use_trusted_upstream_runtime(client.app)
+        config = _config_with_worker_scope(
+            "shared",
+            authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
+        )
+        _publish_committed_runtime_config(client.app, config)
+        bob_headers = _trusted_upstream_headers(
+            user_id="bob",
+            email="bob@example.org",
+            matrix_user_id="@bob:example.org",
+        )
+
+        agent_response = client.get(
+            "/api/credentials/openai/api-key?agent_name=general",
+            headers=bob_headers,
+        )
+        global_response = client.get(
+            "/api/credentials/openai/api-key",
+            headers=bob_headers,
+        )
+
+        assert agent_response.status_code == 403
+        assert global_response.status_code == 200
+        assert global_response.json()["has_key"] is False
 
     def test_shared_agent_name_hides_non_allowlisted_shared_credentials(
         self,

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import Request
@@ -1433,6 +1433,36 @@ class TestCredentialsAPI:
         assert agent_response.status_code == 403
         assert global_response.status_code == 200
         assert global_response.json()["has_key"] is False
+
+    def test_homeassistant_token_connect_authorizes_before_probe(self, client: TestClient) -> None:
+        """Unauthorized agent-scoped Home Assistant connects should not contact the provider."""
+        _use_trusted_upstream_runtime(client.app)
+        config = _config_with_worker_scope(
+            "shared",
+            authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
+        )
+        _publish_committed_runtime_config(client.app, config)
+        bob_headers = trusted_upstream_headers(
+            user_id="bob",
+            email="bob@example.org",
+            matrix_user_id="@bob:example.org",
+        )
+
+        with patch(
+            "mindroom.api.homeassistant_integration._test_connection",
+            new_callable=AsyncMock,
+        ) as test_connection:
+            response = client.post(
+                "/api/homeassistant/connect/token?agent_name=general",
+                headers=bob_headers,
+                json={
+                    "instance_url": "homeassistant.local:8123",
+                    "long_lived_token": "ha-token",
+                },
+            )
+
+        assert response.status_code == 403
+        test_connection.assert_not_awaited()
 
     def test_shared_agent_name_hides_non_allowlisted_shared_credentials(
         self,

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -16,7 +16,7 @@ from mindroom.config.main import Config
 from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.oauth.providers import OAuthProvider
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_key, resolve_worker_target
-from tests.api.conftest import trusted_upstream_headers
+from tests.api.conftest import trusted_upstream_headers, use_trusted_upstream_runtime
 
 
 def _config_with_worker_scope(
@@ -65,22 +65,6 @@ def _use_owner_runtime(api_app: object, matrix_user_id: str = "@alice:example.or
     )
     initialize_api_app(api_app, owner_runtime_paths)
     return owner_runtime_paths
-
-
-def _use_trusted_upstream_runtime(api_app: object) -> constants.RuntimePaths:
-    runtime_paths = main._app_runtime_paths(api_app)
-    trusted_runtime_paths = constants.resolve_primary_runtime_paths(
-        config_path=runtime_paths.config_path,
-        storage_path=runtime_paths.storage_root,
-        process_env={
-            "MINDROOM_TRUSTED_UPSTREAM_AUTH_ENABLED": "true",
-            "MINDROOM_TRUSTED_UPSTREAM_USER_ID_HEADER": "X-Trusted-User",
-            "MINDROOM_TRUSTED_UPSTREAM_EMAIL_HEADER": "X-Trusted-Email",
-            "MINDROOM_TRUSTED_UPSTREAM_MATRIX_USER_ID_HEADER": "X-Trusted-Matrix-User",
-        },
-    )
-    initialize_api_app(api_app, trusted_runtime_paths)
-    return trusted_runtime_paths
 
 
 @pytest.fixture
@@ -1409,7 +1393,7 @@ class TestCredentialsAPI:
 
     def test_agent_credentials_require_agent_reply_permission(self, client: TestClient) -> None:
         """Agent-scoped credential routes should reject requesters outside the agent allowlist."""
-        _use_trusted_upstream_runtime(client.app)
+        use_trusted_upstream_runtime(client.app)
         config = _config_with_worker_scope(
             "shared",
             authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
@@ -1436,7 +1420,7 @@ class TestCredentialsAPI:
 
     def test_agent_oauth_token_credentials_authorize_before_generic_rejection(self, client: TestClient) -> None:
         """Unauthorized agent-scoped OAuth token routes should return 403 before route-specific 400s."""
-        _use_trusted_upstream_runtime(client.app)
+        use_trusted_upstream_runtime(client.app)
         config = _config_with_worker_scope(
             "shared",
             authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
@@ -1462,7 +1446,7 @@ class TestCredentialsAPI:
 
     def test_homeassistant_token_connect_authorizes_before_probe(self, client: TestClient) -> None:
         """Unauthorized agent-scoped Home Assistant connects should not contact the provider."""
-        _use_trusted_upstream_runtime(client.app)
+        use_trusted_upstream_runtime(client.app)
         config = _config_with_worker_scope(
             "shared",
             authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -1434,6 +1434,32 @@ class TestCredentialsAPI:
         assert global_response.status_code == 200
         assert global_response.json()["has_key"] is False
 
+    def test_agent_oauth_token_credentials_authorize_before_generic_rejection(self, client: TestClient) -> None:
+        """Unauthorized agent-scoped OAuth token routes should return 403 before route-specific 400s."""
+        _use_trusted_upstream_runtime(client.app)
+        config = _config_with_worker_scope(
+            "shared",
+            authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
+        )
+        _publish_committed_runtime_config(client.app, config)
+        bob_headers = trusted_upstream_headers(
+            user_id="bob",
+            email="bob@example.org",
+            matrix_user_id="@bob:example.org",
+        )
+
+        token_response = client.get(
+            "/api/credentials/google_drive_oauth?agent_name=general",
+            headers=bob_headers,
+        )
+        copy_response = client.post(
+            "/api/credentials/copied_service/copy-from/google_drive_oauth?agent_name=general",
+            headers=bob_headers,
+        )
+
+        assert token_response.status_code == 403
+        assert copy_response.status_code == 403
+
     def test_homeassistant_token_connect_authorizes_before_probe(self, client: TestClient) -> None:
         """Unauthorized agent-scoped Home Assistant connects should not contact the provider."""
         _use_trusted_upstream_runtime(client.app)

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -2144,6 +2144,47 @@ def test_agent_oauth_management_rejects_requester_not_allowed_for_agent(tmp_path
     assert manager.shared_manager().load_credentials(provider.credential_service) is not None
 
 
+def test_agent_oauth_callback_rechecks_agent_reply_permission(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
+    api_app = _make_test_app(
+        runtime_paths,
+        _config_payload(
+            worker_scope="shared",
+            authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
+        ),
+    )
+    _use_runtime_auth_settings(api_app)
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    manager = get_runtime_credentials_manager(runtime_paths)
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            authorize_response = client.get(
+                f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=shared",
+                headers=trusted_upstream_headers(),
+                follow_redirects=False,
+            )
+            state = _state_from_auth_url(authorize_response.headers["location"])
+            _publish_config(
+                api_app,
+                runtime_paths,
+                _config_payload(
+                    worker_scope="shared",
+                    authorization={"agent_reply_permissions": {"general": ["@bob:example.org"]}},
+                ),
+            )
+            _use_runtime_auth_settings(api_app)
+            callback_response = client.get(
+                f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                headers=trusted_upstream_headers(),
+                follow_redirects=False,
+            )
+
+    assert authorize_response.status_code == 307
+    assert callback_response.status_code == 403
+    assert manager.shared_manager().load_credentials(provider.credential_service) is None
+
+
 def test_global_oauth_status_keeps_existing_access_without_agent_name(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
     api_app = _make_test_app(

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -62,8 +62,12 @@ def _runtime_paths(tmp_path: Path, process_env: dict[str, str] | None = None) ->
     return runtime_paths
 
 
-def _config_payload(worker_scope: str = "user_agent") -> dict[str, Any]:
-    return {
+def _config_payload(
+    worker_scope: str = "user_agent",
+    *,
+    authorization: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload = {
         "models": {"default": {"provider": "openai", "id": "gpt-5.4"}},
         "router": {"model": "default"},
         "agents": {
@@ -76,6 +80,9 @@ def _config_payload(worker_scope: str = "user_agent") -> dict[str, Any]:
             },
         },
     }
+    if authorization is not None:
+        payload["authorization"] = authorization
+    return payload
 
 
 def _make_test_app(runtime_paths: constants.RuntimePaths, payload: dict[str, Any]) -> FastAPI:
@@ -2050,6 +2057,167 @@ def _trusted_upstream_headers(
         "X-Trusted-Email": email,
         "X-Trusted-Matrix-User": matrix_user_id,
     }
+
+
+def test_agent_oauth_management_allows_authorized_requester(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
+    api_app = _make_test_app(
+        runtime_paths,
+        _config_payload(
+            worker_scope="shared",
+            authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
+        ),
+    )
+    _use_runtime_auth_settings(api_app)
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.shared_manager().save_credentials(
+        provider.credential_service,
+        {
+            "token": "stored-token",
+            "refresh_token": "stored-refresh-token",
+            "client_id": "client-id",
+            "scopes": list(provider.scopes),
+            "_source": "oauth",
+            "_oauth_claims": {"email": "alice@example.com", "hd": "example.com"},
+            "_oauth_claims_verified": True,
+        },
+    )
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            status_response = client.get(
+                f"/api/oauth/{provider.id}/status?agent_name=general",
+                headers=_trusted_upstream_headers(),
+            )
+            disconnect_response = client.post(
+                f"/api/oauth/{provider.id}/disconnect?agent_name=general",
+                headers=_trusted_upstream_headers(),
+            )
+
+    assert status_response.status_code == 200
+    assert status_response.json()["connected"] is True
+    assert disconnect_response.status_code == 200
+    assert manager.shared_manager().load_credentials(provider.credential_service) is None
+
+
+def test_agent_oauth_management_rejects_requester_not_allowed_for_agent(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
+    api_app = _make_test_app(
+        runtime_paths,
+        _config_payload(
+            worker_scope="shared",
+            authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
+        ),
+    )
+    _use_runtime_auth_settings(api_app)
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.shared_manager().save_credentials(
+        provider.credential_service,
+        {
+            "token": "stored-token",
+            "refresh_token": "stored-refresh-token",
+            "client_id": "client-id",
+            "scopes": list(provider.scopes),
+            "_source": "oauth",
+        },
+    )
+    bob_headers = _trusted_upstream_headers(
+        user_id="bob",
+        email="bob@example.com",
+        matrix_user_id="@bob:example.org",
+    )
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            connect_response = client.post(
+                f"/api/oauth/{provider.id}/connect?agent_name=general",
+                headers=bob_headers,
+            )
+            authorize_response = client.get(
+                f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=shared",
+                headers=bob_headers,
+                follow_redirects=False,
+            )
+            status_response = client.get(
+                f"/api/oauth/{provider.id}/status?agent_name=general",
+                headers=bob_headers,
+            )
+            disconnect_response = client.post(
+                f"/api/oauth/{provider.id}/disconnect?agent_name=general",
+                headers=bob_headers,
+            )
+
+    assert connect_response.status_code == 403
+    assert authorize_response.status_code == 403
+    assert status_response.status_code == 403
+    assert disconnect_response.status_code == 403
+    assert manager.shared_manager().load_credentials(provider.credential_service) is not None
+
+
+def test_global_oauth_status_keeps_existing_access_without_agent_name(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
+    api_app = _make_test_app(
+        runtime_paths,
+        _config_payload(
+            worker_scope="shared",
+            authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
+        ),
+    )
+    _use_runtime_auth_settings(api_app)
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    bob_headers = _trusted_upstream_headers(
+        user_id="bob",
+        email="bob@example.com",
+        matrix_user_id="@bob:example.org",
+    )
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            status_response = client.get(
+                f"/api/oauth/{provider.id}/status",
+                headers=bob_headers,
+            )
+
+    assert status_response.status_code == 200
+    assert status_response.json()["connected"] is False
+
+
+def test_connect_token_cannot_bypass_agent_reply_permission(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
+    api_app = _make_test_app(
+        runtime_paths,
+        _config_payload(
+            worker_scope="user_agent",
+            authorization={"agent_reply_permissions": {"general": ["@bob:example.org"]}},
+        ),
+    )
+    _use_runtime_auth_settings(api_app)
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    worker_target = resolve_worker_target("user_agent", "general", execution_identity=identity)
+    connect_token = oauth_service._issue_oauth_connect_token(provider, runtime_paths, worker_target)
+    assert connect_token is not None
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            authorize_response = client.get(
+                f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
+                f"&connect_token={connect_token}",
+                headers=_trusted_upstream_headers(),
+                follow_redirects=False,
+            )
+
+    assert authorize_response.status_code == 403
 
 
 def test_agent_connect_token_uses_trusted_upstream_matrix_requester(tmp_path: Path) -> None:

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -39,6 +39,7 @@ from mindroom.tool_system.worker_routing import (
     resolve_worker_key,
     resolve_worker_target,
 )
+from tests.api.conftest import trusted_upstream_headers
 
 
 def _runtime_paths(tmp_path: Path, process_env: dict[str, str] | None = None) -> constants.RuntimePaths:
@@ -2046,19 +2047,6 @@ def _trusted_upstream_oauth_email_template_env() -> dict[str, str]:
     return env
 
 
-def _trusted_upstream_headers(
-    *,
-    user_id: str = "alice",
-    email: str = "alice@example.com",
-    matrix_user_id: str = "@alice:example.org",
-) -> dict[str, str]:
-    return {
-        "X-Trusted-User": user_id,
-        "X-Trusted-Email": email,
-        "X-Trusted-Matrix-User": matrix_user_id,
-    }
-
-
 def test_agent_oauth_management_allows_authorized_requester(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
     api_app = _make_test_app(
@@ -2088,11 +2076,11 @@ def test_agent_oauth_management_allows_authorized_requester(tmp_path: Path) -> N
         with TestClient(api_app) as client:
             status_response = client.get(
                 f"/api/oauth/{provider.id}/status?agent_name=general",
-                headers=_trusted_upstream_headers(),
+                headers=trusted_upstream_headers(),
             )
             disconnect_response = client.post(
                 f"/api/oauth/{provider.id}/disconnect?agent_name=general",
-                headers=_trusted_upstream_headers(),
+                headers=trusted_upstream_headers(),
             )
 
     assert status_response.status_code == 200
@@ -2123,7 +2111,7 @@ def test_agent_oauth_management_rejects_requester_not_allowed_for_agent(tmp_path
             "_source": "oauth",
         },
     )
-    bob_headers = _trusted_upstream_headers(
+    bob_headers = trusted_upstream_headers(
         user_id="bob",
         email="bob@example.com",
         matrix_user_id="@bob:example.org",
@@ -2167,7 +2155,7 @@ def test_global_oauth_status_keeps_existing_access_without_agent_name(tmp_path: 
     )
     _use_runtime_auth_settings(api_app)
     provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
-    bob_headers = _trusted_upstream_headers(
+    bob_headers = trusted_upstream_headers(
         user_id="bob",
         email="bob@example.com",
         matrix_user_id="@bob:example.org",
@@ -2213,7 +2201,7 @@ def test_connect_token_cannot_bypass_agent_reply_permission(tmp_path: Path) -> N
             authorize_response = client.get(
                 f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
                 f"&connect_token={connect_token}",
-                headers=_trusted_upstream_headers(),
+                headers=trusted_upstream_headers(),
                 follow_redirects=False,
             )
 
@@ -2243,13 +2231,13 @@ def test_agent_connect_token_uses_trusted_upstream_matrix_requester(tmp_path: Pa
             authorize_response = client.get(
                 f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
                 f"&connect_token={connect_token}",
-                headers=_trusted_upstream_headers(),
+                headers=trusted_upstream_headers(),
                 follow_redirects=False,
             )
             state = _state_from_auth_url(authorize_response.headers["location"])
             callback_response = client.get(
                 f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
-                headers=_trusted_upstream_headers(),
+                headers=trusted_upstream_headers(),
                 follow_redirects=False,
             )
 
@@ -2341,13 +2329,13 @@ def test_agent_connect_token_accepts_historical_trusted_upstream_matrix_requeste
             authorize_response = client.get(
                 f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
                 f"&connect_token={connect_token}",
-                headers=_trusted_upstream_headers(matrix_user_id=matrix_user_id),
+                headers=trusted_upstream_headers(matrix_user_id=matrix_user_id),
                 follow_redirects=False,
             )
             state = _state_from_auth_url(authorize_response.headers["location"])
             callback_response = client.get(
                 f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
-                headers=_trusted_upstream_headers(matrix_user_id=matrix_user_id),
+                headers=trusted_upstream_headers(matrix_user_id=matrix_user_id),
                 follow_redirects=False,
             )
 
@@ -2384,7 +2372,7 @@ def test_agent_connect_token_rejects_trusted_upstream_requester_mismatch(tmp_pat
             authorize_response = client.get(
                 f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
                 f"&connect_token={connect_token}",
-                headers=_trusted_upstream_headers(
+                headers=trusted_upstream_headers(
                     user_id="bob",
                     email="bob@example.com",
                     matrix_user_id="@bob:example.org",
@@ -2490,7 +2478,7 @@ def test_agent_connect_token_rejects_trusted_upstream_identity_without_matrix_ma
             authorize_response = client.get(
                 f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
                 f"&connect_token={connect_token}",
-                headers=_trusted_upstream_headers(matrix_user_id=""),
+                headers=trusted_upstream_headers(matrix_user_id=""),
                 follow_redirects=False,
             )
 
@@ -2521,7 +2509,7 @@ def test_agent_connect_token_callback_rejects_missing_trusted_upstream_identity(
             authorize_response = client.get(
                 f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
                 f"&connect_token={connect_token}",
-                headers=_trusted_upstream_headers(),
+                headers=trusted_upstream_headers(),
                 follow_redirects=False,
             )
             state = _state_from_auth_url(authorize_response.headers["location"])
@@ -2558,13 +2546,13 @@ def test_agent_connect_token_callback_rejects_changed_trusted_matrix_requester(t
             authorize_response = client.get(
                 f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
                 f"&connect_token={connect_token}",
-                headers=_trusted_upstream_headers(),
+                headers=trusted_upstream_headers(),
                 follow_redirects=False,
             )
             state = _state_from_auth_url(authorize_response.headers["location"])
             callback_response = client.get(
                 f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
-                headers=_trusted_upstream_headers(matrix_user_id="@bob:example.org"),
+                headers=trusted_upstream_headers(matrix_user_id="@bob:example.org"),
                 follow_redirects=False,
             )
 

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -93,6 +93,15 @@ def is_sender_allowed_for_agent_reply(sender_id: str, agent_name: str, config: C
     )
 
 
+def is_sender_allowed_for_agent_credential_management(sender_id: str, agent_name: str, config: Config) -> bool:
+    """Run credential-management permission checks with the test config's bound runtime context."""
+    return mindroom.authorization.is_sender_allowed_for_agent_credential_management(
+        sender_id,
+        agent_name,
+        config,
+    )
+
+
 def get_effective_sender_id_for_reply_permissions(
     sender_id: str,
     event_source: dict[str, object] | None,
@@ -1299,6 +1308,39 @@ def test_reply_permissions_bypass_trusts_persisted_current_internal_accounts(tmp
     state.save(runtime_paths=runtime_paths)
 
     assert is_sender_allowed_for_agent_reply("@mindroom_assistant_oldns:example.com", "assistant", config) is True
+
+
+def test_credential_management_does_not_bypass_agent_allowlist_for_internal_accounts(tmp_path: Path) -> None:
+    """Dashboard credential management is user-initiated and should not inherit reply-time internal trust."""
+    config = _isolated_config(
+        tmp_path,
+        agents={
+            "assistant": {
+                "display_name": "Assistant",
+                "role": "Test assistant",
+                "rooms": ["test_room"],
+            },
+        },
+        authorization={
+            "default_room_access": False,
+            "agent_reply_permissions": {"assistant": ["@alice:example.com"]},
+        },
+    )
+    runtime_paths = _runtime_paths_for(config)
+    state = MatrixState.load(runtime_paths=runtime_paths)
+    state.add_account("agent_assistant", "mindroom_assistant_oldns", "pw", domain="example.com")
+    state.save(runtime_paths=runtime_paths)
+
+    assert is_sender_allowed_for_agent_reply("@mindroom_assistant_oldns:example.com", "assistant", config) is True
+    assert (
+        is_sender_allowed_for_agent_credential_management(
+            "@mindroom_assistant_oldns:example.com",
+            "assistant",
+            config,
+        )
+        is False
+    )
+    assert is_sender_allowed_for_agent_credential_management("@alice:example.com", "assistant", config) is True
 
 
 def test_sender_authorization_trusts_persisted_current_internal_accounts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add an app-level authorization check for agent-scoped credential management target resolution.
- Reuse dashboard requester identity and existing agent reply permissions before allowing agent-scoped OAuth or credential operations.
- Cover OAuth connect/status/disconnect and generic credential routes through the shared resolver while preserving global credential behavior and connect-token target binding.

## Test Plan
- uv run pre-commit run --files src/mindroom/api/credentials.py src/mindroom/authorization.py tests/api/test_credentials_api.py tests/api/test_oauth_api.py
- uv run pytest tests/api/test_oauth_api.py tests/api/test_credentials_api.py tests/test_authorization.py tests/api/test_api.py::test_homeassistant_connect_oauth_uses_pending_oauth_state tests/api/test_api.py::test_homeassistant_connect_rejects_draft_execution_scope_override tests/api/test_api.py::test_spotify_connect_uses_pending_oauth_state tests/api/test_api.py::test_spotify_connect_rejects_draft_execution_scope_override tests/api/test_api.py::test_spotify_status_rejects_isolating_worker_scope tests/api/test_api.py::test_spotify_callback_preserves_runtime_validation_error -n 0 --no-cov -q
- uv run pytest -n 0 --no-cov -q

## Summary by Sourcery

Enforce authorization checks for agent-scoped OAuth and credential management based on dashboard requester identity and existing agent reply permissions.

New Features:
- Support configuration of authorization settings for tests via optional authorization blocks in OAuth and credential test helpers.

Enhancements:
- Introduce an agent credential management authorization helper that derives execution identity from the dashboard request and validates access against agent-specific permissions.
- Reuse agent reply permission logic to gate dashboard-driven credential operations, with a dedicated check for agent credential management.
- Allow global (non-agent-scoped) OAuth and credential status checks to continue functioning without new authorization requirements.

Tests:
- Add OAuth API tests covering authorized and unauthorized agent-scoped management, preservation of global OAuth status behavior, and connect-token authorization binding to agent permissions.
- Add credentials API tests ensuring agent-scoped credential routes enforce agent reply permissions while global routes remain accessible.
- Extend test config helpers to inject authorization settings and trusted-upstream identities for dashboard requester scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent-scoped dashboard/API endpoints (credentials & OAuth) now require the agent's reply allowlist; unauthorized agent-scoped requests return HTTP 403 before any credential data is read or modified.

* **Behavior Change / Bug Fix**
  * Credential-management checks no longer bypass per-agent allowlists for internal accounts; agent-specific allowlists are evaluated first.

* **Documentation**
  * Clarified agent-scoped authorization, trusted-upstream identity resolution, and standalone owner-user requirements.

* **Tests**
  * Added and updated tests for agent-level authorization, trusted-upstream scenarios, and a trusted-upstream headers helper.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1018)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->