### PR TITLE
Fix private OAuth token credential route ordering

### DIFF
--- a/src/mindroom/api/credentials.py
+++ b/src/mindroom/api/credentials.py
@@ -848,14 +848,16 @@ class _DashboardCredentialAccess:
     ) -> _DashboardCredentialAccess:
         """Resolve dashboard credential access for one request."""
         oauth_services = _oauth_services_for_request(request)
-        allow_oauth_private_scopes = any(
+        # Token services are rejected below, but they still need target resolution
+        # first so agent-scoped requests run authorization before route-specific 400s.
+        oauth_service_requires_target_resolution = any(
             oauth_services.match(service) is not None for service in service_names
         ) and _request_may_target_scoped_credentials(request, agent_name)
         target = resolve_request_credentials_target(
             request,
             agent_name=agent_name,
             service_names=service_names,
-            allow_private_scopes=allow_private_scopes or allow_oauth_private_scopes,
+            allow_private_scopes=allow_private_scopes or oauth_service_requires_target_resolution,
         )
         oauth_services.reject_non_editable_services(service_names)
         return cls(target=target, oauth_services=oauth_services)

--- a/src/mindroom/api/credentials.py
+++ b/src/mindroom/api/credentials.py
@@ -162,13 +162,6 @@ class _OAuthCredentialServices:
         for service in services:
             _reject_oauth_token_service(self.match(service))
 
-    def allows_private_scope_for(self, service: str) -> bool:
-        """Return whether this OAuth config service can target a private scope."""
-        if is_oauth_client_config_service(service):
-            return True
-        match = self.match(service)
-        return match is not None and match.tool_config_service and _dashboard_may_edit_oauth_match(match)
-
     def dashboard_may_show_service(self, service: str) -> bool:
         """Return whether a service may appear in dashboard credential listings."""
         match = self.match(service)
@@ -856,7 +849,7 @@ class _DashboardCredentialAccess:
         """Resolve dashboard credential access for one request."""
         oauth_services = _oauth_services_for_request(request)
         allow_oauth_private_scopes = any(
-            oauth_services.allows_private_scope_for(service) for service in service_names
+            oauth_services.match(service) is not None for service in service_names
         ) and _request_may_target_scoped_credentials(request, agent_name)
         target = resolve_request_credentials_target(
             request,


### PR DESCRIPTION
## Summary
- Preserve the OAuth token credential rejection for registered OAuth token services in private agent scopes.
- Keep agent authorization target resolution before the non-editable OAuth service rejection.
- Remove the now-unused private-scope helper.

## Test Plan
- uv run pytest tests/api/test_credentials_api.py::TestCredentialsAPI::test_get_private_oauth_credentials_filters_token_fields -n 0 --no-cov -q
- uv run pytest tests/api/test_credentials_api.py::TestCredentialsAPI::test_get_private_oauth_credentials_filters_token_fields tests/api/test_credentials_api.py::TestCredentialsAPI::test_agent_oauth_token_credentials_authorize_before_generic_rejection -n 0 --no-cov -q
- uv run ruff check src/mindroom/api/credentials.py tests/api/test_credentials_api.py
- uv run pytest tests/api/test_credentials_api.py -k "private_oauth_credentials_filters_token_fields or agent_oauth_token_credentials_authorize_before_generic_rejection or oauth_token_service_rejects_legacy_credential_routes or oauth_client_config_private_agent_save_uses_primary_runtime_store or list_services_includes_private_oauth_tool_settings" -n 0 --no-cov -q

## Summary by Sourcery

Adjust OAuth credential resolution to correctly handle private agent scopes and simplify service matching logic.

Bug Fixes:
- Ensure private OAuth token credentials are still rejected for non-editable registered token services in private agent scopes.
- Preserve agent authorization target resolution before applying generic OAuth service rejection for private scopes.

Enhancements:
- Simplify OAuth service private-scope detection by inlining the match check and removing the unused private-scope helper method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth credential access in the dashboard so services with a registered OAuth provider are correctly eligible for private-scope targeting, reducing incorrect access decisions and improving credential selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1024)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->