### PR TITLE
Harden local provisioning pair and registration flows

### DIFF
--- a/scripts/local_mindroom_provisioning_service.py
+++ b/scripts/local_mindroom_provisioning_service.py
@@ -33,7 +33,7 @@ from urllib.parse import quote
 
 import httpx
 import uvicorn
-from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -52,6 +52,8 @@ RATE_LIMIT_CLEANUP_INTERVAL_SECONDS = 300
 RATE_LIMIT_STALE_SECONDS = 3600
 NAMESPACE_ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789"
 NAMESPACE_LENGTH = 8
+MANAGED_AGENT_USERNAME_PREFIX = "mindroom_"
+PAIR_STATUS_SESSION_HEADER = "X-Local-MindRoom-Pair-Session-Id"
 
 
 @dataclass(slots=True)
@@ -115,6 +117,7 @@ class PairStartResponse(BaseModel):
     """Response for starting pairing."""
 
     pair_code: str
+    pair_session_id: str
     expires_at: datetime
     poll_interval_seconds: int
 
@@ -448,6 +451,30 @@ def _find_pair_session_unlocked(state: ProvisioningState, pair_code: str) -> Pai
     return state.pair_sessions.get(session_id)
 
 
+def _find_pair_status_session_unlocked(
+    state: ProvisioningState,
+    *,
+    pair_session_id: str | None,
+    pair_code: str | None,
+) -> PairSession | None:
+    session_id = pair_session_id.strip() if pair_session_id else ""
+    if session_id:
+        return state.pair_sessions.get(session_id)
+    if pair_code and pair_code.strip():
+        return _find_pair_session_unlocked(state, pair_code)
+    raise HTTPException(status_code=400, detail="Missing pair session id")
+
+
+def _is_managed_agent_username_for_namespace(username: str, namespace: str) -> bool:
+    """Return whether username matches mindroom_<entity>_<namespace>."""
+    suffix = f"_{namespace}"
+    return (
+        username.startswith(MANAGED_AGENT_USERNAME_PREFIX)
+        and username.endswith(suffix)
+        and len(username) > len(MANAGED_AGENT_USERNAME_PREFIX) + len(suffix)
+    )
+
+
 def _expire_if_needed(session: PairSession, now: datetime) -> None:
     if session.status == "pending" and session.expires_at <= now:
         session.status = "expired"
@@ -662,6 +689,7 @@ async def start_pair(
 
     return PairStartResponse(
         pair_code=pair_code,
+        pair_session_id=session_id,
         expires_at=expires_at,
         poll_interval_seconds=config.pair_poll_interval_seconds,
     )
@@ -669,17 +697,25 @@ async def start_pair(
 
 @router.get("/v1/local-mindroom/pair/status", response_model=PairStatusResponse)
 async def pair_status(
-    pair_code: str,
     user_id: Annotated[str, Depends(_verify_browser_user)],
     state: Annotated[ProvisioningState, Depends(_runtime_state_from_request)],
+    pair_code: Annotated[str | None, Query()] = None,
+    x_local_mindroom_pair_session_id: Annotated[
+        str | None,
+        Header(alias=PAIR_STATUS_SESSION_HEADER),
+    ] = None,
 ) -> PairStatusResponse:
     """Poll the status of a previously issued pair code."""
     now = _now_utc()
     async with state.lock:
         _enforce_rate_limit_unlocked(state, key=f"pair:status:{user_id}", limit=60, window_seconds=60)
-        session = _find_pair_session_unlocked(state, pair_code)
+        session = _find_pair_status_session_unlocked(
+            state,
+            pair_session_id=x_local_mindroom_pair_session_id,
+            pair_code=pair_code,
+        )
         if not session or session.user_id != user_id:
-            raise HTTPException(status_code=404, detail="Pair code not found")
+            raise HTTPException(status_code=404, detail="Pair session not found")
 
         _expire_if_needed(session, now)
         if session.status == "connected" and session.connection_id:
@@ -797,6 +833,11 @@ async def register_agent(
     async with state.lock:
         connection = _require_local_client(state, x_local_mindroom_client_id, x_local_mindroom_client_secret)
         _enforce_rate_limit_unlocked(state, key=f"register:agent:{connection.id}", limit=60, window_seconds=60)
+        if not _is_managed_agent_username_for_namespace(payload.username, connection.namespace):
+            raise HTTPException(
+                status_code=403,
+                detail="Requested username is outside this local connection namespace",
+            )
         connection.last_seen_at = now
         _persist_state_unlocked(state, config.state_path)
 
@@ -822,7 +863,7 @@ def create_app(config: ServiceConfig | None = None) -> FastAPI:
         allow_origins=service_config.cors_origins,
         allow_credentials=False,
         allow_methods=["GET", "POST", "DELETE"],
-        allow_headers=["Authorization", "Content-Type", "X-Matrix-Access-Token"],
+        allow_headers=["Authorization", "Content-Type", "X-Matrix-Access-Token", PAIR_STATUS_SESSION_HEADER],
     )
     app.include_router(router)
     return app

--- a/scripts/local_mindroom_provisioning_service.py
+++ b/scripts/local_mindroom_provisioning_service.py
@@ -457,12 +457,13 @@ def _find_pair_status_session_unlocked(
     pair_session_id: str | None,
     pair_code: str | None,
 ) -> PairSession | None:
+    """Resolve pair status by session header, or legacy pair code when no header is sent."""
     session_id = pair_session_id.strip() if pair_session_id else ""
     if session_id:
         return state.pair_sessions.get(session_id)
     if pair_code and pair_code.strip():
         return _find_pair_session_unlocked(state, pair_code)
-    raise HTTPException(status_code=400, detail="Missing pair session id")
+    raise HTTPException(status_code=400, detail="Missing pair session id or pair code")
 
 
 def _is_managed_agent_username_for_namespace(username: str, namespace: str) -> bool:
@@ -705,7 +706,7 @@ async def pair_status(
         Header(alias=PAIR_STATUS_SESSION_HEADER),
     ] = None,
 ) -> PairStatusResponse:
-    """Poll the status of a previously issued pair code."""
+    """Poll a pairing session by session ID header or legacy pair code."""
     now = _now_utc()
     async with state.lock:
         _enforce_rate_limit_unlocked(state, key=f"pair:status:{user_id}", limit=60, window_seconds=60)

--- a/tests/test_local_mindroom_provisioning_service.py
+++ b/tests/test_local_mindroom_provisioning_service.py
@@ -68,12 +68,16 @@ def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.Mon
             headers={"Authorization": "Bearer token-alice"},
         )
         assert start.status_code == 200
-        pair_code = start.json()["pair_code"]
+        start_payload = start.json()
+        pair_code = start_payload["pair_code"]
+        pair_session_id = start_payload["pair_session_id"]
 
         pending = client.get(
             "/v1/local-mindroom/pair/status",
-            params={"pair_code": pair_code},
-            headers={"Authorization": "Bearer token-alice"},
+            headers={
+                "Authorization": "Bearer token-alice",
+                "X-Local-MindRoom-Pair-Session-Id": pair_session_id,
+            },
         )
         assert pending.status_code == 200
         assert pending.json()["status"] == "pending"
@@ -94,11 +98,14 @@ def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.Mon
         assert isinstance(payload["namespace"], str)
         assert len(payload["namespace"]) == 8
         assert payload["namespace"] == payload["connection"]["namespace"]
+        agent_username = f"mindroom_code_{payload['namespace']}"
 
         connected = client.get(
             "/v1/local-mindroom/pair/status",
-            params={"pair_code": pair_code},
-            headers={"Authorization": "Bearer token-alice"},
+            headers={
+                "Authorization": "Bearer token-alice",
+                "X-Local-MindRoom-Pair-Session-Id": pair_session_id,
+            },
         )
         assert connected.status_code == 200
         assert connected.json()["status"] == "connected"
@@ -107,7 +114,7 @@ def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.Mon
             "/v1/local-mindroom/register-agent",
             json={
                 "homeserver": "https://mindroom.chat",
-                "username": "mindroom_code",
+                "username": agent_username,
                 "password": "agent-pass-123",
                 "display_name": "CodeAgent",
             },
@@ -118,7 +125,7 @@ def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.Mon
         )
         assert register.status_code == 200
         assert register.json()["status"] == "created"
-        assert register.json()["user_id"] == "@mindroom_code:mindroom.chat"
+        assert register.json()["user_id"] == f"@{agent_username}:mindroom.chat"
 
         revoke = client.delete(
             f"/v1/local-mindroom/connections/{client_id}",
@@ -131,7 +138,7 @@ def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.Mon
             "/v1/local-mindroom/register-agent",
             json={
                 "homeserver": "https://mindroom.chat",
-                "username": "mindroom_other",
+                "username": f"mindroom_other_{payload['namespace']}",
                 "password": "agent-pass-123",
                 "display_name": "OtherAgent",
             },
@@ -141,6 +148,113 @@ def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.Mon
             },
         )
         assert register_after_revoke.status_code == 403
+
+
+def test_pair_status_accepts_session_header_without_pair_code_query(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pair status polling should not require putting the pair code in the URL."""
+    _patch_matrix_auth(monkeypatch)
+    app = provisioning.create_app(_service_config(tmp_path / "state.json"))
+
+    with TestClient(app) as client:
+        start = client.post(
+            "/v1/local-mindroom/pair/start",
+            headers={"Authorization": "Bearer token-alice"},
+        )
+        assert start.status_code == 200
+        pair_session_id = start.json()["pair_session_id"]
+
+        pending = client.get(
+            "/v1/local-mindroom/pair/status",
+            headers={
+                "Authorization": "Bearer token-alice",
+                "X-Local-MindRoom-Pair-Session-Id": pair_session_id,
+            },
+        )
+
+        assert pending.status_code == 200
+        assert pending.json()["status"] == "pending"
+
+
+def test_pair_status_still_accepts_pair_code_query_for_legacy_clients(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy clients may keep polling with pair_code while they migrate."""
+    _patch_matrix_auth(monkeypatch)
+    app = provisioning.create_app(_service_config(tmp_path / "state.json"))
+
+    with TestClient(app) as client:
+        start = client.post(
+            "/v1/local-mindroom/pair/start",
+            headers={"Authorization": "Bearer token-alice"},
+        )
+        assert start.status_code == 200
+
+        pending = client.get(
+            "/v1/local-mindroom/pair/status",
+            params={"pair_code": start.json()["pair_code"]},
+            headers={"Authorization": "Bearer token-alice"},
+        )
+
+        assert pending.status_code == 200
+        assert pending.json()["status"] == "pending"
+
+
+def test_register_agent_rejects_username_outside_connection_namespace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local client must not register Matrix users outside its assigned namespace."""
+    _patch_matrix_auth(monkeypatch)
+    app = provisioning.create_app(_service_config(tmp_path / "state.json"))
+    register_calls: list[str] = []
+
+    async def _fake_register(
+        config: provisioning.ServiceConfig,
+        payload: provisioning.RegisterAgentRequest,
+    ) -> provisioning.RegisterAgentResponse:
+        del config
+        register_calls.append(payload.username)
+        return provisioning.RegisterAgentResponse(
+            status="created",
+            user_id=f"@{payload.username}:mindroom.chat",
+        )
+
+    monkeypatch.setattr(provisioning, "_register_agent_with_matrix", _fake_register)
+
+    with TestClient(app) as client:
+        pair_code = client.post(
+            "/v1/local-mindroom/pair/start",
+            headers={"Authorization": "Bearer token-alice"},
+        ).json()["pair_code"]
+        complete = client.post(
+            "/v1/local-mindroom/pair/complete",
+            json={
+                "pair_code": pair_code,
+                "client_name": "alice-macbook",
+                "client_pubkey_or_fingerprint": "sha256:abc123",
+            },
+        ).json()
+
+        register = client.post(
+            "/v1/local-mindroom/register-agent",
+            json={
+                "homeserver": "https://mindroom.chat",
+                "username": "mindroom_code_wrongns",
+                "password": "agent-pass-123",
+                "display_name": "CodeAgent",
+            },
+            headers={
+                "X-Local-MindRoom-Client-Id": complete["client_id"],
+                "X-Local-MindRoom-Client-Secret": complete["client_secret"],
+            },
+        )
+
+        assert register.status_code == 403
+        assert register_calls == []
 
 
 def test_register_agent_validates_homeserver(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_local_mindroom_provisioning_service.py
+++ b/tests/test_local_mindroom_provisioning_service.py
@@ -45,6 +45,21 @@ def _patch_matrix_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(provisioning, "_matrix_whoami", _fake_matrix_whoami)
 
 
+def _managed_agent_username(entity_name: str, namespace: str) -> str:
+    return f"{provisioning.MANAGED_AGENT_USERNAME_PREFIX}{entity_name}_{namespace}"
+
+
+def _invalid_managed_agent_username(case: str, namespace: str) -> str:
+    if case == "missing_entity_between_prefix_and_namespace":
+        return _managed_agent_username("", namespace)
+    if case == "wrong_namespace_suffix":
+        return f"{_managed_agent_username('code', namespace)}x"
+    if case == "wrong_prefix_for_namespace":
+        return f"other_code_{namespace}"
+    msg = f"Unknown invalid username case: {case}"
+    raise ValueError(msg)
+
+
 def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """End-to-end happy path: pair -> complete -> register agent -> revoke."""
     _patch_matrix_auth(monkeypatch)
@@ -76,7 +91,7 @@ def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.Mon
             "/v1/local-mindroom/pair/status",
             headers={
                 "Authorization": "Bearer token-alice",
-                "X-Local-MindRoom-Pair-Session-Id": pair_session_id,
+                provisioning.PAIR_STATUS_SESSION_HEADER: pair_session_id,
             },
         )
         assert pending.status_code == 200
@@ -98,13 +113,13 @@ def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.Mon
         assert isinstance(payload["namespace"], str)
         assert len(payload["namespace"]) == 8
         assert payload["namespace"] == payload["connection"]["namespace"]
-        agent_username = f"mindroom_code_{payload['namespace']}"
+        agent_username = _managed_agent_username("code", payload["namespace"])
 
         connected = client.get(
             "/v1/local-mindroom/pair/status",
             headers={
                 "Authorization": "Bearer token-alice",
-                "X-Local-MindRoom-Pair-Session-Id": pair_session_id,
+                provisioning.PAIR_STATUS_SESSION_HEADER: pair_session_id,
             },
         )
         assert connected.status_code == 200
@@ -138,7 +153,7 @@ def test_pairing_and_register_agent_flow(tmp_path: Path, monkeypatch: pytest.Mon
             "/v1/local-mindroom/register-agent",
             json={
                 "homeserver": "https://mindroom.chat",
-                "username": f"mindroom_other_{payload['namespace']}",
+                "username": _managed_agent_username("other", payload["namespace"]),
                 "password": "agent-pass-123",
                 "display_name": "OtherAgent",
             },
@@ -170,7 +185,7 @@ def test_pair_status_accepts_session_header_without_pair_code_query(
             "/v1/local-mindroom/pair/status",
             headers={
                 "Authorization": "Bearer token-alice",
-                "X-Local-MindRoom-Pair-Session-Id": pair_session_id,
+                provisioning.PAIR_STATUS_SESSION_HEADER: pair_session_id,
             },
         )
 
@@ -203,9 +218,36 @@ def test_pair_status_still_accepts_pair_code_query_for_legacy_clients(
         assert pending.json()["status"] == "pending"
 
 
+def test_pair_status_rejects_missing_session_header_and_pair_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pair status should require either the session header or legacy pair_code."""
+    _patch_matrix_auth(monkeypatch)
+    app = provisioning.create_app(_service_config(tmp_path / "state.json"))
+
+    with TestClient(app) as client:
+        result = client.get(
+            "/v1/local-mindroom/pair/status",
+            headers={"Authorization": "Bearer token-alice"},
+        )
+
+        assert result.status_code == 400
+        assert result.json()["detail"] == "Missing pair session id or pair code"
+
+
+@pytest.mark.parametrize(
+    "invalid_username_case",
+    [
+        "missing_entity_between_prefix_and_namespace",
+        "wrong_namespace_suffix",
+        "wrong_prefix_for_namespace",
+    ],
+)
 def test_register_agent_rejects_username_outside_connection_namespace(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    invalid_username_case: str,
 ) -> None:
     """A local client must not register Matrix users outside its assigned namespace."""
     _patch_matrix_auth(monkeypatch)
@@ -238,12 +280,13 @@ def test_register_agent_rejects_username_outside_connection_namespace(
                 "client_pubkey_or_fingerprint": "sha256:abc123",
             },
         ).json()
+        namespace = complete["namespace"]
 
         register = client.post(
             "/v1/local-mindroom/register-agent",
             json={
                 "homeserver": "https://mindroom.chat",
-                "username": "mindroom_code_wrongns",
+                "username": _invalid_managed_agent_username(invalid_username_case, namespace),
                 "password": "agent-pass-123",
                 "display_name": "CodeAgent",
             },


### PR DESCRIPTION
## Summary
- return an opaque pair session id from pair start and allow pair status polling via `X-Local-MindRoom-Pair-Session-Id` instead of putting the pair code in the URL
- keep legacy `pair_code` query polling working for migration
- enforce that register-agent usernames match the authenticated local connection namespace using the existing `mindroom_<entity>_<namespace>` shape
- add service tests for session-header status polling, legacy query compatibility, and namespace rejection

## Tests
- `uv run pytest tests/test_local_mindroom_provisioning_service.py tests/test_cli_connect.py -q`
- `uv run pre-commit run --files scripts/local_mindroom_provisioning_service.py tests/test_local_mindroom_provisioning_service.py`

## Notes
- `uv run pre-commit run --all-files` was attempted; it is blocked by an unrelated existing Ruff `ARG001` issue in `tests/test_hatch_build.py`.

## Summary by Sourcery

Harden local MindRoom pairing and agent registration by introducing opaque pair session identifiers, enforcing namespace-scoped managed usernames, and extending CORS/header support.

New Features:
- Add opaque pair_session_id to pairing start responses and support polling pair status via an X-Local-MindRoom-Pair-Session-Id header.
- Expose managed agent username semantics tied to connection namespaces via a helper for validation.

Enhancements:
- Allow pair status polling to prefer session-id header while preserving legacy pair_code query compatibility, and return clearer 404 errors for missing sessions.
- Enforce that registered agent usernames stay within the authenticated local connection namespace before calling the Matrix registration backend.
- Extend CORS configuration to allow the new pair-status session header.

Tests:
- Expand provisioning service tests to cover session-header based pair status polling, legacy pair_code query compatibility, and rejection of agent usernames outside the connection namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pair-start now returns a pair session ID; pair-status accepts that session header or legacy pair_code and returns 400 if neither is provided.
  * Agent registration enforces namespace-derived managed usernames and rejects mismatches with 403.

* **Bug Fixes**
  * CORS updated to allow the new pair-session header for browser requests.

* **Tests**
  * Added coverage for session-header polling, legacy pair_code support, missing-identifier rejection, and username namespace validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1038)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->