### PR TITLE
Fix docs frontmatter icon rendering

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,7 +1,8 @@
-<!-- This page exists for iOS App Store submission requirements. Not included in sidebar nav. -->
 ---
 icon: lucide/shield-check
 ---
+
+<!-- This page exists for iOS App Store submission requirements. Not included in sidebar nav. -->
 
 # Privacy Policy
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,7 +1,8 @@
-<!-- This page exists for iOS App Store submission requirements. Not included in sidebar nav. -->
 ---
 icon: lucide/life-buoy
 ---
+
+<!-- This page exists for iOS App Store submission requirements. Not included in sidebar nav. -->
 
 # Support
 

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,7 +1,8 @@
-<!-- This page exists for iOS App Store submission requirements. Not included in sidebar nav. -->
 ---
 icon: lucide/file-text
 ---
+
+<!-- This page exists for iOS App Store submission requirements. Not included in sidebar nav. -->
 
 # Terms of Service
 

--- a/tests/test_docs_frontmatter.py
+++ b/tests/test_docs_frontmatter.py
@@ -1,0 +1,16 @@
+"""Tests for documentation metadata that the static site build consumes."""
+
+from pathlib import Path
+
+DOCS_ROOT = Path(__file__).resolve().parents[1] / "docs"
+
+
+def test_lucide_icon_metadata_uses_top_level_frontmatter() -> None:
+    """Zensical renders misplaced frontmatter as literal page content."""
+    misplaced_icon_pages = []
+    for path in sorted(DOCS_ROOT.rglob("*.md")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        if any(line.startswith("icon: lucide/") for line in lines[:10]) and lines[:1] != ["---"]:
+            misplaced_icon_pages.append(path.relative_to(DOCS_ROOT.parent).as_posix())
+
+    assert misplaced_icon_pages == []


### PR DESCRIPTION
## Summary
- Move App Store-only page comments below YAML frontmatter so Zensical parses Lucide icon metadata instead of rendering it as page text.
- Fix the same frontmatter placement issue on support, privacy, and terms pages.
- Add a docs regression test that catches Lucide icon metadata not starting at top-level frontmatter.

## Test Plan
- [x] `.venv/bin/ruff check tests/test_docs_frontmatter.py`
- [x] `.venv/bin/python -m pytest tests/test_docs_frontmatter.py -q -n 0 --no-cov`
- [x] `.venv/bin/zensical build`
- [x] `rg -n "icon: lucide/|lucide/life-buoy|lucide/shield-check|lucide/file-text" site -g "*.html" -g "*.json"` returns no matches

## Notes
- Full `.venv/bin/python -m pytest --no-cov` was attempted locally before isolating this PR branch. It did not pass due to existing environment/unrelated failures: 5 failed, 3 errors, 6766 passed, 125 skipped. Failures involved local git commit setup, Composio cache permissions, sandbox env hook behavior, and local Anthropic gateway socket permissions.

## Summary by Sourcery

Ensure documentation pages with Lucide icons use proper top-level frontmatter so metadata is parsed instead of rendered as content.

Bug Fixes:
- Correct frontmatter placement on support, privacy, and terms docs pages so Lucide icon metadata is recognized by the docs generator instead of shown as body text.

Tests:
- Add a regression test that scans markdown docs to verify Lucide icon metadata appears only in top-level frontmatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Adjusted metadata structure across documentation files for consistency.

* **Tests**
  * Added automated validation for documentation metadata placement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->