### PR TITLE
Verify TLS for voice transcription requests

### DIFF
--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15827,6 +15827,9 @@ On Linux, MindRoom uses systemd user services.
 ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
 │ install     Install and start MindRoom as a background user service.                   │
 │ uninstall   Stop and remove the MindRoom user service.                                 │
+│ start       Start the installed MindRoom user service.                                 │
+│ stop        Stop the installed MindRoom user service without removing it.              │
+│ restart     Restart the installed MindRoom user service.                               │
 │ status      Show MindRoom service status and recent logs.                              │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/src/mindroom/cli/service.py
+++ b/src/mindroom/cli/service.py
@@ -10,8 +10,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 if TYPE_CHECKING:
-    from mindroom.services.config import ServiceActionResult
-    from mindroom.services.config import ServiceManager
+    from mindroom.services.config import ServiceActionResult, ServiceManager
 
 _console = Console()
 _err_console = Console(stderr=True)

--- a/src/mindroom/services/launchd.py
+++ b/src/mindroom/services/launchd.py
@@ -10,10 +10,10 @@ import subprocess
 from pathlib import Path
 
 from mindroom.services.config import (
+    SERVICE_NOT_INSTALLED_MESSAGE,
     InstallResult,
     ServiceActionResult,
     ServiceManager,
-    SERVICE_NOT_INSTALLED_MESSAGE,
     ServiceStatus,
     UninstallResult,
     build_service_command,

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -408,7 +408,7 @@ async def _transcribe_audio(
         files = {"file": (filename, audio_data, upload_mime_type)}
         form_data = {"model": config.voice.stt.model}
 
-        async with httpx.AsyncClient(verify=False) as http_client:  # noqa: S501
+        async with httpx.AsyncClient() as http_client:
             response = await http_client.post(url, headers=headers, files=files, data=form_data)
             if response.status_code != 200:
                 logger.error(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -206,7 +206,7 @@ def test_resolve_service_environment_requires_existing_config(
 
 @patch("mindroom.services.systemd.subprocess.run")
 def test_systemd_lifecycle_actions_use_systemctl(mock_run: MagicMock, tmp_path: Path) -> None:
-    """systemd lifecycle actions preserve the unit and call systemctl."""
+    """Systemd lifecycle actions preserve the unit and call systemctl."""
     unit_path = tmp_path / "mindroom.service"
     unit_path.touch()
     mock_run.return_value = MagicMock(returncode=0, stderr="")
@@ -238,7 +238,7 @@ def test_systemd_lifecycle_action_requires_installed_unit(tmp_path: Path) -> Non
 
 @patch("mindroom.services.systemd.subprocess.run")
 def test_systemd_lifecycle_actions_propagate_systemctl_errors(mock_run: MagicMock, tmp_path: Path) -> None:
-    """systemd lifecycle actions surface non-zero systemctl results."""
+    """Systemd lifecycle actions surface non-zero systemctl results."""
     unit_path = tmp_path / "mindroom.service"
     unit_path.touch()
     mock_run.return_value = MagicMock(returncode=1, stderr="unit failed")
@@ -263,7 +263,7 @@ def test_launchd_lifecycle_actions_use_launchctl(
     mock_getuid: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """launchd lifecycle actions load and unload the existing plist."""
+    """Launchd lifecycle actions load and unload the existing plist."""
     plist_path = tmp_path / "chat.mindroom.local.plist"
     plist_path.touch()
     mock_run.return_value = MagicMock(returncode=0, stderr="")
@@ -350,7 +350,7 @@ def test_launchd_lifecycle_actions_propagate_launchctl_errors(
     mock_getuid: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """launchd lifecycle actions surface non-zero launchctl results."""
+    """Launchd lifecycle actions surface non-zero launchctl results."""
     plist_path = tmp_path / "chat.mindroom.local.plist"
     plist_path.touch()
     status = ServiceStatus(installed=True, running=False)
@@ -374,7 +374,7 @@ def test_launchd_stop_service_propagates_launchctl_errors(
     mock_getuid: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """launchd stop surfaces bootout failures."""
+    """Launchd stop surfaces bootout failures."""
     plist_path = tmp_path / "chat.mindroom.local.plist"
     plist_path.touch()
     status = ServiceStatus(installed=True, running=True, pid=123)
@@ -398,7 +398,7 @@ def test_launchd_restart_service_propagates_bootstrap_errors(
     mock_getuid: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """launchd restart ignores bootout failures but surfaces bootstrap failures."""
+    """Launchd restart ignores bootout failures but surfaces bootstrap failures."""
     plist_path = tmp_path / "chat.mindroom.local.plist"
     plist_path.touch()
     status = ServiceStatus(installed=True, running=True, pid=123)

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -228,7 +228,8 @@ class TestVoiceHandler:
             )
 
         assert transcription == "transcribed text"
-        assert client_init_kwargs == [{}]
+        assert len(client_init_kwargs) == 1
+        assert client_init_kwargs[0].get("verify", True) is not False
         assert post_calls == [
             {
                 "url": "https://stt.example.test/v1/audio/transcriptions",

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -167,6 +167,77 @@ class TestVoiceHandler:
         assert filename == "audio.bin"
         assert mime_type == "audio/unknown"
 
+    @pytest.mark.asyncio
+    async def test_transcribe_audio_uses_configured_stt_host_and_api_key_with_tls_verification(self) -> None:
+        """STT requests should keep TLS verification enabled while honoring configured credentials."""
+        config = _runtime_bound_config(
+            Config(
+                voice=VoiceConfig(
+                    enabled=True,
+                    stt=_VoiceSTTConfig(
+                        api_key="configured-api-key",
+                        host="https://stt.example.test",
+                        model="whisper-1",
+                    ),
+                ),
+            ),
+        )
+        client_init_kwargs: list[dict[str, object]] = []
+        post_calls: list[dict[str, object]] = []
+
+        class FakeResponse:
+            status_code = 200
+
+            def json(self) -> dict[str, str]:
+                return {"text": " transcribed text "}
+
+        class FakeAsyncClient:
+            def __init__(self, **kwargs: object) -> None:
+                client_init_kwargs.append(kwargs)
+
+            async def __aenter__(self) -> FakeAsyncClient:
+                return self
+
+            async def __aexit__(self, *args: object) -> None:
+                return None
+
+            async def post(
+                self,
+                url: str,
+                *,
+                headers: dict[str, str],
+                files: dict[str, tuple[str, bytes, str]],
+                data: dict[str, str],
+            ) -> FakeResponse:
+                post_calls.append(
+                    {
+                        "url": url,
+                        "headers": headers,
+                        "files": files,
+                        "data": data,
+                    },
+                )
+                return FakeResponse()
+
+        with patch("mindroom.voice_handler.httpx.AsyncClient", FakeAsyncClient):
+            transcription = await voice_handler._transcribe_audio(
+                b"audio-bytes",
+                config,
+                runtime_paths_for(config),
+                mime_type="audio/ogg",
+            )
+
+        assert transcription == "transcribed text"
+        assert client_init_kwargs == [{}]
+        assert post_calls == [
+            {
+                "url": "https://stt.example.test/v1/audio/transcriptions",
+                "headers": {"Authorization": "Bearer configured-api-key"},
+                "files": {"file": ("audio.ogg", b"audio-bytes", "audio/ogg")},
+                "data": {"model": "whisper-1"},
+            },
+        ]
+
     def test_sanitize_unavailable_mentions_uses_exact_aliases(self) -> None:
         """Voice mention sanitizing should match exact Matrix mention aliases."""
         config = _runtime_bound_config(


### PR DESCRIPTION
## Summary
- Remove explicit TLS verification disabling from the OpenAI-compatible voice transcription HTTP client.
- Keep configured STT host, API key, model, and upload metadata behavior unchanged.
- Add a focused regression test that fails if STT requests pass verify=False again.

## Tests
- uv run pytest tests/test_voice_handler.py::TestVoiceHandler::test_transcribe_audio_uses_configured_stt_host_and_api_key_with_tls_verification -q -n 0 --no-cov
- uv run pytest tests/test_voice_handler.py -q -n 0 --no-cov
- uv sync --all-extras
- uv run pre-commit run --files src/mindroom/voice_handler.py tests/test_voice_handler.py

## Notes
- Also attempted uv run pre-commit run --all-files; it failed on an unrelated existing ARG001 lint issue in tests/test_hatch_build.py, so only changed-file hooks are reported as passing for this PR.

## Summary by Sourcery

Ensure voice transcription HTTP client uses default TLS verification while preserving existing STT configuration behavior.

Bug Fixes:
- Enable TLS certificate verification for OpenAI-compatible voice transcription requests instead of explicitly disabling it.

Tests:
- Add a regression test verifying STT transcription requests use the configured host and API key while keeping TLS verification enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * TLS certificate verification is now enabled by default for audio transcription service communications.

* **Tests**
  * Added test coverage verifying transcription calls use configured STT host, API key, model, multipart audio upload, and TLS verification.
  * Minor test docstring capitalization updates.

* **Documentation**
  * CLI help updated to list new service lifecycle subcommands: start, stop, restart.

* **Style / Refactor**
  * Minor import reordering and consolidation (no behavior changes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1036)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->