### PR TITLE
Run MindRoom containers under tini

### DIFF
--- a/cluster/k8s/instance/templates/_helpers.tpl
+++ b/cluster/k8s/instance/templates/_helpers.tpl
@@ -58,7 +58,7 @@
 - name: sandbox-runner
   image: {{ $values.mindroom_image | default "ghcr.io/mindroom-ai/mindroom:latest" }}
   imagePullPolicy: {{ $values.mindroom_image_pull_policy | default "Always" }}
-  command: ["/app/run-sandbox-runner.sh"]
+  command: ["tini", "--", "/app/run-sandbox-runner.sh"]
   ports:
   - containerPort: 8766
   env:

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -71,6 +71,8 @@ spec:
           image: {{ include "mindroom-runtime.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
+            - tini
+            - --
             - /app/.venv/bin/mindroom
             - run
             - --api-host
@@ -282,6 +284,8 @@ spec:
           image: {{ include "mindroom-runtime.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
+            - tini
+            - --
             - /app/run-sandbox-runner.sh
           ports:
             - name: sandbox

--- a/local/instances/deploy/Dockerfile.mindroom
+++ b/local/instances/deploy/Dockerfile.mindroom
@@ -49,8 +49,9 @@ WORKDIR /app
 # - curl for health checks
 # - git and git-lfs for remote knowledge base cloning/sync
 # - bash and tmux for shell tooling and detached interactive CLI flows
+# - tini to reap orphaned subprocesses when MindRoom runs as PID 1
 # - common small CLI utilities used by headless auth/install workflows
-RUN apt-get update && apt-get install -y bash bzip2 curl git git-lfs jq nano procps ripgrep tmux unzip \
+RUN apt-get update && apt-get install -y bash bzip2 curl git git-lfs jq nano procps ripgrep tini tmux unzip \
     && printf 'set-option -g exit-empty off\n' > /etc/tmux.conf \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -79,5 +80,7 @@ ENV PATH="/app/.venv/bin:${PATH}"
 USER 1000:1000
 
 EXPOSE 8765
+# Run through an init process so orphaned subprocesses do not accumulate as zombies.
+ENTRYPOINT ["tini", "--"]
 # Run the app from the prebuilt virtualenv to avoid rebuilding at runtime
 CMD ["/app/.venv/bin/mindroom", "run"]

--- a/local/instances/deploy/Dockerfile.mindroom-minimal
+++ b/local/instances/deploy/Dockerfile.mindroom-minimal
@@ -49,8 +49,9 @@ WORKDIR /app
 # - curl for health checks
 # - git and git-lfs for remote knowledge base cloning/sync
 # - bash and tmux for shell tooling and detached interactive CLI flows
+# - tini to reap orphaned subprocesses when MindRoom runs as PID 1
 # - common small CLI utilities used by headless auth/install workflows
-RUN apt-get update && apt-get install -y bash bzip2 curl git git-lfs jq nano procps ripgrep tmux unzip \
+RUN apt-get update && apt-get install -y bash bzip2 curl git git-lfs jq nano procps ripgrep tini tmux unzip \
     && printf 'set-option -g exit-empty off\n' > /etc/tmux.conf \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -79,5 +80,7 @@ ENV PATH="/app/.venv/bin:${PATH}"
 USER 1000:1000
 
 EXPOSE 8765
+# Run through an init process so orphaned subprocesses do not accumulate as zombies.
+ENTRYPOINT ["tini", "--"]
 # Run the app from the prebuilt virtualenv to avoid rebuilding at runtime
 CMD ["/app/.venv/bin/mindroom", "run"]

--- a/tests/test_mindroom_dockerfiles.py
+++ b/tests/test_mindroom_dockerfiles.py
@@ -1,0 +1,36 @@
+"""Checks for MindRoom container process reaping defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_MINDROOM_DOCKERFILES = (
+    _REPO_ROOT / "local/instances/deploy/Dockerfile.mindroom",
+    _REPO_ROOT / "local/instances/deploy/Dockerfile.mindroom-minimal",
+)
+_RUNTIME_DEPLOYMENT_TEMPLATE = _REPO_ROOT / "cluster/k8s/runtime/templates/deployment.yaml"
+_INSTANCE_HELPERS_TEMPLATE = _REPO_ROOT / "cluster/k8s/instance/templates/_helpers.tpl"
+
+
+def test_mindroom_runtime_images_run_under_tini() -> None:
+    """MindRoom containers need an init process to reap orphaned subprocesses."""
+    for dockerfile in _MINDROOM_DOCKERFILES:
+        text = dockerfile.read_text(encoding="utf-8")
+        one_line_text = " ".join(text.split())
+
+        assert "apt-get install -y bash bzip2 curl git git-lfs jq nano procps ripgrep tini tmux unzip" in one_line_text
+        assert 'ENTRYPOINT ["tini", "--"]' in text
+        assert 'CMD ["/app/.venv/bin/mindroom", "run"]' in text
+
+
+def test_kubernetes_command_overrides_run_under_tini() -> None:
+    """Kubernetes command overrides bypass image entrypoints, so add tini explicitly."""
+    runtime_template = _RUNTIME_DEPLOYMENT_TEMPLATE.read_text(encoding="utf-8")
+    instance_helpers = _INSTANCE_HELPERS_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "command:\n            - tini\n            - --\n            - /app/.venv/bin/mindroom" in runtime_template
+    assert (
+        "command:\n            - tini\n            - --\n            - /app/run-sandbox-runner.sh" in runtime_template
+    )
+    assert 'command: ["tini", "--", "/app/run-sandbox-runner.sh"]' in instance_helpers

--- a/tests/test_mindroom_dockerfiles.py
+++ b/tests/test_mindroom_dockerfiles.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -13,13 +14,26 @@ _RUNTIME_DEPLOYMENT_TEMPLATE = _REPO_ROOT / "cluster/k8s/runtime/templates/deplo
 _INSTANCE_HELPERS_TEMPLATE = _REPO_ROOT / "cluster/k8s/instance/templates/_helpers.tpl"
 
 
+def _apt_install_packages(dockerfile_text: str) -> set[str]:
+    match = re.search(r"apt-get install -y (?P<packages>.*?)\\\s*&&", dockerfile_text, re.DOTALL)
+    assert match is not None
+    return set(match.group("packages").split())
+
+
+def _assert_command_starts_with_tini(template_text: str, command: str) -> None:
+    escaped_command = re.escape(command)
+    block_list_pattern = rf"command:\s*\n\s*-\s*tini\s*\n\s*-\s*--\s*\n\s*-\s*{escaped_command}(?=\s)"
+    inline_list_pattern = rf"command:\s*\[\s*\"tini\"\s*,\s*\"--\"\s*,\s*\"{escaped_command}\""
+
+    assert re.search(block_list_pattern, template_text) or re.search(inline_list_pattern, template_text)
+
+
 def test_mindroom_runtime_images_run_under_tini() -> None:
     """MindRoom containers need an init process to reap orphaned subprocesses."""
     for dockerfile in _MINDROOM_DOCKERFILES:
         text = dockerfile.read_text(encoding="utf-8")
-        one_line_text = " ".join(text.split())
 
-        assert "apt-get install -y bash bzip2 curl git git-lfs jq nano procps ripgrep tini tmux unzip" in one_line_text
+        assert "tini" in _apt_install_packages(text)
         assert 'ENTRYPOINT ["tini", "--"]' in text
         assert 'CMD ["/app/.venv/bin/mindroom", "run"]' in text
 
@@ -29,8 +43,6 @@ def test_kubernetes_command_overrides_run_under_tini() -> None:
     runtime_template = _RUNTIME_DEPLOYMENT_TEMPLATE.read_text(encoding="utf-8")
     instance_helpers = _INSTANCE_HELPERS_TEMPLATE.read_text(encoding="utf-8")
 
-    assert "command:\n            - tini\n            - --\n            - /app/.venv/bin/mindroom" in runtime_template
-    assert (
-        "command:\n            - tini\n            - --\n            - /app/run-sandbox-runner.sh" in runtime_template
-    )
-    assert 'command: ["tini", "--", "/app/run-sandbox-runner.sh"]' in instance_helpers
+    _assert_command_starts_with_tini(runtime_template, "/app/.venv/bin/mindroom")
+    _assert_command_starts_with_tini(runtime_template, "/app/run-sandbox-runner.sh")
+    _assert_command_starts_with_tini(instance_helpers, "/app/run-sandbox-runner.sh")


### PR DESCRIPTION
## Summary
- install tini in the MindRoom runtime Docker images and make it the image entrypoint
- prefix Kubernetes command overrides with tini so Helm deployments also reap orphaned subprocesses
- add regression checks for Dockerfiles and Kubernetes templates

## Why
The long-running MindRoom container can run as PID 1 and spawn subprocesses during knowledge refreshes. Without an init process, orphaned child processes can accumulate as zombies.

## Verification
- uv run pytest tests/test_mindroom_dockerfiles.py
- uv run pytest tests/test_helm_instance_worker_isolation.py::test_instance_chart_static_runner_uses_shared_credentials_encryption_key_secret tests/test_helm_instance_worker_isolation.py::test_runtime_chart_static_runner_uses_credentials_encryption_key_secret
- uv run ruff check tests/test_mindroom_dockerfiles.py

Note: pre-commit `ty` currently fails in this local worktree because optional extras are not installed (`playwright`, `psycopg`, `bs4`, `claude_agent_sdk`, etc.).

## Summary by Sourcery

Ensure MindRoom containers run under an init process for proper subprocess reaping across Docker and Kubernetes deployments.

New Features:
- Add tini as the init process for MindRoom runtime containers in Docker images and Kubernetes command overrides.

Tests:
- Add regression tests to verify MindRoom Dockerfiles use tini as entrypoint and default command, and that Kubernetes templates wrap commands with tini.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container startup across images and deployments to run under an init process (tini), adding an ENTRYPOINT and prefixing container commands where applicable.
  * Improved runtime process handling in both primary and sandbox runner containers.

* **Tests**
  * Added automated tests to verify the init process is installed and invoked in container images and deployment templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1031)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->