### PR TITLE
Run smoke stack script with uv

### DIFF
--- a/.github/workflows/smoke-stacks.yml
+++ b/.github/workflows/smoke-stacks.yml
@@ -116,7 +116,7 @@ jobs:
         run: python -m cluster.k8s.kind.smoke_instance
 
       - name: Smoke mindroom-stack compose
-        run: python -m scripts.smoke_mindroom_stack "${GITHUB_WORKSPACE}/mindroom-stack"
+        run: uv run python -m scripts.smoke_mindroom_stack "${GITHUB_WORKSPACE}/mindroom-stack"
 
       - name: Tear down kind cluster
         if: always()


### PR DESCRIPTION
## Summary
- Run the mindroom-stack smoke script through `uv run python` so the repo's `src/` package is importable in CI.
- Keep the smoke script unchanged and avoid duplicating import/path fallback logic.

## Test Plan
- `uv run python -m scripts.smoke_mindroom_stack /tmp/does-not-exist`
- `uv run pytest tests/test_smoke_mindroom_stack.py -q`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow execution to optimize how Python processes are run during automated testing procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1029)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->