### PR TITLE
Retry media fallback for OpenRouter audio errors

### DIFF
--- a/src/mindroom/media_fallback.py
+++ b/src/mindroom/media_fallback.py
@@ -11,7 +11,12 @@ if TYPE_CHECKING:
 _INLINE_MEDIA_FALLBACK_MARKER = "[Inline media unavailable for this model]"
 _INLINE_MEDIA_FIELD_PATTERN = re.compile(r"(?:document|image|audio|video)\.source\.base64(?:\.media_type)?")
 _INLINE_MEDIA_MIME_MISMATCH_PATTERN = re.compile(r"image was specified using the .* media type")
-_INLINE_MEDIA_UNSUPPORTED_PATTERN = re.compile(r"(?:audio|image|video|file|document) input is not supported")
+_INLINE_MEDIA_UNSUPPORTED_PATTERN = re.compile(
+    r"(?:"
+    r"(?:audio|image|video|file|document) input is not supported"
+    r"|support input (?:audio|image|video|file|document)"
+    r")",
+)
 
 
 def _is_media_validation_error_text(error_text: str) -> bool:

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -6061,6 +6061,7 @@ class TestUserIdPassthrough:
                 True,
             ),
             ("Error code: 500 - audio input is not supported", True),
+            ("Error code: 404 - No endpoints found that support input audio", True),
             ("invalid_request_error: max_tokens must be <= 4096", False),
             ("Rate limit exceeded", False),
         ],


### PR DESCRIPTION
## Summary
- recognize OpenRouter's \"No endpoints found that support input audio\" as an inline-media capability error
- retry the existing no-inline-media fallback path instead of surfacing a hard agent error
- add regression coverage for the exact OpenRouter error text

## Tests
- uv run pre-commit run --files src/mindroom/media_fallback.py tests/test_ai_user_id.py
- uv run pytest tests/test_ai_user_id.py::TestUserIdPassthrough::test_should_retry_without_inline_media_error_matching tests/test_team_media_fallback.py -q -n 0 --no-cov
- uv run pytest -q

## Summary by Sourcery

Handle additional inline media capability error text from OpenRouter by routing it through the existing media fallback path instead of surfacing an error.

Bug Fixes:
- Treat OpenRouter "No endpoints found that support input audio" responses as unsupported inline media errors so requests are retried without inline media.

Tests:
- Add regression test cases to ensure the new OpenRouter audio error text triggers the inline media fallback logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded detection of media compatibility errors from providers by recognizing additional error message formats. The system now more reliably identifies when providers don't support specific media types and automatically retries requests with inline media disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1035)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->