### PR TITLE
Remove legacy pair status query polling

### DIFF
--- a/scripts/local_mindroom_provisioning_service.py
+++ b/scripts/local_mindroom_provisioning_service.py
@@ -33,7 +33,7 @@ from urllib.parse import quote
 
 import httpx
 import uvicorn
-from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -451,21 +451,6 @@ def _find_pair_session_unlocked(state: ProvisioningState, pair_code: str) -> Pai
     return state.pair_sessions.get(session_id)
 
 
-def _find_pair_status_session_unlocked(
-    state: ProvisioningState,
-    *,
-    pair_session_id: str | None,
-    pair_code: str | None,
-) -> PairSession | None:
-    """Resolve pair status by session header, or legacy pair code when no header is sent."""
-    session_id = pair_session_id.strip() if pair_session_id else ""
-    if session_id:
-        return state.pair_sessions.get(session_id)
-    if pair_code and pair_code.strip():
-        return _find_pair_session_unlocked(state, pair_code)
-    raise HTTPException(status_code=400, detail="Missing pair session id or pair code")
-
-
 def _is_managed_agent_username_for_namespace(username: str, namespace: str) -> bool:
     """Return whether username matches mindroom_<entity>_<namespace>."""
     suffix = f"_{namespace}"
@@ -700,21 +685,19 @@ async def start_pair(
 async def pair_status(
     user_id: Annotated[str, Depends(_verify_browser_user)],
     state: Annotated[ProvisioningState, Depends(_runtime_state_from_request)],
-    pair_code: Annotated[str | None, Query()] = None,
     x_local_mindroom_pair_session_id: Annotated[
         str | None,
         Header(alias=PAIR_STATUS_SESSION_HEADER),
     ] = None,
 ) -> PairStatusResponse:
-    """Poll a pairing session by session ID header or legacy pair code."""
+    """Poll a pairing session by opaque session ID header."""
     now = _now_utc()
     async with state.lock:
         _enforce_rate_limit_unlocked(state, key=f"pair:status:{user_id}", limit=60, window_seconds=60)
-        session = _find_pair_status_session_unlocked(
-            state,
-            pair_session_id=x_local_mindroom_pair_session_id,
-            pair_code=pair_code,
-        )
+        session_id = x_local_mindroom_pair_session_id.strip() if x_local_mindroom_pair_session_id else ""
+        if not session_id:
+            raise HTTPException(status_code=400, detail="Missing pair session id")
+        session = state.pair_sessions.get(session_id)
         if not session or session.user_id != user_id:
             raise HTTPException(status_code=404, detail="Pair session not found")
 

--- a/tests/test_local_mindroom_provisioning_service.py
+++ b/tests/test_local_mindroom_provisioning_service.py
@@ -193,11 +193,11 @@ def test_pair_status_accepts_session_header_without_pair_code_query(
         assert pending.json()["status"] == "pending"
 
 
-def test_pair_status_still_accepts_pair_code_query_for_legacy_clients(
+def test_pair_status_rejects_pair_code_query_without_session_header(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Legacy clients may keep polling with pair_code while they migrate."""
+    """Pair status polling should not accept the short pair code in the URL."""
     _patch_matrix_auth(monkeypatch)
     app = provisioning.create_app(_service_config(tmp_path / "state.json"))
 
@@ -214,15 +214,15 @@ def test_pair_status_still_accepts_pair_code_query_for_legacy_clients(
             headers={"Authorization": "Bearer token-alice"},
         )
 
-        assert pending.status_code == 200
-        assert pending.json()["status"] == "pending"
+        assert pending.status_code == 400
+        assert pending.json()["detail"] == "Missing pair session id"
 
 
-def test_pair_status_rejects_missing_session_header_and_pair_code(
+def test_pair_status_rejects_missing_session_header(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Pair status should require either the session header or legacy pair_code."""
+    """Pair status should require the opaque session header."""
     _patch_matrix_auth(monkeypatch)
     app = provisioning.create_app(_service_config(tmp_path / "state.json"))
 
@@ -233,7 +233,7 @@ def test_pair_status_rejects_missing_session_header_and_pair_code(
         )
 
         assert result.status_code == 400
-        assert result.json()["detail"] == "Missing pair session id or pair code"
+        assert result.json()["detail"] == "Missing pair session id"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- require `X-Local-MindRoom-Pair-Session-Id` for pair-status polling
- remove the legacy `pair_code` query fallback from `/v1/local-mindroom/pair/status`
- update provisioning service tests to assert query-string pair-code polling is rejected

## Tests
- `uv run pytest tests/test_local_mindroom_provisioning_service.py -q`
- `uv run pytest tests/test_local_mindroom_provisioning_service.py tests/test_cli_connect.py -q`
- `uv run pre-commit run --files scripts/local_mindroom_provisioning_service.py tests/test_local_mindroom_provisioning_service.py`
- `git diff --check`

## Notes
- Existing paired clients continue to use stored local client credentials. This only removes query-string status polling for active pairing flows.

## Summary by Sourcery

Require opaque session header for local mindroom pair status polling and remove legacy pair-code based status lookups.

Enhancements:
- Remove legacy pair status resolution via query-string pair_code and rely solely on the opaque session ID header for active pairing flows.

Tests:
- Update provisioning service tests to assert that pair status requests using only pair_code are rejected with a 400 error and that missing session headers are properly handled.