### PR TITLE
Fix Helm upgrades with old resource values

### DIFF
--- a/cluster/k8s/instance/templates/_helpers.tpl
+++ b/cluster/k8s/instance/templates/_helpers.tpl
@@ -92,7 +92,7 @@
   - name: sandbox-workspace
     mountPath: /app/workspace
   resources:
-    {{- toYaml $values.sandboxRunnerResources | nindent 4 }}
+    {{- toYaml ($values.sandboxRunnerResources | default (dict)) | nindent 4 }}
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:

--- a/cluster/k8s/instance/templates/deployment-mindroom.yaml
+++ b/cluster/k8s/instance/templates/deployment-mindroom.yaml
@@ -213,7 +213,7 @@ spec:
           mountPath: /etc/secrets
           readOnly: true
         resources:
-          {{- toYaml .Values.mindroomResources | nindent 10 }}
+          {{- toYaml (.Values.mindroomResources | default (dict)) | nindent 10 }}
         # Startup only needs the API process to bind the socket; readiness waits for full bootstrap.
         startupProbe:
           httpGet:

--- a/cluster/k8s/instance/templates/deployment-synapse.yaml
+++ b/cluster/k8s/instance/templates/deployment-synapse.yaml
@@ -44,7 +44,7 @@ spec:
           mountPath: /data/log.config
           subPath: log.config
         resources:
-          {{- toYaml .Values.synapseResources | nindent 10 }}
+          {{- toYaml (.Values.synapseResources | default (dict)) | nindent 10 }}
         readinessProbe:
           httpGet:
             path: /_matrix/client/versions

--- a/cluster/k8s/platform/templates/all.yaml
+++ b/cluster/k8s/platform/templates/all.yaml
@@ -13,6 +13,7 @@ metadata:
   namespace: mindroom-{{ .Values.environment }}
 {{ $prov := .Values.provisioner | default (dict) }}
 {{ $autoscaling := .Values.autoscaling | default (dict) }}
+{{ $resources := .Values.resources | default (dict) }}
 {{ $autoscalingEnabledValue := lower (toString ($autoscaling.enabled | default false)) }}
 {{ $autoscalingEnabled := has $autoscalingEnabledValue (list "1" "true" "yes" "on") }}
 {{ $trustedUpstreamAuth := $prov.trustedUpstreamAuth | default (dict) }}
@@ -144,7 +145,7 @@ spec:
               name: platform-config
               key: SUPABASE_ANON_KEY
         resources:
-          {{- toYaml .Values.resources.frontend | nindent 10 }}
+          {{- toYaml ($resources.frontend | default (dict)) | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service
@@ -226,7 +227,7 @@ spec:
           mountPath: /etc/secrets
           readOnly: true
         resources:
-          {{- toYaml .Values.resources.backend | nindent 10 }}
+          {{- toYaml ($resources.backend | default (dict)) | nindent 10 }}
       volumes:
       - name: platform-sensitive
         secret:

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -78,7 +78,7 @@ Only enable trusted upstream auth when the instance is behind a verified access 
 ```bash
 helm upgrade --install instance-1 ./cluster/k8s/instance \
   --namespace mindroom-instances \
-  --reuse-values \
+  --reset-then-reuse-values \
   --set-string trustedUpstreamAuth.enabled=true \
   --set trustedUpstreamAuth.userIdHeader=X-MindRoom-User-Id \
   --set trustedUpstreamAuth.emailHeader=X-MindRoom-User-Email \

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15331,7 +15331,7 @@ Only enable trusted upstream auth when the instance is behind a verified access 
 ```bash
 helm upgrade --install instance-1 ./cluster/k8s/instance \
   --namespace mindroom-instances \
-  --reuse-values \
+  --reset-then-reuse-values \
   --set-string trustedUpstreamAuth.enabled=true \
   --set trustedUpstreamAuth.userIdHeader=X-MindRoom-User-Id \
   --set trustedUpstreamAuth.emailHeader=X-MindRoom-User-Email \

--- a/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
+++ b/skills/mindroom-docs/references/page__deployment__kubernetes__index.md
@@ -74,7 +74,7 @@ Only enable trusted upstream auth when the instance is behind a verified access 
 ```bash
 helm upgrade --install instance-1 ./cluster/k8s/instance \
   --namespace mindroom-instances \
-  --reuse-values \
+  --reset-then-reuse-values \
   --set-string trustedUpstreamAuth.enabled=true \
   --set trustedUpstreamAuth.userIdHeader=X-MindRoom-User-Id \
   --set trustedUpstreamAuth.emailHeader=X-MindRoom-User-Email \

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -18,12 +18,14 @@ def _render_chart(
     *set_args: str,
     release_name: str = "mindroom-demo",
     set_string_args: tuple[str, ...] = (),
+    values_files: tuple[Path, ...] = (),
 ) -> list[dict[str, Any]]:
     completed = _run_helm_template(
         chart_dir,
         *set_args,
         release_name=release_name,
         set_string_args=set_string_args,
+        values_files=values_files,
     )
     completed.check_returncode()
     return [doc for doc in yaml.safe_load_all(completed.stdout) if isinstance(doc, dict)]
@@ -34,6 +36,7 @@ def _run_helm_template(
     *set_args: str,
     release_name: str = "mindroom-demo",
     set_string_args: tuple[str, ...] = (),
+    values_files: tuple[Path, ...] = (),
 ) -> subprocess.CompletedProcess[str]:
     helm = shutil.which("helm")
     if helm is None:
@@ -44,6 +47,7 @@ def _run_helm_template(
             "template",
             release_name,
             str(chart_dir),
+            *(arg for value in values_files for arg in ("--values", str(value))),
             *(arg for value in set_args for arg in ("--set", value)),
             *(arg for value in set_string_args for arg in ("--set-string", value)),
         ],
@@ -437,6 +441,23 @@ def test_instance_chart_renders_configurable_control_plane_resources() -> None:
     }
 
 
+def test_instance_chart_renders_with_pre_resource_release_values(tmp_path: Path) -> None:
+    """Older release values should not break chart upgrades before resources are set."""
+    values_path = tmp_path / "old-instance-values.yaml"
+    values_path.write_text(
+        "customer: demo\nbaseDomain: mindroom.chat\nmindroomResources:\nsynapseResources:\nsandboxRunnerResources:\n",
+        encoding="utf-8",
+    )
+
+    docs = _render_chart(Path("cluster/k8s/instance"), values_files=(values_path,))
+    mindroom = _resource(docs, "Deployment", "mindroom-demo")
+    synapse = _resource(docs, "Deployment", "synapse-demo")
+
+    assert _container(mindroom, "mindroom")["resources"] == {}
+    assert _container(mindroom, "sandbox-runner")["resources"] == {}
+    assert _container(synapse, "synapse")["resources"] == {}
+
+
 def test_platform_chart_renders_default_resources_for_stateless_services() -> None:
     """Platform pods need requests and limits so scheduling and HPA decisions are meaningful."""
     docs = _render_chart(Path("cluster/k8s/platform"), release_name="mindroom-platform")
@@ -451,6 +472,26 @@ def test_platform_chart_renders_default_resources_for_stateless_services() -> No
         "requests": {"cpu": "250m", "memory": "512Mi"},
         "limits": {"cpu": "1000m", "memory": "1Gi"},
     }
+
+
+def test_platform_chart_renders_with_pre_resource_release_values(tmp_path: Path) -> None:
+    """Older release values should not break chart upgrades before resources are set."""
+    values_path = tmp_path / "old-platform-values.yaml"
+    values_path.write_text(
+        "environment: production\ndomain: mindroom.chat\nresources:\n",
+        encoding="utf-8",
+    )
+
+    docs = _render_chart(
+        Path("cluster/k8s/platform"),
+        release_name="mindroom-platform",
+        values_files=(values_path,),
+    )
+    frontend = _resource(docs, "Deployment", "platform-frontend")
+    backend = _resource(docs, "Deployment", "platform-backend")
+
+    assert _container(frontend, "app")["resources"] == {}
+    assert _container(backend, "app")["resources"] == {}
 
 
 def test_platform_chart_can_render_hpa_for_stateless_services() -> None:


### PR DESCRIPTION
## Summary\n- guard platform and instance resource template maps for old release values\n- add Helm render regressions for pre-resource release values\n- document reset-then-reuse-values for chart upgrades\n\n## Tests\n- nix shell nixpkgs#kubernetes-helm -c helm lint cluster/k8s/platform\n- nix shell nixpkgs#kubernetes-helm -c helm lint cluster/k8s/instance\n- nix shell nixpkgs#kubernetes-helm -c uv run pytest tests/test_helm_instance_worker_isolation.py -q\n- nix shell nixpkgs#kubernetes-helm -c uv run pytest

## Summary by Sourcery

Guard Helm charts and upgrade flow against missing resource values from older releases.

Bug Fixes:
- Prevent Helm instance and platform charts from failing when upgrading releases that lack resource configuration values.

Enhancements:
- Default resource value maps to empty dictionaries in Helm templates to tolerate absent configuration.

Documentation:
- Document using `--reset-then-reuse-values` for Helm upgrades in Kubernetes deployment guides.

Tests:
- Add regression tests to ensure instance and platform charts render correctly when provided with pre-resource release values.