### PR TITLE
Clean up SaaS Stripe webhook contract

### DIFF
--- a/cluster/k8s/platform/templates/ingress.yaml
+++ b/cluster/k8s/platform/templates/ingress.yaml
@@ -58,13 +58,6 @@ spec:
             name: platform-backend
             port:
               number: 8000
-      - path: /stripe
-        pathType: Prefix
-        backend:
-          service:
-            name: platform-backend
-            port:
-              number: 8000
 
   tls:
   - hosts:

--- a/saas-platform/platform-backend/src/backend/deps.py
+++ b/saas-platform/platform-backend/src/backend/deps.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 # TTL cache for auth verification (5 minutes, max 100 entries)
 _auth_cache = TTLCache(maxsize=100, ttl=300)
 
+
 def client_ip_from_request(request: Request) -> str:
     """Return the end-user IP for auth monitoring and rate limiting."""
     real_ip = request.headers.get("x-real-ip", "").strip()

--- a/saas-platform/platform-backend/src/backend/routes/subscriptions.py
+++ b/saas-platform/platform-backend/src/backend/routes/subscriptions.py
@@ -49,12 +49,10 @@ async def get_user_subscription(request: Request, user: Annotated[dict, Depends(
         logger.error(f"Failed to create subscription for account {account_id}")
         raise HTTPException(status_code=500, detail="Failed to create subscription")
 
-    # Add max_storage_gb from pricing config if not in database
     subscription = result.data[0]
-    if "max_storage_gb" not in subscription or subscription["max_storage_gb"] is None:
-        tier = subscription.get("tier", "free")
-        limits = get_plan_limits_from_metadata(tier)
-        subscription["max_storage_gb"] = limits["max_storage_gb"]
+    tier = subscription.get("tier", "free")
+    limits = get_plan_limits_from_metadata(tier)
+    subscription["max_storage_gb"] = limits["max_storage_gb"]
 
     return subscription
 
@@ -65,9 +63,6 @@ async def cancel_subscription(
     req: Request, request: CancelSubscriptionRequest, user: Annotated[dict, Depends(verify_user)]
 ) -> dict[str, Any]:
     """Cancel subscription."""
-    if not stripe.api_key:
-        raise HTTPException(status_code=500, detail="Stripe not configured")
-
     sb = ensure_supabase()
     account_id = user["account_id"]
 
@@ -85,6 +80,8 @@ async def cancel_subscription(
         raise HTTPException(status_code=400, detail="No active subscription found")
 
     stripe_sub_id = subscription["stripe_subscription_id"]
+    if not stripe.api_key:
+        raise HTTPException(status_code=500, detail="Stripe not configured")
 
     try:
         if request.cancel_at_period_end:
@@ -111,9 +108,6 @@ async def cancel_subscription(
 @limiter.limit("5/minute")  # Sensitive operation
 async def reactivate_subscription(request: Request, user: Annotated[dict, Depends(verify_user)]) -> dict[str, Any]:
     """Reactivate a cancelled subscription (if still in billing period)."""
-    if not stripe.api_key:
-        raise HTTPException(status_code=500, detail="Stripe not configured")
-
     sb = ensure_supabase()
     account_id = user["account_id"]
 
@@ -131,6 +125,8 @@ async def reactivate_subscription(request: Request, user: Annotated[dict, Depend
         raise HTTPException(status_code=400, detail="No Stripe subscription found")
 
     stripe_sub_id = subscription["stripe_subscription_id"]
+    if not stripe.api_key:
+        raise HTTPException(status_code=500, detail="Stripe not configured")
 
     try:
         # Reactivate by removing the cancel_at_period_end flag

--- a/saas-platform/platform-backend/src/backend/routes/webhooks.py
+++ b/saas-platform/platform-backend/src/backend/routes/webhooks.py
@@ -26,14 +26,9 @@ def _get_tier_from_price(price: dict) -> str:
     """Extract tier from price metadata.
 
     Our sync-stripe-prices.py script sets metadata.plan with the tier name.
-    Also supports metadata.tier for backward compatibility.
     """
-    if metadata := price.get("metadata", {}):
-        # Try 'plan' first (new format), then 'tier' (old format)
-        if plan := metadata.get("plan"):
-            return plan
-        if tier := metadata.get("tier"):
-            return tier
+    if (metadata := price.get("metadata", {})) and (plan := metadata.get("plan")):
+        return plan
 
     msg = (
         f"Unable to determine tier from price. "
@@ -341,7 +336,6 @@ def handle_payment_failed(invoice: dict) -> tuple[bool, str | None]:
     return True, account_id
 
 
-@router.post("/stripe", response_model=WebhookResponse, include_in_schema=False)
 @router.post("/webhooks/stripe", response_model=WebhookResponse)
 @limiter.limit("20/minute")
 async def stripe_webhook(  # noqa: C901, PLR0912, PLR0915

--- a/saas-platform/platform-backend/src/main.py
+++ b/saas-platform/platform-backend/src/main.py
@@ -226,6 +226,7 @@ async def restrict_public_metrics(
             return JSONResponse({"detail": "Not found"}, status_code=404)
     return await call_next(request)
 
+
 # 5. Compute CORS origins: exclude localhost in production
 cors_origins = [o for o in ALLOWED_ORIGINS if not (ENVIRONMENT == "production" and o.startswith("http://localhost"))]
 

--- a/saas-platform/platform-backend/tests/test_accounts.py
+++ b/saas-platform/platform-backend/tests/test_accounts.py
@@ -29,6 +29,7 @@ class TestAccountsEndpoints:
     @pytest.fixture
     def mock_verify_user(self):
         """Mock user verification."""
+
         def override_verify_user():
             return {"account_id": "acc_test_123", "email": "test@example.com"}
 
@@ -83,6 +84,7 @@ class TestAccountsEndpoints:
 
     def test_get_current_account_unauthorized(self, client: TestClient):
         """Test getting account without authentication."""
+
         def override_verify_user():
             raise HTTPException(status_code=401, detail="Unauthorized")
 
@@ -148,7 +150,6 @@ class TestAccountsEndpoints:
             "status": "active",
             "max_agents": 1,
             "max_messages_per_day": 100,
-            "max_storage_gb": 10,
             "created_at": datetime.now(UTC).isoformat(),
         }
         mock_supabase.table().insert().execute.return_value = Mock(data=[new_subscription])
@@ -215,7 +216,6 @@ class TestAccountsEndpoints:
                     "status": "active",
                     "max_agents": 1,
                     "max_messages_per_day": 100,
-                    "max_storage_gb": 10,
                 }
             ]
         )

--- a/saas-platform/platform-backend/tests/test_provisioner_integration.py
+++ b/saas-platform/platform-backend/tests/test_provisioner_integration.py
@@ -293,6 +293,7 @@ class TestProvisionerIntegration:
             mock_db.table().update.side_effect = update_side_effect
 
             with patch("backend.routes.provisioner.run_kubectl") as mock_kubectl:
+
                 async def kubectl_side_effect(args, **kwargs):
                     if args[:2] == ["get", "secret"]:
                         return (0, "", "")

--- a/saas-platform/platform-backend/tests/test_subscriptions.py
+++ b/saas-platform/platform-backend/tests/test_subscriptions.py
@@ -57,7 +57,6 @@ class TestSubscriptionsEndpoints:
             "current_period_end": (datetime.now(UTC) + timedelta(days=30)).isoformat(),
             "max_agents": 10,
             "max_messages_per_day": 1000,
-            "max_storage_gb": 100,
             "created_at": datetime.now(UTC).isoformat(),
             "updated_at": datetime.now(UTC).isoformat(),
         }
@@ -304,7 +303,6 @@ class TestSubscriptionsEndpoints:
             "stripe_subscription_id": "stripe_sub_123",
             "max_agents": 10,
             "max_messages_per_day": 1000,
-            "max_storage_gb": 100,
             "created_at": datetime.now(UTC).isoformat(),
             "updated_at": datetime.now(UTC).isoformat(),
         }

--- a/saas-platform/platform-backend/tests/test_user_rate_limit.py
+++ b/saas-platform/platform-backend/tests/test_user_rate_limit.py
@@ -46,7 +46,6 @@ class _DummyTable:
             "status": data.get("status", "active"),
             "max_agents": data.get("max_agents", 1),
             "max_messages_per_day": data.get("max_messages_per_day", 100),
-            "max_storage_gb": data.get("max_storage_gb", 1),
             "created_at": data.get("created_at"),
         }
         self._insert_data = [inserted_data]

--- a/saas-platform/platform-backend/tests/test_webhooks.py
+++ b/saas-platform/platform-backend/tests/test_webhooks.py
@@ -94,11 +94,10 @@ class TestWebhookEndpoints:
         assert response.status_code == 400
         assert response.json()["detail"] == "Missing signature"
 
-    def test_legacy_webhook_path_missing_signature(self, client: TestClient):
-        """Test the legacy Stripe webhook path used by existing Stripe endpoints."""
+    def test_webhook_stripe_root_path_not_registered(self, client: TestClient):
+        """The Stripe webhook is only registered at the documented path."""
         response = client.post("/stripe", json={})
-        assert response.status_code == 400
-        assert response.json()["detail"] == "Missing signature"
+        assert response.status_code == 404
 
     def test_webhook_invalid_signature(self, client: TestClient, mock_stripe_signature: Mock):
         """Test webhook with invalid signature."""
@@ -501,32 +500,6 @@ class TestWebhookEndpoints:
         # At least one should be rate limited (429)
         assert 429 in responses
 
-    def test_legacy_tier_metadata(self, client: TestClient, mock_stripe_signature: Mock, mock_supabase: MagicMock):
-        """Test handling of legacy 'tier' metadata field."""
-        # Setup with legacy metadata format
-        subscription_data = self._create_subscription_data()
-        # Use 'tier' instead of 'plan' in metadata
-        subscription_data["items"]["data"][0]["price"]["metadata"] = {
-            "tier": "starter",  # Legacy field name
-            "billing_cycle": "monthly",
-        }
-        event = self._create_stripe_event("customer.subscription.created", subscription_data)
-        mock_stripe_signature.return_value = event
-
-        # Mock Supabase responses
-        mock_supabase.table().select().eq().single().execute.return_value = Mock(data={"id": "account_123"})
-        mock_supabase.table().select().eq().execute.return_value = Mock(data=[])
-        mock_supabase.table().insert().execute.return_value = Mock()
-
-        # Make request
-        response = client.post("/webhooks/stripe", content=b"test body", headers={"Stripe-Signature": "valid_sig"})
-
-        # Verify - should handle legacy format successfully
-        assert response.status_code == 200
-        data = response.json()
-        assert data["received"] is True
-        assert data["error"] is None
-
     def test_missing_price_metadata(self, client: TestClient, mock_stripe_signature: Mock, mock_supabase: MagicMock):
         """Test handling of missing price metadata."""
         # Setup with no metadata
@@ -547,3 +520,24 @@ class TestWebhookEndpoints:
         result = response.json()
         assert result["received"] is True
         assert "error" in result or "Unable to determine tier" in str(result)
+
+    def test_price_metadata_requires_plan(
+        self, client: TestClient, mock_stripe_signature: Mock, mock_supabase: MagicMock
+    ):
+        """Stripe price metadata must use the current plan field."""
+        subscription_data = self._create_subscription_data()
+        subscription_data["items"]["data"][0]["price"]["metadata"] = {
+            "tier": "starter",
+            "billing_cycle": "monthly",
+        }
+        event = self._create_stripe_event("customer.subscription.created", subscription_data)
+        mock_stripe_signature.return_value = event
+
+        mock_supabase.table().select().eq().single().execute.return_value = Mock(data={"id": "account_123"})
+
+        response = client.post("/webhooks/stripe", content=b"test body", headers={"Stripe-Signature": "valid_sig"})
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["received"] is True
+        assert "Unable to determine tier" in result["error"]

--- a/saas-platform/platform-frontend/src/lib/supabase/types.ts
+++ b/saas-platform/platform-frontend/src/lib/supabase/types.ts
@@ -1,4 +1,8 @@
 // Database types for Supabase
+type PlanTier = 'free' | 'starter' | 'professional' | 'enterprise'
+type AccountStatus = 'active' | 'suspended' | 'deleted' | 'pending_verification'
+type SubscriptionStatus = 'trialing' | 'active' | 'cancelled' | 'past_due' | 'paused'
+
 export type Database = {
   public: {
     Tables: {
@@ -6,21 +10,57 @@ export type Database = {
         Row: {
           id: string
           email: string
+          full_name: string | null
+          company_name: string | null
+          stripe_customer_id: string | null
+          tier: PlanTier
           is_admin: boolean
+          status: AccountStatus
+          deleted_at: string | null
+          deletion_reason: string | null
+          deletion_requested_by: string | null
+          deletion_requested_at: string | null
+          consent_marketing: boolean
+          consent_analytics: boolean
+          consent_updated_at: string | null
           created_at: string
           updated_at: string
         }
         Insert: {
           id?: string
           email: string
+          full_name?: string | null
+          company_name?: string | null
+          stripe_customer_id?: string | null
+          tier?: PlanTier
           is_admin?: boolean
+          status?: AccountStatus
+          deleted_at?: string | null
+          deletion_reason?: string | null
+          deletion_requested_by?: string | null
+          deletion_requested_at?: string | null
+          consent_marketing?: boolean
+          consent_analytics?: boolean
+          consent_updated_at?: string | null
           created_at?: string
           updated_at?: string
         }
         Update: {
           id?: string
           email?: string
+          full_name?: string | null
+          company_name?: string | null
+          stripe_customer_id?: string | null
+          tier?: PlanTier
           is_admin?: boolean
+          status?: AccountStatus
+          deleted_at?: string | null
+          deletion_reason?: string | null
+          deletion_requested_by?: string | null
+          deletion_requested_at?: string | null
+          consent_marketing?: boolean
+          consent_analytics?: boolean
+          consent_updated_at?: string | null
           created_at?: string
           updated_at?: string
         }
@@ -29,42 +69,51 @@ export type Database = {
         Row: {
           id: string
           account_id: string
-          tier: 'free' | 'starter' | 'professional' | 'enterprise'
-          status: 'active' | 'cancelled' | 'past_due'
+          subscription_id: string | null
           stripe_subscription_id: string | null
-          stripe_customer_id: string | null
+          stripe_price_id: string | null
+          tier: PlanTier
+          status: SubscriptionStatus
+          trial_ends_at: string | null
+          current_period_start: string | null
           current_period_end: string | null
+          cancelled_at: string | null
           max_agents: number
           max_messages_per_day: number
-          max_storage_gb: number
           created_at: string
           updated_at: string
         }
         Insert: {
           id?: string
           account_id: string
-          tier?: 'free' | 'starter' | 'professional' | 'enterprise'
-          status?: 'active' | 'cancelled' | 'past_due'
+          subscription_id?: string | null
           stripe_subscription_id?: string | null
-          stripe_customer_id?: string | null
+          stripe_price_id?: string | null
+          tier?: PlanTier
+          status?: SubscriptionStatus
+          trial_ends_at?: string | null
+          current_period_start?: string | null
           current_period_end?: string | null
+          cancelled_at?: string | null
           max_agents?: number
           max_messages_per_day?: number
-          max_storage_gb?: number
           created_at?: string
           updated_at?: string
         }
         Update: {
           id?: string
           account_id?: string
-          tier?: 'free' | 'starter' | 'professional' | 'enterprise'
-          status?: 'active' | 'cancelled' | 'past_due'
+          subscription_id?: string | null
           stripe_subscription_id?: string | null
-          stripe_customer_id?: string | null
+          stripe_price_id?: string | null
+          tier?: PlanTier
+          status?: SubscriptionStatus
+          trial_ends_at?: string | null
+          current_period_start?: string | null
           current_period_end?: string | null
+          cancelled_at?: string | null
           max_agents?: number
           max_messages_per_day?: number
-          max_storage_gb?: number
           created_at?: string
           updated_at?: string
         }


### PR DESCRIPTION
## Summary
- remove the hidden /stripe Stripe webhook alias and its dedicated ingress path
- require current Stripe price metadata.plan instead of accepting metadata.tier
- keep subscription storage limits derived from pricing config and align frontend Supabase table types with the actual database columns
- validate local subscription state before requiring Stripe config for cancel/reactivate endpoints

## Verification
- uv run pre-commit run --all-files
- cd saas-platform/platform-backend && uv run pytest -q
- cd saas-platform/platform-frontend && bun run test -- --runInBand
- nix shell nixpkgs#kubernetes-helm -c helm template platform cluster/k8s/platform --namespace mindroom-production --set environment=production --set domain=mindroom.chat --set imageTag=vtest --set backendImageTag=vtest --set frontendImageTag=vtest | rg "path: /"

## Summary by Sourcery

Align SaaS subscription and account contracts with the database and Stripe pricing metadata while removing deprecated Stripe webhook paths.

New Features:
- Expand Supabase account and subscription table types on the frontend to cover full account metadata, subscription lifecycle fields, and shared plan/status enums.

Bug Fixes:
- Ensure user subscriptions always derive max_storage_gb from pricing configuration rather than relying on missing or outdated database fields.
- Validate local subscription existence before requiring Stripe configuration when cancelling or reactivating subscriptions, returning clearer errors when no subscription is present.
- Require Stripe price metadata.plan for tier resolution in webhooks and surface graceful errors when price metadata is missing or incomplete.

Enhancements:
- Remove the legacy /stripe webhook endpoint and its Kubernetes ingress route, standardizing on the documented /webhooks/stripe path.
- Align frontend Supabase type definitions and backend tests with the current subscription schema, including removal of the max_storage_gb column from persisted subscription records.

Tests:
- Update webhook, subscription, account, rate limit, and provisioner integration tests to reflect the new webhook contract, metadata requirements, and subscription schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Stripe webhook endpoint path from `/stripe` to `/webhooks/stripe`.

* **Bug Fixes**
  * Ensured subscription storage limits are consistently applied based on tier configuration.
  * Updated Stripe price metadata handling to use standardized plan field format; legacy tier metadata format is no longer supported.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindroom-ai/mindroom/pull/1053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->