### PR TITLE
Fall back cleanly when large-message sidecar upload fails

### DIFF
--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -404,10 +404,7 @@ async def _build_file_content(
     return mxc_uri, file_info, modified_content
 
 
-def _sidecar_upload_is_usable(mxc_uri: str | None, file_info: dict[str, Any] | None) -> bool:
-    if not mxc_uri or file_info is None:
-        return False
-
+def _sidecar_upload_has_common_metadata(file_info: dict[str, Any]) -> bool:
     size = file_info.get("size")
     mimetype = file_info.get("mimetype")
     return (
@@ -417,6 +414,39 @@ def _sidecar_upload_is_usable(mxc_uri: str | None, file_info: dict[str, Any] | N
         and isinstance(mimetype, str)
         and mimetype != ""
     )
+
+
+def _sidecar_upload_has_encrypted_metadata(mxc_uri: str, file_info: dict[str, Any]) -> bool:
+    file_url = file_info.get("url")
+    key = file_info.get("key")
+    iv = file_info.get("iv")
+    hashes = file_info.get("hashes")
+    sha256 = hashes.get("sha256") if isinstance(hashes, dict) else None
+    version = file_info.get("v")
+    return (
+        file_url == mxc_uri
+        and isinstance(key, dict)
+        and isinstance(iv, str)
+        and iv != ""
+        and isinstance(sha256, str)
+        and sha256 != ""
+        and version == "v2"
+    )
+
+
+def _sidecar_upload_is_usable(
+    mxc_uri: str | None,
+    file_info: dict[str, Any] | None,
+    *,
+    room_encrypted: bool,
+) -> bool:
+    if not mxc_uri or file_info is None:
+        return False
+
+    if not _sidecar_upload_has_common_metadata(file_info):
+        return False
+
+    return not room_encrypted or _sidecar_upload_has_encrypted_metadata(mxc_uri, file_info)
 
 
 def _build_text_fallback_content(
@@ -480,6 +510,7 @@ async def prepare_large_message(
     if current_size <= size_limit:
         return content
 
+    room_encrypted = _room_is_encrypted(client, room_id)
     source_content = content["m.new_content"] if is_edit and "m.new_content" in content else content
     preview_text = source_content["body"]
     if is_edit and _is_nonterminal_stream_content(source_content):
@@ -489,11 +520,22 @@ async def prepare_large_message(
             original_size_bytes=current_size,
         )
         mxc_uri, file_info = await _upload_content_json_sidecar(client, room_id, content)
+        if not _sidecar_upload_is_usable(mxc_uri, file_info, room_encrypted=room_encrypted):
+            logger.warning(
+                "large_message_sidecar_unavailable_using_inline_preview",
+                room_id=room_id,
+                original_size_bytes=current_size,
+                is_edit=True,
+                has_mxc_uri=bool(mxc_uri),
+                has_file_info=bool(file_info),
+            )
+            mxc_uri = None
+            file_info = None
         modified_content = _build_nonterminal_streaming_edit_preview(
             content,
             source_content,
             preview_text,
-            room_encrypted=_room_is_encrypted(client, room_id),
+            room_encrypted=room_encrypted,
             mxc_uri=mxc_uri,
             file_info=file_info,
             original_size=current_size,
@@ -525,11 +567,11 @@ async def prepare_large_message(
         size_limit,
     )
 
-    if _sidecar_upload_is_usable(mxc_uri, file_info):
+    if _sidecar_upload_is_usable(mxc_uri, file_info, room_encrypted=room_encrypted):
         _copy_preview_metadata(source_content, modified_content)
         _add_sidecar_metadata(
             modified_content,
-            room_encrypted=_room_is_encrypted(client, room_id),
+            room_encrypted=room_encrypted,
             mxc_uri=mxc_uri,
             file_info=file_info,
             original_size=current_size,

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -255,6 +255,7 @@ def _prefix_by_bytes(text: str, max_bytes: int) -> str:
 
 _CONTINUATION_INDICATOR = "\n\n[Message continues in attached file]"
 _STREAMING_PREVIEW_TRUNCATION_INDICATOR = "\n\n[Streaming preview truncated]"
+_SIDECAR_UPLOAD_FALLBACK_INDICATOR = "\n\n[Message truncated because the attachment upload failed.]"
 
 
 def _create_preview(
@@ -402,6 +403,32 @@ async def _build_file_content(
     return mxc_uri, file_info, modified_content
 
 
+def _sidecar_upload_is_usable(mxc_uri: str | None, file_info: dict[str, Any] | None) -> bool:
+    return bool(mxc_uri) and file_info is not None
+
+
+def _build_text_fallback_content(
+    source_content: dict[str, Any],
+    preview_text: str,
+    size_limit: int,
+) -> dict[str, Any]:
+    """Build a text preview when the full-content sidecar is unavailable."""
+    preview_limit = max(0, size_limit - 5000)
+    while True:
+        preview_content: dict[str, Any] = {
+            "msgtype": "m.text",
+            "body": _create_preview(
+                preview_text,
+                preview_limit,
+                continuation_indicator=_SIDECAR_UPLOAD_FALLBACK_INDICATOR,
+            ),
+        }
+        _copy_preview_metadata(source_content, preview_content)
+        if _calculate_event_size(preview_content) <= size_limit or preview_limit == 0:
+            return preview_content
+        preview_limit = max(0, preview_limit // 2)
+
+
 async def _upload_content_json_sidecar(
     client: nio.AsyncClient,
     room_id: str,
@@ -486,14 +513,25 @@ async def prepare_large_message(
         size_limit,
     )
 
-    _copy_preview_metadata(source_content, modified_content)
-    _add_sidecar_metadata(
-        modified_content,
-        room_encrypted=_room_is_encrypted(client, room_id),
-        mxc_uri=mxc_uri,
-        file_info=file_info,
-        original_size=current_size,
-    )
+    if _sidecar_upload_is_usable(mxc_uri, file_info):
+        _copy_preview_metadata(source_content, modified_content)
+        _add_sidecar_metadata(
+            modified_content,
+            room_encrypted=_room_is_encrypted(client, room_id),
+            mxc_uri=mxc_uri,
+            file_info=file_info,
+            original_size=current_size,
+        )
+    else:
+        logger.warning(
+            "large_message_sidecar_unavailable_using_text_fallback",
+            room_id=room_id,
+            original_size_bytes=current_size,
+            is_edit=is_edit,
+            has_mxc_uri=mxc_uri is not None,
+            has_file_info=file_info is not None,
+        )
+        modified_content = _build_text_fallback_content(source_content, preview_text, size_limit)
 
     if "m.relates_to" in content:
         modified_content["m.relates_to"] = content["m.relates_to"]

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -34,6 +34,7 @@ logger = get_logger(__name__)
 # Conservative limits accounting for Matrix overhead
 _NORMAL_MESSAGE_LIMIT = 55000  # ~55KB for regular messages
 _EDIT_MESSAGE_LIMIT = 27000  # ~27KB for edits (they roughly double in size)
+_LARGE_MESSAGE_PREVIEW_OVERHEAD_BYTES = 5000  # Reserve room for Matrix relation and preview metadata.
 _PASSTHROUGH_CONTENT_KEYS = frozenset(
     {
         "m.mentions",
@@ -389,22 +390,33 @@ async def _build_file_content(
     """Upload full original content JSON and build preview ``m.file`` event."""
     mxc_uri, file_info = await _upload_content_json_sidecar(client, room_id, full_content)
 
-    attachment_overhead = 5000  # Conservative estimate for attachment JSON structure
-    available = size_limit - attachment_overhead
+    available = size_limit - _LARGE_MESSAGE_PREVIEW_OVERHEAD_BYTES
     preview = _create_preview(preview_text, available)
 
     modified_content: dict[str, Any] = {
         "msgtype": "m.file",
         "body": preview,
         "filename": "message-content.json",
-        "info": file_info,
     }
+    if file_info is not None:
+        modified_content["info"] = file_info
 
     return mxc_uri, file_info, modified_content
 
 
 def _sidecar_upload_is_usable(mxc_uri: str | None, file_info: dict[str, Any] | None) -> bool:
-    return bool(mxc_uri) and file_info is not None
+    if not mxc_uri or file_info is None:
+        return False
+
+    size = file_info.get("size")
+    mimetype = file_info.get("mimetype")
+    return (
+        isinstance(size, int)
+        and not isinstance(size, bool)
+        and size >= 0
+        and isinstance(mimetype, str)
+        and mimetype != ""
+    )
 
 
 def _build_text_fallback_content(
@@ -413,7 +425,7 @@ def _build_text_fallback_content(
     size_limit: int,
 ) -> dict[str, Any]:
     """Build a text preview when the full-content sidecar is unavailable."""
-    preview_limit = max(0, size_limit - 5000)
+    preview_limit = max(0, size_limit - _LARGE_MESSAGE_PREVIEW_OVERHEAD_BYTES)
     while True:
         preview_content: dict[str, Any] = {
             "msgtype": "m.text",
@@ -528,8 +540,8 @@ async def prepare_large_message(
             room_id=room_id,
             original_size_bytes=current_size,
             is_edit=is_edit,
-            has_mxc_uri=mxc_uri is not None,
-            has_file_info=file_info is not None,
+            has_mxc_uri=bool(mxc_uri),
+            has_file_info=bool(file_info),
         )
         modified_content = _build_text_fallback_content(source_content, preview_text, size_limit)
 

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -19,6 +19,7 @@ from mindroom.constants import (
 from mindroom.matrix.large_messages import (
     _MATRIX_EVENT_HARD_LIMIT,
     _NORMAL_MESSAGE_LIMIT,
+    _SIDECAR_UPLOAD_FALLBACK_INDICATOR,
     _calculate_event_size,
     _create_preview,
     _is_edit_message,
@@ -29,7 +30,7 @@ from mindroom.matrix.large_messages import (
 from mindroom.matrix.message_content import extract_and_resolve_message
 from mindroom.tool_system.events import _TOOL_TRACE_KEY
 
-_SIDECAR_UPLOAD_FALLBACK_TEXT = "[Message truncated because the attachment upload failed.]"
+_SIDECAR_UPLOAD_FALLBACK_TEXT = _SIDECAR_UPLOAD_FALLBACK_INDICATOR.strip()
 
 
 class _UploadClient:

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -319,6 +319,122 @@ async def test_prepare_large_message_missing_sidecar_file_metadata_falls_back_to
 
 
 @pytest.mark.asyncio
+async def test_prepare_large_message_encrypted_incomplete_file_metadata_falls_back_to_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Encrypted sidecars need encrypted file metadata, not just size and mimetype."""
+
+    async def incomplete_encrypted_file_metadata(
+        _client: nio.AsyncClient,
+        _room_id: str,
+        _full_content: dict[str, object],
+    ) -> tuple[str, dict[str, object]]:
+        return "mxc://server/incomplete-encrypted-metadata", {
+            "size": 123,
+            "mimetype": "application/json",
+        }
+
+    room = MagicMock()
+    room.encrypted = True
+    client = _UploadClient(nio.UploadResponse("mxc://server/unused"))
+    client.rooms = {"!room:server": room}
+    monkeypatch.setattr(
+        "mindroom.matrix.large_messages._upload_content_json_sidecar",
+        incomplete_encrypted_file_metadata,
+    )
+    content = _large_text_content("encrypted missing metadata ")
+
+    result = await prepare_large_message(client, "!room:server", content)
+
+    _assert_text_sidecar_fallback(result, "encrypted missing metadata ")
+
+
+@pytest.mark.asyncio
+async def test_prepare_large_message_encrypted_valid_sidecar_keeps_file_preview(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Encrypted sidecars with complete file metadata should keep the m.file preview."""
+    mxc_uri = "mxc://server/encrypted-sidecar"
+    file_info = {
+        "url": mxc_uri,
+        "key": {"kty": "oct", "k": "secret"},
+        "iv": "iv-value",
+        "hashes": {"sha256": "sha256-value"},
+        "v": "v2",
+        "size": 123,
+        "mimetype": "application/json",
+    }
+
+    async def encrypted_file_metadata(
+        _client: nio.AsyncClient,
+        _room_id: str,
+        _full_content: dict[str, object],
+    ) -> tuple[str, dict[str, object]]:
+        return mxc_uri, file_info
+
+    room = MagicMock()
+    room.encrypted = True
+    client = _UploadClient(nio.UploadResponse("mxc://server/unused"))
+    client.rooms = {"!room:server": room}
+    monkeypatch.setattr("mindroom.matrix.large_messages._upload_content_json_sidecar", encrypted_file_metadata)
+    content = _large_text_content("encrypted sidecar ")
+
+    result = await prepare_large_message(client, "!room:server", content)
+
+    assert result["msgtype"] == "m.file"
+    assert result["file"] == file_info
+    assert "url" not in result
+    assert result["io.mindroom.long_text"]["version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_prepare_streaming_edit_encrypted_incomplete_file_metadata_omits_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streaming edit previews should not advertise unusable encrypted sidecars."""
+
+    async def incomplete_encrypted_file_metadata(
+        _client: nio.AsyncClient,
+        _room_id: str,
+        _full_content: dict[str, object],
+    ) -> tuple[str, dict[str, object]]:
+        return "mxc://server/incomplete-streaming-sidecar", {
+            "size": 123,
+            "mimetype": "application/json",
+        }
+
+    room = MagicMock()
+    room.encrypted = True
+    client = _UploadClient(nio.UploadResponse("mxc://server/unused"))
+    client.rooms = {"!room:server": room}
+    monkeypatch.setattr(
+        "mindroom.matrix.large_messages._upload_content_json_sidecar",
+        incomplete_encrypted_file_metadata,
+    )
+    text = "streaming encrypted fallback " + ("z" * 60000)
+    edit_content = {
+        "body": "* " + text,
+        "m.new_content": {
+            "body": text,
+            "msgtype": "m.text",
+            STREAM_STATUS_KEY: STREAM_STATUS_STREAMING,
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$abc"},
+        "msgtype": "m.text",
+    }
+
+    result = await prepare_large_message(client, "!room:server", edit_content)
+
+    inner = result["m.new_content"]
+    assert inner["msgtype"] == "m.text"
+    assert "file" not in inner
+    assert "url" not in inner
+    assert "io.mindroom.long_text" not in inner
+    assert "[Streaming preview truncated]" in inner["body"]
+    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+
+
+@pytest.mark.asyncio
 async def test_prepare_edit_message_upload_failure_falls_back_to_text() -> None:
     """Edit fallback should stay textual and fit inside the Matrix hard limit."""
     client = _UploadClient(RuntimeError("upload failed"))

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -28,6 +28,43 @@ from mindroom.matrix.large_messages import (
 from mindroom.matrix.message_content import extract_and_resolve_message
 from mindroom.tool_system.events import _TOOL_TRACE_KEY
 
+_SIDECAR_UPLOAD_FALLBACK_TEXT = "[Message truncated because the attachment upload failed.]"
+
+
+class _UploadClient:
+    rooms: dict = {}  # noqa: RUF012
+
+    def __init__(self, upload_result: object | BaseException) -> None:
+        self.upload_result = upload_result
+        self.uploaded_data: bytes | None = None
+
+    async def upload(self, **kwargs) -> tuple[object, None]:  # noqa: ANN003
+        if isinstance(self.upload_result, BaseException):
+            raise self.upload_result
+        data_provider = kwargs.get("data_provider")
+        if data_provider:
+            data = data_provider(None, None)
+            self.uploaded_data = data.read()
+        return self.upload_result, None
+
+
+def _large_text_content(prefix: str) -> dict[str, str]:
+    return {"body": prefix + ("x" * 100000), "msgtype": "m.text"}
+
+
+def _assert_text_sidecar_fallback(result: dict[str, object], expected_prefix: str) -> None:
+    assert result["msgtype"] == "m.text"
+    assert isinstance(result["body"], str)
+    assert result["body"].startswith(expected_prefix)
+    assert _SIDECAR_UPLOAD_FALLBACK_TEXT in result["body"]
+    assert "m.file" not in result.values()
+    assert "filename" not in result
+    assert "info" not in result
+    assert "url" not in result
+    assert "file" not in result
+    assert "io.mindroom.long_text" not in result
+    assert _calculate_event_size(result) <= _NORMAL_MESSAGE_LIMIT
+
 
 def test_calculate_event_size() -> None:
     """Test event size calculation."""
@@ -210,6 +247,68 @@ async def test_prepare_large_message_truncation() -> None:
 
     # Preview should fit in limit
     assert _calculate_event_size(result) <= _NORMAL_MESSAGE_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_prepare_large_message_upload_failure_falls_back_to_text() -> None:
+    """Failed JSON sidecar uploads should not create m.file events without media references."""
+    client = _UploadClient(RuntimeError("upload failed"))
+    content = _large_text_content("upload failure ")
+
+    result = await prepare_large_message(client, "!room:server", content)
+
+    _assert_text_sidecar_fallback(result, "upload failure ")
+
+
+@pytest.mark.asyncio
+async def test_prepare_large_message_missing_content_uri_falls_back_to_text() -> None:
+    """Upload responses without MXC URIs should not create malformed m.file previews."""
+    client = _UploadClient(nio.UploadResponse(""))
+    content = _large_text_content("missing uri ")
+
+    result = await prepare_large_message(client, "!room:server", content)
+
+    _assert_text_sidecar_fallback(result, "missing uri ")
+    assert client.uploaded_data is not None
+    assert json.loads(client.uploaded_data.decode("utf-8")) == content
+
+
+@pytest.mark.asyncio
+async def test_prepare_large_message_missing_sidecar_file_metadata_falls_back_to_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sidecar uploads without usable file metadata should use text instead of broken m.file."""
+
+    async def missing_file_metadata(
+        _client: nio.AsyncClient,
+        _room_id: str,
+        _full_content: dict[str, object],
+    ) -> tuple[str, None]:
+        return "mxc://server/missing-metadata", None
+
+    monkeypatch.setattr("mindroom.matrix.large_messages._upload_content_json_sidecar", missing_file_metadata)
+    client = _UploadClient(nio.UploadResponse("mxc://server/unused"))
+    content = _large_text_content("missing metadata ")
+
+    result = await prepare_large_message(client, "!room:server", content)
+
+    _assert_text_sidecar_fallback(result, "missing metadata ")
+
+
+@pytest.mark.asyncio
+async def test_prepare_large_message_valid_sidecar_keeps_file_preview() -> None:
+    """Successful JSON sidecar uploads should keep the existing m.file preview behavior."""
+    client = _UploadClient(nio.UploadResponse("mxc://server/sidecar"))
+    content = _large_text_content("successful sidecar ")
+
+    result = await prepare_large_message(client, "!room:server", content)
+
+    assert result["msgtype"] == "m.file"
+    assert result["url"] == "mxc://server/sidecar"
+    assert result["info"]["mimetype"] == "application/json"
+    assert result["io.mindroom.long_text"]["version"] == 2
+    assert client.uploaded_data is not None
+    assert json.loads(client.uploaded_data.decode("utf-8")) == content
 
 
 @pytest.mark.asyncio

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -17,6 +17,7 @@ from mindroom.constants import (
     VOICE_RAW_AUDIO_FALLBACK_KEY,
 )
 from mindroom.matrix.large_messages import (
+    _MATRIX_EVENT_HARD_LIMIT,
     _NORMAL_MESSAGE_LIMIT,
     _calculate_event_size,
     _create_preview,
@@ -261,21 +262,43 @@ async def test_prepare_large_message_upload_failure_falls_back_to_text() -> None
 
 
 @pytest.mark.asyncio
-async def test_prepare_large_message_missing_content_uri_falls_back_to_text() -> None:
+async def test_prepare_large_message_missing_content_uri_falls_back_to_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Upload responses without MXC URIs should not create malformed m.file previews."""
+    mock_logger = MagicMock()
+    monkeypatch.setattr("mindroom.matrix.large_messages.logger", mock_logger)
     client = _UploadClient(nio.UploadResponse(""))
     content = _large_text_content("missing uri ")
 
     result = await prepare_large_message(client, "!room:server", content)
 
     _assert_text_sidecar_fallback(result, "missing uri ")
+    mock_logger.warning.assert_any_call(
+        "large_message_sidecar_unavailable_using_text_fallback",
+        room_id="!room:server",
+        original_size_bytes=_calculate_event_size(content),
+        is_edit=False,
+        has_mxc_uri=False,
+        has_file_info=False,
+    )
     assert client.uploaded_data is not None
     assert json.loads(client.uploaded_data.decode("utf-8")) == content
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "file_info",
+    [
+        None,
+        {},
+        {"size": 123},
+        {"mimetype": "application/json"},
+    ],
+)
 async def test_prepare_large_message_missing_sidecar_file_metadata_falls_back_to_text(
     monkeypatch: pytest.MonkeyPatch,
+    file_info: dict[str, object] | None,
 ) -> None:
     """Sidecar uploads without usable file metadata should use text instead of broken m.file."""
 
@@ -283,8 +306,8 @@ async def test_prepare_large_message_missing_sidecar_file_metadata_falls_back_to
         _client: nio.AsyncClient,
         _room_id: str,
         _full_content: dict[str, object],
-    ) -> tuple[str, None]:
-        return "mxc://server/missing-metadata", None
+    ) -> tuple[str, dict[str, object] | None]:
+        return "mxc://server/missing-metadata", file_info
 
     monkeypatch.setattr("mindroom.matrix.large_messages._upload_content_json_sidecar", missing_file_metadata)
     client = _UploadClient(nio.UploadResponse("mxc://server/unused"))
@@ -293,6 +316,39 @@ async def test_prepare_large_message_missing_sidecar_file_metadata_falls_back_to
     result = await prepare_large_message(client, "!room:server", content)
 
     _assert_text_sidecar_fallback(result, "missing metadata ")
+
+
+@pytest.mark.asyncio
+async def test_prepare_edit_message_upload_failure_falls_back_to_text() -> None:
+    """Edit fallback should stay textual and fit inside the Matrix hard limit."""
+    client = _UploadClient(RuntimeError("upload failed"))
+    text = "edit fallback " + ("y" * 50000)
+    relates_to = {"rel_type": "m.replace", "event_id": "$abc"}
+    edit_content = {
+        "body": "* " + text,
+        "m.new_content": {"body": text, "msgtype": "m.text"},
+        "m.relates_to": relates_to,
+        "msgtype": "m.text",
+    }
+
+    result = await prepare_large_message(client, "!room:server", edit_content)
+
+    assert result["msgtype"] == "m.text"
+    assert result["m.relates_to"] == relates_to
+    assert isinstance(result["body"], str)
+    assert result["body"].startswith("* edit fallback ")
+    inner = result["m.new_content"]
+    assert inner["msgtype"] == "m.text"
+    assert inner["m.relates_to"] == relates_to
+    assert inner["body"].startswith("edit fallback ")
+    assert _SIDECAR_UPLOAD_FALLBACK_TEXT in inner["body"]
+    assert "m.file" not in inner.values()
+    assert "filename" not in inner
+    assert "info" not in inner
+    assert "url" not in inner
+    assert "file" not in inner
+    assert "io.mindroom.long_text" not in inner
+    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fall back to a plain text preview when large-message JSON sidecar upload fails or returns incomplete media metadata.
- Preserve existing `m.file` sidecar preview behavior when upload succeeds.
- Add focused regression coverage for upload failure, missing MXC URI, missing file metadata, and successful sidecar upload.

## Tests
- `uv run pytest tests/test_large_messages.py tests/test_large_messages_integration.py -q`
- `uv run pre-commit run --files src/mindroom/matrix/large_messages.py tests/test_large_messages.py`
- `uv run pre-commit run --all-files` was also attempted; it is blocked by unrelated `ARG001` findings in `tests/test_hatch_build.py`.

## Summary by Sourcery

Handle failures and incomplete metadata from large-message sidecar uploads by falling back to a safe text-only preview while preserving existing behavior when uploads succeed.

Bug Fixes:
- Avoid creating malformed or metadata-less m.file events when JSON sidecar uploads fail or return incomplete media information.

Enhancements:
- Introduce a text-only fallback preview path for large messages when sidecar uploads are unavailable or unusable, including logging for observability of these cases.

Tests:
- Add targeted tests covering sidecar upload failures, missing MXC URIs, missing sidecar file metadata, and successful sidecar uploads to validate fallback and existing behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Oversized message handling improved: previews now reserve space, include file preview only when valid metadata exists, and fall back to a textual preview with a truncation indicator when sidecar upload or metadata is unusable. Fallbacks are logged and ensure messages stay within size limits.

* **Tests**
  * Added tests covering sidecar upload failures, missing/invalid metadata, edit-case fallbacks, and successful sidecar previews.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1039)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->