### PR TITLE
Keep SaaS platform off Matrix apex

### DIFF
--- a/cluster/k8s/platform/templates/apex-redirect.yaml
+++ b/cluster/k8s/platform/templates/apex-redirect.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.apexRedirect .Values.apexRedirect.enabled }}
 # Apex redirect: mindroom.chat and www.mindroom.chat -> https://app.<domain>
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -37,3 +38,4 @@ spec:
     - {{ .Values.domain }}
     - www.{{ .Values.domain }}
     secretName: platform-root-tls-cert
+{{- end }}

--- a/cluster/k8s/platform/values-prod.example.yaml
+++ b/cluster/k8s/platform/values-prod.example.yaml
@@ -18,6 +18,10 @@ stripe:
 cleanupScheduler:
   enabled: "true"
 
+# The apex mindroom.chat is the Matrix server name and must stay on hetzner-matrix.
+apexRedirect:
+  enabled: false
+
 monitoring:
   enabled: true
   releaseLabel: monitoring

--- a/cluster/k8s/platform/values.yaml
+++ b/cluster/k8s/platform/values.yaml
@@ -65,6 +65,10 @@ ingress:
   # Keep disabled for local kind; enable in hardened clusters if allowed.
   enableConfigurationSnippet: false
 
+# The apex mindroom.chat is the Matrix server name and must stay on hetzner-matrix.
+apexRedirect:
+  enabled: false
+
 monitoring:
   enabled: true
   releaseLabel: monitoring


### PR DESCRIPTION
## Summary
- disable the platform apex redirect ingress by default
- keep mindroom.chat reserved for the Matrix homeserver
- leave app/api/webhooks platform ingress hosts unchanged

## Verification
- nix run nixpkgs#kubernetes-helm -- lint cluster/k8s/platform
- nix run nixpkgs#kubernetes-helm -- template platform ./cluster/k8s/platform --namespace mindroom-production --set environment=production --set domain=mindroom.chat
- nix run nixpkgs#kubernetes-helm -- template platform ./cluster/k8s/platform --namespace mindroom-production --set environment=production --set domain=mindroom.chat --set apexRedirect.enabled=true

## Summary by Sourcery

Enhancements:
- Introduce an apexRedirect flag defaulting to disabled in Helm values to control creation of the apex redirect ingress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration support for optional apex redirect functionality. The feature is disabled by default and can be enabled through platform configuration values when needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->