### PR TITLE
Polish SaaS landing and glass auth

### DIFF
--- a/cluster/k8s/platform/templates/ingress.yaml
+++ b/cluster/k8s/platform/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   name: platform-ingress
   namespace: mindroom-{{ .Values.environment }}
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
     nginx.ingress.kubernetes.io/client-header-buffer-size: "16k"
@@ -50,7 +49,7 @@ spec:
   - host: webhooks.{{ .Values.domain }}
     http:
       paths:
-      - path: /stripe
+      - path: /webhooks/stripe
         pathType: Prefix
         backend:
           service:

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -258,7 +258,7 @@ Platform ingress hosts:
 
 - `app.{domain}` - Platform frontend
 - `api.{domain}` - Platform backend API
-- `webhooks.{domain}/stripe` - Stripe webhooks
+- `webhooks.{domain}/webhooks/stripe` - Stripe webhooks
 
 ## Local Development with Kind
 

--- a/saas-platform/platform-frontend/src/app/__tests__/page.test.tsx
+++ b/saas-platform/platform-frontend/src/app/__tests__/page.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import LandingPage from '../page'
+
+jest.mock('@/components/landing/HeroParticleBackground', () => ({
+  HeroParticleBackground: () => <div data-testid="hero-particles" />,
+}))
+
+jest.mock('@/components/DarkModeToggle', () => ({
+  DarkModeToggle: () => <button type="button">Toggle dark mode</button>,
+}))
+
+describe('LandingPage', () => {
+  it('links to the public documentation', () => {
+    render(<LandingPage />)
+
+    const docsLinks = screen.getAllByRole('link', { name: 'Docs' })
+    expect(docsLinks.length).toBeGreaterThan(0)
+    expect(docsLinks[0]).toHaveAttribute('href', 'https://docs.mindroom.chat/')
+  })
+})

--- a/saas-platform/platform-frontend/src/app/auth/login/page.tsx
+++ b/saas-platform/platform-frontend/src/app/auth/login/page.tsx
@@ -1,60 +1,30 @@
+import { AuthShell } from '@/components/auth/auth-shell'
 import { AuthWrapper } from '@/components/auth/auth-wrapper'
-import { MindRoomLogo } from '@/components/MindRoomLogo'
 import { getServerRuntimeConfig } from '@/lib/runtime-config'
 import { headers } from 'next/headers'
-import Link from 'next/link'
-import { X } from 'lucide-react'
 import { sanitizePostAuthRedirect } from '@/lib/auth/redirect'
 
-export default async function LoginPage({ searchParams }: { searchParams: { redirect_to?: string } }) {
+export default async function LoginPage({ searchParams }: { searchParams: Promise<{ redirect_to?: string }> }) {
   // Use the request host only as a fallback for local or misconfigured deployments.
   const hdrs = await headers()
+  const params = await searchParams
   const host = hdrs.get('host') || ''
   const { platformDomain } = getServerRuntimeConfig({ requireSupabase: false })
-  const nextTarget = sanitizePostAuthRedirect(searchParams?.redirect_to, platformDomain)
+  const nextTarget = sanitizePostAuthRedirect(params?.redirect_to, platformDomain)
   const base = platformDomain
     ? `https://app.${platformDomain}`
     : (host ? `https://${host}` : '')
   const callback = `${base}/auth/callback?next=${encodeURIComponent(nextTarget)}`
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4 bg-gradient-to-br from-orange-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
-      {/* Background decoration */}
-      <div className="absolute inset-0 overflow-hidden">
-        <div className="absolute top-0 right-0 w-96 h-96 bg-gradient-to-r from-orange-200 to-pink-200 dark:from-orange-900/10 dark:to-pink-900/10 rounded-full filter blur-3xl opacity-20"></div>
-        <div className="absolute bottom-0 left-0 w-96 h-96 bg-gradient-to-r from-blue-200 to-purple-200 dark:from-blue-900/10 dark:to-purple-900/10 rounded-full filter blur-3xl opacity-20"></div>
-      </div>
-
-      <div className="relative max-w-md w-full bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm rounded-3xl shadow-2xl p-8 border border-gray-100 dark:border-gray-700">
-        {/* Close button */}
-        <Link
-          href="/"
-          className="absolute top-4 right-4 p-2 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-          aria-label="Return to home"
-        >
-          <X className="w-5 h-5" />
-        </Link>
-
-        {/* Logo */}
-        <Link href="/" className="flex items-center justify-center gap-3 mb-8 group">
-          <MindRoomLogo className="text-orange-500 group-hover:scale-110 transition-transform duration-300" size={40} />
-        </Link>
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold dark:text-white">Welcome Back</h1>
-          <p className="text-gray-600 dark:text-gray-400 mt-2">Sign in to access your MindRoom</p>
-        </div>
-
-        <AuthWrapper view="sign_in" redirectTo={callback} />
-
-        <div className="mt-6 text-center">
-          <p className="text-gray-600 dark:text-gray-400">
-            Don't have an account?{' '}
-            <Link href="/auth/signup" className="text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300 font-medium">
-              Sign up
-            </Link>
-          </p>
-        </div>
-      </div>
-    </div>
+    <AuthShell
+      title="Welcome back"
+      subtitle="Sign in to open your hosted MindRoom workspace."
+      switchText="Don't have an account?"
+      switchHref="/auth/signup"
+      switchLabel="Sign up"
+    >
+      <AuthWrapper view="sign_in" redirectTo={callback} />
+    </AuthShell>
   )
 }

--- a/saas-platform/platform-frontend/src/app/auth/signup/page.tsx
+++ b/saas-platform/platform-frontend/src/app/auth/signup/page.tsx
@@ -1,63 +1,32 @@
 'use client'
 
+import { AuthShell } from '@/components/auth/auth-shell'
 import { AuthWrapper } from '@/components/auth/auth-wrapper'
 import Link from 'next/link'
-import { X } from 'lucide-react'
-import { MindRoomLogo } from '@/components/MindRoomLogo'
 
 export default function SignupPage() {
-
   return (
-    <div className="min-h-screen flex items-center justify-center px-4 bg-gradient-to-br from-orange-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
-      {/* Background decoration */}
-      <div className="absolute inset-0 overflow-hidden">
-        <div className="absolute top-0 right-0 w-96 h-96 bg-gradient-to-r from-orange-200 to-pink-200 dark:from-orange-900/10 dark:to-pink-900/10 rounded-full filter blur-3xl opacity-20"></div>
-        <div className="absolute bottom-0 left-0 w-96 h-96 bg-gradient-to-r from-blue-200 to-purple-200 dark:from-blue-900/10 dark:to-purple-900/10 rounded-full filter blur-3xl opacity-20"></div>
-      </div>
-
-      <div className="relative max-w-md w-full bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm rounded-3xl shadow-2xl p-8 border border-gray-100 dark:border-gray-700">
-        {/* Close button */}
-        <Link
-          href="/"
-          className="absolute top-4 right-4 p-2 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-          aria-label="Return to home"
-        >
-          <X className="w-5 h-5" />
-        </Link>
-
-        {/* Logo */}
-        <Link href="/" className="flex items-center justify-center gap-3 mb-8 group">
-          <MindRoomLogo className="text-orange-500 group-hover:scale-110 transition-transform duration-300" size={40} />
-        </Link>
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold dark:text-white">Create Your MindRoom</h1>
-          <p className="text-gray-600 dark:text-gray-400 mt-2">Start your 14-day free trial</p>
-        </div>
-
-        <AuthWrapper view="sign_up" />
-
-        <div className="mt-6 text-center">
-          <p className="text-gray-600 dark:text-gray-400">
-            Already have an account?{' '}
-            <Link href="/auth/login" className="text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300 font-medium">
-              Sign in
-            </Link>
-          </p>
-        </div>
-
-        <div className="mt-6 pt-6 border-t dark:border-gray-700">
-          <p className="text-xs text-gray-500 dark:text-gray-500 text-center">
-            By signing up, you agree to our{' '}
-            <Link href="/terms" className="text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300">
-              Terms of Service
-            </Link>{' '}
-            and{' '}
-            <Link href="/privacy" className="text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300">
-              Privacy Policy
-            </Link>
-          </p>
-        </div>
-      </div>
-    </div>
+    <AuthShell
+      title="Create your MindRoom"
+      subtitle="Start with a hosted workspace and bring agents into rooms."
+      switchText="Already have an account?"
+      switchHref="/auth/login"
+      switchLabel="Sign in"
+      footer={(
+        <>
+          By signing up, you agree to our{' '}
+          <Link href="/terms" className="text-[#f4b47e] transition-colors hover:text-[#ffd6b0]">
+            Terms of Service
+          </Link>{' '}
+          and{' '}
+          <Link href="/privacy" className="text-[#f4b47e] transition-colors hover:text-[#ffd6b0]">
+            Privacy Policy
+          </Link>
+          .
+        </>
+      )}
+    >
+      <AuthWrapper view="sign_up" />
+    </AuthShell>
   )
 }

--- a/saas-platform/platform-frontend/src/app/globals.css
+++ b/saas-platform/platform-frontend/src/app/globals.css
@@ -292,3 +292,43 @@ body {
     -webkit-overflow-scrolling: touch;
   }
 }
+
+.auth-glass-page .supabase-auth-ui_ui-button {
+  border-color: rgba(255, 255, 255, 0.18) !important;
+  background: rgba(255, 255, 255, 0.08) !important;
+  color: rgba(248, 245, 255, 0.9) !important;
+  box-shadow: none !important;
+}
+
+.auth-glass-page .supabase-auth-ui_ui-button:hover {
+  background: rgba(255, 255, 255, 0.14) !important;
+  color: #ffffff !important;
+}
+
+.auth-glass-page .supabase-auth-ui_ui-button[type='submit'] {
+  border-color: rgba(244, 180, 126, 0.45) !important;
+  background: rgba(244, 180, 126, 0.92) !important;
+  color: #12102a !important;
+}
+
+.auth-glass-page .supabase-auth-ui_ui-button[type='submit']:hover {
+  background: rgba(255, 214, 176, 0.96) !important;
+}
+
+.auth-glass-page .supabase-auth-ui_ui-input {
+  border-color: rgba(255, 255, 255, 0.18) !important;
+  background: rgba(8, 10, 22, 0.46) !important;
+  color: #f8f5ff !important;
+}
+
+.auth-glass-page .supabase-auth-ui_ui-label {
+  color: rgba(248, 245, 255, 0.72) !important;
+}
+
+.auth-glass-page .supabase-auth-ui_ui-divider {
+  background-color: rgba(255, 255, 255, 0.16) !important;
+}
+
+.auth-glass-page .supabase-auth-ui_ui-anchor[href$='#auth-sign-up'] {
+  display: none !important;
+}

--- a/saas-platform/platform-frontend/src/app/page.tsx
+++ b/saas-platform/platform-frontend/src/app/page.tsx
@@ -45,11 +45,7 @@ const navLinks = [
   { href: '#pricing', label: 'Pricing' },
 ]
 
-const heroStats = [
-  { label: 'Rooms', value: 'Matrix-first' },
-  { label: 'Agents', value: 'Tool-aware' },
-  { label: 'Deploy', value: 'Hosted or OSS' },
-]
+const heroFacts = ['Matrix-first rooms', 'Tool-aware agents', 'Hosted or OSS']
 
 const workflow: IconItem[] = [
   {
@@ -137,6 +133,11 @@ const plans: PricePlan[] = [
     href: '/dashboard',
   },
 ]
+
+const primaryCtaClass = 'inline-flex items-center justify-center gap-2 rounded-md border border-gray-950/10 bg-gray-950 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-800 dark:border-white/16 dark:bg-white/10 dark:text-white dark:hover:bg-white/16'
+const secondaryCtaClass = 'inline-flex items-center justify-center gap-2 rounded-md border border-gray-300 bg-white/70 px-5 py-3 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-50 dark:border-white/14 dark:bg-white/5 dark:text-white/88 dark:hover:bg-white/10'
+const darkPrimaryCtaClass = 'inline-flex items-center justify-center gap-2 rounded-md border border-white/18 bg-white/10 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/16'
+const darkSecondaryCtaClass = 'inline-flex items-center justify-center gap-2 rounded-md border border-white/14 bg-transparent px-5 py-3 text-sm font-semibold text-white/82 transition-colors hover:bg-white/8 hover:text-white'
 
 function SectionHeading({
   eyebrow,
@@ -245,18 +246,23 @@ function ProductPreview() {
   )
 }
 
-function IconGrid({ items }: { items: IconItem[] }) {
+function FeatureRows({ items }: { items: IconItem[] }) {
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+    <div className="grid border-y border-gray-200 dark:border-gray-800 lg:grid-cols-2">
       {items.map((item) => {
         const Icon = item.icon
         return (
-          <article key={item.title} className="rounded-lg border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-950">
-            <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-white">
+          <article
+            key={item.title}
+            className="flex gap-4 border-b border-gray-200 py-6 last:border-b-0 dark:border-gray-800 lg:odd:pr-8 lg:even:border-l lg:even:pl-8 lg:[&:nth-last-child(2)]:border-b-0"
+          >
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-gray-100 text-gray-900 dark:bg-white/8 dark:text-white">
               <Icon className="h-5 w-5" />
             </div>
-            <h3 className="text-base font-semibold text-gray-950 dark:text-white">{item.title}</h3>
-            <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">{item.body}</p>
+            <div>
+              <h3 className="text-base font-semibold text-gray-950 dark:text-white">{item.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">{item.body}</p>
+            </div>
           </article>
         )
       })}
@@ -282,10 +288,10 @@ export default function LandingPage() {
           </div>
           <div className="flex items-center gap-2 sm:gap-3">
             <DarkModeToggle />
-            <Link href="/auth/login" className="hidden rounded-md px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-950 dark:text-gray-300 dark:hover:bg-gray-900 dark:hover:text-white sm:inline-flex">
+            <Link href="/auth/login" className="hidden rounded-md px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-950 dark:text-gray-300 dark:hover:bg-white/8 dark:hover:text-white sm:inline-flex">
               Sign in
             </Link>
-            <Link href="/auth/signup" className="inline-flex items-center gap-2 rounded-md bg-gray-950 px-3 py-2 text-sm font-semibold text-white hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 sm:px-4">
+            <Link href="/auth/signup" className="inline-flex items-center gap-2 rounded-md border border-gray-950/10 bg-gray-950 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-800 dark:border-white/16 dark:bg-white/10 dark:text-white dark:hover:bg-white/16 sm:px-4">
               Start free
               <ArrowRight className="h-4 w-4" />
             </Link>
@@ -313,20 +319,20 @@ export default function LandingPage() {
               Give each agent a role, memory, tools, and a shared Matrix room where people can see the work, the trace, and the decisions.
             </p>
             <div className="mt-7 flex flex-col gap-3 sm:flex-row">
-              <Link href="/auth/signup" className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-950 px-5 py-3 text-sm font-semibold text-white hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200">
+              <Link href="/auth/signup" className={primaryCtaClass}>
                 Create hosted workspace
                 <ArrowRight className="h-4 w-4" />
               </Link>
-              <a href="https://github.com/mindroom-ai/mindroom" target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-300 bg-white px-5 py-3 text-sm font-semibold text-gray-800 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:hover:bg-gray-900">
+              <a href="https://github.com/mindroom-ai/mindroom" target="_blank" rel="noopener noreferrer" className={secondaryCtaClass}>
                 <Github className="h-4 w-4" />
                 View source
               </a>
             </div>
-            <div className="mt-8 grid grid-cols-3 gap-3">
-              {heroStats.map((stat) => (
-                <div key={stat.label} className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-800 dark:bg-gray-900">
-                  <div className="text-xs font-medium text-gray-500 dark:text-gray-400">{stat.label}</div>
-                  <div className="mt-1 text-sm font-semibold text-gray-950 dark:text-white">{stat.value}</div>
+            <div className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm font-medium text-gray-500 dark:text-gray-400">
+              {heroFacts.map((fact, index) => (
+                <div key={fact} className="flex items-center gap-4">
+                  {index > 0 && <span className="hidden h-1 w-1 rounded-full bg-gray-300 dark:bg-gray-700 sm:block" />}
+                  <span>{fact}</span>
                 </div>
               ))}
             </div>
@@ -344,19 +350,22 @@ export default function LandingPage() {
             title="Rooms become durable workspaces."
             body="MindRoom is not another isolated chat window. It keeps agents, people, decisions, and tool output in the same conversational surface."
           />
-          <div className="mt-10 grid gap-4 md:grid-cols-3">
+          <div className="mt-12 border-y border-gray-200 dark:border-gray-800">
             {workflow.map((item, index) => {
               const Icon = item.icon
               return (
-                <article key={item.title} className="rounded-lg border border-gray-200 p-6 dark:border-gray-800">
-                  <div className="mb-5 flex items-center justify-between">
-                    <div className="flex h-11 w-11 items-center justify-center rounded-md bg-orange-100 text-orange-700 dark:bg-orange-500/15 dark:text-orange-300">
+                <article
+                  key={item.title}
+                  className="grid gap-4 border-b border-gray-200 py-7 last:border-b-0 dark:border-gray-800 md:grid-cols-[72px_minmax(0,0.8fr)_minmax(0,1.2fr)] md:items-start"
+                >
+                  <div className="text-sm font-semibold text-gray-400">0{index + 1}</div>
+                  <div className="flex items-center gap-3">
+                    <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-orange-100 text-orange-700 dark:bg-orange-500/15 dark:text-orange-300">
                       <Icon className="h-5 w-5" />
-                    </div>
-                    <span className="text-sm font-semibold text-gray-400">0{index + 1}</span>
+                    </span>
+                    <h3 className="text-lg font-semibold text-gray-950 dark:text-white">{item.title}</h3>
                   </div>
-                  <h3 className="text-lg font-semibold text-gray-950 dark:text-white">{item.title}</h3>
-                  <p className="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-300">{item.body}</p>
+                  <p className="text-sm leading-6 text-gray-600 dark:text-gray-300">{item.body}</p>
                 </article>
               )
             })}
@@ -372,7 +381,7 @@ export default function LandingPage() {
             body="Run a simple assistant, a specialist code agent, or a team of agents that coordinate across Matrix rooms and bridged networks."
           />
           <div className="mt-10">
-            <IconGrid items={platform} />
+            <FeatureRows items={platform} />
           </div>
         </div>
       </section>
@@ -384,11 +393,11 @@ export default function LandingPage() {
             title="Less magic, more operational control."
             body="Hosted MindRoom instances are designed around explicit room access, visible tool traces, isolated credentials, and deployable infrastructure you can inspect."
           />
-          <div className="grid gap-4">
+          <div className="border-y border-gray-200 dark:border-gray-800">
             {security.map((item) => {
               const Icon = item.icon
               return (
-                <article key={item.title} className="rounded-lg border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-950">
+                <article key={item.title} className="border-b border-gray-200 py-6 last:border-b-0 dark:border-gray-800">
                   <div className="flex gap-4">
                     <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300">
                       <Icon className="h-5 w-5" />
@@ -430,28 +439,28 @@ export default function LandingPage() {
               title="Start small, then add rooms and agents."
               body="Use the hosted platform for quick setup or run the open-source stack yourself when you need full control."
             />
-            <Link href="/dashboard" className="inline-flex items-center gap-2 self-start rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-800 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-100 dark:hover:bg-gray-900 lg:self-end">
+            <Link href="/dashboard" className="inline-flex items-center gap-2 self-start rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-50 dark:border-white/14 dark:text-gray-100 dark:hover:bg-white/8 lg:self-end">
               Open dashboard
               <ArrowRight className="h-4 w-4" />
             </Link>
           </div>
-          <div className="mt-10 grid gap-4 lg:grid-cols-3">
+          <div className="mt-10 overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950">
             {plans.map((plan) => (
               <article
                 key={plan.name}
-                className={`rounded-lg border p-6 ${
-                  plan.highlighted
-                    ? 'border-orange-300 bg-orange-50 dark:border-orange-500/40 dark:bg-orange-500/10'
-                    : 'border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950'
+                className={`grid gap-5 border-b border-gray-200 p-5 last:border-b-0 dark:border-gray-800 lg:grid-cols-[0.7fr_0.9fr_1.2fr_auto] lg:items-center ${
+                  plan.highlighted ? 'bg-orange-50/70 dark:bg-orange-500/10' : ''
                 }`}
               >
-                <h3 className="text-lg font-semibold text-gray-950 dark:text-white">{plan.name}</h3>
-                <div className="mt-4 flex items-baseline gap-2">
-                  <span className="text-4xl font-semibold text-gray-950 dark:text-white">{plan.price}</span>
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-950 dark:text-white">{plan.name}</h3>
+                  <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">{plan.description}</p>
+                </div>
+                <div className="flex items-baseline gap-2 lg:justify-center">
+                  <span className="text-3xl font-semibold text-gray-950 dark:text-white">{plan.price}</span>
                   {plan.price !== '$0' && <span className="text-sm text-gray-500 dark:text-gray-400">monthly</span>}
                 </div>
-                <p className="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-300">{plan.description}</p>
-                <ul className="mt-6 space-y-3">
+                <ul className="grid gap-2 sm:grid-cols-3 lg:grid-cols-1">
                   {plan.features.map((feature) => (
                     <li key={feature} className="flex gap-2 text-sm text-gray-700 dark:text-gray-300">
                       <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
@@ -461,10 +470,10 @@ export default function LandingPage() {
                 </ul>
                 <Link
                   href={plan.href}
-                  className={`mt-7 inline-flex w-full items-center justify-center rounded-md px-4 py-2.5 text-sm font-semibold ${
+                  className={`inline-flex items-center justify-center rounded-md px-4 py-2.5 text-sm font-semibold transition-colors ${
                     plan.highlighted
-                      ? 'bg-gray-950 text-white hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200'
-                      : 'border border-gray-300 text-gray-800 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-100 dark:hover:bg-gray-900'
+                      ? 'border border-gray-950/10 bg-gray-950 text-white hover:bg-gray-800 dark:border-white/16 dark:bg-white/10 dark:text-white dark:hover:bg-white/16'
+                      : 'border border-gray-300 text-gray-800 hover:bg-gray-50 dark:border-white/14 dark:text-gray-100 dark:hover:bg-white/8'
                   }`}
                 >
                   {plan.cta}
@@ -475,20 +484,20 @@ export default function LandingPage() {
         </div>
       </section>
 
-      <section className="border-y border-gray-200 bg-gray-50 py-16 dark:border-gray-800 dark:bg-gray-900/30">
+      <section className="border-y border-gray-200 bg-gray-950 py-16 text-white dark:border-gray-800">
         <div className="mx-auto flex max-w-7xl flex-col gap-6 px-4 sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:px-8">
           <div>
-            <h2 className="text-3xl font-semibold text-gray-950 dark:text-white">Bring agents into the room.</h2>
-            <p className="mt-3 max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-300">
+            <h2 className="text-3xl font-semibold text-white">Bring agents into the room.</h2>
+            <p className="mt-3 max-w-2xl text-base leading-7 text-gray-300">
               Create a hosted workspace, or inspect the repo and run MindRoom on your own infrastructure.
             </p>
           </div>
           <div className="flex flex-col gap-3 sm:flex-row">
-            <Link href="/auth/signup" className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-950 px-5 py-3 text-sm font-semibold text-white hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200">
+            <Link href="/auth/signup" className={darkPrimaryCtaClass}>
               Start free
               <ArrowRight className="h-4 w-4" />
             </Link>
-            <a href="https://github.com/mindroom-ai/mindroom" target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-300 bg-white px-5 py-3 text-sm font-semibold text-gray-800 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:hover:bg-gray-900">
+            <a href="https://github.com/mindroom-ai/mindroom" target="_blank" rel="noopener noreferrer" className={darkSecondaryCtaClass}>
               <Code2 className="h-4 w-4" />
               Read the code
             </a>

--- a/saas-platform/platform-frontend/src/app/page.tsx
+++ b/saas-platform/platform-frontend/src/app/page.tsx
@@ -45,6 +45,8 @@ const navLinks = [
   { href: '#pricing', label: 'Pricing' },
 ]
 
+const docsUrl = 'https://docs.mindroom.chat/'
+
 const heroFacts = ['Matrix-first rooms', 'Tool-aware agents', 'Hosted or OSS']
 
 const workflow: IconItem[] = [
@@ -285,6 +287,9 @@ export default function LandingPage() {
                 {link.label}
               </Link>
             ))}
+            <a href={docsUrl} className="text-sm font-medium text-gray-600 hover:text-gray-950 dark:text-gray-300 dark:hover:text-white">
+              Docs
+            </a>
           </div>
           <div className="flex items-center gap-2 sm:gap-3">
             <DarkModeToggle />
@@ -514,6 +519,7 @@ export default function LandingPage() {
           <div className="flex flex-wrap gap-4">
             <Link href="/privacy" className="hover:text-gray-950 dark:hover:text-white">Privacy</Link>
             <Link href="/terms" className="hover:text-gray-950 dark:hover:text-white">Terms</Link>
+            <a href={docsUrl} className="hover:text-gray-950 dark:hover:text-white">Docs</a>
             <a href="https://github.com/mindroom-ai/mindroom" target="_blank" rel="noopener noreferrer" className="hover:text-gray-950 dark:hover:text-white">GitHub</a>
             <Link href="/auth/login" className="hover:text-gray-950 dark:hover:text-white">Sign in</Link>
           </div>

--- a/saas-platform/platform-frontend/src/components/auth/__tests__/auth-wrapper.test.tsx
+++ b/saas-platform/platform-frontend/src/components/auth/__tests__/auth-wrapper.test.tsx
@@ -178,30 +178,29 @@ describe('AuthWrapper', () => {
     })
   })
 
-  describe('Dark Mode Integration', () => {
-    it('should apply dark mode styles when enabled', () => {
+  describe('Glass Auth Styling', () => {
+    it('should use glass-friendly input colors when dark mode is enabled', () => {
       ;(useDarkMode as jest.Mock).mockReturnValue({ isDarkMode: true })
 
       const { Auth } = require('@supabase/auth-ui-react')
       render(<AuthWrapper />)
 
-      // Check that Auth component receives dark mode colors
       const authCall = Auth.mock.calls[0][0]
-      expect(authCall.appearance.variables.default.colors.inputBackground).toBe('#1f2937')
-      expect(authCall.appearance.variables.default.colors.inputBorder).toBe('#374151')
-      expect(authCall.appearance.variables.default.colors.inputText).toBe('#f3f4f6')
+      expect(authCall.appearance.variables.default.colors.inputBackground).toBe('rgba(8, 10, 22, 0.46)')
+      expect(authCall.appearance.variables.default.colors.inputBorder).toBe('rgba(255, 255, 255, 0.18)')
+      expect(authCall.appearance.variables.default.colors.inputText).toBe('#f8f5ff')
     })
 
-    it('should apply light mode styles when disabled', () => {
+    it('should keep the same glass input colors when dark mode is disabled', () => {
       ;(useDarkMode as jest.Mock).mockReturnValue({ isDarkMode: false })
 
       const { Auth } = require('@supabase/auth-ui-react')
       render(<AuthWrapper />)
 
       const authCall = Auth.mock.calls[0][0]
-      expect(authCall.appearance.variables.default.colors.inputBackground).toBe('white')
-      expect(authCall.appearance.variables.default.colors.inputBorder).toBe('#e5e7eb')
-      expect(authCall.appearance.variables.default.colors.inputText).toBe('#1f2937')
+      expect(authCall.appearance.variables.default.colors.inputBackground).toBe('rgba(8, 10, 22, 0.46)')
+      expect(authCall.appearance.variables.default.colors.inputBorder).toBe('rgba(255, 255, 255, 0.18)')
+      expect(authCall.appearance.variables.default.colors.inputText).toBe('#f8f5ff')
     })
   })
 
@@ -300,8 +299,10 @@ describe('AuthWrapper', () => {
 
       const authCall = Auth.mock.calls[0][0]
       expect(authCall.appearance.className.button).toContain('font-semibold')
-      expect(authCall.appearance.className.input).toContain('focus:ring-orange-500')
-      expect(authCall.appearance.className.anchor).toContain('text-orange-600')
+      expect(authCall.appearance.className.button).toContain('bg-white/12')
+      expect(authCall.appearance.className.button).not.toContain('scale')
+      expect(authCall.appearance.className.input).toContain('bg-black/25')
+      expect(authCall.appearance.className.anchor).toContain('text-[#f4b47e]')
     })
 
     it('should set brand colors', () => {
@@ -309,8 +310,8 @@ describe('AuthWrapper', () => {
       render(<AuthWrapper />)
 
       const authCall = Auth.mock.calls[0][0]
-      expect(authCall.appearance.variables.default.colors.brand).toBe('#f97316')
-      expect(authCall.appearance.variables.default.colors.brandAccent).toBe('#ea580c')
+      expect(authCall.appearance.variables.default.colors.brand).toBe('#f4b47e')
+      expect(authCall.appearance.variables.default.colors.brandAccent).toBe('#ffd6b0')
     })
   })
 

--- a/saas-platform/platform-frontend/src/components/auth/auth-shell.tsx
+++ b/saas-platform/platform-frontend/src/components/auth/auth-shell.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import { X } from 'lucide-react'
+import { HeroParticleBackground } from '@/components/landing/HeroParticleBackground'
+import { MindRoomLogo } from '@/components/MindRoomLogo'
+
+type AuthShellProps = {
+  title: string
+  subtitle: string
+  switchText: string
+  switchHref: string
+  switchLabel: string
+  children: ReactNode
+  footer?: ReactNode
+}
+
+export function AuthShell({
+  title,
+  subtitle,
+  switchText,
+  switchHref,
+  switchLabel,
+  children,
+  footer,
+}: AuthShellProps) {
+  return (
+    <main className="auth-glass-page relative min-h-screen overflow-hidden bg-[#0f0d2e] px-4 py-6 text-white sm:px-6">
+      <HeroParticleBackground variant="auth" />
+      <div className="relative z-10 flex min-h-[calc(100vh-3rem)] items-center justify-center">
+        <section className="relative w-full max-w-[440px] rounded-2xl border border-white/20 bg-[#12102a]/35 p-6 shadow-[0_24px_90px_rgba(0,0,0,0.42)] backdrop-blur-md backdrop-saturate-150 sm:p-8">
+          <div className="pointer-events-none absolute inset-0 rounded-2xl shadow-[inset_0_1px_0_rgba(255,255,255,0.16)]" />
+          <Link
+            href="/"
+            className="absolute right-4 top-4 rounded-lg border border-white/10 bg-white/8 p-2 text-white/62 transition-colors hover:bg-white/14 hover:text-white"
+            aria-label="Return to home"
+          >
+            <X className="h-5 w-5" />
+          </Link>
+
+          <Link href="/" className="mx-auto mb-7 flex w-fit items-center gap-3" aria-label="MindRoom home">
+            <MindRoomLogo className="h-11 w-11" size={44} />
+            <span className="text-xl font-semibold text-white">MindRoom</span>
+          </Link>
+
+          <div className="mb-7 text-center">
+            <h1 className="text-3xl font-semibold text-white">{title}</h1>
+            <p className="mt-2 text-sm leading-6 text-white/68">{subtitle}</p>
+          </div>
+
+          {children}
+
+          <div className="mt-6 text-center text-sm text-white/64">
+            {switchText}{' '}
+            <Link href={switchHref} className="font-medium text-[#f4b47e] transition-colors hover:text-[#ffd6b0]">
+              {switchLabel}
+            </Link>
+          </div>
+
+          {footer && (
+            <div className="mt-6 border-t border-white/12 pt-5 text-center text-xs leading-5 text-white/48">
+              {footer}
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/saas-platform/platform-frontend/src/components/auth/auth-wrapper.tsx
+++ b/saas-platform/platform-frontend/src/components/auth/auth-wrapper.tsx
@@ -10,7 +10,6 @@ import {
 } from '@/lib/runtime-config'
 import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { useDarkMode } from '@/hooks/useDarkMode'
 
 interface AuthWrapperProps {
   view?: 'sign_in' | 'sign_up'
@@ -33,9 +32,9 @@ function UnavailableAuth({ view }: Pick<AuthWrapperProps, 'view'>) {
   const label = view === 'sign_up' ? 'Account signup' : 'Sign in'
 
   return (
-    <div className="rounded-xl border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-900 dark:border-orange-900/40 dark:bg-orange-950/30 dark:text-orange-100">
+    <div className="rounded-lg border border-[#f4b47e]/25 bg-[#f4b47e]/10 px-4 py-3 text-sm text-[#ffe4cc]">
       <p className="font-medium">{label} is not available yet.</p>
-      <p className="mt-1 text-orange-800 dark:text-orange-200">
+      <p className="mt-1 text-[#ffd6b0]/86">
         The hosted account backend is not configured for this deployment.
       </p>
     </div>
@@ -48,7 +47,6 @@ function ConfiguredAuthWrapper({
   runtimeConfig,
 }: AuthWrapperProps & { runtimeConfig: RuntimeConfig }) {
   const [origin, setOrigin] = useState('')
-  const { isDarkMode } = useDarkMode()
   const router = useRouter()
 
   useEffect(() => {
@@ -83,28 +81,29 @@ function ConfiguredAuthWrapper({
         variables: {
           default: {
             colors: {
-              brand: '#f97316',
-              brandAccent: '#ea580c',
-              inputBackground: isDarkMode ? '#1f2937' : 'white',
-              inputBorder: isDarkMode ? '#374151' : '#e5e7eb',
-              inputBorderHover: isDarkMode ? '#4b5563' : '#d1d5db',
-              inputBorderFocus: '#f97316',
-              inputText: isDarkMode ? '#f3f4f6' : '#1f2937',
-              inputPlaceholder: isDarkMode ? '#9ca3af' : '#6b7280',
+              brand: '#f4b47e',
+              brandAccent: '#ffd6b0',
+              inputBackground: 'rgba(8, 10, 22, 0.46)',
+              inputBorder: 'rgba(255, 255, 255, 0.18)',
+              inputBorderHover: 'rgba(255, 255, 255, 0.3)',
+              inputBorderFocus: '#f4b47e',
+              inputText: '#f8f5ff',
+              inputPlaceholder: 'rgba(248, 245, 255, 0.56)',
+              messageText: '#fecaca',
             },
             radii: {
-              borderRadiusButton: '0.75rem',
-              buttonBorderRadius: '0.75rem',
-              inputBorderRadius: '0.75rem',
+              borderRadiusButton: '0.625rem',
+              buttonBorderRadius: '0.625rem',
+              inputBorderRadius: '0.625rem',
             },
           },
         },
         className: {
-          button: 'w-full px-4 py-3 font-semibold rounded-xl transition-all hover:shadow-lg hover:scale-[1.02]',
-          input: 'w-full px-4 py-3 border rounded-xl focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-all',
-          label: 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2',
-          anchor: 'text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300 font-medium transition-colors',
-          message: 'text-red-600 dark:text-red-400 text-sm',
+          button: 'w-full rounded-lg border border-white/20 bg-white/12 px-4 py-3 font-semibold text-white shadow-none transition-colors hover:bg-white/18',
+          input: 'w-full rounded-lg border border-white/16 bg-black/25 px-4 py-3 text-white placeholder:text-white/45 transition-colors focus:border-[#f4b47e] focus:outline-none focus:ring-2 focus:ring-[#f4b47e]/35',
+          label: 'mb-2 block text-sm font-medium text-white/72',
+          anchor: 'font-medium text-[#f4b47e] transition-colors hover:text-[#ffd6b0]',
+          message: 'text-sm text-red-200',
           container: 'space-y-4',
         },
       }}
@@ -127,7 +126,7 @@ export function AuthWrapper({ view = 'sign_in', redirectTo }: AuthWrapperProps) 
 
   if (runtimeConfig === undefined) {
     return (
-      <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300">
+      <div className="rounded-lg border border-white/16 bg-white/8 px-4 py-3 text-sm text-white/72">
         Loading authentication...
       </div>
     )

--- a/saas-platform/platform-frontend/src/components/landing/HeroParticleBackground.tsx
+++ b/saas-platform/platform-frontend/src/components/landing/HeroParticleBackground.tsx
@@ -8,6 +8,12 @@ const DESKTOP_PARTICLE_COUNT = 32000
 const BALANCED_PARTICLE_COUNT = 20000
 const LOW_END_PARTICLE_COUNT = 9000
 const MINDROOM_LOGO_SRC = '/res/branding/mindroom.svg'
+type ParticleBackgroundVariant = 'hero' | 'auth'
+
+type HeroParticleBackgroundProps = {
+  variant?: ParticleBackgroundVariant
+  className?: string
+}
 
 function resolveLandingParticleCount() {
   if (typeof window === 'undefined') {
@@ -28,42 +34,71 @@ function resolveLandingParticleCount() {
   return DESKTOP_PARTICLE_COUNT
 }
 
-export function HeroParticleBackground() {
+function variantClassName(variant: ParticleBackgroundVariant) {
+  if (variant === 'auth') {
+    return 'pointer-events-none fixed inset-0 z-0 block overflow-hidden bg-[#0f0d2e] motion-reduce:hidden'
+  }
+
+  return 'pointer-events-none absolute inset-x-0 bottom-0 top-80 z-0 block overflow-hidden bg-gradient-to-b from-transparent via-[#0f0d2e]/55 to-[#0f0d2e] [mask-image:linear-gradient(to_bottom,transparent_0%,black_26%,black_100%)] [-webkit-mask-image:linear-gradient(to_bottom,transparent_0%,black_26%,black_100%)] lg:inset-y-0 lg:left-auto lg:w-[70%] lg:bg-gradient-to-l lg:from-[#0f0d2e] lg:via-[#0f0d2e]/95 lg:to-transparent lg:[mask-image:linear-gradient(to_left,black_62%,transparent_100%)] lg:[-webkit-mask-image:linear-gradient(to_left,black_62%,transparent_100%)] motion-reduce:hidden'
+}
+
+function canvasClassName(variant: ParticleBackgroundVariant) {
+  if (variant === 'auth') {
+    return 'relative h-full w-full opacity-90'
+  }
+
+  return 'relative h-full w-full opacity-[0.58] lg:opacity-80'
+}
+
+export function HeroParticleBackground({
+  variant = 'hero',
+  className = '',
+}: HeroParticleBackgroundProps) {
   const particleCount = useMemo(resolveLandingParticleCount, [])
   const options = useMemo<ParticularDriftUserOptions>(
     () => ({
       imageFit: 'contain',
-      interactive: false,
+      interactive: variant === 'auth',
       cursorMode: 'repel',
-      cursorRadius: 0.12,
-      cursorStrength: 0.9,
+      cursorRadius: variant === 'auth' ? 0.14 : 0.12,
+      cursorStrength: variant === 'auth' ? 1.1 : 0.9,
       backgroundColor: '#0f0d2e',
       particleColor: '#dda290',
       particleCount,
-      particleOpacity: 0.34,
-      particleSize: 1,
-      particleSpeed: 7,
-      attractionStrength: 84,
+      particleOpacity: variant === 'auth' ? 0.46 : 0.34,
+      particleSize: variant === 'auth' ? 1.1 : 1,
+      particleSpeed: variant === 'auth' ? 9 : 7,
+      attractionStrength: variant === 'auth' ? 96 : 84,
       edgeThreshold: 0.32,
       flowFieldScale: 4,
       maxDevicePixelRatio: 1.15,
     }),
-    [particleCount],
+    [particleCount, variant],
   )
 
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none absolute inset-x-0 bottom-0 top-80 z-0 block overflow-hidden bg-gradient-to-b from-transparent via-[#0f0d2e]/55 to-[#0f0d2e] [mask-image:linear-gradient(to_bottom,transparent_0%,black_26%,black_100%)] [-webkit-mask-image:linear-gradient(to_bottom,transparent_0%,black_26%,black_100%)] lg:inset-y-0 lg:left-auto lg:w-[70%] lg:bg-gradient-to-l lg:from-[#0f0d2e] lg:via-[#0f0d2e]/95 lg:to-transparent lg:[mask-image:linear-gradient(to_left,black_62%,transparent_100%)] lg:[-webkit-mask-image:linear-gradient(to_left,black_62%,transparent_100%)] motion-reduce:hidden"
+      className={`${variantClassName(variant)} ${className}`}
+      data-variant={variant}
       data-testid="landing-particle-background"
     >
       <ParticularDriftCanvas
-        className="relative h-full w-full opacity-[0.58] lg:opacity-80"
+        className={canvasClassName(variant)}
         imageUrl={MINDROOM_LOGO_SRC}
         options={options}
       />
-      <div className="absolute inset-0 bg-gradient-to-b from-gray-50 via-gray-50/55 to-transparent dark:from-gray-950 dark:via-gray-950/55 lg:bg-gradient-to-r lg:via-transparent" />
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_70%_45%,rgba(221,162,144,0.16),transparent_48%)]" />
+      {variant === 'auth' ? (
+        <>
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_45%,rgba(221,162,144,0.18),rgba(15,13,46,0.12)_30%,rgba(15,13,46,1)_72%)]" />
+          <div className="absolute inset-0 bg-[#0f0d2e]/20" />
+        </>
+      ) : (
+        <>
+          <div className="absolute inset-0 bg-gradient-to-b from-gray-50 via-gray-50/55 to-transparent dark:from-gray-950 dark:via-gray-950/55 lg:bg-gradient-to-r lg:via-transparent" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_70%_45%,rgba(221,162,144,0.16),transparent_48%)]" />
+        </>
+      )}
     </div>
   )
 }

--- a/saas-platform/platform-frontend/src/components/landing/__tests__/HeroParticleBackground.test.tsx
+++ b/saas-platform/platform-frontend/src/components/landing/__tests__/HeroParticleBackground.test.tsx
@@ -35,6 +35,21 @@ describe('HeroParticleBackground', () => {
     expect(canvas).toHaveAttribute('data-particle-color', '#dda290')
   })
 
+  it('can fill the auth screen with the MindRoom particle field', () => {
+    render(<HeroParticleBackground variant="auth" />)
+
+    const background = screen.getByTestId('landing-particle-background')
+    const canvas = screen.getByTestId('particle-canvas')
+
+    expect(background).toHaveAttribute('data-variant', 'auth')
+    expect(background).toHaveClass('fixed')
+    expect(background).toHaveClass('inset-0')
+    expect(background).toHaveClass('bg-[#0f0d2e]')
+    expect(background).not.toHaveClass('top-80')
+    expect(background).not.toHaveClass('lg:w-[70%]')
+    expect(canvas).toHaveClass('opacity-90')
+  })
+
   it.each([
     { hardwareConcurrency: 4, devicePixelRatio: 1, width: 1440, height: 900, coarsePointer: false, expected: '9000' },
     { hardwareConcurrency: 8, devicePixelRatio: 1, width: 1440, height: 900, coarsePointer: false, expected: '20000' },


### PR DESCRIPTION
## Summary
- reduce the SaaS landing page card density with row/table layouts and quieter CTAs
- add a shared glass auth shell over the existing MindRoom WebGL particle background
- align Supabase auth UI provider buttons, inputs, and submit styling with the glass treatment
- fix Next 15 auth page searchParams handling while preserving redirect sanitization

## Verification
- bun run test -- src/components/landing/__tests__/HeroParticleBackground.test.tsx src/components/auth/__tests__/auth-wrapper.test.tsx --runInBand
- bun run test -- --runInBand
- bun run build
- uv run pytest -q
- uv run pre-commit run --files saas-platform/platform-frontend/src/app/auth/login/page.tsx saas-platform/platform-frontend/src/app/auth/signup/page.tsx saas-platform/platform-frontend/src/app/globals.css saas-platform/platform-frontend/src/app/page.tsx saas-platform/platform-frontend/src/components/auth/__tests__/auth-wrapper.test.tsx saas-platform/platform-frontend/src/components/auth/auth-wrapper.tsx saas-platform/platform-frontend/src/components/auth/auth-shell.tsx saas-platform/platform-frontend/src/components/landing/HeroParticleBackground.tsx saas-platform/platform-frontend/src/components/landing/__tests__/HeroParticleBackground.test.tsx

Note: `uv run pre-commit run --all-files` still hits the existing unrelated `ty` issue in `src/mindroom/api/main.py`; the changed frontend files pass targeted hooks.

## Screenshots
Captured locally from the Next dev server before opening the PR:
- `/tmp/mindroom-saas-polish-01-landing-full.png`
- `/tmp/mindroom-saas-polish-05-auth-login-form-desktop.png`
- `/tmp/mindroom-saas-polish-07-auth-login-mobile-viewport.png`
- `/tmp/mindroom-saas-polish-08-auth-signup-desktop.png`

## Summary by Sourcery

Polish the SaaS marketing landing page and introduce a shared glass-themed auth layout powered by the existing MindRoom particle background, while fixing Next 15 auth search parameter handling.

New Features:
- Add a reusable AuthShell component that wraps login and signup pages in a shared glass UI over the MindRoom particle background.
- Extend the HeroParticleBackground component with an auth variant for full-screen interactive particle fields.

Bug Fixes:
- Update the login page to handle Next 15 async searchParams correctly while preserving sanitized post-auth redirects.

Enhancements:
- Refine landing page layout with lower-density feature rows, streamlined workflow and security sections, and updated pricing card structure and CTAs.
- Unify primary and secondary CTA button styles across the landing page, including dark section variants.
- Restyle Supabase auth UI colors, typography, and radii for a cohesive glass treatment and adjust unavailable/loading auth states accordingly.

Tests:
- Extend HeroParticleBackground tests to cover the new auth variant styling and behavior.
- Update AuthWrapper tests to validate the new glass auth styles and brand colors for Supabase auth UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified auth page layout component and applied it to sign-in and sign-up flows.
  * Added a “Docs” link to the site navigation and footer.

* **Style**
  * Redesigned login and signup with glassmorphism visuals and updated auth color palette.
  * Refreshed landing page layout, CTA styles, and feature/presentation rows.

* **Tests**
  * Updated and added tests to validate new auth and background variant styling.

* **Docs**
  * Updated deployment docs and webhook path documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->