### PR TITLE
Restore room-level media upload grace

### DIFF
--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -552,10 +552,7 @@ class CoalescingGate:
         gate.phase = GatePhase.GRACE
         gate.grace_deadline = time.monotonic() + self._upload_grace_hard_cap_seconds()
         gate.deadline = time.monotonic() + min(grace_seconds, self._upload_grace_hard_cap_seconds())
-        original_candidate_count = candidate_count
         candidate_count = self._extend_candidate_with_grace_media(gate, candidate_count)
-        if candidate_count > original_candidate_count:
-            return candidate_count
         if self._has_item_after_candidate(gate, candidate_count):
             return candidate_count
         grace_start = time.monotonic()
@@ -720,7 +717,7 @@ class CoalescingGate:
                 coalesce_normal_events = current_key[1] is not None
                 await self._wait_for_debounce(gate, coalesce_normal_events=coalesce_normal_events)
                 bypass_grace = self._is_shutting_down() or gate.drain_all_requested
-                use_upload_grace = not bypass_grace and coalesce_normal_events and self._upload_grace_seconds() > 0
+                use_upload_grace = not bypass_grace and self._upload_grace_seconds() > 0
                 candidate_count = self._front_normal_run_length(
                     gate,
                     coalesce_normal_events=coalesce_normal_events,

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 import nio
@@ -11,7 +12,29 @@ from mindroom.coalescing import CoalescingGate
 from mindroom.coalescing_batch import PendingEvent
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from mindroom.coalescing_batch import CoalescedBatch
+
+
+async def _wait_for(condition: Callable[[], bool], *, deadline_seconds: float = 0.5) -> None:
+    """Poll until a test condition becomes true."""
+    ready = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _mark_ready() -> None:
+        if condition():
+            ready.set()
+            return
+        loop.call_later(0.001, _mark_ready)
+
+    _mark_ready()
+    try:
+        async with asyncio.timeout(deadline_seconds):
+            await ready.wait()
+    except TimeoutError as exc:
+        msg = "Timed out waiting for async test condition"
+        raise AssertionError(msg) from exc
 
 
 def _text_event(event_id: str, body: str, origin_server_ts: int) -> nio.RoomMessageText:
@@ -28,7 +51,27 @@ def _text_event(event_id: str, body: str, origin_server_ts: int) -> nio.RoomMess
     )
 
 
-def _pending(event: nio.RoomMessageText) -> PendingEvent:
+def _image_event(event_id: str, origin_server_ts: int) -> nio.RoomMessageImage:
+    """Build one plain Matrix image event."""
+    return nio.RoomMessageImage.from_dict(
+        {
+            "content": {
+                "body": "photo.jpg",
+                "filename": "photo.jpg",
+                "info": {"mimetype": "image/jpeg"},
+                "msgtype": "m.image",
+                "url": "mxc://localhost/photo",
+            },
+            "event_id": event_id,
+            "sender": "@user:localhost",
+            "origin_server_ts": origin_server_ts,
+            "room_id": "!room:localhost",
+            "type": "m.room.message",
+        },
+    )
+
+
+def _pending(event: nio.RoomMessageText | nio.RoomMessageImage) -> PendingEvent:
     """Wrap one Matrix event as pending user ingress."""
     return PendingEvent(
         event=event,
@@ -63,6 +106,59 @@ async def test_room_level_messages_do_not_coalesce() -> None:
         ["$extras:localhost"],
     ]
     assert all("quick succession" not in batch.prompt for batch in batches)
+
+
+@pytest.mark.asyncio
+async def test_room_level_messages_do_not_coalesce_during_upload_grace() -> None:
+    """Room-level text roots must stay separate even when upload grace is enabled."""
+    batches: list[CoalescedBatch] = []
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        batches.append(batch)
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.05,
+        is_shutting_down=lambda: False,
+    )
+    key = ("!room:localhost", None, "@user:localhost")
+
+    await gate.enqueue(key, _pending(_text_event("$first:localhost", "first", 1_000_000)))
+    await gate.enqueue(key, _pending(_text_event("$second:localhost", "second", 1_000_600)))
+
+    await gate.drain_all()
+
+    assert [batch.source_event_ids for batch in batches] == [
+        ["$first:localhost"],
+        ["$second:localhost"],
+    ]
+    assert all("quick succession" not in batch.prompt for batch in batches)
+
+
+@pytest.mark.asyncio
+async def test_room_level_text_waits_for_late_media_upload_grace() -> None:
+    """One room-level text root may still collect a late media upload."""
+    batches: list[CoalescedBatch] = []
+
+    async def dispatch_batch(batch: CoalescedBatch) -> None:
+        batches.append(batch)
+
+    gate = CoalescingGate(
+        dispatch_batch=dispatch_batch,
+        debounce_seconds=lambda: 0.0,
+        upload_grace_seconds=lambda: 0.05,
+        is_shutting_down=lambda: False,
+    )
+    key = ("!room:localhost", None, "@user:localhost")
+
+    await gate.enqueue(key, _pending(_text_event("$text:localhost", "describe this", 1_000_000)))
+    await asyncio.sleep(0.01)
+    await gate.enqueue(key, _pending(_image_event("$image:localhost", 1_000_600)))
+
+    await _wait_for(lambda: len(batches) >= 1)
+
+    assert [batch.source_event_ids for batch in batches] == [["$text:localhost", "$image:localhost"]]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep room-level normal text roots capped to one event while allowing that single text candidate to wait for late media during upload grace
- remove the dead early-return branch in upload grace candidate extension
- add focused regressions for room-level text/text separation with grace enabled and room-level text+late-media batching

## Review follow-up
Addresses PR #1020 review threads about room-level upload grace and the unreachable early return in `_wait_for_upload_grace`.

## Verification
- `uv run pytest tests/test_coalescing.py -q -n 0 --no-cov -v`
- `uv run pytest tests/test_live_message_coalescing.py -q -n 0 --no-cov`
- `uv run ruff check src/mindroom/coalescing.py tests/test_coalescing.py`
- commit hooks: ruff check, ruff format, ty, vulture, Tach boundaries, module privacy

## Summary by Sourcery

Restore room-level upload grace behavior while keeping room-level text messages uncoalesced by default.

Bug Fixes:
- Ensure room-level text roots remain separate even when upload grace is enabled, while still allowing a single text root to collect late media uploads.

Enhancements:
- Simplify upload grace candidate extension by removing an unreachable early return branch and adjusting when upload grace applies in gate draining.

Tests:
- Add async tests covering room-level text/non-text separation with upload grace enabled and room-level text plus late-media batching, including new helpers for building image events and waiting on async conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message coalescing logic during file uploads with refined deadline handling.

* **Tests**
  * Added test coverage to verify message coalescing behavior during upload operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1023)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->