### PR TITLE
Preserve audio MIME type for voice transcription

### DIFF
--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import mimetypes
 import re
 import uuid
 from collections import OrderedDict
@@ -33,6 +34,20 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
 
 logger = get_logger(__name__)
+_STT_AUDIO_EXTENSION_BY_MIME_TYPE = {
+    "audio/aac": ".aac",
+    "audio/flac": ".flac",
+    "audio/m4a": ".m4a",
+    "audio/mp4": ".m4a",
+    "audio/mpeg": ".mp3",
+    "audio/mp3": ".mp3",
+    "audio/ogg": ".ogg",
+    "audio/wav": ".wav",
+    "audio/wave": ".wav",
+    "audio/webm": ".webm",
+    "audio/x-m4a": ".m4a",
+    "audio/x-wav": ".wav",
+}
 _VOICE_MENTION_PATTERN = re.compile(
     r"(?<![\w])@(?P<localpart>[A-Za-z0-9._=/+\-]+)(?::(?P<domain>[A-Za-z0-9.\-:\[\]]+))?",
 )
@@ -285,7 +300,12 @@ async def _handle_voice_message(
             return None
 
         # Transcribe the audio
-        transcription = await _transcribe_audio(voice_audio.content, config, runtime_paths)
+        transcription = await _transcribe_audio(
+            voice_audio.content,
+            config,
+            runtime_paths,
+            mime_type=voice_audio.mime_type,
+        )
         if not transcription:
             logger.warning("Failed to transcribe audio or empty transcription")
             return None
@@ -333,13 +353,29 @@ async def _download_audio(
     return Audio(content=audio_data, mime_type=media_mime_type(event))
 
 
-async def _transcribe_audio(audio_data: bytes, config: Config, runtime_paths: RuntimePaths) -> str | None:
+def _stt_upload_filename_and_mime_type(mime_type: str | None) -> tuple[str, str]:
+    """Return multipart filename and MIME type for an STT upload."""
+    normalized_mime_type = (mime_type or "audio/ogg").split(";", 1)[0].strip().lower() or "audio/ogg"
+    extension = _STT_AUDIO_EXTENSION_BY_MIME_TYPE.get(normalized_mime_type)
+    if extension is None:
+        extension = mimetypes.guess_extension(normalized_mime_type) or ".bin"
+    return f"audio{extension}", normalized_mime_type
+
+
+async def _transcribe_audio(
+    audio_data: bytes,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    *,
+    mime_type: str | None = None,
+) -> str | None:
     """Transcribe audio using OpenAI-compatible API.
 
     Args:
         audio_data: Audio file bytes
         config: Application configuration
         runtime_paths: Explicit runtime context for STT credential lookup
+        mime_type: Matrix-declared MIME type for the audio payload
 
     Returns:
         Transcription text or None if failed
@@ -355,7 +391,8 @@ async def _transcribe_audio(audio_data: bytes, config: Config, runtime_paths: Ru
             return None
         headers = {"Authorization": f"Bearer {api_key}"}
 
-        files = {"file": ("audio.ogg", audio_data, "audio/ogg")}
+        filename, upload_mime_type = _stt_upload_filename_and_mime_type(mime_type)
+        files = {"file": (filename, audio_data, upload_mime_type)}
         form_data = {"model": config.voice.stt.model}
 
         async with httpx.AsyncClient(verify=False) as http_client:  # noqa: S501

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -356,9 +356,22 @@ async def _download_audio(
 def _stt_upload_filename_and_mime_type(mime_type: str | None) -> tuple[str, str]:
     """Return multipart filename and MIME type for an STT upload."""
     normalized_mime_type = (mime_type or "audio/ogg").split(";", 1)[0].strip().lower() or "audio/ogg"
+    if not normalized_mime_type.startswith("audio/"):
+        logger.warning(
+            "Non-audio MIME type declared for STT upload; using OGG fallback",
+            mime_type=normalized_mime_type,
+        )
+        normalized_mime_type = "audio/ogg"
+
     extension = _STT_AUDIO_EXTENSION_BY_MIME_TYPE.get(normalized_mime_type)
     if extension is None:
-        extension = mimetypes.guess_extension(normalized_mime_type) or ".bin"
+        extension = mimetypes.guess_extension(normalized_mime_type)
+        if extension is None:
+            logger.warning(
+                "Unknown audio MIME type for STT upload; using .bin extension",
+                mime_type=normalized_mime_type,
+            )
+            extension = ".bin"
     return f"audio{extension}", normalized_mime_type
 
 

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -122,6 +122,20 @@ class TestVoiceHandler:
         assert config.voice.stt.model == "whisper-1"
         assert config.voice.intelligence.model == "default"
 
+    def test_stt_upload_metadata_preserves_matrix_audio_mp4(self) -> None:
+        """Matrix m4a voice messages should be uploaded to STT as m4a/audio-mp4."""
+        filename, mime_type = voice_handler._stt_upload_filename_and_mime_type("audio/mp4")
+
+        assert filename == "audio.m4a"
+        assert mime_type == "audio/mp4"
+
+    def test_stt_upload_metadata_defaults_to_ogg(self) -> None:
+        """Missing Matrix MIME metadata should keep the legacy OGG upload shape."""
+        filename, mime_type = voice_handler._stt_upload_filename_and_mime_type(None)
+
+        assert filename == "audio.ogg"
+        assert mime_type == "audio/ogg"
+
     def test_sanitize_unavailable_mentions_uses_exact_aliases(self) -> None:
         """Voice mention sanitizing should match exact Matrix mention aliases."""
         config = _runtime_bound_config(
@@ -221,13 +235,15 @@ class TestVoiceHandler:
                 "mindroom.voice_handler._download_audio",
                 new=AsyncMock(return_value=Audio(content=b"audio", mime_type="audio/ogg")),
             ),
-            patch("mindroom.voice_handler._transcribe_audio", return_value="help me"),
+            patch("mindroom.voice_handler._transcribe_audio", return_value="help me") as mock_transcribe,
             patch("mindroom.voice_handler._process_transcription", new_callable=AsyncMock) as mock_process,
         ):
             mock_process.return_value = "@openclaw help me"
             result = await _handle_voice_message(client, room, event, config)
 
         assert result == "🎤 @openclaw help me"
+        mock_transcribe.assert_awaited_once()
+        assert mock_transcribe.await_args.kwargs["mime_type"] == "audio/ogg"
         assert mock_process.await_count == 1
         assert mock_process.await_args.kwargs["available_agent_names"] == ["openclaw"]
         assert mock_process.await_args.kwargs["available_team_names"] == []

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -122,12 +122,29 @@ class TestVoiceHandler:
         assert config.voice.stt.model == "whisper-1"
         assert config.voice.intelligence.model == "default"
 
-    def test_stt_upload_metadata_preserves_matrix_audio_mp4(self) -> None:
-        """Matrix m4a voice messages should be uploaded to STT as m4a/audio-mp4."""
-        filename, mime_type = voice_handler._stt_upload_filename_and_mime_type("audio/mp4")
+    @pytest.mark.parametrize(
+        ("matrix_mime_type", "expected_filename", "expected_mime_type"),
+        [
+            ("audio/mp4", "audio.m4a", "audio/mp4"),
+            ("audio/m4a", "audio.m4a", "audio/m4a"),
+            ("audio/x-m4a", "audio.m4a", "audio/x-m4a"),
+            ("audio/mp3", "audio.mp3", "audio/mp3"),
+            ("audio/webm", "audio.webm", "audio/webm"),
+            ("audio/ogg; codecs=opus", "audio.ogg", "audio/ogg"),
+            ("  AUDIO/WAV  ", "audio.wav", "audio/wav"),
+        ],
+    )
+    def test_stt_upload_metadata_preserves_matrix_audio_mime_type(
+        self,
+        matrix_mime_type: str,
+        expected_filename: str,
+        expected_mime_type: str,
+    ) -> None:
+        """Matrix audio MIME types should be uploaded to STT with matching metadata."""
+        filename, mime_type = voice_handler._stt_upload_filename_and_mime_type(matrix_mime_type)
 
-        assert filename == "audio.m4a"
-        assert mime_type == "audio/mp4"
+        assert filename == expected_filename
+        assert mime_type == expected_mime_type
 
     def test_stt_upload_metadata_defaults_to_ogg(self) -> None:
         """Missing Matrix MIME metadata should keep the legacy OGG upload shape."""
@@ -135,6 +152,20 @@ class TestVoiceHandler:
 
         assert filename == "audio.ogg"
         assert mime_type == "audio/ogg"
+
+    def test_stt_upload_metadata_defaults_to_ogg_for_non_audio_mime_type(self) -> None:
+        """Non-audio Matrix MIME metadata should keep the legacy OGG upload shape."""
+        filename, mime_type = voice_handler._stt_upload_filename_and_mime_type("text/plain")
+
+        assert filename == "audio.ogg"
+        assert mime_type == "audio/ogg"
+
+    def test_stt_upload_metadata_preserves_unknown_audio_mime_type(self) -> None:
+        """Unknown audio MIME metadata should preserve the audio type with a generic extension."""
+        filename, mime_type = voice_handler._stt_upload_filename_and_mime_type("audio/unknown")
+
+        assert filename == "audio.bin"
+        assert mime_type == "audio/unknown"
 
     def test_sanitize_unavailable_mentions_uses_exact_aliases(self) -> None:
         """Voice mention sanitizing should match exact Matrix mention aliases."""


### PR DESCRIPTION
## Summary
- preserve the Matrix-declared audio MIME type when sending voice messages to the STT API
- choose a matching upload filename extension for common audio MIME types, including audio/mp4 as .m4a
- keep the existing audio/ogg fallback when MIME metadata is unavailable

## Tests
- uv run pytest tests/test_voice_handler.py -q

## Summary by Sourcery

Preserve and reuse Matrix-declared audio MIME types when uploading voice messages to the STT API, while maintaining a sensible default for legacy behavior.

New Features:
- Add mapping from common audio MIME types to appropriate STT upload filename extensions and MIME types.

Bug Fixes:
- Ensure voice transcription uploads use the original Matrix audio MIME type instead of always defaulting to OGG, while retaining the previous OGG fallback when metadata is missing.

Tests:
- Add unit tests to verify STT upload metadata for audio/mp4 and for missing MIME types, and update existing voice handler tests to assert the MIME type is forwarded to transcription.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Voice transcription uploads now preserve the original Matrix-declared audio MIME type and choose appropriate upload filename extensions, with sensible fallbacks for unknown or missing types.
* **Tests**
  * Expanded test coverage for audio MIME/filename mapping and updated transcription tests to verify MIME preservation and async invocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1021)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->