### PR TITLE
docs: add iOS beta enrollment guide

### DIFF
--- a/docs/ios-beta.md
+++ b/docs/ios-beta.md
@@ -1,0 +1,41 @@
+---
+icon: fontawesome/brands/apple
+---
+
+# iOS Beta
+
+MindRoom for iOS is distributed through Apple TestFlight while it is in beta.
+
+## Enroll
+
+Install [TestFlight](https://apps.apple.com/app/testflight/id899247664) from the App Store, then join the MindRoom beta:
+
+<p>
+  <a class="md-button md-button--primary" href="https://testflight.apple.com/join/WW68wXxw">Join the iOS Beta</a>
+</p>
+
+Open the link on your iPhone or iPad, tap **Accept**, then install **MindRoom AI** from TestFlight.
+
+If TestFlight says the beta is not accepting new testers, the current build is still waiting for Apple's Beta App Review.
+Try the button again later.
+If TestFlight says the beta is full, expired, or has no build available after the beta opens, email `support@mindroom.chat` with the Apple ID email address you use on your iOS device.
+
+## Sign In
+
+MindRoom is a Matrix client.
+After installing the beta, sign in with the Matrix homeserver and account you normally use.
+
+For the hosted MindRoom flow, use:
+
+- Homeserver: `https://mindroom.chat`
+- Client URL for desktop pairing: `https://chat.mindroom.chat`
+
+Then follow the [Getting Started](getting-started.md) guide to pair your local MindRoom runtime from the chat UI.
+
+## Beta Notes
+
+- TestFlight builds expire after 90 days.
+  Install updates from TestFlight when they appear.
+- The public beta link starts accepting new testers after Apple approves the current TestFlight build for external testing.
+- If the invitation is full, expired, or missing, email `support@mindroom.chat` with your Apple ID email address.
+- Include your device model, iOS version, app version, and homeserver URL when reporting beta issues.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -451,6 +451,44 @@ MindRoom will:
 - Explore [available tools](https://docs.mindroom.chat/tools/)
 - Set up [teams for multi-agent collaboration](https://docs.mindroom.chat/configuration/teams/)
 
+# iOS Beta
+
+MindRoom for iOS is distributed through Apple TestFlight while it is in beta.
+
+## Enroll
+
+Install [TestFlight](https://apps.apple.com/app/testflight/id899247664) from the App Store, then join the MindRoom beta:
+
+<p>
+  <a class="md-button md-button--primary" href="https://testflight.apple.com/join/WW68wXxw">Join the iOS Beta</a>
+</p>
+
+Open the link on your iPhone or iPad, tap **Accept**, then install **MindRoom AI** from TestFlight.
+
+If TestFlight says the beta is not accepting new testers, the current build is still waiting for Apple's Beta App Review.
+Try the button again later.
+If TestFlight says the beta is full, expired, or has no build available after the beta opens, email `support@mindroom.chat` with the Apple ID email address you use on your iOS device.
+
+## Sign In
+
+MindRoom is a Matrix client.
+After installing the beta, sign in with the Matrix homeserver and account you normally use.
+
+For the hosted MindRoom flow, use:
+
+- Homeserver: `https://mindroom.chat`
+- Client URL for desktop pairing: `https://chat.mindroom.chat`
+
+Then follow the [Getting Started](https://docs.mindroom.chat/getting-started/) guide to pair your local MindRoom runtime from the chat UI.
+
+## Beta Notes
+
+- TestFlight builds expire after 90 days.
+  Install updates from TestFlight when they appear.
+- The public beta link starts accepting new testers after Apple approves the current TestFlight build for external testing.
+- If the invitation is full, expired, or missing, email `support@mindroom.chat` with your Apple ID email address.
+- Include your device model, iOS version, app version, and homeserver URL when reporting beta issues.
+
 # Web Dashboard
 
 MindRoom includes a web dashboard for configuring agents, teams, rooms, and integrations without editing YAML files. Changes are synchronized to `config.yaml` in real-time.

--- a/skills/mindroom-docs/references/llms.txt
+++ b/skills/mindroom-docs/references/llms.txt
@@ -5,7 +5,8 @@
 ## MindRoom Docs
 
 - [Home](https://docs.mindroom.chat/)
-- [Getting Started](https://docs.mindroom.chat/getting-started/)
+- [Overview](https://docs.mindroom.chat/getting-started/)
+- [iOS Beta](https://docs.mindroom.chat/ios-beta/)
 - [Dashboard](https://docs.mindroom.chat/dashboard/)
 - [Overview](https://docs.mindroom.chat/configuration/)
 - [Agents](https://docs.mindroom.chat/configuration/agents/)

--- a/skills/mindroom-docs/references/page__ios-beta__index.md
+++ b/skills/mindroom-docs/references/page__ios-beta__index.md
@@ -1,0 +1,37 @@
+# iOS Beta
+
+MindRoom for iOS is distributed through Apple TestFlight while it is in beta.
+
+## Enroll
+
+Install [TestFlight](https://apps.apple.com/app/testflight/id899247664) from the App Store, then join the MindRoom beta:
+
+<p>
+  <a class="md-button md-button--primary" href="https://testflight.apple.com/join/WW68wXxw">Join the iOS Beta</a>
+</p>
+
+Open the link on your iPhone or iPad, tap **Accept**, then install **MindRoom AI** from TestFlight.
+
+If TestFlight says the beta is not accepting new testers, the current build is still waiting for Apple's Beta App Review.
+Try the button again later.
+If TestFlight says the beta is full, expired, or has no build available after the beta opens, email `support@mindroom.chat` with the Apple ID email address you use on your iOS device.
+
+## Sign In
+
+MindRoom is a Matrix client.
+After installing the beta, sign in with the Matrix homeserver and account you normally use.
+
+For the hosted MindRoom flow, use:
+
+- Homeserver: `https://mindroom.chat`
+- Client URL for desktop pairing: `https://chat.mindroom.chat`
+
+Then follow the [Getting Started](https://docs.mindroom.chat/getting-started/) guide to pair your local MindRoom runtime from the chat UI.
+
+## Beta Notes
+
+- TestFlight builds expire after 90 days.
+  Install updates from TestFlight when they appear.
+- The public beta link starts accepting new testers after Apple approves the current TestFlight build for external testing.
+- If the invitation is full, expired, or missing, email `support@mindroom.chat` with your Apple ID email address.
+- Include your device model, iOS version, app version, and homeserver URL when reporting beta issues.

--- a/skills/mindroom-docs/references/reference-index.md
+++ b/skills/mindroom-docs/references/reference-index.md
@@ -12,7 +12,8 @@ Generated from `docs/` via `.github/scripts/generate_skill_references.py`.
 | Title | Source page | Built markdown | Reference file |
 | --- | --- | --- | --- |
 | Home | `index.md` | `index.md` | `page__index.md` |
-| Getting Started | `getting-started.md` | `getting-started/index.md` | `page__getting-started__index.md` |
+| Overview | `getting-started.md` | `getting-started/index.md` | `page__getting-started__index.md` |
+| iOS Beta | `ios-beta.md` | `ios-beta/index.md` | `page__ios-beta__index.md` |
 | Dashboard | `dashboard.md` | `dashboard/index.md` | `page__dashboard__index.md` |
 | Overview | `configuration/index.md` | `configuration/index.md` | `page__configuration__index.md` |
 | Agents | `configuration/agents.md` | `configuration/agents/index.md` | `page__configuration__agents__index.md` |

--- a/zensical.toml
+++ b/zensical.toml
@@ -14,7 +14,10 @@ edit_uri = "edit/main/docs"
 
 nav = [
   { "Home" = "index.md" },
-  { "Getting Started" = "getting-started.md" },
+  { "Getting Started" = [
+    { "Overview" = "getting-started.md" },
+    { "iOS Beta" = "ios-beta.md" },
+  ] },
   { "Dashboard" = "dashboard.md" },
   { "Configuration" = [
     { "Overview" = "configuration/index.md" },


### PR DESCRIPTION
## Summary
- Add a public iOS Beta docs page with TestFlight enrollment steps
- Link the page from the main docs navigation
- Regenerate the bundled mindroom-docs skill references for the new page

## Verification
- uv run zensical build
- uv run python .github/scripts/generate_skill_references.py

## App Review Context
- App Store Connect submission b8fbf3a9-c981-422a-9249-bc0ad0c0857a is Waiting for Review as of May 15, 2026
- Demo Matrix login was verified against https://demo.mindroom.chat with the review account before submission

## Summary by Sourcery

Add public documentation for enrolling in and using the MindRoom iOS beta via TestFlight and wire it into the docs navigation and skill references.

Documentation:
- Introduce an iOS Beta guide covering TestFlight enrollment, sign-in details, and beta usage notes.
- Link the new iOS Beta page from the main documentation navigation.

Chores:
- Regenerate mindroom-docs skill reference index and page artifacts to include the new iOS Beta documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive iOS Beta docs describing enrollment via Apple TestFlight, sign-in guidance for using MindRoom as a Matrix client (homeserver and pairing flow), and beta-specific notes (90-day build expiration, Apple review behavior, troubleshooting and issue-reporting details).
  * Added an “iOS Beta” entry to the docs navigation and reference index to surface the new guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->