### PR TITLE
Add service lifecycle commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -277,6 +277,9 @@ On Linux, MindRoom uses systemd user services.
 ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
 │ install     Install and start MindRoom as a background user service.                   │
 │ uninstall   Stop and remove the MindRoom user service.                                 │
+│ start       Start the installed MindRoom user service.                                 │
+│ stop        Stop the installed MindRoom user service without removing it.              │
+│ restart     Restart the installed MindRoom user service.                               │
 │ status      Show MindRoom service status and recent logs.                              │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -273,6 +273,9 @@ On Linux, MindRoom uses systemd user services.
 ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
 │ install     Install and start MindRoom as a background user service.                   │
 │ uninstall   Stop and remove the MindRoom user service.                                 │
+│ start       Start the installed MindRoom user service.                                 │
+│ stop        Stop the installed MindRoom user service without removing it.              │
+│ restart     Restart the installed MindRoom user service.                               │
 │ status      Show MindRoom service status and recent logs.                              │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/src/mindroom/cli/service.py
+++ b/src/mindroom/cli/service.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 if TYPE_CHECKING:
+    from mindroom.services.config import ServiceActionResult
     from mindroom.services.config import ServiceManager
 
 _console = Console()
@@ -76,6 +77,14 @@ def _ensure_uv_installed(*, no_confirm: bool) -> None:
     _console.print(f"  [green]{message}[/green]")
 
 
+def _print_service_action_result(result: ServiceActionResult) -> None:
+    """Print a service lifecycle result and exit non-zero on failure."""
+    if not result.success:
+        _err_console.print(f"[bold red]Error:[/bold red] {result.message}")
+        raise typer.Exit(1)
+    _console.print(f"[green]{result.message}[/green]")
+
+
 @service_app.command("install")
 def install_service(
     skip_deps: bool = typer.Option(False, "--skip-deps", help="Skip uv dependency check."),
@@ -130,6 +139,27 @@ def uninstall_service(
     _console.print(f"[green]{result.message}[/green]")
     if platform.system() == "Darwin":
         _console.print("[dim]Log files are preserved at ~/Library/Logs/mindroom/[/dim]")
+
+
+@service_app.command("start")
+def start_service() -> None:
+    """Start the installed MindRoom user service."""
+    manager = _manager_or_exit()
+    _print_service_action_result(manager.start_service())
+
+
+@service_app.command("stop")
+def stop_service() -> None:
+    """Stop the installed MindRoom user service without removing it."""
+    manager = _manager_or_exit()
+    _print_service_action_result(manager.stop_service())
+
+
+@service_app.command("restart")
+def restart_service() -> None:
+    """Restart the installed MindRoom user service."""
+    manager = _manager_or_exit()
+    _print_service_action_result(manager.restart_service())
 
 
 @service_app.command("status")

--- a/src/mindroom/services/config.py
+++ b/src/mindroom/services/config.py
@@ -44,6 +44,14 @@ class UninstallResult:
     was_running: bool = False
 
 
+@dataclass(frozen=True)
+class ServiceActionResult:
+    """Result of starting, stopping, or restarting the MindRoom user service."""
+
+    success: bool
+    message: str
+
+
 class ServiceManager(NamedTuple):
     """Platform-specific MindRoom service manager interface."""
 
@@ -51,6 +59,9 @@ class ServiceManager(NamedTuple):
     install_uv: Callable[[], tuple[bool, str]]
     install_service: Callable[[], InstallResult]
     uninstall_service: Callable[[], UninstallResult]
+    start_service: Callable[[], ServiceActionResult]
+    stop_service: Callable[[], ServiceActionResult]
+    restart_service: Callable[[], ServiceActionResult]
     get_service_status: Callable[[], ServiceStatus]
     get_log_command: Callable[[], str]
     get_recent_logs: Callable[[int], list[str]]

--- a/src/mindroom/services/config.py
+++ b/src/mindroom/services/config.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 
 SERVICE_NAME = "mindroom"
+SERVICE_NOT_INSTALLED_MESSAGE = "Service is not installed. Run `mindroom service install` first."
 _PACKAGE_NAME = "mindroom"
 
 

--- a/src/mindroom/services/launchd.py
+++ b/src/mindroom/services/launchd.py
@@ -13,6 +13,7 @@ from mindroom.services.config import (
     InstallResult,
     ServiceActionResult,
     ServiceManager,
+    SERVICE_NOT_INSTALLED_MESSAGE,
     ServiceStatus,
     UninstallResult,
     build_service_command,
@@ -23,7 +24,6 @@ from mindroom.services.runtime import ServiceConfigMissingError, resolve_service
 
 _MACOS_UV_PATHS = [Path("/opt/homebrew/bin/uv")]
 _LABEL = "chat.mindroom.local"
-_SERVICE_NOT_INSTALLED_MESSAGE = "Service is not installed. Run `mindroom service install` first."
 
 
 def _get_plist_path() -> Path:
@@ -141,14 +141,11 @@ def _install_service() -> InstallResult:
     return InstallResult(success=True, message="Installed and started", log_dir=log_dir)
 
 
-def _run_launchctl(args: list[str], failure_action: str) -> ServiceActionResult | None:
-    """Run launchctl and return an error result on failure."""
-    result = subprocess.run(
-        args,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+def _launchctl_error_result(
+    result: subprocess.CompletedProcess[str],
+    failure_action: str,
+) -> ServiceActionResult | None:
+    """Return a lifecycle error result when launchctl fails."""
     if result.returncode == 0:
         return None
 
@@ -163,15 +160,18 @@ def _start_service() -> ServiceActionResult:
     """Start the installed launchd service."""
     status = _get_service_status()
     if not status.installed:
-        return ServiceActionResult(success=False, message=_SERVICE_NOT_INSTALLED_MESSAGE)
+        return ServiceActionResult(success=False, message=SERVICE_NOT_INSTALLED_MESSAGE)
     if status.running:
         return ServiceActionResult(success=True, message="Service already running")
 
     plist_path = _get_plist_path()
-    error = _run_launchctl(
+    result = subprocess.run(
         ["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_path)],
-        "start",
+        capture_output=True,
+        text=True,
+        check=False,
     )
+    error = _launchctl_error_result(result, "start")
     if error is not None:
         return error
     return ServiceActionResult(success=True, message="Service started")
@@ -181,15 +181,18 @@ def _stop_service() -> ServiceActionResult:
     """Stop the installed launchd service without removing it."""
     status = _get_service_status()
     if not status.installed:
-        return ServiceActionResult(success=False, message=_SERVICE_NOT_INSTALLED_MESSAGE)
+        return ServiceActionResult(success=False, message=SERVICE_NOT_INSTALLED_MESSAGE)
     if not status.running:
         return ServiceActionResult(success=True, message="Service already stopped")
 
     plist_path = _get_plist_path()
-    error = _run_launchctl(
+    result = subprocess.run(
         ["launchctl", "bootout", f"gui/{os.getuid()}", str(plist_path)],
-        "stop",
+        capture_output=True,
+        text=True,
+        check=False,
     )
+    error = _launchctl_error_result(result, "stop")
     if error is not None:
         return error
     return ServiceActionResult(success=True, message="Service stopped")
@@ -199,22 +202,23 @@ def _restart_service() -> ServiceActionResult:
     """Restart the installed launchd service."""
     status = _get_service_status()
     if not status.installed:
-        return ServiceActionResult(success=False, message=_SERVICE_NOT_INSTALLED_MESSAGE)
+        return ServiceActionResult(success=False, message=SERVICE_NOT_INSTALLED_MESSAGE)
 
     plist_path = _get_plist_path()
     uid = os.getuid()
-    if status.running:
-        error = _run_launchctl(
-            ["launchctl", "bootout", f"gui/{uid}", str(plist_path)],
-            "restart",
-        )
-        if error is not None:
-            return error
-
-    error = _run_launchctl(
-        ["launchctl", "bootstrap", f"gui/{uid}", str(plist_path)],
-        "restart",
+    subprocess.run(
+        ["launchctl", "bootout", f"gui/{uid}", str(plist_path)],
+        capture_output=True,
+        check=False,
     )
+
+    result = subprocess.run(
+        ["launchctl", "bootstrap", f"gui/{uid}", str(plist_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    error = _launchctl_error_result(result, "restart")
     if error is not None:
         return error
     return ServiceActionResult(success=True, message="Service restarted")

--- a/src/mindroom/services/launchd.py
+++ b/src/mindroom/services/launchd.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from mindroom.services.config import (
     InstallResult,
+    ServiceActionResult,
     ServiceManager,
     ServiceStatus,
     UninstallResult,
@@ -22,6 +23,7 @@ from mindroom.services.runtime import ServiceConfigMissingError, resolve_service
 
 _MACOS_UV_PATHS = [Path("/opt/homebrew/bin/uv")]
 _LABEL = "chat.mindroom.local"
+_SERVICE_NOT_INSTALLED_MESSAGE = "Service is not installed. Run `mindroom service install` first."
 
 
 def _get_plist_path() -> Path:
@@ -139,6 +141,85 @@ def _install_service() -> InstallResult:
     return InstallResult(success=True, message="Installed and started", log_dir=log_dir)
 
 
+def _run_launchctl(args: list[str], failure_action: str) -> ServiceActionResult | None:
+    """Run launchctl and return an error result on failure."""
+    result = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return None
+
+    detail = result.stderr.strip()
+    message = f"Failed to {failure_action} service"
+    if detail:
+        message = f"{message}: {detail}"
+    return ServiceActionResult(success=False, message=message)
+
+
+def _start_service() -> ServiceActionResult:
+    """Start the installed launchd service."""
+    status = _get_service_status()
+    if not status.installed:
+        return ServiceActionResult(success=False, message=_SERVICE_NOT_INSTALLED_MESSAGE)
+    if status.running:
+        return ServiceActionResult(success=True, message="Service already running")
+
+    plist_path = _get_plist_path()
+    error = _run_launchctl(
+        ["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_path)],
+        "start",
+    )
+    if error is not None:
+        return error
+    return ServiceActionResult(success=True, message="Service started")
+
+
+def _stop_service() -> ServiceActionResult:
+    """Stop the installed launchd service without removing it."""
+    status = _get_service_status()
+    if not status.installed:
+        return ServiceActionResult(success=False, message=_SERVICE_NOT_INSTALLED_MESSAGE)
+    if not status.running:
+        return ServiceActionResult(success=True, message="Service already stopped")
+
+    plist_path = _get_plist_path()
+    error = _run_launchctl(
+        ["launchctl", "bootout", f"gui/{os.getuid()}", str(plist_path)],
+        "stop",
+    )
+    if error is not None:
+        return error
+    return ServiceActionResult(success=True, message="Service stopped")
+
+
+def _restart_service() -> ServiceActionResult:
+    """Restart the installed launchd service."""
+    status = _get_service_status()
+    if not status.installed:
+        return ServiceActionResult(success=False, message=_SERVICE_NOT_INSTALLED_MESSAGE)
+
+    plist_path = _get_plist_path()
+    uid = os.getuid()
+    if status.running:
+        error = _run_launchctl(
+            ["launchctl", "bootout", f"gui/{uid}", str(plist_path)],
+            "restart",
+        )
+        if error is not None:
+            return error
+
+    error = _run_launchctl(
+        ["launchctl", "bootstrap", f"gui/{uid}", str(plist_path)],
+        "restart",
+    )
+    if error is not None:
+        return error
+    return ServiceActionResult(success=True, message="Service restarted")
+
+
 def _uninstall_service() -> UninstallResult:
     """Stop and remove the launchd service."""
     plist_path = _get_plist_path()
@@ -170,6 +251,9 @@ manager = ServiceManager(
     install_uv=install_uv,
     install_service=_install_service,
     uninstall_service=_uninstall_service,
+    start_service=_start_service,
+    stop_service=_stop_service,
+    restart_service=_restart_service,
     get_service_status=_get_service_status,
     get_log_command=_get_log_command,
     get_recent_logs=_get_recent_logs,

--- a/src/mindroom/services/systemd.py
+++ b/src/mindroom/services/systemd.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from mindroom.services.config import (
     SERVICE_NAME,
     InstallResult,
+    ServiceActionResult,
     ServiceManager,
     ServiceStatus,
     UninstallResult,
@@ -19,6 +20,7 @@ from mindroom.services.config import (
 from mindroom.services.runtime import ServiceConfigMissingError, resolve_service_environment
 
 _LINUX_UV_PATHS = [Path("/usr/bin/uv")]
+_SERVICE_NOT_INSTALLED_MESSAGE = "Service is not installed. Run `mindroom service install` first."
 
 
 def _get_unit_name() -> str:
@@ -167,6 +169,43 @@ def _install_service() -> InstallResult:
     return InstallResult(success=True, message="Installed and started")
 
 
+def _run_systemctl_action(action: str, success_message: str) -> ServiceActionResult:
+    """Run one systemd user-service lifecycle action."""
+    unit_path = _get_unit_path()
+    if not unit_path.exists():
+        return ServiceActionResult(success=False, message=_SERVICE_NOT_INSTALLED_MESSAGE)
+
+    result = subprocess.run(
+        ["systemctl", "--user", action, _get_unit_name()],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip()
+        message = f"Failed to {action} service"
+        if detail:
+            message = f"{message}: {detail}"
+        return ServiceActionResult(success=False, message=message)
+
+    return ServiceActionResult(success=True, message=success_message)
+
+
+def _start_service() -> ServiceActionResult:
+    """Start the installed systemd user service."""
+    return _run_systemctl_action("start", "Service started")
+
+
+def _stop_service() -> ServiceActionResult:
+    """Stop the installed systemd user service without removing it."""
+    return _run_systemctl_action("stop", "Service stopped")
+
+
+def _restart_service() -> ServiceActionResult:
+    """Restart the installed systemd user service."""
+    return _run_systemctl_action("restart", "Service restarted")
+
+
 def _uninstall_service() -> UninstallResult:
     """Stop and remove the systemd user service."""
     unit_path = _get_unit_path()
@@ -197,6 +236,9 @@ manager = ServiceManager(
     install_uv=install_uv,
     install_service=_install_service,
     uninstall_service=_uninstall_service,
+    start_service=_start_service,
+    stop_service=_stop_service,
+    restart_service=_restart_service,
     get_service_status=_get_service_status,
     get_log_command=_get_log_command,
     get_recent_logs=_get_recent_logs,

--- a/src/mindroom/services/systemd.py
+++ b/src/mindroom/services/systemd.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from mindroom.services.config import (
     SERVICE_NAME,
+    SERVICE_NOT_INSTALLED_MESSAGE,
     InstallResult,
     ServiceActionResult,
     ServiceManager,
@@ -20,7 +21,6 @@ from mindroom.services.config import (
 from mindroom.services.runtime import ServiceConfigMissingError, resolve_service_environment
 
 _LINUX_UV_PATHS = [Path("/usr/bin/uv")]
-_SERVICE_NOT_INSTALLED_MESSAGE = "Service is not installed. Run `mindroom service install` first."
 
 
 def _get_unit_name() -> str:
@@ -173,7 +173,7 @@ def _run_systemctl_action(action: str, success_message: str) -> ServiceActionRes
     """Run one systemd user-service lifecycle action."""
     unit_path = _get_unit_path()
     if not unit_path.exists():
-        return ServiceActionResult(success=False, message=_SERVICE_NOT_INSTALLED_MESSAGE)
+        return ServiceActionResult(success=False, message=SERVICE_NOT_INSTALLED_MESSAGE)
 
     result = subprocess.run(
         ["systemctl", "--user", action, _get_unit_name()],

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -224,12 +224,36 @@ def test_systemd_lifecycle_actions_use_systemctl(mock_run: MagicMock, tmp_path: 
 
 
 def test_systemd_lifecycle_action_requires_installed_unit(tmp_path: Path) -> None:
-    """Starting a missing systemd service should tell users to install first."""
+    """Missing systemd lifecycle actions should tell users to install first."""
     with patch("mindroom.services.systemd._get_unit_path", return_value=tmp_path / "missing.service"):
-        result = _start_systemd_service()
+        start_result = _start_systemd_service()
+        stop_result = _stop_systemd_service()
+        restart_result = _restart_systemd_service()
 
-    assert result.success is False
-    assert "service install" in result.message
+    expected_message = "Service is not installed. Run `mindroom service install` first."
+    assert start_result == ServiceActionResult(success=False, message=expected_message)
+    assert stop_result == ServiceActionResult(success=False, message=expected_message)
+    assert restart_result == ServiceActionResult(success=False, message=expected_message)
+
+
+@patch("mindroom.services.systemd.subprocess.run")
+def test_systemd_lifecycle_actions_propagate_systemctl_errors(mock_run: MagicMock, tmp_path: Path) -> None:
+    """systemd lifecycle actions surface non-zero systemctl results."""
+    unit_path = tmp_path / "mindroom.service"
+    unit_path.touch()
+    mock_run.return_value = MagicMock(returncode=1, stderr="unit failed")
+
+    with patch("mindroom.services.systemd._get_unit_path", return_value=unit_path):
+        start_result = _start_systemd_service()
+        stop_result = _stop_systemd_service()
+        restart_result = _restart_systemd_service()
+
+    assert start_result.success is False
+    assert start_result.message == "Failed to start service: unit failed"
+    assert stop_result.success is False
+    assert stop_result.message == "Failed to stop service: unit failed"
+    assert restart_result.success is False
+    assert restart_result.message == "Failed to restart service: unit failed"
 
 
 @patch("mindroom.services.launchd.os.getuid", return_value=501)
@@ -286,7 +310,7 @@ def test_launchd_restart_starts_stopped_service(
     mock_getuid: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """Restarting a stopped launchd service should start it without requiring bootout."""
+    """Restarting a stopped launchd service should still clear any loaded job."""
     plist_path = tmp_path / "chat.mindroom.local.plist"
     plist_path.touch()
     mock_run.return_value = MagicMock(returncode=0, stderr="")
@@ -301,17 +325,114 @@ def test_launchd_restart_starts_stopped_service(
     assert result.success is True
     mock_getuid.assert_called_once_with()
     assert [call.args[0] for call in mock_run.call_args_list] == [
+        ["launchctl", "bootout", "gui/501", str(plist_path)],
         ["launchctl", "bootstrap", "gui/501", str(plist_path)],
     ]
 
 
 def test_launchd_lifecycle_action_requires_installed_plist(tmp_path: Path) -> None:
-    """Starting a missing launchd service should tell users to install first."""
+    """Missing launchd lifecycle actions should tell users to install first."""
     with patch("mindroom.services.launchd._get_plist_path", return_value=tmp_path / "missing.plist"):
-        result = _start_launchd_service()
+        start_result = _start_launchd_service()
+        stop_result = _stop_launchd_service()
+        restart_result = _restart_launchd_service()
 
-    assert result.success is False
-    assert "service install" in result.message
+    expected_message = "Service is not installed. Run `mindroom service install` first."
+    assert start_result == ServiceActionResult(success=False, message=expected_message)
+    assert stop_result == ServiceActionResult(success=False, message=expected_message)
+    assert restart_result == ServiceActionResult(success=False, message=expected_message)
+
+
+@patch("mindroom.services.launchd.os.getuid", return_value=501)
+@patch("mindroom.services.launchd.subprocess.run")
+def test_launchd_lifecycle_actions_propagate_launchctl_errors(
+    mock_run: MagicMock,
+    mock_getuid: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """launchd lifecycle actions surface non-zero launchctl results."""
+    plist_path = tmp_path / "chat.mindroom.local.plist"
+    plist_path.touch()
+    status = ServiceStatus(installed=True, running=False)
+    mock_run.return_value = MagicMock(returncode=1, stderr="bootstrap failed")
+
+    with (
+        patch("mindroom.services.launchd._get_plist_path", return_value=plist_path),
+        patch("mindroom.services.launchd._get_service_status", return_value=status),
+    ):
+        start_result = _start_launchd_service()
+
+    assert start_result.success is False
+    assert start_result.message == "Failed to start service: bootstrap failed"
+    mock_getuid.assert_called_once_with()
+
+
+@patch("mindroom.services.launchd.os.getuid", return_value=501)
+@patch("mindroom.services.launchd.subprocess.run")
+def test_launchd_stop_service_propagates_launchctl_errors(
+    mock_run: MagicMock,
+    mock_getuid: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """launchd stop surfaces bootout failures."""
+    plist_path = tmp_path / "chat.mindroom.local.plist"
+    plist_path.touch()
+    status = ServiceStatus(installed=True, running=True, pid=123)
+    mock_run.return_value = MagicMock(returncode=1, stderr="bootout failed")
+
+    with (
+        patch("mindroom.services.launchd._get_plist_path", return_value=plist_path),
+        patch("mindroom.services.launchd._get_service_status", return_value=status),
+    ):
+        stop_result = _stop_launchd_service()
+
+    assert stop_result.success is False
+    assert stop_result.message == "Failed to stop service: bootout failed"
+    mock_getuid.assert_called_once_with()
+
+
+@patch("mindroom.services.launchd.os.getuid", return_value=501)
+@patch("mindroom.services.launchd.subprocess.run")
+def test_launchd_restart_service_propagates_bootstrap_errors(
+    mock_run: MagicMock,
+    mock_getuid: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """launchd restart ignores bootout failures but surfaces bootstrap failures."""
+    plist_path = tmp_path / "chat.mindroom.local.plist"
+    plist_path.touch()
+    status = ServiceStatus(installed=True, running=True, pid=123)
+    mock_run.side_effect = [
+        MagicMock(returncode=1, stderr="ignored bootout failure"),
+        MagicMock(returncode=1, stderr="bootstrap failed"),
+    ]
+
+    with (
+        patch("mindroom.services.launchd._get_plist_path", return_value=plist_path),
+        patch("mindroom.services.launchd._get_service_status", return_value=status),
+    ):
+        restart_result = _restart_launchd_service()
+
+    assert restart_result.success is False
+    assert restart_result.message == "Failed to restart service: bootstrap failed"
+    mock_getuid.assert_called_once_with()
+
+
+@patch("mindroom.services.launchd.subprocess.run")
+def test_launchd_stop_service_already_stopped(mock_run: MagicMock, tmp_path: Path) -> None:
+    """Stopping an installed but stopped launchd service should be a no-op."""
+    plist_path = tmp_path / "chat.mindroom.local.plist"
+    plist_path.touch()
+    status = ServiceStatus(installed=True, running=False)
+
+    with (
+        patch("mindroom.services.launchd._get_plist_path", return_value=plist_path),
+        patch("mindroom.services.launchd._get_service_status", return_value=status),
+    ):
+        result = _stop_launchd_service()
+
+    assert result == ServiceActionResult(success=True, message="Service already stopped")
+    mock_run.assert_not_called()
 
 
 def test_service_help_is_registered() -> None:
@@ -413,3 +534,31 @@ def test_service_start_failure_exits_with_message(mock_get_manager: MagicMock) -
 
     assert result.exit_code == 1
     assert "Service is not installed" in result.output
+
+
+@patch("mindroom.cli.service._get_service_manager")
+def test_service_stop_failure_exits_with_message(mock_get_manager: MagicMock) -> None:
+    """Service stop failures should print a concise error and exit non-zero."""
+    mock_manager = MagicMock(spec=ServiceManager)
+    mock_manager.stop_service.return_value = ServiceActionResult(success=False, message="stop failed")
+    mock_get_manager.return_value = mock_manager
+
+    result = runner.invoke(app, ["service", "stop"])
+
+    assert result.exit_code == 1
+    assert "stop failed" in result.output
+    mock_manager.stop_service.assert_called_once_with()
+
+
+@patch("mindroom.cli.service._get_service_manager")
+def test_service_restart_failure_exits_with_message(mock_get_manager: MagicMock) -> None:
+    """Service restart failures should print a concise error and exit non-zero."""
+    mock_manager = MagicMock(spec=ServiceManager)
+    mock_manager.restart_service.return_value = ServiceActionResult(success=False, message="restart failed")
+    mock_get_manager.return_value = mock_manager
+
+    result = runner.invoke(app, ["service", "restart"])
+
+    assert result.exit_code == 1
+    assert "restart failed" in result.output
+    mock_manager.restart_service.assert_called_once_with()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -13,6 +13,7 @@ from typer.testing import CliRunner
 from mindroom.cli.main import app
 from mindroom.services.config import (
     InstallResult,
+    ServiceActionResult,
     ServiceManager,
     ServiceStatus,
     build_service_command,
@@ -21,9 +22,15 @@ from mindroom.services.config import (
 )
 from mindroom.services.launchd import _generate_plist
 from mindroom.services.launchd import _get_log_command as _get_launchd_log_command
+from mindroom.services.launchd import _restart_service as _restart_launchd_service
+from mindroom.services.launchd import _start_service as _start_launchd_service
+from mindroom.services.launchd import _stop_service as _stop_launchd_service
 from mindroom.services.manager import get_service_manager
 from mindroom.services.runtime import ServiceConfigMissingError, resolve_service_environment
 from mindroom.services.systemd import _generate_unit_file, _get_unit_name
+from mindroom.services.systemd import _restart_service as _restart_systemd_service
+from mindroom.services.systemd import _start_service as _start_systemd_service
+from mindroom.services.systemd import _stop_service as _stop_systemd_service
 
 runner = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb"})
 
@@ -197,12 +204,125 @@ def test_resolve_service_environment_requires_existing_config(
         resolve_service_environment(tmp_path / "uv")
 
 
+@patch("mindroom.services.systemd.subprocess.run")
+def test_systemd_lifecycle_actions_use_systemctl(mock_run: MagicMock, tmp_path: Path) -> None:
+    """systemd lifecycle actions preserve the unit and call systemctl."""
+    unit_path = tmp_path / "mindroom.service"
+    unit_path.touch()
+    mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+    with patch("mindroom.services.systemd._get_unit_path", return_value=unit_path):
+        assert _start_systemd_service().success is True
+        assert _stop_systemd_service().success is True
+        assert _restart_systemd_service().success is True
+
+    assert [call.args[0] for call in mock_run.call_args_list] == [
+        ["systemctl", "--user", "start", "mindroom.service"],
+        ["systemctl", "--user", "stop", "mindroom.service"],
+        ["systemctl", "--user", "restart", "mindroom.service"],
+    ]
+
+
+def test_systemd_lifecycle_action_requires_installed_unit(tmp_path: Path) -> None:
+    """Starting a missing systemd service should tell users to install first."""
+    with patch("mindroom.services.systemd._get_unit_path", return_value=tmp_path / "missing.service"):
+        result = _start_systemd_service()
+
+    assert result.success is False
+    assert "service install" in result.message
+
+
+@patch("mindroom.services.launchd.os.getuid", return_value=501)
+@patch("mindroom.services.launchd.subprocess.run")
+def test_launchd_lifecycle_actions_use_launchctl(
+    mock_run: MagicMock,
+    mock_getuid: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """launchd lifecycle actions load and unload the existing plist."""
+    plist_path = tmp_path / "chat.mindroom.local.plist"
+    plist_path.touch()
+    mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+    status = ServiceStatus(installed=True, running=True, pid=123)
+    with (
+        patch("mindroom.services.launchd._get_plist_path", return_value=plist_path),
+        patch("mindroom.services.launchd._get_service_status", return_value=status),
+    ):
+        assert _start_launchd_service().success is True
+        assert _stop_launchd_service().success is True
+        assert _restart_launchd_service().success is True
+
+    assert mock_getuid.call_count == 2
+    assert [call.args[0] for call in mock_run.call_args_list] == [
+        ["launchctl", "bootout", "gui/501", str(plist_path)],
+        ["launchctl", "bootout", "gui/501", str(plist_path)],
+        ["launchctl", "bootstrap", "gui/501", str(plist_path)],
+    ]
+
+
+@patch("mindroom.services.launchd.subprocess.run")
+def test_launchd_start_is_idempotent_when_already_running(mock_run: MagicMock, tmp_path: Path) -> None:
+    """Starting an already running launchd service should not re-bootstrap it."""
+    plist_path = tmp_path / "chat.mindroom.local.plist"
+    plist_path.touch()
+    status = ServiceStatus(installed=True, running=True, pid=123)
+
+    with (
+        patch("mindroom.services.launchd._get_plist_path", return_value=plist_path),
+        patch("mindroom.services.launchd._get_service_status", return_value=status),
+    ):
+        result = _start_launchd_service()
+
+    assert result.success is True
+    assert result.message == "Service already running"
+    mock_run.assert_not_called()
+
+
+@patch("mindroom.services.launchd.os.getuid", return_value=501)
+@patch("mindroom.services.launchd.subprocess.run")
+def test_launchd_restart_starts_stopped_service(
+    mock_run: MagicMock,
+    mock_getuid: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Restarting a stopped launchd service should start it without requiring bootout."""
+    plist_path = tmp_path / "chat.mindroom.local.plist"
+    plist_path.touch()
+    mock_run.return_value = MagicMock(returncode=0, stderr="")
+    status = ServiceStatus(installed=True, running=False)
+
+    with (
+        patch("mindroom.services.launchd._get_plist_path", return_value=plist_path),
+        patch("mindroom.services.launchd._get_service_status", return_value=status),
+    ):
+        result = _restart_launchd_service()
+
+    assert result.success is True
+    mock_getuid.assert_called_once_with()
+    assert [call.args[0] for call in mock_run.call_args_list] == [
+        ["launchctl", "bootstrap", "gui/501", str(plist_path)],
+    ]
+
+
+def test_launchd_lifecycle_action_requires_installed_plist(tmp_path: Path) -> None:
+    """Starting a missing launchd service should tell users to install first."""
+    with patch("mindroom.services.launchd._get_plist_path", return_value=tmp_path / "missing.plist"):
+        result = _start_launchd_service()
+
+    assert result.success is False
+    assert "service install" in result.message
+
+
 def test_service_help_is_registered() -> None:
     """The top-level CLI exposes the service command group."""
     result = runner.invoke(app, ["service", "--help"])
 
     assert result.exit_code == 0
     assert "install" in result.output
+    assert "start" in result.output
+    assert "stop" in result.output
+    assert "restart" in result.output
     assert "uninstall" in result.output
     assert "status" in result.output
 
@@ -235,3 +355,61 @@ def test_service_install_no_confirm(mock_get_manager: MagicMock) -> None:
     assert result.exit_code == 0
     assert "Installed and started" in result.output
     mock_manager.install_service.assert_called_once_with()
+
+
+@patch("mindroom.cli.service._get_service_manager")
+def test_service_start_command_succeeds(mock_get_manager: MagicMock) -> None:
+    """Service start calls the platform manager start action."""
+    mock_manager = MagicMock(spec=ServiceManager)
+    mock_manager.start_service.return_value = ServiceActionResult(success=True, message="Service started")
+    mock_get_manager.return_value = mock_manager
+
+    result = runner.invoke(app, ["service", "start"])
+
+    assert result.exit_code == 0
+    assert "Service started" in result.output
+    mock_manager.start_service.assert_called_once_with()
+
+
+@patch("mindroom.cli.service._get_service_manager")
+def test_service_stop_command_succeeds(mock_get_manager: MagicMock) -> None:
+    """Service stop calls the platform manager stop action."""
+    mock_manager = MagicMock(spec=ServiceManager)
+    mock_manager.stop_service.return_value = ServiceActionResult(success=True, message="Service stopped")
+    mock_get_manager.return_value = mock_manager
+
+    result = runner.invoke(app, ["service", "stop"])
+
+    assert result.exit_code == 0
+    assert "Service stopped" in result.output
+    mock_manager.stop_service.assert_called_once_with()
+
+
+@patch("mindroom.cli.service._get_service_manager")
+def test_service_restart_command_succeeds(mock_get_manager: MagicMock) -> None:
+    """Service restart calls the platform manager restart action."""
+    mock_manager = MagicMock(spec=ServiceManager)
+    mock_manager.restart_service.return_value = ServiceActionResult(success=True, message="Service restarted")
+    mock_get_manager.return_value = mock_manager
+
+    result = runner.invoke(app, ["service", "restart"])
+
+    assert result.exit_code == 0
+    assert "Service restarted" in result.output
+    mock_manager.restart_service.assert_called_once_with()
+
+
+@patch("mindroom.cli.service._get_service_manager")
+def test_service_start_failure_exits_with_message(mock_get_manager: MagicMock) -> None:
+    """Service lifecycle failures should print a concise error and exit non-zero."""
+    mock_manager = MagicMock(spec=ServiceManager)
+    mock_manager.start_service.return_value = ServiceActionResult(
+        success=False,
+        message="Service is not installed. Run `mindroom service install` first.",
+    )
+    mock_get_manager.return_value = mock_manager
+
+    result = runner.invoke(app, ["service", "start"])
+
+    assert result.exit_code == 1
+    assert "Service is not installed" in result.output


### PR DESCRIPTION
## Summary
- Add `mindroom service start`, `stop`, and `restart` CLI commands.
- Add launchd and systemd lifecycle manager actions that preserve installed service files.
- Cover CLI delegation, missing-service errors, systemd actions, and launchd idempotent start/restart behavior.

## Test Plan
- `uv sync --all-extras`
- `uv run pytest`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Add platform-specific lifecycle management and CLI commands for starting, stopping, and restarting the MindRoom user service while preserving installed service definitions.

New Features:
- Introduce CLI commands `mindroom service start`, `stop`, and `restart` that delegate to the platform service manager.
- Add launchd and systemd lifecycle actions for starting, stopping, and restarting the installed user service without uninstalling it.

Enhancements:
- Unify service lifecycle result handling via a `ServiceActionResult` type and a shared CLI printing helper that enforces non-zero exits on failure.

Tests:
- Extend service tests to cover CLI lifecycle commands, error propagation on failures, and platform-specific launchd and systemd lifecycle behavior, including idempotent and missing-service scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mindroom service start, stop, and restart commands to manage the installed background service lifecycle on supported platforms, with success/failure messaging.

* **Documentation**
  * Updated CLI reference to document the new service management subcommands.

* **Tests**
  * Added coverage for service lifecycle actions (start/stop/restart) across platforms and CLI integration tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1033)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->