### PR TITLE
Fix OpenRouter structured output fallback

### DIFF
--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from agno.models.anthropic import Claude
@@ -27,6 +28,8 @@ from mindroom.vertex_claude_prompt_cache import install_vertex_claude_prompt_cac
 
 if TYPE_CHECKING:
     from agno.models.base import Model
+    from agno.run.agent import RunOutput
+    from pydantic import BaseModel
 
     from mindroom.config.main import Config
     from mindroom.config.models import ModelConfig
@@ -35,6 +38,31 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 __all__ = ["get_model_instance"]
+
+
+@dataclass
+class _PromptOnlyStructuredOutputOpenRouter(OpenRouter):
+    """OpenRouter wrapper that defaults structured outputs to prompt-only mode."""
+
+    supports_native_structured_outputs: bool = False
+    supports_json_schema_outputs: bool = False
+
+    def get_request_params(
+        self,
+        response_format: dict[Any, Any] | type[BaseModel] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        run_response: RunOutput | None = None,
+    ) -> dict[str, Any]:
+        request_params = super().get_request_params(
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+            run_response=run_response,
+        )
+        if response_format is not None and not self.supports_native_structured_outputs:
+            request_params.pop("response_format", None)
+        return request_params
 
 
 def _canonical_provider(provider: str) -> str:
@@ -97,7 +125,7 @@ def _create_model_for_provider(  # noqa: C901, PLR0912
             api_key = get_api_key_for_provider(canonical_provider, runtime_paths=runtime_paths)
         if not api_key:
             logger.warning("No OpenRouter API key found in environment or CredentialsManager")
-        return OpenRouter(id=model_id, api_key=api_key, **extra_kwargs)
+        return _PromptOnlyStructuredOutputOpenRouter(id=model_id, api_key=api_key, **extra_kwargs)
 
     if canonical_provider in {"codex", "openai_codex"}:
         extra_kwargs.pop("api_key", None)

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -11,10 +11,12 @@ from agno.models.message import Message
 from agno.models.response import ModelResponse
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 from agno.utils.models.claude import format_messages
+from pydantic import BaseModel
 
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
+from mindroom.model_defaults import CONFIG_INIT_MODEL_PRESETS
 from mindroom.model_loading import get_model_instance
 from mindroom.startup_errors import PermanentStartupError
 from mindroom.vertex_claude_compat import MindroomVertexAIClaude, _strip_vertex_claude_tool_strict
@@ -165,6 +167,46 @@ def test_get_model_instance_with_extra_kwargs() -> None:
 
     # Check that temperature was also passed
     assert model.temperature == 0.8
+
+
+def test_openrouter_uses_prompt_only_structured_outputs_by_default() -> None:
+    """OpenRouter model routing makes native response_format support provider-dependent."""
+    os.environ["OPENROUTER_API_KEY"] = "test-key"
+
+    class SummarySchema(BaseModel):
+        summary: str
+
+    config_data = {
+        "models": {
+            "test_model": {
+                "provider": "openrouter",
+                "id": CONFIG_INIT_MODEL_PRESETS["openrouter"].id,
+            },
+        },
+        "defaults": {
+            "markdown": True,
+        },
+        "router": {
+            "model": "test_model",
+        },
+        "memory": {
+            "embedder": {
+                "provider": "openai",
+                "config": {
+                    "model": "text-embedding-3-small",
+                },
+            },
+        },
+        "agents": {},
+    }
+
+    config, runtime_paths = _config_with_runtime_paths(config_data)
+
+    model = get_model_instance(config, runtime_paths, "test_model")
+    request_params = model.get_request_params(response_format=SummarySchema)
+
+    assert model.supports_native_structured_outputs is False
+    assert "response_format" not in request_params
 
 
 def test_different_providers_with_extra_kwargs() -> None:


### PR DESCRIPTION
## Summary
- default OpenRouter models to prompt-only structured outputs instead of provider JSON mode
- keep native structured output as an explicit model option
- add regression coverage using the current OpenRouter preset

## Tests
- uv run pytest tests/test_extra_kwargs.py::test_openrouter_uses_prompt_only_structured_outputs_by_default -q -n 0 --no-cov
- uv run ruff check src/mindroom/model_loading.py tests/test_extra_kwargs.py
- uv run pytest tests/test_extra_kwargs.py tests/test_thread_summary.py tests/test_model_defaults.py -q -n 0 --no-cov
- uv run pytest -q
- uv run pre-commit run --files src/mindroom/model_loading.py tests/test_extra_kwargs.py

Note: full pytest passed with coverage warnings from the local .coverage database, but exit code was clean.

## Summary by Sourcery

Default OpenRouter models to use prompt-only structured outputs while keeping native structured output support explicitly configurable.

New Features:
- Introduce an OpenRouter wrapper model that disables native structured outputs and JSON schema outputs by default and strips response_format from requests when unsupported.

Tests:
- Add regression test ensuring the OpenRouter preset uses prompt-only structured outputs by default and does not send response_format in request parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * OpenRouter models now default to prompt-based structured outputs for improved API compatibility and reliability.
  * Request parameters are automatically adjusted to exclude unsupported response format specifications when native structured outputs are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1032)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->