### PR TITLE
Add Matrix message extras support

### DIFF
--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -151,6 +151,13 @@ class MatrixMessageOperations:
             return self._result("error", action=action, message="thread_id is required for replies.")
 
         text = message.strip() if isinstance(message, str) and message.strip() else None
+        if text is None and message_extras:
+            return self._result(
+                "error",
+                action=action,
+                room_id=room_id,
+                message="message_extras requires a non-empty message body.",
+            )
         if text is None and not attachment_ids and not attachment_file_paths:
             return self._result(
                 "error",
@@ -637,13 +644,14 @@ class MatrixMessageOperations:
         clear_interactive_question(target)
         interactive_response = parse_and_format_interactive(new_text, extract_mapping=True)
         formatted_text = interactive_response.formatted_text
+        extras_content = build_message_extras_content(message_extras) if message_extras else None
         content = format_message_with_mentions(
             context.config,
             context.runtime_paths,
             formatted_text,
             thread_event_id=thread_id,
             latest_thread_event_id=latest_thread_event_id,
-            extra_content=build_message_extras_content(message_extras) if message_extras else None,
+            extra_content=extras_content,
         )
         delivered = await edit_message_result(
             context.client,
@@ -652,6 +660,7 @@ class MatrixMessageOperations:
             content,
             formatted_text,
             config=context.config,
+            extra_content=extras_content,
         )
         if delivered is None:
             return self._result(

--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -29,11 +29,13 @@ from mindroom.matrix.client_visible_messages import (
 )
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_reaction_content
+from mindroom.matrix.message_extras import build_message_extras_content
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
+    from mindroom.matrix.message_extras import MessageExtraSection
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
 
 logger = get_logger(__name__)
@@ -67,6 +69,7 @@ class MatrixMessageOperations:
         text: str,
         thread_id: str | None,
         ignore_mentions: bool,
+        message_extras: list[MessageExtraSection] | None,
     ) -> str | None:
         formatted_text = parse_and_format_interactive(text, extract_mapping=False).formatted_text
         latest_thread_event_id = await context.conversation_cache.get_latest_thread_event_id_if_needed(
@@ -79,6 +82,8 @@ class MatrixMessageOperations:
             extra_content["com.mindroom.skip_mentions"] = True
         elif context.requester_id != context.client.user_id:
             extra_content[ORIGINAL_SENDER_KEY] = context.requester_id
+        if message_extras:
+            extra_content.update(build_message_extras_content(message_extras))
         content = format_message_with_mentions(
             context.config,
             context.runtime_paths,
@@ -140,6 +145,7 @@ class MatrixMessageOperations:
         room_id: str,
         effective_thread_id: str | None,
         ignore_mentions: bool,
+        message_extras: list[MessageExtraSection] | None,
     ) -> MatrixMessageOperationResult:
         if action in {"thread-reply", "reply"} and effective_thread_id is None:
             return self._result("error", action=action, message="thread_id is required for replies.")
@@ -162,6 +168,7 @@ class MatrixMessageOperations:
                 text=text,
                 thread_id=effective_thread_id,
                 ignore_mentions=ignore_mentions,
+                message_extras=message_extras,
             )
         if text is not None and event_id is None:
             return self._result(
@@ -609,6 +616,7 @@ class MatrixMessageOperations:
         thread_id: str | None,
         target: str | None,
         message: str | None,
+        message_extras: list[MessageExtraSection] | None,
     ) -> MatrixMessageOperationResult:
         if target is None:
             return self._result("error", action="edit", message="target event_id is required for edit.")
@@ -635,6 +643,7 @@ class MatrixMessageOperations:
             formatted_text,
             thread_event_id=thread_id,
             latest_thread_event_id=latest_thread_event_id,
+            extra_content=build_message_extras_content(message_extras) if message_extras else None,
         )
         delivered = await edit_message_result(
             context.client,
@@ -696,6 +705,7 @@ class MatrixMessageOperations:
         target: str | None,
         thread_id: str | None,
         ignore_mentions: bool,
+        message_extras: list[MessageExtraSection] | None,
         read_limit: int,
         page_token: str | None,
         room_timeline_sentinel: str,
@@ -719,6 +729,7 @@ class MatrixMessageOperations:
                 room_id=room_id,
                 effective_thread_id=effective_thread_id,
                 ignore_mentions=ignore_mentions,
+                message_extras=message_extras,
             )
         if action == "react":
             return await self._message_react(
@@ -773,6 +784,7 @@ class MatrixMessageOperations:
                 thread_id=safe_thread,
                 target=target,
                 message=message,
+                message_extras=message_extras,
             )
         return self._result(
             "error",

--- a/src/mindroom/custom_tools/matrix_message.py
+++ b/src/mindroom/custom_tools/matrix_message.py
@@ -27,6 +27,7 @@ class MatrixMessageTools(Toolkit):
     _DEFAULT_READ_LIMIT: ClassVar[int] = 20
     _MAX_READ_LIMIT: ClassVar[int] = 50
     _ROOM_TIMELINE_SENTINEL: ClassVar[str] = "room"
+    _MESSAGE_EXTRAS_ACTIONS: ClassVar[frozenset[str]] = frozenset({"send", "thread-reply", "reply", "edit"})
     _VALID_ACTIONS: ClassVar[frozenset[str]] = frozenset(
         {"send", "thread-reply", "reply", "react", "read", "room-threads", "thread-list", "edit", "context"},
     )
@@ -68,9 +69,9 @@ class MatrixMessageTools(Toolkit):
     def _action_supports_attachments(action: str) -> bool:
         return action in {"send", "thread-reply", "reply"}
 
-    @staticmethod
-    def _action_supports_message_extras(action: str) -> bool:
-        return action in {"send", "thread-reply", "reply", "edit"}
+    @classmethod
+    def _action_supports_message_extras(cls, action: str) -> bool:
+        return action in cls._MESSAGE_EXTRAS_ACTIONS
 
     def _validate_matrix_message_request(
         self,
@@ -122,10 +123,11 @@ class MatrixMessageTools(Toolkit):
         if not message_extras:
             return None, None
         if not self._action_supports_message_extras(action):
+            allowed_actions = ", ".join(sorted(self._MESSAGE_EXTRAS_ACTIONS))
             return None, self._payload(
                 "error",
                 action=action,
-                message="message_extras is only supported for send, reply, thread-reply, and edit actions.",
+                message=f"message_extras is only supported for {allowed_actions} actions.",
             )
         try:
             return parse_message_extra_sections(message_extras), None

--- a/src/mindroom/custom_tools/matrix_message.py
+++ b/src/mindroom/custom_tools/matrix_message.py
@@ -12,6 +12,7 @@ from mindroom.custom_tools import matrix_conversation_operations
 from mindroom.custom_tools.attachment_helpers import normalize_str_list, resolve_context_thread_id, room_access_allowed
 from mindroom.custom_tools.matrix_helpers import check_rate_limit
 from mindroom.custom_tools.tool_payloads import custom_tool_payload
+from mindroom.matrix.message_extras import MessageExtraSection, parse_message_extra_sections
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
 
 
@@ -67,6 +68,10 @@ class MatrixMessageTools(Toolkit):
     def _action_supports_attachments(action: str) -> bool:
         return action in {"send", "thread-reply", "reply"}
 
+    @staticmethod
+    def _action_supports_message_extras(action: str) -> bool:
+        return action in {"send", "thread-reply", "reply", "edit"}
+
     def _validate_matrix_message_request(
         self,
         context: ToolRuntimeContext,
@@ -107,6 +112,29 @@ class MatrixMessageTools(Toolkit):
                 message="Not authorized to access the target room.",
             )
         return None
+
+    def _validate_message_extras(
+        self,
+        *,
+        action: str,
+        message_extras: list[dict[str, object]] | None,
+    ) -> tuple[list[MessageExtraSection] | None, str | None]:
+        if not message_extras:
+            return None, None
+        if not self._action_supports_message_extras(action):
+            return None, self._payload(
+                "error",
+                action=action,
+                message="message_extras is only supported for send, reply, thread-reply, and edit actions.",
+            )
+        try:
+            return parse_message_extra_sections(message_extras), None
+        except (TypeError, ValueError) as exc:
+            return None, self._payload(
+                "error",
+                action=action,
+                message=str(exc),
+            )
 
     @classmethod
     def _check_rate_limit(
@@ -171,6 +199,7 @@ class MatrixMessageTools(Toolkit):
         target: str | None = None,
         thread_id: str | None = None,
         ignore_mentions: bool = True,
+        message_extras: list[dict[str, object]] | None = None,
         limit: int | None = None,
         page_token: str | None = None,
     ) -> str:
@@ -227,6 +256,13 @@ class MatrixMessageTools(Toolkit):
         - The combined limit of `attachment_ids` plus `attachment_file_paths` is 5 per call.
         - A send or reply call may include text, attachments, or both, but not neither.
 
+        Message extras:
+        - `message_extras` adds collapsible MindRoom sections to send, reply, thread-reply, and edit events.
+        - Keep the visible `message` brief; put supporting evidence in extras.
+        - Each section has `title`, `content`, optional `content_type`, and optional `collapsed`.
+        - Supported `content_type` values are `text/plain`, `text/markdown`, and `text/html`; default is `text/markdown`.
+        - Example: `message_extras=[{"title": "Evidence", "content_type": "text/html", "content": "<table><tr><td>42</td></tr></table>", "collapsed": true}]`.
+
         Args:
             action (str): Supported actions are `send`, `reply`, `thread-reply`, `react`, `read`, `room-threads`, `thread-list`, `edit`, and `context`; they send text or attachments, react to an event, read messages, list room thread roots or thread messages, edit a prior event, or return targeting metadata.
             message (str | None): Text body for `send`, `reply`, `thread-reply`, and `edit`; reaction emoji for `react` with a thumbs-up default when empty; use `None` for `read`, `room-threads`, `thread-list`, and `context`.
@@ -236,6 +272,7 @@ class MatrixMessageTools(Toolkit):
             target (str | None): Event ID to react to for `react` or to edit for `edit`.
             thread_id (str | None): Optional explicit thread target; `thread_id="room"` forces room-level scope instead of inheriting the current thread.
             ignore_mentions (bool): Text-send safety flag for `send`, `reply`, and `thread-reply`; default `True` writes `com.mindroom.skip_mentions=True` to suppress mention-triggered agent dispatch, while `False` keeps mentions active and also writes `com.mindroom.original_sender=<human requester id>` when the requester is not the sending bot.
+            message_extras (list[dict[str, object]] | None): Optional collapsible MindRoom sections for supporting evidence. Each section supports title, content, content_type (`text/plain`, `text/markdown`, or `text/html`), and collapsed.
             limit (int | None): Maximum messages returned for `read` or `thread-list`, or thread roots returned for `room-threads`; defaults to 20 and is capped at 50.
             page_token (str | None): Pagination token for `room-threads`, returned by a previous `room-threads` call to fetch the next page of thread roots.
 
@@ -275,6 +312,12 @@ class MatrixMessageTools(Toolkit):
         )
         if validation_error is not None:
             return validation_error
+        parsed_message_extras, extras_error = self._validate_message_extras(
+            action=normalized_action,
+            message_extras=message_extras,
+        )
+        if extras_error is not None:
+            return extras_error
 
         if normalized_action == "context":
             return self._message_context(
@@ -303,6 +346,7 @@ class MatrixMessageTools(Toolkit):
             target=target,
             thread_id=thread_id,
             ignore_mentions=ignore_mentions,
+            message_extras=parsed_message_extras,
             read_limit=self._read_limit(limit),
             page_token=page_token,
             room_timeline_sentinel=self._ROOM_TIMELINE_SENTINEL,

--- a/src/mindroom/custom_tools/matrix_message.py
+++ b/src/mindroom/custom_tools/matrix_message.py
@@ -263,6 +263,8 @@ class MatrixMessageTools(Toolkit):
         - Keep the visible `message` brief; put supporting evidence in extras.
         - Each section has `title`, `content`, optional `content_type`, and optional `collapsed`.
         - Supported `content_type` values are `text/plain`, `text/markdown`, and `text/html`; default is `text/markdown`.
+        - HTML content may use sanitized rich fragments: paragraphs, headings, lists, tables, blockquotes, code/pre blocks, basic inline formatting, and links.
+          Do not include scripts, styles, images, forms, media, SVG/math, or interactive elements; links should use `http`, `https`, or `mailto`.
         - Example: `message_extras=[{"title": "Evidence", "content_type": "text/html", "content": "<table><tr><td>42</td></tr></table>", "collapsed": true}]`.
 
         Args:
@@ -274,7 +276,7 @@ class MatrixMessageTools(Toolkit):
             target (str | None): Event ID to react to for `react` or to edit for `edit`.
             thread_id (str | None): Optional explicit thread target; `thread_id="room"` forces room-level scope instead of inheriting the current thread.
             ignore_mentions (bool): Text-send safety flag for `send`, `reply`, and `thread-reply`; default `True` writes `com.mindroom.skip_mentions=True` to suppress mention-triggered agent dispatch, while `False` keeps mentions active and also writes `com.mindroom.original_sender=<human requester id>` when the requester is not the sending bot.
-            message_extras (list[dict[str, object]] | None): Optional collapsible MindRoom sections for supporting evidence. Each section supports title, content, content_type (`text/plain`, `text/markdown`, or `text/html`), and collapsed.
+            message_extras (list[dict[str, object]] | None): Optional collapsible MindRoom sections for supporting evidence. Each section supports title, content, content_type (`text/plain`, `text/markdown`, or sanitized `text/html`), and collapsed.
             limit (int | None): Maximum messages returned for `read` or `thread-list`, or thread roots returned for `room-threads`; defaults to 20 and is capped at 50.
             page_token (str | None): Pagination token for `room-threads`, returned by a previous `room-threads` call to fetch the next page of thread roots.
 

--- a/src/mindroom/matrix/message_extras.py
+++ b/src/mindroom/matrix/message_extras.py
@@ -1,0 +1,117 @@
+"""MindRoom Matrix message extras content helpers."""
+
+from __future__ import annotations
+
+import collections.abc
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+__all__ = [
+    "MINDROOM_MESSAGE_EXTRAS_KEY",
+    "MINDROOM_MESSAGE_EXTRAS_MAX_CONTENT_CHARS",
+    "MINDROOM_MESSAGE_EXTRAS_MAX_SECTIONS",
+    "MINDROOM_MESSAGE_EXTRAS_MAX_TITLE_CHARS",
+    "MINDROOM_MESSAGE_EXTRAS_VERSION",
+    "MessageExtraContentType",
+    "MessageExtraSection",
+    "build_message_extras_content",
+    "parse_message_extra_sections",
+]
+
+MINDROOM_MESSAGE_EXTRAS_KEY = "com.mindroom.message_extras"
+MINDROOM_MESSAGE_EXTRAS_VERSION = 2
+MINDROOM_MESSAGE_EXTRAS_MAX_SECTIONS = 8
+MINDROOM_MESSAGE_EXTRAS_MAX_TITLE_CHARS = 120
+MINDROOM_MESSAGE_EXTRAS_MAX_CONTENT_CHARS = 16 * 1024
+
+MessageExtraContentType = Literal["text/plain", "text/markdown", "text/html"]
+
+
+@dataclass(frozen=True, slots=True)
+class MessageExtraSection:
+    """One collapsible MindRoom message extra section."""
+
+    title: str
+    content: str
+    content_type: MessageExtraContentType = "text/markdown"
+    collapsed: bool = True
+
+
+def _parse_content_type(value: object) -> MessageExtraContentType:
+    if not isinstance(value, str):
+        msg = "message_extras sections require content_type to be a string."
+        raise TypeError(msg)
+    if value == "text/plain":
+        return "text/plain"
+    if value == "text/markdown":
+        return "text/markdown"
+    if value == "text/html":
+        return "text/html"
+    msg = "message_extras content_type must be one of text/plain, text/markdown, or text/html."
+    raise ValueError(msg)
+
+
+def parse_message_extra_sections(sections: Sequence[Mapping[str, object]]) -> list[MessageExtraSection]:
+    """Parse model/tool supplied section dictionaries into validated sections."""
+    if len(sections) > MINDROOM_MESSAGE_EXTRAS_MAX_SECTIONS:
+        msg = f"message_extras supports at most {MINDROOM_MESSAGE_EXTRAS_MAX_SECTIONS} sections."
+        raise ValueError(msg)
+
+    parsed_sections: list[MessageExtraSection] = []
+    for index, section in enumerate(sections, start=1):
+        if not isinstance(section, collections.abc.Mapping):
+            msg = f"message_extras section {index} must be an object."
+            raise TypeError(msg)
+        raw_title = section.get("title")
+        title = raw_title.strip() if isinstance(raw_title, str) else ""
+        if not title:
+            msg = f"message_extras section {index} requires a non-empty title."
+            raise ValueError(msg)
+        if len(title) > MINDROOM_MESSAGE_EXTRAS_MAX_TITLE_CHARS:
+            msg = f"message_extras section {index} title cannot exceed {MINDROOM_MESSAGE_EXTRAS_MAX_TITLE_CHARS} characters."
+            raise ValueError(msg)
+
+        raw_content = section.get("content")
+        if not isinstance(raw_content, str):
+            msg = f"message_extras section {index} requires string content."
+            raise TypeError(msg)
+        if len(raw_content) > MINDROOM_MESSAGE_EXTRAS_MAX_CONTENT_CHARS:
+            msg = (
+                f"message_extras section {index} content cannot exceed "
+                f"{MINDROOM_MESSAGE_EXTRAS_MAX_CONTENT_CHARS} characters."
+            )
+            raise ValueError(msg)
+
+        content_type = _parse_content_type(section.get("content_type", "text/markdown"))
+        collapsed = section.get("collapsed", True)
+        parsed_sections.append(
+            MessageExtraSection(
+                title=title,
+                content=raw_content,
+                content_type=content_type,
+                collapsed=collapsed if isinstance(collapsed, bool) else True,
+            ),
+        )
+
+    return parsed_sections
+
+
+def build_message_extras_content(sections: Sequence[MessageExtraSection]) -> dict[str, object]:
+    """Build Matrix event content for MindRoom-aware clients to render as extras."""
+    return {
+        MINDROOM_MESSAGE_EXTRAS_KEY: {
+            "version": MINDROOM_MESSAGE_EXTRAS_VERSION,
+            "sections": [
+                {
+                    "title": section.title,
+                    "content_type": section.content_type,
+                    "content": section.content,
+                    "collapsed": section.collapsed,
+                }
+                for section in sections
+            ],
+        },
+    }

--- a/src/mindroom/matrix/message_extras.py
+++ b/src/mindroom/matrix/message_extras.py
@@ -66,7 +66,10 @@ def parse_message_extra_sections(sections: Sequence[Mapping[str, object]]) -> li
             msg = f"message_extras section {index} must be an object."
             raise TypeError(msg)
         raw_title = section.get("title")
-        title = raw_title.strip() if isinstance(raw_title, str) else ""
+        if not isinstance(raw_title, str):
+            msg = f"message_extras section {index} requires a string title."
+            raise TypeError(msg)
+        title = raw_title.strip()
         if not title:
             msg = f"message_extras section {index} requires a non-empty title."
             raise ValueError(msg)
@@ -87,12 +90,15 @@ def parse_message_extra_sections(sections: Sequence[Mapping[str, object]]) -> li
 
         content_type = _parse_content_type(section.get("content_type", "text/markdown"))
         collapsed = section.get("collapsed", True)
+        if not isinstance(collapsed, bool):
+            msg = f"message_extras section {index} requires a boolean for collapsed."
+            raise TypeError(msg)
         parsed_sections.append(
             MessageExtraSection(
                 title=title,
                 content=raw_content,
                 content_type=content_type,
-                collapsed=collapsed if isinstance(collapsed, bool) else True,
+                collapsed=collapsed,
             ),
         )
 

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -248,6 +248,94 @@ async def test_matrix_message_send_defaults_to_room_level() -> None:
 
 
 @pytest.mark.asyncio
+async def test_matrix_message_send_includes_message_extras() -> None:
+    """Send action should attach validated MindRoom message extras."""
+    tool = MatrixMessageTools()
+    ctx = _make_context(thread_id="$ctx-thread:localhost")
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.send_message_result",
+            new=AsyncMock(side_effect=delivered_matrix_side_effect("$evt")),
+        ) as mock_send,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_message(
+                action="send",
+                message="Short answer.",
+                message_extras=[
+                    {
+                        "title": "Evidence",
+                        "content_type": "text/html",
+                        "content": "<table><tr><td>42</td></tr></table>",
+                        "collapsed": False,
+                    },
+                ],
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    sent_content = mock_send.await_args.args[2]
+    assert sent_content["body"] == "Short answer."
+    assert sent_content["com.mindroom.message_extras"] == {
+        "version": 2,
+        "sections": [
+            {
+                "title": "Evidence",
+                "content_type": "text/html",
+                "content": "<table><tr><td>42</td></tr></table>",
+                "collapsed": False,
+            },
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_matrix_message_rejects_invalid_message_extras() -> None:
+    """Invalid extras should return a tool error instead of sending."""
+    tool = MatrixMessageTools()
+    ctx = _make_context(thread_id="$ctx-thread:localhost")
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.send_message_result",
+            new=AsyncMock(side_effect=delivered_matrix_side_effect("$evt")),
+        ) as mock_send,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_message(
+                action="send",
+                message="Short answer.",
+                message_extras=[
+                    {
+                        "title": "Raw",
+                        "content_type": "application/json",
+                        "content": "{}",
+                    },
+                ],
+            ),
+        )
+
+    assert payload["status"] == "error"
+    assert "content_type" in payload["message"]
+    mock_send.assert_not_awaited()
+
+
+def test_matrix_message_tool_description_documents_message_extras() -> None:
+    """The model-facing tool description should briefly explain extras with an example."""
+    description = MatrixMessageTools.matrix_message.__doc__
+
+    assert description is not None
+    assert "message_extras" in description
+    assert "text/plain" in description
+    assert "text/markdown" in description
+    assert "text/html" in description
+    assert '"title": "Evidence"' in description
+
+
+@pytest.mark.asyncio
 async def test_matrix_message_send_room_sentinel_stays_room_level() -> None:
     """thread_id='room' should disable thread metadata for sends."""
     tool = MatrixMessageTools()

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -21,6 +21,7 @@ from mindroom.custom_tools.attachments import AttachmentTools
 from mindroom.custom_tools.matrix_message import MatrixMessageTools
 from mindroom.interactive import parse_and_format_interactive
 from mindroom.matrix.client import RoomThreadsPageError
+from mindroom.matrix.message_extras import MINDROOM_MESSAGE_EXTRAS_KEY
 from mindroom.tool_system.metadata import TOOL_METADATA, get_tool_by_name
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
 from tests.conftest import (
@@ -278,7 +279,7 @@ async def test_matrix_message_send_includes_message_extras() -> None:
     assert payload["status"] == "ok"
     sent_content = mock_send.await_args.args[2]
     assert sent_content["body"] == "Short answer."
-    assert sent_content["com.mindroom.message_extras"] == {
+    assert sent_content[MINDROOM_MESSAGE_EXTRAS_KEY] == {
         "version": 2,
         "sections": [
             {
@@ -289,6 +290,37 @@ async def test_matrix_message_send_includes_message_extras() -> None:
             },
         ],
     }
+
+
+@pytest.mark.asyncio
+async def test_matrix_message_send_rejects_message_extras_without_text_event() -> None:
+    """Extras should not be silently dropped on attachment-only sends."""
+    tool = MatrixMessageTools()
+    ctx = _make_context(thread_id="$ctx-thread:localhost")
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.send_message_result",
+            new=AsyncMock(side_effect=delivered_matrix_side_effect("$evt")),
+        ) as mock_send,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_message(
+                action="send",
+                attachment_ids=["att_context_file"],
+                message_extras=[
+                    {
+                        "title": "Evidence",
+                        "content": "details",
+                    },
+                ],
+            ),
+        )
+
+    assert payload["status"] == "error"
+    assert "non-empty message" in payload["message"]
+    mock_send.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1254,6 +1286,55 @@ async def test_matrix_message_edit_processes_interactive_blocks() -> None:
         ],
         config=ctx.config,
     )
+
+
+@pytest.mark.asyncio
+async def test_matrix_message_edit_includes_message_extras_on_replacement_wrapper() -> None:
+    """Edit action should expose extras on both m.new_content and the outer edit event."""
+    tool = MatrixMessageTools()
+    ctx = _make_context(thread_id="$ctx-thread:localhost")
+    thread_messages = [
+        make_visible_message(event_id="$latest", timestamp=1, sender="@alice:localhost", body="latest"),
+    ]
+    ctx.conversation_cache.get_thread_history.return_value = thread_messages
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.edit_message_result",
+            new=AsyncMock(side_effect=delivered_matrix_side_effect("$edit_evt")),
+        ) as mock_edit,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_message(
+                action="edit",
+                message="Updated answer.",
+                target="$target",
+                message_extras=[
+                    {
+                        "title": "Evidence",
+                        "content": "extra details",
+                    },
+                ],
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    new_content = mock_edit.await_args.args[3]
+    extra_content = mock_edit.await_args.kwargs["extra_content"]
+    expected_extras = {
+        "version": 2,
+        "sections": [
+            {
+                "title": "Evidence",
+                "content_type": "text/markdown",
+                "content": "extra details",
+                "collapsed": True,
+            },
+        ],
+    }
+    assert new_content[MINDROOM_MESSAGE_EXTRAS_KEY] == expected_extras
+    assert extra_content == {MINDROOM_MESSAGE_EXTRAS_KEY: expected_extras}
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -1341,6 +1341,39 @@ async def test_matrix_message_edit_includes_message_extras_on_replacement_wrappe
 
 
 @pytest.mark.asyncio
+async def test_matrix_message_edit_rejects_invalid_message_extras() -> None:
+    """Invalid edit extras should fail before edit delivery."""
+    tool = MatrixMessageTools()
+    ctx = _make_context(thread_id="$ctx-thread:localhost")
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.edit_message_result",
+            new=AsyncMock(side_effect=delivered_matrix_side_effect("$edit_evt")),
+        ) as mock_edit,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_message(
+                action="edit",
+                message="Updated answer.",
+                target="$target",
+                message_extras=[
+                    {
+                        "title": "Raw",
+                        "content_type": "application/json",
+                        "content": "{}",
+                    },
+                ],
+            ),
+        )
+
+    assert payload["status"] == "error"
+    assert "content_type" in payload["message"]
+    mock_edit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_matrix_message_edit_plain_text_clears_existing_interactive_question() -> None:
     """Editing away an interactive block should clear the tracked question."""
     tool = MatrixMessageTools()

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -364,6 +364,9 @@ def test_matrix_message_tool_description_documents_message_extras() -> None:
     assert "text/plain" in description
     assert "text/markdown" in description
     assert "text/html" in description
+    assert "sanitized rich fragments" in description
+    assert "tables" in description
+    assert "Do not include scripts" in description
     assert '"title": "Evidence"' in description
 
 

--- a/tests/test_message_extras.py
+++ b/tests/test_message_extras.py
@@ -62,3 +62,19 @@ def test_parse_message_extra_sections_rejects_unsupported_content_type() -> None
                 },
             ],
         )
+
+
+@pytest.mark.parametrize(
+    ("section", "match"),
+    [
+        ({"title": 42, "content": "details"}, "string title"),
+        ({"title": "Details", "content": "details", "collapsed": "yes"}, "boolean"),
+    ],
+)
+def test_parse_message_extra_sections_rejects_invalid_field_types(
+    section: dict[str, object],
+    match: str,
+) -> None:
+    """Malformed model inputs should fail with precise type errors."""
+    with pytest.raises(TypeError, match=match):
+        parse_message_extra_sections([section])

--- a/tests/test_message_extras.py
+++ b/tests/test_message_extras.py
@@ -1,0 +1,64 @@
+"""Tests for MindRoom Matrix message extras payloads."""
+
+from __future__ import annotations
+
+import pytest
+
+from mindroom.matrix.message_extras import (
+    MINDROOM_MESSAGE_EXTRAS_KEY,
+    MessageExtraSection,
+    build_message_extras_content,
+    parse_message_extra_sections,
+)
+
+
+def test_build_message_extras_content_uses_cinny_schema() -> None:
+    """Message extras should match the schema rendered by MindRoom Cinny."""
+    content = build_message_extras_content(
+        [
+            MessageExtraSection(
+                title="Evidence",
+                content_type="text/html",
+                content="<table><tr><td>42</td></tr></table>",
+                collapsed=False,
+            ),
+            MessageExtraSection(
+                title="Notes",
+                content="**Markdown** details",
+            ),
+        ],
+    )
+
+    assert content == {
+        MINDROOM_MESSAGE_EXTRAS_KEY: {
+            "version": 2,
+            "sections": [
+                {
+                    "title": "Evidence",
+                    "content_type": "text/html",
+                    "content": "<table><tr><td>42</td></tr></table>",
+                    "collapsed": False,
+                },
+                {
+                    "title": "Notes",
+                    "content_type": "text/markdown",
+                    "content": "**Markdown** details",
+                    "collapsed": True,
+                },
+            ],
+        },
+    }
+
+
+def test_parse_message_extra_sections_rejects_unsupported_content_type() -> None:
+    """Tool inputs should fail before sending content Cinny will ignore."""
+    with pytest.raises(ValueError, match="content_type"):
+        parse_message_extra_sections(
+            [
+                {
+                    "title": "Unsafe",
+                    "content_type": "application/json",
+                    "content": "{}",
+                },
+            ],
+        )


### PR DESCRIPTION
## Summary
- add a typed builder/parser for MindRoom Matrix message extras using com.mindroom.message_extras
- wire message_extras into the matrix_message tool for send, reply, thread-reply, and edit actions
- document a brief HTML evidence example in the tool description

## Tests
- uv run pytest -x -n 0 --no-cov -v (6757 passed, 79 skipped)
- uv run pre-commit run --all-files

## Summary by Sourcery

Add structured MindRoom Matrix message extras support to matrix_message operations and document its usage.

New Features:
- Introduce typed MindRoom Matrix message extras payloads and validation helpers for client-visible sections.
- Support optional message_extras on matrix_message send, reply, thread-reply, and edit actions to attach collapsible evidence sections.

Enhancements:
- Extend the matrix_message tool description with guidance and an HTML-based example for message_extras usage.

Tests:
- Add unit tests for message_extras parsing and serialization and for matrix_message behavior when including or rejecting extras in tool calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support attaching collapsible "message extras" sections to send/reply/thread-reply/edit flows (title, collapsed flag, content formats: text/plain, text/markdown, text/html).

* **Documentation**
  * Tool docs updated to mention message_extras, include an example (e.g., "Evidence") and list supported MIME types.

* **Tests**
  * Added tests for parsing/validation, serialization into outbound content, edit/send handling, and negative/error cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1019)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->