### PR TITLE
Fix PyPI release LFS frontend assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           ref: ${{ inputs.release_ref }}
           fetch-depth: 0
+          lfs: true
+      - name: Fetch Git LFS assets
+        run: git lfs pull
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Set up Bun

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -11,6 +11,7 @@ from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 _BUN_INSTALL_MAX_ATTEMPTS = 3
 _BUN_INSTALL_RETRY_DELAY_SECONDS = 2.0
+_GIT_LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1\n"
 
 
 class FrontendBuildHook(BuildHookInterface):
@@ -69,6 +70,22 @@ def _build_frontend(frontend_dir: Path, output_dir: Path, bun: str) -> None:
         [bun, "run", "vite", "build", "--outDir", str(output_dir)],
         cwd=frontend_dir,
     )
+    _assert_no_git_lfs_pointers(output_dir)
+
+
+def _assert_no_git_lfs_pointers(output_dir: Path) -> None:
+    """Reject frontend builds that accidentally bundle unresolved Git LFS pointers."""
+    pointer_files = [
+        path.relative_to(output_dir).as_posix()
+        for path in output_dir.rglob("*")
+        if path.is_file() and path.read_bytes().startswith(_GIT_LFS_POINTER_PREFIX)
+    ]
+    if not pointer_files:
+        return
+
+    joined = ", ".join(pointer_files)
+    msg = f"Frontend build contains unresolved Git LFS pointer assets: {joined}. Run git lfs pull before building."
+    raise RuntimeError(msg)
 
 
 def _run_command(

--- a/tests/test_hatch_build.py
+++ b/tests/test_hatch_build.py
@@ -127,6 +127,45 @@ def test_build_frontend_retries_bun_install_only(
     ]
 
 
+def test_build_frontend_rejects_git_lfs_pointer_assets(
+    hatch_build_module: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Wheel builds must fail instead of bundling unresolved Git LFS pointers."""
+    frontend_dir = tmp_path / "frontend"
+    output_dir = tmp_path / "frontend-dist"
+    frontend_dir.mkdir()
+
+    def fake_run_command(
+        cmd: list[str],
+        *,
+        cwd: Path,
+        retries: int = 1,
+        retry_delay_seconds: float = 0.0,
+    ) -> None:
+        if cmd[-2:] == ["--outDir", str(output_dir)]:
+            output_dir.mkdir(exist_ok=True)
+            (output_dir / "logo.png").write_text(
+                "version https://git-lfs.github.com/spec/v1\n"
+                "oid sha256:4aab59a2761edf3b65c4f82cd0a0f13cb0ab782a4c1ef345034d1f9724cec4f1\n"
+                "size 685151\n",
+            )
+
+    monkeypatch.setattr(hatch_build_module, "_run_command", fake_run_command)
+
+    with pytest.raises(RuntimeError, match="Run git lfs pull before building"):
+        hatch_build_module._build_frontend(frontend_dir, output_dir, "/usr/local/bin/bun")
+
+
+def test_dashboard_shell_uses_canonical_png_logo() -> None:
+    """The installed dashboard should use the canonical PNG logo assets."""
+    repo_root = Path(__file__).resolve().parents[1]
+
+    assert 'href="/favicon.png"' in (repo_root / "frontend/index.html").read_text()
+    assert 'src="/logo.png"' in (repo_root / "frontend/src/App.tsx").read_text()
+
+
 def test_wheel_force_include_does_not_bundle_avatar_assets() -> None:
     """Wheel builds should not ship repo avatar assets inside the package."""
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"


### PR DESCRIPTION
## Summary
- Fetch Git LFS assets in the PyPI release workflow before building distributions.
- Fail frontend wheel builds if unresolved Git LFS pointer files would be bundled.
- Add regression tests covering pointer rejection and canonical PNG dashboard logo references.

## Test Plan
- uv run pytest tests/test_hatch_build.py -x -n 0 --no-cov -v
- uv run pytest
- uv run pre-commit run --all-files
- uv build --wheel
- wheel asset inspection: logo.png, favicon.png, and logo-square.png are real PNG payloads, not Git LFS pointers

## Summary by Sourcery

Ensure frontend build artifacts in PyPI wheels are real assets rather than unresolved Git LFS pointers and update the release workflow accordingly.

New Features:
- Add a safeguard that scans built frontend assets and fails the build if unresolved Git LFS pointer files are present.

Enhancements:
- Ensure the dashboard frontend uses canonical PNG logo and favicon asset references in source and index files.

CI:
- Update the PyPI release GitHub Actions workflow to fetch Git LFS assets before building distributions.

Tests:
- Add tests verifying that frontend builds reject unresolved Git LFS pointer assets and that the dashboard shell references canonical PNG logo assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced build validation to prevent incomplete binary assets from being published in releases.

* **Chores**
  * Improved release workflow to properly handle and validate large binary files during the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1034)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->