### PR TITLE
Handle embedded API server SystemExit

### DIFF
--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -153,14 +153,22 @@ def _signal_name(sig: int) -> str:
     return str(sig)
 
 
-def _raise_embedded_api_server_exit(api_server: _EmbeddedApiServerContext, *, reason: str) -> NoReturn:
+def _raise_embedded_api_server_exit(
+    api_server: _EmbeddedApiServerContext,
+    *,
+    reason: str,
+    cause: BaseException | None = None,
+) -> NoReturn:
     """Raise the fatal lifecycle error for an unexpected API server exit."""
     logger.error(
         "fatal_embedded_api_server_exit",
         **api_server.log_context(),
         reason=reason,
+        exc_info=(type(cause), cause, cause.__traceback__) if cause is not None else None,
     )
     msg = "Embedded API server exited unexpectedly"
+    if cause is not None:
+        raise RuntimeError(msg) from cause
     raise RuntimeError(msg)
 
 
@@ -1853,7 +1861,10 @@ async def _run_api_server(
     config = uvicorn.Config(api_main.app, host=host, port=port, log_level=log_level.lower())
     server = _SignalAwareUvicornServer(config, shutdown_requested)
     logger.info("embedded_api_server_started", **api_server.log_context())
-    await server.serve()
+    try:
+        await server.serve()
+    except SystemExit as exc:
+        _raise_embedded_api_server_exit(api_server, reason="server.serve() raised SystemExit", cause=exc)
     shutdown_expected = shutdown_requested.is_set() if shutdown_requested is not None else False
     logger.info(
         "embedded_api_server_serve_returned",

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -1648,6 +1648,44 @@ class TestAgentBot:
         mock_error.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_run_api_server_converts_uvicorn_system_exit_to_runtime_error(self, tmp_path: Path) -> None:
+        """Uvicorn bind failures call sys.exit; the embedded task should report a normal runtime failure."""
+
+        class ExitingServer:
+            should_exit = False
+            force_exit = False
+
+            def __init__(self, _config: object, _shutdown_requested: asyncio.Event | None) -> None:
+                pass
+
+            async def serve(self) -> None:
+                raise SystemExit(1)
+
+        with (
+            patch("mindroom.orchestrator.uvicorn.Config", return_value=object()),
+            patch("mindroom.orchestrator._SignalAwareUvicornServer", ExitingServer),
+            patch("mindroom.api.main.initialize_api_app"),
+            patch("mindroom.api.main.bind_orchestrator_knowledge_refresh_scheduler"),
+            patch("mindroom.orchestrator.logger.error") as mock_error,
+            pytest.raises(RuntimeError, match="Embedded API server exited unexpectedly") as exc_info,
+        ):
+            await _run_api_server(
+                "127.0.0.1",
+                0,
+                "INFO",
+                self._runtime_paths(tmp_path),
+                shutdown_requested=asyncio.Event(),
+            )
+
+        cause = exc_info.value.__cause__
+        assert isinstance(cause, SystemExit)
+        assert cause.code == 1
+        mock_error.assert_called_once()
+        assert mock_error.call_args.args == ("fatal_embedded_api_server_exit",)
+        assert mock_error.call_args.kwargs["reason"] == "server.serve() raised SystemExit"
+        assert mock_error.call_args.kwargs["exc_info"] == (SystemExit, cause, cause.__traceback__)
+
+    @pytest.mark.asyncio
     async def test_runtime_completion_raises_done_orchestrator_failure_before_clean_shutdown_return(self) -> None:
         """Simultaneous shutdown/API completion must not hide orchestrator failures."""
         shutdown_requested = asyncio.Event()


### PR DESCRIPTION
## Summary
- Convert Uvicorn `SystemExit` from embedded API server startup into the existing runtime failure path
- Preserve the original `SystemExit` as the exception cause
- Add regression coverage for Uvicorn bind/startup exits

## Tests
- `uv run ruff check src/mindroom/orchestrator.py tests/test_multi_agent_bot.py`
- `uv run pytest tests/test_multi_agent_bot.py::TestAgentBot::test_run_api_server_converts_uvicorn_system_exit_to_runtime_error tests/test_multi_agent_bot.py::TestAgentBot::test_run_api_server_fails_fast_when_serve_returns_unexpectedly tests/test_multi_agent_bot.py::TestAgentBot::test_run_api_server_allows_expected_shutdown_after_serve_returns -q -n 0 --no-cov`
- `uv run pytest -q --no-cov`

## Summary by Sourcery

Handle unexpected embedded API server termination by converting Uvicorn SystemExit into the standard runtime failure path and add regression coverage.

Bug Fixes:
- Treat Uvicorn SystemExit during embedded API server startup as a runtime failure while preserving the original exception as the cause.

Tests:
- Add regression tests covering SystemExit from Uvicorn serve, unexpected early returns, and expected shutdown behaviour for the embedded API server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for the embedded API server to gracefully manage unexpected exits and preserve original error context for clearer diagnostics.

* **Tests**
  * Added test coverage for API server exit scenarios to verify proper exception chaining and logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1030)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->