### PR TITLE
Prepare SaaS platform for storage and resource scaling

### DIFF
--- a/cluster/k8s/instance/templates/_helpers.tpl
+++ b/cluster/k8s/instance/templates/_helpers.tpl
@@ -92,12 +92,7 @@
   - name: sandbox-workspace
     mountPath: /app/workspace
   resources:
-    requests:
-      memory: "256Mi"
-      cpu: "100m"
-    limits:
-      memory: "1Gi"
-      cpu: "500m"
+    {{- toYaml $values.sandboxRunnerResources | nindent 4 }}
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:

--- a/cluster/k8s/instance/templates/deployment-mindroom.yaml
+++ b/cluster/k8s/instance/templates/deployment-mindroom.yaml
@@ -213,12 +213,7 @@ spec:
           mountPath: /etc/secrets
           readOnly: true
         resources:
-          requests:
-            memory: "512Mi"
-            cpu: "250m"
-          limits:
-            memory: "2Gi"
-            cpu: "1000m"
+          {{- toYaml .Values.mindroomResources | nindent 10 }}
         # Startup only needs the API process to bind the socket; readiness waits for full bootstrap.
         startupProbe:
           httpGet:

--- a/cluster/k8s/instance/templates/deployment-synapse.yaml
+++ b/cluster/k8s/instance/templates/deployment-synapse.yaml
@@ -44,12 +44,7 @@ spec:
           mountPath: /data/log.config
           subPath: log.config
         resources:
-          requests:
-            memory: "512Mi"
-            cpu: "250m"
-          limits:
-            memory: "2Gi"
-            cpu: "1000m"
+          {{- toYaml .Values.synapseResources | nindent 10 }}
         readinessProbe:
           httpGet:
             path: /_matrix/client/versions

--- a/cluster/k8s/instance/values.yaml
+++ b/cluster/k8s/instance/values.yaml
@@ -6,6 +6,30 @@ storageAccessMode: ReadWriteOnce  # MindRoom storage access mode. Set ReadWriteM
 synapseStorageAccessMode: ReadWriteOnce
 storagePath: "/mindroom_data"  # Base path inside container for persisted state
 
+mindroomResources:
+  requests:
+    memory: "512Mi"
+    cpu: "250m"
+  limits:
+    memory: "2Gi"
+    cpu: "1000m"
+
+synapseResources:
+  requests:
+    memory: "512Mi"
+    cpu: "250m"
+  limits:
+    memory: "2Gi"
+    cpu: "1000m"
+
+sandboxRunnerResources:
+  requests:
+    memory: "256Mi"
+    cpu: "100m"
+  limits:
+    memory: "1Gi"
+    cpu: "500m"
+
 # Docker images
 mindroom_image: ghcr.io/mindroom-ai/mindroom:latest
 mindroom_image_pull_policy: Always

--- a/cluster/k8s/platform/templates/all.yaml
+++ b/cluster/k8s/platform/templates/all.yaml
@@ -12,6 +12,9 @@ metadata:
   name: platform-config
   namespace: mindroom-{{ .Values.environment }}
 {{ $prov := .Values.provisioner | default (dict) }}
+{{ $autoscaling := .Values.autoscaling | default (dict) }}
+{{ $autoscalingEnabledValue := lower (toString ($autoscaling.enabled | default false)) }}
+{{ $autoscalingEnabled := has $autoscalingEnabledValue (list "1" "true" "yes" "on") }}
 {{ $trustedUpstreamAuth := $prov.trustedUpstreamAuth | default (dict) }}
 {{ $trustedUpstreamAuthEnabledValue := lower (toString ($trustedUpstreamAuth.enabled | default false)) }}
 {{ $trustedUpstreamAuthEnabled := has $trustedUpstreamAuthEnabledValue (list "1" "true" "yes" "on") }}
@@ -96,7 +99,9 @@ metadata:
     app: platform-frontend
     environment: {{ .Values.environment }}
 spec:
+  {{- if not $autoscalingEnabled }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: platform-frontend
@@ -138,6 +143,8 @@ spec:
             configMapKeyRef:
               name: platform-config
               key: SUPABASE_ANON_KEY
+        resources:
+          {{- toYaml .Values.resources.frontend | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service
@@ -165,7 +172,9 @@ metadata:
     app: platform-backend
     environment: {{ .Values.environment }}
 spec:
+  {{- if not $autoscalingEnabled }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       app: platform-backend
@@ -216,6 +225,8 @@ spec:
         - name: platform-sensitive
           mountPath: /etc/secrets
           readOnly: true
+        resources:
+          {{- toYaml .Values.resources.backend | nindent 10 }}
       volumes:
       - name: platform-sensitive
         secret:
@@ -238,6 +249,54 @@ spec:
   - name: http
     port: 8000
     targetPort: 8000
+{{- if $autoscalingEnabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: platform-frontend
+  namespace: mindroom-{{ .Values.environment }}
+  labels:
+    app: platform-frontend
+    environment: {{ .Values.environment }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: platform-frontend
+  minReplicas: {{ .Values.autoscaling.frontend.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.frontend.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.frontend.targetCPUUtilizationPercentage }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: platform-backend
+  namespace: mindroom-{{ .Values.environment }}
+  labels:
+    app: platform-backend
+    environment: {{ .Values.environment }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: platform-backend
+  minReplicas: {{ .Values.autoscaling.backend.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.backend.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.backend.targetCPUUtilizationPercentage }}
+{{- end }}
 {{- if .Values.monitoring.enabled }}
 {{- $monitoring := .Values.monitoring | default (dict) }}
 {{- $alerts := $monitoring.alerts | default (dict) }}

--- a/cluster/k8s/platform/values-prod.example.yaml
+++ b/cluster/k8s/platform/values-prod.example.yaml
@@ -18,6 +18,38 @@ stripe:
 cleanupScheduler:
   enabled: "true"
 
+provisioner:
+  # Hetzner Cloud Volumes keep tenant PVCs movable across K3s nodes.
+  instanceStorageClassName: hcloud-volumes
+
+resources:
+  frontend:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+  backend:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+
+autoscaling:
+  # Keep false on a single-node cluster; enable after metrics-server is installed and tested.
+  enabled: false
+  frontend:
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+  backend:
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 65
+
 # The apex mindroom.chat is the Matrix server name and must stay on hetzner-matrix.
 apexRedirect:
   enabled: false

--- a/cluster/k8s/platform/values-staging.example.yaml
+++ b/cluster/k8s/platform/values-staging.example.yaml
@@ -18,6 +18,13 @@ stripe:
 cleanupScheduler:
   enabled: "true"
 
+provisioner:
+  # Use the cloud volume class when staging runs on Hetzner.
+  instanceStorageClassName: hcloud-volumes
+
+autoscaling:
+  enabled: false
+
 monitoring:
   enabled: true
   releaseLabel: monitoring

--- a/cluster/k8s/platform/values.yaml
+++ b/cluster/k8s/platform/values.yaml
@@ -13,6 +13,33 @@ imagePullSecrets: []
 # Replicas
 replicas: 1
 
+resources:
+  frontend:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+  backend:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+
+autoscaling:
+  enabled: false
+  frontend:
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+  backend:
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 65
+
 cleanupScheduler:
   enabled: "false"
 

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -20,6 +20,27 @@ MindRoom uses three Helm charts:
 - kubectl and helm installed
 - NGINX Ingress Controller
 - cert-manager (for TLS certificates)
+- Hetzner Cloud Controller Manager and Hetzner CSI Driver when using `hcloud-volumes`
+
+## Hetzner Scaling Baseline
+
+Start with one K3s server node and keep tenant storage on Hetzner Cloud Volumes.
+This keeps the current bill low while making later worker nodes possible.
+Use `hcloud-volumes` for provisioned instance PVCs and avoid `local-path` for tenant data that must survive node replacement.
+The platform frontend and backend are stateless and can use HPA once metrics-server is installed.
+Tenant MindRoom and Synapse releases stay single-replica stateful workloads; scale capacity by placing more tenants across more nodes.
+
+Production platform values should make the storage class explicit:
+
+```yaml
+provisioner:
+  instanceStorageClassName: hcloud-volumes
+
+autoscaling:
+  enabled: false
+```
+
+Enable `autoscaling.enabled` only after the cluster has metrics-server and enough nodes or headroom to schedule the extra replicas.
 
 ## Instance Deployment
 
@@ -202,6 +223,8 @@ Dedicated workers need access to the same PVC as the primary runtime.
 Set `storageAccessMode: ReadWriteMany` so multiple workers can access agent storage concurrently.
 If your storage class only supports `ReadWriteOnce`, set `controlPlaneNodeName` so the control plane and dedicated workers stay on the same node.
 The chart enforces this constraint during template rendering.
+For the hosted SaaS instance chart, keep the default `static_runner` backend on single-node clusters.
+Switching hosted instances to dedicated Kubernetes workers on a multi-node cluster requires either a real `ReadWriteMany` storage class or explicit node pinning.
 
 ### RBAC And Network Policy
 
@@ -338,3 +361,7 @@ Each customer instance gets:
 - Dedicated ingress routes
 
 Platform services run in `mindroom-{environment}` namespace.
+The hosted SaaS chart currently runs Synapse per tenant, with server names such as `{customer}.mindroom.chat`.
+The public `mindroom.chat` Matrix server is the separate Tuwunel server on `hetzner-matrix`.
+Do not reuse `mindroom.chat` as the default SaaS tenant homeserver until the product has an explicit shared-homeserver mode with tenant isolation, provisioning, room ownership, SSO, and deprovisioning semantics.
+The runtime-only chart is the better starting point for a future bring-your-own-homeserver or shared-homeserver mode.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15273,6 +15273,27 @@ MindRoom uses three Helm charts:
 - kubectl and helm installed
 - NGINX Ingress Controller
 - cert-manager (for TLS certificates)
+- Hetzner Cloud Controller Manager and Hetzner CSI Driver when using `hcloud-volumes`
+
+## Hetzner Scaling Baseline
+
+Start with one K3s server node and keep tenant storage on Hetzner Cloud Volumes.
+This keeps the current bill low while making later worker nodes possible.
+Use `hcloud-volumes` for provisioned instance PVCs and avoid `local-path` for tenant data that must survive node replacement.
+The platform frontend and backend are stateless and can use HPA once metrics-server is installed.
+Tenant MindRoom and Synapse releases stay single-replica stateful workloads; scale capacity by placing more tenants across more nodes.
+
+Production platform values should make the storage class explicit:
+
+```yaml
+provisioner:
+  instanceStorageClassName: hcloud-volumes
+
+autoscaling:
+  enabled: false
+```
+
+Enable `autoscaling.enabled` only after the cluster has metrics-server and enough nodes or headroom to schedule the extra replicas.
 
 ## Instance Deployment
 
@@ -15455,6 +15476,8 @@ Dedicated workers need access to the same PVC as the primary runtime.
 Set `storageAccessMode: ReadWriteMany` so multiple workers can access agent storage concurrently.
 If your storage class only supports `ReadWriteOnce`, set `controlPlaneNodeName` so the control plane and dedicated workers stay on the same node.
 The chart enforces this constraint during template rendering.
+For the hosted SaaS instance chart, keep the default `static_runner` backend on single-node clusters.
+Switching hosted instances to dedicated Kubernetes workers on a multi-node cluster requires either a real `ReadWriteMany` storage class or explicit node pinning.
 
 ### RBAC And Network Policy
 
@@ -15511,7 +15534,7 @@ Platform ingress hosts:
 
 - `app.{domain}` - Platform frontend
 - `api.{domain}` - Platform backend API
-- `webhooks.{domain}/stripe` - Stripe webhooks
+- `webhooks.{domain}/webhooks/stripe` - Stripe webhooks
 
 ## Local Development with Kind
 
@@ -15591,6 +15614,10 @@ Each customer instance gets:
 - Dedicated ingress routes
 
 Platform services run in `mindroom-{environment}` namespace.
+The hosted SaaS chart currently runs Synapse per tenant, with server names such as `{customer}.mindroom.chat`.
+The public `mindroom.chat` Matrix server is the separate Tuwunel server on `hetzner-matrix`.
+Do not reuse `mindroom.chat` as the default SaaS tenant homeserver until the product has an explicit shared-homeserver mode with tenant isolation, provisioning, room ownership, SSO, and deprovisioning semantics.
+The runtime-only chart is the better starting point for a future bring-your-own-homeserver or shared-homeserver mode.
 
 # CLI Reference
 

--- a/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
+++ b/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
@@ -16,6 +16,27 @@ MindRoom uses three Helm charts:
 - kubectl and helm installed
 - NGINX Ingress Controller
 - cert-manager (for TLS certificates)
+- Hetzner Cloud Controller Manager and Hetzner CSI Driver when using `hcloud-volumes`
+
+## Hetzner Scaling Baseline
+
+Start with one K3s server node and keep tenant storage on Hetzner Cloud Volumes.
+This keeps the current bill low while making later worker nodes possible.
+Use `hcloud-volumes` for provisioned instance PVCs and avoid `local-path` for tenant data that must survive node replacement.
+The platform frontend and backend are stateless and can use HPA once metrics-server is installed.
+Tenant MindRoom and Synapse releases stay single-replica stateful workloads; scale capacity by placing more tenants across more nodes.
+
+Production platform values should make the storage class explicit:
+
+```yaml
+provisioner:
+  instanceStorageClassName: hcloud-volumes
+
+autoscaling:
+  enabled: false
+```
+
+Enable `autoscaling.enabled` only after the cluster has metrics-server and enough nodes or headroom to schedule the extra replicas.
 
 ## Instance Deployment
 
@@ -198,6 +219,8 @@ Dedicated workers need access to the same PVC as the primary runtime.
 Set `storageAccessMode: ReadWriteMany` so multiple workers can access agent storage concurrently.
 If your storage class only supports `ReadWriteOnce`, set `controlPlaneNodeName` so the control plane and dedicated workers stay on the same node.
 The chart enforces this constraint during template rendering.
+For the hosted SaaS instance chart, keep the default `static_runner` backend on single-node clusters.
+Switching hosted instances to dedicated Kubernetes workers on a multi-node cluster requires either a real `ReadWriteMany` storage class or explicit node pinning.
 
 ### RBAC And Network Policy
 
@@ -254,7 +277,7 @@ Platform ingress hosts:
 
 - `app.{domain}` - Platform frontend
 - `api.{domain}` - Platform backend API
-- `webhooks.{domain}/stripe` - Stripe webhooks
+- `webhooks.{domain}/webhooks/stripe` - Stripe webhooks
 
 ## Local Development with Kind
 
@@ -334,3 +357,7 @@ Each customer instance gets:
 - Dedicated ingress routes
 
 Platform services run in `mindroom-{environment}` namespace.
+The hosted SaaS chart currently runs Synapse per tenant, with server names such as `{customer}.mindroom.chat`.
+The public `mindroom.chat` Matrix server is the separate Tuwunel server on `hetzner-matrix`.
+Do not reuse `mindroom.chat` as the default SaaS tenant homeserver until the product has an explicit shared-homeserver mode with tenant isolation, provisioning, room ownership, SSO, and deprovisioning semantics.
+The runtime-only chart is the better starting point for a future bring-your-own-homeserver or shared-homeserver mode.

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -502,7 +502,14 @@ def _add_dashboard_cors_middleware(api_app: FastAPI, runtime_paths: constants.Ru
 
 
 _runtime_paths = constants.resolve_primary_runtime_paths()
-app = FastAPI(title="MindRoom Dashboard API", lifespan=_lifespan, **_api_docs_kwargs(_runtime_paths))
+_api_docs = _api_docs_kwargs(_runtime_paths)
+app = FastAPI(
+    title="MindRoom Dashboard API",
+    lifespan=_lifespan,
+    docs_url=_api_docs["docs_url"],
+    redoc_url=_api_docs["redoc_url"],
+    openapi_url=_api_docs["openapi_url"],
+)
 initialize_api_app(app, _runtime_paths)
 _add_dashboard_cors_middleware(app, _runtime_paths)
 

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -411,6 +411,83 @@ def test_platform_chart_can_pin_frontend_and_backend_images_separately() -> None
     assert _container(backend, "app")["image"] == "ghcr.io/mindroom-ai/platform-backend:backend-tag"
 
 
+def test_instance_chart_renders_configurable_control_plane_resources() -> None:
+    """Tenant MindRoom and Synapse resources should be configurable per release."""
+    docs = _render_chart(
+        Path("cluster/k8s/instance"),
+        "mindroomResources.requests.cpu=300m",
+        "mindroomResources.requests.memory=768Mi",
+        "mindroomResources.limits.cpu=1500m",
+        "mindroomResources.limits.memory=3Gi",
+        "synapseResources.requests.cpu=350m",
+        "synapseResources.requests.memory=1Gi",
+        "synapseResources.limits.memory=4Gi",
+        set_string_args=("synapseResources.limits.cpu=2",),
+    )
+    mindroom = _resource(docs, "Deployment", "mindroom-demo")
+    synapse = _resource(docs, "Deployment", "synapse-demo")
+
+    assert _container(mindroom, "mindroom")["resources"] == {
+        "requests": {"cpu": "300m", "memory": "768Mi"},
+        "limits": {"cpu": "1500m", "memory": "3Gi"},
+    }
+    assert _container(synapse, "synapse")["resources"] == {
+        "requests": {"cpu": "350m", "memory": "1Gi"},
+        "limits": {"cpu": "2", "memory": "4Gi"},
+    }
+
+
+def test_platform_chart_renders_default_resources_for_stateless_services() -> None:
+    """Platform pods need requests and limits so scheduling and HPA decisions are meaningful."""
+    docs = _render_chart(Path("cluster/k8s/platform"), release_name="mindroom-platform")
+    frontend = _resource(docs, "Deployment", "platform-frontend")
+    backend = _resource(docs, "Deployment", "platform-backend")
+
+    assert _container(frontend, "app")["resources"] == {
+        "requests": {"cpu": "100m", "memory": "256Mi"},
+        "limits": {"cpu": "500m", "memory": "512Mi"},
+    }
+    assert _container(backend, "app")["resources"] == {
+        "requests": {"cpu": "250m", "memory": "512Mi"},
+        "limits": {"cpu": "1000m", "memory": "1Gi"},
+    }
+
+
+def test_platform_chart_can_render_hpa_for_stateless_services() -> None:
+    """Horizontal autoscaling should be opt-in for platform frontend and backend."""
+    docs = _render_chart(
+        Path("cluster/k8s/platform"),
+        "autoscaling.enabled=true",
+        "autoscaling.frontend.minReplicas=1",
+        "autoscaling.frontend.maxReplicas=3",
+        "autoscaling.frontend.targetCPUUtilizationPercentage=70",
+        "autoscaling.backend.minReplicas=1",
+        "autoscaling.backend.maxReplicas=4",
+        "autoscaling.backend.targetCPUUtilizationPercentage=65",
+        release_name="mindroom-platform",
+    )
+    frontend_hpa = _resource(docs, "HorizontalPodAutoscaler", "platform-frontend")
+    backend_hpa = _resource(docs, "HorizontalPodAutoscaler", "platform-backend")
+
+    assert frontend_hpa["spec"]["scaleTargetRef"] == {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "name": "platform-frontend",
+    }
+    assert frontend_hpa["spec"]["minReplicas"] == 1
+    assert frontend_hpa["spec"]["maxReplicas"] == 3
+    assert frontend_hpa["spec"]["metrics"][0]["resource"]["target"]["averageUtilization"] == 70
+
+    assert backend_hpa["spec"]["scaleTargetRef"] == {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "name": "platform-backend",
+    }
+    assert backend_hpa["spec"]["minReplicas"] == 1
+    assert backend_hpa["spec"]["maxReplicas"] == 4
+    assert backend_hpa["spec"]["metrics"][0]["resource"]["target"]["averageUtilization"] == 65
+
+
 def test_runtime_chart_worker_network_policy_selects_dynamic_worker_labels() -> None:
     """The runtime chart worker NetworkPolicy selector should match generated worker pod labels."""
     docs = _render_runtime_chart()


### PR DESCRIPTION
## Summary
- add configurable resource requests/limits for tenant MindRoom, Synapse, and sandbox runner pods
- add default platform frontend/backend resources and optional HPA rendering
- document the Hetzner single-node scaling baseline, per-tenant Synapse model, and future shared-homeserver direction
- refresh generated MindRoom docs skill references
- fix the FastAPI docs kwargs call shape so the repo-wide `ty` pre-commit hook passes

## Live rollout
- installed Hetzner CSI on `hetzner-saas`
- created the `hcloud-volumes` storage class as non-default
- updated the live platform release to use `INSTANCE_STORAGE_CLASS_NAME=hcloud-volumes` for newly provisioned tenants
- left existing tenant PVCs on their current storage class

## Verification
- `nix shell nixpkgs#kubernetes-helm -c uv run pytest tests/test_helm_instance_worker_isolation.py -q`
- `nix shell nixpkgs#kubernetes-helm -c helm lint cluster/k8s/platform`
- `nix shell nixpkgs#kubernetes-helm -c helm lint cluster/k8s/instance`
- `(cd saas-platform/platform-backend && uv sync --all-extras && uv run pytest tests/test_provisioner_real.py -q)`
- `uv run pre-commit run --files src/mindroom/api/main.py cluster/k8s/instance/templates/_helpers.tpl cluster/k8s/instance/templates/deployment-mindroom.yaml cluster/k8s/instance/templates/deployment-synapse.yaml cluster/k8s/instance/values.yaml cluster/k8s/platform/templates/all.yaml cluster/k8s/platform/values-prod.example.yaml cluster/k8s/platform/values-staging.example.yaml cluster/k8s/platform/values.yaml docs/deployment/kubernetes.md skills/mindroom-docs/references/llms-full.txt skills/mindroom-docs/references/page__deployment__kubernetes__index.md tests/test_helm_instance_worker_isolation.py`

## Summary by Sourcery

Introduce configurable Kubernetes resource settings and autoscaling options for SaaS tenant and platform workloads, and document the recommended Hetzner-based scaling and storage approach.

New Features:
- Allow per-tenant configuration of MindRoom, Synapse, and sandbox runner pod resource requests and limits via Helm values.
- Provide default resource requests/limits and optional HorizontalPodAutoscaler definitions for platform frontend and backend services.

Bug Fixes:
- Adjust FastAPI app initialization to pass documentation URLs as explicit kwargs to satisfy repository typing checks and pre-commit hooks.
- Correct the documented Stripe webhook ingress path in Kubernetes deployment docs.

Enhancements:
- Add production and staging example values for Hetzner Cloud Volumes-based instance storage and platform autoscaling settings.
- Update Helm templates to consume new resource values and autoscaling flags while keeping replicas static when autoscaling is disabled.
- Refresh long-form documentation about hosted SaaS topology, per-tenant Synapse homeservers, and future shared-homeserver considerations.

Documentation:
- Extend Kubernetes deployment guides with Hetzner scaling baseline, storage class recommendations, autoscaling guidance, and hosted SaaS Synapse topology notes.

Tests:
- Add Helm chart tests to verify configurable control-plane resources for tenant workloads and default resources/autoscaling behavior for platform frontend/backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Kubernetes resource requests and limits are now configurable via Helm values for all services
  * Autoscaling support for platform frontend and backend services with configurable replica and CPU utilization targets

* **Documentation**
  * Enhanced deployment guidance for Hetzner Cloud environments with scaling recommendations and storage provisioning configuration

* **Tests**
  * Added comprehensive validation tests for resource configuration and autoscaling capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->