### PR TITLE
Fix SaaS payment setup and Stripe webhook path

### DIFF
--- a/cluster/k8s/platform/templates/ingress.yaml
+++ b/cluster/k8s/platform/templates/ingress.yaml
@@ -58,6 +58,13 @@ spec:
             name: platform-backend
             port:
               number: 8000
+      - path: /stripe
+        pathType: Prefix
+        backend:
+          service:
+            name: platform-backend
+            port:
+              number: 8000
 
   tls:
   - hosts:

--- a/saas-platform/platform-backend/src/backend/routes/accounts.py
+++ b/saas-platform/platform-backend/src/backend/routes/accounts.py
@@ -61,14 +61,13 @@ async def setup_account(request: Request, user: Annotated[dict, Depends(verify_u
         "status": "active",
         "max_agents": limits["max_agents"],
         "max_messages_per_day": limits["max_messages_per_day"],
-        "max_storage_gb": limits["max_storage_gb"],
         "created_at": datetime.now(UTC).isoformat(),
     }
 
     sub_result = sb.table("subscriptions").insert(subscription_data).execute()
     subscription = sub_result.data[0] if sub_result.data else None
     if subscription is not None:
-        subscription.setdefault("max_storage_gb", limits["max_storage_gb"])
+        subscription["max_storage_gb"] = limits["max_storage_gb"]
 
     return {
         "message": "Free tier account created",

--- a/saas-platform/platform-backend/src/backend/routes/webhooks.py
+++ b/saas-platform/platform-backend/src/backend/routes/webhooks.py
@@ -341,6 +341,7 @@ def handle_payment_failed(invoice: dict) -> tuple[bool, str | None]:
     return True, account_id
 
 
+@router.post("/stripe", response_model=WebhookResponse, include_in_schema=False)
 @router.post("/webhooks/stripe", response_model=WebhookResponse)
 @limiter.limit("20/minute")
 async def stripe_webhook(  # noqa: C901, PLR0912, PLR0915

--- a/saas-platform/platform-backend/tests/test_accounts.py
+++ b/saas-platform/platform-backend/tests/test_accounts.py
@@ -186,7 +186,7 @@ class TestAccountsEndpoints:
         data = response.json()
         assert data["subscription"]["max_storage_gb"] == 1
         inserted_subscription = mock_supabase.table().insert.call_args.args[0]
-        assert inserted_subscription["max_storage_gb"] == 1
+        assert "max_storage_gb" not in inserted_subscription
 
     def test_setup_account_existing_user(self, client: TestClient, mock_supabase: MagicMock, mock_verify_user: Mock):
         """Test setting up account when user already has subscription."""

--- a/saas-platform/platform-backend/tests/test_provisioner_integration.py
+++ b/saas-platform/platform-backend/tests/test_provisioner_integration.py
@@ -293,7 +293,12 @@ class TestProvisionerIntegration:
             mock_db.table().update.side_effect = update_side_effect
 
             with patch("backend.routes.provisioner.run_kubectl") as mock_kubectl:
-                mock_kubectl.return_value = (0, "Success", "")
+                async def kubectl_side_effect(args, **kwargs):
+                    if args[:2] == ["get", "secret"]:
+                        return (0, "", "")
+                    return (0, "Success", "")
+
+                mock_kubectl.side_effect = kubectl_side_effect
 
                 with patch("backend.routes.provisioner.run_helm") as mock_helm:
                     mock_helm.return_value = (0, "Release upgraded", "")

--- a/saas-platform/platform-backend/tests/test_stripe_routes.py
+++ b/saas-platform/platform-backend/tests/test_stripe_routes.py
@@ -28,6 +28,7 @@ class TestStripeRoutesEndpoints:
     def mock_stripe(self):
         """Mock Stripe client."""
         with patch("backend.routes.stripe_routes.stripe") as mock:
+            mock.api_key = "sk_test_mock"
             yield mock
 
     @pytest.fixture
@@ -91,7 +92,7 @@ class TestStripeRoutesEndpoints:
         assert data["url"] == "https://billing.stripe.com/session/test_123"
 
     def test_create_customer_portal_no_customer(
-        self, client: TestClient, mock_supabase: MagicMock, mock_verify_user: Mock
+        self, client: TestClient, mock_supabase: MagicMock, mock_stripe: Mock, mock_verify_user: Mock
     ):
         """Test creating portal session when no Stripe customer exists."""
         # Setup
@@ -208,7 +209,9 @@ class TestStripeRoutesEndpoints:
             assert response.status_code == 500
             assert "Failed to create checkout" in response.json()["detail"]
 
-    def test_portal_account_not_found(self, client: TestClient, mock_supabase: MagicMock, mock_verify_user: Mock):
+    def test_portal_account_not_found(
+        self, client: TestClient, mock_supabase: MagicMock, mock_stripe: Mock, mock_verify_user: Mock
+    ):
         """Test portal when account not found."""
         # Setup
         mock_supabase.table().select().eq().single().execute.return_value = Mock(data=None)

--- a/saas-platform/platform-backend/tests/test_webhooks.py
+++ b/saas-platform/platform-backend/tests/test_webhooks.py
@@ -94,6 +94,12 @@ class TestWebhookEndpoints:
         assert response.status_code == 400
         assert response.json()["detail"] == "Missing signature"
 
+    def test_legacy_webhook_path_missing_signature(self, client: TestClient):
+        """Test the legacy Stripe webhook path used by existing Stripe endpoints."""
+        response = client.post("/stripe", json={})
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Missing signature"
+
     def test_webhook_invalid_signature(self, client: TestClient, mock_stripe_signature: Mock):
         """Test webhook with invalid signature."""
         mock_stripe_signature.side_effect = stripe.error.SignatureVerificationError("Invalid signature", None)


### PR DESCRIPTION
## Summary
- stop inserting the derived storage limit into the production subscriptions table during account setup
- serve the existing Stripe webhook endpoint URL at /stripe while keeping /webhooks/stripe
- make payment/provisioner tests model the current production route behavior

## Validation
- `uv sync --locked && uv run pytest -q` in `saas-platform/platform-backend` from clean worktree: 305 passed, 5 skipped
- `uv run ruff check src/backend/routes/accounts.py src/backend/routes/webhooks.py tests/test_accounts.py tests/test_stripe_routes.py tests/test_webhooks.py tests/test_provisioner_integration.py`
- `nix shell nixpkgs#kubernetes-helm -c helm template platform cluster/k8s/platform --namespace mindroom-production --set environment=production --set domain=mindroom.chat --set imageTag=vtest`

## Summary by Sourcery

Adjust SaaS account setup and Stripe webhook handling to better align with existing production behavior and routing.

Bug Fixes:
- Prevent inserting a derived max_storage_gb value into new subscription rows while still returning the limit in API responses.
- Expose the existing Stripe webhook handler on the legacy /stripe path in addition to /webhooks/stripe to maintain compatibility with existing Stripe configuration.
- Ensure Kubernetes/helm provisioning logic correctly handles kubectl calls that may return empty output for secrets.

Build:
- Update Kubernetes ingress configuration to route /stripe paths to the backend service for webhook handling.

Tests:
- Update account setup tests to assert that storage limits are not persisted in the subscriptions table while remaining present in the returned subscription payload.
- Extend webhook tests to cover the legacy /stripe webhook path and ensure consistent error responses.
- Adjust Stripe route tests to consistently use the Stripe mock fixture and validate behavior when customers or accounts are missing.
- Refine provisioner integration tests to model current kubectl behavior when fetching secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alternative webhook endpoint path for Stripe callbacks to improve routing flexibility.

* **Tests**
  * Enhanced webhook test coverage with signature validation checks.
  * Updated subscription setup tests to reflect refactored storage limit handling.
  * Improved test fixtures for Stripe client mocking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->