### PR TITLE
Resolve matrix_message attachment paths from workspace

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -89,6 +89,8 @@ In worker-routed shell and python tools, that workspace is also exposed as `~`, 
 
 `attachment_ids` accepts only context attachment IDs (`att_*`).
 `attachment_file_paths` accepts local file paths and auto-registers them in the current context before sending.
+Relative paths resolve from the agent workspace when one is available.
+Relative paths must stay inside the workspace.
 Use `matrix_message(action="send"|"reply"|"thread-reply", attachment_ids=..., attachment_file_paths=...)` to send attachments.
 
 ### Why use this tool?

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -45,6 +45,7 @@ In `thread_mode: room`, room-level `send` stays plain room messaging and does no
 `read` defaults to 20 messages and caps `limit` at 50.
 `thread-list` returns recent thread messages plus `edit_options` for messages that the current Matrix account can edit.
 Only `send`, `reply`, and `thread-reply` accept attachments, with a combined cap of five `attachment_ids` plus `attachment_file_paths` per call.
+Relative `attachment_file_paths` resolve from the agent workspace when one is available, and they must stay inside that workspace.
 The tool rate-limits each `(agent_name, requester_id, room_id)` combination to 12 weighted actions per 30 seconds, where each attachment increases the weight of a send or reply.
 
 ### Configuration
@@ -66,7 +67,7 @@ matrix_message(action="send", message="Posting this to the room timeline.", thre
 matrix_message(
     action="reply",
     message="I reviewed the thread and attached the export.",
-    attachment_file_paths=["/tmp/report.csv"],
+    attachment_file_paths=["exports/report.csv"],
 )
 matrix_message(action="react", target="$event123", message="✅")
 ```
@@ -228,6 +229,7 @@ Use `mindroom_output_path` before handing attachments to worker-routed workspace
 In worker-routed shell and python tools, the agent workspace is also `~`, `$HOME`, and `$MINDROOM_AGENT_WORKSPACE`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
 The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
 `register_attachment()` turns a local file path into a new context-scoped `att_*` ID and appends that ID to the current runtime context so later tool calls in the same run can reuse it.
+Relative `register_attachment()` paths resolve from the agent workspace when one is available, and they must stay inside that workspace.
 Attachment records include kind, filename, MIME type, room ID, thread ID, sender, creation time, and an `available` flag that reports whether the local file still exists.
 This tool does not send files by itself, but its IDs can be passed to `matrix_message` for `send`, `reply`, or `thread-reply`.
 
@@ -248,7 +250,7 @@ agents:
 list_attachments()
 get_attachment("att_abc123")
 get_attachment("att_abc123", mindroom_output_path="incoming/plan.pdf")
-register_attachment("/tmp/plan.pdf")
+register_attachment("incoming/plan.pdf")
 matrix_message(action="reply", message="Sharing the plan here.", attachment_ids=["att_abc123"])
 ```
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -6483,6 +6483,7 @@ In `thread_mode: room`, room-level `send` stays plain room messaging and does no
 `read` defaults to 20 messages and caps `limit` at 50.
 `thread-list` returns recent thread messages plus `edit_options` for messages that the current Matrix account can edit.
 Only `send`, `reply`, and `thread-reply` accept attachments, with a combined cap of five `attachment_ids` plus `attachment_file_paths` per call.
+Relative `attachment_file_paths` resolve from the agent workspace when one is available, and they must stay inside that workspace.
 The tool rate-limits each `(agent_name, requester_id, room_id)` combination to 12 weighted actions per 30 seconds, where each attachment increases the weight of a send or reply.
 
 ### Configuration
@@ -6504,7 +6505,7 @@ matrix_message(action="send", message="Posting this to the room timeline.", thre
 matrix_message(
     action="reply",
     message="I reviewed the thread and attached the export.",
-    attachment_file_paths=["/tmp/report.csv"],
+    attachment_file_paths=["exports/report.csv"],
 )
 matrix_message(action="react", target="$event123", message="✅")
 ```
@@ -6666,6 +6667,7 @@ Use `mindroom_output_path` before handing attachments to worker-routed workspace
 In worker-routed shell and python tools, the agent workspace is also `~`, `$HOME`, and `$MINDROOM_AGENT_WORKSPACE`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
 The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
 `register_attachment()` turns a local file path into a new context-scoped `att_*` ID and appends that ID to the current runtime context so later tool calls in the same run can reuse it.
+Relative `register_attachment()` paths resolve from the agent workspace when one is available, and they must stay inside that workspace.
 Attachment records include kind, filename, MIME type, room ID, thread ID, sender, creation time, and an `available` flag that reports whether the local file still exists.
 This tool does not send files by itself, but its IDs can be passed to `matrix_message` for `send`, `reply`, or `thread-reply`.
 
@@ -6686,7 +6688,7 @@ agents:
 list_attachments()
 get_attachment("att_abc123")
 get_attachment("att_abc123", mindroom_output_path="incoming/plan.pdf")
-register_attachment("/tmp/plan.pdf")
+register_attachment("incoming/plan.pdf")
 matrix_message(action="reply", message="Sharing the plan here.", attachment_ids=["att_abc123"])
 ```
 
@@ -12274,6 +12276,8 @@ In worker-routed shell and python tools, that workspace is also exposed as `~`, 
 
 `attachment_ids` accepts only context attachment IDs (`att_*`).
 `attachment_file_paths` accepts local file paths and auto-registers them in the current context before sending.
+Relative paths resolve from the agent workspace when one is available.
+Relative paths must stay inside the workspace.
 Use `matrix_message(action="send"|"reply"|"thread-reply", attachment_ids=..., attachment_file_paths=...)` to send attachments.
 
 ### Why use this tool?

--- a/skills/mindroom-docs/references/page__attachments__index.md
+++ b/skills/mindroom-docs/references/page__attachments__index.md
@@ -85,6 +85,8 @@ In worker-routed shell and python tools, that workspace is also exposed as `~`, 
 
 `attachment_ids` accepts only context attachment IDs (`att_*`).
 `attachment_file_paths` accepts local file paths and auto-registers them in the current context before sending.
+Relative paths resolve from the agent workspace when one is available.
+Relative paths must stay inside the workspace.
 Use `matrix_message(action="send"|"reply"|"thread-reply", attachment_ids=..., attachment_file_paths=...)` to send attachments.
 
 ### Why use this tool?

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -41,6 +41,7 @@ In `thread_mode: room`, room-level `send` stays plain room messaging and does no
 `read` defaults to 20 messages and caps `limit` at 50.
 `thread-list` returns recent thread messages plus `edit_options` for messages that the current Matrix account can edit.
 Only `send`, `reply`, and `thread-reply` accept attachments, with a combined cap of five `attachment_ids` plus `attachment_file_paths` per call.
+Relative `attachment_file_paths` resolve from the agent workspace when one is available, and they must stay inside that workspace.
 The tool rate-limits each `(agent_name, requester_id, room_id)` combination to 12 weighted actions per 30 seconds, where each attachment increases the weight of a send or reply.
 
 ### Configuration
@@ -62,7 +63,7 @@ matrix_message(action="send", message="Posting this to the room timeline.", thre
 matrix_message(
     action="reply",
     message="I reviewed the thread and attached the export.",
-    attachment_file_paths=["/tmp/report.csv"],
+    attachment_file_paths=["exports/report.csv"],
 )
 matrix_message(action="react", target="$event123", message="✅")
 ```
@@ -224,6 +225,7 @@ Use `mindroom_output_path` before handing attachments to worker-routed workspace
 In worker-routed shell and python tools, the agent workspace is also `~`, `$HOME`, and `$MINDROOM_AGENT_WORKSPACE`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
 The path must be relative to the workspace and must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, or use environment or user expansion.
 `register_attachment()` turns a local file path into a new context-scoped `att_*` ID and appends that ID to the current runtime context so later tool calls in the same run can reuse it.
+Relative `register_attachment()` paths resolve from the agent workspace when one is available, and they must stay inside that workspace.
 Attachment records include kind, filename, MIME type, room ID, thread ID, sender, creation time, and an `available` flag that reports whether the local file still exists.
 This tool does not send files by itself, but its IDs can be passed to `matrix_message` for `send`, `reply`, or `thread-reply`.
 
@@ -244,7 +246,7 @@ agents:
 list_attachments()
 get_attachment("att_abc123")
 get_attachment("att_abc123", mindroom_output_path="incoming/plan.pdf")
-register_attachment("/tmp/plan.pdf")
+register_attachment("incoming/plan.pdf")
 matrix_message(action="reply", message="Sharing the plan here.", attachment_ids=["att_abc123"])
 ```
 

--- a/src/mindroom/custom_tools/attachments.py
+++ b/src/mindroom/custom_tools/attachments.py
@@ -40,6 +40,7 @@ from mindroom.tool_system.sandbox_proxy import (
     inline_attachment_byte_limit,
     save_attachment_to_worker,
 )
+from mindroom.workspaces import resolve_workspace_relative_path
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
@@ -197,12 +198,9 @@ def _register_attachment_file_path(
     if context.storage_path is None:
         return None, "Attachment storage path is unavailable in this runtime path."
 
-    requested_path = Path(file_path).expanduser()
-    resolved_path = (
-        requested_path.resolve()
-        if requested_path.is_absolute() or workspace_root is None
-        else (workspace_root / requested_path).resolve()
-    )
+    resolved_path, path_error = _resolve_attachment_file_path(file_path, workspace_root=workspace_root)
+    if path_error is not None or resolved_path is None:
+        return None, path_error
     kind, filename, mime_type = _infer_local_attachment_metadata(resolved_path)
     attachment_record = register_local_attachment(
         context.storage_path,
@@ -219,6 +217,28 @@ def _register_attachment_file_path(
 
     append_tool_runtime_attachment_id(attachment_record.attachment_id)
     return attachment_record, None
+
+
+def _resolve_attachment_file_path(
+    file_path: str,
+    *,
+    workspace_root: Path | None = None,
+) -> tuple[Path | None, str | None]:
+    """Resolve one model-requested attachment file path."""
+    requested_path = Path(file_path)
+    if requested_path.is_absolute() or workspace_root is None:
+        return Path(file_path).expanduser().resolve(), None
+    try:
+        return (
+            resolve_workspace_relative_path(
+                workspace_root,
+                requested_path,
+                field_name="attachment file path",
+            ),
+            None,
+        )
+    except ValueError as exc:
+        return None, str(exc)
 
 
 def _resolve_attachment_file_paths(
@@ -661,7 +681,10 @@ class AttachmentTools(Toolkit):
         )
 
     async def register_attachment(self, file_path: str) -> str:
-        """Register a local file as a context attachment ID."""
+        """Register a local file as a context attachment ID.
+
+        Relative paths resolve from the agent workspace when one is available.
+        """
         context = get_tool_runtime_context()
         if context is None:
             return _attachment_tool_payload(
@@ -671,7 +694,11 @@ class AttachmentTools(Toolkit):
         if not isinstance(file_path, str) or not file_path.strip():
             return _attachment_tool_payload("error", message="file_path must be a non-empty string.")
 
-        attachment_record, register_error = _register_attachment_file_path(context, file_path.strip())
+        attachment_record, register_error = _register_attachment_file_path(
+            context,
+            file_path.strip(),
+            workspace_root=self._tool_output_workspace_root,
+        )
         if register_error is not None or attachment_record is None:
             return _attachment_tool_payload(
                 "error",

--- a/src/mindroom/custom_tools/attachments.py
+++ b/src/mindroom/custom_tools/attachments.py
@@ -190,12 +190,19 @@ def _resolve_attachment_ids(
 def _register_attachment_file_path(
     context: ToolRuntimeContext,
     file_path: str,
+    *,
+    workspace_root: Path | None = None,
 ) -> tuple[AttachmentRecord | None, str | None]:
     """Register a local file path in the current tool context."""
     if context.storage_path is None:
         return None, "Attachment storage path is unavailable in this runtime path."
 
-    resolved_path = Path(file_path).expanduser().resolve()
+    requested_path = Path(file_path).expanduser()
+    resolved_path = (
+        requested_path.resolve()
+        if requested_path.is_absolute() or workspace_root is None
+        else (workspace_root / requested_path).resolve()
+    )
     kind, filename, mime_type = _infer_local_attachment_metadata(resolved_path)
     attachment_record = register_local_attachment(
         context.storage_path,
@@ -217,6 +224,8 @@ def _register_attachment_file_path(
 def _resolve_attachment_file_paths(
     context: ToolRuntimeContext,
     attachment_file_paths: list[str],
+    *,
+    workspace_root: Path | None = None,
 ) -> tuple[list[Path], list[str], str | None]:
     """Register file paths and return local paths plus generated attachment IDs."""
     if not attachment_file_paths:
@@ -225,7 +234,11 @@ def _resolve_attachment_file_paths(
     resolved_paths: list[Path] = []
     newly_registered_attachment_ids: list[str] = []
     for attachment_file_path in attachment_file_paths:
-        attachment_record, register_error = _register_attachment_file_path(context, attachment_file_path)
+        attachment_record, register_error = _register_attachment_file_path(
+            context,
+            attachment_file_path,
+            workspace_root=workspace_root,
+        )
         if register_error is not None:
             return [], [], register_error
         if attachment_record is None:
@@ -241,6 +254,7 @@ def resolve_send_attachments(
     *,
     attachment_ids: list[str],
     attachment_file_paths: list[str],
+    workspace_root: Path | None = None,
 ) -> tuple[list[Path], list[str], list[str], str | None]:
     """Resolve context IDs and/or local file paths to sendable attachment paths."""
     attachment_paths, resolved_attachment_ids, attachment_error = _resolve_attachment_ids(
@@ -252,6 +266,7 @@ def resolve_send_attachments(
     file_paths, newly_registered_attachment_ids, file_path_error = _resolve_attachment_file_paths(
         context,
         attachment_file_paths,
+        workspace_root=workspace_root,
     )
     if file_path_error is not None:
         return [], [], [], file_path_error
@@ -303,6 +318,7 @@ async def send_context_attachments(
     thread_id: str | None = None,
     require_joined_room: bool = True,
     inherit_context_thread: bool = True,
+    workspace_root: Path | None = None,
 ) -> tuple[_AttachmentSendResult | None, str | None]:
     """Resolve and send context-scoped attachments to Matrix."""
     attachment_paths, resolved_attachment_ids, newly_registered_attachment_ids, resolve_error = (
@@ -310,6 +326,7 @@ async def send_context_attachments(
             context,
             attachment_ids=attachment_ids,
             attachment_file_paths=attachment_file_paths,
+            workspace_root=workspace_root,
         )
     )
     if resolve_error is not None:

--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -33,6 +33,7 @@ from mindroom.matrix.message_extras import build_message_extras_content
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
 
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.message_extras import MessageExtraSection
@@ -56,6 +57,9 @@ class MatrixMessageOperations:
         nio.RoomMessageText,
         nio.RoomMessageNotice,
     )
+
+    def __init__(self, *, tool_output_workspace_root: Path | None = None) -> None:
+        self._tool_output_workspace_root = tool_output_workspace_root
 
     @staticmethod
     def _result(status: Literal["ok", "error"], **kwargs: object) -> MatrixMessageOperationResult:
@@ -212,6 +216,7 @@ class MatrixMessageOperations:
                         context,
                         attachment_ids=attachment_ids,
                         attachment_file_paths=attachment_file_paths,
+                        workspace_root=self._tool_output_workspace_root,
                     )
                 )
                 if resolve_error is not None:
@@ -290,6 +295,7 @@ class MatrixMessageOperations:
                     thread_id=attachment_thread_id,
                     require_joined_room=False,
                     inherit_context_thread=False,
+                    workspace_root=self._tool_output_workspace_root,
                 )
                 if send_result is not None:
                     attachment_thread_id = send_result.thread_id

--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003 - tool config sync evaluates constructor type hints at runtime.
 from typing import TYPE_CHECKING, Any, Literal
 
 import nio
@@ -33,7 +34,6 @@ from mindroom.matrix.message_extras import build_message_extras_content
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from pathlib import Path
 
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.message_extras import MessageExtraSection

--- a/src/mindroom/custom_tools/matrix_message.py
+++ b/src/mindroom/custom_tools/matrix_message.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict, deque
 from threading import Lock
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from agno.tools import Toolkit
 
@@ -14,6 +14,9 @@ from mindroom.custom_tools.matrix_helpers import check_rate_limit
 from mindroom.custom_tools.tool_payloads import custom_tool_payload
 from mindroom.matrix.message_extras import MessageExtraSection, parse_message_extra_sections
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class MatrixMessageTools(Toolkit):
@@ -31,11 +34,11 @@ class MatrixMessageTools(Toolkit):
     _VALID_ACTIONS: ClassVar[frozenset[str]] = frozenset(
         {"send", "thread-reply", "reply", "react", "read", "room-threads", "thread-list", "edit", "context"},
     )
-    _operations: ClassVar[matrix_conversation_operations.MatrixMessageOperations] = (
-        matrix_conversation_operations.MatrixMessageOperations()
-    )
 
-    def __init__(self) -> None:
+    def __init__(self, *, tool_output_workspace_root: Path | None = None) -> None:
+        self._operations = matrix_conversation_operations.MatrixMessageOperations(
+            tool_output_workspace_root=tool_output_workspace_root,
+        )
         super().__init__(
             name="matrix_message",
             tools=[self.matrix_message],
@@ -255,6 +258,7 @@ class MatrixMessageTools(Toolkit):
         - Attachments are only supported for `send`, `reply`, and `thread-reply`.
         - `attachment_ids` are context-scoped `att_*` IDs.
         - `attachment_file_paths` are local file paths that will be registered into the current attachment context before sending.
+          Relative paths resolve from the agent workspace, the same root used as `HOME` in worker-routed tools.
         - The combined limit of `attachment_ids` plus `attachment_file_paths` is 5 per call.
         - A send or reply call may include text, attachments, or both, but not neither.
 
@@ -271,7 +275,7 @@ class MatrixMessageTools(Toolkit):
             action (str): Supported actions are `send`, `reply`, `thread-reply`, `react`, `read`, `room-threads`, `thread-list`, `edit`, and `context`; they send text or attachments, react to an event, read messages, list room thread roots or thread messages, edit a prior event, or return targeting metadata.
             message (str | None): Text body for `send`, `reply`, `thread-reply`, and `edit`; reaction emoji for `react` with a thumbs-up default when empty; use `None` for `read`, `room-threads`, `thread-list`, and `context`.
             attachment_ids (list[str] | None): Context-scoped `att_*` attachment IDs; only valid for `send`, `reply`, and `thread-reply`, and the combined total with `attachment_file_paths` cannot exceed 5.
-            attachment_file_paths (list[str] | None): Local file paths to register and send in the current context; only valid for `send`, `reply`, and `thread-reply`, and the combined total with `attachment_ids` cannot exceed 5.
+            attachment_file_paths (list[str] | None): Local file paths to register and send in the current context; relative paths resolve from the agent workspace. Only valid for `send`, `reply`, and `thread-reply`, and the combined total with `attachment_ids` cannot exceed 5.
             room_id (str | None): Optional target room ID or alias; defaults to the current room context when omitted.
             target (str | None): Event ID to react to for `react` or to edit for `edit`.
             thread_id (str | None): Optional explicit thread target; `thread_id="room"` forces room-level scope instead of inheriting the current thread.

--- a/src/mindroom/custom_tools/matrix_message.py
+++ b/src/mindroom/custom_tools/matrix_message.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from collections import defaultdict, deque
+from pathlib import Path  # noqa: TC003 - tool config sync evaluates constructor type hints at runtime.
 from threading import Lock
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
 from agno.tools import Toolkit
 
@@ -14,9 +15,6 @@ from mindroom.custom_tools.matrix_helpers import check_rate_limit
 from mindroom.custom_tools.tool_payloads import custom_tool_payload
 from mindroom.matrix.message_extras import MessageExtraSection, parse_message_extra_sections
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 class MatrixMessageTools(Toolkit):

--- a/src/mindroom/tools/matrix_message.py
+++ b/src/mindroom/tools/matrix_message.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.metadata import SetupType, ToolCategory, ToolStatus, register_tool_with_metadata
+from mindroom.tool_system.metadata import (
+    SetupType,
+    ToolCategory,
+    ToolManagedInitArg,
+    ToolStatus,
+    register_tool_with_metadata,
+)
 
 if TYPE_CHECKING:
     from mindroom.custom_tools.matrix_message import MatrixMessageTools
@@ -24,6 +30,7 @@ if TYPE_CHECKING:
     dependencies=["agno"],
     docs_url="https://github.com/mindroom-ai/mindroom",
     function_names=("matrix_message",),
+    managed_init_args=(ToolManagedInitArg.TOOL_OUTPUT_WORKSPACE_ROOT,),
 )
 def matrix_message_tools() -> type[MatrixMessageTools]:
     """Return native Matrix messaging tools."""

--- a/tests/test_attachments_tool.py
+++ b/tests/test_attachments_tool.py
@@ -772,6 +772,27 @@ async def test_attachments_tool_register_attachment_uses_resolved_thread_scope(t
 
 
 @pytest.mark.asyncio
+async def test_attachments_tool_register_attachment_resolves_relative_paths_from_workspace(tmp_path: Path) -> None:
+    """Registering a relative file path should use the agent workspace root."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    generated_file = workspace / "scratch" / "generated.txt"
+    generated_file.parent.mkdir()
+    generated_file.write_text("artifact", encoding="utf-8")
+    tool = AttachmentTools(tool_output_workspace_root=workspace)
+    ctx = _tool_context(tmp_path)
+
+    with tool_runtime_context(ctx):
+        payload = json.loads(await tool.register_attachment("scratch/generated.txt"))
+
+    assert payload["status"] == "ok"
+    assert payload["attachment"]["local_path"] == str(generated_file.resolve())
+    attachment = load_attachment(tmp_path, payload["attachment_id"])
+    assert attachment is not None
+    assert attachment.local_path == generated_file.resolve()
+
+
+@pytest.mark.asyncio
 async def test_send_context_attachments_inherits_resolved_thread_scope(tmp_path: Path) -> None:
     """Attachment sends should stay in the resolved thread even when raw thread_id is absent."""
     sample_file = tmp_path / "upload.txt"
@@ -992,6 +1013,32 @@ async def test_send_context_attachments_sends_local_file_paths_by_auto_registeri
     assert result.newly_registered_attachment_ids == result.resolved_attachment_ids
     assert result.newly_registered_attachment_ids[0] in list_tool_runtime_attachment_ids(current_context)
     mocked.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_context_attachments_rejects_workspace_relative_file_path_escape(tmp_path: Path) -> None:
+    """Workspace-relative attachment paths must not resolve outside the agent workspace."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("secret", encoding="utf-8")
+    ctx = _tool_context(tmp_path)
+
+    with (
+        tool_runtime_context(ctx),
+        patch("mindroom.custom_tools.attachments.send_file_message", new=AsyncMock(return_value="$file_evt")) as mocked,
+    ):
+        result, send_error = await send_context_attachments(
+            ctx,
+            attachment_ids=[],
+            attachment_file_paths=["../outside.txt"],
+            workspace_root=workspace,
+        )
+
+    assert result is None
+    assert send_error is not None
+    assert "workspace" in send_error
+    mocked.assert_not_awaited()
 
 
 def test_tool_runtime_context_none_temporarily_clears_nested_scope(tmp_path: Path) -> None:

--- a/tests/test_matrix_message_docs.py
+++ b/tests/test_matrix_message_docs.py
@@ -30,6 +30,7 @@ def test_matrix_message_description_covers_critical_behavior() -> None:
     assert 'thread_id="room"' in description
     assert "combined limit" in description
     assert "5 per call" in description
+    assert "Relative paths resolve from the agent workspace" in description
 
 
 def test_matrix_message_parameter_descriptions_are_exposed() -> None:
@@ -57,6 +58,7 @@ def test_matrix_message_parameter_descriptions_are_exposed() -> None:
     assert "att_*" in attachment_ids_description
     assert "cannot exceed 5" in attachment_ids_description
     assert "cannot exceed 5" in attachment_paths_description
+    assert "relative paths resolve from the agent workspace" in attachment_paths_description
 
     assert "current room context" in room_id_description
     assert "react" in target_description

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -972,6 +972,49 @@ async def test_matrix_message_send_supports_attachment_file_paths(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_matrix_message_send_resolves_relative_attachment_file_paths_from_workspace(tmp_path: Path) -> None:
+    """Relative attachment_file_paths should resolve from the agent workspace root."""
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    generated_file = workspace_root / "scratch" / "generated.txt"
+    generated_file.parent.mkdir()
+    generated_file.write_text("artifact", encoding="utf-8")
+    tool = MatrixMessageTools(tool_output_workspace_root=workspace_root)
+    ctx = _make_context(storage_path=tmp_path)
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.send_message_result",
+            new=AsyncMock(side_effect=delivered_matrix_side_effect("$evt")),
+        ),
+        patch(
+            "mindroom.custom_tools.attachments.send_file_message",
+            new=AsyncMock(return_value="$file_evt"),
+        ) as mock_send_file,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_message(
+                action="send",
+                message="hello",
+                attachment_file_paths=["scratch/generated.txt"],
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    assert payload["attachment_event_ids"] == ["$file_evt"]
+    mock_send_file.assert_awaited_once_with(
+        ctx.client,
+        ctx.room_id,
+        generated_file.resolve(),
+        config=ctx.config,
+        thread_id="$evt",
+        latest_thread_event_id="$evt",
+        conversation_cache=ctx.conversation_cache,
+    )
+
+
+@pytest.mark.asyncio
 async def test_matrix_message_send_text_failure_does_not_attempt_attachments(tmp_path: Path) -> None:
     """Attachment sends should not start when the text send fails."""
     tool = MatrixMessageTools()


### PR DESCRIPTION
## Summary
- resolve relative matrix_message attachment file paths from the tool workspace root
- keep absolute attachment paths supported
- document the behavior in the matrix_message tool schema

## Tests
- uv run ruff check src/mindroom/custom_tools/attachments.py src/mindroom/custom_tools/matrix_conversation_operations.py src/mindroom/custom_tools/matrix_message.py src/mindroom/tools/matrix_message.py tests/test_matrix_message_docs.py tests/test_matrix_message_tool.py
- uv run pytest -n 0 tests/test_matrix_message_tool.py::test_matrix_message_send_supports_attachment_file_paths tests/test_matrix_message_tool.py::test_matrix_message_send_resolves_relative_attachment_file_paths_from_workspace tests/test_matrix_message_docs.py

## Summary by Sourcery

Resolve matrix_message attachment file paths relative to the agent workspace while preserving absolute path support and propagating the workspace root through the Matrix messaging tool stack.

New Features:
- Allow MatrixMessageTools to be configured with a tool output workspace root that is used for resolving relative attachment file paths.

Bug Fixes:
- Ensure relative attachment_file_paths used by matrix_message are correctly resolved from the agent workspace rather than the process working directory.

Enhancements:
- Wire workspace-root-aware attachment resolution through matrix conversation operations and attachment helpers to centralize path handling.
- Document in the matrix_message tool schema that attachment_file_paths use the agent workspace as the base for relative paths and update tests to enforce this documentation.

Tests:
- Add coverage to verify relative attachment_file_paths resolve from the workspace root and that documentation reflects the new behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachment paths can be resolved relative to a provided workspace root, enabling workspace-relative attachment sending and upload.

* **Tooling**
  * Messaging tool updated to accept and propagate a workspace-root so attachments resolve consistently per tool instance.

* **Documentation**
  * Clarified docs and examples to state relative attachment paths resolve from the agent workspace and must stay inside it.

* **Tests**
  * Added tests for workspace-relative resolution and for rejecting paths that escape the workspace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1022)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->