### PR TITLE
Extend platform ingress timeout for provisioning

### DIFF
--- a/cluster/k8s/platform/templates/ingress.yaml
+++ b/cluster/k8s/platform/templates/ingress.yaml
@@ -8,6 +8,8 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.ingress.proxyReadTimeout | quote }}
+    nginx.ingress.kubernetes.io/proxy-send-timeout: {{ .Values.ingress.proxySendTimeout | quote }}
     nginx.ingress.kubernetes.io/client-header-buffer-size: "16k"
     nginx.ingress.kubernetes.io/large-client-header-buffers: "4 32k"
     cert-manager.io/cluster-issuer: letsencrypt-prod

--- a/cluster/k8s/platform/values.yaml
+++ b/cluster/k8s/platform/values.yaml
@@ -91,6 +91,8 @@ ingress:
   # NGINX blocks configuration-snippet by default in many setups (incl. kind example)
   # Keep disabled for local kind; enable in hardened clusters if allowed.
   enableConfigurationSnippet: false
+  proxyReadTimeout: "300"
+  proxySendTimeout: "300"
 
 # The apex mindroom.chat is the Matrix server name and must stay on hetzner-matrix.
 apexRedirect:

--- a/saas-platform/platform-backend/src/backend/routes/instances.py
+++ b/saas-platform/platform-backend/src/backend/routes/instances.py
@@ -239,7 +239,7 @@ async def provision_user_instance(
 
 # Helper function for user instance actions
 async def _verify_instance_ownership_and_proxy(
-    instance_id: int, user: dict, provisioner_func: Callable
+    request: Request, instance_id: int, user: dict, provisioner_func: Callable
 ) -> dict[str, Any]:
     """Verify user owns instance and proxy to provisioner."""
     sb = ensure_supabase()
@@ -255,7 +255,7 @@ async def _verify_instance_ownership_and_proxy(
     if not result.data:
         raise HTTPException(status_code=404, detail="Instance not found or access denied")
 
-    return await provisioner_func(instance_id, f"Bearer {PROVISIONER_API_KEY}")
+    return await provisioner_func(request, instance_id, f"Bearer {PROVISIONER_API_KEY}")
 
 
 @router.post("/my/instances/{instance_id}/start", response_model=ActionResult)
@@ -264,7 +264,7 @@ async def start_user_instance(
     request: Request, instance_id: int, user: Annotated[dict, Depends(verify_user)]
 ) -> dict[str, Any]:
     """Start user's instance."""
-    return await _verify_instance_ownership_and_proxy(instance_id, user, start_instance_provisioner)
+    return await _verify_instance_ownership_and_proxy(request, instance_id, user, start_instance_provisioner)
 
 
 @router.post("/my/instances/{instance_id}/stop", response_model=ActionResult)
@@ -273,7 +273,7 @@ async def stop_user_instance(
     request: Request, instance_id: int, user: Annotated[dict, Depends(verify_user)]
 ) -> dict[str, Any]:
     """Stop user's instance."""
-    return await _verify_instance_ownership_and_proxy(instance_id, user, stop_instance_provisioner)
+    return await _verify_instance_ownership_and_proxy(request, instance_id, user, stop_instance_provisioner)
 
 
 @router.post("/my/instances/{instance_id}/restart", response_model=ActionResult)
@@ -282,4 +282,4 @@ async def restart_user_instance(
     request: Request, instance_id: int, user: Annotated[dict, Depends(verify_user)]
 ) -> dict[str, Any]:
     """Restart user's instance."""
-    return await _verify_instance_ownership_and_proxy(instance_id, user, restart_instance_provisioner)
+    return await _verify_instance_ownership_and_proxy(request, instance_id, user, restart_instance_provisioner)

--- a/saas-platform/platform-backend/tests/test_instances.py
+++ b/saas-platform/platform-backend/tests/test_instances.py
@@ -1,7 +1,7 @@
 """Comprehensive HTTP API tests for instances endpoints."""
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -376,7 +376,7 @@ class TestInstancesEndpoints:
         assert "started successfully" in data["message"]
 
         # Verify start_instance_provisioner was called
-        mock_start_instance.assert_called_once_with(123, "Bearer test-api-key")
+        mock_start_instance.assert_called_once_with(ANY, 123, "Bearer test-api-key")
 
     def test_start_user_instance_not_owned(self, client: TestClient, mock_supabase: MagicMock, mock_verify_user: Mock):
         """Test starting instance not owned by user."""
@@ -412,7 +412,7 @@ class TestInstancesEndpoints:
         assert "stopped successfully" in data["message"]
 
         # Verify stop_instance_provisioner was called
-        mock_stop_instance.assert_called_once_with(123, "Bearer test-api-key")
+        mock_stop_instance.assert_called_once_with(ANY, 123, "Bearer test-api-key")
 
     def test_restart_user_instance_success(
         self,
@@ -436,7 +436,7 @@ class TestInstancesEndpoints:
         assert "restarted successfully" in data["message"]
 
         # Verify restart_instance_provisioner was called
-        mock_restart_instance.assert_called_once_with(456, "Bearer test-api-key")
+        mock_restart_instance.assert_called_once_with(ANY, 456, "Bearer test-api-key")
 
     def test_background_sync_task(
         self, mock_supabase: MagicMock, mock_check_deployment: AsyncMock, mock_kubectl: AsyncMock


### PR DESCRIPTION
## Summary
- add platform ingress proxy read/send timeout values
- set the default to 300s so user-facing instance provisioning can outlive the backend readiness wait

## Validation
- rendered diff checked locally
- live public provisioning smoke will be rerun after deploying this chart change

## Summary by Sourcery

Enhancements:
- Add configurable NGINX proxy read and send timeout annotations to the platform ingress with defaults set to 300 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configurable NGINX proxy timeout settings to the platform ingress, including read and send timeouts with default values of 300 seconds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->